### PR TITLE
[SYCL][GRAPH] Add graph E2E tests which use free function extension

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -58,6 +58,7 @@ Jack Kirk, Codeplay +
 Ronan Keryell, AMD +
 Andrey Alekseenko, KTH Royal Institute of Technology +
 Fábio Mestre, Codeplay +
+Konrad Kusiak, Codeplay +
 
 == Dependencies
 
@@ -1979,10 +1980,16 @@ can be used adding nodes to a graph when creating a graph from queue recording.
 New methods are also defined that enable submitting an executable graph, 
 e.g. directly to a queue without returning an event.
 
+==== sycl_ext_oneapi_free_function_kernels
+
+`sycl_ext_oneapi_free_function_kernels`, defined in 
+link:../proposed/sycl_ext_oneapi_free_function_kernels.asciidoc[sycl_ext_oneapi_free_function_kernels]
+can be used with SYCL Graphs. 
+
 == Examples and Usage Guide
 
 Detailed code examples and usage guidelines are provided in the
-link:../../SYCLGraphUsageGuide.md[SYCL Graph Usage Guide].
+link:../../syclgraph/SYCLGraphUsageGuide.md[SYCL Graph Usage Guide].
 
 == Future Direction [[future-direction]]
 

--- a/sycl/test-e2e/Graph/Explicit/free_function_kernels.cpp
+++ b/sycl/test-e2e/Graph/Explicit/free_function_kernels.cpp
@@ -1,0 +1,13 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
+
+#define GRAPH_E2E_EXPLICIT
+
+#include "../Inputs/free_function_kernels.cpp"

--- a/sycl/test-e2e/Graph/Inputs/free_function_kernels.cpp
+++ b/sycl/test-e2e/Graph/Inputs/free_function_kernels.cpp
@@ -1,0 +1,44 @@
+// Tests compatibility with free function kernels extension
+
+#include "../graph_common.hpp"
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
+void ff_0(int *ptr) {
+  for (size_t i{0}; i < Size; ++i) {
+    ptr[i] = i;
+  }
+}
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(Size, Queue);
+
+  std::vector<int> HostDataA(Size);
+
+  Queue.memset(PtrA, 0, Size * sizeof(int)).wait();
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id = exp_ext::get_kernel_id<ff_0>();
+  kernel Kernel = Bundle.get_kernel(Kernel_id);
+  auto KernelNode = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, PtrA);
+    cgh.single_task(Kernel);
+  });
+
+  auto ExecGraph = Graph.finalize();
+
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
+    assert(HostDataA[i] == i);
+  }
+  sycl::free(PtrA, Queue);
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Inputs/free_function_kernels.cpp
+++ b/sycl/test-e2e/Graph/Inputs/free_function_kernels.cpp
@@ -3,17 +3,17 @@
 #include "../graph_common.hpp"
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
-void ff_0(int *ptr) {
+void ff_0(int *Ptr) {
   for (size_t i{0}; i < Size; ++i) {
-    ptr[i] = i;
+    Ptr[i] = i;
   }
 }
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 
   int *PtrA = malloc_device<int>(Size, Queue);
 
@@ -22,7 +22,7 @@ int main() {
   Queue.memset(PtrA, 0, Size * sizeof(int)).wait();
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id = exp_ext::get_kernel_id<ff_0>();
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
@@ -38,7 +38,8 @@ int main() {
   for (size_t i = 0; i < Size; i++) {
     assert(HostDataA[i] == i);
   }
-  sycl::free(PtrA, Queue);
 #endif
+  sycl::free(PtrA, Queue);
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/RecordReplay/free_function_kernels.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/free_function_kernels.cpp
@@ -1,0 +1,13 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
+
+#define GRAPH_E2E_RECORD_REPLAY
+
+#include "../Inputs/free_function_kernels.cpp"

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/free_function_kernels.hpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/free_function_kernels.hpp
@@ -1,0 +1,56 @@
+#include "sycl/ext/oneapi/kernel_properties/properties.hpp"
+#include "sycl/kernel_bundle.hpp"
+#include <sycl/ext/oneapi/free_function_queries.hpp>
+
+namespace exp_ext = sycl::ext::oneapi::experimental;
+using namespace sycl;
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
+void ff_0(int *ptr, size_t size) {
+  for (size_t i{0}; i < size; ++i) {
+    ptr[i] = i;
+  }
+}
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
+void ff_1(int *ptr, size_t size) {
+  for (size_t i{0}; i < size; ++i) {
+    ptr[i] += i;
+  }
+}
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
+void ff_2(int *ptr, size_t size, size_t numKernelLoops) {
+  for (size_t j = 0; j < numKernelLoops; j++) {
+    for (size_t i = 0; i < size; i++) {
+      ptr[i] += i;
+    }
+  }
+}
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::nd_range_kernel<3>))
+void ff_3(int *ptr) {
+  size_t GlobalID =
+      ext::oneapi::this_work_item::get_nd_item<3>().get_global_linear_id();
+  ptr[GlobalID] = GlobalID;
+}
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::nd_range_kernel<3>))
+void ff_4(int *ptr) {
+  size_t GlobalID =
+      ext::oneapi::this_work_item::get_nd_item<3>().get_global_linear_id();
+  ptr[GlobalID] *= 2;
+}
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::nd_range_kernel<1>))
+void ff_5(int *ptrA, int *ptrB, int *ptrC) {
+  size_t id = ext::oneapi::this_work_item::get_nd_item<1>().get_global_id();
+  ptrC[id] += ptrA[id] * ptrB[id];
+}
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
+void ff_6(int *ptr, int scalarValue, size_t size) {
+  for (size_t i{0}; i < size; ++i) {
+    ptr[i] = scalarValue;
+  }
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/free_function_kernels.hpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/free_function_kernels.hpp
@@ -1,20 +1,18 @@
+#include "../../graph_common.hpp"
 #include "sycl/ext/oneapi/kernel_properties/properties.hpp"
 #include "sycl/kernel_bundle.hpp"
 #include <sycl/ext/oneapi/free_function_queries.hpp>
 
-namespace exp_ext = sycl::ext::oneapi::experimental;
-using namespace sycl;
-
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
-void ff_0(int *ptr, size_t size) {
-  for (size_t i{0}; i < size; ++i) {
+void ff_0(int *ptr) {
+  for (size_t i{0}; i < Size; ++i) {
     ptr[i] = i;
   }
 }
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
-void ff_1(int *ptr, size_t size) {
-  for (size_t i{0}; i < size; ++i) {
+void ff_1(int *ptr) {
+  for (size_t i{0}; i < Size; ++i) {
     ptr[i] += i;
   }
 }
@@ -49,8 +47,8 @@ void ff_5(int *ptrA, int *ptrB, int *ptrC) {
 }
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
-void ff_6(int *ptr, int scalarValue, size_t size) {
-  for (size_t i{0}; i < size; ++i) {
+void ff_6(int *ptr, int scalarValue) {
+  for (size_t i{0}; i < Size; ++i) {
     ptr[i] = scalarValue;
   }
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/free_function_kernels.hpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/free_function_kernels.hpp
@@ -1,54 +1,57 @@
+#pragma once
+
 #include "../../graph_common.hpp"
 #include "sycl/ext/oneapi/kernel_properties/properties.hpp"
 #include "sycl/kernel_bundle.hpp"
 #include <sycl/ext/oneapi/free_function_queries.hpp>
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
-void ff_0(int *ptr) {
+void ff_0(int *Ptr) {
   for (size_t i{0}; i < Size; ++i) {
-    ptr[i] = i;
+    Ptr[i] = i;
   }
 }
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
-void ff_1(int *ptr) {
+void ff_1(int *Ptr) {
   for (size_t i{0}; i < Size; ++i) {
-    ptr[i] += i;
+    Ptr[i] += i;
   }
 }
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
-void ff_2(int *ptr, size_t size, size_t numKernelLoops) {
-  for (size_t j = 0; j < numKernelLoops; j++) {
-    for (size_t i = 0; i < size; i++) {
-      ptr[i] += i;
+void ff_2(int *Ptr, size_t Size, size_t NumKernelLoops) {
+  for (size_t j{0}; j < NumKernelLoops; j++) {
+    for (size_t i{0}; i < Size; i++) {
+      Ptr[i] += i;
     }
   }
 }
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::nd_range_kernel<3>))
-void ff_3(int *ptr) {
+void ff_3(int *Ptr) {
   size_t GlobalID =
       ext::oneapi::this_work_item::get_nd_item<3>().get_global_linear_id();
-  ptr[GlobalID] = GlobalID;
+  Ptr[GlobalID] = GlobalID;
 }
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::nd_range_kernel<3>))
-void ff_4(int *ptr) {
+void ff_4(int *Ptr) {
   size_t GlobalID =
       ext::oneapi::this_work_item::get_nd_item<3>().get_global_linear_id();
-  ptr[GlobalID] *= 2;
+  Ptr[GlobalID] *= 2;
 }
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::nd_range_kernel<1>))
-void ff_5(int *ptrA, int *ptrB, int *ptrC) {
-  size_t id = ext::oneapi::this_work_item::get_nd_item<1>().get_global_id();
-  ptrC[id] += ptrA[id] * ptrB[id];
+void ff_5(int *PtrA, int *PtrB, int *PtrC) {
+  size_t GlobalID =
+      ext::oneapi::this_work_item::get_nd_item<1>().get_global_id();
+  PtrC[GlobalID] += PtrA[GlobalID] * PtrB[GlobalID];
 }
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((exp_ext::single_task_kernel))
-void ff_6(int *ptr, int scalarValue) {
+void ff_6(int *Ptr, int ScalarValue) {
   for (size_t i{0}; i < Size; ++i) {
-    ptr[i] = scalarValue;
+    Ptr[i] = ScalarValue;
   }
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_before_finalize.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_before_finalize.cpp
@@ -15,9 +15,9 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 
   int *PtrA = malloc_device<int>(Size, Queue);
   int *PtrB = malloc_device<int>(Size, Queue);
@@ -31,7 +31,7 @@ int main() {
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id = exp_ext::get_kernel_id<ff_0>();
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
@@ -52,8 +52,9 @@ int main() {
     assert(HostDataA[i] == 0);
     assert(HostDataB[i] == i);
   }
+#endif
   sycl::free(PtrA, Queue);
   sycl::free(PtrB, Queue);
-#endif
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_before_finalize.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_before_finalize.cpp
@@ -5,8 +5,8 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
 
 // Tests updating a graph node before finalization
 
@@ -17,18 +17,16 @@ int main() {
   queue Queue{};
   context ctxt{Queue.get_context()};
 
-  const size_t N = 1024;
-
   exp_ext::command_graph Graph{ctxt, Queue.get_device()};
 
-  int *PtrA = malloc_device<int>(N, Queue);
-  int *PtrB = malloc_device<int>(N, Queue);
+  int *PtrA = malloc_device<int>(Size, Queue);
+  int *PtrB = malloc_device<int>(Size, Queue);
 
-  std::vector<int> HostDataA(N);
-  std::vector<int> HostDataB(N);
+  std::vector<int> HostDataA(Size);
+  std::vector<int> HostDataB(Size);
 
-  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
-  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrA, 0, Size * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, Size * sizeof(int)).wait();
 
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
@@ -38,7 +36,6 @@ int main() {
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
     cgh.set_arg(0, InputParam);
-    cgh.set_arg(1, N);
     cgh.single_task(Kernel);
   });
   // Swap PtrB to be the input
@@ -49,12 +46,14 @@ int main() {
   // Only PtrB should be filled with values
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
-  Queue.copy(PtrA, HostDataA.data(), N).wait();
-  Queue.copy(PtrB, HostDataB.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrA, HostDataA.data(), Size).wait();
+  Queue.copy(PtrB, HostDataB.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     assert(HostDataA[i] == 0);
     assert(HostDataB[i] == i);
   }
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
 #endif
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_before_finalize.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_before_finalize.cpp
@@ -1,0 +1,60 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests updating a graph node before finalization
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  const size_t N = 1024;
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(N, Queue);
+  int *PtrB = malloc_device<int>(N, Queue);
+
+  std::vector<int> HostDataA(N);
+  std::vector<int> HostDataB(N);
+
+  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter InputParam(Graph, PtrA);
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id = exp_ext::get_kernel_id<ff_0>();
+  kernel Kernel = Bundle.get_kernel(Kernel_id);
+  auto KernelNode = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, InputParam);
+    cgh.set_arg(1, N);
+    cgh.single_task(Kernel);
+  });
+  // Swap PtrB to be the input
+  InputParam.update(PtrB);
+
+  auto ExecGraph = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // Only PtrB should be filled with values
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == 0);
+    assert(HostDataB[i] == i);
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_multiple_exec_graphs.cpp
@@ -1,0 +1,77 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests creating multiple executable graphs from the same modifiable graph and
+// only updating one of them.
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  const size_t N = 1024;
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(N, Queue);
+  int *PtrB = malloc_device<int>(N, Queue);
+
+  std::vector<int> HostDataA(N);
+  std::vector<int> HostDataB(N);
+
+  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter InputParam(Graph, PtrA);
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id = exp_ext::get_kernel_id<ff_1>();
+  kernel Kernel = Bundle.get_kernel(Kernel_id);
+  auto KernelNode = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, InputParam);
+    cgh.set_arg(1, N);
+    cgh.single_task(Kernel);
+  });
+
+  auto ExecGraph = Graph.finalize(exp_ext::property::graph::updatable{});
+  auto ExecGraph2 = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // PtrA values should be modified twice
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+  Queue.ext_oneapi_graph(ExecGraph2).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == i * 2);
+    assert(HostDataB[i] == 0);
+  }
+
+  // Swap PtrB to be the input
+  InputParam.update(PtrB);
+  // Only update ExecGraph, which should now modify PtrB while ExecGraph2
+  // modifies PtrA still
+  ExecGraph.update(KernelNode);
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+  Queue.ext_oneapi_graph(ExecGraph2).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    // A should have been modified 3 times by now, B only once
+    assert(HostDataA[i] == i * 3);
+    assert(HostDataB[i] == i);
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_multiple_exec_graphs.cpp
@@ -5,8 +5,8 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
 
 // Tests creating multiple executable graphs from the same modifiable graph and
 // only updating one of them.
@@ -18,18 +18,16 @@ int main() {
   queue Queue{};
   context ctxt{Queue.get_context()};
 
-  const size_t N = 1024;
-
   exp_ext::command_graph Graph{ctxt, Queue.get_device()};
 
-  int *PtrA = malloc_device<int>(N, Queue);
-  int *PtrB = malloc_device<int>(N, Queue);
+  int *PtrA = malloc_device<int>(Size, Queue);
+  int *PtrB = malloc_device<int>(Size, Queue);
 
-  std::vector<int> HostDataA(N);
-  std::vector<int> HostDataB(N);
+  std::vector<int> HostDataA(Size);
+  std::vector<int> HostDataB(Size);
 
-  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
-  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrA, 0, Size * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, Size * sizeof(int)).wait();
 
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
@@ -39,7 +37,6 @@ int main() {
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
     cgh.set_arg(0, InputParam);
-    cgh.set_arg(1, N);
     cgh.single_task(Kernel);
   });
 
@@ -50,9 +47,9 @@ int main() {
   Queue.ext_oneapi_graph(ExecGraph).wait();
   Queue.ext_oneapi_graph(ExecGraph2).wait();
 
-  Queue.copy(PtrA, HostDataA.data(), N).wait();
-  Queue.copy(PtrB, HostDataB.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrA, HostDataA.data(), Size).wait();
+  Queue.copy(PtrB, HostDataB.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     assert(HostDataA[i] == i * 2);
     assert(HostDataB[i] == 0);
   }
@@ -65,13 +62,15 @@ int main() {
   Queue.ext_oneapi_graph(ExecGraph).wait();
   Queue.ext_oneapi_graph(ExecGraph2).wait();
 
-  Queue.copy(PtrA, HostDataA.data(), N).wait();
-  Queue.copy(PtrB, HostDataB.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrA, HostDataA.data(), Size).wait();
+  Queue.copy(PtrB, HostDataB.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     // A should have been modified 3 times by now, B only once
     assert(HostDataA[i] == i * 3);
     assert(HostDataB[i] == i);
   }
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
 #endif
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_multiple_exec_graphs.cpp
@@ -16,9 +16,9 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 
   int *PtrA = malloc_device<int>(Size, Queue);
   int *PtrB = malloc_device<int>(Size, Queue);
@@ -32,7 +32,7 @@ int main() {
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id = exp_ext::get_kernel_id<ff_1>();
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
@@ -69,8 +69,9 @@ int main() {
     assert(HostDataA[i] == i * 3);
     assert(HostDataB[i] == i);
   }
+#endif
   sycl::free(PtrA, Queue);
   sycl::free(PtrB, Queue);
-#endif
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
@@ -16,7 +16,7 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
   // Use a large N to try and make the kernel slow
   const size_t N = 1 << 16;
@@ -24,7 +24,7 @@ int main() {
   const size_t NumKernelLoops = 4;
   const size_t NumSubmitLoops = 8;
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 
   int *PtrA = malloc_device<int>(N, Queue);
   int *PtrB = malloc_device<int>(N, Queue);
@@ -38,7 +38,7 @@ int main() {
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id = exp_ext::get_kernel_id<ff_2>();
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
@@ -72,8 +72,9 @@ int main() {
     assert(HostDataA[i] == i * NumKernelLoops * NumSubmitLoops);
     assert(HostDataB[i] == i * NumKernelLoops * NumSubmitLoops);
   }
+#endif
   sycl::free(PtrA, Queue);
   sycl::free(PtrB, Queue);
-#endif
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
@@ -1,0 +1,77 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests that updating a graph is ordered with respect to previous executions of
+// the graph which may be in flight.
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  // Use a large N to try and make the kernel slow
+  const size_t N = 1 << 16;
+  // Loop inside kernel to make even slower (too large N runs out of memory)
+  const size_t NumKernelLoops = 4;
+  const size_t NumSubmitLoops = 8;
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(N, Queue);
+  int *PtrB = malloc_device<int>(N, Queue);
+
+  std::vector<int> HostDataA(N);
+  std::vector<int> HostDataB(N);
+
+  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter InputParam(Graph, PtrA);
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id = exp_ext::get_kernel_id<ff_2>();
+  kernel Kernel = Bundle.get_kernel(Kernel_id);
+  auto KernelNode = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, InputParam);
+    cgh.set_arg(1, N);
+    cgh.set_arg(2, NumKernelLoops);
+    cgh.single_task(Kernel);
+  });
+
+  auto ExecGraph = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // Submit a bunch of graphs without waiting
+  for (size_t i = 0; i < NumSubmitLoops; i++) {
+    Queue.ext_oneapi_graph(ExecGraph);
+  }
+
+  // Swap PtrB to be the input
+  InputParam.update(PtrB);
+
+  ExecGraph.update(KernelNode);
+
+  // Submit another set of graphs then wait on all submissions
+  for (size_t i = 0; i < NumSubmitLoops; i++) {
+    Queue.ext_oneapi_graph(ExecGraph);
+  }
+  Queue.wait_and_throw();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == i * NumKernelLoops * NumSubmitLoops);
+    assert(HostDataB[i] == i * NumKernelLoops * NumSubmitLoops);
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
@@ -5,8 +5,8 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
 
 // Tests that updating a graph is ordered with respect to previous executions of
 // the graph which may be in flight.
@@ -72,6 +72,8 @@ int main() {
     assert(HostDataA[i] == i * NumKernelLoops * NumSubmitLoops);
     assert(HostDataB[i] == i * NumKernelLoops * NumSubmitLoops);
   }
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
 #endif
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr.cpp
@@ -5,8 +5,8 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
 
 // Tests updating a graph node using index-based explicit update
 
@@ -17,18 +17,16 @@ int main() {
   queue Queue{};
   context ctxt{Queue.get_context()};
 
-  const size_t N = 1024;
-
   exp_ext::command_graph Graph{ctxt, Queue.get_device()};
 
-  int *PtrA = malloc_device<int>(N, Queue);
-  int *PtrB = malloc_device<int>(N, Queue);
+  int *PtrA = malloc_device<int>(Size, Queue);
+  int *PtrB = malloc_device<int>(Size, Queue);
 
-  std::vector<int> HostDataA(N);
-  std::vector<int> HostDataB(N);
+  std::vector<int> HostDataA(Size);
+  std::vector<int> HostDataB(Size);
 
-  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
-  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrA, 0, Size * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, Size * sizeof(int)).wait();
 
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
@@ -38,7 +36,6 @@ int main() {
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
     cgh.set_arg(0, InputParam);
-    cgh.set_arg(0, N);
     cgh.single_task(Kernel);
   });
 
@@ -47,9 +44,9 @@ int main() {
   // PtrA should be filled with values
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
-  Queue.copy(PtrA, HostDataA.data(), N).wait();
-  Queue.copy(PtrB, HostDataB.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrA, HostDataA.data(), Size).wait();
+  Queue.copy(PtrB, HostDataB.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     assert(HostDataA[i] == i);
     assert(HostDataB[i] == 0);
   }
@@ -59,12 +56,14 @@ int main() {
   ExecGraph.update(KernelNode);
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
-  Queue.copy(PtrA, HostDataA.data(), N).wait();
-  Queue.copy(PtrB, HostDataB.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrA, HostDataA.data(), Size).wait();
+  Queue.copy(PtrB, HostDataB.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     assert(HostDataA[i] == i);
     assert(HostDataB[i] == i);
   }
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
 #endif
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr.cpp
@@ -1,0 +1,70 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests updating a graph node using index-based explicit update
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  const size_t N = 1024;
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(N, Queue);
+  int *PtrB = malloc_device<int>(N, Queue);
+
+  std::vector<int> HostDataA(N);
+  std::vector<int> HostDataB(N);
+
+  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter InputParam(Graph, PtrA);
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id = exp_ext::get_kernel_id<ff_0>();
+  kernel Kernel = Bundle.get_kernel(Kernel_id);
+  auto KernelNode = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, InputParam);
+    cgh.set_arg(0, N);
+    cgh.single_task(Kernel);
+  });
+
+  auto ExecGraph = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // PtrA should be filled with values
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == i);
+    assert(HostDataB[i] == 0);
+  }
+
+  // Swap PtrB to be the input
+  InputParam.update(PtrB);
+  ExecGraph.update(KernelNode);
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == i);
+    assert(HostDataB[i] == i);
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr.cpp
@@ -15,9 +15,9 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 
   int *PtrA = malloc_device<int>(Size, Queue);
   int *PtrB = malloc_device<int>(Size, Queue);
@@ -31,7 +31,7 @@ int main() {
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id = exp_ext::get_kernel_id<ff_0>();
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
@@ -62,8 +62,9 @@ int main() {
     assert(HostDataA[i] == i);
     assert(HostDataB[i] == i);
   }
+#endif
   sycl::free(PtrA, Queue);
   sycl::free(PtrB, Queue);
-#endif
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_3D.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_3D.cpp
@@ -5,8 +5,8 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
 
 // Tests updating a 3D ND-Range graph kernel node using index-based explicit
 // update
@@ -79,6 +79,8 @@ int main() {
     assert(HostDataA[i] == Ref);
     assert(HostDataB[i] == Ref);
   }
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
 #endif
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_3D.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_3D.cpp
@@ -1,0 +1,84 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests updating a 3D ND-Range graph kernel node using index-based explicit
+// update
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  const range<3> GlobalWorkSize(1, 2, 2);
+  const range<3> LocalWorkSize(1, 2, 2);
+  const size_t N = GlobalWorkSize[0] * GlobalWorkSize[1] * GlobalWorkSize[2];
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(N, Queue);
+  int *PtrB = malloc_device<int>(N, Queue);
+
+  std::vector<int> HostDataA(N);
+  std::vector<int> HostDataB(N);
+
+  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter DynParam(Graph, PtrA);
+
+  nd_range<3> NDRange{GlobalWorkSize, LocalWorkSize};
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id_A = exp_ext::get_kernel_id<ff_3>();
+  kernel Kernel_A = Bundle.get_kernel(Kernel_id_A);
+  auto NodeA = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, DynParam);
+    cgh.parallel_for(NDRange, Kernel_A);
+  });
+
+  kernel_id Kernel_id_B = exp_ext::get_kernel_id<ff_4>();
+  kernel Kernel_B = Bundle.get_kernel(Kernel_id_B);
+  auto NodeB = Graph.add(
+      [&](handler &cgh) {
+        cgh.set_arg(0, DynParam);
+        cgh.parallel_for(NDRange, Kernel_B);
+      },
+      exp_ext::property::node::depends_on{NodeA});
+
+  auto ExecGraph = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // PtrA should be filled with values
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == (i * 2));
+    assert(HostDataB[i] == 0);
+  }
+
+  // Swap PtrB to be the input/output
+  DynParam.update(PtrB);
+  ExecGraph.update({NodeA, NodeB});
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    const size_t Ref = i * 2;
+    assert(HostDataA[i] == Ref);
+    assert(HostDataB[i] == Ref);
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_3D.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_3D.cpp
@@ -16,13 +16,13 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
   const range<3> GlobalWorkSize(1, 2, 2);
   const range<3> LocalWorkSize(1, 2, 2);
   const size_t N = GlobalWorkSize[0] * GlobalWorkSize[1] * GlobalWorkSize[2];
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 
   int *PtrA = malloc_device<int>(N, Queue);
   int *PtrB = malloc_device<int>(N, Queue);
@@ -38,7 +38,7 @@ int main() {
   nd_range<3> NDRange{GlobalWorkSize, LocalWorkSize};
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id_A = exp_ext::get_kernel_id<ff_3>();
   kernel Kernel_A = Bundle.get_kernel(Kernel_id_A);
   auto NodeA = Graph.add([&](handler &cgh) {
@@ -79,8 +79,9 @@ int main() {
     assert(HostDataA[i] == Ref);
     assert(HostDataB[i] == Ref);
   }
+#endif
   sycl::free(PtrA, Queue);
   sycl::free(PtrB, Queue);
-#endif
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_double_update.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_double_update.cpp
@@ -5,8 +5,8 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
 
 // Tests updating a graph node using index-based explicit update
 
@@ -17,21 +17,19 @@ int main() {
   queue Queue{};
   context ctxt{Queue.get_context()};
 
-  const size_t N = 1024;
-
   exp_ext::command_graph Graph{ctxt, Queue.get_device()};
 
-  int *PtrA = malloc_device<int>(N, Queue);
-  int *PtrB = malloc_device<int>(N, Queue);
-  int *PtrUnused = malloc_device<int>(N, Queue);
+  int *PtrA = malloc_device<int>(Size, Queue);
+  int *PtrB = malloc_device<int>(Size, Queue);
+  int *PtrUnused = malloc_device<int>(Size, Queue);
 
-  std::vector<int> HostDataA(N);
-  std::vector<int> HostDataB(N);
-  std::vector<int> HostDataUnused(N);
+  std::vector<int> HostDataA(Size);
+  std::vector<int> HostDataB(Size);
+  std::vector<int> HostDataUnused(Size);
 
-  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
-  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
-  Queue.memset(PtrUnused, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrA, 0, Size * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, Size * sizeof(int)).wait();
+  Queue.memset(PtrUnused, 0, Size * sizeof(int)).wait();
 
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
@@ -41,7 +39,6 @@ int main() {
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
     cgh.set_arg(0, InputParam);
-    cgh.set_arg(1, N);
     cgh.single_task(Kernel);
   });
 
@@ -50,10 +47,10 @@ int main() {
   // PtrA should be filled with values
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
-  Queue.copy(PtrA, HostDataA.data(), N).wait();
-  Queue.copy(PtrB, HostDataB.data(), N).wait();
-  Queue.copy(PtrUnused, HostDataUnused.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrA, HostDataA.data(), Size).wait();
+  Queue.copy(PtrB, HostDataB.data(), Size).wait();
+  Queue.copy(PtrUnused, HostDataUnused.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     assert(HostDataA[i] == i);
     assert(HostDataB[i] == 0);
     assert(HostDataUnused[i] == 0);
@@ -66,15 +63,18 @@ int main() {
   ExecGraph.update(KernelNode);
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
-  Queue.copy(PtrA, HostDataA.data(), N).wait();
-  Queue.copy(PtrB, HostDataB.data(), N).wait();
-  Queue.copy(PtrUnused, HostDataUnused.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrA, HostDataA.data(), Size).wait();
+  Queue.copy(PtrB, HostDataB.data(), Size).wait();
+  Queue.copy(PtrUnused, HostDataUnused.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     assert(HostDataA[i] == i);
     assert(HostDataB[i] == i);
     // Check that PtrUnused was never actually used in a kernel
     assert(HostDataUnused[i] == 0);
   }
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
+  sycl::free(PtrUnused, Queue);
 #endif
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_double_update.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_double_update.cpp
@@ -1,0 +1,80 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests updating a graph node using index-based explicit update
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  const size_t N = 1024;
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(N, Queue);
+  int *PtrB = malloc_device<int>(N, Queue);
+  int *PtrUnused = malloc_device<int>(N, Queue);
+
+  std::vector<int> HostDataA(N);
+  std::vector<int> HostDataB(N);
+  std::vector<int> HostDataUnused(N);
+
+  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrUnused, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter InputParam(Graph, PtrA);
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id = exp_ext::get_kernel_id<ff_0>();
+  kernel Kernel = Bundle.get_kernel(Kernel_id);
+  auto KernelNode = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, InputParam);
+    cgh.set_arg(1, N);
+    cgh.single_task(Kernel);
+  });
+
+  auto ExecGraph = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // PtrA should be filled with values
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  Queue.copy(PtrUnused, HostDataUnused.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == i);
+    assert(HostDataB[i] == 0);
+    assert(HostDataUnused[i] == 0);
+  }
+
+  // Swap PtrUnused to be the input, then swap to PtrB without executing
+  InputParam.update(PtrUnused);
+  InputParam.update(PtrB);
+
+  ExecGraph.update(KernelNode);
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  Queue.copy(PtrUnused, HostDataUnused.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == i);
+    assert(HostDataB[i] == i);
+    // Check that PtrUnused was never actually used in a kernel
+    assert(HostDataUnused[i] == 0);
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_double_update.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_double_update.cpp
@@ -15,9 +15,9 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 
   int *PtrA = malloc_device<int>(Size, Queue);
   int *PtrB = malloc_device<int>(Size, Queue);
@@ -34,7 +34,7 @@ int main() {
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id = exp_ext::get_kernel_id<ff_0>();
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
@@ -72,9 +72,10 @@ int main() {
     // Check that PtrUnused was never actually used in a kernel
     assert(HostDataUnused[i] == 0);
   }
+#endif
   sycl::free(PtrA, Queue);
   sycl::free(PtrB, Queue);
   sycl::free(PtrUnused, Queue);
-#endif
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_nodes.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_nodes.cpp
@@ -16,7 +16,7 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
@@ -32,7 +32,7 @@ int main() {
   exp_ext::dynamic_parameter InputParam(Graph, PtrA);
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id_A = exp_ext::get_kernel_id<ff_0>();
   kernel Kernel_A = Bundle.get_kernel(Kernel_id_A);
   auto KernelNodeA = Graph.add([&](handler &cgh) {
@@ -72,8 +72,9 @@ int main() {
     assert(HostDataA[i] == i * 2);
     assert(HostDataB[i] == i * 2);
   }
+#endif
   sycl::free(PtrA, Queue);
   sycl::free(PtrB, Queue);
-#endif
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_nodes.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_nodes.cpp
@@ -1,0 +1,81 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests updating a single dynamic parameter which is registered with multiple
+// graph nodes
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  const size_t N = 1024;
+
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(N, Queue);
+  int *PtrB = malloc_device<int>(N, Queue);
+
+  std::vector<int> HostDataA(N);
+  std::vector<int> HostDataB(N);
+
+  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter InputParam(Graph, PtrA);
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id_A = exp_ext::get_kernel_id<ff_0>();
+  kernel Kernel_A = Bundle.get_kernel(Kernel_id_A);
+  auto KernelNodeA = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, InputParam);
+    cgh.set_arg(1, N);
+    cgh.single_task(Kernel_A);
+  });
+
+  kernel_id Kernel_id_B = exp_ext::get_kernel_id<ff_1>();
+  kernel Kernel_B = Bundle.get_kernel(Kernel_id_B);
+  auto KernelNodeB = Graph.add(
+      [&](handler &cgh) {
+        cgh.set_arg(0, InputParam);
+        cgh.set_arg(1, N);
+        cgh.single_task(Kernel_B);
+      },
+      exp_ext::property::node::depends_on{KernelNodeA});
+
+  auto ExecGraph = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // PtrA should be filled with values
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == i * 2);
+    assert(HostDataB[i] == 0);
+  }
+
+  // Swap PtrB to be the input
+  InputParam.update(PtrB);
+  ExecGraph.update({KernelNodeA, KernelNodeB});
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == i * 2);
+    assert(HostDataB[i] == i * 2);
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_params.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_params.cpp
@@ -16,9 +16,9 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 
   int *PtrA = malloc_device<int>(Size, Queue);
   int *PtrB = malloc_device<int>(Size, Queue);
@@ -43,7 +43,7 @@ int main() {
   nd_range<1> NDRange{Size, 32};
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id = exp_ext::get_kernel_id<ff_5>();
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
@@ -79,9 +79,10 @@ int main() {
   for (size_t i = 0; i < Size; i++) {
     assert(OutData[i] == HostDataB[i] + (HostDataA[i] * HostDataC[i]));
   }
+#endif
   sycl::free(PtrA, Queue);
   sycl::free(PtrB, Queue);
   sycl::free(PtrC, Queue);
-#endif
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_params.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_params.cpp
@@ -5,8 +5,8 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
 
 // Tests updating multiple parameters to a singlegraph node using index-based
 // explicit update
@@ -18,31 +18,29 @@ int main() {
   queue Queue{};
   context ctxt{Queue.get_context()};
 
-  const size_t N = 1024;
-
   exp_ext::command_graph Graph{ctxt, Queue.get_device()};
 
-  int *PtrA = malloc_device<int>(N, Queue);
-  int *PtrB = malloc_device<int>(N, Queue);
-  int *PtrC = malloc_device<int>(N, Queue);
+  int *PtrA = malloc_device<int>(Size, Queue);
+  int *PtrB = malloc_device<int>(Size, Queue);
+  int *PtrC = malloc_device<int>(Size, Queue);
 
-  std::vector<int> HostDataA(N);
-  std::vector<int> HostDataB(N);
-  std::vector<int> HostDataC(N);
-  std::vector<int> OutData(N);
+  std::vector<int> HostDataA(Size);
+  std::vector<int> HostDataB(Size);
+  std::vector<int> HostDataC(Size);
+  std::vector<int> OutData(Size);
 
   std::iota(HostDataA.begin(), HostDataA.end(), 10);
   std::iota(HostDataB.begin(), HostDataB.end(), 100);
 
-  Queue.memcpy(PtrA, HostDataA.data(), N * sizeof(int)).wait();
-  Queue.memcpy(PtrB, HostDataB.data(), N * sizeof(int)).wait();
-  Queue.memset(PtrC, 0, N * sizeof(int)).wait();
+  Queue.memcpy(PtrA, HostDataA.data(), Size * sizeof(int)).wait();
+  Queue.memcpy(PtrB, HostDataB.data(), Size * sizeof(int)).wait();
+  Queue.memset(PtrC, 0, Size * sizeof(int)).wait();
 
   exp_ext::dynamic_parameter ParamA(Graph, PtrA);
   exp_ext::dynamic_parameter ParamB(Graph, PtrB);
   exp_ext::dynamic_parameter ParamOut(Graph, PtrC);
 
-  nd_range<1> NDRange{N, 32};
+  nd_range<1> NDRange{Size, 32};
 
 #ifndef __SYCL_DEVICE_ONLY__
   kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
@@ -61,8 +59,8 @@ int main() {
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
   // Copy to output data to preserve original data for verifying += op
-  Queue.copy(PtrC, OutData.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrC, OutData.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     assert(OutData[i] == HostDataC[i] + (HostDataA[i] * HostDataB[i]));
   }
 
@@ -77,10 +75,13 @@ int main() {
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
   // Copy to output data to preserve original data for verifying += op
-  Queue.copy(PtrB, OutData.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrB, OutData.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     assert(OutData[i] == HostDataB[i] + (HostDataA[i] * HostDataC[i]));
   }
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
+  sycl::free(PtrC, Queue);
 #endif
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_params.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_multiple_params.cpp
@@ -1,0 +1,86 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests updating multiple parameters to a singlegraph node using index-based
+// explicit update
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  const size_t N = 1024;
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(N, Queue);
+  int *PtrB = malloc_device<int>(N, Queue);
+  int *PtrC = malloc_device<int>(N, Queue);
+
+  std::vector<int> HostDataA(N);
+  std::vector<int> HostDataB(N);
+  std::vector<int> HostDataC(N);
+  std::vector<int> OutData(N);
+
+  std::iota(HostDataA.begin(), HostDataA.end(), 10);
+  std::iota(HostDataB.begin(), HostDataB.end(), 100);
+
+  Queue.memcpy(PtrA, HostDataA.data(), N * sizeof(int)).wait();
+  Queue.memcpy(PtrB, HostDataB.data(), N * sizeof(int)).wait();
+  Queue.memset(PtrC, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter ParamA(Graph, PtrA);
+  exp_ext::dynamic_parameter ParamB(Graph, PtrB);
+  exp_ext::dynamic_parameter ParamOut(Graph, PtrC);
+
+  nd_range<1> NDRange{N, 32};
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id = exp_ext::get_kernel_id<ff_5>();
+  kernel Kernel = Bundle.get_kernel(Kernel_id);
+  auto KernelNode = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, ParamA);
+    cgh.set_arg(1, ParamB);
+    cgh.set_arg(2, ParamOut);
+    cgh.parallel_for(NDRange, Kernel);
+  });
+
+  auto ExecGraph = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // PtrA should be filled with values
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  // Copy to output data to preserve original data for verifying += op
+  Queue.copy(PtrC, OutData.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(OutData[i] == HostDataC[i] + (HostDataA[i] * HostDataB[i]));
+  }
+
+  // Update C's host data
+  HostDataC = OutData;
+
+  // Swap PtrB to be the input
+  ParamOut.update(PtrB);
+  ParamB.update(PtrC);
+
+  ExecGraph.update(KernelNode);
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  // Copy to output data to preserve original data for verifying += op
+  Queue.copy(PtrB, OutData.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(OutData[i] == HostDataB[i] + (HostDataA[i] * HostDataC[i]));
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_subgraph.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_subgraph.cpp
@@ -5,8 +5,8 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16004
 
 // Tests updating a graph node in an executable graph that was used as a
 // subgraph node in another executable graph is not reflected in the graph
@@ -19,19 +19,17 @@ int main() {
   queue Queue{};
   context ctxt{Queue.get_context()};
 
-  const size_t N = 1024;
-
   exp_ext::command_graph Graph{ctxt, Queue.get_device()};
   exp_ext::command_graph SubGraph{ctxt, Queue.get_device()};
 
-  int *PtrA = malloc_device<int>(N, Queue);
-  int *PtrB = malloc_device<int>(N, Queue);
+  int *PtrA = malloc_device<int>(Size, Queue);
+  int *PtrB = malloc_device<int>(Size, Queue);
 
-  std::vector<int> HostDataA(N);
-  std::vector<int> HostDataB(N);
+  std::vector<int> HostDataA(Size);
+  std::vector<int> HostDataB(Size);
 
-  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
-  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrA, 0, Size * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, Size * sizeof(int)).wait();
 
   exp_ext::dynamic_parameter InputParam(SubGraph, PtrA);
 
@@ -41,7 +39,6 @@ int main() {
   kernel SubKernel = Bundle.get_kernel(SubKernel_id);
   auto SubKernelNode = SubGraph.add([&](handler &cgh) {
     cgh.set_arg(0, InputParam);
-    cgh.set_arg(1, N);
     cgh.single_task(SubKernel);
   });
 
@@ -51,7 +48,6 @@ int main() {
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
     cgh.set_arg(0, PtrA);
-    cgh.set_arg(1, N);
     cgh.single_task(Kernel);
   });
 
@@ -69,12 +65,14 @@ int main() {
   // Only PtrA should be filled with values
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
-  Queue.copy(PtrA, HostDataA.data(), N).wait();
-  Queue.copy(PtrB, HostDataB.data(), N).wait();
-  for (size_t i = 0; i < N; i++) {
+  Queue.copy(PtrA, HostDataA.data(), Size).wait();
+  Queue.copy(PtrB, HostDataB.data(), Size).wait();
+  for (size_t i = 0; i < Size; i++) {
     assert(HostDataA[i] == i * 2);
     assert(HostDataB[i] == 0);
   }
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
 #endif
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_subgraph.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_subgraph.cpp
@@ -17,10 +17,10 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
-  exp_ext::command_graph SubGraph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
+  exp_ext::command_graph SubGraph{Ctxt, Queue.get_device()};
 
   int *PtrA = malloc_device<int>(Size, Queue);
   int *PtrB = malloc_device<int>(Size, Queue);
@@ -34,7 +34,7 @@ int main() {
   exp_ext::dynamic_parameter InputParam(SubGraph, PtrA);
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id SubKernel_id = exp_ext::get_kernel_id<ff_1>();
   kernel SubKernel = Bundle.get_kernel(SubKernel_id);
   auto SubKernelNode = SubGraph.add([&](handler &cgh) {
@@ -71,8 +71,9 @@ int main() {
     assert(HostDataA[i] == i * 2);
     assert(HostDataB[i] == 0);
   }
+#endif
   sycl::free(PtrA, Queue);
   sycl::free(PtrB, Queue);
-#endif
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_subgraph.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ptr_subgraph.cpp
@@ -1,0 +1,80 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests updating a graph node in an executable graph that was used as a
+// subgraph node in another executable graph is not reflected in the graph
+// containing the subgraph node.
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  const size_t N = 1024;
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph SubGraph{ctxt, Queue.get_device()};
+
+  int *PtrA = malloc_device<int>(N, Queue);
+  int *PtrB = malloc_device<int>(N, Queue);
+
+  std::vector<int> HostDataA(N);
+  std::vector<int> HostDataB(N);
+
+  Queue.memset(PtrA, 0, N * sizeof(int)).wait();
+  Queue.memset(PtrB, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter InputParam(SubGraph, PtrA);
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id SubKernel_id = exp_ext::get_kernel_id<ff_1>();
+  kernel SubKernel = Bundle.get_kernel(SubKernel_id);
+  auto SubKernelNode = SubGraph.add([&](handler &cgh) {
+    cgh.set_arg(0, InputParam);
+    cgh.set_arg(1, N);
+    cgh.single_task(SubKernel);
+  });
+
+  auto SubExecGraph = SubGraph.finalize(exp_ext::property::graph::updatable{});
+
+  kernel_id Kernel_id = exp_ext::get_kernel_id<ff_0>();
+  kernel Kernel = Bundle.get_kernel(Kernel_id);
+  auto KernelNode = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, PtrA);
+    cgh.set_arg(1, N);
+    cgh.single_task(Kernel);
+  });
+
+  Graph.add([&](handler &cgh) { cgh.ext_oneapi_graph(SubExecGraph); },
+            exp_ext::property::node::depends_on{KernelNode});
+
+  // Finalize the parent graph with the original values
+  auto ExecGraph = Graph.finalize();
+
+  // Swap PtrB to be the input
+  InputParam.update(PtrB);
+  // Update the executable graph that was used as a subgraph with the new value,
+  // this should not affect ExecGraph
+  SubExecGraph.update(SubKernelNode);
+  // Only PtrA should be filled with values
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(PtrA, HostDataA.data(), N).wait();
+  Queue.copy(PtrB, HostDataB.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostDataA[i] == i * 2);
+    assert(HostDataB[i] == 0);
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_scalar.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_scalar.cpp
@@ -15,9 +15,9 @@
 
 int main() {
   queue Queue{};
-  context ctxt{Queue.get_context()};
+  context Ctxt{Queue.get_context()};
 
-  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+  exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 
   int *DeviceData = malloc_device<int>(Size, Queue);
 
@@ -30,7 +30,7 @@ int main() {
   exp_ext::dynamic_parameter InputParam(Graph, ScalarValue);
 
 #ifndef __SYCL_DEVICE_ONLY__
-  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(Ctxt);
   kernel_id Kernel_id = exp_ext::get_kernel_id<ff_6>();
   kernel Kernel = Bundle.get_kernel(Kernel_id);
   auto KernelNode = Graph.add([&](handler &cgh) {
@@ -58,7 +58,8 @@ int main() {
   for (size_t i = 0; i < Size; i++) {
     assert(HostData[i] == 99);
   }
-  sycl::free(DeviceData, Queue);
 #endif
+  sycl::free(DeviceData, Queue);
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_scalar.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_scalar.cpp
@@ -1,0 +1,66 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Tests updating a graph node scalar argument using index-based explicit update
+
+#include "../../graph_common.hpp"
+#include "free_function_kernels.hpp"
+
+int main() {
+  queue Queue{};
+  context ctxt{Queue.get_context()};
+
+  const size_t N = 1024;
+
+  exp_ext::command_graph Graph{ctxt, Queue.get_device()};
+
+  int *DeviceData = malloc_device<int>(N, Queue);
+
+  int ScalarValue = 17;
+
+  std::vector<int> HostData(N);
+
+  Queue.memset(DeviceData, 0, N * sizeof(int)).wait();
+
+  exp_ext::dynamic_parameter InputParam(Graph, ScalarValue);
+
+#ifndef __SYCL_DEVICE_ONLY__
+  kernel_bundle Bundle = get_kernel_bundle<bundle_state::executable>(ctxt);
+  kernel_id Kernel_id = exp_ext::get_kernel_id<ff_6>();
+  kernel Kernel = Bundle.get_kernel(Kernel_id);
+  auto KernelNode = Graph.add([&](handler &cgh) {
+    cgh.set_arg(0, DeviceData);
+    cgh.set_arg(1, InputParam);
+    cgh.set_arg(2, N);
+    cgh.single_task(Kernel);
+  });
+
+  auto ExecGraph = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // DeviceData should be filled with current ScalarValue (17)
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(DeviceData, HostData.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostData[i] == 17);
+  }
+
+  // Update ScalarValue to be 99 instead
+  InputParam.update(99);
+  ExecGraph.update(KernelNode);
+  Queue.ext_oneapi_graph(ExecGraph).wait();
+
+  Queue.copy(DeviceData, HostData.data(), N).wait();
+  for (size_t i = 0; i < N; i++) {
+    assert(HostData[i] == 99);
+  }
+#endif
+  return 0;
+}

--- a/sycl/test-e2e/Graph/graph_common.hpp
+++ b/sycl/test-e2e/Graph/graph_common.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 


### PR DESCRIPTION
Dynamic parameters in SYCL Graphs should be used for now with free_function_kernels extension since then the order of kernel arguments is well defined. 

The tests are a copy of few selected ones from `Graph/Update` and modified such that they use the extension. They live in `Graph/Update/FreeFunctionKernels`.

 Since the free function kernels are not yet implemented on CUDA, we should keep for now both copies of the tests (with and without free functions).