### PR TITLE
[UR][L0] Enable zesInit by default given newer L0 IP version

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,7 +116,7 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/nrspruit/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -4,4 +4,4 @@
 # Date:   Fri Nov 29 15:54:31 2024 +0000
 #     Merge pull request #2396 from kswiecicki/init-results-fix
 #     [L0] Add nullopt check before init results access
-set(UNIFIED_RUNTIME_TAG eb076da108a49ef1426f38690547a71905f58015)
+set(UNIFIED_RUNTIME_TAG f59a842cb8d0fcc4c8bb7e3570a42181da1e5ec4)


### PR DESCRIPTION
-pre-commit PR for https://github.com/oneapi-src/unified-runtime/pull/2353