### PR TITLE
[E2E][SYCL] Test for empty command group behavior

### DIFF
--- a/sycl/test-e2e/Basic/empty_command.cpp
+++ b/sycl/test-e2e/Basic/empty_command.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
+#include <sycl/usm.hpp>
 
 #include <latch>
 #include <thread>
@@ -46,11 +47,8 @@ void test_device_event_dep() {
   auto *p = sycl::malloc_shared<int>(1, q);
   *p = 0;
 
-  auto host_event = q.submit([&](handler &cgh) {
-    cgh.host_task([&]() {
-      start_execution.wait();
-    });
-  });
+  auto host_event = q.submit(
+      [&](handler &cgh) { cgh.host_task([&]() { start_execution.wait(); }); });
   auto device_event = q.single_task(host_event, [=]() { *p = 42; });
   auto empty_cg_event =
       q.submit([&](handler &cgh) { cgh.depends_on(device_event); });
@@ -76,11 +74,8 @@ void test_accessor_dep() {
   auto *p = sycl::malloc_shared<int>(1, q);
   *p = 0;
 
-  auto host_event = q.submit([&](handler &cgh) {
-    cgh.host_task([&]() {
-      start_execution.wait();
-    });
-  });
+  auto host_event = q.submit(
+      [&](handler &cgh) { cgh.host_task([&]() { start_execution.wait(); }); });
 
   sycl::buffer<int, 1> b{1};
   auto device_event = q.submit([&](auto &cgh) {

--- a/sycl/test-e2e/Basic/empty_command.cpp
+++ b/sycl/test-e2e/Basic/empty_command.cpp
@@ -1,0 +1,120 @@
+// RUN: %{build} -o %t.out %cxx_std_optionc++20
+// RUN: %{run} %t.out
+
+#include <sycl/sycl.hpp>
+
+#include <latch>
+#include <thread>
+
+using namespace sycl;
+
+void test_host_task_dep() {
+  queue q;
+
+  std::latch start_execution{1};
+
+  int x = 0;
+
+  auto host_event = q.submit([&](handler &cgh) {
+    cgh.host_task([&]() {
+      start_execution.wait();
+      x = 42;
+    });
+  });
+
+  auto empty_cg_event =
+      q.submit([&](handler &cgh) { cgh.depends_on(host_event); });
+
+  // FIXME: This should deadlock, but the dependency is ignored currently.
+  empty_cg_event.wait();
+
+  assert(x == 0);
+  start_execution.count_down();
+
+  empty_cg_event.wait();
+  // FIXME: uncomment once the bug mentioned above is fixed.
+  // assert(x == 42);
+
+  // I'm seeing some weird hang without this:
+  host_event.wait();
+}
+
+void test_device_event_dep() {
+  queue q;
+
+  std::latch start_execution{1};
+  auto *p = sycl::malloc_shared<int>(1, q);
+  *p = 0;
+
+  auto host_event = q.submit([&](handler &cgh) {
+    cgh.host_task([&]() {
+      start_execution.wait();
+    });
+  });
+  auto device_event = q.single_task(host_event, [=]() { *p = 42; });
+  auto empty_cg_event =
+      q.submit([&](handler &cgh) { cgh.depends_on(device_event); });
+
+  // FIXME: This should deadlock, but the dependency is ignored currently.
+  empty_cg_event.wait();
+
+  assert(*p == 0);
+  start_execution.count_down();
+
+  empty_cg_event.wait();
+  // FIXME: uncomment once the bug mentioned above is fixed.
+  // assert(*p == 42);
+
+  q.wait();
+  sycl::free(p, q);
+}
+
+void test_accessor_dep() {
+  queue q;
+
+  std::latch start_execution{1};
+  auto *p = sycl::malloc_shared<int>(1, q);
+  *p = 0;
+
+  auto host_event = q.submit([&](handler &cgh) {
+    cgh.host_task([&]() {
+      start_execution.wait();
+    });
+  });
+
+  sycl::buffer<int, 1> b{1};
+  auto device_event = q.submit([&](auto &cgh) {
+    cgh.depends_on(host_event);
+    sycl::accessor a{b, cgh};
+
+    cgh.single_task([=]() {
+      *p = 42;
+      a[0] = 42;
+    });
+  });
+  auto empty_cg_event = q.submit([&](handler &cgh) {
+    sycl::accessor a{b};
+    // TODO: Clarify with spec people that it should create a dependency indeed.
+    cgh.require(a);
+  });
+
+  // FIXME: This should deadlock, but the dependency is ignored currently.
+  empty_cg_event.wait();
+
+  assert(*p == 0);
+  start_execution.count_down();
+
+  empty_cg_event.wait();
+  // FIXME: uncomment once the bug mentioned above is fixed.
+  // assert(*p == 42);
+
+  q.wait();
+  sycl::free(p, q);
+}
+
+int main() {
+  test_host_task_dep();
+  test_device_event_dep();
+  test_accessor_dep();
+  return 0;
+}

--- a/sycl/test-e2e/Basic/empty_command.cpp
+++ b/sycl/test-e2e/Basic/empty_command.cpp
@@ -87,11 +87,8 @@ void test_accessor_dep() {
       a[0] = 42;
     });
   });
-  auto empty_cg_event = q.submit([&](handler &cgh) {
-    sycl::accessor a{b};
-    // TODO: Clarify with spec people that it should create a dependency indeed.
-    cgh.require(a);
-  });
+  auto empty_cg_event =
+      q.submit([&](handler &cgh) { sycl::accessor a{b, cgh}; });
 
   // FIXME: This should deadlock, but the dependency is ignored currently.
   empty_cg_event.wait();

--- a/sycl/test-e2e/Basic/empty_command.cpp
+++ b/sycl/test-e2e/Basic/empty_command.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out %cxx_std_optionc++20
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
 
 #include <latch>
 #include <thread>


### PR DESCRIPTION
We currently have a bug here and ignore some required dependencies. That will be addressed in a separate functional PR.