### PR TITLE
[SYCL][E2E] set pointer to nullptr to avoid Device Address Sanitizer complain about invalid pointer.

### DIFF
--- a/sycl/test-e2e/syclcompat/launch/launch.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch.cpp
@@ -119,7 +119,7 @@ void test_ptr_arg_launch() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
   LaunchTest lt;
 
-  int *int_ptr;
+  int *int_ptr = nullptr;
 
   syclcompat::launch<int_ptr_kernel>(lt.range_1_, int_ptr);
   syclcompat::launch<int_ptr_kernel>(lt.range_2_, int_ptr);


### PR DESCRIPTION
The `int_ptr` is pointed to random memory, which causes the Device Address Sanitizer to complain that it points to unknown memory. 