### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-7dad678

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-ac93a93",
-      "version": "ac93a93",
-      "updated_at": "2024-11-21T02:09:35Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2216471673/zip",
+      "github_tag": "igc-dev-7dad678",
+      "version": "7dad678",
+      "updated_at": "2024-11-24T10:48:51Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2229466354/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift