### PR TITLE
[SYCL] Remove some `OSUtil::*` funcs from ABI under `-fpreview-breaking-changes`

### DIFF
--- a/sycl/include/sycl/detail/os_util.hpp
+++ b/sycl/include/sycl/detail/os_util.hpp
@@ -43,6 +43,11 @@ namespace detail {
 /// Groups the OS-dependent services.
 class __SYCL_EXPORT OSUtil {
 #if !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
+#ifdef _WIN32
+  // Access control is part of the mangling on Windows, have to preserve this
+  // for backward ABI compatibility.
+public:
+#endif
   /// Returns a directory component of a path.
   static std::string getDirName(const char *Path);
 #endif

--- a/sycl/include/sycl/detail/os_util.hpp
+++ b/sycl/include/sycl/detail/os_util.hpp
@@ -42,12 +42,17 @@ namespace detail {
 
 /// Groups the OS-dependent services.
 class __SYCL_EXPORT OSUtil {
-public:
-  /// Returns an absolute path to a directory where the object was found.
-  static std::string getCurrentDSODir();
-
+#if !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
   /// Returns a directory component of a path.
   static std::string getDirName(const char *Path);
+#endif
+
+public:
+  /// Returns an absolute path to a directory where the object was found.
+#if defined(__INTEL_PREVIEW_BREAKING_CHANGES)
+  __SYCL_DLL_LOCAL
+#endif
+  static std::string getCurrentDSODir();
 
 #ifdef __SYCL_RT_OS_WINDOWS
   static constexpr const char *DirSep = "\\";

--- a/sycl/source/detail/persistent_device_code_cache.hpp
+++ b/sycl/source/detail/persistent_device_code_cache.hpp
@@ -24,10 +24,6 @@ namespace sycl {
 inline namespace _V1 {
 namespace detail {
 
-/* This is temporary solution until std::filesystem is available when SYCL RT
- * is moved to c++17 standard*/
-std::string getDirName(const char *Path);
-
 /* The class manages inter-process synchronization:
  *  - Path passed to the constructor is appended with .lock and used as lock
  *    file.

--- a/sycl/tools/sycl-trace/collector.cpp
+++ b/sycl/tools/sycl-trace/collector.cpp
@@ -18,7 +18,7 @@ sycl::detail::SpinLock GlobalLock;
 
 bool HasZEPrinter = false;
 
-std::string getCurrentDSODir() {
+static std::string getCurrentDSODir() {
   auto CurrentFunc = reinterpret_cast<const void *>(&getCurrentDSODir);
   Dl_info Info;
   int RetCode = dladdr(CurrentFunc, &Info);

--- a/sycl/ur_win_proxy_loader/ur_win_proxy_loader.cpp
+++ b/sycl/ur_win_proxy_loader/ur_win_proxy_loader.cpp
@@ -65,7 +65,7 @@ static OSModuleHandle getOSModuleHandle(const void *VirtAddr) {
 
 // cribbed from sycl/source/detail/os_util.cpp
 /// Returns an absolute path where the object was found.
-std::wstring getCurrentDSODir() {
+static std::wstring getCurrentDSODir() {
   wchar_t Path[MAX_PATH];
   auto Handle = getOSModuleHandle(reinterpret_cast<void *>(&getCurrentDSODir));
   DWORD Ret = GetModuleFileName(


### PR DESCRIPTION
These are used internally in the DSO and don't need to be exposed outside.

`OSUtil::getDirName` will become `static` inside single TU under the `-fpreview-breaking-changes` flag and `private` for the time being without the flag (to make sure no new uses will be added outside the TU).

`OSUtil::getCurrentDSODir` is used in several TUs, so simply make it `__SYCL_DLL_LOCAL` to remove from exported symbols during the next ABI-breaking window.