### PR TITLE
[SYCL] reenable launch_policy test on PVC. 

### DIFF
--- a/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
@@ -20,9 +20,6 @@
  *     launch<F> with policy & use local memory tests
  **************************************************************************/
 
-// XFAIL: arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14826
-
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
test is working on PVC.  
Will need to close issue https://github.com/intel/llvm/issues/14826 once this PR is merged.