### PR TITLE
[LIBCLC] Modify libclc-remangler cmds for cross-compile support

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -113,7 +113,7 @@ if( EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
 
   # If we've requested a custom binary directory, there are some otherwise
   # optional tools which we want to ensure are present.
-  if( NOT TARGET libclc::llvm-spirv OR NOT TARGET libclc::libclc-remangler )
+  if( NOT TARGET llvm-spirv_target OR NOT TARGET libclc-remangler_target )
     message( FATAL_ERROR "libclc toolchain incomplete!" )
   endif()
 endif()

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -456,7 +456,7 @@ function(add_libclc_builtin_set)
             "${LIBCLC_LIBRARY_OUTPUT_INTDIR}/remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}" )
         add_custom_command( OUTPUT "${builtins_remangle_path}"
           COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBCLC_LIBRARY_OUTPUT_INTDIR}
-          COMMAND libclc::libclc-remangler
+          COMMAND ${LIBCLC_REMANGLER_PATH}
           -o "${builtins_remangle_path}"
           --long-width=${long_width}
           --char-signedness=${signedness}
@@ -489,7 +489,7 @@ function(add_libclc_builtin_set)
       math(EXPR libclc-remangler-test-no "${libclc-remangler-test-no}+1")
       set(current-test "libclc-remangler-test-${obj_suffix}-${libclc-remangler-test-no}")
       add_custom_target(${current-test}
-        COMMAND libclc::libclc-remangler
+        COMMAND ${LIBCLC_REMANGLER_PATH}
         --long-width=l32
         --char-signedness=signed
         --input-ir=${target-ir}

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -449,6 +449,7 @@ function(add_libclc_builtin_set)
       set( obj_suffix_mangled "${obj_suffix}")
     endif()
     # All permutations of [l32, l64] and [signed, unsigned]
+    get_host_tool_path(libclc-remangler LIBCLC_REMANGLER libclc-remangler_exe libclc-remangler_target)
     foreach(long_width ${long_widths})
       foreach(signedness ${char_signedness})
         # Remangle
@@ -462,7 +463,7 @@ function(add_libclc_builtin_set)
           --char-signedness=${signedness}
           --input-ir=${builtins_lib}
           ${dummy_in}
-          DEPENDS ${builtins_lib} libclc-remangler_target ${dummy_in})
+          DEPENDS ${builtins_lib} ${libclc-remangler_target} ${dummy_in})
         add_custom_target( "remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}" ALL
           DEPENDS "${builtins_remangle_path}" "${dummy_in}")
         set_target_properties("remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}"
@@ -494,7 +495,7 @@ function(add_libclc_builtin_set)
         --char-signedness=signed
         --input-ir=${target-ir}
         ${dummy_in} -t -o -
-        DEPENDS ${builtins_lib} "${dummy_in}" libclc-remangler_target)
+        DEPENDS ${builtins_lib} "${dummy_in}" ${libclc-remangler_target})
       list(APPEND libclc-remangler-tests ${current-test})
     endforeach()
   endif()

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -456,13 +456,13 @@ function(add_libclc_builtin_set)
             "${LIBCLC_LIBRARY_OUTPUT_INTDIR}/remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}" )
         add_custom_command( OUTPUT "${builtins_remangle_path}"
           COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBCLC_LIBRARY_OUTPUT_INTDIR}
-          COMMAND ${LIBCLC_REMANGLER_PATH}
+          COMMAND ${libclc-remangler_exe}
           -o "${builtins_remangle_path}"
           --long-width=${long_width}
           --char-signedness=${signedness}
           --input-ir=${builtins_lib}
           ${dummy_in}
-          DEPENDS ${builtins_lib} libclc::libclc-remangler ${dummy_in})
+          DEPENDS ${builtins_lib} libclc-remangler_target ${dummy_in})
         add_custom_target( "remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}" ALL
           DEPENDS "${builtins_remangle_path}" "${dummy_in}")
         set_target_properties("remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}"
@@ -489,12 +489,12 @@ function(add_libclc_builtin_set)
       math(EXPR libclc-remangler-test-no "${libclc-remangler-test-no}+1")
       set(current-test "libclc-remangler-test-${obj_suffix}-${libclc-remangler-test-no}")
       add_custom_target(${current-test}
-        COMMAND ${LIBCLC_REMANGLER_PATH}
+        COMMAND ${libclc-remangler_exe}
         --long-width=l32
         --char-signedness=signed
         --input-ir=${target-ir}
         ${dummy_in} -t -o -
-        DEPENDS ${builtins_lib} "${dummy_in}" libclc::libclc-remangler)
+        DEPENDS ${builtins_lib} "${dummy_in}" libclc-remangler_target)
       list(APPEND libclc-remangler-tests ${current-test})
     endforeach()
   endif()

--- a/libclc/utils/libclc-remangler/CMakeLists.txt
+++ b/libclc/utils/libclc-remangler/CMakeLists.txt
@@ -25,6 +25,24 @@ clang_target_link_libraries(libclc-remangler
   LLVMOption
   )
 
+if(CMAKE_CROSSCOMPILING)
+  if(LLVM_NATIVE_TOOL_DIR AND NOT LIBCLC_REMANGLER_PATH)
+    if(EXISTS "${LLVM_NATIVE_TOOL_DIR}/libclc-remangler${LLVM_HOST_EXECUTABLE_SUFFIX}")
+      set(LLVM_CONFIG_PATH "${LLVM_NATIVE_TOOL_DIR}/libclc-remangler${LLVM_HOST_EXECUTABLE_SUFFIX}")
+    endif()
+  endif()
+
+  if(NOT LIBCLC_REMANGLER_PATH)
+    build_native_tool(libclc-remangler LIBCLC_REMANGLER_PATH)
+    set(LIBCLC_REMANGLER_PATH "${LIBCLC_REMANGLER_PATH}" CACHE STRING "")
+
+    add_custom_target(NativeLibCLCRemangler DEPENDS ${LIBCLC_REMANGLER_PATH})
+    add_dependencies(libclc-remangler NativeLibCLCRemangler)
+  endif()
+else()
+  set(LIBCLC_REMANGLER_PATH "${CMAKE_CURRENT_BINARY_DIR}/bin/libclc-remangler" CACHE STRING "")
+endif()
+
 # If we've not already imported a libclc-remangler tool from an external build,
 # set it up now.
 if(NOT TARGET libclc::libclc-remangler)

--- a/libclc/utils/libclc-remangler/CMakeLists.txt
+++ b/libclc/utils/libclc-remangler/CMakeLists.txt
@@ -25,26 +25,12 @@ clang_target_link_libraries(libclc-remangler
   LLVMOption
   )
 
-if(CMAKE_CROSSCOMPILING)
-  if(LLVM_NATIVE_TOOL_DIR AND NOT LIBCLC_REMANGLER_PATH)
-    if(EXISTS "${LLVM_NATIVE_TOOL_DIR}/libclc-remangler${LLVM_HOST_EXECUTABLE_SUFFIX}")
-      set(LLVM_CONFIG_PATH "${LLVM_NATIVE_TOOL_DIR}/libclc-remangler${LLVM_HOST_EXECUTABLE_SUFFIX}")
-    endif()
-  endif()
-
-  if(NOT LIBCLC_REMANGLER_PATH)
-    build_native_tool(libclc-remangler LIBCLC_REMANGLER_PATH)
-    set(LIBCLC_REMANGLER_PATH "${LIBCLC_REMANGLER_PATH}" CACHE STRING "")
-
-    add_custom_target(NativeLibCLCRemangler DEPENDS ${LIBCLC_REMANGLER_PATH})
-    add_dependencies(libclc-remangler NativeLibCLCRemangler)
-  endif()
-else()
-  set(LIBCLC_REMANGLER_PATH "${CMAKE_CURRENT_BINARY_DIR}/bin/libclc-remangler" CACHE STRING "")
-endif()
-
 # If we've not already imported a libclc-remangler tool from an external build,
 # set it up now.
-if(NOT TARGET libclc::libclc-remangler)
-  add_executable(libclc::libclc-remangler ALIAS libclc-remangler)
+if(NOT TARGET libclc-remangler_target)
+  if ( CMAKE_CROSSCOMPILING )
+    setup_host_tool(libclc-remangler LIBCLC_REMANGLER libclc-remangler_exe libclc-remangler_target)
+  else()
+    add_executable(libclc-remangler_target ALIAS libclc-remangler)
+  endif()
 endif()

--- a/libclc/utils/libclc-remangler/CMakeLists.txt
+++ b/libclc/utils/libclc-remangler/CMakeLists.txt
@@ -25,12 +25,4 @@ clang_target_link_libraries(libclc-remangler
   LLVMOption
   )
 
-# If we've not already imported a libclc-remangler tool from an external build,
-# set it up now.
-if(NOT TARGET libclc-remangler_target)
-  if ( CMAKE_CROSSCOMPILING )
-    setup_host_tool(libclc-remangler LIBCLC_REMANGLER libclc-remangler_exe libclc-remangler_target)
-  else()
-    add_executable(libclc-remangler_target ALIAS libclc-remangler)
-  endif()
-endif()
+setup_host_tool(libclc-remangler LIBCLC_REMANGLER libclc-remangler_exe libclc-remangler_target)


### PR DESCRIPTION
Because libclc-remangler commands executed in cmake use `libclc::libclc-remangler`, builds where `CMAKE_CROSSCOMPILING=ON` do not work correctly since cmake assumes the target is not executable on the host machine.

This change modifies the custom commands to use the cache variable `LIBCLC_REMANGLER_PATH` instead, where this variable is set in a similar way as llvm tools such as `llvm-config` by calling `compile_native_tool`.