### PR TITLE
[UR] UR bump for "use after release" fix

### DIFF
--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -1,7 +1,2 @@
-# commit 7a38cc3e21d83940622d63b0b902bf68f9539f6f
-# Merge: 2dac0daaf327 252b3822f0e8
-# Author: Martin Grant <martin.morrisongrant@codeplay.com>
-# Date:   Mon Dec 2 15:41:23 2024 +0000
-#     Merge pull request #2395 from pbalcer/fix-event-pooling
-#     fix event caching
-set(UNIFIED_RUNTIME_TAG 7a38cc3e21d83940622d63b0b902bf68f9539f6f)
+set(UNIFIED_RUNTIME_REPO "https://github.com/RossBrunton/unified-runtime.git")
+set(UNIFIED_RUNTIME_TAG "8412c8bdfbf8262d7ee6d953a85cf956bb50c887")


### PR DESCRIPTION
Pre-commit MR for: https://github.com/oneapi-src/unified-runtime/pull/2368
