### PR TITLE
[SYCL][Joint Matrix][E2E] Uncomment the Joint Matrix tests for combination 32x32x16

### DIFF
--- a/sycl/test-e2e/Matrix/element_wise_all_ops_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_impl.hpp
@@ -242,9 +242,9 @@ int main() {
       test_ewops_ab<bfloat16, 8, 16, use::a, layout::row_major, 1>();
       test_ewops_ab<bfloat16, 16, 8, use::b, layout::ext_intel_packed, 2>();
       test_ewops_c<float, 8, 8>();
-      // test_ewops_ab<bfloat16, 32, 16, use::a, layout::row_major, 1>();
-      // test_ewops_ab<bfloat16, 16, 32, use::b, layout::ext_intel_packed, 2>();
-      // test_ewops_c<float, 32, 32>();
+      test_ewops_ab<bfloat16, 32, 16, use::a, layout::row_major, 1>();
+      test_ewops_ab<bfloat16, 16, 32, use::b, layout::ext_intel_packed, 2>();
+      test_ewops_c<float, 32, 32>();
       break;
     }
   }

--- a/sycl/test-e2e/Matrix/element_wise_ops_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_ops_impl.hpp
@@ -142,8 +142,7 @@ int main() {
       passed &= test<uint8_t, int32_t, 8, 8, 32, 4, class dg2_uint_8x8x32>();
       passed &= test<int8_t, int32_t, 8, 8, 32, 4, class dg2_sint_8x8x32>();
       passed &= test<bfloat16, float, 8, 8, 16, 2, class dg2_bf16_8x16x16>();
-      // passed &= test<bfloat16, float, 32, 32, 16, 2, class
-      // dg2_bf16_32x32x16>();
+      passed &= test<bfloat16, float, 32, 32, 16, 2, class dg2_bf16_32x32x16>();
       break;
     }
   }

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
@@ -12,7 +12,9 @@
 
 // -ffp-model=precise is added to not depend on compiler defaults.
 
+// Waiting for the commit in IGC to be pulled into the driver to resolve the test.
 // XFAIL: gpu
+// XFAIL-TRACKER: CMPLRLLVM-63710
 
 #include "common.hpp"
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
@@ -12,5 +12,7 @@
 
 // -ffp-model=precise is added to not depend on compiler defaults.
 
+// XFAIL: gpu
+
 #include "common.hpp"
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
@@ -12,7 +12,8 @@
 
 // -ffp-model=precise is added to not depend on compiler defaults.
 
-// Waiting for the commit in IGC to be pulled into the driver to resolve the test.
+// Waiting for the commit in IGC to be pulled into the driver to resolve the
+// test.
 // XFAIL: gpu
 // XFAIL-TRACKER: CMPLRLLVM-63710
 

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_impl.hpp
@@ -493,8 +493,8 @@ size_t matrix_size = -1;
 
       test<bfloat16, float, VnniFactor, /*TM*/ 8, /*TN*/ 8, /*TK*/ 16, MCache1,
            NCache1, KCache1, MCache2, NCache2, KCache2>(matrix_size);
-      // test<bfloat16, float, VnniFactor, /*TM*/ 32, /*TN*/ 32, /*TK*/ 16, MCache1,
-      //      NCache1, KCache1, MCache2, NCache2, KCache2>(matrix_size);
+      test<bfloat16, float, VnniFactor, /*TM*/ 32, /*TN*/ 32, /*TK*/ 16,
+           MCache1, NCache1, KCache1, MCache2, NCache2, KCache2>(matrix_size);
       break;
     }
   }

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
@@ -12,7 +12,9 @@
 
 // -ffp-model=precise is added to not depend on compiler defaults.
 
+// Waiting for the commit in IGC to be pulled into the driver
 // XFAIL: gpu
+// XFAIL-TRACKER: CMPLRLLVM-63710
 
 #include "common.hpp"
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
@@ -12,5 +12,7 @@
 
 // -ffp-model=precise is added to not depend on compiler defaults.
 
+// XFAIL: gpu
+
 #include "common.hpp"
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
@@ -12,7 +12,7 @@
 
 // -ffp-model=precise is added to not depend on compiler defaults.
 
-// Waiting for the commit in IGC to be pulled into the driver
+// Waiting for the commit in IGC to be pulled into the driver to resolve the test.
 // XFAIL: gpu
 // XFAIL-TRACKER: CMPLRLLVM-63710
 

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
@@ -12,7 +12,8 @@
 
 // -ffp-model=precise is added to not depend on compiler defaults.
 
-// Waiting for the commit in IGC to be pulled into the driver to resolve the test.
+// Waiting for the commit in IGC to be pulled into the driver to resolve the
+// test.
 // XFAIL: gpu
 // XFAIL-TRACKER: CMPLRLLVM-63710
 

--- a/sycl/test-e2e/Matrix/joint_matrix_rowmajorA_rowmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_rowmajorA_rowmajorB_impl.hpp
@@ -144,8 +144,8 @@ int main() {
           gemm_row_major<8, 8, 32, class su_8x8x32, int8_t, uint8_t, int32_t>();
       res += gemm_row_major<8, 8, 32, class uu_8x8x32, uint8_t, uint8_t,
                             int32_t>();
-      // res += gemm_row_major<32, 32, 16, class dg2_bf16_32x32x16, bfloat16,
-      //                       bfloat16, float>();
+      res += gemm_row_major<32, 32, 16, class dg2_bf16_32x32x16, bfloat16,
+                            bfloat16, float>();
       break;
     }
   }

--- a/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
+++ b/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
@@ -51,7 +51,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 77
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 79
 //
 // List of improperly XFAIL-ed tests.
 // Remove the CHECK once the test has been properly XFAIL-ed.
@@ -96,6 +96,8 @@
 // CHECK-NEXT: Matrix/SG32/joint_matrix_prefetch.cpp
 // CHECK-NEXT: Matrix/SG32/joint_matrix_rowmajorA_rowmajorB.cpp
 // CHECK-NEXT: Matrix/SG32/joint_matrix_unaligned_k.cpp
+// CHECK-NEXT: Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
+// CHECK-NEXT: Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
 // CHECK-NEXT: Matrix/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
 // CHECK-NEXT: Matrix/joint_matrix_colA_rowB_colC.cpp
 // CHECK-NEXT: Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp

--- a/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
+++ b/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
@@ -51,7 +51,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 79
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 77
 //
 // List of improperly XFAIL-ed tests.
 // Remove the CHECK once the test has been properly XFAIL-ed.
@@ -96,8 +96,6 @@
 // CHECK-NEXT: Matrix/SG32/joint_matrix_prefetch.cpp
 // CHECK-NEXT: Matrix/SG32/joint_matrix_rowmajorA_rowmajorB.cpp
 // CHECK-NEXT: Matrix/SG32/joint_matrix_unaligned_k.cpp
-// CHECK-NEXT: Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
-// CHECK-NEXT: Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
 // CHECK-NEXT: Matrix/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
 // CHECK-NEXT: Matrix/joint_matrix_colA_rowB_colC.cpp
 // CHECK-NEXT: Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp


### PR DESCRIPTION
Description:
The support for combination 32x32x16 on DG2 has been implemented in commit https://github.com/intel/intel-graphics-compiler/commit/6a06c93eed6f512ee8d713c179f3eab5e419ef9b.  This PR re-enables the Joint Matrix tests for the combination 32x32x16, which were previously unsupported.

This PR also adds XFAIL: gpu to two tests, joint_matrix_bf16_fill_k_cache_arg_dim.cpp and joint_matrix_bf16_fill_k_cache_runtime_dim.cpp, because the driver has not yet been updated to include the necessary changes in IGC to support these tests. As a result, these tests should not be tested in CI at this time.