### PR TITLE
[SYCL][E2E] Initialize `arch_flag` to an empty string by default

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -45,7 +45,6 @@ match lit_config.params.get("test-mode", "full"):
     case "build-only":
         config.test_mode = "build-only"
         config.sycl_devices = []
-        arch_flag = ""
     case "full":
         config.test_mode = "full"
         config.available_features.add("run-mode")
@@ -659,6 +658,7 @@ config.sycl_dev_features = {}
 
 # Version of the driver for a given device. Empty for non-Intel devices.
 config.intel_driver_ver = {}
+arch_flag = ""
 for sycl_device in config.sycl_devices:
     env = copy.copy(llvm_config.config.environment)
     env["ONEAPI_DEVICE_SELECTOR"] = sycl_device
@@ -798,9 +798,6 @@ for sycl_device in config.sycl_devices:
         )
     elif be == "hip" and config.hip_platform == "NVIDIA":
         config.available_features.add("hip_nvidia")
-        arch_flag = ""
-    else:
-        arch_flag = ""
 
     config.sycl_dev_features[sycl_device] = features.union(config.available_features)
     if is_intel_driver:

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -656,9 +656,10 @@ for sycl_device in config.sycl_devices:
 # discovered already.
 config.sycl_dev_features = {}
 
+# Architecture flag for compiling for AMD HIP devices. Empty otherwise.
+arch_flag = ""
 # Version of the driver for a given device. Empty for non-Intel devices.
 config.intel_driver_ver = {}
-arch_flag = ""
 for sycl_device in config.sycl_devices:
     env = copy.copy(llvm_config.config.environment)
     env["ONEAPI_DEVICE_SELECTOR"] = sycl_device


### PR DESCRIPTION
In an environment with no devices this variable is never set, causing a confusing error when we try to define the `clangxx` expansion. Here we set it to an empty string by default so that instead of exiting with a python error we report all tests as unsupported (due to having no devices).

This same issue is why `arch_flag` was set in build-only mode, so I removed the line that did that too.