### PR TITLE
[SYCL] Honor dependencies of empty command groups

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3592,10 +3592,21 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
 
     return UR_RESULT_SUCCESS;
   }
-  case CGType::None:
-    throw sycl::exception(sycl::make_error_code(sycl::errc::runtime),
-                          "CG type not implemented. " +
-                              codeToString(UR_RESULT_ERROR_INVALID_OPERATION));
+  case CGType::None: {
+    if (RawEvents.empty()) {
+      // urEnqueueEventsWait with zero events acts like a barrier which is NOT
+      // what we want here. On the other hand, there is nothing to wait for, so
+      // we don't need to enqueue anything.
+      return UR_RESULT_SUCCESS;
+    }
+    const detail::AdapterPtr &Adapter = MQueue->getAdapter();
+    ur_event_handle_t Event;
+    ur_result_t Result = Adapter->call_nocheck<UrApiKind::urEnqueueEventsWait>(
+        MQueue->getHandleRef(), RawEvents.size(),
+        RawEvents.size() ? &RawEvents[0] : nullptr, &Event);
+    MEvent->setHandle(Event);
+    return Result;
+  }
   }
   return UR_RESULT_ERROR_INVALID_OPERATION;
 }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -496,21 +496,8 @@ event handler::finalize() {
         MCodeLoc));
     break;
   case detail::CGType::None:
-    if (detail::ur::trace(detail::ur::TraceLevel::TRACE_ALL)) {
-      std::cout << "WARNING: An empty command group is submitted." << std::endl;
-    }
-
-    // Empty nodes are handled by Graph like standard nodes
-    // For Standard mode (non-graph),
-    // empty nodes are not sent to the scheduler to save time
-    if (impl->MGraph || (MQueue && MQueue->getCommandGraph())) {
-      CommandGroup.reset(new detail::CG(detail::CGType::None,
-                                        std::move(impl->CGData), MCodeLoc));
-    } else {
-      detail::EventImplPtr Event = std::make_shared<sycl::detail::event_impl>();
-      MLastEvent = detail::createSyclObjFromImpl<event>(Event);
-      return MLastEvent;
-    }
+    CommandGroup.reset(new detail::CG(detail::CGType::None,
+                                      std::move(impl->CGData), MCodeLoc));
     break;
   }
 

--- a/sycl/test-e2e/Basic/empty_command.cpp
+++ b/sycl/test-e2e/Basic/empty_command.cpp
@@ -26,18 +26,11 @@ void test_host_task_dep() {
   auto empty_cg_event =
       q.submit([&](handler &cgh) { cgh.depends_on(host_event); });
 
-  // FIXME: This should deadlock, but the dependency is ignored currently.
-  empty_cg_event.wait();
-
   assert(x == 0);
   start_execution.count_down();
 
   empty_cg_event.wait();
-  // FIXME: uncomment once the bug mentioned above is fixed.
-  // assert(x == 42);
-
-  // I'm seeing some weird hang without this:
-  host_event.wait();
+  assert(x == 42);
 }
 
 void test_device_event_dep() {
@@ -53,17 +46,12 @@ void test_device_event_dep() {
   auto empty_cg_event =
       q.submit([&](handler &cgh) { cgh.depends_on(device_event); });
 
-  // FIXME: This should deadlock, but the dependency is ignored currently.
-  empty_cg_event.wait();
-
   assert(*p == 0);
   start_execution.count_down();
 
   empty_cg_event.wait();
-  // FIXME: uncomment once the bug mentioned above is fixed.
-  // assert(*p == 42);
+  assert(*p == 42);
 
-  q.wait();
   sycl::free(p, q);
 }
 
@@ -90,17 +78,12 @@ void test_accessor_dep() {
   auto empty_cg_event =
       q.submit([&](handler &cgh) { sycl::accessor a{b, cgh}; });
 
-  // FIXME: This should deadlock, but the dependency is ignored currently.
-  empty_cg_event.wait();
-
   assert(*p == 0);
   start_execution.count_down();
 
   empty_cg_event.wait();
-  // FIXME: uncomment once the bug mentioned above is fixed.
-  // assert(*p == 42);
+  assert(*p == 42);
 
-  q.wait();
   sycl::free(p, q);
 }
 

--- a/sycl/test-e2e/WeakObject/weak_object_utils.hpp
+++ b/sycl/test-e2e/WeakObject/weak_object_utils.hpp
@@ -104,21 +104,6 @@ template <template <typename> typename CallableT> void runTest(sycl::queue Q) {
     sycl::local_accessor<int, 2> LAcc2D{sycl::range<2>{1, 2}, CGH};
     sycl::local_accessor<int, 3> LAcc3D{sycl::range<3>{1, 2, 3}, CGH};
     sycl::stream Stream{1024, 32, CGH};
-    sycl::unsampled_image_accessor<sycl::int4, 1, sycl::access_mode::read,
-                                   sycl::image_target::host_task>
-        UImgAcc1D{UImg1D, CGH};
-    sycl::unsampled_image_accessor<sycl::int4, 2, sycl::access_mode::read,
-                                   sycl::image_target::host_task>
-        UImgAcc2D{UImg2D, CGH};
-    sycl::unsampled_image_accessor<sycl::int4, 3, sycl::access_mode::read,
-                                   sycl::image_target::host_task>
-        UImgAcc3D{UImg3D, CGH};
-    sycl::sampled_image_accessor<sycl::int4, 1, sycl::image_target::host_task>
-        SImgAcc1D{SImg1D, CGH};
-    sycl::sampled_image_accessor<sycl::int4, 2, sycl::image_target::host_task>
-        SImgAcc2D{SImg2D, CGH};
-    sycl::sampled_image_accessor<sycl::int4, 3, sycl::image_target::host_task>
-        SImgAcc3D{SImg3D, CGH};
 
     CallableT<decltype(DAcc1D)>()(DAcc1D);
     CallableT<decltype(DAcc2D)>()(DAcc2D);
@@ -127,13 +112,33 @@ template <template <typename> typename CallableT> void runTest(sycl::queue Q) {
     CallableT<decltype(LAcc2D)>()(LAcc2D);
     CallableT<decltype(LAcc3D)>()(LAcc3D);
     CallableT<decltype(Stream)>()(Stream);
-    CallableT<decltype(UImgAcc1D)>()(UImgAcc1D);
-    CallableT<decltype(UImgAcc2D)>()(UImgAcc2D);
-    CallableT<decltype(UImgAcc3D)>()(UImgAcc3D);
-    CallableT<decltype(SImgAcc1D)>()(SImgAcc1D);
-    CallableT<decltype(SImgAcc2D)>()(SImgAcc2D);
-    CallableT<decltype(SImgAcc3D)>()(SImgAcc3D);
   });
+  if (Q.get_device().has(sycl::aspect::ext_intel_legacy_image)) {
+    Q.submit([&](sycl::handler &CGH) {
+      sycl::unsampled_image_accessor<sycl::int4, 1, sycl::access_mode::read,
+                                     sycl::image_target::host_task>
+          UImgAcc1D{UImg1D, CGH};
+      sycl::unsampled_image_accessor<sycl::int4, 2, sycl::access_mode::read,
+                                     sycl::image_target::host_task>
+          UImgAcc2D{UImg2D, CGH};
+      sycl::unsampled_image_accessor<sycl::int4, 3, sycl::access_mode::read,
+                                     sycl::image_target::host_task>
+          UImgAcc3D{UImg3D, CGH};
+      sycl::sampled_image_accessor<sycl::int4, 1, sycl::image_target::host_task>
+          SImgAcc1D{SImg1D, CGH};
+      sycl::sampled_image_accessor<sycl::int4, 2, sycl::image_target::host_task>
+          SImgAcc2D{SImg2D, CGH};
+      sycl::sampled_image_accessor<sycl::int4, 3, sycl::image_target::host_task>
+          SImgAcc3D{SImg3D, CGH};
+
+      CallableT<decltype(UImgAcc1D)>()(UImgAcc1D);
+      CallableT<decltype(UImgAcc2D)>()(UImgAcc2D);
+      CallableT<decltype(UImgAcc3D)>()(UImgAcc3D);
+      CallableT<decltype(SImgAcc1D)>()(SImgAcc1D);
+      CallableT<decltype(SImgAcc2D)>()(SImgAcc2D);
+      CallableT<decltype(SImgAcc3D)>()(SImgAcc3D);
+    });
+  }
 }
 
 template <template <typename> typename CallableT>
@@ -266,37 +271,6 @@ void runTestMulti(sycl::queue Q1) {
     sycl::local_accessor<int, 3> LAcc3D2{sycl::range<3>{1, 2, 3}, CGH};
     sycl::stream Stream1{1024, 32, CGH};
     sycl::stream Stream2{1024, 32, CGH};
-    sycl::unsampled_image_accessor<sycl::int4, 1, sycl::access_mode::read,
-                                   sycl::image_target::host_task>
-        UImgAcc1D1{UImg1D1, CGH};
-    sycl::unsampled_image_accessor<sycl::int4, 2, sycl::access_mode::read,
-                                   sycl::image_target::host_task>
-        UImgAcc2D1{UImg2D1, CGH};
-    sycl::unsampled_image_accessor<sycl::int4, 3, sycl::access_mode::read,
-                                   sycl::image_target::host_task>
-        UImgAcc3D1{UImg3D1, CGH};
-    sycl::unsampled_image_accessor<sycl::int4, 1, sycl::access_mode::read,
-                                   sycl::image_target::host_task>
-        UImgAcc1D2{UImg1D2, CGH};
-    sycl::unsampled_image_accessor<sycl::int4, 2, sycl::access_mode::read,
-                                   sycl::image_target::host_task>
-        UImgAcc2D2{UImg2D2, CGH};
-    sycl::unsampled_image_accessor<sycl::int4, 3, sycl::access_mode::read,
-                                   sycl::image_target::host_task>
-        UImgAcc3D2{UImg3D2, CGH};
-    sycl::sampled_image_accessor<sycl::int4, 1, sycl::image_target::host_task>
-        SImgAcc1D1{SImg1D1, CGH};
-    sycl::sampled_image_accessor<sycl::int4, 2, sycl::image_target::host_task>
-        SImgAcc2D1{SImg2D1, CGH};
-    sycl::sampled_image_accessor<sycl::int4, 3, sycl::image_target::host_task>
-        SImgAcc3D1{SImg3D1, CGH};
-    sycl::sampled_image_accessor<sycl::int4, 1, sycl::image_target::host_task>
-        SImgAcc1D2{SImg1D2, CGH};
-    sycl::sampled_image_accessor<sycl::int4, 2, sycl::image_target::host_task>
-        SImgAcc2D2{SImg2D2, CGH};
-    sycl::sampled_image_accessor<sycl::int4, 3, sycl::image_target::host_task>
-        SImgAcc3D2{SImg3D2, CGH};
-
     CallableT<decltype(DAcc1D1)>()(DAcc1D1, DAcc1D2);
     CallableT<decltype(DAcc2D1)>()(DAcc2D1, DAcc2D2);
     CallableT<decltype(DAcc3D1)>()(DAcc3D1, DAcc3D2);
@@ -304,11 +278,47 @@ void runTestMulti(sycl::queue Q1) {
     CallableT<decltype(LAcc2D1)>()(LAcc2D1, LAcc2D2);
     CallableT<decltype(LAcc3D1)>()(LAcc3D1, LAcc3D2);
     CallableT<decltype(Stream1)>()(Stream1, Stream2);
-    CallableT<decltype(UImgAcc1D1)>()(UImgAcc1D1, UImgAcc1D2);
-    CallableT<decltype(UImgAcc2D1)>()(UImgAcc2D1, UImgAcc2D2);
-    CallableT<decltype(UImgAcc3D1)>()(UImgAcc3D1, UImgAcc3D2);
-    CallableT<decltype(SImgAcc1D1)>()(SImgAcc1D1, SImgAcc1D2);
-    CallableT<decltype(SImgAcc2D1)>()(SImgAcc2D1, SImgAcc2D2);
-    CallableT<decltype(SImgAcc3D1)>()(SImgAcc3D1, SImgAcc3D2);
   });
+
+  if (Q1.get_device().has(sycl::aspect::ext_intel_legacy_image)) {
+    Q1.submit([&](sycl::handler &CGH) {
+      sycl::unsampled_image_accessor<sycl::int4, 1, sycl::access_mode::read,
+                                     sycl::image_target::host_task>
+          UImgAcc1D1{UImg1D1, CGH};
+      sycl::unsampled_image_accessor<sycl::int4, 2, sycl::access_mode::read,
+                                     sycl::image_target::host_task>
+          UImgAcc2D1{UImg2D1, CGH};
+      sycl::unsampled_image_accessor<sycl::int4, 3, sycl::access_mode::read,
+                                     sycl::image_target::host_task>
+          UImgAcc3D1{UImg3D1, CGH};
+      sycl::unsampled_image_accessor<sycl::int4, 1, sycl::access_mode::read,
+                                     sycl::image_target::host_task>
+          UImgAcc1D2{UImg1D2, CGH};
+      sycl::unsampled_image_accessor<sycl::int4, 2, sycl::access_mode::read,
+                                     sycl::image_target::host_task>
+          UImgAcc2D2{UImg2D2, CGH};
+      sycl::unsampled_image_accessor<sycl::int4, 3, sycl::access_mode::read,
+                                     sycl::image_target::host_task>
+          UImgAcc3D2{UImg3D2, CGH};
+      sycl::sampled_image_accessor<sycl::int4, 1, sycl::image_target::host_task>
+          SImgAcc1D1{SImg1D1, CGH};
+      sycl::sampled_image_accessor<sycl::int4, 2, sycl::image_target::host_task>
+          SImgAcc2D1{SImg2D1, CGH};
+      sycl::sampled_image_accessor<sycl::int4, 3, sycl::image_target::host_task>
+          SImgAcc3D1{SImg3D1, CGH};
+      sycl::sampled_image_accessor<sycl::int4, 1, sycl::image_target::host_task>
+          SImgAcc1D2{SImg1D2, CGH};
+      sycl::sampled_image_accessor<sycl::int4, 2, sycl::image_target::host_task>
+          SImgAcc2D2{SImg2D2, CGH};
+      sycl::sampled_image_accessor<sycl::int4, 3, sycl::image_target::host_task>
+          SImgAcc3D2{SImg3D2, CGH};
+
+      CallableT<decltype(UImgAcc1D1)>()(UImgAcc1D1, UImgAcc1D2);
+      CallableT<decltype(UImgAcc2D1)>()(UImgAcc2D1, UImgAcc2D2);
+      CallableT<decltype(UImgAcc3D1)>()(UImgAcc3D1, UImgAcc3D2);
+      CallableT<decltype(SImgAcc1D1)>()(SImgAcc1D1, SImgAcc1D2);
+      CallableT<decltype(SImgAcc2D1)>()(SImgAcc2D1, SImgAcc2D2);
+      CallableT<decltype(SImgAcc3D1)>()(SImgAcc3D1, SImgAcc3D2);
+    });
+  }
 }

--- a/sycl/test-e2e/XPTI/image/accessors.cpp
+++ b/sycl/test-e2e/XPTI/image/accessors.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: xptifw, opencl
+// REQUIRES: aspect-ext_intel_legacy_image
 // RUN: %clangxx %s -DXPTI_COLLECTOR -DXPTI_CALLBACK_API_EXPORTS %xptifw_lib %shared_lib %fPIC %cxx_std_optionc++17 -o %t_collector.dll
 // RUN: %{build} -o %t.out
 // RUN: env XPTI_TRACE_ENABLE=1 XPTI_FRAMEWORK_DISPATCHER=%xptifw_dispatcher XPTI_SUBSCRIBERS=%t_collector.dll %{run} %t.out | FileCheck %s


### PR DESCRIPTION
This is a recommit of https://github.com/intel/llvm/pull/16180. Post-commit CI had a few tests failing so the original PR was reverted. The reason of the failures is that with proper dependencies tracking we now try to actually create images on the device and it might fail if device isn't capable of that. This updated version of the PR also modifies those failing tests to skip checks on unsupported devices