### PR TITLE
[E2E][SYCL] Actually disable fast math in `marray_common.cpp` test

### DIFF
--- a/sycl/test-e2e/Basic/built-ins/marray_common.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_common.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t_preview.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{build} %{mathflags} -fpreview-breaking-changes -o %t_preview.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t_preview.out%}
 
 #ifdef _WIN32


### PR DESCRIPTION
https://github.com/intel/llvm/pull/15223 updated the normal build command but not the `preview-breaking-changes` one. Fix that here.