### PR TITLE
[SYCL] Remove uses of unimplemented SYCL_PREFER_UR env var.

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -196,7 +196,6 @@ variables in production code.</span>
 
 | Environment variable | Values | Description |
 | -------------------- | ------ | ----------- |
-| `SYCL_PREFER_UR` | Integer | If non-0 then run through Unified Runtime if desired backend is supported there. Default is 0.  |
 | `SYCL_UR_TRACE` | Integer | Described [below](#sycl_ur_trace-options)  | Enable specified level of tracing for UR. |
 | `SYCL_QUEUE_THREAD_POOL_SIZE` | Positive integer | Number of threads in thread pool of queue. |
 | `SYCL_DEVICELIB_NO_FALLBACK` | Any(\*) | Disable loading and linking of device library images |

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/bad-context.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/bad-context.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu && (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O2 -g -o %t
-// RUN: env SYCL_PREFER_UR=1 UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: env UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/host-pointer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/host-pointer.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: env SYCL_PREFER_UR=1 UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} %if gpu %{ not %} %t 2>&1 | FileCheck --check-prefixes %if cpu %{ CHECK-CPU %} %if gpu %{ CHECK-GPU %} %s
+// RUN: env UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} %if gpu %{ not %} %t 2>&1 | FileCheck --check-prefixes %if cpu %{ CHECK-CPU %} %if gpu %{ CHECK-GPU %} %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: env SYCL_PREFER_UR=1 UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
+// RUN: env UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: env SYCL_PREFER_UR=1 UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
+// RUN: env UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/misaligned/misalign-int.cpp
+++ b/sycl/test-e2e/AddressSanitizer/misaligned/misalign-int.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/misaligned/misalign-long.cpp
+++ b/sycl/test-e2e/AddressSanitizer/misaligned/misalign-long.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/misaligned/misalign-short.cpp
+++ b/sycl/test-e2e/AddressSanitizer/misaligned/misalign-short.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/multiple-reports/multiple_kernels.cpp
+++ b/sycl/test-e2e/AddressSanitizer/multiple-reports/multiple_kernels.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -Xarch_device -fsanitize-recover=address -O2 -g -o %t
-// RUN: env SYCL_PREFER_UR=1 %{run} %t 2>&1 | FileCheck %s
+// RUN: %{run} %t 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/multiple-reports/one_kernel.cpp
+++ b/sycl/test-e2e/AddressSanitizer/multiple-reports/one_kernel.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -Xarch_device -fsanitize-recover=address -O2 -g -o %t
-// RUN: env SYCL_PREFER_UR=1 %{run} %t 2>&1 | FileCheck %s
+// RUN: %{run} %t 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/large_group_size.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/large_group_size.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t 2>&1 | FileCheck --check-prefixes CHECK %s
+// RUN: %{run} not %t 2>&1 | FileCheck --check-prefixes CHECK %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_no_local_size.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_no_local_size.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O0 -g -o %t1.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O1 -g -o %t2.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O2 -g -o %t3.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O2 -g -o %t4.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %{run} not %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O2 -g -o %t5.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
+// RUN: %{run} not %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/unaligned_shadow_memory.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/unaligned_shadow_memory.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DTEST1 -O0 -g -o %t1.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK1 %s
+// RUN: %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK1 %s
 // RUN: %{build} %device_asan_flags -DTEST2 -O0 -g -o %t2.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK2 %s
+// RUN: %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK2 %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/private/multiple_private.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/private/multiple_private.cpp
@@ -1,16 +1,16 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} -Wno-error=array-bounds %device_asan_flags -DVAR=1 -O2 -g -o %t1
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t1 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR1 %s
+// RUN: %{run} not %t1 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR1 %s
 // RUN: %{build} -Wno-error=array-bounds %device_asan_flags -DVAR=2 -O2 -g -o %t2
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t2 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR2 %s
+// RUN: %{run} not %t2 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR2 %s
 // RUN: %{build} %device_asan_flags -DVAR=3 -O2 -g -o %t3
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t3 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR3 %s
+// RUN: %{run} not %t3 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR3 %s
 // RUN: %{build} %device_asan_flags -DVAR=4 -O2 -g -o %t4
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t4 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR4 %s
+// RUN: %{run} not %t4 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR4 %s
 // RUN: %{build} %device_asan_flags -DVAR=5 -O2 -g -o %t5
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t5 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR5 %s
+// RUN: %{run} not %t5 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR5 %s
 // RUN: %{build} %device_asan_flags -DVAR=6 -O2 -g -o %t6
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t6 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR6 %s
+// RUN: %{run} not %t6 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR6 %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/private/single_private.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/private/single_private.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>


### PR DESCRIPTION
Also remove the documentation for same.

Since the PI port this env var no longer does anything.