### PR TITLE
[CI][CTS] Turn on `test_multi_ptr`

### DIFF
--- a/devops/cts_exclude_filter_L0_GPU
+++ b/devops/cts_exclude_filter_L0_GPU
@@ -1,2 +1,0 @@
-# CMPLRLLVM-61839
-multi_ptr

--- a/devops/cts_exclude_filter_OCL_CPU
+++ b/devops/cts_exclude_filter_OCL_CPU
@@ -2,5 +2,3 @@
 math_builtin_api
 # https://github.com/intel/llvm/issues/13574
 hierarchical
-# CMPLRLLVM-61839
-multi_ptr


### PR DESCRIPTION
After https://github.com/intel/llvm/pull/15389 and https://github.com/KhronosGroup/SYCL-CTS/pull/935 got merged, these CTS tests can be reenabled.