### PR TITLE
[SYCL][RTC] Preliminary support for ESIMD kernels

### DIFF
--- a/sycl-jit/common/include/Kernel.h
+++ b/sycl-jit/common/include/Kernel.h
@@ -403,6 +403,10 @@ struct RTCBundleInfo {
   RTCBundleBinaryInfo BinaryInfo;
   FrozenSymbolTable SymbolTable;
   FrozenPropertyRegistry Properties;
+
+  RTCBundleInfo() = default;
+  RTCBundleInfo(RTCBundleInfo &&) = default;
+  RTCBundleInfo &operator=(RTCBundleInfo &&) = default;
 };
 
 } // namespace jit_compiler

--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -8,6 +8,7 @@ add_llvm_library(sycl-jit
    lib/fusion/JITContext.cpp
    lib/fusion/ModuleHelper.cpp
    lib/rtc/DeviceCompilation.cpp
+   lib/rtc/ESIMD.cpp
    lib/helper/ConfigHelper.cpp
 
    SHARED
@@ -32,6 +33,7 @@ add_llvm_library(sycl-jit
    TargetParser
    MC
    SYCLLowerIR
+   GenXIntrinsics
    ${LLVM_TARGETS_TO_BUILD}
 
    LINK_LIBS

--- a/sycl-jit/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-jit/jit-compiler/lib/KernelFusion.cpp
@@ -258,12 +258,13 @@ compileSYCL(InMemoryFile SourceFile, View<InMemoryFile> IncludeFiles,
     return errorTo<RTCResult>(std::move(Error), "Device linking failed");
   }
 
-  auto BundleInfoOrError = performPostLink(*Module, UserArgList);
-  if (!BundleInfoOrError) {
-    return errorTo<RTCResult>(BundleInfoOrError.takeError(),
+  auto PostLinkResultOrError = performPostLink(std::move(Module), UserArgList);
+  if (!PostLinkResultOrError) {
+    return errorTo<RTCResult>(PostLinkResultOrError.takeError(),
                               "Post-link phase failed");
   }
-  auto BundleInfo = std::move(*BundleInfoOrError);
+  RTCBundleInfo BundleInfo;
+  std::tie(BundleInfo, Module) = std::move(*PostLinkResultOrError);
 
   auto BinaryInfoOrError =
       translation::KernelTranslator::translateBundleToSPIRV(

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -451,7 +451,9 @@ llvm::Expected<PostLinkResult> jit_compiler::performPostLink(
   MDesc = std::move(ESIMDSplits.front());
 
   if (MDesc.isESIMD()) {
-    // TODO: We're assuming ESIMD lowering is not deactivated (why would it?).
+    // `sycl-post-link` has a `-lower-esimd` option, but there's no clang driver
+    // option to influence it. Rather, the driver sets it unconditionally in the
+    // multi-file output mode, which we are mimicking here.
     lowerEsimdConstructs(MDesc, PerformOpts);
   }
 

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.h
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.h
@@ -27,8 +27,9 @@ compileDeviceCode(InMemoryFile SourceFile, View<InMemoryFile> IncludeFiles,
 llvm::Error linkDeviceLibraries(llvm::Module &Module,
                                 const llvm::opt::InputArgList &UserArgList);
 
-llvm::Expected<RTCBundleInfo>
-performPostLink(llvm::Module &Module,
+using PostLinkResult = std::pair<RTCBundleInfo, std::unique_ptr<llvm::Module>>;
+llvm::Expected<PostLinkResult>
+performPostLink(std::unique_ptr<llvm::Module> Module,
                 const llvm::opt::InputArgList &UserArgList);
 
 llvm::Expected<llvm::opt::InputArgList>

--- a/sycl-jit/jit-compiler/lib/rtc/ESIMD.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/ESIMD.cpp
@@ -1,0 +1,77 @@
+//===------------- ESIMD.cpp - Driver for ESIMD lowering ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ESIMD.h"
+
+#include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/Analysis/LoopAnalysisManager.h"
+#include "llvm/GenXIntrinsics/GenXSPIRVWriterAdaptor.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/SYCLLowerIR/ESIMD/LowerESIMD.h"
+#include "llvm/Transforms/InstCombine/InstCombine.h"
+#include "llvm/Transforms/Scalar/DCE.h"
+#include "llvm/Transforms/Scalar/EarlyCSE.h"
+#include "llvm/Transforms/Scalar/SROA.h"
+
+using namespace llvm;
+
+using string_vector = std::vector<std::string>;
+
+// When ESIMD code was separated from the regular SYCL code,
+// we can safely process ESIMD part.
+void jit_compiler::lowerEsimdConstructs(module_split::ModuleDesc &MD,
+                                        bool PerformOpts) {
+  LoopAnalysisManager LAM;
+  CGSCCAnalysisManager CGAM;
+  FunctionAnalysisManager FAM;
+  ModuleAnalysisManager MAM;
+
+  PassBuilder PB;
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+  ModulePassManager MPM;
+  MPM.addPass(SYCLLowerESIMDPass(/*ModuleContainsScalar=*/false));
+
+  if (PerformOpts) {
+    FunctionPassManager FPM;
+    FPM.addPass(SROAPass(SROAOptions::ModifyCFG));
+    MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
+  }
+  MPM.addPass(ESIMDOptimizeVecArgCallConvPass{});
+  FunctionPassManager MainFPM;
+  MainFPM.addPass(ESIMDLowerLoadStorePass{});
+
+  if (!PerformOpts) {
+    MainFPM.addPass(SROAPass(SROAOptions::ModifyCFG));
+    MainFPM.addPass(EarlyCSEPass(true));
+    MainFPM.addPass(InstCombinePass{});
+    MainFPM.addPass(DCEPass{});
+    // TODO: maybe remove some passes below that don't affect code quality
+    MainFPM.addPass(SROAPass(SROAOptions::ModifyCFG));
+    MainFPM.addPass(EarlyCSEPass(true));
+    MainFPM.addPass(InstCombinePass{});
+    MainFPM.addPass(DCEPass{});
+  }
+  MPM.addPass(ESIMDLowerSLMReservationCalls{});
+  MPM.addPass(createModuleToFunctionPassAdaptor(std::move(MainFPM)));
+  MPM.addPass(GenXSPIRVWriterAdaptor(/*RewriteTypes=*/true,
+                                     /*RewriteSingleElementVectorsIn*/ false));
+  // GenXSPIRVWriterAdaptor pass replaced some functions with "rewritten"
+  // versions so the entry point table must be rebuilt.
+  // TODO Change entry point search to analysis?
+  std::vector<std::string> Names;
+  MD.saveEntryPointNames(Names);
+  MPM.run(MD.getModule(), MAM);
+  MD.rebuildEntryPoints(Names);
+}

--- a/sycl-jit/jit-compiler/lib/rtc/ESIMD.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/ESIMD.cpp
@@ -52,7 +52,7 @@ void jit_compiler::lowerEsimdConstructs(module_split::ModuleDesc &MD,
   FunctionPassManager MainFPM;
   MainFPM.addPass(ESIMDLowerLoadStorePass{});
 
-  if (!PerformOpts) {
+  if (PerformOpts) {
     MainFPM.addPass(SROAPass(SROAOptions::ModifyCFG));
     MainFPM.addPass(EarlyCSEPass(true));
     MainFPM.addPass(InstCombinePass{});

--- a/sycl-jit/jit-compiler/lib/rtc/ESIMD.h
+++ b/sycl-jit/jit-compiler/lib/rtc/ESIMD.h
@@ -1,0 +1,23 @@
+//===-------------- ESIMD.h - Driver for ESIMD lowering -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_JIT_COMPILER_RTC_ESIMD_H
+#define SYCL_JIT_COMPILER_RTC_ESIMD_H
+
+#include "llvm/SYCLLowerIR/ModuleSplitter.h"
+
+namespace jit_compiler {
+
+// Runs a pass pipeline to lower ESIMD constructs on the given split model,
+// which may only contain ESIMD entrypoints. This is a copy of the similar
+// function in `sycl-post-link`.
+void lowerEsimdConstructs(llvm::module_split::ModuleDesc &MD, bool PerformOpts);
+
+} // namespace jit_compiler
+
+#endif // SYCL_JIT_COMPILER_RTC_ESIMD_H

--- a/sycl-jit/jit-compiler/lib/rtc/ESIMD.h
+++ b/sycl-jit/jit-compiler/lib/rtc/ESIMD.h
@@ -14,7 +14,7 @@
 namespace jit_compiler {
 
 // Runs a pass pipeline to lower ESIMD constructs on the given split model,
-// which may only contain ESIMD entrypoints. This is a copy of the similar
+// which must only contain ESIMD entrypoints. This is a copy of the similar
 // function in `sycl-post-link`.
 void lowerEsimdConstructs(llvm::module_split::ModuleDesc &MD, bool PerformOpts);
 

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit.cpp
@@ -241,13 +241,19 @@ int test_esimd() {
   sycl::context ctx = q.get_context();
 
   if (!q.get_device().has(sycl::aspect::ext_intel_esimd)) {
-    std::cout << "Device does not support ESIMD" << std::endl;
-    return -1;
+    std::cout << "Device '"
+              << q.get_device().get_info<sycl::info::device::name>()
+              << "' does not support ESIMD, skipping test." << std::endl;
+    return 0;
   }
 
   bool ok =
       q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl_jit);
   if (!ok) {
+    std::cout << "Apparently this device does not support `sycl_jit` source "
+                 "kernel bundle extension: "
+              << q.get_device().get_info<sycl::info::device::name>()
+              << std::endl;
     return -1;
   }
 


### PR DESCRIPTION
Adds support for compiling source strings that contain ESIMD kernels *only*, hence require no device splitting. I'm using a simplified version of the driver logic in `sycl-post-link`. The pass pipeline construction helper `lowerEsimdConstructs` is also copied from `sycl-post-link`.