### PR TITLE
[SYCL] Fix return type of initialization value extraction

### DIFF
--- a/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
@@ -83,7 +83,7 @@ protected:
 
 #ifndef __SYCL_DEVICE_ONLY__
   template <typename OtherT, typename OtherProps>
-  static constexpr const T &
+  static constexpr const OtherT &
   ExtractInitialVal(const device_global_base<OtherT, OtherProps> &Other) {
     if constexpr (OtherProps::template has_property<device_image_scope_key>())
       return Other.val;


### PR DESCRIPTION
This commit fixes an issue where the function extracting the initial value of a device_global would return it as a reference to a different type, which in turn could cause some unexpected behavior.