### PR TITLE
[SYCL] Remove deprecated getPointerTo

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1577,7 +1577,7 @@ static void translateESIMDIntrinsicCall(CallInst &CI) {
     NewInst = Builder.CreateStore(
         NewCI,
         Builder.CreateBitCast(CastInstruction->getPointerOperand(),
-                              llvm::PointerType::getUnqual(CI.getContext())));
+                              llvm::PointerType::getUnqual(NewCI->getContext())));
   } else {
     NewInst = addCastInstIfNeeded(&CI, NewCI);
   }

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1575,9 +1575,9 @@ static void translateESIMDIntrinsicCall(CallInst &CI) {
     IRBuilder<> Builder(&CI);
 
     NewInst = Builder.CreateStore(
-        NewCI,
-        Builder.CreateBitCast(CastInstruction->getPointerOperand(),
-                              llvm::PointerType::getUnqual(NewCI->getContext())));
+        NewCI, Builder.CreateBitCast(
+                   CastInstruction->getPointerOperand(),
+                   llvm::PointerType::getUnqual(NewCI->getContext())));
   } else {
     NewInst = addCastInstIfNeeded(&CI, NewCI);
   }

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1575,8 +1575,9 @@ static void translateESIMDIntrinsicCall(CallInst &CI) {
     IRBuilder<> Builder(&CI);
 
     NewInst = Builder.CreateStore(
-        NewCI, Builder.CreateBitCast(CastInstruction->getPointerOperand(),
-                                     NewCI->getType()->getPointerTo()));
+        NewCI,
+        Builder.CreateBitCast(CastInstruction->getPointerOperand(),
+                              llvm::PointerType::getUnqual(CI.getContext())));
   } else {
     NewInst = addCastInstIfNeeded(&CI, NewCI);
   }


### PR DESCRIPTION
CMPLRLLVM-63532

Deprecated getPointerTo() got replaced with llvm::PointerType::get(LLVMContext)

