### PR TITLE
CMPLRLLVM-63534: Remove usage of deprecated getPointerTo [Offload]

### DIFF
--- a/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
+++ b/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
@@ -358,7 +358,7 @@ struct Wrapper {
   std::pair<Constant *, Constant *>
   addStructArrayToModule(ArrayRef<Constant *> ArrayData, Type *ElemTy) {
     if (ArrayData.empty()) {
-      auto *PtrTy = ElemTy->getPointerTo();
+      auto *PtrTy = llvm::PointerType::getUnqual(ElemTy->getContext());
       auto *NullPtr = Constant::getNullValue(PtrTy);
       return std::make_pair(NullPtr, NullPtr);
     }


### PR DESCRIPTION
Deprecated getPointerTo() got replaced with llvm::PointerType::get(LLVMContext)

_I did not apply the formatting changes. They were not present in the staged changes when I committed or pushed the branch_ 