### PR TITLE
[SYCL] Don't emit @__cxa_pure_virtual into device code

### DIFF
--- a/clang/lib/CodeGen/CGVTables.cpp
+++ b/clang/lib/CodeGen/CGVTables.cpp
@@ -831,9 +831,16 @@ void CodeGenVTables::addVTableComponent(ConstantArrayBuilder &builder,
 
     // Pure virtual member functions.
     if (cast<CXXMethodDecl>(GD.getDecl())->isPureVirtual()) {
-      if (!PureVirtualFn)
-        PureVirtualFn =
-            getSpecialVirtualFn(CGM.getCXXABI().GetPureVirtualCallName());
+      if (!PureVirtualFn) {
+        // There is no guarantee that special function for handling pure virtual
+        // calls will be provided by a SYCL backend compiler and therefore we
+        // simply emit nullptr here.
+        if (CGM.getLangOpts().SYCLIsDevice)
+          PureVirtualFn = llvm::ConstantPointerNull::get(CGM.GlobalsInt8PtrTy);
+        else
+          PureVirtualFn =
+              getSpecialVirtualFn(CGM.getCXXABI().GetPureVirtualCallName());
+      }
       fnPtr = PureVirtualFn;
 
     // Deleted virtual member functions.

--- a/clang/test/CodeGenSYCL/dont-emit-cxx-pure-virtual.cpp
+++ b/clang/test/CodeGenSYCL/dont-emit-cxx-pure-virtual.cpp
@@ -1,0 +1,40 @@
+// There ios no guarantee that special symbol @__cxa_pure_virtual is suppored
+// by SYCL backend compiler, so we need to make sure that we don't emit it
+// during SYCL device compilation.
+//
+// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+//
+// CHECK-NOT: @__cxa_pure_virtual
+
+SYCL_EXTERNAL bool rand();
+
+class Base {
+public:
+  [[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "a")]]
+  virtual void display() {}
+
+  virtual void pure_host() = 0;
+
+  [[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "a")]]
+  virtual void pure_device() = 0;
+};
+
+class Derived1 : public Base {
+public:
+  [[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "a")]]
+  void display() override {}
+
+  void pure_host() override {}
+
+  [[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "a")]]
+  void pure_device() override {}
+};
+
+SYCL_EXTERNAL void test() {
+  Derived1 d1;
+  Base *b = nullptr;
+  if (rand())
+    b = &d1;
+  b->display();
+}
+

--- a/clang/test/CodeGenSYCL/dont-emit-cxx-pure-virtual.cpp
+++ b/clang/test/CodeGenSYCL/dont-emit-cxx-pure-virtual.cpp
@@ -1,4 +1,4 @@
-// There ios no guarantee that special symbol @__cxa_pure_virtual is suppored
+// There is no guarantee that special symbol @__cxa_pure_virtual is supported
 // by SYCL backend compiler, so we need to make sure that we don't emit it
 // during SYCL device compilation.
 //


### PR DESCRIPTION
This special symbol is used to handling calls to pure virtual functions in regular C++ program. However, for SYCL device code we do not have a guarantee that this symbol will be provided by SYCL backend compilers.

Considering that pure virtual function call is an undefined behavior anyway, this PR replaces `@__cxa_pure_virtual` uses with `null` during SYCL device compilation to avoid issues with unresolved symbols.