### PR TITLE
[Driver][SYCL] Allow for intel_gpu_pvc to pull in the native bfloat lib

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -324,6 +324,17 @@ static bool selectBfloatLibs(const llvm::Triple &Triple, const Compilation &C,
       }
     }
 
+    UseNative = false;
+
+    // Check for intel_gpu_pvc as the target
+    if (Arg *SYCLTarget = Args.getLastArg(options::OPT_fsycl_targets_EQ)) {
+      if (SYCLTarget->getValues().size() == 1) {
+        StringRef SYCLTargetStr = SYCLTarget->getValue();
+        if (SYCLTargetStr == "intel_gpu_pvc")
+          UseNative = true;
+      }
+    }
+
     auto checkBF = [](StringRef Device) {
       return Device.starts_with("pvc") || Device.starts_with("ats");
     };
@@ -334,8 +345,7 @@ static bool selectBfloatLibs(const llvm::Triple &Triple, const Compilation &C,
       Params += Arg;
     }
     size_t DevicesPos = Params.find("-device ");
-    UseNative = false;
-    if (DevicesPos != std::string::npos) {
+    if (!UseNative && DevicesPos != std::string::npos) {
       UseNative = true;
       std::istringstream Devices(Params.substr(DevicesPos + 8));
       for (std::string S; std::getline(Devices, S, ',');)

--- a/clang/test/Driver/sycl-device-lib-bfloat16.cpp
+++ b/clang/test/Driver/sycl-device-lib-bfloat16.cpp
@@ -18,6 +18,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend \
 // RUN:   "-device pvc" %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=BFLOAT16-NATIVE
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_pvc %s \
+// RUN:   --sysroot=%S/Inputs/SYCL -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=BFLOAT16-NATIVE
 
 // Test that unless all targets support bfloat16, AOT compilation uses the
 // fallback library.


### PR DESCRIPTION
When using -fsycl-targets=spir64_gen -Xsycl-target-backend "-device pvc" the driver will pull in the native bfloat16 device library.  This was not occurring when using -fsycl-targets=intel_gpu_pvc