### PR TITLE
[SYCL][RTC] Fix warning caused by default case

### DIFF
--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -205,12 +205,8 @@ public:
         return "ERROR";
       case llvm::DiagnosticSeverity::DS_Warning:
         return "WARNING";
-      case llvm::DiagnosticSeverity::DS_Note:
-        return "NOTE:";
-      case llvm::DiagnosticSeverity::DS_Remark:
-        return "REMARK:";
       default:
-        llvm_unreachable("Unhandled case");
+        return "NOTE:";
       }
     }(DI.getSeverity());
     LogPrinter << Prefix;

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -202,9 +202,9 @@ public:
     auto Prefix = [](DiagnosticSeverity Severity) -> llvm::StringLiteral {
       switch (Severity) {
       case llvm::DiagnosticSeverity::DS_Error:
-        return "ERROR";
+        return "ERROR:";
       case llvm::DiagnosticSeverity::DS_Warning:
-        return "WARNING";
+        return "WARNING:";
       default:
         return "NOTE:";
       }


### PR DESCRIPTION
Fix warning resulting from default case covering other cases, causing post-commit to fail.