### PR TITLE
[SYCL][libclc] Fix cross builds

### DIFF
--- a/clang/tools/clang-offload-bundler/CMakeLists.txt
+++ b/clang/tools/clang-offload-bundler/CMakeLists.txt
@@ -18,6 +18,9 @@ add_clang_tool(clang-offload-bundler
   intrinsics_gen
   )
 
+setup_host_tool(clang-offload-bundler CLANG_OFFLOAD_BUNDLER
+  clang-offload-bundler_exe clang-offload-bundler_target)
+
 set(CLANG_OFFLOAD_BUNDLER_LIB_DEPS
   clangBasic
   clangDriver

--- a/clang/tools/clang-offload-packager/CMakeLists.txt
+++ b/clang/tools/clang-offload-packager/CMakeLists.txt
@@ -12,6 +12,9 @@ add_clang_tool(clang-offload-packager
   ${tablegen_deps}
   )
 
+setup_host_tool(clang-offload-packager CLANG_OFFLOAD_PACKAGER_EXE
+  clang-offload-packager_exe clang-offload-packager_target)
+
 clang_target_link_libraries(clang-offload-packager
   PRIVATE
   clangBasic

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -69,7 +69,7 @@ if( LIBCLC_STANDALONE_BUILD OR CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DI
 
   # Import required tools
   if( NOT EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
-    foreach( tool IN ITEMS clang llvm-as llvm-link opt )
+    foreach( tool IN ITEMS clang llvm-as llvm-link llvm-spirv opt )
       find_program( LLVM_TOOL_${tool} ${tool} PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )
       set( ${tool}_exe ${LLVM_TOOL_${tool}} )
       set( ${tool}_target )
@@ -92,6 +92,7 @@ else()
     get_host_tool_path( clang CLANG clang_exe clang_target )
     get_host_tool_path( llvm-as LLVM_AS llvm-as_exe llvm-as_target )
     get_host_tool_path( llvm-link LLVM_LINK llvm-link_exe llvm-link_target )
+    get_host_tool_path( llvm-spirv LLVM_SPIRV llvm-spirv_exe llvm-spirv_target )
     get_host_tool_path( opt OPT opt_exe opt_target )
   endif()
 endif()
@@ -113,13 +114,15 @@ if( EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
 
   # If we've requested a custom binary directory, there are some otherwise
   # optional tools which we want to ensure are present.
-  if( NOT TARGET libclc::llvm-spirv OR NOT TARGET libclc::libclc-remangler )
-    message( FATAL_ERROR "libclc toolchain incomplete!" )
-  endif()
+  foreach( tool IN ITEMS llvm-spirv libclc-remangler )
+    if( NOT EXISTS "${${tool}_exe}" AND "${${tool}_target}" STREQUAL "" )
+      message( FATAL_ERROR "libclc toolchain incomplete!" )
+    endif()
+  endforeach()
 endif()
 
 foreach( tool IN ITEMS clang opt llvm-as llvm-link )
-  if( NOT EXISTS "${${tool}_exe}" AND "${tool}_target" STREQUAL "" )
+  if( NOT EXISTS "${${tool}_exe}" AND "${${tool}_target}" STREQUAL "" )
     message( FATAL_ERROR "libclc toolchain incomplete - missing tool ${tool}!" )
   endif()
 endforeach()

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -456,13 +456,13 @@ function(add_libclc_builtin_set)
             "${LIBCLC_LIBRARY_OUTPUT_INTDIR}/remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}" )
         add_custom_command( OUTPUT "${builtins_remangle_path}"
           COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBCLC_LIBRARY_OUTPUT_INTDIR}
-          COMMAND libclc::libclc-remangler
+          COMMAND ${libclc-remangler_exe}
           -o "${builtins_remangle_path}"
           --long-width=${long_width}
           --char-signedness=${signedness}
           --input-ir=${builtins_lib}
           ${dummy_in}
-          DEPENDS ${builtins_lib} libclc::libclc-remangler ${dummy_in})
+          DEPENDS ${builtins_lib} ${libclc-remangler_target} ${dummy_in})
         add_custom_target( "remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}" ALL
           DEPENDS "${builtins_remangle_path}" "${dummy_in}")
         set_target_properties("remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}"
@@ -489,12 +489,12 @@ function(add_libclc_builtin_set)
       math(EXPR libclc-remangler-test-no "${libclc-remangler-test-no}+1")
       set(current-test "libclc-remangler-test-${obj_suffix}-${libclc-remangler-test-no}")
       add_custom_target(${current-test}
-        COMMAND libclc::libclc-remangler
+        COMMAND ${libclc-remangler_exe}
         --long-width=l32
         --char-signedness=signed
         --input-ir=${target-ir}
         ${dummy_in} -t -o -
-        DEPENDS ${builtins_lib} "${dummy_in}" libclc::libclc-remangler)
+        DEPENDS ${builtins_lib} "${dummy_in}" ${libclc-remangler_target})
       list(APPEND libclc-remangler-tests ${current-test})
     endforeach()
   endif()

--- a/libclc/utils/libclc-remangler/CMakeLists.txt
+++ b/libclc/utils/libclc-remangler/CMakeLists.txt
@@ -11,6 +11,9 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_tool(libclc-remangler LibclcRemangler.cpp)
 
+setup_host_tool( libclc-remangler LIBCLC_REMANGLER
+  libclc-remangler_exe libclc-remangler_target )
+
 target_include_directories(libclc-remangler PRIVATE
   ${CMAKE_SOURCE_DIR}/../clang/include
   ${CMAKE_BINARY_DIR}/tools/clang/include)
@@ -24,9 +27,3 @@ clang_target_link_libraries(libclc-remangler
   clangSerialization
   LLVMOption
   )
-
-# If we've not already imported a libclc-remangler tool from an external build,
-# set it up now.
-if(NOT TARGET libclc::libclc-remangler)
-  add_executable(libclc::libclc-remangler ALIAS libclc-remangler)
-endif()

--- a/libdevice/CMakeLists.txt
+++ b/libdevice/CMakeLists.txt
@@ -19,6 +19,25 @@ else()
                    will not build libdevice sanitizer")
 endif()
 
+if(NOT EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR})
+  get_host_tool_path(clang CLANG clang_exe clang_target)
+  get_host_tool_path(llvm-ar LLVM_AR llvm-ar_exe llvm-ar_target)
+  get_host_tool_path(append-file APPEND_FILE append-file_exe append-file_target)
+  get_host_tool_path(clang-offload-bundler CLANG_OFFLOAD_BUNDLER clang-offload-bundler_exe clang-offload-bundler_target)
+  get_host_tool_path(clang-offload-packager CLANG_OFFLOAD_PACKAGER clang-offload-packager_exe clang-offload-packager_target)
+  get_host_tool_path(file-table-tform FILE_TABLE_TFORM file-table-tform_exe file-table-tform_target)
+  get_host_tool_path(llvm-foreach LLVM_FOREACH llvm-foreach_exe llvm-foreach_target)
+  get_host_tool_path(llvm-spirv LLVM_SPIRV llvm-spirv_exe llvm-spirv_target)
+  get_host_tool_path(sycl-post-link SYCL_POST_LINK sycl-post-link_exe sycl-post-link_target)
+else()
+  foreach(tool IN ITEMS clang llvm-ar append-file clang-offload-bundler clang-offload-packager file-table-tform llvm-foreach llvm-spirv sycl-post-link)
+    find_program(LLVM_CUSTOM_TOOL_${tool} ${tool}
+      PATHS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
+    set(${tool}_exe ${LLVM_CUSTOM_TOOL_${tool}})
+    set(${tool}_target)
+  endforeach()
+endif()
+
 # Build libdevice for SYCL.
 include(SYCLLibdevice)
 

--- a/llvm/tools/append-file/CMakeLists.txt
+++ b/llvm/tools/append-file/CMakeLists.txt
@@ -9,3 +9,5 @@ add_llvm_tool(append-file
   DEPENDS
   intrinsics_gen
   )
+
+setup_host_tool(append-file APPEND_FILE append_file_exe append_file_target)

--- a/llvm/tools/file-table-tform/CMakeLists.txt
+++ b/llvm/tools/file-table-tform/CMakeLists.txt
@@ -5,3 +5,5 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_tool(file-table-tform
   file-table-tform.cpp
   )
+
+setup_host_tool(file-table-tform FILE_TABLE_TFORM file-table-tform_exe file-table-tform_target)

--- a/llvm/tools/llvm-ar/CMakeLists.txt
+++ b/llvm/tools/llvm-ar/CMakeLists.txt
@@ -19,6 +19,8 @@ add_llvm_tool(llvm-ar
   GENERATE_DRIVER
   )
 
+setup_host_tool(llvm-ar LLVM_AR llvm_ar_exe llvm_ar_target)
+
 add_llvm_tool_symlink(llvm-ranlib llvm-ar)
 add_llvm_tool_symlink(llvm-lib llvm-ar)
 add_llvm_tool_symlink(llvm-dlltool llvm-ar)

--- a/llvm/tools/llvm-foreach/CMakeLists.txt
+++ b/llvm/tools/llvm-foreach/CMakeLists.txt
@@ -5,3 +5,5 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_tool(llvm-foreach
   llvm-foreach.cpp
 )
+
+setup_host_tool(llvm-foreach LLVM_FOREACH llvm-foreach_exe llvm-foreach_target)

--- a/llvm/tools/sycl-post-link/CMakeLists.txt
+++ b/llvm/tools/sycl-post-link/CMakeLists.txt
@@ -33,4 +33,7 @@ add_llvm_tool(sycl-post-link
   LLVMGenXIntrinsics
   )
 
+setup_host_tool(sycl-post-link SYCL_POST_LINK
+  sycl-post-link_exe sycl-post-link_target)
+
 target_link_libraries(sycl-post-link PRIVATE LLVMGenXIntrinsics)


### PR DESCRIPTION
When performing cross builds, we need native versions of various tools, we cannot assume the cross builds that are part of the current build are executable. LLVM provides the setup_host_tool function to handle this, either picking up versions of tools from LLVM_NATIVE_TOOL_DIR, or implicitly building native versions as needed. Use this in more places.

This applies the changes from LLVM #97392 and #97811 and adapts them to DPC++, and makes the same changes in other places that are only needed for DPC++.

Tested with a suitable cross compilation toolchain file:
```console
$ mkdir build
$ cat >build/aarch64-linux.cmake <<EOF
set(CMAKE_SYSTEM_NAME Linux)
set(CMAKE_SYSTEM_PROCESSOR aarch64)

set(CMAKE_C_COMPILER "aarch64-linux-gnu-gcc" CACHE STRING "")
set(CMAKE_CXX_COMPILER "aarch64-linux-gnu-g++" CACHE STRING "")
set(PKG_CONFIG_EXECUTABLE "aarch64-linux-gnu-pkg-config" CACHE STRING "")

set(CMAKE_FIND_ROOT_PATH /usr/aarch64-linux-gnu)
set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
EOF
$ python3 buildbot/configure.py -o build/aarch64-linux    \
  --cmake-opt=--toolchain=$PWD/build/aarch64-linux.cmake  \
  --cmake-opt=-DLLVM_HOST_TRIPLE=aarch64-unknown-linux-gnu
```