### PR TITLE
[CI] Update cts filter after oclcpu update

### DIFF
--- a/devops/cts_exclude_filter_OCL_CPU
+++ b/devops/cts_exclude_filter_OCL_CPU
@@ -1,4 +1,0 @@
-# https://github.com/intel/llvm/issues/13477
-math_builtin_api
-# https://github.com/intel/llvm/issues/13574
-hierarchical


### PR DESCRIPTION
These tests were turned off due to bug in the runtime. Turning on after update.