### PR TITLE
[CI] Add Ubuntu 24.04 base image

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -39,6 +39,10 @@ jobs:
             file: ubuntu2204_base
             tag: latest
             build_args: ""
+          - name: Base Ubuntu 24.04 Docker image
+            file: ubuntu2404_base
+            tag: latest
+            build_args: ""
           - name: Build Ubuntu Docker image
             file: ubuntu2204_build
             tag: latest

--- a/devops/containers/ubuntu2404_base.Dockerfile
+++ b/devops/containers/ubuntu2404_base.Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+USER root
+
+# Install SYCL prerequisites
+COPY scripts/install_build_tools.sh /install.sh
+RUN /install.sh
+
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+# group 109 is required for sycl user to access PVC card.
+RUN groupadd -g 109 render
+RUN usermod -aG render sycl
+
+# Allow sycl user to run as sudo
+RUN echo "sycl  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+COPY actions/cached_checkout /actions/cached_checkout
+COPY actions/cleanup /actions/cleanup
+COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
+COPY scripts/install_drivers.sh /opt/install_drivers.sh
+
+ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -7,7 +7,7 @@ apt update && apt install -yqq \
       ccache \
       git \
       python3 \
-      python3-distutils \
+      python3-psutil \
       python-is-python3 \
       python3-pip \
       zstd \
@@ -25,6 +25,4 @@ apt update && apt install -yqq \
       curl \
       libhwloc-dev \
       libzstd-dev
-
-pip3 install psutil
 

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -36,8 +36,10 @@ identical for Docker and Podman. Choose whatever is available on your system.
 
 The following containers are publicly available for DPC++ compiler development:
 
-- `ghcr.io/intel/llvm/ubuntu2204_base`: contains basic environment setup for
-   building DPC++ compiler from source.
+- `ghcr.io/intel/llvm/ubuntu2204_base`: contains basic Ubuntu 22.04 environment
+   setup for building DPC++ compiler from source.
+- `ghcr.io/intel/llvm/ubuntu2404_base`: contains basic Ubuntu 24.04 environment
+   setup for building DPC++ compiler from source.
 - `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
    base container + pre-installed Intel drivers.
    The image comes in four flavors/tags:


### PR DESCRIPTION
dev-igc requites Ubuntu 24.04 now (because of glibc requirement). I need to update the dev-igc container creation/run to use Ubuntu 24.04, but first I need to add the base image that I can base the dev-igc image on, it can't be done in the same PR.

The changes to the install script are because of changes in 24.04, there should be no net effect.

Some of the Docker CI runs are going to fail here, but they will fail in every PR even without this change because of the new dev-igc requirement, we just need to make sure the new container I added here passes, which it [did](https://github.com/intel/llvm/actions/runs/12145849016/job/33868646520?pr=16250).