### PR TITLE
[SYCL][ESIMD][E2E] Fix ambiguity in device descriptor usages in ESIMD tests

### DIFF
--- a/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba_stateless_64.cpp
@@ -35,7 +35,8 @@ int main(void) {
   queue q;
 
   auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
+            << "\n";
   try {
     q.submit([&](handler &cgh) {
        auto PA = bufa.get_access<access::mode::read_write>(cgh);

--- a/sycl/test-e2e/ESIMD/accessor_gather_scatter_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_gather_scatter_stateless_64.cpp
@@ -30,7 +30,8 @@ int main(void) {
   queue q;
 
   auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
+            << "\n";
   try {
     q.submit([&](handler &cgh) {
        auto PA = bufa.get_access<access::mode::read_write>(cgh);

--- a/sycl/test-e2e/ESIMD/accessor_load_store_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_load_store_stateless_64.cpp
@@ -30,7 +30,8 @@ int main(void) {
   queue q;
 
   auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
+            << "\n";
   try {
     q.submit([&](handler &cgh) {
        auto PA = bufa.get_access<access::mode::read_write>(cgh);

--- a/sycl/test-e2e/ESIMD/accessor_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_stateless_64.cpp
@@ -32,7 +32,8 @@ int main(void) {
     queue q;
 
     auto dev = q.get_device();
-    std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+    std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
+              << "\n";
 
     q.submit([&](handler &cgh) {
        auto PA = bufa.get_access<access::mode::read_write>(cgh);

--- a/sycl/test-e2e/ESIMD/accessor_stateless_ctor_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_stateless_ctor_64.cpp
@@ -32,7 +32,8 @@ int main(void) {
     queue q;
 
     auto dev = q.get_device();
-    std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+    std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
+              << "\n";
 
     q.submit([&](handler &cgh) {
        auto PA = bufa.get_access<access::mode::read_write>(cgh);

--- a/sycl/test-e2e/ESIMD/dpas/dpas_tf32.cpp
+++ b/sycl/test-e2e/ESIMD/dpas/dpas_tf32.cpp
@@ -16,7 +16,8 @@
 int main(int argc, const char *argv[]) {
   queue Q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
   auto Dev = Q.get_device();
-  std::cout << "Running on " << Dev.get_info<info::device::name>() << std::endl;
+  std::cout << "Running on " << Dev.get_info<sycl::info::device::name>()
+            << std::endl;
 
   bool Print = argc > 1 && std::string(argv[1]) == "-debug";
   bool Passed = true;

--- a/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_64.cpp
@@ -31,7 +31,8 @@ int main(void) {
   queue q;
 
   auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
+            << "\n";
   try {
     q.submit([&](handler &cgh) {
        auto PA = bufa.get_access<access::mode::read_write>(cgh);

--- a/sycl/test-e2e/ESIMD/lsc/lsc_gather_scatter_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_gather_scatter_stateless_64.cpp
@@ -31,7 +31,8 @@ int main() {
   queue q;
 
   auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
+            << "\n";
   try {
     q.submit([&](handler &cgh) {
        auto PA = bufa.get_access<access::mode::read_write>(cgh);

--- a/sycl/test-e2e/ESIMD/lsc/lsc_load_store_2d_compare.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_load_store_2d_compare.cpp
@@ -36,7 +36,8 @@ template <typename T> bool test() {
 
   queue q;
   auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
+            << "\n";
   auto *A = malloc_shared<T>(Size, q);
   auto *B = malloc_shared<T>(Size, q);
   auto *C = malloc_shared<T>(Size, q);

--- a/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
+++ b/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
@@ -20,8 +20,8 @@ int main() {
 
   queue Q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
   auto D = Q.get_device();
-  std::cout << "Running on " << D.get_info<info::device::name>()
-            << ", driver=" << D.get_info<info::device::driver_version>()
+  std::cout << "Running on " << D.get_info<sycl::info::device::name>()
+            << ", driver=" << D.get_info<sycl::info::device::driver_version>()
             << std::endl;
 
   constexpr int Size = VL * 2;


### PR DESCRIPTION
Follow-up after https://github.com/intel/llvm/pull/15905
These tests use `using` directive for both `sycl` and `esimd` namespaces and `info` is available in both, so we have to explicitly specify namespace in this case to avoid ambiguity.

Hasn't been noticed before because tests run only on pvc.