### PR TITLE
[CI] Use Ubuntu 24.04 for dev-igc and unstable

### DIFF
--- a/.github/workflows/sycl-containers-igc-dev.yaml
+++ b/.github/workflows/sycl-containers-igc-dev.yaml
@@ -26,9 +26,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Intel Drivers Ubuntu 22.04 Docker image with dev IGC
-            dockerfile: ubuntu2204_intel_drivers_igc_dev
-            imagefile: ubuntu2204_intel_drivers
+          - name: Intel Drivers Ubuntu 24.04 Docker image with dev IGC
+            dockerfile: ubuntu2404_intel_drivers_igc_dev
+            imagefile: ubuntu2404_intel_drivers
             tag: devigc
             build_args: |
                   "use_latest=false"

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -51,8 +51,8 @@ jobs:
             file: ubuntu2204_intel_drivers
             tag: latest
             build_args: "use_latest=false"
-          - name: Intel Drivers (unstable) Ubuntu 22.04 Docker image
-            file: ubuntu2204_intel_drivers
+          - name: Intel Drivers (unstable) Ubuntu 24.04 Docker image
+            file: ubuntu2404_intel_drivers
             tag: unstable
             build_args: "use_latest=true"
           - name: Build + Intel Drivers Ubuntu 22.04 Docker image

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -103,7 +103,7 @@ jobs:
             env: '{"LIT_FILTER":${{ needs.determine_arc_tests.outputs.arc_tests }} }'
           - name: E2E tests with dev igc on Intel Arc A-Series Graphics
             runner: '["Linux", "arc"]'
-            image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:devigc
+            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:devigc
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu
             reset_intel_gpu: true

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -1,21 +1,26 @@
 ARG base_tag=latest
-ARG base_image=ghcr.io/intel/llvm/ubuntu2204_base
+ARG base_image=ghcr.io/intel/llvm/ubuntu2404_base
 
 FROM $base_image:$base_tag
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt install -yqq libllvm14
+ARG use_latest=true
+
+RUN apt update && apt install -yqq wget
 
 COPY scripts/get_release.py /
 COPY scripts/install_drivers.sh /
 COPY dependencies.json /
-COPY dependencies-igc-dev.json /
 
 RUN mkdir /runtimes
 ENV INSTALL_LOCATION=/runtimes
 RUN --mount=type=secret,id=github_token \
-    install_driver_opt="dependencies.json dependencies-igc-dev.json --use-dev-igc"; \
+    if [ "$use_latest" = "true" ]; then \
+      install_driver_opt=" --use-latest"; \
+    else \
+      install_driver_opt=" dependencies.json"; \
+    fi && \
     GITHUB_TOKEN=$(cat /run/secrets/github_token) /install_drivers.sh $install_driver_opt --all
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh

--- a/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
@@ -1,0 +1,24 @@
+ARG base_tag=latest
+ARG base_image=ghcr.io/intel/llvm/ubuntu2404_base
+
+FROM $base_image:$base_tag
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -yqq libllvm14
+
+COPY scripts/get_release.py /
+COPY scripts/install_drivers.sh /
+COPY dependencies.json /
+COPY dependencies-igc-dev.json /
+
+RUN mkdir /runtimes
+ENV INSTALL_LOCATION=/runtimes
+RUN --mount=type=secret,id=github_token \
+    install_driver_opt="dependencies.json dependencies-igc-dev.json --use-dev-igc"; \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) /install_drivers.sh $install_driver_opt --all
+
+COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
+

--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-6ee988a",
-      "version": "6ee988a",
-      "updated_at": "2024-11-26T15:44:10Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2239640503/zip",
+      "github_tag": "igc-dev-3db59df",
+      "version": "3db59df ",
+      "updated_at": "2024-12-03T20:43:00Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2248119261/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }

--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -2,7 +2,7 @@
   "linux": {
     "igc_dev": {
       "github_tag": "igc-dev-3db59df",
-      "version": "3db59df ",
+      "version": "3db59df",
       "updated_at": "2024-12-03T20:43:00Z",
       "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2248119261/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -41,17 +41,20 @@ The following containers are publicly available for DPC++ compiler development:
 - `ghcr.io/intel/llvm/ubuntu2404_base`: contains basic Ubuntu 24.04 environment
    setup for building DPC++ compiler from source.
 - `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
-   base container + pre-installed Intel drivers.
-   The image comes in four flavors/tags:
+   Ubuntu 22.04 base container + pre-installed Intel drivers.
+   The image comes in two flavors/tags:
    * `latest`: Intel drivers are downloaded from release/tag and saved in
     dependencies.json. The drivers are tested/validated everytime we upgrade
     the driver.
+   * `alldeps`: Includes the same Intel drivers as `latest`, as well as the
+   development kits for NVidia/AMD from the `ubuntu2204_build` container.
+- `ghcr.io/intel/llvm/ubuntu2404_intel_drivers`: contains everything from the
+   Ubuntu 24.04 base container + pre-installed Intel drivers.
+   The image comes in two flavors/tags:
    * `devigc`: Intel Graphics Compiler driver from github actions artifacts,
    other drivers are downloaded from release/tag and saved in dependencies.json.
    * `unstable`: Intel drivers are downloaded from release/latest.
    The drivers are installed as it is, not tested or validated.
-   * `alldeps`: Includes the same Intel drivers as `latest`, as well as the
-   development kits for NVidia/AMD from the `ubuntu2204_build` container.
 - `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
    NVidia/AMD and can be used for building DPC++ compiler from source with all
    backends enabled or for end-to-end testing with HIP/CUDA on machines with


### PR DESCRIPTION
dev_igc and unstable need Ubuntu 24.04 now based on the IGC packaging, so move our Dockerfiles and CI to use 24.04 for these.

I needed to manually bump the dev-igc version because the artifacts for the current one are expired so they can't be downloaded anymore so we can't make the Docker image.

The dev-igc CI run is expected to fail here, it always uses the official intel/llvm Docker images, even if the current PR updates them, so we need to wait for this PR to be merged to test it. I'll watch it once we merge.