### PR TITLE
[SYCL][E2E] Expand fp64 emulation testing

### DIFF
--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
@@ -1,3 +1,10 @@
+// -fsycl-fp64-conv-emu is not a language feature, but an implementation
+// feature that is only available for Intel GPUs. In this test we recreate a
+// user-provided scenario of a kernel which only uses double for conversions
+// (the only thing which can be emulated) to make sure that both compilation
+// and execution of such scenario works fine on different HW (w/ and w/o fp64
+// support).
+//
 // REQUIRES: ocloc
 //
 // We require a certain HW here, because we specifically want to exercise AOT

--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: ocloc
+//
 // We require a certain HW here, because we specifically want to exercise AOT
 // compilation and not JIT fallback. However, to make this test run in more
 // environments (and therefore cover more scenarios), the list of HW is bigger

--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
@@ -1,9 +1,15 @@
-// REQUIRES: ocloc, gpu, linux, arch-intel_gpu_dg2_g10
+// We require a certain HW here, because we specifically want to exercise AOT
+// compilation and not JIT fallback. However, to make this test run in more
+// environments (and therefore cover more scenarios), the list of HW is bigger
+// than just a single target.
+//
+// REQUIRES: arch-intel_gpu_dg2_g10 || arch-intel_gpu_dg2_g11 || arch-intel_gpu_dg2_g12 || arch-intel_gpu_pvc || arch-intel_gpu_mtl_h || arch-intel_gpu_mtl_u
+//
 // UNSUPPORTED: cuda, hip
 // UNSUPPORTED-REASON: FP64 emulation is an Intel specific feature.
 
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10 -fsycl-fp64-conv-emu -O0 %s -o %t_opt.out
-// RUN: %{run} %t_opt.out
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10,intel_gpu_dg2_g11,intel_gpu_dg2_g12,intel_gpu_pvc,intel_gpu_mtl_h,intel_gpu_mtl_u -fsycl-fp64-conv-emu -O0 %s -o %t.out
+// RUN: %{run} %t.out
 
 // Tests that aspect::fp64 is not emitted correctly when -fsycl-fp64-conv-emu
 // flag is used.

--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-2.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-2.cpp
@@ -1,3 +1,13 @@
+// -fsycl-fp64-conv-emu is not a language feature, but an implementation
+// feature that is only available for Intel GPUs. In this test we recreate a
+// user-provided scenario where an application has two kinds of kernels: ones
+// which require full fp64 support and ones which can be emulated.
+//
+// The test ensures that the application can be successfully AOT compiled and
+// ran on different HW (w/ and w/o native fp64 support), i.e. it also serves
+// as an integration test for two features: fp64 emulation and optional kernel
+// features AOT.
+//
 // REQUIRES: ocloc
 //
 // We require a certain HW here, because we specifically want to exercise AOT

--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-2.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-2.cpp
@@ -1,8 +1,16 @@
-// REQUIRES: ocloc, linux, arch-intel_gpu_dg2_g10
+// REQUIRES: ocloc
+//
+// We require a certain HW here, because we specifically want to exercise AOT
+// compilation and not JIT fallback. However, to make this test run in more
+// environments (and therefore cover more scenarios), the list of HW is bigger
+// than just a single target.
+//
+// REQUIRES: arch-intel_gpu_dg2_g10 || arch-intel_gpu_dg2_g11 || arch-intel_gpu_dg2_g12 || arch-intel_gpu_pvc || arch-intel_gpu_mtl_h || arch-intel_gpu_mtl_u
+//
 // UNSUPPORTED: cuda, hip
 // UNSUPPORTED-REASON: FP64 emulation is an Intel specific feature.
 
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10 -fsycl-fp64-conv-emu -O0 %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10,intel_gpu_dg2_g11,intel_gpu_dg2_g12,intel_gpu_pvc,intel_gpu_mtl_h,intel_gpu_mtl_u -fsycl-fp64-conv-emu -O0 %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Updated the test to cover more HW so that there is a less change that we will simply skip it.

Note that FP64 emulation is only enabled by default on DG2. Therefore, we include HW which
natively supports `fp64`, but can't include any HW without `fp64` support except for DG2 unless
we tweak the environment to force-enable emulation on those platforms.