### PR TITLE
[SYCL][NFC] Cleanup includes of `context.hpp`

### DIFF
--- a/sycl/include/sycl/detail/backend_traits_cuda.hpp
+++ b/sycl/include/sycl/detail/backend_traits_cuda.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <sycl/context.hpp>
 #include <sycl/detail/backend_traits.hpp>
 #include <sycl/device.hpp>
 #include <sycl/event.hpp>
@@ -35,6 +34,9 @@ typedef unsigned int CUdeviceptr;
 
 namespace sycl {
 inline namespace _V1 {
+
+class context;
+
 namespace detail {
 
 // TODO the interops for context, device, event, platform and program

--- a/sycl/include/sycl/detail/backend_traits_hip.hpp
+++ b/sycl/include/sycl/detail/backend_traits_hip.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <sycl/context.hpp>
 #include <sycl/detail/backend_traits.hpp>
 #include <sycl/device.hpp>
 #include <sycl/event.hpp>
@@ -29,6 +28,9 @@ typedef void *HIPdeviceptr;
 
 namespace sycl {
 inline namespace _V1 {
+
+class context;
+
 namespace detail {
 
 // TODO the interops for context, device, event, platform and program

--- a/sycl/include/sycl/detail/backend_traits_level_zero.hpp
+++ b/sycl/include/sycl/detail/backend_traits_level_zero.hpp
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <sycl/backend_types.hpp>                           // for backend
-#include <sycl/context.hpp>                                 // for context
 #include <sycl/detail/backend_traits.hpp>                   // for BackendI...
 #include <sycl/device.hpp>                                  // for device
 #include <sycl/event.hpp>                                   // for event
@@ -45,6 +44,7 @@ typedef struct _ze_module_handle_t *ze_module_handle_t;
 namespace sycl {
 inline namespace _V1 {
 class queue;
+class context;
 
 namespace detail {
 

--- a/sycl/include/sycl/detail/backend_traits_opencl.hpp
+++ b/sycl/include/sycl/detail/backend_traits_opencl.hpp
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <sycl/backend_types.hpp>         // for backend
-#include <sycl/context.hpp>               // for context
 #include <sycl/detail/backend_traits.hpp> // for BackendInput, BackendReturn
 #include <sycl/detail/cl.h>               // for _cl_event, cl_event, cl_de...
 #include <sycl/detail/ur.hpp>             // for assertion and ur handles
@@ -35,6 +34,7 @@ template <bundle_state State> class kernel_bundle;
 class queue;
 template <typename T, int Dimensions, typename AllocatorT, typename Enable>
 class buffer;
+class context;
 
 namespace detail {
 

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -10,7 +10,6 @@
 
 #include <sycl/access/access.hpp>
 #include <sycl/accessor.hpp>
-#include <sycl/context.hpp>
 #include <sycl/detail/cg_types.hpp>
 #include <sycl/detail/cl.h>
 #include <sycl/detail/common.hpp>
@@ -170,6 +169,7 @@ class kernel_impl;
 class queue_impl;
 class stream_impl;
 class event_impl;
+class context_impl;
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::target AccessTarget, access::placeholder IsPlaceholder>
 class image_accessor;

--- a/sycl/include/sycl/image.hpp
+++ b/sycl/include/sycl/image.hpp
@@ -12,7 +12,6 @@
 #include <sycl/aliases.hpp>                           // for cl_float, cl_half
 #include <sycl/backend_types.hpp>                     // for backend, backe...
 #include <sycl/buffer.hpp>                            // for range
-#include <sycl/context.hpp>                           // for context
 #include <sycl/detail/aligned_allocator.hpp>          // for aligned_allocator
 #include <sycl/detail/backend_traits.hpp>             // for InteropFeature...
 #include <sycl/detail/common.hpp>                     // for convertToArrayOfN
@@ -43,6 +42,7 @@ inline namespace _V1 {
 
 // forward declarations
 class handler;
+class context;
 
 template <int D, typename A> class image;
 

--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <sycl/backend_types.hpp>          // for backend, backend_return_t
-#include <sycl/context.hpp>                // for context
 #include <sycl/detail/export.hpp>          // for __SYCL_EXPORT
 #include <sycl/detail/kernel_desc.hpp>     // for get_spec_constant_symboli...
 #include <sycl/detail/owner_less_base.hpp> // for OwnerLessBase
@@ -46,6 +45,7 @@ template <backend Backend> class backend_traits;
 template <backend Backend, bundle_state State>
 auto get_native(const kernel_bundle<State> &Obj)
     -> backend_return_t<Backend, kernel_bundle<State>>;
+class context;
 
 namespace detail {
 class kernel_id_impl;

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -14,7 +14,6 @@
 #include <sycl/async_handler.hpp>             // for async_handler
 #include <sycl/backend_types.hpp>             // for backend, backe...
 #include <sycl/buffer.hpp>                    // for buffer
-#include <sycl/context.hpp>                   // for context
 #include <sycl/detail/assert_happened.hpp>    // for AssertHappened
 #include <sycl/detail/cg_types.hpp>           // for check_fn_signa...
 #include <sycl/detail/common.hpp>             // for code_location

--- a/sycl/include/sycl/usm.hpp
+++ b/sycl/include/sycl/usm.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <sycl/builtins.hpp>
-#include <sycl/context.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/device.hpp>
@@ -21,6 +20,9 @@
 
 namespace sycl {
 inline namespace _V1 {
+
+class context;
+
 ///
 // Explicit USM
 ///

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -11,6 +11,7 @@
 #include <detail/global_handler.hpp>
 #include <detail/platform_impl.hpp>
 #include <detail/ur.hpp>
+#include <sycl/context.hpp>
 #include <sycl/device.hpp>
 #include <sycl/device_selector.hpp>
 #include <sycl/image.hpp>


### PR DESCRIPTION
Replaced them with forward declarations. Unfortunatly, it isn't enough of a cleanup to actually reduce amount of dependencies of `core.hpp` because of image and buffer properties.