### PR TITLE
[CI] Use clang in precommit and gcc in postcommit for Linux builds

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -45,6 +45,10 @@ jobs:
       build_cache_root: "/__w/"
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
+      # Docker image has last nightly pre-installed and added to the PATH
+      build_image: "ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build"
+      cc: clang
+      cxx: clang++
       changes: ${{ needs.detect_changes.outputs.filters }}
 
   determine_arc_tests:

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -35,11 +35,7 @@ jobs:
       build_cache_root: "/__w/llvm"
       build_cache_suffix: default
       build_artifact_suffix: default
-      build_configure_extra_args: --no-assertions --hip --cuda --native_cpu --cmake-opt="-DSYCL_ENABLE_STACK_PRINTING=ON" --cmake-opt="-DSYCL_LIB_WITH_DEBUG_SYMBOL=ON"
-      # Docker image has last nightly pre-installed and added to the PATH
-      build_image: "ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build"
-      cc: clang
-      cxx: clang++
+      build_configure_extra_args: --no-assertions --hip --cuda --native_cpu --cmake-opt="-DSYCL_ENABLE_STACK_PRINTING=ON" --cmake-opt="-DSYCL_LIB_WITH_DEBUG_SYMBOL=ON"      
       merge_ref: ''
 
   e2e-lin:


### PR DESCRIPTION
`clang` seems to produce more warnings which causes build failures with `-werror` which is enabled by default in CI, so use `clang` in precommit to catch those issues before merging.