### PR TITLE
[SYCL] Prefer `_WIN32` over `WIN32` in `#if` expressions

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -69,7 +69,7 @@ protected:
 #ifdef __SYCL_PIPES_CPP
 // Magic combination found by trial and error:
 __SYCL_EXPORT
-#ifdef WIN32
+#if _WIN32
 inline
 #endif
 #else

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -388,7 +388,7 @@ protected:
 #ifdef __SYCL_GRAPH_IMPL_CPP
 // Magic combination found by trial and error:
 __SYCL_EXPORT
-#if WIN32
+#if _WIN32
 inline
 #endif
 #else


### PR DESCRIPTION
The former is defined by the toolchain while the latter is part of SDK, so using `_WIN32` is preferrable. The issue was exposed downstream due to recent changes from https://github.com/intel/llvm/pull/16178 and https://github.com/intel/llvm/pull/16194.