### PR TITLE
[CI] Fix igc-dev Docker container and bump version

### DIFF
--- a/.github/workflows/sycl-containers-igc-dev.yaml
+++ b/.github/workflows/sycl-containers-igc-dev.yaml
@@ -6,11 +6,13 @@ on:
       - sycl
     paths:
       - 'devops/actions/build_container/**'
+      - 'devops/scripts/**'
       - 'devops/dependencies-igc-dev.json'
       - '.github/workflows/sycl-containers-igc-dev.yaml'
   pull_request:
     paths:
       - 'devops/actions/build_container/**'
+      - 'devops/scripts/**'
       - 'devops/dependencies-igc-dev.json'
       - '.github/workflows/sycl-containers-igc-dev.yaml'
 

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -134,7 +134,8 @@ jobs:
       install_dev_igc_driver: >-
         ${{ !contains(matrix.target_devices, 'ext_oneapi_cuda') &&
         !contains(matrix.target_devices, 'ext_oneapi_hip') &&
-        matrix.use_igc_dev && contains(needs.detect_changes.outputs.filters, 'devigccfg') ||
+        matrix.use_igc_dev &&
+        (contains(needs.detect_changes.outputs.filters, 'devigccfg') || contains(needs.detect_changes.outputs.filters, 'drivers')) ||
         'false' }}
       # Run only if the PR does not have the 'ci-no-devigc' label.
       skip_run: ${{matrix.use_igc_dev && contains(github.event.pull_request.labels.*.name, 'ci-no-devigc') || 'false'}}

--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-3db59df",
-      "version": "3db59df",
-      "updated_at": "2024-12-03T20:43:00Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2248119261/zip",
+      "github_tag": "igc-dev-e0d826a",
+      "version": "e0d826a",
+      "updated_at": "2024-12-17T21:18:30Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2327583926/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }

--- a/devops/scripts/install_drivers.sh
+++ b/devops/scripts/install_drivers.sh
@@ -162,6 +162,9 @@ InstallIGFX () {
     echo "Install libopencl-clang"
     # Workaround only, will download deb and install with dpkg once fixed.
     cp -d libopencl-clang.so.14*  /usr/local/lib/
+    rm /usr/local/lib/libigc.so /usr/local/lib/libigc.so.1* && \
+       ln -s /usr/local/lib/libigc.so.2 /usr/local/lib/libigc.so && \
+       ln -s /usr/local/lib/libigc.so.2 /usr/local/lib/libigc.so.1
     echo "Clean up"
     rm *.deb libopencl-clang.so.14*
     echo "$IGC_DEV_TAG" > /usr/local/lib/igc/IGCTAG.txt

--- a/sycl/test-e2e/ESIMD/PerformanceTests/invoke_simd_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/invoke_simd_smoke.cpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// XFAIL: igc-dev
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16388
 // REQUIRES: gpu-intel-dg2 && level_zero
 // UNSUPPORTED: windows
 

--- a/sycl/test-e2e/ESIMD/PerformanceTests/matrix_transpose.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/matrix_transpose.cpp
@@ -5,8 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// XFAIL: igc-dev
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16088
 // REQUIRES: gpu-intel-dg2 && level_zero
 // UNSUPPORTED: windows
 

--- a/sycl/test-e2e/ESIMD/accessor_local.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_local.cpp
@@ -1,4 +1,6 @@
 // REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
+// XFAIL: igc-dev
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16388
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // This test verifies usage of local_accessor methods operator[]

--- a/sycl/test-e2e/ESIMD/local_accessor_block_load_store.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_block_load_store.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
+// XFAIL: igc-dev
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16388
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // This test verifies usage of block_load/block_store for local_accessor.

--- a/sycl/test-e2e/ESIMD/local_accessor_copy_to_from.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_copy_to_from.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
-//
+// XFAIL: igc-dev
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16388
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/lsc/lsc_local_accessor_block_load_store.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_local_accessor_block_load_store.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: arch-intel_gpu_pvc || gpu-intel-dg2
 // REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// XFAIL: igc-dev
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16388
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
@@ -14,7 +14,7 @@
 
 // Waiting for the commit in IGC to be pulled into the driver to resolve the
 // test.
-// XFAIL: gpu
+// XFAIL: !igc-dev || gpu-intel-dg2
 // XFAIL-TRACKER: CMPLRLLVM-63710
 
 #include "common.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
@@ -14,7 +14,7 @@
 
 // Waiting for the commit in IGC to be pulled into the driver to resolve the
 // test.
-// XFAIL: gpu
+// XFAIL: !igc-dev || gpu-intel-dg2
 // XFAIL-TRACKER: CMPLRLLVM-63710
 
 #include "common.hpp"


### PR DESCRIPTION
igc-dev is using `libigc.so.2` and released igc is using `libigc.so.1`, and there's no symlink to `libigc.so` in the dev-igc packages, so we need to do it ourselves.

Also, fix the workflow so it runs on changes to the driver install script and XFAIL failing tests.

And manually update the igc-dev version since the one we are using here is too old and the artifacts are expired so we can't build the image. The new version also contains an important fix for the joint matrix team.

Closes: https://github.com/intel/llvm/issues/16088
Closes: https://github.com/intel/llvm/issues/16251