### PR TITLE
[SYCL] Emit error when `get_backend_info` is used under `_GLIBCXX_USE_CXX11_ABI=0`

### DIFF
--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -177,7 +177,7 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
-#if _GLIBCXX_USE_CXX11_ABI == 0
+#if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<context, Param>()
 #endif

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -176,7 +176,12 @@ public:
   /// Queries this SYCL context for SYCL backend-specific information.
   ///
   /// The return type depends on information being queried.
-  template <typename Param>
+  template <typename Param
+#if _GLIBCXX_USE_CXX11_ABI == 0
+            ,
+            int = detail::emit_get_backend_info_error<context, Param>()
+#endif
+            >
   typename detail::is_backend_info_desc<Param>::return_type
   get_backend_info() const;
 

--- a/sycl/include/sycl/detail/info_desc_helpers.hpp
+++ b/sycl/include/sycl/detail/info_desc_helpers.hpp
@@ -129,6 +129,18 @@ struct IsKernelInfo<info::kernel_device_specific::ext_codeplay_num_regs>
 #include <sycl/info/sycl_backend_traits.def>
 #undef __SYCL_PARAM_TRAITS_SPEC
 
+template <typename SyclObject, typename Param>
+constexpr int emit_get_backend_info_error() {
+  // Implementation of get_backend_info doesn't seem to be aligned with the
+  // spec and is likely going to be deprecated/removed. However, in pre-C++11
+  // ABI mode if result in ABI mismatch and causes crashes, so emit
+  // compile-time error under those conditions.
+  constexpr bool False = !std::is_same_v<Param, Param>;
+  static_assert(False,
+                "This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0");
+  return 0;
+}
+
 } // namespace detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -222,7 +222,7 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
-#if _GLIBCXX_USE_CXX11_ABI == 0
+#if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<device, Param>()
 #endif

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -221,7 +221,12 @@ public:
   /// Queries this SYCL device for SYCL backend-specific information.
   ///
   /// The return type depends on information being queried.
-  template <typename Param>
+  template <typename Param
+#if _GLIBCXX_USE_CXX11_ABI == 0
+            ,
+            int = detail::emit_get_backend_info_error<device, Param>()
+#endif
+            >
   typename detail::is_backend_info_desc<Param>::return_type
   get_backend_info() const;
 

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -112,7 +112,7 @@ public:
   ///
   /// \return depends on information being queried.
   template <typename Param
-#if _GLIBCXX_USE_CXX11_ABI == 0
+#if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<event, Param>()
 #endif

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -111,7 +111,12 @@ public:
   /// Queries this SYCL event for SYCL backend-specific information.
   ///
   /// \return depends on information being queried.
-  template <typename Param>
+  template <typename Param
+#if _GLIBCXX_USE_CXX11_ABI == 0
+            ,
+            int = detail::emit_get_backend_info_error<event, Param>()
+#endif
+            >
   typename detail::is_backend_info_desc<Param>::return_type
   get_backend_info() const;
 

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -131,7 +131,12 @@ public:
   /// Queries the kernel object for SYCL backend-specific information.
   ///
   /// The return type depends on information being queried.
-  template <typename Param>
+  template <typename Param
+#if _GLIBCXX_USE_CXX11_ABI == 0
+            ,
+            int = detail::emit_get_backend_info_error<kernel, Param>()
+#endif
+            >
   typename detail::is_backend_info_desc<Param>::return_type
   get_backend_info() const;
 

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -132,7 +132,7 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
-#if _GLIBCXX_USE_CXX11_ABI == 0
+#if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<kernel, Param>()
 #endif

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -149,7 +149,12 @@ public:
   /// Queries this SYCL platform for SYCL backend-specific info.
   ///
   /// The return type depends on information being queried.
-  template <typename Param>
+  template <typename Param
+#if _GLIBCXX_USE_CXX11_ABI == 0
+            ,
+            int = detail::emit_get_backend_info_error<platform, Param>()
+#endif
+            >
   typename detail::is_backend_info_desc<Param>::return_type
   get_backend_info() const;
 

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -150,7 +150,7 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
-#if _GLIBCXX_USE_CXX11_ABI == 0
+#if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<platform, Param>()
 #endif

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -343,7 +343,7 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
-#if _GLIBCXX_USE_CXX11_ABI == 0
+#if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<queue, Param>()
 #endif

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -342,7 +342,12 @@ public:
   /// Queries SYCL queue for SYCL backend-specific information.
   ///
   /// The return type depends on information being queried.
-  template <typename Param>
+  template <typename Param
+#if _GLIBCXX_USE_CXX11_ABI == 0
+            ,
+            int = detail::emit_get_backend_info_error<queue, Param>()
+#endif
+            >
   typename detail::is_backend_info_desc<Param>::return_type
   get_backend_info() const;
 

--- a/sycl/test-e2e/Basic/backend_info.cpp
+++ b/sycl/test-e2e/Basic/backend_info.cpp
@@ -1,6 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
+// RUN: %{build} -DTEST_ERRORS -D_GLIBCXX_USE_CXX11_ABI=0 -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note
 
 //==--- backend_info.cpp - SYCL backend info test---------------------------==//
 //
@@ -17,13 +18,18 @@
 using namespace sycl;
 
 int main() {
+#if _GLIBCXX_USE_CXX11_ABI != 0 || TEST_ERRORS
   try {
     // Test get_backend_info for sycl::platform
     std::vector<platform> platform_list = platform::get_platforms();
     for (const auto &platform : platform_list) {
+      // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+      // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::device::version, $1 = (no value)]}}
       std::cout << "  Backend device version: "
                 << platform.get_backend_info<info::device::version>()
                 << std::endl;
+      // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+      // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::platform::version, $1 = (no value)]}}
       std::cout << "  Backend platform version: "
                 << platform.get_backend_info<info::platform::version>()
                 << std::endl;
@@ -33,9 +39,13 @@ int main() {
     std::vector<device> device_list =
         device::get_devices(info::device_type::gpu);
     for (const auto &device : device_list) {
+      // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+      // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::device::version, $1 = (no value)]}}
       std::cout << "  Backend device version: "
                 << device.get_backend_info<info::device::version>()
                 << std::endl;
+      // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+      // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::platform::version, $1 = (no value)]}}
       std::cout << "  Backend platform version: "
                 << device.get_backend_info<info::platform::version>()
                 << std::endl;
@@ -43,22 +53,34 @@ int main() {
 
     // Test get_backend_info for sycl::queue
     queue q;
+    // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+    // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::device::version, $1 = (no value)]}}
     std::cout << "  Backend device version: "
               << q.get_backend_info<info::device::version>() << std::endl;
+    // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+    // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::platform::version, $1 = (no value)]}}
     std::cout << "  Backend platform version: "
               << q.get_backend_info<info::platform::version>() << std::endl;
 
     // Test get_backend_info for sycl::context
     context Ctx = q.get_context();
+    // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+    // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::device::version, $1 = (no value)]}}
     std::cout << "  Backend device version: "
               << Ctx.get_backend_info<info::device::version>() << std::endl;
+    // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+    // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::platform::version, $1 = (no value)]}}
     std::cout << "  Backend platform version: "
               << Ctx.get_backend_info<info::platform::version>() << std::endl;
 
     // Test get_backend_info for sycl::event
     event e = q.single_task([=]() { return; });
+    // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+    // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::device::version, $1 = (no value)]}}
     std::cout << "  Backend device version: "
               << e.get_backend_info<info::device::version>() << std::endl;
+    // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+    // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::platform::version, $1 = (no value)]}}
     std::cout << "  Backend platform version: "
               << e.get_backend_info<info::platform::version>() << std::endl;
 
@@ -73,8 +95,12 @@ int main() {
       auto acc = buf.get_access<access::mode::read_write>(cgh);
       cgh.single_task<class SingleTask>(krn, [=]() { acc[0] = acc[0] + 1; });
     });
+    // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+    // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::device::version, $1 = (no value)]}}
     std::cout << "  Backend device version: "
               << krn.get_backend_info<info::device::version>() << std::endl;
+    // expected-error@*:* {{static assertion failed due to requirement 'False': This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0}}
+    // expected-note@+2 {{while substituting deduced template arguments into function template 'get_backend_info' [with Param = info::platform::version, $1 = (no value)]}}
     std::cout << "  Backend platform version: "
               << krn.get_backend_info<info::platform::version>() << std::endl;
   } catch (exception e) {
@@ -93,5 +119,6 @@ int main() {
     assert(has_non_opencl_backend && "unexpected error code");
   }
   std::cout << "  Backend info query tests passed" << std::endl;
+#endif
   return 0;
 }

--- a/sycl/test-e2e/Basic/backend_info.cpp
+++ b/sycl/test-e2e/Basic/backend_info.cpp
@@ -18,7 +18,8 @@
 using namespace sycl;
 
 int main() {
-#if _GLIBCXX_USE_CXX11_ABI != 0 || TEST_ERRORS
+#if (defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI != 0) ||        \
+    !defined(_GLIBCXX_USE_CXX11_ABI) || TEST_ERRORS
   try {
     // Test get_backend_info for sycl::platform
     std::vector<platform> platform_list = platform::get_platforms();


### PR DESCRIPTION


It doesn't seem that the interfaces match the spec, so it's highly likely that these methods will be deprecated/removed anyway, so there is little point in fixing them to work in `_GLIBCXX_USE_CXX11_ABI=0` mode.

On the other hand, using `_GLIBCXX_USE_CXX11_ABI=0` causes segmentation fault crashes due to ABI mismatches in runtime, so emitting compile-time error is a better thing to do here.