### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-6ee988a

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-3db59df",
-      "version": "3db59df",
-      "updated_at": "2024-12-03T20:43:00Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2248119261/zip",
+      "github_tag": "igc-dev-6ee988a",
+      "version": "6ee988a",
+      "updated_at": "2024-11-26T15:44:10Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2239640503/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift