### PR TITLE
[libclc][BumpPointerAllocator] fix coverity issue: Rule Of Three

### DIFF
--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -105,6 +105,8 @@ class BumpPointerAllocator {
 public:
   BumpPointerAllocator()
       : BlockList(new(InitialBuffer) BlockMeta{nullptr, 0}) {}
+  BumpPointerAllocator(const BumpPointerAllocator &) = delete;
+  BumpPointerAllocator &operator=(const BumpPointerAllocator &) = delete;
 
   void *allocate(size_t N) {
     N = (N + 15u) & ~15u;


### PR DESCRIPTION
Add copy constructor and copy assignment operator.