### PR TITLE
[SYCL] Rewrite Tests Containing Deprecated Overloads #1

### DIFF
--- a/sycl/test/check_device_code/extensions/properties/properties_kernel_launch_bounds.cpp
+++ b/sycl/test/check_device_code/extensions/properties/properties_kernel_launch_bounds.cpp
@@ -4,14 +4,21 @@
 
 #include <sycl/sycl.hpp>
 
+constexpr auto Props = sycl::ext::oneapi::experimental::properties{
+    sycl::ext::oneapi::experimental::max_linear_work_group_size<4>,
+};
+struct TestKernelLaunchBounds {
+  void operator()() const {}
+  auto get(sycl::ext::oneapi::experimental::properties_tag) { return Props; }
+};
+
 int main() {
   sycl::queue Q;
 
-  constexpr auto Props = sycl::ext::oneapi::experimental::properties{
-      sycl::ext::oneapi::experimental::max_linear_work_group_size<4>,
-  };
   // CHECK-IR: spir_kernel void @{{.*}}LaunchBoundsKernel(){{.*}} #[[LaunchBoundsAttrs:[0-9]+]]
-  Q.single_task<class LaunchBoundsKernel>(Props, []() {});
+  Q.submit([&](sycl::handler &h) {
+    h.single_task<class LaunchBoundsKernel>(TestKernelLaunchBounds{});
+  });
 
   return 0;
 }

--- a/sycl/test/check_device_code/extensions/properties/properties_kernel_max_work_group_size.cpp
+++ b/sycl/test/check_device_code/extensions/properties/properties_kernel_max_work_group_size.cpp
@@ -4,26 +4,47 @@
 
 #include <sycl/sycl.hpp>
 
+constexpr auto Props1 = sycl::ext::oneapi::experimental::properties{
+    sycl::ext::oneapi::experimental::max_work_group_size<8>};
+constexpr auto Props2 = sycl::ext::oneapi::experimental::properties{
+    sycl::ext::oneapi::experimental::max_work_group_size<8, 4>};
+constexpr auto Props3 = sycl::ext::oneapi::experimental::properties{
+    sycl::ext::oneapi::experimental::max_work_group_size<8, 4, 2>};
+
+struct TestKernel_Props1 {
+  void operator()() const {}
+  auto get(sycl::ext::oneapi::experimental::properties_tag) { return Props1; }
+};
+
+struct TestKernel_Props2 {
+  void operator()() const {}
+  auto get(sycl::ext::oneapi::experimental::properties_tag) { return Props2; }
+};
+
+struct TestKernel_Props3 {
+  void operator()() const {}
+  auto get(sycl::ext::oneapi::experimental::properties_tag) { return Props3; }
+};
+
 int main() {
   sycl::queue Q;
   sycl::event Ev;
 
-  constexpr auto Props1 = sycl::ext::oneapi::experimental::properties{
-      sycl::ext::oneapi::experimental::max_work_group_size<8>};
-  constexpr auto Props2 = sycl::ext::oneapi::experimental::properties{
-      sycl::ext::oneapi::experimental::max_work_group_size<8, 4>};
-  constexpr auto Props3 = sycl::ext::oneapi::experimental::properties{
-      sycl::ext::oneapi::experimental::max_work_group_size<8, 4, 2>};
-
   // CHECK-IR: spir_kernel void @{{.*}}MaxWGSizeKernel0(){{.*}} #[[MaxWGSizeAttr0:[0-9]+]]
   // CHECK-IR-SAME: !max_work_group_size ![[MaxWGSizeMD0:[0-9]+]]
-  Q.single_task<class MaxWGSizeKernel0>(Props1, []() {});
+  Q.single_task<class MaxWGSizeKernel0>(TestKernel_Props1{});
   // CHECK-IR: spir_kernel void @{{.*}}MaxWGSizeKernel1(){{.*}} #[[MaxWGSizeAttr1:[0-9]+]]
   // CHECK-IR-SAME: !max_work_group_size ![[MaxWGSizeMD1:[0-9]+]]
-  Q.single_task<class MaxWGSizeKernel1>(Ev, Props2, []() {});
+  Q.submit([&](sycl::handler &h) {
+    h.depends_on(Ev);
+    h.single_task<class MaxWGSizeKernel1>(TestKernel_Props2{});
+  });
   // CHECK-IR: spir_kernel void @{{.*}}MaxWGSizeKernel2(){{.*}} #[[MaxWGSizeAttr2:[0-9]+]]
   // CHECK-IR-SAME: !max_work_group_size ![[MaxWGSizeMD2:[0-9]+]]
-  Q.single_task<class MaxWGSizeKernel2>({Ev}, Props3, []() {});
+  Q.submit([&](sycl::handler &h) {
+    h.depends_on({Ev});
+    h.single_task<class MaxWGSizeKernel2>(TestKernel_Props3{});
+  });
 
   return 0;
 }

--- a/sycl/test/extensions/properties/properties_kernel_device_has_warning.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_device_has_warning.cpp
@@ -54,128 +54,245 @@ int funcIndirectlyUsingCPU(int a, int b) { return funcUsingCPU(a, b, 1); }
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((device_has<aspect::fp64>))
 int funcUsingCPUHasFP64(int a) { return funcIndirectlyUsingCPU(a, 1); }
 
+constexpr auto props_64 = properties{device_has<aspect::fp64>};
+constexpr auto props_16 = properties{device_has<aspect::fp16>};
+constexpr auto props_1664 = properties{device_has<aspect::fp16, aspect::fp64>};
+constexpr auto props_6416 = properties{device_has<aspect::fp64, aspect::fp16>};
+constexpr auto props_gpu = properties{device_has<aspect::gpu>};
+constexpr auto props_gpu1664 =
+    properties{device_has<aspect::gpu, aspect::fp16, aspect::fp64>};
+constexpr auto props_1664gpu =
+    properties{device_has<aspect::fp16, aspect::fp64, aspect::gpu>};
+constexpr auto props_emp = properties{};
+constexpr auto props_cpu = properties{device_has<aspect::cpu>};
+constexpr auto props_cpu64 = properties{device_has<aspect::cpu, aspect::fp64>};
+constexpr auto props_64cpu = properties{device_has<aspect::fp64, aspect::cpu>};
+constexpr auto props_gpucpu64 =
+    properties{device_has<aspect::gpu, aspect::cpu, aspect::fp64>};
+constexpr auto props_cpu64gpu =
+    properties{device_has<aspect::cpu, aspect::fp64, aspect::gpu>};
+
+template <typename T> struct K_funcIndirectlyUsingFP16 {
+  T *Props;
+  K_funcIndirectlyUsingFP16(T Props_param) { Props = &Props_param; };
+  void operator()() const { int a = funcIndirectlyUsingFP16(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcIndirectlyUsingFP16_Warn16 {
+  T *Props;
+  K_funcIndirectlyUsingFP16_Warn16(T Props_param) { Props = &Props_param; };
+  // expected-warning-re@+1 {{function '{{.*}}' uses aspect 'fp16' not listed in its 'device_has' property}}
+  void operator()() const { int a = funcIndirectlyUsingFP16(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingFP16AndFP64 {
+  T *Props;
+  K_funcUsingFP16AndFP64(T Props_param) { Props = &Props_param; };
+  void operator()() const { int a = funcUsingFP16AndFP64(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingFP16AndFP64_Warn16 {
+  T *Props;
+  K_funcUsingFP16AndFP64_Warn16(T Props_param) { Props = &Props_param; };
+  // expected-warning-re@+1 {{function '{{.*}}' uses aspect 'fp16' not listed in its 'device_has' property}}
+  void operator()() const { int a = funcUsingFP16AndFP64(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingFP16AndFP64_Warn64 {
+  T *Props;
+  K_funcUsingFP16AndFP64_Warn64(T Props_param) { Props = &Props_param; };
+  // expected-warning-re@+1 {{function '{{.*}}' uses aspect 'fp64' not listed in its 'device_has' property}}
+  void operator()() const { int a = funcUsingFP16AndFP64(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingFP16AndFP64_Warn1664 {
+  T *Props;
+  K_funcUsingFP16AndFP64_Warn1664(T Props_param) { Props = &Props_param; };
+  // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'fp16' not listed in its 'device_has' property}}
+  // expected-warning-re@+1 {{function '{{.*}}' uses aspect 'fp64' not listed in its 'device_has' property}}
+  void operator()() const { int a = funcUsingFP16AndFP64(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingFP16AndFP64_False {
+  T *Props;
+  K_funcUsingFP16AndFP64_False(T Props_param) { Props = &Props_param; };
+  void operator()() const {
+    if constexpr (false) {
+      int a = funcUsingFP16AndFP64(1, 2);
+    }
+  }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingCPUHasFP64 {
+  T *Props;
+  K_funcUsingCPUHasFP64(T Props_param) { Props = &Props_param; };
+  void operator()() const { int a = funcUsingCPUHasFP64(1); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcIndirectlyUsingCPU {
+  T *Props;
+  K_funcIndirectlyUsingCPU(T Props_param) { Props = &Props_param; };
+  void operator()() const { int a = funcIndirectlyUsingCPU(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcIndirectlyUsingCPU_WarnCPU {
+  T *Props;
+  K_funcIndirectlyUsingCPU_WarnCPU(T Props_param) { Props = &Props_param; };
+  // expected-warning-re@+1 {{function '{{.*}}' uses aspect 'cpu' not listed in its 'device_has' property}}
+  void operator()() const { int a = funcIndirectlyUsingCPU(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingCPUAndFP64 {
+  T *Props;
+  K_funcUsingCPUAndFP64(T Props_param) { Props = &Props_param; };
+  void operator()() const { int a = funcUsingCPUAndFP64(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingCPUAndFP64_WarnCPU {
+  T *Props;
+  K_funcUsingCPUAndFP64_WarnCPU(T Props_param) { Props = &Props_param; };
+  // expected-warning-re@+1 {{function '{{.*}}' uses aspect 'cpu' not listed in its 'device_has' property}}
+  void operator()() const { int a = funcUsingCPUAndFP64(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingCPUAndFP64_Warn64 {
+  T *Props;
+  K_funcUsingCPUAndFP64_Warn64(T Props_param) { Props = &Props_param; };
+  // expected-warning-re@+1 {{function '{{.*}}' uses aspect 'fp64' not listed in its 'device_has' property}}
+  void operator()() const { int a = funcUsingCPUAndFP64(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingCPUAndFP64_Warn64CPU {
+  T *Props;
+  K_funcUsingCPUAndFP64_Warn64CPU(T Props_param) { Props = &Props_param; };
+  // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'cpu' not listed in its 'device_has' property}}
+  // expected-warning-re@+1 {{function '{{.*}}' uses aspect 'fp64' not listed in its 'device_has' property}}
+  void operator()() const { int a = funcUsingCPUAndFP64(1, 2); }
+  auto get(properties_tag) { return *Props; }
+};
+
+template <typename T> struct K_funcUsingCPUAndFP64_False {
+  T *Props;
+  K_funcUsingCPUAndFP64_False(T Props_param) { Props = &Props_param; };
+  void operator()() const {
+    if constexpr (false) {
+      int a = funcUsingCPUAndFP64(1, 2);
+    }
+  }
+  auto get(properties_tag) { return *Props; }
+};
+
 int main() {
   queue Q;
   Q.submit([&](handler &CGH) {
     CGH.single_task([=]() { int a = funcUsingFP16HasFP64(1); });
   });
   Q.submit([&](handler &CGH) {
-    // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'fp16' not listed in its 'device_has' property}}
-    CGH.single_task(properties{device_has<aspect::fp64>},
-                    [=]() { int a = funcIndirectlyUsingFP16(1, 2); });
+    CGH.single_task(
+        K_funcIndirectlyUsingFP16_Warn16<decltype(props_64)>(props_64));
   });
   Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::fp16>},
-                    [=]() { int a = funcIndirectlyUsingFP16(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::fp16, aspect::fp64>},
-                    [=]() { int a = funcIndirectlyUsingFP16(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::fp64, aspect::fp16>},
-                    [=]() { int a = funcIndirectlyUsingFP16(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    // expected-warning-re@+3 {{function '{{.*}}' uses aspect 'fp16' not listed in its 'device_has' property}}
-    // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'fp64' not listed in its 'device_has' property}}
-    CGH.single_task(properties{device_has<aspect::gpu>},
-                    [=]() { int a = funcUsingFP16AndFP64(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'fp64' not listed in its 'device_has' property}}
-    CGH.single_task(properties{device_has<aspect::fp16>},
-                    [=]() { int a = funcUsingFP16AndFP64(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'fp16' not listed in its 'device_has' property}}
-    CGH.single_task(properties{device_has<aspect::fp64>},
-                    [=]() { int a = funcUsingFP16AndFP64(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::gpu>}, [=]() {
-      if constexpr (false) {
-        int a = funcUsingFP16AndFP64(1, 2);
-      }
-    });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::fp16, aspect::fp64>},
-                    [=]() { int a = funcUsingFP16AndFP64(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::fp64, aspect::fp16>},
-                    [=]() { int a = funcUsingFP16AndFP64(1, 2); });
+    CGH.single_task(K_funcIndirectlyUsingFP16<decltype(props_16)>(props_16));
   });
   Q.submit([&](handler &CGH) {
     CGH.single_task(
-        properties{device_has<aspect::gpu, aspect::fp16, aspect::fp64>},
-        [=]() { int a = funcUsingFP16AndFP64(1, 2); });
+        K_funcIndirectlyUsingFP16<decltype(props_1664)>(props_1664));
   });
   Q.submit([&](handler &CGH) {
     CGH.single_task(
-        properties{device_has<aspect::fp16, aspect::fp64, aspect::gpu>},
-        [=]() { int a = funcUsingFP16AndFP64(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{}, [=]() { int a = funcUsingCPUHasFP64(1); });
-  });
-  Q.submit([&](handler &CGH) {
-    // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'cpu' not listed in its 'device_has' property}}
-    CGH.single_task(properties{device_has<aspect::fp64>},
-                    [=]() { int a = funcIndirectlyUsingCPU(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::cpu>},
-                    [=]() { int a = funcIndirectlyUsingCPU(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::cpu, aspect::fp64>},
-                    [=]() { int a = funcIndirectlyUsingCPU(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::fp64, aspect::cpu>},
-                    [=]() { int a = funcIndirectlyUsingCPU(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    // expected-warning-re@+3 {{function '{{.*}}' uses aspect 'cpu' not listed in its 'device_has' property}}
-    // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'fp64' not listed in its 'device_has' property}}
-    CGH.single_task(properties{device_has<aspect::gpu>},
-                    [=]() { int a = funcUsingCPUAndFP64(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'fp64' not listed in its 'device_has' property}}
-    CGH.single_task(properties{device_has<aspect::cpu>},
-                    [=]() { int a = funcUsingCPUAndFP64(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    // expected-warning-re@+2 {{function '{{.*}}' uses aspect 'cpu' not listed in its 'device_has' property}}
-    CGH.single_task(properties{device_has<aspect::fp64>},
-                    [=]() { int a = funcUsingCPUAndFP64(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::gpu>}, [=]() {
-      if constexpr (false) {
-        int a = funcUsingCPUAndFP64(1, 2);
-      }
-    });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::cpu, aspect::fp64>},
-                    [=]() { int a = funcUsingCPUAndFP64(1, 2); });
-  });
-  Q.submit([&](handler &CGH) {
-    CGH.single_task(properties{device_has<aspect::fp64, aspect::cpu>},
-                    [=]() { int a = funcUsingCPUAndFP64(1, 2); });
+        K_funcIndirectlyUsingFP16<decltype(props_6416)>(props_6416));
   });
   Q.submit([&](handler &CGH) {
     CGH.single_task(
-        properties{device_has<aspect::gpu, aspect::cpu, aspect::fp64>},
-        [=]() { int a = funcUsingCPUAndFP64(1, 2); });
+        K_funcUsingFP16AndFP64_Warn1664<decltype(props_gpu)>(props_gpu));
   });
   Q.submit([&](handler &CGH) {
     CGH.single_task(
-        properties{device_has<aspect::cpu, aspect::fp64, aspect::gpu>},
-        [=]() { int a = funcUsingCPUAndFP64(1, 2); });
+        K_funcUsingFP16AndFP64_Warn64<decltype(props_16)>(props_16));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingFP16AndFP64_Warn16<decltype(props_64)>(props_64));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingFP16AndFP64_False<decltype(props_gpu)>(props_gpu));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingFP16AndFP64_Warn16<decltype(props_1664)>(props_1664));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingFP16AndFP64_Warn16<decltype(props_6416)>(props_6416));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingFP16AndFP64_Warn16<decltype(props_gpu1664)>(props_gpu1664));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingFP16AndFP64_Warn16<decltype(props_1664gpu)>(props_1664gpu));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(K_funcUsingCPUHasFP64<decltype(props_emp)>(props_emp));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcIndirectlyUsingCPU_WarnCPU<decltype(props_64)>(props_64));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(K_funcIndirectlyUsingCPU<decltype(props_cpu)>(props_cpu));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcIndirectlyUsingCPU<decltype(props_cpu64)>(props_cpu64));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcIndirectlyUsingCPU<decltype(props_64cpu)>(props_64cpu));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingCPUAndFP64_Warn64CPU<decltype(props_gpu)>(props_gpu));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingCPUAndFP64_Warn64<decltype(props_cpu)>(props_cpu));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingCPUAndFP64_WarnCPU<decltype(props_64)>(props_64));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingCPUAndFP64_False<decltype(props_gpu)>(props_gpu));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(K_funcUsingCPUAndFP64<decltype(props_cpu64)>(props_cpu64));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(K_funcUsingCPUAndFP64<decltype(props_64cpu)>(props_64cpu));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingCPUAndFP64<decltype(props_gpucpu64)>(props_gpucpu64));
+  });
+  Q.submit([&](handler &CGH) {
+    CGH.single_task(
+        K_funcUsingCPUAndFP64<decltype(props_cpu64gpu)>(props_cpu64gpu));
   });
 }

--- a/sycl/test/extensions/properties/properties_kernel_negative_device.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_negative_device.cpp
@@ -2,11 +2,6 @@
 
 #include <sycl/sycl.hpp>
 
-struct KernelFunctorWithOnlyWGSizeAttr {
-  // expected-warning@+1 {{kernel has both attribute 'reqd_work_group_size' and kernel properties; conflicting properties are ignored}}
-  void operator() [[sycl::reqd_work_group_size(32)]] () const {}
-};
-
 template <size_t... Is> struct KernelFunctorWithWGSizeWithAttr {
   // expected-warning@+1 {{kernel has both attribute 'reqd_work_group_size' and kernel properties; conflicting properties are ignored}}
   void operator() [[sycl::reqd_work_group_size(32)]] () const {}
@@ -14,11 +9,6 @@ template <size_t... Is> struct KernelFunctorWithWGSizeWithAttr {
     return sycl::ext::oneapi::experimental::properties{
         sycl::ext::oneapi::experimental::work_group_size<Is...>};
   }
-};
-
-struct KernelFunctorWithOnlyWGSizeHintAttr {
-  // expected-warning@+1 {{kernel has both attribute 'work_group_size_hint' and kernel properties; conflicting properties are ignored}}
-  void operator() [[sycl::work_group_size_hint(32)]] () const {}
 };
 
 template <size_t... Is> struct KernelFunctorWithWGSizeHintWithAttr {
@@ -30,11 +20,6 @@ template <size_t... Is> struct KernelFunctorWithWGSizeHintWithAttr {
   }
 };
 
-struct KernelFunctorWithOnlySGSizeAttr {
-  // expected-warning@+1 {{kernel has both attribute 'reqd_sub_group_size' and kernel properties; conflicting properties are ignored}}
-  void operator() [[sycl::reqd_sub_group_size(32)]] () const {}
-};
-
 template <uint32_t I> struct KernelFunctorWithSGSizeWithAttr {
   // expected-warning@+1 {{kernel has both attribute 'reqd_sub_group_size' and kernel properties; conflicting properties are ignored}}
   void operator() [[sycl::reqd_sub_group_size(32)]] () const {}
@@ -42,11 +27,6 @@ template <uint32_t I> struct KernelFunctorWithSGSizeWithAttr {
     return sycl::ext::oneapi::experimental::properties{
         sycl::ext::oneapi::experimental::sub_group_size<I>};
   }
-};
-
-struct KernelFunctorWithOnlyDeviceHasAttr {
-  // expected-warning@+1 {{kernel has both attribute 'device_has' and kernel properties; conflicting properties are ignored}}
-  void operator() [[sycl::device_has(sycl::aspect::cpu)]] () const {}
 };
 
 template <sycl::aspect Aspect> struct KernelFunctorWithDeviceHasWithAttr {
@@ -61,33 +41,11 @@ template <sycl::aspect Aspect> struct KernelFunctorWithDeviceHasWithAttr {
 void check_work_group_size() {
   sycl::queue Q;
 
-  // expected-warning@+4 {{kernel has both attribute 'reqd_work_group_size' and kernel properties; conflicting properties are ignored}}
-  Q.single_task(
-      sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::work_group_size<1>},
-      []() [[sycl::reqd_work_group_size(32)]] {});
-
-  Q.single_task(
-      sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::work_group_size<1>},
-      KernelFunctorWithOnlyWGSizeAttr{});
-
   Q.single_task(KernelFunctorWithWGSizeWithAttr<1>{});
 }
 
 void check_work_group_size_hint() {
   sycl::queue Q;
-
-  // expected-warning@+4 {{kernel has both attribute 'work_group_size_hint' and kernel properties; conflicting properties are ignored}}
-  Q.single_task(
-      sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::work_group_size_hint<1>},
-      []() [[sycl::work_group_size_hint(32)]] {});
-
-  Q.single_task(
-      sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::work_group_size_hint<1>},
-      KernelFunctorWithOnlyWGSizeHintAttr{});
 
   Q.single_task(KernelFunctorWithWGSizeHintWithAttr<1>{});
 }
@@ -95,33 +53,11 @@ void check_work_group_size_hint() {
 void check_sub_group_size() {
   sycl::queue Q;
 
-  // expected-warning@+4 {{kernel has both attribute 'reqd_sub_group_size' and kernel properties; conflicting properties are ignored}}
-  Q.single_task(
-      sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::sub_group_size<1>},
-      []() [[sycl::reqd_sub_group_size(32)]] {});
-
-  Q.single_task(
-      sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::sub_group_size<1>},
-      KernelFunctorWithOnlySGSizeAttr{});
-
   Q.single_task(KernelFunctorWithSGSizeWithAttr<1>{});
 }
 
 void check_device_has() {
   sycl::queue Q;
-
-  // expected-warning@+4 {{kernel has both attribute 'device_has' and kernel properties; conflicting properties are ignored}}
-  Q.single_task(
-      sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::device_has<sycl::aspect::cpu>},
-      []() [[sycl::device_has(sycl::aspect::cpu)]] {});
-
-  Q.single_task(
-      sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::device_has<sycl::aspect::cpu>},
-      KernelFunctorWithOnlyDeviceHasAttr{});
 
   Q.single_task(KernelFunctorWithDeviceHasWithAttr<sycl::aspect::cpu>{});
 }

--- a/sycl/test/virtual-functions/properties-positive.cpp
+++ b/sycl/test/virtual-functions/properties-positive.cpp
@@ -41,6 +41,37 @@ public:
   void bar() override {}
 };
 
+oneapi::properties props_empty{oneapi::assume_indirect_calls};
+oneapi::properties props_void{oneapi::assume_indirect_calls_to<void>};
+oneapi::properties props_int{oneapi::assume_indirect_calls_to<int>};
+oneapi::properties props_base{oneapi::assume_indirect_calls_to<Base>};
+oneapi::properties props_multiple{oneapi::assume_indirect_calls_to<int, Base>};
+
+struct TestKernel_props_empty {
+  void operator()() const {}
+  auto get(oneapi::properties_tag) { return props_empty; }
+};
+
+struct TestKernel_props_void {
+  void operator()() const {}
+  auto get(oneapi::properties_tag) { return props_void; }
+};
+
+struct TestKernel_props_int {
+  void operator()() const {}
+  auto get(oneapi::properties_tag) { return props_int; }
+};
+
+struct TestKernel_props_base {
+  void operator()() const {}
+  auto get(oneapi::properties_tag) { return props_base; }
+};
+
+struct TestKernel_props_multiple {
+  void operator()() const {}
+  auto get(oneapi::properties_tag) { return props_multiple; }
+};
+
 int main() {
   sycl::queue q;
 
@@ -51,11 +82,11 @@ int main() {
   oneapi::properties props_multiple{
      oneapi::assume_indirect_calls_to<int, Base>};
 
-  q.single_task(props_empty, [=]() {});
-  q.single_task(props_void, [=]() {});
-  q.single_task(props_int, [=]() {});
-  q.single_task(props_base, [=]() {});
-  q.single_task(props_multiple, [=]() {});
+  q.single_task(TestKernel_props_empty{});
+  q.single_task(TestKernel_props_void{});
+  q.single_task(TestKernel_props_int{});
+  q.single_task(TestKernel_props_base{});
+  q.single_task(TestKernel_props_multiple{});
 
   return 0;
 }


### PR DESCRIPTION
The overloads for single_task and parallel_for in the sycl_ext_oneapi_kernel_properties extension are being deprecated as mentioned in https://github.com/intel/llvm/pull/14785. So I'm rewriting tests containg such overloads so that they can still run after the deprecation.