### PR TITLE
[SYCL] Update aspect propagation logic for virtual functions

### DIFF
--- a/llvm/test/SYCLLowerIR/PropagateAspectsUsage/VirtualFunctions/virtual-functions-1.ll
+++ b/llvm/test/SYCLLowerIR/PropagateAspectsUsage/VirtualFunctions/virtual-functions-1.ll
@@ -6,8 +6,9 @@ define spir_func void @vfn() #0 {
   ret void
 }
 
-; CHECK: @foo() #1 !sycl_used_aspects ![[#aspects]]
-define spir_kernel void @foo() #1 {
+; CHECK: @foo({{.*}}) #1 !sycl_used_aspects ![[#aspects]]
+define spir_kernel void @foo(ptr %f) #1 {
+  call void %f() #2
   ret void
 }
 
@@ -15,6 +16,7 @@ define spir_kernel void @foo() #1 {
 
 attributes #0 = { "indirectly-callable"="_ZTSv" }
 attributes #1 = { "calls-indirectly"="_ZTSv" }
+attributes #2 = { "virtual-call" }
 
 !sycl_aspects = !{!0}
 !0 = !{!"fp64", i32 6}

--- a/llvm/test/SYCLLowerIR/PropagateAspectsUsage/VirtualFunctions/virtual-functions-2.ll
+++ b/llvm/test/SYCLLowerIR/PropagateAspectsUsage/VirtualFunctions/virtual-functions-2.ll
@@ -15,8 +15,9 @@ define spir_func void @vfnBar() #1 {
   ret void
 }
 
-; CHECK: @kernel() #2 !sycl_used_aspects ![[#aspectsKernel:]]
-define spir_kernel void @kernel() #2 {
+; CHECK: @kernel({{.*}}) #2 !sycl_used_aspects ![[#aspectsKernel:]]
+define spir_kernel void @kernel(ptr %f) #2 {
+  call void %f() #3
   ret void
 }
 
@@ -27,6 +28,7 @@ define spir_kernel void @kernel() #2 {
 attributes #0 = { "indirectly-callable"="setFoo" }
 attributes #1 = { "indirectly-callable"="setBar" }
 attributes #2 = { "calls-indirectly"="setFoo,setBar" }
+attributes #3 = { "virtual-call" }
 
 !sycl_aspects = !{!0}
 !0 = !{!"fp64", i32 6}

--- a/llvm/test/SYCLLowerIR/PropagateAspectsUsage/VirtualFunctions/virtual-functions-3.ll
+++ b/llvm/test/SYCLLowerIR/PropagateAspectsUsage/VirtualFunctions/virtual-functions-3.ll
@@ -25,13 +25,15 @@ define spir_func void @subBar() {
   ret void
 }
 
-; CHECK: @kernelA() #2 !sycl_used_aspects ![[#aspectsFoo]]
-define spir_kernel void @kernelA() #2 {
+; CHECK: @kernelA({{.*}}) #2 !sycl_used_aspects ![[#aspectsFoo]]
+define spir_kernel void @kernelA(ptr %f) #2 {
+  call void %f() #4
   ret void
 }
 
-; CHECK: @kernelB() #3 !sycl_used_aspects ![[#aspectsBar]]
-define spir_kernel void @kernelB() #3 {
+; CHECK: @kernelB({{.*}}) #3 !sycl_used_aspects ![[#aspectsBar]]
+define spir_kernel void @kernelB(ptr %f) #3 {
+  call void %f() #4
   ret void
 }
 
@@ -42,6 +44,7 @@ attributes #0 = { "indirectly-callable"="setFoo" }
 attributes #1 = { "indirectly-callable"="setBar" }
 attributes #2 = { "calls-indirectly"="setFoo" }
 attributes #3 = { "calls-indirectly"="setBar" }
+attributes #4 = { "virtual-call" }
 
 !sycl_aspects = !{!0}
 !0 = !{!"fp64", i32 6}


### PR DESCRIPTION
For virtual functions the "construction" kernels that create objects that have function virtual functions but do not actually perform any virtual calls have the calls-indirectly attribute attached to them by the SYCLVirtualFunctionAnalysisPass. Because of this, aspect propagation will attach the aspects used by the sets referenced by the calls-indirectly to the construction kernel. However, these images should be able to be launched regardless of the optional kernel features used by their virtual functions, so this PR updates the aspect propagation logic to only propagate aspects to functions that have virtual calls. 

```c++
// A "construction" kernel - it is not marked with `calls_indirectly`, does not perform any virtual calls,
// but creates an object with virtual functions
q.single_task([=] {
  // The kernel is not submitted with 'assume_indirect_calls_to' property and therefore
  // it is not considered to be using any of virtual member functions of 'Foo'.
  // This means that the object of 'Foo' can be successfully created by this
  // kernel, regardless of whether a target device supports 'fp64' aspect which
  // is used by 'Foo::foo'.
  // No exceptions are expected to be thrown.
  new (Storage) Foo;
});