### PR TITLE
[SYCL][Devops] Fix `DockerFile` linting issues discovered by trivy

### DIFF
--- a/devops/containers/ubuntu2204_base.Dockerfile
+++ b/devops/containers/ubuntu2204_base.Dockerfile
@@ -29,4 +29,6 @@ COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 COPY scripts/install_drivers.sh /opt/install_drivers.sh
 
+USER sycl
+
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -41,5 +41,7 @@ RUN usermod -aG irc sycl
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 
+USER sycl
+
 ENTRYPOINT ["/docker_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -24,10 +24,9 @@ gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null && \
 # Add rocm repo
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.1.1 jammy main" \
 | tee --append /etc/apt/sources.list.d/rocm.list && \
-printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | tee /etc/apt/preferences.d/rocm-pin-600 && \
-apt update
+printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | tee /etc/apt/preferences.d/rocm-pin-600
 # Install the kernel driver
-RUN apt install -yqq rocm-dev && \
+RUN apt update && apt install -yqq rocm-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -25,15 +25,6 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
-
 USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -25,5 +25,16 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+USER sycl
+
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2204_preinstalled.Dockerfile
+++ b/devops/containers/ubuntu2204_preinstalled.Dockerfile
@@ -10,5 +10,16 @@ ADD sycl_linux.tar.gz /opt/sycl/
 ENV PATH /opt/sycl/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH
 
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+USER sycl
+
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_base.Dockerfile
+++ b/devops/containers/ubuntu2404_base.Dockerfile
@@ -29,4 +29,6 @@ COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 COPY scripts/install_drivers.sh /opt/install_drivers.sh
 
+USER sycl
+
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -25,15 +25,6 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
-
 USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -25,5 +25,16 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+USER sycl
+
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
@@ -20,5 +20,16 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+USER sycl
+
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
@@ -20,15 +20,6 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
-
 USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]

--- a/devops/scripts/docker_entrypoint.sh
+++ b/devops/scripts/docker_entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 if [ -d "$GITHUB_WORKSPACE" ]; then
-  chown -R sycl:sycl $GITHUB_WORKSPACE
-  su sycl
+  sudo chown -R sycl:sycl $GITHUB_WORKSPACE
 fi
 
 exec "$@"


### PR DESCRIPTION
Linter/checker used: [trivy v0.58.0](https://github.com/aquasecurity/trivy/releases/tag/v0.58.0)

Issues addressed:
- AVD-DS-0017 (HIGH): The instruction 'RUN <package-manager> update' should always be followed by '<package-manager> install' in the same RUN statement.
  See https://avd.aquasec.com/misconfig/ds017
- AVD-DS-0002 (HIGH): Specify at least 1 USER command in Dockerfile with non-root user as argument
  See https://avd.aquasec.com/misconfig/ds002
- AVD-DS-0002 (HIGH): Last USER command in Dockerfile should not be 'root'

Issues remaining:
- AVD-DS-0026 (LOW): Add HEALTHCHECK instruction in your Dockerfile
  See https://avd.aquasec.com/misconfig/ds026

I didn't add `HEALTHCHECK` command to our containers, because I don't know if that makes sense and which command to launch. I.e. our containers they only provide some pre-installed tools, but they don't launch any services which we could check.