### PR TITLE
[SYCL][Graph] Fix dyn_cgf_accessor_spv.cpp Test

### DIFF
--- a/sycl/test-e2e/Graph/Update/dyn_cgf_accessor_spv.cpp
+++ b/sycl/test-e2e/Graph/Update/dyn_cgf_accessor_spv.cpp
@@ -44,6 +44,13 @@ int main(int, char **argv) {
   auto AccA = BufA.get_access();
   auto AccB = BufB.get_access();
 
+  // Zero initialize buffers
+  std::vector<int> HostDataA(Size, 0);
+  std::vector<int> HostDataB(Size, 0);
+  Queue.copy(HostDataA.data(), AccA);
+  Queue.copy(HostDataB.data(), AccB);
+  Queue.wait();
+
   auto CGFA = [&](handler &CGH) {
     CGH.require(AccA);
     CGH.set_arg(0, AccA);
@@ -64,8 +71,6 @@ int main(int, char **argv) {
 
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
-  std::vector<int> HostDataA(Size, 0);
-  std::vector<int> HostDataB(Size, 0);
   Queue.copy(BufA.get_access(), HostDataA.data()).wait();
   Queue.copy(BufB.get_access(), HostDataB.data()).wait();
   for (size_t i = 0; i < Size; i++) {


### PR DESCRIPTION
The E2E SYCL-Graph test `Update/dyn_cgf_accessor_spv.cpp` checks that after the first execution of the graph, the accessor referencing `bufferB` has not been written to. This is done by checking for zero on the line

```cpp
assert(check_value(i, 0, HostDataB[i], "HostDataB"));
```

However, we never explicitly initialize `bufferB` to zero in the test, it is still uninitialized at the point of this assert. Therefore this check against zero is based on UB. This patch fixes the test by initializing the buffers to zero at the beginning of the test.