### PR TITLE
[SYCL][NFCI] Address static analyzer concerns

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -807,7 +807,7 @@ public:
 
   char padding[sizeof(detail::AccessorImplDevice<AdjustedDim>) +
                sizeof(PtrType) - sizeof(detail::AccessorBaseHost) -
-               sizeof(MAccData)];
+               sizeof(MAccData)] = {0};
 
   PtrType getQualifiedPtr() const noexcept {
     if constexpr (IsHostBuf)
@@ -2192,7 +2192,7 @@ protected:
       : detail::LocalAccessorBaseHost{Impl} {}
 
   char padding[sizeof(detail::LocalAccessorBaseDevice<AdjustedDim>) +
-               sizeof(PtrType) - sizeof(detail::LocalAccessorBaseHost)];
+               sizeof(PtrType) - sizeof(detail::LocalAccessorBaseHost)] = {0};
   using detail::LocalAccessorBaseHost::getSize;
 
   PtrType getQualifiedPtr() const {

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -106,7 +106,7 @@ void readConfig(bool ForceInitialization) {
       // Finding the position of '='
       Position = BufString.find("=");
       // Checking that the variable name is less than MAX_CONFIG_NAME and more
-      // than zero characters
+      // than zero characters.
       if ((Position < MAX_CONFIG_NAME) && (Position > 0)) {
         // Checking that the value is less than MAX_CONFIG_VALUE and
         // more than zero character

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -106,8 +106,8 @@ void readConfig(bool ForceInitialization) {
       // Finding the position of '='
       Position = BufString.find("=");
       // Checking that the variable name is less than MAX_CONFIG_NAME and more
-      // than zero character
-      if ((Position <= MAX_CONFIG_NAME) && (Position > 0)) {
+      // than zero characters
+      if ((Position < MAX_CONFIG_NAME) && (Position > 0)) {
         // Checking that the value is less than MAX_CONFIG_VALUE and
         // more than zero character
         if ((BufString.length() - (Position + 1) <= MAX_CONFIG_VALUE) &&


### PR DESCRIPTION
Two changes were made:

Special `padding` field in accessors is now zero-initialized. We construct a `host_accessor` object in our stream implementation and static analyzer complained that some of the accessor's fields were uninitialized. It is not like we even reference `padding` field from anywhere, but the code change seems small, so I decided to add the initializer.

Fixed a condition to prevent access to an array of `N` elements at index `N`, which is outside of the array because they are 0-indexed.