### PR TITLE
[SYCL][E2E][Bindless] Add Vulkan interop test sampled_images_semaphore.cpp

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_semaphore.cpp
@@ -1,0 +1,9 @@
+// REQUIRES: cuda
+// REQUIRES: vulkan
+// REQUIRES: build-and-run-mode
+
+// RUN: %{build} %link-vulkan -o %t.out
+// RUN: %{run} %t.out
+
+#define TEST_SEMAPHORE_IMPORT
+#include "sampled_images.cpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_semaphore.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: cuda
+// REQUIRES: cuda || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan
 // REQUIRES: build-and-run-mode
 


### PR DESCRIPTION
The test extends sampled_images.cpp test with semaphore import/wait. Only sycl waiting for vulkan semaphore is tested.
Vulkan waiting for sycl semaphore isn't added, because the test's output is buffer and interop between vulkan and sycl buffers isn't supported.