### PR TITLE
[UR] Don't set codeLocationCallback/ASAN layer twice

### DIFF
--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -176,17 +176,6 @@ static void initializeAdapters(std::vector<AdapterPtr> &Adapters,
     }
   }
 
-  loaderConfigSetCodeLocationCallback(LoaderConfig, codeLocationCallback,
-                                      nullptr);
-
-  if (ProgramManager::getInstance().kernelUsesAsan()) {
-    if (loaderConfigEnableLayer(LoaderConfig, "UR_LAYER_ASAN")) {
-      loaderConfigRelease(LoaderConfig);
-      std::cerr << "Failed to enable ASAN layer\n";
-      return;
-    }
-  }
-
   ur_device_init_flags_t device_flags = 0;
   CHECK_UR_SUCCESS(loaderInit(device_flags, LoaderConfig));
 


### PR DESCRIPTION
This code seems to be redundantly duplicated.
