### PR TITLE
[SYCL] Fix Coverity issues after #16228

### DIFF
--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -164,7 +164,7 @@ public:
             detail::ProgramManager::getInstance().build(DevImgWithDeps,
                                                         MDevices, PropList);
         MDeviceImages.emplace_back(BuiltImg);
-        MUniqueDeviceImages.push_back(std::move(BuiltImg));
+        MUniqueDeviceImages.emplace_back(BuiltImg);
         break;
       }
       case bundle_state::input:

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -164,7 +164,7 @@ public:
             detail::ProgramManager::getInstance().build(DevImgWithDeps,
                                                         MDevices, PropList);
         MDeviceImages.emplace_back(BuiltImg);
-        MUniqueDeviceImages.push_back(BuiltImg);
+        MUniqueDeviceImages.push_back(std::move(BuiltImg));
         break;
       }
       case bundle_state::input:

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -822,7 +822,7 @@ ur_program_handle_t ProgramManager::getBuiltURProgram(
   std::copy(DeviceImagesToLink.begin(), DeviceImagesToLink.end(),
             std::back_inserter(AllImages));
 
-  return getBuiltURProgram(AllImages, Context, {Device});
+  return getBuiltURProgram(std::move(AllImages), Context, {Device});
 }
 
 ur_program_handle_t ProgramManager::getBuiltURProgram(
@@ -2400,7 +2400,8 @@ ProgramManager::getSYCLDeviceImagesWithCompatibleState(
     std::vector<device_image_plain> Images;
     const std::set<RTDeviceBinaryImage *> &Deps = ImgInfoPair.second.Deps;
     Images.reserve(Deps.size() + 1);
-    Images.push_back(createSyclObjFromImpl<device_image_plain>(MainImpl));
+    Images.push_back(
+        createSyclObjFromImpl<device_image_plain>(std::move(MainImpl)));
     for (RTDeviceBinaryImage *Dep : Deps) {
       std::shared_ptr<std::vector<sycl::kernel_id>> DepKernelIDs;
       {
@@ -2414,7 +2415,8 @@ ProgramManager::getSYCLDeviceImagesWithCompatibleState(
           Dep, Ctx, Devs, ImgInfoPair.second.State, DepKernelIDs,
           /*PIProgram=*/nullptr);
 
-      Images.push_back(createSyclObjFromImpl<device_image_plain>(DepImpl));
+      Images.push_back(
+          createSyclObjFromImpl<device_image_plain>(std::move(DepImpl)));
     }
     SYCLDeviceImages.push_back(std::move(Images));
   }
@@ -2600,7 +2602,7 @@ ProgramManager::compile(const DevImgPlainWithDeps &ImgWithDeps,
                              getSyclObjImpl(ObjectImpl->get_context())));
 
     CompiledImages.push_back(
-        createSyclObjFromImpl<device_image_plain>(ObjectImpl));
+        createSyclObjFromImpl<device_image_plain>(std::move(ObjectImpl)));
   }
   return CompiledImages;
 }
@@ -2775,14 +2777,14 @@ ProgramManager::build(const DevImgPlainWithDeps &DevImgWithDeps,
     SpecConstMap = MainInputImpl->get_spec_const_data_ref();
   }
 
-  ur_program_handle_t ResProgram =
-      getBuiltURProgram(BinImgs, Context, Devs, &DevImgWithDeps, SpecConstBlob);
+  ur_program_handle_t ResProgram = getBuiltURProgram(
+      std::move(BinImgs), Context, Devs, &DevImgWithDeps, SpecConstBlob);
 
   DeviceImageImplPtr ExecImpl = std::make_shared<detail::device_image_impl>(
       MainInputImpl->get_bin_image_ref(), Context, Devs,
       bundle_state::executable, std::move(KernelIDs), ResProgram,
       std::move(SpecConstMap), std::move(SpecConstBlob));
-  return createSyclObjFromImpl<device_image_plain>(ExecImpl);
+  return createSyclObjFromImpl<device_image_plain>(std::move(ExecImpl));
 }
 
 // When caching is enabled, the returned UrKernel will already have


### PR DESCRIPTION
All of these Coverity issues are related to using `std::move()` instead of variable copy.