### PR TITLE
[SYCL][E2E] Fix check_e2e tests

### DIFF
--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
@@ -15,7 +15,7 @@
 // REQUIRES: arch-intel_gpu_dg2_g10 || arch-intel_gpu_dg2_g11 || arch-intel_gpu_dg2_g12 || arch-intel_gpu_pvc || arch-intel_gpu_mtl_h || arch-intel_gpu_mtl_u
 //
 // UNSUPPORTED: cuda, hip
-// UNSUPPORTED-REASON: FP64 emulation is an Intel specific feature.
+// UNSUPPORTED-INTENDED: FP64 emulation is an Intel specific feature.
 
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10,intel_gpu_dg2_g11,intel_gpu_dg2_g12,intel_gpu_pvc,intel_gpu_mtl_h,intel_gpu_mtl_u -fsycl-fp64-conv-emu -O0 %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-2.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-2.cpp
@@ -18,7 +18,7 @@
 // REQUIRES: arch-intel_gpu_dg2_g10 || arch-intel_gpu_dg2_g11 || arch-intel_gpu_dg2_g12 || arch-intel_gpu_pvc || arch-intel_gpu_mtl_h || arch-intel_gpu_mtl_u
 //
 // UNSUPPORTED: cuda, hip
-// UNSUPPORTED-REASON: FP64 emulation is an Intel specific feature.
+// UNSUPPORTED-INTENDED: FP64 emulation is an Intel specific feature.
 
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10,intel_gpu_dg2_g11,intel_gpu_dg2_g12,intel_gpu_pvc,intel_gpu_mtl_h,intel_gpu_mtl_u -fsycl-fp64-conv-emu -O0 %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -32,7 +32,7 @@
 // RUN: grep -rI "UNSUPPORTED:" %S/../../test-e2e \
 // RUN: -A 1 --include=*.cpp --no-group-separator | \
 // RUN: grep -v "UNSUPPORTED:" | \
-// RUN: grep -Pv "UNSUPPORTED-TRACKER:\s+(?:https://github.com/[\w\d-]+/[\w\d-]+/issues/[\d]+)|(?:[\w]+-[\d]+)|(?:UNSUPPORTED-INTENDED:\s*.+)" > %t
+// RUN: grep -Pv "(?:UNSUPPORTED-TRACKER:\s+(?:(?:https:\/\/github.com\/[\w\d-]+\/[\w\d-]+\/issues\/[\d]+)|(?:[\w]+-[\d]+)))|(?:UNSUPPORTED-INTENDED:\s*.+)" > %t
 // RUN: cat %t | wc -l | FileCheck %s --check-prefix NUMBER-OF-UNSUPPORTED-WITHOUT-INFO
 // RUN: cat %t | sed 's/\.cpp.*/.cpp/' | sort | FileCheck %s
 //
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 381
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 417
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
@@ -234,6 +234,40 @@
 // CHECK-NEXT: HierPar/hier_par_wgscope.cpp
 // CHECK-NEXT: HostInteropTask/host-task-failure.cpp
 // CHECK-NEXT: HostInteropTask/interop-task.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_bad_opcode.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_bad_operand_syntax.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_duplicate_label.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_illegal_exec_size.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_missing_label.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_missing_region.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_simple.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_undefined_decl.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_undefined_pred.cpp
+// CHECK-NEXT: InlineAsm/Negative/asm_wrong_declare.cpp
+// CHECK-NEXT: InlineAsm/asm_16_empty.cpp
+// CHECK-NEXT: InlineAsm/asm_16_matrix_mult.cpp
+// CHECK-NEXT: InlineAsm/asm_16_no_input_int.cpp
+// CHECK-NEXT: InlineAsm/asm_16_no_opts.cpp
+// CHECK-NEXT: InlineAsm/asm_8_empty.cpp
+// CHECK-NEXT: InlineAsm/asm_8_no_input_int.cpp
+// CHECK-NEXT: InlineAsm/asm_arbitrary_ops_order.cpp
+// CHECK-NEXT: InlineAsm/asm_decl_in_scope.cpp
+// CHECK-NEXT: InlineAsm/asm_float_add.cpp
+// CHECK-NEXT: InlineAsm/asm_float_imm_arg.cpp
+// CHECK-NEXT: InlineAsm/asm_float_neg.cpp
+// CHECK-NEXT: InlineAsm/asm_if.cpp
+// CHECK-NEXT: InlineAsm/asm_imm_arg.cpp
+// CHECK-NEXT: InlineAsm/asm_loop.cpp
+// CHECK-NEXT: InlineAsm/asm_mul.cpp
+// CHECK-NEXT: InlineAsm/asm_multiple_instructions.cpp
+// CHECK-NEXT: InlineAsm/asm_no_operands.cpp
+// CHECK-NEXT: InlineAsm/asm_no_output.cpp
+// CHECK-NEXT: InlineAsm/asm_plus_mod.cpp
+// CHECK-NEXT: InlineAsm/asm_switch.cpp
+// CHECK-NEXT: InlineAsm/letter_example.cpp
+// CHECK-NEXT: InlineAsm/malloc_shared_32.cpp
+// CHECK-NEXT: InlineAsm/malloc_shared_in_out_dif.cpp
+// CHECK-NEXT: InlineAsm/malloc_shared_no_input.cpp
 // CHECK-NEXT: InvokeSimd/Feature/ImplicitSubgroup/SPMD_invoke_ESIMD_external.cpp
 // CHECK-NEXT: InvokeSimd/Feature/ImplicitSubgroup/popcnt.cpp
 // CHECK-NEXT: InvokeSimd/Feature/popcnt.cpp
@@ -300,6 +334,7 @@
 // CHECK-NEXT: NewOffloadDriver/aot-gpu.cpp
 // CHECK-NEXT: NewOffloadDriver/spirv_device_obj_smoke.cpp
 // CHECK-NEXT: NonUniformGroups/ballot_group.cpp
+// CHECK-NEXT: NonUniformGroups/fixed_size_group.cpp
 // CHECK-NEXT: NonUniformGroups/opportunistic_group.cpp
 // CHECK-NEXT: NonUniformGroups/tangle_group.cpp
 // CHECK-NEXT: NonUniformGroups/tangle_group_algorithms.cpp
@@ -358,6 +393,7 @@
 // CHECK-NEXT: Regression/invalid_reqd_wg_size_correct_exception.cpp
 // CHECK-NEXT: Regression/kernel_bundle_ignore_sycl_external.cpp
 // CHECK-NEXT: Regression/kernel_bundle_ignore_sycl_external.cpp
+// CHECK-NEXT: Regression/no-split-reqd-wg-size-2.cpp
 // CHECK-NEXT: Regression/no-split-reqd-wg-size.cpp
 // CHECK-NEXT: Regression/reduction_resource_leak_usm.cpp
 // CHECK-NEXT: Regression/static-buffer-dtor.cpp

--- a/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
+++ b/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
@@ -29,7 +29,7 @@
 // RUN: grep -rI "XFAIL:" %S/../../test-e2e \
 // RUN: -A 1 --include=*.cpp --no-group-separator | \
 // RUN: grep -v "XFAIL:" | \
-// RUN: grep -Pv "XFAIL-TRACKER:\s+(?:https://github.com/[\w\d-]+/[\w\d-]+/issues/[\d]+)|(?:[\w]+-[\d]+)" > %t
+// RUN: grep -Pv "(?:XFAIL-TRACKER:\s+(?:(?:https:\/\/github.com\/[\w\d-]+\/[\w\d-]+\/issues\/[\d]+)|(?:[\w]+-[\d]+)))"
 // RUN: cat %t | wc -l | FileCheck %s --check-prefix NUMBER-OF-XFAIL-WITHOUT-TRACKER
 // RUN: cat %t | sed 's/\.cpp.*/.cpp/' | sort | FileCheck %s
 //


### PR DESCRIPTION
Improve regexp. Currently it filteres out strings like: REQUIRES: sg-16
So these tests are left untracked.