### PR TITLE
[SYCL][Test] Fix expectation in restrict property tests

### DIFF
--- a/sycl/test/check_device_code/extensions/annotated_arg/restrict.cpp
+++ b/sycl/test/check_device_code/extensions/annotated_arg/restrict.cpp
@@ -19,4 +19,4 @@ int main() {
   return 0;
 }
 
-// CHECK-IR: spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_(ptr addrspace(1) noalias noundef align 4 "sycl-restrict" %_arg_AnnotArg)
+// CHECK-IR: spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_(ptr addrspace(1) noalias noundef align 4 "sycl-restrict"

--- a/sycl/test/check_device_code/extensions/annotated_ptr/restrict.cpp
+++ b/sycl/test/check_device_code/extensions/annotated_ptr/restrict.cpp
@@ -18,4 +18,4 @@ int main() {
   return 0;
 }
 
-// CHECK-IR: spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_(ptr addrspace(1) noalias noundef align 4 "sycl-restrict" %_arg_AnnotPtr)
+// CHECK-IR: spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_(ptr addrspace(1) noalias noundef align 4 "sycl-restrict"


### PR DESCRIPTION
This commit fixes an overly strict expectation in both restrict.cpp tests introduced in https://github.com/intel/llvm/pull/16090.