### PR TITLE
[SYCL][DRIVER] Add driver option for libdevice path

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7058,7 +7058,7 @@ def fsycl_help : Flag<["-"], "fsycl-help">, Alias<fsycl_help_EQ>,
   Flags<[NoXarchOption]>, AliasArgs<["all"]>,
   HelpText<"Emit help information from all of the offline compilation tools">;
 def fsycl_libdevice_path_EQ : Joined<["-"], "fsycl-libdevice-path=">,
-  Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>, HelpText<"Path to libdevice library">;
+  Visibility<[ClangOption]>, HelpText<"Path to libdevice library">;
 def fsycl_libspirv_path_EQ : Joined<["-"], "fsycl-libspirv-path=">,
   HelpText<"Path to libspirv library">;
 def fno_sycl_libspirv : Flag<["-"], "fno-sycl-libspirv">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7057,6 +7057,8 @@ def fsycl_help_EQ : Joined<["-"], "fsycl-help=">, Flags<[NoXarchOption]>,
 def fsycl_help : Flag<["-"], "fsycl-help">, Alias<fsycl_help_EQ>,
   Flags<[NoXarchOption]>, AliasArgs<["all"]>,
   HelpText<"Emit help information from all of the offline compilation tools">;
+def fsycl_libdevice_path_EQ : Joined<["-"], "fsycl-libdevice-path=">,
+  Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>, HelpText<"Path to libdevice library">;
 def fsycl_libspirv_path_EQ : Joined<["-"], "fsycl-libspirv-path=">,
   HelpText<"Path to libspirv library">;
 def fno_sycl_libspirv : Flag<["-"], "fno-sycl-libspirv">,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6030,16 +6030,17 @@ class OffloadingActionBuilder final {
 
     bool addSYCLDeviceLibs(const ToolChain *TC, ActionList &DeviceLinkObjects,
                            bool isSpirvAOT, bool isMSVCEnv, bool isNativeCPU,
-                           Action *&NativeCPULib, const char *BoundArch, DerivedArgList &Args) {
+                           Action *&NativeCPULib, const char *BoundArch,
+                           DerivedArgList &Args) {
       int NumOfDeviceLibLinked = 0;
       SmallVector<SmallString<128>, 4> LibLocCandidates;
-      if(Args.hasArg(options::OPT_fsycl_libdevice_path_EQ)) {
-          auto ProvidedPath =
-              Args.getLastArgValue(options::OPT_fsycl_libdevice_path_EQ).str();
-          if (llvm::sys::fs::exists(ProvidedPath))  {
-            SmallString<128> ProvidedPathSS(ProvidedPath);
-            LibLocCandidates.push_back(ProvidedPathSS);
-          }
+      if (Args.hasArg(options::OPT_fsycl_libdevice_path_EQ)) {
+        auto ProvidedPath =
+            Args.getLastArgValue(options::OPT_fsycl_libdevice_path_EQ).str();
+        if (llvm::sys::fs::exists(ProvidedPath)) {
+          SmallString<128> ProvidedPathSS(ProvidedPath);
+          LibLocCandidates.push_back(ProvidedPathSS);
+        }
       }
       SYCLInstallation.getSYCLDeviceLibPath(LibLocCandidates);
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5745,7 +5745,7 @@ class OffloadingActionBuilder final {
           SYCLDeviceLibLinked = addSYCLDeviceLibs(
               TC, SYCLDeviceLibs, UseAOTLink,
               C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment(),
-              IsSYCLNativeCPU, NativeCPULib, BoundArch);
+              IsSYCLNativeCPU, NativeCPULib, BoundArch, Args);
         }
         JobAction *LinkSYCLLibs =
             C.MakeAction<LinkJobAction>(SYCLDeviceLibs, types::TY_LLVM_BC);
@@ -6030,9 +6030,17 @@ class OffloadingActionBuilder final {
 
     bool addSYCLDeviceLibs(const ToolChain *TC, ActionList &DeviceLinkObjects,
                            bool isSpirvAOT, bool isMSVCEnv, bool isNativeCPU,
-                           Action *&NativeCPULib, const char *BoundArch) {
+                           Action *&NativeCPULib, const char *BoundArch, DerivedArgList &Args) {
       int NumOfDeviceLibLinked = 0;
       SmallVector<SmallString<128>, 4> LibLocCandidates;
+      if(Args.hasArg(options::OPT_fsycl_libdevice_path_EQ)) {
+          auto ProvidedPath =
+              Args.getLastArgValue(options::OPT_fsycl_libdevice_path_EQ).str();
+          if (llvm::sys::fs::exists(ProvidedPath))  {
+            SmallString<128> ProvidedPathSS(ProvidedPath);
+            LibLocCandidates.push_back(ProvidedPathSS);
+          }
+      }
       SYCLInstallation.getSYCLDeviceLibPath(LibLocCandidates);
 
       SmallVector<std::string, 8> DeviceLibraries;

--- a/clang/test/Driver/sycl-native-cpu-fsycl.cpp
+++ b/clang/test/Driver/sycl-native-cpu-fsycl.cpp
@@ -65,3 +65,10 @@
 //CHECK_BINDINGS_MULTI_TU:# "{{.*}}" - "SYCL post link", inputs: ["[[LINK2]].bc"], output: "[[POSTL:.*]].table"
 //CHECK_BINDINGS_MULTI_TU:# "{{.*}}" - "offload wrapper", inputs: ["[[POSTL]].table"], output: "[[WRAP:.*]].o"
 //CHECK_BINDINGS_MULTI_TU:# "{{.*}}" - "{{.*}}::Linker", inputs: ["[[FILE1HOST]].o", "[[FILE2HOST]].o", "[[KERNELO]].o", "[[WRAP]].o"], output: "{{.*}}"
+
+// check that -fsycl-libdevice-path is used correctly
+// RUN: %clangxx -ccc-print-phases -std=c++11 -fsycl -fsycl-targets=native_cpu \
+// RUN: -fno-sycl-device-lib=all -fsycl-libdevice-path=%S/Inputs/SYCL %s 2>&1 | FileCheck %s
+
+// CHECK:       [[LIBNATIVECPU:[0-9]*]]: input, "{{.*}}Inputs/SYCL/libsycl-nativecpu_utils.bc", ir, (device-sycl)
+// CHECK-NEXT:  linker, {{{.*}}, [[LIBNATIVECPU]]}, ir, (device-sycl)


### PR DESCRIPTION
Adds a `-fsycl-libdevice-path` that points to a non-default directory for `libdevice`. This is particularly useful when cross-compiling for Native CPU.