### PR TITLE
Remove usage of deprecated getPointerTo()

### DIFF
--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -409,7 +409,7 @@ private:
   std::pair<Constant *, Constant *>
   addStructArrayToModule(ArrayRef<Constant *> ArrayData, Type *ElemTy) {
 
-    auto *PtrTy = ElemTy->getPointerTo();
+    auto *PtrTy = llvm::PointerType::getUnqual(C);
 
     if (ArrayData.size() == 0) {
       auto *NullPtr = Constant::getNullValue(PtrTy);
@@ -917,8 +917,7 @@ private:
       PropRegistry = MySymPropReader->getPropRegistry();
     } else {
       if (PropRegistryFile.empty()) {
-        auto *NullPtr =
-            Constant::getNullValue(getSyclPropSetTy()->getPointerTo());
+        auto *NullPtr = Constant::getNullValue(llvm::PointerType::getUnqual(C));
         return std::pair<Constant *, Constant *>(NullPtr, NullPtr);
       }
       // load the property registry file

--- a/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
+++ b/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
@@ -358,7 +358,7 @@ struct Wrapper {
   std::pair<Constant *, Constant *>
   addStructArrayToModule(ArrayRef<Constant *> ArrayData, Type *ElemTy) {
     if (ArrayData.empty()) {
-      auto *PtrTy = ElemTy->getPointerTo();
+      auto *PtrTy = llvm::PointerType::getUnqual(ElemTy->getContext());
       auto *NullPtr = Constant::getNullValue(PtrTy);
       return std::make_pair(NullPtr, NullPtr);
     }


### PR DESCRIPTION
Replace deprecated `getPointerTo()` with `llvm::PointerType::get(LLVMContext)`.