### PR TITLE
[SYCL] Fix warnings in source/detail code

### DIFF
--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -94,7 +94,7 @@ retrieveKernelBinary(const QueueImplPtr &Queue, const char *KernelName,
     DeviceImage = &detail::ProgramManager::getInstance().getDeviceImage(
         KernelName, Context, Device);
     Program = detail::ProgramManager::getInstance().createURProgram(
-        *DeviceImage, Context, {Device});
+        *DeviceImage, Context, {std::move(Device)});
   }
   return {DeviceImage, Program};
 }

--- a/sycl/source/detail/persistent_device_code_cache.cpp
+++ b/sycl/source/detail/persistent_device_code_cache.cpp
@@ -320,7 +320,7 @@ std::vector<std::vector<char>> PersistentDeviceCodeCache::getItemFromDisc(
 std::vector<std::vector<char>>
 PersistentDeviceCodeCache::getCompiledKernelFromDisc(
     const std::vector<device> &Devices, const std::string &BuildOptionsString,
-    const std::string SourceStr) {
+    const std::string &SourceStr) {
   assert(!Devices.empty());
   std::vector<std::vector<char>> Binaries(Devices.size());
   std::string FileNames;
@@ -518,7 +518,7 @@ std::string PersistentDeviceCodeCache::getCacheItemPath(
 
 std::string PersistentDeviceCodeCache::getCompiledKernelItemPath(
     const device &Device, const std::string &BuildOptionsString,
-    const std::string SourceString) {
+    const std::string &SourceString) {
 
   std::string cache_root{getRootDir()};
   if (cache_root.empty()) {

--- a/sycl/source/detail/persistent_device_code_cache.hpp
+++ b/sycl/source/detail/persistent_device_code_cache.hpp
@@ -170,7 +170,7 @@ public:
   static std::string
   getCompiledKernelItemPath(const device &Device,
                             const std::string &BuildOptionsString,
-                            const std::string SourceString);
+                            const std::string &SourceString);
 
   /* Program binaries built for one or more devices are read from persistent
    * cache and returned in form of vector of programs. Each binary program is
@@ -185,7 +185,7 @@ public:
   static std::vector<std::vector<char>>
   getCompiledKernelFromDisc(const std::vector<device> &Devices,
                             const std::string &BuildOptionsString,
-                            const std::string SourceStr);
+                            const std::string &SourceStr);
 
   /* Stores build program in persistent cache
    */

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -836,7 +836,7 @@ void callFuncForAllSubsets(Func &FuncToCall,
 
   auto it = DeviceSet.begin();
   std::advance(it, index);
-  for (int i = index; i < DeviceSet.size(); i++, it++) {
+  for (size_t i = index; i < DeviceSet.size(); i++, it++) {
     auto InsertedEntry = Subset.insert(Subset.end(), *it);
     callFuncForAllSubsets(FuncToCall, DeviceSet, Subset, i + 1);
     Subset.erase(InsertedEntry);

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -841,7 +841,7 @@ void callFuncForAllSubsets(Func &FuncToCall,
     callFuncForAllSubsets(FuncToCall, DeviceSet, Subset, i + 1);
     Subset.erase(InsertedEntry);
   }
-};
+}
 
 ur_program_handle_t ProgramManager::getBuiltURProgram(
     const BinImgWithDeps &ImgWithDeps, const context &Context,

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -994,8 +994,9 @@ ur_program_handle_t ProgramManager::getBuiltURProgram(
     if (URDevicesSet.size() > sizeof(Mask) * 8 - 1) {
       // Protection for the algorithm below. Although overflow is very unlikely
       // to be reached.
-      throw sycl::exception(make_error_code(errc::runtime),
-                            "Unable to generate device sets");
+      throw sycl::exception(
+          make_error_code(errc::runtime),
+          "Unable to cache built program for more than 31 devices");
     }
     for (; Mask < (1 << URDevicesSet.size()) - 1; ++Mask) {
       std::set<ur_device_handle_t> Subset;

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -213,7 +213,7 @@ public:
   void addImages(sycl_device_binaries DeviceImages);
   void debugPrintBinaryImages() const;
   static std::string getProgramBuildLog(const ur_program_handle_t &Program,
-                                        const ContextImplPtr Context);
+                                        const ContextImplPtr &Context);
 
   uint32_t getDeviceLibReqMask(const RTDeviceBinaryImage &Img);
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -59,7 +59,7 @@ namespace detail {
 template <typename MemOpFuncT, typename... MemOpArgTs>
 ur_result_t callMemOpHelper(MemOpFuncT &MemOpFunc, MemOpArgTs &&...MemOpArgs) {
   try {
-    MemOpFunc(MemOpArgs...);
+    MemOpFunc(std::forward<MemOpArgTs>(MemOpArgs)...);
   } catch (sycl::exception &e) {
     return static_cast<ur_result_t>(get_ur_error(e));
   }
@@ -70,7 +70,7 @@ template <typename MemOpRet, typename MemOpFuncT, typename... MemOpArgTs>
 ur_result_t callMemOpHelperRet(MemOpRet &MemOpResult, MemOpFuncT &MemOpFunc,
                                MemOpArgTs &&...MemOpArgs) {
   try {
-    MemOpResult = MemOpFunc(MemOpArgs...);
+    MemOpResult = MemOpFunc(std::forward<MemOpArgTs>(MemOpArgs)...);
   } catch (sycl::exception &e) {
     return static_cast<ur_result_t>(get_ur_error(e));
   }
@@ -2891,7 +2891,7 @@ ur_result_t ExecCGCommand::enqueueImpCommandBuffer() {
                                                        &RawEvents[0]);
   }
 
-  ur_exp_command_buffer_sync_point_t OutSyncPoint;
+  ur_exp_command_buffer_sync_point_t OutSyncPoint{};
   ur_exp_command_buffer_command_handle_t OutCommand = nullptr;
   switch (MCommandGroup->getType()) {
   case CGType::Kernel: {


### PR DESCRIPTION
Fixes places with copy instead of usage by reference or move.
Protected potential but unlikely constant overflow with exception.