### PR TITLE
[SYCL][libdevice][CMake][Trivial] Fix imf-fallback missing in NVPTX

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -584,7 +584,7 @@ foreach(arch IN LISTS devicelib_arch)
 
     append_to_property(
       ${bc_binary_dir}/libsycl-fallback-imf-${arch}-${dtype}.${bc-suffix}
-      PROPERTY_NAME ${arch})
+      PROPERTY_NAME BC_DEVICE_LIBS_${arch})
   endforeach()
 endforeach()
 


### PR DESCRIPTION
Seems like the IMF fallback libraries are not collected in the merged libdevice for NVPTX and AMDGPU, because the name of the CMake property was wrong.

I don't know why our testing does not catch this. I have seen this result in unresolved symbols earlier, but I have been sitting on this patch for a while and did not try with current trunk.