### PR TITLE
[CI] Avoid running redundant cuda-aws-stop

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -168,7 +168,7 @@ jobs:
 
   cuda-aws-stop:
     needs: [cuda-aws-start, cuda-run-tests]
-    if: always()
+    if: always() && ${{ needs.cuda-aws-start.result != 'skipped' }}
     uses: ./.github/workflows/sycl-aws.yml
     secrets: inherit
     with:


### PR DESCRIPTION
I noticed that this job runs in my local fork, although needed steps were skipped.