### PR TITLE
[SYCL][E2E][Subdevice] Reduce run time of test subdevice_pi.cpp

### DIFF
--- a/sycl/test-e2e/Basic/subdevice_pi.cpp
+++ b/sycl/test-e2e/Basic/subdevice_pi.cpp
@@ -39,8 +39,10 @@ static std::vector<device> partition_affinity(device dev) {
 }
 
 static std::vector<device> partition_equally(device dev) {
+  auto maxUnits = dev.get_info<info::device::max_compute_units>();
   std::vector<device> subdevices =
-      dev.create_sub_devices<info::partition_property::partition_equally>(1);
+      dev.create_sub_devices<info::partition_property::partition_equally>(
+          maxUnits / 2);
 
   return subdevices;
 }


### PR DESCRIPTION
On intel cpu device, the number of subdevices was the same as cpu count. The number could be large on a server. In `shared` subtest, all subdevices belong to the same context and device program is built for every subdevice. Device code compilation may take long time. This PR reduces test time from 10s to 0.4s on 160-core ICX. When device sanitizer is enabled, test time is reduced from ~10min to 14s.