### PR TITLE
[SYCL][Graph] Fix L0 multi-device kernel bundles

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,7 +116,7 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/Bensuo/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -4,4 +4,4 @@
 # Date:   Wed Dec 11 17:23:43 2024 +0000
 #     Merge pull request #2299 from cppchedy/chedy/fix-mipmap-leak
 #     [CUDA][Bindless] Fix memory leak in interop mapping
-set(UNIFIED_RUNTIME_TAG 098deca1f9f3b9f3f0563ee823ac424d8db30668)
+set(UNIFIED_RUNTIME_TAG "l0_cmd-buf_multi-device")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -1,7 +1,7 @@
-# commit 4739d4cc30534d80fba4c876bfbafa51d3cad53a
-# Merge: b0d133d5d5e8 44b4ff98ae79
+# commit b7047f6c36ec17b8560c2f1cd9ac9521715a9127
+# Merge: 73e5f3c6ff2d fcddf077c290
 # Author: Martin Grant <martin.morrisongrant@codeplay.com>
-# Date:   Fri Dec 13 11:30:56 2024 +0000
-#     Merge pull request #2437 from bashbaug/add-opencl-device-queries
-#     add a few missing Intel GPU device queries, fix device ID query
-set(UNIFIED_RUNTIME_TAG 4739d4cc30534d80fba4c876bfbafa51d3cad53a)
+# Date:   Fri Dec 13 14:20:15 2024 +0000
+#     Merge pull request #2454 from Bensuo/l0_cmd-buf_multi-device
+#     Fix L0 command-buffer consumption of multi-device kernels
+set(UNIFIED_RUNTIME_TAG b7047f6c36ec17b8560c2f1cd9ac9521715a9127)


### PR DESCRIPTION
Bumps UR commit to https://github.com/oneapi-src/unified-runtime/pull/2454 which contains a fix for using kernel bundles associated with a multi-device context in a SYCL-Graph