### PR TITLE
[SYCL] Require NVPTX registered target for CodeGenSYCL test

### DIFF
--- a/clang/test/CodeGenSYCL/nvptx-short-ptr.cpp
+++ b/clang/test/CodeGenSYCL/nvptx-short-ptr.cpp
@@ -1,5 +1,6 @@
 // Check that when we see the expected data layouts for NVPTX when we pass the
 // -nvptx-short-ptr option.
+// REQUIRES: nvptx-registered-target
 
 // RUN: %clang_cc1 -fsycl-is-device -disable-llvm-passes \
 // RUN:  -triple nvptx-nvidia-cuda -emit-llvm %s -o - \


### PR DESCRIPTION
This test forwards an option on to the NVPTX backend so must have the NVPTX target registered. This issue was noticed downstream.