### PR TITLE
[SYCL] Move SYCLLowerWGLocalMemoryPass to OptimizerEarlyEPCallback

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1046,8 +1046,8 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
       PB.registerOptimizerEarlyEPCallback([](ModulePassManager &MPM,
                                              OptimizationLevel Level,
                                              ThinOrFullLTOPhase) {
-        // Lowers __sycl_allocateLocalMemory  and __sycl_dynamicLocalMemoryPlaceholder
-        // builtin calls.
+        // Lowers __sycl_allocateLocalMemory  and
+        // __sycl_dynamicLocalMemoryPlaceholder builtin calls.
         MPM.addPass(SYCLLowerWGLocalMemoryPass());
       });
     } else if (LangOpts.SYCLIsHost && !LangOpts.SYCLESIMDBuildHostCode)

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1046,8 +1046,8 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
       PB.registerOptimizerEarlyEPCallback([](ModulePassManager &MPM,
                                              OptimizationLevel Level,
                                              ThinOrFullLTOPhase) {
-        // Allocate static local memory in SYCL kernel scope for each allocation
-        // call.
+        // Lowers __sycl_allocateLocalMemory  and __sycl_dynamicLocalMemoryPlaceholder
+        // builtin calls.
         MPM.addPass(SYCLLowerWGLocalMemoryPass());
       });
     } else if (LangOpts.SYCLIsHost && !LangOpts.SYCLESIMDBuildHostCode)

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1048,6 +1048,8 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
                                              ThinOrFullLTOPhase) {
         // Lowers __sycl_allocateLocalMemory  and
         // __sycl_dynamicLocalMemoryPlaceholder builtin calls.
+        // It is required by design to run SYCLLowerWGLocalMemoryPass after
+        // AlwaysInliner.
         MPM.addPass(SYCLLowerWGLocalMemoryPass());
       });
     } else if (LangOpts.SYCLIsHost && !LangOpts.SYCLESIMDBuildHostCode)


### PR DESCRIPTION
The pass transforms __sycl_allocateLocalMemory call to access of global
variable @WGLocalMem .

Move the transform to beginning of the optimizer since the access
could enable more optimization than the function call.

