### PR TITLE
[DeviceSanitizer] Fix device global type of KernelMetadata

### DIFF
--- a/llvm/lib/SYCLLowerIR/SanitizerKernelMetadata.cpp
+++ b/llvm/lib/SYCLLowerIR/SanitizerKernelMetadata.cpp
@@ -42,7 +42,7 @@ PreservedAnalyses SanitizerKernelMetadataPass::run(Module &M,
   {
     assert(KernelMetadata->getValueType()->isArrayTy());
 
-    auto Name = KernelMetadata->getName();
+    auto Name = KernelMetadata->getName().str();
     KernelMetadata->setName(Name + "_del");
     auto *KernelMetadataOld = KernelMetadata;
 

--- a/llvm/lib/SYCLLowerIR/SanitizerKernelMetadata.cpp
+++ b/llvm/lib/SYCLLowerIR/SanitizerKernelMetadata.cpp
@@ -42,8 +42,6 @@ PreservedAnalyses SanitizerKernelMetadataPass::run(Module &M,
   {
     assert(KernelMetadata->getValueType()->isArrayTy());
 
-    auto Name = KernelMetadata->getName().str();
-    KernelMetadata->setName(Name + "_del");
     auto *KernelMetadataOld = KernelMetadata;
 
     StructType *StructTypeWithArray = StructType::create(Ctx);
@@ -53,7 +51,8 @@ PreservedAnalyses SanitizerKernelMetadataPass::run(Module &M,
         M, StructTypeWithArray, false, GlobalValue::ExternalLinkage,
         ConstantStruct::get(StructTypeWithArray,
                             KernelMetadataOld->getInitializer()),
-        Name, nullptr, GlobalValue::NotThreadLocal, 1);
+        "", nullptr, GlobalValue::NotThreadLocal, 1); // Global AddressSpace
+    KernelMetadata->takeName(KernelMetadataOld);
     KernelMetadata->setUnnamedAddr(GlobalValue::UnnamedAddr::Local);
     KernelMetadata->setDSOLocal(true);
     KernelMetadata->copyAttributesFrom(KernelMetadataOld);

--- a/llvm/test/tools/sycl-post-link/device-sanitizer/asan.ll
+++ b/llvm/test/tools/sycl-post-link/device-sanitizer/asan.ll
@@ -18,7 +18,7 @@ $_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E8MyKernel = comdat any
 
 @__asan_kernel = internal addrspace(1) constant [55 x i8] c"_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E8MyKernel\00"
 @__AsanKernelMetadata = appending dso_local local_unnamed_addr addrspace(1) global [1 x { i64, i64 }] [{ i64, i64 } { i64 ptrtoint (ptr addrspace(1) @__asan_kernel to i64), i64 54 }] #2
-; CHECK-IR: @__AsanKernelMetadata {{.*}} !spirv.Decorations
+; CHECK-IR: @__AsanKernelMetadata = dso_local local_unnamed_addr addrspace(1) global %0 { {{.*}} }, !spirv.Decorations
 @__spirv_BuiltInGlobalInvocationId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
 @__asan_func = internal addrspace(2) constant [106 x i8] c"typeinfo name for main::'lambda'(sycl::_V1::handler&)::operator()(sycl::_V1::handler&) const::MyKernelR_4\00"
 

--- a/llvm/test/tools/sycl-post-link/device-sanitizer/msan.ll
+++ b/llvm/test/tools/sycl-post-link/device-sanitizer/msan.ll
@@ -18,7 +18,7 @@ $_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E8MyKernel = comdat any
 
 @__msan_kernel = internal addrspace(1) constant [55 x i8] c"_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E8MyKernel\00"
 @__MsanKernelMetadata = appending dso_local local_unnamed_addr addrspace(1) global [1 x { i64, i64 }] [{ i64, i64 } { i64 ptrtoint (ptr addrspace(1) @__msan_kernel to i64), i64 54 }] #0
-; CHECK-IR: @__MsanKernelMetadata {{.*}} !spirv.Decorations
+; CHECK-IR: @__MsanKernelMetadata = dso_local local_unnamed_addr addrspace(1) global %0 { {{.*}} }, !spirv.Decorations
 @__spirv_BuiltInGlobalInvocationId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
 @__asan_func = internal addrspace(2) constant [106 x i8] c"typeinfo name for main::'lambda'(sycl::_V1::handler&)::operator()(sycl::_V1::handler&) const::MyKernelR_4\00"
 


### PR DESCRIPTION
OpenCL CPU requires the type of device global wraps with structure type