### PR TITLE
[CI] Add Ubuntu 24.04 oneAPI build image

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -47,6 +47,10 @@ jobs:
             file: ubuntu2204_build
             tag: latest
             build_args: ""
+          - name: Build Ubuntu 24.04 oneAPI Docker image
+            file: ubuntu2404_build_oneapi
+            tag: latest
+            build_args: ""
           - name: Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
             tag: latest

--- a/devops/containers/ubuntu2404_build_oneapi.Dockerfile
+++ b/devops/containers/ubuntu2404_build_oneapi.Dockerfile
@@ -1,0 +1,53 @@
+FROM nvidia/cuda:12.6.3-devel-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+USER root
+
+# Install SYCL prerequisites
+COPY scripts/install_build_tools.sh /install.sh
+RUN /install.sh
+
+SHELL ["/bin/bash", "-ec"]
+
+# Install oneAPI
+
+# Make the directory if it doesn't exist yet.
+# This location is recommended by the distribution maintainers.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings
+# Download the key, convert the signing-key to a full
+# keyring required by apt and store in the keyring directory
+RUN wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null && \
+# Add rocm repo
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/6.3/ubuntu noble main" \
+    | tee /etc/apt/sources.list.d/amdgpu.list && \
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.3 noble main" \
+    |  tee --append /etc/apt/sources.list.d/rocm.list && \
+echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
+    | tee /etc/apt/preferences.d/rocm-pin-600 && \
+echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
+    | tee /etc/apt/preferences.d/rocm-pin-600 && \
+wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor \
+| tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
+echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+| tee /etc/apt/sources.list.d/oneAPI.list && \
+apt update
+# Install the ROCM kernel driver and oneAPI
+RUN apt install -yqq rocm-dev intel-oneapi-compiler-dpcpp-cpp && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
+
+ENTRYPOINT ["/docker_entrypoint.sh"]
+


### PR DESCRIPTION
Add a Ubuntu 24.04 based oneAPI build image. Once I add a build non-oneAPI image I will make sure they share most of the code.

I just took the existing 22.04 build image code and added the official oneAPI apt repo and install oneAPI from there.

I need to have the Docker image present in HEAD before I can test it in in CI, so this is only the first step and nothing is using it yet.

The other Docker CI fail isn't related.