### PR TITLE
[SYCL] Rewrite Tests Containing Deprecated Overloads #1 

### DIFF
--- a/sycl/test-e2e/Basic/max_linear_work_group_size_props.cpp
+++ b/sycl/test-e2e/Basic/max_linear_work_group_size_props.cpp
@@ -57,17 +57,15 @@ template <size_t I> struct KernelFunctorWithMaxWGSizeProp {
   }
 };
 
-template <Variant KernelVariant, size_t I, typename PropertiesT,
-          typename KernelType>
-int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
+template <Variant KernelVariant, size_t I, typename KernelType>
+int test(queue &Q, KernelType KernelFunc) {
   constexpr size_t Dims = 1;
 
   // Positive test case: Specify local size that matches required size.
   try {
     Q.submit([&](handler &CGH) {
       CGH.parallel_for<MaxLinearWGSizePositive<KernelVariant, false, I>>(
-          nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(I)), Props,
-          KernelFunc);
+          nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(I)), KernelFunc);
     });
     Q.wait_and_throw();
   } catch (exception &E) {
@@ -80,8 +78,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
   // Same as above but using the queue shortcuts.
   try {
     Q.parallel_for<MaxLinearWGSizePositive<KernelVariant, true, I>>(
-        nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(I)), Props,
-        KernelFunc);
+        nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(I)), KernelFunc);
     Q.wait_and_throw();
   } catch (exception &E) {
     std::cerr
@@ -96,7 +93,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
   try {
     Q.submit([&](handler &CGH) {
       CGH.parallel_for<MaxLinearWGSizeNoLocalPositive<KernelVariant, false, I>>(
-          repeatRange<Dims>(16), Props, KernelFunc);
+          repeatRange<Dims>(16), KernelFunc);
     });
     Q.wait_and_throw();
   } catch (exception &E) {
@@ -108,7 +105,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
 
   try {
     Q.parallel_for<MaxLinearWGSizeNoLocalPositive<KernelVariant, true, I>>(
-        repeatRange<Dims>(16), Props, KernelFunc);
+        repeatRange<Dims>(16), KernelFunc);
     Q.wait_and_throw();
   } catch (exception &E) {
     std::cerr << "Test case MaxLinearWGSizeNoLocalPositive shortcut failed: "
@@ -121,7 +118,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
   try {
     Q.submit([&](handler &CGH) {
       CGH.parallel_for<MaxLinearWGSizeNegative<KernelVariant, false, I>>(
-          nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)), Props,
+          nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)),
           KernelFunc);
     });
     Q.wait_and_throw();
@@ -146,7 +143,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
   // Same as above but using the queue shortcuts.
   try {
     Q.parallel_for<MaxLinearWGSizeNegative<KernelVariant, true, I>>(
-        nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)), Props,
+        nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)),
         KernelFunc);
     Q.wait_and_throw();
     std::cerr
@@ -173,17 +170,10 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
 }
 
 template <size_t I> int test_max(queue &Q) {
-  auto Props = ext::oneapi::experimental::properties{
-      ext::oneapi::experimental::max_linear_work_group_size<I>};
-  auto KernelFunction = [](auto) {};
-
-  auto EmptyProps = ext::oneapi::experimental::properties{};
   KernelFunctorWithMaxWGSizeProp<I> KernelFunctor;
 
   int Res = 0;
-  Res += test<Variant::Function, I>(Q, Props, KernelFunction);
-  Res += test<Variant::Functor, I>(Q, EmptyProps, KernelFunctor);
-  Res += test<Variant::FunctorAndProperty, I>(Q, Props, KernelFunctor);
+  Res += test<Variant::Functor, I>(Q, KernelFunctor);
   return Res;
 }
 

--- a/sycl/test-e2e/GroupAlgorithm/root_group.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/root_group.cpp
@@ -44,7 +44,11 @@ void testQueriesAndProperties() {
               q, wgRange, wgRange.size() * sizeof(int));
   const auto props = sycl::ext::oneapi::experimental::properties{
       sycl::ext::oneapi::experimental::use_root_sync};
-  q.single_task<class QueryKernel>(props, []() {});
+  struct TestKernel0 {
+    void operator()() const {}
+    auto get(sycl::ext::oneapi::experimental::properties_tag) { return props; }
+  };
+  q.single_task<class QueryKernel>(TestKernel0{});
 
   static auto check_max_num_work_group_sync = [](auto Result) {
     static_assert(std::is_same_v<std::remove_cv_t<decltype(Result)>, size_t>,
@@ -69,10 +73,10 @@ void testRootGroup() {
       sycl::ext::oneapi::experimental::use_root_sync};
   sycl::buffer<int> dataBuf{sycl::range{maxWGs * WorkGroupSize}};
   const auto range = sycl::nd_range<1>{maxWGs * WorkGroupSize, WorkGroupSize};
-  q.submit([&](sycl::handler &h) {
-    sycl::accessor data{dataBuf, h};
-    h.parallel_for<
-        class RootGroupKernel>(range, props, [=](sycl::nd_item<1> it) {
+  struct TestKernel1 {
+    sycl::accessor data;
+    TestKernel1(sycl::accessor data_param) { data = data_param; }
+    void operator()(sycl::nd_item<1> it) const {
       volatile float X = 1.0f;
       volatile float Y = 1.0f;
       auto root = it.ext_oneapi_get_root_group();
@@ -90,7 +94,12 @@ void testRootGroup() {
                 data[root.get_local_range() - root.get_local_id() - 1];
       sycl::group_barrier(root);
       data[root.get_local_id()] = sum;
-    });
+    }
+    auto get(sycl::ext::oneapi::experimental::properties_tag) { return props; }
+  };
+  q.submit([&](sycl::handler &h) {
+    sycl::accessor data{dataBuf, h};
+    h.parallel_for<class RootGroupKernel>(range, TestKernel1(data));
   });
   sycl::host_accessor data{dataBuf};
   const int workItemCount = static_cast<int>(range.get_global_range().size());
@@ -115,28 +124,36 @@ void testRootGroupFunctions() {
   constexpr int testCount = 9;
   sycl::buffer<bool> testResultsBuf{sycl::range{testCount}};
   const auto range = sycl::nd_range<1>{maxWGs * WorkGroupSize, WorkGroupSize};
+
+  struct TestKernel2 {
+    sycl::accessor testResults;
+    TestKernel2(sycl::accessor testResults_param) {
+      testResults = testResults_param;
+    }
+    void operator()(sycl::nd_item<1> it) const {
+      const auto root = it.ext_oneapi_get_root_group();
+      if (root.leader() || root.get_local_id() == 3) {
+        testResults[0] = root.get_group_id() == sycl::id<1>(0);
+        testResults[1] = root.leader() ? root.get_local_id() == sycl::id<1>(0)
+                                       : root.get_local_id() == sycl::id<1>(3);
+        testResults[2] = root.get_group_range() == sycl::range<1>(1);
+        testResults[3] = root.get_local_range() == it.get_global_range();
+        testResults[4] = root.get_max_local_range() == root.get_local_range();
+        testResults[5] = root.get_group_linear_id() == 0;
+        testResults[6] =
+            root.get_local_linear_id() == root.get_local_id().get(0);
+        testResults[7] = root.get_group_linear_range() == 1;
+        testResults[8] =
+            root.get_local_linear_range() == root.get_local_range().size();
+      }
+    }
+    auto get(sycl::ext::oneapi::experimental::properties_tag) { return props; }
+  };
+
   q.submit([&](sycl::handler &h) {
     sycl::accessor testResults{testResultsBuf, h};
-    h.parallel_for<class RootGroupFunctionsKernel>(
-        range, props, [=](sycl::nd_item<1> it) {
-          const auto root = it.ext_oneapi_get_root_group();
-          if (root.leader() || root.get_local_id() == 3) {
-            testResults[0] = root.get_group_id() == sycl::id<1>(0);
-            testResults[1] = root.leader()
-                                 ? root.get_local_id() == sycl::id<1>(0)
-                                 : root.get_local_id() == sycl::id<1>(3);
-            testResults[2] = root.get_group_range() == sycl::range<1>(1);
-            testResults[3] = root.get_local_range() == it.get_global_range();
-            testResults[4] =
-                root.get_max_local_range() == root.get_local_range();
-            testResults[5] = root.get_group_linear_id() == 0;
-            testResults[6] =
-                root.get_local_linear_id() == root.get_local_id().get(0);
-            testResults[7] = root.get_group_linear_range() == 1;
-            testResults[8] =
-                root.get_local_linear_range() == root.get_local_range().size();
-          }
-        });
+    h.parallel_for<class RootGroupFunctionsKernel>(range,
+                                                   TestKernel2(testResults));
   });
   sycl::host_accessor testResults{testResultsBuf};
   for (int i = 0; i < testCount; i++) {


### PR DESCRIPTION
The overloads for single_task and parallel_for in the sycl_ext_oneapi_kernel_properties extension are being deprecated as mentioned in https://github.com/intel/llvm/pull/14785. So I'm rewriting tests containg such overloads so that they can still run after the deprecation.