### PR TITLE
[SYCL][HIP] add missing nearbyint and rint

### DIFF
--- a/libdevice/cmath_wrapper.cpp
+++ b/libdevice/cmath_wrapper.cpp
@@ -200,4 +200,14 @@ DEVICE_EXTERN_C_INLINE
 float rintf(float x) { return __nv_rintf(x); }
 #endif // __NVPTX__
 
+#ifdef __AMDGCN__
+extern "C" SYCL_EXTERNAL float __ocml_nearbyint_f32(float);
+DEVICE_EXTERN_C_INLINE
+float nearbyintf(float x) { return __ocml_nearbyint_f32(x); }
+
+extern "C" SYCL_EXTERNAL float __ocml_rint_f32(float);
+DEVICE_EXTERN_C_INLINE
+float rintf(float x) { return __ocml_rint_f32(x); }
+#endif // __AMDGCN__
+
 #endif // __SPIR__ || __SPIRV__ || __NVPTX__ || __AMDGCN__

--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -193,11 +193,11 @@ double rint(double x) { return __nv_rint(x); }
 #ifdef __AMDGCN__
 extern "C" SYCL_EXTERNAL double __ocml_nearbyint_f64(double);
 DEVICE_EXTERN_C_INLINE
-double nearbyintf(double x) { return __ocml_nearbyint_f64(x); }
+double nearbyint(double x) { return __ocml_nearbyint_f64(x); }
 
 extern "C" SYCL_EXTERNAL double __ocml_rint_f64(double);
 DEVICE_EXTERN_C_INLINE
-double rintf(double x) { return __ocml_rint_f64(x); }
+double rint(double x) { return __ocml_rint_f64(x); }
 #endif // __AMDGCN__
 
 #if defined(_MSC_VER)

--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -190,6 +190,16 @@ DEVICE_EXTERN_C_INLINE
 double rint(double x) { return __nv_rint(x); }
 #endif // __NVPTX__
 
+#ifdef __AMDGCN__
+extern "C" SYCL_EXTERNAL double __ocml_nearbyint_f64(double);
+DEVICE_EXTERN_C_INLINE
+double nearbyintf(double x) { return __ocml_nearbyint_f64(x); }
+
+extern "C" SYCL_EXTERNAL double __ocml_rint_f64(double);
+DEVICE_EXTERN_C_INLINE
+double rintf(double x) { return __ocml_rint_f64(x); }
+#endif // __AMDGCN__
+
 #if defined(_MSC_VER)
 #include <math.h>
 // FLOAT PROPERTIES


### PR DESCRIPTION
Failed to compile OneDNN using DPCPP on AMD with sycl because the code [here](https://github.com/oneapi-src/oneDNN/blob/c852fdc60073a1ae298618c4faf26487b4144755/src/gpu/generic/sycl/eltwise_kernels.hpp#L137) that will run on the device actually calls `nearbyintf` [here](https://github.com/oneapi-src/oneDNN/blob/c852fdc60073a1ae298618c4faf26487b4144755/src/common/math_utils.hpp#L120-L131) , but `nearbyintf` lacks a symbolic definition.
Same solution as https://github.com/intel/llvm/pull/11177 but go straight to the `__ocml` symbols