### PR TITLE
[SYCL][Devops] Propagate a new secret to containers build

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -74,6 +74,7 @@ jobs:
           file: ${{ matrix.file }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          sycl_ci_passwd: ${{ secrets.DOCKER_SUDO_PASSWORD }}
           tags: |
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}-${{ github.sha }}
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}

--- a/devops/actions/build_container/action.yml
+++ b/devops/actions/build_container/action.yml
@@ -21,6 +21,9 @@ inputs:
   file:
     description: "Dockerfile"
     required: true
+  sycl_ci_passwd:
+    description: "Password to assign to sycl_ci user within a container"
+    required: true
 
 runs:
   using: "composite"
@@ -41,3 +44,4 @@ runs:
       file: ${{ github.workspace }}/devops/containers/${{ inputs.file }}.Dockerfile
       secrets: |
         github_token=${{ github.token }}
+        sycl_ci_passwd=${{ inputs.sycl_ci_passwd }}


### PR DESCRIPTION
Extended build containers action with an extra argument which specifies a password that will be assigned to the `sycl_ci` user created within containers.

For now this new secret is unused, so this changes is expected to have no impact on our CI.

This is outlined from #16361 to improve testing for that PR: for security reasons actions are only invoked from the default branch and never from a PR branch. Therefore, to actually test that this secret is properly used without errors we need to update the action first.