### PR TITLE
[SYCL] Use `inline` guarded by `_WIN32` for `has_extension`

### DIFF
--- a/sycl/source/backend/opencl.cpp
+++ b/sycl/source/backend/opencl.cpp
@@ -92,12 +92,24 @@ __SYCL_EXPORT bool has_extension(const sycl::device &SyclDevice,
 } // namespace detail
 
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-__SYCL_EXPORT bool has_extension(const sycl::device &SyclDevice,
-                                 const std::string &Extension) {
+// Magic combination found by trial and error:
+__SYCL_EXPORT
+#if _WIN32
+inline
+#endif
+    bool
+    has_extension(const sycl::device &SyclDevice,
+                  const std::string &Extension) {
   return detail::has_extension(SyclDevice, detail::string_view{Extension});
 }
-__SYCL_EXPORT bool has_extension(const sycl::platform &SyclPlatform,
-                                 const std::string &Extension) {
+// Magic combination found by trial and error:
+__SYCL_EXPORT
+#if _WIN32
+inline
+#endif
+    bool
+    has_extension(const sycl::platform &SyclPlatform,
+                  const std::string &Extension) {
   return detail::has_extension(SyclPlatform, detail::string_view{Extension});
 }
 #endif


### PR DESCRIPTION
I'm only able reproduce link error downstream for this API (and don't know what exactly is causing it), but the
change is the same in nature as parts of
https://github.com/intel/llvm/pull/16178,
https://github.com/intel/llvm/pull/16194 and
https://github.com/intel/llvm/pull/16267