### PR TITLE
[SYCL][E2E] Rewrite Tests Containing Deprecated Overloads #2

### DIFF
--- a/sycl/test-e2e/Basic/max_linear_work_group_size_props.cpp
+++ b/sycl/test-e2e/Basic/max_linear_work_group_size_props.cpp
@@ -57,17 +57,15 @@ template <size_t I> struct KernelFunctorWithMaxWGSizeProp {
   }
 };
 
-template <Variant KernelVariant, size_t I, typename PropertiesT,
-          typename KernelType>
-int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
+template <Variant KernelVariant, size_t I, typename KernelType>
+int test(queue &Q, KernelType KernelFunc) {
   constexpr size_t Dims = 1;
 
   // Positive test case: Specify local size that matches required size.
   try {
     Q.submit([&](handler &CGH) {
       CGH.parallel_for<MaxLinearWGSizePositive<KernelVariant, false, I>>(
-          nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(I)), Props,
-          KernelFunc);
+          nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(I)), KernelFunc);
     });
     Q.wait_and_throw();
   } catch (exception &E) {
@@ -80,8 +78,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
   // Same as above but using the queue shortcuts.
   try {
     Q.parallel_for<MaxLinearWGSizePositive<KernelVariant, true, I>>(
-        nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(I)), Props,
-        KernelFunc);
+        nd_range<Dims>(repeatRange<Dims>(8), range<Dims>(I)), KernelFunc);
     Q.wait_and_throw();
   } catch (exception &E) {
     std::cerr
@@ -96,7 +93,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
   try {
     Q.submit([&](handler &CGH) {
       CGH.parallel_for<MaxLinearWGSizeNoLocalPositive<KernelVariant, false, I>>(
-          repeatRange<Dims>(16), Props, KernelFunc);
+          repeatRange<Dims>(16), KernelFunc);
     });
     Q.wait_and_throw();
   } catch (exception &E) {
@@ -108,7 +105,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
 
   try {
     Q.parallel_for<MaxLinearWGSizeNoLocalPositive<KernelVariant, true, I>>(
-        repeatRange<Dims>(16), Props, KernelFunc);
+        repeatRange<Dims>(16), KernelFunc);
     Q.wait_and_throw();
   } catch (exception &E) {
     std::cerr << "Test case MaxLinearWGSizeNoLocalPositive shortcut failed: "
@@ -121,7 +118,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
   try {
     Q.submit([&](handler &CGH) {
       CGH.parallel_for<MaxLinearWGSizeNegative<KernelVariant, false, I>>(
-          nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)), Props,
+          nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)),
           KernelFunc);
     });
     Q.wait_and_throw();
@@ -146,7 +143,7 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
   // Same as above but using the queue shortcuts.
   try {
     Q.parallel_for<MaxLinearWGSizeNegative<KernelVariant, true, I>>(
-        nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)), Props,
+        nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)),
         KernelFunc);
     Q.wait_and_throw();
     std::cerr
@@ -173,17 +170,10 @@ int test(queue &Q, PropertiesT Props, KernelType KernelFunc) {
 }
 
 template <size_t I> int test_max(queue &Q) {
-  auto Props = ext::oneapi::experimental::properties{
-      ext::oneapi::experimental::max_linear_work_group_size<I>};
-  auto KernelFunction = [](auto) {};
-
-  auto EmptyProps = ext::oneapi::experimental::properties{};
   KernelFunctorWithMaxWGSizeProp<I> KernelFunctor;
 
   int Res = 0;
-  Res += test<Variant::Function, I>(Q, Props, KernelFunction);
-  Res += test<Variant::Functor, I>(Q, EmptyProps, KernelFunctor);
-  Res += test<Variant::FunctorAndProperty, I>(Q, Props, KernelFunctor);
+  Res += test<Variant::Functor, I>(Q, KernelFunctor);
   return Res;
 }
 

--- a/sycl/test-e2e/Graph/Inputs/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/Inputs/work_group_size_prop.cpp
@@ -80,7 +80,8 @@ int test(queue &Queue, KernelType KernelFunc) {
   try {
     add_node(GraphN, Queue, [&](handler &CGH) {
       CGH.parallel_for<ReqdWGSizeNegativeA<KernelVariant, false, Is...>>(
-          nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)), KernelFunc);
+          nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)),
+          KernelFunc);
     });
     auto ExecGraph = GraphN.finalize();
 
@@ -115,7 +116,8 @@ int test(queue &Queue, KernelType KernelFunc) {
     GraphN.begin_recording(Queue);
 
     Queue.parallel_for<ReqdWGSizeNegativeA<KernelVariant, true, Is...>>(
-        nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)), KernelFunc);
+        nd_range<Dims>(repeatRange<Dims>(16), repeatRange<Dims>(8)),
+        KernelFunc);
 
     GraphN.end_recording(Queue);
     auto ExecGraph = GraphN.finalize();

--- a/sycl/test-e2e/GroupAlgorithm/root_group.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/root_group.cpp
@@ -42,9 +42,14 @@ void testQueriesAndProperties() {
           .ext_oneapi_get_info<sycl::ext::oneapi::experimental::info::
                                    kernel_queue_specific::max_num_work_groups>(
               q, wgRange, wgRange.size() * sizeof(int));
-  const auto props = sycl::ext::oneapi::experimental::properties{
-      sycl::ext::oneapi::experimental::use_root_sync};
-  q.single_task<class QueryKernel>(props, []() {});
+  struct TestKernel0 {
+    void operator()() const {}
+    auto get(sycl::ext::oneapi::experimental::properties_tag) {
+      return sycl::ext::oneapi::experimental::properties{
+          sycl::ext::oneapi::experimental::use_root_sync};
+    }
+  };
+  q.single_task<class QueryKernel>(TestKernel0{});
 
   static auto check_max_num_work_group_sync = [](auto Result) {
     static_assert(std::is_same_v<std::remove_cv_t<decltype(Result)>, size_t>,
@@ -54,6 +59,34 @@ void testQueriesAndProperties() {
   check_max_num_work_group_sync(maxWGs);
   check_max_num_work_group_sync(maxWGsWithLimits);
 }
+
+template <typename T> struct TestKernel1 {
+  T m_data;
+  TestKernel1(T &data_) : m_data(data_) {}
+  void operator()(sycl::nd_item<1> it) const {
+    volatile float X = 1.0f;
+    volatile float Y = 1.0f;
+    auto root = it.ext_oneapi_get_root_group();
+    m_data[root.get_local_id()] = root.get_local_id();
+    sycl::group_barrier(root);
+    // Delay half of the workgroups with extra work to check that the barrier
+    // synchronizes the whole device.
+    if (it.get_group(0) % 2 == 0) {
+      X += sycl::sin(X);
+      Y += sycl::cos(Y);
+    }
+    root = sycl::ext::oneapi::experimental::this_work_item::get_root_group<1>();
+    int sum = m_data[root.get_local_id()] +
+              m_data[root.get_local_range() - root.get_local_id() - 1];
+    sycl::group_barrier(root);
+    m_data[root.get_local_id()] = sum;
+  }
+  auto get(sycl::ext::oneapi::experimental::properties_tag) {
+    return sycl::ext::oneapi::experimental::properties{
+        sycl::ext::oneapi::experimental::use_root_sync};
+    ;
+  }
+};
 
 void testRootGroup() {
   sycl::queue q;
@@ -65,32 +98,11 @@ void testRootGroup() {
           .ext_oneapi_get_info<sycl::ext::oneapi::experimental::info::
                                    kernel_queue_specific::max_num_work_groups>(
               q, WorkGroupSize, 0);
-  const auto props = sycl::ext::oneapi::experimental::properties{
-      sycl::ext::oneapi::experimental::use_root_sync};
   sycl::buffer<int> dataBuf{sycl::range{maxWGs * WorkGroupSize}};
   const auto range = sycl::nd_range<1>{maxWGs * WorkGroupSize, WorkGroupSize};
   q.submit([&](sycl::handler &h) {
     sycl::accessor data{dataBuf, h};
-    h.parallel_for<
-        class RootGroupKernel>(range, props, [=](sycl::nd_item<1> it) {
-      volatile float X = 1.0f;
-      volatile float Y = 1.0f;
-      auto root = it.ext_oneapi_get_root_group();
-      data[root.get_local_id()] = root.get_local_id();
-      sycl::group_barrier(root);
-      // Delay half of the workgroups with extra work to check that the barrier
-      // synchronizes the whole device.
-      if (it.get_group(0) % 2 == 0) {
-        X += sycl::sin(X);
-        Y += sycl::cos(Y);
-      }
-      root =
-          sycl::ext::oneapi::experimental::this_work_item::get_root_group<1>();
-      int sum = data[root.get_local_id()] +
-                data[root.get_local_range() - root.get_local_id() - 1];
-      sycl::group_barrier(root);
-      data[root.get_local_id()] = sum;
-    });
+    h.parallel_for<class RootGroupKernel>(range, TestKernel1(data));
   });
   sycl::host_accessor data{dataBuf};
   const int workItemCount = static_cast<int>(range.get_global_range().size());
@@ -98,6 +110,32 @@ void testRootGroup() {
     assert(data[i] == (workItemCount - 1));
   }
 }
+
+template <typename T> struct TestKernel2 {
+  T m_testResults;
+  TestKernel2(T &testResults_) : m_testResults(testResults_) {}
+  void operator()(sycl::nd_item<1> it) const {
+    const auto root = it.ext_oneapi_get_root_group();
+    if (root.leader() || root.get_local_id() == 3) {
+      m_testResults[0] = root.get_group_id() == sycl::id<1>(0);
+      m_testResults[1] = root.leader() ? root.get_local_id() == sycl::id<1>(0)
+                                       : root.get_local_id() == sycl::id<1>(3);
+      m_testResults[2] = root.get_group_range() == sycl::range<1>(1);
+      m_testResults[3] = root.get_local_range() == it.get_global_range();
+      m_testResults[4] = root.get_max_local_range() == root.get_local_range();
+      m_testResults[5] = root.get_group_linear_id() == 0;
+      m_testResults[6] =
+          root.get_local_linear_id() == root.get_local_id().get(0);
+      m_testResults[7] = root.get_group_linear_range() == 1;
+      m_testResults[8] =
+          root.get_local_linear_range() == root.get_local_range().size();
+    }
+  }
+  auto get(sycl::ext::oneapi::experimental::properties_tag) {
+    return sycl::ext::oneapi::experimental::properties{
+        sycl::ext::oneapi::experimental::use_root_sync};
+  }
+};
 
 void testRootGroupFunctions() {
   sycl::queue q;
@@ -109,34 +147,13 @@ void testRootGroupFunctions() {
           .ext_oneapi_get_info<sycl::ext::oneapi::experimental::info::
                                    kernel_queue_specific::max_num_work_groups>(
               q, WorkGroupSize, 0);
-  const auto props = sycl::ext::oneapi::experimental::properties{
-      sycl::ext::oneapi::experimental::use_root_sync};
-
   constexpr int testCount = 9;
   sycl::buffer<bool> testResultsBuf{sycl::range{testCount}};
   const auto range = sycl::nd_range<1>{maxWGs * WorkGroupSize, WorkGroupSize};
   q.submit([&](sycl::handler &h) {
     sycl::accessor testResults{testResultsBuf, h};
-    h.parallel_for<class RootGroupFunctionsKernel>(
-        range, props, [=](sycl::nd_item<1> it) {
-          const auto root = it.ext_oneapi_get_root_group();
-          if (root.leader() || root.get_local_id() == 3) {
-            testResults[0] = root.get_group_id() == sycl::id<1>(0);
-            testResults[1] = root.leader()
-                                 ? root.get_local_id() == sycl::id<1>(0)
-                                 : root.get_local_id() == sycl::id<1>(3);
-            testResults[2] = root.get_group_range() == sycl::range<1>(1);
-            testResults[3] = root.get_local_range() == it.get_global_range();
-            testResults[4] =
-                root.get_max_local_range() == root.get_local_range();
-            testResults[5] = root.get_group_linear_id() == 0;
-            testResults[6] =
-                root.get_local_linear_id() == root.get_local_id().get(0);
-            testResults[7] = root.get_group_linear_range() == 1;
-            testResults[8] =
-                root.get_local_linear_range() == root.get_local_range().size();
-          }
-        });
+    h.parallel_for<class RootGroupFunctionsKernel>(range,
+                                                   TestKernel2(testResults));
   });
   sycl::host_accessor testResults{testResultsBuf};
   for (int i = 0; i < testCount; i++) {

--- a/sycl/test-e2e/GroupAlgorithm/root_group.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/root_group.cpp
@@ -2,7 +2,10 @@
 // XFAIL: (opencl && !cpu && !accelerator)
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/14641
 
-// RUN: %{build} -I . -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue
+// https://github.com/intel/llvm/issues/16451. Rewrite testRootGroup() amd
+// remove the flag once the issue is resolved.
+// RUN: %{build} -I . -o %t.out -Wno-deprecated-declarations %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
 // RUN: %{run} %t.out
 
 // Disabled temporarily while investigation into the failure is ongoing.
@@ -60,34 +63,6 @@ void testQueriesAndProperties() {
   check_max_num_work_group_sync(maxWGsWithLimits);
 }
 
-template <typename T> struct TestKernel1 {
-  T m_data;
-  TestKernel1(T &data_) : m_data(data_) {}
-  void operator()(sycl::nd_item<1> it) const {
-    volatile float X = 1.0f;
-    volatile float Y = 1.0f;
-    auto root = it.ext_oneapi_get_root_group();
-    m_data[root.get_local_id()] = root.get_local_id();
-    sycl::group_barrier(root);
-    // Delay half of the workgroups with extra work to check that the barrier
-    // synchronizes the whole device.
-    if (it.get_group(0) % 2 == 0) {
-      X += sycl::sin(X);
-      Y += sycl::cos(Y);
-    }
-    root = sycl::ext::oneapi::experimental::this_work_item::get_root_group<1>();
-    int sum = m_data[root.get_local_id()] +
-              m_data[root.get_local_range() - root.get_local_id() - 1];
-    sycl::group_barrier(root);
-    m_data[root.get_local_id()] = sum;
-  }
-  auto get(sycl::ext::oneapi::experimental::properties_tag) {
-    return sycl::ext::oneapi::experimental::properties{
-        sycl::ext::oneapi::experimental::use_root_sync};
-    ;
-  }
-};
-
 void testRootGroup() {
   sycl::queue q;
   const auto bundle =
@@ -98,11 +73,32 @@ void testRootGroup() {
           .ext_oneapi_get_info<sycl::ext::oneapi::experimental::info::
                                    kernel_queue_specific::max_num_work_groups>(
               q, WorkGroupSize, 0);
+  const auto props = sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::use_root_sync};
   sycl::buffer<int> dataBuf{sycl::range{maxWGs * WorkGroupSize}};
   const auto range = sycl::nd_range<1>{maxWGs * WorkGroupSize, WorkGroupSize};
   q.submit([&](sycl::handler &h) {
     sycl::accessor data{dataBuf, h};
-    h.parallel_for<class RootGroupKernel>(range, TestKernel1(data));
+    h.parallel_for<
+        class RootGroupKernel>(range, props, [=](sycl::nd_item<1> it) {
+      volatile float X = 1.0f;
+      volatile float Y = 1.0f;
+      auto root = it.ext_oneapi_get_root_group();
+      data[root.get_local_id()] = root.get_local_id();
+      sycl::group_barrier(root);
+      // Delay half of the workgroups with extra work to check that the barrier
+      // synchronizes the whole device.
+      if (it.get_group(0) % 2 == 0) {
+        X += sycl::sin(X);
+        Y += sycl::cos(Y);
+      }
+      root =
+          sycl::ext::oneapi::experimental::this_work_item::get_root_group<1>();
+      int sum = data[root.get_local_id()] +
+                data[root.get_local_range() - root.get_local_id() - 1];
+      sycl::group_barrier(root);
+      data[root.get_local_id()] = sum;
+    });
   });
   sycl::host_accessor data{dataBuf};
   const int workItemCount = static_cast<int>(range.get_global_range().size());

--- a/sycl/test-e2e/Properties/cache_config.cpp
+++ b/sycl/test-e2e/Properties/cache_config.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: gpu, level_zero
 
-// RUN: %{build} -o %t.out
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue https://github.com/intel/llvm/issues/16320. Remove the flag once the issue is resolved.
+// RUN: %{build} -o %t.out -Wno-deprecated-declarations
 // RUN: env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 
 #include <numeric>

--- a/sycl/test-e2e/Properties/cache_config.cpp
+++ b/sycl/test-e2e/Properties/cache_config.cpp
@@ -36,6 +36,14 @@ struct NegativeKernelFunctor {
   auto get(properties_tag) const { return properties{}; }
 };
 
+struct RangeKernelFunctor {
+
+  RangeKernelFunctor() {}
+
+  void operator()(id<2> i) const {}
+  auto get(properties_tag) const { return properties{cache_config(large_slm)}; }
+};
+
 int main() {
   sycl::property_list q_prop{sycl::property::queue::in_order()};
   queue q{q_prop};
@@ -43,22 +51,10 @@ int main() {
   sycl::ext::oneapi::experimental::properties properties{
       cache_config(large_slm)};
 
-  // CHECK: single_task
-  // CHECK: ZE ---> zeKernelSetCacheConfig
-  std::cout << "single_task" << std::endl;
-  q.single_task(properties, [=]() {}).wait();
-
   // CHECK: parallel_for with sycl::range
   // CHECK: ZE ---> zeKernelSetCacheConfig
   std::cout << "parallel_for with sycl::range" << std::endl;
-  q.parallel_for(range<2>{16, 16}, properties, [=](id<2> i) {}).wait();
-
-  // CHECK: parallel_for with sycl::nd_range
-  // CHECK: ZE ---> zeKernelSetCacheConfig
-  std::cout << "parallel_for with sycl::nd_range" << std::endl;
-  q.parallel_for(nd_range<2>{range<2>(4, 4), range<2>(2, 2)}, properties,
-                 [=](nd_item<2> i) {})
-      .wait();
+  q.parallel_for(range<2>{16, 16}, RangeKernelFunctor{}).wait();
 
   // CHECK: parallel_for_work_group(range, func)
   // CHECK: ZE ---> zeKernelSetCacheConfig

--- a/sycl/test-e2e/Properties/cache_config.cpp
+++ b/sycl/test-e2e/Properties/cache_config.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: gpu, level_zero
 
-// TODO: Currently using the -Wno-deprecated-declarations flag due to issue https://github.com/intel/llvm/issues/16320. Remove the flag once the issue is resolved.
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue
+// https://github.com/intel/llvm/issues/16320. Remove the flag once the issue is
+// resolved.
 // RUN: %{build} -o %t.out -Wno-deprecated-declarations
 // RUN: env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/VirtualFunctions/2/1/1/simple-hierarchy.cpp
+++ b/sycl/test-e2e/VirtualFunctions/2/1/1/simple-hierarchy.cpp
@@ -30,6 +30,24 @@ class IncrementBy8 : public BaseIncrement {
   void increment(int *Data) override { *Data += 8; }
 };
 
+template <typename T1, typename T2> struct KernelFunctor {
+  T1 mStorageAcc;
+  T2 mDataAcc;
+  unsigned mTestCase;
+  KernelFunctor(T1 &StorageAcc, T2 &DataAcc, unsigned TestCase)
+      : mStorageAcc(StorageAcc), mDataAcc(DataAcc), mTestCase(TestCase) {}
+  void operator()() const {
+    auto *Ptr =
+        mStorageAcc[0].template construct</* ret type = */ BaseIncrement>(
+            mTestCase);
+    Ptr->increment(
+        mDataAcc.template get_multi_ptr<sycl::access::decorated::no>().get());
+  }
+  auto get(oneapi::properties_tag) const {
+    return oneapi::properties{oneapi::assume_indirect_calls};
+  }
+};
+
 int main() try {
   using storage_t =
       obj_storage_t<BaseIncrement, IncrementBy2, IncrementBy4, IncrementBy8>;
@@ -44,7 +62,6 @@ int main() try {
 
   sycl::queue q(asyncHandler);
 
-  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   for (unsigned TestCase = 0; TestCase < 4; ++TestCase) {
     int HostData = 42;
     int Data = HostData;
@@ -53,12 +70,7 @@ int main() try {
     q.submit([&](sycl::handler &CGH) {
       sycl::accessor StorageAcc(DeviceStorage, CGH, sycl::write_only);
       sycl::accessor DataAcc(DataStorage, CGH, sycl::write_only);
-      CGH.single_task(props, [=]() {
-        auto *Ptr =
-            StorageAcc[0].construct</* ret type = */ BaseIncrement>(TestCase);
-        Ptr->increment(
-            DataAcc.get_multi_ptr<sycl::access::decorated::no>().get());
-      });
+      CGH.single_task(KernelFunctor(StorageAcc, DataAcc, TestCase));
     });
 
     auto *Ptr = HostStorage.construct</* ret type = */ BaseIncrement>(TestCase);

--- a/sycl/test-e2e/VirtualFunctions/2/2/single-construct-single-use.cpp
+++ b/sycl/test-e2e/VirtualFunctions/2/2/single-construct-single-use.cpp
@@ -57,6 +57,22 @@ public:
   void increment(int *Data) override { *Data += 16 + Mod; }
 };
 
+template <typename T1, typename T2> struct KernelFunctor {
+  T1 mStorageAcc;
+  T2 mDataAcc;
+  KernelFunctor(T1 &StorageAcc, T2 &DataAcc)
+      : mStorageAcc(StorageAcc), mDataAcc(DataAcc) {}
+  void operator()() const {
+    auto *Ptr = mStorageAcc[0].template getAs<BaseIncrement>();
+    Ptr->increment(
+        mDataAcc.template get_multi_ptr<sycl::access::decorated::no>().get());
+  }
+  auto get(oneapi::properties_tag) const {
+    return oneapi::properties{
+        oneapi::assume_indirect_calls_to<void, SetIncBy16>};
+  }
+};
+
 int main() try {
   using storage_t = obj_storage_t<BaseIncrement, IncrementBy2, IncrementBy4,
                                   IncrementBy8, IncrementBy16>;
@@ -72,8 +88,6 @@ int main() try {
   sycl::queue q(asyncHandler);
 
   // TODO: cover uses case when objects are passed through USM
-  constexpr oneapi::properties props{
-      oneapi::assume_indirect_calls_to<void, SetIncBy16>};
   for (unsigned TestCase = 0; TestCase < 5; ++TestCase) {
     int HostData = 42;
     int Data = HostData;
@@ -90,11 +104,7 @@ int main() try {
     q.submit([&](sycl::handler &CGH) {
       sycl::accessor StorageAcc(DeviceStorage, CGH, sycl::read_write);
       sycl::accessor DataAcc(DataStorage, CGH, sycl::write_only);
-      CGH.single_task(props, [=]() {
-        auto *Ptr = StorageAcc[0].getAs<BaseIncrement>();
-        Ptr->increment(
-            DataAcc.get_multi_ptr<sycl::access::decorated::no>().get());
-      });
+      CGH.single_task(KernelFunctor(StorageAcc, DataAcc));
     });
 
     auto *Ptr =

--- a/sycl/test-e2e/forward_progress/forward_progress_kernel_param_L0_gpu.cpp
+++ b/sycl/test-e2e/forward_progress/forward_progress_kernel_param_L0_gpu.cpp
@@ -23,41 +23,42 @@ void check_props(sycl::queue &q) {}
 
 // Full specializations for each progress guarantee
 
+template <typename T> struct KernelFunctor {
+  T props;
+  KernelFunctor(const T &props_) : props(props_) {}
+  void operator()() const {}
+  auto get(properties_tag) const { return props; }
+};
+
 template <>
 void check_props<forward_progress_guarantee::parallel>(sycl::queue &q) {
   constexpr auto guarantee = forward_progress_guarantee::parallel;
   // Check properties at execution_scope::root_group coordination level
-  q.single_task(
-      properties{work_group_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
-  q.single_task(
-      properties{sub_group_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{work_group_progress<guarantee, execution_scope::root_group>}));
+  q.single_task(KernelFunctor(
+      properties{sub_group_progress<guarantee, execution_scope::root_group>}));
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::root_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        work_item_progress<guarantee, execution_scope::root_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
 
   // Check properties at execution_scope::work_group coordination level
-  q.single_task(
-      properties{sub_group_progress<guarantee, execution_scope::work_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{sub_group_progress<guarantee, execution_scope::work_group>}));
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::work_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        work_item_progress<guarantee, execution_scope::work_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
 
   // Check properties at execution_scope::sub_group coordination level
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::sub_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(
+        properties{work_item_progress<guarantee, execution_scope::sub_group>}));
   } catch (sycl::exception &ex) {
   }
 }
@@ -66,66 +67,54 @@ template <>
 void check_props<forward_progress_guarantee::weakly_parallel>(sycl::queue &q) {
   constexpr auto guarantee = forward_progress_guarantee::weakly_parallel;
   // Check properties at execution_scope::root_group coordination level
-  q.single_task(
-      properties{work_group_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
-  q.single_task(
-      properties{sub_group_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{work_group_progress<guarantee, execution_scope::root_group>}));
+  q.single_task(KernelFunctor(
+      properties{sub_group_progress<guarantee, execution_scope::root_group>}));
 
-  q.single_task(
-      properties{work_item_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{work_item_progress<guarantee, execution_scope::root_group>}));
 
   // Check properties at execution_scope::work_group coordination level
-  q.single_task(
-      properties{sub_group_progress<guarantee, execution_scope::work_group>},
-      [=]() {});
-  q.single_task(
-      properties{work_item_progress<guarantee, execution_scope::work_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{sub_group_progress<guarantee, execution_scope::work_group>}));
+  q.single_task(KernelFunctor(
+      properties{work_item_progress<guarantee, execution_scope::work_group>}));
 
   // Check properties at execution_scope::sub_group coordination level
-  q.single_task(
-      properties{work_item_progress<guarantee, execution_scope::sub_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{work_item_progress<guarantee, execution_scope::sub_group>}));
 }
 
 template <>
 void check_props<forward_progress_guarantee::concurrent>(sycl::queue &q) {
   constexpr auto guarantee = forward_progress_guarantee::concurrent;
   // Check properties at execution_scope::root_group coordination level
-  q.single_task(
-      properties{work_group_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
-  q.single_task(
-      properties{sub_group_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{work_group_progress<guarantee, execution_scope::root_group>}));
+  q.single_task(KernelFunctor(
+      properties{sub_group_progress<guarantee, execution_scope::root_group>}));
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::root_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        work_item_progress<guarantee, execution_scope::root_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
 
   // Check properties at execution_scope::work_group coordination level
-  q.single_task(
-      properties{sub_group_progress<guarantee, execution_scope::work_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{sub_group_progress<guarantee, execution_scope::work_group>}));
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::work_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        work_item_progress<guarantee, execution_scope::work_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
 
   // Check properties at execution_scope::sub_group coordination level
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::sub_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(
+        properties{work_item_progress<guarantee, execution_scope::sub_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }

--- a/sycl/test-e2e/forward_progress/forward_progress_kernel_param_ocl_cpu.cpp
+++ b/sycl/test-e2e/forward_progress/forward_progress_kernel_param_ocl_cpu.cpp
@@ -22,49 +22,50 @@ void check_props(sycl::queue &q) {}
 
 // Full specializations for each progress guarantee
 
+template <typename T> struct KernelFunctor {
+  T props;
+  KernelFunctor(const T &props_) : props(props_) {}
+  void operator()() const {}
+  auto get(properties_tag) const { return props; }
+};
+
 template <>
 void check_props<forward_progress_guarantee::parallel>(sycl::queue &q) {
   constexpr auto guarantee = forward_progress_guarantee::parallel;
   // Check properties at execution_scope::root_group coordination level
-  q.single_task(
-      properties{work_group_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{work_group_progress<guarantee, execution_scope::root_group>}));
   try {
-    q.single_task(
-        properties{sub_group_progress<guarantee, execution_scope::root_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        sub_group_progress<guarantee, execution_scope::root_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::root_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        work_item_progress<guarantee, execution_scope::root_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
 
   // Check properties at execution_scope::work_group coordination level
   try {
-    q.single_task(
-        properties{sub_group_progress<guarantee, execution_scope::work_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        sub_group_progress<guarantee, execution_scope::work_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::work_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        work_item_progress<guarantee, execution_scope::work_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
 
   // Check properties at execution_scope::sub_group coordination level
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::sub_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(
+        properties{work_item_progress<guarantee, execution_scope::sub_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
@@ -74,29 +75,23 @@ template <>
 void check_props<forward_progress_guarantee::weakly_parallel>(sycl::queue &q) {
   constexpr auto guarantee = forward_progress_guarantee::weakly_parallel;
   // Check properties at execution_scope::root_group coordination level
-  q.single_task(
-      properties{work_group_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
-  q.single_task(
-      properties{sub_group_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{work_group_progress<guarantee, execution_scope::root_group>}));
+  q.single_task(KernelFunctor(
+      properties{sub_group_progress<guarantee, execution_scope::root_group>}));
 
-  q.single_task(
-      properties{work_item_progress<guarantee, execution_scope::root_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{work_item_progress<guarantee, execution_scope::root_group>}));
 
   // Check properties at execution_scope::work_group coordination level
-  q.single_task(
-      properties{sub_group_progress<guarantee, execution_scope::work_group>},
-      [=]() {});
-  q.single_task(
-      properties{work_item_progress<guarantee, execution_scope::work_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{sub_group_progress<guarantee, execution_scope::work_group>}));
+  q.single_task(KernelFunctor(
+      properties{work_item_progress<guarantee, execution_scope::work_group>}));
 
   // Check properties at execution_scope::sub_group coordination level
-  q.single_task(
-      properties{work_item_progress<guarantee, execution_scope::sub_group>},
-      [=]() {});
+  q.single_task(KernelFunctor(
+      properties{work_item_progress<guarantee, execution_scope::sub_group>}));
 }
 
 template <>
@@ -104,48 +99,42 @@ void check_props<forward_progress_guarantee::concurrent>(sycl::queue &q) {
   constexpr auto guarantee = forward_progress_guarantee::concurrent;
   // Check properties at execution_scope::root_group coordination level
   try {
-    q.single_task(
-        properties{work_group_progress<guarantee, execution_scope::root_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        work_group_progress<guarantee, execution_scope::root_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
   try {
-    q.single_task(
-        properties{sub_group_progress<guarantee, execution_scope::root_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        sub_group_progress<guarantee, execution_scope::root_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::root_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        work_item_progress<guarantee, execution_scope::root_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
 
   // Check properties at execution_scope::work_group coordination level
   try {
-    q.single_task(
-        properties{sub_group_progress<guarantee, execution_scope::work_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        sub_group_progress<guarantee, execution_scope::work_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::work_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(properties{
+        work_item_progress<guarantee, execution_scope::work_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }
 
   // Check properties at execution_scope::sub_group coordination level
   try {
-    q.single_task(
-        properties{work_item_progress<guarantee, execution_scope::sub_group>},
-        [=]() {});
+    q.single_task(KernelFunctor(
+        properties{work_item_progress<guarantee, execution_scope::sub_group>}));
     assert(false && "Expected exception not seen!");
   } catch (sycl::exception &ex) {
   }


### PR DESCRIPTION
The overloads for single_task and parallel_for in the sycl_ext_oneapi_kernel_properties extension are being deprecated as mentioned in https://github.com/intel/llvm/pull/14785. So I'm rewriting tests containg such overloads so that they can still run after the deprecation.