### PR TITLE
[UR][L0] For 3-Channel memory, disable Copy engine Usage

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,7 +116,7 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/nrspruit/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -4,4 +4,4 @@
 # Date:   Mon Dec 16 13:53:13 2024 +0000
 #     Merge pull request #2467 from nrspruit/fix_external_import_function_call
 #     [L0] Fix external semaphore import function calls to match the header
-set(UNIFIED_RUNTIME_TAG 39df0317814c164f5242eda8d6f08550f6268492)
+set(UNIFIED_RUNTIME_TAG 791562ac528316af28dead52a7ec0d02bbdf518e)


### PR DESCRIPTION
-pre-commit PR for https://github.com/oneapi-src/unified-runtime/pull/2472