### PR TITLE
[SYCL] test improvement, issue 16309

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
+++ b/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
@@ -1,10 +1,7 @@
 // REQUIRES: gpu
-// RUN: %{build} -o %t.out -g
+// RUN: %{build} -o %t.out %debug_option
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s
 // UNSUPPORTED: hip
-
-// Rather than %debug_option, we just use -g since it's supported everywhere
-// and simplifies things on the FileCheck side.
 
 // Note that the UR call might be urProgramBuild OR urProgramBuildExp .
 // The same is true for Compile and Link.

--- a/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
+++ b/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
@@ -1,21 +1,24 @@
 // REQUIRES: gpu
-// RUN: %{build} -o %t.out %debug_option
+// RUN: %{build} -o %t.out -g
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s
 // UNSUPPORTED: hip
 
-// Debug option -g is not passed to device code compiler when CL-style driver
-// is used and /DEBUG options is passed.
-// XFAIL: cl_options
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16309
+// Rather than %debug_option, we just use -g since it's supported everywhere
+// and simplifies things on the FileCheck side.
+
+// Note that the UR call might be urProgramBuild OR urProgramBuildExp .
+// The same is true for Compile and Link.
+// We want the first match. Don't put parentheses after.
 
 #include "kernel-bundle-merge-options.hpp"
 
 // CHECK: <--- urProgramBuild
 // CHECK-SAME: -g
 
-// TODO: Uncomment when build options are properly passed to compile and link
+// CHECK: <--- urProgramCompile
+// CHECK-SAME: -g
+
+// TODO: Uncomment when build options are properly passed to link
 //       commands for kernel_bundle
-// xCHECK: <--- urProgramCompile(
-// xCHECK-SAME: -g
-// xCHECK: <--- urProgramLink(
+// xCHECK: <--- urProgramLink
 // xCHECK-SAME: -g

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -381,7 +381,7 @@ if cl_options:
         )
     )
     config.substitutions.append(("%include_option", "/FI"))
-    config.substitutions.append(("%debug_option", "/DEBUG"))
+    config.substitutions.append(("%debug_option", "/Zi /DEBUG"))
     config.substitutions.append(("%cxx_std_option", "/std:"))
     config.substitutions.append(("%fPIC", ""))
     config.substitutions.append(("%shared_lib", "/LD"))


### PR DESCRIPTION
The kernel-bundle-merge-options test was recently marked XFAIL (and tracker #16309 opened).  

The root problem is that when using the MSVC CL compiler, the tests set the `debug_option` flag to `/DEBUG` but it is `/Zi` that gets converted to `-g` when the device driver is called. Updating that python var and removing the `XFAIL` from the test.