### PR TITLE
[SYCL] [Graph] Fixed potential dereference of a nullptr

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -1000,6 +1000,7 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
       }
 
       NewEvent = CreateNewEvent();
+      assert(NewEvent);
       ur_event_handle_t UREvent = nullptr;
       // Merge requirements from the nodes into requirements (if any) from the
       // handler.
@@ -1011,10 +1012,8 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
       // If we have no requirements or dependent events for the command buffer,
       // enqueue it directly
       if (CGData.MRequirements.empty() && CGData.MEvents.empty()) {
-        if (NewEvent != nullptr) {
-          NewEvent->setSubmissionTime();
-          NewEvent->setHostEnqueueTime();
-        }
+        NewEvent->setSubmissionTime();
+        NewEvent->setHostEnqueueTime();
         ur_result_t Res =
             Queue->getAdapter()
                 ->call_nocheck<

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -1000,7 +1000,6 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
       }
 
       NewEvent = CreateNewEvent();
-      assert(NewEvent);
       ur_event_handle_t UREvent = nullptr;
       // Merge requirements from the nodes into requirements (if any) from the
       // handler.


### PR DESCRIPTION
We were checking `if (NewEvent != nullptr)` but later we were dereferencing NewEvent without the check. At this point in the code NewEvent should be valid so no assertion is necessary.

Fixes https://github.com/intel/llvm/issues/16332