### PR TITLE
[Driver][SYCL] warning emitted when compiling wrapped object

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10349,7 +10349,10 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       // step.
       ArgStringList ClangArgs{
           TCArgs.MakeArgString("--target=" + TC.getAuxTriple()->str()),
-          "-Wno-override-module", "-c", "-o", Output.getFilename(),
+          "-Wno-override-module",
+          "-c",
+          "-o",
+          Output.getFilename(),
           WrapperFileName};
       llvm::Reloc::Model RelocationModel;
       unsigned PICLevel;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10344,9 +10344,13 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
     if (WrapperCompileEnabled) {
       // TODO Use TC.SelectTool().
+      // Pass -Wno-override-module to the compilation to restrict the warning
+      // that is emitted due to the target in the generated IR from the wrapping
+      // step.
       ArgStringList ClangArgs{
-          TCArgs.MakeArgString("--target=" + TC.getAuxTriple()->str()), "-c",
-          "-o", Output.getFilename(), WrapperFileName};
+          TCArgs.MakeArgString("--target=" + TC.getAuxTriple()->str()),
+          "-Wno-override-module", "-c", "-o", Output.getFilename(),
+          WrapperFileName};
       llvm::Reloc::Model RelocationModel;
       unsigned PICLevel;
       bool IsPIE;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10348,12 +10348,9 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
     if (WrapperCompileEnabled) {
       // TODO Use TC.SelectTool().
-      ArgStringList ClangArgs{
-          TCArgs.MakeArgString("--target=" + HostTripleStr),
-          "-c",
-          "-o",
-          Output.getFilename(),
-          WrapperFileName};
+      ArgStringList ClangArgs{TCArgs.MakeArgString("--target=" + HostTripleStr),
+                              "-c", "-o", Output.getFilename(),
+                              WrapperFileName};
       llvm::Reloc::Model RelocationModel;
       unsigned PICLevel;
       bool IsPIE;

--- a/clang/test/Driver/sycl-offload-aot.cpp
+++ b/clang/test/Driver/sycl-offload-aot.cpp
@@ -156,7 +156,7 @@
 // CHK-TOOLS-FPGA: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_fpga{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
 // CHK-TOOLS-GEN: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_gen{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
 // CHK-TOOLS-CPU: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_x86_64{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
-// CHK-TOOLS-AOT: clang{{.*}} "-c" "-o" "[[OUTPUT6:.+\.o]]" "[[OUTPUT5]]"
+// CHK-TOOLS-AOT: clang{{.*}} "-Wno-override-module" "-c" "-o" "[[OUTPUT6:.+\.o]]" "[[OUTPUT5]]"
 // CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT7]]" "[[OUTPUT6]]" {{.*}} "-lsycl"
 
 // Check to be sure that for windows, the 'exe' tools are called

--- a/clang/test/Driver/sycl-offload-aot.cpp
+++ b/clang/test/Driver/sycl-offload-aot.cpp
@@ -153,10 +153,10 @@
 // CHK-TOOLS-GEN: ocloc{{.*}} "-output" "[[OUTPUT4_T:.+\.out]]" {{.*}} "[[OUTPUT3_T]]"
 // CHK-TOOLS-CPU: opencl-aot{{.*}} "-o=[[OUTPUT4_T:.+\.out]]" {{.*}} "[[OUTPUT3_T]]"
 // CHK-TOOLS-AOT: file-table-tform{{.*}} "-o" "[[OUTPUT4:.+\.table]]" "{{.*}}.table"{{.*}} "[[OUTPUT4_T]]"
-// CHK-TOOLS-FPGA: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_fpga{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
-// CHK-TOOLS-GEN: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_gen{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
-// CHK-TOOLS-CPU: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_x86_64{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
-// CHK-TOOLS-AOT: clang{{.*}} "-Wno-override-module" "-c" "-o" "[[OUTPUT6:.+\.o]]" "[[OUTPUT5]]"
+// CHK-TOOLS-FPGA: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_fpga{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
+// CHK-TOOLS-GEN: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_gen{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
+// CHK-TOOLS-CPU: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_x86_64{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
+// CHK-TOOLS-AOT: clang{{.*}} "--target=[[HOST_TARGET]]" "-c" "-o" "[[OUTPUT6:.+\.o]]" "[[OUTPUT5]]"
 // CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT7]]" "[[OUTPUT6]]" {{.*}} "-lsycl"
 
 // Check to be sure that for windows, the 'exe' tools are called

--- a/clang/test/Driver/sycl-offload-nvptx.cpp
+++ b/clang/test/Driver/sycl-offload-nvptx.cpp
@@ -31,7 +31,8 @@
 // CHK-ACTIONS-WIN: llvm-foreach" {{.*}} "--" "{{.*}}fatbinary"
 // CHK-ACTIONS-WIN: file-table-tform" "-replace=Code,Code"
 // CHK-ACTIONS-WIN-NOT: "-mllvm -sycl-opt"
-// CHK-ACTIONS-WIN: clang-offload-wrapper"{{.*}} "-host=x86_64-pc-windows-msvc" "-target=nvptx64" "-kind=sycl"{{.*}}
+// CHK-ACTIONS-WIN: clang-offload-wrapper"{{.*}} "-host=[[HOST_TARGET:x86_64-pc-windows-msvc.*]]" "-target=nvptx64" "-kind=sycl"{{.*}}
+// CHK-ACTIONS-WIN: clang{{.*}} "--target=[[HOST_TARGET]]" "-c"
 
 /// Check phases w/out specifying a compute capability.
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL -std=c++11 \

--- a/clang/test/Driver/sycl-offload-with-split-old-model.c
+++ b/clang/test/Driver/sycl-offload-with-split-old-model.c
@@ -211,7 +211,7 @@
 // CHK-TOOLS-FPGA: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_fpga" "-kind=sycl" "-batch" "[[OUTPUT7]]"
 // CHK-TOOLS-GEN: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_gen" "-kind=sycl" "-batch" "[[OUTPUT7]]"
 // CHK-TOOLS-CPU: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_x86_64" "-kind=sycl" "-batch" "[[OUTPUT7]]"
-// CHK-TOOLS-AOT: clang{{.*}} "-c" "-o" "[[OUTPUT9:.+\.o]]" "[[OUTPUT8]]"
+// CHK-TOOLS-AOT: clang{{.*}} "-Wno-override-module" "-c" "-o" "[[OUTPUT9:.+\.o]]" "[[OUTPUT8]]"
 // CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT10]]" "[[OUTPUT9]]" {{.*}} "-lsycl"
 
 /// ###########################################################################

--- a/clang/test/Driver/sycl-offload-with-split-old-model.c
+++ b/clang/test/Driver/sycl-offload-with-split-old-model.c
@@ -208,10 +208,10 @@
 // CHK-TOOLS-GEN: llvm-foreach{{.*}} "--out-file-list=[[OUTPUT6:.+\.txt]]{{.*}} "--" "{{.*}}ocloc{{.*}} "-output" "[[OUTPUT6]]" "-file" "[[OUTPUT5]]"
 // CHK-TOOLS-CPU: llvm-foreach{{.*}} "--out-file-list=[[OUTPUT6:.+\.txt]]{{.*}} "--" "{{.*}}opencl-aot{{.*}} "-o=[[OUTPUT6]]" "--device=cpu" "[[OUTPUT5]]"
 // CHK-TOOLS-AOT: file-table-tform{{.*}} "-o" "[[OUTPUT7:.+\.table]]" "[[OUTPUT3]]" "[[OUTPUT6]]"
-// CHK-TOOLS-FPGA: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_fpga" "-kind=sycl" "-batch" "[[OUTPUT7]]"
-// CHK-TOOLS-GEN: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_gen" "-kind=sycl" "-batch" "[[OUTPUT7]]"
-// CHK-TOOLS-CPU: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=spir64_x86_64" "-kind=sycl" "-batch" "[[OUTPUT7]]"
-// CHK-TOOLS-AOT: clang{{.*}} "-Wno-override-module" "-c" "-o" "[[OUTPUT9:.+\.o]]" "[[OUTPUT8]]"
+// CHK-TOOLS-FPGA: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_fpga" "-kind=sycl" "-batch" "[[OUTPUT7]]"
+// CHK-TOOLS-GEN: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_gen" "-kind=sycl" "-batch" "[[OUTPUT7]]"
+// CHK-TOOLS-CPU: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_x86_64" "-kind=sycl" "-batch" "[[OUTPUT7]]"
+// CHK-TOOLS-AOT: clang{{.*}} "--target=[[HOST_TARGET]]" "-c" "-o" "[[OUTPUT9:.+\.o]]" "[[OUTPUT8]]"
 // CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT10]]" "[[OUTPUT9]]" {{.*}} "-lsycl"
 
 /// ###########################################################################


### PR DESCRIPTION
After the switch to using clang to build the wrapped object the embedded target in the IR is caused a warning to be emitted.  Fix this by adjusting the clang-offload-wrapper call to use the same host triple that is used when performing a regular compilation.  Matching these up allows for no diagnostic to be emitted.

Warning emitted: warning: overriding the module target triple with
      x86_64-pc-windows-msvc19.29.30154 [-Woverride-module]