### PR TITLE
[CI] Add Ubuntu 24.04 stable drivers image

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -55,6 +55,10 @@ jobs:
             file: ubuntu2204_intel_drivers
             tag: latest
             build_args: "use_latest=false"
+          - name: Intel Drivers Ubuntu 24.04 Docker image
+            file: ubuntu2404_intel_drivers
+            tag: latest
+            build_args: "use_latest=false"
           - name: Intel Drivers (unstable) Ubuntu 24.04 Docker image
             file: ubuntu2404_intel_drivers
             tag: unstable

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -57,8 +57,7 @@ The following containers are publicly available for DPC++ compiler development:
    * `devigc`: Intel Graphics Compiler driver from github actions artifacts,
    other drivers are downloaded from release/tag and saved in dependencies.json.
    * `unstable`: Intel drivers are downloaded from release/latest.
-   The drivers are installed as it is, not tested or validated, except for
-   `latest`.
+   The drivers are installed as it is, not tested or validated.
 - `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
    NVidia/AMD and can be used for building DPC++ compiler from source with all
    backends enabled or for end-to-end testing with HIP/CUDA on machines with

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -50,11 +50,15 @@ The following containers are publicly available for DPC++ compiler development:
    development kits for NVidia/AMD from the `ubuntu2204_build` container.
 - `ghcr.io/intel/llvm/ubuntu2404_intel_drivers`: contains everything from the
    Ubuntu 24.04 base container + pre-installed Intel drivers.
-   The image comes in two flavors/tags:
+   The image comes in three flavors/tags:
+   * `latest`: Intel drivers are downloaded from release/tag and saved in
+    dependencies.json. The drivers are tested/validated everytime we upgrade
+    the driver.
    * `devigc`: Intel Graphics Compiler driver from github actions artifacts,
    other drivers are downloaded from release/tag and saved in dependencies.json.
    * `unstable`: Intel drivers are downloaded from release/latest.
-   The drivers are installed as it is, not tested or validated.
+   The drivers are installed as it is, not tested or validated, except for
+   `latest`.
 - `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
    NVidia/AMD and can be used for building DPC++ compiler from source with all
    backends enabled or for end-to-end testing with HIP/CUDA on machines with


### PR DESCRIPTION
We need this to bump the stable GPU driver, which requires Ubuntu 24.04 now. We already use a similar version of this image based on the same Dockerfile for the unstable and igc-dev images.