### PR TITLE
[SYCL][ESIMD][E2E] Remove useless XFAIL from hardware dispatch test

### DIFF
--- a/sycl/test-e2e/ESIMD/hardware_dispatch.cpp
+++ b/sycl/test-e2e/ESIMD/hardware_dispatch.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// XFAIL: igc-dev
 // REQUIRES: ocloc && arch-intel_gpu_tgllp
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp %s -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out

--- a/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
+++ b/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
@@ -51,7 +51,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 18
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 17
 //
 // List of improperly XFAIL-ed tests.
 // Remove the CHECK once the test has been properly XFAIL-ed.
@@ -60,7 +60,6 @@
 // CHECK-NEXT: Basic/max_linear_work_group_size_props.cpp
 // CHECK-NEXT: Basic/max_work_group_size_props.cpp
 // CHECK-NEXT: DeviceLib/assert-windows.cpp
-// CHECK-NEXT: ESIMD/hardware_dispatch.cpp
 // CHECK-NEXT: InlineAsm/asm_multiple_instructions.cpp
 // CHECK-NEXT: NewOffloadDriver/multisource.cpp
 // CHECK-NEXT: NewOffloadDriver/split-per-source-main.cpp


### PR DESCRIPTION
The test requires Gen12 and we never use `igc-dev` on Gen12.

Closes: https://github.com/intel/llvm/issues/16400