### PR TITLE
[SYCL] Set -O0 as the default SYCL device optimization if -g is passed

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5606,9 +5606,27 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-Wno-sycl-strict");
       }
 
-      // Set O2 optimization level by default
-      if (!Args.getLastArg(options::OPT_O_Group))
-        CmdArgs.push_back("-O2");
+    // If no optimization controlling flags (-O) are provided, check if
+    // any debug information flags(-g) are passed.
+    // "-fintelfpga" implies "-g" and we preserve the default optimization for
+    // this flow(-O2).
+    // if "-g" is explicitly passed from the command-line, set default
+    // optimization to -O0.
+
+    if (!Args.hasArgNoClaim(options::OPT_O_Group, options::OPT__SLASH_O)) {
+      StringRef OptLevel = "-O2";
+      const Arg *DebugInfoGroup = Args.getLastArg(options::OPT_g_Group);
+      // -fintelfpga -g case
+      if ((Args.hasArg(options::OPT_fintelfpga) &&
+           Args.hasMultipleArgs(options::OPT_g_Group)) ||
+          /* -fsycl -g case */ (!Args.hasArg(options::OPT_fintelfpga) &&
+                                DebugInfoGroup)) {
+        if (!DebugInfoGroup->getOption().matches(options::OPT_g0)) {
+          OptLevel = "-O0";
+        }
+      }
+      CmdArgs.push_back(OptLevel.data());
+    }
 
       // Add the integration header option to generate the header.
       StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
@@ -10876,7 +10894,25 @@ static std::string getSYCLPostLinkOptimizationLevel(const ArgList &Args) {
                     [=](char c) { return c == S[0]; }))
       return std::string("-O") + S[0];
   }
+  // If no optimization controlling flags (-O) are provided, check if
+  // any debug information flags(-g) are passed.
+  // "-fintelfpga" implies "-g" and we preserve the default optimization for
+  // this flow(-O2).
+  // if "-g" is explicitly passed from the command-line, set default
+  // optimization to -O0.
 
+  if (!Args.hasArg(options::OPT_O_Group)) {
+    const Arg *DebugInfoGroup = Args.getLastArg(options::OPT_g_Group);
+    // -fintelfpga -g case
+    if ((Args.hasArg(options::OPT_fintelfpga) &&
+         Args.hasMultipleArgs(options::OPT_g_Group)) ||
+        /* -fsycl -g case */
+        (!Args.hasArg(options::OPT_fintelfpga) && DebugInfoGroup)) {
+      if (!DebugInfoGroup->getOption().matches(options::OPT_g0)) {
+        return "-O0";
+      }
+    }
+  }
   // The default for SYCL device code optimization
   return "-O2";
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5606,26 +5606,26 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-Wno-sycl-strict");
       }
 
-    // If no optimization controlling flags (-O) are provided, check if
-    // any debug information flags(-g) are passed.
-    // "-fintelfpga" implies "-g" and we preserve the default optimization for
-    // this flow(-O2).
-    // if "-g" is explicitly passed from the command-line, set default
-    // optimization to -O0.
+      // If no optimization controlling flags (-O) are provided, check if
+      // any debug information flags(-g) are passed.
+      // "-fintelfpga" implies "-g" and we preserve the default optimization for
+      // this flow(-O2).
+      // if "-g" is explicitly passed from the command-line, set default
+      // optimization to -O0.
 
-    if (!Args.hasArgNoClaim(options::OPT_O_Group, options::OPT__SLASH_O)) {
-      StringRef OptLevel = "-O2";
-      const Arg *DebugInfoGroup = Args.getLastArg(options::OPT_g_Group);
-      // -fintelfpga -g case
-      if ((Args.hasArg(options::OPT_fintelfpga) &&
-           Args.hasMultipleArgs(options::OPT_g_Group)) ||
-          /* -fsycl -g case */ (!Args.hasArg(options::OPT_fintelfpga) &&
-                                DebugInfoGroup)) {
-        if (!DebugInfoGroup->getOption().matches(options::OPT_g0)) {
-          OptLevel = "-O0";
+      if (!Args.hasArgNoClaim(options::OPT_O_Group, options::OPT__SLASH_O)) {
+        StringRef OptLevel = "-O2";
+        const Arg *DebugInfoGroup = Args.getLastArg(options::OPT_g_Group);
+        // -fintelfpga -g case
+        if ((Args.hasArg(options::OPT_fintelfpga) &&
+             Args.hasMultipleArgs(options::OPT_g_Group)) ||
+            /* -fsycl -g case */ (!Args.hasArg(options::OPT_fintelfpga) &&
+                                  DebugInfoGroup)) {
+          if (!DebugInfoGroup->getOption().matches(options::OPT_g0)) {
+            OptLevel = "-O0";
+          }
         }
-      }
-      CmdArgs.push_back(OptLevel.data());
+        CmdArgs.push_back(OptLevel.data());
     }
 
       // Add the integration header option to generate the header.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5626,7 +5626,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
           }
         }
         CmdArgs.push_back(OptLevel.data());
-    }
+      }
 
       // Add the integration header option to generate the header.
       StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -1,16 +1,111 @@
+/// Check that optimizations for sycl device are enabled by default:
+// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang_cl -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-only %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-only %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang -### -fintelfpga -fsycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN:   %clang_cl -### -fintelfpga -fsycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
+// CHECK-DEFAULT-NOT: "-fno-sycl-early-optimizations"
+// CHECK-DEFAULT-NOT: "-disable-llvm-passes"
+// CHECK-DEFAULT: "-fsycl-is-device"
+// CHECK-DEFAULT-SAME: "-O2"
 
+/// Check "-fno-sycl-early-optimizations" is passed to the front-end:
+// RUN:   %clang -### -fsycl --offload-new-driver -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// RUN:   %clang_cl -### -fsycl --offload-new-driver -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// RUN:   %clang -### -fintelfpga %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// RUN:   %clang_cl -### -fintelfpga %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
+// CHECK-NO-SYCL-EARLY-OPTS: "-fno-sycl-early-optimizations"
 
+/// Check that Dead Parameter Elimination Optimization is enabled
+// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DAE %s
+// RUN:   %clang_cl -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DAE %s
+// CHECK-DAE: clang{{.*}} "-fenable-sycl-dae"
 
+/// Check that Dead Parameter Elimination Optimization is disabled
+// RUN:   %clang -### -fsycl --offload-new-driver -fno-sycl-dead-args-optimization %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-DAE %s
+// RUN:   %clang_cl -### -fsycl --offload-new-driver -fno-sycl-dead-args-optimization %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-DAE %s
+// CHECK-NO-DAE-NOT: clang{{.*}} "-fenable-sycl-dae"
+
+// Check "-fgpu-inline-threshold" is passed to the front-end:
+// RUN:   %clang -### -fsycl --offload-new-driver -fgpu-inline-threshold=100000 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-THRESH %s
+// CHECK-THRESH: "-mllvm" "-inline-threshold=100000"
+
+// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-THRESH %s
+// CHECK-NO-THRESH-NOT: "-mllvm" "-inline-threshold
+
+/// Check that optimizations for sycl device are disabled with -g passed:
+// RUN:   %clang -### -fsycl -g %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEBUG %s
+// RUN:   %clang_cl -### -fsycl -g %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-DEBUG %s
+// CHECK-DEBUG: clang{{.*}} "-fsycl-is-device{{.*}}" "-O0"
+// CHECK-DEBUG: sycl-post-link{{.*}} "-O0"
+// CHECK-DEBUG-NOT: "-O2"
 
 /// Check that optimizations for sycl device are enabled with -g and O2 passed:
-
-// RUN:   %clang_cl -### -fsycl -O2 -g %s 2>&1 \
+// RUN:   %clang -### -fsycl -O2 -g %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-G-O2 %s
-// CHECK-G-O2: clang{{.*}} "-fsycl-is-device{{.*}}" "-O3"
-// CHECK-G-O2: sycl-post-link{{.*}} "-O3"
+// For clang_cl, -O2 maps to -O3
+// RUN:   %clang_cl -### -fsycl -O2 -g %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-G-O3 %s
+// CHECK-G-O2: clang{{.*}} "-fsycl-is-device{{.*}}" "-O2"
+// CHECK-G-O2: sycl-post-link{{.*}} "-O2"
 // CHECK-G-O2-NOT: "-O0"
+// CHECK-G-O3: clang{{.*}} "-fsycl-is-device{{.*}}" "-O3"
+// CHECK-G-O3: sycl-post-link{{.*}} "-O3"
+// CHECK-G-O3-NOT: "-O0"
 
+/// Check that -O2 is passed for FPGA
+// RUN:   %clang -### -fintelfpga -fsycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-FPGA %s
+// RUN:   %clang_cl -### -fintelfpga -fsycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-FPGA %s
+// CHECK-FPGA: clang{{.*}} "-fsycl-is-device{{.*}}" "-O2"
+// CHECK-FPGA: sycl-post-link{{.*}} "-O2"
+// CHECK-FPGA-NOT: "-O0"
 
+/// Check that -O2 preserves for FPGA when it's explicitly passed
+// RUN:   %clang -### -O2 -fintelfpga -fsycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-FPGA-O2 %s
+// For clang_cl, -O2 maps to -O3
+// RUN:   %clang_cl -### -O2 -fintelfpga -fsycl-early-optimizations %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-FPGA-O3 %s
+// CHECK-FPGA-O2: clang{{.*}} "-fsycl-is-device{{.*}}" "-O2"
+// CHECK-FPGA-O2: sycl-post-link{{.*}} "-O2"
+// CHECK-FPGA-O2-NOT: "-O0"
+// CHECK-FPGA-O3: clang{{.*}} "-fsycl-is-device{{.*}}" "-O3"
+// CHECK-FPGA-O3: sycl-post-link{{.*}} "-O3"
+// CHECK-FPGA-O3-NOT: "-O0"
+
+/// Check that -O0 is passed for FPGA when -g is explicitly passed
+// RUN:   %clang -### -fintelfpga -g %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-FPGA-O0 %s
+// RUN:   %clang_cl -### -fintelfpga -g %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-FPGA-O0 %s
+// CHECK-FPGA-O0: clang{{.*}} "-fsycl-is-device{{.*}}" "-O0"
+// CHECK-FPGA-O0: sycl-post-link{{.*}} "-O0"
+// CHECK-FPGA-O0-NOT: "-O2"
 
 
 

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -1,55 +1,16 @@
-/// Check that optimizations for sycl device are enabled by default:
-// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-only %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-only %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
-// RUN:   %clang -### -fintelfpga -fsycl-early-optimizations %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
-// RUN:   %clang_cl -### -fintelfpga -fsycl-early-optimizations %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
-// CHECK-DEFAULT-NOT: "-fno-sycl-early-optimizations"
-// CHECK-DEFAULT-NOT: "-disable-llvm-passes"
-// CHECK-DEFAULT: "-fsycl-is-device"
-// CHECK-DEFAULT-SAME: "-O2"
 
-/// Check "-fno-sycl-early-optimizations" is passed to the front-end:
-// RUN:   %clang -### -fsycl --offload-new-driver -fno-sycl-early-optimizations %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fno-sycl-early-optimizations %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
-// RUN:   %clang -### -fintelfpga %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
-// RUN:   %clang_cl -### -fintelfpga %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
-// CHECK-NO-SYCL-EARLY-OPTS: "-fno-sycl-early-optimizations"
 
-/// Check that Dead Parameter Elimination Optimization is enabled
-// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DAE %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DAE %s
-// CHECK-DAE: clang{{.*}} "-fenable-sycl-dae"
 
-/// Check that Dead Parameter Elimination Optimization is disabled
-// RUN:   %clang -### -fsycl --offload-new-driver -fno-sycl-dead-args-optimization %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-DAE %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fno-sycl-dead-args-optimization %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-DAE %s
-// CHECK-NO-DAE-NOT: clang{{.*}} "-fenable-sycl-dae"
 
-// Check "-fgpu-inline-threshold" is passed to the front-end:
-// RUN:   %clang -### -fsycl --offload-new-driver -fgpu-inline-threshold=100000 %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-THRESH %s
-// CHECK-THRESH: "-mllvm" "-inline-threshold=100000"
+/// Check that optimizations for sycl device are enabled with -g and O2 passed:
 
-// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-NO-THRESH %s
-// CHECK-NO-THRESH-NOT: "-mllvm" "-inline-threshold
+// RUN:   %clang_cl -### -fsycl -O2 -g %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-G-O2 %s
+// CHECK-G-O2: clang{{.*}} "-fsycl-is-device{{.*}}" "-O3"
+// CHECK-G-O2: sycl-post-link{{.*}} "-O3"
+// CHECK-G-O2-NOT: "-O0"
+
+
+
+
+

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -228,8 +228,8 @@
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS %s
 // RUN:   %clang_cl -### -fintelfpga -Zi -Od -Xs "-DFOO1 -DFOO2" -Xshardware %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS %s
-// CHK-TOOLS-IMPLIED-OPTS-NOT: clang{{.*}} "-fsycl-is-device"{{.*}} "-O0"
-// CHK-TOOLS-IMPLIED-OPTS: sycl-post-link{{.*}} "-O2"
+// CHK-TOOLS-IMPLIED-OPTS: clang{{.*}} "-fsycl-is-device"{{.*}} "-fno-sycl-early-optimizations"{{.*}} "-O0"
+// CHK-TOOLS-IMPLIED-OPTS: sycl-post-link{{.*}} "-O0"
 // CHK-TOOLS-IMPLIED-OPTS: aoc{{.*}} "-g" "-DFOO1" "-DFOO2"
 
 /// shared objects should not be checked for FPGA contents

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/debug_symbols.cpp
@@ -1,5 +1,5 @@
 // Check that full compilation works:
-// RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g %S/../debug_symbols.cpp -o %t.out
+// RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -O2 %S/../debug_symbols.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //
 // VISALTO enable run

--- a/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
@@ -1,5 +1,5 @@
 // Check that full compilation works:
-// RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -o %t.out
+// RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -O2 -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //
 // VISALTO enable run


### PR DESCRIPTION
Set `O0` as the default SYCL device optimization if `-g` is passed and optimization level is not provided explicitly.
Use of `'-g'` without any optimization-level option will turn off compiler optimizations similar to use of `'-O0'`.