### PR TITLE
[SYCL][Devops] Fix DockerFile linting issues discovered by `trivy`

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -159,8 +159,8 @@ jobs:
     - name: Reset Intel GPU
       if: inputs.reset_intel_gpu == 'true'
       run: |
-        sudo mount -t debugfs none /sys/kernel/debug
-        sudo bash -c 'echo 1 > /sys/kernel/debug/dri/0/i915_wedged'
+        cat /run/secrets/sycl_passwd | sudo -S mount -t debugfs none /sys/kernel/debug
+        cat /run/secrets/sycl_passwd | sudo -S bash -c 'echo 1 > /sys/kernel/debug/dri/0/i915_wedged'
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
@@ -196,9 +196,9 @@ jobs:
       run: |
         if [ "${{ inputs.install_dev_igc_driver }}" = "true" ]; then
             # If libllvm14 is already installed (dev igc docker), still return true.
-            sudo apt-get install -yqq libllvm14 || true;
+            cat /run/secrets/sycl_passwd | sudo -S apt-get install -yqq libllvm14 || true;
         fi
-        sudo -E bash devops/scripts/install_drivers.sh llvm/devops/dependencies.json ${{ inputs.install_dev_igc_driver == 'true' && 'llvm/devops/dependencies-igc-dev.json --use-dev-igc' || '' }} --all
+        cat /run/secrets/sycl_passwd | sudo -S -E bash devops/scripts/install_drivers.sh llvm/devops/dependencies.json ${{ inputs.install_dev_igc_driver == 'true' && 'llvm/devops/dependencies-igc-dev.json --use-dev-igc' || '' }} --all
     - name: Source OneAPI TBB vars.sh
       shell: bash
       run: |

--- a/devops/containers/ubuntu2204_base.Dockerfile
+++ b/devops/containers/ubuntu2204_base.Dockerfile
@@ -8,21 +8,8 @@ USER root
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
-
-# group 109 is required for sycl user to access PVC card.
-RUN groupadd -g 109 render
-RUN usermod -aG render sycl
-
-# Allow sycl user to run as sudo
-RUN echo "sycl  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+COPY scripts/setup-sycl-user.sh /user-setup.sh
+RUN /user-setup.sh
 
 COPY actions/cached_checkout /actions/cached_checkout
 COPY actions/cleanup /actions/cleanup

--- a/devops/containers/ubuntu2204_base.Dockerfile
+++ b/devops/containers/ubuntu2204_base.Dockerfile
@@ -29,4 +29,6 @@ COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 COPY scripts/install_drivers.sh /opt/install_drivers.sh
 
+USER sycl
+
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/containers/ubuntu2204_base.Dockerfile
+++ b/devops/containers/ubuntu2204_base.Dockerfile
@@ -8,14 +8,14 @@ USER root
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
-COPY scripts/setup-sycl-user.sh /user-setup.sh
-RUN /user-setup.sh
+COPY scripts/create-sycl-user.sh /user-setup.sh
+RUN --mount=type=secret,id=sycl_ci_passwd /user-setup.sh
 
 COPY actions/cached_checkout /actions/cached_checkout
 COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 COPY scripts/install_drivers.sh /opt/install_drivers.sh
 
-USER sycl
+USER sycl_ci
 
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -30,12 +30,12 @@ RUN apt update && apt install -yqq rocm-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-COPY scripts/setup-sycl-user.sh /user-setup.sh
-RUN /user-setup.sh
+COPY scripts/create-sycl-user.sh /user-setup.sh
+RUN --mount=type=secret,id=sycl_ci_passwd /user-setup.sh
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 
-USER sycl
+USER sycl_ci
 
 ENTRYPOINT ["/docker_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -30,14 +30,8 @@ RUN apt update && apt install -yqq rocm-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
+COPY scripts/setup-sycl-user.sh /user-setup.sh
+RUN /user-setup.sh
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 

--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -41,5 +41,7 @@ RUN usermod -aG irc sycl
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 
+USER sycl
+
 ENTRYPOINT ["/docker_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -24,10 +24,9 @@ gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null && \
 # Add rocm repo
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.1.1 jammy main" \
 | tee --append /etc/apt/sources.list.d/rocm.list && \
-printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | tee /etc/apt/preferences.d/rocm-pin-600 && \
-apt update
+printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | tee /etc/apt/preferences.d/rocm-pin-600
 # Install the kernel driver
-RUN apt install -yqq rocm-dev && \
+RUN apt update && apt install -yqq rocm-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -25,15 +25,6 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
-
 USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -7,6 +7,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG use_latest=true
 
+USER root
+
 RUN apt update && apt install -yqq wget
 
 COPY scripts/get_release.py /

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-USER sycl
+USER sycl_ci
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -25,5 +25,16 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+USER sycl
+
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2204_preinstalled.Dockerfile
+++ b/devops/containers/ubuntu2204_preinstalled.Dockerfile
@@ -12,10 +12,7 @@ ADD sycl_linux.tar.gz /opt/sycl/
 ENV PATH /opt/sycl/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH
 
-# For preinstalled containers we create a different user which has
-# password-less sudo access
-RUN /user-setup.sh --regular
-USER sycl
+USER sycl_ci
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2204_preinstalled.Dockerfile
+++ b/devops/containers/ubuntu2204_preinstalled.Dockerfile
@@ -10,5 +10,16 @@ ADD sycl_linux.tar.gz /opt/sycl/
 ENV PATH /opt/sycl/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH
 
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+USER sycl
+
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2204_preinstalled.Dockerfile
+++ b/devops/containers/ubuntu2204_preinstalled.Dockerfile
@@ -3,21 +3,14 @@ ARG base_image=ghcr.io/intel/llvm/ubuntu2204_intel_drivers
 
 FROM $base_image:$base_tag
 
+USER ROOT
+
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 RUN mkdir -p /opt/sycl
 ADD sycl_linux.tar.gz /opt/sycl/
 
 ENV PATH /opt/sycl/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH
-
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
 
 USER sycl
 

--- a/devops/containers/ubuntu2204_preinstalled.Dockerfile
+++ b/devops/containers/ubuntu2204_preinstalled.Dockerfile
@@ -3,7 +3,7 @@ ARG base_image=ghcr.io/intel/llvm/ubuntu2204_intel_drivers
 
 FROM $base_image:$base_tag
 
-USER ROOT
+USER root
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 RUN mkdir -p /opt/sycl
@@ -12,6 +12,9 @@ ADD sycl_linux.tar.gz /opt/sycl/
 ENV PATH /opt/sycl/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH
 
+# For preinstalled containers we create a different user which has
+# password-less sudo access
+RUN /user-setup.sh --regular
 USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]

--- a/devops/containers/ubuntu2404_base.Dockerfile
+++ b/devops/containers/ubuntu2404_base.Dockerfile
@@ -8,21 +8,8 @@ USER root
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
-
-# group 109 is required for sycl user to access PVC card.
-RUN groupadd -g 109 render
-RUN usermod -aG render sycl
-
-# Allow sycl user to run as sudo
-RUN echo "sycl  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+COPY scripts/create-sycl-user.sh /user-setup.sh
+RUN /user-setup.sh
 
 COPY actions/cached_checkout /actions/cached_checkout
 COPY actions/cleanup /actions/cleanup

--- a/devops/containers/ubuntu2404_base.Dockerfile
+++ b/devops/containers/ubuntu2404_base.Dockerfile
@@ -29,4 +29,6 @@ COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 COPY scripts/install_drivers.sh /opt/install_drivers.sh
 
+USER sycl
+
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/containers/ubuntu2404_base.Dockerfile
+++ b/devops/containers/ubuntu2404_base.Dockerfile
@@ -9,13 +9,13 @@ COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
 COPY scripts/create-sycl-user.sh /user-setup.sh
-RUN /user-setup.sh
+RUN --mount=type=secret,id=sycl_ci_passwd /user-setup.sh
 
 COPY actions/cached_checkout /actions/cached_checkout
 COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 COPY scripts/install_drivers.sh /opt/install_drivers.sh
 
-USER sycl
+USER sycl_ci
 
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/containers/ubuntu2404_build_oneapi.Dockerfile
+++ b/devops/containers/ubuntu2404_build_oneapi.Dockerfile
@@ -31,7 +31,8 @@ echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
 wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor \
 | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
 echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
-| tee /etc/apt/sources.list.d/oneAPI.list && \
+| tee /etc/apt/sources.list.d/oneAPI.list
+
 # Install the ROCM kernel driver and oneAPI
 RUN apt update && apt install -yqq rocm-dev intel-oneapi-compiler-dpcpp-cpp && \
   apt-get clean && \

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -25,15 +25,6 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
-
 USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -7,6 +7,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG use_latest=true
 
+USER root
+
 RUN apt update && apt install -yqq wget
 
 COPY scripts/get_release.py /

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-USER sycl
+USER sycl_ci
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -25,5 +25,16 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+USER sycl
+
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-USER sycl
+USER sycl_ci
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
@@ -20,5 +20,16 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+RUN usermod -aG video sycl
+RUN usermod -aG irc sycl
+
+USER sycl
+
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
@@ -20,15 +20,6 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-RUN usermod -aG video sycl
-RUN usermod -aG irc sycl
-
 USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]

--- a/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
@@ -5,6 +5,8 @@ FROM $base_image:$base_tag
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+USER root
+
 RUN apt update && apt install -yqq libllvm14
 
 COPY scripts/get_release.py /

--- a/devops/scripts/create-sycl-user.sh
+++ b/devops/scripts/create-sycl-user.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
+# Add sycl user to video/irc groups so that it can access GPU
+usermod -aG video sycl
+usermod -aG irc sycl
+
+# group 109 is required for sycl user to access PVC card.
+groupadd -g 109 render
+usermod -aG render sycl
+
+if [[ -f /run/secrets/sycl_passwd ]]; then
+  # When running in our CI environment, we restrict access to root.
+
+  # Set password for sycl user
+  cat /run/secrets/sycl_passwd | passwd -s sycl
+
+  # Allow sycl user to run as sudo, but only with password
+  echo "sycl  ALL=(root) PASSWD:ALL" >> /etc/sudoers
+else
+  # Otherwise, we allow password-less root to simplify building other
+  # containers on top.
+
+  # Allow sycl user to run as sudo passwrod-less
+  echo "sycl  ALL=(root) NOPASSWD:ALL" >> /etc/sudoers
+fi

--- a/devops/scripts/create-sycl-user.sh
+++ b/devops/scripts/create-sycl-user.sh
@@ -1,30 +1,50 @@
 #!/bin/bash
 
-# By default Ubuntu sets an arbitrary UID value, that is different from host
-# system. When CI passes default UID value of 1001, some of LLVM tools fail to
-# discover user home directory and fail a few LIT tests. Fixes UID and GID to
-# 1001, that is used as default by GitHub Actions.
-groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
-# Add sycl user to video/irc groups so that it can access GPU
-usermod -aG video sycl
-usermod -aG irc sycl
+set -e
 
-# group 109 is required for sycl user to access PVC card.
-groupadd -g 109 render
-usermod -aG render sycl
+if [[ $# -eq 0 ]]; then
+  # When launched without arguments, we assume that it was launched as part of
+  # CI workflow and therefore a different kind of user is created
+  USER_NAME=sycl_ci
+  SET_PASSWD=true
 
-if [[ -f /run/secrets/sycl_passwd ]]; then
-  # When running in our CI environment, we restrict access to root.
-
-  # Set password for sycl user
-  cat /run/secrets/sycl_passwd | passwd -s sycl
-
-  # Allow sycl user to run as sudo, but only with password
-  echo "sycl  ALL=(root) PASSWD:ALL" >> /etc/sudoers
+  # By default Ubuntu sets an arbitrary UID value, that is different from host
+  # system. When CI passes default UID value of 1001, some of LLVM tools fail to
+  # discover user home directory and fail a few LIT tests. Fixes UID and GID to
+  # 1001, that is used as default by GitHub Actions.
+  USER_ID=1001
 else
-  # Otherwise, we allow password-less root to simplify building other
-  # containers on top.
+  if [[ "${1:-}" != "--regular" ]]; then
+    echo "The only supported argument is --regular!"
+    exit 1
+  fi
+  USER_NAME=sycl
+  SET_PASSWD=false
 
-  # Allow sycl user to run as sudo passwrod-less
-  echo "sycl  ALL=(root) NOPASSWD:ALL" >> /etc/sudoers
+  # Some user id which is different from the one assigned to sycl_ci user
+  USER_ID=1234
+fi
+
+groupadd -g $USER_ID $USER_NAME && useradd $USER_NAME -u $USER_ID -g $USER_ID -m -s /bin/bash
+# Add user to video/irc groups so that it can access GPU
+usermod -aG video $USER_NAME
+usermod -aG irc $USER_NAME
+
+# group 109 is required for user to access PVC card.
+groupadd -f -g 109 render
+usermod -aG render $USER_NAME
+
+if [[ $SET_PASSWD == true ]]; then
+  if [[ ! -f /run/secrets/sycl_ci_passwd ]]; then
+    echo "Password is requested, but /run/secrtes/sycl_ci_passwd doesn't exists!"
+    exit 2
+  fi
+
+  # Set password for user
+  echo "$USER_NAME:$(cat /run/secrets/sycl_ci_passwd)" | chpasswd
+
+  # Allow user to run as sudo, but only with password
+  echo "$USER_NAME  ALL=(ALL) PASSWD:ALL" >> /etc/sudoers
+else
+  echo "$USER_NAME  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 fi

--- a/devops/scripts/create-sycl-user.sh
+++ b/devops/scripts/create-sycl-user.sh
@@ -36,7 +36,7 @@ usermod -aG render $USER_NAME
 
 if [[ $SET_PASSWD == true ]]; then
   if [[ ! -f /run/secrets/sycl_ci_passwd ]]; then
-    echo "Password is requested, but /run/secrtes/sycl_ci_passwd doesn't exists!"
+    echo "Password is requested, but /run/secrets/sycl_ci_passwd doesn't exist!"
     exit 2
   fi
 

--- a/devops/scripts/docker_entrypoint.sh
+++ b/devops/scripts/docker_entrypoint.sh
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-if [ -d "$GITHUB_WORKSPACE" ]; then
-  sudo chown -R sycl:sycl $GITHUB_WORKSPACE
-fi
-
 exec "$@"

--- a/devops/scripts/docker_entrypoint.sh
+++ b/devops/scripts/docker_entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 if [ -d "$GITHUB_WORKSPACE" ]; then
-  chown -R sycl:sycl $GITHUB_WORKSPACE
-  su sycl
+  sudo chown -R sycl:sycl $GITHUB_WORKSPACE
 fi
 
 exec "$@"

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -143,15 +143,15 @@ instructions.
 
 ## Changing Docker user
 
-By default all processes within our containers are run as `sycl_ci` user.
+By default all processes within our containers are run as the `sycl_ci` user.
 Note: it **does not** have password-less `root` access.
 
-If you want to change the user, you can do that by specifying
+If you want to change the user, you can do that by specifying the
 `-u <username or uid>` option when running the container.
 
-All containers come with `/user-setup.sh` script which can used to create `sycl`
-user which has all the same groups as `sycl_ci` user, but also has passwrod-less
-access to `root`. Use the script as follows:
+All containers come with the `/user-setup.sh` script which can used to create
+the `sycl` user which has all the same groups as the `sycl_ci` user, but also
+has password-less access to `root`. Use the script as follows:
 
 ```bash
 # Note: the script requires root permissions to create a new user

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -156,6 +156,8 @@ has password-less access to `root`. Use the script as follows:
 ```bash
 # Note: the script requires root permissions to create a new user
 /user-setup.sh --regular
+# Switch to the newly created user
+su - sycl
 ```
 
 ## Managing downloaded Docker images

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -143,10 +143,20 @@ instructions.
 
 ## Changing Docker user
 
-By default all processes inside Docker run as root. Some LLVM or Clang tests
-expect your user to be anything but root. You can change the user by specifying
-`-u <username or uid>` option. All Docker containers come with user `sycl`
-created.
+By default all processes within our containers are run as `sycl_ci` user.
+Note: it **does not** have password-less `root` access.
+
+If you want to change the user, you can do that by specifying
+`-u <username or uid>` option when running the container.
+
+All containers come with `/user-setup.sh` script which can used to create `sycl`
+user which has all the same groups as `sycl_ci` user, but also has passwrod-less
+access to `root`. Use the script as follows:
+
+```bash
+# Note: the script requires root permissions to create a new user
+/user-setup.sh --regular
+```
 
 ## Managing downloaded Docker images
 


### PR DESCRIPTION
This is a re-submit of #16290 with fixes from #16324 and some more extra changes.

Issues addressed:
- AVD-DS-0017 (HIGH): The instruction 'RUN <package-manager> update' should always be followed by '<package-manager> install' in the same RUN statement.
  See https://avd.aquasec.com/misconfig/ds017
- AVD-DS-0002 (HIGH): Specify at least 1 USER command in Dockerfile with non-root user as argument
  See https://avd.aquasec.com/misconfig/ds002
- AVD-DS-0002 (HIGH): Last USER command in Dockerfile should not be 'root'

Issues remaining:
- AVD-DS-0026 (LOW): Add HEALTHCHECK instruction in your Dockerfile
  See https://avd.aquasec.com/misconfig/ds026

I didn't add `HEALTHCHECK` command to our containers, because I don't know if that makes sense and which command to launch. I.e. our containers they only provide some pre-installed tools, but they don't launch any services which we could check.

User creation was outlined into a separate helper script. Our containers only come with `sycl_ci` user now which requires a password to use `sudo`. However, it is still possible to get the original `sycl` user for those who uses that container locally and needs `sudo` access. 