### PR TITLE
[SYCL][E2E]  Update XFAIL-TRACKER for runtime dimension tests

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
@@ -15,7 +15,7 @@
 // Waiting for the commit in IGC to be pulled into the driver to resolve the
 // test.
 // XFAIL: !igc-dev || gpu-intel-dg2
-// XFAIL-TRACKER: CMPLRLLVM-63710
+// XFAIL-TRACKER: GSD-10510
 
 #include "common.hpp"
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
@@ -15,7 +15,7 @@
 // Waiting for the commit in IGC to be pulled into the driver to resolve the
 // test.
 // XFAIL: !igc-dev || gpu-intel-dg2
-// XFAIL-TRACKER: CMPLRLLVM-63710
+// XFAIL-TRACKER: GSD-10510
 
 #include "common.hpp"
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"


### PR DESCRIPTION
The Joint Matrix tests, joint_matrix_bf16_fill_k_cache_arg_dim.cpp and joint_matrix_bf16_fill_k_cache_runtime_dim.cpp fail on DG2 machine for matrix combination 32x32x16. A new Jira issue has been created to track this problem. This PR updates the XFAIL-TRACKER to this new Jira issue for these two tests.