### PR TITLE
[DeviceSAN] Fix kernel name addressspace

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1344,7 +1344,7 @@ static void ExtendSpirKernelArgs(Module &M, FunctionAnalysisManager &FAM,
 
       auto KernelName = F.getName();
       auto *KernelNameGV = GetOrCreateGlobalString(
-          M, "__asan_kernel", KernelName, kSpirOffloadGlobalAS);
+          M, "__asan_kernel", KernelName, kSpirOffloadConstantAS);
       SpirKernelsMetadata.emplace_back(ConstantStruct::get(
           StructTy, ConstantExpr::getPointerCast(KernelNameGV, IntptrTy),
           ConstantInt::get(IntptrTy, KernelName.size())));

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -763,7 +763,7 @@ Constant *getOrCreateGlobalString(Module &M, StringRef Name, StringRef Value,
 static void extendSpirKernelArgs(Module &M) {
   SmallVector<Constant *, 8> SpirKernelsMetadata;
 
-  auto DL = M.getDataLayout();
+  const auto &DL = M.getDataLayout();
   Type *IntptrTy = DL.getIntPtrType(M.getContext());
 
   // SpirKernelsMetadata only saves fixed kernels, and is described by
@@ -781,7 +781,7 @@ static void extendSpirKernelArgs(Module &M) {
 
     auto KernelName = F.getName();
     auto *KernelNameGV = getOrCreateGlobalString(M, "__msan_kernel", KernelName,
-                                                 kSpirOffloadGlobalAS);
+                                                 kSpirOffloadConstantAS);
     SpirKernelsMetadata.emplace_back(ConstantStruct::get(
         StructTy, ConstantExpr::getPointerCast(KernelNameGV, IntptrTy),
         ConstantInt::get(IntptrTy, KernelName.size())));


### PR DESCRIPTION
Fix llvm-spirv: Invalid SPIR-V module: Casts from private/local/global address space are allowed only to generic