### PR TITLE
[E2E] Replace `gpu-intel-dg1` with `arch-intel_gpu_dg1` LIT feature

### DIFF
--- a/sycl/test-e2e/Basic/build_log.cpp
+++ b/sycl/test-e2e/Basic/build_log.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: opencl || level_zero, gpu, ocloc
-// UNSUPPORTED: gpu-intel-dg1
+// UNSUPPORTED: arch-intel_gpu_dg1
 //
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s

--- a/sycl/test-e2e/Basic/query.cpp
+++ b/sycl/test-e2e/Basic/query.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} env ONEAPI_DEVICE_SELECTOR="*:gpu" %t.out
 
-// REQUIRES: gpu-intel-dg1
+// REQUIRES: arch-intel_gpu_dg1
 #include "query.hpp"

--- a/sycl/test-e2e/ESIMD/dp4a.cpp
+++ b/sycl/test-e2e/ESIMD/dp4a.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // TODO enable on Windows
-// REQUIRES: linux && gpu-intel-dg1
+// REQUIRES: linux && arch-intel_gpu_dg1
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/dp4a.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/dp4a.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: gpu-intel-dg1 || gpu-intel-dg2 || arch-intel_gpu_pvc
+// REQUIRES: arch-intel_gpu_dg1 || gpu-intel-dg2 || arch-intel_gpu_pvc
 //
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../dp4a.cpp -o %t.out

--- a/sycl/test-e2e/InvokeSimd/Regression/dp4a.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/dp4a.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: gpu-intel-dg1 || gpu-intel-dg2 || arch-intel_gpu_pvc
+// REQUIRES: arch-intel_gpu_dg1 || gpu-intel-dg2 || arch-intel_gpu_pvc
 //
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out

--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -242,7 +242,6 @@ place. No new tests should use these features:
 
  * **gpu-intel-gen11** - Intel GPU Gen11 availability;
  * **gpu-intel-gen12** - Intel GPU Gen12 availability;
- * **gpu-intel-dg1** - Intel GPU DG1 availability;
  * **gpu-intel-dg2** - Intel GPU DG2 availability;
  * **gpu-intel-pvc** - Intel GPU PVC availability;
  * **gpu-intel-pvc-vg** - Intel GPU PVC-VG availability;
@@ -268,12 +267,6 @@ configure specific single test execution in the command line:
  * **gpu_aot_target_opts** - defines additional options which are passed to AOT
    compilation command line for GPU device. It can be also set by CMake variable
    GPU_AOT_TARGET_OPTS. If not specified "-device *" value is used.
- * **gpu-intel-dg1** - tells LIT infra that Intel GPU DG1 is present in the
-   system. It is developer / CI infra responsibility to make sure that the
-   device is available in the system. Tests requiring DG1 to run must use proper
-   device selector to ensure that. Use SYCL_DEVICE_ALLOWLIST or
-   ONEAPI_DEVICE_SELECTOR to get proper configuration (see
-   [EnvironmentVariables.md](https://github.com/intel/llvm/blob/sycl/sycl/doc/EnvironmentVariables.md));
  * **gpu-intel-dg2** - tells LIT infra that Intel GPU DG2 is present in the
    system. It is developer / CI infra responsibility to make sure that the
    device is available in the system.

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -168,8 +168,6 @@ if lit_config.params.get("gpu-intel-gen12", False):
     config.available_features.add("gpu-intel-gen12")
 
 # Intel GPU DEVICE availability
-if lit_config.params.get("gpu-intel-dg1", False):
-    config.available_features.add("gpu-intel-dg1")
 if lit_config.params.get("gpu-intel-dg2", False):
     config.available_features.add("gpu-intel-dg2")
 if lit_config.params.get("gpu-intel-pvc-vg", False):


### PR DESCRIPTION
So that the user won't have to manually specify `--param gpu-intel-dg1=True` to run tests on DG1.

https://github.com/intel/llvm/pull/16220#discussion_r1865940378