### PR TITLE
[SYCL][E2E] Fix XPASS in fill_any_size.cpp on OCL CPU

### DIFF
--- a/sycl/test-e2e/USM/fill_any_size.cpp
+++ b/sycl/test-e2e/USM/fill_any_size.cpp
@@ -1,7 +1,5 @@
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
-// XFAIL: (opencl && cpu)
-// XFAIL-TRACKER: https://github.com/oneapi-src/unified-runtime/issues/2440
 
 /**
  * Test of the queue::fill interface with a range of pattern sizes and values.


### PR DESCRIPTION
It's passing

https://github.com/intel/llvm/actions/runs/12405518106/job/34632838326