### PR TITLE
[SYCL][Devops] Revert requiring password for `sudo`

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -82,7 +82,6 @@ jobs:
           file: ${{ matrix.file }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          sycl_ci_passwd: ${{ secrets.DOCKER_SUDO_PASSWORD }}
           tags: |
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}-${{ github.sha }}
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -157,10 +157,10 @@ jobs:
     env: ${{ fromJSON(inputs.env) }}
     steps:
     - name: Reset Intel GPU
-      if: false
+      if: inputs.reset_intel_gpu == 'true'
       run: |
-        cat /run/secrets/sycl_passwd | sudo -S mount -t debugfs none /sys/kernel/debug
-        cat /run/secrets/sycl_passwd | sudo -S bash -c 'echo 1 > /sys/kernel/debug/dri/0/i915_wedged'
+        sudo -S mount -t debugfs none /sys/kernel/debug
+        sudo -S bash -c 'echo 1 > /sys/kernel/debug/dri/0/i915_wedged'
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
@@ -196,9 +196,9 @@ jobs:
       run: |
         if [ "${{ inputs.install_dev_igc_driver }}" = "true" ]; then
             # If libllvm14 is already installed (dev igc docker), still return true.
-            cat /run/secrets/sycl_passwd | sudo -S apt-get install -yqq libllvm14 || true;
+            sudo -S apt-get install -yqq libllvm14 || true;
         fi
-        cat /run/secrets/sycl_passwd | sudo -S -E bash devops/scripts/install_drivers.sh llvm/devops/dependencies.json ${{ inputs.install_dev_igc_driver == 'true' && 'llvm/devops/dependencies-igc-dev.json --use-dev-igc' || '' }} --all
+        sudo -S -E bash devops/scripts/install_drivers.sh llvm/devops/dependencies.json ${{ inputs.install_dev_igc_driver == 'true' && 'llvm/devops/dependencies-igc-dev.json --use-dev-igc' || '' }} --all
     - name: Source OneAPI TBB vars.sh
       shell: bash
       run: |

--- a/devops/actions/build_container/action.yml
+++ b/devops/actions/build_container/action.yml
@@ -21,9 +21,6 @@ inputs:
   file:
     description: "Dockerfile"
     required: true
-  sycl_ci_passwd:
-    description: "Password to assign to sycl_ci user within a container"
-    required: true
 
 runs:
   using: "composite"
@@ -44,4 +41,3 @@ runs:
       file: ${{ github.workspace }}/devops/containers/${{ inputs.file }}.Dockerfile
       secrets: |
         github_token=${{ github.token }}
-        sycl_ci_passwd=${{ inputs.sycl_ci_passwd }}

--- a/devops/containers/ubuntu2204_base.Dockerfile
+++ b/devops/containers/ubuntu2204_base.Dockerfile
@@ -9,13 +9,13 @@ COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
 COPY scripts/create-sycl-user.sh /user-setup.sh
-RUN --mount=type=secret,id=sycl_ci_passwd /user-setup.sh
+RUN /user-setup.sh
 
 COPY actions/cached_checkout /actions/cached_checkout
 COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 COPY scripts/install_drivers.sh /opt/install_drivers.sh
 
-USER sycl_ci
+USER sycl
 
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -31,11 +31,11 @@ RUN apt update && apt install -yqq rocm-dev && \
   rm -rf /var/lib/apt/lists/*
 
 COPY scripts/create-sycl-user.sh /user-setup.sh
-RUN --mount=type=secret,id=sycl_ci_passwd /user-setup.sh
+RUN /user-setup.sh
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 
-USER sycl_ci
+USER sycl
 
 ENTRYPOINT ["/docker_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_base.Dockerfile
+++ b/devops/containers/ubuntu2404_base.Dockerfile
@@ -9,13 +9,13 @@ COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
 COPY scripts/create-sycl-user.sh /user-setup.sh
-RUN --mount=type=secret,id=sycl_ci_passwd /user-setup.sh
+RUN /user-setup.sh
 
 COPY actions/cached_checkout /actions/cached_checkout
 COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 COPY scripts/install_drivers.sh /opt/install_drivers.sh
 
-USER sycl_ci
+USER sycl
 
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/containers/ubuntu2404_build_oneapi.Dockerfile
+++ b/devops/containers/ubuntu2404_build_oneapi.Dockerfile
@@ -39,11 +39,11 @@ RUN apt update && apt install -yqq rocm-dev intel-oneapi-compiler-dpcpp-cpp && \
   rm -rf /var/lib/apt/lists/*
 
 COPY scripts/create-sycl-user.sh /user-setup.sh
-RUN --mount=type=secret,id=sycl_ci_passwd /user-setup.sh
+RUN /user-setup.sh
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 
-USER sycl_ci
+USER sycl
 
 ENTRYPOINT ["/docker_entrypoint.sh"]
 

--- a/devops/scripts/create-sycl-user.sh
+++ b/devops/scripts/create-sycl-user.sh
@@ -2,28 +2,13 @@
 
 set -e
 
-if [[ $# -eq 0 ]]; then
-  # When launched without arguments, we assume that it was launched as part of
-  # CI workflow and therefore a different kind of user is created
-  USER_NAME=sycl_ci
-  SET_PASSWD=true
+USER_NAME=sycl
 
-  # By default Ubuntu sets an arbitrary UID value, that is different from host
-  # system. When CI passes default UID value of 1001, some of LLVM tools fail to
-  # discover user home directory and fail a few LIT tests. Fixes UID and GID to
-  # 1001, that is used as default by GitHub Actions.
-  USER_ID=1001
-else
-  if [[ "${1:-}" != "--regular" ]]; then
-    echo "The only supported argument is --regular!"
-    exit 1
-  fi
-  USER_NAME=sycl
-  SET_PASSWD=false
-
-  # Some user id which is different from the one assigned to sycl_ci user
-  USER_ID=1234
-fi
+# By default Ubuntu sets an arbitrary UID value, that is different from host
+# system. When CI passes default UID value of 1001, some of LLVM tools fail to
+# discover user home directory and fail a few LIT tests. Fixes UID and GID to
+# 1001, that is used as default by GitHub Actions.
+USER_ID=1001
 
 groupadd -g $USER_ID $USER_NAME && useradd $USER_NAME -u $USER_ID -g $USER_ID -m -s /bin/bash
 # Add user to video/irc groups so that it can access GPU
@@ -34,17 +19,5 @@ usermod -aG irc $USER_NAME
 groupadd -f -g 109 render
 usermod -aG render $USER_NAME
 
-if [[ $SET_PASSWD == true ]]; then
-  if [[ ! -f /run/secrets/sycl_ci_passwd ]]; then
-    echo "Password is requested, but /run/secrets/sycl_ci_passwd doesn't exist!"
-    exit 2
-  fi
-
-  # Set password for user
-  echo "$USER_NAME:$(cat /run/secrets/sycl_ci_passwd)" | chpasswd
-
-  # Allow user to run as sudo, but only with password
-  echo "$USER_NAME  ALL=(ALL) PASSWD:ALL" >> /etc/sudoers
-else
-  echo "$USER_NAME  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-fi
+# Allow user to run as sudo (without a password)
+echo "$USER_NAME  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -143,22 +143,11 @@ instructions.
 
 ## Changing Docker user
 
-By default all processes within our containers are run as the `sycl_ci` user.
-Note: it **does not** have password-less `root` access.
+By default all processes within our containers are run as the `sycl` user which
+has password-less `sudo` access.
 
 If you want to change the user, you can do that by specifying the
 `-u <username or uid>` option when running the container.
-
-All containers come with the `/user-setup.sh` script which can used to create
-the `sycl` user which has all the same groups as the `sycl_ci` user, but also
-has password-less access to `root`. Use the script as follows:
-
-```bash
-# Note: the script requires root permissions to create a new user
-/user-setup.sh --regular
-# Switch to the newly created user
-su - sycl
-```
 
 ## Managing downloaded Docker images
 


### PR DESCRIPTION
Apparently, I overlooked part of the documentation saying that docker secrets are only available for containers running as a service which isn't the case for our build/test CI pipeline.

Therefore, I'm partially reverting #16411 so that our containers once again use `sycl` user which has password-less `sudo` access.

This PR also reverts #16436 to re-enable GPU reset.