### PR TITLE
[SYCL][E2E] Use correct subtitution for `-O0`

### DIFF
--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-1.cpp
@@ -17,7 +17,7 @@
 // UNSUPPORTED: cuda, hip
 // UNSUPPORTED-REASON: FP64 emulation is an Intel specific feature.
 
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10,intel_gpu_dg2_g11,intel_gpu_dg2_g12,intel_gpu_pvc,intel_gpu_mtl_h,intel_gpu_mtl_u -fsycl-fp64-conv-emu -O0 %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10,intel_gpu_dg2_g11,intel_gpu_dg2_g12,intel_gpu_pvc,intel_gpu_mtl_h,intel_gpu_mtl_u -fsycl-fp64-conv-emu %O0 %s -o %t.out
 // RUN: %{run} %t.out
 
 // Tests that aspect::fp64 is not emitted correctly when -fsycl-fp64-conv-emu

--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-2.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu-2.cpp
@@ -20,7 +20,7 @@
 // UNSUPPORTED: cuda, hip
 // UNSUPPORTED-REASON: FP64 emulation is an Intel specific feature.
 
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10,intel_gpu_dg2_g11,intel_gpu_dg2_g12,intel_gpu_pvc,intel_gpu_mtl_h,intel_gpu_mtl_u -fsycl-fp64-conv-emu -O0 %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg2_g10,intel_gpu_dg2_g11,intel_gpu_dg2_g12,intel_gpu_pvc,intel_gpu_mtl_h,intel_gpu_mtl_u -fsycl-fp64-conv-emu %O0 %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
On Windows clang tries to mimic `cl.exe` interface and it has a different spelling for `-O0` (`/Od`).

Updated a couple of tests to make them work on Windows as well by using a substitution instead of a flag directly.