### PR TITLE
[Driver][SYCL] Support 64bit long double for SYCL GPU compilation

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -377,9 +377,9 @@ public:
     return nullptr;
   }
 
-  /// TranslateOffloadTargetArgs - Create a new derived argument list for
-  /// that contains the Offload target specific flags passed via
-  /// -Xopenmp-target -opt=val OR -Xopenmp-target=<triple> -opt=val
+  /// TranslateOffloadTargetArgs - Create a new derived argument list that
+  /// contains the Offload target specific flags passed via -Xopenmp-target
+  /// -opt=val OR -Xopenmp-target=<triple> -opt=val
   /// Also handles -Xsycl-target OR -Xsycl-target=<triple>
   virtual llvm::opt::DerivedArgList *TranslateOffloadTargetArgs(
       const llvm::opt::DerivedArgList &Args, bool SameTripleAsHost,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6751,6 +6751,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
              (A->getOption().getID() == options::OPT_mlong_double_64))
       // Only allow for -mlong-double-64 for SPIR/SPIR-V
       A->render(Args, CmdArgs);
+    else if ((IsSYCL &&
+              (TC.getTriple().isAMDGCN() || TC.getTriple().isNVPTX())) &&
+             (A->getOption().getID() == options::OPT_mlong_double_64))
+      // similarly, allow 64bit long double for SYCL GPU targets
+      A->render(Args, CmdArgs);
     else if (TC.getTriple().isPPC() &&
              (A->getOption().getID() != options::OPT_mlong_double_80))
       A->render(Args, CmdArgs);

--- a/clang/test/Driver/mlong-double-128.c
+++ b/clang/test/Driver/mlong-double-128.c
@@ -12,8 +12,16 @@
 // RUN: not %clang --target=powerpc -c -### %s -mlong-double-80 2>&1 | FileCheck --check-prefix=ERR2 %s
 // RUN: not %clang --target=spir64-unknown-unknown -c -### %s -mlong-double-128 2>&1 | FileCheck --check-prefix=ERR3 %s
 // RUN: not %clang --target=spir64-unknown-unknown -c -### %s -mlong-double-80 2>&1 | FileCheck --check-prefix=ERR4 %s
+// RUN: not %clang --target=nvptx64-nvidia-cuda -c -### %s -mlong-double-128 2>&1 | FileCheck --check-prefix=ERR5 %s
+// RUN: not %clang --target=nvptx64-nvidia-cuda -c -### %s -mlong-double-80 2>&1 | FileCheck --check-prefix=ERR6 %s
+// RUN: not %clang --target=amd_gpu_gfx1031 -c -### %s -mlong-double-128 2>&1 | FileCheck --check-prefix=ERR7 %s
+// RUN: not %clang --target=amd_gpu_gfx1031 -c -### %s -mlong-double-80 2>&1 | FileCheck --check-prefix=ERR8 %s
 
 // ERR: error: unsupported option '-mlong-double-128' for target 'aarch64'
 // ERR2: error: unsupported option '-mlong-double-80' for target 'powerpc'
 // ERR3: error: unsupported option '-mlong-double-128' for target 'spir64-unknown-unknown'
 // ERR4: error: unsupported option '-mlong-double-80' for target 'spir64-unknown-unknown'
+// ERR5: error: unsupported option '-mlong-double-128' for target 'nvptx64-nvidia-cuda'
+// ERR6: error: unsupported option '-mlong-double-80' for target 'nvptx64-nvidia-cuda'
+// ERR7: error: unsupported option '-mlong-double-128' for target 'amd_gpu_gfx1031'
+// ERR8: error: unsupported option '-mlong-double-80' for target 'amd_gpu_gfx1031'

--- a/clang/test/Driver/sycl-mlong-double.cpp
+++ b/clang/test/Driver/sycl-mlong-double.cpp
@@ -14,18 +14,18 @@
 // CHECK-80: error: unsupported option '-mlong-double-80' for target 'spir64-unknown-unknown'
 // CHECK-80-NOT: clang{{.*}} "-triple" "-spir64-unknown-unknown" {{.*}} "-mlong-double-80"
 
-// RUN: not %clangxx -c -fsycl -mlong-double-128 -target amd_gpu_gfx1031 %s -### 2>&1 | FileCheck --check-prefix=CHECK-128-AMD %s
-// CHECK-128-AMD: error: unsupported option '-mlong-double-128' for target 'amd_gpu_gfx1031'
+// RUN: not %clangxx -c -fsycl -mlong-double-128 --target=x86_64-unknown-linux-gnu -fsycl-targets=amd_gpu_gfx1031 %s -### 2>&1 | FileCheck --check-prefix=CHECK-128-AMD %s
+// CHECK-128-AMD: error: unsupported option '-mlong-double-128' for target 'amdgcn-amd-amdhsa'
 // CHECK-128-AMD-NOT: clang{{.*}} "-triple" "-amd_gpu_gfx1031" {{.*}} "-mlong-double-128"
 
-// RUN: not %clangxx -c -fsycl -mlong-double-80 -target amd_gpu_gfx1031 %s -### 2>&1 | FileCheck --check-prefix=CHECK-80-AMD %s
-// CHECK-80-AMD: error: unsupported option '-mlong-double-80' for target 'amd_gpu_gfx1031'
+// RUN: not %clangxx -c -fsycl -mlong-double-80 --target=x86_64-unknown-linux-gnu -fsycl-targets=amd_gpu_gfx1031 %s -### 2>&1 | FileCheck --check-prefix=CHECK-80-AMD %s
+// CHECK-80-AMD: error: unsupported option '-mlong-double-80' for target 'amdgcn-amd-amdhsa'
 // CHECK-80-AMD-NOT: clang{{.*}} "-triple" "-amd_gpu_gfx1031" {{.*}} "-mlong-double-80"
 
-// RUN: not %clangxx -c -fsycl -mlong-double-128 -target nvptx64-nvidia-cuda %s -### 2>&1 | FileCheck --check-prefix=CHECK-128-NVPTX %s
+// RUN: not %clangxx -c -fsycl -mlong-double-128 --target=x86_64-unknown-linux-gnu -fsycl-targets=nvptx64-nvidia-cuda %s -### 2>&1 | FileCheck --check-prefix=CHECK-128-NVPTX %s
 // CHECK-128-NVPTX: error: unsupported option '-mlong-double-128' for target 'nvptx64-nvidia-cuda'
 // CHECK-128-NVPTX-NOT: clang{{.*}} "-triple" "-nvptx64-nvidia-cuda" {{.*}} "-mlong-double-128"
 
-// RUN: not %clangxx -c -fsycl -mlong-double-80 -target nvptx64-nvidia-cuda %s -### 2>&1 | FileCheck --check-prefix=CHECK-80-NVPTX %s
+// RUN: not %clangxx -c -fsycl -mlong-double-80 --target=x86_64-unknown-linux-gnu -fsycl-targets=nvptx64-nvidia-cuda %s -### 2>&1 | FileCheck --check-prefix=CHECK-80-NVPTX %s
 // CHECK-80-NVPTX: error: unsupported option '-mlong-double-80' for target 'nvptx64-nvidia-cuda'
 // CHECK-80-NVPTX-NOT: clang{{.*}} "-triple" "-nvptx64-nvidia-cuda" {{.*}} "-mlong-double-80"

--- a/clang/test/Driver/sycl-mlong-double.cpp
+++ b/clang/test/Driver/sycl-mlong-double.cpp
@@ -5,7 +5,7 @@
 // CHECK: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu"
 // CHECK-SAME:  "-mlong-double-64"
 
-/// -mlong-double-128 and -mlong-double-80 are not supported for spir64.
+/// -mlong-double-128 and -mlong-double-80 are not supported for spir64, or SYCL GPU targets.
 // RUN: not %clangxx -c -fsycl -mlong-double-128 -target x86_64-unknown-linux-gnu %s -### 2>&1 | FileCheck --check-prefix=CHECK-128 %s
 // CHECK-128: error: unsupported option '-mlong-double-128' for target 'spir64-unknown-unknown'
 // CHECK-128-NOT: clang{{.*}} "-triple" "-spir64-unknown-unknown" {{.*}} "-mlong-double-128"
@@ -13,3 +13,19 @@
 // RUN: not %clangxx -c -fsycl -mlong-double-80 -target x86_64-unknown-linux-gnu %s -### 2>&1 | FileCheck --check-prefix=CHECK-80 %s
 // CHECK-80: error: unsupported option '-mlong-double-80' for target 'spir64-unknown-unknown'
 // CHECK-80-NOT: clang{{.*}} "-triple" "-spir64-unknown-unknown" {{.*}} "-mlong-double-80"
+
+// RUN: not %clangxx -c -fsycl -mlong-double-128 -target amd_gpu_gfx1031 %s -### 2>&1 | FileCheck --check-prefix=CHECK-128-AMD %s
+// CHECK-128-AMD: error: unsupported option '-mlong-double-128' for target 'amd_gpu_gfx1031'
+// CHECK-128-AMD-NOT: clang{{.*}} "-triple" "-amd_gpu_gfx1031" {{.*}} "-mlong-double-128"
+
+// RUN: not %clangxx -c -fsycl -mlong-double-80 -target amd_gpu_gfx1031 %s -### 2>&1 | FileCheck --check-prefix=CHECK-80-AMD %s
+// CHECK-80-AMD: error: unsupported option '-mlong-double-80' for target 'amd_gpu_gfx1031'
+// CHECK-80-AMD-NOT: clang{{.*}} "-triple" "-amd_gpu_gfx1031" {{.*}} "-mlong-double-80"
+
+// RUN: not %clangxx -c -fsycl -mlong-double-128 -target nvptx64-nvidia-cuda %s -### 2>&1 | FileCheck --check-prefix=CHECK-128-NVPTX %s
+// CHECK-128-NVPTX: error: unsupported option '-mlong-double-128' for target 'nvptx64-nvidia-cuda'
+// CHECK-128-NVPTX-NOT: clang{{.*}} "-triple" "-nvptx64-nvidia-cuda" {{.*}} "-mlong-double-128"
+
+// RUN: not %clangxx -c -fsycl -mlong-double-80 -target nvptx64-nvidia-cuda %s -### 2>&1 | FileCheck --check-prefix=CHECK-80-NVPTX %s
+// CHECK-80-NVPTX: error: unsupported option '-mlong-double-80' for target 'nvptx64-nvidia-cuda'
+// CHECK-80-NVPTX-NOT: clang{{.*}} "-triple" "-nvptx64-nvidia-cuda" {{.*}} "-mlong-double-80"


### PR DESCRIPTION
Make sure that `-mlong-double-64` option is supported on HIP/Cuda.