### PR TITLE
[SYCL][E2E] Change XFAIL to UNSUPPORTED in USM/fill_any_size

### DIFF
--- a/sycl/test-e2e/USM/fill_any_size.cpp
+++ b/sycl/test-e2e/USM/fill_any_size.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
-// XFAIL: (opencl && cpu)
-// XFAIL-TRACKER: https://github.com/oneapi-src/unified-runtime/issues/2440
+// UNSUPPORTED: (opencl && cpu)
+// UNSUPPORTED-TRACKER: https://github.com/oneapi-src/unified-runtime/issues/2440
 
 /**
  * Test of the queue::fill interface with a range of pattern sizes and values.


### PR DESCRIPTION
The failure is sporadic, so change from `XFAIL` to `UNSUPPORTED` to avoid `XPASS` reports while the underlying issue is not yet fixed.

Fixes #16434