### PR TITLE
[SYCL][E2E] Remove XFAIL in get_coordinate_ops.cpp

### DIFF
--- a/sycl/test-e2e/Matrix/get_coordinate_ops.cpp
+++ b/sycl/test-e2e/Matrix/get_coordinate_ops.cpp
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: aspect-ext_intel_matrix
-
-// XFAIL: !igc-dev
-// XFAIL-TRACKER: GSD-6376
 // REQUIRES-INTEL-DRIVER: lin: 30049
 
 // RUN: %{build} -o %t.out


### PR DESCRIPTION
It's passing now after the driver update.

https://github.com/intel/llvm/actions/runs/12433578741/job/34716640805