### PR TITLE
[SYCL][E2E] Disable online_compiler_OpenCL.cpp on FPGA

### DIFF
--- a/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
+++ b/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: opencl, opencl_icd, cm-compiler
-// XFAIL: gpu || cpu
+// XFAIL: gpu || cpu || accelerator
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/16406
 // RUN: %{build} -Wno-error=deprecated-declarations -DRUN_KERNELS %opencl_lib -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
It's failing [here](https://github.com/intel/llvm/actions/runs/12433578741/job/34716641336). The test manually calls the GPU driver even when running on CPU or FPGA. 

XFAIL it since it's failing. Root issue will be addressed in the Github issue.