### PR TITLE
[CI][NFC] Rename `use_latest` container build argument to `use_unstable_driver`

### DIFF
--- a/.github/workflows/sycl-containers-igc-dev.yaml
+++ b/.github/workflows/sycl-containers-igc-dev.yaml
@@ -33,7 +33,7 @@ jobs:
             imagefile: ubuntu2404_intel_drivers
             tag: devigc
             build_args: |
-                  "use_latest=false"
+                  "use_unstable_driver=false"
                   "use_igc_dev=true"
     steps:
       - name: Checkout

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -54,22 +54,22 @@ jobs:
           - name: Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
             tag: latest
-            build_args: "use_latest=false"
+            build_args: "use_unstable_driver=false"
           - name: Intel Drivers Ubuntu 24.04 Docker image
             file: ubuntu2404_intel_drivers
             tag: latest
-            build_args: "use_latest=false"
+            build_args: "use_unstable_driver=false"
           - name: Intel Drivers (unstable) Ubuntu 24.04 Docker image
             file: ubuntu2404_intel_drivers
             tag: unstable
-            build_args: "use_latest=true"
+            build_args: "use_unstable_driver=true"
           - name: Build + Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
             tag: alldeps
             build_args: |
               base_image=ghcr.io/intel/llvm/ubuntu2204_build
               base_tag=latest
-              use_latest=false
+              use_unstable_driver=false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -5,7 +5,7 @@ FROM $base_image:$base_tag
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG use_latest=true
+ARG use_unstable_driver=true
 
 USER root
 
@@ -18,7 +18,7 @@ COPY dependencies.json /
 RUN mkdir /runtimes
 ENV INSTALL_LOCATION=/runtimes
 RUN --mount=type=secret,id=github_token \
-    if [ "$use_latest" = "true" ]; then \
+    if [ "$use_unstable_driver" = "true" ]; then \
       install_driver_opt=" --use-latest"; \
     else \
       install_driver_opt=" dependencies.json"; \

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -5,7 +5,7 @@ FROM $base_image:$base_tag
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG use_latest=true
+ARG use_unstable_driver=true
 
 USER root
 
@@ -18,7 +18,7 @@ COPY dependencies.json /
 RUN mkdir /runtimes
 ENV INSTALL_LOCATION=/runtimes
 RUN --mount=type=secret,id=github_token \
-    if [ "$use_latest" = "true" ]; then \
+    if [ "$use_unstable_driver" = "true" ]; then \
       install_driver_opt=" --use-latest"; \
     else \
       install_driver_opt=" dependencies.json"; \


### PR DESCRIPTION
IMO, `use_latest` is confusing - does it mean to use latest docker container image or latest driver? `use_unstable_driver` would be more appropriate.