### PR TITLE
[SYCL][E2E] Fix unexpectedly passing test on build-only mode

### DIFF
--- a/sycl/test-e2e/Matrix/SG32/get_coordinate_ops.cpp
+++ b/sycl/test-e2e/Matrix/SG32/get_coordinate_ops.cpp
@@ -10,7 +10,7 @@
 // REQUIRES: aspect-ext_intel_matrix
 // REQUIRES-INTEL-DRIVER: lin: 30049, win: 101.4943
 
-// XFAIL: !igc-dev
+// XFAIL: !igc-dev && run-mode
 // XFAIL-TRACKER: GSD-6376
 
 // RUN: %{build} -o %t.out


### PR DESCRIPTION
This test is able to compile so I am adding `XFAIL: run-mode` so that it doesn't `XPASS` on build-only mode. Should fix the pre-commit CI.