### PR TITLE
[CI] Add remaining Ubuntu 24.04 Dockerfile

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -43,8 +43,12 @@ jobs:
             file: ubuntu2404_base
             tag: latest
             build_args: ""
-          - name: Build Ubuntu Docker image
+          - name: Build Ubuntu 22.04 Docker image
             file: ubuntu2204_build
+            tag: latest
+            build_args: ""
+          - name: Build Ubuntu 24.04 Docker image
+            file: ubuntu2404_build
             tag: latest
             build_args: ""
           - name: Build Ubuntu 24.04 oneAPI Docker image

--- a/devops/containers/ubuntu2404_build.Dockerfile
+++ b/devops/containers/ubuntu2404_build.Dockerfile
@@ -1,0 +1,42 @@
+FROM nvidia/cuda:12.6.3-devel-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+USER root
+
+# Install SYCL prerequisites
+COPY scripts/install_build_tools.sh /install.sh
+RUN /install.sh
+
+SHELL ["/bin/bash", "-ec"]
+
+# Make the directory if it doesn't exist yet.
+# This location is recommended by the distribution maintainers.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings
+# Download the key, convert the signing-key to a full
+# keyring required by apt and store in the keyring directory
+RUN wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null && \
+# Add rocm repo
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/6.3/ubuntu noble main" \
+    | tee /etc/apt/sources.list.d/amdgpu.list && \
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.3 noble main" \
+    |  tee --append /etc/apt/sources.list.d/rocm.list && \
+echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
+    | tee /etc/apt/preferences.d/rocm-pin-600 && \
+echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
+    | tee /etc/apt/preferences.d/rocm-pin-600
+# Install the ROCM kernel driver
+RUN apt update && apt install -yqq rocm-dev && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY scripts/create-sycl-user.sh /user-setup.sh
+RUN /user-setup.sh
+
+COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
+
+USER sycl
+
+ENTRYPOINT ["/docker_entrypoint.sh"]
+

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -36,20 +36,30 @@ identical for Docker and Podman. Choose whatever is available on your system.
 
 The following containers are publicly available for DPC++ compiler development:
 
-- `ghcr.io/intel/llvm/ubuntu2204_base`: contains basic Ubuntu 22.04 environment
+### Ubuntu 22.04-based images
+- `ghcr.io/intel/llvm/ubuntu2204_base`: contains basic environment
    setup for building DPC++ compiler from source.
-- `ghcr.io/intel/llvm/ubuntu2404_base`: contains basic Ubuntu 24.04 environment
-   setup for building DPC++ compiler from source.
-- `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
-   Ubuntu 22.04 base container + pre-installed Intel drivers.
+  - `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
+   base container + pre-installed Intel drivers.
    The image comes in two flavors/tags:
    * `latest`: Intel drivers are downloaded from release/tag and saved in
     dependencies.json. The drivers are tested/validated everytime we upgrade
     the driver.
    * `alldeps`: Includes the same Intel drivers as `latest`, as well as the
    development kits for NVidia/AMD from the `ubuntu2204_build` container.
+- `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
+   NVidia/AMD and can be used for building DPC++
+   compiler from source with all backends enabled or for end-to-end testing
+   with HIP/CUDA on machines with corresponding GPUs available.
+  - `ghcr.io/intel/llvm/sycl_ubuntu2204_nightly`: contains the latest successfully
+   built nightly build of DPC++ compiler. The image comes in three flavors:
+   with pre-installed Intel drivers (`latest`), without them (`no-drivers`) and
+   with development kits installed (`build`).
+### Ubuntu 24.04-based images
+- `ghcr.io/intel/llvm/ubuntu2404_base`: contains basic environment
+   setup for building DPC++ compiler from source.
 - `ghcr.io/intel/llvm/ubuntu2404_intel_drivers`: contains everything from the
-   Ubuntu 24.04 base container + pre-installed Intel drivers.
+   base container + pre-installed Intel drivers.
    The image comes in three flavors/tags:
    * `latest`: Intel drivers are downloaded from release/tag and saved in
     dependencies.json. The drivers are tested/validated everytime we upgrade
@@ -58,18 +68,11 @@ The following containers are publicly available for DPC++ compiler development:
    other drivers are downloaded from release/tag and saved in dependencies.json.
    * `unstable`: Intel drivers are downloaded from release/latest.
    The drivers are installed as it is, not tested or validated.
-- `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
-   NVidia/AMD, is based on Ubuntu 22.04, and can be used for building DPC++
-   compiler from source with all backends enabled or for end-to-end testing
-   with HIP/CUDA on machines with corresponding GPUs available.
 - `ghcr.io/intel/llvm/ubuntu2404_build`: has development kits installed for
-   NVidia/AMD, is based on Ubuntu 24.04, and can be used for building DPC++
+   NVidia/AMD and can be used for building DPC++
    compiler from source with all backends enabled or for end-to-end testing
    with HIP/CUDA on machines with corresponding GPUs available.  
-- `ghcr.io/intel/llvm/sycl_ubuntu2204_nightly`: contains the latest successfully
-   built nightly build of DPC++ compiler. The image comes in three flavors:
-   with pre-installed Intel drivers (`latest`), without them (`no-drivers`) and
-   with development kits installed (`build`).
+
 
 ## Running Docker container interactively
 

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -59,9 +59,13 @@ The following containers are publicly available for DPC++ compiler development:
    * `unstable`: Intel drivers are downloaded from release/latest.
    The drivers are installed as it is, not tested or validated.
 - `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
-   NVidia/AMD and can be used for building DPC++ compiler from source with all
-   backends enabled or for end-to-end testing with HIP/CUDA on machines with
-   corresponding GPUs available.
+   NVidia/AMD, is based on Ubuntu 22.04, and can be used for building DPC++
+   compiler from source with all backends enabled or for end-to-end testing
+   with HIP/CUDA on machines with corresponding GPUs available.
+- `ghcr.io/intel/llvm/ubuntu2404_build`: has development kits installed for
+   NVidia/AMD, is based on Ubuntu 24.04, and can be used for building DPC++
+   compiler from source with all backends enabled or for end-to-end testing
+   with HIP/CUDA on machines with corresponding GPUs available.  
 - `ghcr.io/intel/llvm/sycl_ubuntu2204_nightly`: contains the latest successfully
    built nightly build of DPC++ compiler. The image comes in three flavors:
    with pre-installed Intel drivers (`latest`), without them (`no-drivers`) and

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -56,7 +56,9 @@ The following containers are publicly available for DPC++ compiler development:
    built nightly build of DPC++ compiler. The image comes in three flavors:
    with pre-installed Intel drivers (`latest`), without them (`no-drivers`) and
    with development kits installed (`build`).
+
 ### Ubuntu 24.04-based images
+
 - `ghcr.io/intel/llvm/ubuntu2404_base`: contains basic environment
    setup for building DPC++ compiler from source.
 - `ghcr.io/intel/llvm/ubuntu2404_intel_drivers`: contains everything from the

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -40,8 +40,8 @@ The following containers are publicly available for DPC++ compiler development:
 
 - `ghcr.io/intel/llvm/ubuntu2204_base`: contains basic environment
    setup for building DPC++ compiler from source.
-  - `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
-   base container + pre-installed Intel drivers.
+- `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
+  base container + pre-installed Intel drivers.
    The image comes in two flavors/tags:
    * `latest`: Intel drivers are downloaded from release/tag and saved in
     dependencies.json. The drivers are tested/validated everytime we upgrade

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -37,6 +37,7 @@ identical for Docker and Podman. Choose whatever is available on your system.
 The following containers are publicly available for DPC++ compiler development:
 
 ### Ubuntu 22.04-based images
+
 - `ghcr.io/intel/llvm/ubuntu2204_base`: contains basic environment
    setup for building DPC++ compiler from source.
   - `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the


### PR DESCRIPTION
This adds the remaining Dockerfiles we'll need for Ubuntu 24.04. 

There will be two more containers added to the workflow after this PR, I can't add them now because they require changes in this PR and CI doesn't use the files from precommit.