### PR TITLE
[SYCL] Use explicit return type in `get_vec_idx` helper

### DIFF
--- a/sycl/include/sycl/vector.hpp
+++ b/sycl/include/sycl/vector.hpp
@@ -1181,7 +1181,7 @@ public:
   }
 
 private:
-  static constexpr auto get_vec_idx(int idx) {
+  static constexpr int get_vec_idx(int idx) {
     int counter = 0;
     int result = -1;
     ((result = counter++ == idx ? Indexes : result), ...);


### PR DESCRIPTION
Apparently, some versions of MSVC (e.g. 14.29.30133) fail to compile it

```
error C3779: 'sycl::_V1::detail::SwizzleOp<VecT,OperationLeftT,OperationRightT,OperationCurrentT,Indexes...>::get_vec_idx': a function that returns 'auto' cannot be used before it is defined
```

when used with `-fsycl-host-compiler`. This has been caught by the existing `bit_cast_win.cpp` test in a downstream environment.