### PR TITLE
[SYCL][CI] Use `-D_FORTIFY_SOURCE=2` in Nightly E2E CI

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -110,7 +110,7 @@ jobs:
       image_options: ${{ matrix.image_options }}
       target_devices: ${{ matrix.target_devices }}
       tests_selector: ${{ matrix.tests_selector }}
-      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' ${{ matrix.extra_lit_opts }}"
+      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0 -D_FORTIFY_SOURCE=2' ${{ matrix.extra_lit_opts }}"
       reset_intel_gpu: ${{ matrix.reset_intel_gpu }}
       ref: ${{ github.sha }}
       merge_ref: ''


### PR DESCRIPTION
See https://github.com/intel/llvm/pull/1117 and
https://github.com/intel/llvm/pull/11436 for the context.

In this mode, `std::memcpy` cannot be used in device code, but its usage occasionally leaks into our code base. I think testing the configuration in CI is the easiest way to prevent that with at least some confidence. Another option would be to modify FE to report any usage of `std::memcpy` in device code only, but I don't know if that's even possible.