### PR TITLE
[compiler-rt] Fix detecting _Float16 support for secondary targets 

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -850,9 +850,12 @@ else ()
     if (CAN_TARGET_${arch})
       cmake_push_check_state()
       # TODO: we should probably make most of the checks in builtin-config depend on the target flags.
-      message(STATUS "Performing additional configure checks with target flags: ${TARGET_${arch}_CFLAGS}")
       set(BUILTIN_CFLAGS_${arch} ${BUILTIN_CFLAGS})
-      list(APPEND CMAKE_REQUIRED_FLAGS ${TARGET_${arch}_CFLAGS} ${BUILTIN_CFLAGS_${arch}})
+      # CMAKE_REQUIRED_FLAGS must be a space separated string but unlike TARGET_${arch}_CFLAGS,
+      # BUILTIN_CFLAGS_${arch} is a CMake list, so we have to join it to create a valid command line.
+      list(JOIN BUILTIN_CFLAGS " " CMAKE_REQUIRED_FLAGS)
+      set(CMAKE_REQUIRED_FLAGS "${TARGET_${arch}_CFLAGS} ${BUILTIN_CFLAGS_${arch}}")
+      message(STATUS "Performing additional configure checks with target flags: ${CMAKE_REQUIRED_FLAGS}")
       # For ARM archs, exclude any VFP builtins if VFP is not supported
       if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em|armv8m.main|armv8.1m.main)$")
         string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")


### PR DESCRIPTION
Cherry pick of https://github.com/llvm/llvm-project/commit/a4c8ef0f401d86040594cc6f01bcdad9392e8ee2, we need this for building with GCC 13.