### PR TITLE
[SYCL][E2E] Re-enable assert_in_multiple_tus.cpp on Arc

### DIFF
--- a/sycl/test-e2e/Assert/assert_in_multiple_tus.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus.cpp
@@ -9,8 +9,8 @@
 // XFAIL: (opencl && gpu)
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/11364
 
-// UNSUPPORTED: gpu-intel-dg2
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15029
+// Test requires at least this version of the Intel GPU driver on Arc.
+// REQUIRES-INTEL-DRIVER: lin: 31294
 
 // RUN: %{build} -DSYCL_FALLBACK_ASSERT=1 -I %S/Inputs %S/Inputs/kernels_in_file2.cpp -o %t.out
 // RUN: %{run} %t.out &> %t.txt ; FileCheck %s --input-file %t.txt %if fpga %{ --check-prefix=CHECK-ACC %}


### PR DESCRIPTION
Test was verified on Arc using the following driver versions: 
24.22.29735.20 - fail
24.31.30508.7 - fail
24.39.31294.12 - pass
24.45.31740.9 - pass

So, re-enable the test and add the minimal required driver version.
Closes https://github.com/intel/llvm/issues/14557