### PR TITLE
[SYCL] Fix `mismatched-new-delete` warning in compression.hpp

### DIFF
--- a/sycl/source/detail/compression.hpp
+++ b/sycl/source/detail/compression.hpp
@@ -41,7 +41,7 @@ private:
 public:
   // Blob (de)compression do not assume format/structure of the input buffer.
   // This function can be used in future for compression in on-disk cache.
-  static std::unique_ptr<char> CompressBlob(const char *src, size_t srcSize,
+  static std::unique_ptr<char[]> CompressBlob(const char *src, size_t srcSize,
                                             size_t &dstSize, int level) {
     auto &instance = GetSingletonInstance();
 
@@ -61,7 +61,7 @@ public:
 
     // Get maximum size of the compressed buffer and allocate it.
     auto dstBufferSize = ZSTD_compressBound(srcSize);
-    auto dstBuffer = std::unique_ptr<char>(new char[dstBufferSize]);
+    auto dstBuffer = std::make_unique<char[]>(dstBufferSize);
 
     if (!dstBuffer)
       throw sycl::exception(sycl::make_error_code(sycl::errc::runtime),
@@ -79,7 +79,7 @@ public:
                             ZSTD_getErrorName(dstSize));
 
     // Pass ownership of the buffer to the caller.
-    return dstBuffer;
+    return std::move(dstBuffer);
   }
 
   static size_t GetDecompressedSize(const char *src, size_t srcSize) {
@@ -93,7 +93,7 @@ public:
     return dstBufferSize;
   }
 
-  static std::unique_ptr<char> DecompressBlob(const char *src, size_t srcSize,
+  static std::unique_ptr<char[]> DecompressBlob(const char *src, size_t srcSize,
                                               size_t &dstSize) {
     auto &instance = GetSingletonInstance();
 
@@ -116,7 +116,7 @@ public:
     auto dstBufferSize = GetDecompressedSize(src, srcSize);
 
     // Allocate buffer for decompressed data.
-    auto dstBuffer = std::unique_ptr<char>(new char[dstBufferSize]);
+    auto dstBuffer = std::make_unique<char[]>(dstBufferSize);
 
     if (!dstBuffer)
       throw sycl::exception(sycl::make_error_code(sycl::errc::runtime),
@@ -135,7 +135,7 @@ public:
     }
 
     // Pass ownership of the buffer to the caller.
-    return dstBuffer;
+    return std::move(dstBuffer);
   }
 
   // Data fields

--- a/sycl/source/detail/device_binary_image.hpp
+++ b/sycl/source/detail/device_binary_image.hpp
@@ -306,7 +306,7 @@ public:
   }
 
 private:
-  std::unique_ptr<char> m_DecompressedData;
+  std::unique_ptr<char[]> m_DecompressedData;
   size_t m_ImageSize;
 };
 #endif // SYCL_RT_ZSTD_NOT_AVAIABLE


### PR DESCRIPTION
Fixed the following warning when DPC++ is built in Release mode with gcc 13:

```
In member function 'void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = char]',
    inlined from 'std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = char; _Dp = std::default_delete<char>]' at /usr/include/c++/13/bits/unique_ptr.h:404:17,
    inlined from 'static std::unique_ptr<char> sycl::_V1::detail::ZSTDCompressor::DecompressBlob(const char*, size_t, size_t&)' at /tmp/llvm/sycl/source/detail/compression.hpp:139:3,
    inlined from 'void sycl::_V1::detail::CompressedRTDeviceBinaryImage::Decompress()' at /tmp/llvm/sycl/source/detail/device_binary_image.cpp:258:54:
/usr/include/c++/13/bits/unique_ptr.h:99:9: error: 'void operator delete(void*, std::size_t)' called on pointer returned from a mismatched allocation function [-Werror=mismatched-new-delete]
   99 |         delete __ptr;
      |         ^~~~~~~~~~~~
In file included from /tmp/llvm/sycl/source/detail/device_binary_image.cpp:13:
In static member function 'static std::unique_ptr<char> sycl::_V1::detail::ZSTDCompressor::DecompressBlob(const char*, size_t, size_t&)',
    inlined from 'void sycl::_V1::detail::CompressedRTDeviceBinaryImage::Decompress()' at /tmp/llvm/sycl/source/detail/device_binary_image.cpp:258:54:
/tmp/llvm/sycl/source/detail/compression.hpp:119:66: note: returned from 'void* operator new [](std::size_t)'
  119 |     auto dstBuffer = std::unique_ptr<char>(new char[dstBufferSize]);
```

Found in: https://github.com/intel/llvm/pull/16463#discussion_r1898045462