### PR TITLE
[SYCL] Add support for __registered_kernels__

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2141,6 +2141,15 @@ def SYCLAddIRAnnotationsMember : InheritableAttr {
   let Documentation = [SYCLAddIRAnnotationsMemberDocs];
 }
 
+def SYCLRegisteredKernels : InheritableAttr {
+  let Spellings = [CXX11<"__sycl_detail__", "__registered_kernels__">];
+  let Args = [VariadicExprArgument<"Args">];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
+  let Subjects = SubjectList<[Empty], ErrorDiag, "Translation Unit Scope">;
+  let AdditionalMembers = SYCLAddIRAttrCommonMembers.MemberCode;
+  let Documentation = [SYCLAddIRAnnotationsMemberDocs];
+}
+
 def C11NoReturn : InheritableAttr {
   let Spellings = [CustomKeyword<"_Noreturn">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2150,6 +2150,13 @@ def SYCLRegisteredKernels : InheritableAttr {
   let Documentation = [SYCLAddIRAnnotationsMemberDocs];
 }
 
+def SYCLRegisteredKernelName : InheritableAttr {
+  let Spellings = [];
+  let Subjects = SubjectList<[Function]>;
+  let Args = [StringArgument<"RegName">];
+  let Documentation = [InternalOnly];
+}
+
 def C11NoReturn : InheritableAttr {
   let Spellings = [CustomKeyword<"_Noreturn">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12522,6 +12522,12 @@ def err_registered_kernels_init_list : Error<
 def err_registered_kernels_init_list_pair_values : Error<
   "each initializer list argument to the '__registered_kernels__' atribute "
   "must contain a pair of values">;
+def err_registered_kernels_resolve_function : Error<
+  "unable to resolve free function kernel '%0'">;
+def err_registered_kernels_name_already_registered : Error<
+  "free function kernel has already been registered with '%0'; cannot register with '%1'">;
+def err_not_sycl_free_function : Error<
+  "attempting to register a function that is not a SYCL free function as '%0'">;
 
 def warn_cuda_maxclusterrank_sm_90 : Warning<
   "'maxclusterrank' requires sm_90 or higher, CUDA arch provided: %0, ignoring "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2402,6 +2402,7 @@ def err_reference_bind_to_vector_element : Error<
   "%select{non-const|volatile}0 reference cannot bind to vector element">;
 def err_reference_bind_to_matrix_element : Error<
   "%select{non-const|volatile}0 reference cannot bind to matrix element">;
+// compilations and its absence in host compilations.
 def err_reference_var_requires_init : Error<
   "declaration of reference variable %0 requires an initializer">;
 def err_reference_without_init : Error<
@@ -12515,12 +12516,12 @@ def warn_launch_bounds_is_cuda_specific : Warning<
   "%0 attribute ignored, only applicable when targeting Nvidia devices">,
   InGroup<IgnoredAttributes>;
 def err_registered_kernels_num_of_args : Error<
-  "'__registered_kernels__' atribute must have at least one argument">;
+  "'__registered_kernels__' attribute must have at least one argument">;
 def err_registered_kernels_init_list : Error<
-  "argument to the '__registered_kernels__' atribute must be an "
+  "argument to the '__registered_kernels__' attribute must be an "
   "initializer list expression">;
 def err_registered_kernels_init_list_pair_values : Error<
-  "each initializer list argument to the '__registered_kernels__' atribute "
+  "each initializer list argument to the '__registered_kernels__' attribute "
   "must contain a pair of values">;
 def err_registered_kernels_resolve_function : Error<
   "unable to resolve free function kernel '%0'">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12514,6 +12514,14 @@ def err_sycl_special_type_num_init_method : Error<
 def warn_launch_bounds_is_cuda_specific : Warning<
   "%0 attribute ignored, only applicable when targeting Nvidia devices">,
   InGroup<IgnoredAttributes>;
+def err_registered_kernels_num_of_args : Error<
+  "'__registered_kernels__' atribute must have at least one argument">;
+def err_registered_kernels_init_list : Error<
+  "argument to the '__registered_kernels__' atribute must be an "
+  "initializer list expression">;
+def err_registered_kernels_init_list_pair_values : Error<
+  "each initializer list argument to the '__registered_kernels__' atribute "
+  "must contain a pair of values">;
 
 def warn_cuda_maxclusterrank_sm_90 : Warning<
   "'maxclusterrank' requires sm_90 or higher, CUDA arch provided: %0, ignoring "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2402,7 +2402,6 @@ def err_reference_bind_to_vector_element : Error<
   "%select{non-const|volatile}0 reference cannot bind to vector element">;
 def err_reference_bind_to_matrix_element : Error<
   "%select{non-const|volatile}0 reference cannot bind to matrix element">;
-// compilations and its absence in host compilations.
 def err_reference_var_requires_init : Error<
   "declaration of reference variable %0 requires an initializer">;
 def err_reference_without_init : Error<

--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -252,8 +252,8 @@ private:
   // We need to store the list of the sycl_kernel functions and their associated
   // generated OpenCL Kernels so we can go back and re-name these after the
   // fact.
-  using KernelFDPairs = llvm::SmallVector<
-                            std::pair<const FunctionDecl *, FunctionDecl *>>;
+  using KernelFDPairs =
+      llvm::SmallVector<std::pair<const FunctionDecl *, FunctionDecl *>>;
   KernelFDPairs SyclKernelsToOpenCLKernels;
 
   // Used to suppress diagnostics during kernel construction, since these were
@@ -297,9 +297,7 @@ public:
                               llvm::DenseSet<QualType> Visited,
                               ValueDecl *DeclToCheck);
 
-  const KernelFDPairs &getKernelFDPairs() {
-    return SyclKernelsToOpenCLKernels;
-  }
+  const KernelFDPairs &getKernelFDPairs() { return SyclKernelsToOpenCLKernels; }
 
   void addSyclOpenCLKernel(const FunctionDecl *SyclKernel,
                            FunctionDecl *OpenCLKernel) {

--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -661,6 +661,10 @@ public:
   void addIntelReqdSubGroupSizeAttr(Decl *D, const AttributeCommonInfo &CI,
                                     Expr *E);
   void handleKernelEntryPointAttr(Decl *D, const ParsedAttr &AL);
+
+  // Used to check whether the function represented by FD is a SYCL
+  // free function kernel or not.
+  bool isFreeFunction(const FunctionDecl *FD);
 };
 
 } // namespace clang

--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -487,6 +487,7 @@ public:
   void handleSYCLIntelMaxWorkGroupsPerMultiprocessor(Decl *D,
                                                      const ParsedAttr &AL);
   void handleSYCLScopeAttr(Decl *D, const ParsedAttr &AL);
+  void handleSYCLRegisteredKernels(Decl *D, const ParsedAttr &AL);
 
   void checkSYCLAddIRAttributesFunctionAttrConflicts(Decl *D);
 

--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -252,8 +252,9 @@ private:
   // We need to store the list of the sycl_kernel functions and their associated
   // generated OpenCL Kernels so we can go back and re-name these after the
   // fact.
-  llvm::SmallVector<std::pair<const FunctionDecl *, FunctionDecl *>>
-      SyclKernelsToOpenCLKernels;
+  using KernelFDPairs = llvm::SmallVector<
+                            std::pair<const FunctionDecl *, FunctionDecl *>>;
+  KernelFDPairs SyclKernelsToOpenCLKernels;
 
   // Used to suppress diagnostics during kernel construction, since these were
   // already emitted earlier. Diagnosing during Kernel emissions also skips the
@@ -296,10 +297,16 @@ public:
                               llvm::DenseSet<QualType> Visited,
                               ValueDecl *DeclToCheck);
 
+  const KernelFDPairs &getKernelFDPairs() {
+    return SyclKernelsToOpenCLKernels;
+  }
+
   void addSyclOpenCLKernel(const FunctionDecl *SyclKernel,
                            FunctionDecl *OpenCLKernel) {
     SyclKernelsToOpenCLKernels.emplace_back(SyclKernel, OpenCLKernel);
   }
+
+  void constructFreeFunctionKernel(FunctionDecl *FD, StringRef NameStr = "");
 
   void addSyclDeviceDecl(Decl *d) { SyclDeviceDecls.insert(d); }
   llvm::SetVector<Decl *> &syclDeviceDecls() { return SyclDeviceDecls; }

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -641,6 +641,12 @@ void CodeGenFunction::EmitKernelMetadata(const FunctionDecl *FD,
 
   llvm::LLVMContext &Context = getLLVMContext();
 
+  if (getLangOpts().SYCLIsDevice)
+    if (FD->hasAttr<SYCLRegisteredKernelNameAttr>())
+      CGM.SYCLAddRegKernelNamePairs(
+          FD->getAttr<SYCLRegisteredKernelNameAttr>()->getRegName(),
+          FD->getNameAsString());
+
   if (FD->hasAttr<OpenCLKernelAttr>() || FD->hasAttr<CUDAGlobalAttr>())
     CGM.GenKernelArgMetadata(Fn, FD, this);
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1430,14 +1430,15 @@ void CodeGenModule::Release() {
 
     if (!SYCLRegKernelNames.empty()) {
       std::vector<llvm::Metadata *> Nodes;
+      llvm::LLVMContext &Ctx = TheModule.getContext();
       for (auto MDKernelNames : SYCLRegKernelNames) {
         llvm::Metadata *Vals[] = {MDKernelNames.first, MDKernelNames.second};
-        Nodes.push_back(llvm::MDTuple::get(TheModule.getContext(), Vals));
+        Nodes.push_back(llvm::MDTuple::get(Ctx, Vals));
       }
 
-      getModule().addModuleFlag(
-          llvm::Module::Append, "sycl_registered_kernels",
-          llvm::MDTuple::get(TheModule.getContext(), Nodes));
+      llvm::NamedMDNode *SYCLRegKernelsMD =
+          TheModule.getOrInsertNamedMetadata("sycl_registered_kernels");
+      SYCLRegKernelsMD->addOperand(llvm::MDNode::get(Ctx, Nodes));
     }
   }
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1427,6 +1427,18 @@ void CodeGenModule::Release() {
         AspectEnumValsMD->addOperand(
             getAspectEnumValueMD(Context, TheModule.getContext(), ECD));
     }
+
+    if (!SYCLRegKernelNames.empty()) {
+      std::vector<llvm::Metadata *> Nodes;
+      for (auto MDKernelNames: SYCLRegKernelNames) {
+        llvm::Metadata *Vals[] = {MDKernelNames.first, MDKernelNames.second};
+        Nodes.push_back(llvm::MDTuple::get(TheModule.getContext(), Vals));
+      }
+
+      getModule().addModuleFlag(
+          llvm::Module::Append, "sycl_registered_kernels",
+          llvm::MDTuple::get(TheModule.getContext(), Nodes));
+    }
   }
 
   // HLSL related end of code gen work items.

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1430,7 +1430,7 @@ void CodeGenModule::Release() {
 
     if (!SYCLRegKernelNames.empty()) {
       std::vector<llvm::Metadata *> Nodes;
-      for (auto MDKernelNames: SYCLRegKernelNames) {
+      for (auto MDKernelNames : SYCLRegKernelNames) {
         llvm::Metadata *Vals[] = {MDKernelNames.first, MDKernelNames.second};
         Nodes.push_back(llvm::MDTuple::get(TheModule.getContext(), Vals));
       }

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -456,6 +456,9 @@ private:
   /// handled differently than regular annotations so they cannot share map.
   llvm::DenseMap<unsigned, llvm::Constant *> SYCLAnnotationArgs;
 
+  typedef std::pair<llvm::Metadata *, llvm::Metadata *> MetadataPair;
+  SmallVector<MetadataPair, 4> SYCLRegKernelNames;
+
   llvm::StringMap<llvm::GlobalVariable *> CFConstantStringMap;
 
   llvm::DenseMap<llvm::Constant *, llvm::GlobalVariable *> ConstantStringMap;
@@ -1482,6 +1485,12 @@ public:
   /// Emit additional args of the annotation.
   llvm::Constant *EmitSYCLAnnotationArgs(
       SmallVectorImpl<std::pair<std::string, std::string>> &Pairs);
+
+  void SYCLAddRegKernelNamePairs(StringRef First, StringRef Second) {
+    SYCLRegKernelNames.push_back(std::make_pair(
+        llvm::MDString::get(getLLVMContext(), First),
+        llvm::MDString::get(getLLVMContext(), Second)));
+  }
 
   /// Add attributes from add_ir_attributes_global_variable on TND to GV.
   void AddGlobalSYCLIRAttributes(llvm::GlobalVariable *GV,

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -1487,9 +1487,9 @@ public:
       SmallVectorImpl<std::pair<std::string, std::string>> &Pairs);
 
   void SYCLAddRegKernelNamePairs(StringRef First, StringRef Second) {
-    SYCLRegKernelNames.push_back(std::make_pair(
-        llvm::MDString::get(getLLVMContext(), First),
-        llvm::MDString::get(getLLVMContext(), Second)));
+    SYCLRegKernelNames.push_back(
+        std::make_pair(llvm::MDString::get(getLLVMContext(), First),
+                       llvm::MDString::get(getLLVMContext(), Second)));
   }
 
   /// Add attributes from add_ir_attributes_global_variable on TND to GV.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5537,87 +5537,6 @@ static void handlePatchableFunctionEntryAttr(Sema &S, Decl *D,
                  PatchableFunctionEntryAttr(S.Context, AL, Count, Offset));
 }
 
-static bool isFreeFunctionKernel(Sema &S, FunctionDecl *FD) {
-  /* If it does not have the attribute, return false. */
-  if (!FD->hasAttr<SYCLAddIRAttributesFunctionAttr>())
-    return false;
-  /* If it does, traverse through the pairs and return true, if
-     it is one of the two free function types. */
-  auto *SAIRAttr = FD->getAttr<SYCLAddIRAttributesFunctionAttr>();
-  SmallVector<std::pair<std::string, std::string>, 4> NameValuePairs =
-      SAIRAttr->getFilteredAttributeNameValuePairs(S.Context);
-  for (const auto &NVPair : NameValuePairs) {
-    if (!NVPair.first.compare("sycl-single-task-kernel") ||
-        !NVPair.first.compare("sycl-nd-range-kernel"))
-      return true;
-  }
-  /* If it does not have free function attributes, return false. */
-  return false;
-}
-
-static void handleSYCLRegisteredKernels(Sema &S, Decl *D, const ParsedAttr &A) {
-  unsigned NumArgs = A.getNumArgs();
-  /* When declared, we expect at least one item in the list. */
-  if (NumArgs == 0) {
-    S.Diag(A.getLoc(), diag::err_registered_kernels_num_of_args);
-    return;
-  }
-
-  /* Traverse through the items in the list. */
-  for (unsigned I = 0; I < NumArgs; I++) {
-    assert(A.isArgExpr(I) && "Expected expression argument");
-    /* Each item in the list must be an initializer list expression. */
-    Expr *ArgExpr = A.getArgAsExpr(I);
-    if (!isa<InitListExpr>(ArgExpr)) {
-      S.Diag(ArgExpr->getExprLoc(), diag::err_registered_kernels_init_list);
-      return;
-    }
-
-    const auto *ArgListE = cast<InitListExpr>(ArgExpr);
-    unsigned NumInits = ArgListE->getNumInits();
-    /* Each init-list expression must have a pair of values. */
-    if (NumInits != 2) {
-      S.Diag(ArgExpr->getExprLoc(),
-             diag::err_registered_kernels_init_list_pair_values);
-      return;
-    }
-
-    /* The first value of the pair muse be a string. */
-    const Expr *FirstExpr = ArgListE->getInit(0);
-    StringRef CurStr;
-    SourceLocation Loc = FirstExpr->getExprLoc();
-    if (!S.checkStringLiteralArgumentAttr(A, FirstExpr, CurStr, &Loc))
-      return;
-
-    /* Resolve the FunctionDecl from the second value of the pair. */
-    auto *SecondE = const_cast<Expr *>(ArgListE->getInit(1));
-    FunctionDecl *FD = nullptr;
-    if (auto *ULE = dyn_cast<UnresolvedLookupExpr>(SecondE)) {
-      FD = S.ResolveSingleFunctionTemplateSpecialization(ULE, true);
-      Loc = ULE->getExprLoc();
-    } else {
-      while (isa<CastExpr>(SecondE))
-        SecondE = cast<CastExpr>(SecondE)->getSubExpr();
-      auto *DRE = dyn_cast<DeclRefExpr>(SecondE);
-      if (DRE)
-        FD = dyn_cast<FunctionDecl>(DRE->getDecl());
-      Loc = SecondE->getExprLoc();
-    }
-    /* Issue a diagnostic if we are unable to resolve the FunctionDecl. */
-    if (!FD) {
-      S.Diag(Loc, diag::err_registered_kernels_resolve_function) << CurStr;
-      return;
-    }
-    /* Issue a diagnostic is the FunctionDecl is not a SYCL free function. */
-    if (!isFreeFunctionKernel(S, FD)) {
-      S.Diag(FD->getLocation(), diag::err_not_sycl_free_function) << CurStr;
-      return;
-    }
-    /* Construct a free function kernel. */
-    S.SYCL().constructFreeFunctionKernel(FD, CurStr);
-  }
-}
-
 static bool SYCLAliasValid(ASTContext &Context, unsigned BuiltinID) {
   constexpr llvm::StringLiteral Prefix = "__builtin_intel_sycl";
   return Context.BuiltinInfo.getName(BuiltinID).starts_with(Prefix);
@@ -7506,7 +7425,7 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
     S.SYCL().handleSYCLAddIRAnnotationsMemberAttr(D, AL);
     break;
   case ParsedAttr::AT_SYCLRegisteredKernels:
-    handleSYCLRegisteredKernels(S, D, AL);
+    S.SYCL().handleSYCLRegisteredKernels(D, AL);
     break;
 
   // Swift attributes.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5426,7 +5426,7 @@ static bool checkAndAddRegisteredKernelName(SemaSYCL &S, FunctionDecl *FD,
   using KernelPair = std::pair<const FunctionDecl *, FunctionDecl *>;
   for (const KernelPair &Pair : S.getKernelFDPairs()) {
     if (Pair.first == FD) {
-      // If the current list of free function entries already contain this
+      // If the current list of free function entries already contains this
       // free function, apply the name Str as an attribute.  But if it already
       // has an attribute name, issue a diagnostic instead.
       if (!Str.empty()) {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5417,8 +5417,8 @@ void SemaSYCL::ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc,
 static void addRegisteredKernelName(SemaSYCL &S, StringRef Str,
                                     FunctionDecl *FD, SourceLocation Loc) {
   if (!Str.empty()) {
-    FD->addAttr(SYCLRegisteredKernelNameAttr::CreateImplicit(
-                    S.getASTContext(), Str, Loc));
+    FD->addAttr(SYCLRegisteredKernelNameAttr::CreateImplicit(S.getASTContext(),
+                                                             Str, Loc));
   }
 }
 
@@ -5435,9 +5435,9 @@ static bool checkAndAddRegisteredKernelName(SemaSYCL &S, FunctionDecl *FD,
           addRegisteredKernelName(S, Str, Pair.second, FD->getLocation());
         else
           S.Diag(FD->getLocation(),
-                     diag::err_registered_kernels_name_already_registered)
-              << Pair.second->getAttr<SYCLRegisteredKernelNameAttr>()->
-                     getRegName()
+                 diag::err_registered_kernels_name_already_registered)
+              << Pair.second->getAttr<SYCLRegisteredKernelNameAttr>()
+                     ->getRegName()
               << Str;
       }
       // An empty name string implies a regular free kernel construction
@@ -5450,21 +5450,19 @@ static bool checkAndAddRegisteredKernelName(SemaSYCL &S, FunctionDecl *FD,
 void SemaSYCL::constructFreeFunctionKernel(FunctionDecl *FD,
                                            StringRef NameStr) {
   if (!checkAndAddRegisteredKernelName(*this, FD, NameStr))
-     return;
+    return;
 
   SyclKernelArgsSizeChecker argsSizeChecker(*this, FD->getLocation(),
                                             false /*IsSIMDKernel*/);
-  SyclKernelDeclCreator kernel_decl(*this, FD->getLocation(),
-                                    FD->isInlined(), false /*IsSIMDKernel */,
-                                    FD);
+  SyclKernelDeclCreator kernel_decl(*this, FD->getLocation(), FD->isInlined(),
+                                    false /*IsSIMDKernel */, FD);
 
   FreeFunctionKernelBodyCreator kernel_body(*this, kernel_decl, FD);
 
-  SyclKernelIntHeaderCreator int_header(
-      *this, getSyclIntegrationHeader(), FD->getType(), FD);
+  SyclKernelIntHeaderCreator int_header(*this, getSyclIntegrationHeader(),
+                                        FD->getType(), FD);
 
-  SyclKernelIntFooterCreator int_footer(*this,
-                                        getSyclIntegrationFooter());
+  SyclKernelIntFooterCreator int_footer(*this, getSyclIntegrationFooter());
   KernelObjVisitor Visitor{*this};
 
   Visitor.VisitFunctionParameters(FD, argsSizeChecker, kernel_decl, kernel_body,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1148,10 +1148,10 @@ static target getAccessTarget(QualType FieldTy,
 
 // FIXME: Free functions must have void return type and be declared at file
 // scope, outside any namespaces.
-static bool isFreeFunction(SemaSYCL &SemaSYCLRef, const FunctionDecl *FD) {
+bool SemaSYCL::isFreeFunction(const FunctionDecl *FD) {
   for (auto *IRAttr : FD->specific_attrs<SYCLAddIRAttributesFunctionAttr>()) {
     SmallVector<std::pair<std::string, std::string>, 4> NameValuePairs =
-        IRAttr->getAttributeNameValuePairs(SemaSYCLRef.getASTContext());
+        IRAttr->getAttributeNameValuePairs(getASTContext());
     for (const auto &NameValuePair : NameValuePairs) {
       if (NameValuePair.first == "sycl-nd-range-kernel" ||
           NameValuePair.first == "sycl-single-task-kernel") {
@@ -5291,7 +5291,7 @@ void SemaSYCL::SetSYCLKernelNames() {
        SyclKernelsToOpenCLKernels) {
     std::string CalculatedName, StableName;
     StringRef KernelName;
-    if (isFreeFunction(*this, Pair.first)) {
+    if (isFreeFunction(Pair.first)) {
       std::tie(CalculatedName, StableName) =
           constructFreeFunctionKernelName(*this, Pair.first, *MangleCtx);
       KernelName = CalculatedName;
@@ -5416,16 +5416,15 @@ void SemaSYCL::ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc,
 
 static void addRegisteredKernelName(SemaSYCL &S, StringRef Str,
                                     FunctionDecl *FD, SourceLocation Loc) {
-  if (!Str.empty()) {
+  if (!Str.empty())
     FD->addAttr(SYCLRegisteredKernelNameAttr::CreateImplicit(S.getASTContext(),
                                                              Str, Loc));
-  }
 }
 
 static bool checkAndAddRegisteredKernelName(SemaSYCL &S, FunctionDecl *FD,
                                             StringRef Str) {
   using KernelPair = std::pair<const FunctionDecl *, FunctionDecl *>;
-  for (const KernelPair &Pair : S.getKernelFDPairs())
+  for (const KernelPair &Pair : S.getKernelFDPairs()) {
     if (Pair.first == FD) {
       // If the current list of free function entries already contain this
       // free function, apply the name Str as an attribute.  But if it already
@@ -5444,6 +5443,7 @@ static bool checkAndAddRegisteredKernelName(SemaSYCL &S, FunctionDecl *FD,
       // call, so simply return.
       return false;
     }
+  }
   return true;
 }
 
@@ -5759,7 +5759,7 @@ void SemaSYCL::MarkDevices() {
 }
 
 void SemaSYCL::ProcessFreeFunction(FunctionDecl *FD) {
-  if (isFreeFunction(*this, FD)) {
+  if (isFreeFunction(FD)) {
     SyclKernelDecompMarker DecompMarker(*this);
     SyclKernelFieldChecker FieldChecker(*this);
     SyclKernelUnionChecker UnionChecker(*this);
@@ -6663,7 +6663,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   unsigned ShimCounter = 1;
   int FreeFunctionCount = 0;
   for (const KernelDesc &K : KernelDescs) {
-    if (!isFreeFunction(S, K.SyclKernel))
+    if (!S.isFreeFunction(K.SyclKernel))
       continue;
     ++FreeFunctionCount;
     // Generate forward declaration for free function.
@@ -6781,7 +6781,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   }
   ShimCounter = 1;
   for (const KernelDesc &K : KernelDescs) {
-    if (!isFreeFunction(S, K.SyclKernel))
+    if (!S.isFreeFunction(K.SyclKernel))
       continue;
 
     O << "\n// Definition of kernel_id of " << K.Name << "\n";

--- a/clang/lib/Sema/SemaSYCLDeclAttr.cpp
+++ b/clang/lib/Sema/SemaSYCLDeclAttr.cpp
@@ -3208,8 +3208,7 @@ void SemaSYCL::handleSYCLRegisteredKernels(Decl *D, const ParsedAttr &A) {
       FD = SemaRef.ResolveSingleFunctionTemplateSpecialization(ULE, true);
       Loc = ULE->getExprLoc();
     } else {
-      if (isa<CastExpr>(SecondE))
-        SecondE = cast<CastExpr>(SecondE)->getSubExpr()->IgnoreParenImpCasts();
+      SecondE = SecondE->IgnoreParenCasts();
       if (auto *DRE = dyn_cast<DeclRefExpr>(SecondE))
         FD = dyn_cast<FunctionDecl>(DRE->getDecl());
       Loc = SecondE->getExprLoc();

--- a/clang/lib/Sema/SemaSYCLDeclAttr.cpp
+++ b/clang/lib/Sema/SemaSYCLDeclAttr.cpp
@@ -3212,7 +3212,7 @@ void SemaSYCL::handleSYCLRegisteredKernels(Decl *D, const ParsedAttr &A) {
       return;
     }
 
-    /* The first value of the pair muse be a string. */
+    /* The first value of the pair must be a string. */
     const Expr *FirstExpr = ArgListE->getInit(0);
     StringRef CurStr;
     SourceLocation Loc = FirstExpr->getExprLoc();

--- a/clang/lib/Sema/SemaSYCLDeclAttr.cpp
+++ b/clang/lib/Sema/SemaSYCLDeclAttr.cpp
@@ -3185,7 +3185,7 @@ void SemaSYCL::handleSYCLRegisteredKernels(Decl *D, const ParsedAttr &A) {
       return;
     }
 
-    const auto *ArgListE = cast<InitListExpr>(ArgExpr);
+    auto *ArgListE = cast<InitListExpr>(ArgExpr);
     unsigned NumInits = ArgListE->getNumInits();
     // Each init-list expression must have a pair of values.
     if (NumInits != 2) {
@@ -3195,14 +3195,14 @@ void SemaSYCL::handleSYCLRegisteredKernels(Decl *D, const ParsedAttr &A) {
     }
 
     // The first value of the pair must be a string.
-    const Expr *FirstExpr = ArgListE->getInit(0);
+    Expr *FirstExpr = ArgListE->getInit(0);
     StringRef CurStr;
     SourceLocation Loc = FirstExpr->getExprLoc();
     if (!SemaRef.checkStringLiteralArgumentAttr(A, FirstExpr, CurStr, &Loc))
       return;
 
     // Resolve the FunctionDecl from the second value of the pair.
-    auto *SecondE = const_cast<Expr *>(ArgListE->getInit(1));
+    Expr *SecondE = ArgListE->getInit(1);
     FunctionDecl *FD = nullptr;
     if (auto *ULE = dyn_cast<UnresolvedLookupExpr>(SecondE)) {
       FD = SemaRef.ResolveSingleFunctionTemplateSpecialization(ULE, true);
@@ -3210,8 +3210,7 @@ void SemaSYCL::handleSYCLRegisteredKernels(Decl *D, const ParsedAttr &A) {
     } else {
       if (isa<CastExpr>(SecondE))
         SecondE = cast<CastExpr>(SecondE)->getSubExpr()->IgnoreParenImpCasts();
-      auto *DRE = dyn_cast<DeclRefExpr>(SecondE);
-      if (DRE)
+      if (auto *DRE = dyn_cast<DeclRefExpr>(SecondE))
         FD = dyn_cast<FunctionDecl>(DRE->getDecl());
       Loc = SecondE->getExprLoc();
     }

--- a/clang/lib/Sema/SemaSYCLDeclAttr.cpp
+++ b/clang/lib/Sema/SemaSYCLDeclAttr.cpp
@@ -3208,7 +3208,7 @@ void SemaSYCL::handleSYCLRegisteredKernels(Decl *D, const ParsedAttr &A) {
     /* Each init-list expression must have a pair of values. */
     if (NumInits != 2) {
       Diag(ArgExpr->getExprLoc(),
-             diag::err_registered_kernels_init_list_pair_values);
+           diag::err_registered_kernels_init_list_pair_values);
       return;
     }
 

--- a/clang/lib/Sema/SemaSYCLDeclAttr.cpp
+++ b/clang/lib/Sema/SemaSYCLDeclAttr.cpp
@@ -3162,3 +3162,88 @@ void SemaSYCL::checkSYCLAddIRAttributesFunctionAttrConflicts(Decl *D) {
       Diag(Attr->getLoc(), diag::warn_sycl_old_and_new_kernel_attributes)
           << Attr;
 }
+
+static bool isFreeFunctionKernel(SemaSYCL &S, FunctionDecl *FD) {
+  /* If it does not have the attribute, return false. */
+  if (!FD->hasAttr<SYCLAddIRAttributesFunctionAttr>())
+    return false;
+  /* If it does, traverse through the pairs and return true, if
+     it is one of the two free function types. */
+  auto *SAIRAttr = FD->getAttr<SYCLAddIRAttributesFunctionAttr>();
+  SmallVector<std::pair<std::string, std::string>, 4> NameValuePairs =
+      SAIRAttr->getFilteredAttributeNameValuePairs(S.getASTContext());
+  for (const auto &NVPair : NameValuePairs) {
+    if (!NVPair.first.compare("sycl-single-task-kernel") ||
+        !NVPair.first.compare("sycl-nd-range-kernel"))
+      return true;
+  }
+  /* If it does not have free function attributes, return false. */
+  return false;
+}
+
+void SemaSYCL::handleSYCLRegisteredKernels(Decl *D, const ParsedAttr &A) {
+  // Check for SYCL device compilation context.
+  if (!getLangOpts().SYCLIsDevice)
+    return;
+
+  unsigned NumArgs = A.getNumArgs();
+  /* When declared, we expect at least one item in the list. */
+  if (NumArgs == 0) {
+    Diag(A.getLoc(), diag::err_registered_kernels_num_of_args);
+    return;
+  }
+
+  /* Traverse through the items in the list. */
+  for (unsigned I = 0; I < NumArgs; I++) {
+    assert(A.isArgExpr(I) && "Expected expression argument");
+    /* Each item in the list must be an initializer list expression. */
+    Expr *ArgExpr = A.getArgAsExpr(I);
+    if (!isa<InitListExpr>(ArgExpr)) {
+      Diag(ArgExpr->getExprLoc(), diag::err_registered_kernels_init_list);
+      return;
+    }
+
+    const auto *ArgListE = cast<InitListExpr>(ArgExpr);
+    unsigned NumInits = ArgListE->getNumInits();
+    /* Each init-list expression must have a pair of values. */
+    if (NumInits != 2) {
+      Diag(ArgExpr->getExprLoc(),
+             diag::err_registered_kernels_init_list_pair_values);
+      return;
+    }
+
+    /* The first value of the pair muse be a string. */
+    const Expr *FirstExpr = ArgListE->getInit(0);
+    StringRef CurStr;
+    SourceLocation Loc = FirstExpr->getExprLoc();
+    if (!SemaRef.checkStringLiteralArgumentAttr(A, FirstExpr, CurStr, &Loc))
+      return;
+
+    /* Resolve the FunctionDecl from the second value of the pair. */
+    auto *SecondE = const_cast<Expr *>(ArgListE->getInit(1));
+    FunctionDecl *FD = nullptr;
+    if (auto *ULE = dyn_cast<UnresolvedLookupExpr>(SecondE)) {
+      FD = SemaRef.ResolveSingleFunctionTemplateSpecialization(ULE, true);
+      Loc = ULE->getExprLoc();
+    } else {
+      while (isa<CastExpr>(SecondE))
+        SecondE = cast<CastExpr>(SecondE)->getSubExpr();
+      auto *DRE = dyn_cast<DeclRefExpr>(SecondE);
+      if (DRE)
+        FD = dyn_cast<FunctionDecl>(DRE->getDecl());
+      Loc = SecondE->getExprLoc();
+    }
+    /* Issue a diagnostic if we are unable to resolve the FunctionDecl. */
+    if (!FD) {
+      Diag(Loc, diag::err_registered_kernels_resolve_function) << CurStr;
+      return;
+    }
+    /* Issue a diagnostic is the FunctionDecl is not a SYCL free function. */
+    if (!isFreeFunctionKernel(*this, FD)) {
+      Diag(FD->getLocation(), diag::err_not_sycl_free_function) << CurStr;
+      return;
+    }
+    /* Construct a free function kernel. */
+    constructFreeFunctionKernel(FD, CurStr);
+  }
+}

--- a/clang/test/CodeGenSYCL/registered-kernel-names.cpp
+++ b/clang/test/CodeGenSYCL/registered-kernel-names.cpp
@@ -27,7 +27,7 @@ template <typename T>
 __attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void tempfoo2(T pt) {
-  T t; 
+  T t;
 }
 
 template void tempfoo2<int>(int);

--- a/clang/test/CodeGenSYCL/registered-kernel-names.cpp
+++ b/clang/test/CodeGenSYCL/registered-kernel-names.cpp
@@ -60,7 +60,7 @@ namespace N {
 
 // Check for the presence of sycl-device module flag in device
 // compilations and its absence in host compilations.
-// CHECK: !{{[0-9]+}} = !{i32 5, !"sycl_registered_kernels", ![[LIST:[0-9]+]]}
+// CHECK: !sycl_registered_kernels = !{![[LIST:[0-9]+]]}
 // CHECK: ![[LIST]] = !{![[ENT1:[0-9]+]], ![[ENT2:[0-9]+]], ![[ENT3:[0-9]+]], ![[ENT4:[0-9]+]],  ![[ENT5:[0-9]+]], ![[ENT6:[0-9]+]], ![[ENT7:[0-9]+]], ![[ENT8:[0-9]+]]}
 // CHECK: ![[ENT1]] = !{!"foo", !"{{.*}}sycl_kernel{{.*}}foo{{.*}}"}
 // CHECK: ![[ENT2]] = !{!"foo3", !"{{.*}}sycl_kernel{{.*}}ff_4{{.*}}"}

--- a/clang/test/CodeGenSYCL/registered-kernel-names.cpp
+++ b/clang/test/CodeGenSYCL/registered-kernel-names.cpp
@@ -63,6 +63,65 @@ namespace N {
 )]];
 }
 
+// Check that the functions registered in the __registered_kernels__ list
+// are defined or declared as appropriate, that the kernels are generated
+// for these functions and are called from the generated kernels.
+
+// Check that the definitions for the functions foo, ff_4, iota,
+// tempfoo2 explicitly instantiated with int, and tempfoo2 specialized
+// with float are generated.
+// CHECK: define {{.*}} void @[[FOO:[_A-Za-z0-9]+]]()
+// CHECK: define {{.*}} void @[[FF_4:[_A-Za-z0-9]+]]()
+// CHECK: define {{.*}} void @[[IOTA:[_A-Za-z0-9]+]](i32 {{.*}} %0, ptr addrspace(4) {{.*}} %1)
+// CHECK: define {{.*}} void @[[TEMPFOO2INT:[_A-Za-z0-9]+]](i32 {{.*}} %pt)
+// CHECK: define {{.*}} void @[[TEMPFOO2SHORT:[_A-Za-z0-9]+]](i16 {{.*}} %0)
+
+// Check generation of the SYCL kernel for foo, and the call to foo.
+// CHECK: define {{.*}} void @_Z17__sycl_kernel_foov()
+// CHECK:   call {{.*}} void @[[FOO]]()
+
+// Check generation of the SYCL kernel for ff_4, and the call to ff_4.
+// CHECK: define {{.*}} void @_Z18__sycl_kernel_ff_4v()
+// CHECK:   call {{.*}} void @[[FF_4]]()
+
+// Check generation of the SYCL kernel for iota, and the call to iota.
+// CHECK: define {{.*}} void @_Z18__sycl_kernel_iotaiPi(i32 {{.*}} %__arg_, ptr addrspace(1) {{.*}} %__arg_1)
+// CHECK:   call {{.*}} void @[[IOTA]](i32 {{.*}} %0, ptr addrspace(4) {{.*}} %2)
+
+// Check generation of the SYCL kernel for tempfoo2<int>, and the call to
+// tempfoo2<int>.
+// CHECK: define {{.*}} void @_Z22__sycl_kernel_tempfoo2IiEvT_(i32 {{.*}} %__arg_pt)
+// CHECK:   call {{.*}} void @[[TEMPFOO2INT]](i32 {{.*}} %0)
+
+// Check generation of the SYCL kernel for tempfoo2<short>, and the call to
+// tempfoo2<short>.
+// CHECK: define {{.*}} void @_Z22__sycl_kernel_tempfoo2IsEvT_(i16 {{.*}} %__arg_)
+// CHECK:   call {{.*}} void @[[TEMPFOO2SHORT]](i16 {{.*}} %0)
+
+// Check generation of the SYCL kernel for tempfoo<int>, the call to
+// tempfoo<int>, and its declaration.
+// CHECK: define {{.*}} void @_Z21__sycl_kernel_tempfooIiEvT_(i32 {{.*}} %__arg_pt)
+// CHECK:   call {{.*}} void @[[TEMPFOOINT:[_A-Za-z0-9]+]](i32 {{.*}} %0)
+// CHECK: declare {{.*}} void @[[TEMPFOOINT]](i32 {{.*}})
+
+// Check generation of the SYCL kernel for tempfoo2<float>, the call to
+// tempfoo2<float>, and its declaration.
+// CHECK: define {{.*}} void @_Z22__sycl_kernel_tempfoo2IfEvT_(float {{.*}} %__arg_f)
+// CHECK:   call {{.*}} void @[[TEMPFOO2FLOAT:[_A-Za-z0-9]+]](float {{.*}} %0)
+// CHECK: declare {{.*}} void @[[TEMPFOO2FLOAT]](float {{.*}})
+
+// Check generation of the SYCL kernel for tempfoo3<5>, the call to
+// tempfoo3<5>, and its definition.
+// CHECK: define {{.*}} void @_Z22__sycl_kernel_tempfoo3ILi5EEvv()
+// CHECK:   call {{.*}} void @[[TEMPFOO35:[_A-Za-z0-9]+]]()
+// CHECK: define {{.*}} void @[[TEMPFOO35]]()
+
+// Check generation of the SYCL kernel for bar, the call to
+// bar, and its declaration.
+// CHECK: define {{.*}} void @_Z17__sycl_kernel_barv()
+// CHECK:   call {{.*}} void @[[BAR:[_A-Za-z0-9]+]]()
+// CHECK: declare {{.*}} void @[[BAR]]()
+
 // Check for the presence of sycl_registered_kernels named metadata.
 // CHECK: !sycl_registered_kernels = !{![[LIST:[0-9]+]]}
 // CHECK: ![[LIST]] = !{![[ENT1:[0-9]+]], ![[ENT2:[0-9]+]], ![[ENT3:[0-9]+]], ![[ENT4:[0-9]+]],  ![[ENT5:[0-9]+]], ![[ENT6:[0-9]+]], ![[ENT7:[0-9]+]], ![[ENT8:[0-9]+]], ![[ENT9:[0-9]+]]}

--- a/clang/test/CodeGenSYCL/registered-kernel-names.cpp
+++ b/clang/test/CodeGenSYCL/registered-kernel-names.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -emit-llvm -triple spir64 -o - %s | FileCheck %s
 
 // This test checks if the sycl_registered_kernels module flag and
 // associated entries are generated for registered kernel names.

--- a/clang/test/CodeGenSYCL/registered-kernel-names.cpp
+++ b/clang/test/CodeGenSYCL/registered-kernel-names.cpp
@@ -9,6 +9,10 @@ void foo() {
 }
 
 __attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
+void bar();
+
+__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-nd-range-kernel", 0)]]
 void ff_4() {
 }
@@ -54,13 +58,14 @@ namespace N {
   {"decl spec", tempfoo2<float>},
   {"def spec", tempfoo2<short>},
   {"foo3", ff_4},
-  {"nontype", tempfoo3<5>}
+  {"nontype", tempfoo3<5>},
+  {"decl non-temp", bar}
 )]];
 }
 
 // Check for the presence of sycl_registered_kernels named metadata.
 // CHECK: !sycl_registered_kernels = !{![[LIST:[0-9]+]]}
-// CHECK: ![[LIST]] = !{![[ENT1:[0-9]+]], ![[ENT2:[0-9]+]], ![[ENT3:[0-9]+]], ![[ENT4:[0-9]+]],  ![[ENT5:[0-9]+]], ![[ENT6:[0-9]+]], ![[ENT7:[0-9]+]], ![[ENT8:[0-9]+]]}
+// CHECK: ![[LIST]] = !{![[ENT1:[0-9]+]], ![[ENT2:[0-9]+]], ![[ENT3:[0-9]+]], ![[ENT4:[0-9]+]],  ![[ENT5:[0-9]+]], ![[ENT6:[0-9]+]], ![[ENT7:[0-9]+]], ![[ENT8:[0-9]+]], ![[ENT9:[0-9]+]]}
 // CHECK: ![[ENT1]] = !{!"foo", !"{{.*}}sycl_kernel{{.*}}foo{{.*}}"}
 // CHECK: ![[ENT2]] = !{!"foo3", !"{{.*}}sycl_kernel{{.*}}ff_4{{.*}}"}
 // CHECK: ![[ENT3]] = !{!"iota", !"{{.*}}sycl_kernel{{.*}}iota{{.*}}"}
@@ -69,3 +74,4 @@ namespace N {
 // CHECK: ![[ENT6]] = !{!"decl temp", !"{{.*}}sycl_kernel{{.*}}tempfoo{{.*}}"}
 // CHECK: ![[ENT7]] = !{!"decl spec", !"{{.*}}sycl_kernel{{.*}}tempfoo2{{.*}}"}
 // CHECK: ![[ENT8]] = !{!"nontype", !"{{.*}}sycl_kernel{{.*}}tempfoo3{{.*}}"}
+// CHECK: ![[ENT9]] = !{!"decl non-temp", !"{{.*}}sycl_kernel{{.*}}bar{{.*}}"}

--- a/clang/test/CodeGenSYCL/registered-kernel-names.cpp
+++ b/clang/test/CodeGenSYCL/registered-kernel-names.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fsycl-is-device -emit-llvm -triple spir64 -o - %s | FileCheck %s
 
-// This test checks if the sycl_registered_kernels module flag and
+// This test checks if the sycl_registered_kernels named metadata and
 // associated entries are generated for registered kernel names.
 
 __attribute__((sycl_device))
@@ -58,8 +58,7 @@ namespace N {
 )]];
 }
 
-// Check for the presence of sycl-device module flag in device
-// compilations and its absence in host compilations.
+// Check for the presence of sycl_registered_kernels named metadata.
 // CHECK: !sycl_registered_kernels = !{![[LIST:[0-9]+]]}
 // CHECK: ![[LIST]] = !{![[ENT1:[0-9]+]], ![[ENT2:[0-9]+]], ![[ENT3:[0-9]+]], ![[ENT4:[0-9]+]],  ![[ENT5:[0-9]+]], ![[ENT6:[0-9]+]], ![[ENT7:[0-9]+]], ![[ENT8:[0-9]+]]}
 // CHECK: ![[ENT1]] = !{!"foo", !"{{.*}}sycl_kernel{{.*}}foo{{.*}}"}

--- a/clang/test/CodeGenSYCL/registered-kernel-names.cpp
+++ b/clang/test/CodeGenSYCL/registered-kernel-names.cpp
@@ -1,0 +1,72 @@
+// RUN: %clang_cc1 -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+
+// This test checks if the sycl_registered_kernels module flag and
+// associated entries are generated for registered kernel names.
+
+__attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
+void foo() {
+}
+
+__attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-nd-range-kernel", 0)]]
+void ff_4() {
+}
+
+__attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
+void iota(int, int *) {
+}
+
+template <typename T>
+__attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
+void tempfoo(T pt);
+
+template <typename T>
+__attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
+void tempfoo2(T pt) {
+  T t; 
+}
+
+template void tempfoo2<int>(int);
+
+template <>
+void tempfoo2(float f);
+
+template <>
+void tempfoo2(short) { }
+
+template <int N>
+__attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
+void tempfoo3() {
+  (void)N;
+}
+
+namespace N {
+[[__sycl_detail__::__registered_kernels__(
+  {"foo", foo},
+  {"iota", (void(*)(int, int *))iota},
+  {"decl temp", tempfoo<int>},
+  {"inst temp", tempfoo2<int>},
+  {"decl spec", tempfoo2<float>},
+  {"def spec", tempfoo2<short>},
+  {"foo3", ff_4},
+  {"nontype", tempfoo3<5>}
+)]];
+}
+
+// Check for the presence of sycl-device module flag in device
+// compilations and its absence in host compilations.
+// CHECK: !{{[0-9]+}} = !{i32 5, !"sycl_registered_kernels", ![[LIST:[0-9]+]]}
+// CHECK: ![[LIST]] = !{![[ENT1:[0-9]+]], ![[ENT2:[0-9]+]], ![[ENT3:[0-9]+]], ![[ENT4:[0-9]+]],  ![[ENT5:[0-9]+]], ![[ENT6:[0-9]+]], ![[ENT7:[0-9]+]], ![[ENT8:[0-9]+]]}
+// CHECK: ![[ENT1]] = !{!"foo", !"{{.*}}sycl_kernel{{.*}}foo{{.*}}"}
+// CHECK: ![[ENT2]] = !{!"foo3", !"{{.*}}sycl_kernel{{.*}}ff_4{{.*}}"}
+// CHECK: ![[ENT3]] = !{!"iota", !"{{.*}}sycl_kernel{{.*}}iota{{.*}}"}
+// CHECK: ![[ENT4]] = !{!"inst temp", !"{{.*}}sycl_kernel{{.*}}tempfoo2{{.*}}"}
+// CHECK: ![[ENT5]] = !{!"def spec", !"{{.*}}sycl_kernel{{.*}}tempfoo2{{.*}}"}
+// CHECK: ![[ENT6]] = !{!"decl temp", !"{{.*}}sycl_kernel{{.*}}tempfoo{{.*}}"}
+// CHECK: ![[ENT7]] = !{!"decl spec", !"{{.*}}sycl_kernel{{.*}}tempfoo2{{.*}}"}
+// CHECK: ![[ENT8]] = !{!"nontype", !"{{.*}}sycl_kernel{{.*}}tempfoo3{{.*}}"}

--- a/clang/test/CodeGenSYCL/registered-kernel-names.cpp
+++ b/clang/test/CodeGenSYCL/registered-kernel-names.cpp
@@ -3,32 +3,26 @@
 // This test checks if the sycl_registered_kernels named metadata and
 // associated entries are generated for registered kernel names.
 
-__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void foo() {
 }
 
-__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void bar();
 
-__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-nd-range-kernel", 0)]]
 void ff_4() {
 }
 
-__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void iota(int, int *) {
 }
 
 template <typename T>
-__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void tempfoo(T pt);
 
 template <typename T>
-__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void tempfoo2(T pt) {
   T t;
@@ -43,7 +37,6 @@ template <>
 void tempfoo2(short) { }
 
 template <int N>
-__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void tempfoo3() {
   (void)N;
@@ -67,36 +60,36 @@ namespace N {
 // are defined or declared as appropriate, that the kernels are generated
 // for these functions and are called from the generated kernels.
 
-// Check that the definitions for the functions foo, ff_4, iota,
-// tempfoo2 explicitly instantiated with int, and tempfoo2 specialized
-// with float are generated.
-// CHECK: define {{.*}} void @[[FOO:[_A-Za-z0-9]+]]()
-// CHECK: define {{.*}} void @[[FF_4:[_A-Za-z0-9]+]]()
-// CHECK: define {{.*}} void @[[IOTA:[_A-Za-z0-9]+]](i32 {{.*}} %0, ptr addrspace(4) {{.*}} %1)
-// CHECK: define {{.*}} void @[[TEMPFOO2INT:[_A-Za-z0-9]+]](i32 {{.*}} %pt)
-// CHECK: define {{.*}} void @[[TEMPFOO2SHORT:[_A-Za-z0-9]+]](i16 {{.*}} %0)
-
-// Check generation of the SYCL kernel for foo, and the call to foo.
+// Check generation of the SYCL kernel for foo, the call to foo, and definition
+// of foo.
 // CHECK: define {{.*}} void @_Z17__sycl_kernel_foov()
-// CHECK:   call {{.*}} void @[[FOO]]()
+// CHECK:   call {{.*}} void @[[FOO:[_A-Za-z0-9]+]]()
+// CHECK: define {{.*}} void @[[FOO:[_A-Za-z0-9]+]]()
 
-// Check generation of the SYCL kernel for ff_4, and the call to ff_4.
+// Check generation of the SYCL kernel for ff_4, the call to ff_4, and the
+// definition of ff_4.
 // CHECK: define {{.*}} void @_Z18__sycl_kernel_ff_4v()
-// CHECK:   call {{.*}} void @[[FF_4]]()
+// CHECK:   call {{.*}} void @[[FF_4:[_A-Za-z0-9]+]]()
+// CHECK: define {{.*}} void @[[FF_4]]()
 
-// Check generation of the SYCL kernel for iota, and the call to iota.
+// Check generation of the SYCL kernel for iota, the call to iota, and the
+// definition of iota.
 // CHECK: define {{.*}} void @_Z18__sycl_kernel_iotaiPi(i32 {{.*}} %__arg_, ptr addrspace(1) {{.*}} %__arg_1)
-// CHECK:   call {{.*}} void @[[IOTA]](i32 {{.*}} %0, ptr addrspace(4) {{.*}} %2)
+// CHECK:   call {{.*}} void @[[IOTA:[_A-Za-z0-9]+]](i32 {{.*}} %0, ptr addrspace(4) {{.*}} %2)
+// CHECK: define {{.*}} void @[[IOTA]](i32 {{.*}} %0, ptr addrspace(4) {{.*}} %1)
 
-// Check generation of the SYCL kernel for tempfoo2<int>, and the call to
-// tempfoo2<int>.
+// Check generation of the SYCL kernel for tempfoo2<int>, the call to
+// tempfoo2<int> and the definition of tempfoo2 explicitly instantiated
+// with int.
 // CHECK: define {{.*}} void @_Z22__sycl_kernel_tempfoo2IiEvT_(i32 {{.*}} %__arg_pt)
-// CHECK:   call {{.*}} void @[[TEMPFOO2INT]](i32 {{.*}} %0)
+// CHECK:   call {{.*}} void @[[TEMPFOO2INT:[_A-Za-z0-9]+]](i32 {{.*}} %0)
+// CHECK: define {{.*}} void @[[TEMPFOO2INT]](i32 {{.*}} %pt)
 
-// Check generation of the SYCL kernel for tempfoo2<short>, and the call to
-// tempfoo2<short>.
+// Check generation of the SYCL kernel for tempfoo2<short>, the call to
+// tempfoo2<short> and the definition of tempfoo2 specialized with short.
 // CHECK: define {{.*}} void @_Z22__sycl_kernel_tempfoo2IsEvT_(i16 {{.*}} %__arg_)
-// CHECK:   call {{.*}} void @[[TEMPFOO2SHORT]](i16 {{.*}} %0)
+// CHECK:   call {{.*}} void @[[TEMPFOO2SHORT:[_A-Za-z0-9]+]](i16 {{.*}} %0)
+// CHECK: define {{.*}} void @[[TEMPFOO2SHORT]](i16 {{.*}} %0)
 
 // Check generation of the SYCL kernel for tempfoo<int>, the call to
 // tempfoo<int>, and its declaration.

--- a/clang/test/CodeGenSYCL/registered-kernel-names.cpp
+++ b/clang/test/CodeGenSYCL/registered-kernel-names.cpp
@@ -52,7 +52,7 @@ void tempfoo3() {
 namespace N {
 [[__sycl_detail__::__registered_kernels__(
   {"foo", foo},
-  {"iota", (void(*)(int, int *))iota},
+  {"iota", (((void(*)(int, int *))(void *)(((iota)))))},
   {"decl temp", tempfoo<int>},
   {"inst temp", tempfoo2<int>},
   {"decl spec", tempfoo2<float>},

--- a/clang/test/SemaSYCL/registered-kernel-names.cpp
+++ b/clang/test/SemaSYCL/registered-kernel-names.cpp
@@ -7,21 +7,21 @@ void foo();
 
 constexpr const char *str = "foo";
 
-// expected-error@+1 {{'__registered_kernels__' atribute must have at least one argument}}
+// expected-error@+1 {{'__registered_kernels__' attribute must have at least one argument}}
 [[__sycl_detail__::__registered_kernels__(
 )]];
 
-// expected-error@+2 {{argument to the '__registered_kernels__' atribute must be an initializer list expression}}
+// expected-error@+2 {{argument to the '__registered_kernels__' attribute must be an initializer list expression}}
 [[__sycl_detail__::__registered_kernels__(
   1
 )]];
 
-// expected-error@+2 {{each initializer list argument to the '__registered_kernels__' atribute must contain a pair of values}}
+// expected-error@+2 {{each initializer list argument to the '__registered_kernels__' attribute must contain a pair of values}}
 [[__sycl_detail__::__registered_kernels__(
   {}
 )]];
 
-// expected-error@+2 {{each initializer list argument to the '__registered_kernels__' atribute must contain a pair of values}}
+// expected-error@+2 {{each initializer list argument to the '__registered_kernels__' attribute must contain a pair of values}}
 [[__sycl_detail__::__registered_kernels__(
   { "foo" }
 )]];
@@ -36,7 +36,7 @@ constexpr const char *str = "foo";
   { str, 1 }
 )]];
 
-// expected-error@+2 {{each initializer list argument to the '__registered_kernels__' atribute must contain a pair of values}}
+// expected-error@+2 {{each initializer list argument to the '__registered_kernels__' attribute must contain a pair of values}}
 [[__sycl_detail__::__registered_kernels__(
   { "foo", 1, foo }
 )]];

--- a/clang/test/SemaSYCL/registered-kernel-names.cpp
+++ b/clang/test/SemaSYCL/registered-kernel-names.cpp
@@ -70,15 +70,18 @@ void good1() {
   {"reg2", good1}
 )]];
 
+
+struct S1 {
+// expected-error@+1 {{'int &' cannot be used as the type of a kernel parameter}}
+  int &ri;
+};
+
 template <typename T>
 __attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
-void uses_throw() {
-  // expected-error@+2 {{cannot use 'throw' with exceptions disabled}}
-  // expected-error@+1 {{SYCL kernel cannot use exceptions}}
-  throw 5;
+void func_with_S1_param(T s) {
 }
 
 [[__sycl_detail__::__registered_kernels__(
-  {"throw", uses_throw<float>}
+  {"ref field", func_with_S1_param<S1>}
 )]];

--- a/clang/test/SemaSYCL/registered-kernel-names.cpp
+++ b/clang/test/SemaSYCL/registered-kernel-names.cpp
@@ -69,3 +69,16 @@ void good1() {
   {"reg1", good1},
   {"reg2", good1}
 )]];
+
+template <typename T>
+__attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
+void uses_throw() {
+  // expected-error@+2 {{cannot use 'throw' with exceptions disabled}}
+  // expected-error@+1 {{SYCL kernel cannot use exceptions}}
+  throw 5;
+}
+
+[[__sycl_detail__::__registered_kernels__(
+  {"throw", uses_throw<float>}
+)]];

--- a/clang/test/SemaSYCL/registered-kernel-names.cpp
+++ b/clang/test/SemaSYCL/registered-kernel-names.cpp
@@ -1,0 +1,71 @@
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -pedantic %s
+
+// The test checks issuing diagnostics for registered kernel names.
+
+// expected-error@+1 {{attempting to register a function that is not a SYCL free function as 'kernelnamefoo'}}
+void foo();
+
+constexpr const char *str = "foo";
+
+// expected-error@+1 {{'__registered_kernels__' atribute must have at least one argument}}
+[[__sycl_detail__::__registered_kernels__(
+)]];
+
+// expected-error@+2 {{argument to the '__registered_kernels__' atribute must be an initializer list expression}}
+[[__sycl_detail__::__registered_kernels__(
+  1
+)]];
+
+// expected-error@+2 {{each initializer list argument to the '__registered_kernels__' atribute must contain a pair of values}}
+[[__sycl_detail__::__registered_kernels__(
+  {}
+)]];
+
+// expected-error@+2 {{each initializer list argument to the '__registered_kernels__' atribute must contain a pair of values}}
+[[__sycl_detail__::__registered_kernels__(
+  { "foo" }
+)]];
+
+// expected-error@+2 {{unable to resolve free function kernel 'foo'}}
+[[__sycl_detail__::__registered_kernels__(
+  { "foo", "foo" }
+)]];
+
+// expected-error@+2 {{'__registered_kernels__' attribute requires a string}}
+[[__sycl_detail__::__registered_kernels__(
+  { str, 1 }
+)]];
+
+// expected-error@+2 {{each initializer list argument to the '__registered_kernels__' atribute must contain a pair of values}}
+[[__sycl_detail__::__registered_kernels__(
+  { "foo", 1, foo }
+)]];
+
+template <typename T>
+__attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
+void func();
+
+namespace N {
+[[__sycl_detail__::__registered_kernels__(
+  {"kernelnamefoo", foo}
+)]];
+}
+
+// expected-error@+3 {{unable to resolve free function kernel 'func'}}
+namespace {
+[[__sycl_detail__::__registered_kernels__(
+  {"func", func<int, int>}
+)]];
+}
+
+// expected-error@+3 {{free function kernel has already been registered with 'reg1'; cannot register with 'reg2'}}
+__attribute__((sycl_device))
+[[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
+void good() {
+}
+
+[[__sycl_detail__::__registered_kernels__(
+  {"reg1", good},
+  {"reg2", good}
+)]];

--- a/clang/test/SemaSYCL/registered-kernel-names.cpp
+++ b/clang/test/SemaSYCL/registered-kernel-names.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 
 // The test checks issuing diagnostics for registered kernel names.
 
@@ -42,7 +42,6 @@ constexpr const char *str = "foo";
 )]];
 
 template <typename T>
-__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void func1();
 
@@ -59,8 +58,7 @@ namespace {
 )]];
 }
 
-// expected-error@+3 {{free function kernel has already been registered with 'reg1'; cannot register with 'reg2'}}
-__attribute__((sycl_device))
+// expected-error@+2 {{free function kernel has already been registered with 'reg1'; cannot register with 'reg2'}}
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void good1() {
 }
@@ -77,7 +75,6 @@ struct S1 {
 };
 
 template <typename T>
-__attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
 void func_with_S1_param(T s) {
 }

--- a/clang/test/SemaSYCL/registered-kernel-names.cpp
+++ b/clang/test/SemaSYCL/registered-kernel-names.cpp
@@ -44,7 +44,7 @@ constexpr const char *str = "foo";
 template <typename T>
 __attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
-void func();
+void func1();
 
 namespace N {
 [[__sycl_detail__::__registered_kernels__(
@@ -55,17 +55,17 @@ namespace N {
 // expected-error@+3 {{unable to resolve free function kernel 'func'}}
 namespace {
 [[__sycl_detail__::__registered_kernels__(
-  {"func", func<int, int>}
+  {"func", func1<int, int>}
 )]];
 }
 
 // expected-error@+3 {{free function kernel has already been registered with 'reg1'; cannot register with 'reg2'}}
 __attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-single-task-kernel", 0)]]
-void good() {
+void good1() {
 }
 
 [[__sycl_detail__::__registered_kernels__(
-  {"reg1", good},
-  {"reg2", good}
+  {"reg1", good1},
+  {"reg2", good1}
 )]];


### PR DESCRIPTION
This change adds support for a new attribute
``__sycl_detail::__registered_kernels__``, which appears at translation
unit scope.  The parameter for this attribute is a list of pairs like:

```
[[__sycl_detail__::__registered_kernels__(
  {"foo", foo},
  {"(void(*)(int, int*))iota", (void(*)(int, int*))iota},
  {"kernel<float>", kernel<float>}
)]];
```

The first element in each pair is a string, and the second element is a
constant expressiton for a pointer to a SYCL free function kernel.

The change creates the kernel's wrapper function and generates
module-level metadata of the form:

```
!sycl_registered_kernels = !{!0, !1}
!0 = !{!"foo", !"mangled-name-of-wrapper-for-foo"}
!1 = !{!"kernel<float>", !"mangled-name-of-wrapper-for-kernel<float>"}
```

where the first element in the pair of strings, is the first element
of the pair in ``__registered_kernels__`` and the second element is the
mangled named of the wrapper corresponding to the free function.