### PR TITLE
[CI] Build the nightly on Ubuntu 22.04

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -16,6 +16,7 @@ jobs:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
       build_configure_extra_args: '--hip --cuda'
+      build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       merge_ref: ''
       retention-days: 90
 


### PR DESCRIPTION
Precommit uses the nightly compiler to build, and user branches not merged into HEAD won't build on 24.04, so we get a glibc error because the nightly was built on 24.04 but the current job is running on 22.04.

Build the nightly on 22.04 to not break precommit and anyone using the nightly images directly.