### PR TITLE
[CI] Use Ubuntu 22.04 for nightly CUDA AWS testing

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -157,7 +157,7 @@ jobs:
     with:
       name: CUDA E2E
       runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
-      image: ghcr.io/intel/llvm/ubuntu2404_build:latest
+      image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
       target_devices: ext_oneapi_cuda:gpu
       ref: ${{ github.sha }}


### PR DESCRIPTION
We use AWS machines for CUDA Nightly testing and the kernel driver AWS has installed is [too old](https://github.com/intel/llvm/actions/runs/12549000224/job/34989741902) for the CUDA version in the 24.04 image, so use 22.04.

