### PR TITLE
[SYCL] Fix Coverity hits

### DIFF
--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -2859,7 +2859,7 @@ private:
           }
         };
 #endif // __SYCL_USE_FALLBACK_ASSERT
-    return submit_with_event_impl(CGF, SI, TlsCodeLocCapture.query(),
+    return submit_with_event_impl(std::move(CGF), SI, TlsCodeLocCapture.query(),
                                   TlsCodeLocCapture.isToplevel());
   }
 

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -1765,7 +1765,7 @@ void modifiable_command_graph::print_graph(sycl::detail::string_view pathstr,
   std::string path{pathstr.data()};
   graph_impl::ReadLock Lock(impl->MMutex);
   if (path.substr(path.find_last_of(".") + 1) == "dot") {
-    impl->printGraphAsDot(path, verbose);
+    impl->printGraphAsDot(std::move(path), verbose);
   } else {
     throw sycl::exception(
         sycl::make_error_code(errc::invalid),

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -1227,7 +1227,8 @@ getOrBuildProgramForDeviceGlobal(QueueImplPtr Queue,
       PM.getDeviceImage(DeviceGlobalEntry->MImages, Context, Device);
   device_image_plain DeviceImage =
       PM.getDeviceImageFromBinaryImage(&Img, Context, Device);
-  device_image_plain BuiltImage = PM.build(DeviceImage, {Device}, {});
+  device_image_plain BuiltImage =
+      PM.build(std::move(DeviceImage), {Device}, {});
   return getSyclObjImpl(BuiltImage)->get_ur_program_ref();
 }
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2723,7 +2723,8 @@ ProgramManager::link(const DevImgPlainWithDeps &ImgWithDeps,
 
   if (Error != UR_RESULT_SUCCESS) {
     if (LinkedProg) {
-      const std::string ErrorMsg = getProgramBuildLog(LinkedProg, ContextImpl);
+      const std::string ErrorMsg =
+          getProgramBuildLog(LinkedProg, std::move(ContextImpl));
       throw sycl::exception(make_error_code(errc::build), ErrorMsg);
     }
     throw set_ur_error(exception(make_error_code(errc::build), "link() failed"),
@@ -2751,7 +2752,7 @@ ProgramManager::link(const DevImgPlainWithDeps &ImgWithDeps,
 
   // TODO: Make multiple sets of device images organized by devices they are
   // compiled for.
-  return {createSyclObjFromImpl<device_image_plain>(ExecutableImpl)};
+  return {createSyclObjFromImpl<device_image_plain>(std::move(ExecutableImpl))};
 }
 
 // The function duplicates most of the code from existing getBuiltPIProgram.

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2849,8 +2849,8 @@ ur_result_t enqueueReadWriteHostPipe(const QueueImplPtr &Queue,
         ProgramManager::getInstance().getDeviceImageFromBinaryImage(
             hostPipeEntry->getDevBinImage(), Queue->get_context(),
             Queue->get_device());
-    device_image_plain BuiltImage =
-        ProgramManager::getInstance().build(devImgPlain, {Device}, {});
+    device_image_plain BuiltImage = ProgramManager::getInstance().build(
+        std::move(devImgPlain), {std::move(Device)}, {});
     Program = getSyclObjImpl(BuiltImage)->get_ur_program_ref();
   }
   assert(Program && "Program for this hostpipe is not compiled.");


### PR DESCRIPTION
All hits are related to using `std::move` instead of variable copy.
Fixes: CMPLRLLVM-64297, CMPLRLLVM-64456 and CMPLRLLVM-64457