### PR TITLE
[CI] Drop support `ext_oneapi_[level_zero|cuda|hip]` in `sycl_devices` LIT parameter

### DIFF
--- a/.github/workflows/sycl-linux-matrix-e2e-on-nightly.yml
+++ b/.github/workflows/sycl-linux-matrix-e2e-on-nightly.yml
@@ -23,7 +23,7 @@ jobs:
             runner: '["Linux", "amdgpu"]'
             image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
-            target_devices: ext_oneapi_hip:gpu
+            target_devices: hip:gpu
 
           - name: Intel L0 GPU
             runner: '["Linux", "gen12"]'
@@ -49,7 +49,7 @@ jobs:
             runner: '["Linux", "cuda"]'
             image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build
             image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
-            target_devices: ext_oneapi_cuda:gpu
+            target_devices: cuda:gpu
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: ${{ matrix.name }}
@@ -79,7 +79,7 @@ jobs:
       runner: '["aws-cuda_${{ github.run_id }}-${{ github.run_attempt }}"]'
       image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build
       image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
-      target_devices: ext_oneapi_cuda:gpu
+      target_devices: cuda:gpu
       env: ${{ inputs.env }}
       ref: ${{ github.sha }}
       merge_ref: ''

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -68,7 +68,7 @@ jobs:
       runner: '["aws_cuda-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}"]'
       image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
-      target_devices: ext_oneapi_cuda:gpu
+      target_devices: cuda:gpu
       # No idea why but that seems to work and be in sync with the main
       # pre-commit workflow.
       ref: ${{ github.event.workflow_run.referenced_workflows[0].sha }}

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -130,12 +130,12 @@ jobs:
             runner: '["Linux", "cuda"]'
             image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
-            target_devices: ext_oneapi_cuda:gpu
+            target_devices: cuda:gpu
           - name: AMD/HIP
             runner: '["Linux", "amdgpu"]'
             image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
-            target_devices: ext_oneapi_hip:gpu
+            target_devices: hip:gpu
             reset_intel_gpu: false
           - name: E2E tests on Intel Arc A-Series Graphics
             runner: '["Linux", "arc"]'
@@ -168,12 +168,12 @@ jobs:
 
       # Do not install drivers on AMD and CUDA runners.
       install_igc_driver: >-
-        ${{ !contains(matrix.target_devices, 'ext_oneapi_cuda') &&
-        !contains(matrix.target_devices, 'ext_oneapi_hip') &&
+        ${{ !contains(matrix.target_devices, 'cuda') &&
+        !contains(matrix.target_devices, 'hip') &&
         contains(needs.detect_changes.outputs.filters, 'drivers') }}
       install_dev_igc_driver: >-
-        ${{ !contains(matrix.target_devices, 'ext_oneapi_cuda') &&
-        !contains(matrix.target_devices, 'ext_oneapi_hip') &&
+        ${{ !contains(matrix.target_devices, 'cuda') &&
+        !contains(matrix.target_devices, 'hip') &&
         matrix.use_igc_dev &&
         (contains(needs.detect_changes.outputs.filters, 'devigccfg') || contains(needs.detect_changes.outputs.filters, 'drivers')) ||
         'false' }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -134,7 +134,7 @@ on:
           - 'opencl:gpu'
           - 'opencl:fpga'
           - 'level_zero:gpu'
-          - 'ext_oneapi_hip:gpu'
+          - 'hip:gpu'
       tests_selector:
         type: choice
         options:

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -48,7 +48,7 @@ jobs:
             runner: '["Linux", "amdgpu"]'
             image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
-            target_devices: ext_oneapi_hip:gpu
+            target_devices: hip:gpu
             tests_selector: e2e
 
           - name: Intel L0 GPU
@@ -159,7 +159,7 @@ jobs:
       runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
       image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
-      target_devices: ext_oneapi_cuda:gpu
+      target_devices: cuda:gpu
       ref: ${{ github.sha }}
       merge_ref: ''
 

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -58,21 +58,21 @@ jobs:
             runner: '["Linux", "amdgpu"]'
             image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
-            target_devices: ext_oneapi_hip:gpu
+            target_devices: hip:gpu
             reset_intel_gpu: false
           - name: E2E tests on Intel Ponte Vecchio GPU
             runner: '["Linux", "pvc"]'
             env: '{"LIT_FILTER_OUT":"ESIMD/unified_memory_api/"}'
             image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
-            target_devices: ext_oneapi_level_zero:gpu;opencl:gpu
+            target_devices: level_zero:gpu;opencl:gpu
             extra_lit_opts: -j 50
           - name: E2E tests with dev igc on Intel Ponte Vecchio GPU
             runner: '["Linux", "pvc"]'
             env: '{"LIT_FILTER_OUT":"ESIMD/unified_memory_api/"}'
             image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:devigc
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
-            target_devices: ext_oneapi_level_zero:gpu;opencl:gpu
+            target_devices: level_zero:gpu;opencl:gpu
             use_igc_dev: true
             extra_lit_opts: -j 50
           # Performance tests below. Specifics:

--- a/.github/workflows/sycl-rel-nightly.yml
+++ b/.github/workflows/sycl-rel-nightly.yml
@@ -56,7 +56,7 @@ jobs:
             runner: '["Linux", "amdgpu"]'
             image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
-            target_devices: ext_oneapi_hip:gpu
+            target_devices: hip:gpu
             tests_selector: e2e
 
           - name: Intel L0 GPU
@@ -156,7 +156,7 @@ jobs:
       runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
       image: ghcr.io/intel/llvm/ubuntu2204_build:latest-0300ac924620a51f76c4929794637b82790f12ab
       image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
-      target_devices: ext_oneapi_cuda:gpu
+      target_devices: cuda:gpu
       ref: draft-sycl-rel-6_0_0
       merge_ref: ''
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -473,8 +473,6 @@ if len(config.sycl_devices) > 1:
         "Running on multiple devices, XFAIL-marked tests will be skipped on corresponding devices"
     )
 
-config.sycl_devices = [x.replace("ext_oneapi_", "") for x in config.sycl_devices]
-
 available_devices = {
     "opencl": ("cpu", "gpu", "fpga"),
     "cuda": "gpu",


### PR DESCRIPTION
Instead of `ext_oneapi_[level_zero|cuda|hip]`, we should use `level_zero/cuda/hip` backend name in LIT, which is in alignment with `ONEAPI_DEVICE_SELECTOR` terminology and `sycl-ls` output.