### PR TITLE
[SYCL] Fix tests that check capture of bindings

### DIFF
--- a/clang/test/CodeGenSYCL/kernel_binding_decls.cpp
+++ b/clang/test/CodeGenSYCL/kernel_binding_decls.cpp
@@ -12,7 +12,7 @@ void foo() {
     float b[3] = { 0, 3.0f, 4.0 };
   } s;
   auto [f1, f2, f3] = s.b;
-  auto Lambda = [=]() { x = 10; f2 = 2.3f; };
+  auto Lambda = [=]() { (void)x; (void)f2; };
   h.single_task(Lambda);
 }
 
@@ -51,11 +51,9 @@ void foo() {
 // CHECK:  store ptr addrspace(4) %this, ptr addrspace(4) %this.addr.ascast
 // CHECK:  %this1 = load ptr addrspace(4), ptr addrspace(4) %this.addr.ascast
 
-// Check the store of 10 into the int value
+// Check the fetch of the x binding.
 // CHECK:  %x = getelementptr inbounds nuw %class.anon, ptr addrspace(4) %this1, i32 0, i32 0
-// CHECK:  store i32 10, ptr addrspace(4) %x
 
-// Check the store of 2.3f into the float value
+// Check the fetch of the f2 binding.
 // CHECK:  %f2 = getelementptr inbounds nuw %class.anon, ptr addrspace(4) %this1, i32 0, i32 1
-// CHECK:  store float 0x4002666660000000, ptr addrspace(4) %f2
 // CHECK:  ret void

--- a/clang/test/SemaSYCL/binding_decl_lambda_nullptr.cpp
+++ b/clang/test/SemaSYCL/binding_decl_lambda_nullptr.cpp
@@ -13,7 +13,7 @@
 void foo() {
   int a[2] = {1, 2};
   auto [bind_x, bind_y] = a;
-  auto Lambda = [=]() { bind_x = 10; };
+  auto Lambda = [=]() { (void)bind_x; };
   sycl::handler h;
   h.single_task<class C>(Lambda);
 }


### PR DESCRIPTION
A recent community change:
    70965ef259 [Clang] Prevent assignment to captured structured bindings inside immutable lambda
issues diagnostics for a construct used inside these tests. 
The assignments within the lambda are not central to the test, so this change just removes those.