### PR TITLE
[SYCL] Unload libraries in jit_compiler and kernel_compiler_opencl destructors

### DIFF
--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -38,14 +38,20 @@ jit_compiler::jit_compiler() {
     static const std::string JITLibraryName = "libsycl-jit.so";
 #endif
 
-    void *LibraryPtr = sycl::detail::ur::loadOsLibrary(JITLibraryName);
+    auto CustomDeleter = [](void *StoredPtr) {
+      if (!StoredPtr)
+        return;
+      std::ignore = sycl::detail::ur::unloadOsLibrary(StoredPtr);
+    };
+    std::unique_ptr<void, decltype(CustomDeleter)> LibraryPtr(
+        sycl::detail::ur::loadOsLibrary(JITLibraryName), CustomDeleter);
     if (LibraryPtr == nullptr) {
       printPerformanceWarning("Could not find JIT library " + JITLibraryName);
       return false;
     }
 
     this->AddToConfigHandle = reinterpret_cast<AddToConfigFuncT>(
-        sycl::detail::ur::getOsLibraryFuncAddress(LibraryPtr,
+        sycl::detail::ur::getOsLibraryFuncAddress(MLibraryHandle,
                                                   "addToJITConfiguration"));
     if (!this->AddToConfigHandle) {
       printPerformanceWarning(
@@ -54,7 +60,7 @@ jit_compiler::jit_compiler() {
     }
 
     this->ResetConfigHandle = reinterpret_cast<ResetConfigFuncT>(
-        sycl::detail::ur::getOsLibraryFuncAddress(LibraryPtr,
+        sycl::detail::ur::getOsLibraryFuncAddress(LibraryPtr.get(),
                                                   "resetJITConfiguration"));
     if (!this->ResetConfigHandle) {
       printPerformanceWarning(
@@ -63,7 +69,8 @@ jit_compiler::jit_compiler() {
     }
 
     this->FuseKernelsHandle = reinterpret_cast<FuseKernelsFuncT>(
-        sycl::detail::ur::getOsLibraryFuncAddress(LibraryPtr, "fuseKernels"));
+        sycl::detail::ur::getOsLibraryFuncAddress(LibraryPtr.get(),
+                                                  "fuseKernels"));
     if (!this->FuseKernelsHandle) {
       printPerformanceWarning(
           "Cannot resolve JIT library function entry point");
@@ -73,7 +80,7 @@ jit_compiler::jit_compiler() {
     this->MaterializeSpecConstHandle =
         reinterpret_cast<MaterializeSpecConstFuncT>(
             sycl::detail::ur::getOsLibraryFuncAddress(
-                LibraryPtr, "materializeSpecConstants"));
+                LibraryPtr.get(), "materializeSpecConstants"));
     if (!this->MaterializeSpecConstHandle) {
       printPerformanceWarning(
           "Cannot resolve JIT library function entry point");
@@ -81,16 +88,22 @@ jit_compiler::jit_compiler() {
     }
 
     this->CompileSYCLHandle = reinterpret_cast<CompileSYCLFuncT>(
-        sycl::detail::ur::getOsLibraryFuncAddress(LibraryPtr, "compileSYCL"));
+        sycl::detail::ur::getOsLibraryFuncAddress(LibraryPtr.get(),
+                                                  "compileSYCL"));
     if (!this->CompileSYCLHandle) {
       printPerformanceWarning(
           "Cannot resolve JIT library function entry point");
       return false;
     }
-
+    MLibraryHandle = LibraryPtr.release();
     return true;
   };
   Available = checkJITLibrary();
+}
+
+jit_compiler::~jit_compiler() {
+  if (MLibraryHandle)
+    std::ignore = sycl::detail::ur::unloadOsLibrary(MLibraryHandle);
 }
 
 static ::jit_compiler::BinaryFormat

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -51,7 +51,7 @@ jit_compiler::jit_compiler() {
     }
 
     this->AddToConfigHandle = reinterpret_cast<AddToConfigFuncT>(
-        sycl::detail::ur::getOsLibraryFuncAddress(MLibraryHandle,
+        sycl::detail::ur::getOsLibraryFuncAddress(LibraryPtr.get(),
                                                   "addToJITConfiguration"));
     if (!this->AddToConfigHandle) {
       printPerformanceWarning(

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -23,7 +23,7 @@ namespace sycl {
 inline namespace _V1 {
 namespace detail {
 
-static std::function<void(void *)> CustomDeleterForLibHandle =
+std::function<void(void *)> jit_compiler::CustomDeleterForLibHandle =
     [](void *StoredPtr) {
       if (!StoredPtr)
         return;
@@ -103,8 +103,6 @@ jit_compiler::jit_compiler()
   };
   Available = checkJITLibrary();
 }
-
-jit_compiler::~jit_compiler() {}
 
 static ::jit_compiler::BinaryFormat
 translateBinaryImageFormat(ur::DeviceBinaryType Type) {

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -60,7 +60,7 @@ public:
 
 private:
   jit_compiler();
-  ~jit_compiler() = default;
+  ~jit_compiler();
   jit_compiler(const jit_compiler &) = delete;
   jit_compiler(jit_compiler &&) = delete;
   jit_compiler &operator=(const jit_compiler &) = delete;
@@ -98,6 +98,7 @@ private:
   CompileSYCLFuncT CompileSYCLHandle = nullptr;
   ResetConfigFuncT ResetConfigHandle = nullptr;
   AddToConfigFuncT AddToConfigHandle = nullptr;
+  void *MLibraryHandle = nullptr;
 #endif // SYCL_EXT_JIT_ENABLE
 };
 

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -61,7 +61,7 @@ public:
 
 private:
   jit_compiler();
-  ~jit_compiler();
+  ~jit_compiler() = default;
   jit_compiler(const jit_compiler &) = delete;
   jit_compiler(jit_compiler &&) = delete;
   jit_compiler &operator=(const jit_compiler &) = delete;
@@ -99,7 +99,8 @@ private:
   CompileSYCLFuncT CompileSYCLHandle = nullptr;
   ResetConfigFuncT ResetConfigHandle = nullptr;
   AddToConfigFuncT AddToConfigHandle = nullptr;
-  std::unique_ptr<void, std::function<void(void *)>> LibraryHandle;
+  static std::function<void(void *)> CustomDeleterForLibHandle;
+  std::unique_ptr<void, decltype(CustomDeleterForLibHandle)> LibraryHandle;
 #endif // SYCL_EXT_JIT_ENABLE
 };
 

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -16,6 +16,7 @@
 #include <KernelFusion.h>
 #endif // SYCL_EXT_JIT_ENABLE
 
+#include <functional>
 #include <unordered_map>
 
 namespace jit_compiler {
@@ -80,7 +81,7 @@ private:
       const ::jit_compiler::SYCLKernelAttribute &Attr) const;
 
   // Indicate availability of the JIT compiler
-  bool Available;
+  bool Available = false;
 
   // Manages the lifetime of the UR structs for device binaries.
   std::vector<DeviceBinariesCollection> JITDeviceBinaries;
@@ -98,7 +99,7 @@ private:
   CompileSYCLFuncT CompileSYCLHandle = nullptr;
   ResetConfigFuncT ResetConfigHandle = nullptr;
   AddToConfigFuncT AddToConfigHandle = nullptr;
-  void *MLibraryHandle = nullptr;
+  std::unique_ptr<void, std::function<void(void *)>> LibraryHandle;
 #endif // SYCL_EXT_JIT_ENABLE
 };
 


### PR DESCRIPTION
Fixes memory leaks in jit_compiler and kernel_compiler_opencl classes.
Libraries loaded to provide compilation utils have to be released.