### PR TITLE
[CI] Fix nightly releases

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -237,7 +237,9 @@ jobs:
           echo "TAG=$(date +'%Y-%m-%d')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
         fi
     - name: Upload binaries
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      # v2.2.0 of the action is broken.
+      # https://github.com/softprops/action-gh-release/issues/556
+      uses: softprops/action-gh-release@v2.1.0
       with:
         files: |
           sycl_linux.tar.gz


### PR DESCRIPTION
We updated the action version recently but that version is [broken](https://github.com/intel/llvm/actions/runs/12592108759/job/35118108288).