### PR TITLE
[SYCL][COMPAT] Replace T{-1} with static_cast<T>(-1) for mask creation

### DIFF
--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <climits>
 #include <sycl/feature_test.hpp>
 #include <type_traits>
 
@@ -307,8 +308,9 @@ inline T bfe(const T source, const uint32_t bit_start,
   static_assert(std::is_unsigned_v<T>);
   // FIXME(syclcompat-lib-reviewers): This ternary was added to catch a case
   // which may be undefined anyway. Consider that we are losing perf here.
-  const T mask =
-      num_bits >= CHAR_BIT * sizeof(T) ? T{-1} : ((T{1} << num_bits) - 1);
+  const T mask = num_bits >= CHAR_BIT * sizeof(T)
+                     ? static_cast<T>(-1)
+                     : ((static_cast<T>(1) << num_bits) - 1);
   return (source >> bit_start) & mask;
 }
 

--- a/sycl/test-e2e/syclcompat/math/math_bfe.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_bfe.cpp
@@ -172,6 +172,8 @@ template <typename T> bool test(const char *Msg, int N) {
 
 int main() {
   const int N = 1000;
+  assert(test<int8_t>("int8", N));
+  assert(test<uint8_t>("uint8", N));
   assert(test<int16_t>("int16", N));
   assert(test<uint16_t>("uint16", N));
   assert(test<int32_t>("int32", N));


### PR DESCRIPTION
Also include `<climits>` header for CHAR_BIT, and tests for char types.