### PR TITLE
[RFC][SYCL][E2E] Use `REQUIRES`/`UNSUPPORTED` in `build-only` mode

### DIFF
--- a/sycl/test-e2e/Adapters/cuda_queue_priority.cpp
+++ b/sycl/test-e2e/Adapters/cuda_queue_priority.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: gpu, cuda, cuda_dev_kit
-// REQUIRES: build-and-run-mode
 // RUN: %{build} %cuda_options -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Adapters/dll-detach-order.cpp
+++ b/sycl/test-e2e/Adapters/dll-detach-order.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// REQUIRES: build-and-run-mode
 // RUN: env SYCL_UR_TRACE=-1 sycl-ls | FileCheck %s
 
 // ensure that the adapters are detached AFTER urLoaderTearDown is done

--- a/sycl/test-e2e/Adapters/sycl-ls-gpu-cuda.cpp
+++ b/sycl/test-e2e/Adapters/sycl-ls-gpu-cuda.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: gpu, cuda
-// REQUIRES: build-and-run-mode
 
 // RUN: env ONEAPI_DEVICE_SELECTOR="cuda:*" sycl-ls --verbose >%t.cuda.out
 // RUN: FileCheck %s --check-prefixes=CHECK-BUILTIN-GPU-CUDA,CHECK-CUSTOM-GPU-CUDA --input-file %t.cuda.out

--- a/sycl/test-e2e/Adapters/sycl-ls-gpu-hip.cpp
+++ b/sycl/test-e2e/Adapters/sycl-ls-gpu-hip.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: gpu, hip, sycl-ls
-// REQUIRES: build-and-run-mode
 
 // RUN: env ONEAPI_DEVICE_SELECTOR="hip:*" sycl-ls --verbose >%t.hip.out
 // RUN: FileCheck %s --check-prefixes=CHECK-BUILTIN-GPU-HIP,CHECK-CUSTOM-GPU-HIP --input-file %t.hip.out

--- a/sycl/test-e2e/Adapters/sycl-ls-gpu-sycl-be.cpp
+++ b/sycl/test-e2e/Adapters/sycl-ls-gpu-sycl-be.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: gpu, cuda, hip, opencl, sycl-ls
-// REQUIRES: build-and-run-mode
 
 // RUN: sycl-ls --verbose >%t.default.out
 // RUN: FileCheck %s --check-prefixes=CHECK-BUILTIN-GPU-OPENCL,CHECK-CUSTOM-GPU-OPENCL --input-file %t.default.out

--- a/sycl/test-e2e/Adapters/sycl-targets-order.cpp
+++ b/sycl/test-e2e/Adapters/sycl-targets-order.cpp
@@ -6,7 +6,6 @@
 // RUN: %{run-unfiltered-devices} env ONEAPI_DEVICE_SELECTOR="cuda:*"   %t-nvptx64-spir64.out
 
 // REQUIRES: opencl, cuda
-// REQUIRES: build-and-run-mode
 
 //==------- sycl-targets-order.cpp - SYCL -fsycl-targets order test --------==//
 //

--- a/sycl/test-e2e/AmdNvidiaJIT/kernel_and_bundle.cpp
+++ b/sycl/test-e2e/AmdNvidiaJIT/kernel_and_bundle.cpp
@@ -1,6 +1,5 @@
 // UNSUPPORTED: windows
 // REQUIRES: cuda || hip
-// REQUIRES: build-and-run-mode
 
 // This test relies on debug output from a pass, make sure that the compiler
 // can generate it.

--- a/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
+++ b/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// REQUIRES: build-and-run-mode
 
 // RUN: %clangxx --driver-mode=cl /std:c++17 /EHsc %sycl_include -I%opencl_include_dir %s -o %t.out /link /defaultlib:%sycl_static_libs_dir/sycl.lib
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Compression/no_zstd_warning.cpp
+++ b/sycl/test-e2e/Compression/no_zstd_warning.cpp
@@ -1,5 +1,4 @@
 // using --offload-compress without zstd should throw an error.
-// REQUIRES: !zstd
-// REQUIRES: build-and-run-mode
+// UNSUPPORTED: zstd
 // RUN: not %{build} %O0 -g --offload-compress %S/Inputs/single_kernel.cpp -o %t_compress.out 2>&1 | FileCheck %s
 // CHECK: '--offload-compress' option is specified but zstd is not available. The device image will not be compressed.

--- a/sycl/test-e2e/DeviceLib/math_fp64_windows_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_fp64_windows_test.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-fp64, windows
-// REQUIRES: build-and-run-mode
 
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 

--- a/sycl/test-e2e/DeviceLib/math_windows_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_windows_test.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// REQUIRES: build-and-run-mode
 
 // TODO: Add hypotf case back when the missing symbol is fixed.
 

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-cuda.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-cuda.cpp
@@ -1,7 +1,6 @@
 // RUN: %{build} -Wno-error=deprecated-declarations -o %t.out %cuda_options
 // RUN: %{run} %t.out
 // REQUIRES: cuda, cuda_dev_kit
-// REQUIRES: build-and-run-mode
 
 #include <cuda.h>
 

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-hip.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-hip.cpp
@@ -3,7 +3,6 @@
 // RUN: %{build} -Wno-error=deprecated-pragma -o %t.out -I%rocm_path/include -L%rocm_path/lib -lamdhip64
 // RUN: %{run} %t.out
 // REQUIRES: hip
-// REQUIRES: build-and-run-mode
 
 #include <iostream>
 #include <sycl/backend.hpp>

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-multiple-dev-cuda.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-multiple-dev-cuda.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: cuda, cuda_dev_kit
-// REQUIRES: build-and-run-mode
 // RUN: %{build} -o %t.out %cuda_options
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: cuda, cuda_dev_kit
-// REQUIRES: build-and-run-mode
 //
 // RUN: %{build} -o %t.out %cuda_options
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/HostInteropTask/interop-task-cuda.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-cuda.cpp
@@ -1,7 +1,6 @@
 // RUN: %{build} -o %t.out %cuda_options
 // RUN: %{run} %t.out
 // REQUIRES: cuda, cuda_dev_kit
-// REQUIRES: build-and-run-mode
 
 #include <iostream>
 #include <sycl/backend.hpp>

--- a/sycl/test-e2e/HostInteropTask/interop-task-hip.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-hip.cpp
@@ -3,7 +3,6 @@
 // RUN: %{build} -Wno-error=deprecated-pragma -Wno-error=deprecated-declarations -o %t.out -I%rocm_path/include -L%rocm_path/lib -lamdhip64
 // RUN: %{run} %t.out
 // REQUIRES: hip
-// REQUIRES: build-and-run-mode
 
 #include <iostream>
 #include <sycl/backend.hpp>

--- a/sycl/test-e2e/KernelCompiler/opencl_queries_negative.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_queries_negative.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // Test when we don't have ocloc (eg CUDA, HIP, etc)
-// REQUIRES: !opencl && !level_zero
+// UNSUPPORTED: opencl, level_zero
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm70.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm70.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: cuda
-// REQUIRES: build-and-run-mode
 // RUN: %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_70 -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_amdgcn.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_amdgcn.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: hip_amd, opencl, gpu, cpu
-// REQUIRES: build-and-run-mode
 
 // RUN: %clangxx -fsycl -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx906 -fsycl-targets=amdgcn-amd-amdhsa %S/Inputs/is_compatible_with_env.cpp -o %t.out
 

--- a/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_nvptx64.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_nvptx64.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: cuda, opencl, gpu, cpu
-// REQUIRES: build-and-run-mode
 
 // RUN: %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda %S/Inputs/is_compatible_with_env.cpp -o %t.out
 

--- a/sycl/test-e2e/PrivateAlloca/UnsupportedDevice/lit.local.cfg
+++ b/sycl/test-e2e/PrivateAlloca/UnsupportedDevice/lit.local.cfg
@@ -1,1 +1,1 @@
-config.required_features += ['!aspect-ext_oneapi_private_alloca']
+config.unsupported_features += ['aspect-ext_oneapi_private_alloca']

--- a/sycl/test-e2e/Regression/compile_on_win_with_mdd.cpp
+++ b/sycl/test-e2e/Regression/compile_on_win_with_mdd.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// REQUIRES: build-and-run-mode
 
 // RUN: %clangxx --driver-mode=cl -fsycl /MDd -c %s -o %t.obj
 // RUN: %clangxx --driver-mode=cl -fsycl %t.obj -Wno-unused-command-line-argument -o %t.out

--- a/sycl/test-e2e/Regression/fsycl-host-compiler-win.cpp
+++ b/sycl/test-e2e/Regression/fsycl-host-compiler-win.cpp
@@ -1,7 +1,6 @@
 // RUN: %{build} -fsycl-host-compiler=cl -DDEFINE_CHECK -fsycl-host-compiler-options="-DDEFINE_CHECK /std:c++17 /Zc:__cplusplus" -o %t.exe
 // RUN: %{run} %t.exe
 // REQUIRES: windows
-// REQUIRES: build-and-run-mode
 //
 //==------- fsycl-host-compiler-win.cpp - external host compiler test ------==//
 //

--- a/sycl/test-e2e/Regression/msvc_crt.cpp
+++ b/sycl/test-e2e/Regression/msvc_crt.cpp
@@ -3,7 +3,6 @@
 // RUN: %{build} /MDd -o %t2.exe
 // RUN: %{run} %t2.exe
 // REQUIRES: system-windows, cl_options
-// REQUIRES: build-and-run-mode
 //==-------------- msvc_crt.cpp - SYCL MSVC CRT test -----------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Regression/multiple-targets.cpp
+++ b/sycl/test-e2e/Regression/multiple-targets.cpp
@@ -3,7 +3,6 @@
 // The test is repeated for per_kernel device code splitting.
 //
 // REQUIRES: cuda || hip || native_cpu
-// REQUIRES: build-and-run-mode
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple},spir64 -o %t1.out %s
 // RUN: %{run} %t1.out
 //

--- a/sycl/test-e2e/SpecConstants/2020/non_native/cuda.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/non_native/cuda.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: cuda
-// REQUIRES: build-and-run-mode
 
 // RUN: %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda %S/Inputs/common.cpp -o %t.out
 // RUN: %{run-unfiltered-devices} env ONEAPI_DEVICE_SELECTOR="cuda:*" %t.out

--- a/sycl/test-e2e/bindless_images/cubemap/cubemap_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/cubemap/cubemap_sampled.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: cuda,aspect-ext_oneapi_cubemap
 // REQUIRES: aspect-ext_oneapi_cubemap_seamless_filtering
-// REQUIRES: build-and-run-mode
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images
 // REQUIRES: windows
-// REQUIRES: build-and-run-mode
 
 // DEFINE: %{link-flags}=%if cl_options %{ /clang:-ld3d12 /clang:-ldxgi /clang:-ldxguid %} %else %{ -ld3d12 -ldxgi -ldxguid %}
 // RUN: %{build} %{link-flags} -o %t.out %if any-device-is-level_zero %{ -DDISABLE_UNORM_TESTS %}

--- a/sycl/test-e2e/bindless_images/examples/example_5_sample_cubemap.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_5_sample_cubemap.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: cuda
-// REQUIRES: build-and-run-mode
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/bindless_images/vulkan_interop/mipmaps.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/mipmaps.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: cuda
 // REQUIRES: vulkan
-// REQUIRES: build-and-run-mode
 
 // RUN: %{build} %link-vulkan -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: cuda || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan
-// REQUIRES: build-and-run-mode
 
 // RUN: %{build} %link-vulkan -o %t.out %if any-device-is-level_zero %{ -Wno-ignored-attributes -DENABLE_LINEAR_TILING -DTEST_L0_SUPPORTED_VK_FORMAT %}
 // RUN: %{run} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out

--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_USM.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_USM.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: cuda
 // REQUIRES: vulkan
-// REQUIRES: build-and-run-mode
 
 // RUN: %{build} %link-vulkan -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/bindless_images/vulkan_interop/unsampled_images.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/unsampled_images.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: cuda || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan
-// REQUIRES: build-and-run-mode
 
 // RUN: %{build} %link-vulkan -o %t.out %if any-device-is-level_zero %{ -Wno-ignored-attributes -DTEST_L0_SUPPORTED_VK_FORMAT %}
 // RUN: %{run} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out

--- a/sycl/test-e2e/bindless_images/vulkan_interop/unsampled_images_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/unsampled_images_semaphore.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: cuda
 // REQUIRES: vulkan
-// REQUIRES: build-and-run-mode
 
 // RUN: %{build} %link-vulkan -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// REQUIRES: build-and-run-mode
 
 // DEFINE: %{sharedflag} = %if cl_options %{/clang:-shared%} %else %{-shared%}
 

--- a/sycl/test-e2e/syclcompat/memory/local_memory_ptr_to_integer.cpp
+++ b/sycl/test-e2e/syclcompat/memory/local_memory_ptr_to_integer.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: cuda
-// REQUIRES: build-and-run-mode
 // RUN:  %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_75 -o %t.out
 // RUN:  %{run} %t.out
 #include <sycl/detail/core.hpp>

--- a/sycl/test/e2e_test_requirements/no-negations-in-tests.cpp
+++ b/sycl/test/e2e_test_requirements/no-negations-in-tests.cpp
@@ -1,0 +1,12 @@
+// RUN: grep -r "UNSUPPORTED:.*!" %S/../../test-e2e \
+// RUN: --include=*.cpp --no-group-separator > %t.unsupported
+// RUN: cat %t.unsupported | wc -l | FileCheck %s --check-prefix UNSUPPORTED-WITH-NEGATIONS
+// RUN: cat %t.unsupported | sed 's/\.cpp.*/.cpp/' | sort | FileCheck %s --check-prefix UNSUPPORTED-CHECK
+//
+// RUN: not grep -r "REQUIRES:.*!" %S/../../test-e2e
+//
+// UNSUPPORTED-WITH-NEGATIONS: 3 
+//
+// UNSUPPORTED-CHECK: Basic/accessor/host_task_accessor_deduction.cpp
+// UNSUPPORTED-CHECK-NEXT: ESIMD/named_barriers/loop.cpp
+// UNSUPPORTED-CHECK-NEXT: GroupAlgorithm/reduce_sycl2020.cpp


### PR DESCRIPTION
Currently the `build-only` mode does not take into account the features to decide if a test should be built on the system/for a particular triple. Instead explicit markup is used to mark these tests as unsupported.

A complication that occurs when trying to take into account features in `build-only` is that we do not have the devices that the tests are being built for, and thus we do not have the device specific features associated with them. Usually the device-specific features will not affect compilation, however this is not always the case, as certain features may implicitly exclude a particular triple. For example consider the feature `accelerator`. If we see a `REQUIRES: accelerator` this test would have never been built CUDA, or AMD triples, as those only support GPU devices. On the other hand however a `UNSUPPORTED: accelerator` statement would not exclude the spir triple, as that triple could be run on other non-accelerator devices.

Due to this we likely need to alter the way we use `REQUIRES`/`UNSUPPORTED` statements in order to support this. I'm looking for comments on what would be acceptable changes to our usage of those directives such that we can handle these statements in `build-only` mode while not adding too large of a burden on test writers.

This pr contains a potential solution which works by trying to construct a set of features to pass the `REQUIRES`/`UNSUPPORTED` statements. For `REQUIRES` statements we begin with the set of device-agnostic features that we already have from the environment, and add all the device-specific features listed in the statement that could possibly appear for the triple. For example, When considering a statement like `REQUIRES: accelerator`, the `accelerator` feature would be added when building for the `spir64` triple, since it may or may not be present, however it would not be added for the `nvptx-nvidia-cuda` triple since we know for certain it could never be present for that triple. We consider `UNSUPPORTED` statements in a similar manner, however for the device-specific features here we only add them to our list of features if we know for certain a feature will always be present for a given triple. In this case if we see `UNSUPPORTED: gpu` we would not add the `gpu` feature for the `spir64` triple, however we would add it for the `nvptx-nvidia-cuda` triple.

Because this method works off the assumption that we want all features listed in `REQUIRES` and none of the features listed in `UNSUPPORTED` this solution cannot support negations in either of these statements (i.e., `REQUIRES: !gpu`). The changes in this pr handle these situations by emitting a warning when a negation is found, and ignoring the clause including it when in `build-only` mode. This limitation only applies to 6 tests currently, and a majority of these negations can be removed by exchanging `REQUIRES` statements with `UNSUPPORTED` and vice versa. Currently the only problematic cases are the ones listed in `test/e2e_test_requirements/no-negations-in-tests.cpp` which contains statements in the form of `UNSUPPORTED: x && !y`