### PR TITLE
[SYCLcompat] Add support for device attribute MAX_PITCH and ASYNC_ENGINE_COUNT

### DIFF
--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -444,6 +444,13 @@ public:
     return get_device_info().get_local_mem_size();
   }
 
+  // For CU_DEVICE_ATTRIBUTE_MAX_PITCH, NVidia GPUs return MAX_INT 
+  // indicating there is no limit (like Intel GPUs)
+  int get_max_pitch() const { return INT_MAX; }
+
+  // CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT is irrelevant in SYCL
+  int get_async_engine_count() const { return 0; }
+
   /// Get the number of bytes of free and total memory on the SYCL device.
   /// \param [out] free_memory The number of bytes of free memory on the SYCL
   /// device.


### PR DESCRIPTION
CU_DEVICE_ATTRIBUTE_AYSNC_ENGINE_COUNT is associated with value 2 for bidirectional data transfer between host and device while executing the kernel and is associated to 1 in case of unidirectional data transfer and for no support of data transfer and parallel execution it's 0.

CU_DEVICE_ATTRIBUTE_MAX_PITCH return INT_MAX, indicating there is no limits! Intel GPU shows the same behavior too!

Signed-off-by: [Deepak Raj H R](https://github.com/the-slow-one/llvm/pull/Deepak.raj.h.r@intel.com)