### PR TITLE
[SYCL][Doc] Reword Docker doc to reference Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Project documentation is available at:
 
 ### How to use DPC++
 
-#### Docker containers
+#### Dockerfiles
 
-See available containers with pre-built/pre-installed DPC++ compiler at:
-[Containers](./sycl/doc/developer/DockerBKMs.md#sycl-containers-overview)
+See available Dockerfiles to create containers with pre-built/pre-installed DPC++ compiler at:
+[Containers](./sycl/doc/developer/DockerBKMs.md#sycl-dockerfiles-overview)
 
 #### Releases
 

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -49,15 +49,10 @@ and a wide range of compute accelerators such as GPU and FPGA.
 * C++ compiler
   * See LLVM's [host compiler toolchain requirements](https://github.com/intel/llvm/blob/sycl/llvm/docs/GettingStarted.rst#host-c-toolchain-both-compiler-and-standard-library)
 
-Alternatively, you can use a Docker image that has everything you need for
-building pre-installed:
+Alternatively, you can create a Docker image that has everything you need for
+building pre-installed using the [Ubuntu 24.04 build Dockerfile](https://github.com/intel/llvm/blob/sycl/devops/containers/ubuntu2404_build.Dockerfile).
 
-```bash
-docker run --name sycl_build -it -v /local/workspace/dir/:/src ghcr.io/intel/llvm/ubuntu2204_build /bin/bash
-```
-
-This command will start a terminal session, from which you can proceed with the
-instructions below. See [Docker BKMs](developer/DockerBKMs.md) for more info on
+See [Docker BKMs](developer/DockerBKMs.md) for more info on
 Docker commands.
 
 ### Create DPC++ workspace

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -34,36 +34,37 @@ identical for Docker and Podman. Choose whatever is available on your system.
 
 ## SYCL Containers overview
 
-The following containers are publicly available for DPC++ compiler development:
+The following Dockerfiles are publicly available for creating DPC++ compiler
+development containers:
 
-### Ubuntu 22.04-based images
+### Ubuntu 22.04-based Dockerfiles
 
-- `ghcr.io/intel/llvm/ubuntu2204_base`: contains basic environment
+- `devops/containers/ubuntu2204_base`: contains basic environment
    setup for building DPC++ compiler from source.
-- `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
-  base container + pre-installed Intel drivers.
-   The image comes in two flavors/tags:
+- `devops/containers/ubuntu2204_intel_drivers`: contains everything from the
+  base Dockerfile + pre-installed Intel drivers.
+   The Dockerfile comes in two flavors/tags:
    * `latest`: Intel drivers are downloaded from release/tag and saved in
     dependencies.json. The drivers are tested/validated everytime we upgrade
     the driver.
    * `alldeps`: Includes the same Intel drivers as `latest`, as well as the
-   development kits for NVidia/AMD from the `ubuntu2204_build` container.
-- `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
+   development kits for NVidia/AMD from the `ubuntu2204_build` Dockerfile.
+- `devops/containers/ubuntu2204_build`: has development kits installed for
    NVidia/AMD and can be used for building DPC++
    compiler from source with all backends enabled or for end-to-end testing
    with HIP/CUDA on machines with corresponding GPUs available.
-  - `ghcr.io/intel/llvm/sycl_ubuntu2204_nightly`: contains the latest successfully
-   built nightly build of DPC++ compiler. The image comes in three flavors:
+  - `devops/containers/sycl_ubuntu2204_nightly`: contains the latest successfully
+   built nightly build of DPC++ compiler. The Dockerfile comes in three flavors:
    with pre-installed Intel drivers (`latest`), without them (`no-drivers`) and
    with development kits installed (`build`).
 
-### Ubuntu 24.04-based images
+### Ubuntu 24.04-based Dockerfiles
 
-- `ghcr.io/intel/llvm/ubuntu2404_base`: contains basic environment
+- `devops/containers/ubuntu2404_base`: contains basic environment
    setup for building DPC++ compiler from source.
-- `ghcr.io/intel/llvm/ubuntu2404_intel_drivers`: contains everything from the
-   base container + pre-installed Intel drivers.
-   The image comes in four flavors/tags:
+- `devops/containers/ubuntu2404_intel_drivers`: contains everything from the
+   base Dockerfile + pre-installed Intel drivers.
+   The Dockerfile comes in four flavors/tags:
    * `latest`: Intel drivers are downloaded from release/tag and saved in
     dependencies.json. The drivers are tested/validated everytime we upgrade
     the driver.
@@ -71,9 +72,9 @@ The following containers are publicly available for DPC++ compiler development:
    other drivers are downloaded from release/tag and saved in dependencies.json.
    * `unstable`: Intel drivers are downloaded from release/latest.
    * `alldeps`: Includes the same Intel drivers as `latest`, as well as the
-   development kits for NVidia/AMD from the `ubuntu2404_build` container.
+   development kits for NVidia/AMD from the `ubuntu2404_build` Dockerfile.
    The drivers are installed as it is, not tested or validated.
-- `ghcr.io/intel/llvm/ubuntu2404_build`: has development kits installed for
+- `devops/containers/ubuntu2404_build`: has development kits installed for
    NVidia/AMD and can be used for building DPC++
    compiler from source with all backends enabled or for end-to-end testing
    with HIP/CUDA on machines with corresponding GPUs available.  

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -32,7 +32,7 @@ container images. Unlike Docker, Podman runs without a daemon and allows you
 to run containers without root permissions. The command line syntax is mostly
 identical for Docker and Podman. Choose whatever is available on your system.
 
-## SYCL Containers overview
+## SYCL Dockerfiles overview
 
 The following Dockerfiles are publicly available for creating DPC++ compiler
 development containers:


### PR DESCRIPTION
We will soon no longer provide pre-built Docker containers, so update the relevant doc to reference the Dockerfile instead.