### PR TITLE
[CI] Update nightly build upload action

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -237,9 +237,7 @@ jobs:
           echo "TAG=$(date +'%Y-%m-%d')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
         fi
     - name: Upload binaries
-      # v2.2.0 of the action is broken.
-      # https://github.com/softprops/action-gh-release/issues/556
-      uses: softprops/action-gh-release@v2.1.0
+      uses: softprops/action-gh-release@v2.2.1
       with:
         files: |
           sycl_linux.tar.gz


### PR DESCRIPTION
They [fixed](https://github.com/softprops/action-gh-release/commit/c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda) the bug.