### PR TITLE
[CI] Set package read permission in Linux run tests YAML 

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -189,6 +189,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   run:


### PR DESCRIPTION
We need this to access private Docker containers. The Linux build YAML already has the right permissions.