### PR TITLE
[NFCI] Avoid double `bit_cast` in `sub_group::load`

### DIFF
--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -82,7 +82,7 @@ vec<T, N> load(const multi_ptr<T, Space, DecorateAddress> src) {
   using VecT = sycl::detail::ConvertToOpenCLType_t<vec<BlockT, N>>;
   VecT Ret = __spirv_SubgroupBlockReadINTEL<VecT>(convertToBlockPtr(src));
 
-  return sycl::bit_cast<typename vec<T, N>::vector_t>(Ret);
+  return sycl::bit_cast<vec<T, N>>(Ret);
 }
 
 template <typename T, access::address_space Space,


### PR DESCRIPTION
`sycl::vec(vector_t)` ctor is implemented as `bit_cast` itself, so having two steps has no advantage over doing all that in once.

Part of the efforts to eliminate `vector_t` usage in the code base before its removal from the SYCL specification.