### PR TITLE
[SYCL] Fix errors when building with GCC 13 (#16480)

### DIFF
--- a/sycl/include/sycl/ext/intel/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_lsu.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "fpga_utils.hpp"
+#include <cstdint>
 #include <sycl/detail/defines.hpp>
 #include <sycl/pointers.hpp>
 

--- a/sycl/test/abi/layout_vec.cpp
+++ b/sycl/test/abi/layout_vec.cpp
@@ -13,7 +13,7 @@ SYCL_EXTERNAL void foo(sycl::vec<int, 4>) {}
 // CHECK:      0 | class sycl::vec<int, 4>
 // ignore empty base classes
 // CHECK:      0 |   struct std::array<int, 4> m_Data
-// CHECK-NEXT: 0 |     typename _AT_Type::_Type _M_elems
+// CHECK-NEXT: 0 |     typename {{.+}}::_Type _M_elems
 // CHECK-NEXT:   | [sizeof=16, dsize=16, align=16,
 // CHECK-NEXT:   |  nvsize=16, nvalign=16]
 
@@ -24,6 +24,6 @@ SYCL_EXTERNAL void foo(sycl::vec<bool, 16>) {}
 // CHECK:      0 | class sycl::vec<_Bool, 16>
 // ignore empty base classes
 // CHECK:      0 |   struct std::array<_Bool, 16> m_Data
-// CHECK-NEXT: 0 |     typename _AT_Type::_Type _M_elems
+// CHECK-NEXT: 0 |     typename {{.+}}::_Type _M_elems
 // CHECK-NEXT:   | [sizeof=16, dsize=16, align=16,
 // CHECK-NEXT:   |  nvsize=16, nvalign=16]


### PR DESCRIPTION
For the ABI check, the problem is libstdc++ changed the name of the template, so change the check to be more general.

For the header, my guess is the new libstdc++ version doesn't include this header internally in some header we include anymore.