### PR TITLE
[DeviceSanitizer] Ensure __USE_SPIR_BUILTIN__ has a value

### DIFF
--- a/libdevice/include/sanitizer_defs.hpp
+++ b/libdevice/include/sanitizer_defs.hpp
@@ -44,7 +44,7 @@ enum ADDRESS_SPACE : uint32_t {
 
 #else // __SYCL_DEVICE_ONLY__
 
-#define __USE_SPIR_BUILTIN__
+#define __USE_SPIR_BUILTIN__ 0
 
 #endif // __SYCL_DEVICE_ONLY__
 


### PR DESCRIPTION
Ensure that `__USE_SPIR_BUILTIN__` is defined to the value `0` when `defined(__SPIR__) || defined(__SPIRV__)` is false to fix build errors like this:

    libdevice/include/sanitizer_defs.hpp:51:25: error: expected value in expression
       51 | #if __USE_SPIR_BUILTIN__
          |                         ^
