### PR TITLE
[SYCL][E2E] Don't cover full combinations in `vec_binary_scalar_order*`

### DIFF
--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order.hpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order.hpp
@@ -93,7 +93,5 @@ bool CheckResult(sycl::vec<T1, N> V, T2 Ref) {
 
 #define CHECK_SIZES(Q, C, T, IS_RELOP, OP)                                     \
   CHECK(Q, C, T, 1, IS_RELOP, OP)                                              \
-  CHECK(Q, C, T, 2, IS_RELOP, OP)                                              \
-  CHECK(Q, C, T, 4, IS_RELOP, OP)                                              \
-  CHECK(Q, C, T, 8, IS_RELOP, OP)                                              \
-  CHECK(Q, C, T, 16, IS_RELOP, OP)
+  CHECK(Q, C, T, 3, IS_RELOP, OP)                                              \
+  CHECK(Q, C, T, 8, IS_RELOP, OP)

--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_arith.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_arith.cpp
@@ -26,25 +26,13 @@ int main() {
     CHECK_SIZES_AND_COMMON_OPS(Q, Failures, double);
   }
 
-  // Check all operators without requirements.
+  // Check operators without requirements.
   CHECK_SIZES_AND_COMMON_OPS(Q, Failures, float);
   CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int8_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int16_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int32_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int64_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint8_t);
   CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint16_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint32_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint64_t);
 
   // Check integer only operators.
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int8_t);
   CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int16_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int32_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int64_t);
   CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint8_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint16_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint32_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint64_t);
   return Failures;
 }

--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_bitwise.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_bitwise.cpp
@@ -19,12 +19,7 @@ int main() {
 
   // Check operators.
   CHECK_SIZES_AND_OPS(Q, Failures, int8_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, int16_t);
   CHECK_SIZES_AND_OPS(Q, Failures, int32_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, int64_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, uint8_t);
   CHECK_SIZES_AND_OPS(Q, Failures, uint16_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, uint32_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, uint64_t);
   return Failures;
 }

--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_logical.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_logical.cpp
@@ -24,12 +24,7 @@ int main() {
   // Check all operators without requirements.
   CHECK_SIZES_AND_OPS(Q, Failures, float);
   CHECK_SIZES_AND_OPS(Q, Failures, int8_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, int16_t);
   CHECK_SIZES_AND_OPS(Q, Failures, int32_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, int64_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, uint8_t);
   CHECK_SIZES_AND_OPS(Q, Failures, uint16_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, uint32_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, uint64_t);
   return Failures;
 }

--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_relational.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_relational.cpp
@@ -29,12 +29,8 @@ int main() {
   // Check all operators without requirements.
   CHECK_SIZES_AND_OPS(Q, Failures, float);
   CHECK_SIZES_AND_OPS(Q, Failures, int8_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, int16_t);
   CHECK_SIZES_AND_OPS(Q, Failures, int32_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, int64_t);
   CHECK_SIZES_AND_OPS(Q, Failures, uint8_t);
   CHECK_SIZES_AND_OPS(Q, Failures, uint16_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, uint32_t);
-  CHECK_SIZES_AND_OPS(Q, Failures, uint64_t);
   return Failures;
 }


### PR DESCRIPTION
First, full coverage belongs to CTS, not to unit tests. Second, implementation is heavily templated and there isn't much differences potential for many intger types or vector sizes.

This PR eliminates test cases that are unlikely to excercise the code not covered by the remaining ones. The purpose of this is to reduce the time these tests takes as they're very close to be a bottleneck on machines with lots of cores where total wall clock time is defined by the longest tests in the suite.