### PR TITLE
[SYCL][E2E] Fix tests disabled during PVC enablement in CI

### DIFF
--- a/sycl/test-e2e/Basic/accessor/host_task_accessor_deduction.cpp
+++ b/sycl/test-e2e/Basic/accessor/host_task_accessor_deduction.cpp
@@ -1,6 +1,2 @@
 // RUN: %{build} -Daccessor_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
 // RUN: %{run} %t.out
-
-// Disabled on PVC without igc-dev due to timeout.
-// UNSUPPORTED: arch-intel_gpu_pvc && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14826

--- a/sycl/test-e2e/DeprecatedFeatures/set_arg_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/set_arg_interop.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl, opencl_icd
 
-// XFAIL: arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14826
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16576
 
 // RUN: %{build} -D__SYCL_INTERNAL_API -o %t.out %opencl_lib -O3
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
@@ -10,6 +10,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Disabled on PVC without igc-dev due to flaky failures.
+// UNSUPPORTED: arch-intel_gpu_pvc && !igc-dev
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14826
+
 // Test checks support of named barrier in a loop in ESIMD kernel.
 // SLM and surface size is 32 bytes, 16 bytes per iteration.
 // Each iteration has 1 barrier and 1 producer. Producer stores data to SLM,

--- a/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
@@ -10,10 +10,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Disabled on PVC without igc-dev due to flaky failures.
-// UNSUPPORTED: arch-intel_gpu_pvc && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14826
-
 // Test checks support of named barrier in a loop in ESIMD kernel.
 // SLM and surface size is 32 bytes, 16 bytes per iteration.
 // Each iteration has 1 barrier and 1 producer. Producer stores data to SLM,

--- a/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
@@ -10,10 +10,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Disabled on PVC due to flaky failures.
-// UNSUPPORTED: arch-intel_gpu_pvc
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14826
-
 // Test checks support of named barrier in a loop in ESIMD kernel.
 // First iteration has 1 barrier and 1 producer, second - 2 barriers and 2
 // producers. Producer stores data to SLM, then all threads read SLM and store

--- a/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
@@ -10,6 +10,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Disabled on PVC due to flaky failures.
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14826
+
 // Test checks support of named barrier in a loop in ESIMD kernel.
 // First iteration has 1 barrier and 1 producer, second - 2 barriers and 2
 // producers. Producer stores data to SLM, then all threads read SLM and store

--- a/sycl/test-e2e/GroupAlgorithm/reduce_sycl2020.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/reduce_sycl2020.cpp
@@ -1,10 +1,6 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -I . -o %t.out
 // RUN: %{run} %t.out
 
-// Disabled on PVC without igc-dev due to timeout.
-// UNSUPPORTED: arch-intel_gpu_pvc && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14826
-
 #include "support.h"
 
 #include <sycl/sub_group.hpp>


### PR DESCRIPTION
These tests were disabled/XFAILed in https://github.com/intel/llvm/pull/14720.

[sycl/test-e2e/DeprecatedFeatures/set_arg_interop.cpp](https://github.com/intel/llvm/pull/16577/files#diff-9a41bc14675723afa4f98932225243790a5fc5b0fbfc54e732ca1ef84cef7df3) is XPASSing flakily (see https://github.com/intel/llvm/issues/16576) so I've marked it unsupported.