### PR TITLE
[NFC][SYCL][E2E] Split `Reduction/reduction_internal.cpp`

### DIFF
--- a/sycl/test-e2e/Reduction/reduction_internal.hpp
+++ b/sycl/test-e2e/Reduction/reduction_internal.hpp
@@ -1,6 +1,3 @@
-// RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
-
 #include <sycl/detail/core.hpp>
 
 #include <sycl/reduction.hpp>
@@ -120,27 +117,9 @@ void testAllStrategies(RedStorage &Storage, RangeTy Range) {
   });
 }
 
-int main() {
-  queue q;
-  RedStorage Storage(q);
-
-  auto TestRange = [&](auto Range) {
-    testAllStrategies<true, true>(Storage, Range);
-    testAllStrategies<true, false>(Storage, Range);
-    testAllStrategies<false, true>(Storage, Range);
-    testAllStrategies<false, false>(Storage, Range);
-  };
-
-  TestRange(range<1>{42});
-  TestRange(range<2>{8, 8});
-  TestRange(range<3>{7, 7, 5});
-  TestRange(nd_range<1>{range<1>{7}, range<1>{7}});
-  TestRange(nd_range<1>{range<1>{3 * 3}, range<1>{3}});
-
-  // TODO: Strategies historically adopted from sycl::range implementation only
-  // support 1-Dim case.
-  //
-  // TestRange(nd_range<2>{range<2>{7, 3}, range<2> {7, 3}});
-  // TestRange(nd_range<2>{range<2>{14, 9}, range<2> {7, 3}});
-  return 0;
+template <typename RangeTy> void testRange(RedStorage &Storage, RangeTy Range) {
+  testAllStrategies<true, true>(Storage, Range);
+  testAllStrategies<true, false>(Storage, Range);
+  testAllStrategies<false, true>(Storage, Range);
+  testAllStrategies<false, false>(Storage, Range);
 }

--- a/sycl/test-e2e/Reduction/reduction_internal_nd_range_1dim.cpp
+++ b/sycl/test-e2e/Reduction/reduction_internal_nd_range_1dim.cpp
@@ -1,0 +1,20 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include "reduction_internal.hpp"
+
+int main() {
+  queue q;
+  RedStorage Storage(q);
+
+  testRange(Storage, nd_range<1>{range<1>{7}, range<1>{7}});
+  testRange(Storage, nd_range<1>{range<1>{3 * 3}, range<1>{3}});
+
+  // TODO: Strategies historically adopted from sycl::range implementation only
+  // support 1-Dim case.
+  //
+  // testRange(Storage, nd_range<2>{range<2>{7, 3}, range<2> {7, 3}});
+  // testRange(Storage, nd_range<2>{range<2>{14, 9}, range<2> {7, 3}});
+
+  return 0;
+}

--- a/sycl/test-e2e/Reduction/reduction_internal_range_1dim.cpp
+++ b/sycl/test-e2e/Reduction/reduction_internal_range_1dim.cpp
@@ -1,0 +1,13 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include "reduction_internal.hpp"
+
+int main() {
+  queue q;
+  RedStorage Storage(q);
+
+  testRange(Storage, range<1>{42});
+
+  return 0;
+}

--- a/sycl/test-e2e/Reduction/reduction_internal_range_2dim.cpp
+++ b/sycl/test-e2e/Reduction/reduction_internal_range_2dim.cpp
@@ -1,0 +1,13 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include "reduction_internal.hpp"
+
+int main() {
+  queue q;
+  RedStorage Storage(q);
+
+  testRange(Storage, range<2>{8, 8});
+
+  return 0;
+}

--- a/sycl/test-e2e/Reduction/reduction_internal_range_3dim.cpp
+++ b/sycl/test-e2e/Reduction/reduction_internal_range_3dim.cpp
@@ -1,0 +1,13 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include "reduction_internal.hpp"
+
+int main() {
+  queue q;
+  RedStorage Storage(q);
+
+  testRange(Storage, range<3>{7, 7, 5});
+
+  return 0;
+}


### PR DESCRIPTION
The test is long enough to be a bottleneck for the total wall clock time when running E2E tests on a machine with enough cores (like our PVC/SPR runners in CI).