### PR TITLE
[SYCL][E2E] Pre-compile `fpga_main.cpp` into `.o` file

### DIFF
--- a/sycl/test-e2e/AOT/fpga-aoc-archive-early.cpp
+++ b/sycl/test-e2e/AOT/fpga-aoc-archive-early.cpp
@@ -8,6 +8,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp -c -o %t_main.o
+
 // Build any early archive binaries.
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_sub.cpp   -o %t_early_sub.a
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_add.cpp   -o %t_early_add.a
@@ -16,11 +18,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Use a variety of archive orders
 ////////////////////////////////////////////////////////////////////////////////
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_add.a %t_early_sub.a %t_early_add_x.a %t_early_sub_x.a -o %t_early.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_early_add.a %t_early_sub.a %t_early_add_x.a %t_early_sub_x.a -o %t_early.out
 // RUN: %{run} %t_early.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_sub_x.a %t_early_add.a %t_early_sub.a %t_early_add_x.a -o %t_early.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_early_sub_x.a %t_early_add.a %t_early_sub.a %t_early_add_x.a -o %t_early.out
 // RUN: %{run} %t_early.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_add_x.a %t_early_sub_x.a %t_early_add.a %t_early_sub.a -o %t_early.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_early_add_x.a %t_early_sub_x.a %t_early_add.a %t_early_sub.a -o %t_early.out
 // RUN: %{run} %t_early.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_sub.a %t_early_add_x.a %t_early_sub_x.a %t_early_add.a -o %t_early.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_early_sub.a %t_early_add_x.a %t_early_sub_x.a %t_early_add.a -o %t_early.out
 // RUN: %{run} %t_early.out

--- a/sycl/test-e2e/AOT/fpga-aoc-archive-early2.cpp
+++ b/sycl/test-e2e/AOT/fpga-aoc-archive-early2.cpp
@@ -8,6 +8,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp -c -o %t_main.o
+
 // Build any early archive binaries.
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_sub.cpp   -o %t_early_sub.a
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_add.cpp   -o %t_early_add.a
@@ -25,11 +27,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Use a variety of archive orders
 ////////////////////////////////////////////////////////////////////////////////
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_add.a %t_early_image_sub.a %t_early_image_add_x.a %t_early_image_sub_x.a -o %t_early_image.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_early_image_add.a %t_early_image_sub.a %t_early_image_add_x.a %t_early_image_sub_x.a -o %t_early_image.out
 // RUN: %{run} %t_early_image.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_sub_x.a %t_early_image_add.a %t_early_image_sub.a %t_early_image_add_x.a -o %t_early_image.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_early_image_sub_x.a %t_early_image_add.a %t_early_image_sub.a %t_early_image_add_x.a -o %t_early_image.out
 // RUN: %{run} %t_early_image.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_add_x.a %t_early_image_sub_x.a %t_early_image_add.a %t_early_image_sub.a -o %t_early_image.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_early_image_add_x.a %t_early_image_sub_x.a %t_early_image_add.a %t_early_image_sub.a -o %t_early_image.out
 // RUN: %{run} %t_early_image.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_sub.a %t_early_image_add_x.a %t_early_image_sub_x.a %t_early_image_add.a -o %t_early_image.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_early_image_sub.a %t_early_image_add_x.a %t_early_image_sub_x.a %t_early_image_add.a -o %t_early_image.out
 // RUN: %{run} %t_early_image.out

--- a/sycl/test-e2e/AOT/fpga-aoc-archive-image.cpp
+++ b/sycl/test-e2e/AOT/fpga-aoc-archive-image.cpp
@@ -8,6 +8,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp -c -o %t_main.o
+
 // Build any image archive binaries.
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %S/Inputs/fpga_sub.cpp   -o %t_image_sub.a
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %S/Inputs/fpga_add.cpp   -o %t_image_add.a
@@ -16,11 +18,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Use a variety of archive orders
 ////////////////////////////////////////////////////////////////////////////////
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_image_add.a %t_image_sub.a %t_image_add_x.a %t_image_sub_x.a -o %t_image.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_image_add.a %t_image_sub.a %t_image_add_x.a %t_image_sub_x.a -o %t_image.out
 // RUN: %{run} %t_image.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_image_sub_x.a %t_image_add.a %t_image_sub.a %t_image_add_x.a -o %t_image.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_image_sub_x.a %t_image_add.a %t_image_sub.a %t_image_add_x.a -o %t_image.out
 // RUN: %{run} %t_image.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_image_add_x.a %t_image_sub_x.a %t_image_add.a %t_image_sub.a -o %t_image.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_image_add_x.a %t_image_sub_x.a %t_image_add.a %t_image_sub.a -o %t_image.out
 // RUN: %{run} %t_image.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_image_sub.a %t_image_add_x.a %t_image_sub_x.a %t_image_add.a -o %t_image.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_image_sub.a %t_image_add_x.a %t_image_sub_x.a %t_image_add.a -o %t_image.out
 // RUN: %{run} %t_image.out

--- a/sycl/test-e2e/AOT/fpga-aoc-archive.cpp
+++ b/sycl/test-e2e/AOT/fpga-aoc-archive.cpp
@@ -9,6 +9,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp -c -o %t_main.o
+
 // Build any early archive binaries.
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_sub.cpp   -o %t_early_sub.a
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_add.cpp   -o %t_early_add.a
@@ -25,7 +27,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // Mix early and image archive usage
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_add.a %t_image_sub.a %t_early_add_x.a %t_image_sub_x.a -o %t_mix.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_early_add.a %t_image_sub.a %t_early_add_x.a %t_image_sub_x.a -o %t_mix.out
 // RUN: %{run} %t_mix.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_image_add.a %t_early_sub.a %t_image_add_x.a %t_early_sub_x.a -o %t_mix.out
+// RUN: %clangxx -fintelfpga -fsycl %t_main.o %t_image_add.a %t_early_sub.a %t_image_add_x.a %t_early_sub_x.a -o %t_mix.out
 // RUN: %{run} %t_mix.out


### PR DESCRIPTION
This particular TU has no device code so can be pre-compiled and passed as an object file to final link invocations without affecting the tests' purpose.

I'm not touching `fpga-aoc-archive-split-per-kernel.cpp`/ `fpga-aoc-archive2.cpp` as these two are the slowest and would need other changes.