### PR TITLE
[SYCL][E2E] Fix `zstd` support detection in LIT with icx on Windows

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -332,7 +332,18 @@ fPIC_opt = "-fPIC" if platform.system() != "Windows" else ""
 dll_opt = "/LD" if cl_options else "-shared"
 
 ps = subprocess.Popen(
-    [config.dpcpp_compiler, "-fsycl", "--offload-compress", dll_opt, fPIC_opt, "-x", "c++", "-", "-o", "-"],
+    [
+        config.dpcpp_compiler,
+        "-fsycl",
+        "--offload-compress",
+        dll_opt,
+        fPIC_opt,
+        "-x",
+        "c++",
+        "-",
+        "-o",
+        "-",
+    ],
     stdin=subprocess.PIPE,
     stdout=subprocess.DEVNULL,
     stderr=subprocess.PIPE,

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -328,8 +328,11 @@ if sp[0] == 0:
 
 # Check if clang is built with ZSTD and compression support.
 fPIC_opt = "-fPIC" if platform.system() != "Windows" else ""
+# -shared is invalid for icx on Windows, use /LD instead.
+dll_opt = "/LD" if cl_options else "-shared"
+
 ps = subprocess.Popen(
-    [config.dpcpp_compiler, "-fsycl", "--offload-compress", "-shared", fPIC_opt, "-x", "c++", "-", "-o", "-"],
+    [config.dpcpp_compiler, "-fsycl", "--offload-compress", dll_opt, fPIC_opt, "-x", "c++", "-", "-o", "-"],
     stdin=subprocess.PIPE,
     stdout=subprocess.DEVNULL,
     stderr=subprocess.PIPE,


### PR DESCRIPTION
Fixes CMPLRLLVM-64568

`-shared` is invalid with `icx` on Windows. This PR makes use of `/LD` instead when compiler accepts MSVC-style args.