### PR TITLE
[SYCL][E2E] Flag USM/fill_any_size UNSUPPORTED for all opencl devices

### DIFF
--- a/sycl/test-e2e/USM/fill_any_size.cpp
+++ b/sycl/test-e2e/USM/fill_any_size.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
 // clang-format off
-// UNSUPPORTED: (opencl && cpu)
+// UNSUPPORTED: opencl
 // UNSUPPORTED-TRACKER: https://github.com/oneapi-src/unified-runtime/issues/2440
 // clang-format on
 


### PR DESCRIPTION
Test added in #16544 was originally flagged as UNSUPPORTED for OpenCL CPU device only, but has now been observed to fail also for other OpenCL devices. Flag the test as UNSUPPORTED for all OpenCL devices.