### PR TITLE
[SYCL][E2E] Disable USM tests on HIP because they randomly fail (#15913)

### DIFF
--- a/sycl/test-e2e/USM/lit.local.cfg
+++ b/sycl/test-e2e/USM/lit.local.cfg
@@ -1,0 +1,4 @@
+import platform
+
+# https://github.com/intel/llvm/issues/15648
+config.unsupported_features += ['hip']

--- a/sycl/test-e2e/USM/lit.local.cfg
+++ b/sycl/test-e2e/USM/lit.local.cfg
@@ -1,3 +1,2 @@
-
 # https://github.com/intel/llvm/issues/15648
 config.unsupported_features += ['hip']

--- a/sycl/test-e2e/USM/lit.local.cfg
+++ b/sycl/test-e2e/USM/lit.local.cfg
@@ -1,4 +1,3 @@
-import platform
 
 # https://github.com/intel/llvm/issues/15648
 config.unsupported_features += ['hip']


### PR DESCRIPTION
Different tests randomly fail, so disabling the ones that happen to fail isn't productive. Just disable them all. I'll ping HIP people on the GH [issue](https://github.com/intel/llvm/issues/15648) to look into this ASAP.

Examples:
[one](https://github.com/intel/llvm/actions/runs/11571336819/job/32209524859), [two](https://github.com/intel/llvm/actions/runs/11555099026/job/32160351729)