### PR TITLE
[SYCL][ESIMD][E2E] Fix DG2 check in lit.local.cfg

### DIFF
--- a/sycl/test-e2e/ESIMD/lit.local.cfg
+++ b/sycl/test-e2e/ESIMD/lit.local.cfg
@@ -8,10 +8,10 @@ config.required_features += ['gpu']
 # so there's no difference in coverage.
 # We should investigate why OCL fails separately.
 
-# Check if any device has arch-intel_gpu_pvc
 has_arch_gpu_intel_pvc = any('arch-intel_gpu_pvc' in T for T in config.sycl_dev_features.values())
+has_gpu_intel_dg2 = any('gpu-intel-dg2' in T for T in config.sycl_dev_features.values())
 
-if 'gpu-intel-dg2' in config.available_features or has_arch_gpu_intel_pvc:
+if has_gpu_intel_dg2 or has_arch_gpu_intel_pvc:
   config.required_features += ['level_zero']
 
 # TODO: Remove this once the warnings are resolved


### PR DESCRIPTION
This only worked when `gpu-intel-dg2` was passed explicitly at the command line. Now we automatically add it based on the device architecture, but it's per-device, so check for it in any device like we do for PVC.