### PR TITLE
[E2E][NFCI] Remove `import platform` from USM LIT cfg file

### DIFF
--- a/sycl/test-e2e/USM/lit.local.cfg
+++ b/sycl/test-e2e/USM/lit.local.cfg
@@ -1,4 +1,2 @@
-import platform
-
 # https://github.com/intel/llvm/issues/15648
 config.unsupported_features += ['hip']


### PR DESCRIPTION
I think `import platform` is not required.
Found in https://github.com/intel/llvm/pull/16591#discussion_r1910675290