### PR TITLE
[SYCL] Don't copy string when tracing is not enabled

### DIFF
--- a/sycl/source/detail/persistent_device_code_cache.hpp
+++ b/sycl/source/detail/persistent_device_code_cache.hpp
@@ -208,20 +208,22 @@ public:
                                       const ur_program_handle_t &NativePrg);
 
   /* Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is set*/
-  static void trace(const std::string &msg, std::string path = "") {
+  static void trace(const std::string &msg, const std::string &path = "") {
     static const bool traceEnabled =
         SYCLConfig<SYCL_CACHE_TRACE>::isTraceDiskCache();
     if (traceEnabled) {
-      std::replace(path.begin(), path.end(), '\\', '/');
+      auto outputPath = path;
+      std::replace(outputPath.begin(), outputPath.end(), '\\', '/');
       std::cerr << "[Persistent Cache]: " << msg << path << std::endl;
     }
   }
   static void trace_KernelCompiler(const std::string &msg,
-                                   std::string path = "") {
+                                   const std::string &path = "") {
     static const bool traceEnabled =
         SYCLConfig<SYCL_CACHE_TRACE>::isTraceKernelCompiler();
     if (traceEnabled) {
-      std::replace(path.begin(), path.end(), '\\', '/');
+      auto outputPath = path;
+      std::replace(outputPath.begin(), outputPath.end(), '\\', '/');
       std::cerr << "[kernel_compiler Persistent Cache]: " << msg << path
                 << std::endl;
     }


### PR DESCRIPTION
Currently we pass by value and always copy the path even if tracing is not enabled which is expensive. Fix to pass by reference and do the copy/modification only if tracing is enabled.