### PR TITLE
[CI] Introduce SPIR-V Backend support in LIT config

### DIFF
--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -250,6 +250,11 @@ place. No new tests should use these features:
 * **gpu-intel-pvc** - Intel GPU PVC availability;
 * **gpu-intel-pvc-vg** - Intel GPU PVC-VG availability;
 
+### Use the LLVM SPIR-V Backend to generate SPIR-V code
+It's possible to use the LLVM SPIR-V Backend instead of the `llvm-spirv` tool
+to convert LLVM IR to SPIR-V. This feature must be set manually by passing the
+`spirv-backend` parameter to `llvm-lit`.
+
 ### llvm-lit parameters
 
 Following options can be passed to llvm-lit tool through --param option to

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -183,7 +183,10 @@ class SYCLEndToEndTest(lit.formats.ShTest):
             )
             sycl_target_opts += hip_arch_opts
             substitutions.append(("%{hip_arch_opts}", hip_arch_opts))
-        elif get_triple("spir64") in triples and "spirv-backend" in test.config.available_features:
+        elif (
+            get_triple("spir64") in triples
+            and "spirv-backend" in test.config.available_features
+        ):
             sycl_target_opts += " -fsycl-use-spirv-backend-for-spirv-gen"
         substitutions.append(("%{sycl_target_opts}", sycl_target_opts))
 

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -183,6 +183,8 @@ class SYCLEndToEndTest(lit.formats.ShTest):
             )
             sycl_target_opts += hip_arch_opts
             substitutions.append(("%{hip_arch_opts}", hip_arch_opts))
+        elif get_triple("spir64") in triples and "spirv-backend" in test.config.available_features:
+            sycl_target_opts += " -fsycl-use-spirv-backend-for-spirv-gen"
         substitutions.append(("%{sycl_target_opts}", sycl_target_opts))
 
         substitutions.append(

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -183,7 +183,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
             )
             sycl_target_opts += hip_arch_opts
             substitutions.append(("%{hip_arch_opts}", hip_arch_opts))
-        elif (
+        if (
             get_triple("spir64") in triples
             and "spirv-backend" in test.config.available_features
         ):

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -225,6 +225,8 @@ if lit_config.params.get("ur_l0_leaks_debug"):
 if lit_config.params.get("enable-perf-tests", False):
     config.available_features.add("enable-perf-tests")
 
+if lit_config.params.get("spirv-backend", False):
+    config.available_features.add("spirv-backend")
 
 # Use this to make sure that any dynamic checks below are done in the build
 # directory and not where the sources are located. This is important for the


### PR DESCRIPTION
We introduce here SPIR-V Backend support in LIT config by adding a new LIT feature 'spirv-backend', and in a way that substitutions in end-to-end tests are aware about the new LIT feature.