### PR TITLE
[SYCL] Remove HIP Nvidia tests/CI support

### DIFF
--- a/sycl-jit/test/internalization/promote-private-non-unit-hip.ll
+++ b/sycl-jit/test/internalization/promote-private-non-unit-hip.ll
@@ -1,4 +1,4 @@
-; REQUIRES: hip_amd
+; REQUIRES: hip
 ; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext \
 ; RUN: -passes=sycl-internalization -S %s | FileCheck %s
 

--- a/sycl-jit/test/kernel-fusion/check-failed-remapping-amdgpu.ll
+++ b/sycl-jit/test/kernel-fusion/check-failed-remapping-amdgpu.ll
@@ -1,4 +1,4 @@
-; REQUIRES: hip_amd
+; REQUIRES: hip
 ; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext \
 ; RUN:   -passes=sycl-kernel-fusion -S %s | FileCheck %s
 

--- a/sycl-jit/test/kernel-fusion/check-remapping-amdgpu.ll
+++ b/sycl-jit/test/kernel-fusion/check-remapping-amdgpu.ll
@@ -1,4 +1,4 @@
-; REQUIRES: hip_amd
+; REQUIRES: hip
 ; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext \
 ; RUN:   -passes=sycl-kernel-fusion -S %s | FileCheck %s
 

--- a/sycl-jit/test/kernel-fusion/check-remapping-interproc-amdgpu.ll
+++ b/sycl-jit/test/kernel-fusion/check-remapping-interproc-amdgpu.ll
@@ -1,4 +1,4 @@
-; REQUIRES: hip_amd
+; REQUIRES: hip
 ; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext \
 ; RUN:   -passes=sycl-kernel-fusion -S %s | FileCheck %s
 

--- a/sycl-jit/test/lit.cfg.py
+++ b/sycl-jit/test/lit.cfg.py
@@ -27,4 +27,4 @@ config.substitutions.append(("%shlibdir", config.llvm_shlib_dir))
 if "NVPTX" in config.llvm_targets_to_build:
     config.available_features.add("cuda")
 if "AMDGPU" in config.llvm_targets_to_build:
-    config.available_features.add("hip_amd")
+    config.available_features.add("hip")

--- a/sycl-jit/test/materializer/basic.ll
+++ b/sycl-jit/test/materializer/basic.ll
@@ -1,4 +1,4 @@
-; RUN: %if hip_amd %{ opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext\
+; RUN: %if hip %{ opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext\
 ; RUN: --mtriple amdgcn-amd-amdhsa -passes=sycl-spec-const-materializer -S %s |\
 ; RUN: FileCheck --check-prefix=CHECK-MATERIALIZER %s %}
 
@@ -6,7 +6,7 @@
 ; RUN: --mtriple nvptx64-nvidia-cuda -passes=sycl-spec-const-materializer -S %s |\
 ; RUN: FileCheck --check-prefix=CHECK-MATERIALIZER %s %}
 
-; RUN: %if hip_amd %{ opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext\
+; RUN: %if hip %{ opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext\
 ; RUN: --mtriple amdgcn-amd-amdhsa -passes=sycl-spec-const-materializer,early-cse,adce -S %s |\
 ; RUN: FileCheck --check-prefix=CHECK-MATERIALIZER-CSE %s %}
 

--- a/sycl-jit/test/materializer/multi_type.ll
+++ b/sycl-jit/test/materializer/multi_type.ll
@@ -1,4 +1,4 @@
-; RUN: %if hip_amd %{ opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext\
+; RUN: %if hip %{ opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext\
 ; RUN: --mtriple amdgcn-amd-amdhsa -passes=sycl-spec-const-materializer -S %s |\
 ; RUN: FileCheck --check-prefix=CHECK-MATERIALIZER %s %}
 
@@ -6,7 +6,7 @@
 ; RUN: --mtriple nvptx64-nvidia-cuda -passes=sycl-spec-const-materializer -S %s |\
 ; RUN: FileCheck --check-prefix=CHECK-MATERIALIZER %s %}
 
-; RUN: %if hip_amd %{ opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext\
+; RUN: %if hip %{ opt -load-pass-plugin %shlibdir/SYCLKernelJIT%shlibext\
 ; RUN: --mtriple amdgcn-amd-amdhsa -passes=sycl-spec-const-materializer,early-cse -S %s |\
 ; RUN: FileCheck --check-prefix=CHECK-MATERIALIZER-CSE %s %}
 

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -415,6 +415,11 @@ option(SYCL_INCLUDE_TESTS
   "Generate build targets for the SYCL unit tests."
   ${LLVM_INCLUDE_TESTS})
 
+# Ensure that HIP platform is uppercase, to match buildbot's output.
+if(NOT "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "")
+  string(TOUPPER ${SYCL_BUILD_PI_HIP_PLATFORM} SYCL_BUILD_PI_HIP_PLATFORM)
+endif()
+
 add_subdirectory(tools)
 
 if (WIN32)
@@ -518,7 +523,7 @@ if("hip" IN_LIST SYCL_ENABLE_BACKENDS)
       "HIP support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
 
-  if(NOT TARGET lld)
+  if(NOT TARGET lld AND "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
     message(FATAL_ERROR
       "HIP support requires adding \"lld\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -415,11 +415,6 @@ option(SYCL_INCLUDE_TESTS
   "Generate build targets for the SYCL unit tests."
   ${LLVM_INCLUDE_TESTS})
 
-# Ensure that HIP platform is uppercase, to match buildbot's output.
-if(NOT "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "")
-  string(TOUPPER ${SYCL_BUILD_PI_HIP_PLATFORM} SYCL_BUILD_PI_HIP_PLATFORM)
-endif()
-
 add_subdirectory(tools)
 
 if (WIN32)
@@ -523,7 +518,7 @@ if("hip" IN_LIST SYCL_ENABLE_BACKENDS)
       "HIP support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
 
-  if(NOT TARGET lld AND "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
+  if(NOT TARGET lld)
     message(FATAL_ERROR
       "HIP support requires adding \"lld\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()

--- a/sycl/test-e2e/Adapters/enqueue-arg-order-buffer.cpp
+++ b/sycl/test-e2e/Adapters/enqueue-arg-order-buffer.cpp
@@ -1,4 +1,3 @@
-// UNSUPPORTED: hip_nvidia
 // RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s
 

--- a/sycl/test-e2e/AtomicRef/assignment_atomic64_generic.cpp
+++ b/sycl/test-e2e/AtomicRef/assignment_atomic64_generic.cpp
@@ -2,7 +2,7 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15791
 
 #include "assignment.h"

--- a/sycl/test-e2e/AtomicRef/exchange.cpp
+++ b/sycl/test-e2e/AtomicRef/exchange.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15791
 
 #include "exchange.h"

--- a/sycl/test-e2e/Basic/built-ins.cpp
+++ b/sycl/test-e2e/Basic/built-ins.cpp
@@ -5,7 +5,7 @@
 // RUN: %{run} %t_var.out | FileCheck %s
 
 // Hits an assertion and kernel page fault with AMD:
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14404
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/host-task-dependency.cpp
+++ b/sycl/test-e2e/Basic/host-task-dependency.cpp
@@ -2,8 +2,7 @@
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
 //
 // TODO: Behaviour is unstable for level zero on Windows. Enable when fixed.
-// TODO: The test is sporadically fails on CUDA. Enable when fixed.
-// UNSUPPORTED: (windows && level_zero) || hip_nvidia
+// UNSUPPORTED: (windows && level_zero)
 
 #define SYCL2020_DISABLE_DEPRECATION_WARNINGS
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_static.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_static.cpp
@@ -4,7 +4,7 @@
 // UNSUPPORTED: opencl && gpu
 // UNSUPPORTED-TRACKER: GSD-4287
 //
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15329
 //
 // Tests static device_global access through device kernels.

--- a/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/free_function_kernels.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/free_function_kernels.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: cuda
 // UNSUPPORTED-INTENDED: Not implemented yet for Nvidia/AMD backends.
 
-// XFAIL: hip_amd
+// XFAIL: hip
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15742
 
 #include <iostream>

--- a/sycl/test-e2e/DeviceImageDependencies/free_function_kernels.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/free_function_kernels.cpp
@@ -7,7 +7,7 @@
 // The name mangling for free function kernels currently does not work with PTX.
 // UNSUPPORTED: cuda
 
-// XFAIL: hip_amd
+// XFAIL: hip
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15742
 
 #include <iostream>

--- a/sycl/test-e2e/HierPar/hier_par_wgscope.cpp
+++ b/sycl/test-e2e/HierPar/hier_par_wgscope.cpp
@@ -3,7 +3,7 @@
 // RUN: %{run} %t.out
 //
 // Test hangs on AMD
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 
 //==- hier_par_wgscope.cpp --- hierarchical parallelism test for WG scope---==//
 //

--- a/sycl/test-e2e/InlineAsm/asm_16_empty.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_empty.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda || hip_nvidia
+// UNSUPPORTED: cuda
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/InlineAsm/asm_8_empty.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_8_empty.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda || hip_nvidia
+// UNSUPPORTED: cuda
 // REQUIRES: gpu,linux,sg-8
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_amdgcn.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_amdgcn.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: hip_amd, opencl, gpu, cpu
+// REQUIRES: hip, opencl, gpu, cpu
 // REQUIRES: build-and-run-mode
 
 // RUN: %clangxx -fsycl -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx906 -fsycl-targets=amdgcn-amd-amdhsa %S/Inputs/is_compatible_with_env.cpp -o %t.out

--- a/sycl/test-e2e/Printf/char.cpp
+++ b/sycl/test-e2e/Printf/char.cpp
@@ -4,7 +4,7 @@
 // The test is written using conversion specifiers table from cppreference [1]
 // [1]: https://en.cppreference.com/w/cpp/io/c/fprintf
 //
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s

--- a/sycl/test-e2e/Printf/double.cpp
+++ b/sycl/test-e2e/Printf/double.cpp
@@ -5,7 +5,7 @@
 // [1]: https://en.cppreference.com/w/cpp/io/c/fprintf
 //
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s

--- a/sycl/test-e2e/Printf/float.cpp
+++ b/sycl/test-e2e/Printf/float.cpp
@@ -4,7 +4,7 @@
 // The test is written using conversion specifiers table from cppreference [1]
 // [1]: https://en.cppreference.com/w/cpp/io/c/fprintf
 //
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s

--- a/sycl/test-e2e/Printf/int.cpp
+++ b/sycl/test-e2e/Printf/int.cpp
@@ -4,7 +4,7 @@
 // The test is written using conversion specifiers table from cppreference [1]
 // [1]: https://en.cppreference.com/w/cpp/io/c/fprintf
 //
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 // FIXME: The 'short' type gets overflown with sporadic values on CUDA.
 // XFAIL: cuda
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/14734

--- a/sycl/test-e2e/Printf/mixed-address-space.cpp
+++ b/sycl/test-e2e/Printf/mixed-address-space.cpp
@@ -1,7 +1,7 @@
 // This test is written with an aim to check that experimental::printf versions
 // for constant and generic address space can be used in the same module.
 //
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 // XFAIL: cuda && windows
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/14733
 // FIXME: Drop the test once generic AS support is considered stable and the

--- a/sycl/test-e2e/Printf/percent-symbol.cpp
+++ b/sycl/test-e2e/Printf/percent-symbol.cpp
@@ -4,7 +4,7 @@
 // The test is written using conversion specifiers table from cppreference [1]
 // [1]: https://en.cppreference.com/w/cpp/io/c/fprintf
 //
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 // XFAIL: cuda && windows
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/14733
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -184,12 +184,6 @@ at the full path specified by this variable.
 
 ***CUDA_LIBS_DIR*** - path to CUDA libraries.
 
-***HIP_PLATFORM*** - platform selection for HIP targeted devices.
-Defaults to AMD if no value is given. Supported values are:
-
-* **AMD**    - for HIP to target AMD GPUs
-* **NVIDIA** - for HIP to target NVIDIA GPUs
-
 ***AMD_ARCH*** - flag may be set for when using HIP AMD triple. For example it
 may be set to "gfx906". Otherwise must be provided via the ***amd_arch*** LIT
 parameter (e.g., ***--param amd_arch=gfx906***) at runtime via the command line

--- a/sycl/test-e2e/Regression/DAE-separate-compile.cpp
+++ b/sycl/test-e2e/Regression/DAE-separate-compile.cpp
@@ -11,7 +11,6 @@
 // Failing on HIP AMD, enable after fixed
 // UNSUPPORTED: hip
 
-
 #include <iostream>
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/Regression/DAE-separate-compile.cpp
+++ b/sycl/test-e2e/Regression/DAE-separate-compile.cpp
@@ -9,7 +9,7 @@
 // RUN: %{run} %t.out
 
 // Failing on HIP AMD, enable after fixed
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 
 
 #include <iostream>

--- a/sycl/test-e2e/Regression/static-buffer-dtor.cpp
+++ b/sycl/test-e2e/Regression/static-buffer-dtor.cpp
@@ -13,7 +13,7 @@
 // RUN: %{run} %t.out
 
 // Failing on HIP AMD
-// UNSUPPORTED: hip_amd
+// UNSUPPORTED: hip
 
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows

--- a/sycl/test-e2e/Sampler/normalized-clampedge-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clampedge-nearest.cpp
@@ -4,7 +4,7 @@
 //
 // Missing __spirv_ImageWrite, __spirv_SampledImage,
 // __spirv_ImageSampleExplicitLod on AMD
-// XFAIL: hip_amd
+// XFAIL: hip
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/14732
 
 /*

--- a/sycl/test-e2e/Tracing/usm/queue_copy_released_pointer.cpp
+++ b/sycl/test-e2e/Tracing/usm/queue_copy_released_pointer.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: windows || hip_amd
+// UNSUPPORTED: windows || hip
 // RUN: %{build} -o %t.out
 // RUN: not --crash env SYCL_TRACE_TERMINATE_ON_WARNING=1 %{run} sycl-trace --verify %t.out | FileCheck %s
 

--- a/sycl/test-e2e/Tracing/usm/queue_single_task_nullptr.cpp
+++ b/sycl/test-e2e/Tracing/usm/queue_single_task_nullptr.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: windows || hip_amd
+// UNSUPPORTED: windows || hip
 // RUN: %{build} -o %t.out
 // RUN: not --crash env SYCL_TRACE_TERMINATE_ON_WARNING=1 %{run} sycl-trace --verify %t.out | FileCheck %s
 

--- a/sycl/test-e2e/Tracing/usm/queue_single_task_released_pointer.cpp
+++ b/sycl/test-e2e/Tracing/usm/queue_single_task_released_pointer.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: windows || hip_amd
+// UNSUPPORTED: windows || hip
 // RUN: %{build} -o %t.out
 // RUN: not --crash env SYCL_TRACE_TERMINATE_ON_WARNING=1 %{run} sycl-trace --verify %t.out | FileCheck %s
 

--- a/sycl/test-e2e/USM/memadvise_flags.cpp
+++ b/sycl/test-e2e/USM/memadvise_flags.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t1.out
-// REQUIRES: cuda || hip_amd
+// REQUIRES: cuda || hip
 // RUN: %{run} %t1.out
 
 //==---------------- memadvise_flags.cpp -----------------------------------==//

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "copy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "copy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "copy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "copy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "memcpy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "memcpy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
@@ -10,7 +10,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 // Temporarily disabled until the failure is addressed.

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "memcpy2d_common.hpp"

--- a/sycl/test-e2e/USM/memory_coherency_hip.cpp
+++ b/sycl/test-e2e/USM/memory_coherency_hip.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t1.out
-// REQUIRES: hip_amd
+// REQUIRES: hip
 // RUN: %{run} %t1.out
 
 //==---- memory_coherency_hip.cpp  -----------------------------------------==//

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -17,10 +17,7 @@ def get_triple(test, backend):
     if backend == "cuda":
         return "nvptx64-nvidia-cuda"
     if backend == "hip":
-        if test.config.hip_platform == "NVIDIA":
-            return "nvptx64-nvidia-cuda"
-        else:
-            return "amdgcn-amd-amdhsa"
+        return "amdgcn-amd-amdhsa"
     if backend == "native_cpu":
         return "native_cpu"
     return "spir64"

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -524,18 +524,6 @@ for d in config.sycl_devices:
     if be not in available_devices or dev not in available_devices[be]:
         lit_config.error("Unsupported device {}".format(d))
 
-# If HIP_PLATFORM flag is not set, default to AMD, and check if HIP platform is supported
-supported_hip_platforms = ["AMD", "NVIDIA"]
-if config.hip_platform == "":
-    config.hip_platform = "AMD"
-if config.hip_platform not in supported_hip_platforms:
-    lit_config.error(
-        "Unknown HIP platform '"
-        + config.hip_platform
-        + "' supported platforms are "
-        + ", ".join(supported_hip_platforms)
-    )
-
 if "cuda:gpu" in config.sycl_devices:
     if "CUDA_PATH" not in os.environ:
         if platform.system() == "Windows":
@@ -839,7 +827,7 @@ for sycl_device in config.sycl_devices:
     # Use short names for LIT rules.
     features.add(be)
 
-    if be == "hip" and config.hip_platform == "AMD":
+    if be == "hip":
         if not config.amd_arch:
             # Guaranteed to be a single element in the set
             arch = [x for x in architecture_feature][0]
@@ -850,15 +838,12 @@ for sycl_device in config.sycl_devices:
                 )
             config.amd_arch = arch.replace(amd_arch_prefix, "")
         llvm_config.with_system_environment("ROCM_PATH")
-        config.available_features.add("hip_amd")
         arch_flag = (
             "-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=" + config.amd_arch
         )
         config.substitutions.append(
             ("%rocm_path", os.environ.get("ROCM_PATH", "/opt/rocm"))
         )
-    elif be == "hip" and config.hip_platform == "NVIDIA":
-        config.available_features.add("hip_nvidia")
 
     config.sycl_dev_features[sycl_device] = features.union(config.available_features)
     if is_intel_driver:

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -30,7 +30,6 @@ config.igc_tag_file = os.path.join("/usr/local/lib/igc/", 'IGCTAG.txt')
 
 config.sycl_devices = lit_config.params.get("sycl_devices", "@SYCL_TEST_E2E_TARGETS@").split(';')
 
-config.hip_platform = "@HIP_PLATFORM@"
 config.amd_arch = lit_config.params.get("amd_arch", "@AMD_ARCH@")
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'
 config.extra_environment = lit_config.params.get("extra_environment", "@LIT_EXTRA_ENVIRONMENT@")

--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -68,10 +68,10 @@ add_lit_testsuite(check-sycl-deploy "Running the SYCL regression tests"
 set_target_properties(check-sycl-deploy PROPERTIES FOLDER "SYCL tests")
 
 set(TRIPLES "spir64-unknown-unknown")
-if (SYCL_BUILD_BACKEND_CUDA OR (SYCL_BUILD_BACKEND_HIP AND "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "NVIDIA"))
+if (SYCL_BUILD_BACKEND_CUDA)
   set(TRIPLES "${TRIPLES},nvptx64-nvidia-cuda")
 endif()
-if ((SYCL_BUILD_BACKEND_HIP AND "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD"))
+if (SYCL_BUILD_BACKEND_HIP)
   set(TRIPLES "${TRIPLES},amdgcn-amd-amdhsa")
 endif()
 

--- a/sycl/test/basic_tests/macros.cpp
+++ b/sycl/test/basic_tests/macros.cpp
@@ -1,12 +1,12 @@
 // RUN: %clangxx %fsycl-host-only -dM -E %s -o %t.host
 // RUN:                %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown -fsycl-device-only -dM -E %s -o %t.device.spirv
 // RUN: %if cuda    %{ %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda    -fsycl-device-only -dM -E %s -o %t.device.cuda %}
-// RUN: %if hip_amd %{ %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa      -fsycl-device-only -dM -E %s -o %t.device.hip %}
+// RUN: %if hip     %{ %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa      -fsycl-device-only -dM -E %s -o %t.device.hip %}
 //
 // RUN: FileCheck %s < %t.host --check-prefixes=COMMON --implicit-check-not=__SPIRV
 // RUN:                FileCheck %s < %t.device.spirv --check-prefixes=DEVICE,COMMON --implicit-check-not=__SPIRV
 // RUN: %if cuda    %{ FileCheck %s < %t.device.cuda  --check-prefixes=DEVICE,COMMON --implicit-check-not=__SPIRV %}
-// RUN: %if hip_amd %{ FileCheck %s < %t.device.hip   --check-prefixes=DEVICE,COMMON --implicit-check-not=__SPIRV %}
+// RUN: %if hip     %{ FileCheck %s < %t.device.hip   --check-prefixes=DEVICE,COMMON --implicit-check-not=__SPIRV %}
 //
 // FIXME: we should also check that we don't leak __SYCL* and SYCL* macro from
 //        our header files.

--- a/sycl/test/basic_tests/macros_no_rdc.cpp
+++ b/sycl/test/basic_tests/macros_no_rdc.cpp
@@ -2,17 +2,17 @@
 // RUN: %clangxx %fsycl-host-only -fno-sycl-rdc -E -dD %s -o %t.host
 // RUN:                %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown -fsycl-device-only -E -dD -fno-sycl-rdc %s -o %t.device.spirv
 // RUN: %if cuda    %{ %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda    -fsycl-device-only -E -dD -fno-sycl-rdc %s -o %t.device.cuda %}
-// RUN: %if hip_amd %{ %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa      -fsycl-device-only -E -dD -fno-sycl-rdc %s -o %t.device.hip  %}
+// RUN: %if hip     %{ %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa      -fsycl-device-only -E -dD -fno-sycl-rdc %s -o %t.device.hip  %}
 //
 // RUN: FileCheck --match-full-lines %s < %t.host --check-prefixes=HOST
 // RUN:                FileCheck --match-full-lines %s < %t.device.spirv --check-prefixes=DEVICE-FULL-LINE --implicit-check-not="#define SYCL_EXTERNAL"
 // RUN: %if cuda    %{ FileCheck --match-full-lines %s < %t.device.cuda  --check-prefixes=DEVICE-FULL-LINE --implicit-check-not="#define SYCL_EXTERNAL" %}
-// RUN: %if hip_amd %{ FileCheck --match-full-lines %s < %t.device.hip   --check-prefixes=DEVICE-FULL-LINE --implicit-check-not="#define SYCL_EXTERNAL" %}
+// RUN: %if hip     %{ FileCheck --match-full-lines %s < %t.device.hip   --check-prefixes=DEVICE-FULL-LINE --implicit-check-not="#define SYCL_EXTERNAL" %}
 //
 // Remove __DPCPP_SYCL_EXTERNAL to simplify regex for DEVICE prefix
 // RUN:                sed 's|__DPCPP_SYCL_EXTERNAL||g' %t.device.spirv | FileCheck %s --check-prefixes=DEVICE
 // RUN: %if cuda    %{ sed 's|__DPCPP_SYCL_EXTERNAL||g' %t.device.cuda  | FileCheck %s --check-prefixes=DEVICE %}
-// RUN: %if hip_amd %{ sed 's|__DPCPP_SYCL_EXTERNAL||g' %t.device.hip   | FileCheck %s --check-prefixes=DEVICE %}
+// RUN: %if hip     %{ sed 's|__DPCPP_SYCL_EXTERNAL||g' %t.device.hip   | FileCheck %s --check-prefixes=DEVICE %}
 // RUN:
 //
 // With -fno-sycl-rdc, device code should not define or use SYCL_EXTERNAL

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 415
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 414
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
@@ -62,7 +62,6 @@
 // CHECK: AOT/early_aot.cpp
 // CHECK-NEXT: AOT/gpu.cpp
 // CHECK-NEXT: AOT/multiple-devices.cpp
-// CHECK-NEXT: Adapters/enqueue-arg-order-buffer.cpp
 // CHECK-NEXT: Adapters/enqueue-arg-order-image.cpp
 // CHECK-NEXT: Adapters/enqueue-arg-order-image.cpp
 // CHECK-NEXT: Adapters/interop-l0-direct.cpp

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -168,7 +168,7 @@ if "nvptx64-nvidia-cuda" in triple:
 
 if "amdgcn-amd-amdhsa" in triple:
     llvm_config.with_system_environment("ROCM_PATH")
-    config.available_features.add("hip_amd")
+    config.available_features.add("hip")
     # For AMD the specific GPU has to be specified with --offload-arch
     if not any([f.startswith("--offload-arch") for f in additional_flags]):
         # If the offload arch wasn't specified in SYCL_CLANG_EXTRA_FLAGS,


### PR DESCRIPTION
As noted in https://github.com/intel/llvm/issues/14432 the configuration isn't supported/tested anymore and there were some PRs removing related `XFAIL`s (https://github.com/intel/llvm/pull/16287, https://github.com/intel/llvm/pull/16307, and possibly others).

This PR goes a step further and removes all the support for that configuration in our LIT tests.