### PR TITLE
[SYCL] Remove `IsDeprecatedDeviceCopyable`

### DIFF
--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -389,7 +389,7 @@ public:
   static constexpr bool has_identity = true;
 
   ReductionIdentityContainer(const T &) {}
-  ReductionIdentityContainer() {}
+  ReductionIdentityContainer() = default;
 
   /// Returns the statically known identity value.
   static constexpr T getIdentity() {
@@ -406,6 +406,10 @@ public:
   static constexpr bool has_identity = true;
 
   ReductionIdentityContainer(const T &Identity) : MIdentity(Identity) {}
+
+  // Make it trivially copyable (need at least on of the special member
+  // functions):
+  ReductionIdentityContainer(const ReductionIdentityContainer &) = default;
 
   /// Returns the identity value given by user.
   T getIdentity() const { return MIdentity; }
@@ -2333,6 +2337,10 @@ void reduCGFuncMulti(handler &CGH, KernelType KernelFunc,
     using Name = __sycl_reduction_kernel<reduction::MainKrn, KernelName,
                                          reduction::strategy::multi,
                                          decltype(KernelTag)>;
+
+    static_assert(is_device_copyable_v<decltype(IdentitiesTuple)>);
+    static_assert(is_device_copyable_v<decltype(BOPsTuple)>);
+    static_assert(is_device_copyable_v<decltype(InitToIdentityProps)>);
 
     CGH.parallel_for<Name>(Range, Properties, [=](nd_item<Dims> NDIt) {
       // We can deduce IsOneWG from the tag type.

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -2338,10 +2338,6 @@ void reduCGFuncMulti(handler &CGH, KernelType KernelFunc,
                                          reduction::strategy::multi,
                                          decltype(KernelTag)>;
 
-    static_assert(is_device_copyable_v<decltype(IdentitiesTuple)>);
-    static_assert(is_device_copyable_v<decltype(BOPsTuple)>);
-    static_assert(is_device_copyable_v<decltype(InitToIdentityProps)>);
-
     CGH.parallel_for<Name>(Range, Properties, [=](nd_item<Dims> NDIt) {
       // We can deduce IsOneWG from the tag type.
       constexpr bool IsOneWG =

--- a/sycl/test/basic_tests/is_device_copyable.cpp
+++ b/sycl/test/basic_tests/is_device_copyable.cpp
@@ -25,14 +25,6 @@ struct BCopyable {
   BCopyable(const BCopyable &x) : i(x.i) {}
 };
 
-// Not trivially copyable, but trivially copy constructible/destructible.
-// Such types are passed to kernels to stay compatible with deprecated
-// sycl 1.2.1 rules.
-struct C : A {
-  const A C2;
-  C() : A{0}, C2{2} {}
-};
-
 // Not copyable type, but it will be declared as device copyable.
 struct DCopyable {
   int i;
@@ -67,7 +59,6 @@ void test() {
   A IamGood;
   IamGood.i = 0;
   BCopyable IamBadButCopyable(1);
-  C IamAlsoGood;
   DCopyable IamAlsoBadButCopyable{0};
   marray<int, 5> MarrayForCopyableIsCopyable(0);
   range<2> Range{1,2};
@@ -78,7 +69,6 @@ void test() {
     int A = IamGood.i;
     int B = IamBadButCopyable.i;
     int C = IamAlsoBadButCopyable.i;
-    int D = IamAlsoGood.i;
     int E = MarrayForCopyableIsCopyable[0];
     int F = Range[1];
     int G = Id[2];


### PR DESCRIPTION
This was discussed in
https://github.com/intel/llvm/pull/15342#discussion_r1751868640 and the consensus seemed to be that we should drop it right away in a separate PR, do it here.

Technically, it is a breaking change that could also be considered a bugfix. An example of a class failing the updated check is

```
struct Kernel {
    Kernel(int);
    Kernel(const Kernel&) = default;
    Kernel& operator=(const Kernel&) { return *this; } // non-trivial
};
```

An additional minor reason (other than not being SYCL-conformant) to drop it right away is to save a tiny bit of compile time that is currently used to support something violating the spec.

This required some fixes in the reductions implementation to make sure the kernel we submit internally are actually device copyable.