### PR TITLE
[SYCL][Graph][E2E] Reduce work in intensive update tests running

### DIFF
--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
@@ -20,9 +20,11 @@ int main() {
 
   // Use a large N to try and make the kernel slow
   const size_t N = 1 << 16;
-  // Loop inside kernel to make even slower (too large N runs out of memory)
-  const size_t NumKernelLoops = 4;
-  const size_t NumSubmitLoops = 8;
+
+  // Reduce amount of work compared to version of test without free functions
+  // due to CMPLRLLVM-64841
+  const size_t NumKernelLoops = 1;
+  const size_t NumSubmitLoops = 1;
 
   exp_ext::command_graph Graph{Ctxt, Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Update/update_with_indices_ordering.cpp
+++ b/sycl/test-e2e/Graph/Update/update_with_indices_ordering.cpp
@@ -18,7 +18,7 @@ int main() {
   const size_t N = 1 << 16;
   // Loop inside kernel to make even slower (too large N runs out of memory)
   const size_t NumKernelLoops = 4;
-  const size_t NumSubmitLoops = 8;
+  const size_t NumSubmitLoops = 2;
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 


### PR DESCRIPTION
On certain setups these two tests take a long time to execute, impairing the ability to run the whole suite of graph E2E tests in lit.

Reduce the number of graph execution iterations used in tests to alleviate this situation. There is an issue with free-function kernels taking longer that the non-free function equivalent, documented in CMPLRLLVM-64841, so only use a single execution iteration for now.