### PR TITLE
[CI] Use `intel_drivers:alldeps` container on `build_e2e_tests` precommit step

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -81,7 +81,7 @@ jobs:
     with:
       name: Build e2e tests
       runner: '["Linux", "build"]'
-      image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
+      image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps
       image_options: -u 1001
       ref: ${{ github.sha }}
       merge_ref: ''


### PR DESCRIPTION
`ubuntu2404_intel_drivers:latest` container was used here previously because there was no Ubuntu 24 version of the `alldeps` container, and we were only building for the `spir64` triple. This container has since been added so we can use it instead. This will allow us to compile for the other triples in the `build-only` step in the future.