### PR TITLE
[CI] Bump IGC version

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -7,9 +7,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "v2.2.3",
-      "version": "2.2.3",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/v2.2.3",
+      "github_tag": "v2.5.6",
+      "version": "2.5.6",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/v2.5.6",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {


### PR DESCRIPTION
We are currently using `24.52.32224.5` and the corresponding IGC version is v.2.5.6 as per [here](https://github.com/intel/compute-runtime/releases/tag/24.52.32224.5). The script doesn't update it, I'll fix it tomorrow but for now just manually bump it.