### PR TITLE
[SYCL][E2E] Enable local-arg-align.cpp

### DIFF
--- a/sycl/test-e2e/Regression/local-arg-align.cpp
+++ b/sycl/test-e2e/Regression/local-arg-align.cpp
@@ -2,9 +2,6 @@
 //
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: true
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/10682
-
 //==-- local-arg-align.cpp - Test for local argument alignmnent ------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
This commit re-enables sycl/test-e2e/Regression/local-arg-align.cpp under the expectation that https://github.com/intel/llvm/pull/16616 addressed the remaining issues.