### PR TITLE
[SYCL][E2E] Add some compile-time "tracking" tests

### DIFF
--- a/sycl/test-e2e/PerformanceTests/CompileTime/core_hpp.cpp
+++ b/sycl/test-e2e/PerformanceTests/CompileTime/core_hpp.cpp
@@ -1,0 +1,6 @@
+// RUN: time -f "Elapsed real time: %es" %{build} -fsycl-device-only -fsyntax-only
+// RUN: time -f "Elapsed real time: %es" %{build} -o %t.out
+
+#include <sycl/detail/core.hpp>
+
+int main() { return 0; }

--- a/sycl/test-e2e/PerformanceTests/CompileTime/single_task_overhead.cpp
+++ b/sycl/test-e2e/PerformanceTests/CompileTime/single_task_overhead.cpp
@@ -1,0 +1,33 @@
+// RUN: time -f "Elapsed real time: %es" %{build} -fsycl-device-only -fsyntax-only
+// RUN: time -f "Elapsed real time: %es" %{build} -fsycl-device-only -fsyntax-only -DSUBMIT
+
+#include <sycl/detail/core.hpp>
+
+template <int N, int M> struct compile_time_heavy_krn {
+  static void foo(int x = N) { compile_time_heavy_krn<N - 1, M>::foo(x); }
+};
+
+template <int M> struct compile_time_heavy_krn<0, M> {
+  static void foo(int x = 0) { std::ignore = x; }
+};
+
+int main() {
+  sycl::queue q;
+  q.single_task([]() { std::ignore = 42; });
+  sycl::detail::loop<2>([&](auto outer_idx) {
+    sycl::detail::loop<200>([&](auto idx) {
+      auto krn = [=]() {
+        compile_time_heavy_krn<idx * 5, outer_idx * 1000 + idx>::foo();
+      };
+      auto s = [&](sycl::handler &cgh) {
+#if SUBMIT
+        cgh.single_task(krn);
+#endif
+      };
+#if SUBMIT
+      q.submit(s);
+#endif
+    });
+  });
+  return 0;
+}

--- a/sycl/test-e2e/PerformanceTests/CompileTime/sycl_hpp.cpp
+++ b/sycl/test-e2e/PerformanceTests/CompileTime/sycl_hpp.cpp
@@ -1,0 +1,6 @@
+// RUN: time -f "Elapsed real time: %es" %{build} -fsycl-device-only -fsyntax-only
+// RUN: time -f "Elapsed real time: %es" %{build} -o %t.out
+
+#include <sycl/sycl.hpp>
+
+int main() { return 0; }

--- a/sycl/test/e2e_test_requirements/no_sycl_hpp_in_e2e_tests.cpp
+++ b/sycl/test/e2e_test_requirements/no_sycl_hpp_in_e2e_tests.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: linux
 //
 // RUN: grep -r -l 'sycl.hpp' %S/../../test-e2e | FileCheck  %s
-// RUN: grep -r -l 'sycl.hpp' %S/../../test-e2e | wc -l | FileCheck %s --check-prefix CHECK-NUM-MATCHES
+// RUN: grep -r -l 'sycl.hpp' %S/../../test-e2e | grep -v 'test-e2e/PerformanceTests/' | wc -l | FileCheck %s --check-prefix CHECK-NUM-MATCHES
 //
 // CHECK-DAG: README.md
 // CHECK-DAG: lit.cfg.py


### PR DESCRIPTION
We run `test-e2e/PerformanceTests` in post-commit and that can be used for

* tracking the compilation time on these tests over time
* running them in pre-commit to measure expected improvements

I also think that since PerformanceTests are "opt-in" in precommit, there is little sense in enforcing no `<sycl/sycl.hpp>` header in them.