### PR TITLE
[CI] Manually bump igc-dev again

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-97b3d8f",
-      "version": "97b3d8f",
-      "updated_at": "2025-01-08T17:43:30Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2403247641/zip",
+      "github_tag": "igc-dev-61b96b3",
+      "version": "61b96b3",
+      "updated_at": "2025-01-15T17:43:30Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2435370337/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
The old artifact expired so we can't download it anymore, which we need to do because I updated a script which causes the containers to be rebuild.