### PR TITLE
[SYCL][Graph] Remove calls to urCommandBufferReleaseCommandExp

### DIFF
--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -1,7 +1,9 @@
-# commit 3a1b4c7b9ba952fad6f6ad36c01101bbf368347b
-# Merge: c270a6b8 264d0468
+# commit 14f4a3ba70b91b3adc411ec6bfc8ae86e948a990
+# Merge: 4643d1c0 3ed86fae
 # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-# Date:   Tue Jan 28 15:16:58 2025 +0000
-#     Merge pull request #2594 from kbenzie/benie/cl-core-functions-no-dlopen
-#     Fix invalid use of dlopen()
-set(UNIFIED_RUNTIME_TAG 3a1b4c7b9ba952fad6f6ad36c01101bbf368347b)
+# Date:   Wed Jan 29 13:55:27 2025 +0000
+#
+#    Merge pull request #2578 from Bensuo/ewan/remove_command_ref_counting
+#
+#    Remove command-buffer command handle ref counting
+set(UNIFIED_RUNTIME_TAG 14f4a3ba70b91b3adc411ec6bfc8ae86e948a990)

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -951,15 +951,6 @@ exec_graph_impl::~exec_graph_impl() {
         }
       }
     }
-
-    for (auto &Iter : MCommandMap) {
-      if (auto Command = Iter.second; Command) {
-        ur_result_t Res = Adapter->call_nocheck<
-            sycl::detail::UrApiKind::urCommandBufferReleaseCommandExp>(Command);
-        (void)Res;
-        assert(Res == UR_RESULT_SUCCESS);
-      }
-    }
   } catch (std::exception &e) {
     __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~exec_graph_impl", e);
   }


### PR DESCRIPTION
Reflects UR change from https://github.com/oneapi-src/unified-runtime/pull/2578 where we no longer need to manually manage the lifetimes of the individual commands in a UR command-buffer.