### PR TITLE
[UR] Unified clang format

### DIFF
--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -1,7 +1,7 @@
-# commit 222e4b1d51536bb38e03e2000a79679af0a44a6d
-# Merge: 30d183a0 28108a7e
+# commit 029a977bc76d1216783c69bfdb18d0db465ea399
+# Merge: 222e4b1d 041179a3
 # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-# Date:   Fri Jan 17 10:28:34 2025 +0000
-#     Merge pull request #2561 from Bensuo/ben/cmd-buffer-l0-fence
-#     [L0][CMDBUF] Optimize fence/event waits during update
-set(UNIFIED_RUNTIME_TAG 222e4b1d51536bb38e03e2000a79679af0a44a6d)
+# Date:   Fri Jan 17 16:36:13 2025 +0000
+#     Merge pull request #1536 from ldrumm/unified-clang-format
+#     Unified clang format
+set(UNIFIED_RUNTIME_TAG 029a977bc76d1216783c69bfdb18d0db465ea399)


### PR DESCRIPTION
https://github.com/oneapi-src/unified-runtime/pull/1536

Align the UR clang-format version with intel/llvm.
