### PR TITLE
[CI] Remove always empty `matrix.extra_cmake_args`

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -242,7 +242,6 @@ jobs:
 
       env: '{"LIT_FILTER":"PerformanceTests/"}'
       extra_lit_opts: -a -j 1 --param enable-perf-tests=True
-      extra_cmake_args: ${{ matrix.extra_cmake_args }}
 
       ref: ${{ github.sha }}
       merge_ref: ''


### PR DESCRIPTION
Unused after https://github.com/intel/llvm/pull/16071.