### PR TITLE
[CI] Remove `nightly:no-drivers` docker image build

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -276,7 +276,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
         build-args: |
           base_image=ghcr.io/intel/llvm/ubuntu2204_build
-          base_tag=latest
+          base_tag=alldeps
         tags: |
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build-${{ github.sha }}
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -267,20 +267,7 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:${{ github.sha }}
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:latest
-    - name: Build and Push Container (no drivers)
-      uses: ./devops/actions/build_container
-      with:
-        push: ${{ github.ref_name == 'sycl' }}
-        file: ubuntu2204_preinstalled
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        build-args: |
-          base_image=ghcr.io/intel/llvm/ubuntu2204_base
-          base_tag=latest
-        tags: |
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:no-drivers-${{ github.sha }}
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:no-drivers
-    - name: Build and Push Container (Build image)
+    - name: Build and Push Container
       uses: ./devops/actions/build_container
       with:
         push: ${{ github.ref_name == 'sycl' }}


### PR DESCRIPTION
We don't use anywhere, and since our images are private nobody else can neither.