### PR TITLE
[E2E] Update end-to-end test cases status for runs with the LLVM SPIR-V Backend

### DIFF
--- a/sycl/test-e2e/MemorySanitizer/check_buffer_memset_memcpy.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_buffer_memset_memcpy.cpp
@@ -4,6 +4,9 @@
 // RUN: %{build} %device_msan_flags -O2 -g -o %t2.out
 // RUN: %{run} %t2.out 2>&1 | FileCheck %s
 
+// XFAIL: spirv-backend && gpu
+// XFAIL-TRACKER: CMPLRLLVM-64705
+
 #include <sycl/detail/core.hpp>
 
 __attribute__((noinline)) int foo(int data1, int data2) {

--- a/sycl/test-e2e/MemorySanitizer/check_device_global.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_device_global.cpp
@@ -6,6 +6,9 @@
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
 // RUN: %{run} not %t3.out 2>&1 | FileCheck %s
 
+// XFAIL: spirv-backend && gpu
+// XFAIL-TRACKER: CMPLRLLVM-64705
+
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/device_global/device_global.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/MemorySanitizer/check_usm.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_usm.cpp
@@ -7,6 +7,9 @@
 // UNSUPPORTED: cpu
 // UNSUPPORTED-TRACKER: CMPLRLLVM-64618
 
+// XFAIL: spirv-backend && gpu
+// XFAIL-TRACKER: CMPLRLLVM-64705
+
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 


### PR DESCRIPTION
Update end-to-end test cases status for runs with the LLVM SPIR-V Backend.