### PR TITLE
[NFC] Use C++17 fold expressions in `detail::CheckDeviceCopyable`

### DIFF
--- a/sycl/include/sycl/detail/is_device_copyable.hpp
+++ b/sycl/include/sycl/detail/is_device_copyable.hpp
@@ -90,10 +90,8 @@ template <typename T>
 inline constexpr bool is_device_copyable_v = is_device_copyable<T>::value;
 namespace detail {
 #ifdef __SYCL_DEVICE_ONLY__
-template <typename T, typename>
-struct CheckFieldsAreDeviceCopyable;
-template <typename T, typename>
-struct CheckBasesAreDeviceCopyable;
+template <typename T, typename> struct CheckFieldsAreDeviceCopyable;
+template <typename T, typename> struct CheckBasesAreDeviceCopyable;
 
 template <typename T, unsigned... FieldIds>
 struct CheckFieldsAreDeviceCopyable<T, std::index_sequence<FieldIds...>> {

--- a/sycl/include/sycl/detail/is_device_copyable.hpp
+++ b/sycl/include/sycl/detail/is_device_copyable.hpp
@@ -90,29 +90,26 @@ template <typename T>
 inline constexpr bool is_device_copyable_v = is_device_copyable<T>::value;
 namespace detail {
 #ifdef __SYCL_DEVICE_ONLY__
-// Checks that the fields of the type T with indices 0 to (NumFieldsToCheck -
-// 1) are device copyable.
-template <typename T, unsigned NumFieldsToCheck>
-struct CheckFieldsAreDeviceCopyable
-    : CheckFieldsAreDeviceCopyable<T, NumFieldsToCheck - 1> {
-  using FieldT = decltype(__builtin_field_type(T, NumFieldsToCheck - 1));
-  static_assert(is_device_copyable_v<FieldT>,
-                "The specified type is not device copyable");
+template <typename T, typename>
+struct CheckFieldsAreDeviceCopyable;
+template <typename T, typename>
+struct CheckBasesAreDeviceCopyable;
+
+template <typename T, unsigned... FieldIds>
+struct CheckFieldsAreDeviceCopyable<T, std::index_sequence<FieldIds...>> {
+  static_assert(
+      ((is_device_copyable_v<decltype(__builtin_field_type(T, FieldIds))> &&
+        ...)),
+      "The specified type is not device copyable");
 };
 
-template <typename T> struct CheckFieldsAreDeviceCopyable<T, 0> {};
-
-// Checks that the base classes of the type T with indices 0 to
-// (NumFieldsToCheck - 1) are device copyable.
-template <typename T, unsigned NumBasesToCheck>
-struct CheckBasesAreDeviceCopyable
-    : CheckBasesAreDeviceCopyable<T, NumBasesToCheck - 1> {
-  using BaseT = decltype(__builtin_base_type(T, NumBasesToCheck - 1));
-  static_assert(is_device_copyable_v<BaseT>,
-                "The specified type is not device copyable");
+template <typename T, unsigned... BaseIds>
+struct CheckBasesAreDeviceCopyable<T, std::index_sequence<BaseIds...>> {
+  static_assert(
+      ((is_device_copyable_v<decltype(__builtin_base_type(T, BaseIds))> &&
+        ...)),
+      "The specified type is not device copyable");
 };
-
-template <typename T> struct CheckBasesAreDeviceCopyable<T, 0> {};
 
 // All the captures of a lambda or functor of type FuncT passed to a kernel
 // must be is_device_copyable, which extends to bases and fields of FuncT.
@@ -127,8 +124,10 @@ template <typename T> struct CheckBasesAreDeviceCopyable<T, 0> {};
 // is currently/temporarily supported only to not break older SYCL programs.
 template <typename FuncT>
 struct CheckDeviceCopyable
-    : CheckFieldsAreDeviceCopyable<FuncT, __builtin_num_fields(FuncT)>,
-      CheckBasesAreDeviceCopyable<FuncT, __builtin_num_bases(FuncT)> {};
+    : CheckFieldsAreDeviceCopyable<
+          FuncT, std::make_index_sequence<__builtin_num_fields(FuncT)>>,
+      CheckBasesAreDeviceCopyable<
+          FuncT, std::make_index_sequence<__builtin_num_bases(FuncT)>> {};
 
 template <typename TransformedArgType, int Dims, typename KernelType>
 class RoundedRangeKernel;

--- a/sycl/test/basic_tests/is_device_copyable_neg.cpp
+++ b/sycl/test/basic_tests/is_device_copyable_neg.cpp
@@ -1,5 +1,4 @@
-// RUN: not %clangxx -fsycl -fsycl-device-only -fsyntax-only \
-// RUN: %s -I %sycl_include 2>&1 | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=warning,note %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // a struct with type that is not device copyable as SYCL kernel parameter.
@@ -57,6 +56,7 @@ void test() {
   B IamAlsoBad{0};
   marray<B, 2> MarrayForNotCopyable;
   queue Q;
+  // expected-error@*:* {{static assertion failed due to requirement 'is_device_copyable_v<A>': The specified type is not device copyable}}
   Q.single_task<class TestA>([=] {
     int A = IamBad.i;
     int B = IamAlsoBad.i;
@@ -64,23 +64,10 @@ void test() {
   });
 
   FunctorA FA;
+  // expected-error@*:* {{static assertion failed due to requirement 'is_device_copyable_v<C>': The specified type is not device copyable}}
   Q.single_task<class TestB>(FA);
 
   FunctorB FB;
+  // expected-error@*:* {{static assertion failed due to requirement 'is_device_copyable_v<D>': The specified type is not device copyable}}
   Q.single_task<class TestC>(FB);
 }
-
-// CHECK: static assertion failed due to requirement 'is_device_copyable_v<A>
-// CHECK: is_device_copyable_neg.cpp:60:5: note: in instantiation of function
-
-// CHECK: static assertion failed due to requirement 'is_device_copyable_v<B>
-// CHECK: is_device_copyable_neg.cpp:60:5: note: in instantiation of function
-
-// CHECK: static assertion failed due to requirement 'is_device_copyable_v<sycl::marray<B, 2>>
-// CHECK: is_device_copyable_neg.cpp:60:5: note: in instantiation of function
-
-// CHECK: static assertion failed due to requirement 'is_device_copyable_v<C>
-// CHECK: is_device_copyable_neg.cpp:67:5: note: in instantiation of function
-
-// CHECK: static assertion failed due to requirement 'is_device_copyable_v<D>
-// CHECK: is_device_copyable_neg.cpp:70:5: note: in instantiation of function


### PR DESCRIPTION
First, that's what idiomatic C++17 is (folds over recursion), second compile of folds scales much better than recursion when the number of fields/bases grow.