### PR TITLE
[CI] Simplify nightly docker images

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -242,7 +242,7 @@ jobs:
         body: "Daily build ${{ steps.tag.outputs.TAG }}"
         target_commitish: ${{ github.sha }}
 
-  ubuntu2204_docker_build_push:
+  docker_build_push:
     if: github.repository == 'intel/llvm'
     runs-on: [Linux, build]
     permissions:
@@ -254,42 +254,16 @@ jobs:
       with:
         name: sycl_linux_default
         path: devops/
-    - name: Build and Push Container (with drivers)
+    - name: Build and Push Container
       uses: ./devops/actions/build_container
       with:
         push: ${{ github.ref_name == 'sycl' }}
-        file: ubuntu2204_preinstalled
+        file: nightly
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
         build-args: |
           base_image=ghcr.io/intel/llvm/ubuntu2404_intel_drivers
-          base_tag=latest
+          base_tag=alldeps
         tags: |
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:${{ github.sha }}
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:latest
-    - name: Build and Push Container (no drivers)
-      uses: ./devops/actions/build_container
-      with:
-        push: ${{ github.ref_name == 'sycl' }}
-        file: ubuntu2204_preinstalled
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        build-args: |
-          base_image=ghcr.io/intel/llvm/ubuntu2204_base
-          base_tag=latest
-        tags: |
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:no-drivers-${{ github.sha }}
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:no-drivers
-    - name: Build and Push Container (Build image)
-      uses: ./devops/actions/build_container
-      with:
-        push: ${{ github.ref_name == 'sycl' }}
-        file: ubuntu2204_preinstalled
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        build-args: |
-          base_image=ghcr.io/intel/llvm/ubuntu2204_build
-          base_tag=latest
-        tags: |
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build-${{ github.sha }}
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:${{ github.sha }}
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:latest

--- a/devops/containers/nightly.Dockerfile
+++ b/devops/containers/nightly.Dockerfile
@@ -1,5 +1,5 @@
-ARG base_tag=latest
-ARG base_image=ghcr.io/intel/llvm/ubuntu2204_intel_drivers
+ARG base_tag=alldeps
+ARG base_image=ghcr.io/intel/llvm/ubuntu2404_intel_drivers
 
 FROM $base_image:$base_tag
 

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -53,10 +53,6 @@ development containers:
    NVidia/AMD and can be used for building DPC++
    compiler from source with all backends enabled or for end-to-end testing
    with HIP/CUDA on machines with corresponding GPUs available.
-  - `devops/containers/sycl_ubuntu2204_nightly`: contains the latest successfully
-   built nightly build of DPC++ compiler. The Dockerfile comes in three flavors:
-   with pre-installed Intel drivers (`latest`), without them (`no-drivers`) and
-   with development kits installed (`build`).
 
 ### Ubuntu 24.04-based Dockerfiles
 
@@ -78,7 +74,8 @@ development containers:
    NVidia/AMD and can be used for building DPC++
    compiler from source with all backends enabled or for end-to-end testing
    with HIP/CUDA on machines with corresponding GPUs available.  
-
+ - `devops/containers/nightly`: contains the latest successfully
+   built nightly build of DPC++ compiler.
 
 ## Running Docker container interactively
 
@@ -199,7 +196,7 @@ Docker containers can be built with the following command:
 docker build -f path/to/devops/containers/file.Dockerfile path/to/devops/
 ```
 
-The `ubuntu2204_preinstalled.Dockerfile` script expects `llvm_sycl.tar.xz` file
+The `nightly.Dockerfile` script expects `llvm_sycl.tar.xz` file
 to be present in `devops/` directory.
 
 Containers other than base provide several configurable arguments, the most


### PR DESCRIPTION
Have a single docker image created with all the dependencies pre-installed so that it could be used for all internal CI needs for every target. Other workflows should be changed after this is merged and new image is uploaded to the registry.