### PR TITLE
[CI] Prebuild E2E tests as part of build workflow

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -14,7 +14,7 @@ on:
       build_image:
         type: string
         required: false
-        default: "ghcr.io/intel/llvm/ubuntu2404_build:latest"
+        default: "ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps"
       build_ref:
         type: string
         required: false
@@ -70,7 +70,7 @@ on:
       build_image:
         type: choice
         options:
-          - "ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build"
+          - 'ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest'
       cc:
         type: choice
         options:
@@ -252,3 +252,37 @@ jobs:
         name: sycl_linux_${{ inputs.build_artifact_suffix }}
         path: ${{ steps.artifact_info.outputs.ARCHIVE_NAME }}
         retention-days: ${{ inputs.retention-days }}
+
+    - name: Copy toolchain
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      # We must have the compiler in the same location as it will be in the E2E
+      # run-tests job.
+      run: cp -r $GITHUB_WORKSPACE/build/install $GITHUB_WORKSPACE/toolchain
+
+    - name: Source OneAPI TBB vars.sh
+      shell: bash
+      run: |
+        # https://github.com/actions/runner/issues/1964 prevents us from using
+        # the ENTRYPOINT in the image.
+        env | sort > env_before
+        if [ -e /runtimes/oneapi-tbb/env/vars.sh ]; then
+          source /runtimes/oneapi-tbb/env/vars.sh;
+        elif [ -e /opt/runtimes/oneapi-tbb/env/vars.sh ]; then
+          source /opt/runtimes/oneapi-tbb/env/vars.sh;
+        else
+          echo "no TBB vars in /opt/runtimes or /runtimes";
+        fi
+        env | sort > env_after
+        comm -13 env_before env_after >> $GITHUB_ENV
+        rm env_before env_after
+
+    - name: Build E2E tests
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      uses: ./devops/actions/run-tests/e2e
+      with:
+        ref: ${{ inputs.ref || github.sha }}
+        merge_ref: ${{ inputs.merge_ref }}
+        e2e_testing_mode: build-only
+        target_devices: all
+        artifact_suffix: default
+        cxx_compiler: $GITHUB_WORKSPACE/toolchain/bin/clang++

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -47,7 +47,7 @@ jobs:
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
       # Docker image has last nightly pre-installed and added to the PATH
-      build_image: "ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build"
+      build_image: "ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest"
       cc: clang
       cxx: clang++
       changes: ${{ needs.detect_changes.outputs.filters }}
@@ -74,23 +74,8 @@ jobs:
             echo 'arc_tests="Matrix/"' >> "$GITHUB_OUTPUT"
           fi
 
-  build_e2e_tests:
-    needs: [build]
-    if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
-    uses: ./.github/workflows/sycl-linux-run-tests.yml
-    with:
-      name: Build e2e tests
-      runner: '["Linux", "build"]'
-      image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps
-      image_options: -u 1001
-      ref: ${{ github.sha }}
-      merge_ref: ''
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.build.outputs.artifact_decompress_command }}
-      e2e_testing_mode: 'build-only'
   run_prebuilt_e2e_tests:
-    needs: [build, build_e2e_tests]
+    needs: [build]
     if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
     strategy:
       fail-fast: false

--- a/devops/actions/run-tests/e2e/action.yml
+++ b/devops/actions/run-tests/e2e/action.yml
@@ -19,6 +19,8 @@ inputs:
     required: false
   retention-days:
     required: false
+  cxx_compiler:
+    required: false
 
 
 runs:
@@ -58,7 +60,7 @@ runs:
     if: inputs.e2e_binaries_artifact == ''
     shell: bash
     run: |
-      cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="$(which clang++)" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" ${{ steps.cmake_opts.outputs.opts }}
+      cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.cxx_compiler || '$(which clang++)'}}" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" ${{ steps.cmake_opts.outputs.opts }}
   - name: SYCL End-to-end tests
     shell: bash {0}
     env:


### PR DESCRIPTION
This will allow us to save time on runner setup and toolchain download/unpacking.