### PR TITLE
[SYCL] Drop undesired fp64 aspect requirement.

### DIFF
--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
@@ -57,7 +57,7 @@ int main() {
 
   auto res = sycl::malloc_host<int>(3, ctx);
   auto KernelLambda = [=]() {
-    res[0] = sycl::ext::intel::math::float2int_rd(4.0) + (int)sqrtf(4.0f) +
+    res[0] = sycl::ext::intel::math::float2int_rd(4.0f) + (int)sqrtf(4.0f) +
              std::exp(std::complex<float>(0.f, 0.f)).real();
   };
   // Test case 1


### PR DESCRIPTION
By using `4.0` instead of `4.0f`, we're using a `double`, implicitly requiring support for `aspect::fp64`. We don't really require it.