### PR TITLE
[SYCL][Bindless][E2E] Fix post-commit from PR #16537

### DIFF
--- a/sycl/test-e2e/bindless_images/3_channel_format.cpp
+++ b/sycl/test-e2e/bindless_images/3_channel_format.cpp
@@ -1,5 +1,8 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images
 
+// Test requires at least this version of the Intel GPU driver on Arc.
+// REQUIRES-INTEL-DRIVER: lin: 32370
+
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out
 


### PR DESCRIPTION
This patch should fix the post-commit failure resulting from enabling the 3-channel image PR in https://github.com/intel/llvm/pull/16537

This is done by adding a `// REQUIRES-INTEL-DRIVER:` comment for LIT to ignore the test until the necessary driver for the functionality is introduced to the GitHub CI.