### PR TITLE
[SYCL][Doc] Add test plan for sycl_ext_oneapi_device_image_backend_content extension

### DIFF
--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -73,8 +73,8 @@ free function syntax adhering to the requirements mentioned in the paragraph abo
 Then, using the device image contents and backend specific API, 
 it should create a Level Zero or OpenCL kernel object corresponding to the kernel. 
 Using interoperability API such as `sycl::make_kernel`, this kernel object can be made into a high-level SYCL kernel object.
-The test, therefore, has two versions of the same SYCL kernel one of which is constructed directly from the source code kernel using only SYCL API and the other constructed using the backend specific API and the SYCL interoperability API.
-The test should run both kernels and verify that they have same effect, for example, by writing to a variable and checking that after each kernel run, the variable has the same value. 
+The test, therefore, has two versions of the same SYCL kernel one of which is constructed directly from the source code kernel using only SYCL API and the other constructed using the`sycl_ext_oneapi_device_image_backend_content` API, backend specific API and the SYCL interoperability API.
+The test should run both kernels and verify that they have the same effect, for example, by writing to a variable and checking that after each kernel run, the variable has the same value. 
 
 The test requires either Level Zero or OpenCL backend and development kits to be available
 in the testing environment. 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -49,7 +49,7 @@ The test needs to check that `ext_oneapi_get_backend` returns the
 same value as `sycl::kernel_bundle::get_backend` on the kernel bundle
 that contains the image.
 
-#### Consistency of backend contents and a view of the backend contents
+#### Consistency of image contents and a view of the image contents
 
 The test needs to check that the values returned by `ext_oneapi_get_backend_content` and
 `ext_oneapi_get_backend_content_view` have the same contents.

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -1,0 +1,81 @@
+# Test plan for [`sycl_ext_oneapi_device_image_backend_content`][spec-link] extension
+
+## Testing scope
+
+### Device coverage
+
+The unit tests must be launched on every supported device configuration we have.
+
+The end-to-end tests, which consist of checking the interoperability with Level Zero
+and OpenCL backends, must be run on devices that are exposed through these 
+low-level interfaces.
+
+### Type coverage
+
+All of the APIs introduced by this extension are not templated and do not have any
+arguments. 
+
+There are however, some requirements related to the value of the 
+`State` template parameter of the `device_image` class on which these 
+APIs are defined. In particular, the `ext_oneapi_device_image_backend_content` 
+and `ext_oneapi_device_image_backend_content_view` functions are only 
+available when `State == sycl::bundle_state::executable`. 
+Tests shouls verify that these functions are indeed only available when this equality occurs.
+
+## Tests
+
+### Unit tests
+
+#### Interface tests
+
+These tests are intended to check that all classes and methods defined by the
+extension have correct implementation, i.e.: right signatures, right return
+types, all necessary constraints are checked/enforced, etc.
+
+These tests must check the following:
+
+- that diagnostic is emitted when `ext_oneapi_get_backend_content` or
+  `ext_oneapi_get_backend_content_view` functions are called and 
+  `State != sycl::bundle_state::executable`
+- the return types of all functions match the spec
+
+Tests in this category may not perform some useful actions to exercise the
+extension functionality in full, but instead they are focused on making sure
+that all APIs are consistent with respect to other APIs.
+
+#### Consistency of backend API
+
+The test needs to check that `ext_oneapi_get_backend` returns the 
+same value as `sycl::kernel_bundle::get_backend` on the kernel bundle
+that contains the image.
+
+#### Consistency of backend contents and a view of the backend contents
+
+The test needs to check that the values returned by `ext_oneapi_get_backend_content` and
+`ext_oneapi_get_backend_content_view` have the same contents.
+
+### End-to-end tests
+
+Tests in this category perform some meaningful actions with the extension to
+see that the extension works in a scenarios which mimic real-life usage of the
+extension.
+
+#### Level Zero and OpenCL interoperability
+
+In general, it is not possible to interpret the device image contents returned by this API 
+in such a way that allows us to retrieve specific kernels inside the device image.
+However, under the conditions that the device be managed by an Level Zero or OpenCL backend and the 
+kernel is defined using the free function syntax, it is possible to retrieve the 
+kernel from the device image contents.
+
+This test selects a Level Zero or OpenCL backend device and defines a simple kernel using 
+free function syntax. Then, using the device image contents and backend specific API, 
+it should create a Level Zero or OpenCL kernel object corresponding to the kernel. 
+Using interoperability API, this kernel object can be made into a high-level SYCL kernel object.
+The test should then run this kernel on the device and verify that it has the same effects as running 
+the original kernel directly on the device, that is, by only using high-level SYCL API.
+
+The test requires either Level Zero or OpenCL backend and development kits to be available
+in the testing environment. 
+
+[spec-link]: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_image_backend_content.asciidoc

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -57,7 +57,7 @@ The test needs to check that the values returned by `ext_oneapi_get_backend_cont
 ### End-to-end tests
 
 Tests in this category perform some meaningful actions with the extension to
-see that the extension works in a scenarios which mimic real-life usage of the
+see that the extension works in scenarios which mimic real-life usage of the
 extension.
 
 #### Level Zero and OpenCL interoperability

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -72,9 +72,9 @@ This test selects a Level Zero or OpenCL backend device and defines a simple ker
 free function syntax adhering to the requirements mentioned in the paragraph above. 
 Then, using the device image contents and backend specific API, 
 it should create a Level Zero or OpenCL kernel object corresponding to the kernel. 
-Using interoperability API, this kernel object can be made into a high-level SYCL kernel object.
-The test should then run this kernel on the device and verify that it has the same effects as running 
-the original kernel directly on the device, that is, by only using high-level SYCL API.
+Using interoperability API such as `sycl::make_kernel`, this kernel object can be made into a high-level SYCL kernel object.
+The test, therefore, has two versions of the same SYCL kernel one of which is constructed directly from the source code kernel using only SYCL API and the other constructed using the backend specific API and the SYCL interoperability API.
+The test should run both kernels and verify that they have same effect, for example, by writing to a variable and checking that after each kernel run, the variable has the same value. 
 
 The test requires either Level Zero or OpenCL backend and development kits to be available
 in the testing environment. 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -65,7 +65,7 @@ extension.
 In general, it is not possible to interpret the device image contents returned by this API 
 in such a way that allows us to retrieve specific kernels inside the device image.
 However, under the conditions that the device be managed by an Level Zero or OpenCL backend and the 
-kernel is defined using the requirements link:{ref1}[here], it is possible to retrieve the 
+kernel is defined using the requirements [here][ref-link], it is possible to retrieve the 
 kernel from the device image contents.
 
 This test selects a Level Zero or OpenCL backend device and defines a simple kernel using 
@@ -78,5 +78,5 @@ the original kernel directly on the device, that is, by only using high-level SY
 The test requires either Level Zero or OpenCL backend and development kits to be available
 in the testing environment. 
 
-:ref1: ../proposed/sycl_ext_oneapi_free_function_kernels.asciidoc#level-zero-and-opencl-compatibility
+[ref-link]: ../proposed/sycl_ext_oneapi_free_function_kernels.asciidoc#level-zero-and-opencl-compatibility
 [spec-link]: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_image_backend_content.asciidoc

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -4,10 +4,10 @@
 
 ### Device coverage
 
-The unit tests must be launched on every supported device configuration we have.
+The unit tests should be launched on every supported device configuration we have.
 
 The end-to-end tests, which consist of checking the interoperability with Level Zero
-and OpenCL backends, must be run on devices that are exposed through these 
+and OpenCL backends, should be run on devices that are exposed through these 
 low-level interfaces.
 
 ### Type coverage
@@ -17,10 +17,10 @@ arguments.
 
 There are, however, some requirements related to the value of the 
 `State` template parameter of the `device_image` class on which these 
-APIs are defined. In particular, the `ext_oneapi_backend_content` 
-and `ext_oneapi_backend_content_view` functions are only 
+APIs are defined. In particular, the `ext_oneapi_get_backend_content` 
+and `ext_oneapi_get_backend_content_view` functions are only 
 available when `State == sycl::bundle_state::executable`. 
-Tests shouls verify that these functions are indeed only available when this equality occurs.
+Tests should verify that these functions are indeed only available when this equality occurs.
 
 ## Tests
 
@@ -32,7 +32,7 @@ These tests are intended to check that all classes and methods defined by the
 extension have correct implementation, i.e.: right signatures, right return
 types, all necessary constraints are checked/enforced, etc.
 
-These tests must check the following:
+These tests should check the following:
 
 - that diagnostic is emitted when `ext_oneapi_get_backend_content` or
   `ext_oneapi_get_backend_content_view` functions are called and 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -74,7 +74,7 @@ Then, using the device image contents and backend specific API,
 it should create a Level Zero or OpenCL kernel object corresponding to the kernel. 
 Using interoperability API such as `sycl::make_kernel`, this kernel object can be made into a high-level SYCL kernel object.
 The test, therefore, has two versions of the same SYCL kernel, one of which is constructed directly from the source code kernel using only SYCL API and the other constructed using the`sycl_ext_oneapi_device_image_backend_content` API, backend specific API and the SYCL interoperability API.
-The test should run both kernels and verify that they have the same effect, for example, by having the kernel write the same value to two distinct memory locations and checking that after both kernels have run, both memory locations have the same value. 
+The test should run both kernels and verify that they have the same effect, for example, by having the kernel write a specific value to a memory location passed as a kernel argument and checking that after both kernels have run, both memory locations have the same value. 
 
 The test requires either Level Zero or OpenCL backend and development kits to be available
 in the testing environment. 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -15,7 +15,7 @@ low-level interfaces.
 All of the APIs introduced by this extension are not templated and do not have any
 arguments. 
 
-There are however, some requirements related to the value of the 
+There are, however, some requirements related to the value of the 
 `State` template parameter of the `device_image` class on which these 
 APIs are defined. In particular, the `ext_oneapi_backend_content` 
 and `ext_oneapi_backend_content_view` functions are only 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -65,7 +65,7 @@ extension.
 In general, it is not possible to interpret the device image contents returned by this API 
 in such a way that allows us to retrieve specific kernels inside the device image.
 However, under the conditions that the device be managed by an Level Zero or OpenCL backend and the 
-kernel is defined using the free function syntax, it is possible to retrieve the 
+kernel is defined using the requirements link:{ref1}[here], it is possible to retrieve the 
 kernel from the device image contents.
 
 This test selects a Level Zero or OpenCL backend device and defines a simple kernel using 
@@ -78,4 +78,5 @@ the original kernel directly on the device, that is, by only using high-level SY
 The test requires either Level Zero or OpenCL backend and development kits to be available
 in the testing environment. 
 
+:ref1: ../proposed/sycl_ext_oneapi_free_function_kernels.asciidoc#level-zero-and-opencl-compatibility
 [spec-link]: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_image_backend_content.asciidoc

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -74,7 +74,7 @@ Then, using the device image contents and backend specific API,
 it should create a Level Zero or OpenCL kernel object corresponding to the kernel. 
 Using interoperability API such as `sycl::make_kernel`, this kernel object can be made into a high-level SYCL kernel object.
 The test, therefore, has two versions of the same SYCL kernel, one of which is constructed directly from the source code kernel using only SYCL API and the other constructed using the`sycl_ext_oneapi_device_image_backend_content` API, backend specific API and the SYCL interoperability API.
-The test should run both kernels and verify that they have the same effect, for example, by writing to a variable and checking that after each kernel run, the variable has the same value. 
+The test should run both kernels and verify that they have the same effect, for example, by having the kernel write the same value to two distinct memory locations and checking that after both kernels have run, both memory locations have the same value. 
 
 The test requires either Level Zero or OpenCL backend and development kits to be available
 in the testing environment. 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -69,7 +69,8 @@ kernel is defined using the requirements [here][ref-link], it is possible to ret
 kernel from the device image contents.
 
 This test selects a Level Zero or OpenCL backend device and defines a simple kernel using 
-free function syntax. Then, using the device image contents and backend specific API, 
+free function syntax adhering to the requirements mentioned in the paragraph above. 
+Then, using the device image contents and backend specific API, 
 it should create a Level Zero or OpenCL kernel object corresponding to the kernel. 
 Using interoperability API, this kernel object can be made into a high-level SYCL kernel object.
 The test should then run this kernel on the device and verify that it has the same effects as running 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -73,7 +73,7 @@ free function syntax adhering to the requirements mentioned in the paragraph abo
 Then, using the device image contents and backend specific API, 
 it should create a Level Zero or OpenCL kernel object corresponding to the kernel. 
 Using interoperability API such as `sycl::make_kernel`, this kernel object can be made into a high-level SYCL kernel object.
-The test, therefore, has two versions of the same SYCL kernel one of which is constructed directly from the source code kernel using only SYCL API and the other constructed using the`sycl_ext_oneapi_device_image_backend_content` API, backend specific API and the SYCL interoperability API.
+The test, therefore, has two versions of the same SYCL kernel, one of which is constructed directly from the source code kernel using only SYCL API and the other constructed using the`sycl_ext_oneapi_device_image_backend_content` API, backend specific API and the SYCL interoperability API.
 The test should run both kernels and verify that they have the same effect, for example, by writing to a variable and checking that after each kernel run, the variable has the same value. 
 
 The test requires either Level Zero or OpenCL backend and development kits to be available

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -17,8 +17,8 @@ arguments.
 
 There are however, some requirements related to the value of the 
 `State` template parameter of the `device_image` class on which these 
-APIs are defined. In particular, the `ext_oneapi_device_image_backend_content` 
-and `ext_oneapi_device_image_backend_content_view` functions are only 
+APIs are defined. In particular, the `ext_oneapi_backend_content` 
+and `ext_oneapi_backend_content_view` functions are only 
 available when `State == sycl::bundle_state::executable`. 
 Tests shouls verify that these functions are indeed only available when this equality occurs.
 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -6,9 +6,8 @@
 
 The unit tests should be launched on every supported device configuration we have.
 
-The end-to-end tests, which consist of checking the interoperability with Level Zero
-and OpenCL backends, should be run on devices that are exposed through these 
-low-level interfaces.
+The end-to-end tests, which consist of checking the interoperability with Level Zero, OpenCL and CUDA backends, 
+should be run on devices that are exposed through these low-level interfaces.
 
 ### Type coverage
 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -84,5 +84,7 @@ in the testing environment.
 Unlike above, for CUDA, there is not a portable way to retrieve a SYCL kernel from a CUBIN module. 
 This test, therefore, will simply get the contents of the CUBIN module and use `cuModuleLoadData` to create a module object out of the image contents and verify that `CUDA_SUCCESS` is returned. 
 
+The test requires CUDA backend and development kit to be available in the testing environment.
+
 [ref-link]: ../proposed/sycl_ext_oneapi_free_function_kernels.asciidoc#level-zero-and-opencl-compatibility
 [spec-link]: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_image_backend_content.asciidoc

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -1,4 +1,4 @@
-#Test plan for [`sycl_ext_oneapi_device_image_backend_content`][spec-link] extension
+# Test plan for [`sycl_ext_oneapi_device_image_backend_content`][spec-link] extension
 
 ## Testing scope
 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -77,7 +77,12 @@ The test, therefore, has two versions of the same SYCL kernel, one of which is c
 The test should run both kernels and verify that they have the same effect, for example, by having the kernel write a specific value to a memory location passed as a kernel argument and checking that after both kernels have run, both memory locations have the same value. 
 
 The test requires either Level Zero or OpenCL backend and development kits to be available
-in the testing environment. 
+in the testing environment.
+
+### CUDA interoperability
+
+Unlike above, for CUDA, there is not a portable way to retrieve a SYCL kernel from a CUBIN module. 
+This test, therefore, will simply get the contents of the CUBIN module and use `cuModuleLoadData` to create a module object out of the image contents and verify that `CUDA_SUCCESS` is returned. 
 
 [ref-link]: ../proposed/sycl_ext_oneapi_free_function_kernels.asciidoc#level-zero-and-opencl-compatibility
 [spec-link]: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_image_backend_content.asciidoc

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -1,5 +1,4 @@
-#Test plan for [`sycl_ext_oneapi_device_image_backend_content`][spec-link] 
-#extension
+#Test plan for [`sycl_ext_oneapi_device_image_backend_content`][spec-link] extension
 
 ## Testing scope
 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -1,4 +1,5 @@
-# Test plan for [`sycl_ext_oneapi_device_image_backend_content`][spec-link] extension
+# Test plan for [`sycl_ext_oneapi_device_image_backend_content`][spec-link] 
+# extension
 
 ## Testing scope
 

--- a/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
+++ b/sycl/test-e2e/DeviceImageBackendContent/test_plan.md
@@ -1,25 +1,29 @@
-# Test plan for [`sycl_ext_oneapi_device_image_backend_content`][spec-link] extension
+#Test plan for [`sycl_ext_oneapi_device_image_backend_content`][spec-link] 
+#extension
 
 ## Testing scope
 
 ### Device coverage
 
-The unit tests should be launched on every supported device configuration we have.
+The unit tests should be launched on every supported device configuration we
+have.
 
-The end-to-end tests, which consist of checking the interoperability with Level Zero, OpenCL and CUDA backends, 
-should be run on devices that are exposed through these low-level interfaces.
+The end-to-end tests, which consist of checking the interoperability with 
+Level Zero, OpenCL and CUDA backends, should be run on devices that are 
+exposed through these low-level interfaces.
 
 ### Type coverage
 
-All of the APIs introduced by this extension are not templated and do not have any
-arguments. 
+All of the APIs introduced by this extension are not templated and do not have
+any arguments. 
 
 There are, however, some requirements related to the value of the 
 `State` template parameter of the `device_image` class on which these 
 APIs are defined. In particular, the `ext_oneapi_get_backend_content` 
 and `ext_oneapi_get_backend_content_view` functions are only 
 available when `State == sycl::bundle_state::executable`. 
-Tests should verify that these functions are indeed only available when this equality occurs.
+Tests should verify that these functions are indeed only 
+available when this equality occurs.
 
 ## Tests
 
@@ -50,8 +54,9 @@ that contains the image.
 
 #### Consistency of image contents and a view of the image contents
 
-The test needs to check that the values returned by `ext_oneapi_get_backend_content` and
-`ext_oneapi_get_backend_content_view` have the same contents.
+The test needs to check that the values returned by 
+`ext_oneapi_get_backend_content` and `ext_oneapi_get_backend_content_view` 
+have the same contents.
 
 ### End-to-end tests
 
@@ -61,29 +66,41 @@ extension.
 
 #### Level Zero and OpenCL interoperability
 
-In general, it is not possible to interpret the device image contents returned by this API 
-in such a way that allows us to retrieve specific kernels inside the device image.
-However, under the conditions that the device be managed by an Level Zero or OpenCL backend and the 
-kernel is defined using the requirements [here][ref-link], it is possible to retrieve the 
-kernel from the device image contents.
+In general, it is not possible to interpret the device image contents returned
+ by this API in such a way that allows us to retrieve specific kernels inside
+the device image. However, under the conditions that the device be managed by 
+an Level Zero or OpenCL backend and the kernel is defined using the
+requirements [here][ref-link], it is possible to retrieve the kernel from the
+ device image contents.
 
-This test selects a Level Zero or OpenCL backend device and defines a simple kernel using 
-free function syntax adhering to the requirements mentioned in the paragraph above. 
-Then, using the device image contents and backend specific API, 
-it should create a Level Zero or OpenCL kernel object corresponding to the kernel. 
-Using interoperability API such as `sycl::make_kernel`, this kernel object can be made into a high-level SYCL kernel object.
-The test, therefore, has two versions of the same SYCL kernel, one of which is constructed directly from the source code kernel using only SYCL API and the other constructed using the`sycl_ext_oneapi_device_image_backend_content` API, backend specific API and the SYCL interoperability API.
-The test should run both kernels and verify that they have the same effect, for example, by having the kernel write a specific value to a memory location passed as a kernel argument and checking that after both kernels have run, both memory locations have the same value. 
+This test selects a Level Zero or OpenCL backend device and defines a simple
+kernel using free function syntax adhering to the requirements mentioned in
+the paragraph above. Then, using the device image contents and backend
+specific API, it should create a Level Zero or OpenCL kernel object
+corresponding to the kernel. Using interoperability API such as
+`sycl::make_kernel`, this kernel object can be made into a high-level SYCL
+kernel object. The test, therefore, has two versions of the same SYCL
+kernel, one of which is constructed directly from the source code kernel
+using only SYCL API and the other constructed using the
+`sycl_ext_oneapi_device_image_backend_content` API, backend specific API and
+the SYCL interoperability API. The test should run both kernels and verify
+that they have the same effect, for example, by having the kernel write a
+specific value to a memory location passed as a kernel argument and
+checking that after both kernels have run, both memory locations have the
+same value.
 
-The test requires either Level Zero or OpenCL backend and development kits to be available
-in the testing environment.
+The test requires either Level Zero or OpenCL backend and development kits
+to be available in the testing environment.
 
 ### CUDA interoperability
 
-Unlike above, for CUDA, there is not a portable way to retrieve a SYCL kernel from a CUBIN module. 
-This test, therefore, will simply get the contents of the CUBIN module and use `cuModuleLoadData` to create a module object out of the image contents and verify that `CUDA_SUCCESS` is returned. 
+Unlike above, for CUDA, there is not a portable way to retrieve a SYCL
+kernel from a CUBIN module. This test, therefore, will simply get the
+contents of the CUBIN module and use `cuModuleLoadData` to create a module
+object out of the image contents and verify that `CUDA_SUCCESS` is returned.
 
-The test requires CUDA backend and development kit to be available in the testing environment.
+The test requires CUDA backend and development kit to be available in the
+testing environment.
 
 [ref-link]: ../proposed/sycl_ext_oneapi_free_function_kernels.asciidoc#level-zero-and-opencl-compatibility
 [spec-link]: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_image_backend_content.asciidoc


### PR DESCRIPTION
This PR adds the test plan for [sycl_ext_oneapi_device_image_backend_content](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_image_backend_content.asciidoc) extension.