### PR TITLE
[SYCL] Deprecate current implementations of get_backend_info()

### DIFF
--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -184,9 +184,11 @@ public:
 #endif
 #endif
             >
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   __SYCL_DEPRECATED(
       "All current implementations of get_backend_info() are to be removed. "
       "Use respective variants of get_info() instead.")
+#endif
   typename detail::is_backend_info_desc<Param>::return_type
       get_backend_info() const;
 

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -177,13 +177,18 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<context, Param>()
 #endif
+#endif
             >
+  __SYCL_DEPRECATED(
+      "All current implementations of get_backend_info() are to be removed. "
+      "Use respective variants of get_info() instead.")
   typename detail::is_backend_info_desc<Param>::return_type
-  get_backend_info() const;
+      get_backend_info() const;
 
   context(const context &rhs) = default;
 

--- a/sycl/include/sycl/detail/info_desc_helpers.hpp
+++ b/sycl/include/sycl/detail/info_desc_helpers.hpp
@@ -129,6 +129,7 @@ struct IsKernelInfo<info::kernel_device_specific::ext_codeplay_num_regs>
 #include <sycl/info/sycl_backend_traits.def>
 #undef __SYCL_PARAM_TRAITS_SPEC
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <typename SyclObject, typename Param>
 constexpr int emit_get_backend_info_error() {
   // Implementation of get_backend_info doesn't seem to be aligned with the
@@ -140,6 +141,7 @@ constexpr int emit_get_backend_info_error() {
                 "This interface is incompatible with _GLIBCXX_USE_CXX11_ABI=0");
   return 0;
 }
+#endif
 
 } // namespace detail
 } // namespace _V1

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -229,9 +229,11 @@ public:
 #endif
 #endif
             >
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   __SYCL_DEPRECATED(
       "All current implementations of get_backend_info() are to be removed. "
       "Use respective variants of get_info() instead.")
+#endif
   typename detail::is_backend_info_desc<Param>::return_type
       get_backend_info() const;
 

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -222,13 +222,18 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<device, Param>()
 #endif
+#endif
             >
+  __SYCL_DEPRECATED(
+      "All current implementations of get_backend_info() are to be removed. "
+      "Use respective variants of get_info() instead.")
   typename detail::is_backend_info_desc<Param>::return_type
-  get_backend_info() const;
+      get_backend_info() const;
 
   /// Check SYCL extension support by device
   ///

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -119,9 +119,11 @@ public:
 #endif
 #endif
             >
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   __SYCL_DEPRECATED(
       "All current implementations of get_backend_info() are to be removed. "
       "Use respective variants of get_info() instead.")
+#endif
   typename detail::is_backend_info_desc<Param>::return_type
       get_backend_info() const;
 

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -112,13 +112,18 @@ public:
   ///
   /// \return depends on information being queried.
   template <typename Param
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<event, Param>()
 #endif
+#endif
             >
+  __SYCL_DEPRECATED(
+      "All current implementations of get_backend_info() are to be removed. "
+      "Use respective variants of get_info() instead.")
   typename detail::is_backend_info_desc<Param>::return_type
-  get_backend_info() const;
+      get_backend_info() const;
 
   /// Queries this SYCL event for profiling information.
   ///

--- a/sycl/include/sycl/info/device_traits_deprecated.def
+++ b/sycl/include/sycl/info/device_traits_deprecated.def
@@ -1,6 +1,6 @@
 // Deprecated and not part of SYCL 2020 spec
 __SYCL_PARAM_TRAITS_DEPRECATED(image_max_array_size,"support for image arrays has been removed in SYCL 2020")
-__SYCL_PARAM_TRAITS_DEPRECATED(opencl_c_version,"use device::get_backend_info instead")
+__SYCL_PARAM_TRAITS_DEPRECATED(opencl_c_version,"use device::get_info instead")
 __SYCL_PARAM_TRAITS_DEPRECATED(atomic64, "use sycl::aspect::atomic64 instead")
 
 //TODO:Remove when possible

--- a/sycl/include/sycl/info/sycl_backend_traits.def
+++ b/sycl/include/sycl/info/sycl_backend_traits.def
@@ -1,3 +1,5 @@
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 __SYCL_PARAM_TRAITS_SPEC(platform, version, std::string, PI_PLATFORM_INFO_VERSION)
 __SYCL_PARAM_TRAITS_SPEC(device, version, std::string, PI_DEVICE_INFO_VERSION)
 __SYCL_PARAM_TRAITS_SPEC(device, backend_version, std::string, PI_DEVICE_INFO_BACKEND_VERSION)
+#endif

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -139,9 +139,11 @@ public:
 #endif
 #endif
             >
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   __SYCL_DEPRECATED(
       "All current implementations of get_backend_info() are to be removed. "
       "Use respective variants of get_info() instead.")
+#endif
   typename detail::is_backend_info_desc<Param>::return_type
       get_backend_info() const;
 

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -132,13 +132,18 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<kernel, Param>()
 #endif
+#endif
             >
+  __SYCL_DEPRECATED(
+      "All current implementations of get_backend_info() are to be removed. "
+      "Use respective variants of get_info() instead.")
   typename detail::is_backend_info_desc<Param>::return_type
-  get_backend_info() const;
+      get_backend_info() const;
 
   /// Query device-specific information from the kernel object using the
   /// info::kernel_device_specific descriptor.

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -150,13 +150,18 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<platform, Param>()
 #endif
+#endif
             >
+  __SYCL_DEPRECATED(
+      "All current implementations of get_backend_info() are to be removed. "
+      "Use respective variants of get_info() instead.")
   typename detail::is_backend_info_desc<Param>::return_type
-  get_backend_info() const;
+      get_backend_info() const;
 
   /// Returns all available SYCL platforms in the system.
   ///

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -157,9 +157,11 @@ public:
 #endif
 #endif
             >
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   __SYCL_DEPRECATED(
       "All current implementations of get_backend_info() are to be removed. "
       "Use respective variants of get_info() instead.")
+#endif
   typename detail::is_backend_info_desc<Param>::return_type
       get_backend_info() const;
 

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -358,9 +358,11 @@ public:
 #endif
 #endif
             >
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   __SYCL_DEPRECATED(
       "All current implementations of get_backend_info() are to be removed. "
       "Use respective variants of get_info() instead.")
+#endif
   typename detail::is_backend_info_desc<Param>::return_type
       get_backend_info() const;
 

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -351,13 +351,18 @@ public:
   ///
   /// The return type depends on information being queried.
   template <typename Param
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
             ,
             int = detail::emit_get_backend_info_error<queue, Param>()
 #endif
+#endif
             >
+  __SYCL_DEPRECATED(
+      "All current implementations of get_backend_info() are to be removed. "
+      "Use respective variants of get_info() instead.")
   typename detail::is_backend_info_desc<Param>::return_type
-  get_backend_info() const;
+      get_backend_info() const;
 
 private:
   // A shorthand for `get_device().has()' which is expected to be a bit quicker

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -224,6 +224,7 @@ context_impl::get_info<info::context::atomic_fence_scope_capabilities>() const {
   return CapabilityList;
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::platform::version::return_type
 context_impl::get_backend_info<info::platform::version>() const {
@@ -234,10 +235,12 @@ context_impl::get_backend_info<info::platform::version>() const {
   }
   return MDevices[0].get_platform().get_info<info::platform::version>();
 }
+#endif
 
 device select_device(DSelectorInvocableType DeviceSelectorInvocable,
                      std::vector<device> &Devices);
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::version::return_type
 context_impl::get_backend_info<info::device::version>() const {
@@ -254,7 +257,9 @@ context_impl::get_backend_info<info::device::version>() const {
   return select_device(default_selector_v, Devices)
       .get_info<info::device::version>();
 }
+#endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::backend_version::return_type
 context_impl::get_backend_info<info::device::backend_version>() const {
@@ -268,6 +273,7 @@ context_impl::get_backend_info<info::device::backend_version>() const {
   // information descriptor and implementations are encouraged to return the
   // empty string as per specification.
 }
+#endif
 
 ur_context_handle_t &context_impl::getHandleRef() { return MContext; }
 const ur_context_handle_t &context_impl::getHandleRef() const {

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -131,6 +131,7 @@ typename Param::return_type device_impl::get_info() const {
 #include <sycl/info/ext_oneapi_device_traits.def>
 #undef __SYCL_PARAM_TRAITS_SPEC
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::platform::version::return_type
 device_impl::get_backend_info<info::platform::version>() const {
@@ -141,7 +142,9 @@ device_impl::get_backend_info<info::platform::version>() const {
   }
   return get_platform().get_info<info::platform::version>();
 }
+#endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::version::return_type
 device_impl::get_backend_info<info::device::version>() const {
@@ -152,7 +155,9 @@ device_impl::get_backend_info<info::device::version>() const {
   }
   return get_info<info::device::version>();
 }
+#endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::backend_version::return_type
 device_impl::get_backend_info<info::device::backend_version>() const {
@@ -166,6 +171,7 @@ device_impl::get_backend_info<info::device::backend_version>() const {
   // information descriptor and implementations are encouraged to return the
   // empty string as per specification.
 }
+#endif
 
 bool device_impl::has_extension(const std::string &ExtensionName) const {
   std::string AllExtensionNames =

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -418,6 +418,7 @@ event_impl::get_info<info::event::command_execution_status>() {
              : info::event_command_status::complete;
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::platform::version::return_type
 event_impl::get_backend_info<info::platform::version>() const {
@@ -438,7 +439,9 @@ event_impl::get_backend_info<info::platform::version>() const {
   // so return empty string.
   return "";
 }
+#endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::version::return_type
 event_impl::get_backend_info<info::device::version>() const {
@@ -456,7 +459,9 @@ event_impl::get_backend_info<info::device::version>() const {
   return ""; // If the queue has been released, no device will be associated so
              // return empty string
 }
+#endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::backend_version::return_type
 event_impl::get_backend_info<info::device::backend_version>() const {
@@ -473,6 +478,7 @@ event_impl::get_backend_info<info::device::backend_version>() const {
   // information descriptor and implementations are encouraged to return the
   // empty string as per specification.
 }
+#endif
 
 void HostProfilingInfo::start() { StartTime = getTimestamp(); }
 

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -106,6 +106,7 @@ void kernel_impl::checkIfValidForNumArgsInfoQuery() const {
       "interoperability function or to query a device built-in kernel");
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::platform::version::return_type
 kernel_impl::get_backend_info<info::platform::version>() const {
@@ -117,10 +118,12 @@ kernel_impl::get_backend_info<info::platform::version>() const {
   auto Devices = MKernelBundleImpl->get_devices();
   return Devices[0].get_platform().get_info<info::platform::version>();
 }
+#endif
 
 device select_device(DSelectorInvocableType DeviceSelectorInvocable,
                      std::vector<device> &Devices);
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::version::return_type
 kernel_impl::get_backend_info<info::device::version>() const {
@@ -137,7 +140,9 @@ kernel_impl::get_backend_info<info::device::version>() const {
   return select_device(default_selector_v, Devices)
       .get_info<info::device::version>();
 }
+#endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::backend_version::return_type
 kernel_impl::get_backend_info<info::device::backend_version>() const {
@@ -151,6 +156,7 @@ kernel_impl::get_backend_info<info::device::backend_version>() const {
   // information descriptor and implementations are encouraged to return the
   // empty string as per specification.
 }
+#endif
 
 } // namespace detail
 } // namespace _V1

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -572,6 +572,7 @@ typename Param::return_type platform_impl::get_info() const {
   return get_platform_info<Param>(this->getHandleRef(), getAdapter());
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::platform::version::return_type
 platform_impl::get_backend_info<info::platform::version>() const {
@@ -582,10 +583,12 @@ platform_impl::get_backend_info<info::platform::version>() const {
   }
   return get_info<info::platform::version>();
 }
+#endif
 
 device select_device(DSelectorInvocableType DeviceSelectorInvocable,
                      std::vector<device> &Devices);
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::version::return_type
 platform_impl::get_backend_info<info::device::version>() const {
@@ -602,7 +605,9 @@ platform_impl::get_backend_info<info::device::version>() const {
   return select_device(default_selector_v, Devices)
       .get_info<info::device::version>();
 }
+#endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::backend_version::return_type
 platform_impl::get_backend_info<info::device::backend_version>() const {
@@ -616,6 +621,7 @@ platform_impl::get_backend_info<info::device::backend_version>() const {
   // information descriptor and implementations are encouraged to return the
   // empty string as per specification.
 }
+#endif
 
 // All devices on the platform must have the given aspect.
 bool platform_impl::has(aspect Aspect) const {

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -73,6 +73,7 @@ template <> device queue_impl::get_info<info::queue::device>() const {
   return get_device();
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::platform::version::return_type
 queue_impl::get_backend_info<info::platform::version>() const {
@@ -83,7 +84,9 @@ queue_impl::get_backend_info<info::platform::version>() const {
   }
   return get_device().get_platform().get_info<info::platform::version>();
 }
+#endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::version::return_type
 queue_impl::get_backend_info<info::device::version>() const {
@@ -94,7 +97,9 @@ queue_impl::get_backend_info<info::device::version>() const {
   }
   return get_device().get_info<info::device::version>();
 }
+#endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::device::backend_version::return_type
 queue_impl::get_backend_info<info::device::backend_version>() const {
@@ -108,6 +113,7 @@ queue_impl::get_backend_info<info::device::backend_version>() const {
   // information descriptor and implementations are encouraged to return the
   // empty string as per specification.
 }
+#endif
 
 static event prepareSYCLEventAssociatedWithQueue(
     const std::shared_ptr<detail::queue_impl> &QueueImpl) {

--- a/sycl/test-e2e/Basic/backend_info.cpp
+++ b/sycl/test-e2e/Basic/backend_info.cpp
@@ -1,7 +1,8 @@
-// RUN: %{build} -o %t.out
+// RUN: %{build} -o %t.out -Wno-deprecated-declarations
 // RUN: %{run} %t.out
 //
-// RUN: %{build} -DTEST_ERRORS -D_GLIBCXX_USE_CXX11_ABI=0 -fsyntax-only -Wno-error=unused-command-line-argument -Xclang -verify -Xclang -verify-ignore-unexpected=note
+
+// RUN: %{build} -DTEST_ERRORS -D_GLIBCXX_USE_CXX11_ABI=0 -fsyntax-only -Wno-deprecated-declarations -Wno-error=unused-command-line-argument -Xclang -verify -Xclang -verify-ignore-unexpected=note
 
 //==--- backend_info.cpp - SYCL backend info test---------------------------==//
 //

--- a/sycl/test/warnings/deprecated_get_backend_info.cpp
+++ b/sycl/test/warnings/deprecated_get_backend_info.cpp
@@ -6,6 +6,8 @@
 using namespace sycl;
 
 int main() {
+#if (defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI != 0) ||        \
+    !defined(_GLIBCXX_USE_CXX11_ABI) || TEST_ERRORS
   try {
     // Test get_backend_info for sycl::platform
     std::vector<platform> platform_list = platform::get_platforms();
@@ -105,6 +107,8 @@ int main() {
     }
     assert(has_non_opencl_backend && "unexpected error code");
   }
-  std::cout << "  Backend info query tests passed" << std::endl;
+  std::cout << "  Deprecation warning tests for get_backend_info() passed"
+            << std::endl;
+#endif
   return 0;
 }

--- a/sycl/test/warnings/deprecated_get_backend_info.cpp
+++ b/sycl/test/warnings/deprecated_get_backend_info.cpp
@@ -1,0 +1,110 @@
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+#include <iostream>
+#include <sycl/detail/core.hpp>
+#include <sycl/kernel_bundle.hpp>
+
+using namespace sycl;
+
+int main() {
+  try {
+    // Test get_backend_info for sycl::platform
+    std::vector<platform> platform_list = platform::get_platforms();
+    for (const auto &platform : platform_list) {
+      // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+      // expected-warning@+2 {{'get_backend_info<sycl::info::device::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+      std::cout << "  Backend device version: "
+                << platform.get_backend_info<info::device::version>()
+                << std::endl;
+      // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+      // expected-warning@+2 {{'get_backend_info<sycl::info::platform::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+      std::cout << "  Backend platform version: "
+                << platform.get_backend_info<info::platform::version>()
+                << std::endl;
+    }
+
+    // Test get_backend_info for sycl::device
+    std::vector<device> device_list =
+        device::get_devices(info::device_type::gpu);
+    for (const auto &device : device_list) {
+      // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+      // expected-warning@+2 {{'get_backend_info<sycl::info::device::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+      std::cout << "  Backend device version: "
+                << device.get_backend_info<info::device::version>()
+                << std::endl;
+      // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+      // expected-warning@+2 {{'get_backend_info<sycl::info::platform::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+      std::cout << "  Backend platform version: "
+                << device.get_backend_info<info::platform::version>()
+                << std::endl;
+    }
+
+    // Test get_backend_info for sycl::queue
+    queue q;
+    // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    // expected-warning@+2 {{'get_backend_info<sycl::info::device::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    std::cout << "  Backend device version: "
+              << q.get_backend_info<info::device::version>() << std::endl;
+    // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    // expected-warning@+2 {{'get_backend_info<sycl::info::platform::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    std::cout << "  Backend platform version: "
+              << q.get_backend_info<info::platform::version>() << std::endl;
+
+    // Test get_backend_info for sycl::context
+    context Ctx = q.get_context();
+    // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    // expected-warning@+2 {{'get_backend_info<sycl::info::device::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    std::cout << "  Backend device version: "
+              << Ctx.get_backend_info<info::device::version>() << std::endl;
+    // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    // expected-warning@+2 {{'get_backend_info<sycl::info::platform::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    std::cout << "  Backend platform version: "
+              << Ctx.get_backend_info<info::platform::version>() << std::endl;
+
+    // Test get_backend_info for sycl::event
+    event e = q.single_task([=]() { return; });
+    // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    // expected-warning@+2 {{'get_backend_info<sycl::info::device::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    std::cout << "  Backend device version: "
+              << e.get_backend_info<info::device::version>() << std::endl;
+    // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    // expected-warning@+2 {{'get_backend_info<sycl::info::platform::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    std::cout << "  Backend platform version: "
+              << e.get_backend_info<info::platform::version>() << std::endl;
+
+    // Test get_backend_info for sycl::kernel
+    // Trivial kernel simply for testing
+    buffer<int, 1> buf(range<1>(1));
+    auto KernelID = sycl::get_kernel_id<class SingleTask>();
+    auto KB = get_kernel_bundle<bundle_state::executable>(q.get_context(),
+                                                          {KernelID});
+    kernel krn = KB.get_kernel(KernelID);
+    q.submit([&](handler &cgh) {
+      auto acc = buf.get_access<access::mode::read_write>(cgh);
+      cgh.single_task<class SingleTask>(krn, [=]() { acc[0] = acc[0] + 1; });
+    });
+    // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    // expected-warning@+2 {{'get_backend_info<sycl::info::device::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    std::cout << "  Backend device version: "
+              << krn.get_backend_info<info::device::version>() << std::endl;
+    // expected-warning@+3 {{'get_backend_info' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    // expected-warning@+2 {{'get_backend_info<sycl::info::platform::version>' is deprecated: All current implementations of get_backend_info() are to be removed. Use respective variants of get_info() instead.}}
+    std::cout << "  Backend platform version: "
+              << krn.get_backend_info<info::platform::version>() << std::endl;
+  } catch (exception e) {
+    // Check if the error code is the only allowed one: errc::backend_mismatch
+    assert(e.code() == sycl::errc::backend_mismatch && "wrong error code");
+    // If so, check if there're truly non-OpenCL backend(s) or it's an
+    // unexpected error
+    std::vector<platform> platform_list = platform::get_platforms();
+    bool has_non_opencl_backend = false;
+    for (const auto &platform : platform_list) {
+      if (platform.get_backend() != backend::opencl) {
+        has_non_opencl_backend = true;
+        break;
+      }
+    }
+    assert(has_non_opencl_backend && "unexpected error code");
+  }
+  std::cout << "  Backend info query tests passed" << std::endl;
+  return 0;
+}

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -137,7 +137,7 @@ int main() {
   using PIUS = sycl::info::device::preferred_interop_user_sync;
   // expected-warning@+1{{'image_max_array_size' is deprecated: support for image arrays has been removed in SYCL 2020}}
   using IMAS = sycl::info::device::image_max_array_size;
-  // expected-warning@+1{{'opencl_c_version' is deprecated: use device::get_backend_info instead}}
+  // expected-warning@+1{{'opencl_c_version' is deprecated: use device::get_info instead}}
   using OCV = sycl::info::device::opencl_c_version;
 
   // expected-warning@+1{{'extensions' is deprecated: deprecated in SYCL 2020, use device::get_info() with info::device::aspects instead}}


### PR DESCRIPTION
The `get_backend_info()` functions implemented in https://github.com/intel/llvm/pull/12906 are returning some info descriptors that are not backend-specific info descriptors but SYCL core info descriptors. This leads to problems as described in https://github.com/intel/llvm/pull/16272 . Therefore, its current implementations are being deprecated, and removed under the `__INTEL_PREVIEW_BREAKING_CHANGES` flag.