### PR TITLE
[GHA] Uplift Linux GPU RT version to 24.52.32224.5

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -8,7 +8,7 @@
     },
     "igc": {
       "github_tag": "v2.5.6",
-      "version": "2.5.6",
+      "version": "v2.5.6",
       "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/v2.5.6",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },


### PR DESCRIPTION
Scheduled drivers uplift