### PR TITLE
[SYCL][E2E] Fix c++23 option in device_global_copy

### DIFF
--- a/sycl/test-e2e/DeviceGlobal/device_global_copy.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_copy.cpp
@@ -1,4 +1,4 @@
-// DEFINE: %{cpp23} = %if cl_options %{/std:c++23%} %else %{-std=c++23%}
+// DEFINE: %{cpp23} = %if cl_options %{/clang:-std=c++23%} %else %{-std=c++23%}
 
 // RUN: %{build} %{cpp23} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
On some Windows configurations, the /std:c++23 option is not recognized. To address this, we instead instruct the compiler to accept it as a clang flag.