### PR TITLE
[SYCL][E2E] Implement support for REQUIRES in build-only mode

### DIFF
--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -72,7 +72,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
                 require_script=True,
             )
         except ValueError as e:
-            return lit.Test.Result(Test.UNRESOLVED, str(e))
+            return lit.Test.Result(lit.Test.UNRESOLVED, str(e))
         script = parsed["RUN:"] or []
         assert parsed["DEFINE:"] == script
         assert parsed["REDEFINE:"] == script

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -37,6 +37,18 @@ config.recursiveExpansionLimit = 10
 config.required_features = []
 config.unsupported_features = []
 
+# Enable RUN_REQUIRES, RUN_UNSUPPORTED and RUN_XFAIL,
+# and change the meaning of REQUIRES, UNSUPPORTED and XFAIL to apply to both build and run.
+# Per-device features are only available in RUN_* directives in this mode.
+# Can be overridden by lit.local.cfg files. If set in lit.local.cfg then the restriction above
+# will also apply to config.required_features and config.unsupported_features.
+# Can be overridden per-test with `ENABLE_RUN_REQUIRES: <true | false>`
+config.enable_run_requires = False
+
+# To be filled by lit.local.cfg files. Ignored if enable_run_requires = False
+config.run_required_features = []
+config.run_unsupported_features = []
+
 # test-mode: Set if tests should run normally or only build/run
 config.test_mode = lit_config.params.get("test-mode", "full")
 config.fallback_build_run_only = False


### PR DESCRIPTION
In general we cannot separate
build only features from features that only have an effect during
execution. Consider a `REQUIRES` expression containing a mix of runtime
and build time features. If the expression evaluates to false in
build-only we would have to solve a Satisfiability (SAT) problem to
check if it only failed due to missing run-time features.
The below design is motivated by this and the fact that current
`REQUIRES`, `UNSUPPORTED` and `XFAIL` lines assume that both run-time
(per-device) and build only features are available.

Add a new directive `ENABLE_RUN_REQUIRES: true`, which, if present, changes
the evaluation of `REQUIRES`, `UNSUPPORTED` and `XFAIL` directives to
only consider device-agnostic features. This allows them to be correctly
evaluated during `test-mode="build-only"` too. To express per-device
(run-time) requirements the directives `RUN_REQUIRES`, `RUN_UNSUPPORTED`
and `RUN_XFAIL` can be added.

The config and directive takes a boolean value to allow gradual adoption
of the feature.

This commit does not yet change the documentation of the `test-mode`
parameter in README.md, if this looks like a good direction I can do
that too with help on the wording.

I also have not figured out how this should interact with https://github.com/intel/llvm/pull/16306 yet, @ayylol input welcome.

I personally made these changes because I encountered this limitation during personal testing with build-only mode in Intel internal repositories, hopefully nobody else was actively working on this.