### PR TITLE
Bump PyJWT to 2.10.1 in .ci/metrics/requirements.lock.txt

### DIFF
--- a/.ci/metrics/requirements.lock.txt
+++ b/.ci/metrics/requirements.lock.txt
@@ -231,7 +231,7 @@ pygithub==2.5.0 \
     --hash=sha256:b0b635999a658ab8e08720bdd3318893ff20e2275f6446fcf35bf3f44f2c0fd2 \
     --hash=sha256:e1613ac508a9be710920d26eb18b1905ebd9926aa49398e88151c1b526aad3cf
     # via -r ./requirements.txt
-pyjwt[crypto]==2.10.0 \
+pyjwt[crypto]==2.10.1 \
     --hash=sha256:543b77207db656de204372350926bed5a86201c4cbff159f623f79c7bb487a15 \
     --hash=sha256:7628a7eb7938959ac1b26e819a1df0fd3259505627b575e4bad6d08f76db695c
     # via pygithub


### PR DESCRIPTION
PR to bump dependency version to resolve security vulnerability found.

In current version, The wrong string if check is run for iss checking, resulting in "acb" being accepted for "_abc_".

Additional details:
Weaknesses: CWE-697
CVE ID: CVE-2024-53861