### PR TITLE
[CI] Install `spirv-tools` on Linux docker containers

### DIFF
--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -32,5 +32,5 @@ apt update && apt install -yqq \
 # https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/cec12d6cf46306d0a015e883d5adb5a8200df1c0/.github/workflows/check-out-of-tree-build.yml#L59
 . /etc/os-release
 curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | apt-key add -
-echo "deb https://packages.lunarg.com/vulkan $VERSION_CODENAME main" | sudo tee -a /etc/apt/sources.list
+echo "deb https://packages.lunarg.com/vulkan $VERSION_CODENAME main" | tee -a /etc/apt/sources.list
 apt update && apt install -yqq spirv-tools

--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -27,11 +27,10 @@ apt update && apt install -yqq \
       libzstd-dev \
       time
 
-# Add LLVM's GPG key to obtain latest release of spriv-tool.
+# To obtain latest release of spriv-tool.
 # Same as what's done in SPRIV-LLVM-TRANSLATOR:
 # https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/cec12d6cf46306d0a015e883d5adb5a8200df1c0/.github/workflows/check-out-of-tree-build.yml#L59
-curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
-curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
-echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy main" | sudo tee -a /etc/apt/sources.list
-echo "deb https://packages.lunarg.com/vulkan jammy main" | sudo tee -a /etc/apt/sources.list
+. /etc/os-release
+curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | apt-key add -
+echo "deb https://packages.lunarg.com/vulkan $VERSION_CODENAME main" | sudo tee -a /etc/apt/sources.list
 apt update && apt install -yqq spirv-tools

--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -25,4 +25,5 @@ apt update && apt install -yqq \
       curl \
       libhwloc-dev \
       libzstd-dev \
-      time
+      time \
+      spirv-tools

--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -25,5 +25,13 @@ apt update && apt install -yqq \
       curl \
       libhwloc-dev \
       libzstd-dev \
-      time \
-      spirv-tools
+      time
+
+# Add LLVM's GPG key to obtain latest release of spriv-tool.
+# Same as what's done in SPRIV-LLVM-TRANSLATOR:
+# https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/cec12d6cf46306d0a015e883d5adb5a8200df1c0/.github/workflows/check-out-of-tree-build.yml#L59
+curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
+curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
+echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy main" | sudo tee -a /etc/apt/sources.list
+echo "deb https://packages.lunarg.com/vulkan jammy main" | sudo tee -a /etc/apt/sources.list
+apt update && apt install -yqq spirv-tools


### PR DESCRIPTION
This is intended to improve test coverage as some `llvm-spirv` tests require `spirv-tools` to execute.