### PR TITLE
[SYCL] Deprecate single_task() and parallel_for() overloads with properties

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2292,49 +2292,64 @@ public:
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             typename PropertiesT>
-  std::enable_if_t<
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  single_task(PropertiesT Props, _KERNELFUNCPARAM(KernelFunc)) {
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::single_task (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<ext::oneapi::experimental::is_property_list<
+      PropertiesT>::value> single_task(PropertiesT Props,
+                                       _KERNELFUNCPARAM(KernelFunc)) {
     single_task_lambda_impl<KernelName, KernelType, PropertiesT>(Props,
                                                                  KernelFunc);
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             typename PropertiesT>
-  std::enable_if_t<
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<1> NumWorkItems, PropertiesT Props,
-               _KERNELFUNCPARAM(KernelFunc)) {
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::single_task (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<ext::oneapi::experimental::is_property_list<
+      PropertiesT>::value> parallel_for(range<1> NumWorkItems,
+                                        PropertiesT Props,
+                                        _KERNELFUNCPARAM(KernelFunc)) {
     parallel_for_lambda_impl<KernelName, KernelType, 1, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             typename PropertiesT>
-  std::enable_if_t<
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<2> NumWorkItems, PropertiesT Props,
-               _KERNELFUNCPARAM(KernelFunc)) {
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::single_task (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<ext::oneapi::experimental::is_property_list<
+      PropertiesT>::value> parallel_for(range<2> NumWorkItems,
+                                        PropertiesT Props,
+                                        _KERNELFUNCPARAM(KernelFunc)) {
     parallel_for_lambda_impl<KernelName, KernelType, 2, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             typename PropertiesT>
-  std::enable_if_t<
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<3> NumWorkItems, PropertiesT Props,
-               _KERNELFUNCPARAM(KernelFunc)) {
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::single_task (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<ext::oneapi::experimental::is_property_list<
+      PropertiesT>::value> parallel_for(range<3> NumWorkItems,
+                                        PropertiesT Props,
+                                        _KERNELFUNCPARAM(KernelFunc)) {
     parallel_for_lambda_impl<KernelName, KernelType, 3, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             typename PropertiesT, int Dims>
-  std::enable_if_t<
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(nd_range<Dims> Range, PropertiesT Properties,
-               _KERNELFUNCPARAM(KernelFunc)) {
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::single_task (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<ext::oneapi::experimental::is_property_list<
+      PropertiesT>::value> parallel_for(nd_range<Dims> Range,
+                                        PropertiesT Properties,
+                                        _KERNELFUNCPARAM(KernelFunc)) {
     parallel_for_impl<KernelName>(Range, Properties, std::move(KernelFunc));
   }
 
@@ -2342,11 +2357,15 @@ public:
 
   template <typename KernelName = detail::auto_name, typename PropertiesT,
             typename... RestT>
-  std::enable_if_t<
-      (sizeof...(RestT) > 1) &&
-      detail::AreAllButLastReductions<RestT...>::value &&
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<1> Range, PropertiesT Properties, RestT &&...Rest) {
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<(sizeof...(RestT) > 1) &&
+                   detail::AreAllButLastReductions<RestT...>::value &&
+                   ext::oneapi::experimental::is_property_list<
+                       PropertiesT>::value> parallel_for(range<1> Range,
+                                                         PropertiesT Properties,
+                                                         RestT &&...Rest) {
 #ifndef __SYCL_DEVICE_ONLY__
     throwIfGraphAssociated<ext::oneapi::experimental::detail::
                                UnsupportedGraphFeatures::sycl_reductions>();
@@ -2357,11 +2376,15 @@ public:
 
   template <typename KernelName = detail::auto_name, typename PropertiesT,
             typename... RestT>
-  std::enable_if_t<
-      (sizeof...(RestT) > 1) &&
-      detail::AreAllButLastReductions<RestT...>::value &&
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<2> Range, PropertiesT Properties, RestT &&...Rest) {
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<(sizeof...(RestT) > 1) &&
+                   detail::AreAllButLastReductions<RestT...>::value &&
+                   ext::oneapi::experimental::is_property_list<
+                       PropertiesT>::value> parallel_for(range<2> Range,
+                                                         PropertiesT Properties,
+                                                         RestT &&...Rest) {
 #ifndef __SYCL_DEVICE_ONLY__
     throwIfGraphAssociated<ext::oneapi::experimental::detail::
                                UnsupportedGraphFeatures::sycl_reductions>();
@@ -2372,11 +2395,15 @@ public:
 
   template <typename KernelName = detail::auto_name, typename PropertiesT,
             typename... RestT>
-  std::enable_if_t<
-      (sizeof...(RestT) > 1) &&
-      detail::AreAllButLastReductions<RestT...>::value &&
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<3> Range, PropertiesT Properties, RestT &&...Rest) {
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<(sizeof...(RestT) > 1) &&
+                   detail::AreAllButLastReductions<RestT...>::value &&
+                   ext::oneapi::experimental::is_property_list<
+                       PropertiesT>::value> parallel_for(range<3> Range,
+                                                         PropertiesT Properties,
+                                                         RestT &&...Rest) {
 #ifndef __SYCL_DEVICE_ONLY__
     throwIfGraphAssociated<ext::oneapi::experimental::detail::
                                UnsupportedGraphFeatures::sycl_reductions>();
@@ -2411,11 +2438,15 @@ public:
 
   template <typename KernelName = detail::auto_name, int Dims,
             typename PropertiesT, typename... RestT>
-  std::enable_if_t<
-      (sizeof...(RestT) > 1) &&
-      detail::AreAllButLastReductions<RestT...>::value &&
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(nd_range<Dims> Range, PropertiesT Properties, RestT &&...Rest) {
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<(sizeof...(RestT) > 1) &&
+                   detail::AreAllButLastReductions<RestT...>::value &&
+                   ext::oneapi::experimental::is_property_list<
+                       PropertiesT>::value> parallel_for(nd_range<Dims> Range,
+                                                         PropertiesT Properties,
+                                                         RestT &&...Rest) {
 #ifndef __SYCL_DEVICE_ONLY__
     throwIfGraphAssociated<ext::oneapi::experimental::detail::
                                UnsupportedGraphFeatures::sycl_reductions>();
@@ -2437,6 +2468,9 @@ public:
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims, typename PropertiesT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
   void parallel_for_work_group(range<Dims> NumWorkGroups, PropertiesT Props,
                                _KERNELFUNCPARAM(KernelFunc)) {
     parallel_for_work_group_lambda_impl<KernelName, KernelType, Dims,
@@ -2446,6 +2480,9 @@ public:
 
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims, typename PropertiesT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
   void parallel_for_work_group(range<Dims> NumWorkGroups,
                                range<Dims> WorkGroupSize, PropertiesT Props,
                                _KERNELFUNCPARAM(KernelFunc)) {

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -2103,11 +2103,14 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType,
             typename PropertiesT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::single_task (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
   std::enable_if_t<
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value, event>
-  single_task(
-      PropertiesT Properties, _KERNELFUNCPARAM(KernelFunc),
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> single_task(PropertiesT Properties, _KERNELFUNCPARAM(KernelFunc),
+                         const detail::code_location &CodeLoc =
+                             detail::code_location::current()) {
     static_assert(
         (detail::check_fn_signature<std::remove_reference_t<KernelType>,
                                     void()>::value ||
@@ -2145,11 +2148,15 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType,
             typename PropertiesT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::single_task (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
   std::enable_if_t<
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value, event>
-  single_task(
-      event DepEvent, PropertiesT Properties, _KERNELFUNCPARAM(KernelFunc),
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> single_task(event DepEvent, PropertiesT Properties,
+                         _KERNELFUNCPARAM(KernelFunc),
+                         const detail::code_location &CodeLoc =
+                             detail::code_location::current()) {
     static_assert(
         (detail::check_fn_signature<std::remove_reference_t<KernelType>,
                                     void()>::value ||
@@ -2191,12 +2198,15 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType,
             typename PropertiesT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::single_task (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
   std::enable_if_t<
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value, event>
-  single_task(
-      const std::vector<event> &DepEvents, PropertiesT Properties,
-      _KERNELFUNCPARAM(KernelFunc),
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> single_task(const std::vector<event> &DepEvents,
+                         PropertiesT Properties, _KERNELFUNCPARAM(KernelFunc),
+                         const detail::code_location &CodeLoc =
+                             detail::code_location::current()) {
     static_assert(
         (detail::check_fn_signature<std::remove_reference_t<KernelType>,
                                     void()>::value ||
@@ -2234,11 +2244,49 @@ public:
   /// specifies global size only.
   ///
   /// \param Range specifies the global work space of the kernel
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, typename PropertiesT,
+            typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(range<1> Range, PropertiesT Properties,
+                          RestT &&...Rest) {
+    return parallel_for_impl<KernelName>(Range, Properties, Rest...);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param Range specifies the global work space of the kernel
   /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
   /// const KernelType &KernelFunc".
   template <typename KernelName = detail::auto_name, typename... RestT>
   event parallel_for(range<1> Range, RestT &&...Rest) {
     return parallel_for_impl<KernelName>(Range, Rest...);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, typename PropertiesT,
+            typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(range<2> Range, PropertiesT Properties,
+                          RestT &&...Rest) {
+    return parallel_for_impl<KernelName>(Range, Properties, Rest...);
   }
 
   /// parallel_for version with a kernel represented as a lambda + range that
@@ -2256,11 +2304,50 @@ public:
   /// specifies global size only.
   ///
   /// \param Range specifies the global work space of the kernel
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, typename PropertiesT,
+            typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(range<3> Range, PropertiesT Properties,
+                          RestT &&...Rest) {
+    return parallel_for_impl<KernelName>(Range, Properties, Rest...);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param Range specifies the global work space of the kernel
   /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
   /// const KernelType &KernelFunc".
   template <typename KernelName = detail::auto_name, typename... RestT>
   event parallel_for(range<3> Range, RestT &&...Rest) {
     return parallel_for_impl<KernelName>(Range, Rest...);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param DepEvent is an event that specifies the kernel dependencies
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, typename PropertiesT,
+            typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(range<1> Range, event DepEvent,
+                          PropertiesT Properties, RestT &&...Rest) {
+    return parallel_for_impl<KernelName>(Range, DepEvent, Properties, Rest...);
   }
 
   /// parallel_for version with a kernel represented as a lambda + range that
@@ -2280,6 +2367,26 @@ public:
   ///
   /// \param Range specifies the global work space of the kernel
   /// \param DepEvent is an event that specifies the kernel dependencies
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, typename PropertiesT,
+            typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(range<2> Range, event DepEvent,
+                          PropertiesT Properties, RestT &&...Rest) {
+    return parallel_for_impl<KernelName>(Range, DepEvent, Properties, Rest...);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param DepEvent is an event that specifies the kernel dependencies
   /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
   /// const KernelType &KernelFunc".
   template <typename KernelName = detail::auto_name, typename... RestT>
@@ -2292,11 +2399,52 @@ public:
   ///
   /// \param Range specifies the global work space of the kernel
   /// \param DepEvent is an event that specifies the kernel dependencies
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, typename PropertiesT,
+            typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(range<3> Range, event DepEvent,
+                          PropertiesT Properties, RestT &&...Rest) {
+    return parallel_for_impl<KernelName>(Range, DepEvent, Properties, Rest...);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param DepEvent is an event that specifies the kernel dependencies
   /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
   /// const KernelType &KernelFunc".
   template <typename KernelName = detail::auto_name, typename... RestT>
   event parallel_for(range<3> Range, event DepEvent, RestT &&...Rest) {
     return parallel_for_impl<KernelName>(Range, DepEvent, Rest...);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param DepEvents is a vector of events that specifies the kernel
+  /// dependencies
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, typename PropertiesT,
+            typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(range<1> Range, const std::vector<event> &DepEvents,
+                          PropertiesT Properties, RestT &&...Rest) {
+    return parallel_for_impl<KernelName>(Range, DepEvents, Properties, Rest...);
   }
 
   /// parallel_for version with a kernel represented as a lambda + range that
@@ -2319,12 +2467,54 @@ public:
   /// \param Range specifies the global work space of the kernel
   /// \param DepEvents is a vector of events that specifies the kernel
   /// dependencies
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, typename PropertiesT,
+            typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(range<2> Range, const std::vector<event> &DepEvents,
+                          PropertiesT Properties, RestT &&...Rest) {
+    return parallel_for_impl<KernelName>(Range, DepEvents, Properties, Rest...);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param DepEvents is a vector of events that specifies the kernel
+  /// dependencies
   /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
   /// const KernelType &KernelFunc".
   template <typename KernelName = detail::auto_name, typename... RestT>
   event parallel_for(range<2> Range, const std::vector<event> &DepEvents,
                      RestT &&...Rest) {
     return parallel_for_impl<KernelName>(Range, DepEvents, Rest...);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range that
+  /// specifies global size only.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param DepEvents is a vector of events that specifies the kernel
+  /// dependencies
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, typename PropertiesT,
+            typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(range<3> Range, const std::vector<event> &DepEvents,
+                          PropertiesT Properties, RestT &&...Rest) {
+    return parallel_for_impl<KernelName>(Range, DepEvents, Properties, Rest...);
   }
 
   /// parallel_for version with a kernel represented as a lambda + range that
@@ -2442,11 +2632,14 @@ public:
   /// const KernelType &KernelFunc".
   template <typename KernelName = detail::auto_name, int Dims,
             typename PropertiesT, typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
   std::enable_if_t<
       detail::AreAllButLastReductions<RestT...>::value &&
           ext::oneapi::experimental::is_property_list<PropertiesT>::value,
-      event>
-  parallel_for(nd_range<Dims> Range, PropertiesT Properties, RestT &&...Rest) {
+      event> parallel_for(nd_range<Dims> Range, PropertiesT Properties,
+                          RestT &&...Rest) {
     constexpr detail::code_location CodeLoc = getCodeLocation<KernelName>();
     detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
     return submit(
@@ -2466,8 +2659,41 @@ public:
             typename... RestT>
   std::enable_if_t<detail::AreAllButLastReductions<RestT...>::value, event>
   parallel_for(nd_range<Dims> Range, RestT &&...Rest) {
-    return parallel_for<KernelName>(
-        Range, ext::oneapi::experimental::empty_properties_t{}, Rest...);
+    constexpr detail::code_location CodeLoc = getCodeLocation<KernelName>();
+    detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
+    return submit(
+        [&](handler &CGH) {
+          CGH.template parallel_for<KernelName>(Range, Rest...);
+        },
+        TlsCodeLocCapture.query());
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + nd_range that
+  /// specifies global, local sizes and offset.
+  ///
+  /// \param Range specifies the global and local work spaces of the kernel
+  /// \param DepEvent is an event that specifies the kernel dependencies
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, int Dims,
+            typename PropertiesT, typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      detail::AreAllButLastReductions<RestT...>::value &&
+          ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(nd_range<Dims> Range, event DepEvent,
+                          PropertiesT Properties, RestT &&...Rest) {
+    constexpr detail::code_location CodeLoc = getCodeLocation<KernelName>();
+    detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
+    return submit(
+        [&](handler &CGH) {
+          CGH.depends_on(DepEvent);
+          CGH.template parallel_for<KernelName>(Range, Properties, Rest...);
+        },
+        TlsCodeLocCapture.query());
   }
 
   /// parallel_for version with a kernel represented as a lambda + nd_range that
@@ -2479,7 +2705,8 @@ public:
   /// const KernelType &KernelFunc".
   template <typename KernelName = detail::auto_name, int Dims,
             typename... RestT>
-  event parallel_for(nd_range<Dims> Range, event DepEvent, RestT &&...Rest) {
+  std::enable_if_t<detail::AreAllButLastReductions<RestT...>::value, event>
+  parallel_for(nd_range<Dims> Range, event DepEvent, RestT &&...Rest) {
     constexpr detail::code_location CodeLoc = getCodeLocation<KernelName>();
     detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
     return submit(
@@ -2496,12 +2723,43 @@ public:
   /// \param Range specifies the global and local work spaces of the kernel
   /// \param DepEvents is a vector of events that specifies the kernel
   /// dependencies
+  /// \param Properties is the kernel properties.
+  /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
+  /// const KernelType &KernelFunc".
+  template <typename KernelName = detail::auto_name, int Dims,
+            typename PropertiesT, typename... RestT>
+  __SYCL_DEPRECATED(
+      "Use sycl::ext::oneapi::experimental::parallel_for (provided in the "
+      "sycl_ext_oneapi_enqueue_functions extension) instead.")
+  std::enable_if_t<
+      detail::AreAllButLastReductions<RestT...>::value &&
+          ext::oneapi::experimental::is_property_list<PropertiesT>::value,
+      event> parallel_for(nd_range<Dims> Range,
+                          const std::vector<event> &DepEvents,
+                          PropertiesT Properties, RestT &&...Rest) {
+    constexpr detail::code_location CodeLoc = getCodeLocation<KernelName>();
+    detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
+    return submit(
+        [&](handler &CGH) {
+          CGH.depends_on(DepEvents);
+          CGH.template parallel_for<KernelName>(Range, Properties, Rest...);
+        },
+        TlsCodeLocCapture.query());
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + nd_range that
+  /// specifies global, local sizes and offset.
+  ///
+  /// \param Range specifies the global and local work spaces of the kernel
+  /// \param DepEvents is a vector of events that specifies the kernel
+  /// dependencies
   /// \param Rest acts as-if: "ReductionTypes&&... Reductions,
   /// const KernelType &KernelFunc".
   template <typename KernelName = detail::auto_name, int Dims,
             typename... RestT>
-  event parallel_for(nd_range<Dims> Range, const std::vector<event> &DepEvents,
-                     RestT &&...Rest) {
+  std::enable_if_t<detail::AreAllButLastReductions<RestT...>::value, event>
+  parallel_for(nd_range<Dims> Range, const std::vector<event> &DepEvents,
+               RestT &&...Rest) {
     constexpr detail::code_location CodeLoc = getCodeLocation<KernelName>();
     detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
     return submit(

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/Inputs/call.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/Inputs/call.cpp
@@ -1,17 +1,28 @@
 #include "declarations.hpp"
 
+template <typename T1, typename T2> struct KernelFunctor {
+  T1 mDeviceStorage;
+  T2 mDataAcc;
+  KernelFunctor(T1 &DeviceStorage, T2 &DataAcc)
+      : mDeviceStorage(DeviceStorage), mDataAcc(DataAcc) {}
+
+  void operator()() const {
+    auto *Ptr = mDeviceStorage->template getAs<BaseIncrement>();
+    Ptr->increment(
+        mDataAcc.template get_multi_ptr<sycl::access::decorated::no>().get());
+  }
+  auto get(oneapi::properties_tag) const {
+    return oneapi::properties{oneapi::assume_indirect_calls};
+  }
+};
+
 int call(sycl::queue Q, storage_t *DeviceStorage, int Init) {
   int Data = Init;
   {
     sycl::buffer<int> DataStorage(&Data, sycl::range{1});
-    constexpr oneapi::properties props{oneapi::assume_indirect_calls};
     Q.submit([&](sycl::handler &CGH) {
       sycl::accessor DataAcc(DataStorage, CGH, sycl::write_only);
-      CGH.single_task(props, [=]() {
-        auto *Ptr = DeviceStorage->getAs<BaseIncrement>();
-        Ptr->increment(
-            DataAcc.get_multi_ptr<sycl::access::decorated::no>().get());
-      });
+      CGH.single_task(KernelFunctor(DeviceStorage, DataAcc));
     });
   }
 

--- a/sycl/test/check_device_code/extensions/properties/properties_kernel_device_has.cpp
+++ b/sycl/test/check_device_code/extensions/properties/properties_kernel_device_has.cpp
@@ -1,5 +1,8 @@
-// RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm -Xclang -disable-llvm-passes %s -o - | FileCheck %s --check-prefix CHECK-IR
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue
+// https://github.com/intel/llvm/issues/16320. Remove the flag once the issue is
+// resolved.
+// RUN: %clangxx -fsycl-device-only -S -Wno-deprecated-declarations -Xclang -emit-llvm -Xclang -disable-llvm-passes %s -o - | FileCheck %s --check-prefix CHECK-IR
+// RUN: %clangxx -fsycl -fsyntax-only -Wno-deprecated-declarations -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/check_device_code/extensions/properties/properties_kernel_sub_group_size.cpp
+++ b/sycl/test/check_device_code/extensions/properties/properties_kernel_sub_group_size.cpp
@@ -1,5 +1,8 @@
-// RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue
+// https://github.com/intel/llvm/issues/16320. Remove the flag once the issue is
+// resolved.
+// RUN: %clangxx -fsycl-device-only -S -Wno-deprecated-declarations -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
+// RUN: %clangxx -fsycl -fsyntax-only -Wno-deprecated-declarations -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/check_device_code/extensions/properties/properties_kernel_work_group_size.cpp
+++ b/sycl/test/check_device_code/extensions/properties/properties_kernel_work_group_size.cpp
@@ -1,5 +1,8 @@
-// RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue
+// https://github.com/intel/llvm/issues/16320. Remove the flag once the issue is
+// resolved.
+// RUN: %clangxx -fsycl-device-only -S -Wno-deprecated-declarations -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
+// RUN: %clangxx -fsycl -fsyntax-only -Wno-deprecated-declarations -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/check_device_code/extensions/properties/properties_kernel_work_group_size_hint.cpp
+++ b/sycl/test/check_device_code/extensions/properties/properties_kernel_work_group_size_hint.cpp
@@ -1,5 +1,8 @@
-// RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue
+// https://github.com/intel/llvm/issues/16320. Remove the flag once the issue is
+// resolved.
+// RUN: %clangxx -fsycl-device-only -S -Wno-deprecated-declarations -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
+// RUN: %clangxx -fsycl -fsyntax-only -Wno-deprecated-declarations -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/warnings/deprecated_single_task_parallel_for_with_props.cpp
+++ b/sycl/test/warnings/deprecated_single_task_parallel_for_with_props.cpp
@@ -1,0 +1,65 @@
+// Ignore unexpected warnings because for some reason the warnings are emitted
+// twice, e.g. once for `single_task`, then for `single_task<TestKernel0,
+// (lambda at ...),
+// sycl::ext::oneapi::experimental::properties<detail::properties_type_list<>>>`.
+// RUN: %clangxx -fsycl -sycl-std=2020 -fsycl-device-only -Xclang -verify -Xclang -verify-ignore-unexpected=warning -Xclang -verify-ignore-unexpected=note %s -fsyntax-only -Wall -Wextra
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+int main() {
+  queue Q;
+  event Ev;
+  range<1> R1{1};
+  range<2> R2(1, 1);
+  range<3> R3(1, 1, 1);
+  nd_range<1> NDR1{R1, R1};
+  constexpr auto Props = sycl::ext::oneapi::experimental::properties{};
+
+  // expected-warning@+1{{'single_task' is deprecated: Use sycl::ext::oneapi::experimental::single_task (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.single_task<class TestKernel0>(Props, []() {});
+  // expected-warning@+1{{'single_task' is deprecated: Use sycl::ext::oneapi::experimental::single_task (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.single_task<class TestKernel1>(Ev, Props, []() {});
+  // expected-warning@+1{{'single_task' is deprecated: Use sycl::ext::oneapi::experimental::single_task (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.single_task<class TestKernel2>({Ev}, Props, []() {});
+
+  // expected-warning@+1{{'parallel_for' is deprecated: Use sycl::ext::oneapi::experimental::parallel_for (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.parallel_for<class TestKernel3>(NDR1, Props, [](nd_item<1>) {});
+
+  // expected-warning@+2{{'single_task' is deprecated: Use sycl::ext::oneapi::experimental::single_task (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.submit([&](handler &CGH) {
+    CGH.single_task<class TestKernel4>(Props, []() {});
+  });
+
+  // expected-warning@+2{{'parallel_for_work_group' is deprecated: Use sycl::ext::oneapi::experimental::parallel_for (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for_work_group<class TestKernel11>(R1, Props,
+                                                    [](sycl::group<1>) {});
+  });
+  // expected-warning@+2{{'parallel_for_work_group' is deprecated: Use sycl::ext::oneapi::experimental::parallel_for (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for_work_group<class TestKernel12>(R2, Props,
+                                                    [](sycl::group<2>) {});
+  });
+  // expected-warning@+2{{'parallel_for_work_group' is deprecated: Use sycl::ext::oneapi::experimental::parallel_for (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for_work_group<class TestKernel13>(R3, Props,
+                                                    [](sycl::group<3>) {});
+  });
+
+  // expected-warning@+2{{'parallel_for_work_group' is deprecated: Use sycl::ext::oneapi::experimental::parallel_for (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for_work_group<class TestKernel14>(R1, R1, Props,
+                                                    [](sycl::group<1>) {});
+  });
+  // expected-warning@+2{{'parallel_for_work_group' is deprecated: Use sycl::ext::oneapi::experimental::parallel_for (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for_work_group<class TestKernel15>(R2, R2, Props,
+                                                    [](sycl::group<2>) {});
+  });
+  // expected-warning@+2{{'parallel_for_work_group' is deprecated: Use sycl::ext::oneapi::experimental::parallel_for (provided in the sycl_ext_oneapi_enqueue_functions extension) instead.}}
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for_work_group<class TestKernel16>(R3, R3, Props,
+                                                    [](sycl::group<3>) {});
+  });
+  return 0;
+}


### PR DESCRIPTION
As the title says, added deprecation messages for such overloads in the `sycl_ext_oneapi_kernel_properties extension`, suggesting users to use `single_task/parallel_for` overloads provided in the `sycl_ext_oneapi_enqueue_functions` extension instead. (As these overloads are to be removed later as mentioned in https://github.com/intel/llvm/pull/14785) Also fixed affected test cases by adding the `Wno-deprecated-declarations` build flag to let them ignore the deprecation warnings.