### PR TITLE
[SYCL][NATIVECPU] claim ownership for native_cpu parts of libclc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -134,6 +134,7 @@ sycl/**/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers
 sycl/doc/design/SYCLNativeCPU.md @intel/dpcpp-nativecpu-pi-reviewers
 sycl/include/sycl/detail/native_cpu.hpp @intel/dpcpp-nativecpu-pi-reviewers
 libdevice/nativecpu* @intel/dpcpp-nativecpu-pi-reviewers
+libclc/libspirv/lib/native_cpu* @intel/dpcpp-nativecpu-pi-reviewers
 
 # SYCL-Graphs extensions
 sycl/include/sycl/ext/oneapi/experimental/graph.hpp @intel/sycl-graphs-reviewers


### PR DESCRIPTION
Assigning ownership of the nativecpu bits in libclc to the Native CPU team.