### PR TITLE
Revert "[CI] Install `spirv-tools` on Linux docker containers"

### DIFF
--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -26,11 +26,3 @@ apt update && apt install -yqq \
       libhwloc-dev \
       libzstd-dev \
       time
-
-# To obtain latest release of spriv-tool.
-# Same as what's done in SPRIV-LLVM-TRANSLATOR:
-# https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/cec12d6cf46306d0a015e883d5adb5a8200df1c0/.github/workflows/check-out-of-tree-build.yml#L59
-. /etc/os-release
-curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | apt-key add -
-echo "deb https://packages.lunarg.com/vulkan $VERSION_CODENAME main" | tee -a /etc/apt/sources.list
-apt update && apt install -yqq spirv-tools


### PR DESCRIPTION
Reverts intel/llvm#16724 as it broke post-commit
Example: https://github.com/intel/llvm/actions/runs/12915358763/job/36017038536