### PR TITLE
[SYCL][E2E] Pass freshly built OpenCL/L0 to e2e tests for in-tree configuration

### DIFF
--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -14,6 +14,12 @@ if(SYCL_TEST_E2E_STANDALONE)
   if( NOT OpenCL_LIBRARY )
     find_package(OpenCL)
   endif()
+else()
+  if( NOT OpenCL_LIBRARY )
+    set(OpenCL_LIBRARY "${LLVM_BINARY_DIR}/lib")
+  endif()
+  set(LEVEL_ZERO_INCLUDE "${LLVM_BINARY_DIR}/_deps/level-zero-loader-src/include")
+  set(LEVEL_ZERO_LIBS_DIR "${LLVM_BINARY_DIR}/lib")
 endif() # Standalone.
 
 if(SYCL_TEST_E2E_STANDALONE)


### PR DESCRIPTION
Our CI uses "standalone" configuration for running E2E tests, but interactive development is (likely) mostly using in-tree configuration. With this change we can enable more tests running by default in such mode.