### PR TITLE
[CI] Temporarily disable tests requiring `spirv-tools` in CI

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -199,9 +199,10 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target check-sycl-unittests
     - name: check-llvm-spirv
       if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
+      # Temporary workaround to disable running tests requiring spriv-tools.
+      env:
+        LIT_OPTS: "--param disable-spriv-tools=True"
       run: |
-        # Temporary workaround to disable running tests requiring spriv-tools.
-        export LIT_OPTS="--param disable-spriv-tools=True"
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm-spirv
     - name: check-xptifw
       if: always() && !cancelled() && contains(inputs.changes, 'xptifw')

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -199,9 +199,9 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target check-sycl-unittests
     - name: check-llvm-spirv
       if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
-      # Temporary workaround to disable running tests requiring spriv-tools.
+      # Temporary workaround to disable running tests requiring spirv-tools.
       env:
-        LIT_OPTS: "--param disable-spriv-tools=True"
+        LIT_OPTS: "--param disable-spirv-tools=True"
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm-spirv
     - name: check-xptifw

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -200,6 +200,8 @@ jobs:
     - name: check-llvm-spirv
       if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
       run: |
+        # Temporary workaround to disable running tests requiring spriv-tools.
+        export LIT_OPTS="--param disable-spriv-tools=True"
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm-spirv
     - name: check-xptifw
       if: always() && !cancelled() && contains(inputs.changes, 'xptifw')

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -158,9 +158,9 @@ jobs:
         cmake --build build --target check-sycl-unittests
     - name: check-llvm-spirv
       if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
-      # Temporary workaround to disable running tests requiring spriv-tools.
+      # Temporary workaround to disable running tests requiring spirv-tools.
       env:
-        LIT_OPTS: "--param disable-spriv-tools=True"
+        LIT_OPTS: "--param disable-spirv-tools=True"
       run: |
         cmake --build build --target check-llvm-spirv
     - name: check-xptifw

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -158,9 +158,10 @@ jobs:
         cmake --build build --target check-sycl-unittests
     - name: check-llvm-spirv
       if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
+      # Temporary workaround to disable running tests requiring spriv-tools.
+      env:
+        LIT_OPTS: "--param disable-spriv-tools=True"
       run: |
-        # Temporary workaround to disable running tests requiring spriv-tools.
-        export LIT_OPTS="--param disable-spriv-tools=True"
         cmake --build build --target check-llvm-spirv
     - name: check-xptifw
       if: always() && !cancelled() && contains(inputs.changes, 'xptifw')

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -159,6 +159,8 @@ jobs:
     - name: check-llvm-spirv
       if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
       run: |
+        # Temporary workaround to disable running tests requiring spriv-tools.
+        export LIT_OPTS="--param disable-spriv-tools=True"
         cmake --build build --target check-llvm-spirv
     - name: check-xptifw
       if: always() && !cancelled() && contains(inputs.changes, 'xptifw')

--- a/llvm-spirv/test/lit.cfg.py
+++ b/llvm-spirv/test/lit.cfg.py
@@ -60,24 +60,27 @@ llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 using_spirv_tools = False
 
-if config.spirv_tools_have_spirv_as:
+# Explicitly disable using spirv tools, if requested.
+disable_spriv_tools = lit_config.params.get("disable-spriv-tools", False)
+
+if config.spirv_tools_have_spirv_as and not disable_spriv_tools:
     llvm_config.add_tool_substitutions(['spirv-as'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-as')
     using_spirv_tools = True
 
-if config.spirv_tools_have_spirv_dis:
+if config.spirv_tools_have_spirv_dis and not disable_spriv_tools:
     llvm_config.add_tool_substitutions(['spirv-dis'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-dis')
     using_spirv_tools = True
 
-if config.spirv_tools_have_spirv_link:
+if config.spirv_tools_have_spirv_link and not disable_spriv_tools:
     llvm_config.add_tool_substitutions(['spirv-link'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-link')
     using_spirv_tools = True
 
 # Unlike spirv-{as,dis,link} above, running spirv-val is optional: if spirv-val is
 # not available, the test must still run and just skip any spirv-val commands.
-if config.spirv_tools_have_spirv_val:
+if config.spirv_tools_have_spirv_val and not disable_spriv_tools:
     llvm_config.add_tool_substitutions(['spirv-val'], [config.spirv_tools_bin_dir])
     using_spirv_tools = True
 else:

--- a/llvm-spirv/test/lit.cfg.py
+++ b/llvm-spirv/test/lit.cfg.py
@@ -61,26 +61,26 @@ llvm_config.add_tool_substitutions(tools, tool_dirs)
 using_spirv_tools = False
 
 # Explicitly disable using spirv tools, if requested.
-disable_spriv_tools = lit_config.params.get("disable-spriv-tools", False)
+disable_spirv_tools = lit_config.params.get("disable-spirv-tools", False)
 
-if config.spirv_tools_have_spirv_as and not disable_spriv_tools:
+if config.spirv_tools_have_spirv_as and not disable_spirv_tools:
     llvm_config.add_tool_substitutions(['spirv-as'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-as')
     using_spirv_tools = True
 
-if config.spirv_tools_have_spirv_dis and not disable_spriv_tools:
+if config.spirv_tools_have_spirv_dis and not disable_spirv_tools:
     llvm_config.add_tool_substitutions(['spirv-dis'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-dis')
     using_spirv_tools = True
 
-if config.spirv_tools_have_spirv_link and not disable_spriv_tools:
+if config.spirv_tools_have_spirv_link and not disable_spirv_tools:
     llvm_config.add_tool_substitutions(['spirv-link'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-link')
     using_spirv_tools = True
 
 # Unlike spirv-{as,dis,link} above, running spirv-val is optional: if spirv-val is
 # not available, the test must still run and just skip any spirv-val commands.
-if config.spirv_tools_have_spirv_val and not disable_spriv_tools:
+if config.spirv_tools_have_spirv_val and not disable_spirv_tools:
     llvm_config.add_tool_substitutions(['spirv-val'], [config.spirv_tools_bin_dir])
     using_spirv_tools = True
 else:


### PR DESCRIPTION
https://github.com/intel/llvm/pull/16724 installed `spirv-tools` on Linux docker containers and now some llvm-spirv tests are failing due to this (example: https://github.com/intel/llvm/actions/runs/12915358763/job/36017038536).
In this PR, we disable detection of `spirv-tools` LIT feature temporarily in CI to fix post-commit.