### PR TITLE
[SYCL] Optimize back-to-back ControlBarrier calls

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.h
@@ -1,0 +1,29 @@
+//==- SYCLOptimizeBackToBackBarrier.h - SYCLOptimizeBackToBackBarrier Pass -==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass cleans up back-to-back ControlBarrier calls.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_SYCL_OPTIMIZE_BACK_TO_BACK_BARRIER_H
+#define LLVM_SYCL_OPTIMIZE_BACK_TO_BACK_BARRIER_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class SYCLOptimizeBackToBackBarrierPass
+    : public PassInfoMixin<SYCLOptimizeBackToBackBarrierPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+
+  static bool isRequired() { return true; }
+};
+
+} // namespace llvm
+
+#endif // LLVM_SYCL_OPTIMIZE_BACK_TO_BACK_BARRIER_H

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -163,6 +163,7 @@
 #include "llvm/SYCLLowerIR/SYCLConditionalCallOnDevice.h"
 #include "llvm/SYCLLowerIR/SYCLCreateNVVMAnnotations.h"
 #include "llvm/SYCLLowerIR/SYCLJointMatrixTransform.h"
+#include "llvm/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.h"
 #include "llvm/SYCLLowerIR/SYCLPropagateAspectsUsage.h"
 #include "llvm/SYCLLowerIR/SYCLPropagateJointMatrixUsage.h"
 #include "llvm/SYCLLowerIR/SYCLVirtualFunctionsAnalysis.h"

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -173,6 +173,7 @@ MODULE_PASS("esimd-remove-host-code", ESIMDRemoveHostCodePass());
 MODULE_PASS("esimd-remove-optnone-noinline", ESIMDRemoveOptnoneNoinlinePass());
 MODULE_PASS("sycl-conditional-call-on-device", SYCLConditionalCallOnDevicePass())
 MODULE_PASS("sycl-joint-matrix-transform", SYCLJointMatrixTransformPass())
+MODULE_PASS("sycl-optimize-back-to-back-barrier", SYCLOptimizeBackToBackBarrierPass())
 MODULE_PASS("sycl-propagate-aspects-usage", SYCLPropagateAspectsUsagePass())
 MODULE_PASS("sycl-propagate-joint-matrix-usage", SYCLPropagateJointMatrixUsagePass())
 MODULE_PASS("sycl-add-opt-level-attribute", SYCLAddOptLevelAttributePass())

--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -65,6 +65,7 @@ add_llvm_component_library(LLVMSYCLLowerIR
   SYCLDeviceRequirements.cpp
   SYCLKernelParamOptInfo.cpp
   SYCLJointMatrixTransform.cpp
+  SYCLOptimizeBackToBackBarrier.cpp
   SYCLPropagateAspectsUsage.cpp
   SYCLPropagateJointMatrixUsage.cpp
   SYCLVirtualFunctionsAnalysis.cpp

--- a/llvm/lib/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.cpp
@@ -31,22 +31,16 @@ enum class Scope {
   Invocation = 4
 };
 
-enum class CompareRes {
-  BIGGER = 0,
-  SMALLER = 1,
-  EQUAL = 2,
-  UNKNOWN = 3
-};
+enum class CompareRes { BIGGER = 0, SMALLER = 1, EQUAL = 2, UNKNOWN = 3 };
 
 // This map is added in case of any future scopes are added to SPIR-V and/or
 // SYCL.
 const std::unordered_map<uint64_t, uint64_t> ScopeWeights = {
-  {static_cast<uint64_t>(Scope::CrossDevice), 1000},
-  {static_cast<uint64_t>(Scope::Device), 800},
-  {static_cast<uint64_t>(Scope::Workgroup), 600},
-  {static_cast<uint64_t>(Scope::Subgroup), 400},
-  {static_cast<uint64_t>(Scope::Invocation), 10}
-};
+    {static_cast<uint64_t>(Scope::CrossDevice), 1000},
+    {static_cast<uint64_t>(Scope::Device), 800},
+    {static_cast<uint64_t>(Scope::Workgroup), 600},
+    {static_cast<uint64_t>(Scope::Subgroup), 400},
+    {static_cast<uint64_t>(Scope::Invocation), 10}};
 
 inline CompareRes compareScopesWithWeights(const uint64_t LHS,
                                            const uint64_t RHS) {
@@ -113,8 +107,8 @@ bool processControlBarrier(Function *F) {
             const auto ConstScopeCand =
                 cast<ConstantInt>(ExecutionScopeCand)->getZExtValue();
             // Pick ControlBarrier with the 'bigger' execution scope.
-            const auto Compare = compareScopesWithWeights(ConstScopeCI,
-                                                          ConstScopeCand);
+            const auto Compare =
+                compareScopesWithWeights(ConstScopeCI, ConstScopeCand);
             if (Compare == CompareRes::SMALLER)
               CIToRemove = CI;
             else if (Compare == CompareRes::UNKNOWN)

--- a/llvm/lib/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.cpp
@@ -22,9 +22,55 @@ static constexpr char CONTROL_BARRIER[] = "_Z22__spirv_ControlBarrieriii";
 static constexpr char ITT_BARRIER[] = "__itt_offload_wg_barrier_wrapper";
 static constexpr char ITT_RESUME[] = "__itt_offload_wi_resume_wrapper";
 
+// Known scopes in SPIR-V.
+enum class Scope {
+  CrossDevice = 0,
+  Device = 1,
+  Workgroup = 2,
+  Subgroup = 3,
+  Invocation = 4
+};
+
+enum class CompareRes {
+  BIGGER = 0,
+  SMALLER = 1,
+  EQUAL = 2,
+  UNKNOWN = 3
+};
+
+// This map is added in case of any future scopes are added to SPIR-V and/or
+// SYCL.
+const std::unordered_map<uint64_t, uint64_t> ScopeWeights = {
+  {static_cast<uint64_t>(Scope::CrossDevice), 1000},
+  {static_cast<uint64_t>(Scope::Device), 800},
+  {static_cast<uint64_t>(Scope::Workgroup), 600},
+  {static_cast<uint64_t>(Scope::Subgroup), 400},
+  {static_cast<uint64_t>(Scope::Invocation), 10}
+};
+
+inline CompareRes compareScopesWithWeights(const uint64_t LHS,
+                                           const uint64_t RHS) {
+  auto LHSIt = ScopeWeights.find(LHS);
+  auto RHSIt = ScopeWeights.find(RHS);
+
+  if (LHSIt == ScopeWeights.end() || RHSIt == ScopeWeights.end())
+    return CompareRes::UNKNOWN;
+
+  const uint64_t LHSWeight = LHSIt->second;
+  const uint64_t RHSWeight = RHSIt->second;
+
+  if (LHSWeight > RHSWeight)
+    return CompareRes::BIGGER;
+  if (LHSWeight < RHSWeight)
+    return CompareRes::SMALLER;
+  return CompareRes::EQUAL;
+}
+
 // The function removes back-to-back ControlBarrier calls in case if they
-// have the same arguments. It also cleans up ITT annotations surrounding
-// the barrier call.
+// have the same memory scope and memory semantics arguments. When two
+// back-to-back ControlBarriers are having different execution scope arguments -
+// pick the one with the 'bigger' scope.
+// It also cleans up ITT annotations surrounding the removed barrier call.
 bool processControlBarrier(Function *F) {
   BasicBlock *PrevBB = nullptr;
   llvm::SmallPtrSet<Instruction *, 8> ToErase;
@@ -50,20 +96,43 @@ bool processControlBarrier(Function *F) {
       auto *Cand = dyn_cast<CallInst>(&*It);
       if (!Cand)
         break;
+      CallInst *CIToRemove = Cand;
       StringRef CandName = Cand->getCalledFunction()->getName();
       if (CandName == ITT_RESUME || CandName == ITT_BARRIER) {
         ToEraseLocalITT.insert(Cand);
         continue;
       } else if (CandName == CONTROL_BARRIER) {
         bool EqualOps = true;
-        for (unsigned I = 0; I != CI->getNumOperands(); ++I) {
+        const auto *ExecutionScopeCI = CI->getOperand(0);
+        const auto *ExecutionScopeCand = Cand->getOperand(0);
+        if (ExecutionScopeCI != ExecutionScopeCand) {
+          if (isa<ConstantInt>(ExecutionScopeCI) &&
+              isa<ConstantInt>(ExecutionScopeCand)) {
+            const auto ConstScopeCI =
+                cast<ConstantInt>(ExecutionScopeCI)->getZExtValue();
+            const auto ConstScopeCand =
+                cast<ConstantInt>(ExecutionScopeCand)->getZExtValue();
+            // Pick ControlBarrier with the 'bigger' execution scope.
+            const auto Compare = compareScopesWithWeights(ConstScopeCI,
+                                                          ConstScopeCand);
+            if (Compare == CompareRes::SMALLER)
+              CIToRemove = CI;
+            else if (Compare == CompareRes::UNKNOWN)
+              // Unknown scopes = unknown rules. Keep ControlBarrier call.
+              EqualOps = false;
+          } else
+            EqualOps = false;
+        }
+        // TODO: may be handle a case with not-matching memory scope and
+        // memory semantic arguments in a smart way.
+        for (unsigned I = 1; I != CI->getNumOperands(); ++I) {
           if (CI->getOperand(I) != Cand->getOperand(I)) {
             EqualOps = false;
             break;
           }
         }
         if (EqualOps) {
-          ToErase.insert(Cand);
+          ToErase.insert(CIToRemove);
           for (auto *ITT : ToEraseLocalITT)
             ToErase.insert(ITT);
           ToEraseLocalITT.clear();

--- a/llvm/lib/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.cpp
@@ -1,0 +1,97 @@
+//=== SYCLOptimizeBackToBackBarrier.cpp - SYCL barrier optimization pass ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass cleans up back-to-back ControlBarrier calls.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/SYCLLowerIR/SYCLOptimizeBackToBackBarrier.h"
+
+#include "llvm/IR/IRBuilder.h"
+
+using namespace llvm;
+
+namespace {
+
+static constexpr char CONTROL_BARRIER[] = "_Z22__spirv_ControlBarrieriii";
+static constexpr char ITT_BARRIER[] = "__itt_offload_wg_barrier_wrapper";
+static constexpr char ITT_RESUME[] = "__itt_offload_wi_resume_wrapper";
+
+// The function removes back-to-back ControlBarrier calls in case if they
+// have the same arguments. It also cleans up ITT annotations surrounding
+// the barrier call.
+bool processControlBarrier(Function *F) {
+  BasicBlock *PrevBB = nullptr;
+  llvm::SmallPtrSet<Instruction *, 8> ToErase;
+  for (auto I = F->user_begin(), E = F->user_end(); I != E;) {
+    User *U = *I++;
+    auto *CI = dyn_cast<CallInst>(U);
+    if (!CI)
+      continue;
+
+    // New basic block - new processing.
+    BasicBlock *CurrentBB = CI->getParent();
+    if (CurrentBB != PrevBB) {
+      PrevBB = CurrentBB;
+      continue;
+    }
+
+    llvm::SmallPtrSet<Instruction *, 2> ToEraseLocalITT;
+    BasicBlock::iterator It(CI);
+    // Iterate over the basic block storing back-to-back barriers and their ITT
+    // annotations into ToErase container.
+    while (It != CurrentBB->begin()) {
+      --It;
+      auto *Cand = dyn_cast<CallInst>(&*It);
+      if (!Cand)
+        break;
+      StringRef CandName = Cand->getCalledFunction()->getName();
+      if (CandName == ITT_RESUME || CandName == ITT_BARRIER) {
+        ToEraseLocalITT.insert(Cand);
+        continue;
+      } else if (CandName == CONTROL_BARRIER) {
+        bool EqualOps = true;
+        for (unsigned I = 0; I != CI->getNumOperands(); ++I) {
+          if (CI->getOperand(I) != Cand->getOperand(I)) {
+            EqualOps = false;
+            break;
+          }
+        }
+        if (EqualOps) {
+          ToErase.insert(Cand);
+          for (auto *ITT : ToEraseLocalITT)
+            ToErase.insert(ITT);
+          ToEraseLocalITT.clear();
+        }
+      }
+    }
+  }
+
+  if (ToErase.empty())
+    return false;
+
+  for (auto *I : ToErase) {
+    I->dropAllReferences();
+    I->eraseFromParent();
+  }
+
+  return true;
+}
+
+} // namespace
+
+PreservedAnalyses
+SYCLOptimizeBackToBackBarrierPass::run(Module &M, ModuleAnalysisManager &MAM) {
+  bool ModuleChanged = false;
+  for (Function &F : M)
+    if (F.isDeclaration())
+      if (F.getName() == CONTROL_BARRIER)
+        ModuleChanged |= processControlBarrier(&F);
+
+  return ModuleChanged ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm/test/SYCLLowerIR/SYCLOptimizeBackToBackBarrier/remove-back-to-back-barrier.ll
+++ b/llvm/test/SYCLLowerIR/SYCLOptimizeBackToBackBarrier/remove-back-to-back-barrier.ll
@@ -2,19 +2,36 @@
 ; The test checks if back-to-back __spirv_ControlBarrier and ITT annotations are
 ; removed.
 
-; CHECK: define spir_func void @_Z3foov()
+; CHECK: define spir_func void @_Z3foov(i32 [[#Arg1:]], i32 [[#Arg2:]])
 ; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
 ; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 1, i32 noundef 912)
 ; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
 ; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
 ; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 2, i32 noundef 912)
 ; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
+; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 64, i32 noundef 2, i32 noundef 912)
+; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
+; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 %0, i32 noundef 2, i32 noundef 912)
+; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
+; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 %[[#Arg1]], i32 noundef 2, i32 noundef 912)
+; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
 ; CHECK-NEXT: ret void
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"
 
-define spir_func void @_Z3foov() {
+define spir_func void @_Z3foov(i32 %0, i32 %1) {i
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 noundef 4, i32 noundef 1, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 noundef 2, i32 noundef 1, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+
   call spir_func void @__itt_offload_wg_barrier_wrapper()
   call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 1, i32 noundef 912)
   call spir_func void @__itt_offload_wi_resume_wrapper()
@@ -30,6 +47,23 @@ define spir_func void @_Z3foov() {
   call spir_func void @__itt_offload_wg_barrier_wrapper()
   call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 2, i32 noundef 912)
   call spir_func void @__itt_offload_wi_resume_wrapper()
+
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 noundef 64, i32 noundef 2, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 %0, i32 noundef 2, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 %0, i32 noundef 2, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 %1, i32 noundef 2, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+
   ret void
 }
 

--- a/llvm/test/SYCLLowerIR/SYCLOptimizeBackToBackBarrier/remove-back-to-back-barrier.ll
+++ b/llvm/test/SYCLLowerIR/SYCLOptimizeBackToBackBarrier/remove-back-to-back-barrier.ll
@@ -2,9 +2,9 @@
 ; The test checks if back-to-back __spirv_ControlBarrier and ITT annotations are
 ; removed.
 
-; CHECK: define spir_func void @_Z3foov(i32 [[#Arg1:]], i32 [[#Arg2:]])
+; CHECK: define spir_func void @_Z3fooii(i32 %[[#Scope1:]], i32 %[[#Scope2:]])
 ; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
-; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 1, i32 noundef 912)
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 2, i32 noundef 1, i32 noundef 912)
 ; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
 ; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
 ; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 2, i32 noundef 912)
@@ -13,17 +13,17 @@
 ; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 64, i32 noundef 2, i32 noundef 912)
 ; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
 ; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
-; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 %0, i32 noundef 2, i32 noundef 912)
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 %[[#Scope1]], i32 noundef 2, i32 noundef 912)
 ; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
 ; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
-; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 %[[#Arg1]], i32 noundef 2, i32 noundef 912)
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 %[[#Scope2]], i32 noundef 2, i32 noundef 912)
 ; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
 ; CHECK-NEXT: ret void
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"
 
-define spir_func void @_Z3foov(i32 %0, i32 %1) {i
+define spir_func void @_Z3fooii(i32 %0, i32 %1) {
   call spir_func void @__itt_offload_wg_barrier_wrapper()
   call void @_Z22__spirv_ControlBarrieriii(i32 noundef 4, i32 noundef 1, i32 noundef 912)
   call spir_func void @__itt_offload_wi_resume_wrapper()

--- a/llvm/test/SYCLLowerIR/SYCLOptimizeBackToBackBarrier/remove-back-to-back-barrier.ll
+++ b/llvm/test/SYCLLowerIR/SYCLOptimizeBackToBackBarrier/remove-back-to-back-barrier.ll
@@ -2,8 +2,8 @@
 ; The test checks if back-to-back __spirv_ControlBarrier and ITT annotations are
 ; removed.
 
-; CHECK: define spir_func void @_Z3fooii(i32 %[[#Scope1:]], i32 %[[#Scope2:]])
-; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
+; CHECK-LABEL: define spir_func void @_Z3fooii(i32 %[[#Scope1:]], i32 %[[#Scope2:]])
+; CHECK: call spir_func void @__itt_offload_wg_barrier_wrapper()
 ; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 2, i32 noundef 1, i32 noundef 912)
 ; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
 ; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
@@ -19,6 +19,14 @@
 ; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 %[[#Scope2]], i32 noundef 2, i32 noundef 912)
 ; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
 ; CHECK-NEXT: ret void
+
+; CHECK-LABEL: define dso_local void @_Z3booi
+; CHECK: call spir_func void @__itt_offload_wg_barrier_wrapper()
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 3, i32 noundef 0)
+; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
+; CHECK: call spir_func void @__itt_offload_wg_barrier_wrapper()
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 3, i32 noundef 0)
+; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"
@@ -64,6 +72,23 @@ define spir_func void @_Z3fooii(i32 %0, i32 %1) {
   call void @_Z22__spirv_ControlBarrieriii(i32 %1, i32 noundef 2, i32 noundef 912)
   call spir_func void @__itt_offload_wi_resume_wrapper()
 
+  ret void
+}
+
+define dso_local void @_Z3booi(i32 noundef %0) local_unnamed_addr #0 {
+  %2 = icmp eq i32 %0, 0
+  br i1 %2, label %3, label %4
+
+3:                                                ; preds = %1
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 3, i32 noundef 0)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+  br label %4
+
+4:                                                ; preds = %3, %1
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 3, i32 noundef 0)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
   ret void
 }
 

--- a/llvm/test/SYCLLowerIR/SYCLOptimizeBackToBackBarrier/remove-back-to-back-barrier.ll
+++ b/llvm/test/SYCLLowerIR/SYCLOptimizeBackToBackBarrier/remove-back-to-back-barrier.ll
@@ -1,0 +1,40 @@
+; RUN: opt -passes=sycl-optimize-back-to-back-barrier -S < %s | FileCheck %s
+; The test checks if back-to-back __spirv_ControlBarrier and ITT annotations are
+; removed.
+
+; CHECK: define spir_func void @_Z3foov()
+; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 1, i32 noundef 912)
+; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
+; CHECK-NEXT: call spir_func void @__itt_offload_wg_barrier_wrapper()
+; CHECK-NEXT: call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 2, i32 noundef 912)
+; CHECK-NEXT: call spir_func void @__itt_offload_wi_resume_wrapper()
+; CHECK-NEXT: ret void
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-unknown"
+
+define spir_func void @_Z3foov() {
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 1, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 1, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 2, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+
+  call spir_func void @__itt_offload_wg_barrier_wrapper()
+  call void @_Z22__spirv_ControlBarrieriii(i32 noundef 3, i32 noundef 2, i32 noundef 912)
+  call spir_func void @__itt_offload_wi_resume_wrapper()
+  ret void
+}
+
+declare spir_func void @_Z22__spirv_ControlBarrieriii(i32 noundef, i32 noundef, i32 noundef)
+
+declare spir_func void @__itt_offload_wg_barrier_wrapper()
+
+declare spir_func void @__itt_offload_wi_resume_wrapper()


### PR DESCRIPTION
This pass removes redundant __spirv_ControlBarrier call (as well as ITT annotations surrounding it) in case if it's neighboring another __spirv_ControlBarrier call with the same memory scope and memory semantics arguments. If the calls have different
execution scope arguments - then pick the one with the 'bigger' scope.