### PR TITLE
[SYCL] sycl-trace is dependency of test-e2e

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -400,6 +400,7 @@ add_custom_target( sycl-toolchain ALL
   DEPENDS sycl-runtime-libraries
           sycl-compiler
           sycl-ls
+          sycl-trace
           ${XPTIFW_LIBS}
   COMMENT "Building SYCL compiler toolchain..."
 )


### PR DESCRIPTION
```
 FAIL: SYCL :: Tracing/usm/queue_single_task_nullptr.cpp (2221 of 2265)
 Exit Code: 2

 Command Output (stdout):
 --
 [...]
 # .---command stderr------------
 # | error: unable to find `sycl-trace' in PATH: No such file or directory
 # `-----------------------------
 [...]

```
The `test-e2e` target depends on `sycl-toolchain` only, so I'm assuming we want `sycl-toolchain` to contain `sycl-trace` so that test-e2e picks up this dependency automatically.