### PR TITLE
[CI] Remove `sycl-devops-pr/**` hack

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
       - sycl
-      - sycl-devops-pr/**
       - sycl-rel-**
       - 'users/**'
 

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
     - sycl
-    - sycl-devops-pr/**
     - sycl-rel-**
     # Do not run builds if changes are only in the following locations
     paths-ignore:

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -1,16 +1,16 @@
 name: SYCL Post Commit
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
     - sycl
-    - sycl-devops-pr/**
     - sycl-rel-**
 
   pull_request:
     branches:
     - sycl
-    - sycl-devops-pr/**
     paths:
     - .github/workflows/sycl-post-commit.yml
     - .github/workflows/sycl-linux-build.yml

--- a/.github/workflows/sycl-windows-precommit.yml
+++ b/.github/workflows/sycl-windows-precommit.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
     - sycl
-    - sycl-devops-pr/**
     - llvmspirv_pulldown
     - sycl-rel-**
     # Do not run builds if changes are only in the following locations


### PR DESCRIPTION
It was originally added in https://github.com/intel/llvm/pull/10002, back when we used `pull_request_target` for pre-commit trigger. Now that `pull_request` is used it isn't (as) necessary.

I'm also adding a `workflow_dispatch` trigger for the post-commit job for cases when somebody wants to test extensive non-CI changes with post-commit before the merge. I think that will work but it's impossible to verify before merging this due to how GHA work.

This will address the following usage scenario:
  * Push CI-related changes to `sycl-devops-pr` (possibly several iterations)
  * Result are ok, open a PR from that branch
    - extra post-commit task is spawned for the commit that has been tested already (this duplication will remain, unfortunately)
  * Address review feedback with a new upload
    - two post-commit jobs are automatically launched (after this PR, no manual dispatch would happen here, leaving only automatic pre-commit testing of the post-commit workflow)