### PR TITLE
[CI] Fix race condition by unsetting `merge_ref` for Windows tasks

### DIFF
--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -106,6 +106,7 @@ jobs:
       compiler: icx
       build_configure_extra_args: --cmake-opt=-DCMAKE_C_FLAGS="/clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt=-DCMAKE_CXX_FLAGS="/clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt="-DCMAKE_EXE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_MODULE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_SHARED_LINKER_FLAGS=/manifest:no" 
       build_cache_suffix: icx
+      merge_ref: ''
       
   e2e-win:
     needs: build-win
@@ -120,6 +121,7 @@ jobs:
       runner: '["Windows","gen12"]'
       sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
       compiler: icx
+      merge_ref: ''
 
   macos_default:
     name: macOS

--- a/.github/workflows/sycl-windows-precommit.yml
+++ b/.github/workflows/sycl-windows-precommit.yml
@@ -43,6 +43,7 @@ jobs:
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
       changes: ${{ needs.detect_changes.outputs.filters }}
+      merge_ref: ''
 
   e2e:
     needs: build
@@ -56,3 +57,4 @@ jobs:
       name: Intel GEN12 Graphics with Level Zero
       runner: '["Windows","gen12"]'
       sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
+      merge_ref: ''


### PR DESCRIPTION
That input parameter was introduced to `sycl-windows-build.yml` in https://github.com/intel/llvm/pull/16560 but it's unclear why.

Note that linux version has had it for quite some time, but we started unsetting it explicitly in https://github.com/intel/llvm/pull/10720. The reason we had it for Linux in the first place is because `GITHUB_SHA` pointed to the PR's source branch for the `pull_request_target` trigger that we used at that time. With switching to `pull_request` trigger it became unnecessary as `GITHUB_SHA` points to the merge commit already.

This change should fix current race condition when a post-commit CI job can test change landed after the current commit if there is a delay with runner allocation.