### PR TITLE
[CI] Fix Windows oneAPI test failures

### DIFF
--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -104,7 +104,7 @@ jobs:
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
       compiler: icx
-      build_configure_extra_args: --cmake-opt=-DCMAKE_C_FLAGS="/clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt=-DCMAKE_CXX_FLAGS="/clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt="-DCMAKE_EXE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_MODULE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_SHARED_LINKER_FLAGS=/manifest:no" 
+      build_configure_extra_args: --cmake-opt=-DCMAKE_C_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt=-DCMAKE_CXX_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt="-DCMAKE_EXE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_MODULE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_SHARED_LINKER_FLAGS=/manifest:no" 
       build_cache_suffix: icx
       
   e2e-win:

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -135,10 +135,7 @@ jobs:
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
       shell: bash
-      run: |
-        if [[ ${{inputs.compiler}} == 'icx' ]]; then
-          export LIT_FILTER="SYCL"
-        fi
+      run: |      
         cmake --build build --target check-llvm
     - name: check-clang
       if: always() && !cancelled() && contains(inputs.changes, 'clang')
@@ -147,10 +144,7 @@ jobs:
     - name: check-sycl
       if: always() && !cancelled() && contains(inputs.changes, 'sycl')
       shell: bash
-      run: |
-         if [[ ${{inputs.compiler}} == 'icx' ]]; then
-           export LIT_XFAIL="regression\host_tanpi_double_accuracy.cpp"
-         fi
+      run: |        
          cmake --build build --target check-sycl
     - name: check-sycl-unittests
       if: always() && !cancelled() && contains(inputs.changes, 'sycl')


### PR DESCRIPTION
It was the math flags.

We can't use `/Qno-intel-libs` and remove the env setup requirement from the e2e phase because of some insane linking errors I can't figure out and I don't think it's worth the time to investigate it any more.

Closes: https://github.com/intel/llvm/issues/16362