### PR TITLE
[UR] Prepare CODEOWNERS file for repo move

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,22 @@ sycl/doc/design/spirv-extensions/ @intel/dpcpp-spirv-doc-reviewers
 sycl/doc/extensions/ @intel/dpcpp-specification-reviewers
 
 # Unified Runtime
+unified-runtime/ @intel/unified-runtime-reviewers
+# TODO: Use specific UR Level Zero adapter team
+unified-runtime/*/adapters/level_zero/ @intel/unified-runtime-reviewers
+# TODO: Use specific UR OpenCL adapter team
+unified-runtime/*/adapters/opencl/ @intel/unified-runtime-reviewers
+unified-runtime/*/adapters/cuda/  @intel/llvm-reviewers-cuda
+unified-runtime/*/adapters/hip/  @intel/llvm-reviewers-cuda
+unified-runtime/*/adapters/native_cpu/ @intel/dpcpp-nativecpu-reviewers
+unified-runtime/source/adapters/**/command_buffer.* @intel/sycl-graphs-reviewers
+unified-runtime/scripts/core/EXP-COMMAND-BUFFER.rst @intel/sycl-graphs-reviewers
+unified-runtime/scripts/core/exp-command-buffer.yml @intel/sycl-graphs-reviewers
+unified-runtime/test/conformance/exp_command_buffer** @intel/sycl-graphs-reviewers
+unified-runtime/source/adapters/**/image.* @intel/bindless-images-reviewers
+unified-runtime/scripts/core/EXP-BINDLESS-IMAGES.rst @intel/bindless-images-reviewers
+unified-runtime/scripts/core/exp-bindless-images.yml @intel/bindless-images-reviewers
+unified-runtime/test/conformance/exp_bindless_images** @intel/bindless-images-reviewers
 sycl/cmake/modules/FetchUnifiedRuntime.cmake @intel/unified-runtime-reviewers
 sycl/cmake/modules/UnifiedRuntimeTag.cmake @intel/unified-runtime-reviewers
 sycl/include/sycl/detail/ur.hpp @intel/unified-runtime-reviewers


### PR DESCRIPTION
Transfer over code owners from https://github.com/oneapi-src/unified-runtime/blob/main/.github/CODEOWNERS mapping to existing teams as closely as possible.
