### PR TITLE
[SYCL][E2E][NFC] Fix NameError if directive fails to parse

### DIFF
--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -72,7 +72,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
                 require_script=True,
             )
         except ValueError as e:
-            return lit.Test.Result(Test.UNRESOLVED, str(e))
+            return lit.Test.Result(lit.Test.UNRESOLVED, str(e))
         script = parsed["RUN:"] or []
         assert parsed["DEFINE:"] == script
         assert parsed["REDEFINE:"] == script


### PR DESCRIPTION
Currently if a test contains a malformed directive, the following exception is raised along with the original parsing error:
```plaintext
Exception during script execution:
(original error)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "llvm/llvm/utils/lit/lit/worker.py", line 76, in _execute_test_handle_errors
    result = test.config.test_format.execute(test, lit_config)
  File "llvm/sycl/test-e2e/format.py", line 232, in execute
    script = self.parseTestScript(test)
  File "llvm/sycl/test-e2e/format.py", line 105, in parseTestScript
    return lit.Test.Result(Test.UNRESOLVED, str(e))
NameError: name 'Test' is not defined
```
The test ends up as UNRESOLVED either way, but fixing it is easy and improves the error message greatly.