### PR TITLE
[SYCLCompat] Fix `compare_mask` implementations and test

### DIFF
--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -598,8 +598,8 @@ template <typename ValueT, class BinaryOperation>
 inline std::enable_if_t<ValueT::size() == 2, unsigned>
 compare_mask(const ValueT a, const ValueT b, const BinaryOperation binary_op) {
   // Since compare returns 0 or 1, -compare will be 0x00000000 or 0xFFFFFFFF
-  return ((-compare(a[0], b[0], binary_op)) << 16) |
-         ((-compare(a[1], b[1], binary_op)) & 0xFFFF);
+  return ((-compare(a[0], b[0], binary_op)) & 0xFFFF) |
+         ((-compare(a[1], b[1], binary_op)) << 16u);
 }
 
 /// Performs 2 elements unordered comparison, compare result of each element is
@@ -613,8 +613,8 @@ template <typename ValueT, class BinaryOperation>
 inline std::enable_if_t<ValueT::size() == 2, unsigned>
 unordered_compare_mask(const ValueT a, const ValueT b,
                        const BinaryOperation binary_op) {
-  return ((-unordered_compare(a[0], b[0], binary_op)) << 16) |
-         ((-unordered_compare(a[1], b[1], binary_op)) & 0xFFFF);
+  return ((-unordered_compare(a[0], b[0], binary_op)) & 0xFFFF) |
+         ((-unordered_compare(a[1], b[1], binary_op)) << 16);
 }
 
 /// Compute vectorized max for two values, with each value treated as a vector

--- a/sycl/test-e2e/syclcompat/math/math_compare.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_compare.cpp
@@ -301,12 +301,12 @@ typename ValueT> void test_compare_mask() {
   //  1.0 == 1.0, 2.0 == 3.0 -> 0xffff0000
   BinaryOpTestLauncher<Container, Container, unsigned>(grid, threads)
       .template launch_test<compare_mask_kernel<Container>>(op1, op3,
-                                                            0xffff0000);
+                                                            0x0000ffff);
 
   //  1.0 == 3.0, 2.0 == 2.0 -> 0x0000ffff
   BinaryOpTestLauncher<Container, Container, unsigned>(grid, threads)
       .template launch_test<compare_mask_kernel<Container>>(op1, op4,
-                                                            0x0000ffff);
+                                                            0xffff0000);
 
   //  1.0 == NaN, 2.0 == NaN -> 0x00000000
   BinaryOpTestLauncher<Container, Container, unsigned>(grid, threads)
@@ -350,12 +350,12 @@ typename ValueT> void test_unordered_compare_mask() {
   //  1.0 == 1.0, 2.0 == 3.0 -> 0xffff0000
   BinaryOpTestLauncher<Container, Container, unsigned>(grid, threads)
       .template launch_test<unordered_compare_mask_kernel<Container>>(
-          op1, op3, 0xffff0000);
+          op1, op3, 0x0000ffff);
 
   //  1.0 == 3.0, 2.0 == 2.0 -> 0x0000ffff
   BinaryOpTestLauncher<Container, Container, unsigned>(grid, threads)
       .template launch_test<unordered_compare_mask_kernel<Container>>(
-          op1, op4, 0x0000ffff);
+          op1, op4, 0xffff0000);
 
   //  1.0 == NaN, 2.0 == NaN -> 0xffffffff
   BinaryOpTestLauncher<Container, Container, unsigned>(grid, threads)


### PR DESCRIPTION
The `compare_mask` and `unordered_compare_mask` implementations were placing the results of the comparison operations in the wrong 2-byte segments of the 4-byte output.

The `math_compare.cpp` test has also been fixed, where the "expected" results were previously incorrect, they now reflect the values returned by the corresponding CUDA math functions.