### PR TITLE
[UR] Rename cluster launch support enum

### DIFF
--- a/sycl/include/sycl/info/device_traits.def
+++ b/sycl/include/sycl/info/device_traits.def
@@ -235,7 +235,7 @@ __SYCL_PARAM_TRAITS_SPEC(device, ext_oneapi_max_work_groups_3d, id<3>,
                          UR_DEVICE_INFO_MAX_WORK_GROUPS_3D)
 __SYCL_PARAM_TRAITS_SPEC(device, ext_oneapi_max_global_work_groups, size_t, __SYCL_TRAIT_HANDLED_IN_RT)
 __SYCL_PARAM_TRAITS_SPEC(device, ext_oneapi_cuda_cluster_group, bool,
-                         UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP)
+                         UR_DEVICE_INFO_CLUSTER_LAUNCH_SUPPORT_EXP)
 
 #ifdef __SYCL_PARAM_TRAITS_TEMPLATE_SPEC_NEEDS_UNDEF
 #undef __SYCL_PARAM_TRAITS_TEMPLATE_SPEC


### PR DESCRIPTION
The `UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP` enum was renamed to `UR_DEVICE_INFO_CLUSTER_LAUNCH_SUPPORT_EXP` in https://github.com/oneapi-src/unified-runtime/pull/2597, this PR updates a reference to it in intel/llvm