### PR TITLE
[CI] Switch default `merge_ref` to empty

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -40,12 +40,6 @@ on:
         description: 'Filter matches for the changed files in the PR'
         default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc, libdevice]'
         required: false
-      merge_ref:
-        description: |
-          Commit-ish to merge post-checkout if non-empty. Must be reachable from
-          the default_branch input paramter.
-        type: string
-        default: 'FETCH_HEAD'
       retention-days:
         description: 'Artifacts retention period'
         type: string
@@ -150,7 +144,6 @@ jobs:
       with:
         path: src
         ref: ${{ inputs.build_ref || github.sha }}
-        merge_ref: ${{ inputs.merge_ref }}
         cache_path: "/__w/repo_cache/"
     - name: Setup oneAPI env
       if: ${{ inputs.cc == 'icx' || inputs.cxx == 'icpx' }}
@@ -281,7 +274,6 @@ jobs:
       uses: ./devops/actions/run-tests/e2e
       with:
         ref: ${{ inputs.ref || github.sha }}
-        merge_ref: ${{ inputs.merge_ref }}
         e2e_testing_mode: build-only
         target_devices: all
         artifact_suffix: default

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -72,7 +72,6 @@ jobs:
       # No idea why but that seems to work and be in sync with the main
       # pre-commit workflow.
       ref: ${{ github.event.workflow_run.referenced_workflows[0].sha }}
-      merge_ref: ''
 
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: llvm_sycl.tar.zst

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -41,7 +41,6 @@ jobs:
     uses: ./.github/workflows/sycl-linux-build.yml
     with:
       build_ref: ${{ github.sha }}
-      merge_ref: ''
       build_cache_root: "/__w/"
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
@@ -97,7 +96,6 @@ jobs:
       extra_lit_opts: --param fallback-to-build-if-requires-build-and-run=True ${{ matrix.extra_lit_opts }}
       reset_intel_gpu: ${{ matrix.reset_intel_gpu }}
       ref: ${{ github.sha }}
-      merge_ref: ''
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
       sycl_toolchain_decompress_command: ${{ needs.build.outputs.artifact_decompress_command }}
@@ -179,7 +177,6 @@ jobs:
       skip_run: ${{matrix.use_igc_dev && contains(github.event.pull_request.labels.*.name, 'ci-no-devigc') || 'false'}}
 
       ref: ${{ github.sha }}
-      merge_ref: ''
 
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
@@ -228,7 +225,6 @@ jobs:
       extra_lit_opts: -a -j 1 --param enable-perf-tests=True
 
       ref: ${{ github.sha }}
-      merge_ref: ''
 
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -38,13 +38,6 @@ on:
       ref:
         type: string
         required: True
-      merge_ref:
-        description: |
-          Commit-ish to merge post-checkout if non-empty. Must be reachable from
-          the default_branch input paramter.
-        type: string
-        default: 'FETCH_HEAD'
-        required: False
 
       sycl_toolchain_artifact:
         type: string
@@ -296,7 +289,6 @@ jobs:
       uses: ./devops/actions/run-tests/e2e
       with:
         ref: ${{ inputs.ref || github.sha }}
-        merge_ref: ${{ inputs.merge_ref }}
         e2e_binaries_artifact: ${{ inputs.e2e_binaries_artifact }}
         extra_cmake_args: ${{ inputs.extra_cmake_args }}
         e2e_testing_mode: ${{ inputs.e2e_testing_mode }}

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -17,7 +17,6 @@ jobs:
       build_artifact_suffix: default
       build_configure_extra_args: '--hip --cuda'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
-      merge_ref: ''
       retention-days: 90
 
       # We upload the build for people to download/use, override its name and
@@ -33,7 +32,6 @@ jobs:
       build_cache_suffix: sprod_shared
       build_artifact_suffix: sprod_shared
       build_configure_extra_args: '--shared-libs --hip --cuda --native_cpu'
-      merge_ref: ''
 
       artifact_archive_name: sycl_linux_shared.tar.zst
 
@@ -112,7 +110,6 @@ jobs:
       extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' ${{ matrix.extra_lit_opts }}"
       reset_intel_gpu: ${{ matrix.reset_intel_gpu }}
       ref: ${{ github.sha }}
-      merge_ref: ''
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
       sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
@@ -129,7 +126,6 @@ jobs:
       image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
       image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
       ref: ${{ github.sha }}
-      merge_ref: ''
       sycl_toolchain_artifact: sycl_linux_oneapi
       sycl_toolchain_archive: ${{ needs.ubuntu2404_oneapi_build.outputs.artifact_archive_name }}
       sycl_toolchain_decompress_command: ${{ needs.ubuntu2404_oneapi_build.outputs.artifact_decompress_command }}
@@ -175,7 +171,6 @@ jobs:
       image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
       target_devices: cuda:gpu
       ref: ${{ github.sha }}
-      merge_ref: ''
 
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -36,7 +36,6 @@ jobs:
       build_cache_suffix: default
       build_artifact_suffix: default
       build_configure_extra_args: --no-assertions --hip --cuda --native_cpu --cmake-opt="-DSYCL_ENABLE_STACK_PRINTING=ON" --cmake-opt="-DSYCL_LIB_WITH_DEBUG_SYMBOL=ON"
-      merge_ref: ''
 
   e2e-lin:
     needs: [build-lin]
@@ -90,7 +89,6 @@ jobs:
       env: ${{ matrix.env || '{}' }}
 
       ref: ${{ github.sha }}
-      merge_ref: ''
 
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.build-lin.outputs.artifact_archive_name }}
@@ -106,8 +104,7 @@ jobs:
       compiler: icx
       build_configure_extra_args: --cmake-opt=-DCMAKE_C_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt=-DCMAKE_CXX_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt="-DCMAKE_EXE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_MODULE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_SHARED_LINKER_FLAGS=/manifest:no" 
       build_cache_suffix: icx
-      merge_ref: ''
-      
+
   e2e-win:
     needs: build-win
     # Continue if build was successful.
@@ -121,7 +118,6 @@ jobs:
       runner: '["Windows","gen12"]'
       sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
       compiler: icx
-      merge_ref: ''
 
   macos_default:
     name: macOS

--- a/.github/workflows/sycl-rel-nightly.yml
+++ b/.github/workflows/sycl-rel-nightly.yml
@@ -39,7 +39,6 @@ jobs:
       build_artifact_suffix: default
       build_configure_extra_args: '--hip --cuda'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
-      merge_ref: ''
       build_ref: sycl-rel-6_0_0
 
       # We upload the build for people to download/use, override its name and
@@ -109,7 +108,6 @@ jobs:
       extra_lit_opts: ${{ matrix.extra_lit_opts }}
       reset_intel_gpu: ${{ matrix.reset_intel_gpu }}
       ref: sycl-rel-6_0_0
-      merge_ref: ''
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
       sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
@@ -120,7 +118,6 @@ jobs:
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
       ref: sycl-rel-6_0_0
-      merge_ref: ''
 
       # We upload both Linux/Windows build via Github's "Releases"
       # functionality, make sure Linux/Windows names follow the same pattern.
@@ -140,7 +137,6 @@ jobs:
       sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
       extra_lit_opts: --param gpu-intel-gen12=True
       ref: sycl-rel-6_0_0
-      merge_ref: ''
 
   cuda-aws-start:
     needs: [ubuntu2204_build]
@@ -162,7 +158,6 @@ jobs:
       image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
       target_devices: cuda:gpu
       ref: sycl-rel-6_0_0
-      merge_ref: ''
 
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}

--- a/.github/workflows/sycl-weekly.yml
+++ b/.github/workflows/sycl-weekly.yml
@@ -19,7 +19,6 @@ jobs:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
       build_configure_extra_args: ''
-      merge_ref: ''
 
   build-sycl-cts:
     needs: ubuntu2204_build

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -18,12 +18,6 @@ on:
       ref:
         type: string
         required: False
-      merge_ref:
-        description: |
-          Commit-ish to merge post-checkout if non-empty. Must be reachable from
-          the default_branch input paramter.
-        type: string
-        default: 'FETCH_HEAD'
       artifact_archive_name:
         type: string
         default: llvm_sycl.tar.gz
@@ -106,7 +100,6 @@ jobs:
       with:
         path: src
         ref: ${{ inputs.ref || github.sha }}
-        merge_ref: ${{ inputs.merge_ref }}
         cache_path: "D:\\\\github\\\\_work\\\\repo_cache\\\\"
     - name: Configure
       shell: cmd

--- a/.github/workflows/sycl-windows-precommit.yml
+++ b/.github/workflows/sycl-windows-precommit.yml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
       changes: ${{ needs.detect_changes.outputs.filters }}
-      merge_ref: ''
 
   e2e:
     needs: build
@@ -56,4 +55,3 @@ jobs:
       name: Intel GEN12 Graphics with Level Zero
       runner: '["Windows","gen12"]'
       sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
-      merge_ref: ''

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -18,13 +18,6 @@ on:
       ref:
         type: string
         required: False
-      merge_ref:
-        description: |
-          Commit-ish to merge post-checkout if non-empty. Must be reachable from
-          the default_branch input paramter.
-        type: string
-        default: 'FETCH_HEAD'
-        required: False
 
       sycl_toolchain_artifact:
         type: string
@@ -76,7 +69,6 @@ jobs:
       with:
         path: llvm
         ref: ${{ inputs.ref || github.sha }}
-        merge_ref: ${{ inputs.merge_ref }}
         cache_path: "D:\\\\github\\\\_work\\\\repo_cache\\\\"
     - name: Download compiler toolchain
       uses: actions/download-artifact@v4

--- a/devops/actions/cached_checkout/action.yml
+++ b/devops/actions/cached_checkout/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: |
       Commit-ish to merge post-checkout if non-empty. Must be reachable from the
       default_branch input paramter.
-    default: 'FETCH_HEAD'
+    default: ''
   path:
     description: 'Path to checkout repo to'
   fetch-depth:

--- a/devops/actions/run-tests/e2e/action.yml
+++ b/devops/actions/run-tests/e2e/action.yml
@@ -3,8 +3,6 @@ name: 'Run SYCL E2E tests'
 inputs:
   ref:
     required: false
-  merge_ref:
-    required: false
   e2e_binaries_artifact:
     required: false
   extra_cmake_args:
@@ -31,7 +29,6 @@ runs:
     with:
       path: llvm
       ref: ${{ inputs.ref || github.sha }}
-      merge_ref: ${{ inputs.merge_ref }}
       cache_path: "/__w/repo_cache/"
 
   - name: Download E2E Binaries


### PR DESCRIPTION
There were a few places that didn't pass explicit `''` and all of them were actual bugs:

* `sycl-nightly.yml` didn't pass it for windows build and run-tests
* `sycl-nightly.yml` didn't pass it for `ubuntu2404_oneapi_build` job (passed for other linux build jobs)