### PR TITLE
[SYCL][E2E] Rewrite Tests Containing Deprecated Overloads #3

### DIFF
--- a/sycl/test-e2e/ClusterLaunch/cluster_launch_parallel_for.cpp
+++ b/sycl/test-e2e/ClusterLaunch/cluster_launch_parallel_for.cpp
@@ -10,6 +10,49 @@
 
 #include <string>
 
+template <int Dim, typename T> struct KernelFunctor {
+  int *mCorrectResultFlag;
+  T mClusterLaunchProperty;
+  sycl::range<Dim> mClusterRange;
+  KernelFunctor(int *CorrectResultFlag, T ClusterLaunchProperty,
+                sycl::range<Dim> ClusterRange)
+      : mCorrectResultFlag(CorrectResultFlag),
+        mClusterLaunchProperty(ClusterLaunchProperty),
+        mClusterRange(ClusterRange) {}
+
+  void operator()(sycl::nd_item<Dim> It) const {
+    uint32_t ClusterDimX, ClusterDimY, ClusterDimZ;
+// Temporary solution till cluster group class is implemented
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__SYCL_CUDA_ARCH__) &&            \
+    (__SYCL_CUDA_ARCH__ >= 900)
+    asm volatile("\n\t"
+                 "mov.u32 %0, %%cluster_nctaid.x; \n\t"
+                 "mov.u32 %1, %%cluster_nctaid.y; \n\t"
+                 "mov.u32 %2, %%cluster_nctaid.z; \n\t"
+                 : "=r"(ClusterDimZ), "=r"(ClusterDimY), "=r"(ClusterDimX));
+#endif
+    if constexpr (Dim == 1) {
+      if (ClusterDimZ == mClusterRange[0] && ClusterDimY == 1 &&
+          ClusterDimX == 1) {
+        *mCorrectResultFlag = 1;
+      }
+    } else if constexpr (Dim == 2) {
+      if (ClusterDimZ == mClusterRange[1] && ClusterDimY == mClusterRange[0] &&
+          ClusterDimX == 1) {
+        *mCorrectResultFlag = 1;
+      }
+    } else {
+      if (ClusterDimZ == mClusterRange[2] && ClusterDimY == mClusterRange[1] &&
+          ClusterDimX == mClusterRange[0]) {
+        *mCorrectResultFlag = 1;
+      }
+    }
+  }
+  auto get(sycl::ext::oneapi::experimental::properties_tag) const {
+    return mClusterLaunchProperty;
+  }
+};
+
 template <int Dim>
 int test_cluster_launch_parallel_for(sycl::queue &Queue,
                                      sycl::range<Dim> GlobalRange,
@@ -25,38 +68,10 @@ int test_cluster_launch_parallel_for(sycl::queue &Queue,
 
   Queue
       .submit([&](sycl::handler &CGH) {
-        CGH.parallel_for(sycl::nd_range<Dim>(GlobalRange, LocalRange),
-                         ClusterLaunchProperty, [=](sycl::nd_item<Dim> It) {
-                           uint32_t ClusterDimX, ClusterDimY, ClusterDimZ;
-// Temporary solution till cluster group class is implemented
-#if defined(__SYCL_DEVICE_ONLY__) && defined(__SYCL_CUDA_ARCH__) &&            \
-    (__SYCL_CUDA_ARCH__ >= 900)
-                           asm volatile("\n\t"
-                                        "mov.u32 %0, %%cluster_nctaid.x; \n\t"
-                                        "mov.u32 %1, %%cluster_nctaid.y; \n\t"
-                                        "mov.u32 %2, %%cluster_nctaid.z; \n\t"
-                                        : "=r"(ClusterDimZ), "=r"(ClusterDimY),
-                                          "=r"(ClusterDimX));
-#endif
-                           if constexpr (Dim == 1) {
-                             if (ClusterDimZ == ClusterRange[0] &&
-                                 ClusterDimY == 1 && ClusterDimX == 1) {
-                               *CorrectResultFlag = 1;
-                             }
-                           } else if constexpr (Dim == 2) {
-                             if (ClusterDimZ == ClusterRange[1] &&
-                                 ClusterDimY == ClusterRange[0] &&
-                                 ClusterDimX == 1) {
-                               *CorrectResultFlag = 1;
-                             }
-                           } else {
-                             if (ClusterDimZ == ClusterRange[2] &&
-                                 ClusterDimY == ClusterRange[1] &&
-                                 ClusterDimX == ClusterRange[0]) {
-                               *CorrectResultFlag = 1;
-                             }
-                           }
-                         });
+        CGH.parallel_for(
+            sycl::nd_range<Dim>(GlobalRange, LocalRange),
+            KernelFunctor<Dim, decltype(ClusterLaunchProperty)>(
+                CorrectResultFlag, ClusterLaunchProperty, ClusterRange));
       })
       .wait_and_throw();
 

--- a/sycl/test-e2e/ClusterLaunch/enqueueLaunchCustom_check_event_deps.cpp
+++ b/sycl/test-e2e/ClusterLaunch/enqueueLaunchCustom_check_event_deps.cpp
@@ -24,6 +24,22 @@ template <typename T> void dummy_kernel(T *Input, int N, sycl::nd_item<1> It) {
 #endif
 }
 
+template <typename T1, typename T2> struct KernelFunctor {
+  T1 mAcc;
+  T2 mClusterLaunchProperty;
+  KernelFunctor(T2 ClusterLaunchProperty, T1 Acc)
+      : mClusterLaunchProperty(ClusterLaunchProperty), mAcc(Acc) {}
+
+  void operator()(sycl::nd_item<1> It) const {
+    dummy_kernel(
+        mAcc.template get_multi_ptr<sycl::access::decorated::yes>().get(), 4096,
+        It);
+  }
+  auto get(sycl::ext::oneapi::experimental::properties_tag) const {
+    return mClusterLaunchProperty;
+  }
+};
+
 int main() {
 
   std::vector<int> HostArray(4096, -20);
@@ -46,13 +62,8 @@ int main() {
       cuda::cluster_size ClusterDims(sycl::range{2});
       properties ClusterLaunchProperty{ClusterDims};
       auto Acc = Buff.template get_access<sycl::access::mode::read_write>(CGH);
-      CGH.parallel_for(
-          sycl::nd_range({4096}, {32}), ClusterLaunchProperty,
-          [=](sycl::nd_item<1> It) {
-            dummy_kernel(
-                Acc.get_multi_ptr<sycl::access::decorated::yes>().get(), 4096,
-                It);
-          });
+      CGH.parallel_for(sycl::nd_range({4096}, {32}),
+                       KernelFunctor(ClusterLaunchProperty, Acc));
     });
     Queue.submit([&](sycl::handler &CGH) {
       auto Acc = Buff.template get_access<sycl::access::mode::read_write>(CGH);

--- a/sycl/test-e2e/DeviceCodeSplit/grf.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/grf.cpp
@@ -67,6 +67,15 @@ bool checkResult(const std::vector<float> &A, int Inc) {
   return true;
 }
 
+template <typename T1, typename T2> struct KernelFunctor {
+  T1 mPA;
+  T2 mProp;
+  KernelFunctor(T1 PA, T2 Prop) : mPA(PA), mProp(Prop) {}
+
+  void operator()(id<1> i) const { mPA[i] += 2; }
+  auto get(properties_tag) const { return mProp; }
+};
+
 int main(void) {
   constexpr unsigned Size = 32;
   constexpr unsigned VL = 16;
@@ -122,8 +131,8 @@ int main(void) {
 
     auto e = q.submit([&](handler &cgh) {
       auto PA = bufa.get_access<access::mode::read_write>(cgh);
-      cgh.parallel_for<class SYCLKernelSpecifiedGRF>(
-          Size, prop, [=](id<1> i) { PA[i] += 2; });
+      cgh.parallel_for<class SYCLKernelSpecifiedGRF>(Size,
+                                                     KernelFunctor(PA, prop));
     });
     e.wait();
   } catch (sycl::exception const &e) {

--- a/sycl/test-e2e/VirtualFunctions/misc/range-non-uniform-vf-2.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/range-non-uniform-vf-2.cpp
@@ -44,6 +44,25 @@ public:
   virtual int bar(int V) { return V / 2; }
 };
 
+template <typename T1, typename T2> struct KernelFunctor {
+  T1 mDeviceStorage;
+  T2 mDataAcc;
+  KernelFunctor(T1 DeviceStorage, T2 DataAcc)
+      : mDeviceStorage(DeviceStorage), mDataAcc(DataAcc) {}
+
+  template <typename T> void operator()(T It) const {
+    // Select method that corresponds to this work-item
+    auto *Ptr = mDeviceStorage->template getAs<BaseOp>();
+    if (It % 2)
+      mDataAcc[It] = Ptr->foo(mDataAcc[It]);
+    else
+      mDataAcc[It] = Ptr->bar(mDataAcc[It]);
+  }
+  auto get(oneapi::properties_tag) const {
+    return oneapi::properties{oneapi::assume_indirect_calls};
+  }
+};
+
 int main() try {
   using storage_t = obj_storage_t<OpA, OpB>;
 
@@ -54,7 +73,6 @@ int main() try {
   auto *DeviceStorage = sycl::malloc_shared<storage_t>(1, q);
   sycl::range R{1024};
 
-  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   for (size_t TestCase = 0; TestCase < 2; ++TestCase) {
     std::vector<int> HostData(R.size());
     std::iota(HostData.begin(), HostData.end(), 0);
@@ -69,14 +87,7 @@ int main() try {
 
     q.submit([&](sycl::handler &CGH) {
       sycl::accessor DataAcc(DataStorage, CGH, sycl::read_write);
-      CGH.parallel_for(R, props, [=](auto It) {
-        // Select method that corresponds to this work-item
-        auto *Ptr = DeviceStorage->template getAs<BaseOp>();
-        if (It % 2)
-          DataAcc[It] = Ptr->foo(DataAcc[It]);
-        else
-          DataAcc[It] = Ptr->bar(DataAcc[It]);
-      });
+      CGH.parallel_for(R, KernelFunctor(DeviceStorage, DataAcc));
     });
 
     BaseOp *Ptr = HostStorage.construct</* ret type = */ BaseOp>(TestCase);

--- a/sycl/test-e2e/VirtualFunctions/misc/range-non-uniform-vf-2.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/range-non-uniform-vf-2.cpp
@@ -4,7 +4,10 @@
 // kernels when different work-items perform calls to different virtual
 // functions using the same object.
 //
-// RUN: %{build} -o %t.out %helper-includes
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue
+// https://github.com/intel/llvm/issues/16839. Remove the flag as well as the
+// variable 'props' once the issue is resolved.
+// RUN: %{build} -o %t.out -Wno-deprecated-declarations %helper-includes
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
@@ -73,6 +76,7 @@ int main() try {
   auto *DeviceStorage = sycl::malloc_shared<storage_t>(1, q);
   sycl::range R{1024};
 
+  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   for (size_t TestCase = 0; TestCase < 2; ++TestCase) {
     std::vector<int> HostData(R.size());
     std::iota(HostData.begin(), HostData.end(), 0);
@@ -87,7 +91,7 @@ int main() try {
 
     q.submit([&](sycl::handler &CGH) {
       sycl::accessor DataAcc(DataStorage, CGH, sycl::read_write);
-      CGH.parallel_for(R, KernelFunctor(DeviceStorage, DataAcc));
+      CGH.parallel_for(R, props, KernelFunctor(DeviceStorage, DataAcc));
     });
 
     BaseOp *Ptr = HostStorage.construct</* ret type = */ BaseOp>(TestCase);

--- a/sycl/test-e2e/VirtualFunctions/misc/range-non-uniform-vf.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/range-non-uniform-vf.cpp
@@ -41,6 +41,23 @@ public:
   virtual float apply(float V) { return sycl::round(V); }
 };
 
+template <typename T1, typename T2> struct KernelFunctor {
+  T1 mDeviceStorage;
+  T2 mDataAcc;
+  KernelFunctor(T1 DeviceStorage, T2 DataAcc)
+      : mDeviceStorage(DeviceStorage), mDataAcc(DataAcc) {}
+
+  void operator()(sycl::item<1> It) const {
+    // Select an object that corresponds to this work-item
+    auto Ind = It % 3;
+    auto *Ptr = mDeviceStorage[Ind].template getAs<BaseOp>();
+    mDataAcc[It] = Ptr->apply(mDataAcc[It]);
+  }
+  auto get(oneapi::properties_tag) const {
+    return oneapi::properties{oneapi::assume_indirect_calls};
+  }
+};
+
 int main() try {
   using storage_t = obj_storage_t<FloorOp, CeilOp, RoundOp>;
 
@@ -51,7 +68,6 @@ int main() try {
   auto *DeviceStorage = sycl::malloc_shared<storage_t>(3, q);
   sycl::range R{1024};
 
-  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   {
     std::vector<float> HostData(R.size());
     for (size_t I = 1; I < HostData.size(); ++I)
@@ -69,12 +85,7 @@ int main() try {
 
     q.submit([&](sycl::handler &CGH) {
       sycl::accessor DataAcc(DataStorage, CGH, sycl::read_write);
-      CGH.parallel_for(R, props, [=](auto it) {
-        // Select an object that corresponds to this work-item
-        auto Ind = it % 3;
-        auto *Ptr = DeviceStorage[Ind].template getAs<BaseOp>();
-        DataAcc[it] = Ptr->apply(DataAcc[it]);
-      });
+      CGH.parallel_for(R, KernelFunctor(DeviceStorage, DataAcc));
     });
 
     BaseOp *Ptr[] = {HostStorage[0].construct</* ret type = */ BaseOp>(0),

--- a/sycl/test-e2e/VirtualFunctions/misc/range-non-uniform-vf.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/range-non-uniform-vf.cpp
@@ -4,7 +4,10 @@
 // kernels when different work-items perform a virtual function calls using
 // different objects.
 //
-// RUN: %{build} -o %t.out %helper-includes
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue
+// https://github.com/intel/llvm/issues/16839. Remove the flag as well as the
+// variable 'props' once the issue is resolved.
+// RUN: %{build} -o %t.out -Wno-deprecated-declarations %helper-includes
 // RUN: %{run} %t.out
 
 #include <sycl/builtins.hpp>
@@ -68,6 +71,7 @@ int main() try {
   auto *DeviceStorage = sycl::malloc_shared<storage_t>(3, q);
   sycl::range R{1024};
 
+  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   {
     std::vector<float> HostData(R.size());
     for (size_t I = 1; I < HostData.size(); ++I)
@@ -85,7 +89,7 @@ int main() try {
 
     q.submit([&](sycl::handler &CGH) {
       sycl::accessor DataAcc(DataStorage, CGH, sycl::read_write);
-      CGH.parallel_for(R, KernelFunctor(DeviceStorage, DataAcc));
+      CGH.parallel_for(R, props, KernelFunctor(DeviceStorage, DataAcc));
     });
 
     BaseOp *Ptr[] = {HostStorage[0].construct</* ret type = */ BaseOp>(0),

--- a/sycl/test-e2e/VirtualFunctions/misc/range-uniform-vf.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/range-uniform-vf.cpp
@@ -41,6 +41,21 @@ public:
   virtual float apply(float V) { return sycl::round(V); }
 };
 
+template <typename T1, typename T2> struct KernelFunctor {
+  T1 mDeviceStorage;
+  T2 mDataAcc;
+  KernelFunctor(T1 DeviceStorage, T2 DataAcc)
+      : mDeviceStorage(DeviceStorage), mDataAcc(DataAcc) {}
+
+  void operator()(sycl::id<1> It) const {
+    auto *Ptr = mDeviceStorage->template getAs<BaseOp>();
+    mDataAcc[It] = Ptr->apply(mDataAcc[It]);
+  }
+  auto get(oneapi::properties_tag) const {
+    return oneapi::properties{oneapi::assume_indirect_calls};
+  }
+};
+
 int main() try {
   using storage_t = obj_storage_t<FloorOp, CeilOp, RoundOp>;
 
@@ -51,7 +66,6 @@ int main() try {
   auto *DeviceStorage = sycl::malloc_shared<storage_t>(1, q);
   sycl::range R{1024};
 
-  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   for (unsigned TestCase = 0; TestCase < 3; ++TestCase) {
     std::vector<float> HostData(R.size());
     for (size_t I = 1; I < HostData.size(); ++I)
@@ -67,10 +81,7 @@ int main() try {
 
     q.submit([&](sycl::handler &CGH) {
       sycl::accessor DataAcc(DataStorage, CGH, sycl::read_write);
-      CGH.parallel_for(R, props, [=](auto it) {
-        auto *Ptr = DeviceStorage->getAs<BaseOp>();
-        DataAcc[it] = Ptr->apply(DataAcc[it]);
-      });
+      CGH.parallel_for(R, KernelFunctor(DeviceStorage, DataAcc));
     });
 
     auto *Ptr = HostStorage.construct</* ret type = */ BaseOp>(TestCase);

--- a/sycl/test-e2e/VirtualFunctions/misc/range-uniform-vf.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/range-uniform-vf.cpp
@@ -4,7 +4,10 @@
 // kernels when every work-item calls the same virtual function on the same
 // object.
 //
-// RUN: %{build} -o %t.out %helper-includes
+// TODO: Currently using the -Wno-deprecated-declarations flag due to issue
+// https://github.com/intel/llvm/issues/16839. Remove the flag as well as the
+// variable 'props' once the issue is resolved.
+// RUN: %{build} -o %t.out -Wno-deprecated-declarations %helper-includes
 // RUN: %{run} %t.out
 
 #include <sycl/builtins.hpp>
@@ -66,6 +69,7 @@ int main() try {
   auto *DeviceStorage = sycl::malloc_shared<storage_t>(1, q);
   sycl::range R{1024};
 
+  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   for (unsigned TestCase = 0; TestCase < 3; ++TestCase) {
     std::vector<float> HostData(R.size());
     for (size_t I = 1; I < HostData.size(); ++I)
@@ -81,7 +85,7 @@ int main() try {
 
     q.submit([&](sycl::handler &CGH) {
       sycl::accessor DataAcc(DataStorage, CGH, sycl::read_write);
-      CGH.parallel_for(R, KernelFunctor(DeviceStorage, DataAcc));
+      CGH.parallel_for(R, props, KernelFunctor(DeviceStorage, DataAcc));
     });
 
     auto *Ptr = HostStorage.construct</* ret type = */ BaseOp>(TestCase);

--- a/sycl/test-e2e/WorkGroupScratchMemory/dynamic_alloc_ptr_alias.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/dynamic_alloc_ptr_alias.cpp
@@ -23,6 +23,36 @@ using namespace sycl;
 
 namespace sycl_ext = sycl::ext::oneapi::experimental;
 
+template <typename T1, typename T2> struct KernelFunctor {
+  T1 m_props;
+  T2 mAcc;
+  KernelFunctor(T1 props, T2 Acc) : m_props(props), mAcc(Acc) {}
+
+  void operator()(nd_item<1> Item) const {
+    int *Ptr =
+        reinterpret_cast<int *>(sycl_ext::get_work_group_scratch_memory());
+    size_t GroupOffset = Item.get_group_linear_id() * ElemPerWG;
+    for (size_t I = 0; I < RepeatWG; ++I) {
+      Ptr[WgSize * I + Item.get_local_linear_id()] = Item.get_local_linear_id();
+    }
+
+    Item.barrier();
+    // Check that multiple calls return the same pointer.
+    unsigned int *PtrAlias = reinterpret_cast<unsigned int *>(
+        sycl_ext::get_work_group_scratch_memory());
+
+    for (size_t I = 0; I < RepeatWG; ++I) {
+      // Check that the memory is accessible from other
+      // work-items
+      size_t BaseIdx = GroupOffset + (I * WgSize);
+      size_t LocalIdx = Item.get_local_linear_id() ^ 1;
+      size_t GlobalIdx = BaseIdx + LocalIdx;
+      mAcc[GlobalIdx] = PtrAlias[WgSize * I + LocalIdx];
+    }
+  }
+  auto get(sycl_ext::properties_tag) const { return m_props; }
+};
+
 int main() {
   queue Q;
   std::vector<int> Vec(Size, 0);
@@ -34,31 +64,7 @@ int main() {
                                                   sizeof(int));
     sycl_ext::properties properties{static_size};
     Cgh.parallel_for(nd_range<1>(range<1>(WgSize * WgCount), range<1>(WgSize)),
-                     properties, [=](nd_item<1> Item) {
-                       int *Ptr = reinterpret_cast<int *>(
-                           sycl_ext::get_work_group_scratch_memory());
-                       size_t GroupOffset =
-                           Item.get_group_linear_id() * ElemPerWG;
-                       for (size_t I = 0; I < RepeatWG; ++I) {
-                         Ptr[WgSize * I + Item.get_local_linear_id()] =
-                             Item.get_local_linear_id();
-                       }
-
-                       Item.barrier();
-                       // Check that multiple calls return the same pointer.
-                       unsigned int *PtrAlias =
-                           reinterpret_cast<unsigned int *>(
-                               sycl_ext::get_work_group_scratch_memory());
-
-                       for (size_t I = 0; I < RepeatWG; ++I) {
-                         // Check that the memory is accessible from other
-                         // work-items
-                         size_t BaseIdx = GroupOffset + (I * WgSize);
-                         size_t LocalIdx = Item.get_local_linear_id() ^ 1;
-                         size_t GlobalIdx = BaseIdx + LocalIdx;
-                         Acc[GlobalIdx] = PtrAlias[WgSize * I + LocalIdx];
-                       }
-                     });
+                     KernelFunctor(properties, Acc));
   });
 
   host_accessor Acc(Buf, read_only);

--- a/sycl/test-e2e/WorkGroupScratchMemory/dynamic_unused.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/dynamic_unused.cpp
@@ -14,6 +14,19 @@ using DataType = int;
 
 namespace sycl_ext = sycl::ext::oneapi::experimental;
 
+template <typename T> struct KernelFunctor {
+  T m_props;
+  DataType *m_a;
+  DataType *m_b;
+  KernelFunctor(T props, DataType *a, DataType *b)
+      : m_props(props), m_a(a), m_b(b) {}
+
+  void operator()(sycl::nd_item<1> it) const {
+    m_b[it.get_local_linear_id()] = m_a[it.get_local_linear_id()];
+  }
+  auto get(sycl_ext::properties_tag) const { return m_props; }
+};
+
 int main() {
   sycl::queue queue;
   DataType *a = sycl::malloc_device<DataType>(Size, queue);
@@ -25,13 +38,12 @@ int main() {
 
   queue
       .submit([&](sycl::handler &cgh) {
-        cgh.parallel_for(sycl::nd_range<1>({Size}, {Size}),
-                         sycl_ext::properties{sycl_ext::work_group_scratch_size(
-                             Size * sizeof(DataType))},
-                         [=](sycl::nd_item<1> it) {
-                           b[it.get_local_linear_id()] =
-                               a[it.get_local_linear_id()];
-                         });
+        cgh.parallel_for(
+            sycl::nd_range<1>({Size}, {Size}),
+            KernelFunctor(
+                sycl_ext::properties{
+                    sycl_ext::work_group_scratch_size(Size * sizeof(DataType))},
+                a, b));
       })
       .wait_and_throw();
 


### PR DESCRIPTION
The overloads for single_task and parallel_for in the sycl_ext_oneapi_kernel_properties extension are being deprecated as mentioned in https://github.com/intel/llvm/pull/14785. So I'm rewriting tests containg such overloads so that they can still run after the deprecation.