### PR TITLE
[CI] Refactor build/run-only logic in `run-tests/e2e/action.yml`

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -44,6 +44,9 @@ on:
         description: 'Artifacts retention period'
         type: string
         default: 3
+      e2e_binaries_artifact:
+        type: string
+        required: False
 
     outputs:
       build_conclusion:
@@ -247,13 +250,13 @@ jobs:
         retention-days: ${{ inputs.retention-days }}
 
     - name: Copy toolchain
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ inputs.e2e_binaries_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
       # We must have the compiler in the same location as it will be in the E2E
       # run-tests job.
       run: cp -r $GITHUB_WORKSPACE/build/install $GITHUB_WORKSPACE/toolchain
 
     - name: Source OneAPI TBB vars.sh
-      shell: bash
+      if: ${{ inputs.e2e_binaries_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
       run: |
         # https://github.com/actions/runner/issues/1964 prevents us from using
         # the ENTRYPOINT in the image.
@@ -270,11 +273,11 @@ jobs:
         rm env_before env_after
 
     - name: Build E2E tests
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ inputs.e2e_binaries_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
       uses: ./devops/actions/run-tests/e2e
       with:
         ref: ${{ inputs.ref || github.sha }}
-        e2e_testing_mode: build-only
+        testing_mode: build-only
         target_devices: all
-        artifact_suffix: default
+        binaries_artifact: ${{ inputs.e2e_binaries_artifact }}
         cxx_compiler: $GITHUB_WORKSPACE/toolchain/bin/clang++

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -257,6 +257,7 @@ jobs:
 
     - name: Source OneAPI TBB vars.sh
       if: ${{ inputs.e2e_binaries_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
+      shell: bash
       run: |
         # https://github.com/actions/runner/issues/1964 prevents us from using
         # the ENTRYPOINT in the image.

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -49,6 +49,7 @@ jobs:
       cc: clang
       cxx: clang++
       changes: ${{ needs.detect_changes.outputs.filters }}
+      e2e_binaries_artifact: sycl_e2e_bin_default
 
   determine_arc_tests:
     name: Decide which Arc tests to run

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -54,23 +54,18 @@ on:
 
       e2e_binaries_artifact:
         description: |
-          By setting this the E2E binaries folder will not be created, rather it
-          will be downloaded and extracted from the specified artifact. When
-          running tests in `run-only` mode this must be provided.
+          Must be set if `e2e_testing_mode` is equal to `run-only` and the
+          artifact must exist. Can be set in other modes resulting in artifact
+          upload.
         type: string
         default: ''
         required: False
       e2e_testing_mode:
         description: |
           Testing mode to run E2E tests in, can be either `full`, `build-only`
-          or `run-only`. In `build-only` mode an artifact of the E2E binaries
-          will be uploaded.
+          or `run-only`.
         type: string
         default: 'full'
-      artifact_suffix:
-        description: 'Suffix for E2E binaries artifact that is output when in `build-only`.'
-        type: string
-        default: 'default'
       retention-days:
         description: 'E2E/SYCL-CTS binaries artifact retention period.'
         type: string
@@ -289,12 +284,11 @@ jobs:
       uses: ./devops/actions/run-tests/e2e
       with:
         ref: ${{ inputs.ref || github.sha }}
-        e2e_binaries_artifact: ${{ inputs.e2e_binaries_artifact }}
+        binaries_artifact: ${{ inputs.e2e_binaries_artifact }}
+        testing_mode: ${{ inputs.e2e_testing_mode }}
         extra_cmake_args: ${{ inputs.extra_cmake_args }}
-        e2e_testing_mode: ${{ inputs.e2e_testing_mode }}
         target_devices: ${{ inputs.target_devices }}
         extra_lit_opts: ${{ inputs.extra_lit_opts }}
-        artifact_suffix: ${{ inputs.artifact_suffix }}
         retention-days: ${{ inputs.retention-days }}
 
     - name: Run SYCL CTS Tests

--- a/devops/actions/run-tests/e2e/action.yml
+++ b/devops/actions/run-tests/e2e/action.yml
@@ -3,17 +3,15 @@ name: 'Run SYCL E2E tests'
 inputs:
   ref:
     required: false
-  e2e_binaries_artifact:
+  binaries_artifact:
     required: false
+  testing_mode:
+    required: true
   extra_cmake_args:
     required: false
-  e2e_testing_mode:
-    required: true
   target_devices:
     required: true
   extra_lit_opts:
-    required: false
-  artifact_suffix:
     required: false
   retention-days:
     required: false
@@ -32,19 +30,19 @@ runs:
       cache_path: "/__w/repo_cache/"
 
   - name: Download E2E Binaries
-    if: inputs.e2e_binaries_artifact != ''
+    if: inputs.testing_mode == 'run-only'
     uses: actions/download-artifact@v4
     with:
-      name: ${{ inputs.e2e_binaries_artifact }}
+      name: ${{ inputs.binaries_artifact }}
   - name: Extract E2E Binaries
-    if: inputs.e2e_binaries_artifact != ''
+    if: inputs.testing_mode == 'run-only'
     shell: bash
     run: |
       mkdir build-e2e
       tar -I 'zstd' -xf e2e_binaries.tar.zst -C build-e2e
 
   - name: Deduce E2E CMake options
-    if: inputs.e2e_binaries_artifact == ''
+    if: inputs.testing_mode != 'run-only'
     id: cmake_opts
     shell: bash
     env:
@@ -54,14 +52,14 @@ runs:
         echo "opts=$CMAKE_EXTRA_ARGS" >> $GITHUB_OUTPUT
       fi
   - name: Configure E2E tests
-    if: inputs.e2e_binaries_artifact == ''
+    if: inputs.testing_mode != 'run-only'
     shell: bash
     run: |
       cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.cxx_compiler || '$(which clang++)'}}" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" ${{ steps.cmake_opts.outputs.opts }}
   - name: SYCL End-to-end tests
     shell: bash {0}
     env:
-      LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time 3600 --time-tests --param test-mode=${{ inputs.e2e_testing_mode }} --param sycl_devices=${{ inputs.target_devices }} ${{ inputs.extra_lit_opts }}
+      LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time 3600 --time-tests --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} ${{ inputs.extra_lit_opts }}
     run: |
       ninja -C build-e2e check-sycl-e2e > e2e.log 2>&1
       exit_code=$?
@@ -72,14 +70,14 @@ runs:
       exit $exit_code
 
   - name: Pack E2E binaries
-    if: ${{ always() && !cancelled() && inputs.e2e_testing_mode == 'build-only'}}
+    if: ${{ always() && !cancelled() && inputs.binaries_artifact != '' && inputs.testing_mode != 'run-only'}}
     shell: bash
     run: |
       tar -I 'zstd -9' -cf e2e_binaries.tar.zst -C ./build-e2e .
   - name: Upload E2E binaries
-    if: ${{ always() && !cancelled() && inputs.e2e_testing_mode == 'build-only'}}
+    if: ${{ always() && !cancelled() && inputs.binaries_artifact != '' && inputs.testing_mode != 'run-only'}}
     uses: actions/upload-artifact@v4
     with:
-      name: sycl_e2e_bin_${{ inputs.artifact_suffix }}
+      name: ${{ inputs.binaries_artifact }}
       path: e2e_binaries.tar.zst
       retention-days: ${{ inputs.retention-days }}


### PR DESCRIPTION
Reduce number of input parameters and make the logic a bit cleaner (IMO). This PR also uses that updated logic to make building E2E tests optional in `sycl-linux-build.yml` and makes enabled in pre-commit only for now, effectively fixing the regression in Nightly CI introduced in https://github.com/intel/llvm/pull/16682.