### PR TITLE
[libclc][libspirv] Add generic implementation of __spirv_LocalInvocationIndex

### DIFF
--- a/libclc/libspirv/include/libspirv/spirv.h
+++ b/libclc/libspirv/include/libspirv/spirv.h
@@ -58,6 +58,7 @@
 #include <libspirv/workitem/get_global_size.h>
 #include <libspirv/workitem/get_group_id.h>
 #include <libspirv/workitem/get_local_id.h>
+#include <libspirv/workitem/get_local_linear_id.h>
 #include <libspirv/workitem/get_local_size.h>
 #include <libspirv/workitem/get_max_sub_group_size.h>
 #include <libspirv/workitem/get_num_groups.h>

--- a/libclc/libspirv/include/libspirv/workitem/get_local_linear_id.h
+++ b/libclc/libspirv/include/libspirv/workitem/get_local_linear_id.h
@@ -1,0 +1,9 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+_CLC_DECL _CLC_OVERLOAD size_t __spirv_LocalInvocationIndex();

--- a/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives.cl
+++ b/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives.cl
@@ -365,17 +365,6 @@ __CLC_GROUP_COLLECTIVE__DF16(_Z20__spirv_GroupFMulKHRjjDF16_,
 #undef __CLC_ADD
 #undef __CLC_MUL
 
-long __clc__get_linear_local_id() {
-  size_t id_x = __spirv_LocalInvocationId_x();
-  size_t id_y = __spirv_LocalInvocationId_y();
-  size_t id_z = __spirv_LocalInvocationId_z();
-  size_t size_x = __spirv_WorkgroupSize_x();
-  size_t size_y = __spirv_WorkgroupSize_y();
-  size_t size_z = __spirv_WorkgroupSize_z();
-  uint sg_size = __spirv_SubgroupMaxSize();
-  return (id_z * size_y * size_x + id_y * size_x + id_x);
-}
-
 long __clc__2d_to_linear_local_id(ulong2 id) {
   size_t size_x = __spirv_WorkgroupSize_x();
   size_t size_y = __spirv_WorkgroupSize_y();
@@ -396,7 +385,7 @@ long __clc__3d_to_linear_local_id(ulong3 id) {
       return _Z28__spirv_SubgroupShuffleINTELI##TYPE_MANGLED##ET_S0_j(         \
           x, local_id);                                                        \
     }                                                                          \
-    bool source = (__clc__get_linear_local_id() == local_id);                  \
+    bool source = (__spirv_LocalInvocationIndex() == local_id);                \
     __local TYPE *scratch = __CLC_APPEND(__clc__get_group_scratch_, TYPE)();   \
     if (source) {                                                              \
       *scratch = x;                                                            \

--- a/libclc/libspirv/lib/generic/SOURCES
+++ b/libclc/libspirv/lib/generic/SOURCES
@@ -206,5 +206,6 @@ shared/vload.cl
 shared/vstore.cl
 workitem/get_global_id.cl
 workitem/get_global_size.cl
+workitem/get_local_linear_id.cl
 workitem/get_num_sub_groups.cl
 workitem/get_sub_group_size.cl

--- a/libclc/libspirv/lib/generic/workitem/get_local_linear_id.cl
+++ b/libclc/libspirv/lib/generic/workitem/get_local_linear_id.cl
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <libspirv/spirv.h>
+
+_CLC_DEF _CLC_OVERLOAD size_t __spirv_LocalInvocationIndex() {
+  return __spirv_LocalInvocationId_z() * __spirv_WorkgroupSize_y() *
+             __spirv_WorkgroupSize_x() +
+         __spirv_LocalInvocationId_y() * __spirv_WorkgroupSize_x() +
+         __spirv_LocalInvocationId_x();
+}

--- a/libclc/libspirv/lib/ptx-nvidiacl/group/collectives.cl
+++ b/libclc/libspirv/lib/ptx-nvidiacl/group/collectives.cl
@@ -624,17 +624,6 @@ __CLC_GROUP_COLLECTIVE__DF16(_Z20__spirv_GroupFMulKHRjjDF16_,
 #undef __CLC_ADD
 #undef __CLC_MUL
 
-long __clc__get_linear_local_id() {
-  size_t id_x = __spirv_LocalInvocationId_x();
-  size_t id_y = __spirv_LocalInvocationId_y();
-  size_t id_z = __spirv_LocalInvocationId_z();
-  size_t size_x = __spirv_WorkgroupSize_x();
-  size_t size_y = __spirv_WorkgroupSize_y();
-  size_t size_z = __spirv_WorkgroupSize_z();
-  uint sg_size = __spirv_SubgroupMaxSize();
-  return (id_z * size_y * size_x + id_y * size_x + id_x);
-}
-
 long __clc__2d_to_linear_local_id(ulong2 id) {
   size_t size_x = __spirv_WorkgroupSize_x();
   size_t size_y = __spirv_WorkgroupSize_y();
@@ -654,7 +643,7 @@ long __clc__3d_to_linear_local_id(ulong3 id) {
     if (scope == Subgroup) {                                                   \
       return __clc__SubgroupShuffle(x, local_id);                              \
     }                                                                          \
-    bool source = (__clc__get_linear_local_id() == local_id);                  \
+    bool source = (__spirv_LocalInvocationIndex() == local_id);                \
     __local TYPE *scratch = __CLC_APPEND(__clc__get_group_scratch_, TYPE)();   \
     if (source) {                                                              \
       *scratch = x;                                                            \


### PR DESCRIPTION
This allows the builtin to be called in implementation of other builtins.