### PR TITLE
[SYCL][Matrix][E2E] Remove `REQUIRES: build-and-run-mode` from Matrix tests

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_hip_gfx90a.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_gfx90a.cpp
@@ -9,8 +9,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx90a %s -o %t.out
 // RUN: %{run} %t.out
 
+// REQUIRES: target-amd
 // REQUIRES: arch-amd_gpu_gfx90a
-// REQUIRES: build-and-run-mode
 
 #include "joint_matrix_hip_apply.hpp"
 #include "joint_matrix_hip_copy.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_hip_half_gfx90a.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_half_gfx90a.cpp
@@ -9,9 +9,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx90a %s -o %t.out
 // RUN: %{run} %t.out
 
+// REQUIRES: target-amd
 // REQUIRES: arch-amd_gpu_gfx90a
 // REQUIRES: aspect-fp16
-// REQUIRES: build-and-run-mode
 
 #include "joint_matrix_hip_apply.hpp"
 #include "joint_matrix_hip_copy.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm70.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm70.cpp
@@ -6,8 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: cuda
-// REQUIRES: build-and-run-mode
+// REQUIRES: target-nvidia
 // RUN: %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_70 -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Matrix/runtime_query_hip_gfx90a.cpp
+++ b/sycl/test-e2e/Matrix/runtime_query_hip_gfx90a.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: target-amd
 // REQUIRES: arch-amd_gpu_gfx90a
-// REQUIRES: build-and-run-mode
 // RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx90a %s -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
As of #16725 tests that do not build for `spir64` do not need to be marked as exceptions for split build/run with `REQUIRES: build-and-run-mode`, instead we can mark them as `REQUIRES: target-<nvidia/amd>`.

This patch replaces the `REQUIRES: build-and-run-mode` directives in Matrix tests with `REQUIRES: target-amd` or `REQUIRES: target-nvidia`.