### PR TITLE
[CI] Update dev-igc even if IGC CI failed

### DIFF
--- a/devops/scripts/update_drivers.py
+++ b/devops/scripts/update_drivers.py
@@ -17,7 +17,7 @@ def get_latest_workflow_runs(repo, workflow_name):
         + repo
         + "/actions/workflows/"
         + workflow_name
-        + ".yml/runs?status=success"
+        + ".yml/runs"
     ).read()
     return json.loads(action_runs)["workflow_runs"][0]
 


### PR DESCRIPTION
IGC public CI has been failing for months and we got confirmation even if the public CI fails the change has already been internally validated.
We can confirm this change works as below:
[Old link](https://api.github.com/repos/intel/intel-graphics-compiler/actions/workflows/build-IGC.yml/runs?status=success)
[New link](https://api.github.com/repos/intel/intel-graphics-compiler/actions/workflows/build-IGC.yml/runs)