### PR TITLE
[SYCL][NFC][Doc] Update sycl_ext_intel_device_info backend limitations

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md
@@ -62,7 +62,7 @@ The device ID can be obtained using the standard get\_info() interface.
 
 A new device descriptor will be added which will provide the device Universal Unique ID (UUID).
 
-The DPC++ default behavior (for the Level Zero platform) would be to expose the UUIDs of all supported devices which enables detection of total number of unique devices.
+The DPC++ default behavior would be to expose the UUIDs of all supported devices which enables detection of total number of unique devices.
 
 
 ## Version ##
@@ -135,8 +135,6 @@ The PCI address can be obtained using the standard get\_info() interface.
 
 A new device descriptor will be added which will provide the physical SIMD width of an execution unit on an Intel GPU.  This data will be used to calculate the computational capabilities of the device.
 
-This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform.
-
 
 ## Version ##
 
@@ -174,8 +172,6 @@ The physical EU SIMD width can be obtained using the standard get\_info() interf
 A new device descriptor will be added which will provide the number of execution units on an Intel GPU.  If the device is a subdevice, then the number of EUs in the subdevice is returned.
 
 This new device descriptor will provide the same information as "max\_compute\_units" does today.  We would like to have an API which is specific for Intel GPUs.
-
-This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform.
 
 
 ## Version ##


### PR DESCRIPTION
SYCL_ENABLE_PCI is deprecated here https://github.com/intel/llvm/commit/2d128632ffdd86b557b07b97a4a8282d103707bc. Remove it as requirement for device info query.
Remove statement that some device info is supported on L0 only if there is at least one another backend that could return it. (mostly it is L0 +hip/cuda).