### PR TITLE
[CI] Use pre-built e2e tests for Arc GPU and Dev IGC PVC pre-commit

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -74,22 +74,37 @@ jobs:
           fi
 
   run_prebuilt_e2e_tests:
-    needs: [build]
+    needs: [build, detect_changes, determine_arc_tests]
     if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: Intel
+          - name: GEN 12 Integrated
             runner: '["Linux", "gen12"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu;opencl:cpu
             reset_intel_gpu: true
             extra_lit_opts: --param gpu-intel-gen12=True
+          - name: Intel Arc A-Series Graphics
+            runner: '["Linux", "arc"]'
+            image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
+            target_devices: level_zero:gpu;opencl:gpu
+            reset_intel_gpu: true
+            extra_lit_opts: --param matrix-xmx8=True
+            env: '{"LIT_FILTER":${{ needs.determine_arc_tests.outputs.arc_tests }} }'
+          - name: Dev IGC on Intel Ponte Vecchio GPU
+            runner: '["Linux", "pvc"]'
+            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:devigc
+            image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
+            target_devices: level_zero:gpu;opencl:gpu
+            use_igc_dev: true
+            extra_lit_opts: -j 50
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: ${{ matrix.name }}
       runner: ${{ matrix.runner }}
+      image: ${{ matrix.image }}
       image_options: ${{ matrix.image_options }}
       target_devices: ${{ matrix.target_devices }}
       extra_lit_opts: --param fallback-to-build-if-requires-build-and-run=True ${{ matrix.extra_lit_opts }}
@@ -100,6 +115,20 @@ jobs:
       sycl_toolchain_decompress_command: ${{ needs.build.outputs.artifact_decompress_command }}
       e2e_binaries_artifact: sycl_e2e_bin_default
       e2e_testing_mode: 'run-only'
+
+      # Do not install drivers on AMD and CUDA runners.
+      install_igc_driver: >-
+        ${{ !contains(matrix.target_devices, 'cuda') &&
+        !contains(matrix.target_devices, 'hip') &&
+        contains(needs.detect_changes.outputs.filters, 'drivers') }}
+      install_dev_igc_driver: >-
+        ${{ !contains(matrix.target_devices, 'cuda') &&
+        !contains(matrix.target_devices, 'hip') &&
+        matrix.use_igc_dev &&
+        (contains(needs.detect_changes.outputs.filters, 'devigccfg') || contains(needs.detect_changes.outputs.filters, 'drivers')) ||
+        'false' }}
+      # Run only if the PR does not have the 'ci-no-devigc' label.
+      skip_run: ${{matrix.use_igc_dev && contains(github.event.pull_request.labels.*.name, 'ci-no-devigc') || 'false'}}
 
   test:
     needs: [build, detect_changes, determine_arc_tests]
@@ -117,13 +146,6 @@ jobs:
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
             target_devices: hip:gpu
             reset_intel_gpu: false
-          - name: E2E tests on Intel Arc A-Series Graphics
-            runner: '["Linux", "arc"]'
-            image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
-            target_devices: level_zero:gpu;opencl:gpu
-            reset_intel_gpu: true
-            extra_lit_opts: --param matrix-xmx8=True
-            env: '{"LIT_FILTER":${{ needs.determine_arc_tests.outputs.arc_tests }} }'
           - name: E2E tests with dev igc on Intel Arc A-Series Graphics
             runner: '["Linux", "arc"]'
             image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:devigc
@@ -137,13 +159,6 @@ jobs:
             runner: '["Linux", "pvc"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu
-            extra_lit_opts: -j 50
-          - name: E2E tests with dev igc on Intel Ponte Vecchio GPU
-            runner: '["Linux", "pvc"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:devigc
-            image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
-            target_devices: level_zero:gpu;opencl:gpu
-            use_igc_dev: true
             extra_lit_opts: -j 50
 
     uses: ./.github/workflows/sycl-linux-run-tests.yml

--- a/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-host.cpp
+++ b/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-host.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t
-// RUN: %force_device_asan_rt %{run} not %t 2>&1 | FileCheck %s
+// RUN: %force_device_asan_rt %{run} not --crash %t 2>&1 | FileCheck %s
 #include <sycl/usm.hpp>
 
 constexpr size_t N = 64;

--- a/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-minus1.cpp
+++ b/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-minus1.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %force_device_asan_rt %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %force_device_asan_rt %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O0 -g -o %t2.out
-// RUN: %force_device_asan_rt %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %force_device_asan_rt %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O0 -g -o %t3.out
-// RUN: %force_device_asan_rt %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
+// RUN: %force_device_asan_rt %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
 #include <sycl/usm.hpp>
 
 constexpr size_t N = 64;

--- a/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-plus1.cpp
+++ b/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-plus1.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %force_device_asan_rt %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %force_device_asan_rt %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O0 -g -o %t2.out
-// RUN: %force_device_asan_rt %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %force_device_asan_rt %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O0 -g -o %t3.out
-// RUN: %force_device_asan_rt %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
+// RUN: %force_device_asan_rt %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
 #include <sycl/usm.hpp>
 
 constexpr size_t N = 64;

--- a/sycl/test-e2e/AddressSanitizer/common/options-invalid-values.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/options-invalid-values.cpp
@@ -4,22 +4,22 @@
 
 // clang-format off
 // Invalid ur option format
-// RUN: env UR_LAYER_ASAN_OPTIONS=a:1,b:1 %{run} not %t 2>&1 | FileCheck %s  --check-prefixes INVALID-FORMAT
+// RUN: env UR_LAYER_ASAN_OPTIONS=a:1,b:1 %{run} not --crash %t 2>&1 | FileCheck %s  --check-prefixes INVALID-FORMAT
 // INVALID-FORMAT: <SANITIZER>[ERROR]: Wrong format of the UR_LAYER_ASAN_OPTIONS environment variable value
 
 // Invalid bool option
-// RUN: env UR_LAYER_ASAN_OPTIONS=debug:yes %{run} not %t 2>&1 | FileCheck %s  --check-prefixes INVALID-BOOL
+// RUN: env UR_LAYER_ASAN_OPTIONS=debug:yes %{run} not --crash %t 2>&1 | FileCheck %s  --check-prefixes INVALID-BOOL
 // INVALID-BOOL: <SANITIZER>[ERROR]: "debug" is set to "yes", which is not an valid setting. Acceptable input are: for enable, use: "1" "true"; for disable, use: "0" "false".
 
 // Invalid quarantine_size_mb
-// RUN: env UR_LAYER_ASAN_OPTIONS=quarantine_size_mb:-1 %{run} not %t 2>&1 | FileCheck %s  --check-prefixes INVALID-QUARANTINE
-// RUN: env UR_LAYER_ASAN_OPTIONS=quarantine_size_mb:4294967296 %{run} not %t 2>&1 | FileCheck %s  --check-prefixes INVALID-QUARANTINE
+// RUN: env UR_LAYER_ASAN_OPTIONS=quarantine_size_mb:-1 %{run} not --crash %t 2>&1 | FileCheck %s  --check-prefixes INVALID-QUARANTINE
+// RUN: env UR_LAYER_ASAN_OPTIONS=quarantine_size_mb:4294967296 %{run} not --crash %t 2>&1 | FileCheck %s  --check-prefixes INVALID-QUARANTINE
 // INVALID-QUARANTINE: <SANITIZER>[ERROR]: "quarantine_size_mb" should be an integer in range[0, 4294967295].
 
 // Invalid redzone and max_redzone
-// RUN: env UR_LAYER_ASAN_OPTIONS=redzone:abc %{run} not %t 2>&1 | FileCheck %s  --check-prefixes INVALID-REDZONE
+// RUN: env UR_LAYER_ASAN_OPTIONS=redzone:abc %{run} not --crash %t 2>&1 | FileCheck %s  --check-prefixes INVALID-REDZONE
 // INVALID-REDZONE: <SANITIZER>[ERROR]: "redzone" should be an integer in range[0, 16].
-// RUN: env UR_LAYER_ASAN_OPTIONS=max_redzone:abc %{run} not %t 2>&1 | FileCheck %s  --check-prefixes INVALID-MAXREDZONE
+// RUN: env UR_LAYER_ASAN_OPTIONS=max_redzone:abc %{run} not --crash %t 2>&1 | FileCheck %s  --check-prefixes INVALID-MAXREDZONE
 // INVALID-MAXREDZONE: <SANITIZER>[ERROR]: "max_redzone" should be an integer in range[0, 2048].
 // clang-format on
 

--- a/sycl/test-e2e/AddressSanitizer/double-free/double-free.cpp
+++ b/sycl/test-e2e/AddressSanitizer/double-free/double-free.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O0 -g -o %t2.out
-// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O0 -g -o %t3.out
-// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
+// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
 #include <sycl/usm.hpp>
 
 constexpr size_t N = 64;

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // Flakily timesout on PVC
 // UNSUPPORTED: arch-intel_gpu_pvc


### PR DESCRIPTION
`not --crash` changes are necessary because run-only mode has slightly different way of running the tests due to https://github.com/intel/llvm/blob/e8564403232c13b3716aa68190084880f2a98a6c/sycl/test-e2e/format.py#L368-L372