### PR TITLE
[SYCL][E2E] Remove `REQUIRES: build-and-run-mode` from `syclcompat` and `Adapters` tests

### DIFF
--- a/sycl/test-e2e/Adapters/cuda_queue_priority.cpp
+++ b/sycl/test-e2e/Adapters/cuda_queue_priority.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: gpu, cuda, cuda_dev_kit
-// REQUIRES: build-and-run-mode
 // RUN: %{build} %cuda_options -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Adapters/dll-detach-order.cpp
+++ b/sycl/test-e2e/Adapters/dll-detach-order.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// REQUIRES: build-and-run-mode
 // RUN: env SYCL_UR_TRACE=-1 sycl-ls | FileCheck %s
 
 // ensure that the adapters are detached AFTER urLoaderTearDown is done

--- a/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// REQUIRES: build-and-run-mode
 
 // DEFINE: %{sharedflag} = %if cl_options %{/clang:-shared%} %else %{-shared%}
 

--- a/sycl/test-e2e/syclcompat/launch/launch_properties.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_properties.cpp
@@ -22,8 +22,9 @@
  *     sycl/test-e2e/ClusterLaunch/cluster_launch_parallel_for.cpp
  **************************************************************************/
 
-// REQUIRES: aspect-ext_oneapi_cuda_cluster_group
-// REQUIRES: build-and-run-mode
+// REQUIRES: target-nvidia, aspect-ext_oneapi_cuda_cluster_group
+// XFAIL: *
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16794
 // RUN: %{build} -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_90 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/syclcompat/memory/local_memory_ptr_to_integer.cpp
+++ b/sycl/test-e2e/syclcompat/memory/local_memory_ptr_to_integer.cpp
@@ -1,5 +1,4 @@
-// REQUIRES: cuda
-// REQUIRES: build-and-run-mode
+// REQUIRES: target-nvidia
 // RUN:  %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_75 -o %t.out
 // RUN:  %{run} %t.out
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
As of #16725 tests can properly react to features that affect compilation on build-only mode (i.e., libraries or OS), additionally we can also mark if a test should only be built for a specific triple using the `target-*` features.

This pr removes `REQUIRES: build-and-run-mode` from syclcompat and Adapters tests, and either lets the test be marked as unsupported due to requiring a missing build feature (`windows` or `cuda_dev_kit`), or the test is marked as unsupported for `spir` by requiring `target-nvidia`