### PR TITLE
Revert "[CI] Temporarily disable tests requiring `spirv-tools` in CI"

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -195,9 +195,6 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target check-sycl-unittests
     - name: check-llvm-spirv
       if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
-      # Temporary workaround to disable running tests requiring spirv-tools.
-      env:
-        LIT_OPTS: "--param disable-spirv-tools=True"
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm-spirv
     - name: check-xptifw

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -145,9 +145,6 @@ jobs:
         cmake --build build --target check-sycl-unittests
     - name: check-llvm-spirv
       if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
-      # Temporary workaround to disable running tests requiring spirv-tools.
-      env:
-        LIT_OPTS: "--param disable-spirv-tools=True"
       run: |
         cmake --build build --target check-llvm-spirv
     - name: check-xptifw

--- a/llvm-spirv/test/lit.cfg.py
+++ b/llvm-spirv/test/lit.cfg.py
@@ -60,27 +60,24 @@ llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 using_spirv_tools = False
 
-# Explicitly disable using spirv tools, if requested.
-disable_spirv_tools = lit_config.params.get("disable-spirv-tools", False)
-
-if config.spirv_tools_have_spirv_as and not disable_spirv_tools:
+if config.spirv_tools_have_spirv_as:
     llvm_config.add_tool_substitutions(['spirv-as'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-as')
     using_spirv_tools = True
 
-if config.spirv_tools_have_spirv_dis and not disable_spirv_tools:
+if config.spirv_tools_have_spirv_dis:
     llvm_config.add_tool_substitutions(['spirv-dis'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-dis')
     using_spirv_tools = True
 
-if config.spirv_tools_have_spirv_link and not disable_spirv_tools:
+if config.spirv_tools_have_spirv_link:
     llvm_config.add_tool_substitutions(['spirv-link'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-link')
     using_spirv_tools = True
 
 # Unlike spirv-{as,dis,link} above, running spirv-val is optional: if spirv-val is
 # not available, the test must still run and just skip any spirv-val commands.
-if config.spirv_tools_have_spirv_val and not disable_spirv_tools:
+if config.spirv_tools_have_spirv_val:
     llvm_config.add_tool_substitutions(['spirv-val'], [config.spirv_tools_bin_dir])
     using_spirv_tools = True
 else:


### PR DESCRIPTION
Reverts intel/llvm#16743. After installing `pkg-config` in CI, `llvm-spirv` can correctly find `spriv-tools` so this workaround is no longer needed.
Example run: https://github.com/intel/llvm/actions/runs/12996166493/job/36244369469?pr=16801#step:14:16