### PR TITLE
[SYCL][Test] Add regression test for `sycl::vec` compilation error in windows, debug

### DIFF
--- a/sycl/test/regression/vec_array_windows.cpp
+++ b/sycl/test/regression/vec_array_windows.cpp
@@ -5,9 +5,11 @@
 
 // REQUIRES: windows
 
-// RUN: not %clangxx -fsycl -D_DEBUG -I %sycl_include %s -fsycl-device-only 2>&1 | FileCheck %s
+// RUN: %clangxx -fsycl -D_DEBUG %s -fsycl-device-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note,warning
 
 #include <sycl/sycl.hpp>
 
-// CHECK: error: SYCL kernel cannot call a variadic function
+// expected-error@* {{SYCL kernel cannot call a variadic function}}
+// expected-error@* {{SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute}}
+// expected-error@* {{SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute}}
 SYCL_EXTERNAL auto GetFirstElement(sycl::vec<int, 3> v) { return v[0]; }

--- a/sycl/test/regression/vec_array_windows.cpp
+++ b/sycl/test/regression/vec_array_windows.cpp
@@ -2,7 +2,6 @@
 // https://github.com/intel/llvm/pull/14130. This PR caused sycl::vec to use
 // std::array as its underlying storage. However, operations on std::array
 // may emit debug-mode-only functions, on which the device compiler may fail.
-// Examples of such failure: CMPLRLLVM-52910, CMPLRLLVM-64902.
 
 // REQUIRES: windows
 

--- a/sycl/test/regression/vec_array_windows.cpp
+++ b/sycl/test/regression/vec_array_windows.cpp
@@ -1,0 +1,14 @@
+// Test to isolate sycl::vec regression after
+// https://github.com/intel/llvm/pull/14130. This PR caused sycl::vec to use
+// std::array as its underlying storage. However, operations on std::array
+// may emit debug-mode-only functions, on which the device compiler may fail.
+// Examples of such failure: CMPLRLLVM-52910, CMPLRLLVM-64902.
+
+// REQUIRES: windows
+
+// RUN: not %clangxx -fsycl -D_DEBUG -I %sycl_include %s -fsycl-device-only 2>&1 | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+// CHECK: error: SYCL kernel cannot call a variadic function
+SYCL_EXTERNAL auto GetFirstElement(sycl::vec<int, 3> v) { return v[0]; }


### PR DESCRIPTION
Test to isolate `sycl::vec` regression after https://github.com/intel/llvm/pull/14130. This PR caused `sycl::vec` to use `std::array` as its underlying storage. However, operations on `std::array` may emit debug-mode-only functions, on which the device compiler may fail.