### PR TITLE
[CI] Simplify CI by using `alldeps` image whenever possible

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -82,7 +82,6 @@ jobs:
         include:
           - name: Intel
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu;opencl:cpu
             reset_intel_gpu: true
@@ -91,7 +90,6 @@ jobs:
     with:
       name: ${{ matrix.name }}
       runner: ${{ matrix.runner }}
-      image: ${{ matrix.image }}
       image_options: ${{ matrix.image_options }}
       target_devices: ${{ matrix.target_devices }}
       extra_lit_opts: --param fallback-to-build-if-requires-build-and-run=True ${{ matrix.extra_lit_opts }}
@@ -112,18 +110,15 @@ jobs:
         include:
           - name: NVIDIA/CUDA
             runner: '["Linux", "cuda"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
             target_devices: cuda:gpu
           - name: AMD/HIP
             runner: '["Linux", "amdgpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
             target_devices: hip:gpu
             reset_intel_gpu: false
           - name: E2E tests on Intel Arc A-Series Graphics
             runner: '["Linux", "arc"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu
             reset_intel_gpu: true
@@ -140,7 +135,6 @@ jobs:
             use_igc_dev: true
           - name: E2E tests on Intel Ponte Vecchio GPU
             runner: '["Linux", "pvc"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu
             extra_lit_opts: -j 50
@@ -197,27 +191,22 @@ jobs:
         include:
           - name: Intel GEN12 Graphics system
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_extra_opts: --device=/dev/dri
             reset_intel_gpu: true
           - name: Intel Arc A-Series Graphics system
             runner: '["Linux", "arc"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_extra_opts: --device=/dev/dri
             reset_intel_gpu: true
           - name: AMD system
             runner: '["Linux", "amdgpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_extra_opts: --device=/dev/dri --device=/dev/kfd
           - name: CUDA system
             runner: '["Linux", "cuda"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_extra_opts: --gpus all
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: Perf tests on ${{ matrix.name }}
       runner: ${{ matrix. runner }}
-      image: ${{ matrix.image }}
       image_options: -u 1001 --privileged --cap-add SYS_ADMIN ${{ matrix.image_extra_opts }}
       target_devices: all
       reset_intel_gpu: ${{ matrix.reset_intel_gpu }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -12,7 +12,6 @@ on:
         required: True
       image:
         type: string
-        default: 'ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps'
         required: False
       image_options:
         type: string
@@ -187,7 +186,7 @@ jobs:
     name: ${{ inputs.name }}
     runs-on: ${{ fromJSON(inputs.runner) }}
     container:
-      image: ${{ inputs.image }}
+      image: ${{ inputs.image || 'ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps'}}
       options: ${{ inputs.image_options }}
     env: ${{ fromJSON(inputs.env) }}
     steps:

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -12,7 +12,8 @@ on:
         required: True
       image:
         type: string
-        required: True
+        default: 'ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps'
+        required: False
       image_options:
         type: string
         required: True
@@ -114,25 +115,29 @@ on:
           - '["Linux", "pvc"]'
           - '["cts-cpu"]'
           - '["Linux", "build"]'
+          - '["cuda"]'
       image:
         type: choice
         options:
           - 'ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest'
+          - 'ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps'
       image_options:
         description: |
           Use option with "--device=/dev/kfd" for AMDGPU, without it for the rest.
         type: choice
         options:
-          - '-u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN'
           - '-u 1001 --device=/dev/dri --device=/dev/kfd --privileged --cap-add SYS_ADMIN'
+          - '-u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN'
+          - '-u 1001 --gpus all --cap-add SYS_ADMIN'
       target_devices:
         type: choice
         options:
+          - 'level_zero:gpu'
           - 'opencl:cpu'
           - 'opencl:gpu'
           - 'opencl:fpga'
-          - 'level_zero:gpu'
           - 'hip:gpu'
+          - 'cuda:gpu'
       tests_selector:
         type: choice
         options:

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -58,14 +58,12 @@ jobs:
         include:
           - name: AMD/HIP
             runner: '["Linux", "amdgpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
             target_devices: hip:gpu
             tests_selector: e2e
 
           - name: Intel L0 GPU
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
             reset_intel_gpu: true
@@ -73,7 +71,6 @@ jobs:
 
           - name: Intel OCL GPU
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: opencl:gpu
             reset_intel_gpu: true
@@ -81,21 +78,18 @@ jobs:
 
           - name: OCL CPU (AMD)
             runner: '["Linux", "amdgpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001
             target_devices: opencl:cpu
             tests_selector: e2e
 
           - name: OCL CPU (Intel/GEN12)
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --privileged --cap-add SYS_ADMIN
             target_devices: opencl:cpu
             tests_selector: e2e
 
           - name: OCL CPU (Intel/Arc)
             runner: '["Linux", "arc"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001
             target_devices: opencl:cpu
             tests_selector: e2e
@@ -103,7 +97,6 @@ jobs:
     with:
       name: ${{ matrix.name }}
       runner: ${{ matrix.runner }}
-      image: ${{ matrix.image }}
       image_options: ${{ matrix.image_options }}
       target_devices: ${{ matrix.target_devices }}
       tests_selector: ${{ matrix.tests_selector }}
@@ -123,7 +116,6 @@ jobs:
       runner: '["Linux", "pvc"]'
       target_devices: level_zero:gpu
       extra_lit_opts: -j 50
-      image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
       image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
       ref: ${{ github.sha }}
       sycl_toolchain_artifact: sycl_linux_oneapi
@@ -167,7 +159,6 @@ jobs:
     with:
       name: CUDA E2E
       runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
-      image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
       target_devices: cuda:gpu
       ref: ${{ github.sha }}
@@ -192,7 +183,6 @@ jobs:
       name: Build SYCL-CTS
       runner: '["Linux", "build"]'
       cts_testing_mode: 'build-only'
-      image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
       image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
       tests_selector: cts
       ref: ${{ github.sha }}
@@ -209,13 +199,11 @@ jobs:
         include:
           - name: SYCL-CTS on OCL CPU
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: opencl:cpu
 
           - name: SYCL-CTS on L0 gen12
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
     uses: ./.github/workflows/sycl-linux-run-tests.yml
@@ -223,7 +211,6 @@ jobs:
       name: ${{ matrix.name }}
       runner: ${{ matrix.runner }}
       cts_testing_mode: 'run-only'
-      image: ${{ matrix.image }}
       image_options: ${{ matrix.image_options }}
       target_devices: ${{ matrix.target_devices }}
       tests_selector: cts

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -159,6 +159,7 @@ jobs:
     with:
       name: CUDA E2E
       runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
+      image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
       target_devices: cuda:gpu
       ref: ${{ github.sha }}

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -54,7 +54,6 @@ jobs:
             reset_intel_gpu: true
           - name: AMD/HIP
             runner: '["Linux", "amdgpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
             target_devices: hip:gpu
             reset_intel_gpu: false
@@ -80,7 +79,6 @@ jobs:
     with:
       name: ${{ matrix.name }}
       runner: ${{ matrix. runner }}
-      image: ${{ matrix.image || 'ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest' }}
       image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' }}
       target_devices: ${{ matrix.target_devices || 'level_zero:gpu' }}
       reset_intel_gpu: ${{ matrix.reset_intel_gpu }}

--- a/.github/workflows/sycl-rel-nightly.yml
+++ b/.github/workflows/sycl-rel-nightly.yml
@@ -54,14 +54,12 @@ jobs:
         include:
           - name: AMD/HIP
             runner: '["Linux", "amdgpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_build:latest
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
             target_devices: hip:gpu
             tests_selector: e2e
 
           - name: Intel L0 GPU
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
             reset_intel_gpu: true
@@ -70,7 +68,6 @@ jobs:
 
           - name: Intel OCL GPU
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: opencl:gpu
             reset_intel_gpu: true
@@ -79,21 +76,18 @@ jobs:
 
           - name: Intel OCL CPU
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --privileged --cap-add SYS_ADMIN
             target_devices: opencl:cpu
             tests_selector: e2e
 
           - name: SYCL-CTS on OCL CPU
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: opencl:cpu
             tests_selector: cts
 
           - name: SYCL-CTS on L0 gen12
             runner: '["Linux", "gen12"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
             tests_selector: cts
@@ -101,7 +95,6 @@ jobs:
     with:
       name: ${{ matrix.name }}
       runner: ${{ matrix.runner }}
-      image: ${{ matrix.image }}
       image_options: ${{ matrix.image_options }}
       target_devices: ${{ matrix.target_devices }}
       tests_selector: ${{ matrix.tests_selector }}

--- a/.github/workflows/sycl-weekly.yml
+++ b/.github/workflows/sycl-weekly.yml
@@ -46,13 +46,11 @@ jobs:
         include:
           - name: SYCL-CTS on OCL CPU PVC w/ LLVM SPIR-V Backend
             runner: '["Linux", "pvc"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: opencl:cpu
 
           - name: SYCL-CTS on L0 GPU PVC w/ LLVM SPIR-V Backend
             runner: '["Linux", "pvc"]'
-            image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
     uses: ./.github/workflows/sycl-linux-run-tests.yml
@@ -60,7 +58,6 @@ jobs:
       name: ${{ matrix.name }}
       runner: ${{ matrix.runner }}
       cts_testing_mode: 'run-only'
-      image: ${{ matrix.image }}
       image_options: ${{ matrix.image_options }}
       target_devices: ${{ matrix.target_devices }}
       tests_selector: cts

--- a/sycl/test-e2e/DeprecatedFeatures/opencl_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/opencl_interop.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: opencl, opencl_icd
+// REQUIRES: opencl, opencl_icd, target-spir
 
 // RUN: %{build} -D__SYCL_INTERNAL_API -o %t.out %opencl_lib
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/DeprecatedFeatures/opencl_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/opencl_interop.cpp
@@ -1,7 +1,7 @@
-// REQUIRES: opencl, opencl_icd, target-spir
+// REQUIRES: any-device-is-opencl, opencl_icd, target-spir
 
 // RUN: %{build} -D__SYCL_INTERNAL_API -o %t.out %opencl_lib
-// RUN: %{run} %t.out
+// RUN: %{run-unfiltered-devices} %t.out
 
 #include <cassert>
 #include <exception>
@@ -25,7 +25,14 @@ cl_platform_id selectOpenCLPlatform() {
   err = clGetPlatformIDs(num_of_platforms, &platforms[0], 0);
   CL_CHECK_ERRORS(err);
 
-  return platforms[0];
+  for (int i = 0; i < num_of_platforms; ++i) {
+    cl_uint num_of_devices = 0;
+    err =
+        clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, 0, 0, &num_of_devices);
+    if (err == CL_SUCCESS && num_of_devices > 0)
+      return platforms[i];
+  }
+  throw std::runtime_error("No OpenCL platforms with available devices!");
 }
 
 cl_device_id selectOpenCLDevice(cl_platform_id platform) {

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_spirv.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_spirv.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: ocloc
+// REQUIRES: ocloc, target-spir
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out %S/Kernels/kernels.spv %S/Kernels/kernels_fp16.spv %S/Kernels/kernels_fp64.spv

--- a/sycl/test-e2e/Regression/device_num.cpp
+++ b/sycl/test-e2e/Regression/device_num.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: any-device-is-hip
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16805
+
 // RUN: %{build} -o %t.out
 // RUN: env PRINT_FULL_DEVICE_INFO=1 %{run-unfiltered-devices} %t.out > %t1.conf
 // RUN: env ONEAPI_DEVICE_SELECTOR="*:0" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out


### PR DESCRIPTION
First step on unifying our "base" image into a single "fat" container similarly to what's been done with nightly images at https://github.com/intel/llvm/pull/16680.