### PR TITLE
[SYCL][E2E] Use "raw string" in `re.search(r"", ...)`

### DIFF
--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -25,13 +25,13 @@ def parse_min_intel_driver_req(line_number, line, output):
     if not output:
         output = {}
 
-    lin = re.search("lin: *([0-9]{5})", line)
+    lin = re.search(r"lin: *([0-9]{5})", line)
     if lin:
         if "lin" in output:
             raise ValueError('Multiple entries for "lin" version')
         output["lin"] = int(lin.group(1))
 
-    win = re.search("win: *([0-9]{3}\.[0-9]{4})", line)
+    win = re.search(r"win: *([0-9]{3}\.[0-9]{4})", line)
     if win:
         if "win" in output:
             raise ValueError('Multiple entries for "win" version')


### PR DESCRIPTION
We've been getting

```
.../sycl/test-e2e/format.py:34: SyntaxWarning: invalid escape sequence '\.'
  win = re.search("win: *([0-9]{3}\.[0-9]{4})", line)
```

before this PR.