### PR TITLE
[NFC][libclc] Fix clcfunc.h merge conflict resolve in b400aa4586c4

### DIFF
--- a/libclc/clc/include/clc/clcfunc.h
+++ b/libclc/clc/include/clc/clcfunc.h
@@ -18,9 +18,4 @@
 #define _CLC_DEF __attribute__((always_inline))
 #endif
 
-#define _CLC_INLINE __attribute__((always_inline)) inline
-#define _CLC_CONVERGENT __attribute__((convergent))
-#define _CLC_PURE __attribute__((pure))
-#define _CLC_CONSTFN __attribute__((const))
-
 #endif // __CLC_CLCFUNC_H_


### PR DESCRIPTION
These 4 macros were moved in 4602c16a6823, but added back by b400aa4586c4, resuling in duplicate definitions in this file.