### PR TITLE
[SYCL][CMake][MSVC] Fix link.exe /OPT detection

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -75,7 +75,7 @@ if(MSVC)
     add_link_options("LINKER:/DEBUG")
 
     # Enable unreferenced removal and ICF in Release mode.
-    check_linker_flag(CXX "LINKER:/OPT:REF LINKER:/OPT:ICF" LINKER_SUPPORTS_OPTS)
+    check_linker_flag(CXX "LINKER:/OPT:REF,/OPT:ICF" LINKER_SUPPORTS_OPTS)
     if (LINKER_SUPPORTS_OPTS AND uppercase_CMAKE_BUILD_TYPE STREQUAL "RELEASE")
       add_link_options("LINKER:/OPT:REF" "LINKER:/OPT:ICF")
     endif()


### PR DESCRIPTION
CMake's check_linker_flag does no split flags by spaces, so the current call passes the single option `"/OPT:REF LINKER:/OPT:ICF"` with a space in it to link.exe. (The first `LINKER:` prefix is parsed). This was also broken before ede906ce6cb425718638091322f425b84676047f ([CMake][MSVC] Wrap more Linker flags for ICX (#16284)), where it would pass `"/OPT:REF /OPT:ICF"` as a single option.

This results in the check failing and so the build does not ever enable these flags, even though they would be supported if the check was correct.

Use comma as the separator as supported by the `LINKER:` syntax to fix it.