### PR TITLE
[CI][E2E] Run E2E tests on NVIDIA with prebuilt binaries in precommit

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -279,6 +279,7 @@ jobs:
         target_devices: all
         binaries_artifact: ${{ inputs.e2e_binaries_artifact }}
         cxx_compiler: $GITHUB_WORKSPACE/toolchain/bin/clang++
+        extra_lit_opts: --param sycl_build_targets="spir;nvidia"
 
     - name: Remove E2E tests before spirv-backend run
       if: ${{ inputs.e2e_binaries_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -86,6 +86,10 @@ jobs:
             target_devices: level_zero:gpu;opencl:gpu;opencl:cpu
             reset_intel_gpu: true
             extra_lit_opts: --param gpu-intel-gen12=True
+          - name: NVIDIA/CUDA
+            runner: '["Linux", "cuda"]'
+            image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
+            target_devices: cuda:gpu
           - name: Intel Arc A-Series Graphics
             runner: '["Linux", "arc"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
@@ -137,10 +141,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: NVIDIA/CUDA
-            runner: '["Linux", "cuda"]'
-            image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
-            target_devices: cuda:gpu
           - name: AMD/HIP
             runner: '["Linux", "amdgpu"]'
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd

--- a/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm72.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm72.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: cuda
+// REQUIRES: target-nvidia
 // RUN: %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_72 -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm80.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm80.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: cuda
+// REQUIRES: target-nvidia
 // RUN: %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_80 -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Regression/build_log.cpp
+++ b/sycl/test-e2e/Regression/build_log.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: gpu
 // RUN: %{build} -o %t.exe
-// RUN: %{run} %t.exe 2> %t.out || true
+// RUN: %{run} %t.exe 2> %t.out
 
 // RUN: FileCheck %s --check-prefix=CHECK-EXPECTED-ERROR --input-file %t.out
 // CHECK-EXPECTED-ERROR: error: backend compiler failed build

--- a/sycl/test-e2e/Regression/kernel_bundle_ignore_sycl_external.cpp
+++ b/sycl/test-e2e/Regression/kernel_bundle_ignore_sycl_external.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// XFAIL: cuda
+// XFAIL: target-nvidia
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/16417
 // UNSUPPORTED: hip
 

--- a/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
@@ -2,7 +2,7 @@
 // RUN: %{run} %t.out
 //
 // XFAIL: cuda
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/00000
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16968
 
 // UNSUPPORTED: gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16072

--- a/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
@@ -1,8 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// Fails on cuda when built for multiple triples
-// XFAIL: cuda && !build-and-run-mode
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/00000
 
 // UNSUPPORTED: gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16072

--- a/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
@@ -1,6 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
+// Fails on cuda when built for multiple triples
+// XFAIL: cuda && !build-and-run-mode
 
 // UNSUPPORTED: gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16072


### PR DESCRIPTION
Reduces time for precommit nvidia job from around 20m to around 5m