### PR TITLE
[CI] Ping assignees after 90 days

### DIFF
--- a/.github/workflows/sycl-issues-ping-assignee.yml
+++ b/.github/workflows/sycl-issues-ping-assignee.yml
@@ -20,7 +20,7 @@ jobs:
   run:
     permissions:
       issues: write 
-    runs-on: ubuntu-20.04 
+    runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
@@ -39,7 +39,7 @@ jobs:
 
     - name: Filter issues and ping
       run: |
-          days_to_stale=60
+          days_to_stale=90
           current_time=$(date +%s)
 
           cat issues.json | jq -c '.[]' | while read -r issue; do


### PR DESCRIPTION
The workflow pings assignees of issues if there are no updates for the last 60 days. Increase to 90 to reduce the number of these messages.