### PR TITLE
[SYCL] Add SYCL registered kernel metadata into property sets

### DIFF
--- a/llvm/include/llvm/Support/PropertySetIO.h
+++ b/llvm/include/llvm/Support/PropertySetIO.h
@@ -211,6 +211,7 @@ public:
   static constexpr char SYCL_HOST_PIPES[] = "SYCL/host pipes";
   static constexpr char SYCL_VIRTUAL_FUNCTIONS[] = "SYCL/virtual functions";
   static constexpr char SYCL_IMPLICIT_LOCAL_ARG[] = "SYCL/implicit local arg";
+  static constexpr char SYCL_REGISTERED_KERNELS[] = "SYCL/registered kernels";
 
   static constexpr char PROPERTY_REQD_WORK_GROUP_SIZE[] =
       "reqd_work_group_size_uint64_t";

--- a/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
@@ -471,6 +471,18 @@ PropSetRegTy computeModuleProperties(const Module &M,
     }
   }
 
+  if (const NamedMDNode *MD = M.getNamedMetadata("sycl_registered_kernels")) {
+    assert(MD->getNumOperands() == 1 && "Invalid sycl_registered_kernels metadata");
+    const MDNode *RegistredKernels = MD->getOperand(0);
+    for (const MDOperand &Op : RegistredKernels->operands()) {
+      const auto *RegisteredKernel = cast<MDNode>(Op);
+      assert(RegisteredKernel->getNumOperands() == 2 && "Invalid sycl_registered_kernels metadata");
+      PropSet.add(PropSetRegTy::SYCL_REGISTERED_KERNELS, 
+                  cast<MDString>(RegisteredKernel->getOperand(0))->getString(),
+                  cast<MDString>(RegisteredKernel->getOperand(1))->getString());
+    }
+  }
+
   return PropSet;
 }
 std::string computeModuleSymbolTable(const Module &M,

--- a/llvm/test/tools/sycl-post-link/sycl-registered-kernels.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-registered-kernels.ll
@@ -1,0 +1,41 @@
+; This test checks that the sycl-post-link ouputs registered kernel data 
+; from !sycl_registered_kernels metadata into the SYCL/registerd_kernels section.
+; RUN: sycl-post-link %s -properties -o %t.table
+; RUN: FileCheck %s -input-file=%t_0.prop
+
+!sycl_registered_kernels = !{!4}
+!4 = !{!5, !6, !7, !8, !9, !10, !11, !12, !13}
+
+; CHECK: [SYCL/registered kernels]
+
+; For each entry in !sycl_registered_kernels, an entry
+; mapping the registered name to the mangled name is added in the
+; SYCL/registered kernels. (Although in the prop files, the
+; mapped values are base64 encoded, so just using simplifed check
+; with a regex.)
+; CHECK-NEXT: foo=2|{{[A-Za-z0-9+/]+}}
+!5 = !{!"foo", !"_Z17__sycl_kernel_foov"}
+
+; CHECK-NEXT: foo3=2|{{[A-Za-z0-9+/]+}}
+!6 = !{!"foo3", !"_Z18__sycl_kernel_ff_4v"}
+
+; CHECK-NEXT: iota=2|{{[A-Za-z0-9+/]+}}
+!7 = !{!"iota", !"_Z18__sycl_kernel_iotaiPi"}
+
+; CHECK-NEXT: inst temp=2|{{[A-Za-z0-9+/]+}}
+!8 = !{!"inst temp", !"_Z22__sycl_kernel_tempfoo2IiEvT_"}
+
+; CHECK-NEXT: def spec=2|{{[A-Za-z0-9+/]+}}
+!9 = !{!"def spec", !"_Z22__sycl_kernel_tempfoo2IsEvT_"}
+
+; CHECK-NEXT: decl temp=2|{{[A-Za-z0-9+/]+}}
+!10 = !{!"decl temp", !"_Z21__sycl_kernel_tempfooIiEvT_"}
+
+; CHECK-NEXT: decl spec=2|{{[A-Za-z0-9+/]+}}
+!11 = !{!"decl spec", !"_Z22__sycl_kernel_tempfoo2IfEvT_"}
+
+; CHECK-NEXT: nontype=2|{{[A-Za-z0-9+/]+}}
+!12 = !{!"nontype", !"_Z22__sycl_kernel_tempfoo3ILi5EEvv"}
+
+; CHECK-NEXT: non-temp=2|{{[A-Za-z0-9+/]+}}
+!13 = !{!"decl non-temp", !"_Z17__sycl_kernel_barv"}


### PR DESCRIPTION
For the sycl kernel compiler extension, see https://github.com/intel/llvm/pull/11985, https://github.com/intel/llvm/pull/16485