### PR TITLE
[SYCL][E2E] Make layout_array.cpp use specific headers

### DIFF
--- a/sycl/test/abi/layout_array.cpp
+++ b/sycl/test/abi/layout_array.cpp
@@ -5,8 +5,9 @@
 
 // clang-format off
 
-// TODO fix individual headers and include them instead of sycl.hpp
-#include <sycl/sycl.hpp>
+#include <sycl/id.hpp>
+#include <sycl/nd_item.hpp>
+#include <sycl/nd_range.hpp>
 
 
 SYCL_EXTERNAL void id(sycl::id<2>) {}

--- a/sycl/test/abi/layout_array.cpp
+++ b/sycl/test/abi/layout_array.cpp
@@ -5,65 +5,66 @@
 
 // clang-format off
 
-// TODO fix individual headers and include them instead of sycl.hpp
-#include <sycl/sycl.hpp>
+#include <sycl/id.hpp>
+#include <sycl/nd_item.hpp>
+#include <sycl/nd_range.hpp>
 
 
 SYCL_EXTERNAL void id(sycl::id<2>) {}
 
-// CHECK-DAG:      0 | class sycl::id<2>
-// CHECK-DAG-NEXT: 0 |   class sycl::detail::array<2> (base)
-// CHECK-DAG-NEXT: 0 |     size_t[2] common_array
-// CHECK-DAG-NEXT:   | [sizeof=16, dsize=16, align=8,
-// CHECK-DAG-NEXT:   |  nvsize=16, nvalign=8]
+// CHECK: 0 | class sycl::id<2>
+// CHECK-NEXT: 0 |   class sycl::detail::array<2> (base)
+// CHECK-NEXT: 0 |     size_t[2] common_array
+// CHECK-NEXT: | [sizeof=16, dsize=16, align=8,
+// CHECK-NEXT: |  nvsize=16, nvalign=8]
 
 //----------------------------
 
 SYCL_EXTERNAL void range(sycl::range<2>) {}
 
-// CHECK-DAG:      0 | class sycl::range<2>
-// CHECK-DAG-NEXT: 0 |   class sycl::detail::array<2> (base)
-// CHECK-DAG-NEXT: 0 |     size_t[2] common_array
-// CHECK-DAG-NEXT:   | [sizeof=16, dsize=16, align=8,
-// CHECK-DAG-NEXT:   |  nvsize=16, nvalign=8]
+// CHECK: 0 | class sycl::range<2>
+// CHECK-NEXT: 0 |   class sycl::detail::array<2> (base)
+// CHECK-NEXT: 0 |     size_t[2] common_array
+// CHECK-NEXT: | [sizeof=16, dsize=16, align=8,
+// CHECK-NEXT: |  nvsize=16, nvalign=8]
 
 //----------------------------
 
 SYCL_EXTERNAL void nd_item(sycl::nd_item<2>) {}
-// CHECK-DAG:      0 | class sycl::nd_item<2> (empty)
-// CHECK-DAG-NEXT:   | [sizeof=1, dsize=0, align=1,
-// CHECK-DAG-NEXT:   |  nvsize=0, nvalign=1]
+// CHECK:      0 | class sycl::nd_item<2> (empty)
+// CHECK-NEXT:   | [sizeof=1, dsize=0, align=1,
+// CHECK-NEXT:   |  nvsize=0, nvalign=1]
 
 //----------------------------
 
 SYCL_EXTERNAL void item(sycl::item<2>) {}
 
-// CHECK-DAG:       0 | class sycl::item<2>
-// CHECK-DAG-NEXT:  0 |   struct sycl::detail::ItemBase<2, true> MImpl
-// CHECK-DAG-NEXT:  0 |     class sycl::range<2> MExtent
-// CHECK-DAG-NEXT:  0 |       class sycl::detail::array<2> (base)
-// CHECK-DAG-NEXT:  0 |         size_t[2] common_array
-// CHECK-DAG-NEXT: 16 |     class sycl::id<2> MIndex
-// CHECK-DAG-NEXT: 16 |       class sycl::detail::array<2> (base)
-// CHECK-DAG-NEXT: 16 |         size_t[2] common_array
-// CHECK-DAG-NEXT: 32 |     class sycl::id<2> MOffset
-// CHECK-DAG-NEXT: 32 |       class sycl::detail::array<2> (base)
-// CHECK-DAG-NEXT: 32 |         size_t[2] common_array
-// CHECK-DAG-NEXT:    | [sizeof=48, dsize=48, align=8,
-// CHECK-DAG-NEXT:    |  nvsize=48, nvalign=8]
+// CHECK: 0 | class sycl::item<2>
+// CHECK-NEXT: 0 |   struct sycl::detail::ItemBase<2, true> MImpl
+// CHECK-NEXT: 0 |     class sycl::range<2> MExtent
+// CHECK-NEXT: 0 |       class sycl::detail::array<2> (base)
+// CHECK-NEXT: 0 |         size_t[2] common_array
+// CHECK-NEXT: 16 |     class sycl::id<2> MIndex
+// CHECK-NEXT: 16 |       class sycl::detail::array<2> (base)
+// CHECK-NEXT: 16 |         size_t[2] common_array
+// CHECK-NEXT: 32 |     class sycl::id<2> MOffset
+// CHECK-NEXT: 32 |       class sycl::detail::array<2> (base)
+// CHECK-NEXT: 32 |         size_t[2] common_array
+// CHECK-NEXT: | [sizeof=48, dsize=48, align=8,
+// CHECK-NEXT: |  nvsize=48, nvalign=8]
 
 //----------------------------
 
 SYCL_EXTERNAL void nd_range(sycl::nd_range<2>) {}
-// CHECK-DAG:       0 | class sycl::nd_range<2>
-// CHECK-DAG-NEXT:  0 |   class sycl::range<2> globalSize
-// CHECK-DAG-NEXT:  0 |     class sycl::detail::array<2> (base)
-// CHECK-DAG-NEXT:  0 |       size_t[2] common_array
-// CHECK-DAG-NEXT: 16 |   class sycl::range<2> localSize
-// CHECK-DAG-NEXT: 16 |     class sycl::detail::array<2> (base)
-// CHECK-DAG-NEXT: 16 |       size_t[2] common_array
-// CHECK-DAG-NEXT: 32 |   class sycl::id<2> offset
-// CHECK-DAG-NEXT: 32 |     class sycl::detail::array<2> (base)
-// CHECK-DAG-NEXT: 32 |       size_t[2] common_array
-// CHECK-DAG-NEXT:    | [sizeof=48, dsize=48, align=8,
-// CHECK-DAG-NEXT:    |  nvsize=48, nvalign=8]
+// CHECK: 0 | class sycl::nd_range<2>
+// CHECK-NEXT: 0 |   class sycl::range<2> globalSize
+// CHECK-NEXT: 0 |     class sycl::detail::array<2> (base)
+// CHECK-NEXT: 0 |       size_t[2] common_array
+// CHECK-NEXT: 16 |   class sycl::range<2> localSize
+// CHECK-NEXT: 16 |     class sycl::detail::array<2> (base)
+// CHECK-NEXT: 16 |       size_t[2] common_array
+// CHECK-NEXT: 32 |   class sycl::id<2> offset
+// CHECK-NEXT: 32 |     class sycl::detail::array<2> (base)
+// CHECK-NEXT: 32 |       size_t[2] common_array
+// CHECK-NEXT: | [sizeof=48, dsize=48, align=8,
+// CHECK-NEXT: |  nvsize=48, nvalign=8]

--- a/sycl/test/abi/layout_array.cpp
+++ b/sycl/test/abi/layout_array.cpp
@@ -5,9 +5,8 @@
 
 // clang-format off
 
-#include <sycl/id.hpp>
-#include <sycl/nd_item.hpp>
-#include <sycl/nd_range.hpp>
+// TODO fix individual headers and include them instead of sycl.hpp
+#include <sycl/sycl.hpp>
 
 
 SYCL_EXTERNAL void id(sycl::id<2>) {}
@@ -31,7 +30,7 @@ SYCL_EXTERNAL void range(sycl::range<2>) {}
 //----------------------------
 
 SYCL_EXTERNAL void nd_item(sycl::nd_item<2>) {}
-// CHECK-DAG:      0 | class sycl::nd_item<> (empty)
+// CHECK-DAG:      0 | class sycl::nd_item<2> (empty)
 // CHECK-DAG-NEXT:   | [sizeof=1, dsize=0, align=1,
 // CHECK-DAG-NEXT:   |  nvsize=0, nvalign=1]
 

--- a/sycl/test/abi/layout_array.cpp
+++ b/sycl/test/abi/layout_array.cpp
@@ -11,59 +11,59 @@
 
 SYCL_EXTERNAL void id(sycl::id<2>) {}
 
-// CHECK: 0 | class sycl::id<2>
-// CHECK-NEXT: 0 |   class sycl::detail::array<2> (base)
-// CHECK-NEXT: 0 |     size_t[2] common_array
-// CHECK-NEXT: | [sizeof=16, dsize=16, align=8,
-// CHECK-NEXT: |  nvsize=16, nvalign=8]
+// CHECK-DAG:      0 | class sycl::id<2>
+// CHECK-DAG-NEXT: 0 |   class sycl::detail::array<2> (base)
+// CHECK-DAG-NEXT: 0 |     size_t[2] common_array
+// CHECK-DAG-NEXT:   | [sizeof=16, dsize=16, align=8,
+// CHECK-DAG-NEXT:   |  nvsize=16, nvalign=8]
 
 //----------------------------
 
 SYCL_EXTERNAL void range(sycl::range<2>) {}
 
-// CHECK: 0 | class sycl::range<2>
-// CHECK-NEXT: 0 |   class sycl::detail::array<2> (base)
-// CHECK-NEXT: 0 |     size_t[2] common_array
-// CHECK-NEXT: | [sizeof=16, dsize=16, align=8,
-// CHECK-NEXT: |  nvsize=16, nvalign=8]
+// CHECK-DAG:      0 | class sycl::range<2>
+// CHECK-DAG-NEXT: 0 |   class sycl::detail::array<2> (base)
+// CHECK-DAG-NEXT: 0 |     size_t[2] common_array
+// CHECK-DAG-NEXT:   | [sizeof=16, dsize=16, align=8,
+// CHECK-DAG-NEXT:   |  nvsize=16, nvalign=8]
 
 //----------------------------
 
 SYCL_EXTERNAL void nd_item(sycl::nd_item<2>) {}
-// CHECK:      0 | class sycl::nd_item<> (empty)
-// CHECK-NEXT:   | [sizeof=1, dsize=0, align=1,
-// CHECK-NEXT:   |  nvsize=0, nvalign=1]
+// CHECK-DAG:      0 | class sycl::nd_item<> (empty)
+// CHECK-DAG-NEXT:   | [sizeof=1, dsize=0, align=1,
+// CHECK-DAG-NEXT:   |  nvsize=0, nvalign=1]
 
 //----------------------------
 
 SYCL_EXTERNAL void item(sycl::item<2>) {}
 
-// CHECK: 0 | class sycl::item<2>
-// CHECK-NEXT: 0 |   struct sycl::detail::ItemBase<2, true> MImpl
-// CHECK-NEXT: 0 |     class sycl::range<2> MExtent
-// CHECK-NEXT: 0 |       class sycl::detail::array<2> (base)
-// CHECK-NEXT: 0 |         size_t[2] common_array
-// CHECK-NEXT: 16 |     class sycl::id<2> MIndex
-// CHECK-NEXT: 16 |       class sycl::detail::array<2> (base)
-// CHECK-NEXT: 16 |         size_t[2] common_array
-// CHECK-NEXT: 32 |     class sycl::id<2> MOffset
-// CHECK-NEXT: 32 |       class sycl::detail::array<2> (base)
-// CHECK-NEXT: 32 |         size_t[2] common_array
-// CHECK-NEXT: | [sizeof=48, dsize=48, align=8,
-// CHECK-NEXT: |  nvsize=48, nvalign=8]
+// CHECK-DAG:       0 | class sycl::item<2>
+// CHECK-DAG-NEXT:  0 |   struct sycl::detail::ItemBase<2, true> MImpl
+// CHECK-DAG-NEXT:  0 |     class sycl::range<2> MExtent
+// CHECK-DAG-NEXT:  0 |       class sycl::detail::array<2> (base)
+// CHECK-DAG-NEXT:  0 |         size_t[2] common_array
+// CHECK-DAG-NEXT: 16 |     class sycl::id<2> MIndex
+// CHECK-DAG-NEXT: 16 |       class sycl::detail::array<2> (base)
+// CHECK-DAG-NEXT: 16 |         size_t[2] common_array
+// CHECK-DAG-NEXT: 32 |     class sycl::id<2> MOffset
+// CHECK-DAG-NEXT: 32 |       class sycl::detail::array<2> (base)
+// CHECK-DAG-NEXT: 32 |         size_t[2] common_array
+// CHECK-DAG-NEXT:    | [sizeof=48, dsize=48, align=8,
+// CHECK-DAG-NEXT:    |  nvsize=48, nvalign=8]
 
 //----------------------------
 
 SYCL_EXTERNAL void nd_range(sycl::nd_range<2>) {}
-// CHECK: 0 | class sycl::nd_range<2>
-// CHECK-NEXT: 0 |   class sycl::range<2> globalSize
-// CHECK-NEXT: 0 |     class sycl::detail::array<2> (base)
-// CHECK-NEXT: 0 |       size_t[2] common_array
-// CHECK-NEXT: 16 |   class sycl::range<2> localSize
-// CHECK-NEXT: 16 |     class sycl::detail::array<2> (base)
-// CHECK-NEXT: 16 |       size_t[2] common_array
-// CHECK-NEXT: 32 |   class sycl::id<2> offset
-// CHECK-NEXT: 32 |     class sycl::detail::array<2> (base)
-// CHECK-NEXT: 32 |       size_t[2] common_array
-// CHECK-NEXT: | [sizeof=48, dsize=48, align=8,
-// CHECK-NEXT: |  nvsize=48, nvalign=8]
+// CHECK-DAG:       0 | class sycl::nd_range<2>
+// CHECK-DAG-NEXT:  0 |   class sycl::range<2> globalSize
+// CHECK-DAG-NEXT:  0 |     class sycl::detail::array<2> (base)
+// CHECK-DAG-NEXT:  0 |       size_t[2] common_array
+// CHECK-DAG-NEXT: 16 |   class sycl::range<2> localSize
+// CHECK-DAG-NEXT: 16 |     class sycl::detail::array<2> (base)
+// CHECK-DAG-NEXT: 16 |       size_t[2] common_array
+// CHECK-DAG-NEXT: 32 |   class sycl::id<2> offset
+// CHECK-DAG-NEXT: 32 |     class sycl::detail::array<2> (base)
+// CHECK-DAG-NEXT: 32 |       size_t[2] common_array
+// CHECK-DAG-NEXT:    | [sizeof=48, dsize=48, align=8,
+// CHECK-DAG-NEXT:    |  nvsize=48, nvalign=8]


### PR DESCRIPTION
The layout_array test is currently prone to failure if any of the types it checks are instantiated by the headers rather than by the test itself. This means that unrelated changes to the SYCL headers may make the test fail due to one of the types being instantiated earlier than the test instantiates other types that go before it. To avoid this issue, this commit makes the test use specific headers, reducing the chance of instantiations.

This commit also fixes a faulty expectation in the `nd_item` test case.