### PR TITLE
[SYCL][E2E] Use target feature in 3 tests that explicitly set the triple 

### DIFF
--- a/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_amdgcn.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_amdgcn.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: hip, opencl, gpu, cpu
+// REQUIRES: target-amd, opencl, gpu, cpu
 
 // RUN: %clangxx -fsycl -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx906 -fsycl-targets=amdgcn-amd-amdhsa %S/Inputs/is_compatible_with_env.cpp -o %t.out
 

--- a/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_nvptx64.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_nvptx64.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: cuda, opencl, gpu, cpu
+// REQUIRES: target-nvidia, opencl, gpu, cpu
 
 // RUN: %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda %S/Inputs/is_compatible_with_env.cpp -o %t.out
 

--- a/sycl/test-e2e/SpecConstants/2020/non_native/cuda.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/non_native/cuda.cpp
@@ -1,6 +1,6 @@
-// REQUIRES: cuda
+// REQUIRES: target-nvidia
 
-// RUN: %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda %S/Inputs/common.cpp -o %t.out
+// RUN: %clangxx -fsycl %{sycl_target_opts} %S/Inputs/common.cpp -o %t.out
 // RUN: %{run-unfiltered-devices} env ONEAPI_DEVICE_SELECTOR="cuda:*" %t.out
 
 // This test checks correctness of SYCL2020 non-native specialization constants


### PR DESCRIPTION
These tests should only build on `build-only` if we have either `target-nvidia` or `target-amd` enabled. Currently they build regardless of what triples are available, and this was not detected because these tests set the triple explicitly rather than through the `%{sycl_target_opts}` expansion.