### PR TITLE
[UR] Choose in-tree unified-runtime directory if present

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -70,7 +70,13 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
 endif()
 
-if(SYCL_UR_USE_FETCH_CONTENT)
+set(UR_INTREE_SOURCE_DIR "${LLVM_SOURCE_DIR}/../unified-runtime")
+cmake_path(NORMAL_PATH UR_INTREE_SOURCE_DIR OUTPUT_VARIABLE UR_INTREE_SOURCE_DIR)
+
+if(IS_DIRECTORY "${UR_INTREE_SOURCE_DIR}")
+  set(UR_INTREE_BINARY_DIR ${LLVM_BINARY_DIR}/unified-runtime)
+  add_subdirectory(${UR_INTREE_SOURCE_DIR} ${UR_INTREE_BINARY_DIR})
+elseif(SYCL_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
   # The fetch_adapter_source function can be used to perform a separate content


### PR DESCRIPTION
Update the CMake build system to use the `<intel/llvm>/unified-runtime` directory if it exists. Fallback to using `FetchContent` when it does not exist.
This is in preparation for moving UR development into the intel/llvm repo.
