### PR TITLE
[CI] Remove sycl_ci user from Dockerfiles

### DIFF
--- a/devops/containers/nightly.Dockerfile
+++ b/devops/containers/nightly.Dockerfile
@@ -12,7 +12,7 @@ ADD sycl_linux.tar.gz /opt/sycl/
 ENV PATH /opt/sycl/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH
 
-USER sycl_ci
+USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-USER sycl_ci
+USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-USER sycl_ci
+USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 

--- a/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=secret,id=github_token \
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 
-USER sycl_ci
+USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
 


### PR DESCRIPTION
This is leftover from some reverted Dockerfile changes. We only create a `sycl` user now, so use that like we did before those changes.