### PR TITLE
[SYCL][Graph] Refine E2E test comment

### DIFF
--- a/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
+++ b/sycl/test-e2e/Graph/Update/FreeFunctionKernels/update_with_indices_ordering.cpp
@@ -21,8 +21,9 @@ int main() {
   // Use a large N to try and make the kernel slow
   const size_t N = 1 << 16;
 
-  // Reduce amount of work compared to version of test without free functions
-  // due to CMPLRLLVM-64841
+  // Reduce amount of work compared to version of test with lambdas,
+  // as using explicit parameters in the free function signature results
+  // in slower IR than is created from constant folding in the lambda.
   const size_t NumKernelLoops = 1;
   const size_t NumSubmitLoops = 1;
 


### PR DESCRIPTION
The code comment in `Update/FreeFunctionKernels/update_with_indices_ordering.cpp` mentions that it is unknown why the execution time is slower than the equivalent `Update/update_with_indices_ordering.cpp` test without free functions.

This has now been investigated in CMPLRLLVM-64841 and has found to be due to the explicit arguments in the free function signature avoiding constant folding from lambdas. Note that we want to keep these parameters as the test is stressing the case where multiple args are passed to the free function.