### PR TITLE
[SYCL][E2E] Use target features in unsupported statements for DeviceLib tests

### DIFF
--- a/sycl/test-e2e/DeviceLib/built-ins/printf.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/printf.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: hip
+// UNSUPPORTED: target-amd
 // HIP doesn't support printf.
 // CUDA doesn't support vector format specifiers ("%v").
 //

--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: hip || cuda
+// UNSUPPORTED: target-amd || target-nvidia
 
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 

--- a/sycl/test-e2e/DeviceLib/exp/exp-std-complex-double-edge-cases.cpp
+++ b/sycl/test-e2e/DeviceLib/exp/exp-std-complex-double-edge-cases.cpp
@@ -2,7 +2,7 @@
 // in SYCL kernels.
 //
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: hip || cuda
+// UNSUPPORTED: target-amd || target-nvidia
 // UNSUPPORTED-INTENDED: This test is intended for backends with SPIR-V support.
 //
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/DeviceLib/exp/exp-std-complex-float-edge-cases.cpp
+++ b/sycl/test-e2e/DeviceLib/exp/exp-std-complex-float-edge-cases.cpp
@@ -1,7 +1,7 @@
 // This test checks edge cases handling for std::exp(std::complex<float>) used
 // in SYCL kernels.
 //
-// UNSUPPORTED: hip || cuda
+// UNSUPPORTED: target-amd || target-nvidia
 // UNSUPPORTED-INTENDED: This test is intended for backends with SPIR-V support.
 //
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/DeviceLib/imf_bfloat16_integeral_convesions.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_bfloat16_integeral_convesions.cpp
@@ -4,7 +4,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 //
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows

--- a/sycl/test-e2e/DeviceLib/imf_double2bfloat16.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_double2bfloat16.cpp
@@ -6,7 +6,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t1.out
 // RUN: %{run} %t1.out
 //
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 #include "imf_utils.hpp"
 #include <sycl/ext/intel/math.hpp>

--- a/sycl/test-e2e/DeviceLib/imf_double2half.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_double2half.cpp
@@ -7,7 +7,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 
-// UNSUPPORTED: cuda, hip
+// UNSUPPORTED: target-nvidia, target-amd
 
 #include "imf_utils.hpp"
 #include <sycl/ext/intel/math.hpp>

--- a/sycl/test-e2e/DeviceLib/imf_float2bfloat16.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_float2bfloat16.cpp
@@ -4,7 +4,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 //
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 // All __imf_* bf16 functions are implemented via fp32 emulation, so we don't
 // need to check whether underlying device supports bf16 or not.

--- a/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
@@ -8,7 +8,7 @@
 // RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl  %t1.o %t2.o  -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: cuda, hip
+// UNSUPPORTED: target-nvidia, target-amd
 
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows

--- a/sycl/test-e2e/DeviceLib/imf_fp32_rounding_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp32_rounding_test.cpp
@@ -4,7 +4,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 //
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 #include "imf_utils.hpp"
 #include <sycl/ext/intel/math.hpp>

--- a/sycl/test-e2e/DeviceLib/imf_fp32_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp32_test.cpp
@@ -4,7 +4,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 //
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows

--- a/sycl/test-e2e/DeviceLib/imf_fp64_rounding_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp64_rounding_test.cpp
@@ -5,7 +5,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 //
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 // Depends on SPIR-V Backend & run-time drivers version.
 // XFAIL: spirv-backend

--- a/sycl/test-e2e/DeviceLib/imf_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp64_test.cpp
@@ -5,7 +5,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 //
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 #include "imf_utils.hpp"
 #include <sycl/ext/intel/math.hpp>
 

--- a/sycl/test-e2e/DeviceLib/imf_fp64_test2.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp64_test2.cpp
@@ -5,7 +5,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 //
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 #include "imf_utils.hpp"
 #include <sycl/ext/intel/math.hpp>

--- a/sycl/test-e2e/DeviceLib/imf_half_type_cast.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_half_type_cast.cpp
@@ -7,7 +7,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 
-// UNSUPPORTED: cuda, hip
+// UNSUPPORTED: target-nvidia, target-amd
 
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows

--- a/sycl/test-e2e/DeviceLib/imf_simd_emulate_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_simd_emulate_test.cpp
@@ -4,7 +4,7 @@
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 //
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 // XFAIL: spirv-backend
 // XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/122075

--- a/sycl/test-e2e/DeviceLib/rand_test.cpp
+++ b/sycl/test-e2e/DeviceLib/rand_test.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 #include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
+++ b/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
@@ -1,5 +1,5 @@
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// UNSUPPORTED: hip || cuda
+// UNSUPPORTED: target-amd || target-nvidia
 // RUN: %clangxx -fsycl -fsycl-link %S/std_complex_math_test.cpp -o %t_device.o %{mathflags}
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict %{mathflags}
 // >> host compilation...

--- a/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: hip || cuda
+// UNSUPPORTED: target-amd || target-nvidia
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
 

--- a/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
@@ -1,5 +1,5 @@
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// UNSUPPORTED: hip || cuda
+// UNSUPPORTED: target-amd || target-nvidia
 // RUN: %{build} %{mathflags} -o %t1.out
 // RUN: %{run} %t1.out
 


### PR DESCRIPTION
These tests fail to build for these triples so they should be marked with unsupported for the target feature rather than the backend.