### PR TITLE
[SYCL][Tests] Use `%python` in check_e2eexpr_logic.cpp

### DIFF
--- a/sycl/test/e2e_test_requirements/check_e2eexpr_logic.cpp
+++ b/sycl/test/e2e_test_requirements/check_e2eexpr_logic.cpp
@@ -5,4 +5,4 @@
 // REQUIRES: linux
 // DEFINE: %{E2EExpr}=%S/../../test-e2e/E2EExpr.py
 // DEFINE: %{lit_source}=%S/../../../llvm/utils/lit
-// RUN: env PYTHONPATH=%{lit_source} python %{E2EExpr}
+// RUN: env PYTHONPATH=%{lit_source} %python %{E2EExpr}


### PR DESCRIPTION
so that it would work on systems with `python3` but without `python`.