### PR TITLE
[SYCL][Graph] Enable host-task update in graphs

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -862,11 +862,11 @@ Table {counter: tableNumber}. Graph update capabilites for supported node types.
 |
 
 * Kernel function
-* Kernel Parameters
+* Kernel parameters
 * ND-range
 
 |
-* Kernel Parameters
+* Kernel parameters
 * ND-range
 
 |`node_type::host_task`

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -551,7 +551,7 @@ Parameters:
 
 |===
 
-==== Dynamic Command Groups
+==== Dynamic Command Groups [[dynamic-command-groups]]
 
 [source,c++]
 ----
@@ -570,12 +570,13 @@ public:
 Dynamic command-groups can be added as nodes to a graph. They provide a
 mechanism that allows updating the command-group function of a node after the
 graph is finalized. There is always one command-group function in the dynamic
-command-group that is set as active, this is the kernel which will execute for
-the node when the graph is finalized into an executable state `command_graph`,
-and all the other command-group functions in `cgfList` will be ignored. The
-executable `command_graph` node can then be updated to a different kernel in
-`cgfList`, by selecting a new active index on the dynamic command-group object
-and calling the `update(node& node)` method on the executable `command_graph`.
+command-group that is set as active, this is the command-group which will
+execute for the node when the graph is finalized into an executable state
+`command_graph`, and all the other command-group functions in `cgfList` will be
+ignored. The executable `command_graph` node can then be updated to a different
+kernel in `cgfList`, by selecting a new active index on the dynamic
+command-group object and calling the `update(node& node)` method on the
+executable `command_graph`.
 
 The `dynamic_command_group` class provides the {crs}[common reference semantics].
 
@@ -584,9 +585,13 @@ about updating command-groups.
 
 ===== Limitations
 
-Dynamic command-groups can only contain kernel operations. Trying to construct
-a dynamic command-group with functions that contain other operations will
-result in an error.
+Dynamic command-groups can only contain the following operations:
+
+* Kernel operations
+* <<host-tasks, Host-tasks>>
+
+Trying to construct a dynamic command-group with functions that contain other
+operations will result in an error.
 
 All the command-group functions in a dynamic command-group must have identical dependencies.
 It is not allowed for a dynamic command-group to have command-group functions that would
@@ -625,9 +630,12 @@ Exceptions:
   property for more information.
 
 * Throws with error code `invalid` if the `dynamic_command_group` is created with
-  command-group functions that are not kernel executions.
+  command-group functions that are not kernel executions or host-tasks.
 
 * Throws with error code `invalid` if `cgfList` is empty.
+
+* Throws with error code `invalid` if the types of all command-groups in
+  `cgfList` do not match.
 
 |
 [source,c++]
@@ -829,10 +837,12 @@ possible.
 
 ===== Supported Features
 
-The only types of nodes that are currently able to be updated in a graph are
-kernel execution nodes.
+The only types of nodes that are currently able to be updated in a graph are:
 
-There are two different API's that can be used to update a graph:
+* Kernel executions
+* <<host-tasks, Host-tasks>>
+
+There are two different APIs that can be used to update a graph:
 
 * <<individual-node-update, Individual Node Update>> which allows updating
 individual nodes of a command-graph.
@@ -840,20 +850,40 @@ individual nodes of a command-graph.
 entirety of the graph simultaneously by using another graph as a
 reference.
 
-The aspects of a kernel execution node that can be changed during update are
-different depending on the API used to perform the update:
+The following table illustrates the aspects of each supported node type that can be changed
+depending on the API used to perform the update.
 
-* For the <<individual-node-update, Individual Node Update>> API it's possible to update
-the kernel function, the parameters to the kernel, and the ND-range.
-* For the <<whole-graph-update, Whole Graph Update>> API, only the parameters of the kernel
-and the ND-range can be updated.
+Table {counter: tableNumber}. Graph update capabilites for supported node types.
+[cols="1,2a,2a"]
+|===
+|Node Type|<<individual-node-update, Individual Node Update>>|<<whole-graph-update, Whole Graph Update>>
+
+|`node_type::kernel`
+|
+
+* Kernel function
+* Kernel Parameters
+* ND-range
+
+|
+* Kernel Parameters
+* ND-range
+
+|`node_type::host_task`
+|
+* Host-task function
+|
+* Host-task function
+
+|===
 
 ===== Individual Node Update [[individual-node-update]]
 
-Individual nodes of an executable graph can be updated directly. Depending on the attribute
-of the node that requires updating, different API's should be used:
+Individual nodes of an executable graph can be updated directly. Depending on the attribute or `node_type` of the node that requires updating, different API's should be used:
 
 ====== Parameter Updates
+
+_Supported Node Types: Kernel_
 
 Parameters to individual nodes in a graph in the `executable` state can be
 updated between graph executions using dynamic parameters. A `dynamic_parameter`
@@ -884,6 +914,8 @@ will maintain the graphs data dependencies.
 
 ====== Execution Range Updates
 
+_Supported Node Types: Kernel_
+
 Another configuration that can be updated is the execution range of the
 kernel, this can be set through `node::update_nd_range()` or
 `node::update_range()` but does not require any prior registration.
@@ -897,10 +929,13 @@ code may be defined as operating in a different dimension.
 
 ====== Command Group Updates
 
-The command-groups of a kernel node can be updated using dynamic command-groups.
-Dynamic command-groups allow replacing the command-group function of a kernel
-node with a different one. This effectively allows updating the kernel function
-and/or the kernel execution range.
+_Supported Node Types: Kernel, Host-task_
+
+The command-groups of a kernel node can be updated using
+<<dynamic-command-groups, Dynamic Command-Groups>>. Dynamic command-groups allow
+replacing the command-group function of a kernel node with a different one. This
+effectively allows updating the kernel function and/or the kernel execution
+range.
 
 Command-group updates are performed by creating an instance of the
 `dynamic_command_group` class. A dynamic command-group is created with a modifiable
@@ -1972,7 +2007,7 @@ Any code like this should be moved to a separate host-task and added to the
 graph via the recording or explicit APIs in order to be compatible with this
 extension.
 
-=== Host Tasks
+=== Host Tasks [[host-tasks]]
 
 :host-task: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:interfaces.hosttasks
 
@@ -1991,6 +2026,9 @@ auto node = graph.add([&](sycl::handler& cgh){
   });
 });
 ----
+
+Host-tasks can be updated using <<executable-graph-update, Executable Graph Update>>.
+
 
 === Queue Behavior In Recording Mode
 

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -581,9 +581,9 @@ graph_impl::add(std::shared_ptr<dynamic_command_group_impl> &DynCGImpl,
                 std::vector<std::shared_ptr<detail::node_impl>> &Deps) {
   // Set of Dependent nodes based on CG event and accessor dependencies.
   std::set<std::shared_ptr<node_impl>> DynCGDeps =
-      getCGEdges(DynCGImpl->MKernels[0]);
+      getCGEdges(DynCGImpl->MCommandGroups[0]);
   for (unsigned i = 1; i < DynCGImpl->getNumCGs(); i++) {
-    auto &CG = DynCGImpl->MKernels[i];
+    auto &CG = DynCGImpl->MCommandGroups[i];
     auto CGEdges = getCGEdges(CG);
     if (CGEdges != DynCGDeps) {
       throw sycl::exception(make_error_code(sycl::errc::invalid),
@@ -593,14 +593,16 @@ graph_impl::add(std::shared_ptr<dynamic_command_group_impl> &DynCGImpl,
   }
 
   // Track and mark the memory objects being used by the graph.
-  for (auto &CG : DynCGImpl->MKernels) {
+  for (auto &CG : DynCGImpl->MCommandGroups) {
     markCGMemObjs(CG);
   }
 
   // Get active dynamic command-group CG and use to create a node object
-  const auto &ActiveKernel = DynCGImpl->getActiveKernel();
+  const auto &ActiveKernel = DynCGImpl->getActiveCG();
+  node_type NodeType =
+      ext::oneapi::experimental::detail::getNodeTypeFromCG(DynCGImpl->MCGType);
   std::shared_ptr<detail::node_impl> NodeImpl =
-      add(node_type::kernel, ActiveKernel, Deps);
+      add(NodeType, ActiveKernel, Deps);
 
   // Add an event associated with this explicit node for mixed usage
   addEventForNode(std::make_shared<sycl::detail::event_impl>(), NodeImpl);
@@ -1400,11 +1402,11 @@ void exec_graph_impl::update(
           "Node passed to update() is not part of the graph.");
     }
 
-    if (!(Node->isEmpty() || Node->MCGType == sycl::detail::CGType::Kernel ||
-          Node->MCGType == sycl::detail::CGType::Barrier)) {
-      throw sycl::exception(errc::invalid,
-                            "Unsupported node type for update. Only kernel, "
-                            "barrier and empty nodes are supported.");
+    if (!Node->isUpdatable()) {
+      throw sycl::exception(
+          errc::invalid,
+          "Unsupported node type for update. Only kernel, host_task, "
+          "barrier and empty nodes are supported.");
     }
 
     if (const auto &CG = Node->MCommandGroup;
@@ -1445,23 +1447,46 @@ void exec_graph_impl::update(
     }
   }
 
-  // Rebuild cached requirements for this graph with updated nodes
+  // Rebuild cached requirements and accessor storage for this graph with
+  // updated nodes
   MRequirements.clear();
+  MAccessors.clear();
   for (auto &Node : MNodeStorage) {
     if (!Node->MCommandGroup)
       continue;
     MRequirements.insert(MRequirements.end(),
                          Node->MCommandGroup->getRequirements().begin(),
                          Node->MCommandGroup->getRequirements().end());
+    MAccessors.insert(MAccessors.end(),
+                      Node->MCommandGroup->getAccStorage().begin(),
+                      Node->MCommandGroup->getAccStorage().end());
   }
 }
 
 void exec_graph_impl::updateImpl(std::shared_ptr<node_impl> Node) {
-  // Kernel node update is the only command type supported in UR for update.
-  // Updating any other types of nodes, e.g. empty & barrier nodes is a no-op.
-  if (Node->MCGType != sycl::detail::CGType::Kernel) {
+  // Updating empty or barrier nodes is a no-op
+  if (Node->isEmpty() || Node->MNodeType == node_type::ext_oneapi_barrier) {
     return;
   }
+
+  // Query the ID cache to find the equivalent exec node for the node passed to
+  // this function.
+  // TODO: Handle subgraphs or any other cases where multiple nodes may be
+  // associated with a single key, once those node types are supported for
+  // update.
+  auto ExecNode = MIDCache.find(Node->MID);
+  assert(ExecNode != MIDCache.end() && "Node ID was not found in ID cache");
+
+  // Update ExecNode with new values from Node, in case we ever need to
+  // rebuild the command buffers
+  ExecNode->second->updateFromOtherNode(Node);
+
+  // Host task update only requires updating the node itself, so can return
+  // early
+  if (Node->MNodeType == node_type::host_task) {
+    return;
+  }
+
   auto ContextImpl = sycl::detail::getSyclObjImpl(MContext);
   const sycl::detail::AdapterPtr &Adapter = ContextImpl->getAdapter();
   auto DeviceImpl = sycl::detail::getSyclObjImpl(MGraphImpl->getDevice());
@@ -1613,18 +1638,6 @@ void exec_graph_impl::updateImpl(std::shared_ptr<node_impl> Node) {
   UpdateDesc.pNewGlobalWorkSize = &NDRDesc.GlobalSize[0];
   UpdateDesc.pNewLocalWorkSize = LocalSize;
   UpdateDesc.newWorkDim = NDRDesc.Dims;
-
-  // Query the ID cache to find the equivalent exec node for the node passed to
-  // this function.
-  // TODO: Handle subgraphs or any other cases where multiple nodes may be
-  // associated with a single key, once those node types are supported for
-  // update.
-  auto ExecNode = MIDCache.find(Node->MID);
-  assert(ExecNode != MIDCache.end() && "Node ID was not found in ID cache");
-
-  // Update ExecNode with new values from Node, in case we ever need to
-  // rebuild the command buffers
-  ExecNode->second->updateFromOtherNode(Node);
 
   ur_exp_command_buffer_command_handle_t Command =
       MCommandMap[ExecNode->second];
@@ -1929,7 +1942,7 @@ void dynamic_parameter_impl::updateValue(const void *NewValue, size_t Size) {
   for (auto &DynCGInfo : MDynCGs) {
     auto DynCG = DynCGInfo.DynCG.lock();
     if (DynCG) {
-      auto &CG = DynCG->MKernels[DynCGInfo.CGIndex];
+      auto &CG = DynCG->MCommandGroups[DynCGInfo.CGIndex];
       dynamic_parameter_impl::updateCGArgValue(CG, DynCGInfo.ArgIndex, NewValue,
                                                Size);
     }
@@ -1952,7 +1965,7 @@ void dynamic_parameter_impl::updateAccessor(
   for (auto &DynCGInfo : MDynCGs) {
     auto DynCG = DynCGInfo.DynCG.lock();
     if (DynCG) {
-      auto &CG = DynCG->MKernels[DynCGInfo.CGIndex];
+      auto &CG = DynCG->MCommandGroups[DynCGInfo.CGIndex];
       dynamic_parameter_impl::updateCGAccessor(CG, DynCGInfo.ArgIndex, Acc);
     }
   }
@@ -2040,38 +2053,67 @@ void dynamic_command_group_impl::finalizeCGFList(
     sycl::handler Handler{MGraph};
     CGF(Handler);
 
-    if (Handler.getType() != sycl::detail::CGType::Kernel) {
+    if (Handler.getType() != sycl::detail::CGType::Kernel &&
+        Handler.getType() != sycl::detail::CGType::CodeplayHostTask) {
       throw sycl::exception(
           make_error_code(errc::invalid),
-          "The only type of command-groups that can be used in "
-          "dynamic command-groups is kernels.");
+          "The only types of command-groups that can be used in "
+          "dynamic command-groups are kernels and host-tasks.");
+    }
+
+    // We need to store the first CG's type so we can check they are all the
+    // same
+    if (CGFIndex == 0) {
+      MCGType = Handler.getType();
+    } else if (MCGType != Handler.getType()) {
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "Command-groups in a dynamic command-group must "
+                            "all be the same type.");
     }
 
     Handler.finalize();
 
     // Take unique_ptr<detail::CG> object from handler and convert to
-    // shared_ptr<detail::CGExecKernel> to store
+    // shared_ptr<detail::CG> to store
     sycl::detail::CG *RawCGPtr = Handler.impl->MGraphNodeCG.release();
-    auto RawCGExecPtr = static_cast<sycl::detail::CGExecKernel *>(RawCGPtr);
-    MKernels.push_back(
-        std::shared_ptr<sycl::detail::CGExecKernel>(RawCGExecPtr));
+    MCommandGroups.push_back(std::shared_ptr<sycl::detail::CG>(RawCGPtr));
 
-    // Track dynamic_parameter usage in command-list
+    // Track dynamic_parameter usage in command-group
     auto &DynamicParams = Handler.impl->MDynamicParameters;
+
+    if (DynamicParams.size() > 0 &&
+        Handler.getType() == sycl::detail::CGType::CodeplayHostTask) {
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "Cannot use dynamic parameters in a host_task");
+    }
     for (auto &[DynamicParam, ArgIndex] : DynamicParams) {
       DynamicParam->registerDynCG(shared_from_this(), CGFIndex, ArgIndex);
     }
   }
 
-  // For each CGExecKernel store the list of alternative kernels, not
+  // Host tasks don't need to store alternative kernels
+  if (MCGType == sycl::detail::CGType::CodeplayHostTask) {
+    return;
+  }
+
+  // For each Kernel CG store the list of alternative kernels, not
   // including itself.
   using CGExecKernelSP = std::shared_ptr<sycl::detail::CGExecKernel>;
   using CGExecKernelWP = std::weak_ptr<sycl::detail::CGExecKernel>;
-  for (auto KernelCG : MKernels) {
+  for (std::shared_ptr<sycl::detail::CG> CommandGroup : MCommandGroups) {
+    CGExecKernelSP KernelCG =
+        std::dynamic_pointer_cast<sycl::detail::CGExecKernel>(CommandGroup);
     std::vector<CGExecKernelWP> Alternatives;
-    std::copy_if(
-        MKernels.begin(), MKernels.end(), std::back_inserter(Alternatives),
-        [&KernelCG](const CGExecKernelSP &K) { return K != KernelCG; });
+
+    // Add all other command groups except for the current one to the list of
+    // alternatives
+    for (auto &OtherCG : MCommandGroups) {
+      CGExecKernelSP OtherKernelCG =
+          std::dynamic_pointer_cast<sycl::detail::CGExecKernel>(OtherCG);
+      if (KernelCG != OtherKernelCG) {
+        Alternatives.push_back(OtherKernelCG);
+      }
+    }
 
     KernelCG->MAlternativeKernels = std::move(Alternatives);
   }
@@ -2087,7 +2129,7 @@ void dynamic_command_group_impl::setActiveIndex(size_t Index) {
   // Update nodes using the dynamic command-group to use the new active CG
   for (auto &Node : MNodes) {
     if (auto NodeSP = Node.lock()) {
-      NodeSP->MCommandGroup = getActiveKernel();
+      NodeSP->MCommandGroup = getActiveCG();
     }
   }
 }

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -1469,6 +1469,8 @@ void exec_graph_impl::update(
         sycl::detail::getSyclObjImpl(MGraphImpl->getContext()),
         sycl::async_handler{}, sycl::property_list{});
 
+    // Track the event for the update command since execution may be blocked by
+    // other scheduler commands
     auto UpdateEvent =
         sycl::detail::Scheduler::getInstance().addCommandGraphUpdate(
             this, std::move(NodesCopy), AllocaQueue, UpdateRequirements,

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -1604,6 +1604,7 @@ public:
 
   /// Type of the CGs in this dynamic command-group
   sycl::detail::CGType MCGType = sycl::detail::CGType::None;
+
 private:
   unsigned long long MID;
   // Used for std::hash in order to create a unique hash for the instance.

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -475,6 +475,7 @@ public:
       HostTaskCG->getAccStorage() = OtherHostTaskCG->getAccStorage();
       HostTaskCG->getRequirements() = OtherHostTaskCG->getRequirements();
       HostTaskCG->MHostTask = OtherHostTaskCG->MHostTask;
+      HostTaskCG->getEvents() = OtherHostTaskCG->getEvents();
       break;
     }
     default:
@@ -1453,6 +1454,12 @@ private:
   unsigned long long MID;
   // Used for std::hash in order to create a unique hash for the instance.
   inline static std::atomic<unsigned long long> NextAvailableID = 0;
+  // True if this graph contains any host-tasks, controls whether we store
+  // events in MUpdateEvents.
+  bool MContainsHostTask = false;
+  // Contains events for updates submitted through the scheduler as we need to
+  // wait on them when enqueuing host-tasks.
+  std::vector<sycl::detail::EventImplPtr> MUpdateEvents;
 };
 
 class dynamic_parameter_impl {

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -1333,7 +1333,7 @@ public:
 
   void update(std::shared_ptr<graph_impl> GraphImpl);
   void update(std::shared_ptr<node_impl> Node);
-  void update(const std::vector<std::shared_ptr<node_impl>> Nodes);
+  void update(const std::vector<std::shared_ptr<node_impl>> &Nodes);
 
   void updateImpl(std::shared_ptr<node_impl> NodeImpl);
 
@@ -1454,12 +1454,10 @@ private:
   unsigned long long MID;
   // Used for std::hash in order to create a unique hash for the instance.
   inline static std::atomic<unsigned long long> NextAvailableID = 0;
-  // True if this graph contains any host-tasks, controls whether we store
-  // events in MUpdateEvents.
+
+  // True if this graph contains any host-tasks, indicates we need special
+  // handling for them during update().
   bool MContainsHostTask = false;
-  // Contains events for updates submitted through the scheduler as we need to
-  // wait on them when enqueuing host-tasks.
-  std::vector<sycl::detail::EventImplPtr> MUpdateEvents;
 };
 
 class dynamic_parameter_impl {

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -448,7 +448,7 @@ public:
   /// @param Other The other node to update, must be of the same node type.
   void updateFromOtherNode(const std::shared_ptr<node_impl> &Other) {
     assert(MNodeType == Other->MNodeType);
-    MCommandGroup = std::move(Other->getCGCopy());
+    MCommandGroup = Other->getCGCopy();
   }
 
   id_type getID() const { return MID; }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -444,43 +444,11 @@ public:
 
     NDRDesc = sycl::detail::NDRDescT{ExecutionRange};
   }
-
+  /// Update this node with the command-group from another node.
+  /// @param Other The other node to update, must be of the same node type.
   void updateFromOtherNode(const std::shared_ptr<node_impl> &Other) {
-    switch (MNodeType) {
-    case node_type::kernel: {
-      auto ExecCG =
-          static_cast<sycl::detail::CGExecKernel *>(MCommandGroup.get());
-      auto OtherExecCG =
-          static_cast<sycl::detail::CGExecKernel *>(Other->MCommandGroup.get());
-
-      ExecCG->MArgs = OtherExecCG->MArgs;
-      ExecCG->MNDRDesc = OtherExecCG->MNDRDesc;
-      ExecCG->MKernelName = OtherExecCG->MKernelName;
-      ExecCG->getAccStorage() = OtherExecCG->getAccStorage();
-      ExecCG->getRequirements() = OtherExecCG->getRequirements();
-
-      auto &OldArgStorage = OtherExecCG->getArgsStorage();
-      auto &NewArgStorage = ExecCG->getArgsStorage();
-      // Rebuild the arg storage and update the args
-      rebuildArgStorage(ExecCG->MArgs, OldArgStorage, NewArgStorage);
-      break;
-    }
-    case node_type::host_task: {
-      auto HostTaskCG =
-          static_cast<sycl::detail::CGHostTask *>(MCommandGroup.get());
-      auto OtherHostTaskCG =
-          static_cast<sycl::detail::CGHostTask *>(Other->MCommandGroup.get());
-
-      HostTaskCG->MArgs = OtherHostTaskCG->MArgs;
-      HostTaskCG->getAccStorage() = OtherHostTaskCG->getAccStorage();
-      HostTaskCG->getRequirements() = OtherHostTaskCG->getRequirements();
-      HostTaskCG->MHostTask = OtherHostTaskCG->MHostTask;
-      HostTaskCG->getEvents() = OtherHostTaskCG->getEvents();
-      break;
-    }
-    default:
-      break;
-    }
+    assert(MNodeType == Other->MNodeType);
+    MCommandGroup = std::move(Other->getCGCopy());
   }
 
   id_type getID() const { return MID; }

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3738,15 +3738,6 @@ ur_result_t UpdateCommandBufferCommand::enqueueImp() {
       }
       break;
     }
-    case ext::oneapi::experimental::node_type::host_task: {
-      for (auto &Req : CG->getRequirements()) {
-        for (const DepDesc &Dep : MDeps) {
-          CheckAndFindAlloca(Req, Dep);
-        }
-      }
-
-      break;
-    }
     default:
       break;
     }

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3709,25 +3709,46 @@ ur_result_t UpdateCommandBufferCommand::enqueueImp() {
   Command::waitForEvents(MQueue, EventImpls, UREvent);
   MEvent->setHandle(UREvent);
 
-  for (auto &Node : MNodes) {
-    auto CG = static_cast<CGExecKernel *>(Node->MCommandGroup.get());
-    for (auto &Arg : CG->MArgs) {
-      if (Arg.MType != kernel_param_kind_t::kind_accessor) {
-        continue;
+  auto CheckAndFindAlloca = [](Requirement *Req, const DepDesc &Dep) {
+    if (Dep.MDepRequirement == Req) {
+      if (Dep.MAllocaCmd) {
+        Req->MData = Dep.MAllocaCmd->getMemAllocation();
+      } else {
+        throw sycl::exception(make_error_code(errc::invalid),
+                              "No allocation available for accessor when "
+                              "updating command buffer!");
       }
-      // Search through deps to get actual allocation for accessor args.
-      for (const DepDesc &Dep : MDeps) {
-        Requirement *Req = static_cast<AccessorImplHost *>(Arg.MPtr);
-        if (Dep.MDepRequirement == Req) {
-          if (Dep.MAllocaCmd) {
-            Req->MData = Dep.MAllocaCmd->getMemAllocation();
-          } else {
-            throw sycl::exception(make_error_code(errc::invalid),
-                                  "No allocation available for accessor when "
-                                  "updating command buffer!");
-          }
+    }
+  };
+
+  for (auto &Node : MNodes) {
+    CG *CG = Node->MCommandGroup.get();
+    switch (Node->MNodeType) {
+    case ext::oneapi::experimental::node_type::kernel: {
+      auto CGExec = static_cast<CGExecKernel *>(CG);
+      for (auto &Arg : CGExec->MArgs) {
+        if (Arg.MType != kernel_param_kind_t::kind_accessor) {
+          continue;
+        }
+        // Search through deps to get actual allocation for accessor args.
+        for (const DepDesc &Dep : MDeps) {
+          Requirement *Req = static_cast<AccessorImplHost *>(Arg.MPtr);
+          CheckAndFindAlloca(Req, Dep);
         }
       }
+      break;
+    }
+    case ext::oneapi::experimental::node_type::host_task: {
+      for (auto &Req : CG->getRequirements()) {
+        for (const DepDesc &Dep : MDeps) {
+          CheckAndFindAlloca(Req, Dep);
+        }
+      }
+
+      break;
+    }
+    default:
+      break;
     }
     MGraph->updateImpl(Node);
   }

--- a/sycl/test-e2e/Graph/Inputs/whole_update_host_task.cpp
+++ b/sycl/test-e2e/Graph/Inputs/whole_update_host_task.cpp
@@ -1,0 +1,152 @@
+// Tests whole graph update with a host-task in the graph
+
+#include "../graph_common.hpp"
+
+using T = int;
+
+void calculate_reference_data(size_t Iterations, size_t Size,
+                              std::vector<T> &ReferenceA,
+                              std::vector<T> &ReferenceB,
+                              std::vector<T> &ReferenceC, T ModValue) {
+  for (size_t n = 0; n < Iterations; n++) {
+    for (size_t i = 0; i < Size; i++) {
+      ReferenceA[i]++;
+      ReferenceB[i] += ReferenceA[i];
+      ReferenceC[i] -= ReferenceA[i];
+      ReferenceB[i]--;
+      ReferenceC[i]--;
+      ReferenceC[i] += ModValue;
+      ReferenceC[i] *= 2;
+    }
+  }
+}
+
+void add_nodes_to_graph(
+    exp_ext::command_graph<exp_ext::graph_state::modifiable> &Graph,
+    queue &Queue, T *PtrA, T *PtrB, T *PtrC, T ModValue) {
+  // Add some commands to the graph
+  auto LastOperation = add_nodes(Graph, Queue, Size, PtrA, PtrB, PtrC);
+
+  // Add a host task which modifies PtrC
+  auto HostTaskOp = add_node(
+      Graph, Queue,
+      [&](handler &CGH) {
+        depends_on_helper(CGH, LastOperation);
+        CGH.host_task([=]() {
+          for (size_t i = 0; i < Size; i++) {
+            PtrC[i] += ModValue;
+          }
+        });
+      },
+      LastOperation);
+
+  // Add another node that depends on the host-task
+  add_node(
+      Graph, Queue,
+      [&](handler &CGH) {
+        depends_on_helper(CGH, HostTaskOp);
+        CGH.parallel_for(range<1>(Size), [=](item<1> Item) {
+          PtrC[Item.get_linear_id()] *= 2;
+        });
+      },
+      HostTaskOp);
+}
+
+int main() {
+  queue Queue{};
+
+  std::vector<T> DataA(Size), DataB(Size), DataC(Size);
+
+  std::iota(DataA.begin(), DataA.end(), 1);
+  std::iota(DataB.begin(), DataB.end(), 10);
+  std::iota(DataC.begin(), DataC.end(), 1000);
+
+  auto DataA2 = DataA;
+  auto DataB2 = DataB;
+  auto DataC2 = DataC;
+
+  const T ModValue = 7;
+  std::vector<T> ReferenceA(DataA), ReferenceB(DataB), ReferenceC(DataC);
+  calculate_reference_data(Iterations, Size, ReferenceA, ReferenceB, ReferenceC,
+                           ModValue);
+
+  exp_ext::command_graph GraphA{Queue.get_context(), Queue.get_device()};
+
+  T *PtrA = malloc_device<T>(Size, Queue);
+  T *PtrB = malloc_device<T>(Size, Queue);
+  T *PtrC = malloc_shared<T>(Size, Queue);
+
+  Queue.copy(DataA.data(), PtrA, Size);
+  Queue.copy(DataB.data(), PtrB, Size);
+  Queue.copy(DataC.data(), PtrC, Size);
+  Queue.wait_and_throw();
+
+  // Fill graphA with nodes
+  add_nodes_to_graph(GraphA, Queue, PtrA, PtrB, PtrC, ModValue);
+
+  auto GraphExec = GraphA.finalize(exp_ext::property::graph::updatable{});
+
+  exp_ext::command_graph GraphB{Queue.get_context(), Queue.get_device()};
+
+  T *PtrA2 = malloc_device<T>(Size, Queue);
+  T *PtrB2 = malloc_device<T>(Size, Queue);
+  T *PtrC2 = malloc_shared<T>(Size, Queue);
+
+  Queue.copy(DataA2.data(), PtrA2, Size);
+  Queue.copy(DataB2.data(), PtrB2, Size);
+  Queue.copy(DataC2.data(), PtrC2, Size);
+  Queue.wait_and_throw();
+
+  // Fill graphB with nodes, with a different set of pointers
+  add_nodes_to_graph(GraphB, Queue, PtrA2, PtrB2, PtrC2, ModValue);
+
+  // Execute several Iterations of the graph for 1st set of buffers
+  event Event;
+  for (unsigned n = 0; n < Iterations; n++) {
+    Event = Queue.submit([&](handler &CGH) {
+      CGH.depends_on(Event);
+      CGH.ext_oneapi_graph(GraphExec);
+    });
+  }
+
+  GraphExec.update(GraphB);
+
+  // Execute several Iterations of the graph for 2nd set of buffers
+  for (unsigned n = 0; n < Iterations; n++) {
+    Event = Queue.submit([&](handler &CGH) {
+      CGH.depends_on(Event);
+      CGH.ext_oneapi_graph(GraphExec);
+    });
+  }
+
+  Queue.wait_and_throw();
+
+  Queue.copy(PtrA, DataA.data(), Size);
+  Queue.copy(PtrB, DataB.data(), Size);
+  Queue.copy(PtrC, DataC.data(), Size);
+
+  Queue.copy(PtrA2, DataA2.data(), Size);
+  Queue.copy(PtrB2, DataB2.data(), Size);
+  Queue.copy(PtrC2, DataC2.data(), Size);
+  Queue.wait_and_throw();
+
+  free(PtrA, Queue);
+  free(PtrB, Queue);
+  free(PtrC, Queue);
+
+  free(PtrA2, Queue);
+  free(PtrB2, Queue);
+  free(PtrC2, Queue);
+
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+
+    assert(check_value(i, ReferenceA[i], DataA2[i], "DataA2"));
+    assert(check_value(i, ReferenceB[i], DataB2[i], "DataB2"));
+    assert(check_value(i, ReferenceC[i], DataC2[i], "DataC2"));
+  }
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Inputs/whole_update_host_task.cpp
+++ b/sycl/test-e2e/Graph/Inputs/whole_update_host_task.cpp
@@ -100,23 +100,20 @@ int main() {
   // Fill graphB with nodes, with a different set of pointers
   add_nodes_to_graph(GraphB, Queue, PtrA2, PtrB2, PtrC2, ModValue);
 
-  // Execute several Iterations of the graph for 1st set of buffers
+  // Execute several Iterations of the graph, updating in between each
+  // execution.
   event Event;
   for (unsigned n = 0; n < Iterations; n++) {
     Event = Queue.submit([&](handler &CGH) {
       CGH.depends_on(Event);
       CGH.ext_oneapi_graph(GraphExec);
     });
-  }
-
-  GraphExec.update(GraphB);
-
-  // Execute several Iterations of the graph for 2nd set of buffers
-  for (unsigned n = 0; n < Iterations; n++) {
+    GraphExec.update(GraphB);
     Event = Queue.submit([&](handler &CGH) {
       CGH.depends_on(Event);
       CGH.ext_oneapi_graph(GraphExec);
     });
+    GraphExec.update(GraphA);
   }
 
   Queue.wait_and_throw();

--- a/sycl/test-e2e/Graph/Inputs/whole_update_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Inputs/whole_update_host_task_accessor.cpp
@@ -1,0 +1,152 @@
+
+// Tests whole graph update with a host-task in the graph
+
+#include "../graph_common.hpp"
+
+using T = int;
+
+void calculate_reference_data(size_t Iterations, size_t Size,
+                              std::vector<T> &ReferenceA,
+                              std::vector<T> &ReferenceB,
+                              std::vector<T> &ReferenceC, T ModValue) {
+  for (size_t n = 0; n < Iterations; n++) {
+    for (size_t i = 0; i < Size; i++) {
+      ReferenceA[i]++;
+      ReferenceB[i] += ReferenceA[i];
+      ReferenceC[i] -= ReferenceA[i];
+      ReferenceB[i]--;
+      ReferenceC[i]--;
+      ReferenceC[i] += ModValue;
+      ReferenceC[i] *= 2;
+    }
+  }
+}
+
+void add_nodes_to_graph(
+    exp_ext::command_graph<exp_ext::graph_state::modifiable> &Graph,
+    queue &Queue, buffer<T> &BufferA, buffer<T> &BufferB, buffer<T> &BufferC,
+    const T &ModValue) {
+  // Add some commands to the graph
+  auto LastOperation = add_nodes(Graph, Queue, Size, BufferA, BufferB, BufferC);
+
+  // Add a host task which modifies PtrC
+  auto HostTaskOp = add_node(
+      Graph, Queue,
+      [&](handler &CGH) {
+        auto AccC = BufferC.get_access<access::mode::read_write,
+                                       access::target::host_task>(CGH);
+        depends_on_helper(CGH, LastOperation);
+        CGH.host_task([=]() {
+          // std::cout << "AccC[0] " << AccC[0] << std::endl;
+          for (size_t i = 0; i < Size; i++) {
+            AccC[i] += ModValue;
+          }
+        });
+      },
+      LastOperation);
+
+  // Add another node that depends on the host-task
+  add_node(
+      Graph, Queue,
+      [&](handler &CGH) {
+        auto AccC = BufferC.get_access(CGH);
+        depends_on_helper(CGH, HostTaskOp);
+        CGH.parallel_for(range<1>(Size), [=](item<1> Item) {
+          AccC[Item.get_linear_id()] *= 2;
+        });
+      },
+      HostTaskOp);
+}
+
+int main() {
+  queue Queue{};
+
+  std::vector<T> DataA(Size), DataB(Size), DataC(Size);
+
+  std::iota(DataA.begin(), DataA.end(), 1);
+  std::iota(DataB.begin(), DataB.end(), 10);
+  std::iota(DataC.begin(), DataC.end(), 1000);
+
+  auto DataA2 = DataA;
+  auto DataB2 = DataB;
+  auto DataC2 = DataC;
+
+  const T ModValue = 7;
+  std::vector<T> ReferenceA(DataA), ReferenceB(DataB), ReferenceC(DataC);
+  calculate_reference_data(Iterations, Size, ReferenceA, ReferenceB, ReferenceC,
+                           ModValue);
+
+  buffer<T> BufferA{DataA.data(), range<1>{DataA.size()}};
+  buffer<T> BufferB{DataB.data(), range<1>{DataB.size()}};
+  buffer<T> BufferC{DataC.data(), range<1>{DataC.size()}};
+  buffer<T> BufferA2{DataA2.data(), range<1>{DataA2.size()}};
+  buffer<T> BufferB2{DataB2.data(), range<1>{DataB2.size()}};
+  buffer<T> BufferC2{DataC2.data(), range<1>{DataC2.size()}};
+  BufferA.set_write_back(false);
+  BufferB.set_write_back(false);
+  BufferC.set_write_back(false);
+  BufferA2.set_write_back(false);
+  BufferB2.set_write_back(false);
+  BufferC2.set_write_back(false);
+
+  {
+    exp_ext::command_graph GraphA{
+        Queue.get_context(),
+        Queue.get_device(),
+        {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+    // Fill graphA with nodes
+    add_nodes_to_graph(GraphA, Queue, BufferA, BufferB, BufferC, ModValue);
+
+    auto GraphExec = GraphA.finalize(exp_ext::property::graph::updatable{});
+
+    exp_ext::command_graph GraphB{
+        Queue.get_context(),
+        Queue.get_device(),
+        {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+    // Fill graphB with nodes, with a different set of pointers
+    add_nodes_to_graph(GraphB, Queue, BufferA2, BufferB2, BufferC2, ModValue);
+
+    // Execute several Iterations of the graph for 1st set of buffers
+    event Event;
+    for (unsigned n = 0; n < Iterations; n++) {
+      Event = Queue.submit([&](handler &CGH) {
+        // CGH.depends_on(Event);
+        CGH.ext_oneapi_graph(GraphExec);
+      });
+    }
+    Queue.wait_and_throw();
+
+    GraphExec.update(GraphB);
+
+    // Execute several Iterations of the graph for 2nd set of buffers
+    for (unsigned n = 0; n < Iterations; n++) {
+      Event = Queue.submit([&](handler &CGH) {
+        CGH.depends_on(Event);
+        CGH.ext_oneapi_graph(GraphExec);
+      });
+    }
+
+    Queue.wait_and_throw();
+  }
+  Queue.copy(BufferA.get_access(), DataA.data());
+  Queue.copy(BufferB.get_access(), DataB.data());
+  Queue.copy(BufferC.get_access(), DataC.data());
+  Queue.copy(BufferA2.get_access(), DataA2.data());
+  Queue.copy(BufferB2.get_access(), DataB2.data());
+  Queue.copy(BufferC2.get_access(), DataC2.data());
+  Queue.wait_and_throw();
+
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+
+    assert(check_value(i, ReferenceA[i], DataA2[i], "DataA2"));
+    assert(check_value(i, ReferenceB[i], DataB2[i], "DataB2"));
+    assert(check_value(i, ReferenceC[i], DataC2[i], "DataC2"));
+  }
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Inputs/whole_update_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Inputs/whole_update_host_task_accessor.cpp
@@ -1,5 +1,4 @@
-
-// Tests whole graph update with a host-task in the graph
+// Tests whole graph update with a host-task in the graph using accessors
 
 #include "../graph_common.hpp"
 
@@ -37,7 +36,6 @@ void add_nodes_to_graph(
                                        access::target::host_task>(CGH);
         depends_on_helper(CGH, LastOperation);
         CGH.host_task([=]() {
-          // std::cout << "AccC[0] " << AccC[0] << std::endl;
           for (size_t i = 0; i < Size; i++) {
             AccC[i] += ModValue;
           }
@@ -112,7 +110,7 @@ int main() {
     event Event;
     for (unsigned n = 0; n < Iterations; n++) {
       Event = Queue.submit([&](handler &CGH) {
-        // CGH.depends_on(Event);
+        CGH.depends_on(Event);
         CGH.ext_oneapi_graph(GraphExec);
       });
     }

--- a/sycl/test-e2e/Graph/Update/Explicit/whole_update_host_task.cpp
+++ b/sycl/test-e2e/Graph/Update/Explicit/whole_update_host_task.cpp
@@ -1,0 +1,12 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// REQUIRES: aspect-usm_shared_allocations
+
+#define GRAPH_E2E_EXPLICIT
+
+#include "../../Inputs/whole_update_host_task.cpp"

--- a/sycl/test-e2e/Graph/Update/Explicit/whole_update_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Update/Explicit/whole_update_host_task_accessor.cpp
@@ -1,0 +1,10 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+#define GRAPH_E2E_EXPLICIT
+
+#include "../../Inputs/whole_update_host_task_accessor.cpp"

--- a/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_host_task.cpp
+++ b/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_host_task.cpp
@@ -1,0 +1,12 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// REQUIRES: aspect-usm_shared_allocations
+
+#define GRAPH_E2E_RECORD_REPLAY
+
+#include "../../Inputs/whole_update_host_task.cpp"

--- a/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_host_task_accessor.cpp
@@ -1,0 +1,10 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+#define GRAPH_E2E_RECORD_REPLAY
+
+#include "../../Inputs/whole_update_host_task_accessor.cpp"

--- a/sycl/test-e2e/Graph/Update/dyn_cgf_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Update/dyn_cgf_host_task_accessor.cpp
@@ -1,0 +1,152 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Tests using dynamic command groups to update a host task node that also uses
+// buffers/accessors
+#include "../graph_common.hpp"
+
+using T = int;
+
+void calculate_reference_data(size_t Iterations, size_t Size,
+                              std::vector<T> &ReferenceA,
+                              std::vector<T> &ReferenceB,
+                              std::vector<T> &ReferenceC, T ModValue) {
+  for (size_t n = 0; n < Iterations; n++) {
+    for (size_t i = 0; i < Size; i++) {
+      ReferenceA[i]++;
+      ReferenceB[i] += ReferenceA[i];
+      ReferenceC[i] -= ReferenceA[i];
+      ReferenceB[i]--;
+      ReferenceC[i]--;
+      ReferenceC[i] += ModValue;
+      ReferenceC[i] *= 2;
+    }
+  }
+}
+
+int main() {
+  queue Queue{};
+
+  std::vector<T> DataA(Size), DataB(Size), DataC(Size);
+
+  std::iota(DataA.begin(), DataA.end(), 1);
+  std::iota(DataB.begin(), DataB.end(), 10);
+  std::iota(DataC.begin(), DataC.end(), 1000);
+
+  auto DataA2 = DataA;
+  auto DataB2 = DataB;
+  auto DataC2 = DataC;
+
+  const T ModValue = 7;
+  std::vector<T> ReferenceA(DataA), ReferenceB(DataB), ReferenceC(DataC);
+  calculate_reference_data(Iterations, Size, ReferenceA, ReferenceB, ReferenceC,
+                           ModValue);
+  // We're not updating the buffers here so we need to stack the reference
+  // calculations for after the host-task update
+  std::vector<T> ReferenceA2(ReferenceA), ReferenceB2(ReferenceB),
+      ReferenceC2(ReferenceC);
+  calculate_reference_data(Iterations, Size, ReferenceA2, ReferenceB2,
+                           ReferenceC2, ModValue * 2);
+
+  buffer<T> BufferA{DataA.data(), range<1>{DataA.size()}};
+  BufferA.set_write_back(false);
+  buffer<T> BufferB{DataB.data(), range<1>{DataB.size()}};
+  BufferB.set_write_back(false);
+  buffer<T> BufferC{DataC.data(), range<1>{DataC.size()}};
+  BufferC.set_write_back(false);
+
+  {
+    exp_ext::command_graph Graph{
+        Queue.get_context(),
+        Queue.get_device(),
+        {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+    // Add some commands to the graph
+    auto LastOperation = add_kernels(Graph, Size, BufferA, BufferB, BufferC);
+
+    // Create two different command groups for the host task
+    auto CGFA = [&](handler &CGH) {
+      auto AccC = BufferC.get_access<access::mode::read_write,
+                                     access::target::host_task>(CGH);
+      CGH.host_task([=]() {
+        for (size_t i = 0; i < Size; i++) {
+          AccC[i] += ModValue;
+        }
+      });
+    };
+    auto CGFB = [&](handler &CGH) {
+      auto AccC = BufferC.get_access<access::mode::read_write,
+                                     access::target::host_task>(CGH);
+      CGH.host_task([=]() {
+        for (size_t i = 0; i < Size; i++) {
+          AccC[i] += ModValue * 2;
+        }
+      });
+    };
+
+    auto DynamicCG = exp_ext::dynamic_command_group(Graph, {CGFA, CGFB});
+    // Add a host task which modifies PtrC
+    auto HostTaskNode = Graph.add(
+        DynamicCG, exp_ext::property::node::depends_on{LastOperation});
+
+    // Add another node that depends on the host-task
+    Graph.add(
+        [&](handler &CGH) {
+          auto AccC = BufferC.get_access(CGH);
+          CGH.parallel_for(range<1>(Size), [=](item<1> Item) {
+            AccC[Item.get_linear_id()] *= 2;
+          });
+        },
+        exp_ext::property::node::depends_on{HostTaskNode});
+
+    auto GraphExec = Graph.finalize(exp_ext::property::graph::updatable{});
+
+    // Execute several Iterations of the graph with the first host-task (CGFA)
+    event Event;
+    for (unsigned n = 0; n < Iterations; n++) {
+      Event = Queue.submit([&](handler &CGH) {
+        CGH.depends_on(Event);
+        CGH.ext_oneapi_graph(GraphExec);
+      });
+    }
+    Queue.wait_and_throw();
+    Queue.copy(BufferA.get_access(), DataA.data());
+    Queue.copy(BufferB.get_access(), DataB.data());
+    Queue.copy(BufferC.get_access(), DataC.data());
+    Queue.wait_and_throw();
+    for (size_t i = 0; i < Size; i++) {
+      assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+      assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+      assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+    }
+
+    // Update to CGFB
+    DynamicCG.set_active_index(1);
+    GraphExec.update(HostTaskNode);
+
+    // Execute several Iterations of the graph for second host-task (CGFB)
+    for (unsigned n = 0; n < Iterations; n++) {
+      Event = Queue.submit([&](handler &CGH) {
+        CGH.depends_on(Event);
+        CGH.ext_oneapi_graph(GraphExec);
+      });
+    }
+
+    Queue.wait_and_throw();
+    Queue.copy(BufferA.get_access(), DataA2.data());
+    Queue.copy(BufferB.get_access(), DataB2.data());
+    Queue.copy(BufferC.get_access(), DataC2.data());
+    Queue.wait_and_throw();
+    for (size_t i = 0; i < Size; i++) {
+      assert(check_value(i, ReferenceA2[i], DataA2[i], "DataA2"));
+      assert(check_value(i, ReferenceB2[i], DataB2[i], "DataB2"));
+      assert(check_value(i, ReferenceC2[i], DataC2[i], "DataC2"));
+    }
+  }
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Update/dyn_cgf_host_task_usm.cpp
+++ b/sycl/test-e2e/Graph/Update/dyn_cgf_host_task_usm.cpp
@@ -1,0 +1,151 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// REQUIRES: aspect-usm_shared_allocations
+
+// Tests using dynamic command groups to update a host task node
+#include "../graph_common.hpp"
+
+using T = int;
+
+void calculate_reference_data(size_t Iterations, size_t Size,
+                              std::vector<T> &ReferenceA,
+                              std::vector<T> &ReferenceB,
+                              std::vector<T> &ReferenceC, T ModValue) {
+  for (size_t n = 0; n < Iterations; n++) {
+    for (size_t i = 0; i < Size; i++) {
+      ReferenceA[i]++;
+      ReferenceB[i] += ReferenceA[i];
+      ReferenceC[i] -= ReferenceA[i];
+      ReferenceB[i]--;
+      ReferenceC[i]--;
+      ReferenceC[i] += ModValue;
+      ReferenceC[i] *= 2;
+    }
+  }
+}
+
+int main() {
+  queue Queue{};
+
+  std::vector<T> DataA(Size), DataB(Size), DataC(Size);
+
+  std::iota(DataA.begin(), DataA.end(), 1);
+  std::iota(DataB.begin(), DataB.end(), 10);
+  std::iota(DataC.begin(), DataC.end(), 1000);
+
+  auto DataA2 = DataA;
+  auto DataB2 = DataB;
+  auto DataC2 = DataC;
+
+  const T ModValue = 7;
+  std::vector<T> ReferenceA(DataA), ReferenceB(DataB), ReferenceC(DataC);
+  calculate_reference_data(Iterations, Size, ReferenceA, ReferenceB, ReferenceC,
+                           ModValue);
+  // We're not updating the buffers here so we need to stack the reference
+  // calculations for after the host-task update
+  std::vector<T> ReferenceA2(ReferenceA), ReferenceB2(ReferenceB),
+      ReferenceC2(ReferenceC);
+  calculate_reference_data(Iterations, Size, ReferenceA2, ReferenceB2,
+                           ReferenceC2, ModValue * 2);
+
+  T *PtrA = sycl::malloc_device<T>(Size, Queue);
+  T *PtrB = sycl::malloc_device<T>(Size, Queue);
+  T *PtrC = sycl::malloc_shared<T>(Size, Queue);
+
+  Queue.copy(DataA.data(), PtrA, Size);
+  Queue.copy(DataB.data(), PtrB, Size);
+  Queue.copy(DataC.data(), PtrC, Size);
+  Queue.wait_and_throw();
+
+  exp_ext::command_graph Graph{
+      Queue.get_context(),
+      Queue.get_device(),
+      {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+  // Add some commands to the graph
+  auto LastOperation = add_kernels_usm(Graph, Size, PtrA, PtrB, PtrC);
+
+  // Create two different command groups for the host task
+  auto CGFA = [&](handler &CGH) {
+    CGH.host_task([=]() {
+      for (size_t i = 0; i < Size; i++) {
+        PtrC[i] += ModValue;
+      }
+    });
+  };
+  auto CGFB = [&](handler &CGH) {
+    CGH.host_task([=]() {
+      for (size_t i = 0; i < Size; i++) {
+        PtrC[i] += ModValue * 2;
+      }
+    });
+  };
+
+  auto DynamicCG = exp_ext::dynamic_command_group(Graph, {CGFA, CGFB});
+  // Add a host task which modifies PtrC using the dynamic CG
+  auto HostTaskNode =
+      Graph.add(DynamicCG, exp_ext::property::node::depends_on{LastOperation});
+
+  // Add another node that depends on the host-task
+  Graph.add(
+      [&](handler &CGH) {
+        CGH.parallel_for(range<1>(Size), [=](item<1> Item) {
+          PtrC[Item.get_linear_id()] *= 2;
+        });
+      },
+      exp_ext::property::node::depends_on{HostTaskNode});
+
+  auto GraphExec = Graph.finalize(exp_ext::property::graph::updatable{});
+
+  // Execute several Iterations of the graph with the first host-task (CGFA)
+  event Event;
+  for (unsigned n = 0; n < Iterations; n++) {
+    Event = Queue.submit([&](handler &CGH) {
+      CGH.depends_on(Event);
+      CGH.ext_oneapi_graph(GraphExec);
+    });
+  }
+  Queue.wait_and_throw();
+  Queue.copy(PtrA, DataA.data(), Size);
+  Queue.copy(PtrB, DataB.data(), Size);
+  Queue.copy(PtrC, DataC.data(), Size);
+  Queue.wait_and_throw();
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
+
+  // Update to CGFB
+  DynamicCG.set_active_index(1);
+  GraphExec.update(HostTaskNode);
+
+  // Execute several Iterations of the graph for second host-task (CGFB)
+  for (unsigned n = 0; n < Iterations; n++) {
+    Event = Queue.submit([&](handler &CGH) {
+      CGH.depends_on(Event);
+      CGH.ext_oneapi_graph(GraphExec);
+    });
+  }
+
+  Queue.wait_and_throw();
+  Queue.copy(PtrA, DataA2.data(), Size);
+  Queue.copy(PtrB, DataB2.data(), Size);
+  Queue.copy(PtrC, DataC2.data(), Size);
+  Queue.wait_and_throw();
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA2[i], DataA2[i], "DataA2"));
+    assert(check_value(i, ReferenceB2[i], DataB2[i], "DataB2"));
+    assert(check_value(i, ReferenceC2[i], DataC2[i], "DataC2"));
+  }
+
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
+  sycl::free(PtrC, Queue);
+  return 0;
+}


### PR DESCRIPTION
- Update spec wording to allow updating host-task function in graphs
- Support host-tasks in dynamic command-groups
- Support host-tasks in whole graph update
- Add E2E tests for both scenarios
- Fix passing incorrect accessors to graph update command after update which could cause issues if the graph was destroyed while the scheduler still had graph execution commands alive