### PR TITLE
[SPIR-V] Reland "Fix OpGroupNonUniformBroadcast version requirement"

### DIFF
--- a/llvm-spirv/test/transcoding/OpLessOrGreater.ll
+++ b/llvm-spirv/test/transcoding/OpLessOrGreater.ll
@@ -1,5 +1,3 @@
-; TODO: Re-enable this test when support for SPIRV 1.5 is enabled.
-; XFAIL:*
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt

--- a/llvm-spirv/test/transcoding/subgroup_spirv_1_5.cl
+++ b/llvm-spirv/test/transcoding/subgroup_spirv_1_5.cl
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: not llvm-spirv --spirv-max-version=1.4 %t.bc 2>&1 | FileCheck --check-prefix=CHECK-ERROR %s
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+// Before SPIR-V 1.5, the Id operand of OpGroupNonUniformBroadcast must come from a constant instruction.
+// CHECK-ERROR: RequiresVersion: Cannot fulfill SPIR-V version restriction:
+// CHECK-ERROR-NEXT: SPIR-V version was restricted to at most 1.4 (66560) but a construct from the input requires SPIR-V version 1.5 (66816) or above
+
+// CHECK-LLVM-LABEL: @test
+// CHECK-LLVM: call spir_func i16 @_Z31sub_group_non_uniform_broadcasttj(i16 %a, i32 %id)
+
+kernel void test(short a, uint id, global short *res) {
+  res[0] = sub_group_non_uniform_broadcast(a, id);
+}


### PR DESCRIPTION
For SPIR-V 1.4 and earlier, the Id operand of
OpGroupNonUniformBroadcast must come from a constant instruction.

Ensure that any emitted SPIR-V module using a non-constant Id operand declares SPIR-V version 1.5. Bail out if the maximum SPIR-V version was restricted to < 1.5, to avoid producing invalid SPIR-V.

Original commit:
KhronosGroup/SPIRV-LLVM-Translator@64fe75e388dc3b7

This reverts commit bbf3800adf1209d062ddb49555bb4f36120575ad
The reland is possible after switch to SPIR-V 1.5