### PR TITLE
[SYCL] Fix sycl/test-e2e/NewOffloadDriver/multisource.cpp

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5524,7 +5524,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                                  JA.isDeviceOffloading(Action::OFK_Host));
   bool IsHostOffloadingAction =
       JA.isHostOffloading(Action::OFK_OpenMP) ||
-      JA.isHostOffloading(Action::OFK_SYCL) ||
       (JA.isHostOffloading(C.getActiveOffloadKinds()) &&
        Args.hasFlag(options::OPT_offload_new_driver,
                     options::OPT_no_offload_new_driver,

--- a/sycl/test-e2e/NewOffloadDriver/multisource.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/multisource.cpp
@@ -37,9 +37,6 @@
 // RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl %{sycl_target_opts} --offload-new-driver %t.main.o %t.a -o %t4.fat
 // RUN: %{run} %t4.fat
 
-// XFAIL:  *
-// XFAIL-TRACKER: CMPLRLLVM-65101
-
 // XFAIL: spirv-backend
 // XFAIL-TRACKER: CMPLRLLVM-64059
 


### PR DESCRIPTION
The line removed makes the device objects have an `.llvm.offloading.section` in the elf, which causes clang-linker-wrapper to try to open the objects as new-style binaries, causing the test to fail.