### PR TITLE
[CI] Add PS script to detect hung tests on Windows

### DIFF
--- a/devops/scripts/windows_detect_hung_tests.ps1
+++ b/devops/scripts/windows_detect_hung_tests.ps1
@@ -1,0 +1,8 @@
+$exitCode = 0
+$hungTests = Get-Process | Where-Object { ($_.Path -match "llvm\\install") -or ($_.Path -match "llvm\\build-e2e") }
+$hungTests | Foreach-Object {
+ $exitCode = 1
+ echo "Test $($_.Path) hung!"
+ Stop-Process -Force $_
+}
+exit $exitCode


### PR DESCRIPTION
This is just the existing code we have in the run-tests yaml moved to a script.

In a subsequent PR I'm going to expand these checks to fix recent hangs we've seen, and I can't use an action because that requires a checkout which will fail if there's a hung test, so we need a normal script.