### PR TITLE
[UR][CUDA] Change MAX_MEMORY_BANDWIDTH device query to uint64

### DIFF
--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -2123,7 +2123,7 @@ typedef enum ur_device_info_t {
   UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 94,
   /// [uint32_t][optional-query] return Intel GPU number of threads per EU
   UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU = 95,
-  /// [uint32_t][optional-query] return max memory bandwidth in Mb/s
+  /// [uint64_t][optional-query] return max memory bandwidth in B/s
   UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 96,
   /// [::ur_bool_t] device supports sRGB images
   UR_DEVICE_INFO_IMAGE_SRGB = 97,

--- a/unified-runtime/include/ur_print.hpp
+++ b/unified-runtime/include/ur_print.hpp
@@ -4186,9 +4186,9 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr,
     os << ")";
   } break;
   case UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH: {
-    const uint32_t *tptr = (const uint32_t *)ptr;
-    if (sizeof(uint32_t) > size) {
-      os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint32_t)
+    const uint64_t *tptr = (const uint64_t *)ptr;
+    if (sizeof(uint64_t) > size) {
+      os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint64_t)
          << ")";
       return UR_RESULT_ERROR_INVALID_SIZE;
     }

--- a/unified-runtime/scripts/core/device.yml
+++ b/unified-runtime/scripts/core/device.yml
@@ -393,7 +393,7 @@ etors:
     - name: GPU_HW_THREADS_PER_EU
       desc: "[uint32_t][optional-query] return Intel GPU number of threads per EU"
     - name: MAX_MEMORY_BANDWIDTH
-      desc: "[uint32_t][optional-query] return max memory bandwidth in Mb/s"
+      desc: "[uint64_t][optional-query] return max memory bandwidth in B/s"
     - name: IMAGE_SRGB
       desc: "[$x_bool_t] device supports sRGB images"
     - name: BUILD_ON_SUBDEVICE

--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -1009,7 +1009,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
           hDevice->get()));
     }
 
-    uint32_t MemoryBandwidth = MemoryClockKHz * MemoryBusWidth * 250;
+    // This is a collection of all constants mentioned in this computation:
+    // https://github.com/jeffhammond/HPCInfo/blob/aae05c733016cc8fbb91ee71fc8076f17fa7b912/cuda/gpu-detect.cu#L241
+    constexpr uint64_t MemoryBandwidthConstant = 250;
+    uint64_t MemoryBandwidth =
+        MemoryBandwidthConstant * MemoryClockKHz * MemoryBusWidth;
 
     return ReturnValue(MemoryBandwidth);
   }

--- a/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
@@ -1643,7 +1643,7 @@ TEST_P(urDeviceGetInfoTest, SuccessIntelMaxMemoryBandwidth) {
       urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
       property_name);
 
-  uint32_t property_value = 0;
+  uint64_t property_value = 0;
   ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
                                              property_size, &property_value,
                                              nullptr),

--- a/unified-runtime/tools/urinfo/urinfo.hpp
+++ b/unified-runtime/tools/urinfo/urinfo.hpp
@@ -271,7 +271,7 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
   std::cout << prefix;
   printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU);
   std::cout << prefix;
-  printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH);
+  printDeviceInfo<uint64_t>(hDevice, UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH);
   std::cout << prefix;
   printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_IMAGE_SRGB);
   std::cout << prefix;


### PR DESCRIPTION
Migrated from [PR 2653](https://github.com/oneapi-src/unified-runtime/pull/2653)