### PR TITLE
[SYCL][E2E] Use target features instead of backend for ESIMD unsupported statements

### DIFF
--- a/sycl/test-e2e/ESIMD/lit.local.cfg
+++ b/sycl/test-e2e/ESIMD/lit.local.cfg
@@ -1,6 +1,6 @@
 import platform
 
-config.unsupported_features += ['cuda', 'hip']
+config.unsupported_features += ['target-nvidia', 'target-amd']
 config.required_features += ['gpu']
 
 # We need this to fix failures when run on OCL.

--- a/sycl/test-e2e/InvokeSimd/lit.local.cfg
+++ b/sycl/test-e2e/InvokeSimd/lit.local.cfg
@@ -1,6 +1,6 @@
 import platform
 
-config.unsupported_features += ['cuda', 'hip']
+config.unsupported_features += ['target-nvidia', 'target-amd']
 config.required_features += ['gpu']
 
 # TODO: enable on Windows once driver is ready.


### PR DESCRIPTION
These tests fail to build for nvptx/amdgcn so instead of marking unsupported based on the backend they should be marked as unsupported based on the build target.