### PR TITLE
[SYCL] Simplify group load/store implementation

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/group_load_store.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_load_store.hpp
@@ -125,8 +125,9 @@ int get_mem_idx(GroupTy g, int vec_or_array_idx) {
 // https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups_char.html
 // https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups_long.html
 // https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups_short.html
-// Reads require 4-byte alignment, writes 16-byte alignment. Supported
-// sizes:
+// https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroup_local_block_io.html
+// Reads require 4-byte alignment for global pointers and 16-byte alignment for
+// local pointers, writes require 16-byte alignment. Supported sizes:
 //
 // +------------+-------------+
 // | block type | # of blocks |
@@ -168,7 +169,7 @@ struct RequiredAlignment<OpType, access::address_space::global_space> {
 
 template <operation_type OpType>
 struct RequiredAlignment<OpType, access::address_space::local_space> {
-  static constexpr int value = (OpType == operation_type::load) ? 4 : 16;
+  static constexpr int value = 16;
 };
 
 template <typename BlockInfoTy> struct BlockTypeInfo;

--- a/sycl/include/sycl/ext/oneapi/experimental/group_load_store.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_load_store.hpp
@@ -156,6 +156,21 @@ struct BlockInfo {
       (num_blocks <= 8 || (num_blocks == 16 && block_size <= 2));
 };
 
+enum class operation_type { load, store };
+
+template <operation_type OpType, access::address_space Space>
+struct RequiredAlignment {};
+
+template <operation_type OpType>
+struct RequiredAlignment<OpType, access::address_space::global_space> {
+  static constexpr int value = (OpType == operation_type::load) ? 4 : 16;
+};
+
+template <operation_type OpType>
+struct RequiredAlignment<OpType, access::address_space::local_space> {
+  static constexpr int value = (OpType == operation_type::load) ? 4 : 16;
+};
+
 template <typename BlockInfoTy> struct BlockTypeInfo;
 
 template <typename IteratorT, std::size_t ElementsPerWorkItem, bool Blocked>
@@ -186,11 +201,10 @@ struct BlockTypeInfo<BlockInfo<IteratorT, ElementsPerWorkItem, Blocked>> {
 // aren't satisfied. If deduced address space is generic then returned pointer
 // will have generic address space and has to be dynamically casted to global or
 // local space before using in a builtin.
-template <int RequiredAlign, std::size_t ElementsPerWorkItem,
-          typename IteratorT, typename Properties>
-auto get_block_op_ptr(IteratorT iter, [[maybe_unused]] Properties props) {
-  using value_type =
-      remove_decoration_t<typename std::iterator_traits<IteratorT>::value_type>;
+template <std::size_t ElementsPerWorkItem, typename IteratorT,
+          typename Properties>
+constexpr auto get_block_op_ptr(IteratorT iter,
+                                [[maybe_unused]] Properties props) {
   using iter_no_cv = std::remove_cv_t<IteratorT>;
 
   constexpr bool blocked = detail::isBlocked(props);
@@ -208,12 +222,10 @@ auto get_block_op_ptr(IteratorT iter, [[maybe_unused]] Properties props) {
   } else if constexpr (!props.template has_property<full_group_key>()) {
     return nullptr;
   } else if constexpr (detail::is_multi_ptr_v<IteratorT>) {
-    return get_block_op_ptr<RequiredAlign, ElementsPerWorkItem>(
-        iter.get_decorated(), props);
+    return get_block_op_ptr<ElementsPerWorkItem>(iter.get_decorated(), props);
   } else if constexpr (!std::is_pointer_v<iter_no_cv>) {
     if constexpr (props.template has_property<contiguous_memory_key>())
-      return get_block_op_ptr<RequiredAlign, ElementsPerWorkItem>(&*iter,
-                                                                  props);
+      return get_block_op_ptr<ElementsPerWorkItem>(&*iter, props);
     else
       return nullptr;
   } else {
@@ -221,26 +233,35 @@ auto get_block_op_ptr(IteratorT iter, [[maybe_unused]] Properties props) {
     // compiler to optimize the IR further.
     __builtin_assume(iter != nullptr);
 
-    // No early return as that would mess up return type deduction.
-    bool is_aligned = alignof(value_type) >= RequiredAlign ||
-                      reinterpret_cast<uintptr_t>(iter) % RequiredAlign == 0;
-
     using block_pointer_type =
         typename BlockTypeInfo<BlkInfo>::block_pointer_type;
 
-    static constexpr auto deduced_address_space =
+    constexpr auto deduced_address_space =
         BlockTypeInfo<BlkInfo>::deduced_address_space;
+
     if constexpr (deduced_address_space ==
                       access::address_space::generic_space ||
                   deduced_address_space ==
                       access::address_space::global_space ||
-                  deduced_address_space == access::address_space::local_space) {
-      return is_aligned ? reinterpret_cast<block_pointer_type>(iter) : nullptr;
+                  (deduced_address_space ==
+                       access::address_space::local_space &&
+                   props.template has_property<
+                       detail::native_local_block_io_key>())) {
+      return reinterpret_cast<block_pointer_type>(iter);
     } else {
       return nullptr;
     }
   }
 }
+
+template <int RequiredAlign, typename IteratorType>
+bool is_aligned(IteratorType iter) {
+  using value_type = remove_decoration_t<
+      typename std::iterator_traits<IteratorType>::value_type>;
+  return alignof(value_type) >= RequiredAlign ||
+         reinterpret_cast<uintptr_t>(&*iter) % RequiredAlign == 0;
+}
+
 } // namespace detail
 
 // Load API span overload.
@@ -266,78 +287,72 @@ group_load(Group g, InputIteratorT in_ptr,
   } else if constexpr (!std::is_same_v<Group, sycl::sub_group>) {
     return group_load(g, in_ptr, out, use_naive{});
   } else {
-    auto ptr =
-        detail::get_block_op_ptr<4 /* load align */, ElementsPerWorkItem>(
-            in_ptr, props);
-    if (!ptr)
-      return group_load(g, in_ptr, out, use_naive{});
+    auto ptr = detail::get_block_op_ptr<ElementsPerWorkItem>(in_ptr, props);
+    static constexpr auto deduced_address_space =
+        detail::deduce_AS<std::remove_cv_t<decltype(ptr)>>::value;
 
     if constexpr (!std::is_same_v<std::nullptr_t, decltype(ptr)>) {
-      // Do optimized load.
-      using value_type = remove_decoration_t<
-          typename std::iterator_traits<InputIteratorT>::value_type>;
-      using block_info = typename detail::BlockTypeInfo<
-          detail::BlockInfo<InputIteratorT, ElementsPerWorkItem, blocked>>;
-      static constexpr auto deduced_address_space =
-          block_info::deduced_address_space;
-      using block_op_type = typename block_info::block_op_type;
-
-      if constexpr (deduced_address_space ==
-                        access::address_space::local_space &&
-                    !props.template has_property<
-                        detail::native_local_block_io_key>())
-        return group_load(g, in_ptr, out, use_naive{});
-
-      block_op_type load;
       if constexpr (deduced_address_space ==
                     access::address_space::generic_space) {
         if (auto local_ptr = detail::dynamic_address_cast<
                 access::address_space::local_space>(ptr)) {
-          if constexpr (props.template has_property<
-                            detail::native_local_block_io_key>())
-            load = __spirv_SubgroupBlockReadINTEL<block_op_type>(local_ptr);
-          else
-            return group_load(g, in_ptr, out, use_naive{});
+          return group_load(g, local_ptr, out, props);
         } else if (auto global_ptr = detail::dynamic_address_cast<
                        access::address_space::global_space>(ptr)) {
-          load = __spirv_SubgroupBlockReadINTEL<block_op_type>(global_ptr);
+          return group_load(g, global_ptr, out, props);
         } else {
           return group_load(g, in_ptr, out, use_naive{});
         }
       } else {
-        load = __spirv_SubgroupBlockReadINTEL<block_op_type>(ptr);
+        using value_type = remove_decoration_t<
+            typename std::iterator_traits<InputIteratorT>::value_type>;
+        using block_info = typename detail::BlockTypeInfo<
+            detail::BlockInfo<InputIteratorT, ElementsPerWorkItem, blocked>>;
+        using block_op_type = typename block_info::block_op_type;
+        // Alignment checks of the pointer.
+        constexpr int ReqAlign =
+            detail::RequiredAlignment<detail::operation_type::load,
+                                      deduced_address_space>::value;
+        if (!detail::is_aligned<ReqAlign>(in_ptr))
+          return group_load(g, in_ptr, out, use_naive{});
+
+        // We know the pointer is aligned and the address space is known. Do the
+        // optimized load.
+        auto load = __spirv_SubgroupBlockReadINTEL<block_op_type>(ptr);
+
+        // TODO: accessor_iterator's value_type is weird, so we need
+        // `std::remove_const_t` below:
+        //
+        // static_assert(
+        //     std::is_same_v<
+        //         typename std::iterator_traits<
+        //             sycl::detail::accessor_iterator<const int,
+        //             1>>::value_type,
+        //         const int>);
+        //
+        // yet
+        //
+        // static_assert(
+        //     std::is_same_v<
+        //         typename std::iterator_traits<const int *>::value_type,
+        //         int>);
+        if constexpr (std::is_same_v<std::remove_const_t<value_type>,
+                                     OutputT>) {
+          static_assert(sizeof(load) == out.size_bytes());
+          sycl::detail::memcpy_no_adl(out.begin(), &load, out.size_bytes());
+        } else {
+          std::remove_const_t<value_type> values[ElementsPerWorkItem];
+          static_assert(sizeof(load) == sizeof(values));
+          sycl::detail::memcpy_no_adl(values, &load, sizeof(values));
+
+          // Note: can't `memcpy` directly into `out` because that might bypass
+          // an implicit conversion required by the specification.
+          for (int i = 0; i < ElementsPerWorkItem; ++i)
+            out[i] = values[i];
+        }
       }
-
-      // TODO: accessor_iterator's value_type is weird, so we need
-      // `std::remove_const_t` below:
-      //
-      // static_assert(
-      //     std::is_same_v<
-      //         typename std::iterator_traits<
-      //             sycl::detail::accessor_iterator<const int, 1>>::value_type,
-      //         const int>);
-      //
-      // yet
-      //
-      // static_assert(
-      //     std::is_same_v<
-      //         typename std::iterator_traits<const int *>::value_type, int>);
-
-      if constexpr (std::is_same_v<std::remove_const_t<value_type>, OutputT>) {
-        static_assert(sizeof(load) == out.size_bytes());
-        sycl::detail::memcpy_no_adl(out.begin(), &load, out.size_bytes());
-      } else {
-        std::remove_const_t<value_type> values[ElementsPerWorkItem];
-        static_assert(sizeof(load) == sizeof(values));
-        sycl::detail::memcpy_no_adl(values, &load, sizeof(values));
-
-        // Note: can't `memcpy` directly into `out` because that might bypass
-        // an implicit conversion required by the specification.
-        for (int i = 0; i < ElementsPerWorkItem; ++i)
-          out[i] = values[i];
-      }
-
-      return;
+    } else {
+      return group_load(g, in_ptr, out, use_naive{});
     }
   }
 }
@@ -365,55 +380,50 @@ group_store(Group g, const span<InputT, ElementsPerWorkItem> in,
   } else if constexpr (!std::is_same_v<Group, sycl::sub_group>) {
     return group_store(g, in, out_ptr, use_naive{});
   } else {
-    auto ptr =
-        detail::get_block_op_ptr<16 /* store align */, ElementsPerWorkItem>(
-            out_ptr, props);
-    if (!ptr)
-      return group_store(g, in, out_ptr, use_naive{});
+    auto ptr = detail::get_block_op_ptr<ElementsPerWorkItem>(out_ptr, props);
 
     if constexpr (!std::is_same_v<std::nullptr_t, decltype(ptr)>) {
-      using block_info = typename detail::BlockTypeInfo<
-          detail::BlockInfo<OutputIteratorT, ElementsPerWorkItem, blocked>>;
       static constexpr auto deduced_address_space =
-          block_info::deduced_address_space;
-      if constexpr (deduced_address_space ==
-                        access::address_space::local_space &&
-                    !props.template has_property<
-                        detail::native_local_block_io_key>())
-        return group_store(g, in, out_ptr, use_naive{});
-
-      // Do optimized store.
-      std::remove_const_t<remove_decoration_t<
-          typename std::iterator_traits<OutputIteratorT>::value_type>>
-          values[ElementsPerWorkItem];
-
-      for (int i = 0; i < ElementsPerWorkItem; ++i) {
-        // Including implicit conversion.
-        values[i] = in[i];
-      }
-
-      using block_op_type = typename block_info::block_op_type;
+          detail::deduce_AS<std::remove_cv_t<decltype(ptr)>>::value;
       if constexpr (deduced_address_space ==
                     access::address_space::generic_space) {
         if (auto local_ptr = detail::dynamic_address_cast<
                 access::address_space::local_space>(ptr)) {
-          if constexpr (props.template has_property<
-                            detail::native_local_block_io_key>())
-            __spirv_SubgroupBlockWriteINTEL(
-                local_ptr, sycl::bit_cast<block_op_type>(values));
-          else
-            return group_store(g, in, out_ptr, use_naive{});
+          return group_store(g, in, local_ptr, props);
         } else if (auto global_ptr = detail::dynamic_address_cast<
                        access::address_space::global_space>(ptr)) {
-          __spirv_SubgroupBlockWriteINTEL(
-              global_ptr, sycl::bit_cast<block_op_type>(values));
+          return group_store(g, in, global_ptr, props);
         } else {
           return group_store(g, in, out_ptr, use_naive{});
         }
       } else {
+        using block_info = typename detail::BlockTypeInfo<
+            detail::BlockInfo<OutputIteratorT, ElementsPerWorkItem, blocked>>;
+        using block_op_type = typename block_info::block_op_type;
+
+        // Alignment checks of the pointer.
+        constexpr int ReqAlign =
+            detail::RequiredAlignment<detail::operation_type::store,
+                                      deduced_address_space>::value;
+        if (!detail::is_aligned<ReqAlign>(out_ptr))
+          return group_store(g, in, out_ptr, use_naive{});
+
+        std::remove_const_t<remove_decoration_t<
+            typename std::iterator_traits<OutputIteratorT>::value_type>>
+            values[ElementsPerWorkItem];
+
+        for (int i = 0; i < ElementsPerWorkItem; ++i) {
+          // Including implicit conversion.
+          values[i] = in[i];
+        }
+
+        // We know the pointer is aligned and the address space is known. Do the
+        // optimized load.
         __spirv_SubgroupBlockWriteINTEL(ptr,
                                         sycl::bit_cast<block_op_type>(values));
       }
+    } else {
+      return group_store(g, in, out_ptr, use_naive{});
     }
   }
 }

--- a/sycl/test/check_device_code/group_load.cpp
+++ b/sycl/test/check_device_code/group_load.cpp
@@ -51,24 +51,24 @@ using plain_ptr = typename sycl::detail::DecoratedType<
 namespace blocked {
 // CHECK-GLOBAL-LABEL: @_ZN7blocked10test_naiveERN4sycl3_V19sub_groupEPU3AS1iRi(
 // CHECK-GLOBAL-NEXT:  entry:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4:[0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7:[0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
 // CHECK-GLOBAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[TMP0]] to i64
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(1) [[P:%.*]], i64 [[IDXPROM_I_I]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) [[ARRAYIDX_I_I]], align 4, !tbaa [[TBAA8:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP1]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7blocked10test_naiveERN4sycl3_V19sub_groupEPU3AS3iRi(
 // CHECK-LOCAL-NEXT:  entry:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5:[0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6:[0-9]+]]
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
 // CHECK-LOCAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[TMP0]] to i64
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P:%.*]], i64 [[IDXPROM_I_I]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(3) [[ARRAYIDX_I_I]], align 4, !tbaa [[TBAA8:![0-9]+]]
 // CHECK-LOCAL-NEXT:    store i32 [[TMP1]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_naive(sycl::sub_group &sg, plain_ptr<int> p, int &out) {
@@ -80,16 +80,32 @@ SYCL_EXTERNAL void test_naive(sycl::sub_group &sg, plain_ptr<int> p, int &out) {
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-GLOBAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    store i32 [[CALL4_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
+// CHECK-GLOBAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    store i32 [[CALL5_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7blocked14test_optimizedERN4sycl3_V19sub_groupEPU3AS3iRi(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-LOCAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    store i32 [[CALL4_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
+// CHECK-LOCAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
+// CHECK-LOCAL:       if.then.i.i:
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
+// CHECK-LOCAL-NEXT:    [[IDXPROM_I_I_I:%.*]] = sext i32 [[TMP1]] to i64
+// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I_I]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(3) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    store i32 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESR_SP_RSQ_SS__EXIT:%.*]]
+// CHECK-LOCAL:       if.end.i.i:
+// CHECK-LOCAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    store i32 [[CALL5_I_I]], ptr addrspace(4) [[OUT]], align 4
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESR_SP_RSQ_SS__EXIT]]
+// CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeESR_SP_RSQ_SS_.exit:
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_optimized(sycl::sub_group &sg, plain_ptr<int> p,
@@ -102,16 +118,32 @@ SYCL_EXTERNAL void test_optimized(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-GLOBAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    store i32 [[CALL4_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
+// CHECK-GLOBAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    store i32 [[CALL5_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7blocked27test_contiguous_auto_detectERN4sycl3_V19sub_groupEPU3AS3iRi(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-LOCAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    store i32 [[CALL4_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
+// CHECK-LOCAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
+// CHECK-LOCAL:       if.then.i.i:
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
+// CHECK-LOCAL-NEXT:    [[IDXPROM_I_I_I:%.*]] = sext i32 [[TMP1]] to i64
+// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I_I]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(3) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    store i32 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESP_SN_RSO_SQ__EXIT:%.*]]
+// CHECK-LOCAL:       if.end.i.i:
+// CHECK-LOCAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    store i32 [[CALL5_I_I]], ptr addrspace(4) [[OUT]], align 4
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESP_SN_RSO_SQ__EXIT]]
+// CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeESP_SN_RSO_SQ_.exit:
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_contiguous_auto_detect(sycl::sub_group &sg,
@@ -133,46 +165,30 @@ using accessor_iter_t = local_accessor<int, 1>::iterator;
 // CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_0_0_COPYLOAD:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ITER:%.*]], align 8, !tbaa [[TBAA15:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_2_0_ITER_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[ITER]], i64 8
 // CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_2_0_COPYLOAD:%.*]] = load i64, ptr addrspace(4) [[AGG_TMP1_SROA_2_0_ITER_SROA_IDX]], align 8, !tbaa [[TBAA18:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
 // CHECK-GLOBAL-NEXT:    [[CONV3_I_I_I:%.*]] = sext i32 [[TMP0]] to i64
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = getelementptr i32, ptr addrspace(4) [[AGG_TMP1_SROA_0_0_COPYLOAD]], i64 [[AGG_TMP1_SROA_2_0_COPYLOAD]]
 // CHECK-GLOBAL-NEXT:    [[ADD_PTR_I_I_I_I_I:%.*]] = getelementptr i32, ptr addrspace(4) [[TMP1]], i64 [[CONV3_I_I_I]]
 // CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(4) [[ADD_PTR_I_I_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7blocked18test_accessor_iterERN4sycl3_V19sub_groupERPiRi(
 // CHECK-LOCAL-NEXT:  entry:
-// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ITER:%.*]], align 8, !tbaa [[TBAA15:![0-9]+]], !nonnull [[META7:![0-9]+]], !noundef [[META7]]
-// CHECK-LOCAL-NEXT:    [[CALL_I_I_I:%.*]] = tail call spir_func noundef ptr addrspace(3) @_Z40__spirv_GenericCastToPtrExplicit_ToLocalPvi(ptr addrspace(4) noundef nonnull [[TMP0]], i32 noundef 4) #[[ATTR6:[0-9]+]]
-// CHECK-LOCAL-NEXT:    [[TOBOOL5_NOT_I_I:%.*]] = icmp eq ptr addrspace(3) [[CALL_I_I_I]], null
-// CHECK-LOCAL-NEXT:    br i1 [[TOBOOL5_NOT_I_I]], label [[IF_ELSE_I_I:%.*]], label [[IF_THEN6_I_I:%.*]]
-// CHECK-LOCAL:       if.then6.i.i:
-// CHECK-LOCAL-NEXT:    [[CALL7_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[CALL_I_I_I]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    br label [[IF_END17_I_I:%.*]]
-// CHECK-LOCAL:       if.else.i.i:
-// CHECK-LOCAL-NEXT:    [[CALL_I38_I_I:%.*]] = tail call spir_func noundef ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobalPvi(ptr addrspace(4) noundef nonnull [[TMP0]], i32 noundef 5) #[[ATTR6]]
-// CHECK-LOCAL-NEXT:    [[TOBOOL9_NOT_NOT_I_I:%.*]] = icmp eq ptr addrspace(1) [[CALL_I38_I_I]], null
-// CHECK-LOCAL-NEXT:    br i1 [[TOBOOL9_NOT_NOT_I_I]], label [[CLEANUP_THREAD_I_I:%.*]], label [[CLEANUP_I_I:%.*]]
-// CHECK-LOCAL:       cleanup.thread.i.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
-// CHECK-LOCAL-NEXT:    [[IDXPROM_I43_I_I:%.*]] = sext i32 [[TMP1]] to i64
-// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I44_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(4) [[TMP0]], i64 [[IDXPROM_I43_I_I]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(4) [[ARRAYIDX_I44_I_I]], align 4, !tbaa [[TBAA8]]
-// CHECK-LOCAL-NEXT:    store i32 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPIINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSA_INS3_14FULL_GROUP_KEYEJEEENSA_INS8_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESO_SM_RSN_SP__EXIT:%.*]]
-// CHECK-LOCAL:       cleanup.i.i:
-// CHECK-LOCAL-NEXT:    [[CALL11_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[CALL_I38_I_I]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    br label [[IF_END17_I_I]]
-// CHECK-LOCAL:       if.end17.i.i:
-// CHECK-LOCAL-NEXT:    [[LOAD_1_I_I:%.*]] = phi i32 [ [[CALL11_I_I]], [[CLEANUP_I_I]] ], [ [[CALL7_I_I]], [[IF_THEN6_I_I]] ]
-// CHECK-LOCAL-NEXT:    store i32 [[LOAD_1_I_I]], ptr addrspace(4) [[OUT]], align 4
-// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPIINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSA_INS3_14FULL_GROUP_KEYEJEEENSA_INS8_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESO_SM_RSN_SP__EXIT]]
-// CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPiiNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSA_INS3_14full_group_keyEJEEENSA_INS8_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeESO_SM_RSN_SP_.exit:
+// CHECK-LOCAL-NEXT:    [[AGG_TMP_I:%.*]] = alloca %"struct.sycl::_V1::sub_group", align 1
+// CHECK-LOCAL-NEXT:    [[AGG_TMP1_I:%.*]] = alloca %"class.sycl::_V1::span", align 8
+// CHECK-LOCAL-NEXT:    [[AGG_TMP2_I:%.*]] = alloca %"class.sycl::_V1::ext::oneapi::experimental::properties.15", align 1
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ITER:%.*]], align 8, !tbaa [[TBAA15:![0-9]+]]
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.start.p0(i64 1, ptr nonnull [[AGG_TMP_I]])
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.start.p0(i64 8, ptr nonnull [[AGG_TMP1_I]])
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.start.p0(i64 3, ptr nonnull [[AGG_TMP2_I]])
+// CHECK-LOCAL-NEXT:    store ptr addrspace(4) [[OUT:%.*]], ptr [[AGG_TMP1_I]], align 8, !tbaa [[TBAA18:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPiiLm1ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSA_INS3_14full_group_keyEJEEENSA_INS8_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESO_SM_NS0_4spanISN_XT2_EEESP_(ptr noundef nonnull byval(%"struct.sycl::_V1::sub_group") align 1 [[AGG_TMP_I]], ptr addrspace(4) noundef [[TMP0]], ptr noundef nonnull byval(%"class.sycl::_V1::span") align 8 [[AGG_TMP1_I]], ptr noundef nonnull byval(%"class.sycl::_V1::ext::oneapi::experimental::properties.15") align 1 [[AGG_TMP2_I]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.end.p0(i64 1, ptr nonnull [[AGG_TMP_I]])
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.end.p0(i64 8, ptr nonnull [[AGG_TMP1_I]])
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.end.p0(i64 3, ptr nonnull [[AGG_TMP2_I]])
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_accessor_iter(sycl::sub_group &sg,
@@ -183,71 +199,37 @@ SYCL_EXTERNAL void test_accessor_iter(sycl::sub_group &sg,
 
 // CHECK-GLOBAL-LABEL: @_ZN7blocked34test_accessor_iter_force_optimizedERN4sycl3_V19sub_groupERNS1_6detail17accessor_iteratorIKiLi1EEERi(
 // CHECK-GLOBAL-NEXT:  entry:
-// CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_0_0_COPYLOAD:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ITER:%.*]], align 8, !tbaa [[TBAA15]]
-// CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_2_0_ITER_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[ITER]], i64 8
-// CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_2_0_COPYLOAD:%.*]] = load i64, ptr addrspace(4) [[AGG_TMP1_SROA_2_0_ITER_SROA_IDX]], align 8, !tbaa [[TBAA18]]
-// CHECK-GLOBAL-NEXT:    [[ADD_PTR_I_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[AGG_TMP1_SROA_0_0_COPYLOAD]], i64 [[AGG_TMP1_SROA_2_0_COPYLOAD]]
-// CHECK-GLOBAL-NEXT:    [[CMP_I_I_I_I:%.*]] = icmp ne ptr addrspace(4) [[ADD_PTR_I_I_I_I]], null
-// CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I_I]])
-// CHECK-GLOBAL-NEXT:    [[CALL_I_I_I:%.*]] = tail call spir_func noundef ptr addrspace(3) @_Z40__spirv_GenericCastToPtrExplicit_ToLocalPKvi(ptr addrspace(4) noundef nonnull [[ADD_PTR_I_I_I_I]], i32 noundef 4) #[[ATTR5:[0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TOBOOL7_NOT_I_I:%.*]] = icmp eq ptr addrspace(3) [[CALL_I_I_I]], null
-// CHECK-GLOBAL-NEXT:    br i1 [[TOBOOL7_NOT_I_I]], label [[IF_ELSE_I_I:%.*]], label [[IF_THEN8_I_I:%.*]]
-// CHECK-GLOBAL:       if.then8.i.i:
-// CHECK-GLOBAL-NEXT:    [[CALL9_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[CALL_I_I_I]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    br label [[IF_END20_I_I:%.*]]
-// CHECK-GLOBAL:       if.else.i.i:
-// CHECK-GLOBAL-NEXT:    [[CALL_I41_I_I:%.*]] = tail call spir_func noundef ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobalPKvi(ptr addrspace(4) noundef nonnull [[ADD_PTR_I_I_I_I]], i32 noundef 5) #[[ATTR5]]
-// CHECK-GLOBAL-NEXT:    [[TOBOOL11_NOT_NOT_I_I:%.*]] = icmp eq ptr addrspace(1) [[CALL_I41_I_I]], null
-// CHECK-GLOBAL-NEXT:    br i1 [[TOBOOL11_NOT_NOT_I_I]], label [[CLEANUP_THREAD_I_I:%.*]], label [[CLEANUP_I_I:%.*]]
-// CHECK-GLOBAL:       cleanup.thread.i.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
-// CHECK-GLOBAL-NEXT:    [[CONV3_I48_I_I:%.*]] = sext i32 [[TMP0]] to i64
-// CHECK-GLOBAL-NEXT:    [[ADD_PTR_I_I_I52_I_I:%.*]] = getelementptr i32, ptr addrspace(4) [[ADD_PTR_I_I_I_I]], i64 [[CONV3_I48_I_I]]
-// CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ADD_PTR_I_I_I52_I_I]], align 4, !tbaa [[TBAA8]]
-// CHECK-GLOBAL-NEXT:    store i32 [[TMP1]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPENS0_6DETAIL17ACCESSOR_ITERATORIKILI1EEEINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSD_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSD_INS3_14FULL_GROUP_KEYEJEEENSD_INSB_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEEST_SR_RSS_SU__EXIT:%.*]]
-// CHECK-GLOBAL:       cleanup.i.i:
-// CHECK-GLOBAL-NEXT:    [[CALL13_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[CALL_I41_I_I]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    br label [[IF_END20_I_I]]
-// CHECK-GLOBAL:       if.end20.i.i:
-// CHECK-GLOBAL-NEXT:    [[LOAD_1_I_I:%.*]] = phi i32 [ [[CALL13_I_I]], [[CLEANUP_I_I]] ], [ [[CALL9_I_I]], [[IF_THEN8_I_I]] ]
-// CHECK-GLOBAL-NEXT:    store i32 [[LOAD_1_I_I]], ptr addrspace(4) [[OUT]], align 4
-// CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPENS0_6DETAIL17ACCESSOR_ITERATORIKILI1EEEINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSD_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSD_INS3_14FULL_GROUP_KEYEJEEENSD_INSB_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEEST_SR_RSS_SU__EXIT]]
-// CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupENS0_6detail17accessor_iteratorIKiLi1EEEiNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSD_INS3_21contiguous_memory_keyEJEEENSD_INS3_14full_group_keyEJEEENSD_INSB_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeEST_SR_RSS_SU_.exit:
+// CHECK-GLOBAL-NEXT:    [[AGG_TMP_I:%.*]] = alloca %"struct.sycl::_V1::sub_group", align 1
+// CHECK-GLOBAL-NEXT:    [[AGG_TMP2_I:%.*]] = alloca %"class.sycl::_V1::span", align 8
+// CHECK-GLOBAL-NEXT:    [[AGG_TMP3_I:%.*]] = alloca %"class.sycl::_V1::ext::oneapi::experimental::properties.7", align 1
+// CHECK-GLOBAL-NEXT:    [[AGG_TMP14:%.*]] = alloca %"class.sycl::_V1::detail::accessor_iterator", align 8
+// CHECK-GLOBAL-NEXT:    call void @llvm.lifetime.start.p0(i64 80, ptr nonnull [[AGG_TMP14]])
+// CHECK-GLOBAL-NEXT:    call void @llvm.lifetime.start.p0(i64 1, ptr nonnull [[AGG_TMP_I]])
+// CHECK-GLOBAL-NEXT:    call void @llvm.lifetime.start.p0(i64 8, ptr nonnull [[AGG_TMP2_I]])
+// CHECK-GLOBAL-NEXT:    call void @llvm.lifetime.start.p0(i64 4, ptr nonnull [[AGG_TMP3_I]])
+// CHECK-GLOBAL-NEXT:    call void @llvm.memcpy.p0.p4.i64(ptr noundef nonnull align 8 dereferenceable(80) [[AGG_TMP14]], ptr addrspace(4) noundef align 8 dereferenceable(80) [[ITER:%.*]], i64 80, i1 false)
+// CHECK-GLOBAL-NEXT:    store ptr addrspace(4) [[OUT:%.*]], ptr [[AGG_TMP2_I]], align 8, !tbaa [[TBAA21:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupENS0_6detail17accessor_iteratorIKiLi1EEEiLm1ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSD_INS3_21contiguous_memory_keyEJEEENSD_INS3_14full_group_keyEJEEENSD_INSB_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_(ptr noundef nonnull byval(%"struct.sycl::_V1::sub_group") align 1 [[AGG_TMP_I]], ptr noundef nonnull byval(%"class.sycl::_V1::detail::accessor_iterator") align 8 [[AGG_TMP14]], ptr noundef nonnull byval(%"class.sycl::_V1::span") align 8 [[AGG_TMP2_I]], ptr noundef nonnull byval(%"class.sycl::_V1::ext::oneapi::experimental::properties.7") align 1 [[AGG_TMP3_I]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    call void @llvm.lifetime.end.p0(i64 80, ptr nonnull [[AGG_TMP14]])
+// CHECK-GLOBAL-NEXT:    call void @llvm.lifetime.end.p0(i64 1, ptr nonnull [[AGG_TMP_I]])
+// CHECK-GLOBAL-NEXT:    call void @llvm.lifetime.end.p0(i64 8, ptr nonnull [[AGG_TMP2_I]])
+// CHECK-GLOBAL-NEXT:    call void @llvm.lifetime.end.p0(i64 4, ptr nonnull [[AGG_TMP3_I]])
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7blocked34test_accessor_iter_force_optimizedERN4sycl3_V19sub_groupERPiRi(
 // CHECK-LOCAL-NEXT:  entry:
-// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ITER:%.*]], align 8, !tbaa [[TBAA15]], !nonnull [[META7]], !noundef [[META7]]
-// CHECK-LOCAL-NEXT:    [[CALL_I_I_I:%.*]] = tail call spir_func noundef ptr addrspace(3) @_Z40__spirv_GenericCastToPtrExplicit_ToLocalPvi(ptr addrspace(4) noundef nonnull [[TMP0]], i32 noundef 4) #[[ATTR6]]
-// CHECK-LOCAL-NEXT:    [[TOBOOL5_NOT_I_I:%.*]] = icmp eq ptr addrspace(3) [[CALL_I_I_I]], null
-// CHECK-LOCAL-NEXT:    br i1 [[TOBOOL5_NOT_I_I]], label [[IF_ELSE_I_I:%.*]], label [[IF_THEN6_I_I:%.*]]
-// CHECK-LOCAL:       if.then6.i.i:
-// CHECK-LOCAL-NEXT:    [[CALL7_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[CALL_I_I_I]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    br label [[IF_END17_I_I:%.*]]
-// CHECK-LOCAL:       if.else.i.i:
-// CHECK-LOCAL-NEXT:    [[CALL_I38_I_I:%.*]] = tail call spir_func noundef ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobalPvi(ptr addrspace(4) noundef nonnull [[TMP0]], i32 noundef 5) #[[ATTR6]]
-// CHECK-LOCAL-NEXT:    [[TOBOOL9_NOT_NOT_I_I:%.*]] = icmp eq ptr addrspace(1) [[CALL_I38_I_I]], null
-// CHECK-LOCAL-NEXT:    br i1 [[TOBOOL9_NOT_NOT_I_I]], label [[CLEANUP_THREAD_I_I:%.*]], label [[CLEANUP_I_I:%.*]]
-// CHECK-LOCAL:       cleanup.thread.i.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
-// CHECK-LOCAL-NEXT:    [[IDXPROM_I43_I_I:%.*]] = sext i32 [[TMP1]] to i64
-// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I44_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(4) [[TMP0]], i64 [[IDXPROM_I43_I_I]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(4) [[ARRAYIDX_I44_I_I]], align 4, !tbaa [[TBAA8]]
-// CHECK-LOCAL-NEXT:    store i32 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPIINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSA_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSA_INS3_14FULL_GROUP_KEYEJEEENSA_INS8_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESQ_SO_RSP_SR__EXIT:%.*]]
-// CHECK-LOCAL:       cleanup.i.i:
-// CHECK-LOCAL-NEXT:    [[CALL11_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[CALL_I38_I_I]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    br label [[IF_END17_I_I]]
-// CHECK-LOCAL:       if.end17.i.i:
-// CHECK-LOCAL-NEXT:    [[LOAD_1_I_I:%.*]] = phi i32 [ [[CALL11_I_I]], [[CLEANUP_I_I]] ], [ [[CALL7_I_I]], [[IF_THEN6_I_I]] ]
-// CHECK-LOCAL-NEXT:    store i32 [[LOAD_1_I_I]], ptr addrspace(4) [[OUT]], align 4
-// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPIINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSA_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSA_INS3_14FULL_GROUP_KEYEJEEENSA_INS8_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESQ_SO_RSP_SR__EXIT]]
-// CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPiiNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSA_INS3_21contiguous_memory_keyEJEEENSA_INS3_14full_group_keyEJEEENSA_INS8_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeESQ_SO_RSP_SR_.exit:
+// CHECK-LOCAL-NEXT:    [[AGG_TMP_I:%.*]] = alloca %"struct.sycl::_V1::sub_group", align 1
+// CHECK-LOCAL-NEXT:    [[AGG_TMP1_I:%.*]] = alloca %"class.sycl::_V1::span", align 8
+// CHECK-LOCAL-NEXT:    [[AGG_TMP2_I:%.*]] = alloca %"class.sycl::_V1::ext::oneapi::experimental::properties.7", align 1
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ITER:%.*]], align 8, !tbaa [[TBAA15]]
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.start.p0(i64 1, ptr nonnull [[AGG_TMP_I]])
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.start.p0(i64 8, ptr nonnull [[AGG_TMP1_I]])
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.start.p0(i64 4, ptr nonnull [[AGG_TMP2_I]])
+// CHECK-LOCAL-NEXT:    store ptr addrspace(4) [[OUT:%.*]], ptr [[AGG_TMP1_I]], align 8, !tbaa [[TBAA18]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPiiLm1ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSA_INS3_21contiguous_memory_keyEJEEENSA_INS3_14full_group_keyEJEEENSA_INS8_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESQ_SO_NS0_4spanISP_XT2_EEESR_(ptr noundef nonnull byval(%"struct.sycl::_V1::sub_group") align 1 [[AGG_TMP_I]], ptr addrspace(4) noundef [[TMP0]], ptr noundef nonnull byval(%"class.sycl::_V1::span") align 8 [[AGG_TMP1_I]], ptr noundef nonnull byval(%"class.sycl::_V1::ext::oneapi::experimental::properties.7") align 1 [[AGG_TMP2_I]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.end.p0(i64 1, ptr nonnull [[AGG_TMP_I]])
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.end.p0(i64 8, ptr nonnull [[AGG_TMP1_I]])
+// CHECK-LOCAL-NEXT:    call void @llvm.lifetime.end.p0(i64 4, ptr nonnull [[AGG_TMP2_I]])
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_accessor_iter_force_optimized(sycl::sub_group &sg,
@@ -263,20 +245,20 @@ SYCL_EXTERNAL void test_accessor_iter_force_optimized(sycl::sub_group &sg,
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(1) [[P]] to i64
 // CHECK-GLOBAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 3
-// CHECK-GLOBAL-NEXT:    [[CMP1_I_NOT_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP1_I_NOT_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I20_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I20_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
 // CHECK-GLOBAL:       if.then.i.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
 // CHECK-GLOBAL-NEXT:    [[IDXPROM_I_I_I:%.*]] = sext i32 [[TMP1]] to i64
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[P]], i64 [[IDXPROM_I_I_I]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i8, ptr addrspace(1) [[ARRAYIDX_I_I_I]], align 1, !tbaa [[TBAA22:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    store i8 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 1, !tbaa [[TBAA22]]
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i8, ptr addrspace(1) [[ARRAYIDX_I_I_I]], align 1, !tbaa [[TBAA25:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    store i8 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 1, !tbaa [[TBAA25]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1CCNS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESR_SP_RSQ_SS__EXIT:%.*]]
 // CHECK-GLOBAL:       if.end.i.i:
-// CHECK-GLOBAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef zeroext i8 @_Z30__spirv_SubgroupBlockReadINTELIhET_PU3AS1Kh(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    store i8 [[CALL4_I_I]], ptr addrspace(4) [[OUT]], align 1
+// CHECK-GLOBAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef zeroext i8 @_Z30__spirv_SubgroupBlockReadINTELIhET_PU3AS1Kh(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    store i8 [[CALL5_I_I]], ptr addrspace(4) [[OUT]], align 1
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1CCNS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESR_SP_RSQ_SS__EXIT]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1ccNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeESR_SP_RSQ_SS_.exit:
 // CHECK-GLOBAL-NEXT:    ret void
@@ -286,21 +268,21 @@ SYCL_EXTERNAL void test_accessor_iter_force_optimized(sycl::sub_group &sg,
 // CHECK-LOCAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
-// CHECK-LOCAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 3
-// CHECK-LOCAL-NEXT:    [[CMP1_I_NOT_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
-// CHECK-LOCAL-NEXT:    br i1 [[CMP1_I_NOT_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
 // CHECK-LOCAL:       if.then.i.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
 // CHECK-LOCAL-NEXT:    [[IDXPROM_I_I_I:%.*]] = sext i32 [[TMP1]] to i64
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds i8, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I_I]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i8, ptr addrspace(3) [[ARRAYIDX_I_I_I]], align 1, !tbaa [[TBAA20:![0-9]+]]
-// CHECK-LOCAL-NEXT:    store i8 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 1, !tbaa [[TBAA20]]
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i8, ptr addrspace(3) [[ARRAYIDX_I_I_I]], align 1, !tbaa [[TBAA23:![0-9]+]]
+// CHECK-LOCAL-NEXT:    store i8 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 1, !tbaa [[TBAA23]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3CCNS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESR_SP_RSQ_SS__EXIT:%.*]]
 // CHECK-LOCAL:       if.end.i.i:
-// CHECK-LOCAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef zeroext i8 @_Z30__spirv_SubgroupBlockReadINTELIhET_PU3AS3Kh(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    store i8 [[CALL4_I_I]], ptr addrspace(4) [[OUT]], align 1
+// CHECK-LOCAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef zeroext i8 @_Z30__spirv_SubgroupBlockReadINTELIhET_PU3AS3Kh(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    store i8 [[CALL5_I_I]], ptr addrspace(4) [[OUT]], align 1
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3CCNS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESR_SP_RSQ_SS__EXIT]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3ccNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeESR_SP_RSQ_SS_.exit:
 // CHECK-LOCAL-NEXT:    ret void
@@ -314,78 +296,78 @@ SYCL_EXTERNAL void test_runtime_align_check(sycl::sub_group &sg,
 
 // CHECK-GLOBAL-LABEL: @_ZN7blocked16test_four_shortsERN4sycl3_V19sub_groupEPU3AS1sNS1_4spanIsLm4EEE(
 // CHECK-GLOBAL-NEXT:  entry:
-// CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA24:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA27:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
 // CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = ptrtoint ptr addrspace(1) [[P]] to i64
 // CHECK-GLOBAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 3
-// CHECK-GLOBAL-NEXT:    [[CMP1_I_NOT_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP1_I_NOT_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I20_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I20_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
 // CHECK-GLOBAL:       if.then.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META26:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META29:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[MUL_I_I_I:%.*]] = shl i32 [[TMP3]], 2
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
 // CHECK-GLOBAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[IF_THEN_I]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
-// CHECK-GLOBAL-NEXT:    [[CMP_I14_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 4
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I14_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I24_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 4
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I24_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
 // CHECK-GLOBAL:       for.body.i.i:
 // CHECK-GLOBAL-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[I_0_I_I]] to i64
 // CHECK-GLOBAL-NEXT:    [[ADD_I_I_I:%.*]] = or disjoint i32 [[MUL_I_I_I]], [[I_0_I_I]]
 // CHECK-GLOBAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[ADD_I_I_I]] to i64
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i16, ptr addrspace(1) [[P]], i64 [[IDXPROM_I_I]]
-// CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = load i16, ptr addrspace(1) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA29:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = load i16, ptr addrspace(1) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA32:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i16, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
-// CHECK-GLOBAL-NEXT:    store i16 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA29]]
+// CHECK-GLOBAL-NEXT:    store i16 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA32]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP31:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP34:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1ssLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT:%.*]]
 // CHECK-GLOBAL:       if.end.i:
-// CHECK-GLOBAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef i64 @_Z30__spirv_SubgroupBlockReadINTELImET_PU3AS1Km(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    store i64 [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 2
+// CHECK-GLOBAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef i64 @_Z30__spirv_SubgroupBlockReadINTELImET_PU3AS1Km(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    store i64 [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 2
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1ssLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7blocked16test_four_shortsERN4sycl3_V19sub_groupEPU3AS3sNS1_4spanIsLm4EEE(
 // CHECK-LOCAL-NEXT:  entry:
-// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA22:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA25:![0-9]+]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-LOCAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
 // CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
-// CHECK-LOCAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 3
-// CHECK-LOCAL-NEXT:    [[CMP1_I_NOT_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
-// CHECK-LOCAL-NEXT:    br i1 [[CMP1_I_NOT_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
 // CHECK-LOCAL:       if.then.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META24:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META27:![0-9]+]]
 // CHECK-LOCAL-NEXT:    [[MUL_I_I_I:%.*]] = shl i32 [[TMP3]], 2
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
 // CHECK-LOCAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[IF_THEN_I]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
-// CHECK-LOCAL-NEXT:    [[CMP_I14_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 4
-// CHECK-LOCAL-NEXT:    br i1 [[CMP_I14_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[CMP_I24_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 4
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I24_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
 // CHECK-LOCAL:       for.body.i.i:
 // CHECK-LOCAL-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[I_0_I_I]] to i64
 // CHECK-LOCAL-NEXT:    [[ADD_I_I_I:%.*]] = or disjoint i32 [[MUL_I_I_I]], [[I_0_I_I]]
 // CHECK-LOCAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[ADD_I_I_I]] to i64
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i16, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I]]
-// CHECK-LOCAL-NEXT:    [[TMP4:%.*]] = load i16, ptr addrspace(3) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA27:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP4:%.*]] = load i16, ptr addrspace(3) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA30:![0-9]+]]
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i16, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
-// CHECK-LOCAL-NEXT:    store i16 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA27]]
+// CHECK-LOCAL-NEXT:    store i16 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA30]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP29:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP32:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3ssLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT:%.*]]
 // CHECK-LOCAL:       if.end.i:
-// CHECK-LOCAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef i64 @_Z30__spirv_SubgroupBlockReadINTELImET_PU3AS3Km(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    store i64 [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 2
+// CHECK-LOCAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef i64 @_Z30__spirv_SubgroupBlockReadINTELImET_PU3AS3Km(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    store i64 [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 2
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3ssLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
 // CHECK-LOCAL-NEXT:    ret void
@@ -401,8 +383,8 @@ SYCL_EXTERNAL void test_four_shorts(sycl::sub_group &sg, plain_ptr<short> p,
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META34:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META37:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[MUL_I_I_I:%.*]] = mul i32 [[TMP2]], 3
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
@@ -418,17 +400,17 @@ SYCL_EXTERNAL void test_four_shorts(sycl::sub_group &sg, plain_ptr<short> p,
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP3]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP37:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP40:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1iiLm3ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7blocked21test_non_power_of_twoERN4sycl3_V19sub_groupEPU3AS3iNS1_4spanIiLm3EEE(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META32:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META35:![0-9]+]]
 // CHECK-LOCAL-NEXT:    [[MUL_I_I_I:%.*]] = mul i32 [[TMP2]], 3
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
@@ -444,9 +426,9 @@ SYCL_EXTERNAL void test_four_shorts(sycl::sub_group &sg, plain_ptr<short> p,
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-LOCAL-NEXT:    store i32 [[TMP3]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP35:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP38:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiLm3ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_non_power_of_two(sycl::sub_group &sg, plain_ptr<int> p,
@@ -459,8 +441,8 @@ SYCL_EXTERNAL void test_non_power_of_two(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META39:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META42:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[MUL_I_I_I:%.*]] = shl i32 [[TMP2]], 2
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
@@ -476,17 +458,17 @@ SYCL_EXTERNAL void test_non_power_of_two(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP3]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP42:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP45:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1iiLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7blocked14test_four_intsERN4sycl3_V19sub_groupEPU3AS3iNS1_4spanIiLm4EEE(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META37:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META40:![0-9]+]]
 // CHECK-LOCAL-NEXT:    [[MUL_I_I_I:%.*]] = shl i32 [[TMP2]], 2
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
@@ -502,9 +484,9 @@ SYCL_EXTERNAL void test_non_power_of_two(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-LOCAL-NEXT:    store i32 [[TMP3]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP40:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP43:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_four_ints(sycl::sub_group &sg, plain_ptr<int> p,
@@ -518,8 +500,8 @@ SYCL_EXTERNAL void test_four_ints(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META44:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META47:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[MUL_I_I_I:%.*]] = mul i32 [[TMP2]], 7
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
@@ -535,17 +517,17 @@ SYCL_EXTERNAL void test_four_ints(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP3]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP47:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP50:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1iiLm7ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7blocked15test_seven_intsERN4sycl3_V19sub_groupEPU3AS3iNS1_4spanIiLm7EEE(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META42:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META45:![0-9]+]]
 // CHECK-LOCAL-NEXT:    [[MUL_I_I_I:%.*]] = mul i32 [[TMP2]], 7
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
@@ -561,9 +543,9 @@ SYCL_EXTERNAL void test_four_ints(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-LOCAL-NEXT:    store i32 [[TMP3]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP45:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP48:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiLm7ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_seven_ints(sycl::sub_group &sg, plain_ptr<int> p,
@@ -581,9 +563,9 @@ namespace striped {
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META49:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META52:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META52:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META55:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i:
 // CHECK-GLOBAL-NEXT:    [[I_0_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I:%.*]] ]
@@ -599,18 +581,18 @@ namespace striped {
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-GLOBAL-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_0_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP55:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP58:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1iiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESP_SN_NS0_4spanISO_XT2_EEESQ_.exit:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped10test_naiveERN4sycl3_V19sub_groupEPU3AS3iNS1_4spanIiLm2EEE(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META47:![0-9]+]]
-// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META50:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META50:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META53:![0-9]+]]
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I:%.*]]
 // CHECK-LOCAL:       for.cond.i:
 // CHECK-LOCAL-NEXT:    [[I_0_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I:%.*]] ]
@@ -626,9 +608,9 @@ namespace striped {
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I]]
 // CHECK-LOCAL-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-LOCAL-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_0_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP53:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP56:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESP_SN_NS0_4spanISO_XT2_EEESQ_.exit:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_naive(sycl::sub_group &sg, plain_ptr<int> p,
@@ -643,8 +625,8 @@ SYCL_EXTERNAL void test_naive(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
-// CHECK-GLOBAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef <2 x i32> @_Z30__spirv_SubgroupBlockReadINTELIDv2_jET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    store <2 x i32> [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 4
+// CHECK-GLOBAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef <2 x i32> @_Z30__spirv_SubgroupBlockReadINTELIDv2_jET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    store <2 x i32> [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 4
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped14test_optimizedERN4sycl3_V19sub_groupEPU3AS3iNS1_4spanIiLm2EEE(
@@ -653,8 +635,38 @@ SYCL_EXTERNAL void test_naive(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-LOCAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
-// CHECK-LOCAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef <2 x i32> @_Z30__spirv_SubgroupBlockReadINTELIDv2_jET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    store <2 x i32> [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 4
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
+// CHECK-LOCAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
+// CHECK-LOCAL:       if.then.i:
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META58:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META61:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
+// CHECK-LOCAL:       for.cond.i.i:
+// CHECK-LOCAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[IF_THEN_I]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
+// CHECK-LOCAL-NEXT:    [[CMP_I24_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 2
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I24_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IILM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
+// CHECK-LOCAL:       for.body.i.i:
+// CHECK-LOCAL-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[I_0_I_I]] to i64
+// CHECK-LOCAL-NEXT:    [[MUL_I_I_I:%.*]] = mul nuw nsw i32 [[TMP4]], [[I_0_I_I]]
+// CHECK-LOCAL-NEXT:    [[ADD_I_I_I:%.*]] = add i32 [[TMP3]], [[MUL_I_I_I]]
+// CHECK-LOCAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[ADD_I_I_I]] to i64
+// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I]]
+// CHECK-LOCAL-NEXT:    [[TMP5:%.*]] = load i32, ptr addrspace(3) [[ARRAYIDX_I_I]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
+// CHECK-LOCAL-NEXT:    store i32 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP64:![0-9]+]]
+// CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit.i:
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IILM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT:%.*]]
+// CHECK-LOCAL:       if.end.i:
+// CHECK-LOCAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef <2 x i32> @_Z30__spirv_SubgroupBlockReadINTELIDv2_jET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    store <2 x i32> [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 4
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IILM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT]]
+// CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_optimized(sycl::sub_group &sg, plain_ptr<int> p,
@@ -667,16 +679,32 @@ SYCL_EXTERNAL void test_optimized(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-GLOBAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    store i32 [[CALL4_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
+// CHECK-GLOBAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    store i32 [[CALL5_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped27test_contiguous_auto_detectERN4sycl3_V19sub_groupEPU3AS3iRi(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-LOCAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    store i32 [[CALL4_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
+// CHECK-LOCAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
+// CHECK-LOCAL:       if.then.i.i:
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
+// CHECK-LOCAL-NEXT:    [[IDXPROM_I_I_I:%.*]] = sext i32 [[TMP1]] to i64
+// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I_I]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(3) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    store i32 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESP_SN_RSO_SQ__EXIT:%.*]]
+// CHECK-LOCAL:       if.end.i.i:
+// CHECK-LOCAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    store i32 [[CALL5_I_I]], ptr addrspace(4) [[OUT]], align 4
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESP_SN_RSO_SQ__EXIT]]
+// CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeESP_SN_RSO_SQ_.exit:
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_contiguous_auto_detect(sycl::sub_group &sg,
@@ -699,9 +727,9 @@ using accessor_iter_t = local_accessor<int, 1>::iterator;
 // CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_2_0_COPYLOAD:%.*]] = load i64, ptr addrspace(4) [[AGG_TMP1_SROA_2_0_ITER_SROA_IDX]], align 8, !tbaa [[TBAA18]]
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META59:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META62:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META62:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META65:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = getelementptr i32, ptr addrspace(4) [[AGG_TMP1_SROA_0_0_COPYLOAD]], i64 [[AGG_TMP1_SROA_2_0_COPYLOAD]]
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
@@ -718,9 +746,9 @@ using accessor_iter_t = local_accessor<int, 1>::iterator;
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP65:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP68:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupENS0_6detail17accessor_iteratorIKiLi1EEEiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSD_INS3_14full_group_keyEJEEENSD_INSB_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped18test_accessor_iterERN4sycl3_V19sub_groupERPiNS1_4spanIiLm2EEE(
@@ -731,7 +759,7 @@ using accessor_iter_t = local_accessor<int, 1>::iterator;
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ITER:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    store i64 [[TMP1]], ptr [[AGG_TMP1]], align 8, !tbaa [[TBAA15]]
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPiiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSA_INS3_14full_group_keyEJEEENSA_INS8_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESO_SM_NS0_4spanISN_XT2_EEESP_(ptr noundef nonnull byval(%"struct.sycl::_V1::sub_group") align 1 [[AGG_TMP]], ptr addrspace(4) noundef [[TMP0]], ptr noundef nonnull byval(%"class.sycl::_V1::span.22") align 8 [[AGG_TMP1]], ptr noundef nonnull byval(%"class.sycl::_V1::ext::oneapi::experimental::properties.30") align 1 [[AGG_TMP2]]) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPiiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSA_INS3_14full_group_keyEJEEENSA_INS8_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESO_SM_NS0_4spanISN_XT2_EEESP_(ptr noundef nonnull byval(%"struct.sycl::_V1::sub_group") align 1 [[AGG_TMP]], ptr addrspace(4) noundef [[TMP0]], ptr noundef nonnull byval(%"class.sycl::_V1::span.22") align 8 [[AGG_TMP1]], ptr noundef nonnull byval(%"class.sycl::_V1::ext::oneapi::experimental::properties.30") align 1 [[AGG_TMP2]]) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_accessor_iter(sycl::sub_group &sg,
@@ -742,55 +770,14 @@ SYCL_EXTERNAL void test_accessor_iter(sycl::sub_group &sg,
 
 // CHECK-GLOBAL-LABEL: @_ZN7striped34test_accessor_iter_force_optimizedERN4sycl3_V19sub_groupERNS1_6detail17accessor_iteratorIKiLi1EEENS1_4spanIiLm2EEE(
 // CHECK-GLOBAL-NEXT:  entry:
-// CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_0_0_COPYLOAD:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ITER:%.*]], align 8, !tbaa [[TBAA15]]
-// CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_2_0_ITER_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[ITER]], i64 8
-// CHECK-GLOBAL-NEXT:    [[AGG_TMP1_SROA_2_0_COPYLOAD:%.*]] = load i64, ptr addrspace(4) [[AGG_TMP1_SROA_2_0_ITER_SROA_IDX]], align 8, !tbaa [[TBAA18]]
+// CHECK-GLOBAL-NEXT:    [[AGG_TMP:%.*]] = alloca %"struct.sycl::_V1::sub_group", align 1
+// CHECK-GLOBAL-NEXT:    [[AGG_TMP1:%.*]] = alloca %"class.sycl::_V1::detail::accessor_iterator", align 8
+// CHECK-GLOBAL-NEXT:    [[AGG_TMP2:%.*]] = alloca %"class.sycl::_V1::span.22", align 8
+// CHECK-GLOBAL-NEXT:    [[AGG_TMP3:%.*]] = alloca %"class.sycl::_V1::ext::oneapi::experimental::properties.28", align 1
+// CHECK-GLOBAL-NEXT:    call void @llvm.memcpy.p0.p4.i64(ptr align 8 [[AGG_TMP1]], ptr addrspace(4) align 8 [[ITER:%.*]], i64 80, i1 false), !tbaa.struct [[TBAA_STRUCT70:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
-// CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-GLOBAL-NEXT:    [[ADD_PTR_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[AGG_TMP1_SROA_0_0_COPYLOAD]], i64 [[AGG_TMP1_SROA_2_0_COPYLOAD]]
-// CHECK-GLOBAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(4) [[ADD_PTR_I_I_I]], null
-// CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-GLOBAL-NEXT:    [[CALL_I_I:%.*]] = tail call spir_func noundef ptr addrspace(3) @_Z40__spirv_GenericCastToPtrExplicit_ToLocalPKvi(ptr addrspace(4) noundef nonnull [[ADD_PTR_I_I_I]], i32 noundef 4) #[[ATTR5]]
-// CHECK-GLOBAL-NEXT:    [[TOBOOL7_NOT_I:%.*]] = icmp eq ptr addrspace(3) [[CALL_I_I]], null
-// CHECK-GLOBAL-NEXT:    br i1 [[TOBOOL7_NOT_I]], label [[IF_ELSE_I:%.*]], label [[IF_THEN8_I:%.*]]
-// CHECK-GLOBAL:       if.then8.i:
-// CHECK-GLOBAL-NEXT:    [[CALL9_I:%.*]] = tail call spir_func noundef <2 x i32> @_Z30__spirv_SubgroupBlockReadINTELIDv2_jET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[CALL_I_I]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    br label [[IF_END20_I:%.*]]
-// CHECK-GLOBAL:       if.else.i:
-// CHECK-GLOBAL-NEXT:    [[CALL_I41_I:%.*]] = tail call spir_func noundef ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobalPKvi(ptr addrspace(4) noundef nonnull [[ADD_PTR_I_I_I]], i32 noundef 5) #[[ATTR5]]
-// CHECK-GLOBAL-NEXT:    [[TOBOOL11_NOT_NOT_I:%.*]] = icmp eq ptr addrspace(1) [[CALL_I41_I]], null
-// CHECK-GLOBAL-NEXT:    br i1 [[TOBOOL11_NOT_NOT_I]], label [[IF_ELSE14_I:%.*]], label [[CLEANUP_THREAD_I:%.*]]
-// CHECK-GLOBAL:       cleanup.thread.i:
-// CHECK-GLOBAL-NEXT:    [[CALL13_I:%.*]] = tail call spir_func noundef <2 x i32> @_Z30__spirv_SubgroupBlockReadINTELIDv2_jET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[CALL_I41_I]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    br label [[IF_END20_I]]
-// CHECK-GLOBAL:       if.else14.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META67:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META70:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I51_I:%.*]]
-// CHECK-GLOBAL:       for.cond.i51.i:
-// CHECK-GLOBAL-NEXT:    [[I_0_I52_I:%.*]] = phi i32 [ 0, [[IF_ELSE14_I]] ], [ [[INC_I61_I:%.*]], [[FOR_BODY_I54_I:%.*]] ]
-// CHECK-GLOBAL-NEXT:    [[CMP_I53_I:%.*]] = icmp samesign ult i32 [[I_0_I52_I]], 2
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I53_I]], label [[FOR_BODY_I54_I]], label [[CLEANUP_I:%.*]]
-// CHECK-GLOBAL:       for.body.i54.i:
-// CHECK-GLOBAL-NEXT:    [[CONV_I55_I:%.*]] = zext nneg i32 [[I_0_I52_I]] to i64
-// CHECK-GLOBAL-NEXT:    [[MUL_I_I56_I:%.*]] = mul nuw nsw i32 [[TMP3]], [[I_0_I52_I]]
-// CHECK-GLOBAL-NEXT:    [[ADD_I_I57_I:%.*]] = add i32 [[TMP2]], [[MUL_I_I56_I]]
-// CHECK-GLOBAL-NEXT:    [[CONV3_I58_I:%.*]] = sext i32 [[ADD_I_I57_I]] to i64
-// CHECK-GLOBAL-NEXT:    [[ADD_PTR_I_I_I59_I:%.*]] = getelementptr i32, ptr addrspace(4) [[ADD_PTR_I_I_I]], i64 [[CONV3_I58_I]]
-// CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(4) [[ADD_PTR_I_I_I59_I]], align 4, !tbaa [[TBAA8]]
-// CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I60_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I55_I]]
-// CHECK-GLOBAL-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I60_I]], align 4, !tbaa [[TBAA8]]
-// CHECK-GLOBAL-NEXT:    [[INC_I61_I]] = add nuw nsw i32 [[I_0_I52_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I51_I]], !llvm.loop [[LOOP73:![0-9]+]]
-// CHECK-GLOBAL:       cleanup.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPENS0_6DETAIL17ACCESSOR_ITERATORIKILI1EEEILM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSD_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSD_INS3_14FULL_GROUP_KEYEJEEENSD_INSB_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT:%.*]]
-// CHECK-GLOBAL:       if.end20.i:
-// CHECK-GLOBAL-NEXT:    [[LOAD_1_I:%.*]] = phi <2 x i32> [ [[CALL9_I]], [[IF_THEN8_I]] ], [ [[CALL13_I]], [[CLEANUP_THREAD_I]] ]
-// CHECK-GLOBAL-NEXT:    store <2 x i32> [[LOAD_1_I]], ptr addrspace(4) [[TMP1]], align 4
-// CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPENS0_6DETAIL17ACCESSOR_ITERATORIKILI1EEEILM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSD_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSD_INS3_14FULL_GROUP_KEYEJEEENSD_INSB_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT]]
-// CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupENS0_6detail17accessor_iteratorIKiLi1EEEiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSD_INS3_21contiguous_memory_keyEJEEENSD_INS3_14full_group_keyEJEEENSD_INSB_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit:
+// CHECK-GLOBAL-NEXT:    store i64 [[TMP0]], ptr [[AGG_TMP2]], align 8, !tbaa [[TBAA15]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupENS0_6detail17accessor_iteratorIKiLi1EEEiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSD_INS3_21contiguous_memory_keyEJEEENSD_INS3_14full_group_keyEJEEENSD_INSB_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_(ptr noundef nonnull byval(%"struct.sycl::_V1::sub_group") align 1 [[AGG_TMP]], ptr noundef nonnull byval(%"class.sycl::_V1::detail::accessor_iterator") align 8 [[AGG_TMP1]], ptr noundef nonnull byval(%"class.sycl::_V1::span.22") align 8 [[AGG_TMP2]], ptr noundef nonnull byval(%"class.sycl::_V1::ext::oneapi::experimental::properties.28") align 1 [[AGG_TMP3]]) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped34test_accessor_iter_force_optimizedERN4sycl3_V19sub_groupERPiNS1_4spanIiLm2EEE(
@@ -801,7 +788,7 @@ SYCL_EXTERNAL void test_accessor_iter(sycl::sub_group &sg,
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ITER:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    store i64 [[TMP1]], ptr [[AGG_TMP1]], align 8, !tbaa [[TBAA15]]
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPiiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSA_INS3_21contiguous_memory_keyEJEEENSA_INS3_14full_group_keyEJEEENSA_INS8_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESQ_SO_NS0_4spanISP_XT2_EEESR_(ptr noundef nonnull byval(%"struct.sycl::_V1::sub_group") align 1 [[AGG_TMP]], ptr addrspace(4) noundef [[TMP0]], ptr noundef nonnull byval(%"class.sycl::_V1::span.22") align 8 [[AGG_TMP1]], ptr noundef nonnull byval(%"class.sycl::_V1::ext::oneapi::experimental::properties.28") align 1 [[AGG_TMP2]]) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPiiLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSA_INS3_21contiguous_memory_keyEJEEENSA_INS3_14full_group_keyEJEEENSA_INS8_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESQ_SO_NS0_4spanISP_XT2_EEESR_(ptr noundef nonnull byval(%"struct.sycl::_V1::sub_group") align 1 [[AGG_TMP]], ptr addrspace(4) noundef [[TMP0]], ptr noundef nonnull byval(%"class.sycl::_V1::span.22") align 8 [[AGG_TMP1]], ptr noundef nonnull byval(%"class.sycl::_V1::ext::oneapi::experimental::properties.28") align 1 [[AGG_TMP2]]) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_accessor_iter_force_optimized(sycl::sub_group &sg,
@@ -813,80 +800,80 @@ SYCL_EXTERNAL void test_accessor_iter_force_optimized(sycl::sub_group &sg,
 
 // CHECK-GLOBAL-LABEL: @_ZN7striped24test_runtime_align_checkERN4sycl3_V19sub_groupEPU3AS1cNS1_4spanIcLm2EEE(
 // CHECK-GLOBAL-NEXT:  entry:
-// CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA75:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA90:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
 // CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = ptrtoint ptr addrspace(1) [[P]] to i64
 // CHECK-GLOBAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 3
-// CHECK-GLOBAL-NEXT:    [[CMP1_I_NOT_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP1_I_NOT_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I20_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I20_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
 // CHECK-GLOBAL:       if.then.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META77:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META80:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META92:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META95:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
 // CHECK-GLOBAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[IF_THEN_I]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
-// CHECK-GLOBAL-NEXT:    [[CMP_I14_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 2
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I14_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1CCLM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I24_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 2
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I24_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1CCLM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
 // CHECK-GLOBAL:       for.body.i.i:
 // CHECK-GLOBAL-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[I_0_I_I]] to i64
 // CHECK-GLOBAL-NEXT:    [[MUL_I_I_I:%.*]] = mul nuw nsw i32 [[TMP4]], [[I_0_I_I]]
 // CHECK-GLOBAL-NEXT:    [[ADD_I_I_I:%.*]] = add i32 [[TMP3]], [[MUL_I_I_I]]
 // CHECK-GLOBAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[ADD_I_I_I]] to i64
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[P]], i64 [[IDXPROM_I_I]]
-// CHECK-GLOBAL-NEXT:    [[TMP5:%.*]] = load i8, ptr addrspace(1) [[ARRAYIDX_I_I]], align 1, !tbaa [[TBAA22]]
+// CHECK-GLOBAL-NEXT:    [[TMP5:%.*]] = load i8, ptr addrspace(1) [[ARRAYIDX_I_I]], align 1, !tbaa [[TBAA25]]
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
-// CHECK-GLOBAL-NEXT:    store i8 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 1, !tbaa [[TBAA22]]
+// CHECK-GLOBAL-NEXT:    store i8 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 1, !tbaa [[TBAA25]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP83:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP98:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1ccLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1CCLM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT:%.*]]
 // CHECK-GLOBAL:       if.end.i:
-// CHECK-GLOBAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef <2 x i8> @_Z30__spirv_SubgroupBlockReadINTELIDv2_hET_PU3AS1Kh(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    store <2 x i8> [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 1
+// CHECK-GLOBAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef <2 x i8> @_Z30__spirv_SubgroupBlockReadINTELIDv2_hET_PU3AS1Kh(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    store <2 x i8> [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 1
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1CCLM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1ccLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped24test_runtime_align_checkERN4sycl3_V19sub_groupEPU3AS3cNS1_4spanIcLm2EEE(
 // CHECK-LOCAL-NEXT:  entry:
-// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA76:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA101:![0-9]+]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-LOCAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
 // CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
-// CHECK-LOCAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 3
-// CHECK-LOCAL-NEXT:    [[CMP1_I_NOT_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
-// CHECK-LOCAL-NEXT:    br i1 [[CMP1_I_NOT_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
 // CHECK-LOCAL:       if.then.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META78:![0-9]+]]
-// CHECK-LOCAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META81:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META103:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META106:![0-9]+]]
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
 // CHECK-LOCAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[IF_THEN_I]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
-// CHECK-LOCAL-NEXT:    [[CMP_I14_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 2
-// CHECK-LOCAL-NEXT:    br i1 [[CMP_I14_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3CCLM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[CMP_I24_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 2
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I24_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3CCLM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
 // CHECK-LOCAL:       for.body.i.i:
 // CHECK-LOCAL-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[I_0_I_I]] to i64
 // CHECK-LOCAL-NEXT:    [[MUL_I_I_I:%.*]] = mul nuw nsw i32 [[TMP4]], [[I_0_I_I]]
 // CHECK-LOCAL-NEXT:    [[ADD_I_I_I:%.*]] = add i32 [[TMP3]], [[MUL_I_I_I]]
 // CHECK-LOCAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[ADD_I_I_I]] to i64
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i8, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I]]
-// CHECK-LOCAL-NEXT:    [[TMP5:%.*]] = load i8, ptr addrspace(3) [[ARRAYIDX_I_I]], align 1, !tbaa [[TBAA20]]
+// CHECK-LOCAL-NEXT:    [[TMP5:%.*]] = load i8, ptr addrspace(3) [[ARRAYIDX_I_I]], align 1, !tbaa [[TBAA23]]
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
-// CHECK-LOCAL-NEXT:    store i8 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 1, !tbaa [[TBAA20]]
+// CHECK-LOCAL-NEXT:    store i8 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 1, !tbaa [[TBAA23]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP84:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP109:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3ccLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3CCLM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT:%.*]]
 // CHECK-LOCAL:       if.end.i:
-// CHECK-LOCAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef <2 x i8> @_Z30__spirv_SubgroupBlockReadINTELIDv2_hET_PU3AS3Kh(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    store <2 x i8> [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 1
+// CHECK-LOCAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef <2 x i8> @_Z30__spirv_SubgroupBlockReadINTELIDv2_hET_PU3AS3Kh(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    store <2 x i8> [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 1
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3CCLM2ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3ccLm2ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
 // CHECK-LOCAL-NEXT:    ret void
@@ -901,80 +888,80 @@ SYCL_EXTERNAL void test_runtime_align_check(sycl::sub_group &sg,
 
 // CHECK-GLOBAL-LABEL: @_ZN7striped16test_four_shortsERN4sycl3_V19sub_groupEPU3AS1sNS1_4spanIsLm4EEE(
 // CHECK-GLOBAL-NEXT:  entry:
-// CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA24]]
+// CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA27]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
 // CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = ptrtoint ptr addrspace(1) [[P]] to i64
 // CHECK-GLOBAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 3
-// CHECK-GLOBAL-NEXT:    [[CMP1_I_NOT_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP1_I_NOT_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I20_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I20_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
 // CHECK-GLOBAL:       if.then.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META85:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META88:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META100:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META103:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
 // CHECK-GLOBAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[IF_THEN_I]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
-// CHECK-GLOBAL-NEXT:    [[CMP_I14_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 4
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I14_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I24_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 4
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I24_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
 // CHECK-GLOBAL:       for.body.i.i:
 // CHECK-GLOBAL-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[I_0_I_I]] to i64
 // CHECK-GLOBAL-NEXT:    [[MUL_I_I_I:%.*]] = mul i32 [[TMP4]], [[I_0_I_I]]
 // CHECK-GLOBAL-NEXT:    [[ADD_I_I_I:%.*]] = add i32 [[TMP3]], [[MUL_I_I_I]]
 // CHECK-GLOBAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[ADD_I_I_I]] to i64
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i16, ptr addrspace(1) [[P]], i64 [[IDXPROM_I_I]]
-// CHECK-GLOBAL-NEXT:    [[TMP5:%.*]] = load i16, ptr addrspace(1) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA29]]
+// CHECK-GLOBAL-NEXT:    [[TMP5:%.*]] = load i16, ptr addrspace(1) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA32]]
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i16, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
-// CHECK-GLOBAL-NEXT:    store i16 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA29]]
+// CHECK-GLOBAL-NEXT:    store i16 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA32]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP91:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP106:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1ssLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT:%.*]]
 // CHECK-GLOBAL:       if.end.i:
-// CHECK-GLOBAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef <4 x i16> @_Z30__spirv_SubgroupBlockReadINTELIDv4_tET_PU3AS1Kt(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    store <4 x i16> [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 2
+// CHECK-GLOBAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef <4 x i16> @_Z30__spirv_SubgroupBlockReadINTELIDv4_tET_PU3AS1Kt(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    store <4 x i16> [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 2
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1ssLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped16test_four_shortsERN4sycl3_V19sub_groupEPU3AS3sNS1_4spanIsLm4EEE(
 // CHECK-LOCAL-NEXT:  entry:
-// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA22]]
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA25]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-LOCAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
 // CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
-// CHECK-LOCAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 3
-// CHECK-LOCAL-NEXT:    [[CMP1_I_NOT_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
-// CHECK-LOCAL-NEXT:    br i1 [[CMP1_I_NOT_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
 // CHECK-LOCAL:       if.then.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META86:![0-9]+]]
-// CHECK-LOCAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META89:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META111:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META114:![0-9]+]]
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
 // CHECK-LOCAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[IF_THEN_I]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
-// CHECK-LOCAL-NEXT:    [[CMP_I14_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 4
-// CHECK-LOCAL-NEXT:    br i1 [[CMP_I14_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[CMP_I24_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 4
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I24_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
 // CHECK-LOCAL:       for.body.i.i:
 // CHECK-LOCAL-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[I_0_I_I]] to i64
 // CHECK-LOCAL-NEXT:    [[MUL_I_I_I:%.*]] = mul i32 [[TMP4]], [[I_0_I_I]]
 // CHECK-LOCAL-NEXT:    [[ADD_I_I_I:%.*]] = add i32 [[TMP3]], [[MUL_I_I_I]]
 // CHECK-LOCAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[ADD_I_I_I]] to i64
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i16, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I]]
-// CHECK-LOCAL-NEXT:    [[TMP5:%.*]] = load i16, ptr addrspace(3) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA27]]
+// CHECK-LOCAL-NEXT:    [[TMP5:%.*]] = load i16, ptr addrspace(3) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA30]]
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i16, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
-// CHECK-LOCAL-NEXT:    store i16 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA27]]
+// CHECK-LOCAL-NEXT:    store i16 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA30]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP92:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP117:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3ssLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT:%.*]]
 // CHECK-LOCAL:       if.end.i:
-// CHECK-LOCAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef <4 x i16> @_Z30__spirv_SubgroupBlockReadINTELIDv4_tET_PU3AS3Kt(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    store <4 x i16> [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 2
+// CHECK-LOCAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef <4 x i16> @_Z30__spirv_SubgroupBlockReadINTELIDv4_tET_PU3AS3Kt(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    store <4 x i16> [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 2
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM4ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3ssLm4ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
 // CHECK-LOCAL-NEXT:    ret void
@@ -988,80 +975,80 @@ SYCL_EXTERNAL void test_four_shorts(sycl::sub_group &sg, plain_ptr<short> p,
 
 // CHECK-GLOBAL-LABEL: @_ZN7striped19test_sixteen_shortsERN4sycl3_V19sub_groupEPU3AS1sNS1_4spanIsLm16EEE(
 // CHECK-GLOBAL-NEXT:  entry:
-// CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA24]]
+// CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA27]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
 // CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = ptrtoint ptr addrspace(1) [[P]] to i64
 // CHECK-GLOBAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 3
-// CHECK-GLOBAL-NEXT:    [[CMP1_I_NOT_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP1_I_NOT_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I20_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I20_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
 // CHECK-GLOBAL:       if.then.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META93:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META96:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META108:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META111:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
 // CHECK-GLOBAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[IF_THEN_I]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
-// CHECK-GLOBAL-NEXT:    [[CMP_I14_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 16
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I14_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM16ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I24_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 16
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I24_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM16ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
 // CHECK-GLOBAL:       for.body.i.i:
 // CHECK-GLOBAL-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[I_0_I_I]] to i64
 // CHECK-GLOBAL-NEXT:    [[MUL_I_I_I:%.*]] = mul i32 [[TMP4]], [[I_0_I_I]]
 // CHECK-GLOBAL-NEXT:    [[ADD_I_I_I:%.*]] = add i32 [[TMP3]], [[MUL_I_I_I]]
 // CHECK-GLOBAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[ADD_I_I_I]] to i64
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i16, ptr addrspace(1) [[P]], i64 [[IDXPROM_I_I]]
-// CHECK-GLOBAL-NEXT:    [[TMP5:%.*]] = load i16, ptr addrspace(1) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA29]]
+// CHECK-GLOBAL-NEXT:    [[TMP5:%.*]] = load i16, ptr addrspace(1) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA32]]
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i16, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
-// CHECK-GLOBAL-NEXT:    store i16 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA29]]
+// CHECK-GLOBAL-NEXT:    store i16 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA32]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP99:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP114:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1ssLm16ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit.i:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM16ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT:%.*]]
 // CHECK-GLOBAL:       if.end.i:
-// CHECK-GLOBAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef <16 x i16> @_Z30__spirv_SubgroupBlockReadINTELIDv16_tET_PU3AS1Kt(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    store <16 x i16> [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 2
+// CHECK-GLOBAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef <16 x i16> @_Z30__spirv_SubgroupBlockReadINTELIDv16_tET_PU3AS1Kt(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    store <16 x i16> [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 2
 // CHECK-GLOBAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS1SSLM16ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1ssLm16ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped19test_sixteen_shortsERN4sycl3_V19sub_groupEPU3AS3sNS1_4spanIsLm16EEE(
 // CHECK-LOCAL-NEXT:  entry:
-// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA22]]
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA25]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-LOCAL-NEXT:    [[CMP_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I]])
 // CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
-// CHECK-LOCAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 3
-// CHECK-LOCAL-NEXT:    [[CMP1_I_NOT_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
-// CHECK-LOCAL-NEXT:    br i1 [[CMP1_I_NOT_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[REM_I_I:%.*]] = and i64 [[TMP2]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I:%.*]] = icmp eq i64 [[REM_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I]], label [[IF_END_I:%.*]], label [[IF_THEN_I:%.*]]
 // CHECK-LOCAL:       if.then.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META94:![0-9]+]]
-// CHECK-LOCAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META97:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META119:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP4:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META122:![0-9]+]]
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
 // CHECK-LOCAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[IF_THEN_I]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
-// CHECK-LOCAL-NEXT:    [[CMP_I14_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 16
-// CHECK-LOCAL-NEXT:    br i1 [[CMP_I14_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM16ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[CMP_I24_I:%.*]] = icmp samesign ult i32 [[I_0_I_I]], 16
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I24_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM16ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_9NAIVE_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEEST_SR_NS0_4SPANISS_XT2_EEESU__EXIT_I:%.*]]
 // CHECK-LOCAL:       for.body.i.i:
 // CHECK-LOCAL-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[I_0_I_I]] to i64
 // CHECK-LOCAL-NEXT:    [[MUL_I_I_I:%.*]] = mul i32 [[TMP4]], [[I_0_I_I]]
 // CHECK-LOCAL-NEXT:    [[ADD_I_I_I:%.*]] = add i32 [[TMP3]], [[MUL_I_I_I]]
 // CHECK-LOCAL-NEXT:    [[IDXPROM_I_I:%.*]] = sext i32 [[ADD_I_I_I]] to i64
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I:%.*]] = getelementptr inbounds i16, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I]]
-// CHECK-LOCAL-NEXT:    [[TMP5:%.*]] = load i16, ptr addrspace(3) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA27]]
+// CHECK-LOCAL-NEXT:    [[TMP5:%.*]] = load i16, ptr addrspace(3) [[ARRAYIDX_I_I]], align 2, !tbaa [[TBAA30]]
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i16, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
-// CHECK-LOCAL-NEXT:    store i16 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA27]]
+// CHECK-LOCAL-NEXT:    store i16 [[TMP5]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA30]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP100:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP125:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3ssLm16ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_9naive_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeEST_SR_NS0_4spanISS_XT2_EEESU_.exit.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM16ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT:%.*]]
 // CHECK-LOCAL:       if.end.i:
-// CHECK-LOCAL-NEXT:    [[CALL4_I:%.*]] = tail call spir_func noundef <16 x i16> @_Z30__spirv_SubgroupBlockReadINTELIDv16_tET_PU3AS3Kt(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    store <16 x i16> [[CALL4_I]], ptr addrspace(4) [[TMP1]], align 2
+// CHECK-LOCAL-NEXT:    [[CALL5_I:%.*]] = tail call spir_func noundef <16 x i16> @_Z30__spirv_SubgroupBlockReadINTELIDv16_tET_PU3AS3Kt(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    store <16 x i16> [[CALL5_I]], ptr addrspace(4) [[TMP1]], align 2
 // CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3SSLM16ENS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI1EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT3_EEVE4TYPEESR_SP_NS0_4SPANISQ_XT2_EEESS__EXIT]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3ssLm16ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
 // CHECK-LOCAL-NEXT:    ret void
@@ -1075,9 +1062,9 @@ SYCL_EXTERNAL void test_sixteen_shorts(sycl::sub_group &sg, plain_ptr<short> p,
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META101:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META104:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META116:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META119:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
 // CHECK-GLOBAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
@@ -1093,18 +1080,18 @@ SYCL_EXTERNAL void test_sixteen_shorts(sycl::sub_group &sg, plain_ptr<short> p,
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP107:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP122:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1iiLm3ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped21test_non_power_of_twoERN4sycl3_V19sub_groupEPU3AS3iNS1_4spanIiLm3EEE(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META102:![0-9]+]]
-// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META105:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META127:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META130:![0-9]+]]
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
 // CHECK-LOCAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
@@ -1120,9 +1107,9 @@ SYCL_EXTERNAL void test_sixteen_shorts(sycl::sub_group &sg, plain_ptr<short> p,
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-LOCAL-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP108:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP133:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiLm3ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_non_power_of_two(sycl::sub_group &sg, plain_ptr<int> p,
@@ -1135,9 +1122,9 @@ SYCL_EXTERNAL void test_non_power_of_two(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META109:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META112:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META124:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META127:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
 // CHECK-GLOBAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
@@ -1153,18 +1140,18 @@ SYCL_EXTERNAL void test_non_power_of_two(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP115:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP130:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1iiLm16ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped17test_sixteen_intsERN4sycl3_V19sub_groupEPU3AS3iNS1_4spanIiLm16EEE(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META110:![0-9]+]]
-// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META113:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META135:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META138:![0-9]+]]
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
 // CHECK-LOCAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
@@ -1180,9 +1167,9 @@ SYCL_EXTERNAL void test_non_power_of_two(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-LOCAL-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP116:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP141:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiLm16ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_sixteen_ints(sycl::sub_group &sg, plain_ptr<int> p,
@@ -1196,9 +1183,9 @@ SYCL_EXTERNAL void test_sixteen_ints(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
-// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META117:![0-9]+]]
-// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META120:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
+// CHECK-GLOBAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META132:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META135:![0-9]+]]
 // CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-GLOBAL:       for.cond.i.i:
 // CHECK-GLOBAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
@@ -1214,18 +1201,18 @@ SYCL_EXTERNAL void test_sixteen_ints(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-GLOBAL-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-GLOBAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP123:![0-9]+]]
+// CHECK-GLOBAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP138:![0-9]+]]
 // CHECK-GLOBAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS1iiLm11ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR4]]
+// CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR7]]
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_ZN7striped16test_eleven_intsERN4sycl3_V19sub_groupEPU3AS3iNS1_4spanIiLm11EEE(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[OUT:%.*]], align 8, !tbaa [[TBAA15]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META118:![0-9]+]]
-// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META121:![0-9]+]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4, !tbaa [[TBAA8]], !noalias [[META143:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupSize, align 4, !tbaa [[TBAA8]], !noalias [[META146:![0-9]+]]
 // CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I:%.*]]
 // CHECK-LOCAL:       for.cond.i.i:
 // CHECK-LOCAL-NEXT:    [[I_0_I_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I_I:%.*]], [[FOR_BODY_I_I:%.*]] ]
@@ -1241,9 +1228,9 @@ SYCL_EXTERNAL void test_sixteen_ints(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw i32, ptr addrspace(4) [[TMP1]], i64 [[CONV_I_I]]
 // CHECK-LOCAL-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-LOCAL-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[I_0_I_I]], 1
-// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP124:![0-9]+]]
+// CHECK-LOCAL-NEXT:    br label [[FOR_COND_I_I]], !llvm.loop [[LOOP149:![0-9]+]]
 // CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiLm11ENS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi1EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT3_EEvE4typeESR_SP_NS0_4spanISQ_XT2_EEESS_.exit:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR5]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR6]]
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_eleven_ints(sycl::sub_group &sg, plain_ptr<int> p,

--- a/sycl/test/check_device_code/group_load_store_native_key.cpp
+++ b/sycl/test/check_device_code/group_load_store_native_key.cpp
@@ -34,8 +34,8 @@ using plain_ptr = typename sycl::detail::DecoratedType<
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-GLOBAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR3:[0-9]+]]
-// CHECK-GLOBAL-NEXT:    store i32 [[CALL4_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
+// CHECK-GLOBAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR3:[0-9]+]]
+// CHECK-GLOBAL-NEXT:    store i32 [[CALL5_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_Z9test_loadRN4sycl3_V19sub_groupEPU3AS3iRi(
@@ -44,9 +44,9 @@ using plain_ptr = typename sycl::detail::DecoratedType<
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
 // CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3:[0-9]+]]
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
-// CHECK-LOCAL-NEXT:    [[IDXPROM_I18_I_I:%.*]] = sext i32 [[TMP0]] to i64
-// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I19_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P]], i64 [[IDXPROM_I18_I_I]]
-// CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(3) [[ARRAYIDX_I19_I_I]], align 4, !tbaa [[TBAA8:![0-9]+]]
+// CHECK-LOCAL-NEXT:    [[IDXPROM_I_I_I:%.*]] = sext i32 [[TMP0]] to i64
+// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I_I]]
+// CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(3) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8:![0-9]+]]
 // CHECK-LOCAL-NEXT:    store i32 [[TMP1]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
 // CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
 // CHECK-LOCAL-NEXT:    ret void
@@ -59,16 +59,32 @@ SYCL_EXTERNAL void test_load(sycl::sub_group &sg, plain_ptr<int> p, int &out) {
 // CHECK-GLOBAL-NEXT:  entry:
 // CHECK-GLOBAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(1) [[P:%.*]], null
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-GLOBAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR3]]
-// CHECK-GLOBAL-NEXT:    store i32 [[CALL4_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
+// CHECK-GLOBAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS1Kj(ptr addrspace(1) noundef nonnull [[P]]) #[[ATTR3]]
+// CHECK-GLOBAL-NEXT:    store i32 [[CALL5_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
 // CHECK-GLOBAL-NEXT:    ret void
 //
 // CHECK-LOCAL-LABEL: @_Z16test_load_nativeRN4sycl3_V19sub_groupEPU3AS3iRi(
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-LOCAL-NEXT:    [[CALL4_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR3]]
-// CHECK-LOCAL-NEXT:    store i32 [[CALL4_I_I]], ptr addrspace(4) [[OUT:%.*]], align 4
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
+// CHECK-LOCAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 15
+// CHECK-LOCAL-NEXT:    [[CMP_I20_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I20_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
+// CHECK-LOCAL:       if.then.i.i:
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
+// CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
+// CHECK-LOCAL-NEXT:    [[IDXPROM_I_I_I:%.*]] = sext i32 [[TMP1]] to i64
+// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I_I]]
+// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(3) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    store i32 [[TMP2]], ptr addrspace(4) [[OUT:%.*]], align 4, !tbaa [[TBAA8]]
+// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESR_SP_RSQ_SS__EXIT:%.*]]
+// CHECK-LOCAL:       if.end.i.i:
+// CHECK-LOCAL-NEXT:    [[CALL5_I_I:%.*]] = tail call spir_func noundef i32 @_Z30__spirv_SubgroupBlockReadINTELIjET_PU3AS3Kj(ptr addrspace(3) noundef nonnull [[P]]) #[[ATTR3]]
+// CHECK-LOCAL-NEXT:    store i32 [[CALL5_I_I]], ptr addrspace(4) [[OUT]], align 4
+// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL10GROUP_LOADINS0_9SUB_GROUPEPU3AS3IINS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEENSB_INS9_25NATIVE_LOCAL_BLOCK_IO_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE17VERIFY_LOAD_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESR_SP_RSQ_SS__EXIT]]
+// CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental10group_loadINS0_9sub_groupEPU3AS3iiNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEENSB_INS9_25native_local_block_io_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE17verify_load_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeESR_SP_RSQ_SS_.exit:
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_load_native(sycl::sub_group &sg, plain_ptr<int> p,
@@ -82,8 +98,8 @@ SYCL_EXTERNAL void test_load_native(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(1) [[P]] to i64
 // CHECK-GLOBAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 15
-// CHECK-GLOBAL-NEXT:    [[CMP1_I_NOT_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP1_I_NOT_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I23_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I23_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
 // CHECK-GLOBAL:       if.then.i.i:
 // CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
@@ -102,27 +118,12 @@ SYCL_EXTERNAL void test_load_native(sycl::sub_group &sg, plain_ptr<int> p,
 // CHECK-LOCAL-NEXT:  entry:
 // CHECK-LOCAL-NEXT:    [[CMP_I_I_I:%.*]] = icmp ne ptr addrspace(3) [[P:%.*]], null
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
-// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
-// CHECK-LOCAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 15
-// CHECK-LOCAL-NEXT:    [[CMP1_I_NOT_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
-// CHECK-LOCAL-NEXT:    br i1 [[CMP1_I_NOT_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
-// CHECK-LOCAL:       if.then.i.i:
 // CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
-// CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
-// CHECK-LOCAL-NEXT:    [[IDXPROM_I_I_I:%.*]] = sext i32 [[TMP1]] to i64
+// CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
+// CHECK-LOCAL-NEXT:    [[IDXPROM_I_I_I:%.*]] = sext i32 [[TMP0]] to i64
 // CHECK-LOCAL-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P]], i64 [[IDXPROM_I_I_I]]
 // CHECK-LOCAL-NEXT:    store i32 [[V:%.*]], ptr addrspace(3) [[ARRAYIDX_I_I_I]], align 4, !tbaa [[TBAA8]]
 // CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
-// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL11GROUP_STOREINS0_9SUB_GROUPEIPU3AS3INS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE18VERIFY_STORE_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESP_RKSN_SO_SQ__EXIT:%.*]]
-// CHECK-LOCAL:       if.end.i.i:
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
-// CHECK-LOCAL-NEXT:    [[TMP2:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
-// CHECK-LOCAL-NEXT:    [[IDXPROM_I18_I_I:%.*]] = sext i32 [[TMP2]] to i64
-// CHECK-LOCAL-NEXT:    [[ARRAYIDX_I19_I_I:%.*]] = getelementptr inbounds i32, ptr addrspace(3) [[P]], i64 [[IDXPROM_I18_I_I]]
-// CHECK-LOCAL-NEXT:    store i32 [[V]], ptr addrspace(3) [[ARRAYIDX_I19_I_I]], align 4, !tbaa [[TBAA8]]
-// CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
-// CHECK-LOCAL-NEXT:    br label [[_ZN4SYCL3_V13EXT6ONEAPI12EXPERIMENTAL11GROUP_STOREINS0_9SUB_GROUPEIPU3AS3INS3_10PROPERTIESINS3_6DETAIL20PROPERTIES_TYPE_LISTIJNS3_14PROPERTY_VALUEINS3_18DATA_PLACEMENT_KEYEJST17INTEGRAL_CONSTANTIILI0EEEEENSB_INS3_21CONTIGUOUS_MEMORY_KEYEJEEENSB_INS3_14FULL_GROUP_KEYEJEEEEEEEEEENST9ENABLE_IFIXAAAASR6DETAILE18VERIFY_STORE_TYPESIT0_T1_ESR6DETAILE18IS_GENERIC_GROUP_VIT_E18IS_PROPERTY_LIST_VIT2_EEVE4TYPEESP_RKSN_SO_SQ__EXIT]]
-// CHECK-LOCAL:       _ZN4sycl3_V13ext6oneapi12experimental11group_storeINS0_9sub_groupEiPU3AS3iNS3_10propertiesINS3_6detail20properties_type_listIJNS3_14property_valueINS3_18data_placement_keyEJSt17integral_constantIiLi0EEEEENSB_INS3_21contiguous_memory_keyEJEEENSB_INS3_14full_group_keyEJEEEEEEEEEENSt9enable_ifIXaaaasr6detailE18verify_store_typesIT0_T1_Esr6detailE18is_generic_group_vIT_E18is_property_list_vIT2_EEvE4typeESP_RKSN_SO_SQ_.exit:
 // CHECK-LOCAL-NEXT:    ret void
 //
 SYCL_EXTERNAL void test_store(sycl::sub_group &sg, int v, plain_ptr<int> p) {
@@ -135,8 +136,8 @@ SYCL_EXTERNAL void test_store(sycl::sub_group &sg, int v, plain_ptr<int> p) {
 // CHECK-GLOBAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
 // CHECK-GLOBAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(1) [[P]] to i64
 // CHECK-GLOBAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 15
-// CHECK-GLOBAL-NEXT:    [[CMP1_I_NOT_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
-// CHECK-GLOBAL-NEXT:    br i1 [[CMP1_I_NOT_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
+// CHECK-GLOBAL-NEXT:    [[CMP_I23_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
+// CHECK-GLOBAL-NEXT:    br i1 [[CMP_I23_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
 // CHECK-GLOBAL:       if.then.i.i:
 // CHECK-GLOBAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
 // CHECK-GLOBAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4
@@ -157,8 +158,8 @@ SYCL_EXTERNAL void test_store(sycl::sub_group &sg, int v, plain_ptr<int> p) {
 // CHECK-LOCAL-NEXT:    tail call void @llvm.assume(i1 [[CMP_I_I_I]])
 // CHECK-LOCAL-NEXT:    [[TMP0:%.*]] = ptrtoint ptr addrspace(3) [[P]] to i64
 // CHECK-LOCAL-NEXT:    [[REM_I_I_I:%.*]] = and i64 [[TMP0]], 15
-// CHECK-LOCAL-NEXT:    [[CMP1_I_NOT_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
-// CHECK-LOCAL-NEXT:    br i1 [[CMP1_I_NOT_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
+// CHECK-LOCAL-NEXT:    [[CMP_I23_I_I:%.*]] = icmp eq i64 [[REM_I_I_I]], 0
+// CHECK-LOCAL-NEXT:    br i1 [[CMP_I23_I_I]], label [[IF_END_I_I:%.*]], label [[IF_THEN_I_I:%.*]]
 // CHECK-LOCAL:       if.then.i.i:
 // CHECK-LOCAL-NEXT:    tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 3, i32 noundef 3, i32 noundef 912) #[[ATTR3]]
 // CHECK-LOCAL-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) @__spirv_BuiltInSubgroupLocalInvocationId, align 4


### PR DESCRIPTION
Simplify handling of multiple address spaces and alignment checks. Additional improvement regarding alignment checks is being done here (to perform compile-time alignment check instead of expensive dynamic check): https://github.com/intel/llvm/pull/16882
Also this PR fixes alignment requirement for local address space: 16-byte alignment is required for both load and store.