### PR TITLE
[CI] Improve windows hang detection script

### DIFF
--- a/devops/scripts/windows_detect_hung_tests.ps1
+++ b/devops/scripts/windows_detect_hung_tests.ps1
@@ -3,6 +3,6 @@ $hungTests = Get-Process | Where-Object { ($_.Path -match "llvm\\install") -or (
 $hungTests | Foreach-Object {
  $exitCode = 1
  echo "Test $($_.Path) hung!"
- Stop-Process -Force $_
+ tskill $_.ID
 }
 exit $exitCode


### PR DESCRIPTION
For whatever reason `tskill` seems to be able to kill processes `Stop-Process` can't. Manually tested this on a runner with hung tests.

