### PR TITLE
[CI] Fix cuda_dev_kit detection on runners

### DIFF
--- a/devops/actions/run-tests/e2e/action.yml
+++ b/devops/actions/run-tests/e2e/action.yml
@@ -55,7 +55,7 @@ runs:
     if: inputs.testing_mode != 'run-only'
     shell: bash
     run: |
-      cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.cxx_compiler || '$(which clang++)'}}" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" ${{ steps.cmake_opts.outputs.opts }}
+      cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.cxx_compiler || '$(which clang++)'}}" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" -DCUDA_LIBS_DIR=/usr/local/cuda/lib64 -DCUDA_INCLUDE=/usr/local/cuda/include ${{ steps.cmake_opts.outputs.opts }}
   - name: SYCL End-to-end tests
     shell: bash {0}
     env:


### PR DESCRIPTION
The CUDA dev kit is already installed in the image we use but we don't pass these CMake vars so it isn't found.

It should be fine to do this unconditionally, lit.py does a full compile with required files and checks the compiler return code, so even if it isn't actually installed it won't cause any problems. The compile is failing today because we don't pass the vars anyway.

Manually tested this on the runners.
Confirming working in [this](https://github.com/intel/llvm/actions/runs/13164735078/job/36742725212?pr=16892) run, as `Adapters/cuda_queue_priority.cpp` passed which requires the feature.