### PR TITLE
[SYCL][E2E] Add CUDA SDK autodetection

### DIFF
--- a/devops/actions/run-tests/e2e/action.yml
+++ b/devops/actions/run-tests/e2e/action.yml
@@ -55,7 +55,7 @@ runs:
     if: inputs.testing_mode != 'run-only'
     shell: bash
     run: |
-      cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.cxx_compiler || '$(which clang++)'}}" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" -DCUDA_LIBS_DIR=/usr/local/cuda/lib64 -DCUDA_INCLUDE=/usr/local/cuda/include ${{ steps.cmake_opts.outputs.opts }}
+      cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.cxx_compiler || '$(which clang++)'}}" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" ${{ steps.cmake_opts.outputs.opts }}
   - name: SYCL End-to-end tests
     shell: bash {0}
     env:

--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -69,6 +69,13 @@ endif()
 
 set(SYCL_E2E_CLANG_CXX_FLAGS "${SYCL_E2E_CLANG_CXX_FLAGS} -Werror")
 
+find_package(CUDAToolkit)
+
+if(CUDAToolkit_FOUND)
+  set(CUDA_LIBS_DIR "${CUDAToolkit_LIBRARY_DIR}")
+  set(CUDA_INCLUDE "${CUDAToolkit_INCLUDE_DIRS}")
+endif()
+
 if(SYCL_TEST_E2E_STANDALONE)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py")

--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -180,9 +180,9 @@ at the full path specified by this variable.
 
 ***LEVEL_ZERO_LIBS_DIR*** - path to Level Zero libraries.
 
-***CUDA_INCLUDE*** - path to CUDA headers.
+***CUDA_INCLUDE*** - path to CUDA headers (autodetected).
 
-***CUDA_LIBS_DIR*** - path to CUDA libraries.
+***CUDA_LIBS_DIR*** - path to CUDA libraries (autodetected).
 
 ***AMD_ARCH*** - flag may be set for when using HIP AMD triple. For example it
 may be set to "gfx906". Otherwise must be provided via the ***amd_arch*** LIT
@@ -288,9 +288,9 @@ configure specific single test execution in the command line:
 * **level_zero_libs_dir** - directory containing Level_Zero native libraries,
   can be also set by CMake variable LEVEL_ZERO_LIBS_DIR.
 * **cuda_include** - directory containing CUDA SDK headers, can be also set by
-  CMake variable CUDA_INCLUDE.
+  CMake variable CUDA_INCLUDE (autodetected).
 * **cuda_libs_dir** - directory containing CUDA SDK libraries, can be also set
-  by CMake variable CUDA_LIBS_DIR.
+  by CMake variable CUDA_LIBS_DIR (autodetected).
 * **run_launcher** - part of `%{run*}` expansion/substitution to alter execution
   of the test by, e.g., running it through Valgrind.
 


### PR DESCRIPTION
Add autodetection of the CUDA SDK using CMake's builtin `find_package`.

I didn't remove the LIT params or handling in lit.py as to not break anyone who may want to use a custom install.

Confirmed working [here](https://github.com/intel/llvm/actions/runs/13166519697/job/36748743079?pr=16896) as `Adapters/cuda_queue_priority.cpp` passed.