### PR TITLE
[test-e2e][L0] do not rely on specific log format

### DIFF
--- a/sycl/test-e2e/Adapters/interop-level-zero-image-ownership.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-image-ownership.cpp
@@ -14,7 +14,7 @@
 // If ownership is ::transfer then the ~image destructor will end up calling
 // zeImageDestroy
 // CHECK: test  ownership::transfer
-// CHECK: ZE ---> zeImageDestroy
+// CHECK: zeImageDestroy
 
 // With ownership ::keep it is must be called manually.
 // CHECK: test  ownership::keep

--- a/sycl/test-e2e/Adapters/level_zero_barrier_optimization.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_barrier_optimization.cpp
@@ -35,9 +35,9 @@ int main() {
 
     // CHECK: Test1
     // CHECK: ---> urEnqueueEventsWaitWithBarrierExt
-    // CHECK: ZE ---> zeEventCreate
-    // CHECK-OPT: ZE ---> zeCommandListAppendWaitOnEvents
-    // CHECK: ZE ---> zeCommandListAppendSignalEvent
+    // CHECK: zeEventCreate
+    // CHECK-OPT: zeCommandListAppendWaitOnEvents
+    // CHECK: zeCommandListAppendSignalEvent
     // CHECK: ) -> UR_RESULT_SUCCESS
     auto BarrierEvent = Q2.ext_oneapi_submit_barrier({EventA, EventB});
     BarrierEvent.wait();
@@ -55,9 +55,9 @@ int main() {
 
     // CHECK: Test2
     // CHECK: ---> urEnqueueEventsWaitWithBarrierExt
-    // CHECK-OPT: ZE ---> {{zeEventCreate|zeEventHostReset}}
-    // CHECK-OPT: ZE ---> zeCommandListAppendWaitOnEvents
-    // CHECK: ZE ---> zeCommandListAppendSignalEvent
+    // CHECK-OPT: {{zeEventCreate|zeEventHostReset}}
+    // CHECK-OPT: zeCommandListAppendWaitOnEvents
+    // CHECK: zeCommandListAppendSignalEvent
     // CHECK: ) -> UR_RESULT_SUCCESS
     auto BarrierEvent = Q1.ext_oneapi_submit_barrier({EventA, EventB});
     BarrierEvent.wait();
@@ -75,10 +75,10 @@ int main() {
     Q3.wait();
     // CHECK: Test3
     // CHECK: ---> urEnqueueEventsWaitWithBarrierExt
-    // CHECK: ZE ---> zeEventCreate
-    // CHECK-NOT: ZE ---> zeCommandListAppendWaitOnEvents
-    // CHECK-NOT: ZE ---> zeCommandListAppendSignalEvent
-    // CHECK: ZE ---> zeCommandListAppendBarrier
+    // CHECK: zeEventCreate
+    // CHECK-NOT: zeCommandListAppendWaitOnEvents
+    // CHECK-NOT: zeCommandListAppendSignalEvent
+    // CHECK: zeCommandListAppendBarrier
     // CHECK: ) -> UR_RESULT_SUCCESS
     auto BarrierEvent = Q3.ext_oneapi_submit_barrier({EventA, EventB});
     BarrierEvent.wait();

--- a/sycl/test-e2e/Adapters/level_zero_batch_barrier.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_batch_barrier.cpp
@@ -23,22 +23,22 @@ int main(int argc, char *argv[]) {
 
   submit_kernel(q); // starts a batch
                     // CHECK: ---> urEnqueueKernelLaunch
-                    // CHECK-NOT: ZE ---> zeCommandQueueExecuteCommandLists
+                    // CHECK-NOT: zeCommandQueueExecuteCommandLists
 
   // continue the batch
   event barrier = q.ext_oneapi_submit_barrier();
   // CHECK: ---> urEnqueueEventsWaitWithBarrierExt
-  // CHECK-NOT: ZE ---> zeCommandQueueExecuteCommandLists
+  // CHECK-NOT: zeCommandQueueExecuteCommandLists
 
   submit_kernel(q);
   // CHECK: ---> urEnqueueKernelLaunch
-  // CHECK-NOT: ZE ---> zeCommandQueueExecuteCommandLists
+  // CHECK-NOT: zeCommandQueueExecuteCommandLists
 
   // interop should close the batch
   ze_event_handle_t ze_event =
       get_native<backend::ext_oneapi_level_zero>(barrier);
   // CHECK: ---> urEventGetNativeHandle
-  // CHECK: ZE ---> zeCommandQueueExecuteCommandLists
+  // CHECK: zeCommandQueueExecuteCommandLists
   zeEventHostSynchronize(ze_event, UINT64_MAX);
 
   // CHECK: ---> urQueueFinish

--- a/sycl/test-e2e/Adapters/level_zero_batch_event_status.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_batch_event_status.cpp
@@ -20,12 +20,12 @@
 // CHECK: UR ---> UrQueue->executeOpenCommandList
 // CHECK: ---> urQueueFinish
 // Look for close and Execute after urQueueFinish
-// CHECK:  ZE ---> zeCommandListClose
-// CHECK:  ZE ---> zeCommandQueueExecuteCommandLists
+// CHECK:  zeCommandListClose
+// CHECK:  zeCommandQueueExecuteCommandLists
 // CHECK: ---> urEventGetInfo
 // No close and execute here, should already have happened.
-// CHECK-NOT:  ZE ---> zeCommandListClose
-// CHECK-NOT:  ZE ---> zeCommandQueueExecuteCommandLists
+// CHECK-NOT:  zeCommandListClose
+// CHECK-NOT:  zeCommandQueueExecuteCommandLists
 // CHECK-NOT: Test Fail
 // CHECK: Test Pass
 // UNSUPPORTED: ze_debug

--- a/sycl/test-e2e/Adapters/level_zero_batch_test.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_batch_test.cpp
@@ -89,172 +89,172 @@
 // validation check.
 // Pattern starts first set of kernel executions.
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB8:  ZE ---> zeCommandListClose(
-// CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
+// CKB8:  zeCommandListClose(
+// CKB8:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urQueueFinish
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB9:  ZE ---> zeCommandListClose(
-// CKB9:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
+// CKB9:  zeCommandListClose(
+// CKB9:  zeCommandQueueExecuteCommandLists(
 // Pattern starts 2nd set of kernel executions
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB8:  ZE ---> zeCommandListClose(
-// CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
+// CKB8:  zeCommandListClose(
+// CKB8:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urQueueFinish
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB9:  ZE ---> zeCommandListClose(
-// CKB9:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
+// CKB9:  zeCommandListClose(
+// CKB9:  zeCommandQueueExecuteCommandLists(
 // Pattern starts 3rd set of kernel executions
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB8:  ZE ---> zeCommandListClose(
-// CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
+// CKB8:  zeCommandListClose(
+// CKB8:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urQueueFinish
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB9:  ZE ---> zeCommandListClose(
-// CKB9:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
+// CKB9:  zeCommandListClose(
+// CKB9:  zeCommandQueueExecuteCommandLists(
 // Now just check for 8 Test Pass kernel validations.
 // CKALL: Test Pass
 // CKALL: Test Pass

--- a/sycl/test-e2e/Adapters/level_zero_batch_test_copy_with_compute.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_batch_test_copy_with_compute.cpp
@@ -42,172 +42,172 @@
 // validation check.
 // Pattern starts first set of kernel executions.
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB8:  ZE ---> zeCommandListClose(
-// CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
+// CKB8:  zeCommandListClose(
+// CKB8:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urQueueFinish
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB9:  ZE ---> zeCommandListClose(
-// CKB9:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
+// CKB9:  zeCommandListClose(
+// CKB9:  zeCommandQueueExecuteCommandLists(
 // Pattern starts 2nd set of kernel executions
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB8:  ZE ---> zeCommandListClose(
-// CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
+// CKB8:  zeCommandListClose(
+// CKB8:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urQueueFinish
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB9:  ZE ---> zeCommandListClose(
-// CKB9:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
+// CKB9:  zeCommandListClose(
+// CKB9:  zeCommandQueueExecuteCommandLists(
 // Pattern starts 3rd set of kernel executions
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urEnqueueKernelLaunch
-// CKALL: ZE ---> zeCommandListAppendLaunchKernel(
-// CKB1:  ZE ---> zeCommandListClose(
-// CKB1:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB4:  ZE ---> zeCommandListClose(
-// CKB4:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB8:  ZE ---> zeCommandListClose(
-// CKB8:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKALL: zeCommandListAppendLaunchKernel(
+// CKB1:  zeCommandListClose(
+// CKB1:  zeCommandQueueExecuteCommandLists(
+// CKB4:  zeCommandListClose(
+// CKB4:  zeCommandQueueExecuteCommandLists(
+// CKB8:  zeCommandListClose(
+// CKB8:  zeCommandQueueExecuteCommandLists(
 // CKALL: ---> urQueueFinish
-// CKB3:  ZE ---> zeCommandListClose(
-// CKB3:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB5:  ZE ---> zeCommandListClose(
-// CKB5:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB7:  ZE ---> zeCommandListClose(
-// CKB7:  ZE ---> zeCommandQueueExecuteCommandLists(
-// CKB9:  ZE ---> zeCommandListClose(
-// CKB9:  ZE ---> zeCommandQueueExecuteCommandLists(
+// CKB3:  zeCommandListClose(
+// CKB3:  zeCommandQueueExecuteCommandLists(
+// CKB5:  zeCommandListClose(
+// CKB5:  zeCommandQueueExecuteCommandLists(
+// CKB7:  zeCommandListClose(
+// CKB7:  zeCommandQueueExecuteCommandLists(
+// CKB9:  zeCommandListClose(
+// CKB9:  zeCommandQueueExecuteCommandLists(
 // Now just check for 16 Test Pass kernel validations.
 // CKALL: Test Pass
 // CKALL: Test Pass

--- a/sycl/test-e2e/Adapters/level_zero_device_scope_events.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_device_scope_events.cpp
@@ -13,19 +13,19 @@
 // MODE1-LABEL: Submitted all kernels
 // MODE1: ---> urEventWait
 // MODE1: ze_event_pool_desc_t flags set to: 1
-// MODE1: ZE ---> zeEventCreate(ZeEventPool, &ZeEventDesc, &ZeEvent)
-// MODE1: ZE ---> zeCommandListAppendWaitOnEvents(CommandList->first, 1, &ZeEvent)
-// MODE1-NEXT: ZE ---> zeCommandListAppendSignalEvent(CommandList->first, HostVisibleEvent->ZeEvent)
+// MODE1: zeEventCreate
+// MODE1: zeCommandListAppendWaitOnEvents
+// MODE1-NEXT: zeCommandListAppendSignalEvent
 // MODE1: Completed all kernels
 
 // With the SYCL_PI_LEVEL_ZERO_DEVICE_SCOPE_EVENTS=2 mode look for pattern that
 // creates host-visible event just before command-list submission.
 //
 // MODE2: ze_event_pool_desc_t flags set to: 1
-// MODE2: ZE ---> zeEventCreate(ZeEventPool, &ZeEventDesc, &ZeEvent)
-// MODE2: ZE ---> zeCommandListAppendBarrier(CommandList->first, HostVisibleEvent->ZeEvent, 0, nullptr)
-// MODE2: ZE ---> zeCommandListClose(CommandList->first)
-// MODE2: ZE ---> zeCommandQueueExecuteCommandLists(ZeCommandQueue, 1, &ZeCommandList, CommandList->second.ZeFence)
+// MODE2: zeEventCreate
+// MODE2: zeCommandListAppendBarrier
+// MODE2: zeCommandListClose
+// MODE2: zeCommandQueueExecuteCommandLists
 // clang-format on
 
 #include <iostream>

--- a/sycl/test-e2e/Adapters/level_zero_eager_init.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_eager_init.cpp
@@ -7,9 +7,9 @@
 // heavy L0 initialization in the hot reportable path.
 //
 // CHECK-LABEL: HOT HOT HOT
-// CHECK-NOT: ZE ---> zeCommandQueueCreate
-// CHECK-NOT: ZE ---> zeCommandListCreate
-// CHECK-NOT: ZE ---> zeFenceCreate
+// CHECK-NOT: zeCommandQueueCreate
+// CHECK-NOT: zeCommandListCreate
+// CHECK-NOT: zeFenceCreate
 //
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Adapters/level_zero_memory_fill.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_memory_fill.cpp
@@ -6,7 +6,7 @@
 // Check that the fill operation is using compute (0 ordinal) engine.
 //
 // CHECK: [getZeQueue]: create queue ordinal = 0
-// CHECKL ZE ---> zeCommandListAppendMemoryFill
+// CHECKL zeCommandListAppendMemoryFill
 
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Adapters/level_zero_usm_device_read_only.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_usm_device_read_only.cpp
@@ -17,12 +17,12 @@ int main(int argc, char *argv[]) {
   auto ptr1 =
       malloc_shared<int>(1, Q, ext::oneapi::property::usm::device_read_only());
   // CHECK: ---> urUSMSharedAlloc
-  // CHECK:ZE ---> zeMemAllocShared
+  // CHECK: zeMemAllocShared
 
   auto ptr2 = aligned_alloc_shared<int>(
       1, 1, Q, ext::oneapi::property::usm::device_read_only());
   // CHECK: ---> urUSMSharedAlloc
-  // CHECK-NOT: ZE ---> zeMemAllocShared
+  // CHECK-NOT: zeMemAllocShared
 
   free(ptr1, Q);
   free(ptr2, Q);

--- a/sycl/test-e2e/Adapters/level_zero_usm_residency.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_usm_residency.cpp
@@ -18,19 +18,19 @@ int main(int argc, char *argv[]) {
 
   auto ptr1 = malloc_device<int>(1, Q);
   // DEVICE: ---> urUSMDeviceAlloc
-  // DEVICE: ZE ---> zeMemAllocDevice
-  // DEVICE: ZE ---> zeContextMakeMemoryResident
+  // DEVICE: zeMemAllocDevice
+  // DEVICE: zeContextMakeMemoryResident
 
   auto ptr2 = malloc_shared<int>(1, Q);
   // SHARED: ---> urUSMSharedAlloc
-  // SHARED: ZE ---> zeMemAllocShared
-  // SHARED: ZE ---> zeContextMakeMemoryResident
-  // SHARED-NOT: ZE ---> zeContextMakeMemoryResident
+  // SHARED: zeMemAllocShared
+  // SHARED: zeContextMakeMemoryResident
+  // SHARED-NOT: zeContextMakeMemoryResident
 
   auto ptr3 = malloc_host<int>(1, Q);
   // HOST: ---> urUSMHostAlloc
-  // HOST: ZE ---> zeMemAllocHost
-  // HOST: ZE ---> zeContextMakeMemoryResident
+  // HOST: zeMemAllocHost
+  // HOST: zeContextMakeMemoryResident
 
   free(ptr1, Q);
   free(ptr2, Q);

--- a/sycl/test-e2e/Basic/buffer/buffer_create.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_create.cpp
@@ -42,4 +42,4 @@ int main() {
 }
 
 // CHECK: {{Integrated|Discrete}} GPU should use [[API:zeMemAllocHost|zeMemAllocDevice]]
-// CHECK: ZE ---> [[API]](
+// CHECK: [[API]](

--- a/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
+++ b/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
@@ -21,9 +21,9 @@
 //
 // CHECK: ---> urProgramCreate
 // CHECK: ---> urProgramCompile
-// CHECK-NOT: ZE ---> zeModuleCreate
+// CHECK-NOT: zeModuleCreate
 // CHECK: ---> urProgramLink
-// CHECK: ZE ---> zeModuleCreate
+// CHECK: zeModuleCreate
 
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>

--- a/sycl/test-e2e/Properties/cache_config.cpp
+++ b/sycl/test-e2e/Properties/cache_config.cpp
@@ -55,12 +55,12 @@ int main() {
       cache_config(large_slm)};
 
   // CHECK: parallel_for with sycl::range
-  // CHECK: ZE ---> zeKernelSetCacheConfig
+  // CHECK: zeKernelSetCacheConfig
   std::cout << "parallel_for with sycl::range" << std::endl;
   q.parallel_for(range<2>{16, 16}, RangeKernelFunctor{}).wait();
 
   // CHECK: parallel_for_work_group(range, func)
-  // CHECK: ZE ---> zeKernelSetCacheConfig
+  // CHECK: zeKernelSetCacheConfig
   std::cout << "parallel_for_work_group(range, func)" << std::endl;
   q.submit([&](handler &cgh) {
     cgh.parallel_for_work_group<class hpar_range>(
@@ -69,7 +69,7 @@ int main() {
   });
 
   // CHECK: parallel_for_work_group(range, range, func)
-  // CHECK: ZE ---> zeKernelSetCacheConfig
+  // CHECK: zeKernelSetCacheConfig
   std::cout << "parallel_for_work_group(range, range, func)" << std::endl;
   q.submit([&](handler &cgh) {
     cgh.parallel_for_work_group<class hpar_range_range>(
@@ -87,7 +87,7 @@ int main() {
   buffer<int> sum_buf{&sum_result, 1};
 
   // CHECK: parallel_for with reduction
-  // CHECK: ZE ---> zeKernelSetCacheConfig
+  // CHECK: zeKernelSetCacheConfig
   std::cout << "parallel_for with reduction" << std::endl;
   q.submit([&](handler &cgh) {
     auto input_values = values_buf.get_access<access_mode::read>(cgh);
@@ -97,25 +97,25 @@ int main() {
   });
 
   // CHECK: KernelFunctor single_task
-  // CHECK: ZE ---> zeKernelSetCacheConfig
+  // CHECK: zeKernelSetCacheConfig
   std::cout << "KernelFunctor single_task" << std::endl;
   q.single_task(KernelFunctor{}).wait();
 
   // CHECK: KernelFunctor parallel_for
-  // CHECK: ZE ---> zeKernelSetCacheConfig
+  // CHECK: zeKernelSetCacheConfig
   std::cout << "KernelFunctor parallel_for" << std::endl;
   q.parallel_for(nd_range<2>{range<2>(4, 4), range<2>(2, 2)}, KernelFunctorND{})
       .wait();
 
   // CHECK: negative parallel_for with sycl::nd_range
-  // CHECK-NOT: ZE ---> zeKernelSetCacheConfig
+  // CHECK-NOT: zeKernelSetCacheConfig
   std::cout << "negative parallel_for with sycl::nd_range" << std::endl;
   q.parallel_for(nd_range<2>{range<2>(4, 4), range<2>(2, 2)},
                  [=](nd_item<2> i) {})
       .wait();
 
   // CHECK: negative parallel_for with KernelFunctor
-  // CHECK-NOT: ZE ---> zeKernelSetCacheConfig
+  // CHECK-NOT: zeKernelSetCacheConfig
   std::cout << "negative parallel_for with KernelFunctor" << std::endl;
   q.parallel_for(nd_range<2>{range<2>(4, 4), range<2>(2, 2)},
                  NegativeKernelFunctor{})

--- a/sycl/test-e2e/USM/usm_pooling.cpp
+++ b/sycl/test-e2e/USM/usm_pooling.cpp
@@ -109,35 +109,35 @@ int main(int argc, char *argv[]) {
 }
 
 // CHECK-NOPOOL: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
-// CHECK-NOPOOL-NEXT:  ZE ---> zeDeviceGetMemoryAccessProperties
-// CHECK-NOPOOL-NEXT:  ZE ---> [[API]](
-// CHECK-NOPOOL-NEXT:  ZE ---> [[API]](
-// CHECK-NOPOOL-NEXT:  ZE ---> zeMemFree
-// CHECK-NOPOOL-NEXT:  ZE ---> zeMemFree
-// CHECK-NOPOOL-NEXT:  ZE ---> [[API]](
-// CHECK-NOPOOL-NEXT:  ZE ---> [[API]](
-// CHECK-NOPOOL-NEXT:  ZE ---> [[API]](
+// CHECK-NOPOOL-NEXT:  zeDeviceGetMemoryAccessProperties
+// CHECK-NOPOOL-NEXT:  [[API]](
+// CHECK-NOPOOL-NEXT:  [[API]](
+// CHECK-NOPOOL-NEXT:  zeMemFree
+// CHECK-NOPOOL-NEXT:  zeMemFree
+// CHECK-NOPOOL-NEXT:  [[API]](
+// CHECK-NOPOOL-NEXT:  [[API]](
+// CHECK-NOPOOL-NEXT:  [[API]](
 
 // CHECK-12345: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
-// CHECK-12345-NEXT:  ZE ---> zeDeviceGetMemoryAccessProperties
-// CHECK-12345-NEXT:  ZE ---> [[API]](
-// CHECK-12345-NEXT:  ZE ---> [[API]](
-// CHECK-12345-NEXT:  ZE ---> zeMemFree
-// CHECK-12345-NEXT:  ZE ---> zeMemFree
-// CHECK-12345-NEXT:  ZE ---> [[API]](
-// CHECK-12345-NEXT:  ZE ---> [[API]](
-// CHECK-12345-NEXT:  ZE ---> [[API]](
+// CHECK-12345-NEXT:  zeDeviceGetMemoryAccessProperties
+// CHECK-12345-NEXT:  [[API]](
+// CHECK-12345-NEXT:  [[API]](
+// CHECK-12345-NEXT:  zeMemFree
+// CHECK-12345-NEXT:  zeMemFree
+// CHECK-12345-NEXT:  [[API]](
+// CHECK-12345-NEXT:  [[API]](
+// CHECK-12345-NEXT:  [[API]](
 
 // CHECK-1245: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
-// CHECK-1245-NEXT:  ZE ---> zeDeviceGetMemoryAccessProperties
-// CHECK-1245-NEXT:  ZE ---> [[API]](
-// CHECK-1245-NEXT:  ZE ---> [[API]](
-// CHECK-1245-NEXT:  ZE ---> zeMemFree
-// CHECK-1245-NEXT:  ZE ---> [[API]](
-// CHECK-1245-NEXT:  ZE ---> [[API]](
+// CHECK-1245-NEXT:  zeDeviceGetMemoryAccessProperties
+// CHECK-1245-NEXT:  [[API]](
+// CHECK-1245-NEXT:  [[API]](
+// CHECK-1245-NEXT:  zeMemFree
+// CHECK-1245-NEXT:  [[API]](
+// CHECK-1245-NEXT:  [[API]](
 
 // CHECK-15: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
-// CHECK-15-NEXT:  ZE ---> zeDeviceGetMemoryAccessProperties
-// CHECK-15-NEXT:  ZE ---> [[API]](
-// CHECK-15-NEXT:  ZE ---> [[API]](
-// CHECK-15-NEXT:  ZE ---> zeMemFree
+// CHECK-15-NEXT:  zeDeviceGetMemoryAccessProperties
+// CHECK-15-NEXT:  [[API]](
+// CHECK-15-NEXT:  [[API]](
+// CHECK-15-NEXT:  zeMemFree


### PR DESCRIPTION
from UR_L0_DEBUG.

L0 API logging will most likely be moved to the
L0 loader and we would like to keep formatting
consistent with current logger format, this means
no "ZE --->" prefix.