### PR TITLE
[SYCL][Docs] Add get_native_context call to interop_handle example

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_backend_level_zero.md
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_backend_level_zero.md
@@ -300,6 +300,8 @@ data to the host to access the data. Users can get type of the allocation using 
     Queue.submit([&](handler &CGH) {
         auto BufferAcc = Buffer.get_access<access::mode::write>(CGH);
         CGH.host_task([=](const interop_handle &IH) {
+            ze_context_handle_t ZeContext =
+                IH.get_native_context<backend::ext_oneapi_level_zero>();
             void *DevicePtr =
                 IH.get_native_mem<backend::ext_oneapi_level_zero>(BufferAcc);
             ze_memory_allocation_properties_t MemAllocProperties{};


### PR DESCRIPTION
The interop_handle example in the L0 backend specification uses a L0 context handle, but it may be unclear to users how that context handle is accessible. Since it needs to be at least associated with the corresponding device, it seems proper to be explicit in the example about how to get it from the interop_handle.