### PR TITLE
[SYCL] Remove the unused Spec Consts variable

### DIFF
--- a/sycl/doc/design/KernelProgramCache.md
+++ b/sycl/doc/design/KernelProgramCache.md
@@ -115,7 +115,6 @@ The kernels map's key consists of two components:
 The third map, called Fast Kernel Cache, is used as an optimization to reduce the
 number of lookups in the kernels map. Its key consists of the following components:
 
-- specialization constants values,
 - the UR handle of the device this kernel is built for,
 - kernel name<sup>[3](#what-is-kname)</sup>.
 

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -220,10 +220,9 @@ public:
       ::boost::unordered_map<ur_program_handle_t, KernelByNameT>;
 
   using KernelFastCacheKeyT =
-      std::tuple<SerializedObj,      /* Serialized spec constants. */
-                 ur_device_handle_t, /* UR device handle pointer */
-                 std::string         /* Kernel Name */
-                 >;
+      std::pair<ur_device_handle_t, /* UR device handle pointer */
+                std::string         /* Kernel Name */
+                >;
 
   using KernelFastCacheValT =
       std::tuple<ur_kernel_handle_t,    /* UR kernel handle pointer. */
@@ -420,7 +419,7 @@ public:
     std::unique_lock<std::mutex> Lock(MKernelFastCacheMutex);
     auto It = MKernelFastCache.find(CacheKey);
     if (It != MKernelFastCache.end()) {
-      traceKernel("Kernel fetched.", std::get<2>(CacheKey), true);
+      traceKernel("Kernel fetched.", CacheKey.second, true);
       return It->second;
     }
     return std::make_tuple(nullptr, nullptr, nullptr, nullptr);
@@ -449,7 +448,7 @@ public:
     std::unique_lock<std::mutex> Lock(MKernelFastCacheMutex);
     // if no insertion took place, thus some other thread has already inserted
     // smth in the cache
-    traceKernel("Kernel inserted.", std::get<2>(CacheKey), true);
+    traceKernel("Kernel inserted.", CacheKey.second, true);
     MKernelFastCache.emplace(CacheKey, CacheVal);
   }
 
@@ -504,7 +503,7 @@ public:
                 FastCacheKeyItr != MProgramToKernelFastCacheKeyMap.end()) {
               for (const auto &FastCacheKey : FastCacheKeyItr->second) {
                 MKernelFastCache.erase(FastCacheKey);
-                traceKernel("Kernel evicted.", std::get<2>(FastCacheKey), true);
+                traceKernel("Kernel evicted.", FastCacheKey.second, true);
               }
               MProgramToKernelFastCacheKeyMap.erase(FastCacheKeyItr);
             }

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1048,11 +1048,9 @@ ProgramManager::getOrCreateKernel(const ContextImplPtr &ContextImpl,
   using KernelArgMaskPairT = KernelProgramCache::KernelArgMaskPairT;
 
   KernelProgramCache &Cache = ContextImpl->getKernelProgramCache();
-  SerializedObj SpecConsts;
-
   ur_device_handle_t UrDevice = DeviceImpl->getHandleRef();
 
-  auto key = std::make_tuple(std::move(SpecConsts), UrDevice, KernelName);
+  auto key = std::make_pair(UrDevice, KernelName);
   if (SYCLConfig<SYCL_CACHE_IN_MEM>::get()) {
     auto ret_tuple = Cache.tryToGetKernelFast(key);
     constexpr size_t Kernel = 0;  // see KernelFastCacheValT tuple


### PR DESCRIPTION
Remove the unused Spec Consts component of the kernel fast cache key.