### PR TITLE
[NFCI][SYCL] Inline some traits related to fixed width int types

### DIFF
--- a/sycl/include/sycl/builtins_utils_scalar.hpp
+++ b/sycl/include/sycl/builtins_utils_scalar.hpp
@@ -80,37 +80,6 @@ constexpr bool check_all_same_op_type_v = CheckAllSameOpType<Ts...>();
 //       as MSVC thinks function definitions are the same otherwise.
 template <size_t... Ns> constexpr bool check_size_in_v = CheckSizeIn<Ns...>();
 
-// Utility traits for getting a signed integer type with the specified size.
-template <size_t Size> struct get_signed_int_by_size {
-  using type = select_scalar_by_size_t<Size, int8_t, int16_t, int32_t, int64_t>;
-};
-template <typename T> struct same_size_signed_int {
-  using type = typename get_signed_int_by_size<sizeof(T)>::type;
-};
-
-template <typename T>
-using same_size_signed_int_t = typename same_size_signed_int<T>::type;
-
-// Utility traits for getting a unsigned integer type with the specified size.
-template <size_t Size> struct get_unsigned_int_by_size {
-  using type =
-      select_scalar_by_size_t<Size, uint8_t, uint16_t, uint32_t, uint64_t>;
-};
-template <typename T> struct same_size_unsigned_int {
-  using type = typename get_unsigned_int_by_size<sizeof(T)>::type;
-};
-template <typename T>
-using same_size_unsigned_int_t = typename same_size_unsigned_int<T>::type;
-
-template <typename T> struct get_fixed_sized_int {
-  static_assert(std::is_integral_v<T>);
-  using type =
-      std::conditional_t<std::is_signed_v<T>, same_size_signed_int_t<T>,
-                         same_size_unsigned_int_t<T>>;
-};
-template <typename T>
-using get_fixed_sized_int_t = typename get_fixed_sized_int<T>::type;
-
 // Utility for converting a swizzle to a vector or preserve the type if it isn't
 // a swizzle.
 template <typename T> struct simplify_if_swizzle {

--- a/sycl/include/sycl/builtins_utils_vec.hpp
+++ b/sycl/include/sycl/builtins_utils_vec.hpp
@@ -67,38 +67,6 @@ struct is_same_op<
     std::enable_if_t<is_vec_or_swizzle_v<T1> && is_vec_or_swizzle_v<T2>>>
     : std::is_same<simplify_if_swizzle_t<T1>, simplify_if_swizzle_t<T2>> {};
 
-template <typename T, size_t N> struct same_size_signed_int<marray<T, N>> {
-  using type = marray<typename same_size_signed_int<T>::type, N>;
-};
-template <typename T, int N> struct same_size_signed_int<vec<T, N>> {
-  using type = vec<typename same_size_signed_int<T>::type, N>;
-};
-template <typename VecT, typename OperationLeftT, typename OperationRightT,
-          template <typename> class OperationCurrentT, int... Indexes>
-struct same_size_signed_int<SwizzleOp<VecT, OperationLeftT, OperationRightT,
-                                      OperationCurrentT, Indexes...>> {
-  // Converts to vec for simplicity.
-  using type =
-      vec<typename same_size_signed_int<typename VecT::element_type>::type,
-          sizeof...(Indexes)>;
-};
-
-template <typename T, size_t N> struct same_size_unsigned_int<marray<T, N>> {
-  using type = marray<typename same_size_unsigned_int<T>::type, N>;
-};
-template <typename T, int N> struct same_size_unsigned_int<vec<T, N>> {
-  using type = vec<typename same_size_unsigned_int<T>::type, N>;
-};
-template <typename VecT, typename OperationLeftT, typename OperationRightT,
-          template <typename> class OperationCurrentT, int... Indexes>
-struct same_size_unsigned_int<SwizzleOp<VecT, OperationLeftT, OperationRightT,
-                                        OperationCurrentT, Indexes...>> {
-  // Converts to vec for simplicity.
-  using type =
-      vec<typename same_size_unsigned_int<typename VecT::element_type>::type,
-          sizeof...(Indexes)>;
-};
-
 // Utility trait for changing the element type of a type T. If T is a scalar,
 // the new type replaces T completely.
 template <typename NewElemT, typename T> struct change_elements {

--- a/sycl/include/sycl/detail/builtins/builtins.hpp
+++ b/sycl/include/sycl/detail/builtins/builtins.hpp
@@ -116,8 +116,13 @@ auto builtin_marray_impl(FuncTy F, const Ts &...x) {
     auto PartialRes = [&]() {
       using elem_ty = get_elem_type_t<T>;
       if constexpr (std::is_integral_v<elem_ty>)
-        return F(to_vec2(x, I * 2)
-                     .template as<vec<get_fixed_sized_int_t<elem_ty>, 2>>()...);
+        return F(
+            to_vec2(x, I * 2)
+                .template as<vec<
+                    std::conditional_t<std::is_signed_v<elem_ty>,
+                                       fixed_width_signed<sizeof(elem_ty)>,
+                                       fixed_width_unsigned<sizeof(elem_ty)>>,
+                    2>>()...);
       else
         return F(to_vec2(x, I * 2)...);
     }();

--- a/sycl/include/sycl/detail/builtins/relational_functions.inc
+++ b/sycl/include/sycl/detail/builtins/relational_functions.inc
@@ -22,13 +22,29 @@ struct bitselect_elem_type
           (!is_vec_or_swizzle_v<T> &&
            check_type_in_v<get_elem_type_t<T>, INTEGER_TYPES>)> {};
 
-template <typename T>
-struct rel_ret_traits
-    : std::conditional<is_scalar_arithmetic_v<T>, bool,
-                       std::conditional_t<
-                           is_marray_v<T>, marray<bool, num_elements<T>::value>,
-                           same_size_signed_int_t<simplify_if_swizzle_t<T>>>> {
+template <typename T, typename = void> struct rel_ret_traits_impl {
+  // Return type trait is instantiated even if the arguments don't pass
+  // requirements check. Make sure it doesn't cause an error.
+  using type = void;
 };
+
+template <typename T>
+struct rel_ret_traits_impl<T, std::enable_if_t<is_scalar_arithmetic_v<T>>> {
+  using type = bool;
+};
+
+template <typename T>
+struct rel_ret_traits_impl<T, std::enable_if_t<is_marray_v<T>>> {
+  using type = marray<bool, T::size()>;
+};
+
+template <typename T>
+struct rel_ret_traits_impl<T, std::enable_if_t<is_vec_or_swizzle_v<T>>> {
+  using type =
+      vec<fixed_width_signed<sizeof(typename T::element_type)>, T::size()>;
+};
+
+template <typename T> using rel_ret_traits = rel_ret_traits_impl<T>;
 } // namespace detail
 
 BUILTIN_CREATE_ENABLER(builtin_enable_bitselect, default_ret_type,
@@ -67,7 +83,7 @@ auto builtin_delegate_rel_impl(FuncTy F, const Ts &...x) {
     return F(simplify_if_swizzle_t<T>{x}...);
   } else if constexpr (is_vec_v<T>) {
     // TODO: using Res{} to avoid Werror. Not sure if ok.
-    vec<same_size_signed_int_t<get_elem_type_t<T>>, T::size()> Res{};
+    vec<fixed_width_signed<sizeof(typename T::element_type)>, T::size()> Res{};
     detail::loop<T::size()>(
         [&](auto idx) { Res[idx] = F(x[idx]...) ? -1 : 0; });
     return Res;


### PR DESCRIPTION
Main reason is to avoid having partial specializations for swizzles in the implementation of the traits as we're going to have big changes in that area. Between this change and having to update the traits this approach seemed better.