### PR TITLE
[SYCL][E2E] Change method for setting a `RUN:` line to execute at run stage

### DIFF
--- a/sycl/test-e2e/Config/config.cpp
+++ b/sycl/test-e2e/Config/config.cpp
@@ -8,13 +8,13 @@
 // RUN: %{build} %debug_option %O0 -o %t.out
 // RUN: echo SYCL_PRINT_EXECUTION_GRAPH=always > %t.cfg
 // RUN: %{run-unfiltered-devices} env SYCL_CONFIG_FILE_NAME=%t.cfg %t.out
-// RUN: %{execute-at-run-stage} cat *.dot > /dev/null
-// RUN: %{execute-at-run-stage} rm *.dot
+// RUN: %{run-aux} cat *.dot > /dev/null
+// RUN: %{run-aux} rm *.dot
 // RUN: %{run-unfiltered-devices} env SYCL_PRINT_EXECUTION_GRAPH=always %t.out
-// RUN: %{execute-at-run-stage} cat *.dot > /dev/null
-// RUN: %{execute-at-run-stage} rm *.dot
+// RUN: %{run-aux} cat *.dot > /dev/null
+// RUN: %{run-aux} rm *.dot
 // RUN: %{run-unfiltered-devices} %t.out
-// RUN: %{execute-at-run-stage} not cat *.dot > /dev/null
+// RUN: %{run-aux} not cat *.dot > /dev/null
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/Config/config.cpp
+++ b/sycl/test-e2e/Config/config.cpp
@@ -8,13 +8,13 @@
 // RUN: %{build} %debug_option %O0 -o %t.out
 // RUN: echo SYCL_PRINT_EXECUTION_GRAPH=always > %t.cfg
 // RUN: %{run-unfiltered-devices} env SYCL_CONFIG_FILE_NAME=%t.cfg %t.out
-// RUN: %if run-mode %{cat *.dot > /dev/null%}
-// RUN: %if run-mode %{rm *.dot%}
+// RUN: %{execute-at-run-stage} cat *.dot > /dev/null
+// RUN: %{execute-at-run-stage} rm *.dot
 // RUN: %{run-unfiltered-devices} env SYCL_PRINT_EXECUTION_GRAPH=always %t.out
-// RUN: %if run-mode %{cat *.dot > /dev/null%}
-// RUN: %if run-mode %{rm *.dot%}
+// RUN: %{execute-at-run-stage} cat *.dot > /dev/null
+// RUN: %{execute-at-run-stage} rm *.dot
 // RUN: %{run-unfiltered-devices} %t.out
-// RUN: %if run-mode %{not cat *.dot > /dev/null%}
+// RUN: %{execute-at-run-stage} not cat *.dot > /dev/null
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortK.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortK.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 2914 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
-// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.30872"
+// RUN: %{run-aux} python3 %S/instruction_count.py %t.dir 2914 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
+// RUN: %{run-aux} echo "Baseline from driver version 1.3.30872"
 
 #include "../BitonicSortK.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortK.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortK.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %if run-mode %{python3 %S/instruction_count.py %t.dir 2914 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm%}
-// RUN: %if run-mode %{echo "Baseline from driver version 1.3.30872"%}
+// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 2914 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
+// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.30872"
 
 #include "../BitonicSortK.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortKv2.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortKv2.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %if run-mode %{python3 %S/instruction_count.py %t.dir 2969 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm%}
-// RUN: %if run-mode %{echo "Baseline from driver version 1.3.30872"%}
+// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 2969 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
+// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.30872"
 
 #include "../BitonicSortKv2.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortKv2.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortKv2.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 2969 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
-// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.30872"
+// RUN: %{run-aux} python3 %S/instruction_count.py %t.dir 2969 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
+// RUN: %{run-aux} echo "Baseline from driver version 1.3.30872"
 
 #include "../BitonicSortKv2.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/Stencil.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/Stencil.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 1699 ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E14Stencil_kernel.asm
-// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.29138"
+// RUN: %{run-aux} python3 %S/instruction_count.py %t.dir 1699 ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E14Stencil_kernel.asm
+// RUN: %{run-aux} echo "Baseline from driver version 1.3.29138"
 
 #include "../Stencil.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/Stencil.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/Stencil.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %if run-mode %{python3 %S/instruction_count.py %t.dir 1699 ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E14Stencil_kernel.asm%}
-// RUN: %if run-mode %{echo "Baseline from driver version 1.3.29138"%}
+// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 1699 ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E14Stencil_kernel.asm
+// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.29138"
 
 #include "../Stencil.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/invoke_simd_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/invoke_simd_smoke.cpp
@@ -12,7 +12,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.dir/exec.out
 // RUN: env  IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 149 _simd16_entry_0001.asm
-// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.29735"
+// RUN: %{run-aux} python3 %S/instruction_count.py %t.dir 149 _simd16_entry_0001.asm
+// RUN: %{run-aux} echo "Baseline from driver version 1.3.29735"
 
 #include "../../InvokeSimd/invoke_simd_smoke.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/invoke_simd_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/invoke_simd_smoke.cpp
@@ -12,7 +12,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.dir/exec.out
 // RUN: env  IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %if run-mode %{python3 %S/instruction_count.py %t.dir 149 _simd16_entry_0001.asm%}
-// RUN: %if run-mode %{echo "Baseline from driver version 1.3.29735"%}
+// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 149 _simd16_entry_0001.asm
+// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.29735"
 
 #include "../../InvokeSimd/invoke_simd_smoke.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/matrix_transpose.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/matrix_transpose.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %if run-mode %{python3 %S/instruction_count.py %t.dir %if igc-dev %{ 1059 %} %else %{ 1116 %} ZTSZZ7runTestjjjRdS_ENKUlRN4sycl3_V17handlerEE_clES3_E3K16.asm%}
-// RUN: %if run-mode %{echo "Baseline from driver version 1.3.30872"%}
+// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir %if igc-dev %{ 1059 %} %else %{ 1116 %} ZTSZZ7runTestjjjRdS_ENKUlRN4sycl3_V17handlerEE_clES3_E3K16.asm
+// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.30872"
 
 #include "../matrix_transpose.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/matrix_transpose.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/matrix_transpose.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir %if igc-dev %{ 1059 %} %else %{ 1116 %} ZTSZZ7runTestjjjRdS_ENKUlRN4sycl3_V17handlerEE_clES3_E3K16.asm
-// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.30872"
+// RUN: %{run-aux} python3 %S/instruction_count.py %t.dir %if igc-dev %{ 1059 %} %else %{ 1116 %} ZTSZZ7runTestjjjRdS_ENKUlRN4sycl3_V17handlerEE_clES3_E3K16.asm
+// RUN: %{run-aux} echo "Baseline from driver version 1.3.30872"
 
 #include "../matrix_transpose.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/stencil2.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/stencil2.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 1699 ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E14Stencil_kernel.asm
-// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.29138"
+// RUN: %{run-aux} python3 %S/instruction_count.py %t.dir 1699 ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E14Stencil_kernel.asm
+// RUN: %{run-aux} echo "Baseline from driver version 1.3.29138"
 
 #include "../stencil2.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/stencil2.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/stencil2.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: %if run-mode %{python3 %S/instruction_count.py %t.dir 1699 ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E14Stencil_kernel.asm%}
-// RUN: %if run-mode %{echo "Baseline from driver version 1.3.29138"%}
+// RUN: %{execute-at-run-stage} python3 %S/instruction_count.py %t.dir 1699 ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E14Stencil_kernel.asm
+// RUN: %{execute-at-run-stage} echo "Baseline from driver version 1.3.29138"
 
 #include "../stencil2.cpp"

--- a/sycl/test-e2e/ESIMD/preemption.cpp
+++ b/sycl/test-e2e/ESIMD/preemption.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: gpu-intel-dg2 || arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: env IGC_DumpToCustomDir=%t.dump IGC_ShaderDumpEnable=1 %{run} %t.out
-// RUN: %if run-mode %{grep enablePreemption %t.dump/*.asm%}
+// RUN: %{execute-at-run-stage} grep enablePreemption %t.dump/*.asm
 
 // The test expects to see "enablePreemption" switch in the compilation
 // switches. It fails if does not find it.

--- a/sycl/test-e2e/ESIMD/preemption.cpp
+++ b/sycl/test-e2e/ESIMD/preemption.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: gpu-intel-dg2 || arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: env IGC_DumpToCustomDir=%t.dump IGC_ShaderDumpEnable=1 %{run} %t.out
-// RUN: %{execute-at-run-stage} grep enablePreemption %t.dump/*.asm
+// RUN: %{run-aux} grep enablePreemption %t.dump/*.asm
 
 // The test expects to see "enablePreemption" switch in the compilation
 // switches. It fails if does not find it.

--- a/sycl/test-e2e/KernelAndProgram/trace_kernel_program_cache.cpp
+++ b/sycl/test-e2e/KernelAndProgram/trace_kernel_program_cache.cpp
@@ -6,12 +6,12 @@
 // or SYCL_CACHE_TRACE is set to 0.
 
 // RUN: env SYCL_CACHE_IN_MEM=0 %{run} %t.out 2> %t.trace1
-// RUN: %{execute-at-run-stage} FileCheck --allow-empty --input-file=%t.trace1 --implicit-check-not "In-Memory Cache" %s
+// RUN: %{run-aux} FileCheck --allow-empty --input-file=%t.trace1 --implicit-check-not "In-Memory Cache" %s
 // RUN: env SYCL_CACHE_TRACE=0 %{run} %t.out 2> %t.trace2
-// RUN: %{execute-at-run-stage}  FileCheck --allow-empty --input-file=%t.trace2 --implicit-check-not "In-Memory Cache" %s
+// RUN: %{run-aux}  FileCheck --allow-empty --input-file=%t.trace2 --implicit-check-not "In-Memory Cache" %s
 
 // RUN: env SYCL_CACHE_TRACE=2 %{run} %t.out 2> %t.trace3
-// RUN: %{execute-at-run-stage} FileCheck %s --input-file=%t.trace3 --check-prefix=CHECK-CACHE-TRACE
+// RUN: %{run-aux} FileCheck %s --input-file=%t.trace3 --check-prefix=CHECK-CACHE-TRACE
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/KernelAndProgram/trace_kernel_program_cache.cpp
+++ b/sycl/test-e2e/KernelAndProgram/trace_kernel_program_cache.cpp
@@ -6,12 +6,12 @@
 // or SYCL_CACHE_TRACE is set to 0.
 
 // RUN: env SYCL_CACHE_IN_MEM=0 %{run} %t.out 2> %t.trace1
-// RUN: %if run-mode %{ FileCheck --allow-empty --input-file=%t.trace1 --implicit-check-not "In-Memory Cache" %s %}
+// RUN: %{execute-at-run-stage} FileCheck --allow-empty --input-file=%t.trace1 --implicit-check-not "In-Memory Cache" %s
 // RUN: env SYCL_CACHE_TRACE=0 %{run} %t.out 2> %t.trace2
-// RUN: %if run-mode %{ FileCheck --allow-empty --input-file=%t.trace2 --implicit-check-not "In-Memory Cache" %s %}
+// RUN: %{execute-at-run-stage}  FileCheck --allow-empty --input-file=%t.trace2 --implicit-check-not "In-Memory Cache" %s
 
 // RUN: env SYCL_CACHE_TRACE=2 %{run} %t.out 2> %t.trace3
-// RUN: %if run-mode %{ FileCheck %s --input-file=%t.trace3 --check-prefix=CHECK-CACHE-TRACE %}
+// RUN: %{execute-at-run-stage} FileCheck %s --input-file=%t.trace3 --check-prefix=CHECK-CACHE-TRACE
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_cache_eviction.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_cache_eviction.cpp
@@ -18,7 +18,7 @@
 
 // -- Test again, with caching.
 // DEFINE: %{cache_vars} = env SYCL_CACHE_PERSISTENT=1 SYCL_CACHE_TRACE=7 SYCL_CACHE_DIR=%t/cache_dir SYCL_CACHE_MAX_SIZE=30000
-// RUN: %if run-mode %{rm -rf %t/cache_dir%}
+// RUN: %{execute-at-run-stage} rm -rf %t/cache_dir
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefix=CHECK
 
 // CHECK: [Persistent Cache]: enabled

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_cache_eviction.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_cache_eviction.cpp
@@ -18,7 +18,7 @@
 
 // -- Test again, with caching.
 // DEFINE: %{cache_vars} = env SYCL_CACHE_PERSISTENT=1 SYCL_CACHE_TRACE=7 SYCL_CACHE_DIR=%t/cache_dir SYCL_CACHE_MAX_SIZE=30000
-// RUN: %{execute-at-run-stage} rm -rf %t/cache_dir
+// RUN: %{run-aux} rm -rf %t/cache_dir
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefix=CHECK
 
 // CHECK: [Persistent Cache]: enabled

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -306,7 +306,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
             # Filter commands based on testing mode
             is_run_line = any(
                 i in directive.command
-                for i in ["%{run}", "%{run-unfiltered-devices}", "%if run-mode"]
+                for i in ["%{run}", "%{run-unfiltered-devices}", "%{execute-at-run-stage}"]
             )
 
             ignore_line_filtering = (

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -306,7 +306,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
             # Filter commands based on testing mode
             is_run_line = any(
                 i in directive.command
-                for i in ["%{run}", "%{run-unfiltered-devices}", "%{execute-at-run-stage}"]
+                for i in ["%{run}", "%{run-unfiltered-devices}", "%{run-aux}"]
             )
 
             ignore_line_filtering = (

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -79,7 +79,7 @@ else:
     lit_config.error("Invalid argument for test-mode")
 
 # Dummy substitution to indicate line should be a run line
-config.substitutions.append(("%{execute-at-run-stage}", ""))
+config.substitutions.append(("%{run-aux}", ""))
 
 # Cleanup environment variables which may affect tests
 possibly_dangerous_env_vars = [

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -78,6 +78,9 @@ elif config.test_mode == "build-only":
 else:
     lit_config.error("Invalid argument for test-mode")
 
+# Dummy substitution to indicate line should be a run line
+config.substitutions.append(("%{execute-at-run-stage}", ""))
+
 # Cleanup environment variables which may affect tests
 possibly_dangerous_env_vars = [
     "COMPILER_PATH",


### PR DESCRIPTION
Previously to explicitly mark that a `RUN:` line should run on the run-stage the `%if run-mode %{...%}` markup was used. However, this markup is misleading given that the entire line is skipped in `build-only` mode, not just the bit enclosed in the braces. This PR replaces this markup with `%{run-aux}`, to avoid this issue.