### PR TITLE
[SYCL][E2E] Don't override CUDA CMake vars if set

### DIFF
--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -69,11 +69,13 @@ endif()
 
 set(SYCL_E2E_CLANG_CXX_FLAGS "${SYCL_E2E_CLANG_CXX_FLAGS} -Werror")
 
-find_package(CUDAToolkit)
+if(NOT DEFINED CUDA_LIBS_DIR AND NOT DEFINED CUDA_INCLUDE)
+  find_package(CUDAToolkit)
 
-if(CUDAToolkit_FOUND)
-  set(CUDA_LIBS_DIR "${CUDAToolkit_LIBRARY_DIR}")
-  set(CUDA_INCLUDE "${CUDAToolkit_INCLUDE_DIRS}")
+  if(CUDAToolkit_FOUND)
+    set(CUDA_LIBS_DIR "${CUDAToolkit_LIBRARY_DIR}")
+    set(CUDA_INCLUDE "${CUDAToolkit_INCLUDE_DIRS}")
+  endif()
 endif()
 
 if(SYCL_TEST_E2E_STANDALONE)


### PR DESCRIPTION
Follow-up from https://github.com/intel/llvm/pull/16896