### PR TITLE
[SYCL] Add XFAIL for fpga to OCL_interop_test.cpp

### DIFF
--- a/sycl/test-e2e/DeviceImageBackendContent/OCL_interop_test.cpp
+++ b/sycl/test-e2e/DeviceImageBackendContent/OCL_interop_test.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: opencl, opencl_icd, aspect-usm_shared_allocations
 // RUN: %{build} %opencl_lib -fno-sycl-dead-args-optimization -o %t.out
 // RUN: %{run} %t.out
+// XFAIL: fpga
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16914
 //
 #include <sycl/backend.hpp>
 #include <sycl/detail/cl.h>
@@ -53,13 +55,11 @@ int main() {
   const sycl::device_image<sycl::bundle_state::executable> &img =
       *(exe_bndl.begin());
   bytes = img.ext_oneapi_get_backend_content();
-  std::cout << bytes.size() << std::endl;
   auto clContext = sycl::get_native<sycl::backend::opencl>(ctxt);
   auto clDevice = sycl::get_native<sycl::backend::opencl>(d);
-
   cl_int status;
   auto clProgram = clCreateProgramWithIL(
-      clContext, reinterpret_cast<unsigned char *>(bytes.data()), bytes.size(),
+      clContext, reinterpret_cast<const void *>(bytes.data()), bytes.size(),
       &status);
   assert(status == CL_SUCCESS);
   status = clBuildProgram(clProgram, 1, &clDevice, "", nullptr, nullptr);

--- a/sycl/test-e2e/DeviceImageBackendContent/OCL_interop_test.cpp
+++ b/sycl/test-e2e/DeviceImageBackendContent/OCL_interop_test.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl, opencl_icd, aspect-usm_shared_allocations
 // RUN: %{build} %opencl_lib -fno-sycl-dead-args-optimization -o %t.out
 // RUN: %{run} %t.out
-// XFAIL: fpga
+// XFAIL: accelerator
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/16914
 //
 #include <sycl/backend.hpp>


### PR DESCRIPTION
Add `XFAIL: accelerator` to `OCL_interop_test.cpp` because of [this](https://github.com/intel/llvm/actions/runs/13187415776/job/36814982904) and remove a rogue print statement meant for debugging purposes during development which is most likely unrelated to the failure.
An issue for the failure has also been created https://github.com/intel/llvm/issues/16914