### PR TITLE
[SYCL] Update vtable emission logic for device code

### DIFF
--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -668,6 +668,8 @@ public:
   bool isFreeFunction(const FunctionDecl *FD);
   
   StmtResult BuildSYCLKernelCallStmt(FunctionDecl *FD, CompoundStmt *Body);
+
+  static bool hasSYCLAddIRAttributesFunctionAttr(const Decl *D, StringRef Attr);
 };
 
 } // namespace clang

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3283,6 +3283,18 @@ void CodeGenModule::SetFunctionAttributes(GlobalDecl GD, llvm::Function *F,
   if (const auto *A = FD->getAttr<SYCLUsesAspectsAttr>())
     applySYCLAspectsMD(A, getContext(), getLLVMContext(), F,
                        "sycl_used_aspects");
+
+  if (getLangOpts().SYCLIsDevice &&
+      FD->hasAttr<SYCLAddIRAttributesFunctionAttr>()) {
+    const auto *A = FD->getAttr<SYCLAddIRAttributesFunctionAttr>();
+    SmallVector<std::pair<std::string, std::string>, 4> NameValuePairs =
+        A->getFilteredAttributeNameValuePairs(getContext());
+
+    llvm::AttrBuilder FnAttrBuilder(F->getContext());
+    for (const auto &NameValuePair : NameValuePairs)
+      FnAttrBuilder.addAttribute(NameValuePair.first, NameValuePair.second);
+    F->addFnAttrs(FnAttrBuilder);
+  }
 }
 
 void CodeGenModule::addUsedGlobal(llvm::GlobalValue *GV) {

--- a/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -318,10 +318,6 @@ namespace {
       if (Diags.hasUnrecoverableErrorOccurred())
         return;
 
-      // No VTable usage is legal in SYCL, so don't bother marking them used.
-      if (Ctx->getLangOpts().SYCLIsDevice)
-        return;
-
       Builder->EmitVTable(RD);
     }
   };

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -7506,3 +7506,18 @@ StmtResult SemaSYCL::BuildSYCLKernelCallStmt(FunctionDecl *FD,
 
   return NewBody;
 }
+
+bool SemaSYCL::hasSYCLAddIRAttributesFunctionAttr(const Decl *D,
+                                                  StringRef Attr) {
+  if (const auto *A = D->getAttr<SYCLAddIRAttributesFunctionAttr>()) {
+    if (hasDependentExpr(A->args_begin(), A->args_size()))
+      return false;
+    auto NameValuePairs = A->getAttributeNameValuePairs(D->getASTContext());
+    for (const auto &Pair : NameValuePairs) {
+      if (Pair.first == Attr) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-call.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-call.cpp
@@ -1,11 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
-// VTables are global variables with possibly external linkage and that causes
-// them to be copied into every module we produce during device code split
-// which in turn leads to multiple definitions error at runtime.
-// XFAIL: run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15069
-//
 // This test covers a scenario where virtual functions defintion and their uses
 // are split into different translation units. In particular:
 // - both virtual functions and construct kernel are in the same translation
@@ -13,6 +7,9 @@
 // - but use kernel is outlined into a separate translation unit
 //
 // RUN: %{build} %S/Inputs/call.cpp -o %t.out %helper-includes
+// RUN: %{run} %t.out
+
+// RUN: %{build} %S/Inputs/call.cpp -o %t.out %helper-includes %O0
 // RUN: %{run} %t.out
 
 #include "Inputs/declarations.hpp"

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs-and-call.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs-and-call.cpp
@@ -1,17 +1,12 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
-// We attach calls-indirectly attribute (and therefore device image property)
-// to construct kernels at compile step. At that stage we may not see virtual
-// function definitions and therefore we won't mark construct kernel as using
-// virtual functions and link operation at runtime will fail due to undefined
-// references to virtual functions from vtable.
-// XFAIL: run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15071
-//
 // This test covers a scenario where virtual functions defintion and their uses
 // are all split into different translation units.
 //
 // RUN: %{build} %S/Inputs/call.cpp %S/Inputs/vf.cpp -o %t.out %helper-includes
+// RUN: %{run} %t.out
+
+// RUN: %{build} %S/Inputs/call.cpp %S/Inputs/vf.cpp -o %t.out %helper-includes %O0
 // RUN: %{run} %t.out
 
 #include "Inputs/declarations.hpp"

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs.cpp
@@ -1,19 +1,14 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
-// We attach calls-indirectly attribute (and therefore device image property)
-// to construct kernels at compile step. At that stage we may not see virtual
-// function definitions and therefore we won't mark construct kernel as using
-// virtual functions and link operation at runtime will fail due to undefined
-// references to virtual functions from vtable.
-// XFAIL: run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15071
-//
 // This test covers a scenario where virtual functions defintion and their uses
 // are split into different translation units. In particular:
 // - use and construct kernesl are in the same translation unit
 // - but virtual functions are defined in a separate translation unit
 //
 // RUN: %{build} %S/Inputs/vf.cpp -o %t.out %helper-includes
+// RUN: %{run} %t.out
+
+// RUN: %{build} %S/Inputs/vf.cpp -o %t.out %helper-includes %O0
 // RUN: %{run} %t.out
 
 #include "Inputs/declarations.hpp"


### PR DESCRIPTION
There PR aims to fix these two issues:

1. #15071: `separate-vf-defs.cpp` / `separate-vf-defs-and-calls` - The construction kernels were not being recognized by `SYCLVirtualFunctionsAnalysisPass` (i.e. attaching calls-indirectly to them). They were not being attached because the definitions for the vtables were not being emitted in those compilation units, and `SYCLVirtualFunctionsAnalysisPass` can only correctly identifies construction kernels by analyzing the vtable definition referenced during object construction.
2. #15069: `separate-call.cpp` - when sycl-post-link was splitting, the vtables were duplicated in the device images. This caused multiple definition errors between the duplicated vtables.

1 is fixed by using `MarkVTableUsed` on classes that have SYCL `indirectly-callable` attribute on one of their members, allowing the vtable definition to be generated. (Note: I would have liked to do this `MarkVTableUsed` call is in `SemaSYCL::addSYCLAddIRAttributesFunctionAttr` instead of `Sema::CheckCompletedCXXClass` but I was having an issue that `MarkVTableUsed` did not update `VTablesUsed` correctly because at that point the class wasn't recognized as virtual). With this, the vtable definition will be generated, but there is another problem - the functions referenced in the vtables did not have the relevant `indirectly-callable` attributes. These are usually attached by code gen if the function has a definition, but the definitions of the virtual functions do not necessarily need to be in the same compilation unit as the construction kernels. To fix this, a separate attribute attachment is added when code gen needs the pointer of some function. (The `sycl_used_aspects` metadata is attached at the same time.)

Since the fix for 1 emit vtables in every device module, we need to change the linkage type of the vtables during device compilation to `linkonce_odr`, otherwise there could be multiple definition issues in the device link set. This change also happens to fix the issue of 2.