### PR TITLE
[SYCLl][Graph] Make UR command-buffer desc mandatory

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -122,7 +122,7 @@ elseif(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/Bensuo/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -4,4 +4,4 @@
 # Date:   Wed Feb 12 10:20:12 2025 +0000
 #     Merge pull request #2672 from lukaszstolarczuk/umf-with-icx-build-0.11.0-dev2
 #     common: Bump UMF version to v0.11.0-dev2
-set(UNIFIED_RUNTIME_TAG 064d3560cbcc24a40380b57adb3690b2bc256d6e)
+set(UNIFIED_RUNTIME_TAG "ewan/command-buffer_desc")


### PR DESCRIPTION
Bumps to UR tag to pull in UR change from https://github.com/oneapi-src/unified-runtime/pull/2676 No DPC++ changes are required as `graph_impl.cpp` already unconditionally passes a descriptor on UR command-buffer creation.