### PR TITLE
[SYCL][Graph] Bump UR to use OpenCL in-order command-buffers

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -122,7 +122,7 @@ elseif(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/Bensuo/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -4,4 +4,4 @@
 # Date:   Thu Feb 6 11:30:48 2025 +0000
 #     Merge pull request #2655 from hvdijk/nativecpu-null-phevent
 #     [NativeCPU] Handle null phEvent.
-set(UNIFIED_RUNTIME_TAG 9d6542bac16db69d907002cb0f8c724c7a50d2dc)
+set(UNIFIED_RUNTIME_TAG "cmd-buf_ocl_097")


### PR DESCRIPTION
Bumps UR commit to pull in https://github.com/oneapi-src/unified-runtime/pull/2681