### PR TITLE
[SYCL][E2E] Limit XFAIL only to CPU and Linux in VirtualFunctions/group-barrier test

### DIFF
--- a/sycl/test-e2e/VirtualFunctions/misc/group-barrier.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/group-barrier.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
 // On CPU it segfaults within the kernel that performs virtual function call.
-// XFAIL: cpu && linux
+// XFAIL: cpu && opencl && linux
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15080
 // UNSUPPORTED: gpu
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15068

--- a/sycl/test-e2e/VirtualFunctions/misc/group-barrier.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/group-barrier.cpp
@@ -1,5 +1,8 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
+// On CPU it segfaults within the kernel that performs virtual function call.
+// XFAIL: cpu && linux
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15080
 // UNSUPPORTED: gpu
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15068
 // On GPU this test (its older version which used nd_item instead of group)

--- a/sycl/test-e2e/VirtualFunctions/misc/group-barrier.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/group-barrier.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
-// On CPU it segfaults within the kernel that performs virtual function call.
-// XFAIL: cpu
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15080
 // UNSUPPORTED: gpu
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15068
 // On GPU this test (its older version which used nd_item instead of group)


### PR DESCRIPTION
Purpose of this PR is re-enabling `VirtualFunctions/group-barrier` e2e test for CPU and Windows OS.