### PR TITLE
[SYCL] Enable SPV_INTEL_fp_max_error by default

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10927,23 +10927,8 @@ static void getTripleBasedSPIRVTransOpts(Compilation &C,
               ",+SPV_INTEL_optnone"
               ",+SPV_KHR_non_semantic_info"
               ",+SPV_KHR_cooperative_matrix"
-              ",+SPV_EXT_shader_atomic_float16_add";
-  auto hasNoOffloadFP32PrecOption = [](const llvm::opt::ArgList &TCArgs) {
-    return !TCArgs.hasFlag(options::OPT_foffload_fp32_prec_sqrt,
-                           options::OPT_fno_offload_fp32_prec_sqrt, false) &&
-           !TCArgs.hasFlag(options::OPT_foffload_fp32_prec_div,
-                           options::OPT_fno_offload_fp32_prec_div, false);
-  };
-  auto shouldUseOffloadFP32PrecOption = [](const llvm::opt::ArgList &TCArgs) {
-    return (TCArgs.hasFlag(options::OPT_fno_offload_fp32_prec_sqrt,
-                           options::OPT_foffload_fp32_prec_sqrt, false) ||
-            TCArgs.hasFlag(options::OPT_fno_offload_fp32_prec_div,
-                           options::OPT_foffload_fp32_prec_div, false));
-  };
-  if ((IsCPU && hasNoOffloadFP32PrecOption(TCArgs)) ||
-      shouldUseOffloadFP32PrecOption(TCArgs)) {
-    ExtArg += ",+SPV_INTEL_fp_max_error";
-  }
+              ",+SPV_EXT_shader_atomic_float16_add"
+              ",+SPV_INTEL_fp_max_error";
 
   TranslatorArgs.push_back(TCArgs.MakeArgString(ExtArg));
 }

--- a/clang/test/Driver/sycl-spirv-ext-old-model.c
+++ b/clang/test/Driver/sycl-spirv-ext-old-model.c
@@ -24,63 +24,6 @@
 // RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown %s -### 2>&1 \
 // RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -fno-offload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -fno-offload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -fno-offload-fp32-prec-sqrt -fno-offload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -fno-offload-fp32-prec-div -fno-offload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -foffload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU,CHECK-CPU-NFPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -foffload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU,CHECK-CPU-NFPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -foffload-fp32-prec-div -foffload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU,CHECK-CPU-NFPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -foffload-fp32-prec-sqrt -foffload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU,CHECK-CPU-NFPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -fno-offload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -fno-offload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -fno-offload-fp32-prec-div -fno-offload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown -fno-offload-fp32-prec-sqrt -fno-offload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -fno-offload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT,CHECK-DEFAULT-FPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -fno-offload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT,CHECK-DEFAULT-FPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -fno-offload-fp32-prec-div -fno-offload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT,CHECK-DEFAULT-FPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -fno-offload-fp32-prec-sqrt -fno-offload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT,CHECK-DEFAULT-FPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -foffload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -foffload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -foffload-fp32-prec-div -foffload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -foffload-fp32-prec-sqrt -foffload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xshardware -fno-offload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW,CHECK-FPGA-HW-FPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xshardware -fno-offload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW,CHECK-FPGA-HW-FPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xshardware -fno-offload-fp32-prec-div -fno-offload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW,CHECK-FPGA-HW-FPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xshardware -fno-offload-fp32-prec-sqrt -fno-offload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW,CHECK-FPGA-HW-FPME
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xshardware -foffload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xshardware -foffload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xshardware -foffload-fp32-prec-div -foffload-fp32-prec-sqrt %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xshardware -foffload-fp32-prec-sqrt -foffload-fp32-prec-div %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW
-
 
 // CHECK-DEFAULT: llvm-spirv{{.*}}"-spirv-ext=-all
 // CHECK-DEFAULT-SAME:,+SPV_EXT_shader_atomic_float_add
@@ -119,7 +62,7 @@
 // CHECK-DEFAULT-SAME:,+SPV_KHR_non_semantic_info
 // CHECK-DEFAULT-SAME:,+SPV_KHR_cooperative_matrix
 // CHECK-DEFAULT-SAME:,+SPV_EXT_shader_atomic_float16_add
-// CHECK-DEFAULT-FPME:,+SPV_INTEL_fp_max_error"
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_fp_max_error
 // CHECK-FPGA-HW: llvm-spirv{{.*}}"-spirv-ext=-all
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_add
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_min_max
@@ -148,8 +91,7 @@
 // CHECK-FPGA-HW-SAME:,+SPV_INTEL_fpga_cluster_attributes,+SPV_INTEL_loop_fuse
 // CHECK-FPGA-HW-SAME:,+SPV_INTEL_fpga_dsp_control
 // CHECK-FPGA-HW-SAME:,+SPV_INTEL_fpga_memory_accesses
-// CHECK-FPGA-HW-SAME:,+SPV_INTEL_fpga_memory_attributes
-// CHECK-FPGA-HW-FPME:,+SPV_INTEL_fp_max_error"
+// CHECK-FPGA-HW-SAME:,+SPV_INTEL_fpga_memory_attributes"
 // CHECK-CPU: llvm-spirv{{.*}}"-spirv-allow-unknown-intrinsics=llvm.genx.,llvm.fpbuiltin"
 // CHECK-CPU-SAME: {{.*}}"-spirv-ext=-all
 // CHECK-CPU-SAME:,+SPV_EXT_shader_atomic_float_add
@@ -185,4 +127,4 @@
 // CHECK-CPU-SAME:,+SPV_INTEL_optnone
 // CHECK-CPU-SAME:,+SPV_KHR_non_semantic_info
 // CHECK-CPU-SAME:,+SPV_KHR_cooperative_matrix
-// CHECK-CPU-NFPME-NOT:,+SPV_INTEL_fp_max_error"
+// CHECK-CPU-SAME:,+SPV_INTEL_fp_max_error

--- a/clang/test/Driver/sycl-spirv-ext.c
+++ b/clang/test/Driver/sycl-spirv-ext.c
@@ -63,6 +63,7 @@
 // CHECK-DEFAULT-SAME:,+SPV_KHR_non_semantic_info
 // CHECK-DEFAULT-SAME:,+SPV_KHR_cooperative_matrix
 // CHECK-DEFAULT-SAME:,+SPV_EXT_shader_atomic_float16_add
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_fp_max_error
 
 // CHECK-CPU: llvm-spirv{{.*}}-spirv-ext=-all
 // CHECK-CPU-SAME:,+SPV_EXT_shader_atomic_float_add

--- a/clang/test/Driver/sycl-spirv-metadata-old-model.cpp
+++ b/clang/test/Driver/sycl-spirv-metadata-old-model.cpp
@@ -9,7 +9,7 @@
 // RUN:  FileCheck -check-prefix CHECK-WITHOUT %s
 
 // CHECK-WITH: llvm-spirv{{.*}} "--spirv-preserve-auxdata"
-// CHECK-WITH-SAME: "-spirv-ext=-all,{{.*}},+SPV_EXT_shader_atomic_float16_add"
+// CHECK-WITH-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_fp_max_error"
 
 // CHECK-WITHOUT: "{{.*}}llvm-spirv"
 // CHECK-WITHOUT-NOT: --spirv-preserve-auxdata

--- a/clang/test/Driver/sycl-spirv-obj-old-model.cpp
+++ b/clang/test/Driver/sycl-spirv-obj-old-model.cpp
@@ -11,7 +11,7 @@
 // SPIRV_DEVICE_OBJ-SAME: "-o" "[[DEVICE_BC:.+\.bc]]"
 // SPIRV_DEVICE_OBJ: llvm-spirv{{.*}} "-o" "[[DEVICE_SPV:.+\.spv]]"
 // SPIRV_DEVICE_OBJ-SAME: "--spirv-preserve-auxdata"
-// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_EXT_shader_atomic_float16_add"
+// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_fp_max_error"
 // SPIRV_DEVICE_OBJ-SAME: "[[DEVICE_BC]]"
 // SPIRV_DEVICE_OBJ: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu"
 // SPIRV_DEVICE_OBJ-SAME: "-fsycl-is-host"

--- a/clang/test/Driver/sycl-spirv-obj.cpp
+++ b/clang/test/Driver/sycl-spirv-obj.cpp
@@ -11,7 +11,7 @@
 // SPIRV_DEVICE_OBJ-SAME: "-o" "[[DEVICE_BC:.+\.bc]]"
 // SPIRV_DEVICE_OBJ: llvm-spirv{{.*}} "-o" "[[DEVICE_SPV:.+\.spv]]"
 // SPIRV_DEVICE_OBJ-SAME: "--spirv-preserve-auxdata"
-// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_EXT_shader_atomic_float16_add"
+// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_fp_max_error"
 // SPIRV_DEVICE_OBJ-SAME: "[[DEVICE_BC]]"
 // SPIRV_DEVICE_OBJ: clang-offload-packager{{.*}} "--image=file=[[DEVICE_SPV]]{{.*}}"
 // SPIRV_DEVICE_OBJ: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu"

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -874,9 +874,8 @@ getTripleBasedSPIRVTransOpts(const ArgList &Args,
             ",+SPV_INTEL_optnone"
             ",+SPV_KHR_non_semantic_info"
             ",+SPV_KHR_cooperative_matrix"
-            ",+SPV_EXT_shader_atomic_float16_add";
-  if (IsCPU)
-    ExtArg += ",+SPV_INTEL_fp_max_error";
+            ",+SPV_EXT_shader_atomic_float16_add"
+            ",+SPV_INTEL_fp_max_error";
   TranslatorArgs.push_back(Args.MakeArgString(ExtArg));
 }
 

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -366,7 +366,8 @@ static void getSPIRVTransOpts(const ArgList &Args,
             ",+SPV_INTEL_tensor_float32_conversion"
             ",+SPV_INTEL_optnone"
             ",+SPV_KHR_non_semantic_info"
-            ",+SPV_KHR_cooperative_matrix";
+            ",+SPV_KHR_cooperative_matrix"
+            ",+SPV_INTEL_fp_max_error";
   TranslatorArgs.push_back(Args.MakeArgString(ExtArg));
 }
 


### PR DESCRIPTION
Since a pass that cleans up unnecessary llvm.fpbuiltin intrinsics was removed from
https://github.com/intel/llvm/pull/16107 we need to enable the extension by default to
successfully translate them.