### PR TITLE
[CI] Use pigz in coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,6 +8,7 @@ permissions: read-all
 
 jobs:
   coverity:
+    if: github.repository == 'intel/llvm'
     name: Coverity
     runs-on: [Linux, build]
     container:
@@ -52,7 +53,7 @@ jobs:
       run: $GITHUB_WORKSPACE/cov-analysis-linux64-*/bin/cov-build --dir cov-int cmake --build $GITHUB_WORKSPACE/build
 
     - name: Compress results
-      run: tar -czf intel_llvm.tgz cov-int
+      run: tar -I pigz -cf intel_llvm.tgz cov-int
 
     - name: Submit build
       run: |

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
     name: Coverity
     runs-on: [Linux, build]
     container:
-      image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps
+      image: ghcr.io/intel/llvm/ubuntu2404_build:latest
       options: -u 1001:1001
 
     steps:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
     name: Coverity
     runs-on: [Linux, build]
     container:
-      image: ghcr.io/intel/llvm/ubuntu2404_build:latest
+      image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps
       options: -u 1001:1001
 
     steps:


### PR DESCRIPTION
It takes ~10mins for gzip to compress the cov-int dir. Use pigz (parallel implementation of gzip) to speed it up.
formats supported by coverity: gzip, zip, lzma, xz or bz2
https://github.com/intel/llvm/pull/16945