### PR TITLE
[CI] Install pigz in docker container

### DIFF
--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -10,7 +10,6 @@ apt update && apt install -yqq \
       python3-psutil \
       python-is-python3 \
       python3-pip \
-      zstd \
       ocl-icd-opencl-dev \
       vim \
       libffi-dev \
@@ -21,6 +20,7 @@ apt update && apt install -yqq \
       zstd \
       zip \
       unzip \
+      pigz \
       jq \
       curl \
       libhwloc-dev \


### PR DESCRIPTION
pigz is a parallel implementation of gzip. coverity accepts a small range of archive formats: gzip, zip, lzma, xz or bz2. So using pigz to speed up the compression of build for coverity.

Also remove the duplicate of zstd.