### PR TITLE
[SYCL][SYCLLowerWGLocalMemoryPass] replace undef with poison

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerWGLocalMemory.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerWGLocalMemory.cpp
@@ -109,15 +109,15 @@ static void lowerAllocaLocalMemCall(CallInst *CI, Module &M) {
   unsigned LocalAS =
       CI->getFunctionType()->getReturnType()->getPointerAddressSpace();
   auto *LocalMemArrayGV =
-      new GlobalVariable(M,                                // module
-                         LocalMemArrayTy,                  // type
-                         false,                            // isConstant
-                         GlobalValue::InternalLinkage,     // Linkage
-                         UndefValue::get(LocalMemArrayTy), // Initializer
-                         LOCALMEMORY_GV_PREF,              // Name prefix
-                         nullptr,                          // InsertBefore
-                         GlobalVariable::NotThreadLocal,   // ThreadLocalMode
-                         LocalAS                           // AddressSpace
+      new GlobalVariable(M,                                 // module
+                         LocalMemArrayTy,                   // type
+                         false,                             // isConstant
+                         GlobalValue::InternalLinkage,      // Linkage
+                         PoisonValue::get(LocalMemArrayTy), // Initializer
+                         LOCALMEMORY_GV_PREF,               // Name prefix
+                         nullptr,                           // InsertBefore
+                         GlobalVariable::NotThreadLocal,    // ThreadLocalMode
+                         LocalAS                            // AddressSpace
       );
   LocalMemArrayGV->setAlignment(Align(Alignment));
 
@@ -203,7 +203,7 @@ static bool dynamicWGLocalMemory(Module &M) {
         usesKernelArgForDynWGLocalMem(TT)
             ? GlobalValue::LinkOnceODRLinkage
             : GlobalValue::ExternalLinkage, // Linkage
-        usesKernelArgForDynWGLocalMem(TT) ? UndefValue::get(LocalMemArrayTy)
+        usesKernelArgForDynWGLocalMem(TT) ? PoisonValue::get(LocalMemArrayTy)
                                           : nullptr, // Initializer
         DYNAMIC_LOCALMEM_GV,                         // Name prefix
         nullptr,                                     // InsertBefore

--- a/llvm/test/SYCLLowerIR/group_local_memory.ll
+++ b/llvm/test/SYCLLowerIR/group_local_memory.ll
@@ -1,9 +1,9 @@
 ; RUN: opt -S -sycllowerwglocalmemory -bugpoint-enable-legacy-pm < %s | FileCheck %s
 ; RUN: opt -S -passes=sycllowerwglocalmemory < %s | FileCheck %s
 
-; CHECK-DAG: [[WGLOCALMEM_1:@WGLocalMem.*]] = internal addrspace(3) global [128 x i8] undef, align 4
-; CHECK-DAG: [[WGLOCALMEM_2:@WGLocalMem.*]] = internal addrspace(3) global [4 x i8] undef, align 4
-; CHECK-DAG: [[WGLOCALMEM_3:@WGLocalMem.*]] = internal addrspace(3) global [256 x i8] undef, align 8
+; CHECK-DAG: [[WGLOCALMEM_1:@WGLocalMem.*]] = internal addrspace(3) global [128 x i8] poison, align 4
+; CHECK-DAG: [[WGLOCALMEM_2:@WGLocalMem.*]] = internal addrspace(3) global [4 x i8] poison, align 4
+; CHECK-DAG: [[WGLOCALMEM_3:@WGLocalMem.*]] = internal addrspace(3) global [256 x i8] poison, align 8
 
 ; CHECK-NOT: __sycl_allocateLocalMemory
 

--- a/llvm/test/SYCLLowerIR/work_group_static.ll
+++ b/llvm/test/SYCLLowerIR/work_group_static.ll
@@ -6,7 +6,7 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-; CHECK: @__sycl_dynamicLocalMemoryPlaceholder_GV = linkonce_odr local_unnamed_addr addrspace(3) global ptr addrspace(3) undef
+; CHECK: @__sycl_dynamicLocalMemoryPlaceholder_GV = linkonce_odr local_unnamed_addr addrspace(3) global ptr addrspace(3) poison
 
 ; Function Attrs: convergent norecurse
 ; CHECK: @_ZTS7KernelA(ptr addrspace(1) %0, ptr addrspace(3) noalias "sycl-implicit-local-arg" %[[IMPLICT_ARG:[a-zA-Z0-9]+]]{{.*}} !kernel_arg_addr_space ![[ADDR_SPACE_MD:[0-9]+]]


### PR DESCRIPTION
This fixes "error: undef deprecator failed" in pre-commit test of #16356