### PR TITLE
[SYCLCOMPAT] Forward launch arguments to avoid copies

### DIFF
--- a/sycl/include/syclcompat/launch_policy.hpp
+++ b/sycl/include/syclcompat/launch_policy.hpp
@@ -194,14 +194,17 @@ launch_policy(dim3, dim3, Ts...) -> launch_policy<
 namespace detail {
 // Custom std::apply helpers to enable inlining
 template <class F, class Tuple, size_t... Is>
-__syclcompat_inline__ constexpr void apply_expand(F f, Tuple t,
+__syclcompat_inline__ constexpr void apply_expand(F &&f, Tuple &&t,
                                                   std::index_sequence<Is...>) {
-  [[clang::always_inline]] f(get<Is>(t)...);
+  [[clang::always_inline]] std::forward<F>(f)(
+      get<Is>(std::forward<Tuple>(t))...);
 }
 
 template <class F, class Tuple>
-__syclcompat_inline__ constexpr void apply_helper(F f, Tuple t) {
-  apply_expand(f, t, std::make_index_sequence<std::tuple_size<Tuple>{}>{});
+__syclcompat_inline__ constexpr void apply_helper(F &&f, Tuple &&t) {
+  apply_expand(
+      std::forward<F>(f), std::forward<Tuple>(t),
+      std::make_index_sequence<std::tuple_size_v<std::decay_t<Tuple>>>{});
 }
 
 template <auto F, typename Range, typename KProps, bool HasLocalMem,


### PR DESCRIPTION
This is important when passing a CUTensorMap argument to a descriptor, since taking the address of a copy of a CUTensorMap will cause runtime issues. e.g.
```
UR CUDA ERROR:
	Value:           700
	Name:            CUDA_ERROR_ILLEGAL_ADDRESS
	Description:     an illegal memory access was encountered
	Function:        operator()
	Source Location: /home/finlay/llvm/build/_deps/unified-runtime-src/source/adapters/cuda/queue.cpp:231
```