### PR TITLE
[SYCL][E2E][Bindless] 3d sampler unsupported for gfx1030

### DIFF
--- a/sycl/test-e2e/bindless_images/sampling_3D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_3D.cpp
@@ -1,7 +1,9 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images
 
 // UNSUPPORTED: arch-amd_gpu_gfx90a
+// UNSUPPORTED: arch-amd_gpu_gfx1030
 // UNSUPPORTED-INTENDED: AMD gfx90a devices don't support 3D linear filter mode
+// UNSUPPORTED-INTENDED: AMD gfx1030 devices don't support the 3D sampler tested here
 
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out

--- a/sycl/test-e2e/bindless_images/sampling_3D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_3D.cpp
@@ -3,7 +3,7 @@
 // UNSUPPORTED: arch-amd_gpu_gfx90a
 // UNSUPPORTED: arch-amd_gpu_gfx1030
 // UNSUPPORTED-INTENDED: AMD gfx90a devices don't support 3D linear filter mode
-// UNSUPPORTED-INTENDED: AMD gfx1030 devices don't support the 3D sampler tested here
+// UNSUPPORTED-INTENDED: AMD gfx1030 devices don't support this 3D sampler
 
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out


### PR DESCRIPTION
This fixes the gfx1030 3D sampling failure mentioned here: https://github.com/intel/llvm/issues/16933
by marking this device unsupported in the test