### PR TITLE
[CI] Change AMD CPU job in Nightly to use proper label

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -77,7 +77,7 @@ jobs:
             tests_selector: e2e
 
           - name: OCL CPU (AMD)
-            runner: '["Linux", "amdgpu"]'
+            runner: '["Linux", "amdcpu"]'
             image_options: -u 1001
             target_devices: opencl:cpu
             tests_selector: e2e


### PR DESCRIPTION
Back when this task was added we only had runners with both AMD CPU and GPUs. Recently, we excluded the only remaining such runner as it's GPU isn't officially supported (we rely on the runner provided by Codeplay). However, we can keep using this old runner for the AMD CPU testing in Nightly as it was originally designed.