### PR TITLE
[SYCL] Use clang options in E2E test to recognize -std=c++20

### DIFF
--- a/sycl/test-e2e/DeviceImageBackendContent/basic_test.cpp
+++ b/sycl/test-e2e/DeviceImageBackendContent/basic_test.cpp
@@ -1,4 +1,6 @@
-// RUN: %{build} -std=c++20 -o %t.out
+// DEFINE: %{cpp20} = %if cl_options %{/clang:-std=c++20%} %else %{-std=c++20%}
+
+// RUN: %{build} %{cpp20} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Follow in the footsteps of https://github.com/intel/llvm/pull/16707 to make sure the `-std` compiler option is handled correctly in all test environments.