### PR TITLE
[SYCL][NativeCPU] Fix kernel argument passing.

### DIFF
--- a/unified-runtime/source/adapters/native_cpu/event.cpp
+++ b/unified-runtime/source/adapters/native_cpu/event.cpp
@@ -146,7 +146,7 @@ void ur_event_handle_t_::wait() {
   // The callback may need to acquire the lock, so we unlock it here
   lock.unlock();
 
-  if (callback)
+  if (callback.valid())
     callback();
 }
 

--- a/unified-runtime/source/adapters/native_cpu/event.hpp
+++ b/unified-runtime/source/adapters/native_cpu/event.hpp
@@ -21,7 +21,9 @@ struct ur_event_handle_t_ : RefCounted {
 
   ~ur_event_handle_t_();
 
-  void set_callback(const std::function<void()> &cb) { callback = cb; }
+  template <typename T> auto set_callback(T &&cb) {
+    callback = std::packaged_task<void()>(std::forward<T>(cb));
+  }
 
   void wait();
 
@@ -60,7 +62,7 @@ private:
   bool done;
   std::mutex mutex;
   std::vector<std::future<void>> futures;
-  std::function<void()> callback;
+  std::packaged_task<void()> callback;
   uint64_t timestamp_start = 0;
   uint64_t timestamp_end = 0;
 };


### PR DESCRIPTION
We were reading the kernel arguments at kernel execution time, but kernel arguments are allowed to change between enqueuing and executing. Make sure to create a copy of kernel arguments ahead of time.

This was previously approved as a unified-runtime PR: https://github.com/oneapi-src/unified-runtime/pull/2700