### PR TITLE
[SYCL][NFC] Pass impl by reference in fill_copy_arg

### DIFF
--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -187,7 +187,7 @@ fill_image_desc(const ext::oneapi::experimental::image_descriptor &ImgDesc) {
 }
 
 static void
-fill_copy_args(std::shared_ptr<detail::handler_impl> impl,
+fill_copy_args(std::shared_ptr<detail::handler_impl> &impl,
                const ext::oneapi::experimental::image_descriptor &SrcImgDesc,
                const ext::oneapi::experimental::image_descriptor &DestImgDesc,
                ur_exp_image_copy_flags_t ImageCopyFlags, size_t SrcPitch,
@@ -254,7 +254,7 @@ fill_copy_args(std::shared_ptr<detail::handler_impl> impl,
 }
 
 static void
-fill_copy_args(std::shared_ptr<detail::handler_impl> impl,
+fill_copy_args(std::shared_ptr<detail::handler_impl> &impl,
                const ext::oneapi::experimental::image_descriptor &Desc,
                ur_exp_image_copy_flags_t ImageCopyFlags,
                sycl::range<3> SrcOffset = {0, 0, 0},
@@ -269,7 +269,7 @@ fill_copy_args(std::shared_ptr<detail::handler_impl> impl,
 }
 
 static void
-fill_copy_args(std::shared_ptr<detail::handler_impl> impl,
+fill_copy_args(std::shared_ptr<detail::handler_impl> &impl,
                const ext::oneapi::experimental::image_descriptor &Desc,
                ur_exp_image_copy_flags_t ImageCopyFlags, size_t SrcPitch,
                size_t DestPitch, sycl::range<3> SrcOffset = {0, 0, 0},
@@ -283,7 +283,7 @@ fill_copy_args(std::shared_ptr<detail::handler_impl> impl,
 }
 
 static void
-fill_copy_args(std::shared_ptr<detail::handler_impl> impl,
+fill_copy_args(std::shared_ptr<detail::handler_impl> &impl,
                const ext::oneapi::experimental::image_descriptor &SrcImgDesc,
                const ext::oneapi::experimental::image_descriptor &DestImgDesc,
                ur_exp_image_copy_flags_t ImageCopyFlags,


### PR DESCRIPTION
There is no need to pass by value in this case.
Shows up in coverity.