### PR TITLE
[Driver][SYCL] Do not emit mismatch warning with -fsycl-force-target

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6488,9 +6488,11 @@ class OffloadingActionBuilder final {
                 break;
               }
             }
-            // Use of -fsycl-force-target allows to override the target used
-            // during the unbundling step.  Do not emit the diagnostic when this
-            // target is found in the found sections.
+            // Use of -fsycl-force-target=triple forces the compiler to use the
+            // specified target triple when extracting device code from any of
+            // the given objects on the command line. If the target specified
+            // in -fsycl-force-target is found in a fat object, do not emit the
+            // target mismatch warning.
             if (const Arg *ForceTarget = C.getInputArgs().getLastArg(
                     options::OPT_fsycl_force_target_EQ)) {
               StringRef Val(ForceTarget->getValue());

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6488,6 +6488,18 @@ class OffloadingActionBuilder final {
                 break;
               }
             }
+            // Use of -fsycl-force-target allows to override the target used
+            // during the unbundling step.  Do not emit the diagnostic when this
+            // target is found in the found sections.
+            if (const Arg *ForceTarget = C.getInputArgs().getLastArg(
+                    options::OPT_fsycl_force_target_EQ)) {
+              StringRef Val(ForceTarget->getValue());
+              llvm::Triple TT(C.getDriver().getSYCLDeviceTriple(Val));
+              if (TT.normalize() == Section) {
+                SectionFound = true;
+                break;
+              }
+            }
           }
           if (SectionFound)
             continue;

--- a/clang/test/Driver/sycl-target-mismatch.cpp
+++ b/clang/test/Driver/sycl-target-mismatch.cpp
@@ -22,4 +22,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen %S/Inputs/SYCL/liblin64.a \
 // RUN:   -Wno-sycl-target -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=SPIR64_DIAG
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen %S/Inputs/SYCL/liblin64.a \
+// RUN:   -fsycl-force-target=spir64 -### %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=SPIR64_DIAG
 // SPIR64_DIAG-NOT: linked binaries do not contain expected

--- a/clang/test/Driver/sycl-target-mismatch.cpp
+++ b/clang/test/Driver/sycl-target-mismatch.cpp
@@ -25,4 +25,4 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen %S/Inputs/SYCL/liblin64.a \
 // RUN:   -fsycl-force-target=spir64 -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=SPIR64_DIAG
-// SPIR64_DIAG-NOT: linked binaries do not contain expected
+// SPIR64_DIAG-NOT: linked binaries do not contain expected {{.*}} target; found targets:


### PR DESCRIPTION
The use of -fsycl-force-target=arg allows for a user to override the default target triple that is used to unbundle device objects from the fat objects.  A diagnostic warning is emitted to inform the user that the expected target values within the given objects is not found.  This diagnostic is not valid when -fsycl-force-target is used with the matching target value.

Avoid emitting this warning when the -fsycl-force-target=arg matches what is found in the incoming objects.