### PR TITLE
[UR] Replace calls to UR in native handle functions to proper OpenCL functions

### DIFF
--- a/sycl/include/sycl/detail/os_util.hpp
+++ b/sycl/include/sycl/detail/os_util.hpp
@@ -106,6 +106,24 @@ void fileTreeWalk(const std::string Path,
                   std::function<void(const std::string)> Func,
                   bool ignoreErrors = false);
 
+void *dynLookup(const char *WinName, const char *LinName, const char *FunName);
+
+// Look up a function name that was dynamically linked
+// This is used by the runtime where it needs to manipulate native handles (e.g.
+// retaining OpenCL handles). On Windows, the symbol name is looked up in
+// `WinName`. In Linux, it uses `LinName`.
+//
+// The library must already have been loaded (perhaps by UR), otherwise this
+// function throws a SYCL runtime exception.
+template <typename fn>
+fn *dynLookupFunction(const char *WinName, const char *LinName,
+                      const char *FunName) {
+  return reinterpret_cast<fn *>(dynLookup(WinName, LinName, FunName));
+}
+#define __SYCL_OCL_CALL(FN, ...)                                               \
+  (sycl::_V1::detail::dynLookupFunction<decltype(FN)>(                         \
+      "OpenCL", "libOpenCL.so", #FN)(__VA_ARGS__))
+
 } // namespace detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -181,7 +181,7 @@ __SYCL_EXPORT event make_event(ur_native_handle_t NativeHandle,
       std::make_shared<event_impl>(UrEvent, Context));
 
   if (Backend == backend::opencl)
-    Adapter->call<UrApiKind::urEventRetain>(UrEvent);
+    __SYCL_OCL_CALL(clRetainEvent, ur::cast<cl_event>(NativeHandle));
   return Event;
 }
 
@@ -205,7 +205,7 @@ make_kernel_bundle(ur_native_handle_t NativeHandle,
         "urProgramCreateWithNativeHandle resulted in a null program handle.");
 
   if (ContextImpl->getBackend() == backend::opencl)
-    Adapter->call<UrApiKind::urProgramRetain>(UrProgram);
+    __SYCL_OCL_CALL(clRetainProgram, ur::cast<cl_program>(NativeHandle));
 
   std::vector<ur_device_handle_t> ProgramDevices;
   uint32_t NumDevices = 0;
@@ -352,7 +352,7 @@ kernel make_kernel(const context &TargetContext,
       &UrKernel);
 
   if (Backend == backend::opencl)
-    Adapter->call<UrApiKind::urKernelRetain>(UrKernel);
+    __SYCL_OCL_CALL(clRetainKernel, ur::cast<cl_kernel>(NativeHandle));
 
   // Construct the SYCL queue from UR queue.
   return detail::createSyclObjFromImpl<kernel>(

--- a/sycl/source/detail/buffer_impl.cpp
+++ b/sycl/source/detail/buffer_impl.cpp
@@ -87,7 +87,7 @@ buffer_impl::getNativeVector(backend BackendName) const {
     auto Adapter = Platform->getAdapter();
 
     if (Platform->getBackend() == backend::opencl) {
-      Adapter->call<UrApiKind::urMemRetain>(NativeMem);
+      __SYCL_OCL_CALL(clRetainMemObject, ur::cast<cl_mem>(NativeMem));
     }
 
     ur_native_handle_t Handle = 0;

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -303,10 +303,11 @@ context_impl::findMatchingDeviceImpl(ur_device_handle_t &DeviceUR) const {
 
 ur_native_handle_t context_impl::getNative() const {
   const auto &Adapter = getAdapter();
-  if (getBackend() == backend::opencl)
-    Adapter->call<UrApiKind::urContextRetain>(getHandleRef());
   ur_native_handle_t Handle;
   Adapter->call<UrApiKind::urContextGetNativeHandle>(getHandleRef(), &Handle);
+  if (getBackend() == backend::opencl) {
+    __SYCL_OCL_CALL(clRetainContext, ur::cast<cl_context>(Handle));
+  }
   return Handle;
 }
 

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -300,11 +300,11 @@ public:
     const auto &ContextImplPtr = detail::getSyclObjImpl(MContext);
     const AdapterPtr &Adapter = ContextImplPtr->getAdapter();
 
-    if (ContextImplPtr->getBackend() == backend::opencl)
-      Adapter->call<UrApiKind::urProgramRetain>(MProgram);
     ur_native_handle_t NativeProgram = 0;
     Adapter->call<UrApiKind::urProgramGetNativeHandle>(MProgram,
                                                        &NativeProgram);
+    if (ContextImplPtr->getBackend() == backend::opencl)
+      __SYCL_OCL_CALL(clRetainProgram, ur::cast<cl_program>(NativeProgram));
 
     return NativeProgram;
   }

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -99,7 +99,7 @@ bool device_impl::is_affinity_supported(
 
 cl_device_id device_impl::get() const {
   // TODO catch an exception and put it to list of asynchronous exceptions
-  getAdapter()->call<UrApiKind::urDeviceRetain>(MDevice);
+  __SYCL_OCL_CALL(clRetainDevice, ur::cast<cl_device_id>(getNative()));
   return ur::cast<cl_device_id>(getNative());
 }
 
@@ -346,10 +346,11 @@ std::vector<device> device_impl::create_sub_devices() const {
 
 ur_native_handle_t device_impl::getNative() const {
   auto Adapter = getAdapter();
-  if (getBackend() == backend::opencl)
-    Adapter->call<UrApiKind::urDeviceRetain>(getHandleRef());
   ur_native_handle_t Handle;
   Adapter->call<UrApiKind::urDeviceGetNativeHandle>(getHandleRef(), &Handle);
+  if (getBackend() == backend::opencl) {
+    __SYCL_OCL_CALL(clRetainDevice, ur::cast<cl_device_id>(Handle));
+  }
   return Handle;
 }
 

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -511,10 +511,10 @@ ur_native_handle_t event_impl::getNative() {
     this->setHandle(UREvent);
     Handle = UREvent;
   }
-  if (MContext->getBackend() == backend::opencl)
-    Adapter->call<UrApiKind::urEventRetain>(Handle);
   ur_native_handle_t OutHandle;
   Adapter->call<UrApiKind::urEventGetNativeHandle>(Handle, &OutHandle);
+  if (MContext->getBackend() == backend::opencl)
+    __SYCL_OCL_CALL(clRetainEvent, ur::cast<cl_event>(OutHandle));
   return OutHandle;
 }
 

--- a/sycl/source/detail/kernel_impl.hpp
+++ b/sycl/source/detail/kernel_impl.hpp
@@ -75,10 +75,10 @@ public:
   ///
   /// \return a valid cl_kernel instance
   cl_kernel get() const {
-    getAdapter()->call<UrApiKind::urKernelRetain>(MKernel);
     ur_native_handle_t nativeHandle = 0;
     getAdapter()->call<UrApiKind::urKernelGetNativeHandle>(MKernel,
                                                            &nativeHandle);
+    __SYCL_OCL_CALL(clRetainKernel, ur::cast<cl_kernel>(nativeHandle));
     return ur::cast<cl_kernel>(nativeHandle);
   }
 
@@ -212,11 +212,11 @@ public:
   ur_native_handle_t getNative() const {
     const AdapterPtr &Adapter = MContext->getAdapter();
 
-    if (MContext->getBackend() == backend::opencl)
-      Adapter->call<UrApiKind::urKernelRetain>(MKernel);
-
     ur_native_handle_t NativeKernel = 0;
     Adapter->call<UrApiKind::urKernelGetNativeHandle>(MKernel, &NativeKernel);
+
+    if (MContext->getBackend() == backend::opencl)
+      __SYCL_OCL_CALL(clRetainKernel, ur::cast<cl_kernel>(NativeKernel));
 
     return NativeKernel;
   }

--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -291,6 +291,39 @@ size_t getDirectorySize(const std::string &Path, bool ignoreErrors) {
   return DirSizeVar;
 }
 
+// Look up a function name that was dynamically linked
+// This is used by the runtime where it needs to manipulate native handles (e.g.
+// retaining OpenCL handles). On Windows, the symbol name is looked up in
+// `WinName`. In Linux, it uses `LinName`.
+//
+// The library must already have been loaded (perhaps by UR), otherwise this
+// function throws a SYCL runtime exception.
+void *dynLookup([[maybe_unused]] const char *WinName,
+                [[maybe_unused]] const char *LinName, const char *FunName) {
+#ifdef __SYCL_RT_OS_WINDOWS
+  auto handle = GetModuleHandleA(WinName);
+  if (!handle) {
+    throw sycl::exception(make_error_code(errc::runtime),
+                          std::string(WinName) + " library is not loaded");
+  }
+  auto *retVal = GetProcAddress(handle, FunName);
+#else
+  auto handle = dlopen(LinName, RTLD_LAZY | RTLD_NOLOAD);
+  if (!handle) {
+    throw sycl::exception(make_error_code(errc::runtime),
+                          std::string(LinName) + " library is not loaded");
+  }
+  auto *retVal = dlsym(handle, FunName);
+  dlclose(handle);
+#endif
+  if (!retVal) {
+    throw sycl::exception(make_error_code(errc::runtime),
+                          "Symbol " + std::string(FunName) +
+                              " could not be found");
+  }
+  return retVal;
+}
+
 } // namespace detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -725,8 +725,6 @@ void queue_impl::destructorNotification() {
 
 ur_native_handle_t queue_impl::getNative(int32_t &NativeHandleDesc) const {
   const AdapterPtr &Adapter = getAdapter();
-  if (getContextImplPtr()->getBackend() == backend::opencl)
-    Adapter->call<UrApiKind::urQueueRetain>(MQueues[0]);
   ur_native_handle_t Handle{};
   ur_queue_native_desc_t UrNativeDesc{UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC,
                                       nullptr, nullptr};
@@ -734,6 +732,9 @@ ur_native_handle_t queue_impl::getNative(int32_t &NativeHandleDesc) const {
 
   Adapter->call<UrApiKind::urQueueGetNativeHandle>(MQueues[0], &UrNativeDesc,
                                                    &Handle);
+  if (getContextImplPtr()->getBackend() == backend::opencl)
+    __SYCL_OCL_CALL(clRetainCommandQueue, ur::cast<cl_command_queue>(Handle));
+
   return Handle;
 }
 

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -273,10 +273,10 @@ public:
   /// \return an OpenCL interoperability queue handle.
 
   cl_command_queue get() {
-    getAdapter()->call<UrApiKind::urQueueRetain>(MQueues[0]);
     ur_native_handle_t nativeHandle = 0;
     getAdapter()->call<UrApiKind::urQueueGetNativeHandle>(MQueues[0], nullptr,
                                                           &nativeHandle);
+    __SYCL_OCL_CALL(clRetainCommandQueue, ur::cast<cl_command_queue>(nativeHandle));
     return ur::cast<cl_command_queue>(nativeHandle);
   }
 

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -57,8 +57,9 @@ SYCLMemObjT::SYCLMemObjT(ur_native_handle_t MemObject,
         make_error_code(errc::invalid),
         "Input context must be the same as the context of cl_mem");
 
-  if (MInteropContext->getBackend() == backend::opencl)
-    Adapter->call<UrApiKind::urMemRetain>(MInteropMemObject);
+  if (MInteropContext->getBackend() == backend::opencl) {
+    __SYCL_OCL_CALL(clRetainMemObject, ur::cast<cl_mem>(MemObject));
+  }
 }
 
 ur_mem_type_t getImageType(int Dimensions) {
@@ -112,8 +113,9 @@ SYCLMemObjT::SYCLMemObjT(ur_native_handle_t MemObject,
         make_error_code(errc::invalid),
         "Input context must be the same as the context of cl_mem");
 
-  if (MInteropContext->getBackend() == backend::opencl)
-    Adapter->call<UrApiKind::urMemRetain>(MInteropMemObject);
+  if (MInteropContext->getBackend() == backend::opencl) {
+    __SYCL_OCL_CALL(clRetainMemObject, ur::cast<cl_mem>(MemObject));
+  }
 }
 
 void SYCLMemObjT::releaseMem(ContextImplPtr Context, void *MemAllocation) {

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -43,7 +43,7 @@ device::device(cl_device_id DeviceId) {
   auto Platform =
       detail::platform_impl::getPlatformFromUrDevice(Device, Adapter);
   impl = Platform->getOrMakeDeviceImpl(Device, Platform);
-  Adapter->call<detail::UrApiKind::urDeviceRetain>(impl->getHandleRef());
+  __SYCL_OCL_CALL(clRetainDevice, DeviceId);
 }
 
 device::device(const device_selector &deviceSelector) {

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -29,9 +29,7 @@ event::event(cl_event ClEvent, const context &SyclContext)
           detail::ur::cast<ur_event_handle_t>(ClEvent), SyclContext)) {
   // This is a special interop constructor for OpenCL, so the event must be
   // retained.
-  // TODO(pi2ur): Don't just cast from cl_event above
-  impl->getAdapter()->call<detail::UrApiKind::urEventRetain>(
-      detail::ur::cast<ur_event_handle_t>(ClEvent));
+  __SYCL_OCL_CALL(clRetainEvent, ClEvent);
 }
 
 bool event::operator==(const event &rhs) const { return rhs.impl == impl; }

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -30,7 +30,7 @@ kernel::kernel(cl_kernel ClKernel, const context &SyclContext) {
   // This is a special interop constructor for OpenCL, so the kernel must be
   // retained.
   if (get_backend() == backend::opencl) {
-    impl->getAdapter()->call<detail::UrApiKind::urKernelRetain>(hKernel);
+    __SYCL_OCL_CALL(clRetainKernel, ClKernel);
   }
 }
 

--- a/sycl/test/Unit/lit.cfg.py
+++ b/sycl/test/Unit/lit.cfg.py
@@ -70,8 +70,11 @@ def find_shlibpath_var():
 for shlibpath_var in find_shlibpath_var():
     # in stand-alone builds, shlibdir is clang's build tree
     # while llvm_libs_dir is installed LLVM (and possibly older clang)
+    # For unit tests, we have a "mock" OpenCL which needs to have
+    # priority and so is at the start of the shlibpath list
     shlibpath = os.path.pathsep.join(
         (
+            os.path.join(config.test_exec_root, "lib"),
             config.shlibdir,
             config.llvm_libs_dir,
             config.environment.get(shlibpath_var, ""),

--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -23,6 +23,8 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type_lower)
 
 include(AddSYCLUnitTest)
 
+add_subdirectory(mock_opencl)
+
 add_custom_target(check-sycl-unittests)
 
 add_subdirectory(ur)

--- a/sycl/unittests/Extensions/CompositeDevice.cpp
+++ b/sycl/unittests/Extensions/CompositeDevice.cpp
@@ -1,4 +1,5 @@
 #include "sycl/platform.hpp"
+#include <detail/device_impl.hpp>
 #include <sycl/sycl.hpp>
 
 #include <helpers/UrMock.hpp>
@@ -143,8 +144,7 @@ TEST(CompositeDeviceTest, PlatformExtOneAPIGetCompositeDevices) {
   // We don't expect to see COMPOSITE_DEVICE_1 here, because one of its
   // components (COMPONENT_DEVICE_D) is not available.
   ASSERT_EQ(Composites.size(), 1u);
-  ASSERT_EQ(sycl::bit_cast<ur_device_handle_t>(
-                sycl::get_native<sycl::backend::opencl>(Composites.front())),
+  ASSERT_EQ(sycl::detail::getSyclObjImpl(Composites.front())->getHandleRef(),
             COMPOSITE_DEVICE_0);
 }
 
@@ -162,8 +162,7 @@ TEST(CompositeDeviceTest, SYCLExtOneAPIExperimentalGetCompositeDevices) {
   // We don't expect to see COMPOSITE_DEVICE_1 here, because one of its
   // components (COMPONENT_DEVICE_D) is not available.
   ASSERT_EQ(Composites.size(), 1u);
-  ASSERT_EQ(sycl::bit_cast<ur_device_handle_t>(
-                sycl::get_native<sycl::backend::opencl>(Composites.front())),
+  ASSERT_EQ(sycl::detail::getSyclObjImpl(Composites.front())->getHandleRef(),
             COMPOSITE_DEVICE_0);
 }
 

--- a/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
+++ b/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
@@ -13,6 +13,7 @@
 #include <sycl/backend/opencl.hpp>
 #include <sycl/sycl.hpp>
 
+#include <helpers/KernelInteropCommon.hpp>
 #include <helpers/TestKernel.hpp>
 #include <helpers/UrMock.hpp>
 
@@ -115,14 +116,26 @@ TEST(GetNative, GetNativeHandle) {
     cgh.single_task<TestKernel<KS>>([=]() { (void)Acc; });
   });
 
+  EXPECT_EQ(mockOpenCLNumContextRetains(), 0ul);
+  EXPECT_EQ(mockOpenCLNumQueueRetains(), 0ul);
+  EXPECT_EQ(mockOpenCLNumDeviceRetains(), 0ul);
+  EXPECT_EQ(mockOpenCLNumEventRetains(), 0ul);
+  ASSERT_EQ(TestCounter, 2 + DeviceRetainCounter - 1)
+      << "Not all the retain methods were called";
+
   get_native<backend::opencl>(Context);
   get_native<backend::opencl>(Queue);
   get_native<backend::opencl>(Device);
   get_native<backend::opencl>(Event);
   get_native<backend::opencl>(Buffer);
 
-  // Depending on global caches state, urDeviceRetain is called either once or
-  // twice, so there'll be 6 or 7 calls.
-  ASSERT_EQ(TestCounter, 6 + DeviceRetainCounter - 1)
-      << "Not all the retain methods were called";
+  EXPECT_EQ(mockOpenCLNumContextRetains(), 1ul);
+  EXPECT_EQ(mockOpenCLNumQueueRetains(), 1ul);
+  EXPECT_EQ(mockOpenCLNumDeviceRetains(), 1ul);
+  EXPECT_EQ(mockOpenCLNumEventRetains(), 1ul);
+
+  // get_native shouldn't retain the SYCL objects, but instead retains the
+  // underlying handles
+  ASSERT_EQ(TestCounter, 2 + DeviceRetainCounter - 1)
+      << "get_native retained SYCL objects";
 }

--- a/sycl/unittests/helpers/KernelInteropCommon.hpp
+++ b/sycl/unittests/helpers/KernelInteropCommon.hpp
@@ -120,3 +120,12 @@ void redefineMockForKernelInterop(sycl::unittest::UrMock<> &Mock) {
   mock::getCallbacks().set_replace_callback("urProgramGetBuildInfo",
                                             &redefined_urProgramGetBuildInfo);
 }
+
+extern "C" {
+size_t mockOpenCLNumKernelRetains();
+size_t mockOpenCLNumQueueRetains();
+size_t mockOpenCLNumMemObjectRetains();
+size_t mockOpenCLNumContextRetains();
+size_t mockOpenCLNumDeviceRetains();
+size_t mockOpenCLNumEventRetains();
+}

--- a/sycl/unittests/helpers/UrMock.hpp
+++ b/sycl/unittests/helpers/UrMock.hpp
@@ -531,6 +531,9 @@ inline ur_result_t mock_urCommandBufferAppendKernelLaunchExp(void *pParams) {
 
 } // namespace MockAdapter
 
+// Will be linked from the mock OpenCL.dll/OpenCL.so
+void loadMockOpenCL();
+
 /// The UrMock<> class sets up UR for adapter mocking with the set of default
 /// overrides above, and ensures the appropriate parts of the sycl runtime and
 /// UR mocking code are reset/torn down in between tests.
@@ -544,6 +547,12 @@ public:
   /// This ensures UR is setup for adapter mocking and also injects our default
   /// entry-point overrides into the mock adapter.
   UrMock() {
+    if constexpr (Backend == backend::opencl) {
+      // Some tests use the interop handles, so we need to ensure the mock
+      // OpenCL library is loaded.
+      loadMockOpenCL();
+    }
+
 #define ADD_DEFAULT_OVERRIDE(func_name, func_override)                         \
   mock::getCallbacks().set_replace_callback(#func_name,                        \
                                             &MockAdapter::func_override);

--- a/sycl/unittests/mock_opencl/CMakeLists.txt
+++ b/sycl/unittests/mock_opencl/CMakeLists.txt
@@ -1,0 +1,9 @@
+get_target_property(SYCL_BINARY_DIR sycl-toolchain BINARY_DIR)
+
+add_library(mockOpenCL SHARED EXCLUDE_FROM_ALL mock_opencl.cpp)
+set_target_properties(mockOpenCL PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY ${SYCL_BINARY_DIR}/unittests/lib
+  LIBRARY_OUTPUT_NAME OpenCL
+  RUNTIME_OUTPUT_DIRECTORY ${SYCL_BINARY_DIR}/unittests/lib
+  RUNTIME_OUTPUT_NAME OpenCL
+)

--- a/sycl/unittests/mock_opencl/mock_opencl.cpp
+++ b/sycl/unittests/mock_opencl/mock_opencl.cpp
@@ -1,0 +1,66 @@
+#include <cstddef>
+
+static size_t kernelRetains = 0;
+static size_t queueRetains = 0;
+static size_t memObjectRetains = 0;
+static size_t contextRetains = 0;
+static size_t deviceRetains = 0;
+static size_t eventRetains = 0;
+
+#if _MSC_VER
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+extern "C" {
+using handle = size_t *;
+using cl_int = int;
+
+EXPORT int clRetainKernel(handle) {
+  kernelRetains++;
+  return 0;
+}
+EXPORT int clRetainCommandQueue(handle) {
+  queueRetains++;
+  return 0;
+}
+EXPORT int clRetainMemObject(handle) {
+  memObjectRetains++;
+  return 0;
+}
+EXPORT int clRetainContext(handle) {
+  contextRetains++;
+  return 0;
+}
+EXPORT int clRetainDevice(handle) {
+  deviceRetains++;
+  return 0;
+}
+EXPORT int clRetainEvent(handle) {
+  eventRetains++;
+  return 0;
+}
+
+EXPORT size_t mockOpenCLNumKernelRetains() { return kernelRetains; }
+
+EXPORT size_t mockOpenCLNumQueueRetains() { return queueRetains; }
+
+EXPORT size_t mockOpenCLNumMemObjectRetains() { return memObjectRetains; }
+
+EXPORT size_t mockOpenCLNumContextRetains() { return contextRetains; }
+
+EXPORT size_t mockOpenCLNumDeviceRetains() { return deviceRetains; }
+
+EXPORT size_t mockOpenCLNumEventRetains() { return deviceRetains; }
+}
+
+namespace sycl {
+namespace _V1 {
+namespace unittest {
+// This function is a no-op - it only exists so that tests can link against it
+// to get the mock OpenCL
+EXPORT void loadMockOpenCL() {}
+} // namespace unittest
+} // namespace _V1
+} // namespace sycl

--- a/sycl/unittests/queue/InteropRetain.cpp
+++ b/sycl/unittests/queue/InteropRetain.cpp
@@ -12,6 +12,7 @@
 
 #include <detail/queue_impl.hpp>
 #include <gtest/gtest.h>
+#include <helpers/KernelInteropCommon.hpp>
 #include <helpers/UrMock.hpp>
 
 namespace {
@@ -33,15 +34,18 @@ TEST(PiInteropTest, CheckRetain) {
   mock::getCallbacks().set_before_callback("urQueueRetain",
                                            &redefinedQueueRetain);
   queue Q{Ctx, default_selector()};
-  EXPECT_TRUE(QueueRetainCalled == 0);
+  EXPECT_EQ(QueueRetainCalled, 0);
+  EXPECT_EQ(mockOpenCLNumQueueRetains(), 0ul);
 
   cl_command_queue OCLQ = get_native<backend::opencl>(Q);
-  EXPECT_TRUE(QueueRetainCalled == 1);
+  EXPECT_EQ(QueueRetainCalled, 0);
+  EXPECT_EQ(mockOpenCLNumQueueRetains(), 1ul);
 
   // The make_queue should not call to urQueueRetain. The
   // urQueueCreateWithNativeHandle should do the "retain" if needed.
   queue Q1 = make_queue<backend::opencl>(OCLQ, Ctx);
-  EXPECT_TRUE(QueueRetainCalled == 1);
+  EXPECT_EQ(QueueRetainCalled, 0);
+  EXPECT_EQ(mockOpenCLNumQueueRetains(), 1ul);
 }
 
 } // namespace


### PR DESCRIPTION
At various points, OpenCL native handles need to be retained to ensure
SYCL semantics. Previously, this relied on the fact that UR handles were
typecast CL handles and shared the same reference count.

However, the SYCL RT shouldn't assume this, so instead we call the
appropriate (dynamically looked-up) CL functions on the native handles
instead.

This is in preperation for https://github.com/oneapi-src/unified-runtime/pull/1176 .

This change should also have no observable effect for SYCL code; there
is no change in lifetime semantics.
