### PR TITLE
[SYCL][E2E] Disable imf_simd_emulate_test.cpp on igc-dev Arc

### DIFF
--- a/sycl/test-e2e/DeviceLib/imf_simd_emulate_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_simd_emulate_test.cpp
@@ -9,8 +9,8 @@
 // XFAIL: spirv-backend && run-mode
 // XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/122075
 
-// XFAIL: igc-dev && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17008
+// UNSUPPORTED: igc-dev
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17008
 
 #include "imf_utils.hpp"
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Seems sporadically failing there too, see [here](https://github.com/intel/llvm/issues/17008).