### PR TITLE
[SYCL] Do not use entire sycl/sycl.hpp in small tests

### DIFF
--- a/sycl/test/extensions/DeviceImageBackendContent/negative_test.cpp
+++ b/sycl/test/extensions/DeviceImageBackendContent/negative_test.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang -fsycl -fsyntax-only -std=c++20 -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/kernel_bundle.hpp>
 
 class kernel;
 


### PR DESCRIPTION
Do not include entire `<sycl/sycl.hpp>` in `sycl/test/extensions/DeviceImageBackendContent/negative_test.cpp`
Use more fine-grained includes instead. For E2E tests, this is a matter of performance, but in this case including all the SYCL headers can go as far as causing compilation issues in environments that require `c++20` but whose `gcc` does not fully implement `c++20` features.