### PR TITLE
[SYCL] Fix min/max known_identity<> wrong when -ffast-math is used.

### DIFF
--- a/sycl/test/basic_tests/reduction/infinite_identity.cpp
+++ b/sycl/test/basic_tests/reduction/infinite_identity.cpp
@@ -1,0 +1,62 @@
+/*
+    See https://github.com/intel/llvm/issues/13813
+
+    -ffast-math implies -fno-honor-infinities. In this case, the known_identity
+   for sycl::minimum<T> cannot be inifinity (which will be 0), but must instead
+    be the max<T> .  Otherwise, reducing sycl::minimum<T>
+    over {4.0f, 1.0f, 3.0f, 2.0f}  will return 0.0 instead of 1.0.
+*/
+
+// RUN: %clangxx -fsycl -fsyntax-only %s
+// RUN: %clangxx -fsycl -fsyntax-only %s -ffast-math
+// RUN: %clangxx -fsycl -fsyntax-only %s -fno-fast-math
+
+#include <sycl/ext/oneapi/bfloat16.hpp>
+#include <sycl/sycl.hpp>
+
+#include <cassert>
+#include <limits>
+
+template <typename OperandT> void test_known_identity_min() {
+  constexpr OperandT identity =
+      sycl::known_identity_v<sycl::minimum<OperandT>, OperandT>;
+#ifdef __FAST_MATH__
+  constexpr OperandT expected = std::numeric_limits<OperandT>::max();
+#else
+  constexpr OperandT expected = std::numeric_limits<OperandT>::infinity();
+#endif
+
+  static_assert(identity == expected,
+                "Known identity for sycl::minimum<T> is incorrect");
+}
+
+template <typename OperandT> void test_known_identity_max() {
+  constexpr OperandT identity =
+      sycl::known_identity_v<sycl::maximum<OperandT>, OperandT>;
+#ifdef __FAST_MATH__
+  constexpr OperandT expected = std::numeric_limits<OperandT>::lowest();
+#else
+  constexpr OperandT expected =
+      -std::numeric_limits<OperandT>::infinity(); // negative infinity
+#endif
+
+  static_assert(identity == expected,
+                "Known identity for sycl::maximum<T> is incorrect");
+}
+
+int main() {
+  test_known_identity_min<float>();
+  test_known_identity_min<double>();
+  test_known_identity_min<sycl::half>();
+
+  test_known_identity_max<float>();
+  test_known_identity_max<double>();
+  test_known_identity_max<sycl::half>();
+
+  // bfloat16 seems to be missing constexpr == which is used above.
+  // commenting out until fixed.
+  // test_known_identity_min<sycl::ext::oneapi::bfloat16>();
+  // test_known_identity_max<sycl::ext::oneapi::bfloat16>();
+
+  return 0;
+}


### PR DESCRIPTION
Technically a workaround, this fixes the problem with `known_identity<minOp/maxOp>` being incorrect when using `-ffast-math`.  It works because we have a `__FAST_MATH__` macro that is defined when that flag is used. Better,  would be to detect `-fno-honor-infinities`. Opening a JIRA/discussion for that, but this is a big improvement in the interim.

See discussion https://github.com/intel/llvm/issues/13813