### PR TITLE
[SYCL][E2E] Add `-O2` to `Matrix/joint_matrix_out_bounds.cpp`

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_out_bounds.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_out_bounds.cpp
@@ -15,7 +15,9 @@
 // UNSUPPORTED: gpu-intel-dg2, cpu
 // UNSUPPORTED-INTENDED: Checked load/stores are not supported by DG2 and CPU HW
 
-// RUN: %{build} -o %t.out
+// Make sure that at least some optimization level is used as we perform
+// reference matrix multiplication on host and that is very slow at O0.
+// RUN: %{build} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 #include "common.hpp"


### PR DESCRIPTION
Computing reference values on host is slow at default `-O0`, making this test very slow. Before this PR, from CI precommit:

```
Slowest Tests:
--------------------------------------------------------------------------
174.00s: SYCL :: Matrix/joint_matrix_out_bounds.cpp
77.60s: SYCL :: KernelCompiler/kernel_compiler_sycl_jit.cpp
```