### PR TITLE
[UR] Deprecate UR_DEVICE_INFO_BFLOAT16

### DIFF
--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -2175,8 +2175,8 @@ typedef enum ur_device_info_t {
   /// [::ur_memory_scope_capability_flags_t] return a bit-field of atomic
   /// memory fence scope capabilities
   UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES = 103,
-  /// [::ur_bool_t] support for bfloat16
-  UR_DEVICE_INFO_BFLOAT16 = 104,
+  /// [::ur_bool_t][deprecated-value] support for bfloat16
+  UR_DEVICE_INFO_BFLOAT16 [[deprecated]] = 104,
   /// [uint32_t] Returns 1 if the device doesn't have a notion of a
   /// queue index. Otherwise, returns the number of queue indices that are
   /// available for this device.

--- a/unified-runtime/include/ur_print.hpp
+++ b/unified-runtime/include/ur_print.hpp
@@ -2882,9 +2882,6 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
   case UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES:
     os << "UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES";
     break;
-  case UR_DEVICE_INFO_BFLOAT16:
-    os << "UR_DEVICE_INFO_BFLOAT16";
-    break;
   case UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES:
     os << "UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES";
     break;
@@ -4375,19 +4372,6 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr,
     os << (const void *)(tptr) << " (";
 
     ur::details::printFlag<ur_memory_scope_capability_flag_t>(os, *tptr);
-
-    os << ")";
-  } break;
-  case UR_DEVICE_INFO_BFLOAT16: {
-    const ur_bool_t *tptr = (const ur_bool_t *)ptr;
-    if (sizeof(ur_bool_t) > size) {
-      os << "invalid size (is: " << size
-         << ", expected: >=" << sizeof(ur_bool_t) << ")";
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
-    os << (const void *)(tptr) << " (";
-
-    os << *tptr;
 
     os << ")";
   } break;

--- a/unified-runtime/scripts/YaML.md
+++ b/unified-runtime/scripts/YaML.md
@@ -337,6 +337,7 @@ plural form *enumerators* is abbreviated to `etors`.
     + `desc` will be used as the etors's description comment
     + If the enum has `typed_etors`, `desc` must begin with type identifier: {`"[type]"`}
     + `desc` may contain the [optional-query] annotation. This denotes the etor as an info query which is optional for adapters to implement, and may legally result in a non-success error code.
+    + `desc` may contain the [deprecated-value] annotation. This marks the etor with the `[[deprecated]]` attribute specifier.
     + `name` must be a unique ISO-C standard identifier, and be all caps
   - An etor may take the following optional scalar field: {`value`, `version`}
     + `value` must be an ISO-C standard identifier

--- a/unified-runtime/scripts/core/PROG.rst
+++ b/unified-runtime/scripts/core/PROG.rst
@@ -196,10 +196,16 @@ points for this are generally of the form:
 
 where ``propName`` selects the information to query out. The object info enum
 representing possible queries will generally be found in the enums section of
-the relevant object. Some info queries would be difficult or impossible to
-support for certain backends, these are denoted with [optional-query] in the
-enum description. Using any enum marked optional in this way may result in
+the relevant object. 
+
+Some info queries would be difficult or impossible to support for certain 
+backends, these are denoted with [optional-query] in the enum description. 
+Using any enum marked optional in this way may result in
 ${X}_RESULT_ERROR_UNSUPPORTED_ENUMERATION if the adapter doesn't support it.
+
+Some info queries may become deprecated, denoted with [deprecated-value] in the 
+enum description. Using any enum marked as deprecated in this way may result in 
+${X}_RESULT_ERROR_INVALID_ENUMERATION if the adapter has ceased to support it.
 
 Programs and Kernels
 ====================

--- a/unified-runtime/scripts/core/device.yml
+++ b/unified-runtime/scripts/core/device.yml
@@ -409,7 +409,7 @@ etors:
     - name: ATOMIC_FENCE_SCOPE_CAPABILITIES
       desc: "[$x_memory_scope_capability_flags_t] return a bit-field of atomic memory fence scope capabilities"
     - name: BFLOAT16
-      desc: "[$x_bool_t] support for bfloat16"
+      desc: "[$x_bool_t][deprecated-value] support for bfloat16"
     - name: MAX_COMPUTE_QUEUE_INDICES
       desc: |
             [uint32_t] Returns 1 if the device doesn't have a notion of a

--- a/unified-runtime/scripts/templates/helper.py
+++ b/unified-runtime/scripts/templates/helper.py
@@ -271,7 +271,7 @@ class type_traits:
     def get_struct_members(type_name, meta):
         struct_type = _remove_const_ptr(type_name)
         if not struct_type in meta["struct"]:
-            raise Exception(f"Cannot return members of non-struct type {struct_type}")
+            raise Exception(f"Cannot return members of non-struct type {struct_type}.")
         return meta["struct"][struct_type]["members"]
 
 
@@ -565,11 +565,19 @@ class function_traits:
 
 class etor_traits:
     RE_OPTIONAL_QUERY = r".*\[optional-query\].*"
+    RE_DEPRECATED = r".*\[deprecated-value\].*"
 
     @classmethod
     def is_optional_query(cls, item):
         try:
             return True if re.match(cls.RE_OPTIONAL_QUERY, item["desc"]) else False
+        except:
+            return False
+
+    @classmethod
+    def is_deprecated_etor(cls, item):
+        try:
+            return True if re.match(cls.RE_DEPRECATED, item["desc"]) else False
         except:
             return False
 
@@ -917,13 +925,14 @@ def make_etor_lines(namespace, tags, obj, meta=None):
     lines = []
     for item in obj["etors"]:
         name = make_etor_name(namespace, tags, obj["name"], item["name"], meta)
+        deprecated = " [[deprecated]]" if etor_traits.is_deprecated_etor(item) else ""
 
         if "value" in item:
             delim = ","
             value = _get_value_name(namespace, tags, item["value"])
-            prologue = "%s = %s%s" % (name, value, delim)
+            prologue = "%s%s = %s%s" % (name, deprecated, value, delim)
         else:
-            prologue = "%s," % (name)
+            prologue = "%s%s," % (name, deprecated)
 
         for line in split_line(subt(namespace, tags, item["desc"], True), 70):
             lines.append(" /// %s" % line)
@@ -1974,7 +1983,7 @@ def transform_queue_related_function_name(
     function_name = function_name[0].lower() + function_name[1:]
 
     if obj["params"][0]["type"] != "$x_queue_handle_t":
-        raise ValueError("First parameter is not a queue handle")
+        raise ValueError("First parameter is not a queue handle.")
 
     params = make_param_lines(namespace, tags, obj, format=format)
     params = params[1:]
@@ -2004,3 +2013,18 @@ def get_optional_queries(specs, namespace, tags):
                     type_name = make_type_name(namespace, tags, obj)
                     optional_queries[type_name] = optional_etors
     return optional_queries
+
+
+"""
+Public:
+    Generator returning non-deprecated enum values.
+"""
+
+
+def get_etors(obj):
+    if not obj_traits.is_enum(obj):
+        raise TypeError("obj parameter is not an enum.")
+    for item in obj["etors"]:
+        if etor_traits.is_deprecated_etor(item):
+            continue
+        yield item

--- a/unified-runtime/scripts/templates/print.hpp.mako
+++ b/unified-runtime/scripts/templates/print.hpp.mako
@@ -191,7 +191,7 @@ template <typename T> inline ${x}_result_t printTagged(std::ostream &os, const v
     %else:
     inline std::ostream &operator<<(std::ostream &os, enum ${th.make_enum_name(n, tags, obj)} value) {
         switch (value) {
-            %for n, item in enumerate(obj['etors']):
+            %for n, item in enumerate(th.get_etors(obj)):
                 <%
                 ename = th.make_etor_name(n, tags, obj['name'], item['name'])
                 %>case ${ename}:
@@ -216,7 +216,7 @@ template <typename T> inline ${x}_result_t printTagged(std::ostream &os, const v
         }
 
         switch (value) {
-            %for n, item in enumerate(obj['etors']):
+            %for n, item in enumerate(th.get_etors(obj)):
                 <%
                 ename = th.make_etor_name(n, tags, obj['name'], item['name'])
                 vtype = th.etor_get_associated_type(n, tags, item)
@@ -281,7 +281,7 @@ template <typename T> inline ${x}_result_t printTagged(std::ostream &os, const v
         ## structure type enum value must be first
         const enum ${th.make_enum_name(n, tags, obj)} *value = (const enum ${th.make_enum_name(n, tags, obj)} *)ptr;
         switch (*value) {
-            %for n, item in enumerate(obj['etors']):
+            %for n, item in enumerate(th.get_etors(obj)):
                 <%
                 ename = th.make_etor_name(n, tags, obj['name'], item['name'])
                 %>
@@ -307,7 +307,7 @@ template <typename T> inline ${x}_result_t printTagged(std::ostream &os, const v
     inline ${x}_result_t printFlag<${th.make_enum_name(n, tags, obj)}>(std::ostream &os, uint32_t flag) {
         uint32_t val = flag;
         bool first = true;
-        %for n, item in enumerate(obj['etors']):
+        %for n, item in enumerate(th.get_etors(obj)):
             <%
             ename = th.make_etor_name(n, tags, obj['name'], item['name'])
             %>

--- a/unified-runtime/scripts/templates/stype_map_helpers.hpp.mako
+++ b/unified-runtime/scripts/templates/stype_map_helpers.hpp.mako
@@ -12,7 +12,7 @@ from templates import helper as th
 
 %for obj in th.extract_objs(specs, r"enum"):
  %if obj["name"] == '$x_structure_type_t':
-  %for etor in obj['etors']:
+  %for etor in th.get_etors(obj):
    %if 'UINT32' not in etor['name']:
 template <>
 struct stype_map<${x}_${etor['desc'][3:]}> : stype_map_impl<${X}_${etor['name'][3:]}> {};

--- a/unified-runtime/scripts/templates/tools-info.hpp.mako
+++ b/unified-runtime/scripts/templates/tools-info.hpp.mako
@@ -32,7 +32,7 @@ namespace urinfo {
 %for obj in th.extract_objs(specs, r"enum"):
 %if obj["name"] == '$x_loader_config_info_t':
 inline void printLoaderConfigInfos(${x}_loader_config_handle_t hLoaderConfig, std::string_view prefix = "  ") {
-%for etor in obj['etors']:
+%for etor in th.get_etors(obj):
 %if 'REFERENCE_COUNT' not in etor['name']:
     <%etype = th.etor_get_associated_type(n, tags, etor)
     %>std::cout << prefix;
@@ -43,7 +43,7 @@ inline void printLoaderConfigInfos(${x}_loader_config_handle_t hLoaderConfig, st
 %endif
 %if obj["name"] == '$x_adapter_info_t':
 inline void printAdapterInfos(${x}_adapter_handle_t hAdapter, std::string_view prefix = "  ") {
-%for etor in obj['etors']:
+%for etor in th.get_etors(obj):
 %if 'REFERENCE_COUNT' not in etor['name']:
     <%etype = th.etor_get_associated_type(n, tags, etor)
     %>std::cout << prefix;
@@ -55,7 +55,7 @@ inline void printAdapterInfos(${x}_adapter_handle_t hAdapter, std::string_view p
 %endif
 %if obj["name"] == '$x_platform_info_t':
 inline void printPlatformInfos(${x}_platform_handle_t hPlatform, std::string_view prefix = "    ") {
-%for etor in obj['etors']:
+%for etor in th.get_etors(obj):
     <%etype = th.etor_get_associated_type(n, tags, etor)
     %>std::cout << prefix;
     printPlatformInfo<${etype}>(hPlatform, ${etor['name'].replace('$X', X)});
@@ -65,7 +65,7 @@ inline void printPlatformInfos(${x}_platform_handle_t hPlatform, std::string_vie
 %endif
 %if obj['name'] == '$x_device_info_t':
 inline void printDeviceInfos(${x}_device_handle_t hDevice, std::string_view prefix = "      ") {
-%for etor in obj['etors']:
+%for etor in th.get_etors(obj):
     <%etype = th.etor_get_associated_type(n, tags, etor)
     %>std::cout << prefix;
 %if etor['name'] == '$X_DEVICE_INFO_UUID':

--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -253,14 +253,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_GROUP;
     return ReturnValue(Capabilities);
   }
-  case UR_DEVICE_INFO_BFLOAT16: {
-    int Major = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
-
-    bool BFloat16 = (Major >= 8) ? true : false;
-    return ReturnValue(BFloat16);
-  }
   case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL: {
     // NVIDIA devices only support one sub-group size (the warp size)
     int WarpSize = 0;

--- a/unified-runtime/source/adapters/hip/device.cpp
+++ b/unified-runtime/source/adapters/hip/device.cpp
@@ -1019,8 +1019,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 #else
     return ReturnValue(ur_bool_t{false});
 #endif
-  case UR_DEVICE_INFO_BFLOAT16:
-    return ReturnValue(true);
   case UR_DEVICE_INFO_ASYNC_BARRIER:
     return ReturnValue(false);
   case UR_DEVICE_INFO_IL_VERSION:

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -897,10 +897,6 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue(uint32_t{Device->ZeDeviceProperties->numEUsPerSubslice});
   case UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU:
     return ReturnValue(uint32_t{Device->ZeDeviceProperties->numThreadsPerEU});
-  case UR_DEVICE_INFO_BFLOAT16: {
-    // bfloat16 math functions are not yet supported on Intel GPUs.
-    return ReturnValue(ur_bool_t{false});
-  }
   case UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES: {
     // There are no explicit restrictions in L0 programming guide, so assume all
     // are supported

--- a/unified-runtime/source/adapters/native_cpu/device.cpp
+++ b/unified-runtime/source/adapters/native_cpu/device.cpp
@@ -344,8 +344,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(bool{0});
   case UR_DEVICE_INFO_ATOMIC_64:
     return ReturnValue(bool{1});
-  case UR_DEVICE_INFO_BFLOAT16:
-    return ReturnValue(bool{0});
   case UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT:
     return ReturnValue(bool{0});
   case UR_DEVICE_INFO_IMAGE_SRGB:

--- a/unified-runtime/source/adapters/opencl/device.cpp
+++ b/unified-runtime/source/adapters/opencl/device.cpp
@@ -1460,7 +1460,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
     return UR_RESULT_SUCCESS;
   }
-
   case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL: {
     const cl_device_info info_name = CL_DEVICE_SUB_GROUP_SIZES_INTEL;
     bool isExtensionSupported;
@@ -1486,7 +1485,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue.template operator()<uint32_t>(SubGroupSizes.data(),
                                                      SubGroupSizes.size());
   }
-
   case UR_DEVICE_INFO_UUID: {
     // Use the cl_khr_device_uuid extension, if available.
     bool isKhrDeviceUuidSupported = false;
@@ -1565,7 +1563,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   // TODO: We can't query to check if these are supported, they will need to be
   // manually updated if support is ever implemented.
   case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS:
-  case UR_DEVICE_INFO_BFLOAT16:
   case UR_DEVICE_INFO_ASYNC_BARRIER:
   case UR_DEVICE_INFO_USM_POOL_SUPPORT: // end of TODO
   case UR_DEVICE_INFO_COMMAND_BUFFER_EVENT_SUPPORT_EXP:

--- a/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
@@ -1758,23 +1758,6 @@ TEST_P(urDeviceGetInfoTest, SuccessAtomicFenceScopeCapabilities) {
   ASSERT_EQ(property_value & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
 }
 
-TEST_P(urDeviceGetInfoTest, SuccessBFloat64) {
-  size_t property_size = 0;
-  const ur_device_info_t property_name = UR_DEVICE_INFO_BFLOAT16;
-
-  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
-      property_name);
-  ASSERT_EQ(property_size, sizeof(ur_bool_t));
-
-  ur_bool_t property_value = false;
-  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
-                                 &property_value, nullptr));
-
-  bool casted_value = static_cast<bool>(property_value);
-  ASSERT_TRUE(casted_value == false || casted_value == true);
-}
-
 TEST_P(urDeviceGetInfoTest, SuccessMaxComputeQueueIndices) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 

--- a/unified-runtime/test/conformance/testing/include/uur/utils.h
+++ b/unified-runtime/test/conformance/testing/include/uur/utils.h
@@ -405,7 +405,6 @@ GetDeviceMemoryOrderCapabilities(ur_device_handle_t device,
 ur_result_t
 GetDeviceMemoryScopeCapabilities(ur_device_handle_t device,
                                  ur_memory_scope_capability_flags_t &flags);
-ur_result_t GetDeviceBFloat16Support(ur_device_handle_t device, bool &support);
 ur_result_t GetDeviceMaxComputeQueueIndices(ur_device_handle_t device,
                                             uint32_t &max_indices);
 ur_result_t GetDeviceHostPipeRWSupported(ur_device_handle_t device,

--- a/unified-runtime/test/conformance/testing/source/utils.cpp
+++ b/unified-runtime/test/conformance/testing/source/utils.cpp
@@ -625,10 +625,6 @@ GetDeviceMemoryScopeCapabilities(ur_device_handle_t device,
       device, UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES, flags);
 }
 
-ur_result_t GetDeviceBFloat16Support(ur_device_handle_t device, bool &support) {
-  return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_BFLOAT16, support);
-}
-
 ur_result_t GetDeviceMaxComputeQueueIndices(ur_device_handle_t device,
                                             uint32_t &max_indices) {
   return GetDeviceInfo<uint32_t>(

--- a/unified-runtime/tools/urinfo/urinfo.hpp
+++ b/unified-runtime/tools/urinfo/urinfo.hpp
@@ -291,8 +291,6 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
   printDeviceInfo<ur_memory_scope_capability_flags_t>(
       hDevice, UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES);
   std::cout << prefix;
-  printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_BFLOAT16);
-  std::cout << prefix;
   printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES);
   std::cout << prefix;
   printDeviceInfo<ur_bool_t>(


### PR DESCRIPTION
* Add support for deprecation of enum values in UR spec.
* Deprecate UR_DEVICE_INFO_BFLOAT16.
* Remove testing for UR_DEVICE_INFO_BFLOAT16.
* Remove UR_DEVICE_INFO_BFLOAT16 support from adapters.
* Resolves https://github.com/oneapi-src/unified-runtime/issues/2385.