### PR TITLE
[libclc] Resolve bad merge; fix libspirv LIT failures

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -341,13 +341,15 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     set( DARCH ${ARCH} )
   endif()
 
+  set( libspirv_dirs ${opencl_dirs} )
+
   set(IS_NATIVE_CPU_ARCH FALSE)
   if( ARCH IN_LIST NATIVECPU_SUPPORTED_ARCH )
     set(IS_NATIVE_CPU_ARCH TRUE)
   endif()
 
   if( IS_NATIVE_CPU_ARCH AND OS STREQUAL linux)
-    LIST( APPEND dirs native_cpu-unknown-linux )
+    LIST( APPEND libspirv_dirs native_cpu-unknown-linux )
   elseif( IS_NATIVE_CPU_ARCH AND NOT OS STREQUAL linux )
     message(WARNING "libclc is being built for an unsupported ARCH/OS"
       " configuration, some SYCL programs may fail to build.")
@@ -395,7 +397,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
   libclc_configure_lib_source(
     libspirv_lib_files
     LIB_ROOT_DIR libspirv
-    DIRS ${dirs} ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS}
+    DIRS ${libspirv_dirs} ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS}
   )
 
   foreach( d ${${t}_devices} )


### PR DESCRIPTION
This is an alternative fix to #17052.

The merge resolution in 98f847a accidentally stopped the compilation of all libspirv builtins, resulting in an empty library.

The libspirv directory structure is almost identical to the OpenCL directory structure, except that it also has a native-cpu directory. Thus we introduce a new variable to manage libspirv directories, which starts out inheriting from the OpenCL directories.