### PR TITLE
[CI][CTS] Add fixed ref for cts

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -311,9 +311,9 @@ jobs:
       if: inputs.tests_selector == 'cts'
       uses: ./devops/actions/run-tests/cts
       with:
+        ref: ${{ inputs.tests_ref }}
         extra_cmake_args: ${{ inputs.extra_cmake_args }}
         cts_testing_mode: ${{ inputs.cts_testing_mode }}
         sycl_cts_artifact: ${{ inputs.sycl_cts_artifact }}
         target_devices: ${{ inputs.target_devices }}
         retention-days: ${{ inputs.retention-days }}
-        tests_ref: ${{ inputs.tests_ref }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -45,11 +45,8 @@ on:
           By default we checkout the devops directory from "inputs.ref" branch.
           devops_ref may be specified to checkout the devops dir from different
           branch.
-          Note: it doesn't affect ./devops/actions/run-tests/* as these actions
-          call checkout again and therefore override the devops directory, so
-          configs/dependecies from input.ref are used.
-      sycl_cts_ref:
-        description: "Commit SHA or branch to checkout"
+      tests_ref:
+        description: "Commit SHA or branch to checkout tests"
         type: string
         default: "main"
         required: False
@@ -319,4 +316,4 @@ jobs:
         sycl_cts_artifact: ${{ inputs.sycl_cts_artifact }}
         target_devices: ${{ inputs.target_devices }}
         retention-days: ${{ inputs.retention-days }}
-        sycl_cts_ref: ${{ inputs.sycl_cts_ref }}
+        tests_ref: ${{ inputs.tests_ref }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -48,6 +48,11 @@ on:
           Note: it doesn't affect ./devops/actions/run-tests/* as these actions
           call checkout again and therefore override the devops directory, so
           configs/dependecies from input.ref are used.
+      sycl_cts_ref:
+        description: "Commit SHA or branch to checkout"
+        type: string
+        default: "main"
+        required: False
 
       sycl_toolchain_artifact:
         type: string
@@ -314,3 +319,4 @@ jobs:
         sycl_cts_artifact: ${{ inputs.sycl_cts_artifact }}
         target_devices: ${{ inputs.target_devices }}
         retention-days: ${{ inputs.retention-days }}
+        sycl_cts_ref: ${{ inputs.sycl_cts_ref }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -298,7 +298,7 @@ jobs:
       if: inputs.tests_selector == 'e2e'
       uses: ./devops/actions/run-tests/e2e
       with:
-        ref: ${{ inputs.ref || github.sha }}
+        ref: ${{ inputs.tests_ref || inputs.ref || github.sha }}
         binaries_artifact: ${{ inputs.e2e_binaries_artifact }}
         testing_mode: ${{ inputs.e2e_testing_mode }}
         extra_cmake_args: ${{ inputs.extra_cmake_args }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -38,18 +38,17 @@ on:
       ref:
         type: string
         required: True
+        description: |
+          Commit SHA or branch to checkout the intel/llvm repo.
       devops_ref:
         type: string
         required: False
         description: |
-          By default we checkout the devops directory from "inputs.ref" branch.
-          devops_ref may be specified to checkout the devops dir from different
-          branch.
+          Commit SHA or branch to checkout the devops directory.
       tests_ref:
-        description: "Commit SHA or branch to checkout tests"
         type: string
-        default: "main"
         required: False
+        description: Commit SHA or branch to checkout e2e/cts tests.
 
       sycl_toolchain_artifact:
         type: string
@@ -311,7 +310,7 @@ jobs:
       if: inputs.tests_selector == 'cts'
       uses: ./devops/actions/run-tests/cts
       with:
-        ref: ${{ inputs.tests_ref }}
+        ref: ${{ inputs.tests_ref || 'main' }}
         extra_cmake_args: ${{ inputs.extra_cmake_args }}
         cts_testing_mode: ${{ inputs.cts_testing_mode }}
         sycl_cts_artifact: ${{ inputs.sycl_cts_artifact }}

--- a/devops/actions/run-tests/cts/action.yml
+++ b/devops/actions/run-tests/cts/action.yml
@@ -11,6 +11,10 @@ inputs:
     required: true
   retention-days:
     required: false
+  sycl_cts_ref:
+    description: "Commit SHA or branch to checkout"
+    required: false
+    default: "main"
 
 runs:
   using: "composite"
@@ -21,8 +25,7 @@ runs:
     with:
       path: khronos_sycl_cts
       repository: 'KhronosGroup/SYCL-CTS'
-      ref: 'main'
-      default_branch: 'main'
+      ref: ${{ inputs.sycl_cts_ref }}
       cache_path: "/__w/repo_cache/"
   - name: SYCL CTS GIT submodules init
     if: inputs.cts_testing_mode != 'run-only'

--- a/devops/actions/run-tests/cts/action.yml
+++ b/devops/actions/run-tests/cts/action.yml
@@ -1,6 +1,10 @@
 name: 'Run SYCL CTS tests'
 
 inputs:
+  ref:
+    description: "Commit SHA or branch to checkout tests"
+    required: false
+    default: "main"
   extra_cmake_args:
     required: false
   cts_testing_mode:
@@ -11,10 +15,6 @@ inputs:
     required: true
   retention-days:
     required: false
-  tests_ref:
-    description: "Commit SHA or branch to checkout tests"
-    required: false
-    default: "main"
 
 runs:
   using: "composite"
@@ -25,7 +25,7 @@ runs:
     with:
       path: khronos_sycl_cts
       repository: 'KhronosGroup/SYCL-CTS'
-      ref: ${{ inputs.tests_ref }}
+      ref: ${{ inputs.ref }}
       cache_path: "/__w/repo_cache/"
   - name: SYCL CTS GIT submodules init
     if: inputs.cts_testing_mode != 'run-only'

--- a/devops/actions/run-tests/cts/action.yml
+++ b/devops/actions/run-tests/cts/action.yml
@@ -11,8 +11,8 @@ inputs:
     required: true
   retention-days:
     required: false
-  sycl_cts_ref:
-    description: "Commit SHA or branch to checkout"
+  tests_ref:
+    description: "Commit SHA or branch to checkout tests"
     required: false
     default: "main"
 
@@ -25,7 +25,7 @@ runs:
     with:
       path: khronos_sycl_cts
       repository: 'KhronosGroup/SYCL-CTS'
-      ref: ${{ inputs.sycl_cts_ref }}
+      ref: ${{ inputs.tests_ref }}
       cache_path: "/__w/repo_cache/"
   - name: SYCL CTS GIT submodules init
     if: inputs.cts_testing_mode != 'run-only'


### PR DESCRIPTION
This patch adds a new input to fix the specific version of cts. In general it's needed for sycl-rel as the cts is continuously changing.