### PR TITLE
[SYCL][E2E] Disable `Regression/multithread_write_accessor.cpp` on Arc + OpenCL

### DIFF
--- a/sycl/test-e2e/Regression/multithread_write_accessor.cpp
+++ b/sycl/test-e2e/Regression/multithread_write_accessor.cpp
@@ -1,6 +1,10 @@
 // RUN: %{build} -o %t.out %threads_lib
 // RUN: %{run} %t.out
 
+// Test flakily times out on Arc + OpenCL
+// UNSUPPORTED: opencl && gpu-intel-dg2
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16877
+
 // XFAIL: arch-intel_gpu_pvc && opencl && !spirv-backend
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/16401
 


### PR DESCRIPTION
This test flakily times out on Arc + OpenCL. Disable it for now.
Example:
https://github.com/intel/llvm/actions/runs/13409625069/job/37483063620
https://github.com/intel/llvm/actions/runs/13417907780/job/37485889352