### PR TITLE
[UR] Update dependentloadflag for L0 adapters dlls

### DIFF
--- a/unified-runtime/source/adapters/level_zero/CMakeLists.txt
+++ b/unified-runtime/source/adapters/level_zero/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2022-2025 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -100,11 +100,6 @@ if(UR_BUILD_ADAPTER_L0)
         SOVERSION "${PROJECT_VERSION_MAJOR}"
     )
 
-    if (WIN32)
-    # 0x800: Search for the DLL only in the System32 folder
-    target_link_options(ur_adapter_level_zero PRIVATE LINKER:/DEPENDENTLOADFLAG:0x800)
-    endif()
-
     target_link_libraries(ur_adapter_level_zero PRIVATE
         ${PROJECT_NAME}::headers
         ${PROJECT_NAME}::common
@@ -205,11 +200,6 @@ if(UR_BUILD_ADAPTER_L0_V2)
         VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
         SOVERSION "${PROJECT_VERSION_MAJOR}"
     )
-
-    if (WIN32)
-    # 0x800: Search for the DLL only in the System32 folder
-    target_link_options(ur_adapter_level_zero_v2 PUBLIC LINKER:/DEPENDENTLOADFLAG:0x800)
-    endif()
 
     target_link_libraries(ur_adapter_level_zero_v2 PRIVATE
         ${PROJECT_NAME}::headers


### PR DESCRIPTION
In ['add_ur_library'](https://github.com/intel/llvm/blob/sycl/unified-runtime/cmake/helpers.cmake#L193) we're already setting up proper value (0x2000) for that flag, for all UR libs.

// Moving PR from UR: https://github.com/oneapi-src/unified-runtime/pull/2703