### PR TITLE
[UR][L0] executeCommandlist returning early for blocking batching

### DIFF
--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -1314,7 +1314,6 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
 
       if (CommandList->second.size() < CommandBatch.QueueBatchSize) {
         CommandBatch.OpenCommandList = CommandList;
-        return UR_RESULT_SUCCESS;
       }
 
       adjustBatchSizeForFullBatch(UseCopyEngine);


### PR DESCRIPTION
SYCL_UR_TRACE makes urEnqueueUSMMemcpy non-blocking even though blocking is set to true. This patch fixes the issue.