### PR TITLE
[UR] option to build LLVM with UR LevelZero v2 adapter

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -36,6 +36,9 @@ set(UR_ENABLE_TRACING ON)
 if("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)
   set(UR_BUILD_ADAPTER_L0 ON)
 endif()
+if("level_zero_v2" IN_LIST SYCL_ENABLE_BACKENDS)
+  set(UR_BUILD_ADAPTER_L0_V2 ON)
+endif()
 if("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   set(UR_BUILD_ADAPTER_CUDA ON)
 endif()
@@ -282,6 +285,10 @@ if("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)
 
   # TODO: L0 adapter does other... things in its cmake - make sure they get
   # added to the new build system
+endif()
+
+if("level_zero_v2" IN_LIST SYCL_ENABLE_BACKENDS)
+  add_sycl_ur_adapter(level_zero_v2)
 endif()
 
 if("cuda" IN_LIST SYCL_ENABLE_BACKENDS)


### PR DESCRIPTION
Use `./buildbot/configure.py --enable-backends level_zero_v2` to build LLVM with Unified Runtime LevelZero_V2 experimental adapter