### PR TITLE
[SYCL][UR] Improve header copy dependencies

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -234,25 +234,31 @@ string(REPLACE "${sycl_inc_dir}" "${SYCL_INCLUDE_BUILD_DIR}"
 string(REPLACE "${sycl_inc_dir}" "${SYCL_INCLUDE_BUILD_DIR}"
   OUT_HEADERS_IN_SYCLCOMPAT_DIR "${HEADERS_IN_SYCLCOMPAT_DIR}")
 
+set(OUT_UR_HEADERS
+  ${SYCL_INCLUDE_BUILD_DIR}/ur_api.h
+  ${SYCL_INCLUDE_BUILD_DIR}/ur_api_funcs.def
+  ${SYCL_INCLUDE_BUILD_DIR}/ur_print.hpp)
+set(UR_HEADERS_TO_COPY
+  ${UNIFIED_RUNTIME_INCLUDE_DIR}/ur_api.h
+  ${UNIFIED_RUNTIME_INCLUDE_DIR}/ur_api_funcs.def
+  ${UNIFIED_RUNTIME_INCLUDE_DIR}/ur_print.hpp)
+
 # Copy SYCL headers from sources to build directory
 add_custom_target(sycl-headers
   DEPENDS ${OUT_HEADERS_IN_SYCL_DIR}
           ${OUT_HEADERS_IN_CL_DIR}
           ${OUT_HEADERS_IN_STD_DIR}
           ${OUT_HEADERS_IN_SYCLCOMPAT_DIR}
+          ${OUT_UR_HEADERS}
           sycl-device-aspect-macros-header
           boost_mp11-headers)
 
-list(APPEND UR_HEADERS_TO_COPY
-  ${UNIFIED_RUNTIME_INCLUDE_DIR}/ur_api.h
-  ${UNIFIED_RUNTIME_INCLUDE_DIR}/ur_api_funcs.def
-  ${UNIFIED_RUNTIME_INCLUDE_DIR}/ur_print.hpp
-)
 add_custom_command(
   OUTPUT  ${OUT_HEADERS_IN_SYCL_DIR}
           ${OUT_HEADERS_IN_CL_DIR}
           ${OUT_HEADERS_IN_STD_DIR}
           ${OUT_HEADERS_IN_SYCLCOMPAT_DIR}
+          ${OUT_UR_HEADERS}
   DEPENDS ${HEADERS_IN_SYCL_DIR}
           ${HEADERS_IN_CL_DIR}
           ${HEADERS_IN_STD_DIR}


### PR DESCRIPTION
When copying the UR headers to `build/include` make sure that the `sycl-headers` target knowns about the dependencies upon the headers in `unified-runtime/include` and make sure that they are copied when changed.

This should hopefully also stop occasional failures in CI:

```
 In file included from /__w/llvm/llvm/src/unified-runtime/source/adapters/native_cpu/ur_interface_loader.cpp:11:
/__w/llvm/llvm/build/include/ur_api.h:15: error: unterminated #ifndef
```
