### PR TITLE
[UR] Logger callback function sink

### DIFF
--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -77,6 +77,11 @@ void *getAdapterOpaqueData([[maybe_unused]] void *OpaqueDataParam) {
 
 ur_code_location_t codeLocationCallback(void *);
 
+void receiveLoggerMessages([[maybe_unused]] ur_logger_level_t level,
+                           const char *msg, void *userData) {
+  // Do something with a message sent from a UR adapter
+}
+
 namespace ur {
 bool trace(TraceLevel Level) {
   auto TraceLevelMask = SYCLConfig<SYCL_UR_TRACE>::get();
@@ -219,6 +224,9 @@ static void initializeAdapters(std::vector<AdapterPtr> &Adapters,
                                     nullptr));
     auto syclBackend = UrToSyclBackend(adapterBackend);
     Adapters.emplace_back(std::make_shared<Adapter>(UrAdapter, syclBackend));
+
+    urAdapterSetLoggerCallback(UrAdapter, receiveLoggerMessages, nullptr,
+                               UR_LOGGER_LEVEL_INFO);
   }
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION

--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -230,8 +230,11 @@ static void initializeAdapters(std::vector<AdapterPtr> &Adapters,
     auto syclBackend = UrToSyclBackend(adapterBackend);
     Adapters.emplace_back(std::make_shared<Adapter>(UrAdapter, syclBackend));
 
-    CHECK_UR_SUCCESS(adapterSetLoggerCallback(UrAdapter, urLoggerCallback,
-                                              nullptr, UR_LOGGER_LEVEL_INFO));
+    const char *env_value = std::getenv("UR_LOG_CALLBACK");
+    if (env_value == nullptr || std::string(env_value) != "disabled") {
+      CHECK_UR_SUCCESS(adapterSetLoggerCallback(UrAdapter, urLoggerCallback,
+                                                nullptr, UR_LOGGER_LEVEL_INFO));
+    }
   }
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION

--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -79,7 +79,7 @@ ur_code_location_t codeLocationCallback(void *);
 
 void urLoggerCallback([[maybe_unused]] ur_logger_level_t level, const char *msg,
                       [[maybe_unused]] void *userData) {
-  std::cout << msg << std::endl;
+  std::cerr << msg << std::endl;
 }
 
 namespace ur {

--- a/sycl/test-e2e/External/README.md
+++ b/sycl/test-e2e/External/README.md
@@ -76,4 +76,3 @@ cmake \
 make check-sycl-e2e
 
 ```
-

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -168,6 +168,8 @@ if config.extra_environment:
             lit_config.note("\tUnset " + var)
             llvm_config.with_environment(var, "")
 
+# Disable the UR logger callback sink during test runs as output to SYCL RT can interfere with some tests relying on standard input/output
+llvm_config.with_environment("UR_LOG_CALLBACK", "disabled")
 
 # Temporarily modify environment to be the same that we use when running tests
 class test_env:

--- a/sycl/test/Unit/lit.cfg.py
+++ b/sycl/test/Unit/lit.cfg.py
@@ -95,3 +95,6 @@ lit_config.note("Using Mock Adapter.")
 
 config.environment["SYCL_CACHE_DIR"] = config.llvm_obj_root + "/sycl_cache"
 lit_config.note("SYCL cache directory: {}".format(config.environment["SYCL_CACHE_DIR"]))
+
+# Disable the UR logger callback sink during test runs as output to SYCL RT can interfere with some tests relying on standard input/output
+config.environment["UR_LOG_CALLBACK"] = "disabled"

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -186,6 +186,9 @@ if config.sycl_headers_filter is not None:
         )
     )
 
+# Disable the UR logger callback sink during test runs as output to SYCL RT can interfere with some tests relying on standard input/output
+llvm_config.with_environment("UR_LOG_CALLBACK", "disabled")
+
 # Dump-only tests do not have clang available
 if not dump_only_tests:
     llvm_config.use_clang(additional_flags=additional_flags)

--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -457,6 +457,10 @@ typedef enum ur_function_t {
   UR_FUNCTION_COMMAND_BUFFER_GET_NATIVE_HANDLE_EXP = 264,
   /// Enumerator for ::urUSMPoolSetInfoExp
   UR_FUNCTION_USM_POOL_SET_INFO_EXP = 265,
+  /// Enumerator for ::urAdapterSetLoggerCallback
+  UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK = 266,
+  /// Enumerator for ::urAdapterSetLoggerCallbackLevel
+  UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL = 267,
   /// @cond
   UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
   /// @endcond
@@ -1422,6 +1426,80 @@ typedef enum ur_adapter_backend_t {
   /// @endcond
 
 } ur_adapter_backend_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Minimum level of messages to be processed by the logger.
+typedef enum ur_logger_level_t {
+  /// Debugging messages used for development purposes.
+  UR_LOGGER_LEVEL_DEBUG = 0,
+  /// General messages not related to debugging, warnings or errors.
+  UR_LOGGER_LEVEL_INFO = 1,
+  /// Used to warn users about potential problems.
+  UR_LOGGER_LEVEL_WARN = 2,
+  /// Used when an error has occurred.
+  UR_LOGGER_LEVEL_ERROR = 3,
+  /// Restrict logger processing any messages.
+  UR_LOGGER_LEVEL_QUIET = 4,
+  /// @cond
+  UR_LOGGER_LEVEL_FORCE_UINT32 = 0x7fffffff
+  /// @endcond
+
+} ur_logger_level_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function to retrieve output from the logger.
+typedef void (*ur_logger_callback_t)(
+    /// [out] Minimum level of messages to be processed by the logger.
+    ur_logger_level_t level,
+    /// [in][out] pointer to data to be passed to callback
+    const char *pLoggerMsg,
+    /// [in][out] pointer to data to be passed to callback
+    void *pUserData);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a callback function for use by the logger to retrieve logging
+/// output.
+///        It is a requirement that the callback function is thread safe and the
+///        creator of the function will be responsible for this.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnLoggerCallback`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the minimum logging level for the logger Callback function.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -12764,6 +12842,26 @@ typedef struct ur_loader_config_set_mocking_enabled_params_t {
   ur_loader_config_handle_t *phLoaderConfig;
   ur_bool_t *penable;
 } ur_loader_config_set_mocking_enabled_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urAdapterSetLoggerCallback
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_adapter_set_logger_callback_params_t {
+  ur_adapter_handle_t *phAdapter;
+  ur_logger_callback_t *ppfnLoggerCallback;
+  void **ppUserData;
+  ur_logger_level_t *plevel;
+} ur_adapter_set_logger_callback_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urAdapterSetLoggerCallbackLevel
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_adapter_set_logger_callback_level_params_t {
+  ur_adapter_handle_t *phAdapter;
+  ur_logger_level_t *plevel;
+} ur_adapter_set_logger_callback_level_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urPlatformGet

--- a/unified-runtime/include/ur_api_funcs.def
+++ b/unified-runtime/include/ur_api_funcs.def
@@ -17,6 +17,8 @@
 
 // Auto-generated file, do not edit.
 
+_UR_API(urAdapterSetLoggerCallback)
+_UR_API(urAdapterSetLoggerCallbackLevel)
 _UR_API(urPlatformGet)
 _UR_API(urPlatformGetInfo)
 _UR_API(urPlatformGetNativeHandle)

--- a/unified-runtime/include/ur_ddi.h
+++ b/unified-runtime/include/ur_ddi.h
@@ -24,6 +24,43 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterSetLoggerCallback
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterSetLoggerCallback_t)(
+    ur_adapter_handle_t, ur_logger_callback_t, void *, ur_logger_level_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterSetLoggerCallbackLevel
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterSetLoggerCallbackLevel_t)(
+    ur_adapter_handle_t, ur_logger_level_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Adapter functions pointers
+typedef struct ur_adapter_dditable_t {
+  ur_pfnAdapterSetLoggerCallback_t pfnSetLoggerCallback;
+  ur_pfnAdapterSetLoggerCallbackLevel_t pfnSetLoggerCallbackLevel;
+} ur_adapter_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Adapter table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t version,
+    /// [in,out] pointer to table of DDI function pointers
+    ur_adapter_dditable_t *pDdiTable);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetAdapterProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetAdapterProcAddrTable_t)(
+    ur_api_version_t, ur_adapter_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urPlatformGet
 typedef ur_result_t(UR_APICALL *ur_pfnPlatformGet_t)(ur_adapter_handle_t,
                                                      uint32_t,
@@ -1966,6 +2003,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetDeviceProcAddrTable_t)(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Container for all DDI tables
 typedef struct ur_dditable_t {
+  ur_adapter_dditable_t Adapter;
   ur_platform_dditable_t Platform;
   ur_context_dditable_t Context;
   ur_event_dditable_t Event;

--- a/unified-runtime/include/ur_print.h
+++ b/unified-runtime/include/ur_print.h
@@ -143,6 +143,16 @@ urPrintAdapterBackend(enum ur_adapter_backend_t value, char *buffer,
                       const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_logger_level_t enum
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL
+urPrintLoggerLevel(enum ur_logger_level_t value, char *buffer,
+                   const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_platform_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1503,6 +1513,26 @@ urPrintLoaderConfigSetCodeLocationCallbackParams(
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigSetMockingEnabledParams(
     const struct ur_loader_config_set_mocking_enabled_params_t *params,
+    char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_set_logger_callback_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterSetLoggerCallbackParams(
+    const struct ur_adapter_set_logger_callback_params_t *params, char *buffer,
+    const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_set_logger_callback_level_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterSetLoggerCallbackLevelParams(
+    const struct ur_adapter_set_logger_callback_level_params_t *params,
     char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/unified-runtime/include/ur_print.hpp
+++ b/unified-runtime/include/ur_print.hpp
@@ -295,6 +295,7 @@ operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os, enum ur_adapter_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_adapter_backend_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_logger_level_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_platform_info_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_api_version_t value);
@@ -1236,6 +1237,12 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     break;
   case UR_FUNCTION_USM_POOL_SET_INFO_EXP:
     os << "UR_FUNCTION_USM_POOL_SET_INFO_EXP";
+    break;
+  case UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK:
+    os << "UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK";
+    break;
+  case UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL:
+    os << "UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL";
     break;
   default:
     os << "unknown enumerator";
@@ -2348,6 +2355,34 @@ inline std::ostream &operator<<(std::ostream &os,
     break;
   case UR_ADAPTER_BACKEND_NATIVE_CPU:
     os << "UR_ADAPTER_BACKEND_NATIVE_CPU";
+    break;
+  default:
+    os << "unknown enumerator";
+    break;
+  }
+  return os;
+}
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_logger_level_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_logger_level_t value) {
+  switch (value) {
+  case UR_LOGGER_LEVEL_DEBUG:
+    os << "UR_LOGGER_LEVEL_DEBUG";
+    break;
+  case UR_LOGGER_LEVEL_INFO:
+    os << "UR_LOGGER_LEVEL_INFO";
+    break;
+  case UR_LOGGER_LEVEL_WARN:
+    os << "UR_LOGGER_LEVEL_WARN";
+    break;
+  case UR_LOGGER_LEVEL_ERROR:
+    os << "UR_LOGGER_LEVEL_ERROR";
+    break;
+  case UR_LOGGER_LEVEL_QUIET:
+    os << "UR_LOGGER_LEVEL_QUIET";
     break;
   default:
     os << "unknown enumerator";
@@ -12376,6 +12411,59 @@ inline std::ostream &operator<<(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_set_logger_callback_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_adapter_set_logger_callback_params_t
+               *params) {
+
+  os << ".hAdapter = ";
+
+  ur::details::printPtr(os, *(params->phAdapter));
+
+  os << ", ";
+  os << ".pfnLoggerCallback = ";
+
+  os << reinterpret_cast<void *>(*(params->ppfnLoggerCallback));
+
+  os << ", ";
+  os << ".pUserData = ";
+
+  ur::details::printPtr(os, *(params->ppUserData));
+
+  os << ", ";
+  os << ".level = ";
+
+  os << *(params->plevel);
+
+  return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_set_logger_callback_level_params_t
+/// type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_adapter_set_logger_callback_level_params_t
+        *params) {
+
+  os << ".hAdapter = ";
+
+  ur::details::printPtr(os, *(params->phAdapter));
+
+  os << ", ";
+  os << ".level = ";
+
+  os << *(params->plevel);
+
+  return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_platform_get_params_t type
 /// @returns
 ///     std::ostream &
@@ -20657,6 +20745,12 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os,
   } break;
   case UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED: {
     os << (const struct ur_loader_config_set_mocking_enabled_params_t *)params;
+  } break;
+  case UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK: {
+    os << (const struct ur_adapter_set_logger_callback_params_t *)params;
+  } break;
+  case UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL: {
+    os << (const struct ur_adapter_set_logger_callback_level_params_t *)params;
   } break;
   case UR_FUNCTION_PLATFORM_GET: {
     os << (const struct ur_platform_get_params_t *)params;

--- a/unified-runtime/scripts/core/INTRO.rst
+++ b/unified-runtime/scripts/core/INTRO.rst
@@ -202,9 +202,9 @@ By default, no messages are printed.
 
 By default, there is a guarantee that *error* messages are flushed immediately. One can change this behavior to flush on lower-level messages.
 
-Loggers redirect messages to *stdout*, *stderr*, or a file (default: *stderr*).
+Loggers redirect messages to *stdout*, *stderr*, a file, or a user configurable callback function (default: *stderr*).
 
-All of these logging options can be set with **UR_LOG_LOADER** and **UR_LOG_NULL** environment variables described in the **Environment Variables** section below.
+All of these logging options (except the callback) can be set with **UR_LOG_LOADER** and **UR_LOG_NULL** environment variables described in the **Environment Variables** section below.
 Both of these environment variables have the same syntax for setting logger options:
 
   "[level:debug|info|warning|error];[flush:<debug|info|warning|error>];[output:stdout|stderr|file,<path>]"
@@ -231,6 +231,10 @@ the ``out.log`` file::
 An example of an environment variable for setting up the null adapter library with logging level set to *warning* and output set to stdout::
 
   UR_LOG_NULL="level:warning;output:stdout"
+
+Logging callback
+^^^^^^^^^^^^^^^^^^^^^
+An API is available to configure the logging callback function :ref:`urAdapterSetLoggerCallback`. Additionally, the logging level can be set using :ref:`urAdapterSetLoggerCallbackLevel`.
 
 Adapter Discovery
 ---------------------

--- a/unified-runtime/scripts/core/adapter.yml
+++ b/unified-runtime/scripts/core/adapter.yml
@@ -206,3 +206,76 @@ etors:
     - name: NATIVE_CPU
       value: "5"
       desc: "The backend is Native CPU"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Minimum level of messages to be processed by the logger."
+class: $xAdapter
+name: $x_logger_level_t
+etors:
+    - name: DEBUG
+      value: "0"
+      desc: "Debugging messages used for development purposes."
+    - name: INFO
+      value: "1"
+      desc: "General messages not related to debugging, warnings or errors."
+    - name: WARN
+      value: "2"
+      desc: "Used to warn users about potential problems."
+    - name: ERROR
+      value: "3"
+      desc: "Used when an error has occurred."
+    - name: QUIET
+      value: "4"
+      desc: "Restrict logger processing any messages."
+--- #--------------------------------------------------------------------------
+type: fptr_typedef
+desc: "Callback function to retrieve output from the logger."
+name: $x_logger_callback_t
+return: "void"
+params:
+    - type: $x_logger_level_t
+      name: level
+      desc: "[out] Minimum level of messages to be processed by the logger."
+      init: DEBUG
+    - type: const char*
+      name: pLoggerMsg
+      desc: "[in][out] pointer to data to be passed to callback"
+    - type: void*
+      name: pUserData
+      desc: "[in][out] pointer to data to be passed to callback"
+--- #--------------------------------------------------------------------------
+type: function
+desc: |
+      Set a callback function for use by the logger to retrieve logging output.
+      It is a requirement that the callback function is thread safe and the
+      creator of the function will be responsible for this.
+class: $xAdapter
+name: SetLoggerCallback
+decl: static
+params:
+    - type: $x_adapter_handle_t
+      name: hAdapter
+      desc: "[in] handle of the adapter"
+    - type: $x_logger_callback_t
+      name: pfnLoggerCallback
+      desc: "[in] Function pointer to callback from the logger."
+    - type: void*
+      name: pUserData
+      desc: "[in][out][optional] pointer to data to be passed to callback"
+    - type: $x_logger_level_t
+      name: level
+      desc: "[in] logging level"
+      init: 0
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Set the minimum logging level for the logger Callback function."
+class: $xAdapter
+name: SetLoggerCallbackLevel
+decl: static
+params:
+    - type: $x_adapter_handle_t
+      name: hAdapter
+      desc: "[in] handle of the adapter"
+    - type: $x_logger_level_t
+      name: level
+      desc: "[in] logging level"

--- a/unified-runtime/scripts/core/registry.yml
+++ b/unified-runtime/scripts/core/registry.yml
@@ -643,6 +643,12 @@ etors:
 - name: USM_POOL_SET_INFO_EXP
   desc: Enumerator for $xUSMPoolSetInfoExp
   value: '265'
+- name: ADAPTER_SET_LOGGER_CALLBACK
+  desc: Enumerator for $xAdapterSetLoggerCallback
+  value: '266'
+- name: ADAPTER_SET_LOGGER_CALLBACK_LEVEL
+  desc: Enumerator for $xAdapterSetLoggerCallbackLevel
+  value: '267'
 ---
 type: enum
 desc: Defines structure types

--- a/unified-runtime/scripts/templates/trcddi.cpp.mako
+++ b/unified-runtime/scripts/templates/trcddi.cpp.mako
@@ -54,7 +54,7 @@ namespace ur_tracing_layer
 
         getContext()->notify_end(${th.make_func_etor(n, tags, obj)}, "${th.make_func_name(n, tags, obj)}", &params, &result, instance);
 
-        if (logger.getLevel() <= logger::Level::INFO) {
+        if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
             std::ostringstream args_str;
             ur::extras::printFunctionParams(args_str, ${th.make_func_etor(n, tags, obj)}, &params);
             logger.info("   <--- ${th.make_func_name(n, tags, obj)}({}) -> {};\n", args_str.str(), result);

--- a/unified-runtime/source/adapters/adapter.def.in
+++ b/unified-runtime/source/adapters/adapter.def.in
@@ -1,6 +1,7 @@
 LIBRARY @TARGET_LIBNAME@
 EXPORTS
 	urGetGlobalProcAddrTable
+	urGetAdapterProcAddrTable
 	urGetBindlessImagesExpProcAddrTable
 	urGetCommandBufferExpProcAddrTable
 	urGetContextProcAddrTable

--- a/unified-runtime/source/adapters/adapter.map.in
+++ b/unified-runtime/source/adapters/adapter.map.in
@@ -1,6 +1,7 @@
 @TARGET_LIBNAME@ {
 	global:
 		urGetGlobalProcAddrTable;
+		urGetAdapterProcAddrTable;
 		urGetBindlessImagesExpProcAddrTable;
 		urGetCommandBufferExpProcAddrTable;
 		urGetContextProcAddrTable;

--- a/unified-runtime/source/adapters/cuda/adapter.cpp
+++ b/unified-runtime/source/adapters/cuda/adapter.cpp
@@ -121,7 +121,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
     ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
     void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
 
-  ur::cuda::adapter->logger.setCallbackSink(pfnLoggerCallback, pUserData, level);
+  ur::cuda::adapter->logger.setCallbackSink(pfnLoggerCallback, pUserData,
+                                            level);
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/cuda/adapter.cpp
+++ b/unified-runtime/source/adapters/cuda/adapter.cpp
@@ -26,7 +26,7 @@ public:
     this->ostream = &std::cerr;
   }
 
-  virtual void print([[maybe_unused]] logger::Level level,
+  virtual void print([[maybe_unused]] ur_logger_level_t level,
                      const std::string &msg) override {
     std::cerr << msg << std::endl;
   }
@@ -39,7 +39,7 @@ public:
 // https://github.com/oneapi-src/unified-runtime/issues/1330
 ur_adapter_handle_t_::ur_adapter_handle_t_()
     : logger(logger::get_logger("cuda",
-                                /*default_log_level*/ logger::Level::ERR)) {
+                                /*default_log_level*/ UR_LOGGER_LEVEL_ERROR)) {
   Platform = std::make_unique<ur_platform_handle_t_>();
 
   if (std::getenv("UR_LOG_CUDA") == nullptr &&
@@ -113,6 +113,23 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  ur::cuda::adapter->logger.setCallbackSink(pfnLoggerCallback, pUserData, level);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    ur_adapter_handle_t, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  ur::cuda::adapter->logger.setCallbackLevel(level);
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/cuda/enqueue.cpp
+++ b/unified-runtime/source/adapters/cuda/enqueue.cpp
@@ -97,10 +97,8 @@ ur_result_t setCuMemAdvise(CUdeviceptr DevPtr, size_t Size,
 
   for (auto &UnmappedFlag : UnmappedMemAdviceFlags) {
     if (URAdviceFlags & UnmappedFlag) {
-      setErrorMessage("Memory advice ignored because the CUDA backend does not "
-                      "support some of the specified flags",
-                      UR_RESULT_SUCCESS);
-      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+      logger::warning("Memory advice ignored because the CUDA backend does not "
+                      "support some of the specified flags.");
     }
   }
 
@@ -1613,19 +1611,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
   // for managed memory. Therefore, ignore prefetch hint if concurrent managed
   // memory access is not available.
   if (!getAttribute(Device, CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS)) {
-    setErrorMessage("Prefetch hint ignored as device does not support "
-                    "concurrent managed access",
-                    UR_RESULT_SUCCESS);
-    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+    logger::warning("Prefetch hint ignored as device does not support "
+                    "concurrent managed access.");
   }
 
   unsigned int IsManaged;
   UR_CHECK_ERROR(cuPointerGetAttribute(
       &IsManaged, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)pMem));
   if (!IsManaged) {
-    setErrorMessage("Prefetch hint ignored as prefetch only works with USM",
-                    UR_RESULT_SUCCESS);
-    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+    logger::warning("Prefetch hint ignored as prefetch only works with USM.");
   }
 
   ur_result_t Result = UR_RESULT_SUCCESS;
@@ -1675,9 +1669,8 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
       (advice & UR_USM_ADVICE_FLAG_DEFAULT)) {
     ur_device_handle_t Device = hQueue->getDevice();
     if (!getAttribute(Device, CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS)) {
-      setErrorMessage("Mem advise ignored as device does not support "
-                      "concurrent managed access",
-                      UR_RESULT_SUCCESS);
+      logger::warning("Mem advise ignored as device does not support "
+                      "concurrent managed access.");
       return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
     }
 

--- a/unified-runtime/source/adapters/cuda/enqueue.cpp
+++ b/unified-runtime/source/adapters/cuda/enqueue.cpp
@@ -99,6 +99,7 @@ ur_result_t setCuMemAdvise(CUdeviceptr DevPtr, size_t Size,
     if (URAdviceFlags & UnmappedFlag) {
       logger::warning("Memory advice ignored because the CUDA backend does not "
                       "support some of the specified flags.");
+      return UR_RESULT_SUCCESS;
     }
   }
 
@@ -1613,6 +1614,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
   if (!getAttribute(Device, CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS)) {
     logger::warning("Prefetch hint ignored as device does not support "
                     "concurrent managed access.");
+    return UR_RESULT_SUCCESS;
   }
 
   unsigned int IsManaged;
@@ -1620,6 +1622,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
       &IsManaged, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)pMem));
   if (!IsManaged) {
     logger::warning("Prefetch hint ignored as prefetch only works with USM.");
+    return UR_RESULT_SUCCESS;
   }
 
   ur_result_t Result = UR_RESULT_SUCCESS;
@@ -1671,7 +1674,7 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
     if (!getAttribute(Device, CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS)) {
       logger::warning("Mem advise ignored as device does not support "
                       "concurrent managed access.");
-      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+      return UR_RESULT_SUCCESS;
     }
 
     // TODO: If ptr points to valid system-allocated pageable memory we should

--- a/unified-runtime/source/adapters/cuda/kernel.cpp
+++ b/unified-runtime/source/adapters/cuda/kernel.cpp
@@ -397,7 +397,7 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
           arrayDesc.Format != CU_AD_FORMAT_SIGNED_INT32 &&
           arrayDesc.Format != CU_AD_FORMAT_HALF &&
           arrayDesc.Format != CU_AD_FORMAT_FLOAT) {
-        setErrorMessage("PI CUDA kernels only support images with channel "
+        setErrorMessage("UR CUDA kernels only support images with channel "
                         "types int32, uint32, float, and half.",
                         UR_RESULT_ERROR_ADAPTER_SPECIFIC);
         return UR_RESULT_ERROR_ADAPTER_SPECIFIC;

--- a/unified-runtime/source/adapters/cuda/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/cuda/ur_interface_loader.cpp
@@ -460,6 +460,18 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
+  return UR_RESULT_SUCCESS;
+}
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/unified-runtime/source/adapters/hip/adapter.cpp
+++ b/unified-runtime/source/adapters/hip/adapter.cpp
@@ -26,7 +26,7 @@ public:
     this->ostream = &std::cerr;
   }
 
-  virtual void print([[maybe_unused]] logger::Level level,
+  virtual void print([[maybe_unused]] ur_logger_level_t level,
                      const std::string &msg) override {
     std::cerr << msg << std::endl;
   }
@@ -38,8 +38,8 @@ public:
 // through UR entry points.
 // https://github.com/oneapi-src/unified-runtime/issues/1330
 ur_adapter_handle_t_::ur_adapter_handle_t_()
-    : logger(
-          logger::get_logger("hip", /*default_log_level*/ logger::Level::ERR)) {
+    : logger(logger::get_logger("hip",
+                                /*default_log_level*/ UR_LOGGER_LEVEL_ERROR)) {
   Platform = std::make_unique<ur_platform_handle_t_>();
   if (std::getenv("UR_LOG_HIP") != nullptr)
     return;
@@ -104,6 +104,23 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  ur::hip::adapter->logger.setCallbackSink(pfnLoggerCallback, pUserData, level);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t, ur_logger_level_t level) {
+
+  ur::hip::adapter->logger.setCallbackLevel(level);
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/hip/enqueue.cpp
+++ b/unified-runtime/source/adapters/hip/enqueue.cpp
@@ -1410,6 +1410,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
       releaseEvent();
       logger::warning("mem_advise ignored as device does not support "
                       "managed memory access.");
+      return UR_RESULT_SUCCESS;
     }
 
     hipPointerAttribute_t attribs;
@@ -1423,7 +1424,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     if (!attribs.isManaged) {
       releaseEvent();
       logger::warning("Prefetch hint ignored as prefetch only works with USM.");
-      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+      return UR_RESULT_SUCCESS;
     }
 
     UR_CHECK_ERROR(
@@ -1480,6 +1481,7 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
       releaseEvent();
       logger::warning("mem_advise ignored as device does not support "
                       "managed memory access.");
+      return UR_RESULT_SUCCESS;
     }
 
     // Passing MEM_ADVICE_SET/MEM_ADVICE_CLEAR_PREFERRED_LOCATION to
@@ -1496,6 +1498,7 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
         releaseEvent();
         logger::warning("mem_advise ignored as device does not support "
                         "concurrent memory access.");
+        return UR_RESULT_SUCCESS;
       }
 
       // TODO: If pMem points to valid system-allocated pageable memory, we
@@ -1515,7 +1518,7 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
       releaseEvent();
       logger::warning("mem_advise is ignored as the pointer argument is not "
                       "a shared USM pointer.");
-      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+      return UR_RESULT_SUCCESS;
     }
 
     const auto DeviceID = Device->get();
@@ -1544,6 +1547,7 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
         releaseEvent();
         logger::warning("mem_advise is ignored as the advice argument is not "
                         "supported by this device.");
+        return UR_RESULT_SUCCESS;
       }
       UR_CHECK_ERROR(Result);
     }

--- a/unified-runtime/source/adapters/hip/enqueue.cpp
+++ b/unified-runtime/source/adapters/hip/enqueue.cpp
@@ -13,6 +13,7 @@
 #include "context.hpp"
 #include "event.hpp"
 #include "kernel.hpp"
+#include "logger/ur_logger.hpp"
 #include "memory.hpp"
 #include "queue.hpp"
 #include "ur_api.h"
@@ -1407,10 +1408,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     // mem_advise.
     if (!Device->getManagedMemSupport()) {
       releaseEvent();
-      setErrorMessage("mem_advise ignored as device does not support "
-                      "managed memory access",
-                      UR_RESULT_SUCCESS);
-      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+      logger::warning("mem_advise ignored as device does not support "
+                      "managed memory access.");
     }
 
     hipPointerAttribute_t attribs;
@@ -1423,8 +1422,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     // async prefetch requires USM pointer (or hip SVM) to work.
     if (!attribs.isManaged) {
       releaseEvent();
-      setErrorMessage("Prefetch hint ignored as prefetch only works with USM",
-                      UR_RESULT_SUCCESS);
+      logger::warning("Prefetch hint ignored as prefetch only works with USM.");
       return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
     }
 
@@ -1480,10 +1478,8 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
     // mem_advise.
     if (!Device->getManagedMemSupport()) {
       releaseEvent();
-      setErrorMessage("mem_advise ignored as device does not support "
-                      "managed memory access",
-                      UR_RESULT_SUCCESS);
-      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+      logger::warning("mem_advise ignored as device does not support "
+                      "managed memory access.");
     }
 
     // Passing MEM_ADVICE_SET/MEM_ADVICE_CLEAR_PREFERRED_LOCATION to
@@ -1498,10 +1494,8 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
                   UR_USM_ADVICE_FLAG_DEFAULT)) {
       if (!Device->getConcurrentManagedAccess()) {
         releaseEvent();
-        setErrorMessage("mem_advise ignored as device does not support "
-                        "concurrent managed access",
-                        UR_RESULT_SUCCESS);
-        return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+        logger::warning("mem_advise ignored as device does not support "
+                        "concurrent memory access.");
       }
 
       // TODO: If pMem points to valid system-allocated pageable memory, we
@@ -1519,9 +1513,8 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
     if (auto ptrAttribs = getPointerAttributes(pMem);
         !ptrAttribs || !ptrAttribs->isManaged) {
       releaseEvent();
-      setErrorMessage("mem_advise is ignored as the pointer argument is not "
-                      "a shared USM pointer",
-                      UR_RESULT_SUCCESS);
+      logger::warning("mem_advise is ignored as the pointer argument is not "
+                      "a shared USM pointer.");
       return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
     }
 
@@ -1549,10 +1542,8 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
       // the runtime.
       if (Result == UR_RESULT_ERROR_INVALID_ENUMERATION) {
         releaseEvent();
-        setErrorMessage("mem_advise is ignored as the advice argument is not "
-                        "supported by this device",
-                        UR_RESULT_SUCCESS);
-        return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+        logger::warning("mem_advise is ignored as the advice argument is not "
+                        "supported by this device.");
       }
       UR_CHECK_ERROR(Result);
     }

--- a/unified-runtime/source/adapters/hip/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/hip/ur_interface_loader.cpp
@@ -452,6 +452,18 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
+  return UR_RESULT_SUCCESS;
+}
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -41,7 +41,7 @@ public:
     this->ostream = &std::cerr;
   }
 
-  virtual void print([[maybe_unused]] logger::Level level,
+  virtual void print([[maybe_unused]] ur_logger_level_t level,
                      const std::string &msg) override {
     fprintf(stderr, "%s", msg.c_str());
   }
@@ -739,4 +739,26 @@ ur_result_t urAdapterGetInfo(ur_adapter_handle_t, ur_adapter_info_t PropName,
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  if (GlobalAdapter) {
+    GlobalAdapter->logger.setCallbackSink(pfnLoggerCallback, pUserData, level);
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t, ur_logger_level_t level) {
+
+  if (GlobalAdapter) {
+    GlobalAdapter->logger.setCallbackLevel(level);
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
 } // namespace ur::level_zero

--- a/unified-runtime/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/level_zero/ur_interface_loader.cpp
@@ -48,6 +48,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   return result;
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+
+  pDdiTable->pfnSetLoggerCallback = ur::level_zero::urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel =
+      ur::level_zero::urAdapterSetLoggerCallbackLevel;
+
+  return result;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     ur_api_version_t version, ur_bindless_images_exp_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);
@@ -547,6 +561,10 @@ ur_result_t urAdapterGetDdiTables(ur_dditable_t *ddi) {
 
   result = ur::level_zero::urGetGlobalProcAddrTable(UR_API_VERSION_CURRENT,
                                                     &ddi->Global);
+  if (result != UR_RESULT_SUCCESS)
+    return result;
+  result = ur::level_zero::urGetAdapterProcAddrTable(UR_API_VERSION_CURRENT,
+                                                     &ddi->Adapter);
   if (result != UR_RESULT_SUCCESS)
     return result;
   result = ur::level_zero::urGetBindlessImagesExpProcAddrTable(

--- a/unified-runtime/source/adapters/level_zero/ur_interface_loader.hpp
+++ b/unified-runtime/source/adapters/level_zero/ur_interface_loader.hpp
@@ -21,15 +21,15 @@ ur_result_t urAdapterGetLastError(ur_adapter_handle_t hAdapter,
 ur_result_t urAdapterGetInfo(ur_adapter_handle_t hAdapter,
                              ur_adapter_info_t propName, size_t propSize,
                              void *pPropValue, size_t *pPropSizeRet);
-ur_result_t urPlatformGet(ur_adapter_handle_t hAdapter, uint32_t NumEntries,
-                          ur_platform_handle_t *phPlatforms,
-                          uint32_t *pNumPlatforms);
 ur_result_t urAdapterSetLoggerCallback(ur_adapter_handle_t hAdapter,
                                        ur_logger_callback_t pfnLoggerCallback,
                                        void *pUserData,
                                        ur_logger_level_t level);
 ur_result_t urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t hAdapter,
                                             ur_logger_level_t level);
+ur_result_t urPlatformGet(ur_adapter_handle_t hAdapter, uint32_t NumEntries,
+                          ur_platform_handle_t *phPlatforms,
+                          uint32_t *pNumPlatforms);
 ur_result_t urPlatformGetInfo(ur_platform_handle_t hPlatform,
                               ur_platform_info_t propName, size_t propSize,
                               void *pPropValue, size_t *pPropSizeRet);

--- a/unified-runtime/source/adapters/level_zero/ur_interface_loader.hpp
+++ b/unified-runtime/source/adapters/level_zero/ur_interface_loader.hpp
@@ -24,6 +24,12 @@ ur_result_t urAdapterGetInfo(ur_adapter_handle_t hAdapter,
 ur_result_t urPlatformGet(ur_adapter_handle_t hAdapter, uint32_t NumEntries,
                           ur_platform_handle_t *phPlatforms,
                           uint32_t *pNumPlatforms);
+ur_result_t urAdapterSetLoggerCallback(ur_adapter_handle_t hAdapter,
+                                       ur_logger_callback_t pfnLoggerCallback,
+                                       void *pUserData,
+                                       ur_logger_level_t level);
+ur_result_t urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t hAdapter,
+                                            ur_logger_level_t level);
 ur_result_t urPlatformGetInfo(ur_platform_handle_t hPlatform,
                               ur_platform_info_t propName, size_t propSize,
                               void *pPropValue, size_t *pPropSizeRet);

--- a/unified-runtime/source/adapters/mock/ur_mockddi.cpp
+++ b/unified-runtime/source/adapters/mock/ur_mockddi.cpp
@@ -262,6 +262,102 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallback
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) try {
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  ur_adapter_set_logger_callback_params_t params = {
+      &hAdapter, &pfnLoggerCallback, &pUserData, &level};
+
+  auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_before_callback("urAdapterSetLoggerCallback"));
+  if (beforeCallback) {
+    result = beforeCallback(&params);
+    if (result != UR_RESULT_SUCCESS) {
+      return result;
+    }
+  }
+
+  auto replaceCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_replace_callback("urAdapterSetLoggerCallback"));
+  if (replaceCallback) {
+    result = replaceCallback(&params);
+  } else {
+
+    result = UR_RESULT_SUCCESS;
+  }
+
+  if (result != UR_RESULT_SUCCESS) {
+    return result;
+  }
+
+  auto afterCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_after_callback("urAdapterSetLoggerCallback"));
+  if (afterCallback) {
+    return afterCallback(&params);
+  }
+
+  return result;
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallbackLevel
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) try {
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  ur_adapter_set_logger_callback_level_params_t params = {&hAdapter, &level};
+
+  auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_before_callback(
+          "urAdapterSetLoggerCallbackLevel"));
+  if (beforeCallback) {
+    result = beforeCallback(&params);
+    if (result != UR_RESULT_SUCCESS) {
+      return result;
+    }
+  }
+
+  auto replaceCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_replace_callback(
+          "urAdapterSetLoggerCallbackLevel"));
+  if (replaceCallback) {
+    result = replaceCallback(&params);
+  } else {
+
+    result = UR_RESULT_SUCCESS;
+  }
+
+  if (result != UR_RESULT_SUCCESS) {
+    return result;
+  }
+
+  auto afterCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_after_callback(
+          "urAdapterSetLoggerCallbackLevel"));
+  if (afterCallback) {
+    return afterCallback(&params);
+  }
+
+  return result;
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
     /// [in] adapter to query for platforms.
@@ -11676,6 +11772,37 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   pDdiTable->pfnAdapterGetLastError = driver::urAdapterGetLastError;
 
   pDdiTable->pfnAdapterGetInfo = driver::urAdapterGetInfo;
+
+  return result;
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Adapter table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t version,
+    /// [in,out] pointer to table of DDI function pointers
+    ur_adapter_dditable_t *pDdiTable) try {
+  if (nullptr == pDdiTable)
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+  if (driver::d_context.version < version)
+    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  pDdiTable->pfnSetLoggerCallback = driver::urAdapterSetLoggerCallback;
+
+  pDdiTable->pfnSetLoggerCallbackLevel =
+      driver::urAdapterSetLoggerCallbackLevel;
 
   return result;
 } catch (...) {

--- a/unified-runtime/source/adapters/native_cpu/adapter.cpp
+++ b/unified-runtime/source/adapters/native_cpu/adapter.cpp
@@ -66,3 +66,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  Adapter.logger.setCallbackSink(pfnLoggerCallback, pUserData, level);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t, ur_logger_level_t level) {
+
+  Adapter.logger.setCallbackLevel(level);
+
+  return UR_RESULT_SUCCESS;
+}

--- a/unified-runtime/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -432,4 +432,17 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
+  return UR_RESULT_SUCCESS;
+}
+
 } // extern "C"

--- a/unified-runtime/source/adapters/opencl/adapter.cpp
+++ b/unified-runtime/source/adapters/opencl/adapter.cpp
@@ -137,3 +137,24 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  if (adapter) {
+    adapter->log.setCallbackSink(pfnLoggerCallback, pUserData, level);
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t, ur_logger_level_t level) {
+
+  if (adapter) {
+    adapter->log.setCallbackLevel(level);
+  }
+
+  return UR_RESULT_SUCCESS;
+}

--- a/unified-runtime/source/adapters/opencl/common.cpp
+++ b/unified-runtime/source/adapters/opencl/common.cpp
@@ -16,14 +16,6 @@ namespace cl_adapter {
 thread_local int32_t ErrorMessageCode = 0;
 thread_local char ErrorMessage[MaxMessageSize]{};
 
-[[maybe_unused]] void setErrorMessage(const char *Message, int32_t ErrorCode) {
-  assert(strlen(Message) < cl_adapter::MaxMessageSize);
-  // Copy at most MaxMessageSize - 1 bytes to ensure the resultant string is
-  // always null terminated.
-  strncpy(cl_adapter::ErrorMessage, Message, MaxMessageSize - 1);
-
-  ErrorMessageCode = ErrorCode;
-}
 } // namespace cl_adapter
 
 ur_result_t mapCLErrorToUR(cl_int Result) {

--- a/unified-runtime/source/adapters/opencl/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/opencl/ur_interface_loader.cpp
@@ -440,6 +440,19 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
+  return UR_RESULT_SUCCESS;
+}
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/unified-runtime/source/common/logger/ur_level.hpp
+++ b/unified-runtime/source/common/logger/ur_level.hpp
@@ -8,22 +8,21 @@
 
 #include <stdexcept>
 #include <string>
+#include <ur_api.h>
 
 namespace logger {
 
-enum class Level { DEBUG, INFO, WARN, ERR, QUIET };
-
-inline constexpr auto level_to_str(Level level) {
+inline constexpr auto level_to_str(ur_logger_level_t level) {
   switch (level) {
-  case Level::DEBUG:
+  case UR_LOGGER_LEVEL_DEBUG:
     return "DEBUG";
-  case Level::INFO:
+  case UR_LOGGER_LEVEL_INFO:
     return "INFO";
-  case Level::WARN:
+  case UR_LOGGER_LEVEL_WARN:
     return "WARNING";
-  case Level::ERR:
+  case UR_LOGGER_LEVEL_ERROR:
     return "ERROR";
-  case Level::QUIET:
+  case UR_LOGGER_LEVEL_QUIET:
     return "QUIET";
   default:
     return "";
@@ -31,20 +30,20 @@ inline constexpr auto level_to_str(Level level) {
 }
 
 inline auto str_to_level(std::string name) {
-  struct lvl_name {
+  struct level_name {
     std::string name;
-    Level lvl;
+    ur_logger_level_t level;
   };
 
-  const lvl_name lvl_names[] = {{"debug", Level::DEBUG},
-                                {"info", Level::INFO},
-                                {"warning", Level::WARN},
-                                {"error", Level::ERR},
-                                {"quiet", Level::QUIET}};
+  const level_name level_names[] = {{"debug", UR_LOGGER_LEVEL_DEBUG},
+                                    {"info", UR_LOGGER_LEVEL_INFO},
+                                    {"warning", UR_LOGGER_LEVEL_WARN},
+                                    {"error", UR_LOGGER_LEVEL_ERROR},
+                                    {"quiet", UR_LOGGER_LEVEL_QUIET}};
 
-  for (auto const &item : lvl_names) {
+  for (auto const &item : level_names) {
     if (item.name.compare(name) == 0) {
-      return item.lvl;
+      return item.level;
     }
   }
   throw std::invalid_argument(

--- a/unified-runtime/source/common/logger/ur_logger_details.hpp
+++ b/unified-runtime/source/common/logger/ur_logger_details.hpp
@@ -125,13 +125,16 @@ public:
     this->standardSink = std::move(legacySink);
   }
 
-  void setCallbackSink(ur_logger_callback_t cb, void *pUserData,
+  void setCallbackSink(ur_logger_callback_t callBack, void *pUserData,
                        ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
     if (!callbackSink) {
       callbackSink = std::make_unique<CallbackSink>("UR_LOG_CALLBACK");
     }
-    callbackSinkLevel = level;
-    callbackSink->setCallback(cb, pUserData);
+
+    if (callBack) {
+      callbackSink->setCallback(callBack, pUserData);
+      callbackSinkLevel = level;
+    }
   }
 
   void setCallbackLevel(ur_logger_level_t level) {

--- a/unified-runtime/source/common/logger/ur_sinks.hpp
+++ b/unified-runtime/source/common/logger/ur_sinks.hpp
@@ -8,10 +8,12 @@
 #define UR_SINKS_HPP 1
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <mutex>
 #include <sstream>
 
+#include "ur_api.h"
 #include "ur_filesystem_resolved.hpp"
 #include "ur_level.hpp"
 #include "ur_print.hpp"
@@ -25,9 +27,9 @@ inline bool isTearDowned = false;
 class Sink {
 public:
   template <typename... Args>
-  void log(logger::Level level, const char *fmt, Args &&...args) {
+  void log(ur_logger_level_t level, const char *fmt, Args &&...args) {
     std::ostringstream buffer;
-    if (!skip_prefix && level != logger::Level::QUIET) {
+    if (!skip_prefix && level != UR_LOGGER_LEVEL_QUIET) {
       buffer << "<" << logger_name << ">"
              << "[" << level_to_str(level) << "]: ";
     }
@@ -50,23 +52,23 @@ public:
 #endif
   }
 
-  void setFlushLevel(logger::Level level) { this->flush_level = level; }
+  void setFlushLevel(ur_logger_level_t level) { this->flush_level = level; }
 
   virtual ~Sink() = default;
 
 protected:
   std::ostream *ostream;
-  logger::Level flush_level;
+  ur_logger_level_t flush_level;
 
   Sink(std::string logger_name, bool skip_prefix = false,
        bool skip_linebreak = false)
       : logger_name(std::move(logger_name)), skip_prefix(skip_prefix),
         skip_linebreak(skip_linebreak) {
     ostream = nullptr;
-    flush_level = logger::Level::ERR;
+    flush_level = UR_LOGGER_LEVEL_ERROR;
   }
 
-  virtual void print(logger::Level level, const std::string &msg) {
+  virtual void print(ur_logger_level_t level, const std::string &msg) {
     std::scoped_lock<std::mutex> lock(output_mutex);
     *ostream << msg;
     if (level >= flush_level) {
@@ -157,8 +159,8 @@ public:
     this->ostream = &std::cout;
   }
 
-  StdoutSink(std::string logger_name, Level flush_lvl, bool skip_prefix = false,
-             bool skip_linebreak = false)
+  StdoutSink(std::string logger_name, ur_logger_level_t flush_lvl,
+             bool skip_prefix = false, bool skip_linebreak = false)
       : StdoutSink(std::move(logger_name), skip_prefix, skip_linebreak) {
     this->flush_level = flush_lvl;
   }
@@ -174,8 +176,8 @@ public:
     this->ostream = &std::cerr;
   }
 
-  StderrSink(std::string logger_name, Level flush_lvl, bool skip_prefix,
-             bool skip_linebreak)
+  StderrSink(std::string logger_name, ur_logger_level_t flush_lvl,
+             bool skip_prefix, bool skip_linebreak)
       : StderrSink(std::move(logger_name), skip_prefix, skip_linebreak) {
     this->flush_level = flush_lvl;
   }
@@ -198,8 +200,9 @@ public:
     this->ostream = &ofstream;
   }
 
-  FileSink(std::string logger_name, filesystem::path file_path, Level flush_lvl,
-           bool skip_prefix = false, bool skip_linebreak = false)
+  FileSink(std::string logger_name, filesystem::path file_path,
+           ur_logger_level_t flush_lvl, bool skip_prefix = false,
+           bool skip_linebreak = false)
       : FileSink(std::move(logger_name), std::move(file_path), skip_prefix,
                  skip_linebreak) {
     this->flush_level = flush_lvl;
@@ -209,6 +212,34 @@ public:
 
 private:
   std::ofstream ofstream;
+};
+
+class CallbackSink : public Sink {
+public:
+  CallbackSink(std::string logger_name, bool skip_prefix = false,
+               bool skip_linebreak = false)
+      : Sink(std::move(logger_name), skip_prefix, skip_linebreak) {}
+
+  CallbackSink(std::string logger_name, ur_logger_level_t flush_lvl,
+               bool skip_prefix, bool skip_linebreak)
+      : CallbackSink(std::move(logger_name), skip_prefix, skip_linebreak) {
+    this->flush_level = flush_lvl;
+  }
+
+  ~CallbackSink() = default;
+
+  void setCallback(ur_logger_callback_t cb, void *pUserData) {
+    callback = cb;
+    userData = pUserData;
+  }
+
+private:
+  ur_logger_callback_t callback;
+  void *userData;
+
+  virtual void print(ur_logger_level_t level, const std::string &msg) override {
+    callback(level, msg.c_str(), userData);
+  }
 };
 
 inline std::unique_ptr<Sink> sink_from_str(std::string logger_name,

--- a/unified-runtime/source/common/logger/ur_sinks.hpp
+++ b/unified-runtime/source/common/logger/ur_sinks.hpp
@@ -240,7 +240,7 @@ private:
   virtual void print(ur_logger_level_t level, const std::string &msg) override {
     if (callback) {
       callback(level, msg.c_str(), userData);
-    } 
+    }
   }
 };
 

--- a/unified-runtime/source/common/logger/ur_sinks.hpp
+++ b/unified-runtime/source/common/logger/ur_sinks.hpp
@@ -234,11 +234,13 @@ public:
   }
 
 private:
-  ur_logger_callback_t callback;
-  void *userData;
+  ur_logger_callback_t callback = nullptr;
+  void *userData = nullptr;
 
   virtual void print(ur_logger_level_t level, const std::string &msg) override {
-    callback(level, msg.c_str(), userData);
+    if (callback) {
+      callback(level, msg.c_str(), userData);
+    } 
   }
 };
 

--- a/unified-runtime/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
@@ -27,7 +27,7 @@ context_t *getContext() {
 ///////////////////////////////////////////////////////////////////////////////
 context_t::context_t()
     : logger(logger::create_logger("sanitizer", false, false,
-                                   logger::Level::WARN)) {}
+                                   UR_LOGGER_LEVEL_WARN)) {}
 
 ur_result_t context_t::tearDown() {
   switch (enabledType) {

--- a/unified-runtime/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/unified-runtime/source/loader/layers/tracing/ur_trcddi.cpp
@@ -49,7 +49,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_GET, "urAdapterGet", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_GET, &params);
     logger.info("   <--- urAdapterGet({}) -> {};\n", args_str.str(), result);
@@ -80,7 +80,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_RELEASE, "urAdapterRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_RELEASE,
                                     &params);
@@ -113,7 +113,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_RETAIN, "urAdapterRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_RETAIN,
                                     &params);
@@ -152,7 +152,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_GET_LAST_ERROR,
                            "urAdapterGetLastError", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ADAPTER_GET_LAST_ERROR, &params);
@@ -200,12 +200,94 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_GET_INFO, "urAdapterGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_GET_INFO,
                                     &params);
     logger.info("   <--- urAdapterGetInfo({}) -> {};\n", args_str.str(),
                 result);
+  }
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallback
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  auto pfnSetLoggerCallback =
+      getContext()->urDdiTable.Adapter.pfnSetLoggerCallback;
+
+  if (nullptr == pfnSetLoggerCallback)
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+  ur_adapter_set_logger_callback_params_t params = {
+      &hAdapter, &pfnLoggerCallback, &pUserData, &level};
+  uint64_t instance =
+      getContext()->notify_begin(UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK,
+                                 "urAdapterSetLoggerCallback", &params);
+
+  auto &logger = getContext()->logger;
+  logger.info("   ---> urAdapterSetLoggerCallback\n");
+
+  ur_result_t result =
+      pfnSetLoggerCallback(hAdapter, pfnLoggerCallback, pUserData, level);
+
+  getContext()->notify_end(UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK,
+                           "urAdapterSetLoggerCallback", &params, &result,
+                           instance);
+
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
+    std::ostringstream args_str;
+    ur::extras::printFunctionParams(
+        args_str, UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK, &params);
+    logger.info("   <--- urAdapterSetLoggerCallback({}) -> {};\n",
+                args_str.str(), result);
+  }
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallbackLevel
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  auto pfnSetLoggerCallbackLevel =
+      getContext()->urDdiTable.Adapter.pfnSetLoggerCallbackLevel;
+
+  if (nullptr == pfnSetLoggerCallbackLevel)
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+  ur_adapter_set_logger_callback_level_params_t params = {&hAdapter, &level};
+  uint64_t instance =
+      getContext()->notify_begin(UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL,
+                                 "urAdapterSetLoggerCallbackLevel", &params);
+
+  auto &logger = getContext()->logger;
+  logger.info("   ---> urAdapterSetLoggerCallbackLevel\n");
+
+  ur_result_t result = pfnSetLoggerCallbackLevel(hAdapter, level);
+
+  getContext()->notify_end(UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL,
+                           "urAdapterSetLoggerCallbackLevel", &params, &result,
+                           instance);
+
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
+    std::ostringstream args_str;
+    ur::extras::printFunctionParams(
+        args_str, UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL, &params);
+    logger.info("   <--- urAdapterSetLoggerCallbackLevel({}) -> {};\n",
+                args_str.str(), result);
   }
 
   return result;
@@ -245,7 +327,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
   getContext()->notify_end(UR_FUNCTION_PLATFORM_GET, "urPlatformGet", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PLATFORM_GET,
                                     &params);
@@ -292,7 +374,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
   getContext()->notify_end(UR_FUNCTION_PLATFORM_GET_INFO, "urPlatformGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PLATFORM_GET_INFO,
                                     &params);
@@ -328,7 +410,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
                            "urPlatformGetApiVersion", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_API_VERSION, &params);
@@ -367,7 +449,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
                            "urPlatformGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE, &params);
@@ -411,7 +493,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
                            "urPlatformCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -454,7 +536,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
                            "urPlatformGetBackendOption", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION, &params);
@@ -503,7 +585,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
   getContext()->notify_end(UR_FUNCTION_DEVICE_GET, "urDeviceGet", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_GET, &params);
     logger.info("   <--- urDeviceGet({}) -> {};\n", args_str.str(), result);
@@ -550,7 +632,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
   getContext()->notify_end(UR_FUNCTION_DEVICE_GET_INFO, "urDeviceGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_GET_INFO,
                                     &params);
@@ -582,7 +664,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
   getContext()->notify_end(UR_FUNCTION_DEVICE_RETAIN, "urDeviceRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_RETAIN,
                                     &params);
@@ -614,7 +696,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
   getContext()->notify_end(UR_FUNCTION_DEVICE_RELEASE, "urDeviceRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_RELEASE,
                                     &params);
@@ -659,7 +741,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
   getContext()->notify_end(UR_FUNCTION_DEVICE_PARTITION, "urDevicePartition",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_PARTITION,
                                     &params);
@@ -704,7 +786,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
   getContext()->notify_end(UR_FUNCTION_DEVICE_SELECT_BINARY,
                            "urDeviceSelectBinary", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_SELECT_BINARY,
                                     &params);
@@ -740,7 +822,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
                            "urDeviceGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE, &params);
@@ -784,7 +866,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
                            "urDeviceCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -828,7 +910,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
                            "urDeviceGetGlobalTimestamps", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS, &params);
@@ -869,7 +951,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
   getContext()->notify_end(UR_FUNCTION_CONTEXT_CREATE, "urContextCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_CREATE,
                                     &params);
@@ -901,7 +983,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
   getContext()->notify_end(UR_FUNCTION_CONTEXT_RETAIN, "urContextRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_RETAIN,
                                     &params);
@@ -933,7 +1015,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
   getContext()->notify_end(UR_FUNCTION_CONTEXT_RELEASE, "urContextRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_RELEASE,
                                     &params);
@@ -982,7 +1064,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
   getContext()->notify_end(UR_FUNCTION_CONTEXT_GET_INFO, "urContextGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_GET_INFO,
                                     &params);
@@ -1019,7 +1101,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
                            "urContextGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE, &params);
@@ -1069,7 +1151,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
                            "urContextCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -1110,7 +1192,7 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
                            "urContextSetExtendedDeleter", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER, &params);
@@ -1155,7 +1237,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
   getContext()->notify_end(UR_FUNCTION_MEM_IMAGE_CREATE, "urMemImageCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_IMAGE_CREATE,
                                     &params);
@@ -1198,7 +1280,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
   getContext()->notify_end(UR_FUNCTION_MEM_BUFFER_CREATE, "urMemBufferCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_BUFFER_CREATE,
                                     &params);
@@ -1231,7 +1313,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
   getContext()->notify_end(UR_FUNCTION_MEM_RETAIN, "urMemRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_RETAIN, &params);
     logger.info("   <--- urMemRetain({}) -> {};\n", args_str.str(), result);
@@ -1262,7 +1344,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
   getContext()->notify_end(UR_FUNCTION_MEM_RELEASE, "urMemRelease", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_RELEASE, &params);
     logger.info("   <--- urMemRelease({}) -> {};\n", args_str.str(), result);
@@ -1303,7 +1385,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
   getContext()->notify_end(UR_FUNCTION_MEM_BUFFER_PARTITION,
                            "urMemBufferPartition", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_BUFFER_PARTITION,
                                     &params);
@@ -1341,7 +1423,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
   getContext()->notify_end(UR_FUNCTION_MEM_GET_NATIVE_HANDLE,
                            "urMemGetNativeHandle", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_GET_NATIVE_HANDLE,
                                     &params);
@@ -1385,7 +1467,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
                            "urMemBufferCreateWithNativeHandle", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -1433,7 +1515,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
                            "urMemImageCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -1481,7 +1563,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
   getContext()->notify_end(UR_FUNCTION_MEM_GET_INFO, "urMemGetInfo", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_GET_INFO,
                                     &params);
@@ -1528,7 +1610,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
   getContext()->notify_end(UR_FUNCTION_MEM_IMAGE_GET_INFO, "urMemImageGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_IMAGE_GET_INFO,
                                     &params);
@@ -1565,7 +1647,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
   getContext()->notify_end(UR_FUNCTION_SAMPLER_CREATE, "urSamplerCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_CREATE,
                                     &params);
@@ -1597,7 +1679,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
   getContext()->notify_end(UR_FUNCTION_SAMPLER_RETAIN, "urSamplerRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_RETAIN,
                                     &params);
@@ -1629,7 +1711,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
   getContext()->notify_end(UR_FUNCTION_SAMPLER_RELEASE, "urSamplerRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_RELEASE,
                                     &params);
@@ -1673,7 +1755,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
   getContext()->notify_end(UR_FUNCTION_SAMPLER_GET_INFO, "urSamplerGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_GET_INFO,
                                     &params);
@@ -1710,7 +1792,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
                            "urSamplerGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE, &params);
@@ -1754,7 +1836,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
                            "urSamplerCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -1796,7 +1878,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
   getContext()->notify_end(UR_FUNCTION_USM_HOST_ALLOC, "urUSMHostAlloc",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_HOST_ALLOC,
                                     &params);
@@ -1840,7 +1922,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
   getContext()->notify_end(UR_FUNCTION_USM_DEVICE_ALLOC, "urUSMDeviceAlloc",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_DEVICE_ALLOC,
                                     &params);
@@ -1885,7 +1967,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
   getContext()->notify_end(UR_FUNCTION_USM_SHARED_ALLOC, "urUSMSharedAlloc",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_SHARED_ALLOC,
                                     &params);
@@ -1920,7 +2002,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
   getContext()->notify_end(UR_FUNCTION_USM_FREE, "urUSMFree", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_FREE, &params);
     logger.info("   <--- urUSMFree({}) -> {};\n", args_str.str(), result);
@@ -1964,7 +2046,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
   getContext()->notify_end(UR_FUNCTION_USM_GET_MEM_ALLOC_INFO,
                            "urUSMGetMemAllocInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_GET_MEM_ALLOC_INFO, &params);
@@ -2002,7 +2084,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_CREATE, "urUSMPoolCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_CREATE,
                                     &params);
@@ -2034,7 +2116,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_RETAIN, "urUSMPoolRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_RETAIN,
                                     &params);
@@ -2066,7 +2148,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_RELEASE, "urUSMPoolRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_RELEASE,
                                     &params);
@@ -2110,7 +2192,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_GET_INFO, "urUSMPoolGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_GET_INFO,
                                     &params);
@@ -2164,7 +2246,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
                            "urVirtualMemGranularityGetInfo", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_VIRTUAL_MEM_GRANULARITY_GET_INFO, &params);
@@ -2207,7 +2289,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_RESERVE,
                            "urVirtualMemReserve", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_RESERVE,
                                     &params);
@@ -2244,7 +2326,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_FREE, "urVirtualMemFree",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_FREE,
                                     &params);
@@ -2289,7 +2371,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_MAP, "urVirtualMemMap",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_MAP,
                                     &params);
@@ -2325,7 +2407,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_UNMAP, "urVirtualMemUnmap",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_UNMAP,
                                     &params);
@@ -2365,7 +2447,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_SET_ACCESS,
                            "urVirtualMemSetAccess", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_VIRTUAL_MEM_SET_ACCESS, &params);
@@ -2417,7 +2499,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_GET_INFO,
                            "urVirtualMemGetInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_GET_INFO,
                                     &params);
@@ -2461,7 +2543,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
   getContext()->notify_end(UR_FUNCTION_PHYSICAL_MEM_CREATE,
                            "urPhysicalMemCreate", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_CREATE,
                                     &params);
@@ -2494,7 +2576,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
   getContext()->notify_end(UR_FUNCTION_PHYSICAL_MEM_RETAIN,
                            "urPhysicalMemRetain", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_RETAIN,
                                     &params);
@@ -2527,7 +2609,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
   getContext()->notify_end(UR_FUNCTION_PHYSICAL_MEM_RELEASE,
                            "urPhysicalMemRelease", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_RELEASE,
                                     &params);
@@ -2574,7 +2656,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemGetInfo(
   getContext()->notify_end(UR_FUNCTION_PHYSICAL_MEM_GET_INFO,
                            "urPhysicalMemGetInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_GET_INFO,
                                     &params);
@@ -2617,7 +2699,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_CREATE_WITH_IL,
                            "urProgramCreateWithIL", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_IL, &params);
@@ -2672,7 +2754,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
                            "urProgramCreateWithBinary", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY, &params);
@@ -2709,7 +2791,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_BUILD, "urProgramBuild", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_BUILD,
                                     &params);
@@ -2745,7 +2827,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_COMPILE, "urProgramCompile",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_COMPILE,
                                     &params);
@@ -2791,7 +2873,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_LINK, "urProgramLink", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_LINK,
                                     &params);
@@ -2823,7 +2905,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_RETAIN, "urProgramRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_RETAIN,
                                     &params);
@@ -2855,7 +2937,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_RELEASE, "urProgramRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_RELEASE,
                                     &params);
@@ -2901,7 +2983,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
                            "urProgramGetFunctionPointer", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER, &params);
@@ -2951,7 +3033,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
                            "urProgramGetGlobalVariablePointer", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER, &params);
@@ -3000,7 +3082,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_GET_INFO, "urProgramGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_GET_INFO,
                                     &params);
@@ -3050,7 +3132,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_GET_BUILD_INFO,
                            "urProgramGetBuildInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_BUILD_INFO, &params);
@@ -3093,7 +3175,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
                            "urProgramSetSpecializationConstants", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS, &params);
@@ -3130,7 +3212,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
                            "urProgramGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE, &params);
@@ -3174,7 +3256,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
                            "urProgramCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -3211,7 +3293,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
   getContext()->notify_end(UR_FUNCTION_KERNEL_CREATE, "urKernelCreate", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_CREATE,
                                     &params);
@@ -3255,7 +3337,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_VALUE,
                            "urKernelSetArgValue", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_ARG_VALUE,
                                     &params);
@@ -3295,7 +3377,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_LOCAL,
                            "urKernelSetArgLocal", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_ARG_LOCAL,
                                     &params);
@@ -3344,7 +3426,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
   getContext()->notify_end(UR_FUNCTION_KERNEL_GET_INFO, "urKernelGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_GET_INFO,
                                     &params);
@@ -3390,7 +3472,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
   getContext()->notify_end(UR_FUNCTION_KERNEL_GET_GROUP_INFO,
                            "urKernelGetGroupInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_GET_GROUP_INFO,
                                     &params);
@@ -3439,7 +3521,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
                            "urKernelGetSubGroupInfo", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO, &params);
@@ -3472,7 +3554,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
   getContext()->notify_end(UR_FUNCTION_KERNEL_RETAIN, "urKernelRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_RETAIN,
                                     &params);
@@ -3504,7 +3586,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
   getContext()->notify_end(UR_FUNCTION_KERNEL_RELEASE, "urKernelRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_RELEASE,
                                     &params);
@@ -3545,7 +3627,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_POINTER,
                            "urKernelSetArgPointer", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_POINTER, &params);
@@ -3589,7 +3671,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_EXEC_INFO,
                            "urKernelSetExecInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_EXEC_INFO,
                                     &params);
@@ -3630,7 +3712,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_SAMPLER,
                            "urKernelSetArgSampler", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_SAMPLER, &params);
@@ -3671,7 +3753,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ,
                            "urKernelSetArgMemObj", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ, &params);
@@ -3713,7 +3795,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
                            "urKernelSetSpecializationConstants", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS, &params);
@@ -3749,7 +3831,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
                            "urKernelGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE, &params);
@@ -3795,7 +3877,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
                            "urKernelCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -3850,7 +3932,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
                            "urKernelGetSuggestedLocalWorkSize", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE, &params);
@@ -3894,7 +3976,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
   getContext()->notify_end(UR_FUNCTION_QUEUE_GET_INFO, "urQueueGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_GET_INFO,
                                     &params);
@@ -3933,7 +4015,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
   getContext()->notify_end(UR_FUNCTION_QUEUE_CREATE, "urQueueCreate", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_CREATE,
                                     &params);
@@ -3965,7 +4047,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
   getContext()->notify_end(UR_FUNCTION_QUEUE_RETAIN, "urQueueRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_RETAIN,
                                     &params);
@@ -3997,7 +4079,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
   getContext()->notify_end(UR_FUNCTION_QUEUE_RELEASE, "urQueueRelease", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_RELEASE,
                                     &params);
@@ -4035,7 +4117,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
                            "urQueueGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE, &params);
@@ -4081,7 +4163,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
                            "urQueueCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -4114,7 +4196,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
   getContext()->notify_end(UR_FUNCTION_QUEUE_FINISH, "urQueueFinish", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_FINISH,
                                     &params);
@@ -4146,7 +4228,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
   getContext()->notify_end(UR_FUNCTION_QUEUE_FLUSH, "urQueueFlush", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_FLUSH, &params);
     logger.info("   <--- urQueueFlush({}) -> {};\n", args_str.str(), result);
@@ -4188,7 +4270,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
   getContext()->notify_end(UR_FUNCTION_EVENT_GET_INFO, "urEventGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_GET_INFO,
                                     &params);
@@ -4233,7 +4315,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
                            "urEventGetProfilingInfo", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_GET_PROFILING_INFO, &params);
@@ -4269,7 +4351,7 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
   getContext()->notify_end(UR_FUNCTION_EVENT_WAIT, "urEventWait", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_WAIT, &params);
     logger.info("   <--- urEventWait({}) -> {};\n", args_str.str(), result);
@@ -4300,7 +4382,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
   getContext()->notify_end(UR_FUNCTION_EVENT_RETAIN, "urEventRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_RETAIN,
                                     &params);
@@ -4332,7 +4414,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
   getContext()->notify_end(UR_FUNCTION_EVENT_RELEASE, "urEventRelease", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_RELEASE,
                                     &params);
@@ -4367,7 +4449,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
                            "urEventGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_GET_NATIVE_HANDLE, &params);
@@ -4411,7 +4493,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
                            "urEventCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -4451,7 +4533,7 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
   getContext()->notify_end(UR_FUNCTION_EVENT_SET_CALLBACK, "urEventSetCallback",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_SET_CALLBACK,
                                     &params);
@@ -4523,7 +4605,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH,
                            "urEnqueueKernelLaunch", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH,
                                     &params);
@@ -4570,7 +4652,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_EVENTS_WAIT,
                            "urEnqueueEventsWait", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT,
                                     &params);
@@ -4620,7 +4702,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
                            "urEnqueueEventsWaitWithBarrier", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER, &params);
@@ -4680,7 +4762,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
                            "urEnqueueMemBufferRead", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ, &params);
@@ -4740,7 +4822,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
                            "urEnqueueMemBufferWrite", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE, &params);
@@ -4816,7 +4898,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
                            "urEnqueueMemBufferReadRect", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT, &params);
@@ -4893,7 +4975,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
                            "urEnqueueMemBufferWriteRect", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT, &params);
@@ -4952,7 +5034,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
                            "urEnqueueMemBufferCopy", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY, &params);
@@ -5024,7 +5106,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
                            "urEnqueueMemBufferCopyRect", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT, &params);
@@ -5089,7 +5171,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
                            "urEnqueueMemBufferFill", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL, &params);
@@ -5154,7 +5236,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ,
                            "urEnqueueMemImageRead", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ, &params);
@@ -5220,7 +5302,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
                            "urEnqueueMemImageWrite", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE, &params);
@@ -5281,7 +5363,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY,
                            "urEnqueueMemImageCopy", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY, &params);
@@ -5343,7 +5425,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP,
                            "urEnqueueMemBufferMap", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP, &params);
@@ -5394,7 +5476,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_MEM_UNMAP, "urEnqueueMemUnmap",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_MEM_UNMAP,
                                     &params);
@@ -5452,7 +5534,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_FILL, "urEnqueueUSMFill",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_FILL,
                                     &params);
@@ -5508,7 +5590,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_MEMCPY, "urEnqueueUSMMemcpy",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_MEMCPY,
                                     &params);
@@ -5561,7 +5643,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_PREFETCH,
                            "urEnqueueUSMPrefetch", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_PREFETCH,
                                     &params);
@@ -5604,7 +5686,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_ADVISE, "urEnqueueUSMAdvise",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_ADVISE,
                                     &params);
@@ -5668,7 +5750,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_FILL_2D,
                            "urEnqueueUSMFill2D", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_FILL_2D,
                                     &params);
@@ -5734,7 +5816,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_MEMCPY_2D,
                            "urEnqueueUSMMemcpy2D", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_MEMCPY_2D,
                                     &params);
@@ -5799,7 +5881,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
                            "urEnqueueDeviceGlobalVariableWrite", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE, &params);
@@ -5864,7 +5946,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
                            "urEnqueueDeviceGlobalVariableRead", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ, &params);
@@ -5928,7 +6010,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_READ_HOST_PIPE,
                            "urEnqueueReadHostPipe", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_READ_HOST_PIPE, &params);
@@ -5994,7 +6076,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
                            "urEnqueueWriteHostPipe", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE, &params);
@@ -6051,7 +6133,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMDeviceAllocExp(
                            "urEnqueueUSMDeviceAllocExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_USM_DEVICE_ALLOC_EXP, &params);
@@ -6108,7 +6190,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMSharedAllocExp(
                            "urEnqueueUSMSharedAllocExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_USM_SHARED_ALLOC_EXP, &params);
@@ -6165,7 +6247,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMHostAllocExp(
                            "urEnqueueUSMHostAllocExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_USM_HOST_ALLOC_EXP, &params);
@@ -6213,7 +6295,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFreeExp(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_FREE_EXP,
                            "urEnqueueUSMFreeExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_FREE_EXP,
                                     &params);
@@ -6254,7 +6336,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreateExp(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_CREATE_EXP,
                            "urUSMPoolCreateExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_CREATE_EXP,
                                     &params);
@@ -6291,7 +6373,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolDestroyExp(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_DESTROY_EXP,
                            "urUSMPoolDestroyExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_DESTROY_EXP,
                                     &params);
@@ -6332,7 +6414,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetDefaultDevicePoolExp(
                            "urUSMPoolGetDefaultDevicePoolExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_POOL_GET_DEFAULT_DEVICE_POOL_EXP, &params);
@@ -6373,7 +6455,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfoExp(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_GET_INFO_EXP,
                            "urUSMPoolGetInfoExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_GET_INFO_EXP,
                                     &params);
@@ -6413,7 +6495,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolSetInfoExp(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_SET_INFO_EXP,
                            "urUSMPoolSetInfoExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_SET_INFO_EXP,
                                     &params);
@@ -6454,7 +6536,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolSetDevicePoolExp(
                            "urUSMPoolSetDevicePoolExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_POOL_SET_DEVICE_POOL_EXP, &params);
@@ -6495,7 +6577,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetDevicePoolExp(
                            "urUSMPoolGetDevicePoolExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_POOL_GET_DEVICE_POOL_EXP, &params);
@@ -6536,7 +6618,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolTrimToExp(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_TRIM_TO_EXP,
                            "urUSMPoolTrimToExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_TRIM_TO_EXP,
                                     &params);
@@ -6589,7 +6671,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
   getContext()->notify_end(UR_FUNCTION_USM_PITCHED_ALLOC_EXP,
                            "urUSMPitchedAllocExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_PITCHED_ALLOC_EXP,
                                     &params);
@@ -6634,7 +6716,7 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
       "urBindlessImagesUnsampledImageHandleDestroyExp", &params, &result,
       instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str,
@@ -6682,7 +6764,7 @@ urBindlessImagesSampledImageHandleDestroyExp(
       "urBindlessImagesSampledImageHandleDestroyExp", &params, &result,
       instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP,
@@ -6730,7 +6812,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
                            "urBindlessImagesImageAllocateExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP, &params);
@@ -6771,7 +6853,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
                            "urBindlessImagesImageFreeExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP, &params);
@@ -6819,7 +6901,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
       UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP,
       "urBindlessImagesUnsampledImageCreateExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP,
@@ -6872,7 +6954,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
                            "urBindlessImagesSampledImageCreateExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP,
@@ -6952,7 +7034,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
                            "urBindlessImagesImageCopyExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP, &params);
@@ -6998,7 +7080,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
                            "urBindlessImagesImageGetInfoExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP, &params);
@@ -7044,7 +7126,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
                            "urBindlessImagesMipmapGetLevelExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP, &params);
@@ -7085,7 +7167,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
                            "urBindlessImagesMipmapFreeExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP, &params);
@@ -7134,7 +7216,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
       UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
       "urBindlessImagesImportExternalMemoryExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
@@ -7184,7 +7266,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
                            "urBindlessImagesMapExternalArrayExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP, &params);
@@ -7232,7 +7314,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
       UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP,
       "urBindlessImagesMapExternalLinearMemoryExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP,
@@ -7276,7 +7358,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
       UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP,
       "urBindlessImagesReleaseExternalMemoryExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP,
@@ -7325,7 +7407,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
       UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
       "urBindlessImagesImportExternalSemaphoreExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
@@ -7370,7 +7452,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
       "urBindlessImagesReleaseExternalSemaphoreExp", &params, &result,
       instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP,
@@ -7434,7 +7516,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
       UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
       "urBindlessImagesWaitExternalSemaphoreExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
@@ -7497,7 +7579,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
       UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
       "urBindlessImagesSignalExternalSemaphoreExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
@@ -7542,7 +7624,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
                            "urCommandBufferCreateExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP, &params);
@@ -7577,7 +7659,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
                            "urCommandBufferRetainExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP, &params);
@@ -7612,7 +7694,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
                            "urCommandBufferReleaseExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP, &params);
@@ -7648,7 +7730,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
                            "urCommandBufferFinalizeExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP, &params);
@@ -7744,7 +7826,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
                            "urCommandBufferAppendKernelLaunchExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP, &params);
@@ -7819,7 +7901,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
                            "urCommandBufferAppendUSMMemcpyExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP, &params);
@@ -7897,7 +7979,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
                            "urCommandBufferAppendUSMFillExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_FILL_EXP, &params);
@@ -7978,7 +8060,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP,
       "urCommandBufferAppendMemBufferCopyExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP,
@@ -8057,7 +8139,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP,
       "urCommandBufferAppendMemBufferWriteExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP,
@@ -8136,7 +8218,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP,
       "urCommandBufferAppendMemBufferReadExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP,
@@ -8231,7 +8313,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP,
       "urCommandBufferAppendMemBufferCopyRectExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP,
@@ -8330,7 +8412,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP,
       "urCommandBufferAppendMemBufferWriteRectExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP,
@@ -8428,7 +8510,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP,
       "urCommandBufferAppendMemBufferReadRectExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP,
@@ -8511,7 +8593,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP,
       "urCommandBufferAppendMemBufferFillExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP,
@@ -8587,7 +8669,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
                            "urCommandBufferAppendUSMPrefetchExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP, &params);
@@ -8662,7 +8744,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
                            "urCommandBufferAppendUSMAdviseExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP, &params);
@@ -8721,7 +8803,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendNativeCommandExp(
                            "urCommandBufferAppendNativeCommandExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_NATIVE_COMMAND_EXP,
@@ -8775,7 +8857,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCommandBufferExp(
                            "urEnqueueCommandBufferExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_COMMAND_BUFFER_EXP, &params);
@@ -8819,7 +8901,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
                            "urCommandBufferUpdateKernelLaunchExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP, &params);
@@ -8858,7 +8940,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
                            "urCommandBufferUpdateSignalEventExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_SIGNAL_EVENT_EXP, &params);
@@ -8902,7 +8984,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
                            "urCommandBufferUpdateWaitEventsExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_WAIT_EVENTS_EXP, &params);
@@ -8948,7 +9030,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
                            "urCommandBufferGetInfoExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP, &params);
@@ -8988,7 +9070,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetNativeHandleExp(
                            "urCommandBufferGetNativeHandleExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_GET_NATIVE_HANDLE_EXP, &params);
@@ -9064,7 +9146,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
                            "urEnqueueCooperativeKernelLaunchExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP, &params);
@@ -9122,7 +9204,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
       UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP,
       "urKernelSuggestMaxCooperativeGroupCountExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP,
@@ -9184,7 +9266,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
                            "urEnqueueTimestampRecordingExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP, &params);
@@ -9267,7 +9349,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
                            "urEnqueueKernelLaunchCustomExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP, &params);
@@ -9307,7 +9389,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_BUILD_EXP, "urProgramBuildExp",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_BUILD_EXP,
                                     &params);
@@ -9347,7 +9429,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_COMPILE_EXP,
                            "urProgramCompileExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_COMPILE_EXP,
                                     &params);
@@ -9398,7 +9480,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_LINK_EXP, "urProgramLinkExp",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_LINK_EXP,
                                     &params);
@@ -9435,7 +9517,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
   getContext()->notify_end(UR_FUNCTION_USM_IMPORT_EXP, "urUSMImportExp",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_IMPORT_EXP,
                                     &params);
@@ -9469,7 +9551,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
   getContext()->notify_end(UR_FUNCTION_USM_RELEASE_EXP, "urUSMReleaseExp",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_RELEASE_EXP,
                                     &params);
@@ -9507,7 +9589,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
                            "urUsmP2PEnablePeerAccessExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_ENABLE_PEER_ACCESS_EXP, &params);
@@ -9546,7 +9628,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
                            "urUsmP2PDisablePeerAccessExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_DISABLE_PEER_ACCESS_EXP, &params);
@@ -9601,7 +9683,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
                            "urUsmP2PPeerAccessGetInfoExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_PEER_ACCESS_GET_INFO_EXP, &params);
@@ -9653,7 +9735,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
                            "urEnqueueEventsWaitWithBarrierExt", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT, &params);
@@ -9726,7 +9808,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
                            "urEnqueueNativeCommandExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP, &params);
@@ -9777,6 +9859,42 @@ __urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 
   dditable.pfnAdapterGetInfo = pDdiTable->pfnAdapterGetInfo;
   pDdiTable->pfnAdapterGetInfo = ur_tracing_layer::urAdapterGetInfo;
+
+  return result;
+}
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Adapter table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+__urdlllocal ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t version,
+    /// [in,out] pointer to table of DDI function pointers
+    ur_adapter_dditable_t *pDdiTable) {
+  auto &dditable = ur_tracing_layer::getContext()->urDdiTable.Adapter;
+
+  if (nullptr == pDdiTable)
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+  if (UR_MAJOR_VERSION(ur_tracing_layer::getContext()->version) !=
+          UR_MAJOR_VERSION(version) ||
+      UR_MINOR_VERSION(ur_tracing_layer::getContext()->version) >
+          UR_MINOR_VERSION(version))
+    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  dditable.pfnSetLoggerCallback = pDdiTable->pfnSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallback =
+      ur_tracing_layer::urAdapterSetLoggerCallback;
+
+  dditable.pfnSetLoggerCallbackLevel = pDdiTable->pfnSetLoggerCallbackLevel;
+  pDdiTable->pfnSetLoggerCallbackLevel =
+      ur_tracing_layer::urAdapterSetLoggerCallbackLevel;
 
   return result;
 }
@@ -11037,6 +11155,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
   if (UR_RESULT_SUCCESS == result) {
     result = ur_tracing_layer::urGetGlobalProcAddrTable(UR_API_VERSION_CURRENT,
                                                         &dditable->Global);
+  }
+
+  if (UR_RESULT_SUCCESS == result) {
+    result = ur_tracing_layer::urGetAdapterProcAddrTable(UR_API_VERSION_CURRENT,
+                                                         &dditable->Adapter);
   }
 
   if (UR_RESULT_SUCCESS == result) {

--- a/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
+++ b/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
@@ -197,6 +197,78 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallback
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  auto pfnSetLoggerCallback =
+      getContext()->urDdiTable.Adapter.pfnSetLoggerCallback;
+
+  if (nullptr == pfnSetLoggerCallback) {
+    return UR_RESULT_ERROR_UNINITIALIZED;
+  }
+
+  if (getContext()->enableParameterValidation) {
+    if (NULL == pfnLoggerCallback)
+      return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (NULL == hAdapter)
+      return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+    if (UR_LOGGER_LEVEL_QUIET < level)
+      return UR_RESULT_ERROR_INVALID_ENUMERATION;
+  }
+
+  if (getContext()->enableLifetimeValidation &&
+      !getContext()->refCountContext->isReferenceValid(hAdapter)) {
+    getContext()->refCountContext->logInvalidReference(hAdapter);
+  }
+
+  ur_result_t result =
+      pfnSetLoggerCallback(hAdapter, pfnLoggerCallback, pUserData, level);
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallbackLevel
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  auto pfnSetLoggerCallbackLevel =
+      getContext()->urDdiTable.Adapter.pfnSetLoggerCallbackLevel;
+
+  if (nullptr == pfnSetLoggerCallbackLevel) {
+    return UR_RESULT_ERROR_UNINITIALIZED;
+  }
+
+  if (getContext()->enableParameterValidation) {
+    if (NULL == hAdapter)
+      return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+    if (UR_LOGGER_LEVEL_QUIET < level)
+      return UR_RESULT_ERROR_INVALID_ENUMERATION;
+  }
+
+  if (getContext()->enableLifetimeValidation &&
+      !getContext()->refCountContext->isReferenceValid(hAdapter)) {
+    getContext()->refCountContext->logInvalidReference(hAdapter);
+  }
+
+  ur_result_t result = pfnSetLoggerCallbackLevel(hAdapter, level);
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
     /// [in] adapter to query for platforms.
@@ -10652,6 +10724,43 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Adapter table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t version,
+    /// [in,out] pointer to table of DDI function pointers
+    ur_adapter_dditable_t *pDdiTable) {
+  auto &dditable = ur_validation_layer::getContext()->urDdiTable.Adapter;
+
+  if (nullptr == pDdiTable)
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+  if (UR_MAJOR_VERSION(ur_validation_layer::getContext()->version) !=
+          UR_MAJOR_VERSION(version) ||
+      UR_MINOR_VERSION(ur_validation_layer::getContext()->version) >
+          UR_MINOR_VERSION(version))
+    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  dditable.pfnSetLoggerCallback = pDdiTable->pfnSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallback =
+      ur_validation_layer::urAdapterSetLoggerCallback;
+
+  dditable.pfnSetLoggerCallbackLevel = pDdiTable->pfnSetLoggerCallbackLevel;
+  pDdiTable->pfnSetLoggerCallbackLevel =
+      ur_validation_layer::urAdapterSetLoggerCallbackLevel;
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's BindlessImagesExp table
 ///        with current process' addresses
 ///
@@ -11954,6 +12063,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
   if (UR_RESULT_SUCCESS == result) {
     result = ur_validation_layer::urGetGlobalProcAddrTable(
         UR_API_VERSION_CURRENT, &dditable->Global);
+  }
+
+  if (UR_RESULT_SUCCESS == result) {
+    result = ur_validation_layer::urGetAdapterProcAddrTable(
+        UR_API_VERSION_CURRENT, &dditable->Adapter);
   }
 
   if (UR_RESULT_SUCCESS == result) {

--- a/unified-runtime/source/loader/loader.def.in
+++ b/unified-runtime/source/loader/loader.def.in
@@ -5,6 +5,8 @@ EXPORTS
 	urAdapterGetLastError
 	urAdapterRelease
 	urAdapterRetain
+	urAdapterSetLoggerCallback
+	urAdapterSetLoggerCallbackLevel
 	urBindlessImagesImageAllocateExp
 	urBindlessImagesImageCopyExp
 	urBindlessImagesImageFreeExp
@@ -105,6 +107,7 @@ EXPORTS
 	urEventRetain
 	urEventSetCallback
 	urEventWait
+	urGetAdapterProcAddrTable
 	urGetBindlessImagesExpProcAddrTable
 	urGetCommandBufferExpProcAddrTable
 	urGetContextProcAddrTable
@@ -179,6 +182,8 @@ EXPORTS
 	urPrintAdapterInfo
 	urPrintAdapterReleaseParams
 	urPrintAdapterRetainParams
+	urPrintAdapterSetLoggerCallbackLevelParams
+	urPrintAdapterSetLoggerCallbackParams
 	urPrintApiVersion
 	urPrintBaseDesc
 	urPrintBaseProperties
@@ -388,6 +393,7 @@ EXPORTS
 	urPrintLoaderConfigSetMockingEnabledParams
 	urPrintLoaderInitParams
 	urPrintLoaderTearDownParams
+	urPrintLoggerLevel
 	urPrintMapFlags
 	urPrintMemBufferCreateParams
 	urPrintMemBufferCreateWithNativeHandleParams

--- a/unified-runtime/source/loader/loader.map.in
+++ b/unified-runtime/source/loader/loader.map.in
@@ -5,6 +5,8 @@
 		urAdapterGetLastError;
 		urAdapterRelease;
 		urAdapterRetain;
+		urAdapterSetLoggerCallback;
+		urAdapterSetLoggerCallbackLevel;
 		urBindlessImagesImageAllocateExp;
 		urBindlessImagesImageCopyExp;
 		urBindlessImagesImageFreeExp;
@@ -105,6 +107,7 @@
 		urEventRetain;
 		urEventSetCallback;
 		urEventWait;
+		urGetAdapterProcAddrTable;
 		urGetBindlessImagesExpProcAddrTable;
 		urGetCommandBufferExpProcAddrTable;
 		urGetContextProcAddrTable;
@@ -179,6 +182,8 @@
 		urPrintAdapterInfo;
 		urPrintAdapterReleaseParams;
 		urPrintAdapterRetainParams;
+		urPrintAdapterSetLoggerCallbackLevelParams;
+		urPrintAdapterSetLoggerCallbackParams;
 		urPrintApiVersion;
 		urPrintBaseDesc;
 		urPrintBaseProperties;
@@ -388,6 +393,7 @@
 		urPrintLoaderConfigSetMockingEnabledParams;
 		urPrintLoaderInitParams;
 		urPrintLoaderTearDownParams;
+		urPrintLoggerLevel;
 		urPrintMapFlags;
 		urPrintMemBufferCreateParams;
 		urPrintMemBufferCreateWithNativeHandleParams;

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -485,6 +485,69 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a callback function for use by the logger to retrieve logging
+/// output.
+///        It is a requirement that the callback function is thread safe and the
+///        creator of the function will be responsible for this.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnLoggerCallback`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) try {
+  auto pfnSetLoggerCallback =
+      ur_lib::getContext()->urDdiTable.Adapter.pfnSetLoggerCallback;
+  if (nullptr == pfnSetLoggerCallback)
+    return UR_RESULT_ERROR_UNINITIALIZED;
+
+  return pfnSetLoggerCallback(hAdapter, pfnLoggerCallback, pUserData, level);
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the minimum logging level for the logger Callback function.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) try {
+  auto pfnSetLoggerCallbackLevel =
+      ur_lib::getContext()->urDdiTable.Adapter.pfnSetLoggerCallbackLevel;
+  if (nullptr == pfnSetLoggerCallbackLevel)
+    return UR_RESULT_ERROR_UNINITIALIZED;
+
+  return pfnSetLoggerCallbackLevel(hAdapter, level);
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves all available platforms for the given adapters
 ///
 /// @details

--- a/unified-runtime/source/loader/ur_libddi.cpp
+++ b/unified-runtime/source/loader/ur_libddi.cpp
@@ -28,6 +28,11 @@ __urdlllocal ur_result_t context_t::ddiInit() {
   }
 
   if (UR_RESULT_SUCCESS == result) {
+    result =
+        urGetAdapterProcAddrTable(UR_API_VERSION_CURRENT, &urDdiTable.Adapter);
+  }
+
+  if (UR_RESULT_SUCCESS == result) {
     result = urGetBindlessImagesExpProcAddrTable(UR_API_VERSION_CURRENT,
                                                  &urDdiTable.BindlessImagesExp);
   }

--- a/unified-runtime/source/loader/ur_print.cpp
+++ b/unified-runtime/source/loader/ur_print.cpp
@@ -130,6 +130,13 @@ ur_result_t urPrintAdapterBackend(enum ur_adapter_backend_t value, char *buffer,
   return str_copy(&ss, buffer, buff_size, out_size);
 }
 
+ur_result_t urPrintLoggerLevel(enum ur_logger_level_t value, char *buffer,
+                               const size_t buff_size, size_t *out_size) {
+  std::stringstream ss;
+  ss << value;
+  return str_copy(&ss, buffer, buff_size, out_size);
+}
+
 ur_result_t urPrintPlatformInfo(enum ur_platform_info_t value, char *buffer,
                                 const size_t buff_size, size_t *out_size) {
   std::stringstream ss;
@@ -1193,6 +1200,22 @@ ur_result_t
 urPrintAdapterGetInfoParams(const struct ur_adapter_get_info_params_t *params,
                             char *buffer, const size_t buff_size,
                             size_t *out_size) {
+  std::stringstream ss;
+  ss << params;
+  return str_copy(&ss, buffer, buff_size, out_size);
+}
+
+ur_result_t urPrintAdapterSetLoggerCallbackParams(
+    const struct ur_adapter_set_logger_callback_params_t *params, char *buffer,
+    const size_t buff_size, size_t *out_size) {
+  std::stringstream ss;
+  ss << params;
+  return str_copy(&ss, buffer, buff_size, out_size);
+}
+
+ur_result_t urPrintAdapterSetLoggerCallbackLevelParams(
+    const struct ur_adapter_set_logger_callback_level_params_t *params,
+    char *buffer, const size_t buff_size, size_t *out_size) {
   std::stringstream ss;
   ss << params;
   return str_copy(&ss, buffer, buff_size, out_size);

--- a/unified-runtime/source/ur_api.cpp
+++ b/unified-runtime/source/ur_api.cpp
@@ -442,6 +442,57 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a callback function for use by the logger to retrieve logging
+/// output.
+///        It is a requirement that the callback function is thread safe and the
+///        creator of the function will be responsible for this.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnLoggerCallback`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  ur_result_t result = UR_RESULT_SUCCESS;
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the minimum logging level for the logger Callback function.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  ur_result_t result = UR_RESULT_SUCCESS;
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves all available platforms for the given adapters
 ///
 /// @details

--- a/unified-runtime/test/layers/sanitizer/sanitizer_options.cpp
+++ b/unified-runtime/test/layers/sanitizer/sanitizer_options.cpp
@@ -30,7 +30,7 @@ struct OptionParserTest : public ::testing::Test {
 
   OptionParserTest()
       : Logger(logger::create_logger("OptionParser", false, false,
-                                     logger::Level::DEBUG)),
+                                     UR_LOGGER_LEVEL_DEBUG)),
         Parser(EnvMap, Logger) {}
 };
 
@@ -122,7 +122,7 @@ struct SanitizerOptionsTest : public ::testing::Test {
 
   SanitizerOptionsTest()
       : Logger(logger::create_logger("SanitizerOptions", false, false,
-                                     logger::Level::DEBUG)) {}
+                                     UR_LOGGER_LEVEL_DEBUG)) {}
 
   void SetEnvAndInit(const std::string &Value) {
     setenv(EnvName.c_str(), Value.c_str(), 1);

--- a/unified-runtime/test/logger/fixtures.hpp
+++ b/unified-runtime/test/logger/fixtures.hpp
@@ -92,8 +92,19 @@ class DefaultLoggerWithFileSink : public UniquePtrLoggerWithFilesink {
 protected:
   void SetUp() override {
     logger = std::make_unique<logger::Logger>(
-        logger::Level::WARN,
+        UR_LOGGER_LEVEL_WARN,
         std::make_unique<logger::FileSink>(logger_name, file_path));
+  }
+};
+
+class LoggerWithCallbackSink : public ::testing::Test {
+protected:
+  std::unique_ptr<logger::Logger> logger;
+
+  void SetUp() override {
+    logger = std::make_unique<logger::Logger>(
+        UR_LOGGER_LEVEL_QUIET, nullptr, UR_LOGGER_LEVEL_WARN,
+        std::make_unique<logger::CallbackSink>("UR_LOG_CALLBACK"));
   }
 };
 

--- a/unified-runtime/test/unit/logger.cpp
+++ b/unified-runtime/test/unit/logger.cpp
@@ -10,6 +10,7 @@
 
 #include "../fixtures.hpp"
 #include "logger/ur_logger_details.hpp"
+#include "ur_api.h"
 
 //////////////////////////////////////////////////////////////////////////////
 TEST_F(DefaultLoggerWithFileSink, DefaultLevelNoOutput) {
@@ -52,7 +53,7 @@ TEST_F(DefaultLoggerWithFileSink, NoBraces) {
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelDebug) {
-  auto level = logger::Level::DEBUG;
+  auto level = UR_LOGGER_LEVEL_DEBUG;
   logger->setLevel(level);
   logger->setFlushLevel(level);
   logger->debug("Test message: {}", "success");
@@ -61,7 +62,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelDebug) {
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelInfo) {
-  auto level = logger::Level::INFO;
+  auto level = UR_LOGGER_LEVEL_INFO;
   logger->setLevel(level);
   logger->setFlushLevel(level);
   logger->info("Test message: {}", "success");
@@ -71,7 +72,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelInfo) {
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelWarning) {
-  auto level = logger::Level::WARN;
+  auto level = UR_LOGGER_LEVEL_WARN;
   logger->setLevel(level);
   logger->warning("Test message: {}", "success");
   logger->info("This should not be printed: {}", 42);
@@ -80,7 +81,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelWarning) {
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelError) {
-  logger->setLevel(logger::Level::ERR);
+  logger->setLevel(UR_LOGGER_LEVEL_ERROR);
   logger->error("Test message: {}", "success");
   logger->warning("This should not be printed: {}", 42);
 
@@ -89,7 +90,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelError) {
 
 //////////////////////////////////////////////////////////////////////////////
 TEST_F(UniquePtrLoggerWithFilesink, SetLogLevelAndFlushLevelDebugWithCtor) {
-  auto level = logger::Level::DEBUG;
+  auto level = UR_LOGGER_LEVEL_DEBUG;
   logger = std::make_unique<logger::Logger>(
       level, std::make_unique<logger::FileSink>(logger_name, file_path, level));
 
@@ -106,15 +107,15 @@ TEST_F(UniquePtrLoggerWithFilesink, NestedFilePath) {
   filesystem::create_directories(file_path);
   file_path /= file_name;
   logger = std::make_unique<logger::Logger>(
-      logger::Level::WARN, std::make_unique<logger::FileSink>(
-                               logger_name, file_path, logger::Level::WARN));
+      UR_LOGGER_LEVEL_WARN, std::make_unique<logger::FileSink>(
+                                logger_name, file_path, UR_LOGGER_LEVEL_WARN));
 
   logger->warning("Test message: {}", "success");
   test_msg << test_msg_prefix << "[WARNING]: Test message: success\n";
 }
 
 TEST_F(UniquePtrLoggerWithFilesinkFail, NullSink) {
-  logger = std::make_unique<logger::Logger>(logger::Level::INFO, nullptr);
+  logger = std::make_unique<logger::Logger>(UR_LOGGER_LEVEL_INFO, nullptr);
   logger->info("This should not be printed: {}", 42);
   test_msg.clear();
 }
@@ -128,7 +129,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(FileSinkLoggerMultipleThreads, Multithreaded) {
   std::vector<std::thread> threads;
   auto local_logger = logger::Logger(
-      logger::Level::WARN,
+      UR_LOGGER_LEVEL_WARN,
       std::make_unique<logger::FileSink>(logger_name, file_path, true));
   constexpr int message_count = 50;
 
@@ -174,7 +175,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(CommonLoggerWithMultipleThreads, StdoutMultithreaded) {
   std::vector<std::thread> threads;
   auto local_logger = logger::Logger(
-      logger::Level::WARN, std::make_unique<logger::StdoutSink>("test", true));
+      UR_LOGGER_LEVEL_WARN, std::make_unique<logger::StdoutSink>("test", true));
   constexpr int message_count = 50;
 
   // Messages below the flush level
@@ -203,4 +204,66 @@ TEST_P(CommonLoggerWithMultipleThreads, StdoutMultithreaded) {
   for (auto &thread : threads) {
     thread.join();
   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+void receiveLoggerMessages([[maybe_unused]] ur_logger_level_t level,
+                           const char *msg, void *userData) {
+  std::string *str = static_cast<std::string *>(userData);
+  *str = msg;
+}
+
+TEST_F(LoggerWithCallbackSink, CallbackSinkTest) {
+  // Pass a callback function to the logger which will be used as an additional
+  // destination sink and any logged messages will be sent to the callback
+  // function
+  std::string callback_message;
+  logger->setCallbackSink(receiveLoggerMessages, &callback_message,
+                          UR_LOGGER_LEVEL_ERROR);
+
+  logger->error("Test message: {}", "success");
+
+  ASSERT_STREQ(callback_message.c_str(),
+               "<UR_LOG_CALLBACK>[ERROR]: Test message: success\n");
+}
+
+TEST_F(LoggerWithCallbackSink, CallbackSinkSetLevel) {
+  // Set log level to DEBUG and confirm a DEBUG message is received
+  std::string callback_message;
+  logger->setCallbackSink(receiveLoggerMessages, &callback_message,
+                          UR_LOGGER_LEVEL_DEBUG);
+
+  logger->debug("Test message: {}", "success");
+  ASSERT_STREQ(callback_message.c_str(),
+               "<UR_LOG_CALLBACK>[DEBUG]: Test message: success\n");
+
+  // Set level to WARN and confirm a DEBUG message is not received
+  logger->setCallbackLevel(UR_LOGGER_LEVEL_WARN);
+  callback_message.clear();
+  logger->debug("Test message: {}", "success");
+  ASSERT_STREQ(callback_message.c_str(), "");
+
+  // While level is DEBUG confirm a ERR message is received
+  callback_message.clear();
+  logger->error("Test message: {}", "success");
+  ASSERT_STREQ(callback_message.c_str(),
+               "<UR_LOG_CALLBACK>[ERROR]: Test message: success\n");
+
+  // Set level to QUIET and confirm no log levels are received
+  logger->setCallbackLevel(UR_LOGGER_LEVEL_QUIET);
+  callback_message.clear();
+  logger->debug("Test message: {}", "success");
+  ASSERT_STREQ(callback_message.c_str(), "");
+
+  callback_message.clear();
+  logger->info("Test message: {}", "success");
+  ASSERT_STREQ(callback_message.c_str(), "");
+
+  callback_message.clear();
+  logger->warn("Test message: {}", "success");
+  ASSERT_STREQ(callback_message.c_str(), "");
+
+  callback_message.clear();
+  logger->error("Test message: {}", "success");
+  ASSERT_STREQ(callback_message.c_str(), "");
 }


### PR DESCRIPTION
Migrated from https://github.com/oneapi-src/unified-runtime/pull/1748

This PR implements https://github.com/oneapi-src/unified-runtime/issues/1330 through a new logger sink: a user configurable callback. It introduces some spec additions:

- `typedef void (*ur_logger_output_callback_t)(ur_logger_level_t level, const char *pLoggerMsg, void *pUserData)`
- `urSetLoggerCallback(ur_adapter_handle_t hAdapter, ur_logger_output_callback_t pfnLoggerCallback, void *pUserData, ur_logger_level_t level`
)`
- `urSetLoggerCallbackLevel(ur_adapter_handle_t hAdapter, ur_logger_level_t level)`
- `typedef enum ur_logger_level_t` (moved the logger::level enum into the spec)

This new logger sink will only be constructed once a user makes a call to `urSetLoggerCallback` (which is called from the UR `urAdapterSetLoggerCallback` entry point), supplying their own callback function. They can set the minimum logging level through `urSetLoggerCallbackLevel`. Any subsequent logging calls will additionally make a call to the supplied callback where the log level, message and user data will be sent.

A callback has been setup in the SYCL RT in `sycl/source/detail/ur.cpp` to print logs to `std::err`:
```
void urLoggerCallback([[maybe_unused]] ur_logger_level_t level, const char *msg,
                      [[maybe_unused]] void *userData) {
  std::cerr << msg << std::endl;
}
```

A new test suite `LoggerWithCallbackSink` has been added to test this new functionality.