### PR TITLE
[UR][L0] Disable command-buffer immediate append path 

### DIFF
--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -26,7 +26,6 @@ namespace {
 // given Context and Device.
 bool checkImmediateAppendSupport(ur_context_handle_t Context,
                                  ur_device_handle_t Device) {
-
   bool DriverSupportsImmediateAppend =
       Context->getPlatform()->ZeCommandListImmediateAppendExt.Supported;
 
@@ -61,8 +60,9 @@ bool checkImmediateAppendSupport(ur_context_handle_t Context,
     return EnableAppendPath;
   }
 
-  return Device->isPVC() && Device->ImmCommandListUsed &&
-         DriverSupportsImmediateAppend;
+  // Immediate Append path is temporarily disabled until related issues are
+  // fixed.
+  return false;
 }
 
 // Checks whether counter based events are supported for a given Device.


### PR DESCRIPTION
There has been some synchronization issues found in the implementation of `zeCommandListImmediateAppendCommandListsExp`. Since the immediate append path relies on this entrypoint, we need to disable it until the issues are fixed.