### PR TITLE
[SYCL][E2E] Use size_t rather than unsigned long in WorkGroupScratchMemory tests

### DIFF
--- a/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
@@ -45,7 +45,7 @@ int main() {
   sycl::queue queue;
   auto size = std::min(
       queue.get_device().get_info<sycl::info::device::max_work_group_size>(),
-      1024ul);
+      size_t{1024});
 
   DataType *a = sycl::malloc_device<DataType>(size, queue);
   DataType *b = sycl::malloc_device<DataType>(size, queue);

--- a/sycl/test-e2e/WorkGroupScratchMemory/dynamic_unused.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/dynamic_unused.cpp
@@ -30,7 +30,7 @@ int main() {
   sycl::queue queue;
   auto size = std::min(
       queue.get_device().get_info<sycl::info::device::max_work_group_size>(),
-      1024ul);
+      size_t{1024});
 
   DataType *a = sycl::malloc_device<DataType>(size, queue);
   DataType *b = sycl::malloc_device<DataType>(size, queue);


### PR DESCRIPTION
The max work group size is a `size_t`, rather than an `unsigned long`.
This trips up older versions of MSVC where `size_t` happens to be
`unsigned long long`.
