### PR TITLE
[CI] Temporarily disable BMG in precommit

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -99,12 +99,12 @@ jobs:
             target_devices: level_zero:gpu;opencl:gpu
             use_igc_dev: true
             extra_lit_opts: -j 50
-          - name: Intel Battlemage Graphics
-            runner: '["Linux", "bmg"]'
-            image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
-            target_devices: level_zero:gpu
-            # The new Xe kernel driver used by BMG doesn't support resetting.
-            reset_intel_gpu: false
+          #- name: Intel Battlemage Graphics
+          #  runner: '["Linux", "bmg"]'
+          #  image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
+          #  target_devices: level_zero:gpu
+          #  # The new Xe kernel driver used by BMG doesn't support resetting.
+          #  reset_intel_gpu: false
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: ${{ matrix.name }}


### PR DESCRIPTION
BMG runner is offline so disabling testing on BMG for now to unblock pre-commit