### PR TITLE
[SYCL][E2E] Do not run level_zero_eager_init.cpp under ze_debug

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero_eager_init.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_eager_init.cpp
@@ -1,4 +1,7 @@
 // REQUIRES: level_zero, level_zero_dev_kit
+// UNSUPPORTED: ze_debug
+// UNSUPPORTED-INTENDED: ze_debug UR emits summary of leaks that contains
+// function names that we match in the test.
 
 // RUN: %{build} -Wno-error=deprecated-declarations %level_zero_options -o %t.out
 // RUN: env UR_L0_DEBUG=1 SYCL_EAGER_INIT=1 %{run} %t.out 2>&1 | FileCheck %s


### PR DESCRIPTION
With ze_debug UR emits summary of leaks that contains ze*Create function names.