### PR TITLE
[SYCL][E2E] Move crashing sub_byte_bitreverse test to unsupported

### DIFF
--- a/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
@@ -3,11 +3,11 @@
 
 // UNSUPPORTED: target-amd || target-nvidia
 
-// XFAIL: gpu
-// XFAIL-TRACKER: https://github.com/intel/intel-graphics-compiler/issues/330
+// UNSUPPORTED: gpu
+// UNSUPPORTED-TRACKER: https://github.com/intel/intel-graphics-compiler/issues/330
 
-// XFAIL: spirv-backend
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16318, CMPLRLLVM-62187
+// UNSUPPORTED: spirv-backend
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16318, CMPLRLLVM-62187
 
 // Make dump directory.
 // RUN: rm -rf %t.spvdir && mkdir %t.spvdir


### PR DESCRIPTION
It's crashing in IGC and potentially contributing to runner instability.