### PR TITLE
[DeviceSanitizer][Refactor] Move symbolizer to a standalone lib.

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -249,6 +249,13 @@ if(TARGET UnifiedRuntimeLoader)
     ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT unified-runtime-loader
     RUNTIME DESTINATION "bin" COMPONENT unified-runtime-loader
   )
+  if(UR_ENABLE_SYMBOLIZER)
+    install(TARGETS ur_sanitizer_symbolizer
+      LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT unified-runtime-loader
+      ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT unified-runtime-loader
+      RUNTIME DESTINATION "bin" COMPONENT unified-runtime-loader
+    )
+  endif()
 endif()
 
 add_custom_target(UnifiedRuntimeAdapters)

--- a/unified-runtime/source/loader/CMakeLists.txt
+++ b/unified-runtime/source/loader/CMakeLists.txt
@@ -169,6 +169,7 @@ if(UR_ENABLE_SANITIZER)
         ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/msan/msan_shadow.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/sanitizer_common/linux/sanitizer_utils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/sanitizer_common/linux/symbolizer_loader.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/sanitizer_common/sanitizer_allocator.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/sanitizer_common/sanitizer_common.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/sanitizer_common/sanitizer_libdevice.hpp
@@ -182,14 +183,22 @@ if(UR_ENABLE_SANITIZER)
     )
 
     if(UR_ENABLE_SYMBOLIZER)
+        add_ur_library(ur_sanitizer_symbolizer SHARED)
+        install_ur_library(ur_sanitizer_symbolizer)
+        set_target_properties(ur_sanitizer_symbolizer PROPERTIES
+            LIBRARY_OUTPUT_NAME ur_sanitizer_symbolizer
+            RUNTIME_OUTPUT_NAME ur_sanitizer_symbolizer
+        )
+        target_link_options(ur_sanitizer_symbolizer PRIVATE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/symbolizer/symbolizer.map")
+
         set(symbolizer_sources
-            ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/sanitizer_common/linux/symbolizer.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/symbolizer/symbolizer.cpp
         )
-        target_sources(ur_loader
-            PRIVATE ${symbolizer_sources}
-        )
-        target_include_directories(ur_loader PRIVATE ${LLVM_INCLUDE_DIRS})
-        target_link_libraries(ur_loader PRIVATE LLVMSupport LLVMSymbolize)
+        target_sources(ur_sanitizer_symbolizer PRIVATE ${symbolizer_sources})
+
+        target_include_directories(ur_sanitizer_symbolizer PRIVATE ${LLVM_INCLUDE_DIRS})
+        target_link_libraries(ur_sanitizer_symbolizer PRIVATE LLVMSupport LLVMSymbolize)
+
         # In in-tree build, if LLVM is built with libc++, we also need to build
         # symbolizer.cpp with libc++ abi and link libc++ in.
         if(NOT UR_STANDALONE_BUILD AND LLVM_LIBCXX_USED)
@@ -208,9 +217,9 @@ if(UR_ENABLE_SANITIZER)
             if(NOT EXISTS ${LIBCXX_PATH} OR NOT EXISTS ${LIBCXX_ABI_PATH})
                 message(FATAL_ERROR "libc++ is required but can't find the libraries")
             endif()
-            # Link with gcc_s fisrt to avoid some symbols resolve to libc++/libc++abi/libunwind's one
-            target_link_libraries(ur_loader PRIVATE gcc_s ${LIBCXX_PATH} ${LIBCXX_ABI_PATH})
-        endif()
+            target_link_libraries(ur_sanitizer_symbolizer PRIVATE ${LIBCXX_PATH} ${LIBCXX_ABI_PATH})
+        endif() 
+        add_dependencies(ur_loader ur_sanitizer_symbolizer)
     endif()
 
     target_include_directories(ur_loader PRIVATE

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/symbolizer_loader.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/symbolizer_loader.cpp
@@ -1,0 +1,32 @@
+/*
+ *
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+ * Exceptions. See LICENSE.TXT
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * @file symbolizer_loader.cpp
+ *
+ */
+
+#include "sanitizer_common/sanitizer_stacktrace.hpp"
+
+#include <dlfcn.h>
+
+extern "C" {
+
+SymbolizeCodeFunction *TryLoadingSymbolizer() {
+  SymbolizeCodeFunction *SymbolizeCode = nullptr;
+  void *Handle = dlopen("libur_sanitizer_symbolizer.so", RTLD_LAZY);
+  if (Handle) {
+    SymbolizeCode = (SymbolizeCodeFunction *)dlsym(Handle, "SymbolizeCode");
+    if (!SymbolizeCode) {
+      dlclose(Handle);
+    }
+  }
+  return SymbolizeCode;
+}
+
+} // extern "C"

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_stacktrace.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_stacktrace.cpp
@@ -15,11 +15,9 @@
 #include "ur_sanitizer_layer.hpp"
 
 extern "C" {
-
-__attribute__((weak)) void SymbolizeCode(const char *ModuleName,
-                                         uint64_t ModuleOffset,
-                                         char *ResultString, size_t ResultSize,
-                                         size_t *RetSize);
+__attribute__((weak)) SymbolizeCodeFunction *TryLoadingSymbolizer() {
+  return nullptr;
+}
 }
 
 namespace ur_sanitizer_layer {
@@ -98,8 +96,8 @@ void StackTrace::print() const {
         Contains(BI, "libomptarget.so")) {
       continue;
     }
-
-    if (&SymbolizeCode != nullptr) {
+    static SymbolizeCodeFunction *SymbolizeCode = TryLoadingSymbolizer();
+    if (SymbolizeCode != nullptr) {
       std::string Result;
       std::string ModuleName;
       uptr Offset;

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_stacktrace.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_stacktrace.hpp
@@ -17,6 +17,9 @@
 
 #include <vector>
 
+typedef void SymbolizeCodeFunction(const char *ModuleName,
+                                   uint64_t ModuleOffset, char *ResultString,
+                                   size_t ResultSize, size_t *RetSize);
 namespace ur_sanitizer_layer {
 
 constexpr size_t MAX_BACKTRACE_FRAMES = 64;

--- a/unified-runtime/source/loader/layers/sanitizer/symbolizer/symbolizer.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/symbolizer/symbolizer.cpp
@@ -48,8 +48,9 @@ static uintptr_t GetModuleBase(const char *ModuleName) {
 
 extern "C" {
 
-void SymbolizeCode(const char *ModuleName, uint64_t ModuleOffset,
-                   char *ResultString, size_t ResultSize, size_t *RetSize) {
+__attribute__((visibility("default"))) void
+SymbolizeCode(const char *ModuleName, uint64_t ModuleOffset, char *ResultString,
+              size_t ResultSize, size_t *RetSize) {
   std::string Result;
   llvm::raw_string_ostream OS(Result);
   llvm::symbolize::Request Request{ModuleName, ModuleOffset};

--- a/unified-runtime/source/loader/layers/sanitizer/symbolizer/symbolizer.map
+++ b/unified-runtime/source/loader/layers/sanitizer/symbolizer/symbolizer.map
@@ -1,0 +1,6 @@
+{
+	global:
+		SymbolizeCode;
+	local:
+		*;
+};


### PR DESCRIPTION
The symbolizer used in sanitizer layer is sometime built with libc++, and that introduces some unwanted libc++ to ur_loader.so and has caused some problems. This PR aims to make the symbolizer a standalone lib. In this way, we can contain the symbols and make sure them does not affect ur_loader.so in any possible way.