### PR TITLE
[SYCL] Fix static_assert with -funsigned-char

### DIFF
--- a/sycl/include/sycl/detail/vector_arith.hpp
+++ b/sycl/include/sycl/detail/vector_arith.hpp
@@ -265,7 +265,8 @@ template <typename Self> struct VecOperators {
           // ensure we generate 0/1 only (and not 2/-1/etc.).
 #if __clang_major__ >= 20
           // Not an integral constant expression prior to clang-20.
-          static_assert((ext_vector<int8_t, 2>{1, 0} == 0)[1] == -1);
+          static_assert(
+              static_cast<int8_t>((ext_vector<int8_t, 2>{1, 0} == 0)[1]) == -1);
 #endif
 
           tmp = reinterpret_cast<decltype(tmp)>((tmp != 0) * -1);


### PR DESCRIPTION
The type of (ext_vector<int8_t, 2>{1, 0} == 0)[1] has type char, not int8_t, and therefore depending on whether -funsigned-char is in effect may either have the value -1 or have the value 255. Cast to int8_t to ensure it always gets taken as signed. This is only needed for the static_assert: the rest of the code already works for signed and unsigned plain char alike.