### PR TITLE
[SYCL][E2E] Add autodetection for build targets

### DIFF
--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -50,10 +50,6 @@ if(NOT SYCL_TEST_E2E_TARGETS)
   set(SYCL_TEST_E2E_TARGETS "all")
 endif()
 
-if(NOT SYCL_TEST_E2E_BUILD_TARGETS)
-  set(SYCL_TEST_E2E_BUILD_TARGETS "all")
-endif()
-
 if(MSVC AND NOT SYCL_TEST_E2E_STANDALONE)
   # We're trying to pass MSVC flags to Clang, which doesn't work by default
   separate_arguments(cxx_flags NATIVE_COMMAND "${CMAKE_CXX_FLAGS}")

--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -50,6 +50,10 @@ if(NOT SYCL_TEST_E2E_TARGETS)
   set(SYCL_TEST_E2E_TARGETS "all")
 endif()
 
+if(NOT SYCL_TEST_E2E_BUILD_TARGETS)
+  set(SYCL_TEST_E2E_BUILD_TARGETS "all")
+endif()
+
 if(MSVC AND NOT SYCL_TEST_E2E_STANDALONE)
   # We're trying to pass MSVC flags to Clang, which doesn't work by default
   separate_arguments(cxx_flags NATIVE_COMMAND "${CMAKE_CXX_FLAGS}")

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -525,8 +525,13 @@ sycl_ls = FindTool("sycl-ls").resolve(llvm_config, config.llvm_tools_dir)
 if not sycl_ls:
     lit_config.fatal("can't find `sycl-ls`")
 
-if len(config.sycl_build_targets) == 1 and next(iter(config.sycl_build_targets)) == "target-all":
-    config.sycl_build_targets = set([config.backend_to_target[be] for be in config.enabled_backends])
+if (
+    len(config.sycl_build_targets) == 1
+    and next(iter(config.sycl_build_targets)) == "target-all"
+):
+    config.sycl_build_targets = set(
+        [config.backend_to_target[be] for be in config.enabled_backends]
+    )
 
 if len(config.sycl_devices) == 1 and config.sycl_devices[0] == "all":
     devices = set()

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -525,6 +525,9 @@ sycl_ls = FindTool("sycl-ls").resolve(llvm_config, config.llvm_tools_dir)
 if not sycl_ls:
     lit_config.fatal("can't find `sycl-ls`")
 
+if len(config.sycl_build_targets) == 1 and next(iter(config.sycl_build_targets)) == "target-all":
+    config.sycl_build_targets = set([config.backend_to_target[be] for be in config.enabled_backends])
+
 if len(config.sycl_devices) == 1 and config.sycl_devices[0] == "all":
     devices = set()
     cmd = (

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -529,9 +529,12 @@ if (
     len(config.sycl_build_targets) == 1
     and next(iter(config.sycl_build_targets)) == "target-all"
 ):
-    config.sycl_build_targets = set(
-        [config.backend_to_target[be] for be in config.enabled_backends]
-    )
+    config.sycl_build_targets = {"target-spir"}
+    sp = subprocess.getstatusoutput(config.dpcpp_compiler + " --print-targets")
+    if "nvptx64" in sp[1]:
+        config.sycl_build_targets.add("target-nvidia")
+    if "amdgcn" in sp[1]:
+        config.sycl_build_targets.add("target-amd")
 
 if len(config.sycl_devices) == 1 and config.sycl_devices[0] == "all":
     devices = set()

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -31,7 +31,7 @@ config.igc_tag_file = os.path.join("/usr/local/lib/igc/", 'IGCTAG.txt')
 config.sycl_devices = lit_config.params.get("sycl_devices", "@SYCL_TEST_E2E_TARGETS@").split(';')
 
 config.sycl_build_targets = set("target-" + t for t in lit_config.params.get(
-    "sycl_build_targets", "@SYCL_TEST_E2E_BUILD_TARGETS@").split(';'))
+    "sycl_build_targets", "all").split(';'))
 
 config.amd_arch = lit_config.params.get("amd_arch", "@AMD_ARCH@")
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -30,7 +30,9 @@ config.igc_tag_file = os.path.join("/usr/local/lib/igc/", 'IGCTAG.txt')
 
 config.sycl_devices = lit_config.params.get("sycl_devices", "@SYCL_TEST_E2E_TARGETS@").split(';')
 
-config.sycl_build_targets = set("target-" + t for t in lit_config.params.get("sycl_build_targets", "spir").split(';'))
+config.sycl_build_targets = set("target-" + t for t in lit_config.params.get(
+    "sycl_build_targets", "@SYCL_TEST_E2E_BUILD_TARGETS@").split(';'))
+config.enabled_backends = "@SYCL_ENABLE_BACKENDS@".split(';')
 
 config.amd_arch = lit_config.params.get("amd_arch", "@AMD_ARCH@")
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -32,7 +32,6 @@ config.sycl_devices = lit_config.params.get("sycl_devices", "@SYCL_TEST_E2E_TARG
 
 config.sycl_build_targets = set("target-" + t for t in lit_config.params.get(
     "sycl_build_targets", "@SYCL_TEST_E2E_BUILD_TARGETS@").split(';'))
-config.enabled_backends = "@SYCL_ENABLE_BACKENDS@".split(';')
 
 config.amd_arch = lit_config.params.get("amd_arch", "@AMD_ARCH@")
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'


### PR DESCRIPTION
Based on the output of `clang++ --print-targets`