### PR TITLE
[SYCL] Reduce heap allocations from `sycl::local_accessor`

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2212,8 +2212,6 @@ protected:
     const auto *this_const = this;
     (void)getSize();
     (void)this_const->getSize();
-    (void)getPtr();
-    (void)this_const->getPtr();
 #endif
   }
 

--- a/sycl/source/accessor.cpp
+++ b/sycl/source/accessor.cpp
@@ -119,11 +119,13 @@ const sycl::range<3> &LocalAccessorBaseHost::getSize() const {
   return impl->MSize;
 }
 void *LocalAccessorBaseHost::getPtr() {
-  // Must not be called.
+  // Must not be/isn't called, user-facing APIs do error-checking.
+  std::abort();
   return nullptr;
 }
 void *LocalAccessorBaseHost::getPtr() const {
-  // Must not be called.
+  // Must not be/isn't called, user-facing APIs do error-checking.
+  std::abort();
   return nullptr;
 }
 const property_list &LocalAccessorBaseHost::getPropList() const {

--- a/sycl/source/accessor.cpp
+++ b/sycl/source/accessor.cpp
@@ -56,10 +56,10 @@ AccessorBaseHost::AccessorBaseHost(id<3> Offset, range<3> AccessRange,
                                    bool IsSubBuffer,
                                    const property_list &PropertyList) {
   verifyAccessorProps(PropertyList);
-  impl = std::shared_ptr<AccessorImplHost>(
-      new AccessorImplHost(Offset, AccessRange, MemoryRange, AccessMode,
-                           (detail::SYCLMemObjI *)SYCLMemObject, Dims, ElemSize,
-                           false, OffsetInBytes, IsSubBuffer, PropertyList));
+  impl = std::make_shared<AccessorImplHost>(
+      Offset, AccessRange, MemoryRange, AccessMode,
+      (detail::SYCLMemObjI *)SYCLMemObject, Dims, ElemSize, false,
+      OffsetInBytes, IsSubBuffer, PropertyList);
 }
 
 AccessorBaseHost::AccessorBaseHost(id<3> Offset, range<3> AccessRange,
@@ -119,19 +119,12 @@ const sycl::range<3> &LocalAccessorBaseHost::getSize() const {
   return impl->MSize;
 }
 void *LocalAccessorBaseHost::getPtr() {
-  // Const cast this in order to call the const getPtr.
-  return const_cast<const LocalAccessorBaseHost *>(this)->getPtr();
+  // Must not be called.
+  return nullptr;
 }
 void *LocalAccessorBaseHost::getPtr() const {
-  char *ptr = impl->MMem.data();
-
-  // Align the pointer to MElemSize.
-  size_t val = reinterpret_cast<size_t>(ptr);
-  if (val % impl->MElemSize != 0) {
-    ptr += impl->MElemSize - val % impl->MElemSize;
-  }
-
-  return ptr;
+  // Must not be called.
+  return nullptr;
 }
 const property_list &LocalAccessorBaseHost::getPropList() const {
   return impl->MPropertyList;

--- a/sycl/source/detail/accessor_impl.hpp
+++ b/sycl/source/detail/accessor_impl.hpp
@@ -134,13 +134,11 @@ public:
   LocalAccessorImplHost(sycl::range<3> Size, int Dims, int ElemSize,
                         const property_list &PropertyList)
       : MSize(Size), MDims(Dims), MElemSize(ElemSize),
-        MMem(Size[0] * Size[1] * Size[2] * ElemSize + ElemSize),
         MPropertyList(PropertyList) {}
 
   sycl::range<3> MSize;
   int MDims;
   int MElemSize;
-  std::vector<char> MMem;
   property_list MPropertyList;
 };
 


### PR DESCRIPTION
Ideally, there should be zero but we can't fix that without ABI break (both present, and potential future one for unanticipated future changes).

Reduce what we can now:
- don't allocate memory on host (no host device, APIs accessing memory must be called from inside "command")
- Use `std::make_shared` to fold two allocation into one for pImpl idiom