### PR TITLE
[Driver][SYCL] Allow for -l:libname.a to be recognized for SYCL kernels

### DIFF
--- a/clang/test/Driver/sycl-offload-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-old-model.cpp
@@ -76,6 +76,8 @@
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_LIB %s
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen %S/Inputs/SYCL/liblin64.a %s 2>&1 \
 // RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_LIB %s
+// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -L%S/Inputs/SYCL -l:liblin64.a %s 2>&1 \
+// RUN:    | FileCheck -check-prefix IMPLIED_DEVICE_LIB %s
 // IMPLIED_DEVICE_LIB: clang-offload-bundler{{.*}} "-type=aoo"{{.*}} "-targets=sycl-spir64_{{.*}}-unknown-unknown,sycl-spir64-unknown-unknown"{{.*}} "-unbundle"
 
 /// Check that the default device triple is not used with -fno-sycl-link-spirv
@@ -118,6 +120,8 @@
 
 // Device section checking only occur when offloading is enabled
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver %S/Inputs/SYCL/liblin64.a %s 2>&1 \
+// RUN:    | FileCheck -check-prefix CHECK_SECTION %s
+// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -L%S/Inputs/SYCL -l:liblin64.a %s 2>&1 \
 // RUN:    | FileCheck -check-prefix CHECK_SECTION %s
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu %S/Inputs/SYCL/liblin64.a %s 2>&1 \
 // RUN:    | FileCheck -check-prefix NO_CHECK_SECTION %s

--- a/clang/test/Driver/sycl-target-mismatch.cpp
+++ b/clang/test/Driver/sycl-target-mismatch.cpp
@@ -2,6 +2,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen %S/Inputs/SYCL/liblin64.a \
 // RUN:   -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=SPIR64_GEN_DIAG
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -L%S/Inputs/SYCL -l:liblin64.a \
+// RUN:   -### %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=SPIR64_GEN_DIAG
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -L%S/Inputs/SYCL -llin64 \
 // RUN:   -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=SPIR64_GEN_DIAG
@@ -13,6 +16,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64 %S/Inputs/SYCL/liblin64.a \
 // RUN:   -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=SPIR64_DIAG
+// RUN: %clangxx -fsycl -fsycl-targets=spir64 -L%S/Inputs/SYCL -l:liblin64.a \
+// RUN:   -### %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=SPIR64_DIAG
 // RUN: %clangxx -fsycl -fsycl-targets=spir64 -L%S/Inputs/SYCL -llin64 \
 // RUN:   -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=SPIR64_DIAG
@@ -20,6 +26,9 @@
 // RUN:   -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=SPIR64_DIAG
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen %S/Inputs/SYCL/liblin64.a \
+// RUN:   -Wno-sycl-target -### %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=SPIR64_DIAG
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -L%S/Inputs/SYCL -l:liblin64.a \
 // RUN:   -Wno-sycl-target -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=SPIR64_DIAG
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen %S/Inputs/SYCL/liblin64.a \


### PR DESCRIPTION
The use of -l:libname.a was not properly recognizing the library passed in to be considered as an archive that contains SYCL kernels.  Update the parsing behaviors to check for this syntax.