### PR TITLE
[SYCL] [UR] Fix issues that cause graph tests to fail

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_cache.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_cache.cpp
@@ -159,6 +159,10 @@ command_list_cache_t::getCommandList(const command_list_descriptor_t &desc) {
   if (it->second.empty())
     ZeCommandListCache.erase(it);
 
+  if (std::holds_alternative<regular_command_list_descriptor_t>(desc)) {
+    ZE2UR_CALL_THROWS(zeCommandListReset, (CommandListHandle.get()));
+  }
+
   return CommandListHandle;
 }
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -851,11 +851,13 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueGenericCommandListsExp(
 
   auto [pWaitEvents, numWaitEvents] =
       getWaitListView(phEventWaitList, numEventsInWaitList);
-
+  ZE_CALL_NOCHECK(zeCommandListHostSynchronize,
+                  (commandListManager.getZeCommandList(), UINT64_MAX));
   ZE2UR_CALL(zeCommandListImmediateAppendCommandListsExp,
              (commandListManager.getZeCommandList(), numCommandLists,
               phCommandLists, zeSignalEvent, numWaitEvents, pWaitEvents));
-
+  ZE_CALL_NOCHECK(zeCommandListHostSynchronize,
+                  (commandListManager.getZeCommandList(), UINT64_MAX));
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -851,6 +851,9 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueGenericCommandListsExp(
 
   auto [pWaitEvents, numWaitEvents] =
       getWaitListView(phEventWaitList, numEventsInWaitList);
+  // zeCommandListImmediateAppendCommandListsExp is not working with in-order
+  // immediate lists what causes problems with synchronization
+  // TODO: remove synchronization when it is not needed
   ZE_CALL_NOCHECK(zeCommandListHostSynchronize,
                   (commandListManager.getZeCommandList(), UINT64_MAX));
   ZE2UR_CALL(zeCommandListImmediateAppendCommandListsExp,


### PR DESCRIPTION
Fixes issues with v2 level zero adapter in UR command buffer implementation, that resulted in failure of some tests in sycl/test-e2e/Graph/RecordReplay when using level zero adapter v2