### PR TITLE
[SYCL][CUDA] Fix flaky interop task test

### DIFF
--- a/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
@@ -43,6 +43,9 @@ int main() {
         cuMemcpyDtoH(&tmp, ptr, sizeof(int));
         tmp++;
         cuMemcpyHtoD(ptr, &tmp, sizeof(int));
+
+        auto stream = ih.get_native_queue<backend::ext_oneapi_cuda>();
+        cuStreamSynchronize(stream);
       });
     });
     Q.wait();


### PR DESCRIPTION
In host tasks, `Q.wait()` doesn't wait on interop asynchronous work, it simply waits on the lambba being executed.

So for correct execution the CUDA stream must be waited on inside of the lambda.

This made the test flaky because in some cases the copies had been completed before being checked, and in some cases they hadn't, this extra wait fixes that.

Fixes https://github.com/intel/llvm/issues/17026