### PR TITLE
[SYCL][LIBCLC] Use half builtins for generic math functions

### DIFF
--- a/libclc/libspirv/lib/generic/math/acosh.cl
+++ b/libclc/libspirv/lib/generic/math/acosh.cl
@@ -118,6 +118,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_acosh, double)
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_acosh, __builtin_acosh, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_acosh, __builtin_acoshf, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/asinh.cl
+++ b/libclc/libspirv/lib/generic/math/asinh.cl
@@ -366,6 +366,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_asinh, double)
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_asinh, __builtin_asinh, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_asinh, __builtin_asinhf, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/atan.cl
+++ b/libclc/libspirv/lib/generic/math/atan.cl
@@ -178,6 +178,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_atan, double);
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_atan, __builtin_atan, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_atan, __builtin_atanf16, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/atan2.cl
+++ b/libclc/libspirv/lib/generic/math/atan2.cl
@@ -250,6 +250,6 @@ _CLC_BINARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_atan2, double,
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_BINARY_BUILTIN(half, __spirv_ocl_atan2, __builtin_atan2, half, half)
+_CLC_DEFINE_BINARY_BUILTIN(half, __spirv_ocl_atan2, __builtin_atan2f16, half, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/cbrt.cl
+++ b/libclc/libspirv/lib/generic/math/cbrt.cl
@@ -149,6 +149,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_cbrt, double)
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_cbrt, __builtin_cbrt, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_cbrt, __builtin_cbrtf, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/clc_exp10.cl
+++ b/libclc/libspirv/lib/generic/math/clc_exp10.cl
@@ -157,6 +157,6 @@ _CLC_UNARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_exp10, double)
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __clc_exp10, __builtin_exp10, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __clc_exp10, __builtin_exp10f16, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/clc_fmod.cl
+++ b/libclc/libspirv/lib/generic/math/clc_fmod.cl
@@ -171,6 +171,6 @@ _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_fmod, double,
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_BINARY_BUILTIN(half, __clc_fmod, __builtin_fmod, half, half)
+_CLC_DEFINE_BINARY_BUILTIN(half, __clc_fmod, __builtin_fmodf16, half, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/clc_hypot.cl
+++ b/libclc/libspirv/lib/generic/math/clc_hypot.cl
@@ -94,6 +94,6 @@ _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_hypot, double,
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_BINARY_BUILTIN(half, __clc_hypot, __builtin_hypot, half, half)
+_CLC_DEFINE_BINARY_BUILTIN(half, __clc_hypot, __builtin_hypotf, half, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/clc_remainder.cl
+++ b/libclc/libspirv/lib/generic/math/clc_remainder.cl
@@ -207,7 +207,7 @@ _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_remainder, double,
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_BINARY_BUILTIN(half, __clc_remainder, __builtin_remainder, half,
+_CLC_DEFINE_BINARY_BUILTIN(half, __clc_remainder, __builtin_remainderf, half,
                            half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/cos.cl
+++ b/libclc/libspirv/lib/generic/math/cos.cl
@@ -67,6 +67,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_cos, double);
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_cos, __builtin_cos, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_cos, __builtin_cosf16, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/cosh.cl
+++ b/libclc/libspirv/lib/generic/math/cosh.cl
@@ -214,6 +214,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_cosh, double)
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_cosh, __builtin_cosh, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_cosh, __builtin_coshf16, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/erf.cl
+++ b/libclc/libspirv/lib/generic/math/erf.cl
@@ -545,6 +545,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_erf, double);
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_erf, __builtin_erf, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_erf, __builtin_erff, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/erfc.cl
+++ b/libclc/libspirv/lib/generic/math/erfc.cl
@@ -554,6 +554,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_erfc, double);
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_erfc, __builtin_erfc, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_erfc, __builtin_erfcf, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/exp.cl
+++ b/libclc/libspirv/lib/generic/math/exp.cl
@@ -80,6 +80,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_exp, double)
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_exp, __builtin_exp, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_exp, __builtin_expf16, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/exp2.cl
+++ b/libclc/libspirv/lib/generic/math/exp2.cl
@@ -75,6 +75,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_exp2, double)
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_exp2, __builtin_exp2, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_exp2, __builtin_exp2f16, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/expm1.cl
+++ b/libclc/libspirv/lib/generic/math/expm1.cl
@@ -154,6 +154,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_expm1, double)
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_expm1, __builtin_expm1, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_expm1, __builtin_expm1f, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/fdim.cl
+++ b/libclc/libspirv/lib/generic/math/fdim.cl
@@ -19,6 +19,6 @@
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_BINARY_BUILTIN(half, __spirv_ocl_fdim, __builtin_fdim, half, half)
+_CLC_DEFINE_BINARY_BUILTIN(half, __spirv_ocl_fdim, __builtin_fdimf, half, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/frexp.cl
+++ b/libclc/libspirv/lib/generic/math/frexp.cl
@@ -42,11 +42,11 @@
     return BUILTIN(x, y);                                                      \
   }
 
-_CLC_DEFINE_NO_VEC(half, __spirv_ocl_frexp, __builtin_frexp, half, global int *)
+_CLC_DEFINE_NO_VEC(half, __spirv_ocl_frexp, __builtin_frexpf16, half, global int *)
 _CLC_V_V_VP_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, half, __spirv_ocl_frexp, half, global, int)
-_CLC_DEFINE_NO_VEC(half, __spirv_ocl_frexp, __builtin_frexp, half, local int *)
+_CLC_DEFINE_NO_VEC(half, __spirv_ocl_frexp, __builtin_frexpf16, half, local int *)
 _CLC_V_V_VP_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, half, __spirv_ocl_frexp, half, local, int)
-_CLC_DEFINE_NO_VEC(half, __spirv_ocl_frexp, __builtin_frexp, half, int *)
+_CLC_DEFINE_NO_VEC(half, __spirv_ocl_frexp, __builtin_frexpf16, half, int *)
 _CLC_V_V_VP_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, half, __spirv_ocl_frexp, half, , int)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/log.cl
+++ b/libclc/libspirv/lib/generic/math/log.cl
@@ -37,6 +37,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_log, double);
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_log, __builtin_log, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_log, __builtin_logf16, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/log10.cl
+++ b/libclc/libspirv/lib/generic/math/log10.cl
@@ -29,6 +29,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_log10, double);
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_log10, __builtin_log10, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_log10, __builtin_log10f16, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/log1p.cl
+++ b/libclc/libspirv/lib/generic/math/log1p.cl
@@ -171,6 +171,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_log1p, double);
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_log1p, __builtin_log1p, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_log1p, __builtin_log1pf, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/log2.cl
+++ b/libclc/libspirv/lib/generic/math/log2.cl
@@ -29,6 +29,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_log2, double);
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_log2, __builtin_log2, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_log2, __builtin_log2f16, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/logb.cl
+++ b/libclc/libspirv/lib/generic/math/logb.cl
@@ -43,6 +43,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_logb, double)
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_logb, __builtin_logb, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_logb, __builtin_logbf, half)
 
 #endif

--- a/libclc/libspirv/lib/generic/math/sin.cl
+++ b/libclc/libspirv/lib/generic/math/sin.cl
@@ -69,6 +69,6 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_sin, double);
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_sin, __builtin_sin, half)
+_CLC_DEFINE_UNARY_BUILTIN_SCALARIZE(half, __spirv_ocl_sin, __builtin_sinf16, half)
 
 #endif


### PR DESCRIPTION
`__builtin_<name>()` without a suffix is equivalent to the C math function `<name>()`, these functions take and return `double` values.

Instead of using these use the `f16` suffixed builtins which take and return `half` values.

On CPU targets these will be usually lowered to
the single precision library calls (with promotion/truncation). On other targets (for example GPUs) the half builtins might be lowered directly to hardware instructions.

Some of the builtins are not available for half precision, in these cases use the `f` suffixed builtins (which take and return `float`s).