### PR TITLE
[CI] Improve Windows hang detection script for unittests

### DIFF
--- a/devops/scripts/windows_detect_hung_tests.ps1
+++ b/devops/scripts/windows_detect_hung_tests.ps1
@@ -1,5 +1,5 @@
 $exitCode = 0
-$hungTests = Get-Process | Where-Object { ($_.Path -match "llvm\\install") -or ($_.Path -match "llvm\\build-e2e") }
+$hungTests = Get-Process | Where-Object { ($_.Path -match "llvm\\install") -or ($_.Path -match "llvm\\build-e2e") -or ($_.Path -match "llvm\\build") }
 $hungTests | Foreach-Object {
  $exitCode = 1
  echo "Test $($_.Path) hung!"


### PR DESCRIPTION
We just had a unit test hang issue [here](https://github.com/intel/llvm/issues/17168) that broke a ton of PRs, so improve the script to detect that case.