### PR TITLE
[SYCL] Fix image_array.cpp on GPU

### DIFF
--- a/sycl/test-e2e/Basic/image/image_array.cpp
+++ b/sycl/test-e2e/Basic/image/image_array.cpp
@@ -47,7 +47,7 @@ int main() {
 
   constexpr int ResBufSize = ENUM_SIZE;
   std::vector<int> ResBufData(ResBufSize, 0);
-  std::cout << "Success" << std::endl;
+
   {
     sycl::image<2> Img(Img1HostData.data(), ChanOrder, ChanType, ImgSize);
 


### PR DESCRIPTION
Fix issue https://github.com/intel/llvm/issues/15398 by adding group barriers between write and read statements. Also revised the parameters of the second write-read test case (from `42, 42` to `53, 55`) to prevent failures from it been covered by success of the first write-read test case.