### PR TITLE
[UR] Bump clang-format to 19 to match intel/llvm

### DIFF
--- a/unified-runtime/CMakeLists.txt
+++ b/unified-runtime/CMakeLists.txt
@@ -251,13 +251,13 @@ endif()
 
 # Check if clang-format (in correct version) is available for Cpp code formatting.
 if(UR_FORMAT_CPP_STYLE)
-    find_program(CLANG_FORMAT NAMES clang-format-18 clang-format-18.1 clang-format)
+    find_program(CLANG_FORMAT NAMES clang-format-19 clang-format-19.1 clang-format)
 
     if(CLANG_FORMAT)
         get_program_version_major_minor(${CLANG_FORMAT} CLANG_FORMAT_VERSION)
         message(STATUS "Found clang-format: ${CLANG_FORMAT} (version: ${CLANG_FORMAT_VERSION})")
 
-        set(CLANG_FORMAT_REQUIRED "18.1")
+        set(CLANG_FORMAT_REQUIRED "19.1")
         if(NOT (CLANG_FORMAT_VERSION VERSION_EQUAL CLANG_FORMAT_REQUIRED))
             message(FATAL_ERROR "required clang-format version is ${CLANG_FORMAT_REQUIRED}")
         endif()

--- a/unified-runtime/third_party/requirements.txt
+++ b/unified-runtime/third_party/requirements.txt
@@ -6,7 +6,7 @@ breathe==4.33.1
 bs4==0.0.1
 certifi==2024.07.04
 chardet==3.0.4
-clang-format==18.1.7
+clang-format==19.1.6
 colorama==0.4.1
 docutils==0.15.2
 exhale==0.3.0


### PR DESCRIPTION
The clang-format used as part of the CI jobs and code generation has
been bumped to match the same version used in intel/llvm.
