### PR TITLE
[SYCL] Temporarily disable CommandGraphExtensionTests

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
@@ -1,15 +1,16 @@
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_sycl_unittest(CommandGraphExtensionTests OBJECT
-  Barrier.cpp
-  CommandGraph.cpp
-  CommonReferenceSemantics.cpp
-  Exceptions.cpp
-  InOrderQueue.cpp
-  MultiThreaded.cpp
-  Queries.cpp
-  Regressions.cpp
-  Subgraph.cpp
-  Update.cpp
-  Properties.cpp
-)
+# https://github.com/intel/llvm/issues/17168
+# add_sycl_unittest(CommandGraphExtensionTests OBJECT
+#   Barrier.cpp
+#   CommandGraph.cpp
+#   CommonReferenceSemantics.cpp
+#   Exceptions.cpp
+#   InOrderQueue.cpp
+#   MultiThreaded.cpp
+#   Queries.cpp
+#   Regressions.cpp
+#   Subgraph.cpp
+#   Update.cpp
+#   Properties.cpp
+# )


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/17168.