### PR TITLE
[CI] Actions using GitHub runners should use latest Ubuntu

### DIFF
--- a/.github/workflows/sycl-aws.yml
+++ b/.github/workflows/sycl-aws.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   aws:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: aws
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sycl-containers-igc-dev.yaml
+++ b/.github/workflows/sycl-containers-igc-dev.yaml
@@ -22,7 +22,7 @@ jobs:
   build_and_push_images:
     if: github.repository == 'intel/llvm'
     name: Build and Push IGC Dev Docker Images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -29,7 +29,7 @@ jobs:
   build_and_push_images:
     if: github.repository == 'intel/llvm'
     name: Build and Push Docker Images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -45,7 +45,7 @@ jobs:
             })
 
   aws-start:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: aws
     steps:
       - uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
   aws-stop:
     needs: [aws-start, e2e-cuda]
     if: always()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: aws
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sycl-stale-issues.yml
+++ b/.github/workflows/sycl-stale-issues.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v9
       with:

--- a/.github/workflows/sycl-sync-main.yml
+++ b/.github/workflows/sycl-sync-main.yml
@@ -9,7 +9,7 @@ jobs:
   sync:
     permissions:
       contents: write  # for Git to git push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository == 'intel/llvm'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sycl-update-gpu-driver.yml
+++ b/.github/workflows/sycl-update-gpu-driver.yml
@@ -11,7 +11,7 @@ jobs:
   update_driver_linux:
     permissions:
       contents: write  # for Git to git push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository == 'intel/llvm'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/sycl-update-igc-dev-driver.yml
+++ b/.github/workflows/sycl-update-igc-dev-driver.yml
@@ -11,7 +11,7 @@ jobs:
   update_driver_linux:
     permissions:
       contents: write  # for Git to git push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository == 'intel/llvm'
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
We need to remove 20.04 because of https://github.com/actions/runner-images/issues/11101, so just move everything to latest. 

This has no effect on our self-hosted runners.

Nightly [here](https://github.com/intel/llvm/actions/runs/13525863179).