### PR TITLE
[CI] Re-enable GPU resetting for PVC

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -91,12 +91,14 @@ jobs:
             runner: '["Linux", "pvc"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu
+            reset_intel_gpu: true
             extra_lit_opts: -j 50
           - name: Dev IGC on Intel Ponte Vecchio GPU
             runner: '["Linux", "pvc"]'
             image: ghcr.io/intel/llvm/ubuntu2404_intel_drivers:devigc
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu
+            reset_intel_gpu: true
             use_igc_dev: true
             extra_lit_opts: -j 50
           - name: Intel Battlemage Graphics

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -205,7 +205,13 @@ jobs:
       if: inputs.reset_intel_gpu == 'true'
       run: |
         sudo mount -t debugfs none /sys/kernel/debug
-        sudo bash -c 'echo 1 > /sys/kernel/debug/dri/0/i915_wedged'
+        base_dir="/sys/kernel/debug/dri"
+
+        for dir in "$base_dir"/*; do
+         if [ -f "$dir/i915_wedged" ]; then
+          sudo bash -c 'echo 1 > $dir/i915_wedged'
+         fi
+        done
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.devops_ref || inputs.ref }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -209,7 +209,7 @@ jobs:
 
         for dir in "$base_dir"/*; do
          if [ -f "$dir/i915_wedged" ]; then
-          sudo bash -c 'echo 1 > $dir/i915_wedged'
+          sudo bash -c 'echo 1 > $0/i915_wedged' $dir
          fi
         done
     - uses: actions/checkout@v4

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -76,6 +76,7 @@ jobs:
             runner: '["Linux", "pvc"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
+            reset_intel_gpu: true
 
           - name: Intel L0 Battlemage GPU
             runner: '["Linux", "bmg"]'
@@ -113,6 +114,7 @@ jobs:
             runner: '["Linux", "pvc"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
+            reset_intel_gpu: true
             extra_lit_opts: --param test-preview-mode=True
 
     uses: ./.github/workflows/sycl-linux-run-tests.yml
@@ -137,6 +139,7 @@ jobs:
       name: Intel PVC L0 oneAPI
       runner: '["Linux", "pvc"]'
       target_devices: level_zero:gpu
+      reset_intel_gpu: true
       extra_lit_opts: -j 50
       image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
       ref: ${{ github.sha }}
@@ -268,7 +271,7 @@ jobs:
             runner: '["Linux", "pvc"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
-            reset_intel_gpu: false
+            reset_intel_gpu: true
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     secrets: inherit
     with:


### PR DESCRIPTION
The out-of-tree kernel driver for PVC enables a different framebuffer driver that takes the `dri/0` spot, so on those runners `dri/1` is the one with the `i915_wedged` file. 

Just find all folders with `i915_wedged` and reset those.