### PR TITLE
[DevTSAN] Support thread sanitizer for device offloading in TSAN pass

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -193,9 +193,12 @@ llvm/include/llvm/Transforms/Instrumentation/AddressSanitizer.h @intel/dpcpp-san
 llvm/include/llvm/Transforms/Instrumentation/AddressSanitizerCommon.h @intel/dpcpp-sanitizers-review
 llvm/include/llvm/Transforms/Instrumentation/AddressSanitizerOptions.h @intel/dpcpp-sanitizers-review
 llvm/include/llvm/Transforms/Instrumentation/MemorySanitizer.h @intel/dpcpp-sanitizers-review
+llvm/include/llvm/Transforms/Instrumentation/ThreadSanitizer.h @intel/dpcpp-sanitizers-review
 llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp @intel/dpcpp-sanitizers-review
 llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp @intel/dpcpp-sanitizers-review
+llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp @intel/dpcpp-sanitizers-review
 llvm/test/Instrumentation/AddressSanitizer/ @intel/dpcpp-sanitizers-review
 llvm/test/Instrumentation/MemorySanitizer/ @intel/dpcpp-sanitizers-review
+llvm/test/Instrumentation/ThreadSanitizer/ @intel/dpcpp-sanitizers-review
 sycl/test-e2e/AddressSanitizer/ @intel/dpcpp-sanitizers-review
 sycl/test-e2e/MemorySanitizer/ @intel/dpcpp-sanitizers-review

--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -496,7 +496,6 @@ ThreadSanitizerOnSpirv::GetOrCreateGlobalString(StringRef Name, StringRef Value,
   return StringGV;
 }
 
-
 void ThreadSanitizer::initialize(Module &M, const TargetLibraryInfo &TLI) {
   const DataLayout &DL = M.getDataLayout();
   LLVMContext &Ctx = M.getContext();
@@ -962,13 +961,12 @@ bool ThreadSanitizer::instrumentLoadOrStore(const InstructionInfo &II,
       OnAccessFunc = TsanCompoundRW[Idx];
     else if (IsVolatile)
       OnAccessFunc = IsWrite ? TsanVolatileWrite[Idx] : TsanVolatileRead[Idx];
-    else
-      OnAccessFunc = [&]() {
-        if (Spirv)
-          return IsWrite ? Spirv->TsanWrite[Idx] : Spirv->TsanRead[Idx];
-        else
-          return IsWrite ? TsanWrite[Idx] : TsanRead[Idx];
-      }();
+    else {
+      if (Spirv)
+        OnAccessFunc = IsWrite ? Spirv->TsanWrite[Idx] : Spirv->TsanRead[Idx];
+      else
+        OnAccessFunc = IsWrite ? TsanWrite[Idx] : TsanRead[Idx];
+    }
   } else {
     if (IsCompoundRW)
       OnAccessFunc = TsanUnalignedCompoundRW[Idx];

--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -257,9 +257,7 @@ void ThreadSanitizerOnSpirv::initialize() {
 
   for (size_t i = 0; i < kNumberOfAccessSizes; ++i) {
     const unsigned ByteSize = 1U << i;
-    const unsigned BitSize = ByteSize * 8;
     std::string ByteSizeStr = utostr(ByteSize);
-    std::string BitSizeStr = utostr(BitSize);
     // __tsan_readX/__tsan_writeX(
     //   ...
     //   char* file,
@@ -392,7 +390,7 @@ void ThreadSanitizerOnSpirv::extendSpirKernelArgs() {
       Types.push_back(I->getType());
     }
 
-    // New argument: uintptr_t as(1)*, which is allocated in shared USM buffer
+    // New argument: uintptr_t as(1)*, which is allocated in USM buffer
     Types.push_back(PointerType::get(IntptrTy, kSpirOffloadGlobalAS));
 
     FunctionType *NewFTy = FunctionType::get(F->getReturnType(), Types, false);

--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -260,6 +260,12 @@ void ThreadSanitizerOnSpirv::initialize() {
     const unsigned BitSize = ByteSize * 8;
     std::string ByteSizeStr = utostr(ByteSize);
     std::string BitSizeStr = utostr(BitSize);
+    // __tsan_readX/__tsan_writeX(
+    //   ...
+    //   char* file,
+    //   unsigned int line,
+    //   char* func
+    // )
     SmallString<32> ReadName("__tsan_read" + ByteSizeStr);
     TsanRead[i] = M.getOrInsertFunction(ReadName, Attr, IRB.getVoidTy(),
                                         IntptrTy, IRB.getInt32Ty(), Int8PtrTy,

--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -961,12 +961,10 @@ bool ThreadSanitizer::instrumentLoadOrStore(const InstructionInfo &II,
       OnAccessFunc = TsanCompoundRW[Idx];
     else if (IsVolatile)
       OnAccessFunc = IsWrite ? TsanVolatileWrite[Idx] : TsanVolatileRead[Idx];
-    else {
-      if (Spirv)
-        OnAccessFunc = IsWrite ? Spirv->TsanWrite[Idx] : Spirv->TsanRead[Idx];
-      else
-        OnAccessFunc = IsWrite ? TsanWrite[Idx] : TsanRead[Idx];
-    }
+    else if (Spirv)
+      OnAccessFunc = IsWrite ? Spirv->TsanWrite[Idx] : Spirv->TsanRead[Idx];
+    else
+      OnAccessFunc = IsWrite ? TsanWrite[Idx] : TsanRead[Idx];
   } else {
     if (IsCompoundRW)
       OnAccessFunc = TsanUnalignedCompoundRW[Idx];

--- a/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/basic.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/basic.ll
@@ -1,0 +1,22 @@
+; RUN: opt < %s -passes='function(tsan),module(tsan-module)' -tsan-instrument-func-entry-exit=0 -tsan-instrument-memintrinsics=0 -S | FileCheck %s
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: sanitize_thread
+define linkonce_odr dso_local spir_func void @_Z3fooPc(ptr addrspace(4) %array) #0 {
+; CHECK-LABEL: void @_Z3fooPc
+entry:
+  %array.addr = alloca ptr addrspace(4), align 8
+  %array.addr.ascast = addrspacecast ptr %array.addr to ptr addrspace(4)
+  store ptr addrspace(4) %array, ptr addrspace(4) %array.addr.ascast, align 8
+  %0 = load ptr addrspace(4), ptr addrspace(4) %array.addr.ascast, align 8
+  %arrayidx = getelementptr inbounds i8, ptr addrspace(4) %0, i64 0
+  %1 = load i8, ptr addrspace(4) %arrayidx, align 1
+  %inc = add i8 %1, 1
+  ; CHECK: ptrtoint ptr addrspace(4) %arrayidx to i64
+  ; CHECK: call void @__tsan_write1
+  store i8 %inc, ptr addrspace(4) %arrayidx, align 1
+  ret void
+}
+
+attributes #0 = { sanitize_thread }

--- a/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/basic.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/basic.ll
@@ -3,20 +3,87 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: sanitize_thread
-define linkonce_odr dso_local spir_func void @_Z3fooPc(ptr addrspace(4) %array) #0 {
-; CHECK-LABEL: void @_Z3fooPc
+define linkonce_odr dso_local spir_func void @write_1_byte(ptr addrspace(4) %a) #0 {
+; CHECK-LABEL: void @write_1_byte
 entry:
-  %array.addr = alloca ptr addrspace(4), align 8
-  %array.addr.ascast = addrspacecast ptr %array.addr to ptr addrspace(4)
-  store ptr addrspace(4) %array, ptr addrspace(4) %array.addr.ascast, align 8
-  %0 = load ptr addrspace(4), ptr addrspace(4) %array.addr.ascast, align 8
-  %arrayidx = getelementptr inbounds i8, ptr addrspace(4) %0, i64 0
-  %1 = load i8, ptr addrspace(4) %arrayidx, align 1
-  %inc = add i8 %1, 1
-  ; CHECK: ptrtoint ptr addrspace(4) %arrayidx to i64
+  %tmp1 = load i8, ptr addrspace(4) %a, align 1
+  %inc = add i8 %tmp1, 1
+  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
   ; CHECK: call void @__tsan_write1
-  store i8 %inc, ptr addrspace(4) %arrayidx, align 1
+  store i8 %inc, ptr addrspace(4) %a, align 1
   ret void
+}
+
+; Function Attrs: sanitize_thread
+define linkonce_odr dso_local spir_func void @write_2_bytes(ptr addrspace(4) %a) #0 {
+; CHECK-LABEL: void @write_2_bytes
+entry:
+  %tmp1 = load i16, ptr addrspace(4) %a, align 2
+  %inc = add i16 %tmp1, 1
+  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
+  ; CHECK: call void @__tsan_write2
+  store i16 %inc, ptr addrspace(4) %a, align 2
+  ret void
+}
+
+; Function Attrs: sanitize_thread
+define linkonce_odr dso_local spir_func void @write_4_bytes(ptr addrspace(4) %a) #0 {
+; CHECK-LABEL: void @write_4_bytes
+entry:
+  %tmp1 = load i32, ptr addrspace(4) %a, align 4
+  %inc = add i32 %tmp1, 1
+  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
+  ; CHECK: call void @__tsan_write4
+  store i32 %inc, ptr addrspace(4) %a, align 4
+  ret void
+}
+
+; Function Attrs: sanitize_thread
+define linkonce_odr dso_local spir_func void @write_8_bytes(ptr addrspace(4) %a) #0 {
+; CHECK-LABEL: void @write_8_bytes
+entry:
+  %tmp1 = load i64, ptr addrspace(4) %a, align 8
+  %inc = add i64 %tmp1, 1
+  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
+  ; CHECK: call void @__tsan_write8
+  store i64 %inc, ptr addrspace(4) %a, align 8
+  ret void
+}
+
+define linkonce_odr dso_local spir_func i8 @read_1_byte(ptr addrspace(4) %a) #0 {
+; CHECK-LABEL: i8 @read_1_byte
+entry:
+  %tmp1 = load i8, ptr addrspace(4) %a, align 1
+  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
+  ; CHECK: call void @__tsan_read1
+  ret i8 %tmp1
+}
+
+define linkonce_odr dso_local spir_func i16 @read_2_bytes(ptr addrspace(4) %a) #0 {
+; CHECK-LABEL: i16 @read_2_bytes
+entry:
+  %tmp1 = load i16, ptr addrspace(4) %a, align 2
+  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
+  ; CHECK: call void @__tsan_read2
+  ret i16 %tmp1
+}
+
+define linkonce_odr dso_local spir_func i32 @read_4_bytes(ptr addrspace(4) %a) #0 {
+; CHECK-LABEL: i32 @read_4_bytes
+entry:
+  %tmp1 = load i32, ptr addrspace(4) %a, align 4
+  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
+  ; CHECK: call void @__tsan_read4
+  ret i32 %tmp1
+}
+
+define linkonce_odr dso_local spir_func i64 @read_8_bytes(ptr addrspace(4) %a) #0 {
+; CHECK-LABEL: i64 @read_8_bytes
+entry:
+  %tmp1 = load i64, ptr addrspace(4) %a, align 8
+  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
+  ; CHECK: call void @__tsan_read8
+  ret i64 %tmp1
 }
 
 attributes #0 = { sanitize_thread }

--- a/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/extend_launch_info_arg.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/extend_launch_info_arg.ll
@@ -1,0 +1,16 @@
+; RUN: opt < %s -passes='function(tsan),module(tsan-module)' -tsan-instrument-func-entry-exit=0 -tsan-instrument-memintrinsics=0 -S | FileCheck %s
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-LABEL: @__TsanKernelMetadata = appending dso_local local_unnamed_addr addrspace(1) global
+; CHECK-SAME: i64 ptrtoint (ptr addrspace(2) @__tsan_kernel to i64
+
+; Function Attrs: sanitize_thread
+define spir_kernel void @test() #0 {
+; CHECK-LABEL: void @test(ptr addrspace(1) noundef %__tsan_launch)
+entry:
+  ; CHECK: store ptr addrspace(1) %__tsan_launch, ptr addrspace(3) @__TsanLaunchInfo
+  ret void
+}
+
+attributes #0 = { sanitize_thread }


### PR DESCRIPTION
This PR is going to support thread sanitizer for device offloading (IR part)
  1.defined a new class 'ThreadSanitizerOnSpirv' to do SPIR-V specific
    instrumentation.
  2.added an extra argument '__tsan_launch' to each spir kernels.
  3.disable inserting module ctor for kernel code.
  4.created a new global '__TsanKernelMetadata' to record spir kernels'
    information.