### PR TITLE
[CI][CTS] Use ccache for SYCL-CTS

### DIFF
--- a/devops/actions/run-tests/cts/action.yml
+++ b/devops/actions/run-tests/cts/action.yml
@@ -34,6 +34,9 @@ runs:
     shell: bash
     env:
       CMAKE_EXTRA_ARGS: ${{ inputs.extra_cmake_args }}
+      # Since this cache doesn't take up much space, the default cache size (5G)
+      # is likely sufficient.
+      CCACHE_DIR: "/__w/build_cache_sycl_cts"
     run: |
       cts_exclude_filter=""
       # If CTS_TESTS_TO_BUILD is null - use filter
@@ -54,11 +57,14 @@ runs:
         echo "::endgroup::"
       fi
 
+      mkdir -p $CCACHE_DIR
       cmake -GNinja -B./build-cts -S./khronos_sycl_cts -DCMAKE_CXX_COMPILER=$(which clang++) \
       -DSYCL_IMPLEMENTATION=DPCPP \
       -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="$cts_exclude_filter" \
       -DSYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS=OFF \
       -DDPCPP_INSTALL_DIR="$(dirname $(which clang++))/.." \
+      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       $CMAKE_EXTRA_ARGS
       # Ignore errors so that if one category build fails others still have a
       # chance to finish and be executed at the run stage. Note that


### PR DESCRIPTION
Locally on pvc machine ccache gives ~x4 speedup.