### PR TITLE
[SYCL][E2E] Fix compilation of 2 PVC tests on windows

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero_sub_sub_device.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_sub_sub_device.cpp
@@ -1,4 +1,4 @@
-// REQUIRES:  arch-intel_gpu_pvc, level_zero
+// REQUIRES:  arch-intel_gpu_pvc, level_zero, linux
 
 // XFAIL: arch-intel_gpu_pvc && run-mode
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15602

--- a/sycl/test-e2e/Adapters/level_zero_sub_sub_device.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_sub_sub_device.cpp
@@ -1,4 +1,4 @@
-// REQUIRES:  arch-intel_gpu_pvc, level_zero, linux
+// REQUIRES:  arch-intel_gpu_pvc, level_zero
 
 // XFAIL: arch-intel_gpu_pvc && run-mode
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15602
@@ -32,7 +32,6 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/properties/all_properties.hpp>
 #include <sycl/usm.hpp>
-#include <unistd.h>
 
 using namespace sycl;
 using namespace std::chrono;

--- a/sycl/test-e2e/ESIMD/srnd.cpp
+++ b/sycl/test-e2e/ESIMD/srnd.cpp
@@ -26,7 +26,8 @@ bool test(queue &Q) {
   for (int i = 0; i < N; ++i) {
     float value = esimd_test::getRandomValue<float>();
     while (sycl::fabs(value) > std::numeric_limits<half>::max() ||
-           sycl::fabs(value) < std::numeric_limits<half>::min() || std::isnan(value))
+           sycl::fabs(value) < std::numeric_limits<half>::min() ||
+           std::isnan(value))
       value = esimd_test::getRandomValue<float>();
 
     Input[i] = value;

--- a/sycl/test-e2e/ESIMD/srnd.cpp
+++ b/sycl/test-e2e/ESIMD/srnd.cpp
@@ -25,8 +25,8 @@ bool test(queue &Q) {
 
   for (int i = 0; i < N; ++i) {
     float value = esimd_test::getRandomValue<float>();
-    while (fabs(value) > std::numeric_limits<half>::max() ||
-           fabs(value) < std::numeric_limits<half>::min() || std::isnan(value))
+    while (sycl::fabs(value) > std::numeric_limits<half>::max() ||
+           sycl::fabs(value) < std::numeric_limits<half>::min() || std::isnan(value))
       value = esimd_test::getRandomValue<float>();
 
     Input[i] = value;

--- a/sycl/test-e2e/ESIMD/srnd.cpp
+++ b/sycl/test-e2e/ESIMD/srnd.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: arch-intel_gpu_pvc
+// REQUIRES: arch-intel_gpu_pvc, linux
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/srnd.cpp
+++ b/sycl/test-e2e/ESIMD/srnd.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: arch-intel_gpu_pvc, linux
+// REQUIRES: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
We don't actually run these on windows, but if we enable `build-only` these will build.