### PR TITLE
[SYCL][E2E] Add `cl_options` to build features list

### DIFF
--- a/sycl/test-e2e/E2EExpr.py
+++ b/sycl/test-e2e/E2EExpr.py
@@ -18,6 +18,7 @@ class E2EExpr(BooleanExpression):
         "system-linux",
         "windows",
         "system-windows",
+        "cl_options",
         "enable-perf-tests",
         "preview-breaking-changes-supported",
         "has_ndebug",


### PR DESCRIPTION
This should be a build-specific feature. We use it to decide whether we should build tests like [`Regression/msvc_crt.cpp`](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/Regression/msvc_crt.cpp).