### PR TITLE
[SYCL][E2E] Disable tests that sporadically fail on BMG 

### DIFF
--- a/sycl/test-e2e/Assert/lit.local.cfg
+++ b/sycl/test-e2e/Assert/lit.local.cfg
@@ -1,0 +1,4 @@
+import platform
+
+# https://github.com/intel/llvm/issues/17203
+config.unsupported_features += ['arch-intel_gpu_bmg_g21']

--- a/sycl/test-e2e/Assert/lit.local.cfg
+++ b/sycl/test-e2e/Assert/lit.local.cfg
@@ -1,4 +1,3 @@
-import platform
-
 # https://github.com/intel/llvm/issues/17203
 config.unsupported_features += ['arch-intel_gpu_bmg_g21']
+

--- a/sycl/test-e2e/InlineAsm/asm_multiple_instructions.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_multiple_instructions.cpp
@@ -5,8 +5,8 @@
 // RUN: %{run} %t.out
 // The test is failing when writing directly to output buffer.
 // If temporary variable is used (see TO_PASS mode) the test succeeded.
-// XFAIL: gpu && run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16412
+// UNSUPPORTED: gpu && run-mode
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16412
 #include "include/asmhelper.h"
 #include <iostream>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/letter_example.cpp
+++ b/sycl/test-e2e/InlineAsm/letter_example.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: sg-16,aspect-usm_shared_allocations
-// XFAIL: arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16921
+// UNSUPPORTED: arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16921
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/InlineAsm/malloc_shared_32.cpp
+++ b/sycl/test-e2e/InlineAsm/malloc_shared_32.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: sg-32,aspect-usm_shared_allocations
-// XFAIL: arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16921
+// UNSUPPORTED: arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16921
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
I reproduced the assert tests locking up the whole machine and causing GPU resets, so just disable them all for now. This is probably one of the major causes of the instability.

For some reason `letter_example.cpp` is causing GPU resets on BMG, which is another good candidate as for the runner instability, so just move all XFAILing InlineAsm tests to UNSUPPORTED so they don't run at all on failing platforms.

