### PR TITLE
[SYCL] reenabling USM tests on DG2

### DIFF
--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
+// UNSUPPORTED: hip && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "copy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
+// UNSUPPORTED: hip && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "copy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
+// UNSUPPORTED:  hip && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "copy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
+// UNSUPPORTED: hip && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "copy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
+// UNSUPPORTED: hip && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "memcpy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
+// UNSUPPORTED: hip && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "memcpy2d_common.hpp"

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
@@ -10,7 +10,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
+// UNSUPPORTED: hip && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 // Temporarily disabled until the failure is addressed.

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
@@ -13,7 +13,7 @@
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
 
-// UNSUPPORTED: (gpu-intel-dg2 || hip) && linux
+// UNSUPPORTED: hip && linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15648
 
 #include "memcpy2d_common.hpp"

--- a/sycl/test-e2e/USM/usm_pooling.cpp
+++ b/sycl/test-e2e/USM/usm_pooling.cpp
@@ -1,9 +1,6 @@
 // REQUIRES: level_zero
 // RUN: %{build} -o %t.out
 
-// UNSUPPORTED: gpu-intel-dg2
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/12397
-
 // Allocate 2 items of 2MB. Free 2. Allocate 3 more of 2MB.
 
 // With no pooling: 1,2,3,4,5 allocs lead to ZE call.


### PR DESCRIPTION
These are all working now on DG2 and should be reenabled.

https://github.com/intel/llvm/issues/16568
https://github.com/intel/llvm/issues/15648