### PR TITLE
[SYCL][E2E] XFAIL max_sub_groups test for FPGA

### DIFF
--- a/sycl/test-e2e/Experimental/launch_queries/max_sub_groups.cpp
+++ b/sycl/test-e2e/Experimental/launch_queries/max_sub_groups.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// XFAIL: accelerator
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17209
+
 #include <sycl/detail/core.hpp>
 #include <sycl/detail/info_desc_helpers.hpp>
 #include <sycl/kernel.hpp>


### PR DESCRIPTION
This commit adds an XFAIL for FPGA in the
sycl/test-e2e/Experimental/launch_queries/max_sub_groups.cpp as it currently triggers an assert.
See https://github.com/intel/llvm/issues/17209.