### PR TITLE
[DevTSAN] Support thread sanitizer for device offloading in sycl-tool-chain

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/ComputeModuleRuntimeInfo.h
+++ b/llvm/include/llvm/SYCLLowerIR/ComputeModuleRuntimeInfo.h
@@ -30,6 +30,7 @@ struct GlobalBinImageProps {
 };
 bool isModuleUsingAsan(const Module &M);
 bool isModuleUsingMsan(const Module &M);
+bool isModuleUsingTsan(const Module &M);
 using PropSetRegTy = llvm::util::PropertySetRegistry;
 using EntryPointSet = SetVector<Function *>;
 

--- a/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
@@ -54,6 +54,10 @@ bool isModuleUsingMsan(const Module &M) {
   return M.getNamedGlobal("__MsanKernelMetadata");
 }
 
+bool isModuleUsingTsan(const Module &M) {
+  return M.getNamedGlobal("__TsanKernelMetadata");
+}
+
 // This function traverses over reversed call graph by BFS algorithm.
 // It means that an edge links some function @func with functions
 // which contain call of function @func. It starts from
@@ -406,6 +410,8 @@ PropSetRegTy computeModuleProperties(const Module &M,
       PropSet.add(PropSetRegTy::SYCL_MISC_PROP, "sanUsed", "asan");
     else if (isModuleUsingMsan(M))
       PropSet.add(PropSetRegTy::SYCL_MISC_PROP, "sanUsed", "msan");
+    else if (isModuleUsingTsan(M))
+      PropSet.add(PropSetRegTy::SYCL_MISC_PROP, "sanUsed", "tsan");
   }
 
   if (GlobProps.EmitDeviceGlobalPropSet) {

--- a/llvm/lib/SYCLLowerIR/SanitizerKernelMetadata.cpp
+++ b/llvm/lib/SYCLLowerIR/SanitizerKernelMetadata.cpp
@@ -33,6 +33,9 @@ PreservedAnalyses SanitizerKernelMetadataPass::run(Module &M,
     KernelMetadata = M.getNamedGlobal("__MsanKernelMetadata");
 
   if (!KernelMetadata)
+    KernelMetadata = M.getNamedGlobal("__TsanKernelMetadata");
+
+  if (!KernelMetadata)
     return PreservedAnalyses::all();
 
   auto &DL = M.getDataLayout();

--- a/llvm/test/tools/sycl-post-link/device-sanitizer/tsan.ll
+++ b/llvm/test/tools/sycl-post-link/device-sanitizer/tsan.ll
@@ -1,0 +1,15 @@
+; This test checks that the post-link tool properly generates "sanUsed=tsan"
+; in [SYCL/misc properties], and fixes the attributes and metadata of @__TsanKernelMetadata
+
+; RUN: sycl-post-link -properties -split=kernel -symbols -S < %s -o %t.table
+
+; RUN: FileCheck %s -input-file=%t_0.prop --check-prefix CHECK-PROP
+; CHECK-PROP: [SYCL/misc properties]
+; CHECK-PROP: sanUsed=2|gAAAAAAAAAAdzFmb
+
+; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK-IR
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+
+@__TsanKernelMetadata = addrspace(1) global [1 x { i64, i64 }] [{ i64, i64 } { i64 0, i64 58 }]
+; CHECK-IR: @__TsanKernelMetadata {{.*}} !spirv.Decorations

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -800,8 +800,8 @@ processInputModule(std::unique_ptr<Module> M) {
   if (M->getTargetTriple().find("spir") != std::string::npos)
     Modified |= removeDeviceGlobalFromCompilerUsed(*M.get());
 
-  // MemorySanitizer specific passes
-  if (isModuleUsingAsan(*M) || isModuleUsingMsan(*M)) {
+  // Sanitizer specific passes
+  if (isModuleUsingAsan(*M) || isModuleUsingMsan(*M) || isModuleUsingTsan(*M)) {
     // Fix attributes and metadata of KernelMetadata
     Modified |= runModulePass<SanitizerKernelMetadataPass>(*M);
   }


### PR DESCRIPTION
This PR is going to support thread sanitizer for device offloading (sycl-tool-chain part)
  1.defined a new helper function 'isModuleUsingTsan'
  2.fix attribute for '__TsanKernelMetadata'