### PR TITLE
[libspirv] Restore overloads of generic address space

### DIFF
--- a/libclc/clc/include/clc/math/unary_def_with_int_ptr.inc
+++ b/libclc/clc/include/clc/math/unary_def_with_int_ptr.inc
@@ -18,3 +18,10 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE FUNCTION(__CLC_GENTYPE x,
                                               local __CLC_INTN *iptr) {
   return __CLC_FUNCTION(FUNCTION)(x, iptr);
 }
+
+#if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE FUNCTION(__CLC_GENTYPE x,
+                                              generic __CLC_INTN *iptr) {
+  return __CLC_FUNCTION(FUNCTION)(x, iptr);
+}
+#endif

--- a/libclc/clc/include/clc/math/unary_def_with_ptr.inc
+++ b/libclc/clc/include/clc/math/unary_def_with_ptr.inc
@@ -18,3 +18,10 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE FUNCTION(__CLC_GENTYPE x,
                                               local __CLC_GENTYPE *ptr) {
   return __CLC_FUNCTION(FUNCTION)(x, ptr);
 }
+
+#if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE FUNCTION(__CLC_GENTYPE x,
+                                              generic __CLC_GENTYPE *ptr) {
+  return __CLC_FUNCTION(FUNCTION)(x, ptr);
+}
+#endif

--- a/libclc/clc/lib/generic/math/clc_frexp.cl
+++ b/libclc/clc/lib/generic/math/clc_frexp.cl
@@ -40,3 +40,10 @@
 #define __CLC_ADDRESS_SPACE local
 #include <clc/math/gentype.inc>
 #undef __CLC_ADDRESS_SPACE
+
+#if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
+#define __CLC_BODY <clc_frexp.inc>
+#define __CLC_ADDRESS_SPACE generic
+#include <clc/math/gentype.inc>
+#undef __CLC_ADDRESS_SPACE
+#endif


### PR DESCRIPTION
This adds some missing generic address space overloads of CLC functions: frexp, and whichever functions make use of the
unary_def_with_(int_)?ptr.inc files.

Note that this commit doesn't map the equivalent SPIR-V functions to these CLC implementations. This is because the generic SPIR-V implementation of FP16 types currently use the clang builtins as opposed to the software implementations. As discussed in #17163, this is not the proper behaviour for generic implementations, as not all targets support the builtins. In future work we will need to either provide target-specific overrides for the builtin implementations, or provide an easy mechanism by which the CLC implementations can select between builtins or software implementations automatically.