### PR TITLE
Don't use `std::ignore` for unused parameters

### DIFF
--- a/unified-runtime/source/adapters/cuda/adapter.cpp
+++ b/unified-runtime/source/adapters/cuda/adapter.cpp
@@ -90,8 +90,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
-    ur_adapter_handle_t, const char **ppMessage, int32_t *pError) {
-  std::ignore = pError;
+    ur_adapter_handle_t, const char **ppMessage, int32_t * /*pError*/) {
   *ppMessage = ErrorMessage;
   return ErrorMessageCode;
 }

--- a/unified-runtime/source/adapters/cuda/context.cpp
+++ b/unified-runtime/source/adapters/cuda/context.cpp
@@ -45,9 +45,8 @@ ur_context_handle_t_::getOwningURPool(umf_memory_pool_t *UMFPool) {
 ///
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextCreate(uint32_t DeviceCount, const ur_device_handle_t *phDevices,
-                const ur_context_properties_t *pProperties,
+                const ur_context_properties_t * /*pProperties*/,
                 ur_context_handle_t *phContext) {
-  std::ignore = pProperties;
 
   std::unique_ptr<ur_context_handle_t_> ContextPtr{nullptr};
   try {

--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -1198,7 +1198,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
 /// \return PI_SUCCESS if the function is executed successfully
 /// CUDA devices are always root devices so retain always returns success.
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceRetain(ur_device_handle_t) {
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceRetain(ur_device_handle_t /*hDevice*/) {
   return UR_RESULT_SUCCESS;
 }
 
@@ -1210,7 +1211,8 @@ urDevicePartition(ur_device_handle_t, const ur_device_partition_properties_t *,
 
 /// \return UR_RESULT_SUCCESS always since CUDA devices are always root
 /// devices.
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceRelease(ur_device_handle_t) {
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceRelease(ur_device_handle_t /*hDevice*/) {
   return UR_RESULT_SUCCESS;
 }
 
@@ -1337,9 +1339,8 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
 /// \return If available, the first binary that is PTX
 ///
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceSelectBinary(
-    ur_device_handle_t hDevice, const ur_device_binary_t *pBinaries,
+    ur_device_handle_t /*hDevice*/, const ur_device_binary_t *pBinaries,
     uint32_t NumBinaries, uint32_t *pSelectedBinary) {
-  std::ignore = hDevice;
 
   // Look for an image for the NVPTX64 target, and return the first one that is
   // found

--- a/unified-runtime/source/adapters/cuda/enqueue.cpp
+++ b/unified-runtime/source/adapters/cuda/enqueue.cpp
@@ -1179,11 +1179,9 @@ static ur_result_t commonEnqueueMemImageNDCopy(
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ur_mem_handle_t hImage, bool blockingRead,
-    ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
-    size_t slicePitch, void *pDst, uint32_t numEventsInWaitList,
+    ur_rect_offset_t origin, ur_rect_region_t region, size_t /*rowPitch*/,
+    size_t /*slicePitch*/, void *pDst, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = rowPitch;
-  std::ignore = slicePitch;
 
   UR_ASSERT(hImage->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
@@ -1253,13 +1251,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hImage, bool blockingWrite,
-    ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
-    size_t slicePitch, void *pSrc, uint32_t numEventsInWaitList,
+    ur_queue_handle_t hQueue, ur_mem_handle_t hImage, bool /*blockingWrite*/,
+    ur_rect_offset_t origin, ur_rect_region_t region, size_t /*rowPitch*/,
+    size_t /*slicePitch*/, void *pSrc, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = blockingWrite;
-  std::ignore = rowPitch;
-  std::ignore = slicePitch;
 
   UR_ASSERT(hImage->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
   auto &Image = std::get<SurfaceMem>(hImage->Mem);
@@ -1597,9 +1592,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     ur_queue_handle_t hQueue, const void *pMem, size_t size,
-    ur_usm_migration_flags_t flags, uint32_t numEventsInWaitList,
+    ur_usm_migration_flags_t /*flags*/, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = flags;
 
   size_t PointerRangeSize = 0;
   UR_CHECK_ERROR(cuPointerGetAttribute(

--- a/unified-runtime/source/adapters/cuda/event.cpp
+++ b/unified-runtime/source/adapters/cuda/event.cpp
@@ -285,9 +285,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ur_context_handle_t hContext,
-    const ur_event_native_properties_t *pProperties,
+    const ur_event_native_properties_t * /*pProperties*/,
     ur_event_handle_t *phEvent) {
-  std::ignore = pProperties;
 
   std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
 

--- a/unified-runtime/source/adapters/cuda/image.cpp
+++ b/unified-runtime/source/adapters/cuda/image.cpp
@@ -259,15 +259,13 @@ ur_result_t urTextureCreate(ur_sampler_handle_t hSampler,
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMPitchedAllocExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t pool,
+    const ur_usm_desc_t * /*pUSMDesc*/, ur_usm_pool_handle_t /*pool*/,
     size_t widthInBytes, size_t height, size_t elementSizeBytes, void **ppMem,
     size_t *pResultPitch) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
             UR_RESULT_ERROR_INVALID_CONTEXT);
-  std::ignore = pUSMDesc;
-  std::ignore = pool;
 
   UR_ASSERT((height > 0), UR_RESULT_ERROR_INVALID_VALUE);
   UR_ASSERT((elementSizeBytes > 0), UR_RESULT_ERROR_INVALID_VALUE);

--- a/unified-runtime/source/adapters/cuda/kernel.cpp
+++ b/unified-runtime/source/adapters/cuda/kernel.cpp
@@ -190,12 +190,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetNativeHandle(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
-    ur_kernel_handle_t hKernel, ur_device_handle_t hDevice, uint32_t workDim,
-    const size_t *pLocalWorkSize, size_t dynamicSharedMemorySize,
-    uint32_t *pGroupCountRet) {
+    ur_kernel_handle_t hKernel, ur_device_handle_t /*hDevice*/,
+    uint32_t workDim, const size_t *pLocalWorkSize,
+    size_t dynamicSharedMemorySize, uint32_t *pGroupCountRet) {
   UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_KERNEL);
-
-  std::ignore = hDevice;
 
   size_t localWorkSize = pLocalWorkSize[0];
   localWorkSize *= (workDim >= 2 ? pLocalWorkSize[1] : 1);
@@ -244,9 +242,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize,
-    const ur_kernel_arg_value_properties_t *pProperties,
+    const ur_kernel_arg_value_properties_t * /*pProperties*/,
     const void *pArgValue) {
-  std::ignore = pProperties;
   UR_ASSERT(argSize, UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE);
 
   ur_result_t Result = UR_RESULT_SUCCESS;
@@ -260,8 +257,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgValue(
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize,
-    const ur_kernel_arg_local_properties_t *pProperties) {
-  std::ignore = pProperties;
+    const ur_kernel_arg_local_properties_t * /*pProperties*/) {
   UR_ASSERT(argSize, UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE);
 
   ur_result_t Result = UR_RESULT_SUCCESS;
@@ -357,11 +353,10 @@ urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
   return UR_RESULT_ERROR_INVALID_ENUMERATION;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelSetArgPointer(ur_kernel_handle_t hKernel, uint32_t argIndex,
-                      const ur_kernel_arg_pointer_properties_t *pProperties,
-                      const void *pArgValue) {
-  std::ignore = pProperties;
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgPointer(
+    ur_kernel_handle_t hKernel, uint32_t argIndex,
+    const ur_kernel_arg_pointer_properties_t * /*pProperties*/,
+    const void *pArgValue) {
   try {
     // setKernelArg is expecting a pointer to our argument
     hKernel->setKernelArg(argIndex, sizeof(pArgValue), &pArgValue);
@@ -416,14 +411,11 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
 }
 
 // A NOP for the CUDA backend
-UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
-    ur_kernel_handle_t hKernel, ur_kernel_exec_info_t propName, size_t propSize,
-    const ur_kernel_exec_info_properties_t *pProperties,
-    const void *pPropValue) {
-  std::ignore = hKernel;
-  std::ignore = propSize;
-  std::ignore = pPropValue;
-  std::ignore = pProperties;
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetExecInfo(ur_kernel_handle_t /*hKernel*/,
+                    ur_kernel_exec_info_t propName, size_t /*propSize*/,
+                    const ur_kernel_exec_info_properties_t * /*pProperties*/,
+                    const void * /*pPropValue*/) {
 
   switch (propName) {
   case UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS:
@@ -436,23 +428,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
-    ur_native_handle_t hNativeKernel, ur_context_handle_t hContext,
-    ur_program_handle_t hProgram,
-    const ur_kernel_native_properties_t *pProperties,
-    ur_kernel_handle_t *phKernel) {
-  std::ignore = hNativeKernel;
-  std::ignore = hContext;
-  std::ignore = hProgram;
-  std::ignore = pProperties;
-  std::ignore = phKernel;
+    ur_native_handle_t /*hNativeKernel*/, ur_context_handle_t /*hContext*/,
+    ur_program_handle_t /*hProgram*/,
+    const ur_kernel_native_properties_t * /*pProperties*/,
+    ur_kernel_handle_t * /*phKernel*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelSetArgSampler(ur_kernel_handle_t hKernel, uint32_t argIndex,
-                      const ur_kernel_arg_sampler_properties_t *pProperties,
-                      ur_sampler_handle_t hArgValue) {
-  std::ignore = pProperties;
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel, uint32_t argIndex,
+    const ur_kernel_arg_sampler_properties_t * /*pProperties*/,
+    ur_sampler_handle_t hArgValue) {
 
   ur_result_t Result = UR_RESULT_SUCCESS;
   try {

--- a/unified-runtime/source/adapters/cuda/platform.cpp
+++ b/unified-runtime/source/adapters/cuda/platform.cpp
@@ -189,16 +189,14 @@ urPlatformGet(ur_adapter_handle_t, uint32_t, ur_platform_handle_t *phPlatforms,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetApiVersion(
-    ur_platform_handle_t hDriver, ur_api_version_t *pVersion) {
-  std::ignore = hDriver;
+    ur_platform_handle_t /*hDriver*/, ur_api_version_t *pVersion) {
   *pVersion = UR_API_VERSION_CURRENT;
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform, ur_native_handle_t *phNativePlatform) {
-  std::ignore = hPlatform;
-  std::ignore = phNativePlatform;
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetNativeHandle(ur_platform_handle_t /*hPlatform*/,
+                          ur_native_handle_t * /*phNativePlatform*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -214,9 +212,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 // Return empty string for cuda.
 // TODO: Determine correct string to be passed.
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
-    ur_platform_handle_t hPlatform, const char *pFrontendOption,
+    ur_platform_handle_t /*hPlatform*/, const char *pFrontendOption,
     const char **ppPlatformOption) {
-  std::ignore = hPlatform;
   using namespace std::literals;
   if (pFrontendOption == nullptr)
     return UR_RESULT_ERROR_INVALID_NULL_POINTER;

--- a/unified-runtime/source/adapters/cuda/program.cpp
+++ b/unified-runtime/source/adapters/cuda/program.cpp
@@ -260,10 +260,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramBuildExp(ur_program_handle_t,
 /// Loads the images from a UR program into a CUmodule that can be
 /// used later on to extract functions (kernels).
 /// See \ref ur_program_handle_t for implementation details.
-UR_APIEXPORT ur_result_t UR_APICALL urProgramBuild(ur_context_handle_t hContext,
-                                                   ur_program_handle_t hProgram,
-                                                   const char *pOptions) {
-  std::ignore = hContext;
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramBuild(ur_context_handle_t /*hContext*/, ur_program_handle_t hProgram,
+               const char *pOptions) {
 
   ur_result_t Result = UR_RESULT_SUCCESS;
 
@@ -361,11 +360,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
-                      ur_program_build_info_t propName, size_t propSize,
-                      void *pPropValue, size_t *pPropSizeRet) {
-  std::ignore = hDevice;
+UR_APIEXPORT ur_result_t UR_APICALL urProgramGetBuildInfo(
+    ur_program_handle_t hProgram, ur_device_handle_t /*hDevice*/,
+    ur_program_build_info_t propName, size_t propSize, void *pPropValue,
+    size_t *pPropSizeRet) {
 
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
 

--- a/unified-runtime/source/adapters/cuda/queue.cpp
+++ b/unified-runtime/source/adapters/cuda/queue.cpp
@@ -168,15 +168,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(ur_queue_handle_t hQueue) {
 // There is no CUDA counterpart for queue flushing and we don't run into the
 // same problem of having to flush cross-queue dependencies as some of the
 // other plugins, so it can be left as no-op.
-UR_APIEXPORT ur_result_t UR_APICALL urQueueFlush(ur_queue_handle_t hQueue) {
-  std::ignore = hQueue;
+UR_APIEXPORT ur_result_t UR_APICALL urQueueFlush(ur_queue_handle_t /*hQueue*/) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urQueueGetNativeHandle(ur_queue_handle_t hQueue, ur_queue_native_desc_t *pDesc,
-                       ur_native_handle_t *phNativeQueue) {
-  std::ignore = pDesc;
+UR_APIEXPORT ur_result_t UR_APICALL urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue, ur_queue_native_desc_t * /*pDesc*/,
+    ur_native_handle_t *phNativeQueue) {
 
   ScopedContext Active(hQueue->getDevice());
   *phNativeQueue =

--- a/unified-runtime/source/adapters/cuda/usm.cpp
+++ b/unified-runtime/source/adapters/cuda/usm.cpp
@@ -123,7 +123,6 @@ ur_result_t USMDeviceAllocImpl(void **ResultPtr, ur_context_handle_t,
   }
 
 #ifdef NDEBUG
-  std::ignore = Alignment;
 #else
   assert((Alignment == 0 ||
           reinterpret_cast<std::uintptr_t>(*ResultPtr) % Alignment == 0));
@@ -145,7 +144,6 @@ ur_result_t USMSharedAllocImpl(void **ResultPtr, ur_context_handle_t,
   }
 
 #ifdef NDEBUG
-  std::ignore = Alignment;
 #else
   assert((Alignment == 0 ||
           reinterpret_cast<std::uintptr_t>(*ResultPtr) % Alignment == 0));
@@ -164,7 +162,6 @@ ur_result_t USMHostAllocImpl(void **ResultPtr, ur_context_handle_t hContext,
   }
 
 #ifdef NDEBUG
-  std::ignore = Alignment;
 #else
   assert((Alignment == 0 ||
           reinterpret_cast<std::uintptr_t>(*ResultPtr) % Alignment == 0));

--- a/unified-runtime/source/adapters/cuda/usm.cpp
+++ b/unified-runtime/source/adapters/cuda/usm.cpp
@@ -113,7 +113,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMFree(ur_context_handle_t hContext,
 ur_result_t USMDeviceAllocImpl(void **ResultPtr, ur_context_handle_t,
                                ur_device_handle_t Device,
                                ur_usm_device_mem_flags_t, size_t Size,
-                               uint32_t Alignment) {
+                               [[maybe_unused]] uint32_t Alignment) {
   try {
     ScopedContext Active(Device);
     *ResultPtr = umfPoolMalloc(Device->MemoryPoolDevice, Size);
@@ -122,11 +122,8 @@ ur_result_t USMDeviceAllocImpl(void **ResultPtr, ur_context_handle_t,
     return Err;
   }
 
-#ifdef NDEBUG
-#else
   assert((Alignment == 0 ||
           reinterpret_cast<std::uintptr_t>(*ResultPtr) % Alignment == 0));
-#endif
   return UR_RESULT_SUCCESS;
 }
 
@@ -134,7 +131,7 @@ ur_result_t USMSharedAllocImpl(void **ResultPtr, ur_context_handle_t,
                                ur_device_handle_t Device,
                                ur_usm_host_mem_flags_t,
                                ur_usm_device_mem_flags_t, size_t Size,
-                               uint32_t Alignment) {
+                               [[maybe_unused]] uint32_t Alignment) {
   try {
     ScopedContext Active(Device);
     *ResultPtr = umfPoolMalloc(Device->MemoryPoolShared, Size);
@@ -143,17 +140,14 @@ ur_result_t USMSharedAllocImpl(void **ResultPtr, ur_context_handle_t,
     return Err;
   }
 
-#ifdef NDEBUG
-#else
   assert((Alignment == 0 ||
           reinterpret_cast<std::uintptr_t>(*ResultPtr) % Alignment == 0));
-#endif
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t USMHostAllocImpl(void **ResultPtr, ur_context_handle_t hContext,
                              ur_usm_host_mem_flags_t, size_t Size,
-                             uint32_t Alignment) {
+                             [[maybe_unused]] uint32_t Alignment) {
   try {
     *ResultPtr = umfPoolMalloc(hContext->MemoryPoolHost, Size);
     UMF_CHECK_PTR(*ResultPtr);
@@ -161,11 +155,8 @@ ur_result_t USMHostAllocImpl(void **ResultPtr, ur_context_handle_t hContext,
     return Err;
   }
 
-#ifdef NDEBUG
-#else
   assert((Alignment == 0 ||
           reinterpret_cast<std::uintptr_t>(*ResultPtr) % Alignment == 0));
-#endif
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/hip/command_buffer.cpp
+++ b/unified-runtime/source/adapters/hip/command_buffer.cpp
@@ -283,12 +283,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     uint32_t numKernelAlternatives, ur_kernel_handle_t *phKernelAlternatives,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
     ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
   // Preconditions
   // Command handles can only be obtained from updatable command-buffers
   UR_ASSERT(!(phCommand && !hCommandBuffer->IsUpdatable),
@@ -380,13 +379,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, void *pDst, const void *pSrc,
     size_t size, uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
@@ -413,13 +410,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     ur_mem_handle_t hDstMem, size_t srcOffset, size_t dstOffset, size_t size,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
@@ -459,13 +454,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     size_t srcSlicePitch, size_t dstRowPitch, size_t dstSlicePitch,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
@@ -504,13 +497,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     size_t offset, size_t size, const void *pSrc,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
@@ -541,13 +532,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_mem_handle_t hBuffer,
     size_t offset, size_t size, void *pDst, uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
@@ -581,13 +570,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     size_t hostRowPitch, size_t hostSlicePitch, void *pSrc,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
@@ -626,13 +613,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     size_t hostRowPitch, size_t hostSlicePitch, void *pDst,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
@@ -668,13 +653,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     size_t /*Size*/, ur_usm_migration_flags_t /*Flags*/,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   // Prefetch cmd is not supported by Hip Graph.
   // We implement it as an empty node to enforce dependencies.
   hipGraphNode_t GraphNode;
@@ -704,13 +687,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     size_t /*Size*/, ur_usm_advice_flags_t /*Advice*/,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   // Mem-Advise cmd is not supported by Hip Graph.
   // We implement it as an empty node to enforce dependencies.
   hipGraphNode_t GraphNode;
@@ -740,13 +721,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     const void *pPattern, size_t patternSize, size_t offset, size_t size,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
   auto ArgsAreMultiplesOfPatternSize =
       (offset % patternSize == 0) || (size % patternSize == 0);
 
@@ -771,13 +750,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     const void *pPattern, size_t patternSize, size_t size,
     uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) {
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  std::ignore = phCommand;
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *pSyncPoint,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) {
 
   auto PatternIsValid = (pPattern != nullptr);
 
@@ -1032,19 +1009,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
-    ur_exp_command_buffer_command_handle_t hCommand,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hCommand;
-  std::ignore = phEvent;
+    ur_exp_command_buffer_command_handle_t /*hCommand*/,
+    ur_event_handle_t * /*phEvent*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
-    ur_exp_command_buffer_command_handle_t hCommand,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *phEventWaitList) {
-  std::ignore = hCommand;
-  std::ignore = NumEventsInWaitList;
-  std::ignore = phEventWaitList;
+    ur_exp_command_buffer_command_handle_t /*hCommand*/,
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/hip/context.cpp
+++ b/unified-runtime/source/adapters/hip/context.cpp
@@ -106,8 +106,6 @@ urContextRetain(ur_context_handle_t hContext) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextGetNativeHandle([[maybe_unused]] ur_context_handle_t hContext,
                          [[maybe_unused]] ur_native_handle_t *phNativeContext) {
-  std::ignore = hContext;
-  std::ignore = phNativeContext;
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/hip/enqueue.cpp
+++ b/unified-runtime/source/adapters/hip/enqueue.cpp
@@ -1331,9 +1331,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     ur_queue_handle_t hQueue, const void *pMem, size_t size,
-    ur_usm_migration_flags_t flags, uint32_t numEventsInWaitList,
+    ur_usm_migration_flags_t /*flags*/, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = flags;
 
   void *HIPDevicePtr = const_cast<void *>(pMem);
   ur_device_handle_t Device = hQueue->getDevice();

--- a/unified-runtime/source/adapters/hip/event.cpp
+++ b/unified-runtime/source/adapters/hip/event.cpp
@@ -298,9 +298,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
 /// \param[out] phEvent Set to the UR event object created from native handle.
 UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ur_context_handle_t hContext,
-    const ur_event_native_properties_t *pProperties,
+    const ur_event_native_properties_t * /*pProperties*/,
     ur_event_handle_t *phEvent) {
-  std::ignore = pProperties;
 
   std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
 

--- a/unified-runtime/source/adapters/hip/image.cpp
+++ b/unified-runtime/source/adapters/hip/image.cpp
@@ -250,15 +250,13 @@ ur_result_t urTextureCreate(ur_sampler_handle_t hSampler,
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMPitchedAllocExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t pool,
+    const ur_usm_desc_t * /*pUSMDesc*/, ur_usm_pool_handle_t /*pool*/,
     size_t widthInBytes, size_t height, size_t elementSizeBytes, void **ppMem,
     size_t *pResultPitch) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
             UR_RESULT_ERROR_INVALID_CONTEXT);
-  std::ignore = pUSMDesc;
-  std::ignore = pool;
 
   UR_ASSERT((height > 0), UR_RESULT_ERROR_INVALID_VALUE);
   UR_ASSERT((elementSizeBytes > 0), UR_RESULT_ERROR_INVALID_VALUE);
@@ -922,8 +920,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     [[maybe_unused]] ur_context_handle_t hContext,
-    ur_exp_image_mem_native_handle_t hImageMem, ur_image_info_t propName,
-    void *pPropValue, size_t *pPropSizeRet) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
+    [[maybe_unused]] ur_image_info_t propName,
+    [[maybe_unused]] void *pPropValue, [[maybe_unused]] size_t *pPropSizeRet) {
   // hipArrayGetDescriptor and hipArray3DGetDescriptor are supported only since
   // ROCm 5.6.0, so we can't query image array information for older versions.
 #if HIP_VERSION >= 50600000
@@ -1002,10 +1001,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 #else
-  std::ignore = hImageMem;
-  std::ignore = propName;
-  std::ignore = pPropValue;
-  std::ignore = pPropSizeRet;
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 #endif
 }
@@ -1123,20 +1118,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
-    ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
+    ur_context_handle_t /*hContext*/, ur_device_handle_t /*hDevice*/,
+    const ur_image_format_t * /*pImageFormat*/,
+    const ur_image_desc_t * /*pImageDesc*/,
     [[maybe_unused]] ur_exp_external_mem_handle_t hExternalMem,
-    ur_exp_image_mem_native_handle_t *phImageMem) {
+    ur_exp_image_mem_native_handle_t * /*phImageMem*/) {
   // hipExternalMemoryGetMappedMipmappedArray should be introduced from ROCm 6.
   // However, there is an issue at the moment with the required function symbol
   // missing from the libamdhip64.so library, despite being shown in the docs.
   // TODO: Update this with a link to a bug report filed on the ROCm github.
-  std::ignore = hContext;
-  std::ignore = hDevice;
-  std::ignore = pImageFormat;
-  std::ignore = pImageDesc;
-  std::ignore = hExternalMem;
-  std::ignore = phImageMem;
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/hip/kernel.cpp
+++ b/unified-runtime/source/adapters/hip/kernel.cpp
@@ -169,15 +169,9 @@ urKernelGetNativeHandle(ur_kernel_handle_t, ur_native_handle_t *) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
-    ur_kernel_handle_t hKernel, ur_device_handle_t hDevice, uint32_t workDim,
-    const size_t *pLocalWorkSize, size_t dynamicSharedMemorySize,
-    uint32_t *pGroupCountRet) {
-  std::ignore = hKernel;
-  std::ignore = hDevice;
-  std::ignore = workDim;
-  std::ignore = pLocalWorkSize;
-  std::ignore = dynamicSharedMemorySize;
-  std::ignore = pGroupCountRet;
+    ur_kernel_handle_t /*hKernel*/, ur_device_handle_t /*hDevice*/,
+    uint32_t /*workDim*/, const size_t * /*pLocalWorkSize*/,
+    size_t /*dynamicSharedMemorySize*/, uint32_t * /*pGroupCountRet*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -195,8 +189,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgValue(
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize,
-    const ur_kernel_arg_local_properties_t *pProperties) {
-  std::ignore = pProperties;
+    const ur_kernel_arg_local_properties_t * /*pProperties*/) {
   UR_ASSERT(argSize, UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE);
 
   ur_result_t Result = UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/hip/platform.cpp
+++ b/unified-runtime/source/adapters/hip/platform.cpp
@@ -127,10 +127,9 @@ urPlatformGetApiVersion(ur_platform_handle_t, ur_api_version_t *pVersion) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform, ur_native_handle_t *phNativePlatform) {
-  std::ignore = hPlatform;
-  std::ignore = phNativePlatform;
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetNativeHandle(ur_platform_handle_t /*hPlatform*/,
+                          ur_native_handle_t * /*phNativePlatform*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/level_zero/enqueue_native.cpp
+++ b/unified-runtime/source/adapters/level_zero/enqueue_native.cpp
@@ -15,21 +15,14 @@
 namespace ur::level_zero {
 
 ur_result_t urEnqueueNativeCommandExp(
-    ur_queue_handle_t hQueue,
-    ur_exp_enqueue_native_command_function_t pfnNativeEnqueue, void *data,
-    uint32_t numMemsInMemList, const ur_mem_handle_t *phMemList,
-    const ur_exp_enqueue_native_command_properties_t *pProperties,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = pfnNativeEnqueue;
-  std::ignore = data;
-  std::ignore = numMemsInMemList;
-  std::ignore = phMemList;
-  std::ignore = pProperties;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/,
+    ur_exp_enqueue_native_command_function_t /*pfnNativeEnqueue*/,
+    void * /*data*/, uint32_t /*numMemsInMemList*/,
+    const ur_mem_handle_t * /*phMemList*/,
+    const ur_exp_enqueue_native_command_properties_t * /*pProperties*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/level_zero/enqueued_pool.cpp
+++ b/unified-runtime/source/adapters/level_zero/enqueued_pool.cpp
@@ -64,9 +64,8 @@ bool EnqueuedPool::cleanup() {
     auto hPool = umfPoolByPtr(It.Ptr);
     assert(hPool != nullptr);
 
-    auto umfRet = umfPoolFree(hPool, It.Ptr);
+    auto umfRet [[maybe_unused]] = umfPoolFree(hPool, It.Ptr);
     assert(umfRet == UMF_RESULT_SUCCESS);
-    std::ignore = umfRet;
 
     urEventReleaseInternal(It.Event);
   }
@@ -88,9 +87,8 @@ bool EnqueuedPool::cleanupForQueue(ur_queue_handle_t Queue) {
     auto hPool = umfPoolByPtr(It->Ptr);
     assert(hPool != nullptr);
 
-    auto umfRet = umfPoolFree(hPool, It->Ptr);
+    auto umfRet [[maybe_unused]] = umfPoolFree(hPool, It->Ptr);
     assert(umfRet == UMF_RESULT_SUCCESS);
-    std::ignore = umfRet;
 
     urEventReleaseInternal(It->Event);
 

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -1003,17 +1003,13 @@ ur_result_t urEventCreateWithNativeHandle(
 
 ur_result_t urEventSetCallback(
     /// [in] handle of the event object
-    ur_event_handle_t Event,
+    ur_event_handle_t /*Event*/,
     /// [in] execution status of the event
-    ur_execution_info_t ExecStatus,
+    ur_execution_info_t /*ExecStatus*/,
     /// [in] execution status of the event
-    ur_event_callback_t Notify,
+    ur_event_callback_t /*Notify*/,
     /// [in][out][optional] pointer to data to be passed to callback.
-    void *UserData) {
-  std::ignore = Event;
-  std::ignore = ExecStatus;
-  std::ignore = Notify;
-  std::ignore = UserData;
+    void * /*UserData*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -363,11 +363,9 @@ ur_result_t urBindlessImagesImageAllocateExp(
 }
 
 ur_result_t
-urBindlessImagesImageFreeExp(ur_context_handle_t hContext,
-                             ur_device_handle_t hDevice,
+urBindlessImagesImageFreeExp(ur_context_handle_t /*hContext*/,
+                             ur_device_handle_t /*hDevice*/,
                              ur_exp_image_mem_native_handle_t hImageMem) {
-  std::ignore = hContext;
-  std::ignore = hDevice;
   UR_CALL(ur::level_zero::urMemRelease(
       reinterpret_cast<ur_mem_handle_t>(hImageMem)));
   return UR_RESULT_SUCCESS;
@@ -613,14 +611,9 @@ ur_result_t urBindlessImagesImageGetInfoExp(
 }
 
 ur_result_t urBindlessImagesMipmapGetLevelExp(
-    ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_image_mem_native_handle_t hImageMem, uint32_t mipmapLevel,
-    ur_exp_image_mem_native_handle_t *phImageMem) {
-  std::ignore = hContext;
-  std::ignore = hDevice;
-  std::ignore = hImageMem;
-  std::ignore = mipmapLevel;
-  std::ignore = phImageMem;
+    ur_context_handle_t /*hContext*/, ur_device_handle_t /*hDevice*/,
+    ur_exp_image_mem_native_handle_t /*hImageMem*/, uint32_t /*mipmapLevel*/,
+    ur_exp_image_mem_native_handle_t * /*phImageMem*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -933,9 +926,8 @@ ur_result_t urBindlessImagesImportExternalSemaphoreExp(
 }
 
 ur_result_t urBindlessImagesReleaseExternalSemaphoreExp(
-    ur_context_handle_t hContext, ur_device_handle_t hDevice,
+    ur_context_handle_t hContext, ur_device_handle_t /*hDevice*/,
     ur_exp_external_semaphore_handle_t hExternalSemaphore) {
-  std::ignore = hDevice;
   auto UrPlatform = hContext->getPlatform();
   if (UrPlatform->ZeExternalSemaphoreExt.Supported == false) {
     logger::error(logger::LegacyMessage("[UR][L0] "),

--- a/unified-runtime/source/adapters/level_zero/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.cpp
@@ -654,10 +654,9 @@ ur_result_t urKernelSetArgValue(
     /// [in] size of argument type
     size_t ArgSize,
     /// [in][optional] argument properties
-    const ur_kernel_arg_value_properties_t *Properties,
+    const ur_kernel_arg_value_properties_t * /*Properties*/,
     /// [in] argument value represented as matching arg type.
     const void *PArgValue) {
-  std::ignore = Properties;
 
   UR_ASSERT(Kernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
@@ -706,8 +705,7 @@ ur_result_t urKernelSetArgLocal(
     /// [in] size of the local buffer to be allocated by the runtime
     size_t ArgSize,
     /// [in][optional] argument properties
-    const ur_kernel_arg_local_properties_t *Properties) {
-  std::ignore = Properties;
+    const ur_kernel_arg_local_properties_t * /*Properties*/) {
 
   UR_CALL(ur::level_zero::urKernelSetArgValue(Kernel, ArgIndex, ArgSize,
                                               nullptr, nullptr));
@@ -892,7 +890,7 @@ ur_result_t urKernelGetSubGroupInfo(
     /// [in] handle of the Kernel object
     ur_kernel_handle_t Kernel,
     /// [in] handle of the Device object
-    ur_device_handle_t Device,
+    ur_device_handle_t /*Device*/,
     /// [in] name of the SubGroup property to query
     ur_kernel_sub_group_info_t PropName,
     /// [in] size of the Kernel SubGroup property value
@@ -903,7 +901,6 @@ ur_result_t urKernelGetSubGroupInfo(
     /// [out][optional] pointer to the actual size in bytes of data being
     /// queried by propName.
     size_t *PropSizeRet) {
-  std::ignore = Device;
 
   UrReturnHelper ReturnValue(PropSize, PropValue, PropSizeRet);
 
@@ -971,11 +968,10 @@ ur_result_t urKernelSetArgPointer(
     /// [in] argument index in range [0, num args - 1]
     uint32_t ArgIndex,
     /// [in][optional] argument properties
-    const ur_kernel_arg_pointer_properties_t *Properties,
+    const ur_kernel_arg_pointer_properties_t * /*Properties*/,
     /// [in][optional] SVM pointer to memory location holding the argument
     /// value. If null then argument value is considered null.
     const void *ArgValue) {
-  std::ignore = Properties;
 
   // KernelSetArgValue is expecting a pointer to the argument
   UR_CALL(ur::level_zero::urKernelSetArgValue(
@@ -989,14 +985,12 @@ ur_result_t urKernelSetExecInfo(
     /// [in] name of the execution attribute
     ur_kernel_exec_info_t PropName,
     /// [in] size in byte the attribute value
-    size_t PropSize,
+    size_t /*PropSize*/,
     /// [in][optional] pointer to execution info properties
-    const ur_kernel_exec_info_properties_t *Properties,
+    const ur_kernel_exec_info_properties_t * /*Properties*/,
     /// [in][range(0, propSize)] pointer to memory location holding the property
     /// value.
     const void *PropValue) {
-  std::ignore = PropSize;
-  std::ignore = Properties;
 
   std::scoped_lock<ur_shared_mutex> Guard(Kernel->Mutex);
   for (auto &ZeKernel : Kernel->ZeKernels) {
@@ -1039,10 +1033,9 @@ ur_result_t urKernelSetArgSampler(
     /// [in] argument index in range [0, num args - 1]
     uint32_t ArgIndex,
     /// [in][optional] argument properties
-    const ur_kernel_arg_sampler_properties_t *Properties,
+    const ur_kernel_arg_sampler_properties_t * /*Properties*/,
     /// [in] handle of Sampler object.
     ur_sampler_handle_t ArgValue) {
-  std::ignore = Properties;
   std::scoped_lock<ur_shared_mutex> Guard(Kernel->Mutex);
   if (ArgIndex > Kernel->ZeKernelProperties->numKernelArgs - 1) {
     return UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX;
@@ -1062,7 +1055,6 @@ ur_result_t urKernelSetArgMemObj(
     const ur_kernel_arg_mem_obj_properties_t *Properties,
     /// [in][optional] handle of Memory object.
     ur_mem_handle_t ArgValue) {
-  std::ignore = Properties;
 
   std::scoped_lock<ur_shared_mutex> Guard(Kernel->Mutex);
   // The ArgValue may be a NULL pointer in which case a NULL value is used for
@@ -1168,15 +1160,12 @@ ur_result_t urKernelCreateWithNativeHandle(
 
 ur_result_t urKernelSetSpecializationConstants(
     /// [in] handle of the kernel object
-    ur_kernel_handle_t Kernel,
+    ur_kernel_handle_t /*Kernel*/,
     /// [in] the number of elements in the pSpecConstants array
-    uint32_t Count,
+    uint32_t /*Count*/,
     const ur_specialization_constant_info_t
         /// [in] array of specialization constant value descriptions
-        *SpecConstants) {
-  std::ignore = Kernel;
-  std::ignore = Count;
-  std::ignore = SpecConstants;
+        * /*SpecConstants*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -380,8 +380,6 @@ static ur_result_t enqueueMemImageCommandHelper(
 
     // TODO: Level Zero does not support row_pitch/slice_pitch for images yet.
     // Check that SYCL RT did not want pitch larger than default.
-    std::ignore = RowPitch;
-    std::ignore = SlicePitch;
     UR_ASSERT(SrcMem->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
 #ifndef NDEBUG
@@ -1279,7 +1277,7 @@ ur_result_t urEnqueueUSMPrefetch(
     /// [in] size in bytes to be fetched
     size_t Size,
     /// [in] USM prefetch flags
-    ur_usm_migration_flags_t Flags,
+    ur_usm_migration_flags_t /*Flags*/,
     /// [in] size of the event wait list
     uint32_t NumEventsInWaitList,
     /// [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -1290,7 +1288,6 @@ ur_result_t urEnqueueUSMPrefetch(
     /// [in,out][optional] return an event object that identifies this
     /// particular command instance.
     ur_event_handle_t *OutEvent) {
-  std::ignore = Flags;
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
@@ -1408,39 +1405,29 @@ ur_result_t urEnqueueUSMAdvise(
 
 ur_result_t urEnqueueUSMFill2D(
     /// [in] handle of the queue to submit to.
-    ur_queue_handle_t Queue,
+    ur_queue_handle_t /*Queue*/,
     /// [in] pointer to memory to be filled.
-    void *Mem,
+    void * /*Mem*/,
     /// [in] the total width of the destination memory including padding.
-    size_t Pitch,
+    size_t /*Pitch*/,
     /// [in] the size in bytes of the pattern.
-    size_t PatternSize,
+    size_t /*PatternSize*/,
     /// [in] pointer with the bytes of the pattern to set.
-    const void *Pattern,
+    const void * /*Pattern*/,
     /// [in] the width in bytes of each row to fill.
-    size_t Width,
+    size_t /*Width*/,
     /// [in] the height of the columns to fill.
-    size_t Height,
+    size_t /*Height*/,
     /// [in] size of the event wait list
-    uint32_t NumEventsInWaitList,
+    uint32_t /*NumEventsInWaitList*/,
     /// [in][optional][range(0, numEventsInWaitList)] pointer to a list of
     /// events that must be complete before the kernel execution. If
     /// nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
-    const ur_event_handle_t *EventWaitList,
+    const ur_event_handle_t * /*EventWaitList*/,
     /// [in,out][optional] return an event object that identifies this
     /// particular kernel execution instance.
-    ur_event_handle_t *OutEvent) {
-  std::ignore = Queue;
-  std::ignore = Mem;
-  std::ignore = Pitch;
-  std::ignore = PatternSize;
-  std::ignore = Pattern;
-  std::ignore = Width;
-  std::ignore = Height;
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = OutEvent;
+    ur_event_handle_t * /*OutEvent*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1691,12 +1678,11 @@ ur_result_t urMemBufferPartition(
     /// [in] allocation and usage information flags
     ur_mem_flags_t Flags,
     /// [in] buffer creation type
-    ur_buffer_create_type_t BufferCreateType,
+    ur_buffer_create_type_t /*BufferCreateType*/,
     /// [in] pointer to buffer create region information
     const ur_buffer_region_t *BufferCreateInfo,
     /// [out] pointer to the handle of sub buffer created
     ur_mem_handle_t *RetMem) {
-  std::ignore = BufferCreateType;
   UR_ASSERT(Buffer && !Buffer->isImage() &&
                 !(static_cast<_ur_buffer *>(Buffer))->isSubBuffer(),
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
@@ -1872,24 +1858,19 @@ ur_result_t urMemGetInfo(
 
 ur_result_t urMemImageGetInfo(
     /// [in] handle to the image object being queried.
-    ur_mem_handle_t Memory,
+    ur_mem_handle_t /*Memory*/,
     /// [in] type of image info to retrieve.
-    ur_image_info_t ImgInfoType,
+    ur_image_info_t /*ImgInfoType*/,
     /// [in] the number of bytes of memory pointer to by pImgInfo.
-    size_t PropSize,
+    size_t /*PropSize*/,
     /// [out][optional] array of bytes holding the info. If propSize is less
     /// than the real number of bytes needed to return the info then the
     /// ::UR_RESULT_ERROR_INVALID_SIZE error is returned and pImgInfo is not
     /// used.
-    void *ImgInfo,
+    void * /*ImgInfo*/,
     /// [out][optional] pointer to the actual size in bytes of data queried by
     /// pImgInfo.
-    size_t *PropSizeRet) {
-  std::ignore = Memory;
-  std::ignore = ImgInfoType;
-  std::ignore = PropSize;
-  std::ignore = ImgInfo;
-  std::ignore = PropSizeRet;
+    size_t * /*PropSizeRet*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1928,43 +1909,25 @@ ur_result_t urEnqueueUSMFill(
 }
 
 /// Host Pipes
-ur_result_t urEnqueueReadHostPipe(ur_queue_handle_t hQueue,
-                                  ur_program_handle_t hProgram,
-                                  const char *pipe_symbol, bool blocking,
-                                  void *pDst, size_t size,
-                                  uint32_t numEventsInWaitList,
-                                  const ur_event_handle_t *phEventWaitList,
-                                  ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hProgram;
-  std::ignore = pipe_symbol;
-  std::ignore = blocking;
-  std::ignore = pDst;
-  std::ignore = size;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+ur_result_t urEnqueueReadHostPipe(ur_queue_handle_t /*hQueue*/,
+                                  ur_program_handle_t /*hProgram*/,
+                                  const char * /*pipe_symbol*/,
+                                  bool /*blocking*/, void * /*pDst*/,
+                                  size_t /*size*/,
+                                  uint32_t /*numEventsInWaitList*/,
+                                  const ur_event_handle_t * /*phEventWaitList*/,
+                                  ur_event_handle_t * /*phEvent*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-ur_result_t urEnqueueWriteHostPipe(ur_queue_handle_t hQueue,
-                                   ur_program_handle_t hProgram,
-                                   const char *pipe_symbol, bool blocking,
-                                   void *pSrc, size_t size,
-                                   uint32_t numEventsInWaitList,
-                                   const ur_event_handle_t *phEventWaitList,
-                                   ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hProgram;
-  std::ignore = pipe_symbol;
-  std::ignore = blocking;
-  std::ignore = pSrc;
-  std::ignore = size;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+ur_result_t urEnqueueWriteHostPipe(
+    ur_queue_handle_t /*hQueue*/, ur_program_handle_t /*hProgram*/,
+    const char * /*pipe_symbol*/, bool /*blocking*/, void * /*pSrc*/,
+    size_t /*size*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/level_zero/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/memory.hpp
@@ -224,19 +224,15 @@ struct _ur_image final : ur_mem_handle_t_ {
 
   ur_result_t getImageZeHandle(char *&ZeHandle, access_mode_t,
                                ur_device_handle_t,
-                               const ur_event_handle_t *phWaitEvents,
-                               uint32_t numWaitEvents) {
-    std::ignore = phWaitEvents;
-    std::ignore = numWaitEvents;
+                               const ur_event_handle_t * /* phWaitEvents*/,
+                               uint32_t /*numWaitEvents*/) {
     ZeHandle = reinterpret_cast<char *>(ZeImage);
     return UR_RESULT_SUCCESS;
   }
   ur_result_t getImageZeHandlePtr(char **&ZeHandlePtr, access_mode_t,
                                   ur_device_handle_t,
-                                  const ur_event_handle_t *phWaitEvents,
-                                  uint32_t numWaitEvents) {
-    std::ignore = phWaitEvents;
-    std::ignore = numWaitEvents;
+                                  const ur_event_handle_t * /*phWaitEvents*/,
+                                  uint32_t /*numWaitEvents*/) {
     ZeHandlePtr = reinterpret_cast<char **>(&ZeImage);
     return UR_RESULT_SUCCESS;
   }

--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -111,10 +111,9 @@ ur_result_t urPlatformGetInfo(
 
 ur_result_t urPlatformGetApiVersion(
     /// [in] handle of the platform
-    ur_platform_handle_t Driver,
+    ur_platform_handle_t /*Driver*/,
     /// [out] api version
     ur_api_version_t *Version) {
-  std::ignore = Driver;
   *Version = UR_API_VERSION_CURRENT;
   return UR_RESULT_SUCCESS;
 }
@@ -133,10 +132,9 @@ ur_result_t urPlatformCreateWithNativeHandle(
     /// [in] the native handle of the platform.
     ur_native_handle_t NativePlatform, ur_adapter_handle_t,
     /// [in][optional] pointer to native platform properties struct.
-    const ur_platform_native_properties_t *Properties,
+    const ur_platform_native_properties_t * /*Properties*/,
     /// [out] pointer to the handle of the platform object created.
     ur_platform_handle_t *Platform) {
-  std::ignore = Properties;
   auto ZeDriver = ur_cast<ze_driver_handle_t>(NativePlatform);
 
   uint32_t NumPlatforms = 0;
@@ -173,13 +171,12 @@ ur_result_t urPlatformCreateWithNativeHandle(
 // frontend_option=-ftarget-compile-fast.
 ur_result_t urPlatformGetBackendOption(
     /// [in] handle of the platform instance.
-    ur_platform_handle_t Platform,
+    ur_platform_handle_t /*Platform*/,
     /// [in] string containing the frontend option.
     const char *FrontendOption,
     /// [out] returns the correct platform specific compiler option based on
     /// the frontend option.
     const char **PlatformOption) {
-  std::ignore = Platform;
   using namespace std::literals;
   if (FrontendOption == nullptr) {
     return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/program.cpp
+++ b/unified-runtime/source/adapters/level_zero/program.cpp
@@ -65,10 +65,9 @@ ur_result_t urProgramCreateWithIL(
     /// [in] length of `pIL` in bytes.
     size_t Length,
     /// [in][optional] pointer to program creation properties.
-    const ur_program_properties_t *Properties,
+    const ur_program_properties_t * /*Properties*/,
     /// [out] pointer to handle of program object created.
     ur_program_handle_t *Program) {
-  std::ignore = Properties;
   UR_ASSERT(Context, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(IL && Program, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   try {
@@ -835,7 +834,6 @@ ur_result_t urProgramGetBuildInfo(
     /// [out][optional] pointer to the actual size in bytes of data being
     /// queried by propName.
     size_t *PropSizeRet) {
-  std::ignore = Device;
 
   std::shared_lock<ur_shared_mutex> Guard(Program->Mutex);
   UrReturnHelper ReturnValue(PropSize, PropValue, PropSizeRet);
@@ -903,17 +901,13 @@ ur_result_t urProgramGetBuildInfo(
 
 ur_result_t urProgramSetSpecializationConstant(
     /// [in] handle of the Program object
-    ur_program_handle_t Program,
+    ur_program_handle_t /*Program*/,
     /// [in] specification constant Id
-    uint32_t SpecId,
+    uint32_t /*SpecId*/,
     /// [in] size of the specialization constant value
-    size_t SpecSize,
+    size_t /*SpecSize*/,
     /// [in] pointer to the specialization value bytes
-    const void *SpecValue) {
-  std::ignore = Program;
-  std::ignore = SpecId;
-  std::ignore = SpecSize;
-  std::ignore = SpecValue;
+    const void * /*SpecValue*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -916,24 +916,14 @@ ur_result_t urQueueFlush(
 }
 
 ur_result_t urEnqueueKernelLaunchCustomExp(
-    ur_queue_handle_t hQueue, ur_kernel_handle_t hKernel, uint32_t workDim,
-    const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
-    const size_t *pLocalWorkSize, uint32_t numPropsInLaunchPropList,
-    const ur_exp_launch_property_t *launchPropList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hKernel;
-  std::ignore = workDim;
-  std::ignore = pGlobalWorkOffset;
-  std::ignore = pGlobalWorkSize;
-  std::ignore = pLocalWorkSize;
-  std::ignore = numPropsInLaunchPropList;
-  std::ignore = launchPropList;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-
+    ur_queue_handle_t /*hQueue*/, ur_kernel_handle_t /*hKernel*/,
+    uint32_t /*workDim*/, const size_t * /*pGlobalWorkOffset*/,
+    const size_t * /*pGlobalWorkSize*/, const size_t * /*pLocalWorkSize*/,
+    uint32_t /*numPropsInLaunchPropList*/,
+    const ur_exp_launch_property_t * /*launchPropList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
   logger::error("[UR][L0] {} function not implemented!",
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/level_zero/sampler.cpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.cpp
@@ -146,20 +146,15 @@ ur_result_t urSamplerRelease(
 
 ur_result_t urSamplerGetInfo(
     /// [in] handle of the sampler object
-    ur_sampler_handle_t Sampler,
+    ur_sampler_handle_t /*Sampler*/,
     /// [in] name of the sampler property to query
-    ur_sampler_info_t PropName,
+    ur_sampler_info_t /*PropName*/,
     /// [in] size in bytes of the sampler property value provided
-    size_t PropValueSize,
+    size_t /*PropValueSize*/,
     /// [out] value of the sampler property
-    void *PropValue,
+    void * /*PropValue*/,
     /// [out] size in bytes returned in sampler property value
-    size_t *PropSizeRet) {
-  std::ignore = Sampler;
-  std::ignore = PropName;
-  std::ignore = PropValueSize;
-  std::ignore = PropValue;
-  std::ignore = PropSizeRet;
+    size_t * /*PropSizeRet*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -167,11 +162,9 @@ ur_result_t urSamplerGetInfo(
 
 ur_result_t urSamplerGetNativeHandle(
     /// [in] handle of the sampler.
-    ur_sampler_handle_t Sampler,
+    ur_sampler_handle_t /*Sampler*/,
     /// [out] a pointer to the native handle of the sampler.
-    ur_native_handle_t *NativeSampler) {
-  std::ignore = Sampler;
-  std::ignore = NativeSampler;
+    ur_native_handle_t * /*NativeSampler*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -179,17 +172,13 @@ ur_result_t urSamplerGetNativeHandle(
 
 ur_result_t urSamplerCreateWithNativeHandle(
     /// [in] the native handle of the sampler.
-    ur_native_handle_t NativeSampler,
+    ur_native_handle_t /*NativeSampler*/,
     /// [in] handle of the context object
-    ur_context_handle_t Context,
+    ur_context_handle_t /*Context*/,
     /// [in][optional] pointer to native sampler properties struct.
-    const ur_sampler_native_properties_t *Properties,
+    const ur_sampler_native_properties_t * /*Properties*/,
     /// [out] pointer to the handle of the sampler object created.
-    ur_sampler_handle_t *Sampler) {
-  std::ignore = NativeSampler;
-  std::ignore = Context;
-  std::ignore = Properties;
-  std::ignore = Sampler;
+    ur_sampler_handle_t * /*Sampler*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/level_zero/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/usm.hpp
@@ -77,8 +77,8 @@ protected:
   virtual ur_result_t allocateImpl(void **, size_t, uint32_t) = 0;
 
 public:
-  virtual void get_last_native_error(const char **ErrMsg, int32_t *ErrCode) {
-    std::ignore = ErrMsg;
+  virtual void get_last_native_error(const char ** /*ErrMsg*/,
+                                     int32_t *ErrCode) {
     *ErrCode = static_cast<int32_t>(getLastStatusRef());
   };
   virtual umf_result_t initialize(ur_context_handle_t, ur_device_handle_t) {

--- a/unified-runtime/source/adapters/level_zero/usm_p2p.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm_p2p.cpp
@@ -13,21 +13,15 @@
 
 namespace ur::level_zero {
 
-ur_result_t urUsmP2PEnablePeerAccessExp(ur_device_handle_t commandDevice,
-                                        ur_device_handle_t peerDevice) {
-
-  std::ignore = commandDevice;
-  std::ignore = peerDevice;
+ur_result_t urUsmP2PEnablePeerAccessExp(ur_device_handle_t /*commandDevice*/,
+                                        ur_device_handle_t /*peerDevice*/) {
 
   // L0 has peer devices enabled by default
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t urUsmP2PDisablePeerAccessExp(ur_device_handle_t commandDevice,
-                                         ur_device_handle_t peerDevice) {
-
-  std::ignore = commandDevice;
-  std::ignore = peerDevice;
+ur_result_t urUsmP2PDisablePeerAccessExp(ur_device_handle_t /*commandDevice*/,
+                                         ur_device_handle_t /*peerDevice*/) {
 
   // L0 has peer devices enabled by default
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -130,28 +130,18 @@ ur_result_t urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t commandBuffer, ur_kernel_handle_t hKernel,
     uint32_t workDim, const size_t *pGlobalWorkOffset,
     const size_t *pGlobalWorkSize, const size_t *pLocalWorkSize,
-    uint32_t numKernelAlternatives, ur_kernel_handle_t *kernelAlternatives,
-    uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *syncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *eventWaitList,
-    ur_exp_command_buffer_sync_point_t *retSyncPoint, ur_event_handle_t *event,
-    ur_exp_command_buffer_command_handle_t *command) try {
+    uint32_t /*numKernelAlternatives*/,
+    ur_kernel_handle_t * /*kernelAlternatives*/,
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*syncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*eventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*retSyncPoint*/,
+    ur_event_handle_t * /*event*/,
+    ur_exp_command_buffer_command_handle_t * /*command*/) try {
   // TODO: These parameters aren't implemented in V1 yet, and are a fair amount
   // of work. Need to know semantics: should they be checked before kernel
   // execution (difficult) or before kernel appending to list (easy fix).
-  std::ignore = numEventsInWaitList;
-  std::ignore = eventWaitList;
-  std::ignore = event;
-
-  // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = syncPointWaitList;
-  std::ignore = retSyncPoint;
-
-  // TODO
-  std::ignore = numKernelAlternatives;
-  std::ignore = kernelAlternatives;
-  std::ignore = command;
   auto commandListLocked = commandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendKernelLaunch(
       hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, 0,
@@ -163,22 +153,14 @@ ur_result_t urCommandBufferAppendKernelLaunchExp(
 
 ur_result_t urCommandBufferAppendUSMMemcpyExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, void *pDst, const void *pSrc,
-    size_t size, uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
+    size_t size, uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
-  // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
   // Responsibility of UMD to offload to copy engine
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendUSMMemcpy(false, pDst, pSrc, size, 0,
@@ -192,22 +174,16 @@ ur_result_t urCommandBufferAppendUSMMemcpyExp(
 ur_result_t urCommandBufferAppendMemBufferCopyExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_mem_handle_t hSrcMem,
     ur_mem_handle_t hDstMem, size_t srcOffset, size_t dstOffset, size_t size,
-    uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
   // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
   // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
   // Responsibility of UMD to offload to copy engine
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendMemBufferCopy(
@@ -221,22 +197,16 @@ ur_result_t urCommandBufferAppendMemBufferCopyExp(
 ur_result_t urCommandBufferAppendMemBufferWriteExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_mem_handle_t hBuffer,
     size_t offset, size_t size, const void *pSrc,
-    uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
   // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
   // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
   // Responsibility of UMD to offload to copy engine
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendMemBufferWrite(hBuffer, false, offset, size,
@@ -249,23 +219,16 @@ ur_result_t urCommandBufferAppendMemBufferWriteExp(
 
 ur_result_t urCommandBufferAppendMemBufferReadExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_mem_handle_t hBuffer,
-    size_t offset, size_t size, void *pDst, uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
+    size_t offset, size_t size, void *pDst,
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
   // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
-
   // Responsibility of UMD to offload to copy engine
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendMemBufferRead(hBuffer, false, offset, size,
@@ -281,22 +244,16 @@ ur_result_t urCommandBufferAppendMemBufferCopyRectExp(
     ur_mem_handle_t hDstMem, ur_rect_offset_t srcOrigin,
     ur_rect_offset_t dstOrigin, ur_rect_region_t region, size_t srcRowPitch,
     size_t srcSlicePitch, size_t dstRowPitch, size_t dstSlicePitch,
-    uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
   // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
   // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
   // Responsibility of UMD to offload to copy engine
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendMemBufferCopyRect(
@@ -313,22 +270,15 @@ ur_result_t urCommandBufferAppendMemBufferWriteRectExp(
     ur_rect_offset_t bufferOffset, ur_rect_offset_t hostOffset,
     ur_rect_region_t region, size_t bufferRowPitch, size_t bufferSlicePitch,
     size_t hostRowPitch, size_t hostSlicePitch, void *pSrc,
-    uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
   // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
 
   // Responsibility of UMD to offload to copy engine
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
@@ -347,22 +297,15 @@ ur_result_t urCommandBufferAppendMemBufferReadRectExp(
     ur_rect_offset_t bufferOffset, ur_rect_offset_t hostOffset,
     ur_rect_region_t region, size_t bufferRowPitch, size_t bufferSlicePitch,
     size_t hostRowPitch, size_t hostSlicePitch, void *pDst,
-    uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
   // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
 
   // Responsibility of UMD to offload to copy engine
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
@@ -379,22 +322,13 @@ ur_result_t urCommandBufferAppendMemBufferReadRectExp(
 ur_result_t urCommandBufferAppendUSMFillExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, void *pMemory,
     const void *pPattern, size_t patternSize, size_t size,
-    uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
-
-  // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendUSMFill(pMemory, patternSize, pPattern, size,
@@ -407,23 +341,15 @@ ur_result_t urCommandBufferAppendUSMFillExp(
 ur_result_t urCommandBufferAppendMemBufferFillExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_mem_handle_t hBuffer,
     const void *pPattern, size_t patternSize, size_t offset, size_t size,
-    uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
   // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
-
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendMemBufferFill(
       hBuffer, pPattern, patternSize, offset, size, 0, nullptr, nullptr));
@@ -435,22 +361,15 @@ ur_result_t urCommandBufferAppendMemBufferFillExp(
 ur_result_t urCommandBufferAppendUSMPrefetchExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, const void *pMemory,
     size_t size, ur_usm_migration_flags_t flags,
-    uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
 
   // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
 
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendUSMPrefetch(pMemory, size, flags, 0, nullptr,
@@ -463,22 +382,15 @@ ur_result_t urCommandBufferAppendUSMPrefetchExp(
 
 ur_result_t urCommandBufferAppendUSMAdviseExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, const void *pMemory,
-    size_t size, ur_usm_advice_flags_t advice, uint32_t numSyncPointsInWaitList,
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
-    ur_exp_command_buffer_command_handle_t *phCommand) try {
-
+    size_t size, ur_usm_advice_flags_t advice,
+    uint32_t /*numSyncPointsInWaitList*/,
+    const ur_exp_command_buffer_sync_point_t * /*pSyncPointWaitList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_exp_command_buffer_sync_point_t * /*pSyncPoint*/,
+    ur_event_handle_t * /*phEvent*/,
+    ur_exp_command_buffer_command_handle_t * /*phCommand*/) try {
   // the same issue as in urCommandBufferAppendKernelLaunchExp
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
-  // sync mechanic can be ignored, because all lists are in-order
-  std::ignore = numSyncPointsInWaitList;
-  std::ignore = pSyncPointWaitList;
-  std::ignore = pSyncPoint;
-
-  std::ignore = phCommand;
 
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   UR_CALL(commandListLocked->appendUSMAdvise(pMemory, size, advice, nullptr));

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -53,13 +53,10 @@ ur_context_handle_t_::ur_context_handle_t_(ze_context_handle_t hContext,
       commandListCache(hContext,
                        phDevices[0]->Platform->ZeCopyOffloadExtensionSupported),
       eventPoolCache(this, phDevices[0]->Platform->getNumDevices(),
-                     [context = this, platform = phDevices[0]->Platform](
-                         DeviceId deviceId, v2::event_flags_t flags)
+                     [context = this](DeviceId /* deviceId*/,
+                                      v2::event_flags_t flags)
                          -> std::unique_ptr<v2::event_provider> {
                        assert((flags & v2::EVENT_FLAGS_COUNTER) != 0);
-
-                       std::ignore = deviceId;
-                       std::ignore = platform;
 
                        // TODO: just use per-context id?
                        return std::make_unique<v2::provider_normal>(
@@ -115,9 +112,8 @@ ur_context_handle_t_::getP2PDevices(ur_device_handle_t hDevice) const {
 namespace ur::level_zero {
 ur_result_t urContextCreate(uint32_t deviceCount,
                             const ur_device_handle_t *phDevices,
-                            const ur_context_properties_t *pProperties,
+                            const ur_context_properties_t * /*pProperties*/,
                             ur_context_handle_t *phContext) try {
-  std::ignore = pProperties;
 
   ur_platform_handle_t hPlatform = phDevices[0]->Platform;
   ZeStruct<ze_context_desc_t> contextDesc{};

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
@@ -182,9 +182,8 @@ ur_kernel_handle_t_::getProperties(ur_device_handle_t hDevice) const {
 
 ur_result_t ur_kernel_handle_t_::setArgValue(
     uint32_t argIndex, size_t argSize,
-    const ur_kernel_arg_value_properties_t *pProperties,
+    const ur_kernel_arg_value_properties_t * /*pProperties*/,
     const void *pArgValue) {
-  std::ignore = pProperties;
 
   // OpenCL: "the arg_value pointer can be NULL or point to a NULL value
   // in which case a NULL value will be used as the value for the argument
@@ -221,9 +220,9 @@ ur_result_t ur_kernel_handle_t_::setArgValue(
 }
 
 ur_result_t ur_kernel_handle_t_::setArgPointer(
-    uint32_t argIndex, const ur_kernel_arg_pointer_properties_t *pProperties,
+    uint32_t argIndex,
+    const ur_kernel_arg_pointer_properties_t * /*pProperties*/,
     const void *pArgValue) {
-  std::ignore = pProperties;
 
   // KernelSetArgValue is expecting a pointer to the argument
   return setArgValue(argIndex, sizeof(const void *), nullptr, &pArgValue);
@@ -450,15 +449,12 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
   return exceptionToResult(std::current_exception());
 }
 
-ur_result_t
-urKernelSetArgLocal(ur_kernel_handle_t hKernel, uint32_t argIndex,
-                    size_t argSize,
-                    const ur_kernel_arg_local_properties_t *pProperties) try {
+ur_result_t urKernelSetArgLocal(
+    ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize,
+    const ur_kernel_arg_local_properties_t * /*pProperties*/) try {
   TRACK_SCOPE_LATENCY("urKernelSetArgLocal");
 
   std::scoped_lock<ur_shared_mutex> guard(hKernel->Mutex);
-
-  std::ignore = pProperties;
 
   return hKernel->setArgValue(argIndex, argSize, nullptr, nullptr);
 } catch (...) {
@@ -471,14 +467,12 @@ ur_result_t urKernelSetExecInfo(
     /// [in] name of the execution attribute
     ur_kernel_exec_info_t propName,
     /// [in] size in byte the attribute value
-    size_t propSize,
+    size_t /*propSize*/,
     /// [in][optional] pointer to execution info properties
-    const ur_kernel_exec_info_properties_t *pProperties,
+    const ur_kernel_exec_info_properties_t * /*pProperties*/,
     /// [in][range(0, propSize)] pointer to memory location holding the property
     /// value.
     const void *pPropValue) try {
-  std::ignore = propSize;
-  std::ignore = pProperties;
 
   std::scoped_lock<ur_shared_mutex> guard(hKernel->Mutex);
 
@@ -702,13 +696,12 @@ ur_result_t urKernelSuggestMaxCooperativeGroupCountExp(
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t
-urKernelSetArgSampler(ur_kernel_handle_t hKernel, uint32_t argIndex,
-                      const ur_kernel_arg_sampler_properties_t *pProperties,
-                      ur_sampler_handle_t hArgValue) try {
+ur_result_t urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel, uint32_t argIndex,
+    const ur_kernel_arg_sampler_properties_t * /*pProperties*/,
+    ur_sampler_handle_t hArgValue) try {
   TRACK_SCOPE_LATENCY("urKernelSetArgSampler");
   std::scoped_lock<ur_shared_mutex> guard(hKernel->Mutex);
-  std::ignore = pProperties;
   return hKernel->setArgValue(argIndex, sizeof(void *), nullptr,
                               &hArgValue->ZeSampler);
 } catch (...) {

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -46,28 +46,21 @@ ur_usm_handle_t::ur_usm_handle_t(ur_context_handle_t hContext, size_t size,
       ptr(const_cast<void *>(ptr)) {}
 
 void *ur_usm_handle_t::getDevicePtr(
-    ur_device_handle_t hDevice, device_access_mode_t access, size_t offset,
-    size_t size, std::function<void(void *src, void *dst, size_t)> migrate) {
-  std::ignore = hDevice;
-  std::ignore = access;
-  std::ignore = offset;
-  std::ignore = size;
-  std::ignore = migrate;
+    ur_device_handle_t /*hDevice*/, device_access_mode_t /*access*/,
+    size_t /*offset*/, size_t /*size*/,
+    std::function<void(void *src, void *dst, size_t)> /*migrate*/) {
   return ptr;
 }
 
 void *
-ur_usm_handle_t::mapHostPtr(ur_map_flags_t flags, size_t offset, size_t size,
+ur_usm_handle_t::mapHostPtr(ur_map_flags_t /*flags*/, size_t /*offset*/,
+                            size_t /*size*/,
                             std::function<void(void *src, void *dst, size_t)>) {
-  std::ignore = flags;
-  std::ignore = offset;
-  std::ignore = size;
   return ptr;
 }
 
 void ur_usm_handle_t::unmapHostPtr(
-    void *pMappedPtr, std::function<void(void *src, void *dst, size_t)>) {
-  std::ignore = pMappedPtr;
+    void * /*pMappedPtr*/, std::function<void(void *src, void *dst, size_t)>) {
   /* nop */
 }
 
@@ -118,29 +111,20 @@ ur_integrated_buffer_handle_t::ur_integrated_buffer_handle_t(
 }
 
 void *ur_integrated_buffer_handle_t::getDevicePtr(
-    ur_device_handle_t hDevice, device_access_mode_t access, size_t offset,
-    size_t size, std::function<void(void *src, void *dst, size_t)> migrate) {
-  std::ignore = hDevice;
-  std::ignore = access;
-  std::ignore = offset;
-  std::ignore = size;
-  std::ignore = migrate;
+    ur_device_handle_t /*hDevice*/, device_access_mode_t /*access*/,
+    size_t /*offset*/, size_t /*size*/,
+    std::function<void(void *src, void *dst, size_t)> /*migrate*/) {
   return ptr.get();
 }
 
 void *ur_integrated_buffer_handle_t::mapHostPtr(
-    ur_map_flags_t flags, size_t offset, size_t size,
-    std::function<void(void *src, void *dst, size_t)> migrate) {
-  std::ignore = flags;
-  std::ignore = offset;
-  std::ignore = size;
-  std::ignore = migrate;
+    ur_map_flags_t /*flags*/, size_t /*offset*/, size_t /*size*/,
+    std::function<void(void *src, void *dst, size_t)> /*migrate*/) {
   return ptr.get();
 }
 
 void ur_integrated_buffer_handle_t::unmapHostPtr(
-    void *pMappedPtr, std::function<void(void *src, void *dst, size_t)>) {
-  std::ignore = pMappedPtr;
+    void * /*pMappedPtr*/, std::function<void(void *src, void *dst, size_t)>) {
   /* nop */
 }
 
@@ -260,13 +244,11 @@ void *ur_discrete_buffer_handle_t::getActiveDeviceAlloc(size_t offset) {
 }
 
 void *ur_discrete_buffer_handle_t::getDevicePtr(
-    ur_device_handle_t hDevice, device_access_mode_t access, size_t offset,
-    size_t size, std::function<void(void *src, void *dst, size_t)> migrate) {
+    ur_device_handle_t hDevice, device_access_mode_t /*access*/, size_t offset,
+    size_t /*size*/,
+    std::function<void(void *src, void *dst, size_t)> /*migrate*/) {
   TRACK_SCOPE_LATENCY("ur_discrete_buffer_handle_t::getDevicePtr");
 
-  std::ignore = access;
-  std::ignore = size;
-  std::ignore = migrate;
   if (!activeAllocationDevice) {
     if (!hDevice) {
       hDevice = hContext->getDevices()[0];
@@ -470,7 +452,7 @@ ur_mem_image_t::ur_mem_image_t(ur_context_handle_t hContext,
   UR_CALL_THROWS(ur2zeImageDesc(pImageFormat, pImageDesc, zeImageDesc));
 }
 
-static void verifyImageRegion(ze_image_desc_t &zeImageDesc,
+static void verifyImageRegion([[maybe_unused]] ze_image_desc_t &zeImageDesc,
                               ze_image_region_t &zeRegion, size_t rowPitch,
                               size_t slicePitch) {
 #ifndef NDEBUG
@@ -483,8 +465,6 @@ static void verifyImageRegion(ze_image_desc_t &zeImageDesc,
         (zeImageDesc.format.layout == ZE_IMAGE_FORMAT_LAYOUT_8_8_8_8 &&
          rowPitch == 4 * zeRegion.width)))
     throw UR_RESULT_ERROR_INVALID_IMAGE_SIZE;
-#else
-  std::ignore = zeImageDesc;
 #endif
   if (!(slicePitch == 0 || slicePitch == rowPitch * zeRegion.height))
     throw UR_RESULT_ERROR_INVALID_IMAGE_SIZE;
@@ -741,16 +721,11 @@ ur_result_t urMemImageCreateWithNativeHandle(
   return exceptionToResult(std::current_exception());
 }
 
-ur_result_t urMemImageGetInfo(ur_mem_handle_t hMemory, ur_image_info_t propName,
-                              size_t propSize, void *pPropValue,
-                              size_t *pPropSizeRet) {
+ur_result_t urMemImageGetInfo(ur_mem_handle_t /*hMemory*/,
+                              ur_image_info_t /*propName*/, size_t /*propSize*/,
+                              void * /*pPropValue*/,
+                              size_t * /*pPropSizeRet*/) {
   logger::error("{} function not implemented!", __FUNCTION__);
-
-  std::ignore = hMemory;
-  std::ignore = propName;
-  std::ignore = propSize;
-  std::ignore = pPropValue;
-  std::ignore = pPropSizeRet;
 
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -144,8 +144,7 @@ void ur_queue_immediate_in_order_t::deferEventFree(ur_event_handle_t hEvent) {
 }
 
 ur_result_t ur_queue_immediate_in_order_t::queueGetNativeHandle(
-    ur_queue_native_desc_t *pDesc, ur_native_handle_t *phNativeQueue) {
-  std::ignore = pDesc;
+    ur_queue_native_desc_t * /*pDesc*/, ur_native_handle_t *phNativeQueue) {
   *phNativeQueue = reinterpret_cast<ur_native_handle_t>(
       this->commandListManager.get_no_lock()->getZeCommandList());
   return UR_RESULT_SUCCESS;
@@ -618,18 +617,11 @@ ur_queue_immediate_in_order_t::enqueueUSMAdvise(const void *pMem, size_t size,
 }
 
 ur_result_t ur_queue_immediate_in_order_t::enqueueUSMFill2D(
-    void *pMem, size_t pitch, size_t patternSize, const void *pPattern,
-    size_t width, size_t height, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = pMem;
-  std::ignore = pitch;
-  std::ignore = patternSize;
-  std::ignore = pPattern;
-  std::ignore = width;
-  std::ignore = height;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    void * /*pMem*/, size_t /*pitch*/, size_t /*patternSize*/,
+    const void * /*pPattern*/, size_t /*width*/, size_t /*height*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -703,32 +695,20 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueDeviceGlobalVariableRead(
 }
 
 ur_result_t ur_queue_immediate_in_order_t::enqueueReadHostPipe(
-    ur_program_handle_t hProgram, const char *pipe_symbol, bool blocking,
-    void *pDst, size_t size, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = hProgram;
-  std::ignore = pipe_symbol;
-  std::ignore = blocking;
-  std::ignore = pDst;
-  std::ignore = size;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_program_handle_t /*hProgram*/, const char * /*pipe_symbol*/,
+    bool /*blocking*/, void * /*pDst*/, size_t /*size*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t ur_queue_immediate_in_order_t::enqueueWriteHostPipe(
-    ur_program_handle_t hProgram, const char *pipe_symbol, bool blocking,
-    void *pSrc, size_t size, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = hProgram;
-  std::ignore = pipe_symbol;
-  std::ignore = blocking;
-  std::ignore = pSrc;
-  std::ignore = size;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_program_handle_t /*hProgram*/, const char * /*pipe_symbol*/,
+    bool /*blocking*/, void * /*pSrc*/, size_t /*size*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -760,52 +740,34 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueUSMFreeExp(
 }
 
 ur_result_t ur_queue_immediate_in_order_t::bindlessImagesImageCopyExp(
-    const void *pSrc, void *pDst, const ur_image_desc_t *pSrcImageDesc,
-    const ur_image_desc_t *pDstImageDesc,
-    const ur_image_format_t *pSrcImageFormat,
-    const ur_image_format_t *pDstImageFormat,
-    ur_exp_image_copy_region_t *pCopyRegion,
-    ur_exp_image_copy_flags_t imageCopyFlags, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = pDst;
-  std::ignore = pSrc;
-  std::ignore = pSrcImageDesc;
-  std::ignore = pDstImageDesc;
-  std::ignore = imageCopyFlags;
-  std::ignore = pSrcImageFormat;
-  std::ignore = pDstImageFormat;
-  std::ignore = pCopyRegion;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    const void * /*pSrc*/, void * /*pDst*/,
+    const ur_image_desc_t * /*pSrcImageDesc*/,
+    const ur_image_desc_t * /*pDstImageDesc*/,
+    const ur_image_format_t * /*pSrcImageFormat*/,
+    const ur_image_format_t * /*pDstImageFormat*/,
+    ur_exp_image_copy_region_t * /*pCopyRegion*/,
+    ur_exp_image_copy_flags_t /*imageCopyFlags*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t
 ur_queue_immediate_in_order_t::bindlessImagesWaitExternalSemaphoreExp(
-    ur_exp_external_semaphore_handle_t hSemaphore, bool hasWaitValue,
-    uint64_t waitValue, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = hSemaphore;
-  std::ignore = hasWaitValue;
-  std::ignore = waitValue;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_exp_external_semaphore_handle_t /*hSemaphore*/, bool /*hasWaitValue*/,
+    uint64_t /*waitValue*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t
 ur_queue_immediate_in_order_t::bindlessImagesSignalExternalSemaphoreExp(
-    ur_exp_external_semaphore_handle_t hSemaphore, bool hasSignalValue,
-    uint64_t signalValue, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = hSemaphore;
-  std::ignore = hasSignalValue;
-  std::ignore = signalValue;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_exp_external_semaphore_handle_t /*hSemaphore*/, bool /*hasSignalValue*/,
+    uint64_t /*signalValue*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -948,22 +910,13 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCommandBufferExp(
 }
 
 ur_result_t ur_queue_immediate_in_order_t::enqueueKernelLaunchCustomExp(
-    ur_kernel_handle_t hKernel, uint32_t workDim,
-    const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
-    const size_t *pLocalWorkSize, uint32_t numPropsInLaunchPropList,
-    const ur_exp_launch_property_t *launchPropList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hKernel;
-  std::ignore = workDim;
-  std::ignore = pGlobalWorkOffset;
-  std::ignore = pGlobalWorkSize;
-  std::ignore = pLocalWorkSize;
-  std::ignore = numPropsInLaunchPropList;
-  std::ignore = launchPropList;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_kernel_handle_t /*hKernel*/, uint32_t /*workDim*/,
+    const size_t * /*pGlobalWorkOffset*/, const size_t * /*pGlobalWorkSize*/,
+    const size_t * /*pLocalWorkSize*/, uint32_t /*numPropsInLaunchPropList*/,
+    const ur_exp_launch_property_t * /*launchPropList*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -387,10 +387,9 @@ ur_result_t urUSMHostAlloc(
 
 ur_result_t urUSMFree(
     /// [in] handle of the context object
-    ur_context_handle_t hContext,
+    ur_context_handle_t /*hContext*/,
     /// [in] pointer to USM memory object
     void *pMem) try {
-  std::ignore = hContext;
   return umf::umf2urResult(umfFree(pMem));
 } catch (umf_result_t e) {
   return umf::umf2urResult(e);

--- a/unified-runtime/source/adapters/native_cpu/context.cpp
+++ b/unified-runtime/source/adapters/native_cpu/context.cpp
@@ -19,9 +19,8 @@
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(
     [[maybe_unused]] uint32_t DeviceCount, const ur_device_handle_t *phDevices,
-    const ur_context_properties_t *pProperties,
+    const ur_context_properties_t * /*pProperties*/,
     ur_context_handle_t *phContext) {
-  std::ignore = pProperties;
   assert(DeviceCount == 1);
 
   // TODO: Proper error checking.
@@ -65,34 +64,24 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext, ur_native_handle_t *phNativeContext) {
-  std::ignore = hContext;
-  std::ignore = phNativeContext;
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextGetNativeHandle(ur_context_handle_t /*hContext*/,
+                         ur_native_handle_t * /*phNativeContext*/) {
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
-    ur_native_handle_t hNativeContext, ur_adapter_handle_t hAdapter,
-    uint32_t numDevices, const ur_device_handle_t *phDevices,
-    const ur_context_native_properties_t *pProperties,
-    ur_context_handle_t *phContext) {
-  std::ignore = hNativeContext;
-  std::ignore = hAdapter;
-  std::ignore = numDevices;
-  std::ignore = phDevices;
-  std::ignore = pProperties;
-  std::ignore = phContext;
+    ur_native_handle_t /*hNativeContext*/, ur_adapter_handle_t /*hAdapter*/,
+    uint32_t /*numDevices*/, const ur_device_handle_t * /*phDevices*/,
+    const ur_context_native_properties_t * /*pProperties*/,
+    ur_context_handle_t * /*phContext*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
-    ur_context_handle_t hContext, ur_context_extended_deleter_t pfnDeleter,
-    void *pUserData) {
-  std::ignore = hContext;
-  std::ignore = pfnDeleter;
-  std::ignore = pUserData;
+    ur_context_handle_t /*hContext*/,
+    ur_context_extended_deleter_t /*pfnDeleter*/, void * /*pUserData*/) {
 
   DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/device.cpp
+++ b/unified-runtime/source/adapters/native_cpu/device.cpp
@@ -476,42 +476,31 @@ urDeviceRelease(ur_device_handle_t hDevice) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
-    ur_device_handle_t hDevice,
-    const ur_device_partition_properties_t *pProperties, uint32_t NumDevices,
-    ur_device_handle_t *phSubDevices, uint32_t *pNumDevicesRet) {
-  std::ignore = hDevice;
-  std::ignore = NumDevices;
-  std::ignore = pProperties;
-  std::ignore = phSubDevices;
-  std::ignore = pNumDevicesRet;
+    ur_device_handle_t /*hDevice*/,
+    const ur_device_partition_properties_t * /*pProperties*/,
+    uint32_t /*NumDevices*/, ur_device_handle_t * /*phSubDevices*/,
+    uint32_t * /*pNumDevicesRet*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice, ur_native_handle_t *phNativeDevice) {
-  std::ignore = hDevice;
-  std::ignore = phNativeDevice;
+    ur_device_handle_t /*hDevice*/, ur_native_handle_t * /*phNativeDevice*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
-    ur_native_handle_t hNativeDevice, ur_adapter_handle_t hAdapter,
-    const ur_device_native_properties_t *pProperties,
-    ur_device_handle_t *phDevice) {
-  std::ignore = hNativeDevice;
-  std::ignore = hAdapter;
-  std::ignore = pProperties;
-  std::ignore = phDevice;
+    ur_native_handle_t /*hNativeDevice*/, ur_adapter_handle_t /*hAdapter*/,
+    const ur_device_native_properties_t * /*pProperties*/,
+    ur_device_handle_t * /*phDevice*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
-    ur_device_handle_t hDevice, uint64_t *pDeviceTimestamp,
+    ur_device_handle_t /*hDevice*/, uint64_t *pDeviceTimestamp,
     uint64_t *pHostTimestamp) {
-  std::ignore = hDevice;
   if (pHostTimestamp) {
     *pHostTimestamp = get_timestamp();
   }
@@ -522,12 +511,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceSelectBinary(
-    ur_device_handle_t hDevice, const ur_device_binary_t *pBinaries,
+    ur_device_handle_t /*hDevice*/, const ur_device_binary_t *pBinaries,
     uint32_t NumBinaries, uint32_t *pSelectedBinary) {
-  std::ignore = hDevice;
-  std::ignore = pBinaries;
-  std::ignore = NumBinaries;
-  std::ignore = pSelectedBinary;
 
 #define UR_DEVICE_BINARY_TARGET_NATIVE_CPU "native_cpu"
   // look for a binary with type "native_cpu"

--- a/unified-runtime/source/adapters/native_cpu/enqueue.cpp
+++ b/unified-runtime/source/adapters/native_cpu/enqueue.cpp
@@ -375,10 +375,9 @@ static inline ur_result_t doCopy_impl(ur_queue_handle_t hQueue, void *DstPtr,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingRead,
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool /*blockingRead*/,
     size_t offset, size_t size, void *pDst, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = blockingRead;
 
   void *FromPtr = /*Src*/ hBuffer->_mem + offset;
   auto res = doCopy_impl(hQueue, pDst, FromPtr, size, numEventsInWaitList,
@@ -387,10 +386,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingWrite,
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool /*blockingWrite*/,
     size_t offset, size_t size, const void *pSrc, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = blockingWrite;
 
   void *ToPtr = hBuffer->_mem + offset;
   auto res = doCopy_impl(hQueue, ToPtr, pSrc, size, numEventsInWaitList,
@@ -475,72 +473,43 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hImage, bool blockingRead,
-    ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
-    size_t slicePitch, void *pDst, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hImage;
-  std::ignore = blockingRead;
-  std::ignore = origin;
-  std::ignore = region;
-  std::ignore = rowPitch;
-  std::ignore = slicePitch;
-  std::ignore = pDst;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, ur_mem_handle_t /*hImage*/,
+    bool /*blockingRead*/, ur_rect_offset_t /*origin*/,
+    ur_rect_region_t /*region*/, size_t /*rowPitch*/, size_t /*slicePitch*/,
+    void * /*pDst*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hImage, bool blockingWrite,
-    ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
-    size_t slicePitch, void *pSrc, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hImage;
-  std::ignore = blockingWrite;
-  std::ignore = origin;
-  std::ignore = region;
-  std::ignore = rowPitch;
-  std::ignore = slicePitch;
-  std::ignore = pSrc;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, ur_mem_handle_t /*hImage*/,
+    bool /*blockingWrite*/, ur_rect_offset_t /*origin*/,
+    ur_rect_region_t /*region*/, size_t /*rowPitch*/, size_t /*slicePitch*/,
+    void * /*pSrc*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hImageSrc,
-    ur_mem_handle_t hImageDst, ur_rect_offset_t srcOrigin,
-    ur_rect_offset_t dstOrigin, ur_rect_region_t region,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hImageSrc;
-  std::ignore = hImageDst;
-  std::ignore = srcOrigin;
-  std::ignore = dstOrigin;
-  std::ignore = region;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, ur_mem_handle_t /*hImageSrc*/,
+    ur_mem_handle_t /*hImageDst*/, ur_rect_offset_t /*srcOrigin*/,
+    ur_rect_offset_t /*dstOrigin*/, ur_rect_region_t /*region*/,
+    uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingMap,
-    ur_map_flags_t mapFlags, size_t offset, size_t size,
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool /*blockingMap*/,
+    ur_map_flags_t /*mapFlags*/, size_t offset, size_t /*size*/,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent, void **ppRetMap) {
-  std::ignore = blockingMap;
-  std::ignore = mapFlags;
-  std::ignore = size;
 
   return withTimingEvent(UR_COMMAND_MEM_BUFFER_MAP, hQueue, numEventsInWaitList,
                          phEventWaitList, phEvent, [&]() {
@@ -550,11 +519,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hMem, void *pMappedPtr,
+    ur_queue_handle_t hQueue, ur_mem_handle_t /*hMem*/, void * /*pMappedPtr*/,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
-  std::ignore = hMem;
-  std::ignore = pMappedPtr;
   return withTimingEvent(UR_COMMAND_MEM_UNMAP, hQueue, numEventsInWaitList,
                          phEventWaitList, phEvent,
                          [&]() { return UR_RESULT_SUCCESS; });
@@ -617,10 +584,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue, bool blocking, void *pDst, const void *pSrc,
+    ur_queue_handle_t hQueue, bool /*blocking*/, void *pDst, const void *pSrc,
     size_t size, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = blocking;
   return withTimingEvent(
       UR_COMMAND_USM_MEMCPY, hQueue, numEventsInWaitList, phEventWaitList,
       phEvent, [&]() {
@@ -635,143 +601,79 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue, const void *pMem, size_t size,
-    ur_usm_migration_flags_t flags, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = pMem;
-  std::ignore = size;
-  std::ignore = flags;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, const void * /*pMem*/, size_t /*size*/,
+    ur_usm_migration_flags_t /*flags*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   // TODO: properly implement USM prefetch
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
-                   ur_usm_advice_flags_t advice, ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = pMem;
-  std::ignore = size;
-  std::ignore = advice;
-  std::ignore = phEvent;
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMAdvise(
+    ur_queue_handle_t /*hQueue*/, const void * /*pMem*/, size_t /*size*/,
+    ur_usm_advice_flags_t /*advice*/, ur_event_handle_t * /*phEvent*/) {
 
   // TODO: properly implement USM advise
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue, void *pMem, size_t pitch, size_t patternSize,
-    const void *pPattern, size_t width, size_t height,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = pMem;
-  std::ignore = pitch;
-  std::ignore = patternSize;
-  std::ignore = pPattern;
-  std::ignore = width;
-  std::ignore = height;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, void * /*pMem*/, size_t /*pitch*/,
+    size_t /*patternSize*/, const void * /*pPattern*/, size_t /*width*/,
+    size_t /*height*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue, bool blocking, void *pDst, size_t dstPitch,
-    const void *pSrc, size_t srcPitch, size_t width, size_t height,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = blocking;
-  std::ignore = pDst;
-  std::ignore = dstPitch;
-  std::ignore = pSrc;
-  std::ignore = srcPitch;
-  std::ignore = width;
-  std::ignore = height;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, bool /*blocking*/, void * /*pDst*/,
+    size_t /*dstPitch*/, const void * /*pSrc*/, size_t /*srcPitch*/,
+    size_t /*width*/, size_t /*height*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue, ur_program_handle_t hProgram, const char *name,
-    bool blockingWrite, size_t count, size_t offset, const void *pSrc,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hProgram;
-  std::ignore = name;
-  std::ignore = blockingWrite;
-  std::ignore = count;
-  std::ignore = offset;
-  std::ignore = pSrc;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, ur_program_handle_t /*hProgram*/,
+    const char * /*name*/, bool /*blockingWrite*/, size_t /*count*/,
+    size_t /*offset*/, const void * /*pSrc*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue, ur_program_handle_t hProgram, const char *name,
-    bool blockingRead, size_t count, size_t offset, void *pDst,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hProgram;
-  std::ignore = name;
-  std::ignore = blockingRead;
-  std::ignore = count;
-  std::ignore = offset;
-  std::ignore = pDst;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, ur_program_handle_t /*hProgram*/,
+    const char * /*name*/, bool /*blockingRead*/, size_t /*count*/,
+    size_t /*offset*/, void * /*pDst*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueReadHostPipe(
-    ur_queue_handle_t hQueue, ur_program_handle_t hProgram,
-    const char *pipe_symbol, bool blocking, void *pDst, size_t size,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hProgram;
-  std::ignore = pipe_symbol;
-  std::ignore = blocking;
-  std::ignore = pDst;
-  std::ignore = size;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, ur_program_handle_t /*hProgram*/,
+    const char * /*pipe_symbol*/, bool /*blocking*/, void * /*pDst*/,
+    size_t /*size*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
-    ur_queue_handle_t hQueue, ur_program_handle_t hProgram,
-    const char *pipe_symbol, bool blocking, void *pSrc, size_t size,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hProgram;
-  std::ignore = pipe_symbol;
-  std::ignore = blocking;
-  std::ignore = pSrc;
-  std::ignore = size;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+    ur_queue_handle_t /*hQueue*/, ur_program_handle_t /*hProgram*/,
+    const char * /*pipe_symbol*/, bool /*blocking*/, void * /*pSrc*/,
+    size_t /*size*/, uint32_t /*numEventsInWaitList*/,
+    const ur_event_handle_t * /*phEventWaitList*/,
+    ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/event.cpp
+++ b/unified-runtime/source/adapters/native_cpu/event.cpp
@@ -79,44 +79,31 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
-    ur_event_handle_t hEvent, ur_native_handle_t *phNativeEvent) {
-  std::ignore = hEvent;
-  std::ignore = phNativeEvent;
+    ur_event_handle_t /*hEvent*/, ur_native_handle_t * /*phNativeEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
-    ur_native_handle_t hNativeEvent, ur_context_handle_t hContext,
-    const ur_event_native_properties_t *pProperties,
-    ur_event_handle_t *phEvent) {
-  std::ignore = hNativeEvent;
-  std::ignore = hContext;
-  std::ignore = pProperties;
-  std::ignore = phEvent;
+    ur_native_handle_t /*hNativeEvent*/, ur_context_handle_t /*hContext*/,
+    const ur_event_native_properties_t * /*pProperties*/,
+    ur_event_handle_t * /*phEvent*/) {
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(
+    ur_event_handle_t /*hEvent*/, ur_execution_info_t /*execStatus*/,
+    ur_event_callback_t /*pfnNotify*/, void * /*pUserData*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urEventSetCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
-                   ur_event_callback_t pfnNotify, void *pUserData) {
-  std::ignore = hEvent;
-  std::ignore = execStatus;
-  std::ignore = pfnNotify;
-  std::ignore = pUserData;
-
-  DIE_NO_IMPLEMENTATION;
-}
-
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t hQueue, bool blocking, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = blocking;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
+urEnqueueTimestampRecordingExp(ur_queue_handle_t /*hQueue*/, bool /*blocking*/,
+                               uint32_t /*numEventsInWaitList*/,
+                               const ur_event_handle_t * /*phEventWaitList*/,
+                               ur_event_handle_t * /*phEvent*/) {
 
   DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/kernel.cpp
+++ b/unified-runtime/source/adapters/native_cpu/kernel.cpp
@@ -56,11 +56,9 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize,
-    const ur_kernel_arg_value_properties_t *pProperties,
+    const ur_kernel_arg_value_properties_t * /*pProperties*/,
     const void *pArgValue) {
   // TODO: error checking
-  std::ignore = argIndex;
-  std::ignore = pProperties;
 
   UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(argSize, UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE);
@@ -72,8 +70,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgValue(
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize,
-    const ur_kernel_arg_local_properties_t *pProperties) {
-  std::ignore = pProperties;
+    const ur_kernel_arg_local_properties_t * /*pProperties*/) {
   // emplace a placeholder kernel arg, gets replaced with a pointer to the
   // memory pool before enqueueing the kernel.
   hKernel->addPtrArg(nullptr, argIndex);
@@ -86,9 +83,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
                                                     size_t propSize,
                                                     void *pPropValue,
                                                     size_t *pPropSizeRet) {
-  std::ignore = hKernel;
-  std::ignore = propName;
-  std::ignore = pPropValue;
 
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
   // todo: check if we need this
@@ -112,10 +106,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
+urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t /*hDevice*/,
                      ur_kernel_group_info_t propName, size_t propSize,
                      void *pPropValue, size_t *pPropSizeRet) {
-  std::ignore = hDevice;
 
   UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
@@ -168,12 +161,10 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
   return UR_RESULT_ERROR_INVALID_ENUMERATION;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
-                        ur_kernel_sub_group_info_t propName, size_t propSize,
-                        void *pPropValue, size_t *pPropSizeRet) {
-  std::ignore = hKernel;
-  std::ignore = hDevice;
+UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+    ur_kernel_handle_t /*hKernel*/, ur_device_handle_t /*hDevice*/,
+    ur_kernel_sub_group_info_t propName, size_t propSize, void *pPropValue,
+    size_t *pPropSizeRet) {
 
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
   switch (propName) {
@@ -214,12 +205,10 @@ urKernelRelease(ur_kernel_handle_t hKernel) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelSetArgPointer(ur_kernel_handle_t hKernel, uint32_t argIndex,
-                      const ur_kernel_arg_pointer_properties_t *pProperties,
-                      const void *pArgValue) {
-  std::ignore = argIndex;
-  std::ignore = pProperties;
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgPointer(
+    ur_kernel_handle_t hKernel, uint32_t argIndex,
+    const ur_kernel_arg_pointer_properties_t * /*pProperties*/,
+    const void *pArgValue) {
 
   UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(pArgValue, UR_RESULT_ERROR_INVALID_NULL_POINTER);
@@ -229,37 +218,27 @@ urKernelSetArgPointer(ur_kernel_handle_t hKernel, uint32_t argIndex,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
-    ur_kernel_handle_t hKernel, ur_kernel_exec_info_t propName, size_t propSize,
-    const ur_kernel_exec_info_properties_t *pProperties,
-    const void *pPropValue) {
-  std::ignore = hKernel;
-  std::ignore = propName;
-  std::ignore = propSize;
-  std::ignore = pProperties;
-  std::ignore = pPropValue;
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetExecInfo(ur_kernel_handle_t /*hKernel*/,
+                    ur_kernel_exec_info_t /*propName*/, size_t /*propSize*/,
+                    const ur_kernel_exec_info_properties_t * /*pProperties*/,
+                    const void * /*pPropValue*/) {
 
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelSetArgSampler(ur_kernel_handle_t hKernel, uint32_t argIndex,
-                      const ur_kernel_arg_sampler_properties_t *pProperties,
-                      ur_sampler_handle_t hArgValue) {
-  std::ignore = hKernel;
-  std::ignore = argIndex;
-  std::ignore = pProperties;
-  std::ignore = hArgValue;
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgSampler(
+    ur_kernel_handle_t /*hKernel*/, uint32_t /*argIndex*/,
+    const ur_kernel_arg_sampler_properties_t * /*pProperties*/,
+    ur_sampler_handle_t /*hArgValue*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
-                     const ur_kernel_arg_mem_obj_properties_t *pProperties,
+                     const ur_kernel_arg_mem_obj_properties_t * /*pProperties*/,
                      ur_mem_handle_t hArgValue) {
-  std::ignore = argIndex;
-  std::ignore = pProperties;
 
   UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
@@ -276,33 +255,23 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSetSpecializationConstants(
-    ur_kernel_handle_t hKernel, uint32_t count,
-    const ur_specialization_constant_info_t *pSpecConstants) {
-  std::ignore = hKernel;
-  std::ignore = count;
-  std::ignore = pSpecConstants;
+    ur_kernel_handle_t /*hKernel*/, uint32_t /*count*/,
+    const ur_specialization_constant_info_t * /*pSpecConstants*/) {
 
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ur_native_handle_t *phNativeKernel) {
-  std::ignore = hKernel;
-  std::ignore = phNativeKernel;
+    ur_kernel_handle_t /*hKernel*/, ur_native_handle_t * /*phNativeKernel*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
-    ur_native_handle_t hNativeKernel, ur_context_handle_t hContext,
-    ur_program_handle_t hProgram,
-    const ur_kernel_native_properties_t *pProperties,
-    ur_kernel_handle_t *phKernel) {
-  std::ignore = hNativeKernel;
-  std::ignore = hContext;
-  std::ignore = hProgram;
-  std::ignore = pProperties;
-  std::ignore = phKernel;
+    ur_native_handle_t /*hNativeKernel*/, ur_context_handle_t /*hContext*/,
+    ur_program_handle_t /*hProgram*/,
+    const ur_kernel_native_properties_t * /*pProperties*/,
+    ur_kernel_handle_t * /*phKernel*/) {
 
   DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/memory.cpp
+++ b/unified-runtime/source/adapters/native_cpu/memory.cpp
@@ -12,16 +12,11 @@
 #include "common.hpp"
 #include "ur_api.h"
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
-    ur_context_handle_t hContext, ur_mem_flags_t flags,
-    const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
-    void *pHost, ur_mem_handle_t *phMem) {
-  std::ignore = hContext;
-  std::ignore = flags;
-  std::ignore = pImageFormat;
-  std::ignore = pImageDesc;
-  std::ignore = pHost;
-  std::ignore = phMem;
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemImageCreate(ur_context_handle_t /*hContext*/, ur_mem_flags_t /*flags*/,
+                 const ur_image_format_t * /*pImageFormat*/,
+                 const ur_image_desc_t * /*pImageDesc*/, void * /*pHost*/,
+                 ur_mem_handle_t * /*phMem*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
@@ -62,8 +57,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
-  std::ignore = hMem;
+UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t /*hMem*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
@@ -77,10 +71,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
     ur_mem_handle_t hBuffer, ur_mem_flags_t flags,
-    ur_buffer_create_type_t bufferCreateType, const ur_buffer_region_t *pRegion,
-    ur_mem_handle_t *phMem) {
+    ur_buffer_create_type_t /*bufferCreateType*/,
+    const ur_buffer_region_t *pRegion, ur_mem_handle_t *phMem) {
 
-  std::ignore = bufferCreateType;
   UR_ASSERT(hBuffer && !hBuffer->isImage() &&
                 !(static_cast<_ur_buffer *>(hBuffer))->isSubBuffer(),
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
@@ -106,64 +99,42 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urMemGetNativeHandle(ur_mem_handle_t hMem, ur_device_handle_t hDevice,
-                     ur_native_handle_t *phNativeMem) {
-  std::ignore = hMem;
-  std::ignore = hDevice;
-  std::ignore = phNativeMem;
+urMemGetNativeHandle(ur_mem_handle_t /*hMem*/, ur_device_handle_t /*hDevice*/,
+                     ur_native_handle_t * /*phNativeMem*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
-    ur_native_handle_t hNativeMem, ur_context_handle_t hContext,
-    const ur_mem_native_properties_t *pProperties, ur_mem_handle_t *phMem) {
-  std::ignore = hNativeMem;
-  std::ignore = hContext;
-  std::ignore = pProperties;
-  std::ignore = phMem;
+    ur_native_handle_t /*hNativeMem*/, ur_context_handle_t /*hContext*/,
+    const ur_mem_native_properties_t * /*pProperties*/,
+    ur_mem_handle_t * /*phMem*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
-    ur_native_handle_t hNativeMem, ur_context_handle_t hContext,
-    const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
-    const ur_mem_native_properties_t *pProperties, ur_mem_handle_t *phMem) {
-  std::ignore = hNativeMem;
-  std::ignore = hContext;
-  std::ignore = pImageFormat;
-  std::ignore = pImageDesc;
-  std::ignore = pProperties;
-  std::ignore = phMem;
+    ur_native_handle_t /*hNativeMem*/, ur_context_handle_t /*hContext*/,
+    const ur_image_format_t * /*pImageFormat*/,
+    const ur_image_desc_t * /*pImageDesc*/,
+    const ur_mem_native_properties_t * /*pProperties*/,
+    ur_mem_handle_t * /*phMem*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
-                                                 ur_mem_info_t propName,
-                                                 size_t propSize,
-                                                 void *pPropValue,
-                                                 size_t *pPropSizeRet) {
-  std::ignore = hMemory;
-  std::ignore = propName;
-  std::ignore = propSize;
-  std::ignore = pPropValue;
-  std::ignore = pPropSizeRet;
+UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t /*hMemory*/,
+                                                 ur_mem_info_t /*propName*/,
+                                                 size_t /*propSize*/,
+                                                 void * /*pPropValue*/,
+                                                 size_t * /*pPropSizeRet*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
-                                                      ur_image_info_t propName,
-                                                      size_t propSize,
-                                                      void *pPropValue,
-                                                      size_t *pPropSizeRet) {
-  std::ignore = hMemory;
-  std::ignore = propName;
-  std::ignore = propSize;
-  std::ignore = pPropValue;
-  std::ignore = pPropSizeRet;
+UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(
+    ur_mem_handle_t /*hMemory*/, ur_image_info_t /*propName*/,
+    size_t /*propSize*/, void * /*pPropValue*/, size_t * /*pPropSizeRet*/) {
 
   DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/memory.hpp
+++ b/unified-runtime/source/adapters/native_cpu/memory.hpp
@@ -56,9 +56,8 @@ struct _ur_buffer final : ur_mem_handle_t_ {
       : ur_mem_handle_t_(HostPtr, Size, false) {}
   _ur_buffer(ur_context_handle_t /* Context*/, size_t Size)
       : ur_mem_handle_t_(Size, false) {}
-  _ur_buffer(_ur_buffer *b, size_t Offset, size_t Size)
+  _ur_buffer(_ur_buffer *b, size_t Offset, size_t /*Size*/)
       : ur_mem_handle_t_(b->_mem + Offset, false), SubBuffer(b) {
-    std::ignore = Size;
     SubBuffer.Origin = Offset;
   }
 

--- a/unified-runtime/source/adapters/native_cpu/platform.cpp
+++ b/unified-runtime/source/adapters/native_cpu/platform.cpp
@@ -87,13 +87,9 @@ urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
-    ur_platform_handle_t hPlatform, const char *pFrontendOption,
+    ur_platform_handle_t /*hPlatform*/, const char *pFrontendOption,
     const char **ppPlatformOption) {
-  std::ignore = hPlatform;
-  std::ignore = pFrontendOption;
-  std::ignore = ppPlatformOption;
 
-  std::ignore = hPlatform;
   using namespace std::literals;
   if (pFrontendOption == nullptr)
     return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -112,10 +108,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
   DIE_NO_IMPLEMENTATION;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform, ur_native_handle_t *phNativePlatform) {
-  std::ignore = hPlatform;
-  std::ignore = phNativePlatform;
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetNativeHandle(ur_platform_handle_t /*hPlatform*/,
+                          ur_native_handle_t * /*phNativePlatform*/) {
 
   DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/program.cpp
+++ b/unified-runtime/source/adapters/native_cpu/program.cpp
@@ -16,15 +16,10 @@
 #include <cstdint>
 #include <memory>
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramCreateWithIL(ur_context_handle_t hContext, const void *pIL,
-                      size_t length, const ur_program_properties_t *pProperties,
-                      ur_program_handle_t *phProgram) {
-  std::ignore = hContext;
-  std::ignore = pIL;
-  std::ignore = length;
-  std::ignore = pProperties;
-  std::ignore = phProgram;
+UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithIL(
+    ur_context_handle_t /*hContext*/, const void * /*pIL*/, size_t /*length*/,
+    const ur_program_properties_t * /*pProperties*/,
+    ur_program_handle_t * /*phProgram*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
@@ -55,16 +50,14 @@ deserializeWGMetadata(const ur_program_metadata_t &MetadataElement,
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
     ur_context_handle_t hContext, uint32_t numDevices,
-    ur_device_handle_t *phDevices, size_t *pLengths, const uint8_t **ppBinaries,
-    const ur_program_properties_t *pProperties,
+    ur_device_handle_t *phDevices, size_t * /*pLengths*/,
+    const uint8_t **ppBinaries, const ur_program_properties_t *pProperties,
     ur_program_handle_t *phProgram) {
   if (numDevices > 1)
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 
   auto hDevice = phDevices[0];
   auto pBinary = ppBinaries[0];
-  std::ignore = pLengths;
-  std::ignore = pProperties;
 
   UR_ASSERT(hContext, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
@@ -118,22 +111,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinaryExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramBuild(ur_context_handle_t hContext,
-                                                   ur_program_handle_t hProgram,
-                                                   const char *pOptions) {
-  std::ignore = hContext;
-  std::ignore = hProgram;
-  std::ignore = pOptions;
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramBuild(ur_context_handle_t /*hContext*/,
+               ur_program_handle_t /*hProgram*/, const char * /*pOptions*/) {
 
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urProgramCompile(ur_context_handle_t hContext, ur_program_handle_t hProgram,
-                 const char *pOptions) {
-  std::ignore = hContext;
-  std::ignore = hProgram;
-  std::ignore = pOptions;
+urProgramCompile(ur_context_handle_t /*hContext*/,
+                 ur_program_handle_t /*hProgram*/, const char * /*pOptions*/) {
 
   // Currently for Native CPU the program is offline compiled, so
   // urProgramCompile is a no-op.
@@ -141,16 +128,12 @@ urProgramCompile(ur_context_handle_t hContext, ur_program_handle_t hProgram,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urProgramLink(ur_context_handle_t hContext, uint32_t count,
-              const ur_program_handle_t *phPrograms, const char *pOptions,
-              ur_program_handle_t *phProgram) {
+urProgramLink(ur_context_handle_t /*hContext*/, uint32_t /*count*/,
+              const ur_program_handle_t * /*phPrograms*/,
+              const char * /*pOptions*/, ur_program_handle_t *phProgram) {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
   }
-  std::ignore = hContext;
-  std::ignore = count;
-  std::ignore = phPrograms;
-  std::ignore = pOptions;
 
   // Currently for Native CPU the program is already linked and all its
   // symbols are resolved, so this is a no-op.
@@ -199,24 +182,16 @@ urProgramRelease(ur_program_handle_t hProgram) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
-    ur_device_handle_t hDevice, ur_program_handle_t hProgram,
-    const char *pFunctionName, void **ppFunctionPointer) {
-  std::ignore = hDevice;
-  std::ignore = hProgram;
-  std::ignore = pFunctionName;
-  std::ignore = ppFunctionPointer;
+    ur_device_handle_t /*hDevice*/, ur_program_handle_t /*hProgram*/,
+    const char * /*pFunctionName*/, void ** /*ppFunctionPointer*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
-    ur_device_handle_t, ur_program_handle_t hProgram,
-    const char *pGlobalVariableName, size_t *pGlobalVariableSizeRet,
-    void **ppGlobalVariablePointerRet) {
-  std::ignore = hProgram;
-  std::ignore = pGlobalVariableName;
-  std::ignore = pGlobalVariableSizeRet;
-  std::ignore = ppGlobalVariablePointerRet;
+    ur_device_handle_t, ur_program_handle_t /*hProgram*/,
+    const char * /*pGlobalVariableName*/, size_t * /*pGlobalVariableSizeRet*/,
+    void ** /*ppGlobalVariablePointerRet*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
@@ -253,46 +228,32 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
   return UR_RESULT_ERROR_INVALID_ENUMERATION;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
-                      ur_program_build_info_t propName, size_t propSize,
-                      void *pPropValue, size_t *pPropSizeRet) {
-  std::ignore = hProgram;
-  std::ignore = hDevice;
-  std::ignore = propName;
-  std::ignore = propSize;
-  std::ignore = pPropValue;
-  std::ignore = pPropSizeRet;
+UR_APIEXPORT ur_result_t UR_APICALL urProgramGetBuildInfo(
+    ur_program_handle_t /*hProgram*/, ur_device_handle_t /*hDevice*/,
+    ur_program_build_info_t /*propName*/, size_t /*propSize*/,
+    void * /*pPropValue*/, size_t * /*pPropSizeRet*/) {
 
   CONTINUE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
-    ur_program_handle_t hProgram, uint32_t count,
-    const ur_specialization_constant_info_t *pSpecConstants) {
-  std::ignore = hProgram;
-  std::ignore = count;
-  std::ignore = pSpecConstants;
+    ur_program_handle_t /*hProgram*/, uint32_t /*count*/,
+    const ur_specialization_constant_info_t * /*pSpecConstants*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram, ur_native_handle_t *phNativeProgram) {
-  std::ignore = hProgram;
-  std::ignore = phNativeProgram;
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetNativeHandle(ur_program_handle_t /*hProgram*/,
+                         ur_native_handle_t * /*phNativeProgram*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
-    ur_native_handle_t hNativeProgram, ur_context_handle_t hContext,
-    const ur_program_native_properties_t *pProperties,
-    ur_program_handle_t *phProgram) {
-  std::ignore = hNativeProgram;
-  std::ignore = hContext;
-  std::ignore = pProperties;
-  std::ignore = phProgram;
+    ur_native_handle_t /*hNativeProgram*/, ur_context_handle_t /*hContext*/,
+    const ur_program_native_properties_t * /*pProperties*/,
+    ur_program_handle_t * /*phProgram*/) {
 
   DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/queue.cpp
+++ b/unified-runtime/source/adapters/native_cpu/queue.cpp
@@ -14,16 +14,11 @@
 #include "ur/ur.hpp"
 #include "ur_api.h"
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
-                                                   ur_queue_info_t propName,
-                                                   size_t propSize,
-                                                   void *pPropValue,
-                                                   size_t *pPropSizeRet) {
-  std::ignore = hQueue;
-  std::ignore = propName;
-  std::ignore = propSize;
-  std::ignore = pPropValue;
-  std::ignore = pPropSizeRet;
+UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t /*hQueue*/,
+                                                   ur_queue_info_t /*propName*/,
+                                                   size_t /*propSize*/,
+                                                   void * /*pPropValue*/,
+                                                   size_t * /*pPropSizeRet*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
@@ -40,7 +35,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
-  std::ignore = hQueue;
   hQueue->incrementReferenceCount();
 
   return UR_RESULT_SUCCESS;
@@ -52,25 +46,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urQueueGetNativeHandle(ur_queue_handle_t hQueue, ur_queue_native_desc_t *pDesc,
-                       ur_native_handle_t *phNativeQueue) {
-  std::ignore = hQueue;
-  std::ignore = pDesc;
-  std::ignore = phNativeQueue;
+UR_APIEXPORT ur_result_t UR_APICALL urQueueGetNativeHandle(
+    ur_queue_handle_t /*hQueue*/, ur_queue_native_desc_t * /*pDesc*/,
+    ur_native_handle_t * /*phNativeQueue*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
-    ur_native_handle_t hNativeQueue, ur_context_handle_t hContext,
-    ur_device_handle_t hDevice, const ur_queue_native_properties_t *pProperties,
-    ur_queue_handle_t *phQueue) {
-  std::ignore = hNativeQueue;
-  std::ignore = hContext;
-  std::ignore = hDevice;
-  std::ignore = pProperties;
-  std::ignore = phQueue;
+    ur_native_handle_t /*hNativeQueue*/, ur_context_handle_t /*hContext*/,
+    ur_device_handle_t /*hDevice*/,
+    const ur_queue_native_properties_t * /*pProperties*/,
+    ur_queue_handle_t * /*phQueue*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
@@ -80,8 +67,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(ur_queue_handle_t hQueue) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueFlush(ur_queue_handle_t hQueue) {
-  std::ignore = hQueue;
+UR_APIEXPORT ur_result_t UR_APICALL urQueueFlush(ur_queue_handle_t /*hQueue*/) {
 
   DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/sampler.cpp
+++ b/unified-runtime/source/adapters/native_cpu/sampler.cpp
@@ -12,58 +12,43 @@
 
 #include "common.hpp"
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urSamplerCreate(ur_context_handle_t hContext, const ur_sampler_desc_t *pDesc,
-                ur_sampler_handle_t *phSampler) {
-  std::ignore = hContext;
-  std::ignore = pDesc;
-  std::ignore = phSampler;
+UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreate(
+    ur_context_handle_t /*hContext*/, const ur_sampler_desc_t * /*pDesc*/,
+    ur_sampler_handle_t * /*phSampler*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urSamplerRetain(ur_sampler_handle_t hSampler) {
-  std::ignore = hSampler;
+urSamplerRetain(ur_sampler_handle_t /*hSampler*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urSamplerRelease(ur_sampler_handle_t hSampler) {
-  std::ignore = hSampler;
+urSamplerRelease(ur_sampler_handle_t /*hSampler*/) {
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetInfo(
+    ur_sampler_handle_t /*hSampler*/, ur_sampler_info_t /*propName*/,
+    size_t /*propSize*/, void * /*pPropValue*/, size_t * /*pPropSizeRet*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
-                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
-  std::ignore = hSampler;
-  std::ignore = propName;
-  std::ignore = propSize;
-  std::ignore = pPropValue;
-  std::ignore = pPropSizeRet;
-
-  DIE_NO_IMPLEMENTATION;
-}
-
-UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler, ur_native_handle_t *phNativeSampler) {
-  std::ignore = hSampler;
-  std::ignore = phNativeSampler;
+urSamplerGetNativeHandle(ur_sampler_handle_t /*hSampler*/,
+                         ur_native_handle_t * /*phNativeSampler*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
-    ur_native_handle_t hNativeSampler, ur_context_handle_t hContext,
-    const ur_sampler_native_properties_t *pProperties,
-    ur_sampler_handle_t *phSampler) {
-  std::ignore = hNativeSampler;
-  std::ignore = hContext;
-  std::ignore = pProperties;
-  std::ignore = phSampler;
+    ur_native_handle_t /*hNativeSampler*/, ur_context_handle_t /*hContext*/,
+    const ur_sampler_native_properties_t * /*pProperties*/,
+    ur_sampler_handle_t * /*phSampler*/) {
 
   DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/usm.cpp
+++ b/unified-runtime/source/adapters/native_cpu/usm.cpp
@@ -39,28 +39,23 @@ static ur_result_t alloc_helper(ur_context_handle_t hContext,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
-               ur_usm_pool_handle_t pool, size_t size, void **ppMem) {
-  std::ignore = pool;
+               ur_usm_pool_handle_t /*pool*/, size_t size, void **ppMem) {
 
   return alloc_helper(hContext, pUSMDesc, size, ppMem, UR_USM_TYPE_HOST);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
-                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t pool,
+urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t /*hDevice*/,
+                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t /*pool*/,
                  size_t size, void **ppMem) {
-  std::ignore = hDevice;
-  std::ignore = pool;
 
   return alloc_helper(hContext, pUSMDesc, size, ppMem, UR_USM_TYPE_DEVICE);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
-                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t pool,
+urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t /*hDevice*/,
+                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t /*pool*/,
                  size_t size, void **ppMem) {
-  std::ignore = hDevice;
-  std::ignore = pool;
 
   return alloc_helper(hContext, pUSMDesc, size, ppMem, UR_USM_TYPE_SHARED);
 }
@@ -105,54 +100,39 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
   return UR_RESULT_ERROR_INVALID_VALUE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMPoolCreate(ur_context_handle_t hContext, ur_usm_pool_desc_t *pPoolDesc,
-                ur_usm_pool_handle_t *ppPool) {
-  std::ignore = hContext;
-  std::ignore = pPoolDesc;
-  std::ignore = ppPool;
+UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolCreate(
+    ur_context_handle_t /*hContext*/, ur_usm_pool_desc_t * /*pPoolDesc*/,
+    ur_usm_pool_handle_t * /*ppPool*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urUSMPoolRetain(ur_usm_pool_handle_t pPool) {
-  std::ignore = pPool;
+urUSMPoolRetain(ur_usm_pool_handle_t /*pPool*/) {
 
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urUSMPoolRelease(ur_usm_pool_handle_t pPool) {
-  std::ignore = pPool;
+urUSMPoolRelease(ur_usm_pool_handle_t /*pPool*/) {
 
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolGetInfo(
+    ur_usm_pool_handle_t /*hPool*/, ur_usm_pool_info_t /*propName*/,
+    size_t /*propSize*/, void * /*pPropValue*/, size_t * /*pPropSizeRet*/) {
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urUSMImportExp(
+    ur_context_handle_t /*Context*/, void * /*HostPtr*/, size_t /*Size*/) {
   DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urUSMPoolGetInfo(ur_usm_pool_handle_t hPool, ur_usm_pool_info_t propName,
-                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
-  std::ignore = hPool;
-  std::ignore = propName;
-  std::ignore = propSize;
-  std::ignore = pPropValue;
-  std::ignore = pPropSizeRet;
-
-  DIE_NO_IMPLEMENTATION;
-}
-
-UR_APIEXPORT ur_result_t UR_APICALL urUSMImportExp(ur_context_handle_t Context,
-                                                   void *HostPtr, size_t Size) {
-  std::ignore = Context;
-  std::ignore = HostPtr;
-  std::ignore = Size;
-  DIE_NO_IMPLEMENTATION;
-}
-
-UR_APIEXPORT ur_result_t UR_APICALL urUSMReleaseExp(ur_context_handle_t Context,
-                                                    void *HostPtr) {
-  std::ignore = Context;
-  std::ignore = HostPtr;
+urUSMReleaseExp(ur_context_handle_t /*Context*/, void * /*HostPtr*/) {
   DIE_NO_IMPLEMENTATION;
 }
 

--- a/unified-runtime/source/ur/ur.hpp
+++ b/unified-runtime/source/ur/ur.hpp
@@ -408,8 +408,7 @@ template <typename T>
 ur_result_t getInfo(size_t param_value_size, void *param_value,
                     size_t *param_value_size_ret, T value) {
 
-  auto assignment = [](void *param_value, T value, size_t value_size) {
-    std::ignore = value_size;
+  auto assignment = [](void *param_value, T value, size_t /*value_size*/) {
     *static_cast<T *>(param_value) = value;
   };
 

--- a/unified-runtime/test/adapters/level_zero/enqueue_alloc.cpp
+++ b/unified-runtime/test/adapters/level_zero/enqueue_alloc.cpp
@@ -148,7 +148,6 @@ struct urL0EnqueueAllocMultiQueueMultiDeviceTest
     ASSERT_NE(hostAlloc, nullptr);
     ASSERT_SUCCESS(urEnqueueUSMMemcpy(queues[0], true, hostAlloc, ptr, size, 0,
                                       nullptr, nullptr));
-    std::ignore = pattern;
     for (size_t i = 0; i * sizeof(uint8_t) < size; i++) {
       ASSERT_EQ(*static_cast<uint8_t *>(hostAlloc), pattern);
     }


### PR DESCRIPTION
`std::ignore` seems to have been adopted as some sort of ersatz `(void)` cast or `[[maybe_unused]]` annotation on unused parameters. Since the following are true:
  1. The behavior of `std::ignore` outside of `std::tie` is not formally specified;
  2. C++ already has builtin ways to express ignorance of a value;
  3. Compiling `std::tie` is much more expensive than using the builtin alternatives [1];
  4. It's confusing to read;
  5. It requires an extra header inclusion: I decided to simply omit the argument name in all cases where this is possible.

This is a mostly completely mechanical transformation, using the following script:
```
find unified-runtime -name "*.[ch]pp" \
  | xargs sed -i '/^\s*std::ignore\s*=\s*[a-zA-Z_][a-zA-Z0-9_]*;/d' \
  &&  git ls-files -m | parallel clang-tidy \
    '--checks="-*,misc-unused-parameters"' --fix --fix-errors -p build
```
Followed by manually introducting `[[maybe_unused]]` in `NDEBUG` blocks in a few places.

[1]: Both clang and gcc with libstdc++ and libc++ show similar slowdowns compiling the std::ignore vs void.
I didn't try with MSVC but I see no reason it wouldn't be similar
```
$ ipython3
In [1]: def ignore(n):
   ...:     ignores = 'std::ignore = x;\n' * n
   ...:     return f'''#include <tuple>\nint foo(int x) {{ {ignores} \n return x;}}'''
   ...:

In [2]: def void(n):
   ...:     voids = '(void)x;\n' * n
   ...:     return f'''int foo(int x) {{ {voids} \n return x;\n}}'''
   ...:

In [3]: with open("ignore.cpp", "w") as f:
   ...:     f.write(ignore(100000))
   ...:

In [4]: with open("voids.cpp", "w") as f:
   ...:     f.write(void(100000))
   ...:
$ time c++ -S voids.cpp
c++ -S voids.cpp  0.18s user 0.03s system 99% cpu 0.211 total
$ time c++ -S ignore.cpp
c++ -S ignore.cpp  4.50s user 0.34s system 99% cpu 4.836 total
```