### PR TITLE
[SYCL] Fix for kernel as functor object in `khr_free_function_commands` extension interfaces

### DIFF
--- a/sycl/include/sycl/ext/khr/free_function_commands.hpp
+++ b/sycl/include/sycl/ext/khr/free_function_commands.hpp
@@ -76,21 +76,21 @@ void launch(handler &h, range<3> r, const kernel &k, ArgsT &&...args) {
 template <typename... ArgsT>
 void launch(queue q, range<1> r, const kernel &k, ArgsT &&...args) {
   submit(q, [&](handler &h) {
-    parallel_for(h, r, k, std::forward<ArgsT>(args)...);
+    launch<KernelType>(h, r, k, std::forward<ArgsT>(args)...);
   });
 }
 
 template <typename... ArgsT>
 void launch(queue q, range<2> r, const kernel &k, ArgsT &&...args) {
   submit(q, [&](handler &h) {
-    parallel_for(h, r, k, std::forward<ArgsT>(args)...);
+    launch<KernelType>(h, r, k, std::forward<ArgsT>(args)...);
   });
 }
 
 template <typename... ArgsT>
 void launch(queue q, range<3> r, const kernel &k, ArgsT &&...args) {
   submit(q, [&](handler &h) {
-    parallel_for(h, r, k, std::forward<ArgsT>(args)...);
+    launch<KernelType>(h, r, k, std::forward<ArgsT>(args)...);
   });
 }
 


### PR DESCRIPTION
Purpose of this PR is a fix for `template <typename... ArgsT>void launch()` interfaces.