### PR TITLE
[SYCL][CUDA] Fix adapter cupti linking

### DIFF
--- a/unified-runtime/source/adapters/cuda/CMakeLists.txt
+++ b/unified-runtime/source/adapters/cuda/CMakeLists.txt
@@ -109,8 +109,8 @@ if (UR_ENABLE_TRACING)
 endif()
 
 if (CUDA_cupti_LIBRARY)
+  # cupti is dynamically loaded so the adapter still works if it's not available
   target_compile_definitions("ur_adapter_cuda" PRIVATE CUPTI_LIB_PATH="${CUDA_cupti_LIBRARY}")
-  list(APPEND EXTRA_LIBS ${CUDA_cupti_LIBRARY})
 endif()
 
 target_link_libraries(${TARGET_NAME} PRIVATE


### PR DESCRIPTION
`cupti` shouldn't be linked against the adapter, when it is the adapter is unusable if the library is not available, instead of just the tracing being affected.

The code is already setup to dynamically load `cupti` so this can just be removed.