### PR TITLE
[SYCL][E2e] disable get_last_event.cpp on DG2/Arc

### DIFF
--- a/sycl/test-e2e/InOrderEventsExt/get_last_event.cpp
+++ b/sycl/test-e2e/InOrderEventsExt/get_last_event.cpp
@@ -1,5 +1,9 @@
-// UNSUPPORTED: windows
+// UNSUPPORTED: (windows && cuda)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14324
+
+// UNSUPPORTED: gpu-intel-dg2
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17066
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Issue reported https://github.com/intel/llvm/issues/17066  and observed in multiple PR.

Marking get_last_event.cpp unsupported on DG2/Arc  and re-enabling it (mostly) on Windows.

Note that on Windows, this test only ever failed on CUDA. ( https://github.com/intel/llvm/issues/14324 ) It should not have been disabled on ALL Windows.