### PR TITLE
[SYCL][NFCI] Optimize moving device image arguments

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -300,9 +300,9 @@ make_kernel_bundle(ur_native_handle_t NativeHandle,
   auto KernelIDs = std::make_shared<std::vector<kernel_id>>();
   auto DevImgImpl = std::make_shared<device_image_impl>(
       nullptr, TargetContext, Devices, State, KernelIDs, UrProgram);
-  device_image_plain DevImg{DevImgImpl};
 
-  return std::make_shared<kernel_bundle_impl>(TargetContext, Devices, DevImg);
+  return std::make_shared<kernel_bundle_impl>(TargetContext, Devices,
+                                              device_image_plain{DevImgImpl});
 }
 
 // TODO: Unused. Remove when allowed.

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -71,14 +71,14 @@ public:
   device_image_impl(const RTDeviceBinaryImage *BinImage, context Context,
                     std::vector<device> Devices, bundle_state State,
                     std::shared_ptr<std::vector<kernel_id>> KernelIDs,
-                    ur_program_handle_t Program,
-                    const SpecConstMapT &SpecConstMap,
-                    const std::vector<unsigned char> &SpecConstsBlob)
+                    ur_program_handle_t Program, SpecConstMapT &&SpecConstMap,
+                    std::vector<unsigned char> &&SpecConstsBlob)
       : MBinImage(BinImage), MContext(std::move(Context)),
         MDevices(std::move(Devices)), MState(State), MProgram(Program),
-        MKernelIDs(std::move(KernelIDs)), MSpecConstsBlob(SpecConstsBlob),
+        MKernelIDs(std::move(KernelIDs)),
+        MSpecConstsBlob(std::move(SpecConstsBlob)),
         MSpecConstsDefValBlob(getSpecConstsDefValBlob()),
-        MSpecConstSymMap(SpecConstMap) {}
+        MSpecConstSymMap(std::move(SpecConstMap)) {}
 
   bool has_kernel(const kernel_id &KernelIDCand) const noexcept {
     return std::binary_search(MKernelIDs->begin(), MKernelIDs->end(),

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2675,8 +2675,8 @@ ProgramManager::compile(const DevImgPlainWithDeps &ImgWithDeps,
     DeviceImageImplPtr ObjectImpl = std::make_shared<detail::device_image_impl>(
         InputImpl->get_bin_image_ref(), InputImpl->get_context(), Devs,
         bundle_state::object, InputImpl->get_kernel_ids_ptr(), Prog,
-        InputImpl->get_spec_const_data_ref(),
-        InputImpl->get_spec_const_blob_ref());
+        device_image_impl::SpecConstMapT{InputImpl->get_spec_const_data_ref()},
+        std::vector<unsigned char>{InputImpl->get_spec_const_blob_ref()});
 
     std::string CompileOptions;
     applyCompileOptionsFromEnvironment(CompileOptions);


### PR DESCRIPTION
Some device image arguments are passed as reference and copied, while in some cases they could instead be moved. This commit makes them r-value arguments, moving the choice to copy out a level.