### PR TITLE
[llvm-foreach] Avoid running llvm-foreach when waiting for child processes

### DIFF
--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -263,8 +263,7 @@ int main(int argc, char **argv) {
     // Do not start execution of a new job until previous one(s) are finished,
     // if the maximum number of parallel workers is reached.
     if (JobsSubmitted.size() == JobsInParallel)
-      if (int Result =
-              checkIfJobsAreFinished(JobsSubmitted))
+      if (int Result = checkIfJobsAreFinished(JobsSubmitted))
         Res = Result;
 
     JobsSubmitted.emplace_back(

--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -92,25 +92,14 @@ static void error(std::error_code EC, const Twine &Prefix) {
     error(Prefix + ": " + EC.message());
 }
 
-// With BlockingWait=false this function just goes through the all
-// submitted jobs to check if some of them have finished.
-int checkIfJobsAreFinished(std::list<sys::ProcessInfo> &JobsSubmitted,
-                           bool BlockingWait = true) {
+// This function returns 0 if all jobs have successfully completed..
+int checkIfJobsAreFinished(std::list<sys::ProcessInfo> &JobsSubmitted) {
   std::string ErrMsg;
   auto It = JobsSubmitted.begin();
   while (It != JobsSubmitted.end()) {
-    sys::ProcessInfo WaitResult = sys::Wait(
-        *It, /*SecondsToWait*/ BlockingWait ? std::nullopt : std::optional(0),
-        &ErrMsg);
-
-    // Check if the job has finished (PID will be 0 if it's not).
-    if (!BlockingWait && !WaitResult.Pid) {
-      It++;
-      continue;
-    }
-    assert(BlockingWait || WaitResult.Pid);
+    sys::ProcessInfo WaitResult = sys::Wait(*It, std::nullopt, &ErrMsg);
+    assert(WaitResult.Pid);
     It = JobsSubmitted.erase(It);
-
     if (WaitResult.ReturnCode != 0) {
       errs() << "llvm-foreach: " << ErrMsg << '\n';
       return WaitResult.ReturnCode;
@@ -271,13 +260,13 @@ int main(int argc, char **argv) {
         IncOutArg += ("_" + Twine(j)).str();
       Args[OutIncrementArg.ArgNum] = IncOutArg;
     }
-
     // Do not start execution of a new job until previous one(s) are finished,
     // if the maximum number of parallel workers is reached.
-    while (JobsSubmitted.size() == JobsInParallel)
+    if (JobsSubmitted.size() == JobsInParallel) {
       if (int Result =
-              checkIfJobsAreFinished(JobsSubmitted, /*BlockingWait*/ false))
+              checkIfJobsAreFinished(JobsSubmitted))
         Res = Result;
+    }
 
     JobsSubmitted.emplace_back(
         sys::ExecuteNoWait(Prog, Args, /*Env=*/std::nullopt,
@@ -285,9 +274,8 @@ int main(int argc, char **argv) {
   }
 
   // Wait for all commands to be executed.
-  while (!JobsSubmitted.empty())
-    if (int Result =
-            checkIfJobsAreFinished(JobsSubmitted, /*BlockingWait*/ true))
+  if (!JobsSubmitted.empty())
+    if (int Result = checkIfJobsAreFinished(JobsSubmitted))
       Res = Result;
 
   if (!OutputFileList.empty()) {

--- a/llvm/tools/llvm-foreach/llvm-foreach.cpp
+++ b/llvm/tools/llvm-foreach/llvm-foreach.cpp
@@ -262,11 +262,10 @@ int main(int argc, char **argv) {
     }
     // Do not start execution of a new job until previous one(s) are finished,
     // if the maximum number of parallel workers is reached.
-    if (JobsSubmitted.size() == JobsInParallel) {
+    if (JobsSubmitted.size() == JobsInParallel)
       if (int Result =
               checkIfJobsAreFinished(JobsSubmitted))
         Res = Result;
-    }
 
     JobsSubmitted.emplace_back(
         sys::ExecuteNoWait(Prog, Args, /*Env=*/std::nullopt,


### PR DESCRIPTION
This resolves https://github.com/intel/llvm/issues/15177

Currently, we have a 'while' loop that keeps checking for child processes to complete. This causes llvm-foreach to run and consume resources when its child processes are active.
Instead, we can use blocking waits to wait for child processes. During blocking waits. parent process is idle and does not consume resources.

I tested this on a fairly large program compilation (with AOT) and it seems to work as expected.

No new tests are needed.
Thanks