### PR TITLE
[SYCL] Set `__SYCL_USE_NEW_VEC_IMPL` macro only with preview breaking changes

### DIFF
--- a/sycl/include/sycl/detail/type_traits/vec_marray_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits/vec_marray_traits.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#define __SYCL_USE_NEW_VEC_IMPL 1
-
 #ifndef __SYCL_USE_NEW_VEC_IMPL
 #if defined(__INTEL_PREVIEW_BREAKING_CHANGES)
 #define __SYCL_USE_NEW_VEC_IMPL 1


### PR DESCRIPTION

This line was used for debugging and shouldn't have been committed in   https://github.com/intel/llvm/commit/47404a4a569c323077023fb91f5b7f86b61317c8