### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-7f12958

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-e651db8",
-      "version": "e651db8",
-      "updated_at": "2025-02-26T22:36:50Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2659517987/zip",
+      "github_tag": "igc-dev-7f12958",
+      "version": "7f12958",
+      "updated_at": "2025-03-01T06:03:59Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2674642385/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift