### PR TITLE
[libspirv] Disable bitwise-conditional-parentheses warning

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -554,6 +554,8 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     list( APPEND spirv_build_flags
       -I${CMAKE_CURRENT_SOURCE_DIR}/generic/include
       -I${CMAKE_CURRENT_SOURCE_DIR}/libspirv/include/
+      # FIXME: Fix libclc to not require disabling this noisy warning
+      -Wno-bitwise-conditional-parentheses
     )
 
     add_libclc_builtin_set(


### PR DESCRIPTION
Upstream, this warning was moved from being universal to applying only to the OpenCL builtins. A pulldown thus also disabled it from libspirv. Until the warnings in libspirv are fixed, we should keep disabling the warning there to avoid needlessly noisy builds.