### PR TITLE
[libspirv] Fix missing OpenCL log2 builtin

### DIFF
--- a/libclc/generic/lib/math/log2.cl
+++ b/libclc/generic/lib/math/log2.cl
@@ -2,4 +2,7 @@
 #include <clc/clcmacro.h>
 #include <clc/math/clc_log2.h>
 
+#define FUNCTION log2
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
 #include <clc/math/gentype.inc>


### PR DESCRIPTION
This was a mistaken resolution of f8948d3c4754e06cdd3e2903bfbfe74438f6b463, which removed the builtin from the OpenCL layer.