### PR TITLE
[SYCL][CUDA] Fix cupti library dynamic loading

### DIFF
--- a/unified-runtime/source/adapters/cuda/CMakeLists.txt
+++ b/unified-runtime/source/adapters/cuda/CMakeLists.txt
@@ -79,7 +79,9 @@ else()
   message(WARNING "CUDA adapter USM pools are disabled, set UMF_ENABLE_POOL_TRACKING to enable them")
 endif()
 
-if (UR_ENABLE_TRACING)
+# Only enable xpti tracing on Linux as tracing tools aren't available on
+# Windows yet.
+if (UR_ENABLE_TRACING AND UNIX)
   include(FindCUDACupti)
   # The following two ifs can be removed when FindCUDA -> FindCUDAToolkit.
   # CUDA_CUPTI_INCLUDE_DIR -> CUDAToolkit_CUPTI_INCLUDE_DIR
@@ -109,18 +111,12 @@ if (UR_ENABLE_TRACING)
   target_sources(${TARGET_NAME} PRIVATE ${XPTI_PROXY_SRC})
 endif()
 
-if (CUDA_cupti_LIBRARY)
-  # cupti is dynamically loaded so the adapter still works if it's not available
-  target_compile_definitions("ur_adapter_cuda" PRIVATE CUPTI_LIB_PATH="${CUDA_cupti_LIBRARY}")
-endif()
-
 target_link_libraries(${TARGET_NAME} PRIVATE
     ${PROJECT_NAME}::headers
     ${PROJECT_NAME}::common
     ${PROJECT_NAME}::umf
     Threads::Threads
     cudadrv
-    ${EXTRA_LIBS}
 )
 
 target_include_directories(${TARGET_NAME} PRIVATE

--- a/unified-runtime/source/adapters/cuda/tracing.cpp
+++ b/unified-runtime/source/adapters/cuda/tracing.cpp
@@ -143,12 +143,14 @@ bool cupti_table_t_::isInitialized() const {
 }
 
 bool loadCUDATracingLibrary(cuda_tracing_context_t_ *Ctx) {
-#if defined(XPTI_ENABLE_INSTRUMENTATION) && defined(CUPTI_LIB_PATH)
+#if defined(XPTI_ENABLE_INSTRUMENTATION) && !defined(_WIN32)
+  const char *CuptiLibName = "libcupti.so";
+
   if (!Ctx)
     return false;
   if (Ctx->Library)
     return true;
-  auto Lib{ur_loader::LibLoader::loadAdapterLibrary(CUPTI_LIB_PATH)};
+  auto Lib{ur_loader::LibLoader::loadAdapterLibrary(CuptiLibName)};
   if (!Lib)
     return false;
   cupti_table_t_ Table;
@@ -165,7 +167,7 @@ bool loadCUDATracingLibrary(cuda_tracing_context_t_ *Ctx) {
 #else
   (void)Ctx;
   return false;
-#endif // XPTI_ENABLE_INSTRUMENTATION && CUPTI_LIB_PATH
+#endif // defined(XPTI_ENABLE_INSTRUMENTATION) && !defined(_WIN32)
 }
 
 void unloadCUDATracingLibrary(cuda_tracing_context_t_ *Ctx) {


### PR DESCRIPTION
This patch fixes loading the cupti library on Linux to rely on the dynamic linker to figure out where the library is.

It also disable cupti tracing on Windows, as far as I know this is only used on Linux at the moment since the tracing tools don't support Windows. Additionally there are some potential security issues of loading the library just by name on Windows, so we just leave Windows support out for now.

This is following up on the discussions on https://github.com/oneapi-src/unified-runtime/pull/1070, statically linking the cupti library was also ruled out as it makes the adapter library go from around 600KiB to around 32MiB.