### PR TITLE
[UR] Add UR_EXTERNAL_DEPENDENCIES CMake option

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -33,6 +33,9 @@ set(UR_BUILD_XPTI_LIBS OFF)
 set(UR_ENABLE_SYMBOLIZER ON CACHE BOOL "Enable symbolizer for sanitizer layer.")
 set(UR_ENABLE_TRACING ON)
 
+set(UR_EXTERNAL_DEPENDENCIES "sycl-headers" CACHE LIST
+  "List of external CMake targets for executables/libraries to depend on" FORCE)
+
 if("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)
   set(UR_BUILD_ADAPTER_L0 ON)
 endif()

--- a/unified-runtime/CMakeLists.txt
+++ b/unified-runtime/CMakeLists.txt
@@ -48,6 +48,8 @@ option(UR_BUILD_XPTI_LIBS "Build the XPTI libraries when tracing is enabled" ON)
 option(UR_STATIC_LOADER "Build loader as a static library" OFF)
 option(UR_FORCE_LIBSTDCXX "Force use of libstdc++ in a build using libc++ on Linux" OFF)
 option(UR_ENABLE_LATENCY_HISTOGRAM "Enable latncy histogram" OFF)
+set(UR_EXTERNAL_DEPENDENCIES "" CACHE LIST
+    "List of external CMake targets for executables/libraries to depend on")
 set(UR_DPCXX "" CACHE FILEPATH "Path of the DPC++ compiler executable")
 set(UR_DPCXX_BUILD_FLAGS "" CACHE STRING "Build flags to pass to DPC++ when compiling device programs")
 set(UR_SYCL_LIBRARY_DIR "" CACHE PATH

--- a/unified-runtime/cmake/helpers.cmake
+++ b/unified-runtime/cmake/helpers.cmake
@@ -191,6 +191,9 @@ function(add_ur_executable name)
     add_ur_target_compile_options(${name})
     add_ur_target_exec_options(${name})
     add_ur_target_link_options(${name})
+    if(UR_EXTERNAL_DEPENDENCIES)
+        add_dependencies(${name} ${UR_EXTERNAL_DEPENDENCIES})
+    endif()
 endfunction()
 
 function(add_ur_library name)
@@ -201,6 +204,9 @@ function(add_ur_library name)
         target_link_options(${name} PRIVATE
             $<$<STREQUAL:$<TARGET_LINKER_FILE_NAME:${name}>,link.exe>:LINKER:/DEPENDENTLOADFLAG:0x2000>
         )
+    endif()
+    if(UR_EXTERNAL_DEPENDENCIES)
+        add_dependencies(${name} ${UR_EXTERNAL_DEPENDENCIES})
     endif()
 endfunction()
 


### PR DESCRIPTION
The `UR_EXTERNAL_DEPENDENCIES` option can be used to specify a list of CMake targets that all libraries and executables in the UR build should depend on, e.g. the `sycl-headers` target.

Following on from https://github.com/intel/llvm/pull/17093