### PR TITLE
[SYCL][HIP] Disable legacy images on HIP

### DIFF
--- a/sycl/test-e2e/Adapters/enqueue-arg-order-image.cpp
+++ b/sycl/test-e2e/Adapters/enqueue-arg-order-image.cpp
@@ -1,5 +1,7 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // UNSUPPORTED: target-amd
+// UNSUPPORTED-INTENDED: Legacy images aren't supported on AMD, but also fail
+// to compile, bindless images should be used instead.
 
 // spir-v gen for legacy images at O0 not working
 // UNSUPPORTED: O0

--- a/sycl/test-e2e/Adapters/enqueue-arg-order-image.cpp
+++ b/sycl/test-e2e/Adapters/enqueue-arg-order-image.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // UNSUPPORTED: target-amd
 // UNSUPPORTED-INTENDED: Legacy images aren't supported on AMD, but also fail
-// to compile, bindless images should be used instead.
+// to compile. Bindless images should be used instead.
 
 // spir-v gen for legacy images at O0 not working
 // UNSUPPORTED: O0

--- a/sycl/test-e2e/Basic/image/image.cpp
+++ b/sycl/test-e2e/Basic/image/image.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Basic/image/image_accessor_range.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_range.cpp
@@ -3,7 +3,7 @@
 // UNSUPPORTED: true
 
 // UNSUPPORTED: cuda
-// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images. Bindless
 // images should be used instead.
 //
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/Basic/image/image_accessor_range.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_range.cpp
@@ -2,8 +2,9 @@
 // FIXME: Investigate OS-agnostic failures
 // UNSUPPORTED: true
 
-// UNSUPPORTED: cuda || hip
-// CUDA does not support SYCL 1.2.1 images.
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// images should be used instead.
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/image/image_accessor_readsampler.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_readsampler.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // UNSUPPORTED: cuda
-// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images. Bindless
 // images should be used instead.
 //
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/Basic/image/image_accessor_readsampler.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_readsampler.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: cuda || target-amd
-// CUDA cannot support SYCL 1.2.1 images.
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// images should be used instead.
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/image/image_accessor_readwrite.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_readwrite.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // UNSUPPORTED: cuda
-// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images. Bindless
 // images should be used instead.
 //
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/Basic/image/image_accessor_readwrite.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_readwrite.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: cuda || target-amd
-// CUDA cannot support SYCL 1.2.1 images.
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// images should be used instead.
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/image/image_accessor_readwrite_half.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_readwrite_half.cpp
@@ -1,7 +1,8 @@
 // REQUIRES: aspect-fp16, aspect-ext_intel_legacy_image
 
-// UNSUPPORTED: cuda, target-amd
-// CUDA cannot support SYCL 1.2.1 images.
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// images should be used instead.
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/image/image_accessor_readwrite_half.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_readwrite_half.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: aspect-fp16, aspect-ext_intel_legacy_image
 
 // UNSUPPORTED: cuda
-// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images. Bindless
 // images should be used instead.
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/Basic/image/image_array.cpp
+++ b/sycl/test-e2e/Basic/image/image_array.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/image/image_max_size.cpp
+++ b/sycl/test-e2e/Basic/image/image_max_size.cpp
@@ -4,7 +4,7 @@
 
 // UNSUPPORTED: cuda
 // UNSUPPORTED-INTENDED: CUDA does not support info::device::image3d_max_width
-// query, bindless images should be used instead.
+// query. Bindless images should be used instead.
 
 // The test checks that 'image' with max allowed sizes is handled correctly.
 

--- a/sycl/test-e2e/Basic/image/image_max_size.cpp
+++ b/sycl/test-e2e/Basic/image/image_max_size.cpp
@@ -2,8 +2,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: cuda || target-amd
-// CUDA does not support info::device::image3d_max_width query.
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA does not support info::device::image3d_max_width
+// query, bindless images should be used instead.
 
 // The test checks that 'image' with max allowed sizes is handled correctly.
 

--- a/sycl/test-e2e/Basic/image/image_read.cpp
+++ b/sycl/test-e2e/Basic/image/image_read.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 // Temporarily add explicit '-O2' to avoid GPU hang issue with O0 optimization.
 // RUN: %{build} -O2 -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/image/image_read_fp16.cpp
+++ b/sycl/test-e2e/Basic/image/image_read_fp16.cpp
@@ -1,7 +1,5 @@
 // REQUIRES: aspect-fp16, aspect-ext_intel_legacy_image
 
-// UNSUPPORTED: target-amd
-
 // Temporarily add explicit '-O2' to avoid GPU hang issue with O0 optimization.
 // RUN: %{build} -O2 -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/image/image_sample.cpp
+++ b/sycl/test-e2e/Basic/image/image_sample.cpp
@@ -1,7 +1,6 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// UNSUPPORTED: target-amd
 
 #include <sycl/accessor_image.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/image/image_write.cpp
+++ b/sycl/test-e2e/Basic/image/image_write.cpp
@@ -2,11 +2,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: target-amd
-// TODO: re-enable on cuda device.
-// See https://github.com/intel/llvm/issues/1542#issuecomment-707877817 for more
-// details.
-
 #include "image_write.h"
 
 int main() {

--- a/sycl/test-e2e/Basic/image/image_write_fp16.cpp
+++ b/sycl/test-e2e/Basic/image/image_write_fp16.cpp
@@ -1,7 +1,5 @@
 // REQUIRES: aspect-fp16, aspect-ext_intel_legacy_image
 
-// UNSUPPORTED: target-amd
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Basic/image/lit.local.cfg
+++ b/sycl/test-e2e/Basic/image/lit.local.cfg
@@ -2,4 +2,7 @@
 # the OpenCL environments support of the "Unknown" image format:
 # https://github.com/KhronosGroup/SPIRV-Headers/issues/487
 # After the issue is resolved we will re-enable Image support.
-config.unsupported_features += ['spirv-backend']
+#
+# Legacy images aren't supported on AMD and also don't compile, so mark them
+# unsupported here, bindless images should be used instead.
+config.unsupported_features += ['spirv-backend', 'target-amd']

--- a/sycl/test-e2e/Basic/image/lit.local.cfg
+++ b/sycl/test-e2e/Basic/image/lit.local.cfg
@@ -4,5 +4,5 @@
 # After the issue is resolved we will re-enable Image support.
 #
 # Legacy images aren't supported on AMD and also don't compile, so mark them
-# unsupported here, bindless images should be used instead.
+# unsupported here. Bindless images should be used instead.
 config.unsupported_features += ['spirv-backend', 'target-amd']

--- a/sycl/test-e2e/Basic/image/srgba-read.cpp
+++ b/sycl/test-e2e/Basic/image/srgba-read.cpp
@@ -3,9 +3,6 @@
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/14387
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
-//
-// UNSUPPORTED: target-amd
-// UNSUPPORTED-INTENDED: legacy image not supported on AMD
 
 #include <iostream>
 #include <sycl/accessor_image.hpp>

--- a/sycl/test-e2e/Regression/image_access.cpp
+++ b/sycl/test-e2e/Regression/image_access.cpp
@@ -1,9 +1,6 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
-//
-// UNSUPPORTED: hip
-// CUDA doesn't fully support OpenCL spec conform images.
 
 //==-------------- image_access.cpp - SYCL image accessors test  -----------==//
 //

--- a/sycl/test-e2e/Sampler/basic-rw-float.cpp
+++ b/sycl/test-e2e/Sampler/basic-rw-float.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Sampler/basic-rw.cpp
+++ b/sycl/test-e2e/Sampler/basic-rw.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Sampler/lit.local.cfg
+++ b/sycl/test-e2e/Sampler/lit.local.cfg
@@ -5,4 +5,7 @@
 # merged with intel/llvm to address an issue of mapping from SPIR-V friendly builtins
 # to Image Read/Write instructions
 # After the 1 issue is resolved and 2 is merged we will re-enable Image support.
-config.unsupported_features += ['spirv-backend']
+#
+# Legacy images aren't supported on AMD and also don't compile, so mark them
+# unsupported here, bindless images should be used instead.
+config.unsupported_features += ['spirv-backend', 'target-amd']

--- a/sycl/test-e2e/Sampler/lit.local.cfg
+++ b/sycl/test-e2e/Sampler/lit.local.cfg
@@ -7,5 +7,5 @@
 # After the 1 issue is resolved and 2 is merged we will re-enable Image support.
 #
 # Legacy images aren't supported on AMD and also don't compile, so mark them
-# unsupported here, bindless images should be used instead.
+# unsupported here. Bindless images should be used instead.
 config.unsupported_features += ['spirv-backend', 'target-amd']

--- a/sycl/test-e2e/Sampler/normalized-clamp-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clamp-linear-float.cpp
@@ -1,5 +1,9 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd, cuda
+//
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// images should be used instead.
+//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Sampler/normalized-clamp-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clamp-linear-float.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 //
 // UNSUPPORTED: cuda
-// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images, bindless
+// UNSUPPORTED-INTENDED: CUDA doesn't fully support SYCL 1.2.1 images. Bindless
 // images should be used instead.
 //
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/Sampler/normalized-clamp-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clamp-nearest.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Sampler/normalized-clampedge-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clampedge-linear-float.cpp
@@ -5,7 +5,7 @@
 
 // UNSUPPORTED: cuda
 // UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
-// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// any 8-bit per channel type (such as unorm_int8). Bindless images should be
 // used instead.
 
 /*

--- a/sycl/test-e2e/Sampler/normalized-clampedge-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clampedge-linear-float.cpp
@@ -1,12 +1,12 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: cuda
+//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// XFAIL: target-amd
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14732
 
-// CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
-// type (such as unorm_int8)
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
+// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// used instead.
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/normalized-clampedge-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clampedge-nearest.cpp
@@ -1,11 +1,6 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-//
-// Missing __spirv_ImageWrite, __spirv_SampledImage,
-// __spirv_ImageSampleExplicitLod on AMD
-// XFAIL: target-amd
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14732
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/normalized-mirror-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-mirror-linear-float.cpp
@@ -1,10 +1,11 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
-// type (such as unorm_int8)
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
+// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// used instead.
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/normalized-mirror-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-mirror-linear-float.cpp
@@ -4,7 +4,7 @@
 
 // UNSUPPORTED: cuda
 // UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
-// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// any 8-bit per channel type (such as unorm_int8). Bindless images should be
 // used instead.
 
 /*

--- a/sycl/test-e2e/Sampler/normalized-mirror-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-mirror-nearest.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// CUDA is not handling repeat or mirror correctly with normalized coordinates.
-// Waiting on a fix.
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA is not handling repeat or mirror correctly with
+// normalized coordinates. Bindless images should be used instead.
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/normalized-none-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-none-linear-float.cpp
@@ -1,10 +1,11 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
-// type (such as unorm_int8)
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
+// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// used instead.
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/normalized-none-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-none-linear-float.cpp
@@ -4,7 +4,7 @@
 
 // UNSUPPORTED: cuda
 // UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
-// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// any 8-bit per channel type (such as unorm_int8). Bindless images should be
 // used instead.
 
 /*

--- a/sycl/test-e2e/Sampler/normalized-none-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-none-nearest.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Sampler/normalized-repeat-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-repeat-linear-float.cpp
@@ -1,10 +1,11 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
-// type (such as unorm_int8)
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
+// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// used instead.
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/normalized-repeat-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-repeat-linear-float.cpp
@@ -4,7 +4,7 @@
 
 // UNSUPPORTED: cuda
 // UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
-// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// any 8-bit per channel type (such as unorm_int8). Bindless images should be
 // used instead.
 
 /*

--- a/sycl/test-e2e/Sampler/normalized-repeat-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-repeat-nearest.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// CUDA is not handling repeat or mirror correctly with normalized coordinates.
-// Waiting on a fix.
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA is not handling repeat or mirror correctly with
+// normalized coordinates. Bindless images should be used instead.
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/unnormalized-clamp-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clamp-linear-float.cpp
@@ -1,10 +1,11 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
-// type (such as unorm_int8)
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
+// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// used instead.
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/unnormalized-clamp-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clamp-linear-float.cpp
@@ -4,7 +4,7 @@
 
 // UNSUPPORTED: cuda
 // UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
-// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// any 8-bit per channel type (such as unorm_int8). Bindless images should be
 // used instead.
 
 /*

--- a/sycl/test-e2e/Sampler/unnormalized-clamp-nearest.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clamp-nearest.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Sampler/unnormalized-clampedge-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clampedge-linear-float.cpp
@@ -1,10 +1,11 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
-// type (such as unorm_int8)
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
+// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// used instead.
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/unnormalized-clampedge-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clampedge-linear-float.cpp
@@ -4,7 +4,7 @@
 
 // UNSUPPORTED: cuda
 // UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
-// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// any 8-bit per channel type (such as unorm_int8). Bindless images should be
 // used instead.
 
 /*

--- a/sycl/test-e2e/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clampedge-nearest.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Sampler/unnormalized-none-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-none-linear-float.cpp
@@ -1,10 +1,11 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
-// type (such as unorm_int8)
+// UNSUPPORTED: cuda
+// UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
+// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// used instead.
 
 /*
     This file sets up an image, initializes it with data,

--- a/sycl/test-e2e/Sampler/unnormalized-none-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-none-linear-float.cpp
@@ -4,7 +4,7 @@
 
 // UNSUPPORTED: cuda
 // UNSUPPORTED-INTENDED: CUDA works with image_channel_type::fp32, but not with
-// any 8-bit per channel type (such as unorm_int8), bindless images should be
+// any 8-bit per channel type (such as unorm_int8). Bindless images should be
 // used instead.
 
 /*

--- a/sycl/test-e2e/Sampler/unnormalized-none-nearest.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-none-nearest.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: target-amd
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Tracing/image_printers.cpp
+++ b/sycl/test-e2e/Tracing/image_printers.cpp
@@ -31,14 +31,11 @@ int main() {
     sycl::image<2> Img(ImgHostData.data(), ChanOrder, ChanType, ImgSize);
     queue Q;
 
-// legacy Images uses an API that is not supported in hip 4.x
-#if HIP_VERSION_MAJOR >= 5
     Q.submit([&](sycl::handler &CGH) {
       auto ImgAcc = Img.get_access<sycl::float4, SYCLWrite>(CGH);
 
       CGH.single_task<class EmptyTask>([=]() {});
     });
-#endif
   }
   return 0;
 }

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -283,9 +283,6 @@ class SYCLEndToEndTest(lit.formats.ShTest):
             if "cuda:gpu" in sycl_devices:
                 extra_env.append("UR_CUDA_ENABLE_IMAGE_SUPPORT=1")
 
-            if "hip:gpu" in sycl_devices:
-                extra_env.append("UR_HIP_ENABLE_IMAGE_SUPPORT=1")
-
             return extra_env
 
         extra_env = get_extra_env(devices_for_test)

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -760,8 +760,6 @@ for sycl_device in config.sycl_devices:
     env["ONEAPI_DEVICE_SELECTOR"] = sycl_device
     if sycl_device.startswith("cuda:"):
         env["UR_CUDA_ENABLE_IMAGE_SUPPORT"] = "1"
-    if sycl_device.startswith("hip:"):
-        env["UR_HIP_ENABLE_IMAGE_SUPPORT"] = "1"
     # When using the ONEAPI_DEVICE_SELECTOR environment variable, sycl-ls
     # prints warnings that might derail a user thinking something is wrong
     # with their test run. It's just us filtering here, so silence them unless

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,13 +54,12 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 313
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 282
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
 //
 // CHECK: Adapters/enqueue-arg-order-image.cpp
-// CHECK-NEXT: Adapters/enqueue-arg-order-image.cpp
 // CHECK-NEXT: Adapters/interop-l0-direct.cpp
 // CHECK-NEXT: Adapters/interop-level-zero-buffer-ownership.cpp
 // CHECK-NEXT: Adapters/interop-level-zero-buffer.cpp
@@ -94,19 +93,7 @@
 // CHECK-NEXT: Basic/gpu_max_wgs_error.cpp
 // CHECK-NEXT: Basic/group_async_copy.cpp
 // CHECK-NEXT: Basic/host-task-dependency.cpp
-// CHECK-NEXT: Basic/image/image.cpp
 // CHECK-NEXT: Basic/image/image_accessor_range.cpp
-// CHECK-NEXT: Basic/image/image_accessor_range.cpp
-// CHECK-NEXT: Basic/image/image_accessor_readsampler.cpp
-// CHECK-NEXT: Basic/image/image_accessor_readwrite.cpp
-// CHECK-NEXT: Basic/image/image_accessor_readwrite_half.cpp
-// CHECK-NEXT: Basic/image/image_array.cpp
-// CHECK-NEXT: Basic/image/image_max_size.cpp
-// CHECK-NEXT: Basic/image/image_read.cpp
-// CHECK-NEXT: Basic/image/image_read_fp16.cpp
-// CHECK-NEXT: Basic/image/image_sample.cpp
-// CHECK-NEXT: Basic/image/image_write.cpp
-// CHECK-NEXT: Basic/image/image_write_fp16.cpp
 // CHECK-NEXT: Basic/kernel_info_attr.cpp
 // CHECK-NEXT: Basic/submit_time.cpp
 // CHECK-NEXT: DeviceImageDependencies/dynamic.cpp
@@ -319,7 +306,6 @@
 // CHECK-NEXT: Regression/event_destruction.cpp
 // CHECK-NEXT: Regression/get_subgroup_sizes.cpp
 // CHECK-NEXT: Regression/get_subgroup_sizes.cpp
-// CHECK-NEXT: Regression/image_access.cpp
 // CHECK-NEXT: Regression/invalid_reqd_wg_size_correct_exception.cpp
 // CHECK-NEXT: Regression/kernel_bundle_ignore_sycl_external.cpp
 // CHECK-NEXT: Regression/kernel_bundle_ignore_sycl_external.cpp
@@ -328,23 +314,6 @@
 // CHECK-NEXT: Regression/reduction_resource_leak_usm.cpp
 // CHECK-NEXT: Regression/static-buffer-dtor.cpp
 // CHECK-NEXT: Regression/static-buffer-dtor.cpp
-// CHECK-NEXT: Sampler/basic-rw-float.cpp
-// CHECK-NEXT: Sampler/basic-rw.cpp
-// CHECK-NEXT: Sampler/normalized-clamp-linear-float.cpp
-// CHECK-NEXT: Sampler/normalized-clamp-nearest.cpp
-// CHECK-NEXT: Sampler/normalized-clampedge-linear-float.cpp
-// CHECK-NEXT: Sampler/normalized-mirror-linear-float.cpp
-// CHECK-NEXT: Sampler/normalized-mirror-nearest.cpp
-// CHECK-NEXT: Sampler/normalized-none-linear-float.cpp
-// CHECK-NEXT: Sampler/normalized-none-nearest.cpp
-// CHECK-NEXT: Sampler/normalized-repeat-linear-float.cpp
-// CHECK-NEXT: Sampler/normalized-repeat-nearest.cpp
-// CHECK-NEXT: Sampler/unnormalized-clamp-linear-float.cpp
-// CHECK-NEXT: Sampler/unnormalized-clamp-nearest.cpp
-// CHECK-NEXT: Sampler/unnormalized-clampedge-linear-float.cpp
-// CHECK-NEXT: Sampler/unnormalized-clampedge-nearest.cpp
-// CHECK-NEXT: Sampler/unnormalized-none-linear-float.cpp
-// CHECK-NEXT: Sampler/unnormalized-none-nearest.cpp
 // CHECK-NEXT: Scheduler/HostAccDestruction.cpp
 // CHECK-NEXT: Scheduler/InOrderQueueDeps.cpp
 // CHECK-NEXT: SpecConstants/2020/kernel-bundle-api.cpp

--- a/unified-runtime/source/adapters/hip/device.cpp
+++ b/unified-runtime/source/adapters/hip/device.cpp
@@ -12,7 +12,6 @@
 #include "adapter.hpp"
 #include "context.hpp"
 #include "event.hpp"
-#include "logger/ur_logger.hpp"
 
 #include <hip/hip_runtime.h>
 #include <sstream>
@@ -226,18 +225,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(uint64_t{MaxAlloc});
   }
   case UR_DEVICE_INFO_IMAGE_SUPPORTED: {
-    bool Enabled = false;
-    if (std::getenv("UR_HIP_ENABLE_IMAGE_SUPPORT") != nullptr) {
-      Enabled = true;
-    } else {
-      logger::always(
-          "Images are not fully supported by the HIP BE, their support is "
-          "disabled by default. Their partial support can be activated by "
-          "setting UR_HIP_ENABLE_IMAGE_SUPPORT environment variable at "
-          "runtime.");
-    }
-
-    return ReturnValue(Enabled);
+    // Legacy images are not supported, bindless images should be used instead.
+    return ReturnValue(ur_bool_t{false});
   }
   case UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS: {
     // This call doesn't match to HIP as it doesn't have images, but instead


### PR DESCRIPTION
Legacy image support for HIP was initially hidden behind an environment variable as it's not really supported, bindless images should be used instead.

But after looking a bit closer at the existing support, it's pretty much entirely broken, almost none of our existing legacy images tests even compile for AMD.

So this patch fully disables the legacy images for HIP and cleans up all the related `UNSUPPORTED`, in a lot of cases `target-amd` had to be kept since the `build-only` mode doesn't know about the device aspects.

It also cleans up existing `UNSUPPORTED` tags for `cuda` in the same tests.