### PR TITLE
[UR] [V2] Fix synchronization between command_list_manager usages

### DIFF
--- a/unified-runtime/source/adapters/level_zero/CMakeLists.txt
+++ b/unified-runtime/source/adapters/level_zero/CMakeLists.txt
@@ -158,6 +158,7 @@ if(UR_BUILD_ADAPTER_L0_V2)
         ${CMAKE_CURRENT_SOURCE_DIR}/v2/event.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/v2/kernel.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/v2/memory.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/v2/lockable.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/v2/queue_api.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/v2/queue_immediate_in_order.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/v2/usm.hpp

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -40,7 +40,6 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
 
 ur_result_t ur_exp_command_buffer_handle_t_::finalizeCommandBuffer() {
   // It is not allowed to append to command list from multiple threads.
-  std::scoped_lock<ur_shared_mutex> guard(this->Mutex);
   auto commandListLocked = commandListManager.lock();
   UR_ASSERT(!isFinalized, UR_RESULT_ERROR_INVALID_OPERATION);
   // Close the command lists and have them ready for dispatch.

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -498,10 +498,8 @@ ur_result_t urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t CommandBuffer, ur_queue_handle_t UrQueue,
     uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
     ur_event_handle_t *Event) try {
-  auto commandListLocked = CommandBuffer->commandListManager.lock();
-  return UrQueue->get().enqueueCommandBuffer(
-      commandListLocked->getZeCommandList(), Event, NumEventsInWaitList,
-      EventWaitList);
+  return UrQueue->get().enqueueCommandBufferExp(
+      CommandBuffer, NumEventsInWaitList, EventWaitList, Event);
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -41,9 +41,10 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
 ur_result_t ur_exp_command_buffer_handle_t_::finalizeCommandBuffer() {
   // It is not allowed to append to command list from multiple threads.
   std::scoped_lock<ur_shared_mutex> guard(this->Mutex);
+  auto commandListLocked = commandListManager.lock();
   UR_ASSERT(!isFinalized, UR_RESULT_ERROR_INVALID_OPERATION);
   // Close the command lists and have them ready for dispatch.
-  ZE2UR_CALL(zeCommandListClose, (this->commandListManager.getZeCommandList()));
+  ZE2UR_CALL(zeCommandListClose, (commandListLocked->getZeCommandList()));
   isFinalized = true;
   return UR_RESULT_SUCCESS;
 }
@@ -130,7 +131,8 @@ ur_result_t urCommandBufferAppendKernelLaunchExp(
   std::ignore = numKernelAlternatives;
   std::ignore = kernelAlternatives;
   std::ignore = command;
-  UR_CALL(commandBuffer->commandListManager.appendKernelLaunch(
+  auto commandListLocked = commandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendKernelLaunch(
       hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, 0,
       nullptr, nullptr));
   return UR_RESULT_SUCCESS;
@@ -157,8 +159,9 @@ ur_result_t urCommandBufferAppendUSMMemcpyExp(
 
   std::ignore = phCommand;
   // Responsibility of UMD to offload to copy engine
-  UR_CALL(hCommandBuffer->commandListManager.appendUSMMemcpy(
-      false, pDst, pSrc, size, 0, nullptr, nullptr));
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendUSMMemcpy(false, pDst, pSrc, size, 0,
+                                             nullptr, nullptr));
 
   return UR_RESULT_SUCCESS;
 } catch (...) {
@@ -185,7 +188,8 @@ ur_result_t urCommandBufferAppendMemBufferCopyExp(
 
   std::ignore = phCommand;
   // Responsibility of UMD to offload to copy engine
-  UR_CALL(hCommandBuffer->commandListManager.appendMemBufferCopy(
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferCopy(
       hSrcMem, hDstMem, srcOffset, dstOffset, size, 0, nullptr, nullptr));
 
   return UR_RESULT_SUCCESS;
@@ -213,8 +217,9 @@ ur_result_t urCommandBufferAppendMemBufferWriteExp(
 
   std::ignore = phCommand;
   // Responsibility of UMD to offload to copy engine
-  UR_CALL(hCommandBuffer->commandListManager.appendMemBufferWrite(
-      hBuffer, false, offset, size, pSrc, 0, nullptr, nullptr));
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferWrite(hBuffer, false, offset, size,
+                                                  pSrc, 0, nullptr, nullptr));
 
   return UR_RESULT_SUCCESS;
 } catch (...) {
@@ -241,8 +246,9 @@ ur_result_t urCommandBufferAppendMemBufferReadExp(
   std::ignore = phCommand;
 
   // Responsibility of UMD to offload to copy engine
-  UR_CALL(hCommandBuffer->commandListManager.appendMemBufferRead(
-      hBuffer, false, offset, size, pDst, 0, nullptr, nullptr));
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferRead(hBuffer, false, offset, size,
+                                                 pDst, 0, nullptr, nullptr));
 
   return UR_RESULT_SUCCESS;
 } catch (...) {
@@ -271,7 +277,8 @@ ur_result_t urCommandBufferAppendMemBufferCopyRectExp(
 
   std::ignore = phCommand;
   // Responsibility of UMD to offload to copy engine
-  UR_CALL(hCommandBuffer->commandListManager.appendMemBufferCopyRect(
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferCopyRect(
       hSrcMem, hDstMem, srcOrigin, dstOrigin, region, srcRowPitch,
       srcSlicePitch, dstRowPitch, dstSlicePitch, 0, nullptr, nullptr));
 
@@ -303,7 +310,8 @@ ur_result_t urCommandBufferAppendMemBufferWriteRectExp(
   std::ignore = phCommand;
 
   // Responsibility of UMD to offload to copy engine
-  UR_CALL(hCommandBuffer->commandListManager.appendMemBufferWriteRect(
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferWriteRect(
       hBuffer, false, bufferOffset, hostOffset, region, bufferRowPitch,
       bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, 0, nullptr,
       nullptr));
@@ -336,7 +344,8 @@ ur_result_t urCommandBufferAppendMemBufferReadRectExp(
   std::ignore = phCommand;
 
   // Responsibility of UMD to offload to copy engine
-  UR_CALL(hCommandBuffer->commandListManager.appendMemBufferReadRect(
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferReadRect(
       hBuffer, false, bufferOffset, hostOffset, region, bufferRowPitch,
       bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, 0, nullptr,
       nullptr));
@@ -366,8 +375,9 @@ ur_result_t urCommandBufferAppendUSMFillExp(
 
   std::ignore = phCommand;
 
-  UR_CALL(hCommandBuffer->commandListManager.appendUSMFill(
-      pMemory, patternSize, pPattern, size, 0, nullptr, nullptr));
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendUSMFill(pMemory, patternSize, pPattern, size,
+                                           0, nullptr, nullptr));
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -393,7 +403,8 @@ ur_result_t urCommandBufferAppendMemBufferFillExp(
 
   std::ignore = phCommand;
 
-  UR_CALL(hCommandBuffer->commandListManager.appendMemBufferFill(
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferFill(
       hBuffer, pPattern, patternSize, offset, size, 0, nullptr, nullptr));
   return UR_RESULT_SUCCESS;
 } catch (...) {
@@ -420,8 +431,9 @@ ur_result_t urCommandBufferAppendUSMPrefetchExp(
 
   std::ignore = phCommand;
 
-  UR_CALL(hCommandBuffer->commandListManager.appendUSMPrefetch(
-      pMemory, size, flags, 0, nullptr, nullptr));
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendUSMPrefetch(pMemory, size, flags, 0, nullptr,
+                                               nullptr));
 
   return UR_RESULT_SUCCESS;
 } catch (...) {
@@ -447,8 +459,8 @@ ur_result_t urCommandBufferAppendUSMAdviseExp(
 
   std::ignore = phCommand;
 
-  UR_CALL(hCommandBuffer->commandListManager.appendUSMAdvise(pMemory, size,
-                                                             advice, nullptr));
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
+  UR_CALL(commandListLocked->appendUSMAdvise(pMemory, size, advice, nullptr));
 
   return UR_RESULT_SUCCESS;
 } catch (...) {
@@ -479,6 +491,18 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
     assert(false && "Command-buffer info request not implemented");
   }
   return UR_RESULT_ERROR_INVALID_ENUMERATION;
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+ur_result_t urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t CommandBuffer, ur_queue_handle_t UrQueue,
+    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
+    ur_event_handle_t *Event) try {
+  auto commandListLocked = CommandBuffer->commandListManager.lock();
+  return UrQueue->get().enqueueCommandBuffer(
+      commandListLocked->getZeCommandList(), Event, NumEventsInWaitList,
+      EventWaitList);
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -13,6 +13,7 @@
 #include "common.hpp"
 #include "context.hpp"
 #include "kernel.hpp"
+#include "lockable.hpp"
 #include "queue_api.hpp"
 #include <ze_api.h>
 
@@ -24,7 +25,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
 
   ~ur_exp_command_buffer_handle_t_() = default;
 
-  ur_command_list_manager commandListManager;
+  lockable<ur_command_list_manager> commandListManager;
 
   ur_result_t finalizeCommandBuffer();
   // Indicates if command-buffer commands can be updated after it is closed.

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -196,8 +196,7 @@ ur_result_t ur_command_list_manager::appendKernelLaunch(
 
   ze_kernel_handle_t hZeKernel = hKernel->getZeHandle(device);
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> Lock(this->Mutex,
-                                                          hKernel->Mutex);
+  std::scoped_lock<ur_shared_mutex> Lock(hKernel->Mutex);
 
   ze_group_count_t zeThreadGroupDimensions{1, 1, 1};
   uint32_t WG[3]{};
@@ -235,8 +234,6 @@ ur_result_t ur_command_list_manager::appendUSMMemcpy(
     ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_command_list_manager::appendUSMMemcpy");
 
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
-
   auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_USM_MEMCPY);
 
   auto [pWaitEvents, numWaitEvents] =
@@ -262,8 +259,7 @@ ur_result_t ur_command_list_manager::appendMemBufferFill(
   auto hBuffer = hMem->getBuffer();
   UR_ASSERT(offset + size <= hBuffer->getSize(), UR_RESULT_ERROR_INVALID_SIZE);
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(this->Mutex,
-                                                          hBuffer->getMutex());
+  std::scoped_lock<ur_shared_mutex> lock(hBuffer->getMutex());
 
   return appendGenericFillUnlocked(hBuffer, offset, patternSize, pPattern, size,
                                    numEventsInWaitList, phEventWaitList,
@@ -275,8 +271,6 @@ ur_result_t ur_command_list_manager::appendUSMFill(
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_command_list_manager::appendUSMFill");
-
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
 
   ur_usm_handle_t dstHandle(context, size, pMem);
   return appendGenericFillUnlocked(&dstHandle, 0, patternSize, pPattern, size,
@@ -291,8 +285,6 @@ ur_result_t ur_command_list_manager::appendUSMPrefetch(
   TRACK_SCOPE_LATENCY("ur_command_list_manager::appendUSMPrefetch");
 
   std::ignore = flags;
-
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
 
   auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_USM_PREFETCH);
 
@@ -319,8 +311,6 @@ ur_command_list_manager::appendUSMAdvise(const void *pMem, size_t size,
                                          ur_usm_advice_flags_t advice,
                                          ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_command_list_manager::appendUSMAdvise");
-
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
 
   auto zeAdvice = ur_cast<ze_memory_advice_t>(advice);
 
@@ -354,8 +344,7 @@ ur_result_t ur_command_list_manager::appendMemBufferRead(
 
   ur_usm_handle_t dstHandle(context, size, pDst);
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(this->Mutex,
-                                                          hBuffer->getMutex());
+  std::scoped_lock<ur_shared_mutex> lock(hBuffer->getMutex());
 
   return appendGenericCopyUnlocked(hBuffer, &dstHandle, blockingRead, offset, 0,
                                    size, numEventsInWaitList, phEventWaitList,
@@ -373,8 +362,7 @@ ur_result_t ur_command_list_manager::appendMemBufferWrite(
 
   ur_usm_handle_t srcHandle(context, size, pSrc);
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(this->Mutex,
-                                                          hBuffer->getMutex());
+  std::scoped_lock<ur_shared_mutex> lock(hBuffer->getMutex());
 
   return appendGenericCopyUnlocked(
       &srcHandle, hBuffer, blockingWrite, 0, offset, size, numEventsInWaitList,
@@ -395,8 +383,8 @@ ur_result_t ur_command_list_manager::appendMemBufferCopy(
   UR_ASSERT(dstOffset + size <= hBufferDst->getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex, ur_shared_mutex> lock(
-      this->Mutex, hBufferSrc->getMutex(), hBufferDst->getMutex());
+  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(
+      hBufferSrc->getMutex(), hBufferDst->getMutex());
 
   return appendGenericCopyUnlocked(hBufferSrc, hBufferDst, false, srcOffset,
                                    dstOffset, size, numEventsInWaitList,
@@ -415,8 +403,7 @@ ur_result_t ur_command_list_manager::appendMemBufferReadRect(
   auto hBuffer = hMem->getBuffer();
   ur_usm_handle_t dstHandle(context, 0, pDst);
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(this->Mutex,
-                                                          hBuffer->getMutex());
+  std::scoped_lock<ur_shared_mutex> lock(hBuffer->getMutex());
 
   return appendRegionCopyUnlocked(
       hBuffer, &dstHandle, blockingRead, bufferOrigin, hostOrigin, region,
@@ -436,8 +423,7 @@ ur_result_t ur_command_list_manager::appendMemBufferWriteRect(
   auto hBuffer = hMem->getBuffer();
   ur_usm_handle_t srcHandle(context, 0, pSrc);
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(this->Mutex,
-                                                          hBuffer->getMutex());
+  std::scoped_lock<ur_shared_mutex> lock(hBuffer->getMutex());
 
   return appendRegionCopyUnlocked(
       &srcHandle, hBuffer, blockingWrite, hostOrigin, bufferOrigin, region,
@@ -457,8 +443,8 @@ ur_result_t ur_command_list_manager::appendMemBufferCopyRect(
   auto hBufferSrc = hSrc->getBuffer();
   auto hBufferDst = hDst->getBuffer();
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex, ur_shared_mutex> lock(
-      this->Mutex, hBufferSrc->getMutex(), hBufferDst->getMutex());
+  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(
+      hBufferSrc->getMutex(), hBufferDst->getMutex());
 
   return appendRegionCopyUnlocked(
       hBufferSrc, hBufferDst, false, srcOrigin, dstOrigin, region, srcRowPitch,
@@ -474,8 +460,6 @@ ur_result_t ur_command_list_manager::appendUSMMemcpy2D(
 
   ur_rect_offset_t zeroOffset{0, 0, 0};
   ur_rect_region_t region{width, height, 0};
-
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
 
   ur_usm_handle_t srcHandle(context, 0, pSrc);
   ur_usm_handle_t dstHandle(context, 0, pDst);

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -31,13 +31,14 @@ struct wait_list_view {
   }
 };
 
-struct ur_command_list_manager : public _ur_object {
+struct ur_command_list_manager {
 
   ur_command_list_manager(ur_context_handle_t context,
                           ur_device_handle_t device,
                           v2::raii::command_list_unique_handle &&commandList,
                           v2::event_flags_t flags = v2::EVENT_FLAGS_COUNTER,
                           ur_queue_t_ *queue = nullptr);
+  ur_command_list_manager(ur_command_list_manager &&src) = default;
   ~ur_command_list_manager();
 
   ur_result_t appendKernelLaunch(ur_kernel_handle_t hKernel, uint32_t workDim,

--- a/unified-runtime/source/adapters/level_zero/v2/lockable.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/lockable.hpp
@@ -1,0 +1,58 @@
+//===--------- memory.hpp - Level Zero Adapter ---------------------------===//
+//
+// Copyright (C) 2024 Intel Corporation
+//
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include <mutex>
+
+template <typename T> struct locked {
+public:
+  locked(T *object, std::unique_lock<std::mutex> &&lock)
+      : lock_(std::move(lock)) {
+    object_ = object;
+  }
+  T *operator->() { return object_; }
+
+private:
+  std::unique_lock<std::mutex> lock_;
+  T *object_;
+};
+
+/*
+  lockable<T> wraps T class object in exclusive access lock, similar to one used
+  in rust
+
+  construction:
+    lockable<X> l(arguments, to, construct, X);
+
+  access without synchronization:
+    X* obj_ptr = l.get_no_lock();
+    obj_ptr->print_name();
+
+  exclusive access to object kept in l:
+    // as long as lock exists, thread has exclusive access to underlaying object
+    locked<X> lock = l.lock();
+    // that object is accessed through ->() operator on lock object
+    lock->print_name();
+*/
+
+template <typename T> struct lockable {
+public:
+  template <typename... Args>
+  lockable(Args &&...args) : object_(std::forward<Args>(args)...) {}
+  locked<T> lock() {
+    std::unique_lock lock{mut_};
+    return locked<T>(&object_, std::move(lock));
+  }
+  T *get_no_lock() { return &object_; }
+
+private:
+  T object_;
+  std::mutex mut_;
+};

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -489,7 +489,7 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferMap(
 
   auto hBuffer = hMem->getBuffer();
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(hBuffer->getMutex());
+  std::scoped_lock<ur_shared_mutex> lock(hBuffer->getMutex());
 
   auto commandListLocked = commandListManager.lock();
   auto zeSignalEvent =
@@ -821,7 +821,7 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCooperativeKernelLaunchExp(
 
   ze_kernel_handle_t hZeKernel = hKernel->getZeHandle(hDevice);
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> Lock(hKernel->Mutex);
+  std::scoped_lock<ur_shared_mutex> Lock(hKernel->Mutex);
 
   auto commandListLocked = commandListManager.lock();
   ze_group_count_t zeThreadGroupDimensions{1, 1, 1};
@@ -921,8 +921,9 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCommandBufferExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
 
+  auto commandListLocked = hCommandBuffer->commandListManager.lock();
   ze_command_list_handle_t commandBufferCommandList =
-      hCommandBuffer->commandListManager.getZeCommandList();
+      commandListLocked->getZeCommandList();
   return enqueueGenericCommandListsExp(1, &commandBufferCommandList, phEvent,
                                        numEventsInWaitList, phEventWaitList,
                                        UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP);

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -135,7 +135,7 @@ ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
 }
 
 void ur_queue_immediate_in_order_t::deferEventFree(ur_event_handle_t hEvent) {
-  std::unique_lock<ur_shared_mutex> lock(this->Mutex);
+  auto commandListLocked = commandListManager.lock();
   deferredEvents.push_back(hEvent);
 }
 
@@ -150,7 +150,6 @@ ur_result_t ur_queue_immediate_in_order_t::queueGetNativeHandle(
 ur_result_t ur_queue_immediate_in_order_t::queueFinish() {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::queueFinish");
 
-  std::unique_lock<ur_shared_mutex> lock(this->Mutex);
   auto commandListLocked = commandListManager.lock();
   // TODO: use zeEventHostSynchronize instead?
   TRACK_SCOPE_LATENCY(

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -22,8 +22,9 @@
 namespace v2 {
 
 wait_list_view ur_queue_immediate_in_order_t::getWaitListView(
+    locked<ur_command_list_manager> &commandList,
     const ur_event_handle_t *phWaitEvents, uint32_t numWaitEvents) {
-  return commandListManager.getWaitListView(phWaitEvents, numWaitEvents);
+  return commandList->getWaitListView(phWaitEvents, numWaitEvents);
 }
 
 static int32_t getZeOrdinal(ur_device_handle_t hDevice) {
@@ -87,10 +88,10 @@ ur_queue_immediate_in_order_t::ur_queue_immediate_in_order_t(
               }),
           eventFlagsFromQueueFlags(flags)) {}
 
-ze_event_handle_t
-ur_queue_immediate_in_order_t::getSignalEvent(ur_event_handle_t *hUserEvent,
-                                              ur_command_t commandType) {
-  return commandListManager.getSignalEvent(hUserEvent, commandType);
+ze_event_handle_t ur_queue_immediate_in_order_t::getSignalEvent(
+    locked<ur_command_list_manager> &commandList, ur_event_handle_t *hUserEvent,
+    ur_command_t commandType) {
+  return commandList->getSignalEvent(hUserEvent, commandType);
 }
 
 ur_result_t
@@ -112,8 +113,9 @@ ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
   case UR_QUEUE_INFO_DEVICE_DEFAULT:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   case UR_QUEUE_INFO_EMPTY: {
-    auto status = ZE_CALL_NOCHECK(zeCommandListHostSynchronize,
-                                  (commandListManager.getZeCommandList(), 0));
+    auto status = ZE_CALL_NOCHECK(
+        zeCommandListHostSynchronize,
+        (commandListManager.get_no_lock()->getZeCommandList(), 0));
     if (status == ZE_RESULT_SUCCESS) {
       return ReturnValue(true);
     } else if (status == ZE_RESULT_NOT_READY) {
@@ -141,7 +143,7 @@ ur_result_t ur_queue_immediate_in_order_t::queueGetNativeHandle(
     ur_queue_native_desc_t *pDesc, ur_native_handle_t *phNativeQueue) {
   std::ignore = pDesc;
   *phNativeQueue = reinterpret_cast<ur_native_handle_t>(
-      this->commandListManager.getZeCommandList());
+      this->commandListManager.get_no_lock()->getZeCommandList());
   return UR_RESULT_SUCCESS;
 }
 
@@ -149,12 +151,12 @@ ur_result_t ur_queue_immediate_in_order_t::queueFinish() {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::queueFinish");
 
   std::unique_lock<ur_shared_mutex> lock(this->Mutex);
-
+  auto commandListLocked = commandListManager.lock();
   // TODO: use zeEventHostSynchronize instead?
   TRACK_SCOPE_LATENCY(
       "ur_queue_immediate_in_order_t::zeCommandListHostSynchronize");
   ZE2UR_CALL(zeCommandListHostSynchronize,
-             (commandListManager.getZeCommandList(), UINT64_MAX));
+             (commandListLocked->getZeCommandList(), UINT64_MAX));
 
   // Free deferred events
   for (auto &hEvent : deferredEvents) {
@@ -196,7 +198,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueKernelLaunch(
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueKernelLaunch");
 
-  UR_CALL(commandListManager.appendKernelLaunch(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendKernelLaunch(
       hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize,
       numEventsInWaitList, phEventWaitList, phEvent));
 
@@ -210,26 +213,26 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueEventsWait(
     ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueEventsWait");
 
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
-
+  auto commandListLocked = commandListManager.lock();
   if (!numEventsInWaitList && !phEvent) {
     // nop
     return UR_RESULT_SUCCESS;
   }
 
-  auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_EVENTS_WAIT);
+  auto zeSignalEvent =
+      getSignalEvent(commandListLocked, phEvent, UR_COMMAND_EVENTS_WAIT);
   auto [pWaitEvents, numWaitEvents] =
-      getWaitListView(phEventWaitList, numEventsInWaitList);
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
   if (numWaitEvents > 0) {
     ZE2UR_CALL(
         zeCommandListAppendWaitOnEvents,
-        (commandListManager.getZeCommandList(), numWaitEvents, pWaitEvents));
+        (commandListLocked->getZeCommandList(), numWaitEvents, pWaitEvents));
   }
 
   if (zeSignalEvent) {
     ZE2UR_CALL(zeCommandListAppendSignalEvent,
-               (commandListManager.getZeCommandList(), zeSignalEvent));
+               (commandListLocked->getZeCommandList(), zeSignalEvent));
   }
   return UR_RESULT_SUCCESS;
 }
@@ -240,20 +243,19 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueEventsWaitWithBarrierImpl(
   TRACK_SCOPE_LATENCY(
       "ur_queue_immediate_in_order_t::enqueueEventsWaitWithBarrier");
 
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
-
+  auto commandListLocked = commandListManager.lock();
   if (!numEventsInWaitList && !phEvent) {
     // nop
     return UR_RESULT_SUCCESS;
   }
 
-  auto zeSignalEvent =
-      getSignalEvent(phEvent, UR_COMMAND_EVENTS_WAIT_WITH_BARRIER);
+  auto zeSignalEvent = getSignalEvent(commandListLocked, phEvent,
+                                      UR_COMMAND_EVENTS_WAIT_WITH_BARRIER);
   auto [pWaitEvents, numWaitEvents] =
-      getWaitListView(phEventWaitList, numEventsInWaitList);
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
   ZE2UR_CALL(zeCommandListAppendBarrier,
-             (commandListManager.getZeCommandList(), zeSignalEvent,
+             (commandListLocked->getZeCommandList(), zeSignalEvent,
               numWaitEvents, pWaitEvents));
 
   return UR_RESULT_SUCCESS;
@@ -288,7 +290,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferRead(
     void *pDst, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueMemBufferRead");
-  UR_CALL(commandListManager.appendMemBufferRead(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferRead(
       hMem, blockingRead, offset, size, pDst, numEventsInWaitList,
       phEventWaitList, phEvent));
   return UR_RESULT_SUCCESS;
@@ -299,7 +302,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferWrite(
     const void *pSrc, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueMemBufferWrite");
-  UR_CALL(commandListManager.appendMemBufferWrite(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferWrite(
       hMem, blockingWrite, offset, size, pSrc, numEventsInWaitList,
       phEventWaitList, phEvent));
   return UR_RESULT_SUCCESS;
@@ -314,7 +318,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferReadRect(
   TRACK_SCOPE_LATENCY(
       "ur_queue_immediate_in_order_t::enqueueMemBufferReadRect");
 
-  UR_CALL(commandListManager.appendMemBufferReadRect(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferReadRect(
       hMem, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch,
       bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList,
       phEventWaitList, phEvent));
@@ -331,7 +336,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferWriteRect(
   TRACK_SCOPE_LATENCY(
       "ur_queue_immediate_in_order_t::enqueueMemBufferWriteRect");
 
-  UR_CALL(commandListManager.appendMemBufferWriteRect(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferWriteRect(
       hMem, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch,
       bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList,
       phEventWaitList, phEvent));
@@ -345,7 +351,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferCopy(
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueMemBufferCopy");
 
-  UR_CALL(commandListManager.appendMemBufferCopy(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferCopy(
       hSrc, hDst, srcOffset, dstOffset, size, numEventsInWaitList,
       phEventWaitList, phEvent));
   return UR_RESULT_SUCCESS;
@@ -360,7 +367,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferCopyRect(
   TRACK_SCOPE_LATENCY(
       "ur_queue_immediate_in_order_t::enqueueMemBufferCopyRect");
 
-  UR_CALL(commandListManager.appendMemBufferCopyRect(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferCopyRect(
       hSrc, hDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch,
       dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList,
       phEvent));
@@ -373,7 +381,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferFill(
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueMemBufferFill");
 
-  UR_CALL(commandListManager.appendMemBufferFill(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendMemBufferFill(
       hMem, pPattern, patternSize, offset, size, numEventsInWaitList,
       phEventWaitList, phEvent));
 
@@ -389,21 +398,23 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemImageRead(
 
   auto hImage = hMem->getImage();
 
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
+  auto commandListLocked = commandListManager.lock();
 
-  auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_MEM_IMAGE_READ);
-  auto waitListView = getWaitListView(phEventWaitList, numEventsInWaitList);
+  auto zeSignalEvent =
+      getSignalEvent(commandListLocked, phEvent, UR_COMMAND_MEM_IMAGE_READ);
+  auto waitListView =
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
   auto [zeImage, zeRegion] =
       hImage->getRWRegion(origin, region, rowPitch, slicePitch);
 
   ZE2UR_CALL(zeCommandListAppendImageCopyToMemory,
-             (commandListManager.getZeCommandList(), pDst, zeImage, &zeRegion,
+             (commandListLocked->getZeCommandList(), pDst, zeImage, &zeRegion,
               zeSignalEvent, waitListView.num, waitListView.handles));
 
   if (blockingRead) {
     ZE2UR_CALL(zeCommandListHostSynchronize,
-               (commandListManager.getZeCommandList(), UINT64_MAX));
+               (commandListLocked->getZeCommandList(), UINT64_MAX));
   }
 
   return UR_RESULT_SUCCESS;
@@ -418,21 +429,23 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemImageWrite(
 
   auto hImage = hMem->getImage();
 
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
+  auto commandListLocked = commandListManager.lock();
 
-  auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_MEM_IMAGE_WRITE);
-  auto waitListView = getWaitListView(phEventWaitList, numEventsInWaitList);
+  auto zeSignalEvent =
+      getSignalEvent(commandListLocked, phEvent, UR_COMMAND_MEM_IMAGE_WRITE);
+  auto waitListView =
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
   auto [zeImage, zeRegion] =
       hImage->getRWRegion(origin, region, rowPitch, slicePitch);
 
   ZE2UR_CALL(zeCommandListAppendImageCopyFromMemory,
-             (commandListManager.getZeCommandList(), zeImage, pSrc, &zeRegion,
+             (commandListLocked->getZeCommandList(), zeImage, pSrc, &zeRegion,
               zeSignalEvent, waitListView.num, waitListView.handles));
 
   if (blockingWrite) {
     ZE2UR_CALL(zeCommandListHostSynchronize,
-               (commandListManager.getZeCommandList(), UINT64_MAX));
+               (commandListLocked->getZeCommandList(), UINT64_MAX));
   }
 
   return UR_RESULT_SUCCESS;
@@ -448,10 +461,11 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemImageCopy(
   auto hImageSrc = hSrc->getImage();
   auto hImageDst = hDst->getImage();
 
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
-
-  auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_MEM_IMAGE_COPY);
-  auto waitListView = getWaitListView(phEventWaitList, numEventsInWaitList);
+  auto commandListLocked = commandListManager.lock();
+  auto zeSignalEvent =
+      getSignalEvent(commandListLocked, phEvent, UR_COMMAND_MEM_IMAGE_COPY);
+  auto waitListView =
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
   auto desc = ur_mem_image_t::getCopyRegions(*hImageSrc, *hImageDst, srcOrigin,
                                              dstOrigin, region);
@@ -460,7 +474,7 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemImageCopy(
   auto [zeImageDst, zeRegionDst] = desc.dst;
 
   ZE2UR_CALL(zeCommandListAppendImageCopyRegion,
-             (commandListManager.getZeCommandList(), zeImageDst, zeImageSrc,
+             (commandListLocked->getZeCommandList(), zeImageDst, zeImageSrc,
               &zeRegionDst, &zeRegionSrc, zeSignalEvent, waitListView.num,
               waitListView.handles));
 
@@ -476,17 +490,19 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferMap(
 
   auto hBuffer = hMem->getBuffer();
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(this->Mutex,
-                                                          hBuffer->getMutex());
+  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> lock(hBuffer->getMutex());
 
-  auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_MEM_BUFFER_MAP);
+  auto commandListLocked = commandListManager.lock();
+  auto zeSignalEvent =
+      getSignalEvent(commandListLocked, phEvent, UR_COMMAND_MEM_BUFFER_MAP);
 
-  auto waitListView = getWaitListView(phEventWaitList, numEventsInWaitList);
+  auto waitListView =
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
   auto pDst = ur_cast<char *>(hBuffer->mapHostPtr(
       mapFlags, offset, size, [&](void *src, void *dst, size_t size) {
         ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                          (commandListManager.getZeCommandList(), dst, src,
+                          (commandListLocked->getZeCommandList(), dst, src,
                            size, nullptr, waitListView.num,
                            waitListView.handles));
         waitListView.clear();
@@ -496,18 +512,18 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferMap(
   if (waitListView) {
     // If memory was not migrated, we need to wait on the events here.
     ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
-               (commandListManager.getZeCommandList(), waitListView.num,
+               (commandListLocked->getZeCommandList(), waitListView.num,
                 waitListView.handles));
   }
 
   if (zeSignalEvent) {
     ZE2UR_CALL(zeCommandListAppendSignalEvent,
-               (commandListManager.getZeCommandList(), zeSignalEvent));
+               (commandListLocked->getZeCommandList(), zeSignalEvent));
   }
 
   if (blockingMap) {
     ZE2UR_CALL(zeCommandListHostSynchronize,
-               (commandListManager.getZeCommandList(), UINT64_MAX));
+               (commandListLocked->getZeCommandList(), UINT64_MAX));
   }
 
   return UR_RESULT_SUCCESS;
@@ -520,28 +536,30 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemUnmap(
 
   auto hBuffer = hMem->getBuffer();
 
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
+  auto commandListLocked = commandListManager.lock();
 
-  auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_MEM_UNMAP);
+  auto zeSignalEvent =
+      getSignalEvent(commandListLocked, phEvent, UR_COMMAND_MEM_UNMAP);
 
-  auto waitListView = getWaitListView(phEventWaitList, numEventsInWaitList);
+  auto waitListView =
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
   // TODO: currently unmapHostPtr deallocates memory immediately,
   // since the memory might be used by the user, we need to make sure
   // all dependencies are completed.
   ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
-             (commandListManager.getZeCommandList(), waitListView.num,
+             (commandListLocked->getZeCommandList(), waitListView.num,
               waitListView.handles));
   waitListView.clear();
 
   hBuffer->unmapHostPtr(pMappedPtr, [&](void *src, void *dst, size_t size) {
     ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                      (commandListManager.getZeCommandList(), dst, src, size,
+                      (commandListLocked->getZeCommandList(), dst, src, size,
                        nullptr, waitListView.num, waitListView.handles));
   });
   if (zeSignalEvent) {
     ZE2UR_CALL(zeCommandListAppendSignalEvent,
-               (commandListManager.getZeCommandList(), zeSignalEvent));
+               (commandListLocked->getZeCommandList(), zeSignalEvent));
   }
   return UR_RESULT_SUCCESS;
 }
@@ -552,7 +570,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueUSMFill(
     ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueUSMFill");
 
-  UR_CALL(commandListManager.appendUSMFill(pMem, patternSize, pPattern, size,
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendUSMFill(pMem, patternSize, pPattern, size,
                                            numEventsInWaitList, phEventWaitList,
                                            phEvent));
   return UR_RESULT_SUCCESS;
@@ -565,7 +584,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueUSMMemcpy(
   // TODO: parametrize latency tracking with 'blocking'
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueUSMMemcpy");
 
-  UR_CALL(commandListManager.appendUSMMemcpy(blocking, pDst, pSrc, size,
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendUSMMemcpy(blocking, pDst, pSrc, size,
                                              numEventsInWaitList,
                                              phEventWaitList, phEvent));
 
@@ -577,7 +597,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueUSMPrefetch(
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueUSMPrefetch");
-  UR_CALL(commandListManager.appendUSMPrefetch(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendUSMPrefetch(
       pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent));
   return UR_RESULT_SUCCESS;
 }
@@ -588,7 +609,8 @@ ur_queue_immediate_in_order_t::enqueueUSMAdvise(const void *pMem, size_t size,
                                                 ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueUSMAdvise");
 
-  UR_CALL(commandListManager.appendUSMAdvise(pMem, size, advice, phEvent));
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendUSMAdvise(pMem, size, advice, phEvent));
   return UR_RESULT_SUCCESS;
 }
 
@@ -613,7 +635,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueUSMMemcpy2D(
     size_t srcPitch, size_t width, size_t height, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::enqueueUSMMemcpy2D");
-  UR_CALL(commandListManager.appendUSMMemcpy2D(
+  auto commandListLocked = commandListManager.lock();
+  UR_CALL(commandListLocked->appendUSMMemcpy2D(
       blocking, pDst, dstPitch, pSrc, srcPitch, width, height,
       numEventsInWaitList, phEventWaitList, phEvent));
   return UR_RESULT_SUCCESS;
@@ -799,22 +822,24 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCooperativeKernelLaunchExp(
 
   ze_kernel_handle_t hZeKernel = hKernel->getZeHandle(hDevice);
 
-  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> Lock(this->Mutex,
-                                                          hKernel->Mutex);
+  std::scoped_lock<ur_shared_mutex, ur_shared_mutex> Lock(hKernel->Mutex);
 
+  auto commandListLocked = commandListManager.lock();
   ze_group_count_t zeThreadGroupDimensions{1, 1, 1};
   uint32_t WG[3]{};
   UR_CALL(calculateKernelWorkDimensions(hZeKernel, hDevice,
                                         zeThreadGroupDimensions, WG, workDim,
                                         pGlobalWorkSize, pLocalWorkSize));
 
-  auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_KERNEL_LAUNCH);
+  auto zeSignalEvent =
+      getSignalEvent(commandListLocked, phEvent, UR_COMMAND_KERNEL_LAUNCH);
 
-  auto waitListView = getWaitListView(phEventWaitList, numEventsInWaitList);
+  auto waitListView =
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
   auto memoryMigrate = [&](void *src, void *dst, size_t size) {
     ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                      (commandListManager.getZeCommandList(), dst, src, size,
+                      (commandListLocked->getZeCommandList(), dst, src, size,
                        nullptr, waitListView.num, waitListView.handles));
     waitListView.clear();
   };
@@ -826,7 +851,7 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCooperativeKernelLaunchExp(
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::"
                       "zeCommandListAppendLaunchCooperativeKernel");
   ZE2UR_CALL(zeCommandListAppendLaunchCooperativeKernel,
-             (commandListManager.getZeCommandList(), hZeKernel,
+             (commandListLocked->getZeCommandList(), hZeKernel,
               &zeThreadGroupDimensions, zeSignalEvent, waitListView.num,
               waitListView.handles));
 
@@ -841,14 +866,14 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueTimestampRecordingExp(
   TRACK_SCOPE_LATENCY(
       "ur_queue_immediate_in_order_t::enqueueTimestampRecordingExp");
 
-  std::scoped_lock<ur_shared_mutex> lock(this->Mutex);
-
+  auto commandListLocked = commandListManager.lock();
   if (!phEvent && !*phEvent) {
     return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
   }
-  getSignalEvent(phEvent, UR_COMMAND_TIMESTAMP_RECORDING_EXP);
+  getSignalEvent(commandListLocked, phEvent,
+                 UR_COMMAND_TIMESTAMP_RECORDING_EXP);
   auto [pWaitEvents, numWaitEvents] =
-      getWaitListView(phEventWaitList, numEventsInWaitList);
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
   (*phEvent)->recordStartTimestamp();
 
@@ -856,12 +881,12 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueTimestampRecordingExp(
       (*phEvent)->getEventEndTimestampAndHandle();
 
   ZE2UR_CALL(zeCommandListAppendWriteGlobalTimestamp,
-             (commandListManager.getZeCommandList(), timestampPtr,
+             (commandListLocked->getZeCommandList(), timestampPtr,
               zeSignalEvent, numWaitEvents, pWaitEvents));
 
   if (blocking) {
     ZE2UR_CALL(zeCommandListHostSynchronize,
-               (commandListManager.getZeCommandList(), UINT64_MAX));
+               (commandListLocked->getZeCommandList(), UINT64_MAX));
   }
 
   return UR_RESULT_SUCCESS;
@@ -874,21 +899,22 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueGenericCommandListsExp(
   TRACK_SCOPE_LATENCY(
       "ur_queue_immediate_in_order_t::enqueueGenericCommandListsExp");
 
-  std::scoped_lock<ur_shared_mutex> Lock(this->Mutex);
-  auto zeSignalEvent = getSignalEvent(phEvent, callerCommand);
+  auto commandListLocked = commandListManager.lock();
+  auto zeSignalEvent =
+      getSignalEvent(commandListLocked, phEvent, callerCommand);
 
   auto [pWaitEvents, numWaitEvents] =
-      getWaitListView(phEventWaitList, numEventsInWaitList);
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
   // zeCommandListImmediateAppendCommandListsExp is not working with in-order
   // immediate lists what causes problems with synchronization
   // TODO: remove synchronization when it is not needed
   ZE_CALL_NOCHECK(zeCommandListHostSynchronize,
-                  (commandListManager.getZeCommandList(), UINT64_MAX));
+                  (commandListLocked->getZeCommandList(), UINT64_MAX));
   ZE2UR_CALL(zeCommandListImmediateAppendCommandListsExp,
-             (commandListManager.getZeCommandList(), numCommandLists,
+             (commandListLocked->getZeCommandList(), numCommandLists,
               phCommandLists, zeSignalEvent, numWaitEvents, pWaitEvents));
   ZE_CALL_NOCHECK(zeCommandListHostSynchronize,
-                  (commandListManager.getZeCommandList(), UINT64_MAX));
+                  (commandListLocked->getZeCommandList(), UINT64_MAX));
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -21,6 +21,7 @@
 #include "ur/ur.hpp"
 
 #include "command_list_manager.hpp"
+#include "lockable.hpp"
 
 namespace v2 {
 
@@ -32,14 +33,16 @@ private:
   ur_device_handle_t hDevice;
   ur_queue_flags_t flags;
 
-  ur_command_list_manager commandListManager;
+  lockable<ur_command_list_manager> commandListManager;
   std::vector<ur_event_handle_t> deferredEvents;
   std::vector<ur_kernel_handle_t> submittedKernels;
 
-  wait_list_view getWaitListView(const ur_event_handle_t *phWaitEvents,
+  wait_list_view getWaitListView(locked<ur_command_list_manager> &commandList,
+                                 const ur_event_handle_t *phWaitEvents,
                                  uint32_t numWaitEvents);
 
-  ze_event_handle_t getSignalEvent(ur_event_handle_t *hUserEvent,
+  ze_event_handle_t getSignalEvent(locked<ur_command_list_manager> &commandList,
+                                   ur_event_handle_t *hUserEvent,
                                    ur_command_t commandType);
 
   void deferEventFree(ur_event_handle_t hEvent) override;


### PR DESCRIPTION
Changes:
Command_list_manager no longer synchronize its calls, instead the responsibility to ensure exclusivity belongs to the caller.
To add synchronization I implemented the mechanism similar to rust lock as suggested in https://github.com/intel/llvm/pull/17061#discussion_r1963023035.