### PR TITLE
[SYCL][E2E] Fix lit ROCM_PATH setup for build-only

### DIFF
--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-hip.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-hip.cpp
@@ -1,8 +1,4 @@
-// FIXME: the rocm include path and link path are highly platform dependent,
-// we should set this with some variable instead.
-// https://github.com/intel/llvm/issues/17018
-
-// RUN: %{run-aux} %{build} -Wno-error=deprecated-pragma -o %t.out -I%rocm_path/include -L%rocm_path/lib -lamdhip64
+// RUN: %{build} -Wno-error=deprecated-pragma -o %t.out -I%rocm_path/include -L%rocm_path/lib -lamdhip64
 // RUN: %{run} %t.out
 // REQUIRES: target-amd
 

--- a/sycl/test-e2e/HostInteropTask/interop-task-hip.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-hip.cpp
@@ -1,8 +1,4 @@
-// FIXME: the rocm include path and link path are highly platform dependent,
-// we should set this with some variable instead.
-// https://github.com/intel/llvm/issues/17018
-
-// RUN: %{run-aux} %{build} -Wno-error=deprecated-pragma -Wno-error=deprecated-declarations -o %t.out -I%rocm_path/include -L%rocm_path/lib -lamdhip64
+// RUN: %{build} -Wno-error=deprecated-pragma -Wno-error=deprecated-declarations -o %t.out -I%rocm_path/include -L%rocm_path/lib -lamdhip64
 // RUN: %{run} %t.out
 // REQUIRES: target-amd
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -577,6 +577,13 @@ for d in config.sycl_devices:
     if be not in available_devices or dev not in available_devices[be]:
         lit_config.error("Unsupported device {}".format(d))
 
+# Set ROCM_PATH to help clang find the HIP installation.
+if "target-amd" in config.sycl_build_targets:
+    llvm_config.with_system_environment("ROCM_PATH")
+    config.substitutions.append(
+        ("%rocm_path", os.environ.get("ROCM_PATH", "/opt/rocm"))
+    )
+
 if "cuda:gpu" in config.sycl_devices:
     if "CUDA_PATH" not in os.environ:
         if platform.system() == "Windows":
@@ -900,10 +907,6 @@ for sycl_device in config.sycl_devices:
                     "Cannot detect architecture for AMD HIP device, specify it explicitly"
                 )
             config.amd_arch = arch.replace(amd_arch_prefix, "")
-        llvm_config.with_system_environment("ROCM_PATH")
-        config.substitutions.append(
-            ("%rocm_path", os.environ.get("ROCM_PATH", "/opt/rocm"))
-        )
 
     config.sycl_dev_features[sycl_device] = features.union(config.available_features)
     if is_intel_driver:


### PR DESCRIPTION
`ROCM_PATH` and the `%rocm_path` substitutions need to be set for compilation.

The `FIXME` in these tests dates from where the ROCm path was hardcoded, it should've been removed when the substitutions were introduced, so removing it now.

Fixes: https://github.com/intel/llvm/issues/17018