### PR TITLE
[UR] Fix various defects from static analysis

### DIFF
--- a/unified-runtime/source/common/ur_singleton.hpp
+++ b/unified-runtime/source/common/ur_singleton.hpp
@@ -12,7 +12,6 @@
 #ifndef UR_SINGLETON_H
 #define UR_SINGLETON_H 1
 
-#include <cassert>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -77,8 +76,9 @@ public:
   void retain(key_tn key) {
     std::lock_guard<std::mutex> lk(mut);
     auto iter = map.find(getKey(key));
-    assert(iter != map.end());
-    iter->second.ref_count++;
+    if (iter != map.end()) {
+      iter->second.ref_count++;
+    }
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -86,11 +86,12 @@ public:
   void release(key_tn key) {
     std::lock_guard<std::mutex> lk(mut);
     auto iter = map.find(getKey(key));
-    assert(iter != map.end());
-    if (iter->second.ref_count == 0) {
-      map.erase(iter);
-    } else {
-      iter->second.ref_count--;
+    if (iter != map.end()) {
+      if (iter->second.ref_count == 0) {
+        map.erase(iter);
+      } else {
+        iter->second.ref_count--;
+      }
     }
   }
 

--- a/unified-runtime/test/conformance/device/urDevicePartition.cpp
+++ b/unified-runtime/test/conformance/device/urDevicePartition.cpp
@@ -61,6 +61,7 @@ TEST_P(urDevicePartitionTest, PartitionByCountsSuccess) {
 
   uint32_t n_cu_in_device = 0;
   ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(device, n_cu_in_device));
+  ASSERT_NE(n_cu_in_device, 0);
 
   enum class Combination { ONE, HALF, ALL_MINUS_ONE, ALL };
 

--- a/unified-runtime/test/conformance/testing/source/fixtures.cpp
+++ b/unified-runtime/test/conformance/testing/source/fixtures.cpp
@@ -12,7 +12,7 @@ std::string deviceTestWithParamPrinter<BoolTestParam>(
     const ::testing::TestParamInfo<std::tuple<DeviceTuple, BoolTestParam>>
         &info) {
   auto device = std::get<0>(info.param).device;
-  auto param = std::get<1>(info.param);
+  auto &param = std::get<1>(info.param);
 
   std::stringstream ss;
   ss << param.name << (param.value ? "Enabled" : "Disabled");
@@ -24,7 +24,7 @@ std::string platformTestWithParamPrinter<BoolTestParam>(
     const ::testing::TestParamInfo<
         std::tuple<ur_platform_handle_t, BoolTestParam>> &info) {
   auto platform = std::get<0>(info.param);
-  auto param = std::get<1>(info.param);
+  auto &param = std::get<1>(info.param);
 
   std::stringstream ss;
   ss << param.name << (param.value ? "Enabled" : "Disabled");
@@ -36,7 +36,7 @@ std::string deviceTestWithParamPrinter<SamplerCreateParamT>(
     const ::testing::TestParamInfo<
         std::tuple<DeviceTuple, uur::SamplerCreateParamT>> &info) {
   auto device = std::get<0>(info.param).device;
-  auto param = std::get<1>(info.param);
+  auto &param = std::get<1>(info.param);
 
   const auto normalized = std::get<0>(param);
   const auto addr_mode = std::get<1>(param);
@@ -58,7 +58,7 @@ std::string deviceTestWithParamPrinter<ur_image_format_t>(
     const ::testing::TestParamInfo<std::tuple<DeviceTuple, ur_image_format_t>>
         &info) {
   auto device = std::get<0>(info.param).device;
-  auto param = std::get<1>(info.param);
+  auto &param = std::get<1>(info.param);
   auto ChannelOrder = param.channelOrder;
   auto ChannelType = param.channelType;
 


### PR DESCRIPTION
- Don't use iterators that may be at the end
- Use references for param tuples
- Avoid integer overflow
