### PR TITLE
[SYCL][ESIMD] Revert some SPIR-V intrinsic changes

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1245,6 +1245,21 @@ static Instruction *addCastInstIfNeeded(Instruction *OldI, Instruction *NewI,
   return NewI;
 }
 
+// Translates the following intrinsics:
+//   %res = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+//   %res = call double @llvm.fmuladd.f64(double %a, double %b, double %c)
+// To
+//   %mul = fmul <type> %a, <type> %b
+//   %res = fadd <type> %mul, <type> %c
+// TODO: Remove when newer GPU driver is used in CI.
+void translateFmuladd(CallInst *CI) {
+  assert(CI->getIntrinsicID() == Intrinsic::fmuladd);
+  IRBuilder<> Bld(CI);
+  auto *Mul = Bld.CreateFMul(CI->getOperand(0), CI->getOperand(1));
+  auto *Res = Bld.CreateFAdd(Mul, CI->getOperand(2));
+  CI->replaceAllUsesWith(Res);
+}
+
 // Translates an LLVM intrinsic to a form, digestable by the BE.
 bool translateLLVMIntrinsic(CallInst *CI) {
   Function *F = CI->getCalledFunction();
@@ -1255,6 +1270,9 @@ bool translateLLVMIntrinsic(CallInst *CI) {
   case Intrinsic::assume:
     // no translation - it will be simply removed.
     // TODO: make use of 'assume' info in the BE
+    break;
+  case Intrinsic::fmuladd:
+    translateFmuladd(CI);
     break;
   default:
     return false; // "intrinsic wasn't translated, keep the original call"

--- a/llvm/test/SYCLLowerIR/ESIMD/lower_llvm_intrin.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/lower_llvm_intrin.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -passes=LowerESIMD -S < %s | FileCheck %s
 
-; This test checks that LowerESIMD pass does not lower some llvm intrinsics
-; which can now be handled by the VC BE.
+; This test checks that LowerESIMD pass correctly lowers some llvm intrinsics
+; which can't be handled by the VC BE.
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
@@ -10,15 +10,17 @@ declare double @llvm.fmuladd.f64(double %x, double %y, double %z)
 
 define spir_func float @test_fmuladd_f32(float %x, float %y, float %z) {
   %1 = call float @llvm.fmuladd.f32(float %x, float %y, float %z)
-; CHECK: %[[A:[0-9a-zA-Z\._]+]] = call float @llvm.fmuladd.f32(float %x, float %y, float %z)
+; CHECK: %[[A:[0-9a-zA-Z\._]+]] = fmul float %x, %y
+; CHECK: %[[B:[0-9a-zA-Z\._]+]] = fadd float %[[A]], %z  
   ret float %1
-; CHECK: ret float %[[A]]
+; CHECK: ret float %[[B]]
 }
 
 define spir_func double @test_fmuladd_f64(double %x, double %y, double %z) {
   %1 = call double @llvm.fmuladd.f64(double %x, double %y, double %z)
-; CHECK: %[[A:[0-9a-zA-Z\._]+]] = call double @llvm.fmuladd.f64(double %x, double %y, double %z)
+; CHECK: %[[A:[0-9a-zA-Z\._]+]] = fmul double %x, %y
+; CHECK: %[[B:[0-9a-zA-Z\._]+]] = fadd double %[[A]], %z
   ret double %1
-; CHECK: ret double %[[A]]
+; CHECK: ret double %[[B]]
 }
 

--- a/sycl/include/sycl/ext/intel/esimd/detail/intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/intrin.hpp
@@ -13,13 +13,6 @@
 
 /// @cond ESIMD_DETAIL
 
-/// **************************** WARNING ************************************
-/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
-/// it is imperitive to exactly follow the pattern of the existing SPIR-V
-/// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated functions and cause compilation errors.
-/// **************************** WARNING ************************************
-
 #include <sycl/ext/intel/esimd/common.hpp>
 #include <sycl/ext/intel/esimd/detail/types.hpp>
 #include <sycl/ext/intel/esimd/detail/util.hpp>

--- a/sycl/include/sycl/ext/intel/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/math_intrin.hpp
@@ -13,13 +13,6 @@
 
 /// @cond ESIMD_DETAIL
 
-/// **************************** WARNING ************************************
-/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
-/// it is imperitive to exactly follow the pattern of the existing SPIR-V
-/// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated functions and cause compilation errors.
-/// **************************** WARNING ************************************
-
 #include <sycl/builtins.hpp>
 #include <sycl/ext/intel/esimd/common.hpp>
 #include <sycl/ext/intel/esimd/detail/elem_type_traits.hpp>
@@ -39,73 +32,45 @@
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_exp2(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_exp2(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+    __spirv_ocl_native_exp2(__ESIMD_raw_vec_t(T, N));
 
 template <typename T>
 extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_recip(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_recip(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+    __spirv_ocl_native_recip(__ESIMD_raw_vec_t(T, N));
 
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_cos(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_cos(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+    __spirv_ocl_native_cos(__ESIMD_raw_vec_t(T, N));
 
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_log2(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_log2(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+    __spirv_ocl_native_log2(__ESIMD_raw_vec_t(T, N));
 
 template <typename T>
 extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_rsqrt(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_rsqrt(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+    __spirv_ocl_native_rsqrt(__ESIMD_raw_vec_t(T, N));
 
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_sin(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_sin(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+    __spirv_ocl_native_sin(__ESIMD_raw_vec_t(T, N));
 
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_sqrt(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_sqrt(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+    __spirv_ocl_native_sqrt(__ESIMD_raw_vec_t(T, N));
 
 template <typename T>
 extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_powr(T, T);
 template <typename T, int N>
 __ESIMD_INTRIN __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_powr(__ESIMD_raw_vec_t(T, N),
-                            __ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
-
-template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_fabs(T);
-template <typename T, int N>
-extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_fabs(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
-
-template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_s_abs(T);
-template <typename T, int N>
-extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_s_abs(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
-
-template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_fmin(T, T);
-template <typename T, int N>
-extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_fmin(__ESIMD_raw_vec_t(T, N),
-                     __ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
-
-template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_fmax(T, T);
-template <typename T, int N>
-extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_fmax(__ESIMD_raw_vec_t(T, N),
-                     __ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
-
-template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_rsqrt(T);
-template <typename T, int N>
-extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_rsqrt(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+    __spirv_ocl_native_powr(__ESIMD_raw_vec_t(T, N), __ESIMD_raw_vec_t(T, N));
 
 // saturation intrinsics
 template <typename T0, typename T1, int SZ>
@@ -136,7 +101,15 @@ template <typename T0, typename T1, int SZ>
 __ESIMD_INTRIN __ESIMD_raw_vec_t(T0, SZ)
     __esimd_sstrunc_sat(__ESIMD_raw_vec_t(T1, SZ) src) __ESIMD_INTRIN_END;
 
-/// 3 kinds of max, the missing fmax uses spir-v intrinsics above
+template <typename T, int SZ>
+__ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
+    __esimd_abs(__ESIMD_raw_vec_t(T, SZ) src0) __ESIMD_INTRIN_END;
+
+/// 3 kinds of max
+template <typename T, int SZ>
+__ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
+    __esimd_fmax(__ESIMD_raw_vec_t(T, SZ) src0,
+                 __ESIMD_raw_vec_t(T, SZ) src1) __ESIMD_INTRIN_END;
 template <typename T, int SZ>
 __ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
     __esimd_umax(__ESIMD_raw_vec_t(T, SZ) src0,
@@ -146,7 +119,12 @@ __ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
     __esimd_smax(__ESIMD_raw_vec_t(T, SZ) src0,
                  __ESIMD_raw_vec_t(T, SZ) src1) __ESIMD_INTRIN_END;
 
-/// 3 kinds of min, the missing fmin uses spir-v instrinsics above
+/// 3 kinds of min
+template <typename T, int SZ>
+__ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
+    __esimd_fmin(__ESIMD_raw_vec_t(T, SZ) src0,
+                 __ESIMD_raw_vec_t(T, SZ) src1) __ESIMD_INTRIN_END;
+
 template <typename T, int SZ>
 __ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
     __esimd_umin(__ESIMD_raw_vec_t(T, SZ) src0,

--- a/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
@@ -11,13 +11,6 @@
 
 /// @cond ESIMD_DETAIL
 
-/// **************************** WARNING ************************************
-/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
-/// it is imperitive to exactly follow the pattern of the existing SPIR-V
-/// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated functions and cause compilation errors.
-/// **************************** WARNING ************************************
-
 #pragma once
 
 #include <sycl/accessor.hpp>

--- a/sycl/include/sycl/ext/intel/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/math.hpp
@@ -100,11 +100,10 @@ __esimd_abs_common_internal(simd<TArg, SZ> src0) {
   simd<TArg, SZ> Result;
   if constexpr (detail::is_generic_floating_point_v<TArg>) {
     using CppT = __ESIMD_DNS::element_type_traits<TArg>::EnclosingCppT;
-    Result =
-        __ESIMD_DNS::convert_vector<TArg, CppT, SZ>(__spirv_ocl_fabs<CppT, SZ>(
-            __ESIMD_DNS::convert_vector<CppT, TArg, SZ>(src0.data())));
+    Result = __ESIMD_DNS::convert_vector<TArg, CppT, SZ>(__esimd_abs<CppT, SZ>(
+        __ESIMD_DNS::convert_vector<CppT, TArg, SZ>(src0.data())));
   } else
-    Result = simd<TArg, SZ>(__spirv_ocl_s_abs<TArg, SZ>(src0.data()));
+    Result = simd<TArg, SZ>(__esimd_abs<TArg, SZ>(src0.data()));
   return convert<TRes>(Result);
 }
 
@@ -190,7 +189,7 @@ __ESIMD_API simd<T, SZ>(max)(simd<T, SZ> src0, simd<T, SZ> src1, Sat sat = {}) {
   if constexpr (detail::is_generic_floating_point_v<T>) {
     using CppT = __ESIMD_DNS::element_type_traits<T>::EnclosingCppT;
     auto Result =
-        __ESIMD_DNS::convert_vector<T, CppT, SZ>(__spirv_ocl_fmax<CppT, SZ>(
+        __ESIMD_DNS::convert_vector<T, CppT, SZ>(__esimd_fmax<CppT, SZ>(
             __ESIMD_DNS::convert_vector<CppT, T, SZ>(src0.data()),
             __ESIMD_DNS::convert_vector<CppT, T, SZ>(src1.data())));
     if constexpr (is_sat)
@@ -279,7 +278,7 @@ __ESIMD_API simd<T, SZ>(min)(simd<T, SZ> src0, simd<T, SZ> src1, Sat sat = {}) {
   if constexpr (detail::is_generic_floating_point_v<T>) {
     using CppT = __ESIMD_DNS::element_type_traits<T>::EnclosingCppT;
     auto Result =
-        __ESIMD_DNS::convert_vector<T, CppT, SZ>(__spirv_ocl_fmin<CppT, SZ>(
+        __ESIMD_DNS::convert_vector<T, CppT, SZ>(__esimd_fmin<CppT, SZ>(
             __ESIMD_DNS::convert_vector<CppT, T, SZ>(src0.data()),
             __ESIMD_DNS::convert_vector<CppT, T, SZ>(src1.data())));
     if constexpr (is_sat)
@@ -456,24 +455,20 @@ __ESIMD_UNARY_INTRINSIC_DEF(__ESIMD_EMATH_SPIRV_COND, cos, cos)
 template <class T, int N, class Sat = saturation_off_tag>
 __ESIMD_API std::enable_if_t<std::is_same_v<T, double>, simd<double, N>>
 rsqrt(simd<T, N> src, Sat sat = {}) {
-  __ESIMD_DNS::vector_type_t<__ESIMD_DNS::__raw_t<double>, N> res =
-      __spirv_ocl_rsqrt<__ESIMD_DNS::__raw_t<double>, N>(src.data());
   if constexpr (std::is_same_v<Sat, saturation_off_tag>)
-    return res;
+    return inv(sqrt(src));
   else
-    return esimd::saturate<double>(simd<double, N>(res));
+    return esimd::saturate<double>(inv(sqrt(src)));
 }
 
 /** Scalar version.                                                       */
 template <class T, class Sat = saturation_off_tag>
 __ESIMD_API std::enable_if_t<std::is_same_v<T, double>, double>
 rsqrt(T src, Sat sat = {}) {
-  __ESIMD_DNS::__raw_t<double> res =
-      __spirv_ocl_rsqrt<__ESIMD_DNS::__raw_t<double>>(src);
   if constexpr (std::is_same_v<Sat, saturation_off_tag>)
-    return res;
+    return inv(sqrt(src));
   else
-    return esimd::saturate<double>(simd<double, 1>(res))[0];
+    return esimd::saturate<double>(inv(sqrt(src)));
 }
 
 #undef __ESIMD_UNARY_INTRINSIC_DEF

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
@@ -12,13 +12,6 @@
 
 /// @cond ESIMD_DETAIL
 
-/// **************************** WARNING ************************************
-/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
-/// it is imperitive to exactly follow the pattern of the existing SPIR-V
-/// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated functions and cause compilation errors.
-/// **************************** WARNING ************************************
-
 #include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
 #include <sycl/ext/intel/esimd/detail/math_intrin.hpp>
 #include <sycl/ext/intel/esimd/detail/types.hpp>
@@ -105,26 +98,10 @@ __ESIMD_INTRIN __ESIMD_raw_vec_t(sycl::half, N)
                  __ESIMD_DNS::vector_type_t<uint16_t, N> src2)
         __ESIMD_INTRIN_END;
 
-template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_fma(T, T, T);
 template <typename T, int N>
-extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_fma(__ESIMD_raw_vec_t(T, N) a, __ESIMD_raw_vec_t(T, N) b,
-                    __ESIMD_raw_vec_t(T, N) c) __ESIMD_INTRIN_END;
-
-template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_popcount(T);
-template <typename T, int N>
-extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_popcount(__ESIMD_raw_vec_t(T, N) src0) __ESIMD_INTRIN_END;
-
-template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_ctz(T);
-template <typename T, int N>
-extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_ctz(__ESIMD_raw_vec_t(T, N) src0) __ESIMD_INTRIN_END;
-
-template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_clz(T);
-template <typename T, int N>
-extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_clz(__ESIMD_raw_vec_t(T, N) src0) __ESIMD_INTRIN_END;
+__ESIMD_INTRIN __ESIMD_raw_vec_t(T, N)
+    __esimd_fmadd(__ESIMD_raw_vec_t(T, N) a, __ESIMD_raw_vec_t(T, N) b,
+                  __ESIMD_raw_vec_t(T, N) c) __ESIMD_INTRIN_END;
 
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_FRem(T);
 template <typename T, int N>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -10,13 +10,6 @@
 
 /// @cond ESIMD_DETAIL
 
-/// **************************** WARNING ************************************
-/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
-/// it is imperitive to exactly follow the pattern of the existing SPIR-V
-/// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated functions and cause compilation errors.
-/// **************************** WARNING ************************************
-
 #pragma once
 
 #include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -32,7 +32,11 @@ template <typename T, int N>
 __ESIMD_API std::enable_if_t<std::is_integral_v<T> && sizeof(T) < 8,
                              __ESIMD_NS::simd<T, N>>
 popcount(__ESIMD_NS::simd<T, N> vec) {
-  return __spirv_ocl_popcount<T, N>(vec.data());
+#ifdef __SYCL_DEVICE_ONLY__
+  return __spirv_ocl_popcount(vec.data());
+#else
+  return vec;
+#endif
 }
 
 /// Count the number of leading zeros.
@@ -44,7 +48,11 @@ template <typename T, int N>
 __ESIMD_API std::enable_if_t<std::is_integral_v<T> && sizeof(T) < 8,
                              __ESIMD_NS::simd<T, N>>
 clz(__ESIMD_NS::simd<T, N> vec) {
-  return __spirv_ocl_clz<T, N>(vec.data());
+#ifdef __SYCL_DEVICE_ONLY__
+  return __spirv_ocl_clz(vec.data());
+#else
+  return vec;
+#endif
 }
 
 /// Count the number of trailing zeros.
@@ -55,7 +63,11 @@ template <typename T, int N>
 __ESIMD_API std::enable_if_t<std::is_integral_v<T> && sizeof(T) < 8,
                              __ESIMD_NS::simd<T, N>>
 ctz(__ESIMD_NS::simd<T, N> vec) {
-  return __spirv_ocl_ctz<T, N>(vec.data());
+#ifdef __SYCL_DEVICE_ONLY__
+  return __spirv_ocl_ctz(vec.data());
+#else
+  return vec;
+#endif
 }
 
 /// @} sycl_esimd_bitmanip
@@ -752,7 +764,7 @@ ESIMD_INLINE __ESIMD_NS::simd<T, N> fma(__ESIMD_NS::simd<T, N> a,
   static_assert(__ESIMD_DNS::is_generic_floating_point_v<T>,
                 "fma only supports floating point types");
   using CppT = __ESIMD_DNS::element_type_traits<T>::EnclosingCppT;
-  auto Ret = __spirv_ocl_fma<__ESIMD_DNS::__raw_t<CppT>, N>(
+  auto Ret = __esimd_fmadd<__ESIMD_DNS::__raw_t<CppT>, N>(
       __ESIMD_DNS::convert_vector<CppT, T, N>(a.data()),
       __ESIMD_DNS::convert_vector<CppT, T, N>(b.data()),
       __ESIMD_DNS::convert_vector<CppT, T, N>(c.data()));

--- a/sycl/test/check_device_code/esimd/rsqrt_double.cpp
+++ b/sycl/test/check_device_code/esimd/rsqrt_double.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -S -emit-llvm %s -o - | \
-// RUN: FileCheck %s --implicit-check-not=recip
+// RUN: FileCheck %s --implicit-check-not=__spirv_ocl_rsqrt
 
 // This test checks that all we use SPIR-V rsqrt for doubles.
 
@@ -9,5 +9,5 @@
 SYCL_ESIMD_KERNEL SYCL_EXTERNAL void kernel() {
   __ESIMD_NS::simd<double, 16> v(0, 1);
   v = __ESIMD_NS::rsqrt(v);
-  // CHECK: __spirv_ocl_rsqrt
+  // CHECK: recip
 }


### PR DESCRIPTION
These require a new driver driver than the minimum supported version by customers, so we need to revert.