### PR TITLE
[CI] Fix lit warning from L0 SDK path

### DIFF
--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -111,7 +111,7 @@ jobs:
       shell: cmd
       run: |
         mkdir build-e2e
-        cmake -GNinja -B build-e2e -S.\llvm\sycl\test-e2e -DSYCL_TEST_E2E_TARGETS="level_zero:gpu" -DCMAKE_CXX_COMPILER="clang++" -DLEVEL_ZERO_LIBS_DIR="D:\github\level-zero_win-sdk\lib" -DLEVEL_ZERO_INCLUDE="D:\github\level-zero_win-sdk\include" -DLLVM_LIT="..\llvm\llvm\utils\lit\lit.py"
+        cmake -GNinja -B build-e2e -S.\llvm\sycl\test-e2e -DSYCL_TEST_E2E_TARGETS="level_zero:gpu" -DCMAKE_CXX_COMPILER="clang++" -DLEVEL_ZERO_LIBS_DIR="D:\\github\\level-zero_win-sdk\\lib" -DLEVEL_ZERO_INCLUDE="D:\\github\\level-zero_win-sdk\\include" -DLLVM_LIT="..\\llvm\\llvm\\utils\\lit\\lit.py"
     - name: Run End-to-End tests
       shell: bash
       run: |


### PR DESCRIPTION
Fixes this warning

```
D:\github\_work\llvm\llvm\build-e2e\lit.site.cfg.py:22: SyntaxWarning: invalid escape sequence '\g'
  config.level_zero_libs_dir = "D:\github\level-zero_win-sdk\lib"
D:\github\_work\llvm\llvm\build-e2e\lit.site.cfg.py:23: SyntaxWarning: invalid escape sequence '\g'
  config.level_zero_include = "D:\github\level-zero_win-sdk\include"
```

Tests using the L0 SDK such as `SYCL :: Adapters/interop-level-zero.cpp` passed, so it seems this didn't break anything.