### PR TITLE
[SYCL] Fix FP accuracy regressions

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -714,12 +714,10 @@ static Value *emitUnaryMaybeConstrainedFPBuiltin(
     unsigned ConstrainedIntrinsicID,
     unsigned FPAccuracyIntrinsicID = Intrinsic::not_intrinsic) {
   llvm::Value *Src0 = CGF.EmitScalarExpr(E->getArg(0));
-  std::string Name;
-  Function *Func;
   FuncNamePair Res =
     EmitMaybeIntrinsic(CGF, E, FPAccuracyIntrinsicID, IntrinsicID, Src0);
-  Func = Res.first;
-  Name = Res.second;
+  Function *Func = Res.first;
+  StringRef Name = Res.second;
   if (Func)
     return CGF.CreateBuiltinCallWithAttr(Name, Func, {Src0},
                                          FPAccuracyIntrinsicID);
@@ -742,12 +740,10 @@ static Value *emitBinaryMaybeConstrainedFPBuiltin(
     unsigned FPAccuracyIntrinsicID = Intrinsic::not_intrinsic) {
   llvm::Value *Src0 = CGF.EmitScalarExpr(E->getArg(0));
   llvm::Value *Src1 = CGF.EmitScalarExpr(E->getArg(1));
-  std::string Name;
-  Function *Func;
   FuncNamePair Res =
       EmitMaybeIntrinsic(CGF, E, FPAccuracyIntrinsicID, IntrinsicID, Src0);
-  Func = Res.first;
-  Name = Res.second;
+  Function *Func = Res.first;
+  StringRef Name = Res.second;
   if (Func)
     return CGF.CreateBuiltinCallWithAttr(Name, Func, {Src0, Src1},
                                          FPAccuracyIntrinsicID);

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -678,11 +678,13 @@ static Function *getIntrinsic(CodeGenFunction &CGF, llvm::Value *Src0,
              : CGF.CGM.getIntrinsic(IntrinsicID, Src0->getType());
 }
 
-static Function *emitMaybeIntrinsic(CodeGenFunction &CGF, const CallExpr *E,
-                                    unsigned FPAccuracyIntrinsicID,
-                                    unsigned IntrinsicID, llvm::Value *Src0,
-                                    StringRef &Name) {
+using FuncNamePair = std::pair<Function *, std::string>;
+static FuncNamePair EmitMaybeIntrinsic(CodeGenFunction &CGF, const CallExpr *E,
+                                       unsigned FPAccuracyIntrinsicID,
+                                       unsigned IntrinsicID,
+                                       llvm::Value *Src0) {
   Function *Func = nullptr;
+  std::string Name;
   if (FPAccuracyIntrinsicID != Intrinsic::not_intrinsic) {
     if (!CGF.getLangOpts().FPAccuracyVal.empty() ||
         !CGF.getLangOpts().FPAccuracyFuncMap.empty()) {
@@ -692,16 +694,16 @@ static Function *emitMaybeIntrinsic(CodeGenFunction &CGF, const CallExpr *E,
             << "-ffp-accuracy"
             << "-fmath-errno";
       } else {
-        std::string Name =
+        Name =
             CGF.CGM.getContext().BuiltinInfo.getName(CGF.getCurrentBuiltinID());
         // Use fpbuiltin intrinsic only when needed.
-        StringRef BuiltinName = Name;
         Func = getIntrinsic(CGF, Src0, FPAccuracyIntrinsicID, IntrinsicID,
-                            CGF.hasAccuracyRequirement(BuiltinName));
+                            CGF.hasAccuracyRequirement(Name));
       }
     }
   }
-  return Func;
+  FuncNamePair Res = std::pair<Function *, std::string>(Func, Name);
+  return Res;
 }
 
 // Emit a simple mangled intrinsic that has 1 argument and a return type
@@ -712,9 +714,12 @@ static Value *emitUnaryMaybeConstrainedFPBuiltin(
     unsigned ConstrainedIntrinsicID,
     unsigned FPAccuracyIntrinsicID = Intrinsic::not_intrinsic) {
   llvm::Value *Src0 = CGF.EmitScalarExpr(E->getArg(0));
-  StringRef Name;
-  Function *Func = emitMaybeIntrinsic(CGF, E, FPAccuracyIntrinsicID,
-                                      IntrinsicID, Src0, Name);
+  std::string Name;
+  Function *Func;
+  FuncNamePair Res =
+    EmitMaybeIntrinsic(CGF, E, FPAccuracyIntrinsicID, IntrinsicID, Src0);
+  Func = Res.first;
+  Name = Res.second;
   if (Func)
     return CGF.CreateBuiltinCallWithAttr(Name, Func, {Src0},
                                          FPAccuracyIntrinsicID);
@@ -737,9 +742,12 @@ static Value *emitBinaryMaybeConstrainedFPBuiltin(
     unsigned FPAccuracyIntrinsicID = Intrinsic::not_intrinsic) {
   llvm::Value *Src0 = CGF.EmitScalarExpr(E->getArg(0));
   llvm::Value *Src1 = CGF.EmitScalarExpr(E->getArg(1));
-  StringRef Name;
-  Function *Func = emitMaybeIntrinsic(CGF, E, FPAccuracyIntrinsicID,
-                                      IntrinsicID, Src0, Name);
+  std::string Name;
+  Function *Func;
+  FuncNamePair Res =
+      EmitMaybeIntrinsic(CGF, E, FPAccuracyIntrinsicID, IntrinsicID, Src0);
+  Func = Res.first;
+  Name = Res.second;
   if (Func)
     return CGF.CreateBuiltinCallWithAttr(Name, Func, {Src0, Src1},
                                          FPAccuracyIntrinsicID);
@@ -747,10 +755,10 @@ static Value *emitBinaryMaybeConstrainedFPBuiltin(
   CodeGenFunction::CGFPOptionsRAII FPOptsRAII(CGF, E);
   if (CGF.Builder.getIsFPConstrained()) {
     Function *F = CGF.CGM.getIntrinsic(ConstrainedIntrinsicID, Src0->getType());
-    return CGF.Builder.CreateConstrainedFPCall(F, { Src0, Src1 });
+    return CGF.Builder.CreateConstrainedFPCall(F, {Src0, Src1});
   } else {
     Function *F = CGF.CGM.getIntrinsic(IntrinsicID, Src0->getType());
-    return CGF.Builder.CreateCall(F, { Src0, Src1 });
+    return CGF.Builder.CreateCall(F, {Src0, Src1});
   }
 }
 

--- a/clang/test/CodeGen/fp-accuracy.c
+++ b/clang/test/CodeGen/fp-accuracy.c
@@ -90,7 +90,7 @@ double rsqrt(double);
 // CHECK: call double @llvm.fpbuiltin.pow.f64(double {{.*}}, double {{.*}}) #[[ATTR_HIGH]]
 // CHECK: call double @llvm.fpbuiltin.rsqrt.f64(double {{.*}}) #[[ATTR_HIGH]]
 // CHECK: call double @llvm.fpbuiltin.sin.f64(double {{.*}}) #[[ATTR_HIGH]]
-// CHECK: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_HIGH]]
+// CHECK: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK: call double @llvm.fpbuiltin.sinh.f64(double {{.*}}) #[[ATTR_HIGH]]
 // CHECK: call double @llvm.fpbuiltin.sqrt.f64(double {{.*}}) #[[ATTR_HIGH]]
 // CHECK: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_HIGH]]
@@ -125,7 +125,7 @@ double rsqrt(double);
 // CHECK-F1: call double @llvm.fpbuiltin.pow.f64(double {{.*}}, double {{.*}}) #[[ATTR_F1_HIGH]]
 // CHECK-F1: call i32 (double, ...) @rsqrt(double {{.*}})
 // CHECK-F1: call double @llvm.sin.f64(double {{.*}})
-// CHECK-F1: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F1_MEDIUM]]
+// CHECK-F1: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F1: call double @llvm.sinh.f64(double {{.*}})
 // CHECK-F1: call double @llvm.sqrt.f64(double {{.*}})
 // CHECK-F1: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F1_LOW:[0-9]+]]
@@ -161,7 +161,7 @@ double rsqrt(double);
 // CHECK-F2: call double @llvm.fpbuiltin.pow.f64(double {{.*}}, double {{.*}}) #[[ATTR_F2_MEDIUM]]
 // CHECK-F2: call double @llvm.fpbuiltin.rsqrt.f64(double {{.*}}) #[[ATTR_F2_MEDIUM]]
 // CHECK-F2: call double @llvm.fpbuiltin.sin.f64(double {{.*}}) #[[ATTR_F2_MEDIUM]]
-// CHECK-F2:    call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F2_MEDIUM]]
+// CHECK-F2: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F2: call double @llvm.fpbuiltin.sinh.f64(double {{.*}}) #[[ATTR_F2_MEDIUM]]
 // CHECK-F2: call double @llvm.fpbuiltin.sqrt.f64(double {{.*}}) #[[ATTR_F2_MEDIUM]]
 // CHECK-F2: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F2_HIGH:[0-9]+]]
@@ -197,7 +197,7 @@ double rsqrt(double);
 // CHECK-F3: call double @llvm.fpbuiltin.pow.f64(double {{.*}}, double {{.*}}) #[[ATTR_F3_HIGH]]
 // CHECK-F3: call double @llvm.fpbuiltin.rsqrt.f64(double {{.*}}) #[[ATTR_F3_HIGH]]
 // CHECK-F3: call double @llvm.fpbuiltin.sin.f64(double {{.*}}) #[[ATTR_F3_HIGH]]
-// CHECK-F3: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F3_MEDIUM]]
+// CHECK-F3: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F3: call double @llvm.fpbuiltin.sinh.f64(double {{.*}}) #[[ATTR_F3_HIGH]]
 // CHECK-F3: call double @llvm.fpbuiltin.sqrt.f64(double {{.*}}) #[[ATTR_F3_HIGH]]
 // CHECK-F3: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F3_LOW:[0-9]+]]
@@ -208,7 +208,7 @@ double rsqrt(double);
 // CHECK-F3: call float @llvm.fpbuiltin.sin.f32(float {{.*}}) #[[ATTR_F3_HIGH]]
 // CHECK-F3: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F3_LOW]]
 // CHECK-F3: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F3_MEDIUM]]
-// CHECK-F3: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F3_MEDIUM]]
+// CHECK-F3: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F3: call float @llvm.fpbuiltin.tan.f32(float {{.*}}) #[[ATTR_F3_HIGH]]
 // CHECK-F3: call float @llvm.fpbuiltin.hypot.f32(float {{.*}}, float {{.*}}) #[[ATTR_F3_HIGH]]
 
@@ -252,7 +252,7 @@ double rsqrt(double);
 // CHECK-F4: call double @llvm.fpbuiltin.pow.f64(double {{.*}}, double {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call double @llvm.fpbuiltin.rsqrt.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call double @llvm.fpbuiltin.sin.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
-// CHECK-F4: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}})
+// CHECK-F4: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F4: call double @llvm.fpbuiltin.sinh.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call double @llvm.fpbuiltin.sqrt.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
@@ -288,7 +288,7 @@ double rsqrt(double);
 // CHECK-F5: call double @llvm.pow.f64(double {{.*}}, double {{.*}})
 // CHECK-F5: call i32 (double, ...) @rsqrt(double {{.*}})
 // CHECK-F5: call double @llvm.fpbuiltin.sin.f64(double {{.*}}) #[[ATTR_F5_HIGH:[0-9]+]]
-// CHECK-F5: call {{.*}} @sincos(double {{.*}}, ptr {{.*}}, ptr {{.*}})
+// CHECK-F5: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F5: call double @llvm.sinh.f64(double {{.*}})
 // CHECK-F5: call double @llvm.sqrt.f64(double {{.*}})
 // CHECK-F5: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F5_HIGH]]
@@ -325,7 +325,7 @@ double rsqrt(double);
 // CHECK-F6: call double @llvm.fpbuiltin.pow.f64(double {{.*}}, double {{.*}}) #[[ATTR_F6_MEDIUM]]
 // CHECK-F6: call double @llvm.fpbuiltin.rsqrt.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
 // CHECK-F6: call double @llvm.fpbuiltin.sin.f64(double {{.*}}) #[[ATTR_F6_HIGH]]
-// CHECK-F6: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F6: call double @llvm.fpbuiltin.sinh.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
 // CHECK-F6: call double @llvm.fpbuiltin.sqrt.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
 // CHECK-F6: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
@@ -410,7 +410,7 @@ void f1(float a, float b) {
 // CHECK: call float @llvm.fpbuiltin.sin.f32(float {{.*}}) #[[ATTR_HIGH]]
 // CHECK: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_HIGH]]
 // CHECK: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_HIGH]]
-// CHECK: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_HIGH]]
+// CHECK: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK: call float @llvm.fpbuiltin.tan.f32(float {{.*}}) #[[ATTR_HIGH]]
 // CHECK: call float @llvm.fpbuiltin.hypot.f32(float {{.*}}, float {{.*}}) #[[ATTR_HIGH]]
 // CHECK: call float @llvm.fpbuiltin.ldexp.f32(float {{.*}}, i32 {{.*}}) #[[ATTR_HIGH]]
@@ -420,7 +420,7 @@ void f1(float a, float b) {
 // CHECK-F1: call float @llvm.sin.f32(float {{.*}})
 // CHECK-F1: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F1_LOW]]
 // CHECK-F1: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F1_MEDIUM]]
-// CHECK-F1: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F1_MEDIUM]]
+// CHECK-F1: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F1: call float @llvm.tan.f32(float {{.*}})
 // CHECK-F1: call float @hypotf(float {{.*}}, float {{.*}})
 // CHECK-F1: call float @ldexpf(float {{.*}}, i32 {{.*}})
@@ -430,7 +430,7 @@ void f1(float a, float b) {
 // CHECK-F2: call float @llvm.fpbuiltin.sin.f32(float {{.*}}) #[[ATTR_F2_MEDIUM]]
 // CHECK-F2: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F2_HIGH]]
 // CHECK-F2: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F2_MEDIUM]]
-// CHECK-F2: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F2_MEDIUM]]
+// CHECK-F2: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F2: call float @llvm.fpbuiltin.tan.f32(float {{.*}}) #[[ATTR_F2_MEDIUM]]
 // CHECK-F2: call float @llvm.fpbuiltin.hypot.f32(float {{.*}}, float {{.*}}) #[[ATTR_F2_MEDIUM]]
 // CHECK-F2: call float @llvm.fpbuiltin.ldexp.f32(float {{.*}}, i32 {{.*}}) #[[ATTR_F2_MEDIUM]]
@@ -440,7 +440,7 @@ void f1(float a, float b) {
 // CHECK-F4: call float @llvm.fpbuiltin.sin.f32(float {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
-// CHECK-F4: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F4: call float @llvm.fpbuiltin.tan.f32(float {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call float @llvm.fpbuiltin.hypot.f32(float {{.*}}, float {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call float @llvm.fpbuiltin.ldexp.f32(float {{.*}}, i32 {{.*}}) #[[ATTR_F4_MEDIUM]]
@@ -461,7 +461,7 @@ void f1(float a, float b) {
 // CHECK-F5: call float @llvm.sin.f32(float {{.*}})
 // CHECK-F5: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F5_HIGH]]
 // CHECK-F5: call double @llvm.log10.f64(double {{.*}})
-// CHECK-F5: call {{.*}} @sincos(double {{.*}}, ptr {{.*}}, ptr {{.*}})
+// CHECK-F5: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F5: call float @llvm.tan.f32(float {{.*}})
 // CHECK-F5: call float @hypotf(float {{.*}}, float {{.*}})
 // CHECK-F5: call float @ldexpf(float {{.*}}, i32 {{.*}})
@@ -483,7 +483,7 @@ void f1(float a, float b) {
 // CHECK-F6: call float @llvm.fpbuiltin.sin.f32(float {{.*}}) #[[ATTR_F6_MEDIUM]]
 // CHECK-F6: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
 // CHECK-F6: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
-// CHECK-F6: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-F6: call float @llvm.fpbuiltin.tan.f32(float {{.*}}) #[[ATTR_F6_MEDIUM]]
 // CHECK-F6: call float @llvm.fpbuiltin.hypot.f32(float {{.*}}, float {{.*}}) #[[ATTR_F6_MEDIUM]]
 // CHECK-F6: call float @llvm.fpbuiltin.ldexp.f32(float {{.*}}, i32 {{.*}}) #[[ATTR_F6_MEDIUM]]
@@ -590,7 +590,7 @@ void f1(float a, float b) {
 // CHECK-DEFAULT: call double @llvm.pow.f64(double {{.*}}, double {{.*}})
 // CHECK-DEFAULT: call i32 (double, ...) @rsqrt(double {{.*}})
 // CHECK-DEFAULT: call double @llvm.sin.f64(double {{.*}})
-// CHECK-DEFAULT: call {{.*}} @sincos(double {{.*}}, ptr {{.*}}, ptr {{.*}})
+// CHECK-DEFAULT: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-DEFAULT: call double @llvm.sinh.f64(double {{.*}})
 // CHECK-DEFAULT: call double @llvm.sqrt.f64(double {{.*}})
 // CHECK-DEFAULT: call double @llvm.tan.f64(double {{.*}})
@@ -601,7 +601,7 @@ void f1(float a, float b) {
 // CHECK-DEFAULT: call float @llvm.sin.f32(float {{.*}})
 // CHECK-DEFAULT: call double @llvm.tan.f64(double {{.*}})
 // CHECK-DEFAULT: call double @llvm.log10.f64(double {{.*}})
-// CHECK-DEFAULT: call {{.*}} @sincos(double {{.*}}, ptr {{.*}}, ptr {{.*}})
+// CHECK-DEFAULT: call { double, double } @llvm.sincos.f64(double {{.*}})
 // CHECK-DEFAULT: call float @llvm.tan.f32(float {{.*}})
 // CHECK-DEFAULT: call float @hypotf(float {{.*}}, float {{.*}})
 //


### PR DESCRIPTION
This patch resolves conflicts introduced by:
cd269fee05a0 - (2024-12-14) [StrTable] Switch Clang builtins to use string tables - Chandler Carruth
