### PR TITLE
[libspirv] Fix mapping to CLC hypot builtin

### DIFF
--- a/libclc/libspirv/lib/generic/math/hypot.cl
+++ b/libclc/libspirv/lib/generic/math/hypot.cl
@@ -7,10 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include <libspirv/spirv.h>
+#include <clc/math/clc_hypot.h>
 
-#include <math/clc_hypot.h>
-
-#define __CLC_FUNC __spirv_ocl_hypot
-#define __CLC_SW_FUNC __clc_hypot
-#define __CLC_BODY <clc_sw_binary.inc>
+#define FUNCTION __spirv_ocl_hypot
+#define __CLC_FUNCTION(x) __clc_hypot
+#define __CLC_BODY <clc/shared/binary_def.inc>
 #include <clc/math/gentype.inc>


### PR DESCRIPTION
A recent pulldown moved the <math/clc_hypot.h> header, so the build was failing. While fixing this, change the builtin mapping to mirror the OpenCL's form.