### PR TITLE
[SYCL][E2E] Disable flaky test multithread_write_accessor.cpp

### DIFF
--- a/sycl/test-e2e/Regression/multithread_write_accessor.cpp
+++ b/sycl/test-e2e/Regression/multithread_write_accessor.cpp
@@ -1,8 +1,8 @@
 // RUN: %{build} -o %t.out %threads_lib
 // RUN: %{run} %t.out
 
-// Test flakily times out on Arc + OpenCL
-// UNSUPPORTED: opencl && gpu-intel-dg2
+// Test flakily times out on many platforms
+// UNSUPPORTED: *
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16877
 
 // XFAIL: arch-intel_gpu_pvc && opencl && !spirv-backend


### PR DESCRIPTION
Test is [failing](https://github.com/intel/llvm/issues/16877) for a ton of people and I don't want anyone to have to deal with it until it's fixed.