### PR TITLE
[SYCL][E2E] Disable memops2d tests on Windows again

### DIFF
--- a/sycl/test-e2e/USM/memops2d/lit.local.cfg
+++ b/sycl/test-e2e/USM/memops2d/lit.local.cfg
@@ -3,3 +3,6 @@
 # Temporarily disabled until the failure is addressed:
 # https://github.com/llvm/llvm-project/issues/127791
 config.unsupported_features += ['spirv-backend']
+
+# https://github.com/intel/llvm/issues/8126
+config.unsupported_features += ['windows']


### PR DESCRIPTION
Still sporadically failing on Windows, see [here](https://github.com/intel/llvm/issues/8126).