### PR TITLE
[CI] Run postcommit when GPU driver changes

### DIFF
--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -18,6 +18,8 @@ on:
     - .github/workflows/sycl-macos-build-and-test.yml
     - ./devops/actions/cleanup
     - ./devops/actions/cached_checkout
+    - ./devops/dependencies.json
+    - ./devops/dependencies-igc-dev.json
 
 concurrency:
   #  Cancel a currently running workflow from the same PR or commit hash.


### PR DESCRIPTION
We test differently in pre and postcommit, and we need to also test driver updates in postcommit to ensure there are no failures.