### PR TITLE
[SYCL][E2E] minor test change to ease release

### DIFF
--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
@@ -161,7 +161,7 @@ void test_build_and_run() {
 
   // Compilation with props and devices
   std::string log;
-  std::vector<std::string> flags{"-g", "-fno-fast-math"};
+  std::vector<std::string> flags{"-fno-fast-math"};
   std::vector<sycl::device> devs = kbSrc.get_devices();
   exe_kb kbExe2 = syclex::build(
       kbSrc, devs,

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit.cpp
@@ -259,7 +259,7 @@ int test_build_and_run() {
 
   // Compilation with props and devices
   std::string log;
-  std::vector<std::string> flags{"-g", "-fno-fast-math",
+  std::vector<std::string> flags{"-fno-fast-math",
                                  "-fsycl-instrument-device-code"};
   std::vector<sycl::device> devs = kbSrc.get_devices();
   exe_kb kbExe2 = syclex::build(

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit_cache.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit_cache.cpp
@@ -96,7 +96,7 @@ int test_persistent_cache() {
   // Different build_options means no cache hit.
   // CHECK: [kernel_compiler Persistent Cache]: cache miss: [[KEY2:.*]]
   // CHECK: [kernel_compiler Persistent Cache]: storing device code IR: {{.*}}/[[KEY2]]
-  std::vector<std::string> flags{"-g", "-fno-fast-math"};
+  std::vector<std::string> flags{"-O0", "-fno-fast-math"};
   exe_kb kbExe1c =
       syclex::build(kbSrc1, syclex::properties{syclex::build_options{flags}});
 


### PR DESCRIPTION
The debug story for sycl-jit is not determined yet, so supporting the `-g` flag for the kernel_compiler is not a strict requirement. 
 Meanwhile, on the SPIR-V side we are changing some opcodes to be extensions.  This upshot of all that is that between the open source and closed source side, drivers and code gen, the -g flag, *when passed to the kernel_compiler*, is leading to errors. This will resolve itself once both the open source and closed source sides of the compiler, and the matching drivers, have all made the switch to the same SPIRV symbols. In the meantime, these tests are being adjusted so they pass in all contexts. 