### PR TITLE
[SYCL][RTC] Propagate `-Xs` options along in-memory pipeline

### DIFF
--- a/sycl-jit/common/include/Kernel.h
+++ b/sycl-jit/common/include/Kernel.h
@@ -409,7 +409,14 @@ struct RTCDevImgInfo {
   RTCDevImgInfo &operator=(RTCDevImgInfo &&) = default;
 };
 
-using RTCBundleInfo = DynArray<RTCDevImgInfo>;
+struct RTCBundleInfo {
+  DynArray<RTCDevImgInfo> DevImgInfos;
+  sycl::detail::string CompileOptions;
+
+  RTCBundleInfo() = default;
+  RTCBundleInfo(RTCBundleInfo &&) = default;
+  RTCBundleInfo &operator=(RTCBundleInfo &&) = default;
+};
 
 // LLVM's APIs prefer `char *` for byte buffers.
 using RTCDeviceCodeIR = DynArray<char>;

--- a/sycl-jit/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-jit/jit-compiler/lib/KernelFusion.cpp
@@ -361,7 +361,8 @@ compileSYCL(InMemoryFile SourceFile, View<InMemoryFile> IncludeFiles,
   }
   auto [BundleInfo, Modules] = std::move(*PostLinkResultOrError);
 
-  for (auto [DevImgInfo, Module] : llvm::zip_equal(BundleInfo, Modules)) {
+  for (auto [DevImgInfo, Module] :
+       llvm::zip_equal(BundleInfo.DevImgInfos, Modules)) {
     auto BinaryInfoOrError =
         translation::KernelTranslator::translateDevImgToSPIRV(
             *Module, JITContext::getInstance());
@@ -371,6 +372,8 @@ compileSYCL(InMemoryFile SourceFile, View<InMemoryFile> IncludeFiles,
     }
     DevImgInfo.BinaryInfo = std::move(*BinaryInfoOrError);
   }
+
+  encodeBuildOptions(BundleInfo, UserArgList);
 
   if (llvm::timeTraceProfilerEnabled()) {
     auto Error = llvm::timeTraceProfilerWrite(

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.h
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.h
@@ -44,6 +44,9 @@ performPostLink(std::unique_ptr<llvm::Module> Module,
 llvm::Expected<llvm::opt::InputArgList>
 parseUserArgs(View<const char *> UserArgs);
 
+void encodeBuildOptions(RTCBundleInfo &BundleInfo,
+                        const llvm::opt::InputArgList &UserArgList);
+
 void configureDiagnostics(llvm::LLVMContext &Context, std::string &BuildLog);
 
 } // namespace jit_compiler

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -1155,7 +1155,7 @@ sycl_device_binaries jit_compiler::createDeviceBinaries(
     const std::string &Prefix) {
   auto Collection = std::make_unique<DeviceBinariesCollection>();
 
-  for (const auto &DevImgInfo : BundleInfo) {
+  for (const auto &DevImgInfo : BundleInfo.DevImgInfos) {
     DeviceBinaryContainer Binary;
     for (const auto &Symbol : DevImgInfo.SymbolTable) {
       // Create an offload entry for each kernel. We prepend a unique prefix to
@@ -1182,6 +1182,8 @@ sycl_device_binaries jit_compiler::createDeviceBinaries(
         }
       }
       Binary.addProperty(std::move(PropSet));
+
+      Binary.setCompileOptions(BundleInfo.CompileOptions.c_str());
     }
 
     Collection->addDeviceBinary(std::move(Binary),

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -27,10 +27,10 @@ class JITContext;
 struct SYCLKernelInfo;
 struct SYCLKernelAttribute;
 struct RTCDevImgInfo;
+struct RTCBundleInfo;
 template <typename T> class DynArray;
 using ArgUsageMask = DynArray<uint8_t>;
 using JITEnvVar = DynArray<char>;
-using RTCBundleInfo = DynArray<RTCDevImgInfo>;
 } // namespace jit_compiler
 
 namespace sycl {

--- a/sycl/source/detail/jit_device_binaries.cpp
+++ b/sycl/source/detail/jit_device_binaries.cpp
@@ -89,6 +89,18 @@ void DeviceBinaryContainer::addProperty(PropertySetContainer &&Cont) {
   PropertySets.push_back(std::move(Cont));
 }
 
+void DeviceBinaryContainer::setCompileOptions(std::string_view CompileOpts) {
+  // Forbid calls to this method after the first PI struct has been created.
+  assert(Fused && "Reallocating string would invalidate existing UR structs");
+  if (CompileOpts.empty()) {
+    CompileOptions.reset();
+    return;
+  }
+  CompileOptions.reset(new char[CompileOpts.length() + 1]);
+  std::memcpy(CompileOptions.get(), CompileOpts.data(),
+              CompileOpts.length() + 1);
+}
+
 sycl_device_binary_struct DeviceBinaryContainer::getPIDeviceBinary(
     const unsigned char *BinaryStart, size_t BinarySize, const char *TargetSpec,
     sycl_device_binary_type Format) {
@@ -96,7 +108,7 @@ sycl_device_binary_struct DeviceBinaryContainer::getPIDeviceBinary(
   DeviceBinary.Version = SYCL_DEVICE_BINARY_VERSION;
   DeviceBinary.Kind = SYCL_DEVICE_BINARY_OFFLOAD_KIND_SYCL;
   DeviceBinary.Format = Format;
-  DeviceBinary.CompileOptions = "";
+  DeviceBinary.CompileOptions = CompileOptions ? CompileOptions.get() : "";
   DeviceBinary.LinkOptions = "";
   DeviceBinary.ManifestStart = nullptr;
   DeviceBinary.ManifestEnd = nullptr;

--- a/sycl/source/detail/jit_device_binaries.hpp
+++ b/sycl/source/detail/jit_device_binaries.hpp
@@ -13,6 +13,7 @@
 
 #include <cstring>
 #include <memory>
+#include <string_view>
 
 namespace sycl {
 inline namespace _V1 {
@@ -113,6 +114,8 @@ public:
 
   void addProperty(PropertySetContainer &&Cont);
 
+  void setCompileOptions(std::string_view CompileOpts);
+
   sycl_device_binary_struct getPIDeviceBinary(const unsigned char *BinaryStart,
                                               size_t BinarySize,
                                               const char *TargetSpec,
@@ -124,6 +127,7 @@ private:
   std::vector<_sycl_offload_entry_struct> PIOffloadEntries;
   std::vector<PropertySetContainer> PropertySets;
   std::vector<_sycl_device_binary_property_set_struct> PIPropertySets;
+  std::unique_ptr<char[]> CompileOptions;
 };
 
 /// Representation of sycl_device_binaries_struct for creation of JIT device

--- a/sycl/test-e2e/KernelCompiler/sycl_device_flags.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_device_flags.cpp
@@ -13,7 +13,8 @@
 // UNSUPPORTED-INTENDED:  IGC shader dump not available on Windows.
 
 // RUN: %{build} -o %t.out
-// RUN: env IGC_DumpToCustomDir=%T.dump IGC_ShaderDumpEnable=1 NEO_CACHE_PERSISTENT=0 %{run} %t.out %T.dump/
+// RUN: env IGC_DumpToCustomDir=%T.dump_0 IGC_ShaderDumpEnable=1 NEO_CACHE_PERSISTENT=0 %{run} %t.out sycl %T.dump_0/
+// RUN: env IGC_DumpToCustomDir=%T.dump_1 IGC_ShaderDumpEnable=1 NEO_CACHE_PERSISTENT=0 %{run} %t.out sycl_jit %T.dump_1/
 
 // clang-format off
 /*
@@ -105,28 +106,32 @@ int test_dump(std::string &dump_dir) {
 
 int main(int argc, char *argv[]) {
 
-  if (argc != 2) {
-    std::cerr << "Usage: " << argv[0] << " <dump_directory>" << std::endl;
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " <lang> <dump_directory>"
+              << std::endl;
     return 1;
   }
-  std::string dump_dir = argv[1];
 
   namespace syclex = sycl::ext::oneapi::experimental;
   using source_kb = sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source>;
   using exe_kb = sycl::kernel_bundle<sycl::bundle_state::executable>;
 
+  syclex::source_language lang = std::strcmp(argv[1], "sycl_jit") == 0
+                                     ? syclex::source_language::sycl_jit
+                                     : syclex::source_language::sycl;
+  std::string dump_dir = argv[2];
+
   sycl::queue q;
   sycl::context ctx = q.get_context();
 
-  bool ok =
-      q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl);
+  bool ok = q.get_device().ext_oneapi_can_compile(lang);
   if (!ok) {
     std::cout << "compiling from SYCL source not supported" << std::endl;
     return 0; // if kernel compilation is not supported, do nothing.
   }
 
-  source_kb kbSrc = syclex::create_kernel_bundle_from_source(
-      ctx, syclex::source_language::sycl, SYCLSource);
+  source_kb kbSrc =
+      syclex::create_kernel_bundle_from_source(ctx, lang, SYCLSource);
 
   // Flags with and without space, inner quotes.
   std::vector<std::string> flags{"-Xs '-doubleGRF'",


### PR DESCRIPTION
Ensures that `-Xs` option arguments are baked into the device image(s), from which they are picked up by the progam manager.