### PR TITLE
[CI] Fix workflow to check use of private emails

### DIFF
--- a/.github/workflows/email-check.yaml
+++ b/.github/workflows/email-check.yaml
@@ -2,8 +2,9 @@ name: "Check for private emails used in PRs"
 
 on:
   pull_request:
-    types:
-      - opened
+    branches:
+      - sycl
+      - sycl-rel-**
 
 permissions:
   contents: read


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
> By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened.

By adding `types: - opened`, we are restricting this workflow to run only when the PR is first opened. I don't see a good reason to do that. This PR removed it and also makes sure that this workflow is triggered only on certain branches.