### PR TITLE
[E2E] Disable flaky `bindless_images/sampling_2D.cpp` on HIP

### DIFF
--- a/sycl/test-e2e/bindless_images/sampling_2D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D.cpp
@@ -1,5 +1,8 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images_2d_usm
 
+// UNSUPPORTED: hip
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17212
+
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out
 


### PR DESCRIPTION
This test has been failing flakily on HIP.
Example: https://github.com/intel/llvm/actions/runs/13632741740/job/38160479157