### PR TITLE
[SYCL][Graph] Disable all Graph E2E testing on Windows Battlemage

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/lit.local.cfg
+++ b/sycl/test-e2e/Graph/RecordReplay/lit.local.cfg
@@ -1,5 +1,1 @@
 config.required_features += ['aspect-ext_oneapi_limited_graph']
-
-# https://github.com/intel/llvm/issues/17165
-if 'windows' in config.available_features:
-   config.unsupported_features += ['arch-intel_gpu_bmg_g21']

--- a/sycl/test-e2e/Graph/Update/lit.local.cfg
+++ b/sycl/test-e2e/Graph/Update/lit.local.cfg
@@ -1,5 +1,1 @@
 config.required_features += ['aspect-ext_oneapi_graph']
-
-# https://github.com/intel/llvm/issues/17165
-if 'windows' in config.available_features:
-   config.unsupported_features += ['arch-intel_gpu_bmg_g21']

--- a/sycl/test-e2e/Graph/lit.local.cfg
+++ b/sycl/test-e2e/Graph/lit.local.cfg
@@ -1,0 +1,3 @@
+# https://github.com/intel/llvm/issues/17165
+if 'windows' in config.available_features:
+   config.unsupported_features += ['arch-intel_gpu_bmg_g21']


### PR DESCRIPTION
We currently only disable the RecordReplay variant of E2E testing on battlemage, however we have many other tests and the likihood is that if the RecordReplay tests are failing then other tests will start failing too.

Disable all Graphs tests until Graph support on Windows battlemage can be investigated more thoroughly.

See https://github.com/intel/llvm/issues/17165