### PR TITLE
[UR] Install `black` in requirements.txt

### DIFF
--- a/unified-runtime/third_party/requirements.txt
+++ b/unified-runtime/third_party/requirements.txt
@@ -16,7 +16,7 @@ Jinja2==3.1.4
 lxml==4.9.3
 Mako==1.3.0
 MarkupSafe==2.1.5
-packaging==19.2
+packaging==24.2
 Pygments==2.17.2
 pyparsing==2.4.5
 pytest>=7.0
@@ -39,3 +39,6 @@ sphinxcontrib-websupport==1.2.4
 sphinx-rtd-theme==1.0.0
 urllib3==2.2.2
 dataclasses-json==0.6.7
+
+# Unified-runtime is formatted using black
+black==25.1.0


### PR DESCRIPTION
Unified-runtime is formatted using black, so include it in the Python
environment. `packaging` was also bumped since it is a dependency.

This does not make any changes to CI or cmake.
