### PR TITLE
[SYCL][E2E] Re-enable copy_dynamic_size on CUDA

### DIFF
--- a/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/copy_dynamic_size.cpp
@@ -1,8 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-//
-// UNSUPPORTED: cuda
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16968
 
 // UNSUPPORTED: gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16072


### PR DESCRIPTION
I don't know what fixed it, but this is fixed on the `sycl` branch and in the latest nightlies.

Fixes https://github.com/intel/llvm/issues/16968