### PR TITLE
[SYCL] Fix device aspect macro header CMake dependency

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -200,6 +200,8 @@ add_custom_command(
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/source/device_aspect_macros_generator.py ${CMAKE_CURRENT_SOURCE_DIR}/include/sycl ${SYCL_INCLUDE_BUILD_DIR}/sycl
   OUTPUT  ${SYCL_INCLUDE_BUILD_DIR}/sycl/device_aspect_macros.hpp
   COMMENT "Generating device_aspect_macros.hpp"
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/include/sycl/info/aspects.def
+          ${CMAKE_CURRENT_SOURCE_DIR}/include/sycl/info/aspects_deprecated.def
 )
 
 add_custom_target(sycl-device-aspect-macros-header


### PR DESCRIPTION
Without this patch the header wasn't getting re-generated when the `.def` files are changed, which causes build failures on existing builds when new aspects are introduced.