### PR TITLE
[SYCL][NFC] Use no output file instead of default output file in LIT tests

### DIFF
--- a/sycl/test/basic_tests/header_footer_diagnostics.cpp
+++ b/sycl/test/basic_tests/header_footer_diagnostics.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -Werror=reserved-identifier -Werror=old-style-cast %s
+// RUN: %clangxx -fsycl -Werror=reserved-identifier -Werror=old-style-cast %s -fsyntax-only
 
 // Check that the generated header and footer files do not generate
 // errors when pedantic warnings are enabled.

--- a/sycl/test/basic_tests/is_group_trait.cpp
+++ b/sycl/test/basic_tests/is_group_trait.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s
+// RUN: %clangxx -fsycl %s -fsyntax-only
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/esimd/slm_init_local_accessor.cpp
+++ b/sycl/test/esimd/slm_init_local_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl  %s
+// RUN: %clangxx -fsycl  %s -fsyntax-only
 
 // This test verifies usage of slm_init and local_accessor in different kernels
 // passes.


### PR DESCRIPTION
This occasionally causes errors on windows when multiple files compile to the same output file.

See #7872 for more context