### PR TITLE
[UR][CMake]Set CMAKE_MSVC_RUNTIME_LIBRARY to fix UMF linking issues

### DIFF
--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -51,6 +51,9 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
     # Prevent L0 loader from exporting extra symbols
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS OFF)
 
+    set(CMAKE_MSVC_RUNTIME_LIBRARY_BAK "${CMAKE_MSVC_RUNTIME_LIBRARY}")
+    # UMF has not yet been able to build as static
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     message(STATUS "Level Zero Adapter: Will fetch Level Zero Loader from ${UR_LEVEL_ZERO_LOADER_REPO}")
     include(FetchContent)
     FetchContent_Declare(level-zero-loader
@@ -65,6 +68,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
 
     # Restore original flags
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_BAK}")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "${CMAKE_MSVC_RUNTIME_LIBRARY_BAK}")
 
     target_compile_options(ze_loader PRIVATE
         $<$<IN_LIST:$<CXX_COMPILER_ID>,GNU;Clang;Intel;IntelLLVM>:-Wno-error>


### PR DESCRIPTION
Caller might set CMAKE_MSVC_RUNTIME_LIBRARY to MultiThreaded to do
static linking of MSVC runtime. However, UMF is not yet ready for static
linking. Override the CMAKE_MSVC_RUNTIME_LIBRARY to fix lnking failures.
