### PR TITLE
[CI] Run `git gc` when creating a repo cache

### DIFF
--- a/devops/actions/cached_checkout/action.yml
+++ b/devops/actions/cached_checkout/action.yml
@@ -34,6 +34,7 @@ runs:
         git pull --prune
       else
         git clone https://github.com/${{ inputs.repository }}.git .
+        git gc
       fi
   - name: Checkout
     env:


### PR DESCRIPTION
Without this cached checkout is slow.

Note this is only when we re-create the cache, which only happens if it got deleted/doesn't exist for some reason.