### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-a9e1ef2

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-e651db8",
-      "version": "e651db8",
-      "updated_at": "2025-02-26T22:36:50Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2659517987/zip",
+      "github_tag": "igc-dev-a9e1ef2",
+      "version": "a9e1ef2",
+      "updated_at": "2025-03-09T09:38:44Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2717684926/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift