### PR TITLE
[SYCL] Remove redundant check if Kernel is on host

### DIFF
--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -543,8 +543,6 @@ event handler::finalize() {
         NewEvent->setSubmissionTime();
 
         EnqueueKernel();
-        if (NewEvent->isHost() || NewEvent->getHandle() == nullptr)
-          NewEvent->setComplete();
         NewEvent->setEnqueued();
 
         MLastEvent = detail::createSyclObjFromImpl<event>(NewEvent);


### PR DESCRIPTION
This is shortcut path for Kernel CG only. 
It handles only device kernels that means that there is no necessity to check if event is a host event.
I also do not see necessity to check if Handle != nullptr since there is a separated path for discarded event case. That means that in path for kernel + no discarding events this check is not necessary at all.