### PR TITLE
[SYCL][E2E] Remove XFAIL from `DeviceLib/assert-windows.cpp` test

### DIFF
--- a/sycl/test-e2e/DeviceLib/assert-windows.cpp
+++ b/sycl/test-e2e/DeviceLib/assert-windows.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: cpu,windows
 //
-// XFAIL: *
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16507
-//
 // RUN: %{build} -o %t.out
 //
 // MSVC implementation of assert does not call an unreachable built-in, so the


### PR DESCRIPTION
This test was xfailed because previously we would ignore features in `build-only` mode so it would be incorrectly ran on Linux, despite the Windows requirement. This was fixed in #16725.

Fixes #16507