### PR TITLE
[CI] Add GPU reset for BMG

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -112,13 +112,12 @@ jobs:
             runner: '["Linux", "bmg"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
-            # The new Xe kernel driver used by BMG doesn't support resetting.
-            reset_intel_gpu: false
+            reset_intel_gpu: true
           - name: SPIR-V Backend / Intel Battlemage Graphics
             runner: '["Linux", "bmg"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu;opencl:cpu
-            reset_intel_gpu: false
+            reset_intel_gpu: true
             extra_lit_opts: --param spirv-backend=True
             e2e_binaries_artifact: sycl_e2e_bin_default_spirv_backend
     uses: ./.github/workflows/sycl-linux-run-tests.yml

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -203,15 +203,22 @@ jobs:
     steps:
     - name: Reset Intel GPU
       if: inputs.reset_intel_gpu == 'true'
+      shell: bash      
       run: |
-        sudo mount -t debugfs none /sys/kernel/debug
-        base_dir="/sys/kernel/debug/dri"
+        if [[ '${{ inputs.runner }}' == '["Linux", "bmg"]' ]]; then
+          sudo bash -c 'echo 0000:05:00.0 > /sys/bus/pci/drivers/xe/unbind'
+          sudo bash -c 'echo 1 > /sys/bus/pci/devices/0000:05:00.0/reset'
+          sudo bash -c 'echo 0000:05:00.0 > /sys/bus/pci/drivers/xe/bind'
+        else
+          sudo mount -t debugfs none /sys/kernel/debug
+          base_dir="/sys/kernel/debug/dri"
 
-        for dir in "$base_dir"/*; do
-         if [ -f "$dir/i915_wedged" ]; then
-          sudo bash -c 'echo 1 > $0/i915_wedged' $dir
-         fi
-        done
+          for dir in "$base_dir"/*; do
+           if [ -f "$dir/i915_wedged" ]; then
+            sudo bash -c 'echo 1 > $0/i915_wedged' $dir
+           fi
+          done
+        fi
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.devops_ref || inputs.repo_ref }}

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -82,6 +82,7 @@ jobs:
             runner: '["Linux", "bmg"]'
             image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu
+            reset_intel_gpu: true
 
           - name: Intel L0 Arc A-Series GPU
             runner: '["Linux", "arc"]'

--- a/sycl/test-e2e/KernelAndProgram/persistent-cache-multi-device.cpp
+++ b/sycl/test-e2e/KernelAndProgram/persistent-cache-multi-device.cpp
@@ -9,6 +9,9 @@
 // XFAIL: spirv-backend && run-mode
 // XFAIL-TRACKER: CMPLRLLVM-64705
 
+// XFAIL: linux && arch-intel_gpu_bmg_g21 && !igc-dev && run-mode
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17453
+
 // Test checks that persistent cache works correctly with multiple devices.
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/build_twice.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/build_twice.cpp
@@ -10,6 +10,9 @@
 // XFAIL: spirv-backend && run-mode
 // XFAIL-TRACKER: CMPLRLLVM-64705
 
+// XFAIL: linux && arch-intel_gpu_bmg_g21 && !igc-dev && run-mode
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17453
+
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
 

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
@@ -32,6 +32,9 @@
 // XFAIL: spirv-backend && run-mode
 // XFAIL-TRACKER: CMPLRLLVM-64705
 
+// XFAIL: linux && arch-intel_gpu_bmg_g21 && !igc-dev && run-mode
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17453
+
 #include <cmath>
 #include <complex>
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
I talked to the KMD team and they recommended doing it this way for the `xe` module.

Maybe this will improve stability.

I hardcoded the PCI ID but we only have one Linux BMG runner so it should be fine for now.

Confirmed this works by checking the dmesg log of the runner.