### PR TITLE
[SYCL][NFC] Cleanup SYCL RT CMakeLists [1/N]

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -258,6 +258,7 @@ if(TARGET UnifiedRuntimeLoader)
 endif()
 
 add_custom_target(UnifiedRuntimeAdapters)
+add_dependencies(UnifiedRuntimeLoader UnifiedRuntimeAdapters)
 
 function(add_sycl_ur_adapter NAME)
   add_dependencies(UnifiedRuntimeAdapters ur_adapter_${NAME})

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -185,8 +185,6 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
       "${UNIFIED_RUNTIME_COMMON_INCLUDE_DIR}"
   )
 
-  add_dependencies(${LIB_OBJ_NAME} UnifiedRuntimeAdapters ur_umf)
-
   target_link_libraries(${LIB_NAME}
     PRIVATE
       UnifiedRuntime-Headers
@@ -198,8 +196,6 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
       PRIVATE
       UnifiedRuntimeLoader
     )
-  else()
-    add_dependencies(${LIB_NAME} UnifiedRuntimeLoader)
   endif()
 
   target_include_directories(${LIB_NAME}
@@ -207,8 +203,6 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
       "${UNIFIED_RUNTIME_SRC_INCLUDE_DIR}"
       "${UNIFIED_RUNTIME_COMMON_INCLUDE_DIR}"
   )
-
-  add_dependencies(${LIB_NAME} UnifiedRuntimeAdapters ur_umf)
 
   add_common_options(${LIB_NAME} ${LIB_OBJ_NAME})
 

--- a/sycl/ur_win_proxy_loader/CMakeLists.txt
+++ b/sycl/ur_win_proxy_loader/CMakeLists.txt
@@ -12,6 +12,7 @@ set_property(SOURCE ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc
                "RC_COPYRIGHT=\"Copyright (C) 2023 Intel Corporation\"")
 configure_file(../../llvm/resources/windows_version_resource.rc ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc @ONLY)
 add_library(ur_win_proxy_loader SHARED  ur_win_proxy_loader.cpp  ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc)
+add_dependencies(ur_win_proxy_loader UnifiedRuntimeLoader)
 install(TARGETS ur_win_proxy_loader
   RUNTIME DESTINATION "bin" COMPONENT ur_win_proxy_loader
 )


### PR DESCRIPTION
This is one patch in a series intended to re-organize `add_sycl_rt_library` helper function to make it shorter and simpler.

Cleaned up `add_dependencies` calls:
- UR adapters are linked with UMF, there is an implicit dependency already
- `LIB_OBJ_NAME` is an `OBJECT` library, it is not linked to anything and therefore should not have any dependencies except for header files

Ideally, we should not have any `add_dependencies` calls, but due to dynamic loading mechanisms used everywhere, we need those dependencies set explicitly to ensure that everything is re-built correctly.