### PR TITLE
[UR] Add UNSUPPORTED_FEATURE return for urDeviceGetGlobalTimestamps

### DIFF
--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -2790,6 +2790,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the adapter has no means to support the operation.
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     /// [in] handle of the device instance
     ur_device_handle_t hDevice,
@@ -3184,6 +3186,8 @@ typedef void (*ur_context_extended_deleter_t)(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnDeleter`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the adapter has no means to support the operation.
 UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
     /// [in] handle of the context.
     ur_context_handle_t hContext,

--- a/unified-runtime/scripts/core/context.yml
+++ b/unified-runtime/scripts/core/context.yml
@@ -281,3 +281,6 @@ params:
     - type: void*
       name: pUserData
       desc: "[in][out][optional] pointer to data to be passed to callback."
+returns:
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+        - "If the adapter has no means to support the operation."

--- a/unified-runtime/scripts/core/device.yml
+++ b/unified-runtime/scripts/core/device.yml
@@ -864,6 +864,9 @@ params:
       desc: |
             [out][optional] pointer to the Host's global timestamp that
             correlates with the Device's global timestamp value
+returns:
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+        - "If the adapter has no means to support the operation."
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Memory order capabilities"

--- a/unified-runtime/source/adapters/opencl/device.cpp
+++ b/unified-runtime/source/adapters/opencl/device.cpp
@@ -1723,7 +1723,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
   RetErr = cl_adapter::getPlatformVersion(Platform, PlatVer);
 
   if (PlatVer < oclv::V2_1 || DevVer < oclv::V2_1) {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
   if (pDeviceTimestamp) {

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -1179,6 +1179,8 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the adapter has no means to support the operation.
 ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     /// [in] handle of the device instance
     ur_device_handle_t hDevice,
@@ -1475,6 +1477,8 @@ ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnDeleter`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the adapter has no means to support the operation.
 ur_result_t UR_APICALL urContextSetExtendedDeleter(
     /// [in] handle of the context.
     ur_context_handle_t hContext,

--- a/unified-runtime/source/ur_api.cpp
+++ b/unified-runtime/source/ur_api.cpp
@@ -1053,6 +1053,8 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the adapter has no means to support the operation.
 ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     /// [in] handle of the device instance
     ur_device_handle_t hDevice,
@@ -1310,6 +1312,8 @@ ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnDeleter`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the adapter has no means to support the operation.
 ur_result_t UR_APICALL urContextSetExtendedDeleter(
     /// [in] handle of the context.
     ur_context_handle_t hContext,

--- a/unified-runtime/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
@@ -31,39 +31,32 @@ using urDeviceGetGlobalTimestampTest = uur::urDeviceTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceGetGlobalTimestampTest);
 
 TEST_P(urDeviceGetGlobalTimestampTest, Success) {
-  // See https://github.com/oneapi-src/unified-runtime/issues/2633
-  UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
-
   uint64_t device_time = 0;
   uint64_t host_time = 0;
-  ASSERT_SUCCESS(urDeviceGetGlobalTimestamps(device, &device_time, &host_time));
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetGlobalTimestamps(device, &device_time, &host_time));
   ASSERT_NE(device_time, 0);
   ASSERT_NE(host_time, 0);
 }
 
 TEST_P(urDeviceGetGlobalTimestampTest, SuccessHostTimer) {
-  UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
-
   uint64_t host_time = 0;
-  ASSERT_SUCCESS(urDeviceGetGlobalTimestamps(device, nullptr, &host_time));
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetGlobalTimestamps(device, nullptr, &host_time));
   ASSERT_NE(host_time, 0);
 }
 
 TEST_P(urDeviceGetGlobalTimestampTest, SuccessNoTimers) {
-  UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
-
-  ASSERT_SUCCESS(urDeviceGetGlobalTimestamps(device, nullptr, nullptr));
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetGlobalTimestamps(device, nullptr, nullptr));
 }
 
 TEST_P(urDeviceGetGlobalTimestampTest, SuccessSynchronizedTime) {
-  // Returns `UR_RESULT_ERROR_INVALID_OPERATION`
-  UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
-
   uint64_t deviceStartTime = 0, deviceEndTime = 0;
   uint64_t hostStartTime = 0, hostEndTime = 0;
   uint64_t hostOnlyStartTime = 0, hostOnlyEndTime = 0;
 
-  ASSERT_SUCCESS(
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
       urDeviceGetGlobalTimestamps(device, &deviceStartTime, &hostStartTime));
   ASSERT_SUCCESS(
       urDeviceGetGlobalTimestamps(device, nullptr, &hostOnlyStartTime));

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -37,11 +37,9 @@ struct urEnqueueUSMFill2DTestWithParam
     UUR_RETURN_ON_FATAL_FAILURE(urQueueTestWithParam::SetUp());
 
     bool memfill2d_support = false;
-    [[maybe_unused]] ur_result_t result = urContextGetInfo(
-        context, UR_CONTEXT_INFO_USM_FILL2D_SUPPORT, sizeof(memfill2d_support),
-        &memfill2d_support, nullptr);
-    ASSERT_TRUE(result == UR_RESULT_SUCCESS ||
-                result == UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);
+    ASSERT_SUCCESS(urContextGetInfo(context, UR_CONTEXT_INFO_USM_FILL2D_SUPPORT,
+                                    sizeof(memfill2d_support),
+                                    &memfill2d_support, nullptr));
     if (!memfill2d_support) {
       GTEST_SKIP() << "2D USM mem fill is not supported";
     }


### PR DESCRIPTION
Similar to urContextSetExtendedDeleter this entry point isn't supported
by devices that report a CL version < 2.1. We aren't going to support
versions this old forever, so it's simplest to just allow the
UNSUPPORTED_FEATURE return for now.

Also cleans up some weird api usage I noticed in a fixture along the
way.

Fixes https://github.com/oneapi-src/unified-runtime/issues/2633