### PR TITLE
[SYCL][CI] Limit the scope of Linux pre-commit build

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -170,7 +170,7 @@ jobs:
           --cmake-opt="-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV"
     - name: Compile
       id: build
-      run: cmake --build $GITHUB_WORKSPACE/build
+      run: cmake --build $GITHUB_WORKSPACE/build --target sycl-toolchain
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
       run: |


### PR DESCRIPTION
We don't need to build default `all` target, `sycl-toolchain` is enough for us.