### PR TITLE
[SYCL] Preserve fpbuiltin-max-error information in fpmath metadata

### DIFF
--- a/llvm/lib/Transforms/Scalar/FPBuiltinFnSelection.cpp
+++ b/llvm/lib/Transforms/Scalar/FPBuiltinFnSelection.cpp
@@ -19,6 +19,7 @@
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/IntrinsicsNVPTX.h"
+#include "llvm/IR/MDBuilder.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -102,8 +103,17 @@ static bool replaceWithLLVMIR(FPBuiltinIntrinsic &BuiltinCall) {
   BuiltinCall.replaceAllUsesWith(Replacement);
   // ConstantFolder may fold original arguments to a constant, meaning we might
   // have no instruction anymore.
-  if (auto *ReplacementI = dyn_cast<Instruction>(Replacement))
+  if (auto *ReplacementI = dyn_cast<Instruction>(Replacement)) {
     ReplacementI->copyFastMathFlags(&BuiltinCall);
+    // Copy accuracy from fp-max-error attribute to fpmath metadata just in case
+    // if the backend can do something useful with it.
+    std::optional<float> Accuracy = BuiltinCall.getRequiredAccuracy();
+    if (Accuracy.has_value()) {
+      llvm::MDBuilder MDHelper(BuiltinCall.getContext());
+      llvm::MDNode *Node = MDHelper.createFPMath(Accuracy.value());
+      ReplacementI->setMetadata(LLVMContext::MD_fpmath, Node);
+    }
+  }
   LLVM_DEBUG(dbgs() << DEBUG_TYPE << ": Replaced call to `"
                     << BuiltinCall.getCalledFunction()->getName()
                     << "` with equivalent IR. \n `");

--- a/llvm/test/Transforms/FPBuiltinFnSelection/Generic/fp-builtin-intrinsics-preserve-fpmath.ll
+++ b/llvm/test/Transforms/FPBuiltinFnSelection/Generic/fp-builtin-intrinsics-preserve-fpmath.ll
@@ -1,0 +1,16 @@
+; RUN: opt  -fpbuiltin-fn-selection -S < %s 2>&1 | FileCheck %s
+
+; Check that "fpbuiltin-max-error" attribute value is copied to fpmath metadata
+
+; CHECK: %[[#]] = call float @llvm.sqrt.f32(float %{{.*}}), !fpmath ![[#MD:]]
+; CHECK: ![[#MD]] = !{float 5.000000e-01}
+
+define void @test_scalar_cr(float %f) {
+entry:
+  %t1 = call float @llvm.fpbuiltin.sqrt.f32(float %f) #0
+  ret void
+}
+
+declare float @llvm.fpbuiltin.sqrt.f32(float)
+
+attributes #0 = { "fpbuiltin-max-error"="0.5" }


### PR DESCRIPTION
FPBuiltinFnSelection pass is modified to create fpmath metadata during replacement of
llvm.fpbuiltin.* intrinsics with native LLVM instructions or LLVM std intrinsics.