### PR TITLE
[DeviceSanitizer] Skip adding device sanitizers internal variable to bundler symbol table

### DIFF
--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -700,6 +700,7 @@ class ObjectFileHandler final : public FileHandler {
         if (SF->isIR() &&
             (Name == "llvm.used" || Name == "llvm.compiler.used" ||
              Name == "__AsanDeviceGlobalMetadata" ||
+             Name == "__MsanDeviceGlobalMetadata" ||
              Name == "__AsanKernelMetadata" || Name == "__MsanKernelMetadata"))
           continue;
 

--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -701,7 +701,9 @@ class ObjectFileHandler final : public FileHandler {
             (Name == "llvm.used" || Name == "llvm.compiler.used" ||
              Name == "__AsanDeviceGlobalMetadata" ||
              Name == "__MsanDeviceGlobalMetadata" ||
-             Name == "__AsanKernelMetadata" || Name == "__MsanKernelMetadata"))
+             Name == "__TsanDeviceGlobalMetadata" ||
+             Name == "__AsanKernelMetadata" || Name == "__MsanKernelMetadata" ||
+             Name == "__TsanKernelMetadata"))
           continue;
 
         // Add symbol name with the target prefix to the buffer.

--- a/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c
+++ b/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c
@@ -1,5 +1,5 @@
 // RUN: llvm-as %s.ll -o %t-in.bc
-// RUN: clang -c -o %t-in.o %s
+// RUN: %clang -c -o %t-in.o %s
 // RUN: clang-offload-bundler -type=o -targets=openmp-spir64_gen,host-x86_64-unknown-linux-gnu -input=%t-in.bc -input=%t-in.o -output=%t-out.o
 // RUN: llvm-readobj --string-dump=.tgtsym %t-out.o | FileCheck %s.ll
 

--- a/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c
+++ b/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c
@@ -1,0 +1,6 @@
+// RUN: llvm-as %s.ll -o %t-in.bc
+// RUN: clang -c -o %t-in.o %s
+// RUN: clang-offload-bundler -type=o -targets=openmp-spir64_gen,host-x86_64-unknown-linux-gnu -input=%t-in.bc -input=%t-in.o -output=%t-out.o
+// RUN: llvm-readobj --string-dump=.tgtsym %t-out.o | FileCheck %s.ll
+
+int main() {return 0;}

--- a/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c.ll
+++ b/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c.ll
@@ -1,6 +1,3 @@
-target triple = "spir64_gen"
-target device_triples = "spir64_gen"
-
 @__AsanKernelMetadata = global i64 0
 ;CHECK-NOT: __AsanKernelMetadata
 @__MsanKernelMetadata = global i64 0

--- a/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c.ll
+++ b/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c.ll
@@ -1,0 +1,21 @@
+target triple = "spir64_gen"
+target device_triples = "spir64_gen"
+
+@__AsanKernelMetadata = global i64 0
+;CHECK-NOT: __AsanKernelMetadata
+@__MsanKernelMetadata = global i64 0
+;CHECK-NOT: __MsanKernelMetadata
+@__TsanKernelMetadata = global i64 0
+;CHECK-NOT: __TsanKernelMetadata
+@__AsanDeviceGlobalMetadata = global i64 0
+;CHECK-NOT: __AsanDeviceGlobalMetadata
+@__MsanDeviceGlobalMetadata = global i64 0
+;CHECK-NOT: __MsanDeviceGlobalMetadata
+@__TsanDeviceGlobalMetadata = global i64 0
+;CHECK-NOT: __TsanDeviceGlobalMetadata
+
+@not_skipping = global i64 0
+;CHECK: not_skipping
+
+@__another_global = global i64 0
+;CHECK: __another_global


### PR DESCRIPTION
`__MsanDeviceGlobalMetadata` etc are sanitizer internal variables, and should not be bundled to the symbol table.
