### PR TITLE
[SYCL][NativeCPU] Fix __clc_exp10.

### DIFF
--- a/libclc/libspirv/lib/generic/math/clc_exp10.cl
+++ b/libclc/libspirv/lib/generic/math/clc_exp10.cl
@@ -123,22 +123,27 @@ _CLC_DEF _CLC_OVERLOAD double __clc_exp10(double x) {
   int m = n >> 6;
 
   double r =
-      R_LN10 * fma(-R_LOG10_2_BY_64_TL, dn, fma(-R_LOG10_2_BY_64_LD, dn, x));
+      R_LN10 * __spirv_ocl_fma(-R_LOG10_2_BY_64_TL, dn,
+                               __spirv_ocl_fma(-R_LOG10_2_BY_64_LD, dn, x));
 
   // 6 term tail of Taylor expansion of e^r
   double z2 =
-      r *
-      fma(r,
-          fma(r,
-              fma(r,
-                  fma(r, fma(r, 0x1.6c16c16c16c17p-10, 0x1.1111111111111p-7),
-                      0x1.5555555555555p-5),
-                  0x1.5555555555555p-3),
-              0x1.0000000000000p-1),
-          1.0);
+      r * __spirv_ocl_fma(
+              r,
+              __spirv_ocl_fma(
+                  r,
+                  __spirv_ocl_fma(
+                      r,
+                      __spirv_ocl_fma(r,
+                                      __spirv_ocl_fma(r, 0x1.6c16c16c16c17p-10,
+                                                      0x1.1111111111111p-7),
+                                      0x1.5555555555555p-5),
+                      0x1.5555555555555p-3),
+                  0x1.0000000000000p-1),
+              1.0);
 
   double2 tv = USE_TABLE(two_to_jby64_ep_tbl, j);
-  z2 = fma(tv.s0 + tv.s1, z2, tv.s1) + tv.s0;
+  z2 = __spirv_ocl_fma(tv.s0 + tv.s1, z2, tv.s1) + tv.s0;
 
   int small_value = (m < -1022) || ((m == -1022) && (z2 < 1.0));
 
@@ -147,7 +152,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_exp10(double x) {
   double z3 = z2 * as_double(((long)n1 + 1023) << 52);
   z3 *= as_double(((long)n2 + 1023) << 52);
 
-  z2 = ldexp(z2, m);
+  z2 = __spirv_ocl_ldexp(z2, m);
   z2 = small_value ? z3 : z2;
 
   z2 = __clc_isnan(x) ? x : z2;


### PR DESCRIPTION
In the libspirv builtins, no definitions of fma and ldexp are provided, and there must be no references to them. Call __spirv_ocl_fma and __spirv_ocl_ldexp instead.