### PR TITLE
[DeviceSanitizers] Adjust backtrace addresses to call instruction

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
@@ -30,9 +30,7 @@ StackTrace GetCurrentBacktrace() {
   }
 
   StackTrace Stack;
-  if (FrameCount > 1)
-    Stack.stack =
-        std::vector<BacktraceFrame>(&Frames[0], &Frames[FrameCount - 1]);
+  Stack.stack = std::vector<BacktraceFrame>(&Frames[0], &Frames[FrameCount]);
 
   return Stack;
 }

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
@@ -25,7 +25,7 @@ StackTrace GetCurrentBacktrace() {
   // call instruction. Adjust the addresses so that symbolizer would give more
   // precise result.
   for (int I = 0; I < FrameCount; I++) {
-    *(uintptr_t *)&Frames[I] -= 1;
+    reinterpret_cast<uintptr_t>(Frames[I]) -= 1;
   }
 
   StackTrace Stack;

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
@@ -21,6 +21,13 @@ StackTrace GetCurrentBacktrace() {
   BacktraceFrame Frames[MAX_BACKTRACE_FRAMES];
   int FrameCount = backtrace(Frames, MAX_BACKTRACE_FRAMES);
 
+  // The Frames contain the return addresses, which is one instruction after the
+  // call instruction. Adjust the addresses so that symbolizer would give more
+  // precise result.
+  for (int I = 0; I < FrameCount; I++) {
+    (uintptr_t &)Frames[I] = (uintptr_t &)Frames[I] - 1;
+  }
+
   StackTrace Stack;
   Stack.stack =
       std::vector<BacktraceFrame>(&Frames[0], &Frames[FrameCount - 1]);

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
@@ -29,8 +29,9 @@ StackTrace GetCurrentBacktrace() {
   }
 
   StackTrace Stack;
-  Stack.stack =
-      std::vector<BacktraceFrame>(&Frames[0], &Frames[FrameCount - 1]);
+  if (FrameCount > 1)
+    Stack.stack =
+        std::vector<BacktraceFrame>(&Frames[0], &Frames[FrameCount - 1]);
 
   return Stack;
 }

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
@@ -13,6 +13,7 @@
 #include "sanitizer_common/sanitizer_stacktrace.hpp"
 
 #include <execinfo.h>
+#include <stdint.h>
 #include <string>
 
 namespace ur_sanitizer_layer {
@@ -25,7 +26,7 @@ StackTrace GetCurrentBacktrace() {
   // call instruction. Adjust the addresses so that symbolizer would give more
   // precise result.
   for (int I = 0; I < FrameCount; I++) {
-    *(char **)&Frames[I] -= 1;
+    Frames[I] = (void *)((uintptr_t)Frames[I] - 1);
   }
 
   StackTrace Stack;

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
@@ -25,7 +25,7 @@ StackTrace GetCurrentBacktrace() {
   // call instruction. Adjust the addresses so that symbolizer would give more
   // precise result.
   for (int I = 0; I < FrameCount; I++) {
-    *(char *)&Frames[I] -= 1;
+    *(char **)&Frames[I] -= 1;
   }
 
   StackTrace Stack;

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
@@ -25,7 +25,7 @@ StackTrace GetCurrentBacktrace() {
   // call instruction. Adjust the addresses so that symbolizer would give more
   // precise result.
   for (int I = 0; I < FrameCount; I++) {
-    (uintptr_t &)Frames[I] = (uintptr_t &)Frames[I] - 1;
+    *(uintptr_t *)&Frames[I] -= 1;
   }
 
   StackTrace Stack;

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/backtrace.cpp
@@ -25,7 +25,7 @@ StackTrace GetCurrentBacktrace() {
   // call instruction. Adjust the addresses so that symbolizer would give more
   // precise result.
   for (int I = 0; I < FrameCount; I++) {
-    reinterpret_cast<uintptr_t>(Frames[I]) -= 1;
+    *(char *)&Frames[I] -= 1;
   }
 
   StackTrace Stack;


### PR DESCRIPTION
`backtrace()` would return buffers with return addresses, which is one instruction past the call. If that instruction belongs to other source lines, then the llvm-symbolizer would give out wrong result.
Test will be added internally. It is hard to write test for this using SYCL as SYCL does not generate code with that pattern.