### PR TITLE
[SYCL] Build L0 v2 adapter by default

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -167,8 +167,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DLLVM_INSTALL_UTILS=ON \
           -DNATIVECPU_USE_OCK=Off \
-          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV \
-          --level_zero_v1_and_v2
+          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
     - name: Compile
       id: build
       run: cmake --build $GITHUB_WORKSPACE/build --target sycl-toolchain

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -70,13 +70,13 @@ def do_configure(args, passthrough_args):
     if sys.platform != "darwin":
         # For more info on the enablement of level_zero_v2 refer to this document:
         # https://github.com/intel/llvm/blob/sycl/unified-runtime/source/adapters/level_zero/v2/README.md
-        if args.level_zero_v2:
+        if args.level_zero_adapter_version == "V1":
+            sycl_enabled_backends.append("level_zero")
+        if args.level_zero_adapter_version == "V2":
             sycl_enabled_backends.append("level_zero_v2")
-        elif args.level_zero_v1_and_v2:
+        if args.level_zero_adapter_version == "ALL":
             sycl_enabled_backends.append("level_zero")
             sycl_enabled_backends.append("level_zero_v2")
-        else:
-            sycl_enabled_backends.append("level_zero")
 
     # lld is needed on Windows or for the HIP adapter on AMD
     if platform.system() == "Windows" or (args.hip and args.hip_platform == "AMD"):
@@ -340,12 +340,11 @@ def main():
         help="choose hardware platform for HIP backend",
     )
     parser.add_argument(
-        "--level_zero_v2", action="store_true", help="Enable SYCL Level Zero V2"
-    )
-    parser.add_argument(
-        "--level_zero_v1_and_v2",
-        action="store_true",
-        help="Enable SYCL Level Zero Legacy and V2",
+        "--level_zero_adapter_version",
+        type=str,
+        choices=["V1", "V2", "ALL"],
+        default="ALL",
+        help="Choose version of Level Zero adapter to build",
     )
     parser.add_argument(
         "--host-target",

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 # If SYCL_ENABLE_BACKENDS is undefined, we default to enabling OpenCL and Level
 # Zero backends.
 if (NOT DEFINED SYCL_ENABLE_BACKENDS)
-  set(SYCL_ENABLE_BACKENDS "opencl;level_zero")
+  set(SYCL_ENABLE_BACKENDS "opencl;level_zero;level_zero_v2")
 endif()
 
 # Option to enable JIT, this in turn makes kernel fusion and spec constant

--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -160,6 +160,7 @@ For a description of parallel for range rounding in DPC++ see
 | `SYCL_ENABLE_PCI` (Deprecated) | Integer | When set to 1, enables obtaining the GPU PCI address when using the Level Zero backend. The default is 1. This option is kept for compatibility reasons and is immediately deprecated. |
 | `SYCL_PI_LEVEL_ZERO_DISABLE_USM_ALLOCATOR` | Any(\*) | Disable USM allocator in Level Zero adapter (each memory request will go directly to Level Zero runtime) |
 | `SYCL_PI_LEVEL_ZERO_TRACK_INDIRECT_ACCESS_MEMORY` | Any(\*) | Enable support of the kernels with indirect access and corresponding deferred release of memory allocations in the Level Zero adapter. |
+| `SYCL_UR_USE_LEVEL_ZERO_V2` | Integer | Enable ('1') or disable ('0') the use of a preview version of the Level Zero adapter, which features a redesigned architecture aimed at optimizing performance for different queue modes (immediate/batched, in-order/out-of-order). This version is expected to reduce runtime overhead and currently only support immediate, in-order mode. If you experience any performance or functional issues with this adapter enabled, please report them on GitHub, specifying the adapter used. |
 
 `(*) Note: Any means this environment variable is effective when set to any non-null value.`
 

--- a/unified-runtime/source/adapters/level_zero/v2/README.md
+++ b/unified-runtime/source/adapters/level_zero/v2/README.md
@@ -6,6 +6,14 @@ L0 v2 adapter can be enabled by setting passing `UR_BUILD_ADAPTER_L0_V2=1` optio
 
 Currently, L0 v2 is only available as an experimental adapter to gather feedback and adding missing features. L0 v2 is planned to be the default adapter for L0 in 2026.0 release.
 
+To enable L0 v2 adapter at runtime, set, `SYCL_UR_USE_LEVEL_ZERO_V2=1`.
+
+This forces UR and SYCL to use the v2 adapter instead of the legacy version.
+
+Alternatively, `UR_ADAPTER_FORCE_LOAD` env variable can be used.
+
+SYCL E2E tests can be used to test v2 adapter by passing `level_zero_v2:gpu` to llvm-lit `sycl_devices`.
+
 # Code structure
 
 v2 adapters is is a standalone adapter but reuses some logic from the legacy L0 adapter implementation - most notably: adapter.cpp, platform.cpp, device.cpp

--- a/unified-runtime/source/loader/ur_adapter_registry.hpp
+++ b/unified-runtime/source/loader/ur_adapter_registry.hpp
@@ -324,13 +324,15 @@ private:
       // Skip legacy L0 adapter if the v2 adapter is requested, and vice versa.
       if (std::string(adapterName).find("level_zero") != std::string::npos) {
         auto v2Requested = getenv_tobool("UR_LOADER_USE_LEVEL_ZERO_V2", false);
+        v2Requested |= getenv_tobool("SYCL_UR_USE_LEVEL_ZERO_V2", false);
         auto v2Adapter =
             std::string(adapterName).find("v2") != std::string::npos;
 
         if (v2Requested != v2Adapter) {
-          logger::info("The adapter '{}' is skipped because {} {}.",
-                       adapterName, "UR_LOADER_USE_LEVEL_ZERO_V2",
-                       v2Requested ? "is set" : "is not set");
+          logger::info(
+              "The adapter '{}' is skipped because {} {}.", adapterName,
+              "UR_LOADER_USE_LEVEL_ZERO_V2 or SYCL_UR_USE_LEVEL_ZERO_V2",
+              v2Requested ? "is set" : "is not set");
           continue;
         }
       }


### PR DESCRIPTION
L0 v2 adapter is expected to be shipped as part of 2025.2 release.

Refactor params to configure.py into a single 'choice' param.