### PR TITLE
[UR] Handle adapters returning no platforms during testing

### DIFF
--- a/unified-runtime/test/conformance/source/environment.cpp
+++ b/unified-runtime/test/conformance/source/environment.cpp
@@ -80,6 +80,9 @@ void uur::PlatformEnvironment::populatePlatforms() {
   for (auto a : adapters) {
     uint32_t count = 0;
     ASSERT_SUCCESS(urPlatformGet(&a, 1, 0, nullptr, &count));
+    if (count == 0) {
+      continue;
+    }
     std::vector<ur_platform_handle_t> platform_list(count);
     ASSERT_SUCCESS(urPlatformGet(&a, 1, count, platform_list.data(), nullptr));
 
@@ -87,6 +90,9 @@ void uur::PlatformEnvironment::populatePlatforms() {
       platforms.push_back(p);
     }
   }
+
+  ASSERT_FALSE(platforms.empty())
+      << "No platforms are available on any adapters";
 }
 
 void uur::PlatformEnvironment::SetUp() {


### PR DESCRIPTION
When initialising tests, adapters may return no platforms. This patch
ensures that that doesn't cause a failure unless there are no platforms
in any adapter.
