### PR TITLE
[SYCL][UR][CUDA] Move CUDA device memory pools to the context

### DIFF
--- a/unified-runtime/source/adapters/cuda/common.hpp
+++ b/unified-runtime/source/adapters/cuda/common.hpp
@@ -73,6 +73,8 @@ void assertion(bool Condition, const char *Message = nullptr);
 
 namespace umf {
 
+ur_result_t getProviderNativeError(const char *, int32_t);
+
 inline umf_result_t setCUMemoryProviderParams(
     umf_cuda_memory_provider_params_handle_t CUMemoryProviderParams,
     int cuDevice, void *cuContext, umf_usm_memory_type_t memType) {
@@ -91,5 +93,14 @@ inline umf_result_t setCUMemoryProviderParams(
 
   return UMF_RESULT_SUCCESS;
 }
+
+ur_result_t
+createHostMemoryProvider(CUcontext contextCUDA,
+                         umf_memory_provider_handle_t *memoryProviderHost);
+
+ur_result_t
+createDeviceMemoryProviders(ur_device_handle_t_ *DeviceHandle,
+                            umf_memory_provider_handle_t *memoryDeviceProvider,
+                            umf_memory_provider_handle_t *memorySharedProvider);
 
 } // namespace umf

--- a/unified-runtime/source/adapters/cuda/device.hpp
+++ b/unified-runtime/source/adapters/cuda/device.hpp
@@ -82,28 +82,9 @@ public:
     // CUDA doesn't really have this concept, and could allow almost 100% of
     // global memory in one allocation, but is dependent on device usage.
     UR_CHECK_ERROR(cuDeviceTotalMem(&MaxAllocSize, cuDevice));
-
-    MemoryProviderDevice = nullptr;
-    MemoryProviderShared = nullptr;
-    MemoryPoolDevice = nullptr;
-    MemoryPoolShared = nullptr;
   }
 
-  ~ur_device_handle_t_() {
-    if (MemoryPoolDevice) {
-      umfPoolDestroy(MemoryPoolDevice);
-    }
-    if (MemoryPoolShared) {
-      umfPoolDestroy(MemoryPoolShared);
-    }
-    if (MemoryProviderDevice) {
-      umfMemoryProviderDestroy(MemoryProviderDevice);
-    }
-    if (MemoryProviderShared) {
-      umfMemoryProviderDestroy(MemoryProviderShared);
-    }
-    cuDevicePrimaryCtxRelease(CuDevice);
-  }
+  ~ur_device_handle_t_() { cuDevicePrimaryCtxRelease(CuDevice); }
 
   native_type get() const noexcept { return CuDevice; };
 
@@ -139,16 +120,6 @@ public:
 
   // bookkeeping for mipmappedArray leaks in Mapping external Memory
   std::map<CUarray, CUmipmappedArray> ChildCuarrayFromMipmapMap;
-
-  // UMF CUDA memory provider and pool for the device memory
-  // (UMF_MEMORY_TYPE_DEVICE)
-  umf_memory_provider_handle_t MemoryProviderDevice;
-  umf_memory_pool_handle_t MemoryPoolDevice;
-
-  // UMF CUDA memory provider and pool for the shared memory
-  // (UMF_MEMORY_TYPE_SHARED)
-  umf_memory_provider_handle_t MemoryProviderShared;
-  umf_memory_pool_handle_t MemoryPoolShared;
 };
 
 int getAttribute(ur_device_handle_t Device, CUdevice_attribute Attribute);

--- a/unified-runtime/source/adapters/cuda/memory.cpp
+++ b/unified-runtime/source/adapters/cuda/memory.cpp
@@ -422,7 +422,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
 ur_result_t allocateMemObjOnDeviceIfNeeded(ur_mem_handle_t Mem,
                                            const ur_device_handle_t hDevice) {
   ScopedContext Active(hDevice);
-  auto DeviceIdx = Mem->getContext()->getDeviceIndex(hDevice);
+  ur_context_handle_t Context = Mem->getContext();
+  auto DeviceIdx = Context->getDeviceIndex(hDevice);
   ur_lock LockGuard(Mem->MemoryAllocationMutex);
 
   if (Mem->isBuffer()) {
@@ -442,7 +443,8 @@ ur_result_t allocateMemObjOnDeviceIfNeeded(ur_mem_handle_t Mem,
                                        CU_MEMHOSTALLOC_DEVICEMAP));
       UR_CHECK_ERROR(cuMemHostGetDevicePointer(&DevPtr, Buffer.HostPtr, 0));
     } else {
-      *(void **)&DevPtr = umfPoolMalloc(hDevice->MemoryPoolDevice, Buffer.Size);
+      *(void **)&DevPtr =
+          umfPoolMalloc(Context->MemoryDevicePools[DeviceIdx], Buffer.Size);
       UMF_CHECK_PTR(*(void **)&DevPtr);
     }
   } else {

--- a/unified-runtime/source/adapters/cuda/platform.cpp
+++ b/unified-runtime/source/adapters/cuda/platform.cpp
@@ -13,67 +13,10 @@
 #include "common.hpp"
 #include "context.hpp"
 #include "device.hpp"
-#include "umf_helpers.hpp"
 
 #include <cassert>
 #include <cuda.h>
 #include <sstream>
-
-static ur_result_t
-CreateDeviceMemoryProvidersPools(ur_platform_handle_t_ *Platform) {
-  umf_cuda_memory_provider_params_handle_t CUMemoryProviderParams = nullptr;
-
-  umf_result_t UmfResult =
-      umfCUDAMemoryProviderParamsCreate(&CUMemoryProviderParams);
-  UMF_RETURN_UR_ERROR(UmfResult);
-
-  OnScopeExit Cleanup(
-      [=]() { umfCUDAMemoryProviderParamsDestroy(CUMemoryProviderParams); });
-
-  for (auto &Device : Platform->Devices) {
-    ur_device_handle_t_ *device_handle = Device.get();
-    CUdevice device = device_handle->get();
-    CUcontext context = device_handle->getNativeContext();
-
-    // create UMF CUDA memory provider for the device memory
-    // (UMF_MEMORY_TYPE_DEVICE)
-    UmfResult = umf::setCUMemoryProviderParams(CUMemoryProviderParams, device,
-                                               context, UMF_MEMORY_TYPE_DEVICE);
-    UMF_RETURN_UR_ERROR(UmfResult);
-
-    UmfResult = umfMemoryProviderCreate(umfCUDAMemoryProviderOps(),
-                                        CUMemoryProviderParams,
-                                        &device_handle->MemoryProviderDevice);
-    UMF_RETURN_UR_ERROR(UmfResult);
-
-    // create UMF CUDA memory provider for the shared memory
-    // (UMF_MEMORY_TYPE_SHARED)
-    UmfResult = umf::setCUMemoryProviderParams(CUMemoryProviderParams, device,
-                                               context, UMF_MEMORY_TYPE_SHARED);
-    UMF_RETURN_UR_ERROR(UmfResult);
-
-    UmfResult = umfMemoryProviderCreate(umfCUDAMemoryProviderOps(),
-                                        CUMemoryProviderParams,
-                                        &device_handle->MemoryProviderShared);
-    UMF_RETURN_UR_ERROR(UmfResult);
-
-    // create UMF CUDA memory pool for the device memory
-    // (UMF_MEMORY_TYPE_DEVICE)
-    UmfResult =
-        umfPoolCreate(umfProxyPoolOps(), device_handle->MemoryProviderDevice,
-                      nullptr, 0, &device_handle->MemoryPoolDevice);
-    UMF_RETURN_UR_ERROR(UmfResult);
-
-    // create UMF CUDA memory pool for the shared memory
-    // (UMF_MEMORY_TYPE_SHARED)
-    UmfResult =
-        umfPoolCreate(umfProxyPoolOps(), device_handle->MemoryProviderShared,
-                      nullptr, 0, &device_handle->MemoryPoolShared);
-    UMF_RETURN_UR_ERROR(UmfResult);
-  }
-
-  return UR_RESULT_SUCCESS;
-}
 
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform, ur_platform_info_t PlatformInfoType,
@@ -155,8 +98,6 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
                   new ur_device_handle_t_{Device, Context, EvBase, &Platform,
                                           static_cast<uint32_t>(i)});
             }
-
-            UR_CHECK_ERROR(CreateDeviceMemoryProvidersPools(&Platform));
           } catch (const std::bad_alloc &) {
             // Signal out-of-memory situation
             for (int i = 0; i < NumDevices; ++i) {

--- a/unified-runtime/source/common/CMakeLists.txt
+++ b/unified-runtime/source/common/CMakeLists.txt
@@ -40,11 +40,11 @@ if (NOT DEFINED UMF_REPO)
 endif()
 
 if (NOT DEFINED UMF_TAG)
-    # commit 5a515c56c92be75944c8246535c408cee7711114
-    # Author: Lukasz Dorau <lukasz.dorau@intel.com>
-    # Date:   Mon Feb 17 10:56:05 2025 +0100
-    # Merge pull request #1086 from vinser52/svinogra_l0_linking
-    set(UMF_TAG 5a515c56c92be75944c8246535c408cee7711114)
+    # commit 998debed7a8551bdf6774be810559bb6cef6542b
+    # Author: Krzysztof Filipek <krzysztof.filipek@intel.com>
+    # Date:   Thu Mar 13 09:53:27 2025 +0100
+    # Merge pull request #1183 from ldorau/Fix_segfault_in_cu_memory_provider_get_last_native_error
+    set(UMF_TAG v0.11.0-dev4)
 endif()
 
 message(STATUS "Will fetch Unified Memory Framework from ${UMF_REPO}")
@@ -127,5 +127,4 @@ add_library(${PROJECT_NAME}::umf ALIAS ur_umf)
 target_link_libraries(ur_umf INTERFACE
     umf::umf
     umf::headers
-    umf::disjoint_pool
 )

--- a/unified-runtime/source/common/umf_helpers.hpp
+++ b/unified-runtime/source/common/umf_helpers.hpp
@@ -239,21 +239,6 @@ static inline auto poolMakeUniqueFromOps(umf_memory_pool_ops_t *ops,
       UMF_RESULT_SUCCESS, pool_unique_handle_t(hPool, umfPoolDestroy)};
 }
 
-static inline auto
-poolMakeUniqueFromOpsProviderHandle(umf_memory_pool_ops_t *ops,
-                                    umf_memory_provider_handle_t provider,
-                                    void *params) {
-  umf_memory_pool_handle_t hPool;
-  auto ret = umfPoolCreate(ops, provider, params, 0, &hPool);
-  if (ret != UMF_RESULT_SUCCESS) {
-    return std::pair<umf_result_t, pool_unique_handle_t>{
-        ret, pool_unique_handle_t(nullptr, nullptr)};
-  }
-
-  return std::pair<umf_result_t, pool_unique_handle_t>{
-      UMF_RESULT_SUCCESS, pool_unique_handle_t(hPool, umfPoolDestroy)};
-}
-
 static inline auto providerMakeUniqueFromOps(umf_memory_provider_ops_t *ops,
                                              void *params) {
   umf_memory_provider_handle_t hProvider;


### PR DESCRIPTION
Move CUDA device memory pools to the context.

This PR fixes a segfault caused by https://github.com/intel/llvm/issues/17450

Ref: https://github.com/intel/llvm/issues/17450