### PR TITLE
[BENCHMARK] fix default timeout parameter

### DIFF
--- a/unified-runtime/scripts/benchmarks/utils/utils.py
+++ b/unified-runtime/scripts/benchmarks/utils/utils.py
@@ -20,9 +20,12 @@ def run(
     cwd=None,
     add_sycl=False,
     ld_library=[],
-    timeout=options.timeout,
+    timeout=None,
 ):
     try:
+        if timeout is None:
+            timeout = options.timeout
+
         if isinstance(command, str):
             command = command.split()
 


### PR DESCRIPTION
Previously, the default value for `timeout` was bound at function definition time using `options.timeout`, which become outdated if `options.timeout` changes later. This commit changes the default value to `None` and assigns the current `options.timeout` inside the function, ensuring that the latest value is used when no explicit timeout is provided.