### PR TITLE
Remove now unnecessary use of `--cmake-opt` from CI

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -46,8 +46,8 @@ jobs:
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults --hip --cuda \
-          --cmake-opt="-DNATIVECPU_USE_OCK=Off" \
-          --cmake-opt="-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV"
+          -DNATIVECPU_USE_OCK=Off \
+          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
 
     - name: Build with coverity
       run: $GITHUB_WORKSPACE/cov-analysis-linux64-*/bin/cov-build --dir cov-int cmake --build $GITHUB_WORKSPACE/build --target sycl-toolchain

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -163,11 +163,11 @@ jobs:
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults ${{ inputs.build_configure_extra_args }} \
-          --cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          --cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          --cmake-opt="-DLLVM_INSTALL_UTILS=ON" \
-          --cmake-opt="-DNATIVECPU_USE_OCK=Off" \
-          --cmake-opt="-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV" \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DLLVM_INSTALL_UTILS=ON \
+          -DNATIVECPU_USE_OCK=Off \
+          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV \
           --level_zero_v1_and_v2
     - name: Compile
       id: build

--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -50,8 +50,8 @@ jobs:
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults $ARGS \
-          --cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          --cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          --cmake-opt="-DLLVM_INSTALL_UTILS=ON"
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DLLVM_INSTALL_UTILS=ON
     - name: Compile
       run: cmake --build $GITHUB_WORKSPACE/build --target deploy-sycl-toolchain

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -43,7 +43,7 @@ jobs:
       build_cache_root: "/__w/"
       build_cache_suffix: oneapi
       build_artifact_suffix: oneapi
-      build_configure_extra_args: --cmake-opt=-DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" --cmake-opt=-DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
+      build_configure_extra_args: -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
       cc: icx
       cxx: icpx
 

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -37,7 +37,7 @@ jobs:
       build_cache_root: "/__w/llvm"
       build_cache_suffix: default
       build_artifact_suffix: default
-      build_configure_extra_args: --no-assertions --hip --cuda --native_cpu --cmake-opt="-DSYCL_ENABLE_STACK_PRINTING=ON" --cmake-opt="-DSYCL_LIB_WITH_DEBUG_SYMBOL=ON"
+      build_configure_extra_args: --no-assertions --hip --cuda --native_cpu -DSYCL_ENABLE_STACK_PRINTING=ON -DSYCL_LIB_WITH_DEBUG_SYMBOL=ON
 
   e2e-lin:
     needs: [build-lin]
@@ -102,7 +102,7 @@ jobs:
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
       compiler: icx
-      build_configure_extra_args: --cmake-opt=-DCMAKE_C_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt=-DCMAKE_CXX_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" --cmake-opt="-DCMAKE_EXE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_MODULE_LINKER_FLAGS=/manifest:no" --cmake-opt="-DCMAKE_SHARED_LINKER_FLAGS=/manifest:no" 
+      build_configure_extra_args: -DCMAKE_C_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" -DCMAKE_CXX_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" -DCMAKE_EXE_LINKER_FLAGS=/manifest:no -DCMAKE_MODULE_LINKER_FLAGS=/manifest:no -DCMAKE_SHARED_LINKER_FLAGS=/manifest:no
       build_cache_suffix: icx
 
   e2e-win:

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -124,13 +124,13 @@ jobs:
         IF NOT EXIST D:\github\_work\cache\${{inputs.build_cache_suffix}} MKDIR D:\github\_work\cache\${{inputs.build_cache_suffix}}
         python.exe src/buildbot/configure.py -o build ^
           --ci-defaults %ARGS% ^
-          --cmake-opt="-DCMAKE_C_COMPILER=${{inputs.compiler}}" ^
-          --cmake-opt="-DCMAKE_CXX_COMPILER=${{inputs.compiler}}" ^
-          --cmake-opt="-DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install" ^
-          --cmake-opt="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache" ^
-          --cmake-opt="-DCMAKE_C_COMPILER_LAUNCHER=ccache" ^
-          --cmake-opt="-DLLVM_INSTALL_UTILS=ON" ^
-          --cmake-opt="-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV"
+          "-DCMAKE_C_COMPILER=${{inputs.compiler}}" ^
+          "-DCMAKE_CXX_COMPILER=${{inputs.compiler}}" ^
+          "-DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install" ^
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache ^
+          -DLLVM_INSTALL_UTILS=ON ^
+          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
     - name: Build
       id: build
       shell: bash


### PR DESCRIPTION
Since ae76189d5fdd we can now pass `-D` options to cmake through the configure wrapper scripts without needing the `--cmake-opt` flag. This makes these definitions a little more succinct and easier to read.