### PR TITLE
[SYCL][Graph] Fix issue with unit tests hanging

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
@@ -1,16 +1,15 @@
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# https://github.com/intel/llvm/issues/17168
-# add_sycl_unittest(CommandGraphExtensionTests OBJECT
-#   Barrier.cpp
-#   CommandGraph.cpp
-#   CommonReferenceSemantics.cpp
-#   Exceptions.cpp
-#   InOrderQueue.cpp
-#   MultiThreaded.cpp
-#   Queries.cpp
-#   Regressions.cpp
-#   Subgraph.cpp
-#   Update.cpp
-#   Properties.cpp
-# )
+add_sycl_unittest(CommandGraphExtensionTests OBJECT
+  Barrier.cpp
+  CommandGraph.cpp
+  CommonReferenceSemantics.cpp
+  Exceptions.cpp
+  InOrderQueue.cpp
+  MultiThreaded.cpp
+  Queries.cpp
+  Regressions.cpp
+  Subgraph.cpp
+  Update.cpp
+  Properties.cpp
+)

--- a/sycl/unittests/Extensions/CommandGraph/Regressions.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Regressions.cpp
@@ -25,38 +25,47 @@ TEST_F(CommandGraphTest, AccessorModeRegression) {
   buffer<int> BufferC{range<1>{16}};
   buffer<int> BufferD{range<1>{16}};
   buffer<int> BufferE{range<1>{16}};
-  Graph.begin_recording(Queue);
 
-  auto EventA = Queue.submit([&](handler &CGH) {
-    auto AccA = BufferA.get_access<access_mode::read>(CGH);
-    auto AccB = BufferB.get_access<access_mode::read>(CGH);
-    auto AccC = BufferC.get_access<access_mode::write>(CGH);
-    CGH.single_task<TestKernel<>>([]() {});
-  });
-  auto EventB = Queue.submit([&](handler &CGH) {
-    auto AccA = BufferA.get_access<access_mode::read>(CGH);
-    auto AccB = BufferB.get_access<access_mode::read>(CGH);
-    auto AccD = BufferD.get_access<access_mode::write>(CGH);
-    CGH.single_task<TestKernel<>>([]() {});
-  });
-  auto EventC = Queue.submit([&](handler &CGH) {
-    auto AccA = BufferA.get_access<access_mode::read>(CGH);
-    auto AccB = BufferB.get_access<access_mode::read>(CGH);
-    auto AccE = BufferE.get_access<access_mode::write>(CGH);
-    CGH.single_task<TestKernel<>>([]() {});
-  });
+  {
+    // Buffers must outlive graph
+    experimental::command_graph ScopedGraph{
+        Queue.get_context(),
+        Dev,
+        {experimental::property::graph::assume_buffer_outlives_graph{}}};
 
-  Graph.end_recording(Queue);
+    ScopedGraph.begin_recording(Queue);
 
-  experimental::node NodeA = experimental::node::get_node_from_event(EventA);
-  EXPECT_EQ(NodeA.get_predecessors().size(), 0ul);
-  EXPECT_EQ(NodeA.get_successors().size(), 0ul);
-  experimental::node NodeB = experimental::node::get_node_from_event(EventB);
-  EXPECT_EQ(NodeB.get_predecessors().size(), 0ul);
-  EXPECT_EQ(NodeB.get_successors().size(), 0ul);
-  experimental::node NodeC = experimental::node::get_node_from_event(EventC);
-  EXPECT_EQ(NodeC.get_predecessors().size(), 0ul);
-  EXPECT_EQ(NodeC.get_successors().size(), 0ul);
+    auto EventA = Queue.submit([&](handler &CGH) {
+      auto AccA = BufferA.get_access<access_mode::read>(CGH);
+      auto AccB = BufferB.get_access<access_mode::read>(CGH);
+      auto AccC = BufferC.get_access<access_mode::write>(CGH);
+      CGH.single_task<TestKernel<>>([]() {});
+    });
+    auto EventB = Queue.submit([&](handler &CGH) {
+      auto AccA = BufferA.get_access<access_mode::read>(CGH);
+      auto AccB = BufferB.get_access<access_mode::read>(CGH);
+      auto AccD = BufferD.get_access<access_mode::write>(CGH);
+      CGH.single_task<TestKernel<>>([]() {});
+    });
+    auto EventC = Queue.submit([&](handler &CGH) {
+      auto AccA = BufferA.get_access<access_mode::read>(CGH);
+      auto AccB = BufferB.get_access<access_mode::read>(CGH);
+      auto AccE = BufferE.get_access<access_mode::write>(CGH);
+      CGH.single_task<TestKernel<>>([]() {});
+    });
+
+    ScopedGraph.end_recording(Queue);
+
+    experimental::node NodeA = experimental::node::get_node_from_event(EventA);
+    EXPECT_EQ(NodeA.get_predecessors().size(), 0ul);
+    EXPECT_EQ(NodeA.get_successors().size(), 0ul);
+    experimental::node NodeB = experimental::node::get_node_from_event(EventB);
+    EXPECT_EQ(NodeB.get_predecessors().size(), 0ul);
+    EXPECT_EQ(NodeB.get_successors().size(), 0ul);
+    experimental::node NodeC = experimental::node::get_node_from_event(EventC);
+    EXPECT_EQ(NodeC.get_predecessors().size(), 0ul);
+    EXPECT_EQ(NodeC.get_successors().size(), 0ul);
+  }
 }
 
 TEST_F(CommandGraphTest, QueueRecordBarrierMultipleGraph) {


### PR DESCRIPTION
- Re-enable command graph extension tests
- Fix test that could incorrectly let buffers be destroyed before the command_graph they were used in

Resolves #17168 