### PR TITLE
[SYCL][E2E] Disable flaky test event_profiling_info.cpp

### DIFF
--- a/sycl/test-e2e/Basic/event_profiling_info.cpp
+++ b/sycl/test-e2e/Basic/event_profiling_info.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: aspect-queue_profiling
+// UNSUPPORTED: linux
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/13591
 // RUN: %{build} -o %t.out
 //
 // RUN: %{run} %t.out


### PR DESCRIPTION
Already a GH issue, seems to fail on many configurations.