### PR TITLE
[SYCL][libdevice] Keep sign bit of result for std::sin(-0)

### DIFF
--- a/libdevice/fallback-cmath.cpp
+++ b/libdevice/fallback-cmath.cpp
@@ -168,8 +168,13 @@ float __devicelib_fmaf(float x, float y, float z) {
   return __spirv_ocl_fma(x, y, z);
 }
 
+#if !defined(__NVPTX__) && !defined(__AMDGCN__)
+DEVICE_EXTERN_C_INLINE
+float __devicelib_sinf(float x) { return (x == 0.0f) ? x : __spirv_ocl_sin(x); }
+#else
 DEVICE_EXTERN_C_INLINE
 float __devicelib_sinf(float x) { return __spirv_ocl_sin(x); }
+#endif
 
 DEVICE_EXTERN_C_INLINE
 float __devicelib_cosf(float x) { return __spirv_ocl_cos(x); }

--- a/libdevice/fallback-cmath.cpp
+++ b/libdevice/fallback-cmath.cpp
@@ -168,7 +168,7 @@ float __devicelib_fmaf(float x, float y, float z) {
   return __spirv_ocl_fma(x, y, z);
 }
 
-#if !defined(__NVPTX__) && !defined(__AMDGCN__)
+#if defined(__SPIR__) || defined(__SPIRV__)
 DEVICE_EXTERN_C_INLINE
 float __devicelib_sinf(float x) { return (x == 0.0f) ? x : __spirv_ocl_sin(x); }
 #else


### PR DESCRIPTION
For input '-0', __spirv_ocl_sin returns +0 for float and returns -0 for double, MSVC complex math implementation does depend on this, discarding the signbit for sin(-0) will lead to some corner case failures in exp(std::complex<float>) e2e tests. This patch is a workaround for the issue.