### PR TITLE
[UR][L0] Memory interop support given external buffer

### DIFF
--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1115,7 +1115,7 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue(false);
   }
   case UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP: {
-    // L0 does not support importing external memory.
+    // L0 supports importing external memory.
     return ReturnValue(true);
   }
   case UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP: {

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1116,7 +1116,7 @@ ur_result_t urDeviceGetInfo(
   }
   case UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP: {
     // L0 does not support importing external memory.
-    return ReturnValue(false);
+    return ReturnValue(true);
   }
   case UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP: {
     return ReturnValue(Device->Platform->ZeExternalSemaphoreExt.Supported);

--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -729,15 +729,47 @@ ur_result_t urBindlessImagesMapExternalArrayExp(
 ur_result_t urBindlessImagesMapExternalLinearMemoryExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice, uint64_t offset,
     uint64_t size, ur_exp_external_mem_handle_t hExternalMem, void **phRetMem) {
-  std::ignore = hContext;
-  std::ignore = hDevice;
-  std::ignore = size;
-  std::ignore = offset;
-  std::ignore = hExternalMem;
-  std::ignore = phRetMem;
-  logger::error("[UR][L0] {} function not implemented!",
-                "{} function not implemented!", __FUNCTION__);
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  UR_ASSERT(hContext && hDevice && hExternalMem,
+            UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(offset && size, UR_RESULT_ERROR_INVALID_BUFFER_SIZE);
+
+  struct ur_ze_external_memory_data *externalMemoryData =
+      reinterpret_cast<ur_ze_external_memory_data *>(hExternalMem);
+  UR_ASSERT(externalMemoryData && externalMemoryData->importExtensionDesc,
+            UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  struct ur_ze_external_memory_data *mappedMemory =
+      new struct ur_ze_external_memory_data;
+
+  mappedMemory->importExtensionDesc = externalMemoryData->importExtensionDesc;
+  mappedMemory->type = externalMemoryData->type;
+  mappedMemory->size = size;
+
+  ze_device_mem_alloc_desc_t allocDesc = {};
+  allocDesc.stype = ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
+  allocDesc.flags = 0;
+  allocDesc.ordinal = 0;
+
+  ze_result_t zeResult =
+      zeMemAllocDevice(hContext->ZeContext, &allocDesc, size, 1,
+                       hDevice->ZeDevice, &(mappedMemory->importExtensionDesc));
+  if (zeResult != ZE_RESULT_SUCCESS) {
+    return UR_RESULT_ERROR_OUT_OF_RESOURCES;
+  }
+
+  zeResult = zeContextMakeMemoryResident(hContext->ZeContext, hDevice->ZeDevice,
+                                         mappedMemory, size);
+  if (zeResult != ZE_RESULT_SUCCESS) {
+    zeMemFree(hContext->ZeContext, mappedMemory);
+    return UR_RESULT_ERROR_UNKNOWN;
+  }
+  *phRetMem = reinterpret_cast<void *>(
+      reinterpret_cast<uintptr_t>(mappedMemory) + offset);
+
+  externalMemoryData->urMemoryHandle =
+      reinterpret_cast<ur_mem_handle_t>(*phRetMem);
+
+  return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urBindlessImagesReleaseExternalMemoryExp(

--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -738,21 +738,14 @@ ur_result_t urBindlessImagesMapExternalLinearMemoryExp(
   UR_ASSERT(externalMemoryData && externalMemoryData->importExtensionDesc,
             UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
-  struct ur_ze_external_memory_data *mappedMemory =
-      new struct ur_ze_external_memory_data;
-
-  mappedMemory->importExtensionDesc = externalMemoryData->importExtensionDesc;
-  mappedMemory->type = externalMemoryData->type;
-  mappedMemory->size = size;
-
   ze_device_mem_alloc_desc_t allocDesc = {};
   allocDesc.stype = ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
   allocDesc.flags = 0;
-  allocDesc.ordinal = 0;
+  allocDesc.pNext = externalMemoryData->importExtensionDesc;
+  void *mappedMemory;
 
-  ze_result_t zeResult =
-      zeMemAllocDevice(hContext->ZeContext, &allocDesc, size, 1,
-                       hDevice->ZeDevice, &(mappedMemory->importExtensionDesc));
+  ze_result_t zeResult = zeMemAllocDevice(hContext->ZeContext, &allocDesc, size,
+                                          1, hDevice->ZeDevice, &mappedMemory);
   if (zeResult != ZE_RESULT_SUCCESS) {
     return UR_RESULT_ERROR_OUT_OF_RESOURCES;
   }


### PR DESCRIPTION
Enable L0 to directly import the memory allocated for NPU/iGPU and let SYCL kernel running on iGPU be able to directly access the data it will reduce the overhead of data movement between NPU/iGPU and iGPU.