### PR TITLE
[UR][CI] Install python deps in venv

### DIFF
--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -74,6 +74,7 @@ jobs:
               - 'sycl/test-e2e/(ESIMD|InvokeSimd)/**'
             ur:
               - 'unified-runtime/**'
+              - .github/workflows/ur-*
 
       - name: Set output
         id: result

--- a/.github/workflows/ur-build-hw.yml
+++ b/.github/workflows/ur-build-hw.yml
@@ -94,9 +94,14 @@ jobs:
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-    - name: Install UR python dependencies
+    # Latest distros do not allow global pip installation
+    - name: Install UR python dependencies in venv
       working-directory: ${{github.workspace}}/unified-runtime
-      run: pip install -r third_party/requirements.txt
+      run: |
+        python3 -m venv .venv
+        . .venv/bin/activate
+        echo "$PATH" >> $GITHUB_PATH
+        pip install -r third_party/requirements.txt
 
     - name: Download DPC++
       run: |


### PR DESCRIPTION
Latest distros don't allow global pip installations.