### PR TITLE
[UR][L0] Create pool descriptors from subdevices...

### DIFF
--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -243,3 +243,19 @@ struct ur_device_handle_t_ : _ur_object {
   // unique ephemeral identifer of the device in the adapter
   std::optional<DeviceId> Id;
 };
+
+inline std::vector<ur_device_handle_t>
+CollectDevicesAndSubDevices(const std::vector<ur_device_handle_t> &Devices) {
+  std::vector<ur_device_handle_t> DevicesAndSubDevices;
+  std::function<void(const std::vector<ur_device_handle_t> &)>
+      CollectDevicesAndSubDevicesRec =
+          [&](const std::vector<ur_device_handle_t> &Devices) {
+            for (auto &Device : Devices) {
+              DevicesAndSubDevices.push_back(Device);
+              CollectDevicesAndSubDevicesRec(Device->SubDevices);
+            }
+          };
+  CollectDevicesAndSubDevicesRec(Devices);
+
+  return DevicesAndSubDevices;
+}

--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -949,12 +949,9 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
     }
   }
 
-  auto [Ret, Descriptors] = usm::pool_descriptor::create(this, Context);
-  if (Ret) {
-    logger::error("urUSMPoolCreate: failed to create pool descriptors");
-    throw UsmAllocationException(Ret);
-  }
-
+  auto DevicesAndSubDevices = CollectDevicesAndSubDevices(Context->Devices);
+  auto Descriptors = usm::pool_descriptor::createFromDevices(
+      this, Context, DevicesAndSubDevices);
   for (auto &Desc : Descriptors) {
     umf::pool_unique_handle_t Pool = nullptr;
     if (IsProxy) {
@@ -965,7 +962,7 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
       Pool = usm::makeDisjointPool(MakeProvider(&Desc), PoolConfig);
     }
 
-    Ret = PoolManager.addPool(Desc, std::move(Pool));
+    auto Ret = PoolManager.addPool(Desc, std::move(Pool));
     if (Ret) {
       logger::error("urUSMPoolCreate: failed to store UMF pool");
       throw UsmAllocationException(Ret);

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -166,11 +166,10 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t hContext,
     logger::info("USM pooling is disabled. Skiping pool limits adjustment.");
   }
 
-  auto [result, descriptors] = usm::pool_descriptor::create(this, hContext);
-  if (result != UR_RESULT_SUCCESS) {
-    throw result;
-  }
-
+  auto devicesAndSubDevices =
+      CollectDevicesAndSubDevices(hContext->getDevices());
+  auto descriptors = usm::pool_descriptor::createFromDevices(
+      this, hContext, devicesAndSubDevices);
   for (auto &desc : descriptors) {
     if (disjointPoolConfigs.has_value()) {
       auto &poolConfig =


### PR DESCRIPTION
stored in device handle. The pool_descriptor::create function retrieves subdevices partitioned with UR_DEVICE_PARTITION_BY_CSLICE by default. This causes problem in a SYCL scenario where user obtains subdevices partitioned with eg. sycl::info::partition_affinity_domain::numa.