### PR TITLE
Revert "[SYCL][E2E] mark failing tests on v2 L0 adapter"

### DIFF
--- a/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
+++ b/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
@@ -1,7 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17271
 
 //==- handler.cpp - SYCL handler explicit memory operations test -*- C++-*--==//
 //

--- a/sycl/test-e2e/InorderQueue/in_order_usm_host_dependency.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_usm_host_dependency.cpp
@@ -1,7 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17271
 
 // Test checks that dependency chain between commands is preserved for in-order
 // queue in the case when usm commands and host tasks are interleaved.

--- a/sycl/test-e2e/USM/copy.cpp
+++ b/sycl/test-e2e/USM/copy.cpp
@@ -12,9 +12,6 @@
 // UNSUPPORTED: spirv-backend && arch-intel_gpu_bmg_g21
 // UNSUPPORTED-TRACKER: CMPLRLLVM-64705
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17271
-
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
@@ -33,9 +33,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17271
-
 #include <sycl/detail/core.hpp>
 
 #include <syclcompat/memory.hpp>

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test1_usmnone.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test1_usmnone.cpp
@@ -10,9 +10,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17271
-
 #define SYCLCOMPAT_USM_LEVEL_NONE
 #include <sycl/detail/core.hpp>
 #include <syclcompat/memory.hpp>

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test2.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test2.cpp
@@ -33,9 +33,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17271
-
 #include <sycl/detail/core.hpp>
 
 #include <syclcompat/memory.hpp>

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test2_usmnone.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test2_usmnone.cpp
@@ -9,9 +9,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17271
-
 #define SYCLCOMPAT_USM_LEVEL_NONE
 #include <sycl/detail/core.hpp>
 #include <syclcompat/memory.hpp>

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
@@ -32,9 +32,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17271
-
 #include <sycl/detail/core.hpp>
 
 #include <syclcompat/memory.hpp>

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test3_usmnone.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test3_usmnone.cpp
@@ -11,9 +11,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17271
-
 #define SYCLCOMPAT_USM_LEVEL_NONE
 #include <sycl/detail/core.hpp>
 #include <syclcompat/memory.hpp>


### PR DESCRIPTION
This reverts commit 6733ee2d2d6577068db36c65abfa731235e62ab8.

The driver version on CI is new enough already,.