### PR TITLE
[UR] Bump UMF to v0.11.0-dev4

### DIFF
--- a/sycl/test-e2e/Regression/static-buffer-dtor.cpp
+++ b/sycl/test-e2e/Regression/static-buffer-dtor.cpp
@@ -21,6 +21,9 @@
 // UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17255
 
+// UNSUPPORTED: cuda
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17450
+
 #include <sycl/detail/core.hpp>
 
 int main() {

--- a/unified-runtime/source/common/CMakeLists.txt
+++ b/unified-runtime/source/common/CMakeLists.txt
@@ -40,11 +40,11 @@ if (NOT DEFINED UMF_REPO)
 endif()
 
 if (NOT DEFINED UMF_TAG)
-    # commit 5a515c56c92be75944c8246535c408cee7711114
-    # Author: Lukasz Dorau <lukasz.dorau@intel.com>
-    # Date:   Mon Feb 17 10:56:05 2025 +0100
-    # Merge pull request #1086 from vinser52/svinogra_l0_linking
-    set(UMF_TAG 5a515c56c92be75944c8246535c408cee7711114)
+    # commit 998debed7a8551bdf6774be810559bb6cef6542b
+    # Author: Krzysztof Filipek <krzysztof.filipek@intel.com>
+    # Date:   Thu Mar 13 09:53:27 2025 +0100
+    # Merge pull request #1183 from ldorau/Fix_segfault_in_cu_memory_provider_get_last_native_error
+    set(UMF_TAG v0.11.0-dev4)
 endif()
 
 message(STATUS "Will fetch Unified Memory Framework from ${UMF_REPO}")
@@ -127,5 +127,4 @@ add_library(${PROJECT_NAME}::umf ALIAS ur_umf)
 target_link_libraries(ur_umf INTERFACE
     umf::umf
     umf::headers
-    umf::disjoint_pool
 )


### PR DESCRIPTION
Bump UMF to v0.11.0-dev4.
From now on disjoint_pool is part of libumf,
instead of being a separate library.