### PR TITLE
[UR] Fix cfi initialization

### DIFF
--- a/unified-runtime/cmake/helpers.cmake
+++ b/unified-runtime/cmake/helpers.cmake
@@ -83,7 +83,7 @@ set(CFI_FLAGS "")
 if (CXX_HAS_CFI_SANITIZE)
     # cfi-icall requires called functions in shared libraries to also be built with cfi-icall, which we can't
     # guarantee. -fsanitize=cfi depends on -flto
-    set(CFI_FLAGS "-flto -fsanitize=cfi -fno-sanitize=cfi-icall -fsanitize-ignorelist=${PROJECT_SOURCE_DIR}/sanitizer-ignorelist.txt")
+    set(CFI_FLAGS "-flto;-fsanitize=cfi;-fno-sanitize=cfi-icall;-fsanitize-ignorelist=${PROJECT_SOURCE_DIR}/sanitizer-ignorelist.txt")
 endif()
 
 function(add_ur_target_compile_options name)
@@ -103,6 +103,8 @@ function(add_ur_target_compile_options name)
             -fstack-protector-strong
             -fvisibility=hidden
 
+            ${CFI_FLAGS}
+
             $<$<BOOL:${CXX_HAS_FCF_PROTECTION_FULL}>:-fcf-protection=full>
             $<$<BOOL:${CXX_HAS_FSTACK_CLASH_PROTECTION}>:-fstack-clash-protection>
 
@@ -110,10 +112,6 @@ function(add_ur_target_compile_options name)
             $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>
             $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>
         )
-        # Cmake can't handle mixing strings without quotes as the options above
-        # are and strings with quotes like ${CFI_FLAGS} is, so this needs a
-        # separate call.
-        target_compile_options(${name} PRIVATE ${CFI_FLAGS})
         if (UR_DEVELOPER_MODE)
             target_compile_options(${name} PRIVATE -Werror -Wextra)
         endif()
@@ -154,7 +152,8 @@ function(add_ur_target_link_options name)
     if(NOT MSVC)
         if (NOT APPLE)
             target_link_options(${name} PRIVATE
-                "LINKER:-z,relro,-z,now,-z,noexecstack ${CFI_FLAGS}"
+                ${CFI_FLAGS}
+                "LINKER:-z,relro,-z,now,-z,noexecstack"
             )
             if (UR_DEVELOPER_MODE)
                 target_link_options(${name} PRIVATE -Werror -Wextra)

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.hpp
@@ -132,8 +132,6 @@ private:
   ur_mutex VirtualMemMapsMutex;
 
   uptr LocalShadowOffset = 0;
-
-  uptr PrivateShadowOffset = 0;
 };
 
 // clang-format off


### PR DESCRIPTION
There were a number of problems preventing CFI from being enabled, this hopefully fixes them.

As part of this, an unused variable compile error in `clang` was fixed.