### PR TITLE
[UR][NFC] Remove unused function from v2 adapter

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -493,15 +493,4 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
-
-ur_result_t urCommandBufferEnqueueExp(
-    ur_exp_command_buffer_handle_t CommandBuffer, ur_queue_handle_t UrQueue,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_event_handle_t *Event) try {
-  return UrQueue->get().enqueueCommandBufferExp(
-      CommandBuffer, NumEventsInWaitList, EventWaitList, Event);
-} catch (...) {
-  return exceptionToResult(std::current_exception());
-}
-
 } // namespace ur::level_zero


### PR DESCRIPTION
`urCommandBufferEnqueueExp` was changed in https://github.com/intel/llvm/pull/16984 to `urEnqueueCommandBufferExp` but added back accidentally to the v2 L0 adapter in https://github.com/intel/llvm/pull/17297