### PR TITLE
[SYCL] Update sampler_impl to use context_impl instead of context

### DIFF
--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -24,12 +24,13 @@ sampler_impl::sampler_impl(coordinate_normalization_mode normalizationMode,
   verifyProps(MPropList);
 }
 
-sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
-  const AdapterPtr &Adapter = getSyclObjImpl(syclContext)->getAdapter();
+sampler_impl::sampler_impl(cl_sampler clSampler,
+                           const ContextImplPtr &syclContext) {
+  const AdapterPtr &Adapter = syclContext->getAdapter();
   ur_sampler_handle_t Sampler{};
   Adapter->call<UrApiKind::urSamplerCreateWithNativeHandle>(
       reinterpret_cast<ur_native_handle_t>(clSampler),
-      getSyclObjImpl(syclContext)->getHandleRef(), nullptr, &Sampler);
+      syclContext->getHandleRef(), nullptr, &Sampler);
 
   MContextToSampler[syclContext] = Sampler;
   bool NormalizedCoords;
@@ -85,7 +86,7 @@ sampler_impl::~sampler_impl() {
     for (auto &Iter : MContextToSampler) {
       // TODO catch an exception and add it to the list of asynchronous
       // exceptions
-      const AdapterPtr &Adapter = getSyclObjImpl(Iter.first)->getAdapter();
+      const AdapterPtr &Adapter = Iter.first->getAdapter();
       Adapter->call<UrApiKind::urSamplerRelease>(Iter.second);
     }
   } catch (std::exception &e) {
@@ -93,10 +94,11 @@ sampler_impl::~sampler_impl() {
   }
 }
 
-ur_sampler_handle_t sampler_impl::getOrCreateSampler(const context &Context) {
+ur_sampler_handle_t
+sampler_impl::getOrCreateSampler(const ContextImplPtr &ContextImpl) {
   {
     std::lock_guard<std::mutex> Lock(MMutex);
-    auto It = MContextToSampler.find(Context);
+    auto It = MContextToSampler.find(ContextImpl);
     if (It != MContextToSampler.end())
       return It->second;
   }
@@ -133,10 +135,10 @@ ur_sampler_handle_t sampler_impl::getOrCreateSampler(const context &Context) {
 
   ur_result_t errcode_ret = UR_RESULT_SUCCESS;
   ur_sampler_handle_t resultSampler = nullptr;
-  const AdapterPtr &Adapter = getSyclObjImpl(Context)->getAdapter();
+  const AdapterPtr &Adapter = ContextImpl->getAdapter();
 
   errcode_ret = Adapter->call_nocheck<UrApiKind::urSamplerCreate>(
-      getSyclObjImpl(Context)->getHandleRef(), &desc, &resultSampler);
+      ContextImpl->getHandleRef(), &desc, &resultSampler);
 
   if (errcode_ret == UR_RESULT_ERROR_UNSUPPORTED_FEATURE)
     throw sycl::exception(sycl::errc::feature_not_supported,
@@ -144,7 +146,7 @@ ur_sampler_handle_t sampler_impl::getOrCreateSampler(const context &Context) {
 
   Adapter->checkUrResult(errcode_ret);
   std::lock_guard<std::mutex> Lock(MMutex);
-  MContextToSampler[Context] = resultSampler;
+  MContextToSampler[ContextImpl] = resultSampler;
 
   return resultSampler;
 }

--- a/sycl/source/detail/sampler_impl.hpp
+++ b/sycl/source/detail/sampler_impl.hpp
@@ -9,13 +9,16 @@
 #pragma once
 
 #include <sycl/__spirv/spirv_types.hpp>
-#include <sycl/context.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/ur.hpp>
 #include <sycl/property_list.hpp>
 
 #include <mutex>
 #include <unordered_map>
+
+#ifdef __SYCL_INTERNAL_API
+#include <sycl/detail/cl.h>
+#endif
 
 namespace sycl {
 inline namespace _V1 {
@@ -25,13 +28,17 @@ enum class filtering_mode : unsigned int;
 enum class coordinate_normalization_mode : unsigned int;
 
 namespace detail {
+
+class context_impl;
+using ContextImplPtr = std::shared_ptr<context_impl>;
+
 class sampler_impl {
 public:
   sampler_impl(coordinate_normalization_mode normalizationMode,
                addressing_mode addressingMode, filtering_mode filteringMode,
                const property_list &propList);
 
-  sampler_impl(cl_sampler clSampler, const context &syclContext);
+  sampler_impl(cl_sampler clSampler, const ContextImplPtr &syclContext);
 
   addressing_mode get_addressing_mode() const;
 
@@ -39,7 +46,7 @@ public:
 
   coordinate_normalization_mode get_coordinate_normalization_mode() const;
 
-  ur_sampler_handle_t getOrCreateSampler(const context &Context);
+  ur_sampler_handle_t getOrCreateSampler(const ContextImplPtr &ContextImpl);
 
   ~sampler_impl();
 
@@ -49,7 +56,7 @@ private:
   /// Protects all the fields that can be changed by class' methods.
   std::mutex MMutex;
 
-  std::unordered_map<context, ur_sampler_handle_t> MContextToSampler;
+  std::unordered_map<ContextImplPtr, ur_sampler_handle_t> MContextToSampler;
 
   coordinate_normalization_mode MCoordNormMode;
   addressing_mode MAddrMode;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2316,7 +2316,8 @@ void SetArgBasedOnType(
     const AdapterPtr &Adapter, ur_kernel_handle_t Kernel,
     const std::shared_ptr<device_image_impl> &DeviceImageImpl,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc,
-    const sycl::context &Context, detail::ArgDesc &Arg, size_t NextTrueIndex) {
+    const ContextImplPtr &ContextImpl, detail::ArgDesc &Arg,
+    size_t NextTrueIndex) {
   switch (Arg.MType) {
   case kernel_param_kind_t::kind_work_group_memory:
     break;
@@ -2355,7 +2356,7 @@ void SetArgBasedOnType(
     sampler *SamplerPtr = (sampler *)Arg.MPtr;
     ur_sampler_handle_t Sampler =
         (ur_sampler_handle_t)detail::getSyclObjImpl(*SamplerPtr)
-            ->getOrCreateSampler(Context);
+            ->getOrCreateSampler(ContextImpl);
     Adapter->call<UrApiKind::urKernelSetArgSampler>(Kernel, NextTrueIndex,
                                                     nullptr, Sampler);
     break;
@@ -2414,7 +2415,7 @@ static ur_result_t SetKernelParamsAndLaunch(
   auto setFunc = [&Adapter, Kernel, &DeviceImageImpl, &getMemAllocationFunc,
                   &Queue](detail::ArgDesc &Arg, size_t NextTrueIndex) {
     SetArgBasedOnType(Adapter, Kernel, DeviceImageImpl, getMemAllocationFunc,
-                      Queue->get_context(), Arg, NextTrueIndex);
+                      Queue->getContextImplPtr(), Arg, NextTrueIndex);
   };
 
   applyFuncOnFilteredArgs(EliminatedArgMask, Args, setFunc);
@@ -2600,11 +2601,11 @@ ur_result_t enqueueImpCommandBufferKernel(
   }
 
   const sycl::detail::AdapterPtr &Adapter = ContextImpl->getAdapter();
-  auto SetFunc = [&Adapter, &UrKernel, &DeviceImageImpl, &Ctx,
+  auto SetFunc = [&Adapter, &UrKernel, &DeviceImageImpl, &ContextImpl,
                   &getMemAllocationFunc](sycl::detail::ArgDesc &Arg,
                                          size_t NextTrueIndex) {
     sycl::detail::SetArgBasedOnType(Adapter, UrKernel, DeviceImageImpl,
-                                    getMemAllocationFunc, Ctx, Arg,
+                                    getMemAllocationFunc, ContextImpl, Arg,
                                     NextTrueIndex);
   };
   // Copy args for modification

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -746,7 +746,8 @@ void SetArgBasedOnType(
     const detail::AdapterPtr &Adapter, ur_kernel_handle_t Kernel,
     const std::shared_ptr<device_image_impl> &DeviceImageImpl,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc,
-    const sycl::context &Context, detail::ArgDesc &Arg, size_t NextTrueIndex);
+    const ContextImplPtr &ContextImpl, detail::ArgDesc &Arg,
+    size_t NextTrueIndex);
 
 template <typename FuncT>
 void applyFuncOnFilteredArgs(const KernelArgMask *EliminatedArgMask,

--- a/sycl/source/sampler.cpp
+++ b/sycl/source/sampler.cpp
@@ -21,7 +21,8 @@ sampler::sampler(coordinate_normalization_mode normalizationMode,
           normalizationMode, addressingMode, filteringMode, propList)) {}
 
 sampler::sampler(cl_sampler clSampler, const context &syclContext)
-    : impl(std::make_shared<detail::sampler_impl>(clSampler, syclContext)) {}
+    : impl(std::make_shared<detail::sampler_impl>(
+          clSampler, detail::getSyclObjImpl(syclContext))) {}
 
 addressing_mode sampler::get_addressing_mode() const {
   return impl->get_addressing_mode();


### PR DESCRIPTION
Update `sampler_impl` to use `context_impl` instead of `context`.

These changes decrease the amount of `std::shared_ptr` copies to improve performance. 