### PR TITLE
[Sycl][Graph] Reimplement topological sort algorithm

### DIFF
--- a/sycl/doc/design/CommandGraph.md
+++ b/sycl/doc/design/CommandGraph.md
@@ -100,11 +100,15 @@ Edges are stored in each node as lists of predecessor and successor nodes.
 
 ## Execution Order
 
-The current way graph nodes are linearized into execution order is using a
-reversed depth-first sorting algorithm. Alternative algorithms, such as
-breadth-first, are possible and may give better performance on certain
-workloads/hardware. In the future there might be options for allowing the
-user to control this implementation detail.
+Graph nodes are currently linearized into execution order using a topological
+sort algorithm. This algorithm uses a breadth-first search approach
+and is an implementation of Kahn's algorithm. Alternative algorithms, such as
+depth-first search, are possible and may give better performance on certain
+workloads/hardware. However, depth first searches are usually implemented 
+using recursion, which can lead to stack overflow issues on large graphs.
+In the future, there might be options for allowing the user to control this
+implementation detail. It might also be possible to automatically change
+which algorithm is used based on characteristics such as the graph's size.
 
 ## Scheduler Integration
 

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -8,6 +8,7 @@
 
 #define __SYCL_GRAPH_IMPL_CPP
 
+#include <stack>
 #include <detail/graph_impl.hpp>
 #include <detail/handler_impl.hpp>
 #include <detail/kernel_arg_mask.hpp>
@@ -15,7 +16,6 @@
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/commands.hpp>
 #include <detail/sycl_mem_obj_t.hpp>
-#include <stack>
 #include <sycl/detail/common.hpp>
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
 #include <sycl/detail/string_view.hpp>
@@ -47,15 +47,15 @@ void sortTopological(std::set<std::weak_ptr<node_impl>,
                               std::owner_less<std::weak_ptr<node_impl>>> &Roots,
                      std::list<std::shared_ptr<node_impl>> &Schedule,
                      bool PartitionBounded) {
-  std::stack<std::weak_ptr<node_impl>> Stack;
+  std::stack<std::weak_ptr<node_impl>> Source;
 
   for (auto &Node : Roots) {
-    Stack.push(Node);
+    Source.push(Node);
   }
 
-  while (!Stack.empty()) {
-    auto Node = Stack.top().lock();
-    Stack.pop();
+  while (!Source.empty()) {
+    auto Node = Source.top().lock();
+    Source.pop();
     Schedule.push_back(Node);
 
     for (size_t i = 0; i < Node->MSuccessors.size(); ++i) {
@@ -68,7 +68,7 @@ void sortTopological(std::set<std::weak_ptr<node_impl>,
       auto &TotalVisitedEdges = Succ->MTotalVisitedEdges;
       ++TotalVisitedEdges;
       if (TotalVisitedEdges == Succ->MPredecessors.size()) {
-        Stack.push(Succ);
+        Source.push(Succ);
       }
     }
   }

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -102,8 +102,8 @@ public:
   /// subgraph node.
   std::shared_ptr<exec_graph_impl> MSubGraphImpl;
 
-  /// Used for tracking visited status during cycle checks.
-  bool MVisited = false;
+  /// Used for tracking visited status during cycle checks and node scheduling.
+  size_t MTotalVisitedEdges = 0;
 
   /// Partition number needed to assign a Node to a a partition.
   /// Note : This number is only used during the partitionning process and
@@ -1130,17 +1130,6 @@ public:
   unsigned long long getID() const { return MID; }
 
 private:
-  /// Iterate over the graph depth-first and run \p NodeFunc on each node.
-  /// @param NodeFunc A function which receives as input a node in the graph to
-  /// perform operations on as well as the stack of nodes encountered in the
-  /// current path. The return value of this function determines whether an
-  /// early exit is triggered, if true the depth-first search will end
-  /// immediately and no further nodes will be visited.
-  void
-  searchDepthFirst(std::function<bool(std::shared_ptr<node_impl> &,
-                                      std::deque<std::shared_ptr<node_impl>> &)>
-                       NodeFunc);
-
   /// Check the graph for cycles by performing a depth-first search of the
   /// graph. If a node is visited more than once in a given path through the
   /// graph, a cycle is present and the search ends immediately.

--- a/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
@@ -10,6 +10,7 @@ add_sycl_unittest(CommandGraphExtensionTests OBJECT
   Queries.cpp
   Regressions.cpp
   Subgraph.cpp
+  TopologicalSort.cpp
   Update.cpp
   Properties.cpp
 )

--- a/sycl/unittests/Extensions/CommandGraph/TopologicalSort.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/TopologicalSort.cpp
@@ -113,9 +113,9 @@ TEST_F(CommandGraphTest, CheckTopologicalSort) {
   bool FoundMatchingSchedule = false;
   for (auto &AcceptableSchedule : ValidSchedules) {
 
-    auto out = std::mismatch(Schedule.begin(), Schedule.end(),
+    auto Out = std::mismatch(Schedule.begin(), Schedule.end(),
                              AcceptableSchedule.begin());
-    if (out.first == Schedule.end() && out.second == AcceptableSchedule.end()) {
+    if (Out.first == Schedule.end() && Out.second == AcceptableSchedule.end()) {
       FoundMatchingSchedule = true;
       break;
     }

--- a/sycl/unittests/Extensions/CommandGraph/TopologicalSort.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/TopologicalSort.cpp
@@ -1,0 +1,125 @@
+//==------------------------ TopologicalSort.cpp----------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include "Common.hpp"
+
+using namespace sycl;
+using namespace sycl::ext::oneapi;
+
+// Checks that the topological sort that is executed at graph finalize
+// produces a valid schedule. A schedule is valid if, for every edge (U,V) from
+// node A to node B, U comes before V in the ordering.
+TEST_F(CommandGraphTest, CheckTopologicalSort) {
+
+  //       Graph structure
+  //           (6)-----------------
+  //         /    \               |
+  //        /      \              |
+  //       (3)---->(0)            |
+  //        \    /  |  \          |
+  //         \  /   |   \         |
+  //          (1)  (2)  (5)       |
+  //                |             |
+  //                |             |
+  //               (4) <----------|
+  size_t NumNodes = 7;
+  experimental::command_graph Graph{Queue.get_context(), Dev};
+  auto Node6 = Graph.add(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node3 = Graph.add(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node0 = Graph.add(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node1 = Graph.add(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node2 = Graph.add(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node5 = Graph.add(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node4 = Graph.add(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  Graph.make_edge(Node6, Node3);
+  Graph.make_edge(Node6, Node0);
+  Graph.make_edge(Node6, Node4);
+  Graph.make_edge(Node3, Node0);
+  Graph.make_edge(Node3, Node1);
+  Graph.make_edge(Node0, Node1);
+  Graph.make_edge(Node0, Node2);
+  Graph.make_edge(Node0, Node5);
+  Graph.make_edge(Node2, Node4);
+
+  // Intentionally make a cycle to make sure that the topological sort at
+  // finalize is not affected by cycle checks.
+  ASSERT_THROW(
+      {
+        try {
+          Graph.make_edge(Node4, Node6);
+        } catch (const sycl::exception &e) {
+          ASSERT_EQ(e.code(), make_error_code(sycl::errc::invalid));
+          throw;
+        }
+      },
+      sycl::exception);
+
+  // Make another cycle to check that the cycle checking algorithm is stateless.
+  ASSERT_THROW(
+      {
+        try {
+          Graph.make_edge(Node2, Node3);
+        } catch (const sycl::exception &e) {
+          ASSERT_EQ(e.code(), make_error_code(sycl::errc::invalid));
+          throw;
+        }
+      },
+      sycl::exception);
+
+  auto ExecGraph = Graph.finalize();
+
+  auto ExecGraphImpl = sycl::detail::getSyclObjImpl(ExecGraph);
+
+  // Creating an executable graph with finalize copies all the nodes to new
+  // objects. The new nodes will have an ID equal to OldNodeID + NumNodes. This
+  // is implementation dependent but is the only way to test this functionality
+  size_t Node6ID = sycl::detail::getSyclObjImpl(Node6)->getID() + NumNodes;
+  size_t Node3ID = sycl::detail::getSyclObjImpl(Node3)->getID() + NumNodes;
+  size_t Node0ID = sycl::detail::getSyclObjImpl(Node0)->getID() + NumNodes;
+  size_t Node1ID = sycl::detail::getSyclObjImpl(Node1)->getID() + NumNodes;
+  size_t Node2ID = sycl::detail::getSyclObjImpl(Node2)->getID() + NumNodes;
+  size_t Node5ID = sycl::detail::getSyclObjImpl(Node5)->getID() + NumNodes;
+  size_t Node4ID = sycl::detail::getSyclObjImpl(Node4)->getID() + NumNodes;
+
+  std::unordered_map<size_t, size_t> mapExecutionIDToTestID = {
+      {Node6ID, 6}, {Node3ID, 3}, {Node0ID, 0}, {Node1ID, 1},
+      {Node2ID, 2}, {Node5ID, 5}, {Node4ID, 4}};
+
+  // List of all valid topological sorts for this graph.
+  std::vector<std::vector<size_t>> ValidSchedules = {
+      {6, 3, 0, 1, 2, 4, 5}, {6, 3, 0, 1, 2, 5, 4}, {6, 3, 0, 1, 5, 2, 4},
+      {6, 3, 0, 2, 1, 4, 5}, {6, 3, 0, 2, 1, 5, 4}, {6, 3, 0, 2, 4, 1, 5},
+      {6, 3, 0, 2, 4, 5, 1}, {6, 3, 0, 2, 5, 1, 4}, {6, 3, 0, 2, 5, 4, 1},
+      {6, 3, 0, 5, 1, 2, 4}, {6, 3, 0, 5, 2, 1, 4}, {6, 3, 0, 5, 2, 4, 1}};
+
+  std::vector<size_t> Schedule;
+  for (auto &NodeImpl : ExecGraphImpl->getSchedule()) {
+    Schedule.push_back(mapExecutionIDToTestID[NodeImpl->getID()]);
+  }
+  ASSERT_EQ(Schedule.size(), 7ul);
+
+  bool FoundMatchingSchedule = false;
+  for (auto &AcceptableSchedule : ValidSchedules) {
+
+    auto out = std::mismatch(Schedule.begin(), Schedule.end(),
+                             AcceptableSchedule.begin());
+    if (out.first == Schedule.end() && out.second == AcceptableSchedule.end()) {
+      FoundMatchingSchedule = true;
+      break;
+    }
+  }
+
+  ASSERT_TRUE(FoundMatchingSchedule);
+}


### PR DESCRIPTION
The current implementation of the topological sort algorithm relies on a recursive function. This causes stack overflow issues when the graphs are very large. There is also a performance issue in the current implementation related to the way std::find() is being used.

This commit reimplements the topological sort algorithm to fix these issues:

- Uses an iterative approach instead of recursive.
- Removes the use of std::find() and instead relies on keeping the state with a helper variable.
- Reimplements the cycle checking algorithm to use the same topological sort function as the one used during scheduling.
- Fixes a bug with make_edge() not removing the dest node from the list of root nodes.