### PR TITLE
[CI] Add SYCL-CTS on Win

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -201,12 +201,12 @@ jobs:
     with:
       mode: stop
 
-  build-sycl-cts:
+  build-sycl-cts-linux:
     needs: ubuntu2204_build
     if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
-      name: Build SYCL-CTS
+      name: Build SYCL-CTS for Linux
       runner: '["Linux", "build"]'
       cts_testing_mode: 'build-only'
       image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
@@ -215,9 +215,10 @@ jobs:
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
       sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
+      sycl_cts_artifact: sycl_cts_bin_linux
 
-  run-sycl-cts:
-    needs: [ubuntu2204_build, build-sycl-cts]
+  run-sycl-cts-linux:
+    needs: [ubuntu2204_build, build-sycl-cts-linux]
     if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
     strategy:
       fail-fast: false
@@ -244,7 +245,41 @@ jobs:
       sycl_toolchain_artifact: sycl_linux_default
       sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
       sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
-      sycl_cts_artifact: sycl_cts_bin
+      sycl_cts_artifact: sycl_cts_bin_linux
+
+  build-sycl-cts-win:
+    needs: build-win
+    if: ${{ always() && !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
+    uses: ./.github/workflows/sycl-windows-run-tests.yml
+    with:
+      name: Build SYCL-CTS for Windows
+      runner: '["Windows", "build-e2e"]'
+      cts_testing_mode: 'build-only'
+      tests_selector: cts
+      ref: ${{ github.sha }}
+      sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
+      sycl_cts_artifact: sycl_cts_bin_win
+
+  run-sycl-cts-win:
+    needs: [build-win, build-sycl-cts-win]
+    if: ${{ always() && !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: SYCL-CTS on L0 gen12
+            runner: '["Windows", "gen12"]'
+            target_devices: level_zero:gpu
+    uses: ./.github/workflows/sycl-windows-run-tests.yml
+    with:
+      name: ${{ matrix.name }}
+      runner: ${{ matrix.runner }}
+      cts_testing_mode: 'run-only'
+      target_devices: ${{ matrix.target_devices }}
+      tests_selector: cts
+      ref: ${{ github.sha }}
+      sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
+      sycl_cts_artifact: sycl_cts_bin_win
 
   aggregate_benchmark_results:
     if: always() && !cancelled()

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -10,6 +10,18 @@ on:
         type: string
         required: True
 
+      target_devices:
+        type: string
+        required: False
+      extra_cmake_args:
+        type: string
+        required: False
+      tests_selector:
+        description: |
+          Two possible options: "e2e" and "cts".
+        type: string
+        default: "e2e"
+
       extra_lit_opts:
         description: |
           Extra options to be added to LIT_OPTS.
@@ -28,6 +40,10 @@ on:
           Note: it doesn't affect ./devops/actions/run-tests/* as these actions
           call checkout again and therefore override the devops directory, so
           configs/dependecies from input.ref are used.
+      tests_ref:
+        type: string
+        required: False
+        description: Commit SHA or branch to checkout e2e/cts tests.
 
       sycl_toolchain_artifact:
         type: string
@@ -47,6 +63,23 @@ on:
         type: string
         required: false
         default: "cl"
+
+      cts_testing_mode:
+        description: |
+          Testing mode to run SYCL-CTS in, can be either `full`, `build-only`
+          or `run-only`. In `build-only` mode an artifact of the CTS binaries
+          will be uploaded.
+        type: string
+        default: 'full'
+
+      sycl_cts_artifact:
+        type: string
+        default: ''
+        required: False
+      artifact_retention_days:
+        description: 'E2E/SYCL-CTS binaries artifact retention period.'
+        type: string
+        default: 1
 
 permissions: read-all
 
@@ -86,6 +119,7 @@ jobs:
     - name: Register cleanup after job is finished
       uses: ./devops/actions/cleanup
     - uses: ./devops/actions/cached_checkout
+      if: inputs.tests_selector == 'e2e'
       with:
         path: llvm
         ref: ${{ inputs.ref || github.sha }}
@@ -103,16 +137,19 @@ jobs:
     - name: Setup SYCL toolchain
       run: |
         echo "PATH=$env:GITHUB_WORKSPACE\\install\\bin;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "LIB=$env:GITHUB_WORKSPACE\\install\\lib;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - run: |
         sycl-ls
     - run: |
         sycl-ls --verbose
     - name: Configure E2E with Level Zero target
+      if: inputs.tests_selector == 'e2e'
       shell: cmd
       run: |
         mkdir build-e2e
         cmake -GNinja -B build-e2e -S.\llvm\sycl\test-e2e -DSYCL_TEST_E2E_TARGETS="level_zero:gpu" -DCMAKE_CXX_COMPILER="clang++" -DLEVEL_ZERO_LIBS_DIR="D:\\github\\level-zero_win-sdk\\lib" -DLEVEL_ZERO_INCLUDE="D:\\github\\level-zero_win-sdk\\include" -DLLVM_LIT="..\\llvm\\llvm\\utils\\lit\\lit.py"
     - name: Run End-to-End tests
+      if: inputs.tests_selector == 'e2e'
       shell: bash
       run: |
         # Run E2E tests.
@@ -121,6 +158,18 @@ jobs:
         fi
         export LIT_OPTS="-v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time 3600 --time-tests ${{ inputs.extra_lit_opts }}"
         cmake --build build-e2e --target check-sycl-e2e
+
+    - name: Run SYCL CTS Tests
+      if: inputs.tests_selector == 'cts'
+      uses: ./devops/actions/run-tests/windows/cts
+      with:
+        ref: ${{ inputs.tests_ref || 'main' }}
+        extra_cmake_args: ${{ inputs.extra_cmake_args }}
+        cts_testing_mode: ${{ inputs.cts_testing_mode }}
+        sycl_cts_artifact: ${{ inputs.sycl_cts_artifact }}
+        target_devices: ${{ inputs.target_devices }}
+        retention-days: ${{ inputs.artifact_retention_days }}
+
     - name:  Detect hung tests
       if: always()
       shell: powershell
@@ -135,4 +184,4 @@ jobs:
       if: always()
       run: |
         rmdir /q /s install
-        rmdir /q /s build-e2e
+        if exist build-e2e rmdir /q /s build-e2e

--- a/devops/actions/run-tests/windows/cts/action.yml
+++ b/devops/actions/run-tests/windows/cts/action.yml
@@ -1,4 +1,4 @@
-name: 'Run SYCL CTS tests on Linux'
+name: 'Run SYCL CTS tests on Windows'
 
 inputs:
   ref:
@@ -26,7 +26,7 @@ runs:
       path: khronos_sycl_cts
       repository: 'KhronosGroup/SYCL-CTS'
       ref: ${{ inputs.ref }}
-      cache_path: "/__w/repo_cache/"
+      cache_path: "D:\\\\github\\\\_work\\\\repo_cache\\\\"
   - name: SYCL CTS GIT submodules init
     if: inputs.cts_testing_mode != 'run-only'
     shell: bash
@@ -57,11 +57,13 @@ runs:
         echo "::endgroup::"
       fi
 
-      cmake -GNinja -B./build-cts -S./khronos_sycl_cts -DCMAKE_CXX_COMPILER=$(which clang++) \
+      cmake -GNinja -B./build-cts -S./khronos_sycl_cts \
       -DSYCL_IMPLEMENTATION=DPCPP \
       -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="$cts_exclude_filter" \
       -DSYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS=OFF \
       -DDPCPP_INSTALL_DIR="$(dirname $(which clang++))/.." \
+      -DCMAKE_CXX_COMPILER=cl \
+      -DCMAKE_BUILD_TYPE=Release \
       $CMAKE_EXTRA_ARGS
       # Ignore errors so that if one category build fails others still have a
       # chance to finish and be executed at the run stage. Note that


### PR DESCRIPTION
This patch adds SYCL-CTS build&launch on Win.
Also prepare the workflow for separate actions like it was done for Linux.