### PR TITLE
RFC: [UR] Add non-adapter-specific testing to CI

### DIFF
--- a/.github/workflows/ur-precommit.yml
+++ b/.github/workflows/ur-precommit.yml
@@ -74,6 +74,53 @@ jobs:
       platform: ${{ matrix.adapter.platform || '' }}
       other_adapter_name: ${{ matrix.adapter.other_adapter || '' }}
 
+  non_adapter:
+    name: Non-adapter testing
+    needs: [detect_changes, source_checks]
+    if: ${{ always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur') }}
+    strategy:
+      matrix:
+        os: ['ubuntu-24.04', 'windows-2022']
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - name: Checkout LLVM
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - uses: actions/setup-python@6ca8e8598faa206f7140a65ba31b899bebe16f58 # v5.0.0
+      with:
+        python-version: "3.10"
+
+    # Latest distros do not allow global pip installation
+    - name: Install UR python dependencies in venv
+      working-directory: ${{github.workspace}}/unified-runtime
+      run: |
+        python3 -m venv .venv
+        . .venv/bin/activate
+        echo "$PATH" >> $GITHUB_PATH
+        pip install -r third_party/requirements.txt
+        pip install -r third_party/requirements_testing.txt
+
+    - name: Install hwloc
+      if: matrix.os == 'ubuntu-24.04'
+      run: sudo apt-get install -y libhwloc-dev
+
+    - name: Configure Unified Runtime project
+      working-directory: ${{github.workspace}}/unified-runtime
+      run: >
+        cmake
+        -B${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=Release
+        -DUR_ENABLE_TRACING=ON
+        -DUR_DEVELOPER_MODE=ON
+        -DUR_BUILD_TESTS=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build -j $(nproc)
+
+    - name: Non-adapter tests
+      run: cmake --build ${{github.workspace}}/build -- check-unified-runtime
+
   macos:
     name: MacOS build only
     needs: [detect_changes, source_checks]


### PR DESCRIPTION
Currently we only run adapter-specific tests. This adds a new
job that runs non-conformance tests.
