### PR TITLE
[SYCL] Restore ABI-combatibility for `local_accessor` ctor

### DIFF
--- a/sycl/source/accessor.cpp
+++ b/sycl/source/accessor.cpp
@@ -119,13 +119,25 @@ const sycl::range<3> &LocalAccessorBaseHost::getSize() const {
   return impl->MSize;
 }
 void *LocalAccessorBaseHost::getPtr() {
+  // `local_accessor_base::GDBMethodsAnchor` was/is inline and used to call
+  // `(void)getPtr()` inside. As such, binaries compiled with older toolchain
+  // are calling this method from the `sycl::local_accessor` ctor on host and we
+  // cannot "abort" for them.
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
   // Must not be/isn't called, user-facing APIs do error-checking.
   std::abort();
+#endif
   return nullptr;
 }
 void *LocalAccessorBaseHost::getPtr() const {
+  // `local_accessor_base::GDBMethodsAnchor` was/is inline and used to call
+  // `(void)getPtr()` inside. As such, binaries compiled with older toolchain
+  // are calling this method from the `sycl::local_accessor` ctor on host and we
+  // cannot "abort" for them.
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
   // Must not be/isn't called, user-facing APIs do error-checking.
   std::abort();
+#endif
   return nullptr;
 }
 const property_list &LocalAccessorBaseHost::getPropList() const {


### PR DESCRIPTION
Initially broken in https://github.com/intel/llvm/pull/17147.