### PR TITLE
Revert "[CI] bump level-zero version"

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.21.2",
-      "version": "v1.21.2",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.21.2",
+      "github_tag": "v1.20.2",
+      "version": "v1.20.2",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.20.2",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
Reverts intel/llvm#17485
It's causing arc and gen12 jobs to fail:
https://github.com/intel/llvm/actions/runs/13930776997/job/38988553691?pr=17513
https://github.com/intel/llvm/actions/runs/13931604336/job/38990417392