### PR TITLE
[UR][CUDA][HIP] Add missing catch for native commands

### DIFF
--- a/unified-runtime/source/adapters/cuda/enqueue_native.cpp
+++ b/unified-runtime/source/adapters/cuda/enqueue_native.cpp
@@ -55,6 +55,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     return Err;
   } catch (CUresult CuErr) {
     return mapErrorUR(CuErr);
+  } catch (...) {
+    return UR_RESULT_ERROR_UNKNOWN;
   }
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/hip/enqueue_native.cpp
+++ b/unified-runtime/source/adapters/hip/enqueue_native.cpp
@@ -58,6 +58,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     return Err;
   } catch (hipError_t hipErr) {
     return mapErrorUR(hipErr);
+  } catch (...) {
+    return UR_RESULT_ERROR_UNKNOWN;
   }
   return UR_RESULT_SUCCESS;
 }


### PR DESCRIPTION
This UR entry point calls a user function pointer, which may throw exceptions so we need an exception catchall there to ensure they don't cross the UR C API boundary.

It's unclear if exceptions should even be allowed in these user functions, but this is still a worthwhile precaution.