### PR TITLE
[CI] Align `windows/cts/action.yml` with linux

### DIFF
--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -164,6 +164,7 @@ jobs:
       uses: ./devops/actions/run-tests/windows/cts
       with:
         ref: ${{ inputs.tests_ref || 'main' }}
+        cts_exclude_ref: ${{ inputs.repo_ref }}
         extra_cmake_args: ${{ inputs.extra_cmake_args }}
         cts_testing_mode: ${{ inputs.cts_testing_mode }}
         sycl_cts_artifact: ${{ inputs.sycl_cts_artifact }}

--- a/devops/actions/run-tests/windows/cts/action.yml
+++ b/devops/actions/run-tests/windows/cts/action.yml
@@ -3,8 +3,10 @@ name: 'Run SYCL CTS tests on Windows'
 inputs:
   ref:
     description: "Commit SHA or branch to checkout tests"
-    required: false
-    default: "main"
+    required: true
+  cts_exclude_ref:
+    description: "Commit SHA or branch to checkout the cts_exclude_filter dir"
+    required: true
   extra_cmake_args:
     required: false
   cts_testing_mode:
@@ -19,6 +21,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+  - name: Checkout cts_exclude_filter folder
+    uses: actions/checkout@v4
+    with:
+      ref: ${{ inputs.cts_exclude_ref }}
+      path: cts_exclude
+      sparse-checkout: |
+        sycl/cts_exclude_filter
+  - name: Move sycl to root
+    shell: bash
+    run: |
+      mv cts_exclude/sycl .
+      rm -rf cts_exclude
   - name: Checkout SYCL CTS tests
     if: inputs.cts_testing_mode != 'run-only'
     uses: ./devops/actions/cached_checkout
@@ -42,11 +56,11 @@ runs:
       # If CTS_TESTS_TO_BUILD is null - use filter
       if [ -z "$CTS_TESTS_TO_BUILD" ]; then
         if [ "${{ contains(inputs.cts_testing_mode, 'build-only')  }}" = "true" ]; then
-          cts_exclude_filter=$PWD/devops/cts_exclude_filter_compfails
+          cts_exclude_filter=$PWD/sycl/cts_exclude_filter/compfails
         elif [ "${{ contains(inputs.target_devices, 'opencl:cpu')  }}" = "true" ]; then
-          cts_exclude_filter=$PWD/devops/cts_exclude_filter_OCL_CPU
+          cts_exclude_filter=$PWD/sycl/cts_exclude_filter/OCL_CPU
         elif [ "${{ contains(inputs.target_devices, 'level_zero:gpu')  }}" = "true" ]; then
-          cts_exclude_filter=$PWD/devops/cts_exclude_filter_L0_GPU
+          cts_exclude_filter=$PWD/sycl/cts_exclude_filter/L0_GPU
         fi
 
         # List excluded SYCL CTS categories:
@@ -107,8 +121,8 @@ runs:
 
   # If the suite was built on another machine then the build contains the full
   # set of tests. We have special files to filter out some test categories,
-  # see "devops/cts_exclude_filter_*". Each configuration has its own file, e.g.
-  # there is "cts_exclude_filter_OCL_CPU" for opencl:cpu device. Therefore,
+  # see "sycl/cts_exclude_filter/*". Each configuration has its own file, e.g.
+  # there is "cts_exclude_filter/OCL_CPU" for opencl:cpu device. Therefore,
   # these files may differ from each other, so when there is a pre-built set of
   # tests, we need to filter it according to the filter-file.
   - name: Filter SYCL CTS test categories
@@ -117,9 +131,9 @@ runs:
     run: |
       cts_exclude_filter=""
       if [ "${{ contains(inputs.target_devices, 'opencl:cpu')  }}" = "true" ]; then
-        cts_exclude_filter=$PWD/devops/cts_exclude_filter_OCL_CPU
+        cts_exclude_filter=$PWD/sycl/cts_exclude_filter/OCL_CPU
       elif [ "${{ contains(inputs.target_devices, 'level_zero:gpu')  }}" = "true" ]; then
-        cts_exclude_filter=$PWD/devops/cts_exclude_filter_L0_GPU
+        cts_exclude_filter=$PWD/sycl/cts_exclude_filter/L0_GPU
       fi
 
       while IFS= read -r line; do


### PR DESCRIPTION
https://github.com/intel/llvm/pull/17501 enabled CTS on win. But for this patch I used the old version of cts/action.yml (before https://github.com/intel/llvm/pull/17228). So it caused the Nightly failure - https://github.com/intel/llvm/actions/runs/13938048645. This patch aligns windows/cts/action.yml with the linux version.