### PR TITLE
Revert "[CI] bump level-zero version"

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.21.3",
-      "version": "v1.21.3",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.21.3",
+      "github_tag": "v1.20.2",
+      "version": "v1.20.2",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.20.2",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
Reverts intel/llvm#17523

It's causing Arc and Gen12 jobs to fail again because `level_zero:gpu` not found after the bump.
https://github.com/intel/llvm/actions/runs/13948718319/job/39043347845
https://github.com/intel/llvm/actions/runs/13948718319/job/39043347817