### PR TITLE
[SYCL][E2E] Update current directory in `with test_env:`

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -174,10 +174,13 @@ class test_env:
         self.old_environ = dict(os.environ)
         os.environ.clear()
         os.environ.update(config.environment)
+        self.old_dir = os.getcwd()
+        os.chdir(config.sycl_obj_root)
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         os.environ.clear()
         os.environ.update(self.old_environ)
+        os.chdir(self.old_dir)
 
 
 config.substitutions.append(("%sycl_libs_dir", config.sycl_libs_dir))


### PR DESCRIPTION
`open_check_file` creates files in `config.sycl_obj_root`, make sure we are in that directory when trying to compile those check files.

Fixes incorrect `preview-breaking-changes-supported` detection in in-tree configuration (which most people are likely to use locally/interactively).