### PR TITLE
[UR] Have ur_getenv return nullopt when empty

### DIFF
--- a/unified-runtime/source/common/ur_util.cpp
+++ b/unified-runtime/source/common/ur_util.cpp
@@ -86,7 +86,7 @@ std::optional<std::string> ur_getenv(const char *name) {
   return std::nullopt;
 #else
   const char *tmp_env = getenv(name);
-  if (tmp_env != nullptr) {
+  if (tmp_env != nullptr && tmp_env[0] != '\0') {
     return std::string(tmp_env);
   } else {
     return std::nullopt;


### PR DESCRIPTION
The fact that an unset environment variable and an empty one have
different behaviours is confusing and likely unintentional. In addition,
it causes a crash in getenv_to_vec.
