### PR TITLE
[clang-linker-wrapper] Dump any device code format

### DIFF
--- a/clang/test/Driver/linker-wrapper-sycl.cpp
+++ b/clang/test/Driver/linker-wrapper-sycl.cpp
@@ -47,11 +47,6 @@
 // RUN: clang-linker-wrapper -sycl-device-libraries=%t.devicelib.o -sycl-post-link-options="SYCL_POST_LINK_OPTIONS" -llvm-spirv-options="LLVM_SPIRV_OPTIONS" "--host-triple=x86_64-unknown-linux-gnu" "--triple=spir64" "--linker-path=/usr/bin/ld" -shared "--" HOST_LINKER_FLAGS "-dynamic-linker" HOST_DYN_LIB "-o" "a.out" HOST_LIB_PATH HOST_STAT_LIB %t.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-SHARED %s
 // CHK-SHARED: "{{.*}}clang"{{.*}} -fPIC
 
-// RUN: rm %T/linker_wrapper_dump || true
-// RUN: clang-linker-wrapper -sycl-dump-device-code=%T/linker_wrapper_dump -sycl-device-libraries=%t.devicelib.o "--host-triple=x86_64-unknown-linux-gnu" "--triple=spir64" "--linker-path=/usr/bin/ld" -shared "--" HOST_LINKER_FLAGS "-dynamic-linker" HOST_DYN_LIB "-o" "a.out" HOST_LIB_PATH HOST_STAT_LIB %t.o --dry-run
-// RUN: ls %T/linker_wrapper_dump | FileCheck -check-prefix=CHK-SYCL-DUMP-DEVICE %s
-// CHK-SYCL-DUMP-DEVICE: {{.*}}.spv
-
 /// Check for list of commands for standalone clang-linker-wrapper run for sycl (AOT for Intel GPU)
 // -------
 // Generate .o file as linker wrapper input.

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -2607,24 +2607,11 @@ int main(int Argc, char **Argv) {
 
   if (Args.hasArg(OPT_sycl_dump_device_code_EQ)) {
     Arg *A = Args.getLastArg(OPT_sycl_dump_device_code_EQ);
-    SmallString<128> Dir(A->getValue());
-    if (Dir.empty())
-      sys::path::native(Dir = "./");
+    OffloadImageDumpDir = A->getValue();
+    if (OffloadImageDumpDir.empty())
+      sys::path::native(OffloadImageDumpDir = "./");
     else
-      Dir.append(sys::path::get_separator());
-
-    OffloadImageDumpDir = Dir;
-
-    if (!DryRun) {
-      std::error_code EC = sys::fs::create_directory(OffloadImageDumpDir,
-                                                     /*IgnoreExisting*/ true);
-      if (EC)
-        reportError(createStringError(
-            EC,
-            formatv(
-                "failed to create dump directory. path: {0}, error_code: {1}",
-                OffloadImageDumpDir, EC.value())));
-    }
+      OffloadImageDumpDir.append(sys::path::get_separator());
   }
 
   {

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1083,9 +1083,9 @@ wrapSYCLBinariesFromFile(std::vector<module_split::SplitModule> &SplitModules,
     if (!OffloadImageDumpDir.empty()) {
       StringRef CopyFrom = SI.ModuleFilePath;
       SmallString<128> CopyTo = OffloadImageDumpDir;
-      StringRef Filename = llvm::sys::path::filename(CopyFrom);
+      StringRef Filename = sys::path::filename(CopyFrom);
       CopyTo.append(Filename);
-      std::error_code EC = llvm::sys::fs::copy_file(CopyFrom, CopyTo);
+      std::error_code EC = sys::fs::copy_file(CopyFrom, CopyTo);
       if (EC)
         return createStringError(EC, formatv("failed to copy file. From: "
                                              "{0} to: {1}, error_code: {2}",
@@ -2609,19 +2609,22 @@ int main(int Argc, char **Argv) {
     Arg *A = Args.getLastArg(OPT_sycl_dump_device_code_EQ);
     SmallString<128> Dir(A->getValue());
     if (Dir.empty())
-      llvm::sys::path::native(Dir = "./");
+      sys::path::native(Dir = "./");
     else
-      Dir.append(llvm::sys::path::get_separator());
+      Dir.append(sys::path::get_separator());
 
     OffloadImageDumpDir = Dir;
 
-    std::error_code EC = llvm::sys::fs::create_directory(
-        OffloadImageDumpDir, /*IgnoreExisting*/ true);
-    if (EC)
-      reportError(createStringError(
-          EC,
-          formatv("failed to create dump directory. path: {0}, error_code: {1}",
-                  OffloadImageDumpDir, EC.value())));
+    if (!DryRun) {
+      std::error_code EC = sys::fs::create_directory(OffloadImageDumpDir,
+                                                     /*IgnoreExisting*/ true);
+      if (EC)
+        reportError(createStringError(
+            EC,
+            formatv(
+                "failed to create dump directory. path: {0}, error_code: {1}",
+                OffloadImageDumpDir, EC.value())));
+    }
   }
 
   {

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1081,20 +1081,11 @@ wrapSYCLBinariesFromFile(std::vector<module_split::SplitModule> &SplitModules,
 
   for (auto &SI : SplitModules) {
     if (!OffloadImageDumpDir.empty()) {
-      std::error_code EC = llvm::sys::fs::create_directory(
-          OffloadImageDumpDir, /*IgnoreExisting*/ true);
-      if (EC)
-        return createStringError(
-            EC,
-            formatv(
-                "failed to create dump directory. path: {0}, error_code: {1}",
-                OffloadImageDumpDir, EC.value()));
-
       StringRef CopyFrom = SI.ModuleFilePath;
       SmallString<128> CopyTo = OffloadImageDumpDir;
       StringRef Filename = llvm::sys::path::filename(CopyFrom);
       CopyTo.append(Filename);
-      EC = llvm::sys::fs::copy_file(CopyFrom, CopyTo);
+      std::error_code EC = llvm::sys::fs::copy_file(CopyFrom, CopyTo);
       if (EC)
         return createStringError(EC, formatv("failed to copy file. From: "
                                              "{0} to: {1}, error_code: {2}",
@@ -2623,6 +2614,14 @@ int main(int Argc, char **Argv) {
       Dir.append(llvm::sys::path::get_separator());
 
     OffloadImageDumpDir = Dir;
+
+    std::error_code EC = llvm::sys::fs::create_directory(
+        OffloadImageDumpDir, /*IgnoreExisting*/ true);
+    if (EC)
+      reportError(createStringError(
+          EC,
+          formatv("failed to create dump directory. path: {0}, error_code: {1}",
+                  OffloadImageDumpDir, EC.value())));
   }
 
   {

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -242,7 +242,7 @@ Flags<[WrapperOnlyOption]>,  HelpText<"Embed LLVM IR for runtime kernel fusion">
 
 def sycl_dump_device_code_EQ : Joined<["--", "-"], "sycl-dump-device-code=">,
   Flags<[WrapperOnlyOption]>,
-  HelpText<"Path to the folder where the tool dumps SPIR-V device code. Other formats aren't dumped.">;
+  HelpText<"Directory to dump offloading images to.">;
 
 // Options to enable/disable device dynamic linking.
 def sycl_allow_device_image_dependencies : Flag<["--", "-"], "sycl-allow-device-image-dependencies">,


### PR DESCRIPTION
Despite the option name sycl-dump-device-code it enables dumping of only SPIR-V files emitted by the translator tool. This change dumps device code right before embedding it into the fat object. The tool dumps offloading image of any format.