### PR TITLE
[CODEOWNERS] Add llvm-reviewers-benchmarking to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,6 +128,9 @@ devops/ @intel/dpcpp-devops-reviewers
 # dev-igc driver update
 devops/dependencies-igc-dev.json @intel/sycl-matrix-reviewers @intel/dpcpp-esimd-reviewers @intel/dpcpp-devops-reviewers
 
+# Benchmarking scripts
+devops/scripts/benchmarks/ @intel/llvm-reviewers-benchmarking
+
 # Kernel fusion JIT compiler
 sycl-jit/ @intel/dpcpp-kernel-fusion-reviewers
 sycl/doc/design/KernelFusionJIT.md @intel/dpcpp-kernel-fusion-reviewers


### PR DESCRIPTION
Scripts enabling CI for benchmarking has gotten pretty big and complicated: https://github.com/intel/llvm/pull/17545

Most of this code were developed by the UR team, and thus it no longer makes sense to ask dpcpp-devops-reviewers for PR approvals. This PR updates CODEOWNERS to ask llvm-reviewers-benchmarking for benchmarking scripts instead.

**Note:** The current path here puts `/devops/scripts/benchmarks` under llvm-reviewers-benchmarking: This path currently does not exist, but is chosen on purpose in anticipation for https://github.com/intel/llvm/pull/17545.

The folder `/devops/scripts/benchmarking` will be removed in the future as a part of the effort to unify SYCL and UR benchmarking CI infrastructure; See https://github.com/intel/llvm/pull/17229