### PR TITLE
[CI][sycl-cts][win] Use less threads

### DIFF
--- a/devops/actions/run-tests/windows/cts/action.yml
+++ b/devops/actions/run-tests/windows/cts/action.yml
@@ -82,7 +82,7 @@ runs:
       # Ignore errors so that if one category build fails others still have a
       # chance to finish and be executed at the run stage. Note that
       # "test_conformance" target skips building "test_all" executable.
-      ninja -C build-cts -k0 $( [ -n "$CTS_TESTS_TO_BUILD" ] && echo "$CTS_TESTS_TO_BUILD" || echo "test_conformance")
+      ninja -j$(($(nproc) / 2)) -C build-cts -k0 $( [ -n "$CTS_TESTS_TO_BUILD" ] && echo "$CTS_TESTS_TO_BUILD" || echo "test_conformance")
 
   - name: Pack SYCL-CTS binaries
     if: always() && !cancelled() && inputs.cts_testing_mode == 'build-only'


### PR DESCRIPTION
The latest nightly failed with `LLVM_ERROR: out of memory`: https://github.com/intel/llvm/actions/runs/13961174902/job/39083625837

I reduced the number of threads used to build SYCL-CTS by half: https://github.com/intel/llvm/actions/runs/13967576732/job/39101413789 (the failure is expected and unrelated).