### PR TITLE
remove terminating semicolons from do-while-0

### DIFF
--- a/unified-runtime/source/adapters/native_cpu/common.hpp
+++ b/unified-runtime/source/adapters/native_cpu/common.hpp
@@ -25,14 +25,14 @@ extern thread_local char ErrorMessage[MaxMessageSize];
                   __FUNCTION__, __FILE__, __LINE__);                           \
                                                                                \
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;                                \
-  } while (false);
+  } while (false)
 
 #define CONTINUE_NO_IMPLEMENTATION                                             \
   do {                                                                         \
     logger::warning("Not Implemented : {} - File : {} / Line : {}",            \
                     __FUNCTION__, __FILE__, __LINE__);                         \
     return UR_RESULT_SUCCESS;                                                  \
-  } while (false);
+  } while (false)
 
 #define CASE_UR_UNSUPPORTED(not_supported)                                     \
   case not_supported:                                                          \

--- a/unified-runtime/source/adapters/native_cpu/context.cpp
+++ b/unified-runtime/source/adapters/native_cpu/context.cpp
@@ -69,7 +69,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextGetNativeHandle(
     ur_context_handle_t hContext, ur_native_handle_t *phNativeContext) {
   std::ignore = hContext;
   std::ignore = phNativeContext;
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
@@ -84,7 +84,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phContext;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
@@ -94,5 +94,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
   std::ignore = pfnDeleter;
   std::ignore = pUserData;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/device.cpp
+++ b/unified-runtime/source/adapters/native_cpu/device.cpp
@@ -487,7 +487,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetNativeHandle(
   std::ignore = hDevice;
   std::ignore = phNativeDevice;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(

--- a/unified-runtime/source/adapters/native_cpu/kernel.cpp
+++ b/unified-runtime/source/adapters/native_cpu/kernel.cpp
@@ -252,7 +252,7 @@ urKernelSetArgSampler(ur_kernel_handle_t hKernel, uint32_t argIndex,
   std::ignore = pProperties;
   std::ignore = hArgValue;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -290,7 +290,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetNativeHandle(
   std::ignore = hKernel;
   std::ignore = phNativeKernel;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
@@ -304,7 +304,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phKernel;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(

--- a/unified-runtime/source/adapters/native_cpu/memory.cpp
+++ b/unified-runtime/source/adapters/native_cpu/memory.cpp
@@ -23,7 +23,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
   std::ignore = pHost;
   std::ignore = phMem;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
@@ -65,7 +65,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
 UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
   std::ignore = hMem;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
@@ -117,7 +117,7 @@ urMemGetNativeHandle(ur_mem_handle_t hMem, ur_device_handle_t hDevice,
   std::ignore = hDevice;
   std::ignore = phNativeMem;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
@@ -128,7 +128,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phMem;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
@@ -142,7 +142,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phMem;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
@@ -156,7 +156,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
@@ -170,5 +170,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }

--- a/unified-runtime/source/adapters/native_cpu/program.cpp
+++ b/unified-runtime/source/adapters/native_cpu/program.cpp
@@ -26,7 +26,7 @@ urProgramCreateWithIL(ur_context_handle_t hContext, const void *pIL,
   std::ignore = pProperties;
   std::ignore = phProgram;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 static ur_result_t
@@ -206,7 +206,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
   std::ignore = pFunctionName;
   std::ignore = ppFunctionPointer;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
@@ -218,7 +218,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
   std::ignore = pGlobalVariableSizeRet;
   std::ignore = ppGlobalVariablePointerRet;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -264,7 +264,7 @@ urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  CONTINUE_NO_IMPLEMENTATION
+  CONTINUE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
@@ -274,7 +274,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
   std::ignore = count;
   std::ignore = pSpecConstants;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramGetNativeHandle(
@@ -282,7 +282,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetNativeHandle(
   std::ignore = hProgram;
   std::ignore = phNativeProgram;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
@@ -294,5 +294,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phProgram;
 
-  DIE_NO_IMPLEMENTATION
+  DIE_NO_IMPLEMENTATION;
 }


### PR DESCRIPTION
The whole point of surrounding a macro definition in `do { } while (0)` is to safely handle the case of missing braces in an if statement. Remove the semicolon from the definitions of `DIE_NO_IMPLEMENTATION`, and `CONTINUE_NO_IMPLEMENTATION`; and put them around all its uses.