### PR TITLE
Revert "[SYCL] Move function pointer diagnostics to BuildResolvedCallExpr"

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -7124,18 +7124,6 @@ ExprResult Sema::BuildResolvedCallExpr(Expr *Fn, NamedDecl *NDecl,
       return ExprError();
   }
 
-  // Diagnose function pointers in SYCL.
-  if (!FDecl && !getLangOpts().SYCLAllowFuncPtr && getLangOpts().SYCLIsDevice &&
-      !isUnevaluatedContext()) {
-    bool MaybeConstantExpr = false;
-    Expr *NonDirectCallee = TheCall->getCallee();
-    if (!NonDirectCallee->isValueDependent())
-      MaybeConstantExpr = NonDirectCallee->isCXX11ConstantExpr(getASTContext());
-    if (!MaybeConstantExpr)
-      SYCL().DiagIfDeviceCode(TheCall->getExprLoc(), diag::err_sycl_restrict)
-          << SemaSYCL::KernelCallFunctionPointer;
-  }
-
   return CheckForImmediateInvocation(MaybeBindToTemporary(TheCall), FDecl);
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -693,6 +693,17 @@ public:
         SemaSYCLRef.Diag(e->getExprLoc(), diag::err_builtin_target_unsupported)
             << Name << "SYCL device";
       }
+    } else if (!SemaSYCLRef.getLangOpts().SYCLAllowFuncPtr &&
+               !e->isTypeDependent() &&
+               !isa<CXXPseudoDestructorExpr>(e->getCallee())) {
+      bool MaybeConstantExpr = false;
+      Expr *NonDirectCallee = e->getCallee();
+      if (!NonDirectCallee->isValueDependent())
+        MaybeConstantExpr =
+            NonDirectCallee->isCXX11ConstantExpr(SemaSYCLRef.getASTContext());
+      if (!MaybeConstantExpr)
+        SemaSYCLRef.Diag(e->getExprLoc(), diag::err_sycl_restrict)
+            << SemaSYCL::KernelCallFunctionPointer;
     }
     return true;
   }

--- a/clang/test/SemaSYCL/constexpr-function-pointer.cpp
+++ b/clang/test/SemaSYCL/constexpr-function-pointer.cpp
@@ -1,12 +1,9 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -sycl-std=2020 -std=c++17 %s
-// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify=host -sycl-std=2020 -std=c++17 %s
 
 // This test checks that the compiler doesn't emit an error when indirect call
 // was made through a function pointer that is constant expression, and makes
 // sure that the error is emitted when a function pointer is not a constant
 // expression.
-
-// host-no-diagnostics
 
 void t() {}
 
@@ -24,8 +21,6 @@ void bar1(const SomeFunc fptr) {
 }
 
 template <auto f> void fooNTTP() { f(); }
-
-template <typename FTy> void templated(FTy f) { f(); } // #call-templated
 
 __attribute__((sycl_device)) void bar() {
   // OK
@@ -53,19 +48,4 @@ __attribute__((sycl_device)) void bar() {
   fff();
 
   fooNTTP<t>();
-
-  templated(t);
-  // expected-error@#call-templated {{SYCL kernel cannot call through a function pointer}}
-  // expected-note@-2 {{called by 'bar'}}
-}
-
-void from_host() {
-  const auto f1 = t;
-  f1();
-  auto f2 = t;
-  f2();
-
-  fooNTTP<t>();
-
-  templated(t);
 }


### PR DESCRIPTION
Reverts intel/llvm#16987