### PR TITLE
[UR] Skip new command-buffer CTS test on L0 V2

### DIFF
--- a/unified-runtime/test/conformance/exp_command_buffer/native-command/common.h
+++ b/unified-runtime/test/conformance/exp_command_buffer/native-command/common.h
@@ -16,6 +16,8 @@ struct urCommandBufferNativeAppendTest : uur::urQueueTest {
 
     UUR_RETURN_ON_FATAL_FAILURE(checkCommandBufferSupport(device));
 
+    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
+
     // Create a static command-buffer
     ur_exp_command_buffer_desc_t desc{UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC,
                                       nullptr, false, false, false};


### PR DESCRIPTION
All UR command-buffer CTS tests are marked as XFail on V2 [See CTS generic base class for command-buffer](https://github.com/intel/llvm/blob/sycl/unified-runtime/test/conformance/exp_command_buffer/fixtures.h#L48)

This was omitted by accident from the new command-buffer CTS tests added in https://github.com/intel/llvm/pull/17494 which don't derive from that base class. Fixed by adding in now.