### PR TITLE
Optimize use of shared_ptr on kernel enqueue fast path

### DIFF
--- a/sycl/source/accessor.cpp
+++ b/sycl/source/accessor.cpp
@@ -20,7 +20,10 @@ device getDeviceFromHandler(handler &cgh) {
   if (cgh.MQueue)
     return cgh.MQueue->get_device();
 
-  return getSyclObjImpl(cgh)->MGraph->getDevice();
+  const auto &HandlerImpl = getSyclObjImpl(cgh);
+  const auto &GraphImpl = HandlerImpl->MGraph;
+
+  return GraphImpl->getDevice();
 }
 
 // property::no_init is supported now for

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -73,7 +73,7 @@ ProgramManager &ProgramManager::getInstance() {
 }
 
 static ur_program_handle_t
-createBinaryProgram(const ContextImplPtr Context,
+createBinaryProgram(const ContextImplPtr &Context,
                     const std::vector<device> &Devices,
                     const uint8_t **Binaries, size_t *Lengths,
                     const std::vector<ur_program_metadata_t> &Metadata) {
@@ -104,7 +104,7 @@ createBinaryProgram(const ContextImplPtr Context,
   return Program;
 }
 
-static ur_program_handle_t createSpirvProgram(const ContextImplPtr Context,
+static ur_program_handle_t createSpirvProgram(const ContextImplPtr &Context,
                                               const unsigned char *Data,
                                               size_t DataLen) {
   ur_program_handle_t Program = nullptr;
@@ -1700,7 +1700,7 @@ static inline bool isDeviceImageCompressed(sycl_device_binary Bin) {
 }
 
 ProgramManager::ProgramPtr ProgramManager::build(
-    ProgramPtr Program, const ContextImplPtr Context,
+    ProgramPtr Program, const ContextImplPtr &Context,
     const std::string &CompileOptions, const std::string &LinkOptions,
     std::vector<ur_device_handle_t> &Devices, uint32_t DeviceLibReqMask,
     const std::vector<ur_program_handle_t> &ExtraProgramsToLink,

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -369,7 +369,7 @@ static void appendCompileOptionsFromImage(std::string &CompileOpts,
 
   appendCompileOptionsForGRFSizeProperties(CompileOpts, Img, isEsimdImage);
 
-  const auto PlatformImpl = detail::getSyclObjImpl(Devs[0].get_platform());
+  const auto &PlatformImpl = detail::getSyclObjImpl(Devs[0].get_platform());
 
   // Add optimization flags.
   auto str = getUint32PropAsOptStr(Img, "optLevel");
@@ -945,7 +945,7 @@ ur_program_handle_t ProgramManager::getBuiltURProgram(
     }
 
     std::vector<ur_device_handle_t> URDevices;
-    for (auto Dev : Devs)
+    for (auto &Dev : Devs)
       URDevices.push_back(getSyclObjImpl(Dev).get()->getHandleRef());
 
     ProgramPtr BuiltProgram =

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -350,7 +350,7 @@ private:
 
   using ProgramPtr = std::unique_ptr<std::remove_pointer_t<ur_program_handle_t>,
                                      decltype(&::urProgramRelease)>;
-  ProgramPtr build(ProgramPtr Program, const ContextImplPtr Context,
+  ProgramPtr build(ProgramPtr Program, const ContextImplPtr &Context,
                    const std::string &CompileOptions,
                    const std::string &LinkOptions,
                    std::vector<ur_device_handle_t> &Devices,

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -386,7 +386,7 @@ event queue_impl::submit_impl(const detail::type_erased_cgfo_ty &CGF,
 
   addEvent(Event);
 
-  auto EventImpl = detail::getSyclObjImpl(Event);
+  const auto &EventImpl = detail::getSyclObjImpl(Event);
   for (auto &Stream : Streams) {
     // We don't want stream flushing to be blocking operation that is why submit
     // a host task to print stream buffer. It will fire up as soon as the kernel

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -126,7 +126,7 @@ static event prepareSYCLEventAssociatedWithQueue(
 static event createDiscardedEvent() {
   EventImplPtr EventImpl =
       std::make_shared<event_impl>(event_impl::HES_Discarded);
-  return createSyclObjFromImpl<event>(EventImpl);
+  return createSyclObjFromImpl<event>(std::move(EventImpl));
 }
 
 const std::vector<event> &

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -2012,7 +2012,7 @@ void handler::setUserFacingNodeType(ext::oneapi::experimental::node_type Type) {
 }
 
 std::optional<std::array<size_t, 3>> handler::getMaxWorkGroups() {
-  auto Dev = detail::getSyclObjImpl(detail::getDeviceFromHandler(*this));
+  const auto &Dev = detail::getSyclObjImpl(detail::getDeviceFromHandler(*this));
   std::array<size_t, 3> UrResult = {};
   auto Ret = Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
       Dev->getHandleRef(),


### PR DESCRIPTION
Introduce a series of optimizations to how the shared_ptr type variables are passed, to minimize the number of reference counter increments and decrements.