### PR TITLE
[SYCL] Resolve build failure in SYCLPostLink component in `shared libs` mode

### DIFF
--- a/llvm/lib/SYCLPostLink/CMakeLists.txt
+++ b/llvm/lib/SYCLPostLink/CMakeLists.txt
@@ -14,6 +14,7 @@ add_llvm_component_library(LLVMSYCLPostLink
   LLVMDemangle
   LLVMTargetParser
   LLVMTransformUtils
+  LLVMSYCLLowerIR
 
   LINK_COMPONENTS
   Analysis


### PR DESCRIPTION
This change resolve a build issue that was introduced in #17454.