### PR TITLE
[NFC][SYCL] Inline `_KERNELFUNCPARAM` macro

### DIFF
--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -50,15 +50,6 @@
 #include <variant>     // for hash
 #include <vector>      // for vector
 
-// having _TWO_ mid-param #ifdefs makes the functions very difficult to read.
-// Here we simplify the KernelFunc param is simplified to be
-// _KERNELFUNCPARAM(KernelFunc) Once the queue kernel functions are defined,
-// these macros are #undef immediately.
-// replace _KERNELFUNCPARAM(KernelFunc) with   KernelType KernelFunc
-//                                     or     const KernelType &KernelFunc
-
-#define _KERNELFUNCPARAM(a) const KernelType &a
-
 namespace sycl {
 inline namespace _V1 {
 
@@ -2605,7 +2596,7 @@ public:
                     "member function instead.")
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value,
-      event> single_task(PropertiesT Properties, _KERNELFUNCPARAM(KernelFunc),
+      event> single_task(PropertiesT Properties, const KernelType &KernelFunc,
                          const detail::code_location &CodeLoc =
                              detail::code_location::current()) {
     static_assert(
@@ -2631,7 +2622,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(
-      _KERNELFUNCPARAM(KernelFunc),
+      const KernelType &KernelFunc,
       const detail::code_location &CodeLoc = detail::code_location::current()) {
     return single_task<KernelName, KernelType>(
         ext::oneapi::experimental::empty_properties_t{}, KernelFunc, CodeLoc);
@@ -2652,7 +2643,7 @@ public:
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value,
       event> single_task(event DepEvent, PropertiesT Properties,
-                         _KERNELFUNCPARAM(KernelFunc),
+                         const KernelType &KernelFunc,
                          const detail::code_location &CodeLoc =
                              detail::code_location::current()) {
     static_assert(
@@ -2680,7 +2671,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(
-      event DepEvent, _KERNELFUNCPARAM(KernelFunc),
+      event DepEvent, const KernelType &KernelFunc,
       const detail::code_location &CodeLoc = detail::code_location::current()) {
     return single_task<KernelName, KernelType>(
         DepEvent, ext::oneapi::experimental::empty_properties_t{}, KernelFunc,
@@ -2703,7 +2694,7 @@ public:
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value,
       event> single_task(const std::vector<event> &DepEvents,
-                         PropertiesT Properties, _KERNELFUNCPARAM(KernelFunc),
+                         PropertiesT Properties, const KernelType &KernelFunc,
                          const detail::code_location &CodeLoc =
                              detail::code_location::current()) {
     static_assert(
@@ -2732,7 +2723,7 @@ public:
   /// \param CodeLoc contains the code location of user code
   template <typename KernelName = detail::auto_name, typename KernelType>
   event single_task(
-      const std::vector<event> &DepEvents, _KERNELFUNCPARAM(KernelFunc),
+      const std::vector<event> &DepEvents, const KernelType &KernelFunc,
       const detail::code_location &CodeLoc = detail::code_location::current()) {
     return single_task<KernelName, KernelType>(
         DepEvents, ext::oneapi::experimental::empty_properties_t{}, KernelFunc,
@@ -3053,7 +3044,7 @@ public:
             int Dim>
   event parallel_for(range<Dim> Range, id<Dim> WorkItemOffset,
                      const std::vector<event> &DepEvents,
-                     _KERNELFUNCPARAM(KernelFunc)) {
+                     const KernelType &KernelFunc) {
     static_assert(1 <= Dim && Dim <= 3, "Invalid number of dimensions");
     return parallel_for_impl<KernelName>(Range, WorkItemOffset, DepEvents,
                                          KernelFunc);
@@ -3070,7 +3061,7 @@ public:
             int Dims>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL 2020")
   event parallel_for_impl(range<Dims> Range, id<Dims> WorkItemOffset,
-                          _KERNELFUNCPARAM(KernelFunc)) {
+                          const KernelType &KernelFunc) {
     // Actual code location needs to be captured from KernelInfo object.
     const detail::code_location CodeLoc = {};
     return submit(
@@ -3093,7 +3084,7 @@ public:
             int Dims>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL 2020")
   event parallel_for_impl(range<Dims> Range, id<Dims> WorkItemOffset,
-                          event DepEvent, _KERNELFUNCPARAM(KernelFunc)) {
+                          event DepEvent, const KernelType &KernelFunc) {
     // Actual code location needs to be captured from KernelInfo object.
     const detail::code_location CodeLoc = {};
     return submit(
@@ -3119,7 +3110,7 @@ public:
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL 2020")
   event parallel_for_impl(range<Dims> Range, id<Dims> WorkItemOffset,
                           const std::vector<event> &DepEvents,
-                          _KERNELFUNCPARAM(KernelFunc)) {
+                          const KernelType &KernelFunc) {
     // Actual code location needs to be captured from KernelInfo object.
     const detail::code_location CodeLoc = {};
     return submit(
@@ -3428,9 +3419,6 @@ public:
   ///
   // TODO(#15184) Remove this function in the next ABI-breaking window.
   bool ext_codeplay_supports_fusion() const;
-
-// Clean KERNELFUNC macros.
-#undef _KERNELFUNCPARAM
 
   /// Shortcut for executing a graph of commands.
   ///


### PR DESCRIPTION
There is a single unique value for it since
https://github.com/intel/llvm/pull/16118, so there is no reason for having it.