### PR TITLE
Enable cmake argument passthrough in the SYCL configure wrapper (#17189)

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 
 
-def do_configure(args):
+def do_configure(args, passthrough_args):
     # Get absolute path to source directory
     abs_src_dir = os.path.abspath(
         args.src_dir if args.src_dir else os.path.join(__file__, "../..")
@@ -244,6 +244,7 @@ def do_configure(args):
             ]
         )
 
+    cmake_cmd += passthrough_args
     print("[Cmake Command]: {}".format(" ".join(map(shlex.quote, cmake_cmd))))
 
     try:
@@ -398,11 +399,11 @@ def main():
         "--native-cpu-libclc-targets",
         help="Target triples for libclc, used by the Native CPU backend",
     )
-    args = parser.parse_args()
+    args, passthrough_args = parser.parse_known_intermixed_args()
 
     print("args:{}".format(args))
 
-    return do_configure(args)
+    return do_configure(args, passthrough_args)
 
 
 if __name__ == "__main__":

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -228,7 +228,8 @@ Secondly, set the `CUDA_LIB_PATH` environment variable and pass the CMake
 variable `CUDA_TOOLKIT_ROOT_DIR` as follows:
 
 ```sh
-CUDA_LIB_PATH=/path/to/cuda/toolkit/lib64/stubs CC=gcc CXX=g++ python $DPCPP_HOME/llvm/buildbot/configure.py --cuda --cmake-opt="-DCUDA_TOOLKIT_ROOT_DIR=/path/to/cuda/toolkit"
+CC=gcc CXX=g++ python $DPCPP_HOME/llvm/buildbot/configure.py \
+    --cuda -DCUDA_Toolkit_ROOT=/path/to/cuda/toolkit
 
 CUDA_LIB_PATH=/path/to/cuda/toolkit/lib64/stubs CC=gcc CXX=g++ python $DPCPP_HOME/llvm/buildbot/compile.py
 
@@ -256,12 +257,12 @@ instruction on how to install this refer to
 
 The DPC++ build assumes that ROCm is installed in `/opt/rocm`, if it is
 installed somewhere else, the directory must be provided through the CMake
-variable `UR_HIP_ROCM_DIR` which can be passed using the
-`--cmake-opt` option of `configure.py` as follows:
+variable `UR_HIP_ROCM_DIR` which can be passed through to cmake using the
+configure helper script as follows:
 
 ```sh
 python $DPCPP_HOME/llvm/buildbot/configure.py --hip \
-  --cmake-opt=-DUR_HIP_ROCM_DIR=/usr/local/rocm
+  -DUR_HIP_ROCM_DIR=/usr/local/rocm
 ```
 If further customization is required — for instance when the layout of
 individual directories can not be inferred from `UR_HIP_ROCM_DIR` —

--- a/sycl/doc/design/SYCLNativeCPU.md
+++ b/sycl/doc/design/SYCLNativeCPU.md
@@ -47,9 +47,7 @@ SYCL Native CPU uses [libclc](https://github.com/intel/llvm/tree/sycl/libclc) to
 SYCL Native CPU uses the [oneAPI Construction Kit](https://github.com/codeplaysoftware/oneapi-construction-kit) (OCK) in order to support some core SYCL functionalities and improve performances, the OCK is fetched by default when SYCL Native CPU is enabled, and can optionally be disabled using the `NATIVECPU_USE_OCK` CMake variable (please note that disabling the OCK will result in limited functionalities and performances on the SYCL Native CPU backend):
 
 ```
-python3 buildbot/configure.py \
-  --native_cpu \
-  --cmake-opt=-DNATIVECPU_USE_OCK=Off
+python3 buildbot/configure.py --native_cpu -DNATIVECPU_USE_OCK=Off
 ```
 
 By default the oneAPI Construction Kit is pulled at the project's configure time using CMake `FetchContent`. This behaviour can be overridden by setting `NATIVECPU_OCK_USE_FETCHCONTENT=Off` and `OCK_SOURCE_DIR=<path>`


### PR DESCRIPTION
Hundreds of `--cmake-opt=-DFOO=BAR` on the command line make it hard to see the wood for the trees, so introduce an alternative which is to simply pass unknown argument flags straight through to cmake. This should make using the wrapper a little more pleasant and readable.

CHERRY-PICK OF: c62abaeee9e6cb48d04fb623075705710089bd3f