### PR TITLE
[SYCL][E2E] Mark bfloat16 AOT test unsupported

### DIFF
--- a/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
@@ -5,7 +5,7 @@
 
 // REQUIRES: opencl-aot, ocloc, gpu-intel-gen12, any-device-is-gpu
 
-// XFAIL: linux
+// XFAIL: !gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/17305
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend "-device gen12lp" %s -o %t.out

--- a/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
@@ -5,7 +5,7 @@
 
 // REQUIRES: opencl-aot, ocloc, gpu-intel-gen12, any-device-is-gpu
 
-// UNSUPPORTED: gpu-intel-gen12
+// UNSUPPORTED: *
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17305
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend "-device gen12lp" %s -o %t.out

--- a/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
@@ -5,7 +5,7 @@
 
 // REQUIRES: opencl-aot, ocloc, gpu-intel-gen12, any-device-is-gpu
 
-// UNSUPPORTED: *
+// UNSUPPORTED: true
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17305
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend "-device gen12lp" %s -o %t.out

--- a/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
@@ -5,8 +5,8 @@
 
 // REQUIRES: opencl-aot, ocloc, gpu-intel-gen12, any-device-is-gpu
 
-// XFAIL: !gpu-intel-gen12
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17305
+// UNSUPPORTED: gpu-intel-gen12
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17305
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend "-device gen12lp" %s -o %t.out
 // RUN: %if gpu %{%{run} %t.out %}


### PR DESCRIPTION
It fails in precommit L0 Gen12 but passes in postcommit L0 Gen12, weird.