### PR TITLE
[SYCL] Add spill_memory_size standalone test

### DIFF
--- a/sycl/test-e2e/KernelQueries/spill_memory_size.cpp
+++ b/sycl/test-e2e/KernelQueries/spill_memory_size.cpp
@@ -1,0 +1,75 @@
+//==--- spill_memory_size.cpp --- kernel_queries extension tests -----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/detail/core.hpp>
+#include <sycl/detail/info_desc_helpers.hpp>
+#include <sycl/kernel.hpp>
+#include <sycl/kernel_bundle.hpp>
+#include <sycl/nd_item.hpp>
+#include <sycl/nd_range.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+
+using value_type = uint64_t;
+
+namespace kernels {
+template <class T, std::size_t Dim>
+using sycl_global_accessor =
+    sycl::accessor<T, Dim, sycl::access::mode::read_write,
+                   sycl::access::target::global_buffer>;
+class TestKernel {
+public:
+  TestKernel(sycl_global_accessor<value_type, 1> acc) : acc_(acc) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    const auto gtid = item.get_global_linear_id();
+    acc_[gtid] = 42;
+  }
+
+private:
+  sycl_global_accessor<value_type, 1> acc_;
+};
+} // namespace kernels
+
+int main() {
+  sycl::queue q{};
+  const auto ctx = q.get_context();
+  auto bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctx);
+  assert(!bundle.empty());
+  auto kernel = bundle.template get_kernel<kernels::TestKernel>();
+  const auto dev = q.get_device();
+
+  if (dev.has(sycl::aspect::ext_intel_spill_memory_size)) {
+    const auto spillMemSz = kernel.template get_info<
+        sycl::ext::intel::info::kernel_device_specific::spill_memory_size>(dev);
+
+    static_assert(
+        std::is_same_v<std::remove_cv_t<decltype(spillMemSz)>, std::size_t>,
+        "spill_memory_size query must return size_t");
+  } else {
+    try {
+      const auto spillMemSz = kernel.template get_info<
+          sycl::ext::intel::info::kernel_device_specific::spill_memory_size>(
+          dev);
+    } catch (const sycl::exception &e) {
+      // 'feature_not_supported' is the expected outcome from the query above.
+      if (e.code() ==
+          sycl::make_error_code(sycl::errc::feature_not_supported)) {
+        return 0;
+      }
+      std::cerr << e.code() << ":\t";
+      std::cerr << e.what() << std::endl;
+      return 1;
+    }
+  }
+}


### PR DESCRIPTION
This adds a standalone version of the test for the kernel queries extension according to #17593. We already have a similar test in `kernel_info.cpp` (added with the implementation #16834), so I'm not sure this is necessary. This one additionally tests for the exception in the case when a device does not have the aspect.
T
here is likely a better way of structuring the test though. Should I split it into one requiring the aspect and the other, testing for the exception? Is there a mechanism to require the absence of the aspect?