### PR TITLE
[DeviceSanitizers] Set names to nameless globals

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2893,8 +2893,8 @@ void ModuleAddressSanitizer::instrumentDeviceGlobal(IRBuilder<> &IRB) {
   StructType *StructTy = StructType::get(IntptrTy, IntptrTy, IntptrTy);
 
   for (auto &G : M.globals()) {
-    // DeviceASAN cannot handle nameless globals, therefore we set a name for
-    // them so that we can handle them like regular globals.
+    // DeviceSanitizers cannot handle nameless globals, therefore we set a name
+    // for them so that we can handle them like regular globals.
     if (G.getName().empty() && G.hasInternalLinkage())
       G.setName("nameless_global");
 

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1830,7 +1830,8 @@ void AddressSanitizer::instrumentSyclStaticLocalMemory(
 // Instument dynamic local memory
 bool AddressSanitizer::instrumentSyclDynamicLocalMemory(
     Function &F, ArrayRef<Instruction *> RetVec) {
-  InstrumentationIRBuilder IRB(F.getEntryBlock().getFirstNonPHI());
+  InstrumentationIRBuilder IRB(&F.getEntryBlock(),
+                               F.getEntryBlock().getFirstNonPHIIt());
 
   SmallVector<Argument *> LocalArgs;
   for (auto &Arg : F.args()) {
@@ -1868,7 +1869,8 @@ bool AddressSanitizer::instrumentSyclDynamicLocalMemory(
 // "__asan_launch" if it's an extended kernel, and store 0 if not
 void AddressSanitizer::instrumentInitAsanLaunchInfo(
     Function &F, const TargetLibraryInfo *TLI) {
-  InstrumentationIRBuilder IRB(F.getEntryBlock().getFirstNonPHI());
+  InstrumentationIRBuilder IRB(&F.getEntryBlock(),
+                               F.getEntryBlock().getFirstNonPHIIt());
   if (F.arg_size()) {
     auto *LastArg = F.getArg(F.arg_size() - 1);
     if (LastArg->getName() == "__asan_launch") {
@@ -2891,6 +2893,11 @@ void ModuleAddressSanitizer::instrumentDeviceGlobal(IRBuilder<> &IRB) {
   StructType *StructTy = StructType::get(IntptrTy, IntptrTy, IntptrTy);
 
   for (auto &G : M.globals()) {
+    // DeviceASAN cannot handle nameless globals, therefore we set a name for
+    // them so that we can handle them like regular globals.
+    if (G.getName().empty() && G.hasInternalLinkage())
+      G.setName("nameless_global");
+
     if (isUnsupportedDeviceGlobal(&G))
       continue;
 

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -939,8 +939,8 @@ void MemorySanitizerOnSpirv::instrumentGlobalVariables() {
   StructType *StructTy = StructType::get(IntptrTy, IntptrTy);
 
   for (auto &G : M.globals()) {
-    // DeviceASAN cannot handle nameless globals, therefore we set a name for
-    // them so that we can handle them like regular globals.
+    // DeviceSanitizers cannot handle nameless globals, therefore we set a name
+    // for them so that we can handle them like regular globals.
     if (G.getName().empty() && G.hasInternalLinkage())
       G.setName("nameless_global");
 

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -939,6 +939,11 @@ void MemorySanitizerOnSpirv::instrumentGlobalVariables() {
   StructType *StructTy = StructType::get(IntptrTy, IntptrTy);
 
   for (auto &G : M.globals()) {
+    // DeviceASAN cannot handle nameless globals, therefore we set a name for
+    // them so that we can handle them like regular globals.
+    if (G.getName().empty() && G.hasInternalLinkage())
+      G.setName("nameless_global");
+
     if (isUnsupportedDeviceGlobal(&G)) {
       for (auto *User : G.users())
         if (auto *Inst = dyn_cast<Instruction>(User))

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/device_global.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/device_global.ll
@@ -6,8 +6,12 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 @dev_global = addrspace(1) global { [4 x i32] } zeroinitializer #0
+@0 = internal addrspace(1) global i32 0, align 4 ;nameless global
+@1 = internal addrspace(1) global i32 0, align 4 ;nameless global
 
 ; CHECK: @dev_global = addrspace(1) global { { [4 x i32] }, [16 x i8] }
+; CHECK: @nameless_global 
+; CHECK: @nameless_global.1
 ; CHECK: @__AsanDeviceGlobalMetadata = appending local_unnamed_addr addrspace(1) global [1 x { i64, i64, i64 }] [{ i64, i64, i64 } { i64 16, i64 32, i64 ptrtoint (ptr addrspace(1) @dev_global to i64) }]
 
 attributes #0 = { "sycl-device-global-size"="16" "sycl-device-image-scope" }

--- a/llvm/test/Instrumentation/MemorySanitizer/SPIRV/instrument_device_global.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/SPIRV/instrument_device_global.ll
@@ -5,6 +5,8 @@ target triple = "spir64-unknown-unknown"
 @.str = external addrspace(1) constant [59 x i8]
 @__spirv_BuiltInGlobalInvocationId = external addrspace(1) constant <3 x i64>
 @dev_global_no_users = dso_local addrspace(1) global { [4 x i32] } zeroinitializer
+@0 = internal global i32 0, align 4 ;nameless global
+@1 = internal global i32 0, align 4 ;nameless global
 
 define spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv() {
 entry:
@@ -12,6 +14,8 @@ entry:
   ret void
 }
 
+; CHECK: @nameless_global 
+; CHECK: @nameless_global.1
 ; CHECK: @__MsanDeviceGlobalMetadata
 ; CHECK-NOT: @__spirv_BuiltInGlobalInvocationId
 ; CHECK-NOT: @dev_global_no_users


### PR DESCRIPTION
DeviceSanitizer cannot handle nameless globals, but we cannot skip instrumenting them either. Therefore, we set names to nameless globals and process them like regular globals.

Also, this PR update two now deprecated API usage of `getFirstNonPHI`