### PR TITLE
[DeviceSanitizer][Coverity] die when fail to create context

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
@@ -16,7 +16,13 @@
 #include "msan/msan_ddi.hpp"
 
 namespace ur_sanitizer_layer {
-context_t *getContext() { return context_t::get_direct(); }
+context_t *getContext() {
+  try {
+    return context_t::get_direct();
+  } catch (...) {
+    die("Failed to get sanitizer context.");
+  }
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 context_t::context_t()


### PR DESCRIPTION
There is uncaught exception through logger creation in sanitizer layer `context_t` 's creation. We catch exceptions here and die if the creation of sanitizer layer context fails.