### PR TITLE
[CI] Do not enable assertions by default in configure.py script

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -45,6 +45,7 @@ jobs:
       build_cache_root: "/__w/"
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
+      build_configure_extra_args: --enable-assertions
       # Docker image has last nightly pre-installed and added to the PATH
       build_image: "ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest"
       cc: clang

--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -49,6 +49,7 @@ jobs:
         cd $GITHUB_WORKSPACE/build
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
+          --enable-assertions \
           --ci-defaults $ARGS \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -15,7 +15,7 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      build_configure_extra_args: '--hip --cuda'
+      build_configure_extra_args: '--enable-assertions --hip --cuda'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       retention-days: 90
 
@@ -31,7 +31,7 @@ jobs:
       build_cache_root: "/__w/"
       build_cache_suffix: sprod_shared
       build_artifact_suffix: sprod_shared
-      build_configure_extra_args: '--shared-libs --hip --cuda --native_cpu'
+      build_configure_extra_args: '--enable-assertions --shared-libs --hip --cuda --native_cpu'
 
       artifact_archive_name: sycl_linux_shared.tar.zst
 
@@ -43,7 +43,7 @@ jobs:
       build_cache_root: "/__w/"
       build_cache_suffix: oneapi
       build_artifact_suffix: oneapi
-      build_configure_extra_args: -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
+      build_configure_extra_args: --enable-assertions -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
       cc: icx
       cxx: icpx
 
@@ -156,6 +156,7 @@ jobs:
       # We upload both Linux/Windows build via Github's "Releases"
       # functionality, make sure Linux/Windows names follow the same pattern.
       artifact_archive_name: sycl_windows.tar.gz
+      build_configure_extra_args: --enable-assertions
 
   e2e-win:
     needs: build-win

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -41,7 +41,7 @@ jobs:
       build_cache_root: "/__w/llvm"
       build_cache_suffix: default
       build_artifact_suffix: default
-      build_configure_extra_args: --no-assertions --hip --cuda --native_cpu -DSYCL_ENABLE_STACK_PRINTING=ON -DSYCL_LIB_WITH_DEBUG_SYMBOL=ON
+      build_configure_extra_args: --hip --cuda --native_cpu -DSYCL_ENABLE_STACK_PRINTING=ON -DSYCL_LIB_WITH_DEBUG_SYMBOL=ON
 
   e2e-lin:
     needs: [detect_changes, build-lin]
@@ -113,7 +113,7 @@ jobs:
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
       compiler: icx
-      build_configure_extra_args: -DCMAKE_C_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" -DCMAKE_CXX_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" -DCMAKE_EXE_LINKER_FLAGS=/manifest:no -DCMAKE_MODULE_LINKER_FLAGS=/manifest:no -DCMAKE_SHARED_LINKER_FLAGS=/manifest:no
+      build_configure_extra_args: --enable-assertions -DCMAKE_C_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" -DCMAKE_CXX_FLAGS="/fp:precise /clang:-Wno-nonportable-include-path /clang:-Wno-cast-function-type-mismatch" -DCMAKE_EXE_LINKER_FLAGS=/manifest:no -DCMAKE_MODULE_LINKER_FLAGS=/manifest:no -DCMAKE_SHARED_LINKER_FLAGS=/manifest:no
       build_cache_suffix: icx
 
   e2e-win:

--- a/.github/workflows/sycl-rel-nightly.yml
+++ b/.github/workflows/sycl-rel-nightly.yml
@@ -38,7 +38,7 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      build_configure_extra_args: '--hip --cuda'
+      build_configure_extra_args: '--enable-assertions --hip --cuda'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       build_ref: sycl-rel-6_1_0
 
@@ -105,6 +105,7 @@ jobs:
       # We upload both Linux/Windows build via Github's "Releases"
       # functionality, make sure Linux/Windows names follow the same pattern.
       artifact_archive_name: sycl_windows.tar.gz
+      build_configure_extra_args: --enable-assertions
 
   e2e-win:
     needs: build-win

--- a/.github/workflows/sycl-weekly.yml
+++ b/.github/workflows/sycl-weekly.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      build_configure_extra_args: ''
+      build_configure_extra_args: '--enable-assertions'
 
   # This job builds SYCL-CTS with -fsycl-use-spirv-backend-for-spirv-gen.
   build-sycl-cts:

--- a/.github/workflows/sycl-windows-precommit.yml
+++ b/.github/workflows/sycl-windows-precommit.yml
@@ -43,6 +43,7 @@ jobs:
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
       changes: ${{ needs.detect_changes.outputs.filters }}
+      build_configure_extra_args: "--enable-assertions"
 
   e2e:
     needs: build

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -54,7 +54,7 @@ def do_configure(args, passthrough_args):
     sycl_build_pi_hip_platform = "AMD"
     sycl_clang_extra_flags = ""
     sycl_werror = "OFF"
-    llvm_enable_assertions = "ON"
+    llvm_enable_assertions = "OFF"
     llvm_enable_doxygen = "OFF"
     llvm_enable_sphinx = "OFF"
     llvm_build_shared_libs = "OFF"
@@ -122,8 +122,8 @@ def do_configure(args, passthrough_args):
         sycl_werror = "ON"
         xpti_enable_werror = "ON"
 
-    if args.no_assertions:
-        llvm_enable_assertions = "OFF"
+    if args.enable_assertions:
+        llvm_enable_assertions = "ON"
 
     if args.docs:
         llvm_enable_sphinx = "ON"
@@ -357,7 +357,7 @@ def main():
         help="build compiler with all supported targets, it doesn't change runtime build",
     )
     parser.add_argument(
-        "--no-assertions", action="store_true", help="build without assertions"
+        "--enable-assertions", action="store_true", help="Build with assertions."
     )
     parser.add_argument(
         "--docs", action="store_true", help="build Doxygen documentation"


### PR DESCRIPTION
In release build, upstream LLVM require users to explicitly specify `LLVM_ENABLE_ASSERTIONS` to build with assertions. However, in configure.py script, we do the opposite: we enable assertions by default and ask users to specify `--no-assertions` to disable them.
This PR aligns configure.py script with the upstream.