### PR TITLE
[SYCL] Fix 'move instead of copy' Coverity hits

### DIFF
--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -647,12 +647,12 @@ template <> class SYCLConfig<SYCL_JIT_AMDGCN_PTX_TARGET_CPU> {
 
 public:
   static std::string get() {
-    const std::string DefaultValue{""};
+    std::string DefaultValue{""};
 
     const char *ValStr = getCachedValue();
 
     if (!ValStr)
-      return std::move(DefaultValue);
+      return DefaultValue;
 
     return std::string{ValStr};
   }
@@ -675,7 +675,7 @@ template <> class SYCLConfig<SYCL_JIT_AMDGCN_PTX_TARGET_FEATURES> {
 
 public:
   static std::string get() {
-    const std::string DefaultValue{""};
+    std::string DefaultValue{""};
 
     const char *ValStr = getCachedValue();
 

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -652,7 +652,7 @@ public:
     const char *ValStr = getCachedValue();
 
     if (!ValStr)
-      return DefaultValue;
+      return std::move(DefaultValue);
 
     return std::string{ValStr};
   }

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -1044,8 +1044,7 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
   std::shared_ptr<detail::kernel_bundle_impl> KernelBundleImplPtr;
   if (TargetFormat == ::jit_compiler::BinaryFormat::SPIRV) {
     detail::getSyclObjImpl(get_kernel_bundle<bundle_state::executable>(
-        Queue->get_context(), {Queue->get_device()},
-        {std::move(FusedKernelId)}));
+        Queue->get_context(), {Queue->get_device()}, {FusedKernelId}));
   }
 
   std::unique_ptr<detail::CG> FusedCG;

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -1042,10 +1042,6 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
       FusedOrCachedKernelName);
 
   std::shared_ptr<detail::kernel_bundle_impl> KernelBundleImplPtr;
-  if (TargetFormat == ::jit_compiler::BinaryFormat::SPIRV) {
-    detail::getSyclObjImpl(get_kernel_bundle<bundle_state::executable>(
-        Queue->get_context(), {Queue->get_device()}, {FusedKernelId}));
-  }
 
   std::unique_ptr<detail::CG> FusedCG;
   FusedCG.reset(new detail::CGExecKernel(

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -137,7 +137,7 @@ translateBinaryImageFormat(ur::DeviceBinaryType Type) {
   }
 }
 
-::jit_compiler::BinaryFormat getTargetFormat(QueueImplPtr &Queue) {
+::jit_compiler::BinaryFormat getTargetFormat(const QueueImplPtr &Queue) {
   auto Backend = Queue->getDeviceImplPtr()->getBackend();
   switch (Backend) {
   case backend::ext_oneapi_level_zero:
@@ -154,7 +154,7 @@ translateBinaryImageFormat(ur::DeviceBinaryType Type) {
   }
 }
 
-::jit_compiler::TargetInfo getTargetInfo(QueueImplPtr &Queue) {
+::jit_compiler::TargetInfo getTargetInfo(const QueueImplPtr &Queue) {
   ::jit_compiler::BinaryFormat Format = getTargetFormat(Queue);
   return ::jit_compiler::TargetInfo::get(
       Format, static_cast<::jit_compiler::DeviceArchitecture>(
@@ -659,7 +659,7 @@ updatePromotedArgs(const ::jit_compiler::SYCLKernelInfo &FusedKernelInfo,
 }
 
 ur_kernel_handle_t jit_compiler::materializeSpecConstants(
-    QueueImplPtr Queue, const RTDeviceBinaryImage *BinImage,
+    const QueueImplPtr &Queue, const RTDeviceBinaryImage *BinImage,
     const std::string &KernelName,
     const std::vector<unsigned char> &SpecConstBlob) {
 #ifndef _WIN32

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -1044,14 +1044,16 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
   std::shared_ptr<detail::kernel_bundle_impl> KernelBundleImplPtr;
   if (TargetFormat == ::jit_compiler::BinaryFormat::SPIRV) {
     detail::getSyclObjImpl(get_kernel_bundle<bundle_state::executable>(
-        Queue->get_context(), {Queue->get_device()}, {FusedKernelId}));
+        Queue->get_context(), {Queue->get_device()},
+        {std::move(FusedKernelId)}));
   }
 
   std::unique_ptr<detail::CG> FusedCG;
   FusedCG.reset(new detail::CGExecKernel(
       NDRDesc, nullptr, nullptr, std::move(KernelBundleImplPtr),
-      std::move(CGData), std::move(FusedArgs), FusedOrCachedKernelName, {}, {},
-      CGType::Kernel, KernelCacheConfig, false /* KernelIsCooperative */,
+      std::move(CGData), std::move(FusedArgs),
+      std::move(FusedOrCachedKernelName), {}, {}, CGType::Kernel,
+      KernelCacheConfig, false /* KernelIsCooperative */,
       false /* KernelUsesClusterLaunch*/, 0 /* KernelWorkGroupMemorySize */));
   return FusedCG;
 }

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -44,7 +44,7 @@ public:
   fuseKernels(QueueImplPtr Queue, std::vector<ExecCGCommand *> &InputKernels,
               const property_list &);
   ur_kernel_handle_t
-  materializeSpecConstants(QueueImplPtr Queue,
+  materializeSpecConstants(const QueueImplPtr &Queue,
                            const RTDeviceBinaryImage *BinImage,
                            const std::string &KernelName,
                            const std::vector<unsigned char> &SpecConstBlob);

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -593,7 +593,7 @@ ur_kernel_handle_t Scheduler::completeSpecConstMaterialization(
     [[maybe_unused]] std::vector<unsigned char> &SpecConstBlob) {
 #if SYCL_EXT_JIT_ENABLE && !_WIN32
   return detail::jit_compiler::get_instance().materializeSpecConstants(
-      Queue, BinImage, KernelName, SpecConstBlob);
+      std::move(Queue), BinImage, KernelName, SpecConstBlob);
 #else  // SYCL_EXT_JIT_ENABLE && !_WIN32
   if (detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() > 0) {
     std::cerr << "WARNING: Materialization of spec constants not supported by "

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -587,13 +587,13 @@ void Scheduler::cleanupAuxiliaryResources(BlockingT Blocking) {
 }
 
 ur_kernel_handle_t Scheduler::completeSpecConstMaterialization(
-    [[maybe_unused]] QueueImplPtr Queue,
+    [[maybe_unused]] const QueueImplPtr &Queue,
     [[maybe_unused]] const RTDeviceBinaryImage *BinImage,
     [[maybe_unused]] const std::string &KernelName,
     [[maybe_unused]] std::vector<unsigned char> &SpecConstBlob) {
 #if SYCL_EXT_JIT_ENABLE && !_WIN32
   return detail::jit_compiler::get_instance().materializeSpecConstants(
-      std::move(Queue), BinImage, KernelName, SpecConstBlob);
+      Queue, BinImage, KernelName, SpecConstBlob);
 #else  // SYCL_EXT_JIT_ENABLE && !_WIN32
   if (detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() > 0) {
     std::cerr << "WARNING: Materialization of spec constants not supported by "

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -453,7 +453,7 @@ public:
   void deferMemObjRelease(const std::shared_ptr<detail::SYCLMemObjI> &MemObj);
 
   ur_kernel_handle_t completeSpecConstMaterialization(
-      QueueImplPtr Queue, const RTDeviceBinaryImage *BinImage,
+      const QueueImplPtr &Queue, const RTDeviceBinaryImage *BinImage,
       const std::string &KernelName, std::vector<unsigned char> &SpecConstBlob);
 
   void releaseResources(BlockingT Blocking = BlockingT::BLOCKING);


### PR DESCRIPTION
Avoid copying by:
- Making the `Queue` parameter of `completeSpecConstMaterialization` passed by a const reference. Also changes `materializeSpecConstants`, `getTargetInfo` and `getTargetFormat` to accomodate this change.
- Makes returned `DefaultValue` string non const so that the move ctor is called automatically in two `get` functions.
- Remove dead if statement that copied value for a function call.