### PR TITLE
Updated Driver In order lists check and required version

### DIFF
--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -76,7 +76,9 @@ bool checkCounterBasedEventsSupport(ur_device_handle_t Device) {
     return std::atoi(UrRet) != 0;
   }();
 
-  return Device->ImmCommandListUsed && Device->useDriverInOrderLists() &&
+  return Device->ImmCommandListUsed &&
+         Device->Platform->allowDriverInOrderLists(
+             true /*Only Allow Driver In Order List if requested*/) &&
          useDriverCounterBasedEvents &&
          Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
 }
@@ -647,12 +649,9 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
  */
 bool canBeInOrder(ur_context_handle_t Context,
                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
-  const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
-  // In-order command-lists are not available in old driver version.
-  bool DriverInOrderRequested = UrRet ? std::atoi(UrRet) != 0 : false;
-  bool CompatibleDriver = Context->getPlatform()->isDriverVersionNewerOrSimilar(
-      1, 3, L0_DRIVER_INORDER_MIN_VERSION);
-  bool CanUseDriverInOrderLists = CompatibleDriver && DriverInOrderRequested;
+  bool CanUseDriverInOrderLists =
+      Context->getPlatform()->allowDriverInOrderLists(
+          true /*Only Allow Driver In Order List if requested*/);
   return CanUseDriverInOrderLists ? CommandBufferDesc->isInOrder : false;
 }
 

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -76,10 +76,7 @@ bool checkCounterBasedEventsSupport(ur_device_handle_t Device) {
     return std::atoi(UrRet) != 0;
   }();
 
-  return Device->ImmCommandListUsed &&
-         Device->Platform->allowDriverInOrderLists(
-             true /*Only Allow Driver In Order List if requested*/) &&
-         useDriverCounterBasedEvents &&
+  return Device->ImmCommandListUsed && useDriverCounterBasedEvents &&
          Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
 }
 
@@ -649,9 +646,12 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
  */
 bool canBeInOrder(ur_context_handle_t Context,
                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
-  bool CanUseDriverInOrderLists =
-      Context->getPlatform()->allowDriverInOrderLists(
-          true /*Only Allow Driver In Order List if requested*/);
+  const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
+  // In-order command-lists are not available in old driver version.
+  bool DriverInOrderRequested = UrRet ? std::atoi(UrRet) != 0 : false;
+  bool CompatibleDriver = Context->getPlatform()->isDriverVersionNewerOrSimilar(
+      1, 3, L0_DRIVER_INORDER_MIN_VERSION);
+  bool CanUseDriverInOrderLists = CompatibleDriver && DriverInOrderRequested;
   return CanUseDriverInOrderLists ? CommandBufferDesc->isInOrder : false;
 }
 

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -76,7 +76,8 @@ bool checkCounterBasedEventsSupport(ur_device_handle_t Device) {
     return std::atoi(UrRet) != 0;
   }();
 
-  return Device->ImmCommandListUsed && Device->useDriverInOrderListrs() &&
+  return Device->ImmCommandListUsed &&
+         Device->Platform->allowDriverInOrderLists() &&
          useDriverCounterBasedEvents &&
          Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
 }
@@ -648,8 +649,7 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
 bool canBeInOrder(ur_context_handle_t Context,
                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
   bool CanUseDriverInOrderLists =
-      Context->getPlatform()->allowDriverInOrderLists(
-          true /*Only Allow Driver In Order List if requested*/);
+      Context->getPlatform()->allowDriverInOrderLists();
   return CanUseDriverInOrderLists ? CommandBufferDesc->isInOrder : false;
 }
 

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -77,7 +77,8 @@ bool checkCounterBasedEventsSupport(ur_device_handle_t Device) {
   }();
 
   return Device->ImmCommandListUsed &&
-         Device->Platform->allowDriverInOrderLists() &&
+         Device->Platform->allowDriverInOrderLists(
+             true /*Only Allow Driver In Order List if requested*/) &&
          useDriverCounterBasedEvents &&
          Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
 }
@@ -649,7 +650,8 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
 bool canBeInOrder(ur_context_handle_t Context,
                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
   bool CanUseDriverInOrderLists =
-      Context->getPlatform()->allowDriverInOrderLists();
+      Context->getPlatform()->allowDriverInOrderLists(
+          true /*Only Allow Driver In Order List if requested*/);
   return CanUseDriverInOrderLists ? CommandBufferDesc->isInOrder : false;
 }
 

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -76,7 +76,8 @@ bool checkCounterBasedEventsSupport(ur_device_handle_t Device) {
     return std::atoi(UrRet) != 0;
   }();
 
-  return Device->ImmCommandListUsed && useDriverCounterBasedEvents &&
+  return Device->ImmCommandListUsed && Device->useDriverInOrderListrs() &&
+         useDriverCounterBasedEvents &&
          Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
 }
 
@@ -646,12 +647,9 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
  */
 bool canBeInOrder(ur_context_handle_t Context,
                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
-  const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
-  // In-order command-lists are not available in old driver version.
-  bool DriverInOrderRequested = UrRet ? std::atoi(UrRet) != 0 : false;
-  bool CompatibleDriver = Context->getPlatform()->isDriverVersionNewerOrSimilar(
-      1, 3, L0_DRIVER_INORDER_MIN_VERSION);
-  bool CanUseDriverInOrderLists = CompatibleDriver && DriverInOrderRequested;
+  bool CanUseDriverInOrderLists =
+      Context->getPlatform()->allowDriverInOrderLists(
+          true /*Only Allow Driver In Order List if requested*/);
   return CanUseDriverInOrderLists ? CommandBufferDesc->isInOrder : false;
 }
 

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -610,3 +610,75 @@ extern thread_local int32_t ErrorAdapterNativeCode;
                                       int32_t AdapterErrorCode);
 
 #define L0_DRIVER_INORDER_MIN_VERSION 29534
+// Definitions for the External Semaphore Extension
+
+#ifndef ZE_INTEL_EXTERNAL_SEMAPHORE_EXP_NAME
+/// @brief Event sync mode extension name
+#define ZE_INTEL_EXTERNAL_SEMAPHORE_EXP_NAME                                   \
+  "ZE_intel_experimental_external_semaphore"
+#endif // ZE_INTEL_EXTERNAL_SEMAPHORE_EXP_NAME
+
+typedef enum _ze_intel_external_semaphore_exp_version_t {
+  ZE_EXTERNAL_SEMAPHORE_EXP_VERSION_1_0 =
+      ZE_MAKE_VERSION(1, 0), ///< version 1.0
+  ZE_EXTERNAL_SEMAPHORE_EXP_VERSION_CURRENT =
+      ZE_MAKE_VERSION(1, 0), ///< latest known version
+  ZE_EXTERNAL_SEMAPHORE_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+} ze_intel_external_semaphore_exp_version_t;
+typedef enum _ze_intel_external_semaphore_exp_flags_t {
+  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_FD,
+  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_WIN32,
+  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_WIN32_KMT,
+  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_D3D12_FENCE,
+  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_D3D11_FENCE,
+  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_KEYED_MUTEX,
+  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_KEYED_MUTEX_KMT,
+  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_FD,
+  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_WIN32
+} ze_intel_external_semaphore_exp_flags_t;
+
+typedef struct _ze_intel_external_semaphore_exp_desc_t {
+  ze_structure_type_t stype;
+  const void *pNext;
+  ze_intel_external_semaphore_exp_flags_t flags;
+} ze_intel_external_semaphore_exp_desc_t;
+
+typedef struct _ze_intel_external_semaphore_win32_exp_desc_t {
+  ze_structure_type_t stype;
+  const void *pNext;
+  void *handle;
+  const char *name;
+} ze_intel_external_semaphore_win32_exp_desc_t;
+
+typedef struct _ze_intel_external_semaphore_fd_exp_desc_t {
+  ze_structure_type_t stype;
+  const void *pNext;
+  int fd;
+} ze_intel_external_semaphore_desc_fd_exp_desc_t;
+
+typedef struct _ze_intel_external_semaphore_signal_exp_params_t {
+  ze_structure_type_t stype;
+  const void *pNext;
+  uint64_t value;
+} ze_intel_external_semaphore_signal_exp_params_t;
+
+typedef struct _ze_intel_external_semaphore_wait_exp_params_t {
+  ze_structure_type_t stype;
+  const void *pNext;
+
+  uint64_t value;
+} ze_intel_external_semaphore_wait_exp_params_t;
+
+typedef struct _ze_intel_external_semaphore_exp_handle_t
+    *ze_intel_external_semaphore_exp_handle_t;
+
+#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_EXP_DESC                    \
+  (ze_structure_type_t)0x0003001E
+#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WIN32_EXP_DESC              \
+  (ze_structure_type_t)0x0003001F
+#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_FD_EXP_DESC                 \
+  (ze_structure_type_t)0x00030023
+#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXP           \
+  (ze_structure_type_t)0x00030024
+#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXP             \
+  (ze_structure_type_t)0x00030025

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -608,5 +608,3 @@ extern thread_local int32_t ErrorAdapterNativeCode;
 [[maybe_unused]] void setErrorMessage(const char *pMessage,
                                       ur_result_t ErrorCode,
                                       int32_t AdapterErrorCode);
-
-#define L0_DRIVER_INORDER_MIN_VERSION 29534

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -618,44 +618,6 @@ extern thread_local int32_t ErrorAdapterNativeCode;
   "ZE_intel_experimental_external_semaphore"
 #endif // ZE_INTEL_EXTERNAL_SEMAPHORE_EXP_NAME
 
-typedef enum _ze_intel_external_semaphore_exp_version_t {
-  ZE_EXTERNAL_SEMAPHORE_EXP_VERSION_1_0 =
-      ZE_MAKE_VERSION(1, 0), ///< version 1.0
-  ZE_EXTERNAL_SEMAPHORE_EXP_VERSION_CURRENT =
-      ZE_MAKE_VERSION(1, 0), ///< latest known version
-  ZE_EXTERNAL_SEMAPHORE_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
-} ze_intel_external_semaphore_exp_version_t;
-typedef enum _ze_intel_external_semaphore_exp_flags_t {
-  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_FD,
-  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_WIN32,
-  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_WIN32_KMT,
-  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_D3D12_FENCE,
-  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_D3D11_FENCE,
-  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_KEYED_MUTEX,
-  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_KEYED_MUTEX_KMT,
-  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_FD,
-  ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_WIN32
-} ze_intel_external_semaphore_exp_flags_t;
-
-typedef struct _ze_intel_external_semaphore_exp_desc_t {
-  ze_structure_type_t stype;
-  const void *pNext;
-  ze_intel_external_semaphore_exp_flags_t flags;
-} ze_intel_external_semaphore_exp_desc_t;
-
-typedef struct _ze_intel_external_semaphore_win32_exp_desc_t {
-  ze_structure_type_t stype;
-  const void *pNext;
-  void *handle;
-  const char *name;
-} ze_intel_external_semaphore_win32_exp_desc_t;
-
-typedef struct _ze_intel_external_semaphore_fd_exp_desc_t {
-  ze_structure_type_t stype;
-  const void *pNext;
-  int fd;
-} ze_intel_external_semaphore_desc_fd_exp_desc_t;
-
 typedef struct _ze_intel_external_semaphore_signal_exp_params_t {
   ze_structure_type_t stype;
   const void *pNext;

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -610,37 +610,3 @@ extern thread_local int32_t ErrorAdapterNativeCode;
                                       int32_t AdapterErrorCode);
 
 #define L0_DRIVER_INORDER_MIN_VERSION 29534
-// Definitions for the External Semaphore Extension
-
-#ifndef ZE_INTEL_EXTERNAL_SEMAPHORE_EXP_NAME
-/// @brief Event sync mode extension name
-#define ZE_INTEL_EXTERNAL_SEMAPHORE_EXP_NAME                                   \
-  "ZE_intel_experimental_external_semaphore"
-#endif // ZE_INTEL_EXTERNAL_SEMAPHORE_EXP_NAME
-
-typedef struct _ze_intel_external_semaphore_signal_exp_params_t {
-  ze_structure_type_t stype;
-  const void *pNext;
-  uint64_t value;
-} ze_intel_external_semaphore_signal_exp_params_t;
-
-typedef struct _ze_intel_external_semaphore_wait_exp_params_t {
-  ze_structure_type_t stype;
-  const void *pNext;
-
-  uint64_t value;
-} ze_intel_external_semaphore_wait_exp_params_t;
-
-typedef struct _ze_intel_external_semaphore_exp_handle_t
-    *ze_intel_external_semaphore_exp_handle_t;
-
-#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_EXP_DESC                    \
-  (ze_structure_type_t)0x0003001E
-#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WIN32_EXP_DESC              \
-  (ze_structure_type_t)0x0003001F
-#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_FD_EXP_DESC                 \
-  (ze_structure_type_t)0x00030023
-#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXP           \
-  (ze_structure_type_t)0x00030024
-#define ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXP             \
-  (ze_structure_type_t)0x00030025

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -207,7 +207,7 @@ ur_result_t ur_context_handle_t_::initialize() {
 
   ZeCommandQueueDesc.index = 0;
   ZeCommandQueueDesc.mode = ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS;
-  if (Device->useDriverInOrderLists() &&
+  if (Device->Platform->allowDriverInOrderLists() &&
       Device->useDriverCounterBasedEvents()) {
     logger::debug(
         "L0 Synchronous Immediate Command List needed with In Order property.");
@@ -673,8 +673,8 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
     for (auto ZeCommandListIt = ZeCommandListCache.begin();
          ZeCommandListIt != ZeCommandListCache.end(); ++ZeCommandListIt) {
       // If this is an InOrder Queue, then only allow lists which are in order.
-      if (Queue->Device->useDriverInOrderLists() && Queue->isInOrderQueue() &&
-          !(ZeCommandListIt->second.InOrderList)) {
+      if (Queue->Device->Platform->allowDriverInOrderLists() &&
+          Queue->isInOrderQueue() && !(ZeCommandListIt->second.InOrderList)) {
         continue;
       }
       // Only allow to reuse Regular Command Lists
@@ -740,8 +740,8 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
       continue;
 
     // If this is an InOrder Queue, then only allow lists which are in order.
-    if (Queue->Device->useDriverInOrderLists() && Queue->isInOrderQueue() &&
-        !(it->second.IsInOrderList)) {
+    if (Queue->Device->Platform->allowDriverInOrderLists() &&
+        Queue->isInOrderQueue() && !(it->second.IsInOrderList)) {
       continue;
     }
 

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -207,7 +207,8 @@ ur_result_t ur_context_handle_t_::initialize() {
 
   ZeCommandQueueDesc.index = 0;
   ZeCommandQueueDesc.mode = ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS;
-  if (Device->Platform->allowDriverInOrderLists() &&
+  if (Device->Platform->allowDriverInOrderLists(
+          true /*Only Allow Driver In Order List if requested*/) &&
       Device->useDriverCounterBasedEvents()) {
     logger::debug(
         "L0 Synchronous Immediate Command List needed with In Order property.");
@@ -673,7 +674,8 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
     for (auto ZeCommandListIt = ZeCommandListCache.begin();
          ZeCommandListIt != ZeCommandListCache.end(); ++ZeCommandListIt) {
       // If this is an InOrder Queue, then only allow lists which are in order.
-      if (Queue->Device->Platform->allowDriverInOrderLists() &&
+      if (Queue->Device->Platform->allowDriverInOrderLists(
+              true /*Only Allow Driver In Order List if requested*/) &&
           Queue->isInOrderQueue() && !(ZeCommandListIt->second.InOrderList)) {
         continue;
       }
@@ -740,7 +742,8 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
       continue;
 
     // If this is an InOrder Queue, then only allow lists which are in order.
-    if (Queue->Device->Platform->allowDriverInOrderLists() &&
+    if (Queue->Device->Platform->allowDriverInOrderLists(
+            true /*Only Allow Driver In Order List if requested*/) &&
         Queue->isInOrderQueue() && !(it->second.IsInOrderList)) {
       continue;
     }

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1668,22 +1668,6 @@ bool ur_device_handle_t_::useRelaxedAllocationLimits() {
   return EnableRelaxedAllocationLimits;
 }
 
-bool ur_device_handle_t_::useDriverInOrderLists() {
-  // Use in-order lists implementation from L0 driver instead
-  // of adapter's implementation.
-
-  static const bool UseDriverInOrderLists = [&] {
-    const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
-    // bool CompatibleDriver = this->Platform->isDriverVersionNewerOrSimilar(
-    //     1, 3, L0_DRIVER_INORDER_MIN_VERSION);
-    if (!UrRet)
-      return false;
-    return std::atoi(UrRet) != 0;
-  }();
-
-  return UseDriverInOrderLists;
-}
-
 bool ur_device_handle_t_::useDriverCounterBasedEvents() {
   // Use counter-based events implementation from L0 driver.
 

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -155,9 +155,6 @@ struct ur_device_handle_t_ : _ur_object {
   // Read env settings to select immediate commandlist mode.
   ImmCmdlistMode useImmediateCommandLists();
 
-  // Whether Adapter uses driver's implementation of in-order lists or not
-  bool useDriverInOrderLists();
-
   // Whether Adapter uses driver's implementation of counter-based events or not
   bool useDriverCounterBasedEvents();
 

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -223,22 +223,6 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
         if (Queue->isInOrderQueue() && InOrderBarrierBySignal &&
             !Queue->isProfilingEnabled()) {
           if (EventWaitList.Length) {
-            if (CmdList->second.IsInOrderList) {
-              for (unsigned i = EventWaitList.Length; i-- > 0;) {
-                // If the event is a multidevice event, then given driver in
-                // order lists, we cannot include this into the wait event list
-                // due to driver limitations.
-                if (EventWaitList.UrEventList[i]->IsMultiDevice) {
-                  EventWaitList.Length--;
-                  if (EventWaitList.Length != i) {
-                    std::swap(EventWaitList.UrEventList[i],
-                              EventWaitList.UrEventList[EventWaitList.Length]);
-                    std::swap(EventWaitList.ZeEventList[i],
-                              EventWaitList.ZeEventList[EventWaitList.Length]);
-                  }
-                }
-              }
-            }
             ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
                        (CmdList->first, EventWaitList.Length,
                         EventWaitList.ZeEventList));
@@ -1505,8 +1489,8 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
   // the native driver implementation will already ensure in-order semantics.
   // The only exception is when a different immediate command was last used on
   // the same UR Queue.
-  if (CurQueue->Device->useDriverInOrderLists() && CurQueue->isInOrderQueue() &&
-      CurQueue->UsingImmCmdLists) {
+  if (CurQueue->Device->Platform->allowDriverInOrderLists() &&
+      CurQueue->isInOrderQueue() && CurQueue->UsingImmCmdLists) {
     auto QueueGroup = CurQueue->getQueueGroup(UseCopyEngine);
     uint32_t QueueGroupOrdinal, QueueIndex;
     auto NextIndex = QueueGroup.getQueueIndex(&QueueGroupOrdinal, &QueueIndex,
@@ -1535,7 +1519,7 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
 
     // For in-order queue and wait-list which is empty or has events only from
     // the same queue then we don't need to wait on any other additional events
-    if (CurQueue->Device->useDriverInOrderLists() &&
+    if (CurQueue->Device->Platform->allowDriverInOrderLists() &&
         CurQueue->isInOrderQueue() &&
         WaitListEmptyOrAllEventsFromSameQueue(CurQueue, EventListLength,
                                               EventList)) {

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -1489,7 +1489,8 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
   // the native driver implementation will already ensure in-order semantics.
   // The only exception is when a different immediate command was last used on
   // the same UR Queue.
-  if (CurQueue->Device->Platform->allowDriverInOrderLists() &&
+  if (CurQueue->Device->Platform->allowDriverInOrderLists(
+          true /*Only Allow Driver In Order List if requested*/) &&
       CurQueue->isInOrderQueue() && CurQueue->UsingImmCmdLists) {
     auto QueueGroup = CurQueue->getQueueGroup(UseCopyEngine);
     uint32_t QueueGroupOrdinal, QueueIndex;
@@ -1519,7 +1520,8 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
 
     // For in-order queue and wait-list which is empty or has events only from
     // the same queue then we don't need to wait on any other additional events
-    if (CurQueue->Device->Platform->allowDriverInOrderLists() &&
+    if (CurQueue->Device->Platform->allowDriverInOrderLists(
+            true /*Only Allow Driver In Order List if requested*/) &&
         CurQueue->isInOrderQueue() &&
         WaitListEmptyOrAllEventsFromSameQueue(CurQueue, EventListLength,
                                               EventList)) {

--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -503,21 +503,17 @@ bool ur_platform_handle_t_::allowDriverInOrderLists(bool OnlyIfRequested) {
 #define L0_DRIVER_INORDER_MINOR_VERSION 6
 #define L0_DRIVER_INORDER_PATCH_VERSION 32149
 
-  static const bool UseDriverInOrderLists = [&] {
+  static const bool UseEnvVarDriverInOrderLists = [&] {
     const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
+    return UrRet ? std::atoi(UrRet) != 0 : false;
+  }();
+  static const bool UseDriverInOrderLists = [this] {
     bool CompatibleDriver = this->isDriverVersionNewerOrSimilar(
         1, L0_DRIVER_INORDER_MINOR_VERSION, L0_DRIVER_INORDER_PATCH_VERSION);
-    bool DriverInOrderRequested = UrRet ? std::atoi(UrRet) != 0 : false;
-    bool CanUseDriverInOrderLists = CompatibleDriver || DriverInOrderRequested;
-    return CanUseDriverInOrderLists;
+    return CompatibleDriver || UseEnvVarDriverInOrderLists;
   }();
 
-  if (OnlyIfRequested) {
-    const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
-    bool DriverInOrderRequested = UrRet ? std::atoi(UrRet) != 0 : false;
-    return DriverInOrderRequested;
-  }
-  return UseDriverInOrderLists;
+  return OnlyIfRequested ? UseEnvVarDriverInOrderLists : UseDriverInOrderLists;
 }
 
 /// Checks the version of the level-zero driver.

--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -494,6 +494,30 @@ ur_result_t ur_platform_handle_t_::initialize() {
   return UR_RESULT_SUCCESS;
 }
 
+bool ur_platform_handle_t_::allowDriverInOrderLists(bool OnlyIfRequested) {
+  // Use in-order lists implementation from L0 driver instead
+  // of adapter's implementation.
+
+  // The following driver version is known to be passing and only this or newer
+  // drivers should be allowed by default for in order lists.
+#define L0_DRIVER_INORDER_MINOR_VERSION 6
+#define L0_DRIVER_INORDER_PATCH_VERSION 32149
+
+  static const bool UseDriverInOrderLists = [&] {
+    const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
+    bool CompatibleDriver = this->isDriverVersionNewerOrSimilar(
+        1, L0_DRIVER_INORDER_MINOR_VERSION, L0_DRIVER_INORDER_PATCH_VERSION);
+    bool DriverInOrderRequested = UrRet ? std::atoi(UrRet) != 0 : false;
+    if (OnlyIfRequested) {
+      return DriverInOrderRequested;
+    }
+    bool CanUseDriverInOrderLists = CompatibleDriver || DriverInOrderRequested;
+    return CanUseDriverInOrderLists;
+  }();
+
+  return UseDriverInOrderLists;
+}
+
 /// Checks the version of the level-zero driver.
 /// @param VersionMajor Major verion number to compare to.
 /// @param VersionMinor Minor verion number to compare to.

--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -508,13 +508,15 @@ bool ur_platform_handle_t_::allowDriverInOrderLists(bool OnlyIfRequested) {
     bool CompatibleDriver = this->isDriverVersionNewerOrSimilar(
         1, L0_DRIVER_INORDER_MINOR_VERSION, L0_DRIVER_INORDER_PATCH_VERSION);
     bool DriverInOrderRequested = UrRet ? std::atoi(UrRet) != 0 : false;
-    if (OnlyIfRequested) {
-      return DriverInOrderRequested;
-    }
     bool CanUseDriverInOrderLists = CompatibleDriver || DriverInOrderRequested;
     return CanUseDriverInOrderLists;
   }();
 
+  if (OnlyIfRequested) {
+    const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
+    bool DriverInOrderRequested = UrRet ? std::atoi(UrRet) != 0 : false;
+    return DriverInOrderRequested;
+  }
   return UseDriverInOrderLists;
 }
 

--- a/unified-runtime/source/adapters/level_zero/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/platform.hpp
@@ -48,6 +48,10 @@ struct ur_platform_handle_t_ : public _ur_platform {
   // Zero.
   ZeDriverVersionStringExtension ZeDriverVersionString;
 
+  // Helper function to check if the driver supports Driver In Order Lists or
+  // the User has Requested this support.
+  bool allowDriverInOrderLists(bool OnlyIfRequested = false);
+
   // Cache versions info from zeDriverGetProperties.
   std::string ZeDriverVersion;
   std::string ZeDriverApiVersion;

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -1198,11 +1198,13 @@ ur_queue_handle_t_::ur_queue_handle_t_(
   CopyCommandBatch.QueueBatchSize = ZeCommandListBatchCopyConfig.startSize();
 
   this->CounterBasedEventsEnabled =
-      UsingImmCmdLists && isInOrderQueue() && Device->useDriverInOrderLists() &&
+      UsingImmCmdLists && isInOrderQueue() &&
+      Device->Platform->allowDriverInOrderLists() &&
       Device->useDriverCounterBasedEvents() &&
       Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
   this->InterruptBasedEventsEnabled =
-      isLowPowerEvents() && isInOrderQueue() && Device->useDriverInOrderLists();
+      isLowPowerEvents() && isInOrderQueue() &&
+      Device->Platform->allowDriverInOrderLists();
 }
 
 void ur_queue_handle_t_::adjustBatchSizeForFullBatch(bool IsCopy) {
@@ -2297,7 +2299,7 @@ ur_result_t ur_queue_handle_t_::createCommandList(
   ZeCommandListDesc.commandQueueGroupOrdinal = QueueGroupOrdinal;
 
   bool IsInOrderList = false;
-  if (Device->useDriverInOrderLists() && isInOrderQueue()) {
+  if (Device->Platform->allowDriverInOrderLists() && isInOrderQueue()) {
     ZeCommandListDesc.flags = ZE_COMMAND_LIST_FLAG_IN_ORDER;
     IsInOrderList = true;
   }
@@ -2434,7 +2436,8 @@ ur_command_list_ptr_t &ur_queue_handle_t_::ur_queue_group_t::getImmCmdList() {
     ZeCommandQueueDesc.flags |= ZE_COMMAND_QUEUE_FLAG_EXPLICIT_ONLY;
   }
 
-  if (Queue->Device->useDriverInOrderLists() && Queue->isInOrderQueue()) {
+  if (Queue->Device->Platform->allowDriverInOrderLists() &&
+      Queue->isInOrderQueue()) {
     isInOrderList = true;
     ZeCommandQueueDesc.flags |= ZE_COMMAND_QUEUE_FLAG_IN_ORDER;
   }

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -1199,12 +1199,14 @@ ur_queue_handle_t_::ur_queue_handle_t_(
 
   this->CounterBasedEventsEnabled =
       UsingImmCmdLists && isInOrderQueue() &&
-      Device->Platform->allowDriverInOrderLists() &&
+      Device->Platform->allowDriverInOrderLists(
+          true /*Only Allow Driver In Order List if requested*/) &&
       Device->useDriverCounterBasedEvents() &&
       Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
   this->InterruptBasedEventsEnabled =
       isLowPowerEvents() && isInOrderQueue() &&
-      Device->Platform->allowDriverInOrderLists();
+      Device->Platform->allowDriverInOrderLists(
+          true /*Only Allow Driver In Order List if requested*/);
 }
 
 void ur_queue_handle_t_::adjustBatchSizeForFullBatch(bool IsCopy) {
@@ -2299,7 +2301,9 @@ ur_result_t ur_queue_handle_t_::createCommandList(
   ZeCommandListDesc.commandQueueGroupOrdinal = QueueGroupOrdinal;
 
   bool IsInOrderList = false;
-  if (Device->Platform->allowDriverInOrderLists() && isInOrderQueue()) {
+  if (Device->Platform->allowDriverInOrderLists(
+          true /*Only Allow Driver In Order List if requested*/) &&
+      isInOrderQueue()) {
     ZeCommandListDesc.flags = ZE_COMMAND_LIST_FLAG_IN_ORDER;
     IsInOrderList = true;
   }
@@ -2436,7 +2440,8 @@ ur_command_list_ptr_t &ur_queue_handle_t_::ur_queue_group_t::getImmCmdList() {
     ZeCommandQueueDesc.flags |= ZE_COMMAND_QUEUE_FLAG_EXPLICIT_ONLY;
   }
 
-  if (Queue->Device->Platform->allowDriverInOrderLists() &&
+  if (Queue->Device->Platform->allowDriverInOrderLists(
+          true /*Only Allow Driver In Order List if requested*/) &&
       Queue->isInOrderQueue()) {
     isInOrderList = true;
     ZeCommandQueueDesc.flags |= ZE_COMMAND_QUEUE_FLAG_IN_ORDER;


### PR DESCRIPTION
@nrspruit's [patch ](https://github.com/intel/llvm/pull/17106)rebased and posted here as I work on fixing this patch. 

- Refactor's the check for driver in order lists into one place, but still disables driver in order lists by default.
