### PR TITLE
[Driver][SYCL] Update tests and option availability

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5788,7 +5788,7 @@ def offloadlib : Flag<["--"], "offloadlib">,
 def : Flag<["-"], "nogpulib">,
       Alias<no_offloadlib>,
       Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
-def : Flag<["-"], "nocudalib">, Alias<no_offloadlib>;
+def : Flag<["-"], "nocudalib">, Alias<no_offloadlib>, Visibility<[ClangOption, CLOption]>;
 def gpulibc : Flag<["-"], "gpulibc">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
   HelpText<"Link the LLVM C Library for GPUs">;
 def nogpulibc : Flag<["-"], "nogpulibc">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1689,7 +1689,7 @@ void SYCL::x86_64::BackendCompiler::ConstructJob(
 // Unsupported options for SYCL device compilation.
 //  -fcf-protection, -fsanitize, -fprofile-generate, -fprofile-instr-generate
 //  -ftest-coverage, -fcoverage-mapping, -fcreate-profile, -fprofile-arcs
-//  -fcs-profile-generate -forder-file-instrumentation, --coverage
+//  -fcs-profile-generate, --coverage
 static ArrayRef<options::ID> getUnsupportedOpts() {
   static constexpr options::ID UnsupportedOpts[] = {
       options::OPT_fsanitize_EQ,      // -fsanitize

--- a/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
+++ b/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
@@ -98,23 +98,23 @@
 
 // AUTO_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch={{.*}},kind=sycl,compile-opts=-device_options [[DEVICE]] -ze-intel-enable-auto-large-GRF-mode{{.*}}"
 
-// LARGE_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch=,kind=sycl,compile-opts=-device_options pvc -ze-opt-large-register-file"
+// LARGE_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch=generic,kind=sycl,compile-opts=-device_options pvc -ze-opt-large-register-file"
 
-// SMALL_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch=,kind=sycl,compile-opts=-device_options pvc -ze-intel-128-GRF-per-thread"
+// SMALL_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch=generic,kind=sycl,compile-opts=-device_options pvc -ze-intel-128-GRF-per-thread"
 
 // DEFAULT_AOT-NOT: -device_options
 
-// MULTIPLE_ARGS_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch=,kind=sycl,compile-opts=-device_options pvc -ze-intel-128-GRF-per-thread -device_options pvc -ze-opt-large-register-file"
+// MULTIPLE_ARGS_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch=generic,kind=sycl,compile-opts=-device_options pvc -ze-intel-128-GRF-per-thread -device_options pvc -ze-opt-large-register-file"
 
 // AUTO_JIT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64-unknown-unknown,arch={{.*}},kind=sycl,compile-opts=-ftarget-register-alloc-mode=pvc:-ze-intel-enable-auto-large-GRF-mode"
 
-// LARGE_JIT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64-unknown-unknown,arch=,kind=sycl,compile-opts=-ftarget-register-alloc-mode=pvc:-ze-opt-large-register-file"
+// LARGE_JIT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64-unknown-unknown,arch=generic,kind=sycl,compile-opts=-ftarget-register-alloc-mode=pvc:-ze-opt-large-register-file"
 
-// SMALL_JIT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64-unknown-unknown,arch=,kind=sycl,compile-opts=-ftarget-register-alloc-mode=pvc:-ze-intel-128-GRF-per-thread"
+// SMALL_JIT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64-unknown-unknown,arch=generic,kind=sycl,compile-opts=-ftarget-register-alloc-mode=pvc:-ze-intel-128-GRF-per-thread"
 
 // DEFAULT_JIT-NOT: -ftarget-register-alloc-mode=
 
-// MULTIPLE_ARGS_JIT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64-unknown-unknown,arch=,kind=sycl,compile-opts=-ftarget-register-alloc-mode=pvc:-ze-intel-128-GRF-per-thread -ftarget-register-alloc-mode=pvc:-ze-opt-large-register-file"
+// MULTIPLE_ARGS_JIT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64-unknown-unknown,arch=generic,kind=sycl,compile-opts=-ftarget-register-alloc-mode=pvc:-ze-intel-128-GRF-per-thread -ftarget-register-alloc-mode=pvc:-ze-opt-large-register-file"
 
 // BAD_DEVICE: unsupported argument 'dg2:auto' to option '-ftarget-register-alloc-mode='
 // BAD_MODE: unsupported argument 'pvc:superlarge' to option '-ftarget-register-alloc-mode='

--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -31,8 +31,6 @@
 // RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-fcs-profile-generate \
 // RUN:    -DOPT_CC1=-fprofile-instrument=csllvm \
 // RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
-// RUN: %clangxx -fsycl -forder-file-instrumentation -### %s 2>&1 \
-// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-forder-file-instrumentation
 // RUN: %clangxx -fsycl --coverage -### %s 2>&1 \
 // RUN:  | FileCheck %s -DARCH=spir64 -DOPT=--coverage \
 // RUN:    -DOPT_CC1=-coverage-notes-file \


### PR DESCRIPTION
Perform a few updates to clean up some LIT testing issues
  - Update `-nocudalib` to be available for Windows
  - Remove -forder-file-instrumentation usage (option removed)
  - Update arch= usage in testing with new offload model