### PR TITLE
[SYCL][E2E][Matrix] Restrict XFAIL in some tests to DG2

### DIFF
--- a/sycl/test-e2e/Matrix/SG32/get_coordinate_ops.cpp
+++ b/sycl/test-e2e/Matrix/SG32/get_coordinate_ops.cpp
@@ -15,8 +15,8 @@
 // REQUIRES: aspect-ext_intel_matrix
 // REQUIRES-INTEL-DRIVER: lin: 30049, win: 101.4943
 
-// XFAIL: arch-intel_gpu_pvc
-// XFAIL-TRACKER: GSD-10524
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-TRACKER: GSD-10524
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Matrix/SG32/get_coordinate_ops.cpp
+++ b/sycl/test-e2e/Matrix/SG32/get_coordinate_ops.cpp
@@ -15,9 +15,6 @@
 // REQUIRES: aspect-ext_intel_matrix
 // REQUIRES-INTEL-DRIVER: lin: 30049, win: 101.4943
 
-// UNSUPPORTED: arch-intel_gpu_pvc
-// UNSUPPORTED-TRACKER: GSD-10524
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -18,8 +18,11 @@
 // This tests support of col major layout for matrix B which does transpose and
 // then VNNI transform. This is currently only available on AMX
 
-// XFAIL: gpu
+// XFAIL: gpu && !gpu-intel-pvc
 // XFAIL-TRACKER: GSD-5768
+
+// UNSUPPORTED: gpu-intel-pvc
+// UNSUPPORTED-TRACKER: GSD-5768
 
 #include "common.hpp"
 

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -18,8 +18,11 @@
 // This tests support of col major layout for matrix B which does transpose and
 // then VNNI transform. This is currently only available on AMX
 
-// XFAIL: gpu-intel-dg2 || arch-intel_gpu_bmg_g21
+// XFAIL: arch-intel_gpu_bmg_g21
 // XFAIL-TRACKER: GSD-5768
+
+// UNSUPPORTED: gpu-intel-dg2
+// UNSUPPORTED-INTENDED: SG size = 32 is not currently supported for SYCL Joint Matrix by IGC on DG2
 
 #include "common.hpp"
 

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -18,6 +18,9 @@
 // This tests support of col major layout for matrix B which does transpose and
 // then VNNI transform. This is currently only available on AMX
 
+// XFAIL: gpu-intel-dg2
+// XFAIL-TRACKER: GSD-5768
+
 #include "common.hpp"
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -18,7 +18,7 @@
 // This tests support of col major layout for matrix B which does transpose and
 // then VNNI transform. This is currently only available on AMX
 
-// XFAIL: gpu-intel-dg2
+// XFAIL: gpu-intel-dg2 || arch-intel_gpu_bmg_g21
 // XFAIL-TRACKER: GSD-5768
 
 #include "common.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -18,12 +18,6 @@
 // This tests support of col major layout for matrix B which does transpose and
 // then VNNI transform. This is currently only available on AMX
 
-// XFAIL: gpu && !gpu-intel-pvc
-// XFAIL-TRACKER: GSD-5768
-
-// UNSUPPORTED: gpu-intel-pvc
-// UNSUPPORTED-TRACKER: GSD-5768
-
 #include "common.hpp"
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -17,7 +17,7 @@
 // This tests support of col major layout for matrix B which does transpose and
 // then VNNI transform. This is currently only available on AMX
 
-// XFAIL: gpu-intel-dg2
+// XFAIL: gpu-intel-dg2 || arch-intel_gpu_bmg_g21
 // XFAIL-TRACKER: GSD-5768
 
 #include "common.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -17,6 +17,9 @@
 // This tests support of col major layout for matrix B which does transpose and
 // then VNNI transform. This is currently only available on AMX
 
+// XFAIL: gpu-intel-dg2
+// XFAIL-TRACKER: GSD-5768
+
 #include "common.hpp"
 
 constexpr size_t TN = 16;

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -17,8 +17,11 @@
 // This tests support of col major layout for matrix B which does transpose and
 // then VNNI transform. This is currently only available on AMX
 
-// XFAIL: gpu
+// XFAIL: gpu && !gpu-intel-pvc
 // XFAIL-TRACKER: GSD-5768
+
+// UNSUPPORTED: gpu-intel-pvc
+// UNSUPPORTED-TRACKER: GSD-5768
 
 #include "common.hpp"
 

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -17,12 +17,6 @@
 // This tests support of col major layout for matrix B which does transpose and
 // then VNNI transform. This is currently only available on AMX
 
-// XFAIL: gpu && !gpu-intel-pvc
-// XFAIL-TRACKER: GSD-5768
-
-// UNSUPPORTED: gpu-intel-pvc
-// UNSUPPORTED-TRACKER: GSD-5768
-
 #include "common.hpp"
 
 constexpr size_t TN = 16;


### PR DESCRIPTION
XPASSing in [nightly](https://github.com/intel/llvm/actions/runs/14050841978) but failing in pre/postcommit, make them XFAIL only where they actually fail.