### PR TITLE
[SYCL][UR] Log sycl-ls adapter errors in verbose mode

### DIFF
--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -364,21 +364,21 @@ int main(int argc, char **argv) {
     if (DiscardFilters && FilterEnvVars.size())
       unsetFilterEnvVars();
 
-    // Store the original UR_LOG_LOADER environment variable and enable printing
-    // of any errors related to adapter loading.
-    const char *orig_ur_log_loader_var = std::getenv("UR_LOG_LOADER");
-    std::string orig_ur_log_loader_var_str;
-    if (orig_ur_log_loader_var != NULL)
-      orig_ur_log_loader_var_str.assign(orig_ur_log_loader_var);
-
-    setenv("UR_LOG_LOADER", "level:error;output:stderr", 1);
+    // In verbose mode, if UR logging has not already been enabled by the user,
+    // enable the printing of any errors related to adapter loading.
+    const char *ur_log_loader_var = std::getenv("UR_LOG_LOADER");
+    if (verbose && ur_log_loader_var == nullptr)
+      setenv("UR_LOG_LOADER", "level:info;output:stderr", 1);
 
     const auto &Platforms = platform::get_platforms();
 
-    if (orig_ur_log_loader_var == NULL)
+    if (verbose && ur_log_loader_var == nullptr) {
       unsetenv("UR_LOG_LOADER");
-    else
-      setenv("UR_LOG_LOADER", orig_ur_log_loader_var_str.c_str(), 1);
+    } else if (Platforms.size() == 0) {
+      std::cout
+          << "No platforms found - run with '--verbose' to get more details."
+          << std::endl;
+    }
 
     // Keep track of the number of devices per backend
     std::map<backend, size_t> DeviceNums;

--- a/unified-runtime/source/common/linux/ur_lib_loader.cpp
+++ b/unified-runtime/source/common/linux/ur_lib_loader.cpp
@@ -58,7 +58,7 @@ LibLoader::loadAdapterLibrary(const char *name) {
         (strstr(err, name) == NULL || strstr(err, "required by") != NULL)) {
       // If the adapter cannot be loaded due to missing dependencies or any
       // other related error, it is considered as an error.
-      logger::error("failed to load adapter '{}' with error: {}", name, err);
+      logger::info("failed to load adapter '{}' with error: {}", name, err);
     } else {
       // Simply having the adapter library missing isn't an error.
       logger::info("failed to load adapter '{}' with error: {}", name,


### PR DESCRIPTION
Log sycl-ls adapter errors in verbose mode. Additionally, inform the user about verbose mode when no platforms are found.