### PR TITLE
[SYCL] Fix CUDA interop self-contained-headers test

### DIFF
--- a/sycl/test/self-contained-headers/lit.local.cfg
+++ b/sycl/test/self-contained-headers/lit.local.cfg
@@ -8,9 +8,6 @@ config.test_format = SYCLHeadersTest()
 # cross-platform
 config.sycl_headers_xfail = [
     os.path.join(
-        "sycl", "ext", "oneapi", "experimental", "backend", "cuda.hpp"
-    ),
-    os.path.join(
         "sycl", "ext", "intel", "esimd", "detail", "types_elementary.hpp"
     ),
 ]

--- a/sycl/test/self-contained-headers/sycl/ext/oneapi/experimental/backend/cuda.hpp.cpp
+++ b/sycl/test/self-contained-headers/sycl/ext/oneapi/experimental/backend/cuda.hpp.cpp
@@ -1,0 +1,9 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+//
+// Check that the experimental CUDA interop header doesn't have any warnings.
+// This is a special test because this header requires a specific macro to be
+// set when it is included.
+
+#define SYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL
+#include <sycl/ext/oneapi/experimental/backend/cuda.hpp>


### PR DESCRIPTION
This header needs a sepcific macro to be defined when it is included which is why the generic test gives out warnings. Add a specific test for it so we can define the macro.