### PR TITLE
[SYCL] Avoid passing the device object by value

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -288,7 +288,7 @@ sycl::range<1> GetZeroDimAccessRange(BufferT Buffer) {
   return std::min(Buffer.size(), size_t{1});
 }
 
-__SYCL_EXPORT device getDeviceFromHandler(handler &CommandGroupHandlerRef);
+bool handlerDeviceHasAspect(handler &cgh, aspect Aspect);
 
 template <typename DataT, int Dimensions, access::mode AccessMode,
           access::target AccessTarget, access::placeholder IsPlaceholder,

--- a/sycl/include/sycl/accessor_image.hpp
+++ b/sycl/include/sycl/accessor_image.hpp
@@ -390,8 +390,8 @@ public:
         MImgChannelOrder(ImageRef.getChannelOrder()),
         MImgChannelType(ImageRef.getChannelType()) {
 
-    device Device = getDeviceFromHandler(CommandGroupHandlerRef);
-    if (!Device.has(aspect::ext_intel_legacy_image))
+    if (!handlerDeviceHasAspect(CommandGroupHandlerRef,
+                                aspect::ext_intel_legacy_image))
       throw sycl::exception(
           sycl::errc::feature_not_supported,
           "SYCL 1.2.1 images are not supported by this device.");
@@ -829,10 +829,10 @@ public:
                         {ImageRef.getRowPitch(), ImageRef.getSlicePitch(), 0},
                         ImageRef.getChannelType(), ImageRef.getChannelOrder(),
                         PropList) {
-    device Device = detail::getDeviceFromHandler(CommandGroupHandlerRef);
     // Avoid aspect::image warning.
     aspect ImageAspect = aspect::image;
-    if (AccessTarget == image_target::device && !Device.has(ImageAspect))
+    if (AccessTarget == image_target::device &&
+        !detail::handlerDeviceHasAspect(CommandGroupHandlerRef, ImageAspect))
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Device associated with command group handler does not have "
@@ -1140,10 +1140,10 @@ public:
                         {ImageRef.getRowPitch(), ImageRef.getSlicePitch(), 0},
                         ImageRef.getChannelType(), ImageRef.getChannelOrder(),
                         ImageRef.getSampler(), PropList) {
-    device Device = detail::getDeviceFromHandler(CommandGroupHandlerRef);
     // Avoid aspect::image warning.
     aspect ImageAspect = aspect::image;
-    if (AccessTarget == image_target::device && !Device.has(ImageAspect))
+    if (AccessTarget == image_target::device &&
+        !detail::handlerDeviceHasAspect(CommandGroupHandlerRef, ImageAspect))
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Device associated with command group handler does not have "

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -206,6 +206,7 @@ class HandlerAccess;
 class HostTask;
 
 using EventImplPtr = std::shared_ptr<event_impl>;
+using DeviceImplPtr = std::shared_ptr<device_impl>;
 
 template <typename RetType, typename Func, typename Arg>
 static Arg member_ptr_helper(RetType (Func::*)(Arg) const);
@@ -242,6 +243,7 @@ template <typename Type> struct get_kernel_wrapper_name_t {
 };
 
 __SYCL_EXPORT device getDeviceFromHandler(handler &);
+const DeviceImplPtr &getDeviceImplFromHandler(handler &cgh);
 
 // Checks if a device_global has any registered kernel usage.
 __SYCL_EXPORT bool isDeviceGlobalUsedInKernel(const void *DeviceGlobalPtr);
@@ -3448,6 +3450,9 @@ private:
             typename PropertyListT>
   friend class accessor;
   friend device detail::getDeviceFromHandler(handler &);
+  friend const detail::DeviceImplPtr &
+  detail::getDeviceImplFromHandler(handler &cgh);
+  friend bool detail::handlerDeviceHasAspect(handler &cgh, aspect Aspect);
 
   template <typename DataT, int Dimensions, access::mode AccessMode,
             access::target AccessTarget, access::placeholder IsPlaceholder>

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -2653,7 +2653,7 @@ template <> struct NDRangeReduction<reduction::strategy::auto_select> {
     };
 
     if constexpr (Reduction::has_float64_atomics) {
-      if (getDeviceFromHandler(CGH).has(aspect::atomic64))
+      if (handlerDeviceHasAspect(CGH, aspect::atomic64))
         return Delegate(Impl<Strat::group_reduce_and_atomic_cross_wg>{});
 
       if constexpr (Reduction::has_fast_reduce)
@@ -2667,7 +2667,7 @@ template <> struct NDRangeReduction<reduction::strategy::auto_select> {
         // aspect::atomic64 if the result type of the reduction is 64-bit. If
         // the device does not support this, we need to fall back to more
         // reliable strategies.
-        if (!getDeviceFromHandler(CGH).has(aspect::atomic64)) {
+        if (!handlerDeviceHasAspect(CGH, aspect::atomic64)) {
           if constexpr (Reduction::has_fast_reduce)
             return Delegate(Impl<Strat::group_reduce_and_multiple_kernels>{});
           else

--- a/sycl/source/accessor.cpp
+++ b/sycl/source/accessor.cpp
@@ -14,13 +14,14 @@
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
-device getDeviceFromHandler(handler &cgh) {
+
+bool handlerDeviceHasAspect(handler &cgh, aspect Aspect) {
   assert((cgh.MQueue || getSyclObjImpl(cgh)->MGraph) &&
          "One of MQueue or MGraph should be nonnull!");
   if (cgh.MQueue)
-    return cgh.MQueue->get_device();
+    return cgh.MQueue->getDeviceImplPtr()->has(Aspect);
 
-  return getSyclObjImpl(cgh)->MGraph->getDevice();
+  return getSyclObjImpl(cgh)->MGraph->getDeviceImplPtr()->has(Aspect);
 }
 
 // property::no_init is supported now for

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -919,6 +919,10 @@ public:
   /// @return Device associated with graph.
   sycl::device getDevice() const { return MDevice; }
 
+  const DeviceImplPtr &getDeviceImplPtr() const {
+    return getSyclObjImpl(MDevice);
+  }
+
   /// List of root nodes.
   std::set<std::weak_ptr<node_impl>, std::owner_less<std::weak_ptr<node_impl>>>
       MRoots;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -42,6 +42,24 @@ inline namespace _V1 {
 
 namespace detail {
 
+device getDeviceFromHandler(handler &cgh) {
+  assert((cgh.MQueue || getSyclObjImpl(cgh)->MGraph) &&
+         "One of MQueue or MGraph should be nonnull!");
+  if (cgh.MQueue)
+    return cgh.MQueue->get_device();
+
+  return getSyclObjImpl(cgh)->MGraph->getDevice();
+}
+
+const DeviceImplPtr &getDeviceImplFromHandler(handler &cgh) {
+  assert((cgh.MQueue || getSyclObjImpl(cgh)->MGraph) &&
+         "One of MQueue or MGraph should be nonnull!");
+  if (cgh.MQueue)
+    return cgh.MQueue->getDeviceImplPtr();
+
+  return getSyclObjImpl(cgh)->MGraph->getDeviceImplPtr();
+}
+
 bool isDeviceGlobalUsedInKernel(const void *DeviceGlobalPtr) {
   DeviceGlobalMapEntry *DGEntry =
       detail::ProgramManager::getInstance().getDeviceGlobalEntry(
@@ -2012,10 +2030,10 @@ void handler::setUserFacingNodeType(ext::oneapi::experimental::node_type Type) {
 }
 
 std::optional<std::array<size_t, 3>> handler::getMaxWorkGroups() {
-  auto Dev = detail::getSyclObjImpl(detail::getDeviceFromHandler(*this));
+  auto const &DeviceImpl = detail::getDeviceImplFromHandler(*this);
   std::array<size_t, 3> UrResult = {};
-  auto Ret = Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-      Dev->getHandleRef(),
+  auto Ret = DeviceImpl->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+      DeviceImpl->getHandleRef(),
       UrInfoCode<
           ext::oneapi::experimental::info::device::max_work_groups<3>>::value,
       sizeof(UrResult), &UrResult, nullptr);


### PR DESCRIPTION
Introduce two new helper functions, which are used to avoid passing the device object by value in selected places.