### PR TITLE
[SYCL][E2E] Remove XFAIL directive in VirtualFunctions~misc~group-barrier.cpp

### DIFF
--- a/sycl/test-e2e/VirtualFunctions/misc/group-barrier.cpp
+++ b/sycl/test-e2e/VirtualFunctions/misc/group-barrier.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
-// On CPU it segfaults within the kernel that performs virtual function call.
-// XFAIL: cpu && opencl && linux
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15080
 // UNSUPPORTED: gpu
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15068
 // On GPU this test (its older version which used nd_item instead of group)


### PR DESCRIPTION
This PR purpose is to remove XFAIL directive in test because test was failing because of old `oclcpu` but since `syclos oclcpu` has been uplifted there is no need in XFAIL directive anymore.