### PR TITLE
[UR][L0] Enable support for using L0 spec External Semaphores

### DIFF
--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -782,59 +782,125 @@ ur_result_t urBindlessImagesImportExternalSemaphoreExp(
                   " {} function not supported!", __FUNCTION__);
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
-  ze_intel_external_semaphore_exp_desc_t SemDesc = {
-      ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_EXP_DESC, nullptr,
-      ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_FD};
-  ze_intel_external_semaphore_exp_handle_t ExtSemaphoreHandle;
-  ze_intel_external_semaphore_desc_fd_exp_desc_t FDExpDesc = {
-      ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_FD_EXP_DESC, nullptr, 0};
-  _ze_intel_external_semaphore_win32_exp_desc_t Win32ExpDesc = {
-      ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WIN32_EXP_DESC, nullptr,
-      nullptr, nullptr};
-  void *pNext = const_cast<void *>(pExternalSemaphoreDesc->pNext);
-  while (pNext != nullptr) {
-    const ur_base_desc_t *BaseDesc = static_cast<const ur_base_desc_t *>(pNext);
-    if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR) {
-      auto FileDescriptor =
-          static_cast<const ur_exp_file_descriptor_t *>(pNext);
-      FDExpDesc.fd = FileDescriptor->fd;
-      SemDesc.pNext = &FDExpDesc;
-      switch (semHandleType) {
-      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD:
-        SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_FD;
-        break;
-      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_FD:
-        SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_FD;
-        break;
-      default:
-        return UR_RESULT_ERROR_INVALID_VALUE;
+  if (UrPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
+    ze_external_semaphore_ext_desc_t SemDesc = {
+        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_EXT_DESC, nullptr,
+        ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_FD};
+    ze_external_semaphore_ext_handle_t ExtSemaphoreHandle;
+    ze_external_semaphore_fd_ext_desc_t FDExpDesc = {
+        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_FD_EXT_DESC, nullptr, 0};
+    ze_external_semaphore_win32_ext_desc_t Win32ExpDesc = {
+        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WIN32_EXT_DESC, nullptr, nullptr,
+        nullptr};
+    void *pNext = const_cast<void *>(pExternalSemaphoreDesc->pNext);
+    while (pNext != nullptr) {
+      const ur_base_desc_t *BaseDesc =
+          static_cast<const ur_base_desc_t *>(pNext);
+      if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR) {
+        auto FileDescriptor =
+            static_cast<const ur_exp_file_descriptor_t *>(pNext);
+        FDExpDesc.fd = FileDescriptor->fd;
+        SemDesc.pNext = &FDExpDesc;
+        switch (semHandleType) {
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD:
+          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_FD;
+          break;
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_FD:
+          SemDesc.flags =
+              ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_VK_TIMELINE_SEMAPHORE_FD;
+          break;
+        default:
+          return UR_RESULT_ERROR_INVALID_VALUE;
+        }
+      } else if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE) {
+        SemDesc.pNext = &Win32ExpDesc;
+        auto Win32Handle = static_cast<const ur_exp_win32_handle_t *>(pNext);
+        switch (semHandleType) {
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT:
+          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_WIN32;
+          break;
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE:
+          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D12_FENCE;
+          break;
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_WIN32_NT:
+          SemDesc.flags =
+              ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_VK_TIMELINE_SEMAPHORE_WIN32;
+          break;
+        default:
+          return UR_RESULT_ERROR_INVALID_VALUE;
+        }
+        Win32ExpDesc.handle = Win32Handle->handle;
       }
-    } else if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE) {
-      SemDesc.pNext = &Win32ExpDesc;
-      auto Win32Handle = static_cast<const ur_exp_win32_handle_t *>(pNext);
-      switch (semHandleType) {
-      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT:
-        SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_WIN32;
-        break;
-      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE:
-        SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_D3D12_FENCE;
-        break;
-      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_WIN32_NT:
-        SemDesc.flags =
-            ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_WIN32;
-        break;
-      default:
-        return UR_RESULT_ERROR_INVALID_VALUE;
-      }
-      Win32ExpDesc.handle = Win32Handle->handle;
+      pNext = const_cast<void *>(BaseDesc->pNext);
     }
-    pNext = const_cast<void *>(BaseDesc->pNext);
-  }
+    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp,
+               (hDevice->ZeDevice, &SemDesc, &ExtSemaphoreHandle));
+    *phExternalSemaphoreHandle =
+        (ur_exp_external_semaphore_handle_t)ExtSemaphoreHandle;
 
-  ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp,
-             (hDevice->ZeDevice, &SemDesc, &ExtSemaphoreHandle));
-  *phExternalSemaphoreHandle =
-      (ur_exp_external_semaphore_handle_t)ExtSemaphoreHandle;
+  } else {
+    ze_intel_external_semaphore_exp_desc_t SemDesc = {
+        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_EXP_DESC, nullptr,
+        ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_FD};
+    ze_intel_external_semaphore_exp_handle_t ExtSemaphoreHandle;
+    ze_intel_external_semaphore_desc_fd_exp_desc_t FDExpDesc = {
+        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_FD_EXP_DESC, nullptr, 0};
+    _ze_intel_external_semaphore_win32_exp_desc_t Win32ExpDesc = {
+        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WIN32_EXP_DESC, nullptr,
+        nullptr, nullptr};
+    void *pNext = const_cast<void *>(pExternalSemaphoreDesc->pNext);
+    while (pNext != nullptr) {
+      const ur_base_desc_t *BaseDesc =
+          static_cast<const ur_base_desc_t *>(pNext);
+      if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR) {
+        auto FileDescriptor =
+            static_cast<const ur_exp_file_descriptor_t *>(pNext);
+        FDExpDesc.fd = FileDescriptor->fd;
+        SemDesc.pNext = &FDExpDesc;
+        switch (semHandleType) {
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD:
+          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_FD;
+          break;
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_FD:
+          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_FD;
+          break;
+        default:
+          return UR_RESULT_ERROR_INVALID_VALUE;
+        }
+      } else if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE) {
+        SemDesc.pNext = &Win32ExpDesc;
+        auto Win32Handle = static_cast<const ur_exp_win32_handle_t *>(pNext);
+        switch (semHandleType) {
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT:
+          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_WIN32;
+          break;
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE:
+          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_D3D12_FENCE;
+          break;
+        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_WIN32_NT:
+          SemDesc.flags =
+              ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_WIN32;
+          break;
+        default:
+          return UR_RESULT_ERROR_INVALID_VALUE;
+        }
+        Win32ExpDesc.handle = Win32Handle->handle;
+      }
+      pNext = const_cast<void *>(BaseDesc->pNext);
+    }
+
+    ze_device_handle_t translatedDevice;
+    ZE2UR_CALL(zelLoaderTranslateHandle, (ZEL_HANDLE_DEVICE, hDevice->ZeDevice,
+                                          (void **)&translatedDevice));
+    // If the L0 loader is not aware of the extension, the handles need to be
+    // translated
+    ZE2UR_CALL(
+        UrPlatform->ZeExternalSemaphoreExt.zexExpImportExternalSemaphoreExp,
+        (translatedDevice, &SemDesc, &ExtSemaphoreHandle));
+
+    *phExternalSemaphoreHandle =
+        (ur_exp_external_semaphore_handle_t)ExtSemaphoreHandle;
+  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -849,9 +915,15 @@ ur_result_t urBindlessImagesReleaseExternalSemaphoreExp(
                   " {} function not supported!", __FUNCTION__);
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
-  ZE2UR_CALL(
-      UrPlatform->ZeExternalSemaphoreExt.zexDeviceReleaseExternalSemaphoreExp,
-      ((ze_intel_external_semaphore_exp_handle_t)hExternalSemaphore));
+  if (UrPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
+    ZE2UR_CALL(
+        UrPlatform->ZeExternalSemaphoreExt.zexDeviceReleaseExternalSemaphoreExp,
+        ((ze_external_semaphore_ext_handle_t)hExternalSemaphore));
+  } else {
+    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
+                   .zexExpDeviceReleaseExternalSemaphoreExp,
+               ((ze_intel_external_semaphore_exp_handle_t)hExternalSemaphore));
+  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -898,15 +970,36 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
   const auto &ZeCommandList = CommandList->first;
   const auto &WaitList = (*Event)->WaitList;
 
-  ze_intel_external_semaphore_wait_params_exp_t WaitParams = {
-      ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXP, nullptr, 0};
-  WaitParams.value = hasValue ? waitValue : 0;
-  const ze_intel_external_semaphore_exp_handle_t hExtSemaphore =
-      reinterpret_cast<ze_intel_external_semaphore_exp_handle_t>(hSemaphore);
-  ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
-                 .zexCommandListAppendWaitExternalSemaphoresExp,
-             (ZeCommandList, 1, &hExtSemaphore, &WaitParams, ZeEvent,
-              WaitList.Length, WaitList.ZeEventList));
+  if (UrPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
+    ze_external_semaphore_wait_params_ext_t WaitParams = {
+        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXT, nullptr, 0};
+    WaitParams.value = hasValue ? waitValue : 0;
+    ze_external_semaphore_ext_handle_t hExtSemaphore =
+        reinterpret_cast<ze_external_semaphore_ext_handle_t>(hSemaphore);
+    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
+                   .zexCommandListAppendWaitExternalSemaphoresExp,
+               (ZeCommandList, 1, &hExtSemaphore, &WaitParams, ZeEvent,
+                WaitList.Length, WaitList.ZeEventList));
+  } else {
+    ze_command_list_handle_t translatedCommandList;
+    ZE2UR_CALL(zelLoaderTranslateHandle,
+               (ZEL_HANDLE_COMMAND_LIST, ZeCommandList,
+                (void **)&translatedCommandList));
+    ze_event_handle_t translatedEvent = ZeEvent;
+    if (ZeEvent) {
+      ZE2UR_CALL(zelLoaderTranslateHandle,
+                 (ZEL_HANDLE_EVENT, ZeEvent, (void **)&translatedEvent));
+    }
+    ze_intel_external_semaphore_wait_params_exp_t WaitParams = {
+        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXP, nullptr, 0};
+    WaitParams.value = hasValue ? waitValue : 0;
+    const ze_intel_external_semaphore_exp_handle_t hExtSemaphore =
+        reinterpret_cast<ze_intel_external_semaphore_exp_handle_t>(hSemaphore);
+    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
+                   .zexExpCommandListAppendWaitExternalSemaphoresExp,
+               (translatedCommandList, 1, &hExtSemaphore, &WaitParams,
+                translatedEvent, WaitList.Length, WaitList.ZeEventList));
+  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -915,13 +1008,6 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ur_exp_external_semaphore_handle_t hSemaphore,
     bool hasValue, uint64_t signalValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  std::ignore = hQueue;
-  std::ignore = hSemaphore;
-  std::ignore = hasValue;
-  std::ignore = signalValue;
-  std::ignore = numEventsInWaitList;
-  std::ignore = phEventWaitList;
-  std::ignore = phEvent;
   auto UrPlatform = hQueue->Context->getPlatform();
   if (UrPlatform->ZeExternalSemaphoreExt.Supported == false) {
     logger::error(logger::LegacyMessage("[UR][L0] "),
@@ -960,16 +1046,39 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
   const auto &ZeCommandList = CommandList->first;
   const auto &WaitList = (*Event)->WaitList;
 
-  ze_intel_external_semaphore_signal_params_exp_t SignalParams = {
-      ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXP, nullptr, 0};
-  SignalParams.value = hasValue ? signalValue : 0;
-  const ze_intel_external_semaphore_exp_handle_t hExtSemaphore =
-      reinterpret_cast<ze_intel_external_semaphore_exp_handle_t>(hSemaphore);
+  if (UrPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
+    ze_external_semaphore_signal_params_ext_t SignalParams = {
+        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXT, nullptr, 0};
+    SignalParams.value = hasValue ? signalValue : 0;
+    ze_external_semaphore_ext_handle_t hExtSemaphore =
+        reinterpret_cast<ze_external_semaphore_ext_handle_t>(hSemaphore);
 
-  ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
-                 .zexCommandListAppendSignalExternalSemaphoresExp,
-             (ZeCommandList, 1, &hExtSemaphore, &SignalParams, ZeEvent,
-              WaitList.Length, WaitList.ZeEventList));
+    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
+                   .zexCommandListAppendSignalExternalSemaphoresExp,
+               (ZeCommandList, 1, &hExtSemaphore, &SignalParams, ZeEvent,
+                WaitList.Length, WaitList.ZeEventList));
+  } else {
+    ze_intel_external_semaphore_signal_params_exp_t SignalParams = {
+        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXP, nullptr,
+        0};
+    SignalParams.value = hasValue ? signalValue : 0;
+    const ze_intel_external_semaphore_exp_handle_t hExtSemaphore =
+        reinterpret_cast<ze_intel_external_semaphore_exp_handle_t>(hSemaphore);
+
+    ze_command_list_handle_t translatedCommandList;
+    ZE2UR_CALL(zelLoaderTranslateHandle,
+               (ZEL_HANDLE_COMMAND_LIST, ZeCommandList,
+                (void **)&translatedCommandList));
+    ze_event_handle_t translatedEvent = ZeEvent;
+    if (ZeEvent) {
+      ZE2UR_CALL(zelLoaderTranslateHandle,
+                 (ZEL_HANDLE_EVENT, ZeEvent, (void **)&translatedEvent));
+    }
+    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
+                   .zexExpCommandListAppendSignalExternalSemaphoresExp,
+               (translatedCommandList, 1, &hExtSemaphore, &SignalParams,
+                translatedEvent, WaitList.Length, WaitList.ZeEventList));
+  }
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -990,6 +990,14 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
       ZE2UR_CALL(zelLoaderTranslateHandle,
                  (ZEL_HANDLE_EVENT, ZeEvent, (void **)&translatedEvent));
     }
+    std::vector<ze_event_handle_t> EventHandles(WaitList.Length + 1, nullptr);
+    if (WaitList.Length > 0) {
+      for (size_t i = 0; i < WaitList.Length; i++) {
+        ze_event_handle_t ZeEvent = WaitList.ZeEventList[i];
+        ZE2UR_CALL(zelLoaderTranslateHandle,
+                   (ZEL_HANDLE_EVENT, ZeEvent, (void **)&EventHandles[i + 1]));
+      }
+    }
     ze_intel_external_semaphore_wait_params_exp_t WaitParams = {
         ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXP, nullptr, 0};
     WaitParams.value = hasValue ? waitValue : 0;
@@ -998,7 +1006,7 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
     ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
                    .zexExpCommandListAppendWaitExternalSemaphoresExp,
                (translatedCommandList, 1, &hExtSemaphore, &WaitParams,
-                translatedEvent, WaitList.Length, WaitList.ZeEventList));
+                translatedEvent, WaitList.Length, EventHandles.data()));
   }
 
   return UR_RESULT_SUCCESS;
@@ -1074,10 +1082,18 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
       ZE2UR_CALL(zelLoaderTranslateHandle,
                  (ZEL_HANDLE_EVENT, ZeEvent, (void **)&translatedEvent));
     }
+    std::vector<ze_event_handle_t> EventHandles(WaitList.Length + 1, nullptr);
+    if (WaitList.Length > 0) {
+      for (size_t i = 0; i < WaitList.Length; i++) {
+        ze_event_handle_t ZeEvent = WaitList.ZeEventList[i];
+        ZE2UR_CALL(zelLoaderTranslateHandle,
+                   (ZEL_HANDLE_EVENT, ZeEvent, (void **)&EventHandles[i + 1]));
+      }
+    }
     ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
                    .zexExpCommandListAppendSignalExternalSemaphoresExp,
                (translatedCommandList, 1, &hExtSemaphore, &SignalParams,
-                translatedEvent, WaitList.Length, WaitList.ZeEventList));
+                translatedEvent, WaitList.Length, EventHandles.data()));
   }
 
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -277,7 +277,7 @@ ur_result_t ur_platform_handle_t_::initialize() {
     }
     // Check if extension is available for Spec External Sempahores
     if (strncmp(extension.name, ZE_EXTERNAL_SEMAPHORES_EXTENSION_NAME,
-      strlen(ZE_EXTERNAL_SEMAPHORES_EXTENSION_NAME) + 1) == 0) {
+                strlen(ZE_EXTERNAL_SEMAPHORES_EXTENSION_NAME) + 1) == 0) {
       if (extension.version == ZE_EXTERNAL_SEMAPHORE_EXT_VERSION_1_0) {
         ZeExternalSemaphoreExtensionSupported = true;
       }
@@ -356,10 +356,10 @@ ur_result_t ur_platform_handle_t_::initialize() {
          0);
     ZeExternalSemaphoreExt.Supported |=
         (ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
-              (ZeDriver, "zeDeviceReleaseExternalSemaphoreExt",
-              reinterpret_cast<void **>(
-                  &ZeExternalSemaphoreExt
-                        .zexDeviceReleaseExternalSemaphoreExp))) ==
+                         (ZeDriver, "zeDeviceReleaseExternalSemaphoreExt",
+                          reinterpret_cast<void **>(
+                              &ZeExternalSemaphoreExt
+                                   .zexDeviceReleaseExternalSemaphoreExp))) ==
          0);
   } else if (ZeIntelExternalSemaphoreExtensionSupported) {
     ZeExternalSemaphoreExt.Supported |=

--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -332,42 +332,58 @@ ur_result_t ur_platform_handle_t_::initialize() {
   ZeUSMImport.setZeUSMImport(this);
 
   if (ZeExternalSemaphoreExtensionSupported) {
+#ifdef UR_STATIC_LEVEL_ZERO
+    ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp =
+        zeDeviceImportExternalSemaphoreExt;
+    ZeExternalSemaphoreExt.zexCommandListAppendWaitExternalSemaphoresExp =
+        zeCommandListAppendWaitExternalSemaphoreExt;
+    ZeExternalSemaphoreExt.zexCommandListAppendSignalExternalSemaphoresExp =
+        zeCommandListAppendSignalExternalSemaphoreExt;
+    ZeExternalSemaphoreExt.zexDeviceReleaseExternalSemaphoreExp =
+        zeDeviceReleaseExternalSemaphoreExt;
+#else
+    ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp =
+        (ze_pfnDeviceImportExternalSemaphoreExt_t)
+            ur_loader::LibLoader::getFunctionPtr(
+                GlobalAdapter->processHandle,
+                "zeDeviceImportExternalSemaphoreExt");
+
+    ZeExternalSemaphoreExt.zexCommandListAppendWaitExternalSemaphoresExp =
+        (ze_pfnCommandListAppendWaitExternalSemaphoresExt_t)
+            ur_loader::LibLoader::getFunctionPtr(
+                GlobalAdapter->processHandle,
+                "zeCommandListAppendWaitExternalSemaphoreExt");
+
+    ZeExternalSemaphoreExt.zexCommandListAppendSignalExternalSemaphoresExp =
+        (ze_pfnCommandListAppendSignalExternalSemaphoresExt_t)
+            ur_loader::LibLoader::getFunctionPtr(
+                GlobalAdapter->processHandle,
+                "zeCommandListAppendSignalExternalSemaphoreExt");
+
+    ZeExternalSemaphoreExt.zexDeviceReleaseExternalSemaphoreExp =
+        (ze_pfnDeviceReleaseExternalSemaphoreExt_t)
+            ur_loader::LibLoader::getFunctionPtr(
+                GlobalAdapter->processHandle,
+                "zeDeviceReleaseExternalSemaphoreExt");
+#endif
     ZeExternalSemaphoreExt.Supported |=
-        (ZE_CALL_NOCHECK(
-             zeDriverGetExtensionFunctionAddress,
-             (ZeDriver, "zeDeviceImportExternalSemaphoreExt",
-              reinterpret_cast<void **>(
-                  &ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp))) ==
-         0);
+        ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp != nullptr;
     ZeExternalSemaphoreExt.Supported |=
-        (ZE_CALL_NOCHECK(
-             zeDriverGetExtensionFunctionAddress,
-             (ZeDriver, "zeCommandListAppendWaitExternalSemaphoreExt",
-              reinterpret_cast<void **>(
-                  &ZeExternalSemaphoreExt
-                       .zexCommandListAppendWaitExternalSemaphoresExp))) == 0);
+        ZeExternalSemaphoreExt.zexCommandListAppendWaitExternalSemaphoresExp !=
+        nullptr;
     ZeExternalSemaphoreExt.Supported |=
-        (ZE_CALL_NOCHECK(
-             zeDriverGetExtensionFunctionAddress,
-             (ZeDriver, "zeCommandListAppendSignalExternalSemaphoreExt",
-              reinterpret_cast<void **>(
-                  &ZeExternalSemaphoreExt
-                       .zexCommandListAppendSignalExternalSemaphoresExp))) ==
-         0);
+        ZeExternalSemaphoreExt
+            .zexCommandListAppendSignalExternalSemaphoresExp != nullptr;
     ZeExternalSemaphoreExt.Supported |=
-        (ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
-                         (ZeDriver, "zeDeviceReleaseExternalSemaphoreExt",
-                          reinterpret_cast<void **>(
-                              &ZeExternalSemaphoreExt
-                                   .zexDeviceReleaseExternalSemaphoreExp))) ==
-         0);
+        ZeExternalSemaphoreExt.zexDeviceReleaseExternalSemaphoreExp != nullptr;
+    ZeExternalSemaphoreExt.LoaderExtension = true;
   } else if (ZeIntelExternalSemaphoreExtensionSupported) {
     ZeExternalSemaphoreExt.Supported |=
         (ZE_CALL_NOCHECK(
              zeDriverGetExtensionFunctionAddress,
              (ZeDriver, "zeIntelDeviceImportExternalSemaphoreExp",
               reinterpret_cast<void **>(
-                  &ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp))) ==
+                  &ZeExternalSemaphoreExt.zexExpImportExternalSemaphoreExp))) ==
          0);
     ZeExternalSemaphoreExt.Supported |=
         (ZE_CALL_NOCHECK(
@@ -375,22 +391,23 @@ ur_result_t ur_platform_handle_t_::initialize() {
              (ZeDriver, "zeIntelCommandListAppendWaitExternalSemaphoresExp",
               reinterpret_cast<void **>(
                   &ZeExternalSemaphoreExt
-                       .zexCommandListAppendWaitExternalSemaphoresExp))) == 0);
+                       .zexExpCommandListAppendWaitExternalSemaphoresExp))) ==
+         0);
     ZeExternalSemaphoreExt.Supported |=
         (ZE_CALL_NOCHECK(
              zeDriverGetExtensionFunctionAddress,
              (ZeDriver, "zeIntelCommandListAppendSignalExternalSemaphoresExp",
               reinterpret_cast<void **>(
                   &ZeExternalSemaphoreExt
-                       .zexCommandListAppendSignalExternalSemaphoresExp))) ==
+                       .zexExpCommandListAppendSignalExternalSemaphoresExp))) ==
          0);
     ZeExternalSemaphoreExt.Supported |=
-        (ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
-                         (ZeDriver, "zeIntelDeviceReleaseExternalSemaphoreExp",
-                          reinterpret_cast<void **>(
-                              &ZeExternalSemaphoreExt
-                                   .zexDeviceReleaseExternalSemaphoreExp))) ==
-         0);
+        (ZE_CALL_NOCHECK(
+             zeDriverGetExtensionFunctionAddress,
+             (ZeDriver, "zeIntelDeviceReleaseExternalSemaphoreExp",
+              reinterpret_cast<void **>(
+                  &ZeExternalSemaphoreExt
+                       .zexExpDeviceReleaseExternalSemaphoreExp))) == 0);
   }
 
   // Check if mutable command list extension is supported and initialize

--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -349,13 +349,13 @@ ur_result_t ur_platform_handle_t_::initialize() {
                 "zeDeviceImportExternalSemaphoreExt");
 
     ZeExternalSemaphoreExt.zexCommandListAppendWaitExternalSemaphoresExp =
-        (ze_pfnCommandListAppendWaitExternalSemaphoresExt_t)
+        (ze_pfnCommandListAppendWaitExternalSemaphoreExt_t)
             ur_loader::LibLoader::getFunctionPtr(
                 GlobalAdapter->processHandle,
                 "zeCommandListAppendWaitExternalSemaphoreExt");
 
     ZeExternalSemaphoreExt.zexCommandListAppendSignalExternalSemaphoresExp =
-        (ze_pfnCommandListAppendSignalExternalSemaphoresExt_t)
+        (ze_pfnCommandListAppendSignalExternalSemaphoreExt_t)
             ur_loader::LibLoader::getFunctionPtr(
                 GlobalAdapter->processHandle,
                 "zeCommandListAppendSignalExternalSemaphoreExt");

--- a/unified-runtime/source/adapters/level_zero/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/platform.hpp
@@ -126,20 +126,36 @@ struct ur_platform_handle_t_ : public _ur_platform {
   // Structure with function pointers for External Semaphore Extension.
   struct ZeExternalSemaphoreExtension {
     bool Supported = false;
-    ze_result_t (*zexImportExternalSemaphoreExp)(
+    // If LoaderExtension is true, the L0 loader is aware of the MCL extension.
+    // If it is false, the extension has to be loaded directly from the driver
+    // using zeDriverGetExtensionFunctionAddress. If it is loaded directly from
+    // the driver, any handles passed to it must be translated using
+    // zelLoaderTranslateHandle.
+    bool LoaderExtension = false;
+    // Spec Functions
+    ze_pfnDeviceImportExternalSemaphoreExt_t zexImportExternalSemaphoreExp =
+        nullptr;
+    ze_pfnCommandListAppendWaitExternalSemaphoreExt_t
+        zexCommandListAppendWaitExternalSemaphoresExp = nullptr;
+    ze_pfnCommandListAppendSignalExternalSemaphoreExt_t
+        zexCommandListAppendSignalExternalSemaphoresExp = nullptr;
+    ze_pfnDeviceReleaseExternalSemaphoreExt_t
+        zexDeviceReleaseExternalSemaphoreExp = nullptr;
+    // Driver EXP Functions
+    ze_result_t (*zexExpImportExternalSemaphoreExp)(
         ze_device_handle_t, const ze_intel_external_semaphore_exp_desc_t *,
         ze_intel_external_semaphore_exp_handle_t *);
-    ze_result_t (*zexCommandListAppendWaitExternalSemaphoresExp)(
+    ze_result_t (*zexExpCommandListAppendWaitExternalSemaphoresExp)(
         ze_command_list_handle_t, unsigned int,
         const ze_intel_external_semaphore_exp_handle_t *,
         const ze_intel_external_semaphore_wait_params_exp_t *,
         ze_event_handle_t, uint32_t, ze_event_handle_t *);
-    ze_result_t (*zexCommandListAppendSignalExternalSemaphoresExp)(
+    ze_result_t (*zexExpCommandListAppendSignalExternalSemaphoresExp)(
         ze_command_list_handle_t, size_t,
         const ze_intel_external_semaphore_exp_handle_t *,
         const ze_intel_external_semaphore_signal_params_exp_t *,
         ze_event_handle_t, uint32_t, ze_event_handle_t *);
-    ze_result_t (*zexDeviceReleaseExternalSemaphoreExp)(
+    ze_result_t (*zexExpDeviceReleaseExternalSemaphoreExp)(
         ze_intel_external_semaphore_exp_handle_t);
   } ZeExternalSemaphoreExt;
 

--- a/unified-runtime/source/adapters/level_zero/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/platform.hpp
@@ -126,11 +126,11 @@ struct ur_platform_handle_t_ : public _ur_platform {
   // Structure with function pointers for External Semaphore Extension.
   struct ZeExternalSemaphoreExtension {
     bool Supported = false;
-    // If LoaderExtension is true, the L0 loader is aware of the MCL extension.
-    // If it is false, the extension has to be loaded directly from the driver
-    // using zeDriverGetExtensionFunctionAddress. If it is loaded directly from
-    // the driver, any handles passed to it must be translated using
-    // zelLoaderTranslateHandle.
+    // If LoaderExtension is true, the L0 loader is aware of the External
+    // Semaphore Extension. If it is false, the extension has to be loaded
+    // directly from the driver using zeDriverGetExtensionFunctionAddress. If it
+    // is loaded directly from the driver, any handles passed to it must be
+    // translated using zelLoaderTranslateHandle.
     bool LoaderExtension = false;
     // Spec Functions
     ze_pfnDeviceImportExternalSemaphoreExt_t zexImportExternalSemaphoreExp =


### PR DESCRIPTION
- Implements the spec version of the L0 Extension External Semaphores
- Implements handling the translation of handles if the driver only supports the EXP functions.