### PR TITLE
[DeviceMSAN] Re-enable device global test

### DIFF
--- a/sycl/test-e2e/MemorySanitizer/check_device_global.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_device_global.cpp
@@ -6,13 +6,6 @@
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
 // RUN: %{run} not %t3.out 2>&1 | FileCheck %s
 
-// XFAIL: spirv-backend && gpu && run-mode
-// XFAIL-TRACKER: CMPLRLLVM-64705
-
-// Test is flaky on required platforms, disable until it can be fixed
-// UNSUPPORTED: true
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16978
-
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/device_global/device_global.hpp>
 #include <sycl/usm.hpp>


### PR DESCRIPTION
We can't reproduce https://github.com/intel/llvm/issues/16978 locally, try to enable it again because maybe it has been fixed by other patch.