### PR TITLE
[NFCI][SYCL] Make get_group_id to return by reference

### DIFF
--- a/sycl/include/sycl/group.hpp
+++ b/sycl/include/sycl/group.hpp
@@ -120,7 +120,7 @@ public:
   __SYCL2020_DEPRECATED("use sycl::group::get_group_id() instead")
   size_t get_id(int dimension) const { return index[dimension]; }
 
-  id<Dimensions> get_group_id() const { return index; }
+  id<Dimensions> &get_group_id() { return index; }
 
   size_t get_group_id(int dimension) const { return index[dimension]; }
 


### PR DESCRIPTION
It will enforce address space to the return value helping to avoid invalid AS cast from local to private for sret argument that would appear after https://github.com/llvm/llvm-project/pull/128166 and the related work.