### PR TITLE
[Coverity][UR] Remove noexcept keywords from pool_manager methods

### DIFF
--- a/unified-runtime/source/common/ur_pool_manager.hpp
+++ b/unified-runtime/source/common/ur_pool_manager.hpp
@@ -174,7 +174,7 @@ public:
     return {UR_RESULT_SUCCESS, std::move(manager)};
   }
 
-  ur_result_t addPool(const D &desc, unique_pool_handle_t &&hPool) noexcept {
+  ur_result_t addPool(const D &desc, unique_pool_handle_t &&hPool) {
     if (!descToPoolMap.try_emplace(desc, std::move(hPool)).second) {
       logger::error("Pool for pool descriptor: {}, already exists", desc);
       return UR_RESULT_ERROR_INVALID_ARGUMENT;
@@ -183,7 +183,7 @@ public:
     return UR_RESULT_SUCCESS;
   }
 
-  std::optional<pool_handle_t> getPool(const D &desc) noexcept {
+  std::optional<pool_handle_t> getPool(const D &desc) {
     auto it = descToPoolMap.find(desc);
     if (it == descToPoolMap.end()) {
       logger::error("Pool descriptor doesn't match any existing pool: {}",
@@ -193,7 +193,7 @@ public:
 
     return it->second.get();
   }
-  template <typename Func> void forEachPool(Func func) noexcept {
+  template <typename Func> void forEachPool(Func func) {
     for (const auto &[desc, pool] : descToPoolMap) {
       if (!func(pool.get()))
         break;


### PR DESCRIPTION
This should fix coverity issues in `ur_pool_manager.hpp`, `ur_util.hpp` and `ur_adapter_registry.hpp` files reported in: https://coverity.devtools.intel.com/prod6/#/project-view/26752/10020