### PR TITLE
[NFC][SYCL][ESIMD] Delete copy and move assignment operators.

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDVerifier.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDVerifier.cpp
@@ -97,6 +97,8 @@ public:
   BuffDeleter() = delete;
   BuffDeleter(const BuffDeleter &) = delete;
   BuffDeleter(BuffDeleter &&) = delete;
+  BuffDeleter &operator=(BuffDeleter &) = delete;
+  BuffDeleter &operator=(BuffDeleter &&) = delete;
 
 private:
   char *Buff;


### PR DESCRIPTION
Delete copy and move assignment operators to comply with Rule of Five.