### PR TITLE
[UR] Fix unnecessary check in async alloc extension

### DIFF
--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -9392,7 +9392,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolGetInfoExp(
 ///         + `::UR_USM_POOL_INFO_USED_HIGH_EXP < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPropValue`
-///         + `pPropValue == NULL`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE

--- a/unified-runtime/scripts/core/exp-async-alloc.yml
+++ b/unified-runtime/scripts/core/exp-async-alloc.yml
@@ -392,8 +392,6 @@ params:
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_ENUMERATION:
         - "If `propName` is not supported by the adapter."
-    - $X_RESULT_ERROR_INVALID_NULL_POINTER:
-        - "`pPropValue == NULL`"
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If any device associated with `hContext` reports `false` for $X_DEVICE_INFO_USM_POOL_SUPPORT"
     - $X_RESULT_ERROR_INVALID_DEVICE

--- a/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
+++ b/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
@@ -7030,9 +7030,6 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolSetInfoExp(
     if (NULL == pPropValue)
       return UR_RESULT_ERROR_INVALID_NULL_POINTER;
 
-    if (pPropValue == NULL)
-      return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-
     if (NULL == hPool)
       return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
 

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -7072,7 +7072,6 @@ ur_result_t UR_APICALL urUSMPoolGetInfoExp(
 ///         + `::UR_USM_POOL_INFO_USED_HIGH_EXP < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPropValue`
-///         + `pPropValue == NULL`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE

--- a/unified-runtime/source/ur_api.cpp
+++ b/unified-runtime/source/ur_api.cpp
@@ -6205,7 +6205,6 @@ ur_result_t UR_APICALL urUSMPoolGetInfoExp(
 ///         + `::UR_USM_POOL_INFO_USED_HIGH_EXP < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPropValue`
-///         + `pPropValue == NULL`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE


### PR DESCRIPTION
This null pointer check is already performed as the parameter isn't marked optional, so we don't need to manually specify it.