### PR TITLE
[SYCL][AsyncAlloc] Fix minor async alloc issues

### DIFF
--- a/sycl/source/detail/cg.hpp
+++ b/sycl/source/detail/cg.hpp
@@ -686,7 +686,7 @@ public:
       ur_event_handle_t event, CG::StorageInitHelper CGData,
       detail::code_location loc = {})
       : CG(CGType::AsyncAlloc, std::move(CGData), std::move(loc)), MSize(size),
-        MMemPool(MemPool), MEvent(event) {}
+        MMemPool(std::move(MemPool)), MEvent(event) {}
 
   std::shared_ptr<ext::oneapi::experimental::detail::memory_pool_impl>
   getMemPool() const {

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -567,7 +567,7 @@ void context_impl::verifyProps(const property_list &Props) const {
 std::shared_ptr<sycl::ext::oneapi::experimental::detail::memory_pool_impl>
 context_impl::get_default_memory_pool(const context &Context,
                                       const device &Device,
-                                      const usm::alloc &Kind) {
+                                      [[maybe_unused]] const usm::alloc &Kind) {
 
   assert(Kind == usm::alloc::device);
 

--- a/sycl/source/detail/handler_impl.hpp
+++ b/sycl/source/detail/handler_impl.hpp
@@ -207,8 +207,8 @@ public:
   /// potential logging.
   /// Event computed from async alloc which is passed through for processing.
   std::shared_ptr<ext::oneapi::experimental::detail::memory_pool_impl> MMemPool;
-  size_t MAllocSize;
-  ur_event_handle_t MAsyncAllocEvent;
+  size_t MAllocSize = 0;
+  ur_event_handle_t MAsyncAllocEvent = nullptr;
 
   // Allocation ptr to be freed asynchronously.
   void *MFreePtr = nullptr;

--- a/sycl/source/detail/memory_pool_impl.cpp
+++ b/sycl/source/detail/memory_pool_impl.cpp
@@ -123,10 +123,14 @@ memory_pool_impl::~memory_pool_impl() {
   if (MIsDefaultPool)
     return;
 
-  ur_usm_pool_handle_t handle = this->get_handle();
-  sycl::context ctx = this->get_context();
-  sycl::device dev = this->get_device();
-  destroy_memory_pool(ctx, dev, handle);
+  try {
+    ur_usm_pool_handle_t handle = this->get_handle();
+    sycl::context ctx = this->get_context();
+    sycl::device dev = this->get_device();
+    destroy_memory_pool(ctx, dev, handle);
+  } catch (std::exception &e) {
+    __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~memory_pool_impl", e);
+  }
 }
 
 size_t memory_pool_impl::get_threshold() const {

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3748,6 +3748,7 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     return UR_RESULT_SUCCESS;
   }
   case CGType::AsyncFree: {
+    assert(MQueue && "Async free submissions should have an associated queue");
     CGAsyncFree *AsyncFree = (CGAsyncFree *)MCommandGroup.get();
     const detail::AdapterPtr &Adapter = MQueue->getAdapter();
     void *ptr = AsyncFree->getPtr();


### PR DESCRIPTION
This patch fixes a couple static analysis issues with the recent [async alloc patch](https://github.com/intel/llvm/pull/16900):

* Use `std::move` for shared pointer in `CGAsyncAlloc` constructor. It is already passed by-value to the constructor so we can just move it when assigning it to the member.
* Assert that the queue is available in `AsyncFree`
* Catch any exceptions from the memory pool destructor
* Initialize AsyncAlloc fields in handler
* Add `[[maybe_unused]]` for parameter only used in assert