### PR TITLE
[SYCL][E2E] Add missing zeInit to interop tests

### DIFF
--- a/sycl/test-e2e/Adapters/interop-level-zero-buffer-multi-dim.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-buffer-multi-dim.cpp
@@ -16,6 +16,14 @@ using namespace sycl;
 int main() {
 #ifdef SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
   try {
+    // Initialize Level Zero driver is required if this test is linked
+    // statically with Level Zero loader, the driver will not be init otherwise.
+    ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+    if (result != ZE_RESULT_SUCCESS) {
+      std::cout << "zeInit failed\n";
+      return 1;
+    }
+
     platform Plt{gpu_selector_v};
 
     auto Devices = Plt.get_devices();

--- a/sycl/test-e2e/Adapters/interop-level-zero-buffer-ownership.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-buffer-ownership.cpp
@@ -119,6 +119,14 @@ void test_copyback_and_free(
 int main() {
 #ifdef SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
   try {
+    // Initialize Level Zero driver is required if this test is linked
+    // statically with Level Zero loader, the driver will not be init otherwise.
+    ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+    if (result != ZE_RESULT_SUCCESS) {
+      std::cout << "zeInit failed\n";
+      return 1;
+    }
+
     platform Plt{gpu_selector_v};
 
     auto Devices = Plt.get_devices();

--- a/sycl/test-e2e/Adapters/interop-level-zero-buffer.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-buffer.cpp
@@ -36,6 +36,14 @@ public:
 int main() {
 #ifdef SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
   try {
+    // Initialize Level Zero driver is required if this test is linked
+    // statically with Level Zero loader, the driver will not be init otherwise.
+    ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+    if (result != ZE_RESULT_SUCCESS) {
+      std::cout << "zeInit failed\n";
+      return 1;
+    }
+
     queue Queue{};
 
     auto Context = Queue.get_info<info::queue::context>();

--- a/sycl/test-e2e/Adapters/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-get-native-mem.cpp
@@ -23,6 +23,14 @@ constexpr size_t SIZE = 16;
 int main() {
 #ifdef SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
   try {
+    // Initialize Level Zero driver is required if this test is linked
+    // statically with Level Zero loader, the driver will not be init otherwise.
+    ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+    if (result != ZE_RESULT_SUCCESS) {
+      std::cout << "zeInit failed\n";
+      return 1;
+    }
+
     platform Plt{gpu_selector_v};
 
     auto Devices = Plt.get_devices();

--- a/sycl/test-e2e/Adapters/interop-level-zero-image-get-native-mem.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-image-get-native-mem.cpp
@@ -42,6 +42,14 @@ using namespace sycl;
 
 int main() {
 #ifdef SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
+
   constexpr auto BE = sycl::backend::ext_oneapi_level_zero;
   sycl::device D =
       sycl::ext::oneapi::filter_selector("level_zero:gpu").select_device();

--- a/sycl/test-e2e/Adapters/interop-level-zero-image-ownership.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-image-ownership.cpp
@@ -144,6 +144,14 @@ void test(sycl::ext::oneapi::level_zero::ownership Ownership) {
 
 int main() {
 #ifdef SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
+
   std::cout << "test  ownership::transfer" << std::endl;
   test(sycl::ext::oneapi::level_zero::ownership::transfer);
 

--- a/sycl/test-e2e/Adapters/interop-level-zero-image.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-image.cpp
@@ -32,6 +32,14 @@ using namespace sycl;
 
 int main() {
 #ifdef SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
+
   constexpr auto BE = sycl::backend::ext_oneapi_level_zero;
 
   platform Plt{gpu_selector_v};

--- a/sycl/test-e2e/Adapters/interop-level-zero-keep-ownership.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-keep-ownership.cpp
@@ -14,6 +14,13 @@
 using namespace sycl;
 
 int main() {
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
 
   // Creat SYCL platform/device
   device Device(gpu_selector_v);

--- a/sycl/test-e2e/Adapters/interop-level-zero.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero.cpp
@@ -16,6 +16,14 @@ using namespace sycl;
 
 int main() {
 #ifdef SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
+
   queue Queue{};
 
   event DefaultEvent;

--- a/sycl/test-e2e/Adapters/level_zero_batch_barrier.cpp
+++ b/sycl/test-e2e/Adapters/level_zero_batch_barrier.cpp
@@ -21,6 +21,14 @@ void submit_kernel(queue &q) {
 }
 
 int main(int argc, char *argv[]) {
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
+
   queue q;
 
   submit_kernel(q); // starts a batch


### PR DESCRIPTION
Level Zero loader is now linked statically with adapters and tests. This means that both adapters and tests need to call zeInit to initalize the loader.