### PR TITLE
[SYCL][E2E] Add lit feature to check if multi-device emulation is supported

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/dependency/shadow-virtual-mem.cpp
+++ b/sycl/test-e2e/AddressSanitizer/dependency/shadow-virtual-mem.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aspect-ext_oneapi_virtual_mem, linux, (gpu && level_zero) && multi-device-emulation
+// REQUIRES: aspect-ext_oneapi_virtual_mem, linux, (gpu && level_zero)
 // RUN: %{build} -o %t.out
 // RUN: %{run} NEOReadDebugKeys=1 CreateMultipleRootDevices=2 %t.out
 

--- a/sycl/test-e2e/AddressSanitizer/dependency/shadow-virtual-mem.cpp
+++ b/sycl/test-e2e/AddressSanitizer/dependency/shadow-virtual-mem.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aspect-ext_oneapi_virtual_mem, linux, (gpu && level_zero)
+// REQUIRES: aspect-ext_oneapi_virtual_mem, linux, (gpu && level_zero) && multi-device-emulation
 // RUN: %{build} -o %t.out
 // RUN: %{run} NEOReadDebugKeys=1 CreateMultipleRootDevices=2 %t.out
 

--- a/sycl/test-e2e/KernelAndProgram/persistent-cache-multi-device.cpp
+++ b/sycl/test-e2e/KernelAndProgram/persistent-cache-multi-device.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: (level_zero || opencl) && linux && gpu
+// REQUIRES: (level_zero || opencl) && linux && gpu && multi-device-emulation
 
 // RUN: %{build} -o %t.out
 // RUN: rm -rf %t/cache_dir

--- a/sycl/test-e2e/KernelCompiler/opencl_multi_device.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_multi_device.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: (opencl || level_zero) && ocloc
+// REQUIRES: (opencl || level_zero) && ocloc && multi-device-emulation
 // UNSUPPORTED: accelerator
 // UNSUPPORTED-INTENDED: while accelerator is AoT only, this cannot run there.
 

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/build_twice.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/build_twice.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: gpu && linux && (opencl || level_zero)
+// REQUIRES: gpu && linux && (opencl || level_zero) && multi-device-emulation
 
 // Test to check that we can create input kernel bundle and call build twice for
 // overlapping set of devices and execute the kernel on each device.

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/compile_link.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/compile_link.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: gpu && linux && (opencl || level_zero)
+// REQUIRES: gpu && linux && (opencl || level_zero) && multi-device-emulation
 
 // RUN: %{build} -o %t.out
 // RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=3 %{run} %t.out

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: ocloc && gpu && linux && target-spir
+// REQUIRES: ocloc && gpu && linux && target-spir && multi-device-emulation
 
 // Test to check several use cases for multi-device kernel bundles.
 // Test covers AOT and JIT cases. Kernel is using some math functions to enforce


### PR DESCRIPTION
CreateMultipleRootDevices=[num] environment variable is used in some tests to emulate multiple devices.
It is not guaranteed to be always supported. For example, ZE_AFFINITY_MASK=0 can be set which will make this feature unusable, or in some scenarios when docker container doesn't have required system directory mappings this feature also may not work, etc.

So, create a lit feature which checks if such multi-device emulation works (it is a NEO feature, so can be supported only for opencl:gpu or level_zero:gpu)