### PR TITLE
[UR][HIP] Fix HIP adapter compilation on Windows

### DIFF
--- a/unified-runtime/source/adapters/hip/CMakeLists.txt
+++ b/unified-runtime/source/adapters/hip/CMakeLists.txt
@@ -110,12 +110,21 @@ if("${UR_HIP_PLATFORM}" STREQUAL "AMD")
     # Import HIP runtime library
     add_library(rocmdrv SHARED IMPORTED GLOBAL)
 
-    set_target_properties(
-    rocmdrv PROPERTIES
-        IMPORTED_LOCATION                    "${UR_HIP_LIB_DIR}/libamdhip64.so"
-        INTERFACE_INCLUDE_DIRECTORIES        "${HIP_HEADERS}"
-        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_HEADERS}"
-    )
+    if(WIN32)
+      set_target_properties(
+      rocmdrv PROPERTIES
+          IMPORTED_IMPLIB                      "${UR_HIP_LIB_DIR}/amdhip64.lib"
+          INTERFACE_INCLUDE_DIRECTORIES        "${HIP_HEADERS}"
+          INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_HEADERS}"
+      )
+    else()
+      set_target_properties(
+      rocmdrv PROPERTIES
+          IMPORTED_LOCATION                    "${UR_HIP_LIB_DIR}/libamdhip64.so"
+          INTERFACE_INCLUDE_DIRECTORIES        "${HIP_HEADERS}"
+          INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_HEADERS}"
+      )
+    endif()
 
     if(UR_ENABLE_COMGR)
         set(UR_COMGR_VERSION5_HEADER "${UR_HIP_INCLUDE_DIR}/amd_comgr/amd_comgr.h")

--- a/unified-runtime/source/adapters/hip/context.cpp
+++ b/unified-runtime/source/adapters/hip/context.cpp
@@ -61,7 +61,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
 
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
 
-  switch (uint32_t{propName}) {
+  switch (propName) {
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(static_cast<uint32_t>(hContext->Devices.size()));
   case UR_CONTEXT_INFO_DEVICES:

--- a/unified-runtime/source/adapters/hip/device.cpp
+++ b/unified-runtime/source/adapters/hip/device.cpp
@@ -13,6 +13,7 @@
 #include "context.hpp"
 #include "event.hpp"
 
+#include <array>
 #include <hip/hip_runtime.h>
 #include <sstream>
 

--- a/unified-runtime/source/adapters/hip/kernel.hpp
+++ b/unified-runtime/source/adapters/hip/kernel.hpp
@@ -11,6 +11,7 @@
 
 #include <ur_api.h>
 
+#include <array>
 #include <atomic>
 #include <cassert>
 #include <numeric>


### PR DESCRIPTION
I don't have access to a device to validate it's all perfect at runtime, but these fixes did let me build everything successfully, and the compiler was able to build Blender GPU kernels library on Windows, using HIP SDK 6.2.4 and VS2022 17.12.1.