### PR TITLE
[ESIMD] Move RAII deleter init after buffer allocation.

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDVerifier.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDVerifier.cpp
@@ -164,8 +164,8 @@ public:
             continue;
 
           id::OutputBuffer NameBuf;
-          BuffDeleter NameBufDeleter(NameBuf.getBuffer());
           NameNode->print(NameBuf);
+          BuffDeleter NameBufDeleter(NameBuf.getBuffer());
           StringRef Name(NameBuf.getBuffer(), NameBuf.getCurrentPosition());
 
           // We are interested in functions defined in SYCL namespace, but


### PR DESCRIPTION
The buffer seems to be allocated in the call to `NameNode->print(NameBuf)`, so we need to move the RAII deleter after that call, otherwise the buffer keeps leaking because when the RAII deleter is created, there's no buffer yet.