### PR TITLE
[SYCL][NativeCPU][NFC] Prevent generating unnamed functions

### DIFF
--- a/llvm/lib/SYCLNativeCPUUtils/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PrepareSYCLNativeCPU.cpp
@@ -365,6 +365,8 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
           OldF->takeName(OrigF);
           if (OrigF->use_empty()) {
             RemovableFuncs.insert(OrigF);
+          } else {
+            OrigF->setName(Name + ".orig");
           }
         } else {
           OldF->setName(Name);


### PR DESCRIPTION
When we rename wrapper functions to take the name of the original, that leaves in place a call to the original meaning the original cannot be removed. When we take its name, the original's name would be cleared. Append ".orig" instead to make it easier to keep track of which is which.