### PR TITLE
[SYCL] Use libur_loader_opencl.so rather than libOpenCL.so on Linux

### DIFF
--- a/sycl/include/sycl/detail/os_util.hpp
+++ b/sycl/include/sycl/detail/os_util.hpp
@@ -120,9 +120,13 @@ fn *dynLookupFunction(const char *WinName, const char *LinName,
                       const char *FunName) {
   return reinterpret_cast<fn *>(dynLookup(WinName, LinName, FunName));
 }
+// On Linux, the name of OpenCL that was used to link against may be either
+// `OpenCL.so`, `OpenCL.so.1` or possibly anything else.
+// `libur_adapter_opencl.so` is a more stable name, since it is hardcoded into
+// the loader.
 #define __SYCL_OCL_CALL(FN, ...)                                               \
   (sycl::_V1::detail::dynLookupFunction<decltype(FN)>(                         \
-      "OpenCL", "libOpenCL.so", #FN)(__VA_ARGS__))
+      "OpenCL", "libur_adapter_opencl.so", #FN)(__VA_ARGS__))
 
 } // namespace detail
 } // namespace _V1

--- a/sycl/unittests/mock_opencl/CMakeLists.txt
+++ b/sycl/unittests/mock_opencl/CMakeLists.txt
@@ -1,9 +1,17 @@
 get_target_property(SYCL_BINARY_DIR sycl-toolchain BINARY_DIR)
 
+# Linux looks up ur_adapter_opencl rather than libOpenCL.
+# On Windows, this is copied into libOpenCL.dll.
+if(WIN32)
+  set(LIBNAME OpenCL)
+else()
+  set(LIBNAME ur_adapter_opencl)
+endif()
+
 add_library(mockOpenCL SHARED EXCLUDE_FROM_ALL mock_opencl.cpp)
 set_target_properties(mockOpenCL PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${SYCL_BINARY_DIR}/unittests/lib
-  LIBRARY_OUTPUT_NAME OpenCL
+  LIBRARY_OUTPUT_NAME ${LIBNAME}
   RUNTIME_OUTPUT_DIRECTORY ${SYCL_BINARY_DIR}/unittests/lib
-  RUNTIME_OUTPUT_NAME OpenCL
+  RUNTIME_OUTPUT_NAME ${LIBNAME}
 )


### PR DESCRIPTION
The name of OpenCL may vary between different implementations, but
libur_adapter_opencl.so shouldn't.
