### PR TITLE
[UR] [V2] Add wait before enqueue in command buffer

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -51,13 +51,8 @@ ur_event_handle_t ur_exp_command_buffer_handle_t_::getExecutionEventUnlocked() {
   return currentExecution;
 }
 
-ur_result_t ur_exp_command_buffer_handle_t_::registerExecutionEvent(
-    [[maybe_unused]] locked<ur_command_list_manager> &commandList,
+ur_result_t ur_exp_command_buffer_handle_t_::registerExecutionEventUnlocked(
     ur_event_handle_t nextExecutionEvent) {
-  assert(
-      commandList->getZeCommandList() ==
-          commandListManager.get_no_lock()->getZeCommandList() &&
-      "Provided command list is not the same as the one in the command buffer");
   if (currentExecution) {
     UR_CALL(currentExecution->release());
     currentExecution = nullptr;

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -47,7 +47,43 @@ ur_result_t ur_exp_command_buffer_handle_t_::finalizeCommandBuffer() {
   isFinalized = true;
   return UR_RESULT_SUCCESS;
 }
+ur_result_t ur_exp_command_buffer_handle_t_::awaitExecution(
+    locked<ur_command_list_manager> &commandList) {
+  std::ignore = commandList;
+  assert(
+      commandList->getZeCommandList() ==
+          commandListManager.get_no_lock()->getZeCommandList() &&
+      "Provided command list is not the same as the one in the command buffer");
+  if (currentExecution) {
+    ZE2UR_CALL(zeEventHostSynchronize, (currentExecution->getZeEvent(), UINT64_MAX));
+    UR_CALL(currentExecution->release());
+    currentExecution = nullptr;
+  }
+  return UR_RESULT_SUCCESS;
+}
 
+ur_result_t ur_exp_command_buffer_handle_t_::registerExecutionEvent(
+    locked<ur_command_list_manager> &commandList,
+    ur_event_handle_t nextExecutionEvent) {
+  std::ignore = commandList;
+  assert(
+      commandList->getZeCommandList() ==
+          commandListManager.get_no_lock()->getZeCommandList() &&
+      "Provided command list is not the same as the one in the command buffer");
+  assert(currentExecution == nullptr &&
+         "Current execution event is not null, it should be awaited first");
+  if (nextExecutionEvent) {
+    currentExecution = nextExecutionEvent;
+    UR_CALL(nextExecutionEvent->retain());
+  }
+  return UR_RESULT_SUCCESS;
+}
+
+ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
+  if (currentExecution) {
+    currentExecution->release();
+  }
+}
 namespace ur::level_zero {
 
 ur_result_t

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -47,12 +47,7 @@ ur_result_t ur_exp_command_buffer_handle_t_::finalizeCommandBuffer() {
   isFinalized = true;
   return UR_RESULT_SUCCESS;
 }
-ur_event_handle_t ur_exp_command_buffer_handle_t_::getCurrentExecutionEvent(
-    [[maybe_unused]] locked<ur_command_list_manager> &commandList) {
-  assert(
-      commandList->getZeCommandList() ==
-          commandListManager.get_no_lock()->getZeCommandList() &&
-      "Provided command list is not the same as the one in the command buffer");
+ur_event_handle_t ur_exp_command_buffer_handle_t_::getExecutionEventUnlocked() {
   return currentExecution;
 }
 

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -55,7 +55,8 @@ ur_result_t ur_exp_command_buffer_handle_t_::awaitExecution(
           commandListManager.get_no_lock()->getZeCommandList() &&
       "Provided command list is not the same as the one in the command buffer");
   if (currentExecution) {
-    ZE2UR_CALL(zeEventHostSynchronize, (currentExecution->getZeEvent(), UINT64_MAX));
+    ZE2UR_CALL(zeEventHostSynchronize,
+               (currentExecution->getZeEvent(), UINT64_MAX));
     UR_CALL(currentExecution->release());
     currentExecution = nullptr;
   }

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -25,7 +25,8 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
 
   ~ur_exp_command_buffer_handle_t_();
 
-  ur_result_t awaitExecution(locked<ur_command_list_manager> &commandList);
+  ur_event_handle_t
+  getCurrentExecutionEvent(locked<ur_command_list_manager> &commandList);
   ur_result_t
   registerExecutionEvent(locked<ur_command_list_manager> &commandList,
                          ur_event_handle_t nextExecutionEvent);

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -23,7 +23,12 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
       v2::raii::command_list_unique_handle &&commandList,
       const ur_exp_command_buffer_desc_t *desc);
 
-  ~ur_exp_command_buffer_handle_t_() = default;
+  ~ur_exp_command_buffer_handle_t_();
+
+  ur_result_t awaitExecution(locked<ur_command_list_manager> &commandList);
+  ur_result_t
+  registerExecutionEvent(locked<ur_command_list_manager> &commandList,
+                         ur_event_handle_t nextExecutionEvent);
 
   lockable<ur_command_list_manager> commandListManager;
 
@@ -36,6 +41,8 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
 private:
   // Indicates if command-buffer was finalized.
   bool isFinalized = false;
+
+  ur_event_handle_t currentExecution = nullptr;
 };
 
 struct ur_exp_command_buffer_command_handle_t_ : public _ur_object {

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -27,8 +27,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
 
   ur_event_handle_t getExecutionEventUnlocked();
   ur_result_t
-  registerExecutionEvent(locked<ur_command_list_manager> &commandList,
-                         ur_event_handle_t nextExecutionEvent);
+  registerExecutionEventUnlocked(ur_event_handle_t nextExecutionEvent);
 
   lockable<ur_command_list_manager> commandListManager;
 

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -25,8 +25,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
 
   ~ur_exp_command_buffer_handle_t_();
 
-  ur_event_handle_t
-  getCurrentExecutionEvent(locked<ur_command_list_manager> &commandList);
+  ur_event_handle_t getExecutionEventUnlocked();
   ur_result_t
   registerExecutionEvent(locked<ur_command_list_manager> &commandList,
                          ur_event_handle_t nextExecutionEvent);

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -162,7 +162,7 @@ wait_list_view ur_command_list_manager::getWaitListView(
     ur_event_handle_t additionalWaitEvent) {
 
   uint32_t totalNumWaitEvents =
-      numWaitEvents + additionalWaitEvent != nullptr ? 1 : 0;
+      numWaitEvents + (additionalWaitEvent != nullptr ? 1 : 0);
   waitList.resize(totalNumWaitEvents);
   for (uint32_t i = 0; i < numWaitEvents; i++) {
     waitList[i] = phWaitEvents[i]->getZeEvent();

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -157,16 +157,20 @@ ur_result_t ur_command_list_manager::appendRegionCopyUnlocked(
   return UR_RESULT_SUCCESS;
 }
 
-wait_list_view
-ur_command_list_manager::getWaitListView(const ur_event_handle_t *phWaitEvents,
-                                         uint32_t numWaitEvents) {
+wait_list_view ur_command_list_manager::getWaitListView(
+    const ur_event_handle_t *phWaitEvents, uint32_t numWaitEvents,
+    ur_event_handle_t additionalWaitEvent) {
 
-  waitList.resize(numWaitEvents);
+  uint32_t totalNumWaitEvents =
+      numWaitEvents + additionalWaitEvent != nullptr ? 1 : 0;
+  waitList.resize(totalNumWaitEvents);
   for (uint32_t i = 0; i < numWaitEvents; i++) {
     waitList[i] = phWaitEvents[i]->getZeEvent();
   }
-
-  return {waitList.data(), static_cast<uint32_t>(numWaitEvents)};
+  if (additionalWaitEvent != nullptr) {
+    waitList[totalNumWaitEvents - 1] = additionalWaitEvent->getZeEvent();
+  }
+  return {waitList.data(), static_cast<uint32_t>(totalNumWaitEvents)};
 }
 
 ze_event_handle_t

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -128,8 +128,9 @@ struct ur_command_list_manager {
 
   ze_command_list_handle_t getZeCommandList();
 
-  wait_list_view getWaitListView(const ur_event_handle_t *phWaitEvents,
-                                 uint32_t numWaitEvents);
+  wait_list_view
+  getWaitListView(const ur_event_handle_t *phWaitEvents, uint32_t numWaitEvents,
+                  ur_event_handle_t additionalWaitEvent = nullptr);
   ze_event_handle_t getSignalEvent(ur_event_handle_t *hUserEvent,
                                    ur_command_t commandType);
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -929,7 +929,7 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCommandBufferExp(
   ze_command_list_handle_t commandBufferCommandList =
       commandListLocked->getZeCommandList();
   ur_event_handle_t internalEvent = nullptr;
-  if (!phEvent) {
+  if (phEvent == nullptr) {
     phEvent = &internalEvent;
   }
   UR_CALL(hCommandBuffer->awaitExecution(commandListLocked));
@@ -937,6 +937,9 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCommandBufferExp(
                                         numEventsInWaitList, phEventWaitList,
                                         UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP));
   UR_CALL(hCommandBuffer->registerExecutionEvent(commandListLocked, *phEvent));
+  if (internalEvent != nullptr) {
+    internalEvent->release();
+  }
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -932,7 +932,17 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCommandBufferExp(
   if (phEvent == nullptr) {
     phEvent = &internalEvent;
   }
-  UR_CALL(hCommandBuffer->awaitExecution(commandListLocked));
+  ur_event_handle_t executionEvent =
+      hCommandBuffer->getCurrentExecutionEvent(commandListLocked);
+  std::vector<ur_event_handle_t> extendedWaitList;
+  if (executionEvent != nullptr) {
+    extendedWaitList.resize(numEventsInWaitList + 1);
+    std::copy(phEventWaitList, phEventWaitList + numEventsInWaitList,
+              extendedWaitList.begin());
+    extendedWaitList[numEventsInWaitList] = executionEvent;
+    phEventWaitList = extendedWaitList.data();
+    numEventsInWaitList++;
+  }
   UR_CALL(enqueueGenericCommandListsExp(1, &commandBufferCommandList, phEvent,
                                         numEventsInWaitList, phEventWaitList,
                                         UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP));

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -23,8 +23,10 @@ namespace v2 {
 
 wait_list_view ur_queue_immediate_in_order_t::getWaitListView(
     locked<ur_command_list_manager> &commandList,
-    const ur_event_handle_t *phWaitEvents, uint32_t numWaitEvents) {
-  return commandList->getWaitListView(phWaitEvents, numWaitEvents);
+    const ur_event_handle_t *phWaitEvents, uint32_t numWaitEvents,
+    ur_event_handle_t additionalWaitEvent) {
+  return commandList->getWaitListView(phWaitEvents, numWaitEvents,
+                                      additionalWaitEvent);
 }
 
 static int32_t getZeOrdinal(ur_device_handle_t hDevice) {
@@ -898,7 +900,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueTimestampRecordingExp(
 ur_result_t ur_queue_immediate_in_order_t::enqueueGenericCommandListsExp(
     uint32_t numCommandLists, ze_command_list_handle_t *phCommandLists,
     ur_event_handle_t *phEvent, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_command_t callerCommand) {
+    const ur_event_handle_t *phEventWaitList, ur_command_t callerCommand,
+    ur_event_handle_t additionalWaitEvent) {
   TRACK_SCOPE_LATENCY(
       "ur_queue_immediate_in_order_t::enqueueGenericCommandListsExp");
 
@@ -907,7 +910,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueGenericCommandListsExp(
       getSignalEvent(commandListLocked, phEvent, callerCommand);
 
   auto [pWaitEvents, numWaitEvents] =
-      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
+      getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList,
+                      additionalWaitEvent);
   // zeCommandListImmediateAppendCommandListsExp is not working with in-order
   // immediate lists what causes problems with synchronization
   // TODO: remove synchronization when it is not needed
@@ -933,19 +937,11 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCommandBufferExp(
     phEvent = &internalEvent;
   }
   ur_event_handle_t executionEvent =
-      hCommandBuffer->getCurrentExecutionEvent(commandListLocked);
-  std::vector<ur_event_handle_t> extendedWaitList;
-  if (executionEvent != nullptr) {
-    extendedWaitList.resize(numEventsInWaitList + 1);
-    std::copy(phEventWaitList, phEventWaitList + numEventsInWaitList,
-              extendedWaitList.begin());
-    extendedWaitList[numEventsInWaitList] = executionEvent;
-    phEventWaitList = extendedWaitList.data();
-    numEventsInWaitList++;
-  }
-  UR_CALL(enqueueGenericCommandListsExp(1, &commandBufferCommandList, phEvent,
-                                        numEventsInWaitList, phEventWaitList,
-                                        UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP));
+      hCommandBuffer->getExecutionEventUnlocked();
+
+  UR_CALL(enqueueGenericCommandListsExp(
+      1, &commandBufferCommandList, phEvent, numEventsInWaitList,
+      phEventWaitList, UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP, executionEvent));
   UR_CALL(hCommandBuffer->registerExecutionEvent(commandListLocked, *phEvent));
   if (internalEvent != nullptr) {
     internalEvent->release();

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -942,7 +942,7 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCommandBufferExp(
   UR_CALL(enqueueGenericCommandListsExp(
       1, &commandBufferCommandList, phEvent, numEventsInWaitList,
       phEventWaitList, UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP, executionEvent));
-  UR_CALL(hCommandBuffer->registerExecutionEvent(commandListLocked, *phEvent));
+  UR_CALL(hCommandBuffer->registerExecutionEventUnlocked(*phEvent));
   if (internalEvent != nullptr) {
     internalEvent->release();
   }

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -928,9 +928,16 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCommandBufferExp(
   auto commandListLocked = hCommandBuffer->commandListManager.lock();
   ze_command_list_handle_t commandBufferCommandList =
       commandListLocked->getZeCommandList();
-  return enqueueGenericCommandListsExp(1, &commandBufferCommandList, phEvent,
-                                       numEventsInWaitList, phEventWaitList,
-                                       UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP);
+  ur_event_handle_t internalEvent = nullptr;
+  if (!phEvent) {
+    phEvent = &internalEvent;
+  }
+  UR_CALL(hCommandBuffer->awaitExecution(commandListLocked));
+  UR_CALL(enqueueGenericCommandListsExp(1, &commandBufferCommandList, phEvent,
+                                        numEventsInWaitList, phEventWaitList,
+                                        UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP));
+  UR_CALL(hCommandBuffer->registerExecutionEvent(commandListLocked, *phEvent));
+  return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_queue_immediate_in_order_t::enqueueKernelLaunchCustomExp(

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -37,9 +37,10 @@ private:
   std::vector<ur_event_handle_t> deferredEvents;
   std::vector<ur_kernel_handle_t> submittedKernels;
 
-  wait_list_view getWaitListView(locked<ur_command_list_manager> &commandList,
-                                 const ur_event_handle_t *phWaitEvents,
-                                 uint32_t numWaitEvents);
+  wait_list_view
+  getWaitListView(locked<ur_command_list_manager> &commandList,
+                  const ur_event_handle_t *phWaitEvents, uint32_t numWaitEvents,
+                  ur_event_handle_t additionalWaitEvent = nullptr);
 
   ze_event_handle_t getSignalEvent(locked<ur_command_list_manager> &commandList,
                                    ur_event_handle_t *hUserEvent,
@@ -56,7 +57,8 @@ private:
   ur_result_t enqueueGenericCommandListsExp(
       uint32_t numCommandLists, ze_command_list_handle_t *phCommandLists,
       ur_event_handle_t *phEvent, uint32_t numEventsInWaitList,
-      const ur_event_handle_t *phEventWaitList, ur_command_t callerCommand);
+      const ur_event_handle_t *phEventWaitList, ur_command_t callerCommand,
+      ur_event_handle_t additionalWaitEvent);
 
   ur_result_t
   enqueueEventsWaitWithBarrierImpl(uint32_t numEventsInWaitList,

--- a/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
@@ -122,7 +122,6 @@ TEST_P(urCommandBufferFillCommandsTest, Buffer) {
   verifyData(output, size);
 }
 
-
 TEST_P(urCommandBufferFillCommandsTest, ExecuteTwice) {
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferFillExp(
       cmd_buf_handle, buffer, pattern.data(), pattern_size, 0, size, 0, nullptr,

--- a/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
@@ -122,6 +122,28 @@ TEST_P(urCommandBufferFillCommandsTest, Buffer) {
   verifyData(output, size);
 }
 
+
+TEST_P(urCommandBufferFillCommandsTest, ExecuteTwice) {
+  ASSERT_SUCCESS(urCommandBufferAppendMemBufferFillExp(
+      cmd_buf_handle, buffer, pattern.data(), pattern_size, 0, size, 0, nullptr,
+      0, nullptr, &sync_point, nullptr, nullptr));
+
+  std::vector<uint8_t> output(size, 1);
+  ASSERT_SUCCESS(urCommandBufferAppendMemBufferReadExp(
+      cmd_buf_handle, buffer, 0, size, output.data(), 1, &sync_point, 0,
+      nullptr, nullptr, nullptr, nullptr));
+
+  ASSERT_SUCCESS(urCommandBufferFinalizeExp(cmd_buf_handle));
+
+  ASSERT_SUCCESS(
+      urEnqueueCommandBufferExp(queue, cmd_buf_handle, 0, nullptr, nullptr));
+  ASSERT_SUCCESS(
+      urEnqueueCommandBufferExp(queue, cmd_buf_handle, 0, nullptr, nullptr));
+  ASSERT_SUCCESS(urQueueFinish(queue));
+
+  verifyData(output, size);
+}
+
 TEST_P(urCommandBufferFillCommandsTest, USM) {
   ASSERT_SUCCESS(urCommandBufferAppendUSMFillExp(
       cmd_buf_handle, device_ptr, pattern.data(), pattern_size, size, 0,

--- a/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
@@ -122,27 +122,6 @@ TEST_P(urCommandBufferFillCommandsTest, Buffer) {
   verifyData(output, size);
 }
 
-TEST_P(urCommandBufferFillCommandsTest, ExecuteTwice) {
-  ASSERT_SUCCESS(urCommandBufferAppendMemBufferFillExp(
-      cmd_buf_handle, buffer, pattern.data(), pattern_size, 0, size, 0, nullptr,
-      0, nullptr, &sync_point, nullptr, nullptr));
-
-  std::vector<uint8_t> output(size, 1);
-  ASSERT_SUCCESS(urCommandBufferAppendMemBufferReadExp(
-      cmd_buf_handle, buffer, 0, size, output.data(), 1, &sync_point, 0,
-      nullptr, nullptr, nullptr, nullptr));
-
-  ASSERT_SUCCESS(urCommandBufferFinalizeExp(cmd_buf_handle));
-
-  ASSERT_SUCCESS(
-      urEnqueueCommandBufferExp(queue, cmd_buf_handle, 0, nullptr, nullptr));
-  ASSERT_SUCCESS(
-      urEnqueueCommandBufferExp(queue, cmd_buf_handle, 0, nullptr, nullptr));
-  ASSERT_SUCCESS(urQueueFinish(queue));
-
-  verifyData(output, size);
-}
-
 TEST_P(urCommandBufferFillCommandsTest, USM) {
   ASSERT_SUCCESS(urCommandBufferAppendUSMFillExp(
       cmd_buf_handle, device_ptr, pattern.data(), pattern_size, size, 0,

--- a/unified-runtime/test/conformance/exp_command_buffer/fixtures.h
+++ b/unified-runtime/test/conformance/exp_command_buffer/fixtures.h
@@ -45,7 +45,6 @@ static void checkCommandBufferUpdateSupport(
 
 struct urCommandBufferExpTest : uur::urContextTest {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
 
     UUR_RETURN_ON_FATAL_FAILURE(uur::urContextTest::SetUp());
 
@@ -72,7 +71,6 @@ struct urCommandBufferExpTest : uur::urContextTest {
 template <class T>
 struct urCommandBufferExpTestWithParam : urQueueTestWithParam<T> {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
 
     UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());
 
@@ -97,7 +95,6 @@ struct urCommandBufferExpTestWithParam : urQueueTestWithParam<T> {
 
 struct urCommandBufferExpExecutionTest : uur::urKernelExecutionTest {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
 
     UUR_RETURN_ON_FATAL_FAILURE(uur::urKernelExecutionTest::SetUp());
 

--- a/unified-runtime/test/conformance/exp_command_buffer/update/invalid_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/invalid_update.cpp
@@ -309,6 +309,8 @@ TEST_P(InvalidUpdateTest, CommandBufferMismatch) {
 // that isn't supported.
 struct InvalidUpdateCommandBufferExpExecutionTest : uur::urKernelExecutionTest {
   void SetUp() override {
+    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
+
     program_name = "fill_usm";
     UUR_RETURN_ON_FATAL_FAILURE(uur::urKernelExecutionTest::SetUp());
 


### PR DESCRIPTION
According to @MichalMrozek, zeCommandListImmediateAppendCommandListsExp has the same requirements as zeCommandQueueExecuteCommandLists, because of this, the command list must not be referenced by device when it is enqueued. This PR fixes this issue by adding event to synchronize append and execution