### PR TITLE
[SYCL][E2E][Joint Matrix] Remove some workarounds

### DIFF
--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_bf16_fill_k_cache_impl.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_bf16_fill_k_cache_impl.hpp
@@ -483,13 +483,10 @@ int main(
            MCache1, NCache1, KCache1, MCache2, NCache2, KCache2>(matrix_size);
       test<bfloat16, float, VnniFactor, /*TM*/ 32, /*TN*/ 64, /*TK*/ 16,
            MCache1, NCache1, KCache1, MCache2, NCache2, KCache2>(matrix_size);
-// `#ifndef PREFETCH` is a workaround for GSD-10535.
-#ifndef PREFETCH
       // The test is commented out due flaky results: GSD-10537.
       // test<bfloat16, float, VnniFactor, /*TM*/ 1, /*TN*/ 64, /*TK*/ 32,
       // MCache1,
       //      NCache1, /*KCache1*/ 32, MCache2, NCache2, KCache2>(matrix_size);
-#endif // PREFETCH
       test<bfloat16, float, VnniFactor, /*TM*/ 32, /*TN*/ 64, /*TK*/ 32,
            MCache1, NCache1, /*KCache1*/ 32, MCache2, NCache2, KCache2>(
           matrix_size);

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll.cpp
@@ -11,12 +11,11 @@
 
 // REQUIRES: aspect-ext_intel_matrix
 
-// RUN: %{build} -mllvm -inline-threshold=5000 %fp-model-precise -o %t.out -DMANUAL_UNROLL -DVNNI
+// RUN: %{build} -mllvm -inline-threshold=2000 %fp-model-precise -o %t.out -DMANUAL_UNROLL -DVNNI
 // RUN: %{run} %t.out
 
 // -mllvm -inline-threshold=2000 added as a workaround,
 // since IGC doesn't support some variants of IR for Joint Matrix currently
-// -inline-threshold increased to 5000 to workaround bug in IGC: GSD-10534
 // -ffp-model=precise is added to not depend on compiler defaults.
 
 #include "common.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll_init.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll_init.cpp
@@ -11,12 +11,11 @@
 
 // REQUIRES: aspect-ext_intel_matrix, gpu
 
-// RUN: %{build} -mllvm -inline-threshold=5000 %fp-model-precise -o %t_gpu.out -DINIT_LIST -DMANUAL_UNROLL -DVNNI
+// RUN: %{build} -mllvm -inline-threshold=2000 %fp-model-precise -o %t_gpu.out -DINIT_LIST -DMANUAL_UNROLL -DVNNI
 // RUN: %{run} %t_gpu.out
 
 // -mllvm -inline-threshold=2000 added as a workaround,
 // since IGC doesn't support some variants of IR for Joint Matrix currently
-// -inline-threshold increased to 5000 to workaround bug in IGC: GSD-10534
 // -ffp-model=precise is added to not depend on compiler defaults.
 
 #include "common.hpp"


### PR DESCRIPTION
Since drivers are updated in SYCLOS CI, removed couple workarounds.