### PR TITLE
[UR][CUDA] Use different throttle reasons API based on CUDA version

### DIFF
--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -1089,8 +1089,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   case UR_DEVICE_INFO_CURRENT_CLOCK_THROTTLE_REASONS: {
     unsigned long long ClocksEventReasons;
+#if (CUDA_VERSION >= 12060)
     UR_CHECK_ERROR(nvmlDeviceGetCurrentClocksEventReasons(hDevice->getNVML(),
                                                           &ClocksEventReasons));
+#else
+    UR_CHECK_ERROR(nvmlDeviceGetCurrentClocksThrottleReasons(
+        hDevice->getNVML(), &ClocksEventReasons));
+#endif
     ur_device_throttle_reasons_flags_t ThrottleReasons = 0;
     constexpr unsigned long long NVMLThrottleFlags[] = {
         nvmlClocksThrottleReasonSwPowerCap,


### PR DESCRIPTION
Our pre-commit CI uses CUDA 12.6 but nightly uses CUDA 12.1, it turns out nvml which is part of CUDA 12.6 has nvmlDeviceGetCurrentClocksEventReasons API, but nvml which is part of CUDA 12.1 doesn't have it, but only supports older deprecated nvmlDeviceGetCurrentClocksThrottleReasons.

NVML doesn't provide a version macro to check the support for that API, so use new API nvmlDeviceGetCurrentClocksEventReasons based on cuda version.