### PR TITLE
[CI] Fix shared build job name in Nightly

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -23,7 +23,7 @@ jobs:
       # prefer widespread gzip compression.
       artifact_archive_name: sycl_linux.tar.gz
 
-  ubuntu2204_shared_build:
+  ubuntu2404_shared_build:
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl-linux-build.yml
     secrets: inherit

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -23,7 +23,7 @@ jobs:
       # prefer widespread gzip compression.
       artifact_archive_name: sycl_linux.tar.gz
 
-  ubuntu2404_shared_build:
+  linux_shared_build:
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl-linux-build.yml
     secrets: inherit


### PR DESCRIPTION
The job's name is `ubuntu2204_shared_build`  while we use `ubuntu2404_intel_drivers` docker image to build DPCPP.
Example: https://github.com/intel/llvm/actions/runs/14121213165/job/39561695852#step:2:22