### PR TITLE
[DevTSAN] Cleanup private shadow memory when function exit

### DIFF
--- a/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/cleanup_private_shadow.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/cleanup_private_shadow.ll
@@ -1,0 +1,14 @@
+; RUN: opt < %s -passes='function(tsan),module(tsan-module)' -tsan-instrument-func-entry-exit=0 -tsan-instrument-memintrinsics=0 -S | FileCheck %s
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+
+%"class.sycl::_V1::range" = type { %"class.sycl::_V1::detail::array" }
+%"class.sycl::_V1::detail::array" = type { [1 x i64] }
+
+define spir_kernel void @test() {
+entry:
+  %agg.tmp = alloca %"class.sycl::_V1::range", align 8
+; CHECK: [[REG1:%[0-9]+]] = ptrtoint ptr %agg.tmp to i64
+; CHECK-NEXT: call void @__tsan_cleanup_private(i64 [[REG1]], i32 8)
+  ret void
+}

--- a/sycl/test-e2e/ThreadSanitizer/check_both_read.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_both_read.cpp
@@ -1,8 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_tsan_flags -O0 -g -o %t1.out
 // RUN: %{run} %t1.out 2>&1 | FileCheck %s
-// UNSUPPORTED: true
-// UNSUPPORTED-TRACKER: CMPLRLLVM-66203
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 

--- a/sycl/test-e2e/ThreadSanitizer/check_no_race.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_no_race.cpp
@@ -3,8 +3,6 @@
 // RUN: %{run} %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_tsan_flags -O2 -g -o %t2.out
 // RUN: %{run} %t2.out 2>&1 | FileCheck %s
-// UNSUPPORTED: true
-// UNSUPPORTED-TRACKER: CMPLRLLVM-66203
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 


### PR DESCRIPTION
We need to skip the check for private memory, otherwise OpenCL CPU device may generate false positive reports due to stack re-use in different threads. However, SPIR-V builts 'ToPrivate' doesn't work as expected on OpenCL CPU device. So we need to manually cleanup private shadow before each function exit point.