### PR TITLE
[UR] Added "roundtrip" GetInfo comformance tests

### DIFF
--- a/unified-runtime/test/conformance/context/urContextGetInfo.cpp
+++ b/unified-runtime/test/conformance/context/urContextGetInfo.cpp
@@ -42,6 +42,27 @@ TEST_P(urContextGetInfoTest, SuccessDevices) {
   ASSERT_EQ(property_value, device);
 }
 
+TEST_P(urContextGetInfoTest, SuccessRoundtripDevices) {
+  const ur_context_info_t property_name = UR_CONTEXT_INFO_DEVICES;
+  size_t property_size = sizeof(ur_device_handle_t);
+
+  ur_native_handle_t native_context;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urContextGetNativeHandle(context, &native_context));
+
+  ur_context_handle_t from_native_context;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urContextCreateWithNativeHandle(
+      native_context, adapter, 1, &device, nullptr, &from_native_context));
+
+  ur_device_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urContextGetInfo(from_native_context, property_name,
+                                  property_size, &property_value, nullptr));
+
+  size_t devices_count = property_size / sizeof(ur_device_handle_t);
+  ASSERT_EQ(devices_count, 1);
+  ASSERT_EQ(property_value, device);
+}
+
 TEST_P(urContextGetInfoTest, SuccessUSMMemCpy2DSupport) {
   const ur_context_info_t property_name = UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT;
   size_t property_size = 0;

--- a/unified-runtime/test/conformance/kernel/urKernelGetInfo.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelGetInfo.cpp
@@ -77,6 +77,31 @@ TEST_P(urKernelGetInfoTest, SuccessContext) {
   ASSERT_EQ(context, property_value);
 }
 
+TEST_P(urKernelGetInfoTest, SuccessRoundtripContext) {
+  const ur_kernel_info_t property_name = UR_KERNEL_INFO_CONTEXT;
+  size_t property_size = 0;
+
+  ur_native_handle_t native_kernel;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urKernelGetNativeHandle(kernel, &native_kernel));
+
+  ur_kernel_handle_t from_native_kernel;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urKernelCreateWithNativeHandle(
+      native_kernel, context, program, nullptr, &from_native_kernel));
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(urKernelGetInfo(from_native_kernel,
+                                                   property_name, 0, nullptr,
+                                                   &property_size),
+                                   property_name);
+  ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
+
+  ur_context_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urKernelGetInfo(from_native_kernel, property_name,
+                                 property_size, &property_value, nullptr));
+
+  ASSERT_EQ(property_value, context);
+}
+
 TEST_P(urKernelGetInfoTest, SuccessProgram) {
   const ur_kernel_info_t property_name = UR_KERNEL_INFO_PROGRAM;
   size_t property_size = 0;
@@ -91,6 +116,55 @@ TEST_P(urKernelGetInfoTest, SuccessProgram) {
                                  &property_value, nullptr));
 
   ASSERT_EQ(program, property_value);
+}
+
+TEST_P(urKernelGetInfoTest, SuccessRoundtripProgram) {
+  const ur_kernel_info_t property_name = UR_KERNEL_INFO_PROGRAM;
+  size_t property_size = sizeof(ur_program_handle_t);
+
+  ur_native_handle_t native_kernel;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urKernelGetNativeHandle(kernel, &native_kernel));
+
+  ur_kernel_handle_t from_native_kernel;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urKernelCreateWithNativeHandle(
+      native_kernel, context, program, nullptr, &from_native_kernel));
+
+  ur_program_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urKernelGetInfo(from_native_kernel, property_name,
+                                 property_size, &property_value, nullptr));
+
+  ASSERT_EQ(property_value, program);
+}
+
+TEST_P(urKernelGetInfoTest, SuccessRoundtripNullProgram) {
+  const ur_kernel_info_t property_name = UR_KERNEL_INFO_PROGRAM;
+  size_t property_size = sizeof(ur_program_handle_t);
+
+  ur_native_handle_t native_kernel;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urKernelGetNativeHandle(kernel, &native_kernel));
+
+  ur_kernel_handle_t from_native_kernel;
+  auto result = urKernelCreateWithNativeHandle(native_kernel, context, nullptr,
+                                               nullptr, &from_native_kernel);
+  if (result == UR_RESULT_ERROR_INVALID_NULL_HANDLE) {
+    GTEST_SKIP() << "Implementation requires a valid program";
+  }
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(result);
+
+  ur_program_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urKernelGetInfo(from_native_kernel, property_name,
+                                 property_size, &property_value, nullptr));
+
+  // We can't assume that the two program handles are equal (since creating the
+  // link to the UR structures has been severed by going through native handle,
+  // so just check the underlying native pointers
+  ur_native_handle_t original_program;
+  ur_native_handle_t new_program;
+  ASSERT_SUCCESS(urProgramGetNativeHandle(program, &original_program));
+  ASSERT_SUCCESS(urProgramGetNativeHandle(property_value, &new_program));
+  ASSERT_EQ(original_program, new_program);
 }
 
 TEST_P(urKernelGetInfoTest, SuccessAttributes) {

--- a/unified-runtime/test/conformance/platform/urPlatformGetInfo.cpp
+++ b/unified-runtime/test/conformance/platform/urPlatformGetInfo.cpp
@@ -128,6 +128,31 @@ TEST_P(urPlatformGetInfoTest, SuccessAdapter) {
   ASSERT_NE(adapter_found, uur::AdapterEnvironment::instance->adapters.end());
 }
 
+TEST_P(urPlatformGetInfoTest, SuccessRoundtripAdapter) {
+  const ur_platform_info_t property_name = UR_PLATFORM_INFO_ADAPTER;
+  size_t property_size = sizeof(ur_adapter_handle_t);
+
+  ur_adapter_handle_t adapter = nullptr;
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urPlatformGetInfo(platform, UR_PLATFORM_INFO_ADAPTER,
+                        sizeof(ur_adapter_handle_t), &adapter, nullptr),
+      UR_PLATFORM_INFO_ADAPTER);
+
+  ur_native_handle_t native_platform;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urPlatformGetNativeHandle(platform, &native_platform));
+
+  ur_platform_handle_t from_native_platform;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urPlatformCreateWithNativeHandle(
+      native_platform, adapter, nullptr, &from_native_platform));
+
+  ur_adapter_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urPlatformGetInfo(from_native_platform, property_name,
+                                   property_size, &property_value, nullptr));
+
+  ASSERT_EQ(adapter, property_value);
+}
+
 TEST_P(urPlatformGetInfoTest, InvalidNullHandlePlatform) {
   size_t property_size = 0;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,

--- a/unified-runtime/test/conformance/program/urProgramGetInfo.cpp
+++ b/unified-runtime/test/conformance/program/urProgramGetInfo.cpp
@@ -51,6 +51,25 @@ TEST_P(urProgramGetInfoTest, SuccessContext) {
   ASSERT_EQ(property_value, context);
 }
 
+TEST_P(urProgramGetInfoTest, SuccessRoundtripContext) {
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_CONTEXT;
+  size_t property_size = sizeof(ur_context_handle_t);
+
+  ur_native_handle_t native_program;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urProgramGetNativeHandle(program, &native_program));
+
+  ur_program_handle_t from_native_program;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urProgramCreateWithNativeHandle(
+      native_program, context, nullptr, &from_native_program));
+
+  ur_context_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urProgramGetInfo(from_native_program, property_name,
+                                  property_size, &property_value, nullptr));
+
+  ASSERT_EQ(property_value, context);
+}
+
 TEST_P(urProgramGetInfoTest, SuccessNumDevices) {
   size_t property_size = 0;
   const ur_program_info_t property_name = UR_PROGRAM_INFO_NUM_DEVICES;

--- a/unified-runtime/test/conformance/queue/urQueueGetInfo.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueGetInfo.cpp
@@ -27,6 +27,25 @@ TEST_P(urQueueGetInfoTest, SuccessContext) {
   ASSERT_EQ(context, property_value);
 }
 
+TEST_P(urQueueGetInfoTest, SuccessRoundtripContext) {
+  const ur_queue_info_t property_name = UR_QUEUE_INFO_CONTEXT;
+  size_t property_size = sizeof(ur_context_handle_t);
+
+  ur_native_handle_t native_queue;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urQueueGetNativeHandle(queue, nullptr, &native_queue));
+
+  ur_queue_handle_t from_native_queue;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urQueueCreateWithNativeHandle(
+      native_queue, context, device, nullptr, &from_native_queue));
+
+  ur_context_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urQueueGetInfo(from_native_queue, property_name, property_size,
+                                &property_value, nullptr));
+
+  ASSERT_EQ(property_value, context);
+}
+
 TEST_P(urQueueGetInfoTest, SuccessDevice) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
@@ -43,6 +62,73 @@ TEST_P(urQueueGetInfoTest, SuccessDevice) {
                                 &property_value, nullptr));
 
   ASSERT_EQ(device, property_value);
+}
+
+TEST_P(urQueueGetInfoTest, SuccessRoundtripDevice) {
+  // Segfaults
+  UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
+
+  const ur_queue_info_t property_name = UR_QUEUE_INFO_DEVICE;
+  size_t property_size = 0;
+
+  ur_native_handle_t native_queue;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urQueueGetNativeHandle(queue, nullptr, &native_queue));
+
+  ur_queue_handle_t from_native_queue;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urQueueCreateWithNativeHandle(
+      native_queue, context, device, nullptr, &from_native_queue));
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(urQueueGetInfo(from_native_queue,
+                                                  property_name, 0, nullptr,
+                                                  &property_size),
+                                   property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_handle_t));
+
+  ur_device_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urQueueGetInfo(from_native_queue, property_name, property_size,
+                                &property_value, nullptr));
+
+  ASSERT_EQ(property_value, device);
+}
+
+TEST_P(urQueueGetInfoTest, SuccessRoundtripNullDevice) {
+  // Segfaults
+  UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
+
+  const ur_queue_info_t property_name = UR_QUEUE_INFO_DEVICE;
+  size_t property_size = 0;
+
+  ur_native_handle_t native_queue;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urQueueGetNativeHandle(queue, nullptr, &native_queue));
+
+  ur_queue_handle_t from_native_queue;
+  auto result = urQueueCreateWithNativeHandle(native_queue, context, nullptr,
+                                              nullptr, &from_native_queue);
+  if (result == UR_RESULT_ERROR_INVALID_NULL_HANDLE) {
+    GTEST_SKIP() << "Implementation requires a valid device";
+  }
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(result);
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(urQueueGetInfo(from_native_queue,
+                                                  property_name, 0, nullptr,
+                                                  &property_size),
+                                   property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_handle_t));
+
+  ur_device_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urQueueGetInfo(from_native_queue, property_name, property_size,
+                                &property_value, nullptr));
+
+  // We can't assume that the two device handles are equal (since creating the
+  // link to the UR structures has been severed by going through native handle,
+  // so just check the underlying native pointers
+  ur_native_handle_t original_device;
+  ur_native_handle_t new_device;
+  ASSERT_SUCCESS(urDeviceGetNativeHandle(device, &original_device));
+  ASSERT_SUCCESS(urDeviceGetNativeHandle(property_value, &new_device));
+  ASSERT_EQ(original_device, new_device);
 }
 
 TEST_P(urQueueGetInfoTest, SuccessFlags) {

--- a/unified-runtime/test/conformance/sampler/urSamplerGetInfo.cpp
+++ b/unified-runtime/test/conformance/sampler/urSamplerGetInfo.cpp
@@ -48,6 +48,25 @@ TEST_P(urSamplerGetInfoTest, SuccessContext) {
   ASSERT_EQ(property_value, context);
 }
 
+TEST_P(urSamplerGetInfoTest, SuccessRoundtripContext) {
+  const ur_sampler_info_t property_name = UR_SAMPLER_INFO_CONTEXT;
+  size_t property_size = sizeof(ur_context_handle_t);
+
+  ur_native_handle_t native_sampler;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urSamplerGetNativeHandle(sampler, &native_sampler));
+
+  ur_sampler_handle_t from_native_sampler;
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urSamplerCreateWithNativeHandle(
+      native_sampler, context, nullptr, &from_native_sampler));
+
+  ur_context_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urSamplerGetInfo(from_native_sampler, property_name,
+                                  property_size, &property_value, nullptr));
+
+  ASSERT_EQ(property_value, context);
+}
+
 TEST_P(urSamplerGetInfoTest, SuccessNormalizedCoords) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 


### PR DESCRIPTION
This tests that converting a UR handle to a native handle, then back
into a UR handle preserves/recreates any handles contained within it.

The event test is a special case; since urEventCreateWithNativeHandle
doesn't accept a queue paramater. For this, we tollerate a different
queue being created, as long as they both have the same underlying
native handle.
