### PR TITLE
[SYCL] Optimize creation of global objects in GlobalHandler

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -188,6 +188,11 @@ ProgramManager &GlobalHandler::getProgramManager() {
 
 std::unordered_map<PlatformImplPtr, ContextImplPtr> &
 GlobalHandler::getPlatformToDefaultContextCache() {
+  // The optimization with static reference is not done because
+  // there are public methods of the GlobalHandler
+  // that can set the MPlatformToDefaultContextCache back to nullptr.
+  // So one time initialization is not possible and we need
+  // to call getOrCreate on every access.
   return getOrCreate(MPlatformToDefaultContextCache);
 }
 

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -136,11 +136,11 @@ GlobalHandler &GlobalHandler::instance() {
 }
 
 template <typename T, typename... Types>
-T &GlobalHandler::getOrCreate(InstWithLock<T> &IWL, Types... Args) {
+T &GlobalHandler::getOrCreate(InstWithLock<T> &IWL, Types &&...Args) {
   const LockGuard Lock{IWL.Lock};
 
   if (!IWL.Inst)
-    IWL.Inst = std::make_unique<T>(Args...);
+    IWL.Inst = std::make_unique<T>(std::forward<Types>(Args)...);
 
   return *IWL.Inst;
 }
@@ -182,7 +182,8 @@ void GlobalHandler::registerSchedulerUsage(bool ModifyCounter) {
 }
 
 ProgramManager &GlobalHandler::getProgramManager() {
-  return getOrCreate(MProgramManager);
+  static ProgramManager &PM = getOrCreate(MProgramManager);
+  return PM;
 }
 
 std::unordered_map<PlatformImplPtr, ContextImplPtr> &
@@ -191,31 +192,41 @@ GlobalHandler::getPlatformToDefaultContextCache() {
 }
 
 std::mutex &GlobalHandler::getPlatformToDefaultContextCacheMutex() {
-  return getOrCreate(MPlatformToDefaultContextCacheMutex);
+  static std::mutex &PlatformToDefaultContextCacheMutex =
+      getOrCreate(MPlatformToDefaultContextCacheMutex);
+  return PlatformToDefaultContextCacheMutex;
 }
 
-Sync &GlobalHandler::getSync() { return getOrCreate(MSync); }
+Sync &GlobalHandler::getSync() {
+  static Sync &sync = getOrCreate(MSync);
+  return sync;
+}
 
 std::vector<PlatformImplPtr> &GlobalHandler::getPlatformCache() {
   return getOrCreate(MPlatformCache);
 }
 
 std::mutex &GlobalHandler::getPlatformMapMutex() {
-  return getOrCreate(MPlatformMapMutex);
+  static std::mutex &PlatformMapMutex = getOrCreate(MPlatformMapMutex);
+  return PlatformMapMutex;
 }
 
 std::mutex &GlobalHandler::getFilterMutex() {
-  return getOrCreate(MFilterMutex);
+  static std::mutex &FilterMutex = getOrCreate(MFilterMutex);
+  return FilterMutex;
 }
 
 std::vector<AdapterPtr> &GlobalHandler::getAdapters() {
+  static std::vector<AdapterPtr> &adapters = getOrCreate(MAdapters);
   enableOnCrashStackPrinting();
-  return getOrCreate(MAdapters);
+  return adapters;
 }
 
 ods_target_list &
 GlobalHandler::getOneapiDeviceSelectorTargets(const std::string &InitValue) {
-  return getOrCreate(MOneapiDeviceSelectorTargets, InitValue);
+  static ods_target_list &OneapiDeviceSelectorTargets =
+      getOrCreate(MOneapiDeviceSelectorTargets, InitValue);
+  return OneapiDeviceSelectorTargets;
 }
 
 XPTIRegistry &GlobalHandler::getXPTIRegistry() {
@@ -223,9 +234,8 @@ XPTIRegistry &GlobalHandler::getXPTIRegistry() {
 }
 
 ThreadPool &GlobalHandler::getHostTaskThreadPool() {
-  int Size = SYCLConfig<SYCL_QUEUE_THREAD_POOL_SIZE>::get();
-  ThreadPool &TP = getOrCreate(MHostTaskThreadPool, Size);
-
+  static ThreadPool &TP = getOrCreate(
+      MHostTaskThreadPool, SYCLConfig<SYCL_QUEUE_THREAD_POOL_SIZE>::get());
   return TP;
 }
 

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -208,7 +208,9 @@ Sync &GlobalHandler::getSync() {
 }
 
 std::vector<PlatformImplPtr> &GlobalHandler::getPlatformCache() {
-  return getOrCreate(MPlatformCache);
+  static std::vector<PlatformImplPtr> &PlatformCache =
+      getOrCreate(MPlatformCache);
+  return PlatformCache;
 }
 
 std::mutex &GlobalHandler::getPlatformMapMutex() {

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -113,7 +113,7 @@ private:
   };
 
   template <typename T, typename... Types>
-  T &getOrCreate(InstWithLock<T> &IWL, Types... Args);
+  T &getOrCreate(InstWithLock<T> &IWL, Types &&...Args);
 
   InstWithLock<Scheduler> MScheduler;
   InstWithLock<ProgramManager> MProgramManager;


### PR DESCRIPTION
This PR optimizes global object singleton creation by removing the `getOrCreate()` from the hot path for most of the global objects.

- `getOrCreate()` method locks mutex on every call 
- We cannot just use the C++11 way of creating static singleton variables inside corresponding methods because we need to control the destruction order of global objects. Therefore, we use static variables to cache the result of the `getOrCreate()` method so that it calls only once per global object.
- The optimization is not done for the `GlobalHandler::getPlatformToDefaultContextCache` method because there are public methods of the `GlobalHandler` that can set the `MPlatformToDefaultContextCache` back to `nullptr`.