### PR TITLE
[UR] Don't build hip/cuda adapter tests if dpcpp isn't available

### DIFF
--- a/unified-runtime/README.md
+++ b/unified-runtime/README.md
@@ -140,7 +140,7 @@ List of options provided by CMake:
 | UR_STATIC_ADAPTER_L0    | Build the Level-Zero adapter as static and embed in the loader | ON/OFF   | OFF |
 | UR_HIP_PLATFORM         | Build HIP adapter for AMD or NVIDIA platform           | AMD/NVIDIA | AMD     |
 | UR_ENABLE_COMGR         | Enable comgr lib usage           | AMD/NVIDIA | AMD     |
-| UR_DPCXX | Path of the DPC++ compiler executable to build CTS device binaries | File path | `""` |
+| UR_DPCXX | Path of the DPC++ compiler executable to build device binaries for testing | File path | `""` |
 | UR_DEVICE_CODE_EXTRACTOR | Path of the `clang-offload-extract` executable from the DPC++ package, required for CTS device binaries | File path | `"${dirname(UR_DPCXX)}/clang-offload-extract"` |
 | UR_DPCXX_BUILD_FLAGS | Build flags to pass to DPC++ when compiling device programs | Space-separated options list | `""` |
 | UR_SYCL_LIBRARY_DIR | Path of the SYCL runtime library directory to build CTS device binaries | Directory path | `""` |

--- a/unified-runtime/test/adapters/cuda/CMakeLists.txt
+++ b/unified-runtime/test/adapters/cuda/CMakeLists.txt
@@ -3,6 +3,12 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+if(NOT UR_DPCXX)
+    message(WARNING
+        "UR_DPCXX is not defined, skipping adapter-specific tests for Cuda")
+    return()
+endif()
+
 add_adapter_test(cuda
     FIXTURE DEVICES
     SOURCES

--- a/unified-runtime/test/adapters/hip/CMakeLists.txt
+++ b/unified-runtime/test/adapters/hip/CMakeLists.txt
@@ -3,6 +3,12 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+if(NOT UR_DPCXX)
+    message(WARNING
+        "UR_DPCXX is not defined, skipping adapter-specific tests for HIP")
+    return()
+endif()
+
 add_adapter_test(hip
     FIXTURE KERNELS
     SOURCES


### PR DESCRIPTION
These tests require device code, which isn't available if `UR_DPCXX`
is not set.
