### PR TITLE
[UR][L0] Report USM async allocations support

### DIFF
--- a/sycl/test-e2e/AsyncAlloc/device/memory_pool.cpp
+++ b/sycl/test-e2e/AsyncAlloc/device/memory_pool.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// XFAIL: level_zero
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17772
+
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/properties/queue_properties.hpp>

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1219,6 +1219,8 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue(true);
   case UR_DEVICE_INFO_MULTI_DEVICE_COMPILE_SUPPORT_EXP:
     return ReturnValue(true);
+  case UR_DEVICE_INFO_ASYNC_USM_ALLOCATIONS_SUPPORT_EXP:
+    return ReturnValue(true);
   case UR_DEVICE_INFO_CURRENT_CLOCK_THROTTLE_REASONS: {
     ur_device_throttle_reasons_flags_t ThrottleReasons = 0;
     if (!ParamValue) {


### PR DESCRIPTION
L0 has most of the support for async allocations ready, however it wasn't reporting the correct aspect so the tests didn't run.

This patch enables the aspect and disables the one test that was failing for L0. See https://github.com/intel/llvm/issues/17772 for ticket to fix L0 support.