### PR TITLE
[SYCL][E2E] enable graph tests for L0 v2 adapter

### DIFF
--- a/sycl/test-e2e/Graph/Profiling/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/Profiling/event_profiling_info.cpp
@@ -6,6 +6,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
+// UNSUPPORTED: level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17760
+
 // This test checks the profiling of an event returned
 // from graph submission with event::get_profiling_info().
 // It first tests a graph made exclusively of memory operations,

--- a/sycl/test-e2e/Graph/Profiling/event_profiling_info_usm.cpp
+++ b/sycl/test-e2e/Graph/Profiling/event_profiling_info_usm.cpp
@@ -6,6 +6,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
+// UNSUPPORTED: level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17760
+
 // This test checks the profiling of an event returned
 // from graph submission with event::get_profiling_info().
 // It first tests a graph made exclusively of memory operations,

--- a/sycl/test-e2e/Graph/Update/lit.local.cfg
+++ b/sycl/test-e2e/Graph/Update/lit.local.cfg
@@ -1,1 +1,3 @@
 config.required_features += ['aspect-ext_oneapi_graph']
+# V2 does not have support for MCL yet
+config.unsupported_features += ['level_zero_v2_adapter']

--- a/sycl/test-e2e/Graph/lit.local.cfg
+++ b/sycl/test-e2e/Graph/lit.local.cfg
@@ -1,4 +1,3 @@
 # https://github.com/intel/llvm/issues/17165
 if 'windows' in config.available_features:
    config.unsupported_features += ['arch-intel_gpu_bmg_g21']
-config.unsupported_features += ['level_zero_v2_adapter']


### PR DESCRIPTION
The V2 adapter now has all required functionality.