### PR TITLE
[CI] Run build on Ubuntu 22, pre-commit if CUDA adapter changes.

### DIFF
--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -75,6 +75,8 @@ jobs:
             ur:
               - 'unified-runtime/**'
               - .github/workflows/ur-*
+            ur_cuda_adapter:
+              - 'unified-runtime/source/adapters/cuda/**'
 
       - name: Set output
         id: result
@@ -87,7 +89,7 @@ jobs:
               return '${{ steps.changes.outputs.changes }}';
             }
             // Treat everything as changed for huge PRs.
-            return ["llvm", "llvm_spirv", "clang", "sycl_jit", "xptifw", "libclc", "sycl", "ci", "esimd", "ur"];
+            return ["llvm", "llvm_spirv", "clang", "sycl_jit", "xptifw", "libclc", "sycl", "ci", "esimd", "ur", "ur_cuda_adapter"];
 
       - run: echo '${{ steps.result.outputs.result }}'
      

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -52,6 +52,22 @@ jobs:
       changes: ${{ needs.detect_changes.outputs.filters }}
       e2e_binaries_artifact: sycl_e2e_bin_default
 
+  # If a PR changes CUDA adapter, run the build on Ubuntu 22.04 as well.
+  # Ubuntu 22.04 container has CUDA 12.1 installed while Ubuntu 24.0 image
+  # has CUDA 12.6.1 installed.
+  # The idea is to ensure that the code works with both CUDA versions.
+  build_ubuntu2204:
+    needs: [detect_changes]
+    if: always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur_cuda_adapter')
+    uses: ./.github/workflows/sycl-linux-build.yml
+    with:
+      build_ref: ${{ github.sha }}
+      build_cache_root: "/__w/"
+      build_artifact_suffix: "default"
+      build_cache_suffix: "default"
+      build_image: "ghcr.io/intel/llvm/ubuntu2204_build:latest"
+      changes: ${{ needs.detect_changes.outputs.filters }}
+
   run_prebuilt_e2e_tests:
     needs: [build, detect_changes]
     if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}


### PR DESCRIPTION
Our Ubuntu 22.04 container has CUDA 12.1 installed while Ubuntu 24.04 image has CUDA 12.6.1 installed.
If a PR changes CUDA adapter, we should test the change with both CUDA versions.