### PR TITLE
[SYCL][E2E] Decrease per-test timeout in run-only mode

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -1011,6 +1011,11 @@ if lit_config.params.get("print_features", False):
 try:
     import psutil
 
-    lit_config.maxIndividualTestTime = 600
+    if config.test_mode == "run-only":
+        lit_config.maxIndividualTestTime = 300
+    else:
+        lit_config.maxIndividualTestTime = 600
+
 except ImportError:
     pass
+

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -1018,4 +1018,3 @@ try:
 
 except ImportError:
     pass
-


### PR DESCRIPTION
I've looked through logs of some recent pre-commit jobs (both Lin/Win) and the only test that was longer than 5 min on just some occasions is `KernelCompiler/sycl.cpp`. I talked to Chris and he'll upload a change to reduce its time soon. The rest seemed to be comfortably under 5 minutes, so set per-test timeout to that value in run-only mode.