### PR TITLE
[SYCL] Reduce test time for kernel compiler tests

### DIFF
--- a/sycl/test-e2e/KernelCompiler/opencl.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl.cpp
@@ -12,7 +12,6 @@
 
 // -- Test the kernel_compiler with OpenCL source.
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
 // RUN: %{l0_leak_check} %{run} %t.out
 
 // -- Test again, with caching.

--- a/sycl/test-e2e/KernelCompiler/sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl.cpp
@@ -16,7 +16,6 @@
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17255
 
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
 // RUN: %{l0_leak_check} %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/KernelCompiler/sycl_device_globals.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_device_globals.cpp
@@ -15,7 +15,6 @@
 // UNSUPPORTED-TRACKER: GSD-4287
 
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
 // RUN: %{l0_leak_check} %{run} %t.out
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
We don't need to run twice (once with leak check, once without).  If the leak check isn't there, it still runs