### PR TITLE
[CI] 2nd attempt to skip filtering large PR

### DIFF
--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Check file changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
-        if: ${{ steps.changed_files.outputs.changed_files }} < 500
+        if: ${{ fromJSON(steps.changed_files.outputs.changed_files) }} < 500
         id: changes
         with:
           filters: |

--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const changedFiles = context.payload.pull_request.changed_files;
-            console.log("Number of files changed:", changedFiles);
-            return { changed_file_cnt: changedFiles } ;
+            console.log("Number of files changed:");
+            console.log(context.payload.pull_request.changed_files);
+            return context.payload.pull_request.changed_files ;
 
       - name: Check file changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
-        if: ${{ steps.changed_files.outputs.changed_file_cnt }} < 500
+        if: ${{ steps.changed_files.outputs.changed_files }} < 500
         id: changes
         with:
           filters: |

--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            console.log("Number of files changed:");
-            console.log(context.payload.pull_request.changed_files);
-            return context.payload.pull_request.changed_files ;
+            const changedFiles = context.payload.pull_request.changed_files;
+            console.log("Number of files changed:", changedFiles);
+            return { changed_file_cnt: changedFiles } ;
 
       - name: Check file changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
-        if: ${{ steps.changed_files.outputs.changed_files }} < 500
+        if: ${{ steps.changed_files.outputs.changed_file_cnt }} < 500
         id: changes
         with:
           filters: |

--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Check file changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
-        if: ${{ fromJSON(steps.changed_files.outputs.changed_files) }} < 500
+        if: ${{ steps.changed_files.outputs.changed_files }} < 500
         id: changes
         with:
           filters: |


### PR DESCRIPTION
Problem
Output Access: The output from the changed_files step is being accessed
incorrectly. The changed_files step returns a value, but it's not being
stored in a way that can be directly accessed in the if condition.

Type Mismatch: The output from the changed_files step is likely a
string, and you're trying to compare it as a number. This can lead to
unexpected behavior.

Solution
To fix the issue, you need to ensure that the output from the
changed_files step is correctly stored and accessed

Why It Works for steps.result.outputs.result for
steps.result.outputs.result

Direct Access: The script directly accesses
context.payload.pull_request.changed_files and performs the comparison
within the JavaScript environment, which is more flexible and allows for
direct manipulation of data.

Output Return: The script returns a value based on the condition, which
is then used as the output of the step. This output can be accessed in
subsequent steps using ${{ steps.result.outputs.result }}.

Difference from if Condition
The if condition in GitHub Actions is evaluated using the expression
syntax, which requires correct access to step outputs and proper
handling of data types. The issue you faced was due to incorrect access
to the output and potential type mismatch, whereas the script handles
these aspects internally and directly.
