### PR TITLE
[SYCL] Void unused variable

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -371,7 +371,7 @@ static constexpr std::array<T, N> RepeatValue(const T &Arg) {
     assert(false);                                                             \
   }
 #else
-#define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, [[maybe_unused]] e)
+#define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, e) (void)e;
 #endif
 
 // Tag to help create CTAD definition to avoid ctad-maybe-unsupported warning

--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -371,7 +371,7 @@ static constexpr std::array<T, N> RepeatValue(const T &Arg) {
     assert(false);                                                             \
   }
 #else
-#define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, e)
+#define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, [[maybe_unused]] e)
 #endif
 
 // Tag to help create CTAD definition to avoid ctad-maybe-unsupported warning


### PR DESCRIPTION
If assertions are disabled this warning is treated as an error: warning C4101: 'e': unreferenced local variable