### PR TITLE
[SYCL] Reduce compile time overhead of `StoreLambda` for simple kernels

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -233,6 +233,7 @@ set(SYCL_COMMON_SOURCES
     "builtins/math_functions.cpp"
     "builtins/native_math_functions.cpp"
     "builtins/relational_functions.cpp"
+    "cg_types.cpp"
     "detail/accessor_impl.cpp"
     "detail/allowlist.cpp"
     "detail/bindless_images.cpp"

--- a/sycl/source/cg_types.cpp
+++ b/sycl/source/cg_types.cpp
@@ -1,0 +1,18 @@
+//==---- cg_types.cpp - Auxiliary types required by command group class ----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <sycl/detail/cg_types.hpp>
+
+namespace sycl {
+inline namespace _V1 {
+
+namespace detail {
+__SYCL_EXPORT bool do_not_dce(void (*)(void *)) { return true; }
+} // namespace detail
+} // namespace _V1
+} // namespace sycl


### PR DESCRIPTION
In particular, those that are trivially copyable and destructible (so, no accessors or other special classes as arguments).

Doesn't seem to help :(