### PR TITLE
[SYCL][UR][Bench] bump IGC depdency version fro benchmarks

### DIFF
--- a/devops/scripts/benchmarks/utils/compute_runtime.py
+++ b/devops/scripts/benchmarks/utils/compute_runtime.py
@@ -97,7 +97,7 @@ class ComputeRuntime:
             options.workdir,
             "vc-intrinsics",
             "https://github.com/intel/vc-intrinsics",
-            "facb2076a2ce6cd6527c1e16570ba0fbaa2f1dba",
+            "b980474c99859f7e4eb157828c5e80202b062177",
         )
         self.llvm_project = git_clone(
             options.workdir,


### PR DESCRIPTION
To fix compilation issue with the newest compute-runtime