### PR TITLE
[CI] Bump Level Zero version to 1.20.6

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.20.2",
-      "version": "v1.20.2",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.20.2",
+      "github_tag": "v1.20.6",
+      "version": "v1.20.6",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.20.6",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
Theory from [here](https://github.com/intel/llvm/pull/17774#issuecomment-2769890613) is we need to match the version from [here](https://github.com/intel/compute-runtime/blob/25.09.32961.7/manifests/manifest.yml#L50-L56).