### PR TITLE
[SYCL] Void unused variable (#17766)

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -371,7 +371,7 @@ static constexpr std::array<T, N> RepeatValue(const T &Arg) {
     assert(false);                                                             \
   }
 #else
-#define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, e)
+#define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, e) (void)e;
 #endif
 
 } // namespace detail


### PR DESCRIPTION
If assertions are disabled this warning is treated as an error: warning
C4101: 'e': unreferenced local variable
CHERRY-PICK OF 9303f5a8c7947f3c7d7c8cd0a7043513a7023092