### PR TITLE
[SYCL][UR][L0 v2] fix urQueueCreateWithNativeHandle

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -35,7 +35,8 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     const ur_exp_command_buffer_desc_t *desc)
     : commandListManager(
           context, device,
-          std::forward<v2::raii::command_list_unique_handle>(commandList)),
+          std::forward<v2::raii::command_list_unique_handle>(commandList),
+          v2::EVENT_FLAGS_COUNTER, nullptr),
       isUpdatable(desc ? desc->isUpdatable : false) {}
 
 ur_result_t ur_exp_command_buffer_handle_t_::finalizeCommandBuffer() {

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -172,7 +172,7 @@ ur_command_list_manager::getWaitListView(const ur_event_handle_t *phWaitEvents,
 ze_event_handle_t
 ur_command_list_manager::getSignalEvent(ur_event_handle_t *hUserEvent,
                                         ur_command_t commandType) {
-  if (hUserEvent && queue) {
+  if (hUserEvent) {
     *hUserEvent = eventPool->allocate();
     (*hUserEvent)->resetQueueAndCommand(queue, commandType);
     return (*hUserEvent)->getZeEvent();

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -36,8 +36,7 @@ struct ur_command_list_manager {
   ur_command_list_manager(ur_context_handle_t context,
                           ur_device_handle_t device,
                           v2::raii::command_list_unique_handle &&commandList,
-                          v2::event_flags_t flags = v2::EVENT_FLAGS_COUNTER,
-                          ur_queue_t_ *queue = nullptr);
+                          v2::event_flags_t flags, ur_queue_t_ *queue);
   ur_command_list_manager(ur_command_list_manager &&src) = default;
   ~ur_command_list_manager();
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -90,7 +90,7 @@ ur_queue_immediate_in_order_t::ur_queue_immediate_in_order_t(
                   }
                 }
               }),
-          eventFlagsFromQueueFlags(flags)) {}
+          eventFlagsFromQueueFlags(flags), this) {}
 
 ze_event_handle_t ur_queue_immediate_in_order_t::getSignalEvent(
     locked<ur_command_list_manager> &commandList, ur_event_handle_t *hUserEvent,


### PR DESCRIPTION
getSignalEvent in ur_command_list_manager returned nullptr when queue was not set. This was the case when initializing the command list manager in queue ctor called from urQueueCreateWithNativeHandle.

Fix this by passing queue to the command list manager and removing the default nullptr value from the ctor (to avoid this issue in future).

Also, even if queue is nullptr, return the event instead of nullptr from getSignalEvent. This event is mostly functional, it just cannot be used for profiling.