### PR TITLE
[SYCL] Stabilize linux pre-commit on 6.1 release branch

### DIFF
--- a/sycl/test-e2e/AOT/cpu.cpp
+++ b/sycl/test-e2e/AOT/cpu.cpp
@@ -8,7 +8,8 @@
 
 // REQUIRES: opencl-aot, cpu
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %S/Inputs/aot.cpp -o %t.out
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 %S/Inputs/aot.cpp -o %t.out
 // RUN: %{run} %t.out
 
 // Test that opencl-aot can handle multiple build options.

--- a/sycl/test-e2e/AOT/double.cpp
+++ b/sycl/test-e2e/AOT/double.cpp
@@ -3,7 +3,9 @@
 
 // REQUIRES: ocloc, opencl-aot, any-device-is-cpu
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -o %t.tgllp.out %s
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
+
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 
 // ocloc on windows does not have support for PVC, so this command will

--- a/sycl/test-e2e/AOT/half.cpp
+++ b/sycl/test-e2e/AOT/half.cpp
@@ -3,7 +3,9 @@
 
 // REQUIRES: ocloc, opencl-aot, any-device-is-cpu
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -o %t.tgllp.out %s
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
+
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 
 // ocloc on windows does not have support for PVC, so this command will

--- a/sycl/test-e2e/Adapters/sycl-targets-order.cpp
+++ b/sycl/test-e2e/Adapters/sycl-targets-order.cpp
@@ -5,8 +5,7 @@
 // RUN: %{run-unfiltered-devices} env ONEAPI_DEVICE_SELECTOR="opencl:*" %t-nvptx64-spir64.out
 // RUN: %{run-unfiltered-devices} env ONEAPI_DEVICE_SELECTOR="cuda:*"   %t-nvptx64-spir64.out
 
-// REQUIRES: opencl, cuda
-// REQUIRES: build-and-run-mode
+// REQUIRES: opencl, target-spir, any-triple-is-nvidia
 
 //==------- sycl-targets-order.cpp - SYCL -fsycl-targets order test --------==//
 //
@@ -36,7 +35,7 @@ int main(int argc, char **argv) {
   sycl::buffer<unsigned int, 1> buffer(4);
 
   // size of the index space for the kernel
-  sycl::range<1> NumOfWorkItems{buffer.get_count()};
+  sycl::range<1> NumOfWorkItems{buffer.size()};
 
   // submit a command group(work) to the queue
   queue.submit([&](sycl::handler &cgh) {
@@ -55,7 +54,7 @@ int main(int argc, char **argv) {
 
   // check the results
   bool mismatch = false;
-  for (unsigned int i = 0; i < buffer.get_count(); ++i) {
+  for (unsigned int i = 0; i < buffer.size(); ++i) {
     if (host_accessor[i] != i) {
       std::cout << "The result is incorrect for element: " << i
                 << " , expected: " << i << " , got: " << host_accessor[i]

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global.cpp
@@ -15,7 +15,7 @@
 // a choice based on that. This is rather fragile but workarounds the issue for
 // the time being.
 
-// DEFINE: %{not} = not %if test-mode-run-only %{ --crash %}
+// DEFINE: %{not} = not %if run-mode && !build-mode %{ --crash %}
 
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
 // RUN: %{run} %{not} %t1.out 2>&1 | FileCheck %s

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global.cpp
@@ -1,10 +1,28 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
+
+// The following is an ugly hack to make CI pass. The issue here is that when
+// sycl-toolchain is built with assertions enabled, then we hit one at
+// `DeviceGlobalUSMMem::~DeviceGlobalUSMMem()` and exit with abort. If not, then
+// sanitizer does `exit(1)`.
+//
+// That doesn't matter as long as LIT does *not* use "external shell", but when
+// it does, the difference between `not` and `not --crash` becomes crucial and
+// we cannot have a single command that would match both behaviors. Ideally,
+// we'd need to make a choice based on how the toolchain was built.
+// Unfortunately, we don't have that information at the LIT level and
+// propagating it all the way down to it would be ugly. Instead, rely on the
+// fact that "no-assertion" mode doesn't use "run-only" lit invocations and make
+// a choice based on that. This is rather fragile but workarounds the issue for
+// the time being.
+
+// DEFINE: %{not} = not %if test-mode-run-only %{ --crash %}
+
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} %{not} %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} %{not} %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} %{not} %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/BFloat16/bfloat16_example_aot.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example_aot.cpp
@@ -11,7 +11,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xsycl-target-backend=spir64_gen "-device gen12lp" %s -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device gen12lp" %s -o %t.out
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device gen12lp" %s -o %t.out
 // RUN: %{run} %t.out
 
 #include "bfloat16_example.hpp"

--- a/sycl/test-e2e/BFloat16/bfloat16_example_aot_cpu.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example_aot_cpu.cpp
@@ -8,7 +8,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
 // RUN: %if cpu %{ %{run} %t.out %}
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
 // RUN: %if cpu %{ %{run} %t.out %}
 
 #include "bfloat16_example.hpp"

--- a/sycl/test-e2e/Compression/compression_aot.cpp
+++ b/sycl/test-e2e/Compression/compression_aot.cpp
@@ -1,5 +1,6 @@
 // End-to-End test for testing device image compression in AOT.
 // REQUIRES: zstd, opencl-aot, cpu
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %O0 --offload-compress --offload-compression-level=3 %S/Inputs/single_kernel.cpp -o %t_compress.out
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 %O0 --offload-compress --offload-compression-level=3 %S/Inputs/single_kernel.cpp -o %t_compress.out
 // RUN: %{run} %t_compress.out

--- a/sycl/test-e2e/Compression/compression_separate_compile.cpp
+++ b/sycl/test-e2e/Compression/compression_separate_compile.cpp
@@ -3,25 +3,26 @@
 
 // REQUIRES: zstd, opencl-aot, cpu, linux
 
+// CPU AOT targets host isa, so we compile everything on the run system instead.
 //////////////////////  Compile device images
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-host-compiler=clang++ -fsycl-host-compiler-options='-std=c++17 -Wno-attributes -Wno-deprecated-declarations -fPIC -DENABLE_KERNEL1' -DENABLE_KERNEL1 -c %s -o %t_kernel1_aot.o
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-host-compiler=clang++ -fsycl-host-compiler-options='-std=c++17 -Wno-attributes -Wno-deprecated-declarations -fPIC -DENABLE_KERNEL2' -DENABLE_KERNEL2 -c %s -o %t_kernel2_aot.o
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-host-compiler=clang++ -fsycl-host-compiler-options='-std=c++17 -Wno-attributes -Wno-deprecated-declarations -fPIC -DENABLE_KERNEL1' -DENABLE_KERNEL1 -c %s -o %t_kernel1_aot.o
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-host-compiler=clang++ -fsycl-host-compiler-options='-std=c++17 -Wno-attributes -Wno-deprecated-declarations -fPIC -DENABLE_KERNEL2' -DENABLE_KERNEL2 -c %s -o %t_kernel2_aot.o
 
 //////////////////////   Link device images
-// RUN: %clangxx --offload-compress -fsycl -fsycl-link -fsycl-targets=spir64_x86_64 -fPIC %t_kernel1_aot.o %t_kernel2_aot.o -o %t_compressed_image.o -v
+// RUN: %{run-aux} %clangxx --offload-compress -fsycl -fsycl-link -fsycl-targets=spir64_x86_64 -fPIC %t_kernel1_aot.o %t_kernel2_aot.o -o %t_compressed_image.o -v
 
 // Make sure the clang-offload-wrapper is called with the --offload-compress
 // option.
-// RUN: %clangxx --offload-compress -fsycl -fsycl-link -fsycl-targets=spir64_x86_64 -fPIC %t_kernel1_aot.o %t_kernel2_aot.o -o %t_compressed_image.o -### &> %t_driver_opts.txt
-// RUN: FileCheck -input-file=%t_driver_opts.txt %s --check-prefix=CHECK-DRIVER-OPTS
+// RUN: %{run-aux} %clangxx --offload-compress -fsycl -fsycl-link -fsycl-targets=spir64_x86_64 -fPIC %t_kernel1_aot.o %t_kernel2_aot.o -o %t_compressed_image.o -### &> %t_driver_opts.txt
+// RUN: %{run-aux} FileCheck -input-file=%t_driver_opts.txt %s --check-prefix=CHECK-DRIVER-OPTS
 
 // CHECK-DRIVER-OPTS: clang-offload-wrapper{{.*}} "-offload-compress"
 
 //////////////////////   Compile the host program
-// RUN: %clangxx -fsycl -std=c++17 -Wno-attributes -Wno-deprecated-declarations -fPIC -c %s -o %t_main.o
+// RUN: %{run-aux} %clangxx -fsycl -std=c++17 -Wno-attributes -Wno-deprecated-declarations -fPIC -c %s -o %t_main.o
 
 //////////////////////   Link the host program and compressed device images
-// RUN: %clangxx -fsycl %t_main.o %t_kernel1_aot.o %t_kernel2_aot.o %t_compressed_image.o -o %t_compress.out
+// RUN: %{run-aux} %clangxx -fsycl %t_main.o %t_kernel1_aot.o %t_kernel2_aot.o %t_compressed_image.o -o %t_compress.out
 
 // RUN: %{run} %t_compress.out
 

--- a/sycl/test-e2e/DeviceArchitecture/device_architecture_on_device_aot.cpp
+++ b/sycl/test-e2e/DeviceArchitecture/device_architecture_on_device_aot.cpp
@@ -1,5 +1,7 @@
 // REQUIRES: opencl-aot, cpu
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %s -o %t.out
+
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeviceCodeSplit/aot-cpu.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/aot-cpu.cpp
@@ -1,5 +1,6 @@
 // REQUIRES: opencl-aot, cpu
 
-// RUN: %clangxx -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_x86_64 -I %S/Inputs -o %t.out %S/split-per-source-main.cpp %S/Inputs/split-per-source-second-file.cpp \
-// RUN: -fsycl-dead-args-optimization
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_x86_64 -I %S/Inputs -o %t.out \
+// RUN:   %S/split-per-source-main.cpp %S/Inputs/split-per-source-second-file.cpp -fsycl-dead-args-optimization
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/DeviceLib/assert-aot.cpp
+++ b/sycl/test-e2e/DeviceLib/assert-aot.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: opencl-aot, cpu, linux
 
-// RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=spir64_x86_64 %S/assert.cpp -o %t.aot.out
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=spir64_x86_64 %S/assert.cpp -o %t.aot.out
 // RUN: env EXPECTED_SIGNAL=SIGABRT SHOULD_CRASH=1 %{run} %t.aot.out 2>&1 | FileCheck %S/assert.cpp --check-prefixes=CHECK-MESSAGE

--- a/sycl/test-e2e/DeviceLib/cmath-aot.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath-aot.cpp
@@ -3,14 +3,15 @@
 
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %{mathflags} %S/cmath_test.cpp -o %t.cmath.out
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 %{mathflags} %S/cmath_test.cpp -o %t.cmath.out
 // RUN: %{run} %t.cmath.out
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %{mathflags} %S/cmath_fp64_test.cpp -o %t.cmath.fp64.out
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 %{mathflags} %S/cmath_fp64_test.cpp -o %t.cmath.fp64.out
 // RUN: %{run} %t.cmath.fp64.out
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %{mathflags} %S/std_complex_math_test.cpp -o %t.complex.out
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 %{mathflags} %S/std_complex_math_test.cpp -o %t.complex.out
 // RUN: %{run} %t.complex.out
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %{mathflags} %S/std_complex_math_fp64_test.cpp -o %t.complex.fp64.out
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 %{mathflags} %S/std_complex_math_fp64_test.cpp -o %t.complex.fp64.out
 // RUN: %{run} %t.complex.fp64.out

--- a/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
+++ b/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
@@ -2,37 +2,36 @@
 // cannot do that reliably when number of devices is unknown.
 //
 // REQUIRES: level_zero, ocloc
-// REQUIRES: build-and-run-mode
 //
 // DEFINE: %{cache_vars} = env SYCL_CACHE_PERSISTENT=1 SYCL_CACHE_TRACE=1 SYCL_CACHE_DIR=%t/cache_dir
 // DEFINE: %{build_cmd} = %{build}
-// RUN: mkdir -p %t/cache_dir
+// RUN: %{run-aux} mkdir -p %t/cache_dir
 //
 // The following block of code should be copy-pasted as-is to verify different
 // JIT/AOT options. Don't know how to avoid code duplication.
 // ******************************
 // Check the logs first.
-// RUN: %{build_cmd} -DVALUE=1 -o %t.out
-// RUN: rm -rf %t/cache_dir/*
+// RUN: %{run-aux} %{build_cmd} -DVALUE=1 -o %t.out
+// RUN: %{run-aux} rm -rf %t/cache_dir/*
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-WRITE
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 //
 // Now try to substitute the cached image and verify it is actually taken and
 // the code/binary there is executed.
-// RUN: mv %t/cache_dir/*/*/*/*/*.bin %t.value1.bin
-// RUN: rm -rf %t/cache_dir/*
-// RUN: %{build_cmd} -DVALUE=2 -o %t.out
+// RUN: %{run-aux} mv %t/cache_dir/*/*/*/*/*.bin %t.value1.bin
+// RUN: %{run-aux} rm -rf %t/cache_dir/*
+// RUN: %{run-aux} %{build_cmd} -DVALUE=2 -o %t.out
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefixes RESULT2
-// RUN: mv %t.value1.bin %t/cache_dir/*/*/*/*/*.bin
+// RUN: %{run-aux} mv %t.value1.bin %t/cache_dir/*/*/*/*/*.bin
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefixes RESULT1
 // ******************************
 //
 // REDEFINE: %{build_cmd} = %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device acm-g10" %s
 // ******************************
 // Check the logs first.
-// RUN: %{build_cmd} -DVALUE=1 -o %t.out
-// RUN: rm -rf %t/cache_dir/*
+// RUN: %{run-aux} %{build_cmd} -DVALUE=1 -o %t.out
+// RUN: %{run-aux} rm -rf %t/cache_dir/*
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-WRITE
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
@@ -40,30 +39,30 @@
 //
 // Now try to substitute the cached image and verify it is actually taken and
 // the code/binary there is executed.
-// RUN: mv %t/cache_dir/*/*/*/*/*.bin %t.value1.bin
-// RUN: rm -rf %t/cache_dir/*
-// RUN: %{build_cmd} -DVALUE=2 -o %t.out
+// RUN: %{run-aux} mv %t/cache_dir/*/*/*/*/*.bin %t.value1.bin
+// RUN: %{run-aux} rm -rf %t/cache_dir/*
+// RUN: %{run-aux} %{build_cmd} -DVALUE=2 -o %t.out
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefixes RESULT2
-// RUN: mv %t.value1.bin %t/cache_dir/*/*/*/*/*.bin
+// RUN: %{run-aux} mv %t.value1.bin %t/cache_dir/*/*/*/*/*.bin
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefixes RESULT1
 // ******************************
 //
 // REDEFINE: %{build_cmd} = %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device acm-g10,acm-g11" %s
 // ******************************
 // Check the logs first.
-// RUN: %{build_cmd} -DVALUE=1 -o %t.out
-// RUN: rm -rf %t/cache_dir/*
+// RUN: %{run-aux} %{build_cmd} -DVALUE=1 -o %t.out
+// RUN: %{run-aux} rm -rf %t/cache_dir/*
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-WRITE
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 //
 // Now try to substitute the cached image and verify it is actually taken and
 // the code/binary there is executed.
-// RUN: mv %t/cache_dir/*/*/*/*/*.bin %t.value1.bin
-// RUN: rm -rf %t/cache_dir/*
-// RUN: %{build_cmd} -DVALUE=2 -o %t.out
+// RUN: %{run-aux} mv %t/cache_dir/*/*/*/*/*.bin %t.value1.bin
+// RUN: %{run-aux} rm -rf %t/cache_dir/*
+// RUN: %{run-aux} %{build_cmd} -DVALUE=2 -o %t.out
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefixes RESULT2
-// RUN: mv %t.value1.bin %t/cache_dir/*/*/*/*/*.bin
+// RUN: %{run-aux} mv %t.value1.bin %t/cache_dir/*/*/*/*/*.bin
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefixes RESULT1
 // ******************************
 

--- a/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
@@ -1,10 +1,11 @@
 // REQUIRES: opencl-aot, cpu
 
+// CPU AOT targets host isa, so we compile on the run system instead.
 // Test with `--offload-new-driver`
-// RUN: %clangxx -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_x86_64 -I %S/Inputs -o %t.out %S/split-per-source-main.cpp %S/Inputs/split-per-source-second-file.cpp \
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_x86_64 -I %S/Inputs -o %t.out %S/split-per-source-main.cpp %S/Inputs/split-per-source-second-file.cpp \
 // RUN: -fsycl-dead-args-optimization --offload-new-driver
 // RUN: %{run} %t.out
 
 // Test -O0 with `--offload-new-driver`
-// RUN: %clangxx %O0 -fsycl -fsycl-targets=spir64-x86_64 %S/Inputs/aot.cpp
+// RUN: %{run-aux} %clangxx %O0 -fsycl -fsycl-targets=spir64-x86_64 %S/Inputs/aot.cpp
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/NewOffloadDriver/cpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/cpu.cpp
@@ -8,8 +8,9 @@
 
 // REQUIRES: opencl-aot, cpu
 
+// CPU AOT targets host isa, so we compile on the run system instead.
 // Test with  `--offload-new-driver`
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 --offload-new-driver %S/Inputs/aot.cpp -o %t.out
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 --offload-new-driver %S/Inputs/aot.cpp -o %t.out
 // RUN: %{run} %t.out
 
 // Test that opencl-aot can handle multiple build options.

--- a/sycl/test-e2e/NonUniformGroups/ballot_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/ballot_group.cpp
@@ -1,7 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// RUN: %if any-device-is-cpu && opencl-aot %{ %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //
 // REQUIRES: cpu || gpu

--- a/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
@@ -1,7 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// RUN: %if any-device-is-cpu && opencl-aot %{ %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //
 // REQUIRES: cpu || gpu

--- a/sycl/test-e2e/NonUniformGroups/fixed_size_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fixed_size_group.cpp
@@ -1,7 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// RUN: %if any-device-is-cpu && opencl-aot %{ %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //
 // REQUIRES: cpu || gpu

--- a/sycl/test-e2e/NonUniformGroups/fixed_size_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fixed_size_group_algorithms.cpp
@@ -1,12 +1,15 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 //
-// RUN: %if any-device-is-cpu && opencl-aot %{ %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-device-code-split=per_kernel -o %t.x86.out %s %}
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-device-code-split=per_kernel -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //
 // REQUIRES: cpu || gpu
 // REQUIRES: sg-32
 // REQUIRES: aspect-ext_oneapi_fixed_size_group
+// UNSUPPORTED: target-amd
+// UNSUPPORTED-INTENDED: fixed_size_group aspect not available on amd
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/fixed_size_group.hpp>

--- a/sycl/test-e2e/NonUniformGroups/opportunistic_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/opportunistic_group.cpp
@@ -1,7 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// RUN: %if any-device-is-cpu && opencl-aot %{ %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //
 // REQUIRES: cpu || gpu

--- a/sycl/test-e2e/NonUniformGroups/opportunistic_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/opportunistic_group_algorithms.cpp
@@ -1,7 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// RUN: %if any-device-is-cpu && opencl-aot %{ %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //
 // REQUIRES: cpu || gpu

--- a/sycl/test-e2e/NonUniformGroups/tangle_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/tangle_group.cpp
@@ -1,11 +1,12 @@
 // RUN: %{build} -fno-sycl-early-optimizations -o %t.out
 // RUN: %{run} %t.out
 //
-// RUN: %if any-device-is-cpu && opencl-aot %{ %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s %}
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //
 // REQUIRES: cpu || gpu
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: target-nvidia || target-amd
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/tangle_group.hpp>

--- a/sycl/test-e2e/NonUniformGroups/tangle_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/tangle_group_algorithms.cpp
@@ -1,13 +1,16 @@
 // RUN: %{build} -fno-sycl-early-optimizations -o %t.out
 // RUN: %{run} %t.out
 //
-// RUN: %if any-device-is-cpu && opencl-aot %{ %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s %}
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //
 // REQUIRES: cpu || gpu
 // REQUIRES: sg-32
 // REQUIRES: aspect-ext_oneapi_tangle_group
-// UNSUPPORTED: cuda || windows
+// UNSUPPORTED: target-amd
+// UNSUPPORTED-INTENDED: tangle groups not available on amd
+// UNSUPPORTED: target-nvidia || windows
 // Tangle groups exhibit unpredictable behavior on Windows.
 // The test is disabled while we investigate the root cause.
 

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
@@ -11,22 +11,22 @@
 // manager can handle this as well. With this option program manager will
 // compile the main program, load and compile device libraries and then link
 // everything together.
-// RUN: %{build} -fsycl-device-lib-jit-link -o %t.out
+// RUN: %{build} -fsycl-device-lib-jit-link -o %t_jit.out
 
 // Check the default case when in-memory caching is enabled.
-// RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=4 SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s --check-prefixes=CHECK-SPIRV-JIT-LINK-TRACE
+// RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=4 SYCL_UR_TRACE=2 %{run} %t_jit.out | FileCheck %s --check-prefixes=CHECK-SPIRV-JIT-LINK-TRACE
 
 // Check the case when in-memory caching of the programs is disabled.
-// RUN: env SYCL_CACHE_IN_MEM=0 NEOReadDebugKeys=1 CreateMultipleRootDevices=4 %{run} %t.out
+// RUN: env SYCL_CACHE_IN_MEM=0 NEOReadDebugKeys=1 CreateMultipleRootDevices=4 %{run} %t_jit.out
 
 // Test AOT next.
-// RUN: %{build} -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device *" -o %t.out
+// RUN: %{build} -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device *" -o %t_aot.out
 
 // Check the default case when in-memory caching is enabled.
-// RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=4 SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s --check-prefixes=CHECK-AOT-TRACE
+// RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=4 SYCL_UR_TRACE=2 %{run} %t_aot.out | FileCheck %s --check-prefixes=CHECK-AOT-TRACE
 
 // Check the case when in-memory caching of the programs is disabled.
-// RUN: env SYCL_CACHE_IN_MEM=0 NEOReadDebugKeys=1 CreateMultipleRootDevices=4 %{run} %t.out
+// RUN: env SYCL_CACHE_IN_MEM=0 NEOReadDebugKeys=1 CreateMultipleRootDevices=4 %{run} %t_aot.out
 
 #include <cmath>
 #include <complex>

--- a/sycl/test-e2e/SpecConstants/2020/non_native/SpecConstBuffer.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/non_native/SpecConstBuffer.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: opencl-aot, cpu
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %S/Inputs/common.cpp -o %t.out \
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 %S/Inputs/common.cpp -o %t.out \
 // RUN:          -fsycl-dead-args-optimization
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s
 

--- a/sycl/test-e2e/SpecConstants/2020/non_native/cpu.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/non_native/cpu.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: opencl-aot, cpu
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %S/Inputs/common.cpp -o %t.out \
+// CPU AOT targets host isa, so we compile on the run system instead.
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 %S/Inputs/common.cpp -o %t.out \
 // RUN:          -fsycl-dead-args-optimization
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/bindless_images/cubemap/cubemap_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/cubemap/cubemap_sampled.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: cuda,aspect-ext_oneapi_cubemap
 // REQUIRES: aspect-ext_oneapi_cubemap_seamless_filtering
-// REQUIRES: build-and-run-mode
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/bindless_images/examples/example_5_sample_cubemap.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_5_sample_cubemap.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: cuda
-// REQUIRES: build-and-run-mode
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -40,17 +40,14 @@ config.unsupported_features = []
 # test-mode: Set if tests should run normally or only build/run
 config.test_mode = lit_config.params.get("test-mode", "full")
 if config.test_mode == "full":
+    config.available_features.add("build-mode")
     config.available_features.add("run-mode")
-    config.available_features.add("build-and-run-mode")
 elif config.test_mode == "run-only":
     lit_config.note("run-only test mode enabled, only executing tests")
-    # run-only uses external shell, some tests might have hacks to workaround
-    # failures caused by that.
-    config.available_features.add("test-mode-run-only")
-
     config.available_features.add("run-mode")
 elif config.test_mode == "build-only":
     lit_config.note("build-only test mode enabled, only compiling tests")
+    config.available_features.add("build-mode")
     config.sycl_devices = []
 else:
     lit_config.error("Invalid argument for test-mode")

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -44,6 +44,10 @@ if config.test_mode == "full":
     config.available_features.add("build-and-run-mode")
 elif config.test_mode == "run-only":
     lit_config.note("run-only test mode enabled, only executing tests")
+    # run-only uses external shell, some tests might have hacks to workaround
+    # failures caused by that.
+    config.available_features.add("test-mode-run-only")
+
     config.available_features.add("run-mode")
 elif config.test_mode == "build-only":
     lit_config.note("build-only test mode enabled, only compiling tests")

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -38,20 +38,18 @@ config.required_features = []
 config.unsupported_features = []
 
 # test-mode: Set if tests should run normally or only build/run
-match lit_config.params.get("test-mode", "full"):
-    case "run-only":
-        config.test_mode = "run-only"
-        config.available_features.add("run-mode")
-    case "build-only":
-        config.test_mode = "build-only"
-        config.sycl_devices = []
-        arch_flag = ""
-    case "full":
-        config.test_mode = "full"
-        config.available_features.add("run-mode")
-        config.available_features.add("build-and-run-mode")
-    case _:
-        lit_config.error("Invalid argument for test-mode")
+config.test_mode = lit_config.params.get("test-mode", "full")
+if config.test_mode == "full":
+    config.available_features.add("run-mode")
+    config.available_features.add("build-and-run-mode")
+elif config.test_mode == "run-only":
+    lit_config.note("run-only test mode enabled, only executing tests")
+    config.available_features.add("run-mode")
+elif config.test_mode == "build-only":
+    lit_config.note("build-only test mode enabled, only compiling tests")
+    config.sycl_devices = []
+else:
+    lit_config.error("Invalid argument for test-mode")
 
 # Cleanup environment variables which may affect tests
 possibly_dangerous_env_vars = [


### PR DESCRIPTION
This is a joined cherry-pick of intel/llvm#16217, intel/llvm#16865 and intel/llvm#17023 intended to port necessary test tweaks to fix infrastructure-related pre-commit issues on `sycl-rel_6_1_0` branch.

Descriptions of cherry-picked commits:

---

[SYCL][E2E] Change pattern matching to if-else statements in `lit.cfg.py` (#16217)

Fixes #16211

Patch-By: David Garcia Orozco <david.garcia.orozco@intel.com>

---

[SYCL][E2E] Hack `AddressSanitizer/.../device_global.cpp` to pass CI (#16865)

Closes https://github.com/intel/llvm/issues/16850.

Patch-By: aelovikov-intel <andrei.elovikov@intel.com>

---

[SYCL][E2E] Clean-up `test-mode`s by removing workarounds (#17023)

- Removes the `build-and-run-mode` feature from e2e lit infrastructure,
as well as the remaining `REQUIRES: build-and-run-mode` markups found in
tests.
- Removes the `run-only` mode ignore line filtering workaround on
`REQUIRES: build-and-run-mode`.
- Adds `build-mode` to remove `test-mode-run-only` mode, this can be
tested for by checking `run-mode && !build-mode`.
- Marks CPU aot compilation lines with `%{run-aux}`, as those need to be
compiled on a system with the same CPU isa as the running system.

Patch-By: David Garcia Orozco <david.garcia.orozco@intel.com>

---