### PR TITLE
[SYCL][sycl-rel] Fix AddSecurityFlags having no side effects

### DIFF
--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -31,7 +31,7 @@ macro(add_link_option_ext flag name)
   endif()
 endmacro()
 
-function(append_common_extra_security_flags)
+macro(append_common_extra_security_flags)
   if( LLVM_ON_UNIX )
     # Fortify Source (strongly recommended):
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -70,7 +70,7 @@ function(append_common_extra_security_flags)
       CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS
       CMAKE_SHARED_LINKER_FLAGS)
   endif()
-endfunction()
+endmacro()
 
 if ( EXTRA_SECURITY_FLAGS )
     if (EXTRA_SECURITY_FLAGS STREQUAL "none")


### PR DESCRIPTION
This is a cherry-pick of intel/llvm#17690

---

CMake has a notion of scopes for variables and we fell into a pitfall of setting local variables instead of applying changes globally to the whole project.

For reference, see:
- https://cmake.org/cmake/help/v3.20/command/set.html
- https://cmake.org/cmake/help/v3.20/command/include.html