### PR TITLE
[SYCL][sycl-rel] Stabilize 6.1 nightly

### DIFF
--- a/clang/test/Driver/linker-wrapper-sycl-win.cpp
+++ b/clang/test/Driver/linker-wrapper-sycl-win.cpp
@@ -90,8 +90,8 @@
 // CHK-CMDS-AOT-NV-NEXT: "{{.*}}llvm-link.exe" -only-needed [[FIRSTLLVMLINKOUT]].bc {{.*}}.bc -o [[SECONDLLVMLINKOUT:.*]].bc --suppress-warnings
 // CHK-CMDS-AOT-NV-NEXT: "{{.*}}sycl-post-link.exe"{{.*}} SYCL_POST_LINK_OPTIONS -o [[SYCLPOSTLINKOUT:.*]].table [[SECONDLLVMLINKOUT]].bc
 // CHK-CMDS-AOT-NV-NEXT: "{{.*}}clang.exe"{{.*}} -o [[CLANGOUT:.*]] --target=nvptx64-nvidia-cuda -march={{.*}}
-// CHK-CMDS-AOT-NV-NEXT: "{{.*}}ptxas"{{.*}} --output-file [[PTXASOUT:.*]] [[CLANGOUT]]
-// CHK-CMDS-AOT-NV-NEXT: "{{.*}}fatbinary"{{.*}} --create [[FATBINOUT:.*]] --image=profile={{.*}},file=[[CLANGOUT]] --image=profile={{.*}},file=[[PTXASOUT]]
+// CHK-CMDS-AOT-NV-NEXT: "{{.*}}ptxas{{.*}} --output-file [[PTXASOUT:.*]] [[CLANGOUT]]
+// CHK-CMDS-AOT-NV-NEXT: "{{.*}}fatbinary{{.*}} --create [[FATBINOUT:.*]] --image=profile={{.*}},file=[[CLANGOUT]] --image=profile={{.*}},file=[[PTXASOUT]]
 // CHK-CMDS-AOT-NV-NEXT: offload-wrapper: input: [[FATBINOUT]], output: [[WRAPPEROUT:.*]].bc
 // CHK-CMDS-AOT-NV-NEXT: "{{.*}}clang.exe"{{.*}} -c -o [[LLCOUT:.*]].o [[WRAPPEROUT]].bc
 // CHK-CMDS-AOT-NV-NEXT: "{{.*}}ld" -- HOST_LINKER_FLAGS -dynamic-linker HOST_DYN_LIB -o a.out [[LLCOUT]].o HOST_LIB_PATH HOST_STAT_LIB {{.*}}.o

--- a/sycl/test/basic_tests/header_footer_diagnostics.cpp
+++ b/sycl/test/basic_tests/header_footer_diagnostics.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -Werror=reserved-identifier -Werror=old-style-cast %s
+// RUN: %clangxx -fsycl -Werror=reserved-identifier -Werror=old-style-cast %s -fsyntax-only
 
 // Check that the generated header and footer files do not generate
 // errors when pedantic warnings are enabled.

--- a/sycl/test/basic_tests/is_group_trait.cpp
+++ b/sycl/test/basic_tests/is_group_trait.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s
+// RUN: %clangxx -fsycl %s -fsyntax-only
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/esimd/slm_init_local_accessor.cpp
+++ b/sycl/test/esimd/slm_init_local_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl  %s
+// RUN: %clangxx -fsycl  %s -fsyntax-only
 
 // This test verifies usage of slm_init and local_accessor in different kernels
 // passes.

--- a/sycl/test/syclcompat/launch/launch_policy_neg.cpp
+++ b/sycl/test/syclcompat/launch/launch_policy_neg.cpp
@@ -19,7 +19,8 @@
  *  Description:
  *     Negative tests for new launch_policy.
  **************************************************************************/
-
+// UNSUPPORTED: windows
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17116
 // RUN: not %clangxx -fsycl -fsyntax-only %s -DCHECK1 2>&1 | FileCheck -vv %s --check-prefixes=CHECK1
 // RUN: not %clangxx -fsycl -fsyntax-only %s -DCHECK2 2>&1 | FileCheck -vv %s --check-prefixes=CHECK2
 // RUN: not %clangxx -fsycl -fsyntax-only %s -DCHECK3 2>&1 | FileCheck -vv %s --check-prefixes=CHECK3


### PR DESCRIPTION
This is a joined cherry-pick of intel/llvm#17367, intel/llvm#17362 and intel/llvm#17746 intended to fix a few remaining issues we see in 6.1 nightly validation run.

Descriptions of cherry-picked commits:

---

[SYCL] Disable launch_policy_neg.cpp on Windows (#17367)

Fails to compile on new MSVC.

Patch-by: Sarnie, Nick <nick.sarnie@intel.com>

---

[SYCL] Avoid testing race condition

Use no output file instead of default output file in LIT tests.
This occasionally caused errors on windows when multiple files compile
to the same output file. Using `-fsyntax-only` hjere also avoids running the full compiler pipeline

See #7872 for more context

Patch-By: David Garcia Orozco <david.garcia.orozco@intel.com>

---

[SYCL] Fix clang-linker-wrapper Windows test (#17746)

Failing now because I recently added `ptxas` to the path on these
runners.

Patch-by: Sarnie, Nick <nick.sarnie@intel.com>

---