### PR TITLE
[NFCI][SYCL] Simplify `SYCL_LANGUAGE_VERSION` guards

### DIFF
--- a/sycl/include/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/detail/defines_elementary.hpp
@@ -57,8 +57,7 @@
 #endif // __SYCL_DEPRECATED
 
 #ifndef __SYCL2020_DEPRECATED
-#if SYCL_LANGUAGE_VERSION == 202012L &&                                        \
-    !defined(SYCL2020_DISABLE_DEPRECATION_WARNINGS)
+#if !defined(SYCL2020_DISABLE_DEPRECATION_WARNINGS)
 #define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
 #else
 #define __SYCL2020_DEPRECATED(message)

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1194,8 +1194,7 @@ private:
     // Range rounding is supported only for newer SYCL standards.
 #if !defined(__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__) &&                  \
     !defined(DPCPP_HOST_DEVICE_OPENMP) &&                                      \
-    !defined(DPCPP_HOST_DEVICE_PERF_NATIVE) &&                                 \
-    SYCL_LANGUAGE_VERSION >= 202012L
+    !defined(DPCPP_HOST_DEVICE_PERF_NATIVE)
     auto [RoundedRange, HasRoundedRange] = getRoundedRange(UserRange);
     if (HasRoundedRange) {
       using NameWT = typename detail::get_kernel_wrapper_name_t<NameT>::name;
@@ -1224,8 +1223,7 @@ private:
 #endif
     } else
 #endif // !__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ &&
-       // !DPCPP_HOST_DEVICE_OPENMP && !DPCPP_HOST_DEVICE_PERF_NATIVE &&
-       // SYCL_LANGUAGE_VERSION >= 202012L
+       // !DPCPP_HOST_DEVICE_OPENMP && !DPCPP_HOST_DEVICE_PERF_NATIVE
     {
       (void)UserRange;
       (void)Props;
@@ -1838,11 +1836,8 @@ public:
 
   template <typename T> struct ShouldEnableSetArg {
     static constexpr bool value =
-        std::is_trivially_copyable_v<std::remove_reference_t<T>>
-#if SYCL_LANGUAGE_VERSION && SYCL_LANGUAGE_VERSION <= 201707
-            && std::is_standard_layout<std::remove_reference_t<T>>::value
-#endif
-        || is_same_type<sampler, T>::value // Sampler
+        std::is_trivially_copyable_v<std::remove_reference_t<T>> ||
+        is_same_type<sampler, T>::value // Sampler
         || (!is_same_type<cl_mem, T>::value &&
             std::is_pointer_v<remove_cv_ref_t<T>>) // USM
         || is_same_type<cl_mem, T>::value;         // Interop

--- a/sycl/test/basic_tests/set_arg_error.cpp
+++ b/sycl/test/basic_tests/set_arg_error.cpp
@@ -50,12 +50,5 @@ int main() {
         5, ntc);
     h.set_arg( // expected-error {{no matching member function for call to 'set_arg'}}
         4, NonTriviallyCopyable{});
-#if SYCL_LANGUAGE_VERSION && SYCL_LANGUAGE_VERSION <= 201707
-    NonStdLayout nstd;
-    h.set_arg( // expected-error {{no matching member function for call to 'set_arg'}}
-        6, nstd);
-    h.set_arg( // expected-error {{no matching member function for call to 'set_arg'}}
-        7, NonStdLayout{});
-#endif
   });
 }


### PR DESCRIPTION
SYCL 1.2 support has been removed quite some time ago, FE only reports `202012L`

https://github.com/intel/llvm/blob/9e38e3a05f42b32819a4a570973b925df97e174b/clang/lib/Basic/Version.cpp#L129-L133

so we can expect it's at least that.