### PR TITLE
[UR][L0] Fix L0 teardown checks for stability

### DIFF
--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -40,10 +40,10 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
     set(BUILD_STATIC ON)
 
     if (UR_LEVEL_ZERO_LOADER_REPO STREQUAL "")
-        set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
+        set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/nrspruit/level-zero.git")
     endif()
     if (UR_LEVEL_ZERO_LOADER_TAG STREQUAL "")
-        set(UR_LEVEL_ZERO_LOADER_TAG v1.21.1)
+        set(UR_LEVEL_ZERO_LOADER_TAG cd83892e09c339b1688de3aa67cd902fb277b297)
     endif()
 
     # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -285,8 +285,11 @@ ur_result_t ContextReleaseHelper(ur_context_handle_t Context) {
   if (DestroyZeContext) {
     auto ZeResult = ZE_CALL_NOCHECK(zeContextDestroy, (DestroyZeContext));
     // Gracefully handle the case that L0 was already unloaded.
-    if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+    if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
       return ze2urResult(ZeResult);
+    if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+      ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+    }
   }
 
   return Result;
@@ -311,8 +314,11 @@ ur_result_t ur_context_handle_t_::finalize() {
             (Event->IsInteropNativeHandle && checkL0LoaderTeardown())) {
           auto ZeResult = ZE_CALL_NOCHECK(zeEventDestroy, (Event->ZeEvent));
           // Gracefully handle the case that L0 was already unloaded.
-          if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+          if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
             return ze2urResult(ZeResult);
+          if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+            ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+          }
         }
         Event->ZeEvent = nullptr;
         delete Event;
@@ -326,8 +332,11 @@ ur_result_t ur_context_handle_t_::finalize() {
       for (auto &ZePool : ZePoolCache) {
         auto ZeResult = ZE_CALL_NOCHECK(zeEventPoolDestroy, (ZePool));
         // Gracefully handle the case that L0 was already unloaded.
-        if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+        if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
           return ze2urResult(ZeResult);
+        if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+          ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+        }
       }
       ZePoolCache.clear();
     }
@@ -336,8 +345,11 @@ ur_result_t ur_context_handle_t_::finalize() {
   // Destroy the command list used for initializations
   auto ZeResult = ZE_CALL_NOCHECK(zeCommandListDestroy, (ZeCommandListInit));
   // Gracefully handle the case that L0 was already unloaded.
-  if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+  if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
     return ze2urResult(ZeResult);
+  if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+    ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+  }
 
   std::scoped_lock<ur_mutex> Lock(ZeCommandListCacheMutex);
   for (auto &List : ZeComputeCommandListCache) {
@@ -346,8 +358,11 @@ ur_result_t ur_context_handle_t_::finalize() {
       if (ZeCommandList) {
         auto ZeResult = ZE_CALL_NOCHECK(zeCommandListDestroy, (ZeCommandList));
         // Gracefully handle the case that L0 was already unloaded.
-        if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+        if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
           return ze2urResult(ZeResult);
+        if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+          ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+        }
       }
     }
   }
@@ -357,8 +372,11 @@ ur_result_t ur_context_handle_t_::finalize() {
       if (ZeCommandList) {
         auto ZeResult = ZE_CALL_NOCHECK(zeCommandListDestroy, (ZeCommandList));
         // Gracefully handle the case that L0 was already unloaded.
-        if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+        if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
           return ze2urResult(ZeResult);
+        if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+          ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+        }
       }
     }
   }

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -1125,8 +1125,11 @@ ur_result_t urEventReleaseInternal(ur_event_handle_t Event) {
           (Event->IsInteropNativeHandle && checkL0LoaderTeardown())) {
         auto ZeResult = ZE_CALL_NOCHECK(zeEventDestroy, (Event->ZeEvent));
         // Gracefully handle the case that L0 was already unloaded.
-        if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+        if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
           return ze2urResult(ZeResult);
+        if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+          ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+        }
       }
       Event->ZeEvent = nullptr;
       auto Context = Event->Context;

--- a/unified-runtime/source/adapters/level_zero/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.cpp
@@ -944,8 +944,11 @@ ur_result_t urKernelRelease(
           (Kernel->IsInteropNativeHandle && checkL0LoaderTeardown())) {
         auto ZeResult = ZE_CALL_NOCHECK(zeKernelDestroy, (ZeKernel));
         // Gracefully handle the case that L0 was already unloaded.
-        if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+        if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
           return ze2urResult(ZeResult);
+        if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+          ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+        }
       }
     }
   }

--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -1668,8 +1668,11 @@ ur_result_t urMemRelease(
         auto ZeResult = ZE_CALL_NOCHECK(
             zeImageDestroy, (ur_cast<ze_image_handle_t>(ZeHandleImage)));
         // Gracefully handle the case that L0 was already unloaded.
-        if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+        if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
           return ze2urResult(ZeResult);
+        if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+          ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+        }
       }
     }
     delete Image;

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -651,8 +651,11 @@ ur_result_t urQueueRelease(
       if (Queue->Healthy && it->second.ZeFence != nullptr) {
         auto ZeResult = ZE_CALL_NOCHECK(zeFenceDestroy, (it->second.ZeFence));
         // Gracefully handle the case that L0 was already unloaded.
-        if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+        if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
           return ze2urResult(ZeResult);
+        if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+          ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+        }
       }
       if (Queue->UsingImmCmdLists && Queue->OwnZeCommandQueue) {
         std::scoped_lock<ur_mutex> Lock(
@@ -1609,8 +1612,11 @@ ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
                 (Queue->IsInteropNativeHandle && checkL0LoaderTeardown())) {
               auto ZeResult = ZE_CALL_NOCHECK(zeCommandQueueDestroy, (ZeQueue));
               // Gracefully handle the case that L0 was already unloaded.
-              if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+              if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
                 return ze2urResult(ZeResult);
+              if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+                ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+              }
             }
           }
   }

--- a/unified-runtime/source/adapters/level_zero/sampler.cpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.cpp
@@ -131,8 +131,11 @@ ur_result_t urSamplerRelease(
 
   auto ZeResult = ZE_CALL_NOCHECK(zeSamplerDestroy, (Sampler->ZeSampler));
   // Gracefully handle the case that L0 was already unloaded.
-  if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+  if (ZeResult && (ZeResult != ZE_RESULT_ERROR_UNINITIALIZED || ZeResult != ZE_RESULT_ERROR_UNKNOWN))
     return ze2urResult(ZeResult);
+  if ( ZeResult == ZE_RESULT_ERROR_UNKNOWN) {
+    ZeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+  }
   delete Sampler;
 
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/v2/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/common.hpp
@@ -83,8 +83,11 @@ struct ze_handle_wrapper {
         (ownZeHandle && IsInteropNativeHandle && checkL0LoaderTeardown())) {
       auto zeResult = destroy(handle);
       // Gracefully handle the case that L0 was already unloaded.
-      if (zeResult && zeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+      if (zeResult && (zeResult != ZE_RESULT_ERROR_UNINITIALIZED || zeResult != ZE_RESULT_ERROR_UNKNOWN))
         throw ze2urResult(zeResult);
+      if ( zeResult == ZE_RESULT_ERROR_UNKNOWN) {
+        zeResult = ZE_RESULT_ERROR_UNINITIALIZED;
+      }
     }
 
     handle = nullptr;


### PR DESCRIPTION
- Address the race conditions with L0 Loader teardown timing such that L0 teardown is verified before handle destruction in all cases and uses a L0 loader api to verify stability.