### PR TITLE
[NFC][libclc][libspirv] Replace OpenCL as_TYPE with clc __clc_as_TYPE

### DIFF
--- a/libclc/clc/include/clc/clc_as_type.h
+++ b/libclc/clc/include/clc/clc_as_type.h
@@ -2,6 +2,7 @@
 #define __CLC_CLC_AS_TYPE_H__
 
 #define __clc_as_char(x) __builtin_astype(x, char)
+#define __clc_as_schar(x) __builtin_astype(x, schar)
 #define __clc_as_uchar(x) __builtin_astype(x, uchar)
 #define __clc_as_short(x) __builtin_astype(x, short)
 #define __clc_as_ushort(x) __builtin_astype(x, ushort)
@@ -12,6 +13,7 @@
 #define __clc_as_float(x) __builtin_astype(x, float)
 
 #define __clc_as_char2(x) __builtin_astype(x, char2)
+#define __clc_as_schar2(x) __builtin_astype(x, schar2)
 #define __clc_as_uchar2(x) __builtin_astype(x, uchar2)
 #define __clc_as_short2(x) __builtin_astype(x, short2)
 #define __clc_as_ushort2(x) __builtin_astype(x, ushort2)
@@ -22,6 +24,7 @@
 #define __clc_as_float2(x) __builtin_astype(x, float2)
 
 #define __clc_as_char3(x) __builtin_astype(x, char3)
+#define __clc_as_schar3(x) __builtin_astype(x, schar3)
 #define __clc_as_uchar3(x) __builtin_astype(x, uchar3)
 #define __clc_as_short3(x) __builtin_astype(x, short3)
 #define __clc_as_ushort3(x) __builtin_astype(x, ushort3)
@@ -32,6 +35,7 @@
 #define __clc_as_float3(x) __builtin_astype(x, float3)
 
 #define __clc_as_char4(x) __builtin_astype(x, char4)
+#define __clc_as_schar4(x) __builtin_astype(x, schar4)
 #define __clc_as_uchar4(x) __builtin_astype(x, uchar4)
 #define __clc_as_short4(x) __builtin_astype(x, short4)
 #define __clc_as_ushort4(x) __builtin_astype(x, ushort4)
@@ -43,6 +47,7 @@
 
 #define __clc_as_char8(x) __builtin_astype(x, char8)
 #define __clc_as_uchar8(x) __builtin_astype(x, uchar8)
+#define __clc_as_schar8(x) __builtin_astype(x, schar8)
 #define __clc_as_short8(x) __builtin_astype(x, short8)
 #define __clc_as_ushort8(x) __builtin_astype(x, ushort8)
 #define __clc_as_int8(x) __builtin_astype(x, int8)
@@ -52,6 +57,7 @@
 #define __clc_as_float8(x) __builtin_astype(x, float8)
 
 #define __clc_as_char16(x) __builtin_astype(x, char16)
+#define __clc_as_schar16(x) __builtin_astype(x, schar16)
 #define __clc_as_uchar16(x) __builtin_astype(x, uchar16)
 #define __clc_as_short16(x) __builtin_astype(x, short16)
 #define __clc_as_ushort16(x) __builtin_astype(x, ushort16)

--- a/libclc/libspirv/include/libspirv/relational.h
+++ b/libclc/libspirv/include/libspirv/relational.h
@@ -23,7 +23,7 @@
 #define _CLC_DEFINE_RELATIONAL_UNARY_VEC3(RET_TYPE, FUNCTION, ARG_TYPE)        \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG_TYPE x) {                       \
     return __clc_as_##RET_TYPE(((RET_TYPE){FUNCTION(x.s0), FUNCTION(x.s1),     \
-                                     FUNCTION(x.s2)} != (RET_TYPE)0));         \
+                                           FUNCTION(x.s2)} != (RET_TYPE)0));   \
   }
 
 #define _CLC_DEFINE_RELATIONAL_UNARY_VEC4(RET_TYPE, FUNCTION, ARG_TYPE)        \
@@ -82,8 +82,9 @@
 #define _CLC_DEFINE_RELATIONAL_BINARY_VEC2(RET_TYPE, FUNCTION, ARG0_TYPE,      \
                                            ARG1_TYPE)                          \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG0_TYPE x, ARG1_TYPE y) {         \
-    return __clc_as_##RET_TYPE(((RET_TYPE){FUNCTION(x.lo, y.lo),               \
-                                     FUNCTION(x.hi, y.hi)} != (RET_TYPE)0));   \
+    return __clc_as_##RET_TYPE(                                                \
+        ((RET_TYPE){FUNCTION(x.lo, y.lo), FUNCTION(x.hi, y.hi)} !=             \
+         (RET_TYPE)0));                                                        \
   }
 
 #define _CLC_DEFINE_RELATIONAL_BINARY_VEC3(RET_TYPE, FUNCTION, ARG0_TYPE,      \

--- a/libclc/libspirv/include/libspirv/relational.h
+++ b/libclc/libspirv/include/libspirv/relational.h
@@ -1,7 +1,7 @@
 #ifndef CLC_RELATIONAL
 #define CLC_RELATIONAL
 
-#include <as_type.h>
+#include <clc/clc_as_type.h>
 
 /*
  * Contains relational macros that have to return 1 for scalar and -1 for vector
@@ -16,26 +16,26 @@
 
 #define _CLC_DEFINE_RELATIONAL_UNARY_VEC2(RET_TYPE, FUNCTION, ARG_TYPE)        \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG_TYPE x) {                       \
-    return as_##RET_TYPE(                                                      \
+    return __clc_as_##RET_TYPE(                                                \
         ((RET_TYPE){FUNCTION(x.lo), FUNCTION(x.hi)} != (RET_TYPE)0));          \
   }
 
 #define _CLC_DEFINE_RELATIONAL_UNARY_VEC3(RET_TYPE, FUNCTION, ARG_TYPE)        \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG_TYPE x) {                       \
-    return as_##RET_TYPE(((RET_TYPE){FUNCTION(x.s0), FUNCTION(x.s1),           \
+    return __clc_as_##RET_TYPE(((RET_TYPE){FUNCTION(x.s0), FUNCTION(x.s1),     \
                                      FUNCTION(x.s2)} != (RET_TYPE)0));         \
   }
 
 #define _CLC_DEFINE_RELATIONAL_UNARY_VEC4(RET_TYPE, FUNCTION, ARG_TYPE)        \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG_TYPE x) {                       \
-    return as_##RET_TYPE(                                                      \
+    return __clc_as_##RET_TYPE(                                                \
         ((RET_TYPE){FUNCTION(x.s0), FUNCTION(x.s1), FUNCTION(x.s2),            \
                     FUNCTION(x.s3)} != (RET_TYPE)0));                          \
   }
 
 #define _CLC_DEFINE_RELATIONAL_UNARY_VEC8(RET_TYPE, FUNCTION, ARG_TYPE)        \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG_TYPE x) {                       \
-    return as_##RET_TYPE(                                                      \
+    return __clc_as_##RET_TYPE(                                                \
         ((RET_TYPE){FUNCTION(x.s0), FUNCTION(x.s1), FUNCTION(x.s2),            \
                     FUNCTION(x.s3), FUNCTION(x.s4), FUNCTION(x.s5),            \
                     FUNCTION(x.s6), FUNCTION(x.s7)} != (RET_TYPE)0));          \
@@ -43,7 +43,7 @@
 
 #define _CLC_DEFINE_RELATIONAL_UNARY_VEC16(RET_TYPE, FUNCTION, ARG_TYPE)       \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG_TYPE x) {                       \
-    return as_##RET_TYPE(                                                      \
+    return __clc_as_##RET_TYPE(                                                \
         ((RET_TYPE){FUNCTION(x.s0), FUNCTION(x.s1), FUNCTION(x.s2),            \
                     FUNCTION(x.s3), FUNCTION(x.s4), FUNCTION(x.s5),            \
                     FUNCTION(x.s6), FUNCTION(x.s7), FUNCTION(x.s8),            \
@@ -74,7 +74,7 @@
 #define _CLC_DEFINE_RELATIONAL_BINARY_VEC(RET_TYPE, FUNCTION, ARG0_TYPE,       \
                                           ARG1_TYPE)                           \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG0_TYPE x, ARG1_TYPE y) {         \
-    return as_##RET_TYPE(                                                      \
+    return __clc_as_##RET_TYPE(                                                \
         (RET_TYPE)((RET_TYPE){FUNCTION(x.lo, y.lo), FUNCTION(x.hi, y.hi)} !=   \
                    (RET_TYPE)0));                                              \
   }
@@ -82,14 +82,14 @@
 #define _CLC_DEFINE_RELATIONAL_BINARY_VEC2(RET_TYPE, FUNCTION, ARG0_TYPE,      \
                                            ARG1_TYPE)                          \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG0_TYPE x, ARG1_TYPE y) {         \
-    return as_##RET_TYPE(((RET_TYPE){FUNCTION(x.lo, y.lo),                     \
+    return __clc_as_##RET_TYPE(((RET_TYPE){FUNCTION(x.lo, y.lo),               \
                                      FUNCTION(x.hi, y.hi)} != (RET_TYPE)0));   \
   }
 
 #define _CLC_DEFINE_RELATIONAL_BINARY_VEC3(RET_TYPE, FUNCTION, ARG0_TYPE,      \
                                            ARG1_TYPE)                          \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG0_TYPE x, ARG1_TYPE y) {         \
-    return as_##RET_TYPE(                                                      \
+    return __clc_as_##RET_TYPE(                                                \
         ((RET_TYPE){FUNCTION(x.s0, y.s0), FUNCTION(x.s1, y.s1),                \
                     FUNCTION(x.s2, y.s2)} != (RET_TYPE)0));                    \
   }
@@ -97,7 +97,7 @@
 #define _CLC_DEFINE_RELATIONAL_BINARY_VEC4(RET_TYPE, FUNCTION, ARG0_TYPE,      \
                                            ARG1_TYPE)                          \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG0_TYPE x, ARG1_TYPE y) {         \
-    return as_##RET_TYPE(                                                      \
+    return __clc_as_##RET_TYPE(                                                \
         ((RET_TYPE){FUNCTION(x.s0, y.s0), FUNCTION(x.s1, y.s1),                \
                     FUNCTION(x.s2, y.s2),                                      \
                     FUNCTION(x.s3, y.s3)} != (RET_TYPE)0));                    \
@@ -106,7 +106,7 @@
 #define _CLC_DEFINE_RELATIONAL_BINARY_VEC8(RET_TYPE, FUNCTION, ARG0_TYPE,      \
                                            ARG1_TYPE)                          \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG0_TYPE x, ARG1_TYPE y) {         \
-    return as_##RET_TYPE(                                                      \
+    return __clc_as_##RET_TYPE(                                                \
         ((RET_TYPE){                                                           \
              FUNCTION(x.s0, y.s0), FUNCTION(x.s1, y.s1), FUNCTION(x.s2, y.s2), \
              FUNCTION(x.s3, y.s3), FUNCTION(x.s4, y.s4), FUNCTION(x.s5, y.s5), \
@@ -116,7 +116,7 @@
 #define _CLC_DEFINE_RELATIONAL_BINARY_VEC16(RET_TYPE, FUNCTION, ARG0_TYPE,     \
                                             ARG1_TYPE)                         \
   _CLC_DEF _CLC_OVERLOAD RET_TYPE FUNCTION(ARG0_TYPE x, ARG1_TYPE y) {         \
-    return as_##RET_TYPE(                                                      \
+    return __clc_as_##RET_TYPE(                                                \
         ((RET_TYPE){                                                           \
              FUNCTION(x.s0, y.s0), FUNCTION(x.s1, y.s1), FUNCTION(x.s2, y.s2), \
              FUNCTION(x.s3, y.s3), FUNCTION(x.s4, y.s4), FUNCTION(x.s5, y.s5), \

--- a/libclc/libspirv/include/libspirv/spirv.h
+++ b/libclc/libspirv/include/libspirv/spirv.h
@@ -46,8 +46,8 @@
 /* Supported builtins */
 #include <libspirv/spirv_builtins.h>
 
-/* Reinterpreting Types Using as_type() and as_typen() */
-#include <as_type.h>
+/* Reinterpreting Types Using __clc_as_type() and __clc_as_typen() */
+#include <clc/clc_as_type.h>
 
 /* Preprocessor Directives and Macros */
 #include <macros.h>

--- a/libclc/libspirv/lib/amdgcn-amdhsa/images/image_common.cl
+++ b/libclc/libspirv/lib/amdgcn-amdhsa/images/image_common.cl
@@ -8,42 +8,42 @@
 // https://github.com/ROCm/clr/tree/amd-staging/hipamd/include/hip/amd_detail/texture_fetch_functions.h
 _CLC_CONST_AS const unsigned int SAMPLER_OBJECT_OFFSET_DWORD = 12;
 
-// Using the builtin as_type() and as_typen() functions to reinterpret types.
+// Using __clc_as_type() and __clc_as_typen() functions to reinterpret types.
 // The restriction being is that element "type"s need to be of the same size.
 #define _CLC_DEFINE_BUILTIN_CAST_VEC4_TO_VEC3(vec4_elem_t, to_t)               \
   _CLC_DEF to_t##3 __clc_cast_from_##vec4_elem_t##4_to_##to_t##3(              \
       vec4_elem_t##4 from) {                                                   \
-    vec4_elem_t##3 casted = as_##vec4_elem_t##3(from);                         \
-    return as_##to_t##3(casted);                                               \
+    vec4_elem_t##3 casted = __clc_as_##vec4_elem_t##3(from);                   \
+    return __clc_as_##to_t##3(casted);                                         \
   }
 #define _CLC_DEFINE_BUILTIN_CAST_VEC4_TO_VEC2(vec4_elem_t, to_t)               \
   _CLC_DEF to_t##2 __clc_cast_from_##vec4_elem_t##4_to_##to_t##2(              \
       vec4_elem_t##4 from) {                                                   \
-    vec4_elem_t##4 casted = as_##vec4_elem_t##4(from);                         \
-    return as_##to_t##2((vec4_elem_t##2)(casted.x, casted.y));                 \
+    vec4_elem_t##4 casted = __clc_as_##vec4_elem_t##4(from);                   \
+    return __clc_as_##to_t##2((vec4_elem_t##2)(casted.x, casted.y));           \
   }
 #define _CLC_DEFINE_BUILTIN_CAST_VEC4_TO_SCALAR(vec4_elem_t, to_t)             \
   _CLC_DEF to_t __clc_cast_from_##vec4_elem_t##4_to_##to_t(                    \
       vec4_elem_t##4 from) {                                                   \
-    vec4_elem_t##4 casted = as_##vec4_elem_t##4(from);                         \
-    return as_##to_t(casted.x);                                                \
+    vec4_elem_t##4 casted = __clc_as_##vec4_elem_t##4(from);                   \
+    return __clc_as_##to_t(casted.x);                                          \
   }
 #define _CLC_DEFINE_BUILTIN_CAST_VEC3_TO_VEC4(from_t, vec4_elem_t)             \
   _CLC_DEF vec4_elem_t##4 __clc_cast_from_##from_t##3_to_##vec4_elem_t##4(     \
       from_t##3 from) {                                                        \
-    vec4_elem_t##3 casted = as_##vec4_elem_t##3(from);                         \
-    return as_##vec4_elem_t##4(casted);                                        \
+    vec4_elem_t##3 casted = __clc_as_##vec4_elem_t##3(from);                   \
+    return __clc_as_##vec4_elem_t##4(casted);                                  \
   }
 #define _CLC_DEFINE_BUILTIN_CAST_VEC2_TO_VEC4(from_t, vec4_elem_t)             \
   _CLC_DEF vec4_elem_t##4 __clc_cast_from_##from_t##2_to_##vec4_elem_t##4(     \
       from_t##2 from) {                                                        \
-    vec4_elem_t##2 casted = as_##vec4_elem_t##2(from);                         \
+    vec4_elem_t##2 casted = __clc_as_##vec4_elem_t##2(from);                   \
     return (vec4_elem_t##4)(casted.x, casted.y, 0, 0);                         \
   }
 #define _CLC_DEFINE_BUILTIN_CAST_SCALAR_TO_VEC4(from_t, vec4_elem_t)           \
   _CLC_DEF vec4_elem_t##4 __clc_cast_from_##from_t##_to_##vec4_elem_t##4(      \
       from_t from) {                                                           \
-    vec4_elem_t casted = as_##vec4_elem_t(from);                               \
+    vec4_elem_t casted = __clc_as_##vec4_elem_t(from);                         \
     return (vec4_elem_t##4)(casted, 0, 0, 0);                                  \
   }
 

--- a/libclc/libspirv/lib/amdgcn-amdhsa/images/image_common.h
+++ b/libclc/libspirv/lib/amdgcn-amdhsa/images/image_common.h
@@ -2,6 +2,7 @@
 #define CLC_SPIRV_IMAGE_COMMON
 
 #include <clc/clc.h>
+#include <clc/clc_as_type.h>
 
 #ifdef cl_khr_fp16
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
@@ -32,7 +33,7 @@ extern _CLC_CONST_AS const unsigned int SAMPLER_OBJECT_OFFSET_DWORD;
 
 // Helpers for casting between two builtin vector types and/or scalar types.
 
-// Using the builtin as_type() and as_typen() functions to reinterpret types.
+// Using __clc_as_type() and __clc_as_typen() functions to reinterpret types.
 // The restriction being is that element "type"s need to be of the same size.
 #define _CLC_DECLARE_BUILTIN_CAST_VEC4_TO_VEC3(vec4_elem_t, to_t)              \
   _CLC_DECL to_t##3 __clc_cast_from_##vec4_elem_t##4_to_##to_t##3(             \

--- a/libclc/libspirv/lib/amdgcn-amdhsa/misc/sub_group_shuffle.cl
+++ b/libclc/libspirv/lib/amdgcn-amdhsa/misc/sub_group_shuffle.cl
@@ -39,10 +39,10 @@ __AMDGCN_CLC_SUBGROUP_SUB_I32(unsigned short, t);
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 _CLC_DEF half _Z28__spirv_SubgroupShuffleINTELIDF16_ET_S0_j(
     half Data, unsigned int InvocationId) {
-  unsigned short tmp = as_ushort(Data);
+  unsigned short tmp = __clc_as_ushort(Data);
   tmp = (unsigned short)_Z28__spirv_SubgroupShuffleINTELIiET_S0_j((int)tmp,
                                                                   InvocationId);
-  return as_half(tmp);
+  return __clc_as_half(tmp);
 }
 #endif // cl_khr_fp16
 
@@ -51,12 +51,12 @@ _CLC_DEF half _Z28__spirv_SubgroupShuffleINTELIDF16_ET_S0_j(
 // 32-bit types.
 // __spirv_SubgroupShuffleINTEL - unsigned int
 // __spirv_SubgroupShuffleINTEL-  float
-#define __AMDGCN_CLC_SUBGROUP_I32(TYPE, CAST_TYPE, MANGLED_TYPE_NAME)          \
-  _CLC_DEF TYPE _Z28__spirv_SubgroupShuffleINTELI##MANGLED_TYPE_NAME##ET_S0_j( \
-      TYPE Data, unsigned int InvocationId) {                                  \
-    return __builtin_astype(                                                   \
-        _Z28__spirv_SubgroupShuffleINTELIiET_S0_j(as_int(Data), InvocationId), \
-        CAST_TYPE);                                                            \
+#define __AMDGCN_CLC_SUBGROUP_I32(TYPE, CAST_TYPE, MANGLED_TYPE_NAME)                \
+  _CLC_DEF TYPE _Z28__spirv_SubgroupShuffleINTELI##MANGLED_TYPE_NAME##ET_S0_j(       \
+      TYPE Data, unsigned int InvocationId) {                                        \
+    return __builtin_astype(                                                         \
+        _Z28__spirv_SubgroupShuffleINTELIiET_S0_j(__clc_as_int(Data), InvocationId), \
+        CAST_TYPE);                                                                  \
   }
 __AMDGCN_CLC_SUBGROUP_I32(unsigned int, uint, j);
 __AMDGCN_CLC_SUBGROUP_I32(float, float, f);
@@ -69,7 +69,7 @@ __AMDGCN_CLC_SUBGROUP_I32(float, float, f);
 #define __AMDGCN_CLC_SUBGROUP_I64(TYPE, CAST_TYPE, MANGLED_TYPE_NAME)          \
   _CLC_DEF TYPE _Z28__spirv_SubgroupShuffleINTELI##MANGLED_TYPE_NAME##ET_S0_j( \
       TYPE Data, unsigned int InvocationId) {                                  \
-    int2 tmp = as_int2(Data);                                                  \
+    int2 tmp = __clc_as_int2(Data);                                            \
     tmp.lo = _Z28__spirv_SubgroupShuffleINTELIiET_S0_j(tmp.lo, InvocationId);  \
     tmp.hi = _Z28__spirv_SubgroupShuffleINTELIiET_S0_j(tmp.hi, InvocationId);  \
     return __builtin_astype(tmp, CAST_TYPE);                                   \
@@ -178,10 +178,10 @@ __AMDGCN_CLC_SUBGROUP_XOR_SUB_I32(unsigned short, t);
 #ifdef cl_khr_fp16
 _CLC_DEF half _Z31__spirv_SubgroupShuffleXorINTELIDF16_ET_S0_j(
     half Data, unsigned int InvocationId) {
-  unsigned short tmp = as_ushort(Data);
+  unsigned short tmp = __clc_as_ushort(Data);
   tmp = (unsigned short)_Z31__spirv_SubgroupShuffleXorINTELIiET_S0_j(
       (int)tmp, InvocationId);
-  return as_half(tmp);
+  return __clc_as_half(tmp);
 }
 #endif // cl_khr_fp16
 #undef __AMDGCN_CLC_SUBGROUP_XOR_SUB_I32
@@ -194,7 +194,7 @@ _CLC_DEF half _Z31__spirv_SubgroupShuffleXorINTELIDF16_ET_S0_j(
       _Z31__spirv_SubgroupShuffleXorINTELI##MANGLED_TYPE_NAME##ET_S0_j(        \
           TYPE Data, unsigned int InvocationId) {                              \
     return __builtin_astype(_Z31__spirv_SubgroupShuffleXorINTELIiET_S0_j(      \
-                                as_int(Data), InvocationId),                   \
+                                __clc_as_int(Data), InvocationId),             \
                             CAST_TYPE);                                        \
   }
 __AMDGCN_CLC_SUBGROUP_XOR_I32(unsigned int, uint, j);
@@ -209,7 +209,7 @@ __AMDGCN_CLC_SUBGROUP_XOR_I32(float, float, f);
   _CLC_DEF TYPE                                                                \
       _Z31__spirv_SubgroupShuffleXorINTELI##MANGLED_TYPE_NAME##ET_S0_j(        \
           TYPE Data, unsigned int InvocationId) {                              \
-    int2 tmp = as_int2(Data);                                                  \
+    int2 tmp = __clc_as_int2(Data);                                            \
     tmp.lo =                                                                   \
         _Z31__spirv_SubgroupShuffleXorINTELIiET_S0_j(tmp.lo, InvocationId);    \
     tmp.hi =                                                                   \
@@ -335,11 +335,11 @@ __AMDGCN_CLC_SUBGROUP_UP_SUB_I32(unsigned short, t);
 #ifdef cl_khr_fp16
 _CLC_DEF half _Z30__spirv_SubgroupShuffleUpINTELIDF16_ET_S0_S0_j(
     half previous, half current, unsigned int delta) {
-  unsigned short tmpP = as_ushort(previous);
-  unsigned short tmpC = as_ushort(current);
+  unsigned short tmpP = __clc_as_ushort(previous);
+  unsigned short tmpC = __clc_as_ushort(current);
   tmpC = (unsigned short)_Z30__spirv_SubgroupShuffleUpINTELIiET_S0_S0_j(
       (int)tmpP, (int)tmpC, delta);
-  return as_half(tmpC);
+  return __clc_as_half(tmpC);
 }
 #endif // cl_khr_fp16
 #undef __AMDGCN_CLC_SUBGROUP_UP_SUB_I32
@@ -352,7 +352,8 @@ _CLC_DEF half _Z30__spirv_SubgroupShuffleUpINTELIDF16_ET_S0_S0_j(
       _Z30__spirv_SubgroupShuffleUpINTELI##MANGLED_TYPE_NAME##ET_S0_S0_j(      \
           TYPE previous, TYPE current, unsigned int delta) {                   \
     return __builtin_astype(_Z30__spirv_SubgroupShuffleUpINTELIiET_S0_S0_j(    \
-                                as_int(previous), as_int(current), delta),     \
+                                __clc_as_int(previous), __clc_as_int(current), \
+                                delta),                                        \
                             CAST_TYPE);                                        \
   }
 __AMDGCN_CLC_SUBGROUP_UP_I32(unsigned int, uint, j);
@@ -367,8 +368,8 @@ __AMDGCN_CLC_SUBGROUP_UP_I32(float, float, f);
   _CLC_DEF TYPE                                                                \
       _Z30__spirv_SubgroupShuffleUpINTELI##MANGLED_TYPE_NAME##ET_S0_S0_j(      \
           TYPE previous, TYPE current, unsigned int delta) {                   \
-    int2 tmp_previous = as_int2(previous);                                     \
-    int2 tmp_current = as_int2(current);                                       \
+    int2 tmp_previous = __clc_as_int2(previous);                               \
+    int2 tmp_current = __clc_as_int2(current);                                 \
     int2 ret;                                                                  \
     ret.lo = _Z30__spirv_SubgroupShuffleUpINTELIiET_S0_S0_j(                   \
         tmp_previous.lo, tmp_current.lo, delta);                               \
@@ -495,11 +496,11 @@ __AMDGCN_CLC_SUBGROUP_DOWN_TO_I32(unsigned short, t);
 #ifdef cl_khr_fp16
 _CLC_DEF half _Z32__spirv_SubgroupShuffleDownINTELIDF16_ET_S0_S0_j(
     half current, half next, unsigned int delta) {
-  unsigned short tmpC = as_ushort(current);
-  unsigned short tmpN = as_ushort(next);
+  unsigned short tmpC = __clc_as_ushort(current);
+  unsigned short tmpN = __clc_as_ushort(next);
   tmpC = (unsigned short)_Z32__spirv_SubgroupShuffleDownINTELIiET_S0_S0_j(
       (int)tmpC, (int)tmpN, delta);
-  return as_half(tmpC);
+  return __clc_as_half(tmpC);
 }
 #endif // cl_khr_fp16
 #undef __AMDGCN_CLC_SUBGROUP_DOWN_TO_I32
@@ -507,13 +508,13 @@ _CLC_DEF half _Z32__spirv_SubgroupShuffleDownINTELIDF16_ET_S0_S0_j(
 // 32-bit types.
 // __spirv_SubgroupShuffleDownINTEL - unsigned int
 // __spirv_SubgroupShuffleDownINTEL - float
-#define __AMDGCN_CLC_SUBGROUP_DOWN_I32(TYPE, CAST_TYPE, MANGLED_TYPE_NAME)     \
-  _CLC_DEF TYPE                                                                \
-      _Z32__spirv_SubgroupShuffleDownINTELI##MANGLED_TYPE_NAME##ET_S0_S0_j(    \
-          TYPE current, TYPE next, unsigned int delta) {                       \
-    return __builtin_astype(_Z32__spirv_SubgroupShuffleDownINTELIiET_S0_S0_j(  \
-                                as_int(current), as_int(next), delta),         \
-                            CAST_TYPE);                                        \
+#define __AMDGCN_CLC_SUBGROUP_DOWN_I32(TYPE, CAST_TYPE, MANGLED_TYPE_NAME)        \
+  _CLC_DEF TYPE                                                                   \
+      _Z32__spirv_SubgroupShuffleDownINTELI##MANGLED_TYPE_NAME##ET_S0_S0_j(       \
+          TYPE current, TYPE next, unsigned int delta) {                          \
+    return __builtin_astype(_Z32__spirv_SubgroupShuffleDownINTELIiET_S0_S0_j(     \
+                               __clc_as_int(current), __clc_as_int(next), delta), \
+                            CAST_TYPE);                                           \
   }
 __AMDGCN_CLC_SUBGROUP_DOWN_I32(unsigned int, uint, j);
 __AMDGCN_CLC_SUBGROUP_DOWN_I32(float, float, f);
@@ -525,8 +526,8 @@ __AMDGCN_CLC_SUBGROUP_DOWN_I32(float, float, f);
   _CLC_DEF TYPE                                                                \
       _Z32__spirv_SubgroupShuffleDownINTELI##MANGLED_TYPE_NAME##ET_S0_S0_j(    \
           TYPE current, TYPE next, unsigned int delta) {                       \
-    int2 tmp_current = as_int2(current);                                       \
-    int2 tmp_next = as_int2(next);                                             \
+    int2 tmp_current = __clc_as_int2(current);                                 \
+    int2 tmp_next = __clc_as_int2(next);                                       \
     int2 ret;                                                                  \
     ret.lo = _Z32__spirv_SubgroupShuffleDownINTELIiET_S0_S0_j(                 \
         tmp_current.lo, tmp_next.lo, delta);                                   \

--- a/libclc/libspirv/lib/generic/atomic/atomic_store.cl
+++ b/libclc/libspirv/lib/generic/atomic/atomic_store.cl
@@ -15,7 +15,7 @@ _Z19__spirv_AtomicStorePU3AS1fN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE
     volatile global float *p, enum Scope scope,
     enum MemorySemanticsMask semantics, float val) {
   _Z19__spirv_AtomicStorePU3AS1jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagEj(
-      (volatile global uint *)p, scope, semantics, as_uint(val));
+      (volatile global uint *)p, scope, semantics, __clc_as_uint(val));
 }
 
 _CLC_DEF void
@@ -23,7 +23,7 @@ _Z19__spirv_AtomicStorePU3AS3fN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE
     volatile local float *p, enum Scope scope,
     enum MemorySemanticsMask semantics, float val) {
   _Z19__spirv_AtomicStorePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagEj(
-      (volatile local uint *)p, scope, semantics, as_uint(val));
+      (volatile local uint *)p, scope, semantics, __clc_as_uint(val));
 }
 
 #define FDECL(TYPE, PREFIX, AS, BYTE_SIZE, MEM_ORDER) \

--- a/libclc/libspirv/lib/generic/atomic/atomic_xchg.cl
+++ b/libclc/libspirv/lib/generic/atomic/atomic_xchg.cl
@@ -14,18 +14,18 @@ _CLC_DEF float
 _Z22__spirv_AtomicExchangePU3AS1fN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagEf(
     volatile global float *p, enum Scope scope,
     enum MemorySemanticsMask semantics, float val) {
-  return as_float(
+  return __clc_as_float(
       _Z22__spirv_AtomicExchangePU3AS1jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagEj(
-          (volatile global uint *)p, scope, semantics, as_uint(val)));
+          (volatile global uint *)p, scope, semantics, __clc_as_uint(val)));
 }
 
 _CLC_DEF float
 _Z22__spirv_AtomicExchangePU3AS3fN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagEf(
     volatile local float *p, enum Scope scope,
     enum MemorySemanticsMask semantics, float val) {
-  return as_float(
+  return __clc_as_float(
       _Z22__spirv_AtomicExchangePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagEj(
-          (volatile local uint *)p, scope, semantics, as_uint(val)));
+          (volatile local uint *)p, scope, semantics, __clc_as_uint(val)));
 }
 
 #define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, SUB, FN_NAME)                                                                        \

--- a/libclc/libspirv/lib/generic/float16.cl
+++ b/libclc/libspirv/lib/generic/float16.cl
@@ -19,2433 +19,2433 @@
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16_rte(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16_rtn(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16_rtp(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16_rtz(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16_sat(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16_sat(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16_sat(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16_sat_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16_sat_rte(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16_sat_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16_sat_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16_sat_rtn(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16_sat_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16_sat_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16_sat_rtp(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16_sat_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_ConvertFToS_Rchar16_sat_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar16_sat_rtz(as_half16(args_0));
+  return __spirv_ConvertFToS_Rchar16_sat_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2_rte(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2_rtn(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2_rtp(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2_rtz(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2_sat(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2_sat(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2_sat(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2_sat_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2_sat_rte(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2_sat_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2_sat_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2_sat_rtn(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2_sat_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2_sat_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2_sat_rtp(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2_sat_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_ConvertFToS_Rchar2_sat_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar2_sat_rtz(as_half2(args_0));
+  return __spirv_ConvertFToS_Rchar2_sat_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3_rte(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3_rtn(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3_rtp(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3_rtz(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3_sat(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3_sat(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3_sat(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3_sat_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3_sat_rte(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3_sat_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3_sat_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3_sat_rtn(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3_sat_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3_sat_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3_sat_rtp(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3_sat_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_ConvertFToS_Rchar3_sat_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar3_sat_rtz(as_half3(args_0));
+  return __spirv_ConvertFToS_Rchar3_sat_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4_rte(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4_rtn(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4_rtp(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4_rtz(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4_sat(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4_sat(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4_sat(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4_sat_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4_sat_rte(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4_sat_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4_sat_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4_sat_rtn(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4_sat_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4_sat_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4_sat_rtp(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4_sat_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_ConvertFToS_Rchar4_sat_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar4_sat_rtz(as_half4(args_0));
+  return __spirv_ConvertFToS_Rchar4_sat_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8_rte(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8_rtn(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8_rtp(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8_rtz(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8_sat(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8_sat(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8_sat(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8_sat_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8_sat_rte(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8_sat_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8_sat_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8_sat_rtn(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8_sat_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8_sat_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8_sat_rtp(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8_sat_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_ConvertFToS_Rchar8_sat_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar8_sat_rtz(as_half8(args_0));
+  return __spirv_ConvertFToS_Rchar8_sat_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar_rte(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar_rtn(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar_rtp(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar_rtz(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar_sat(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar_sat(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar_sat(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar_sat_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar_sat_rte(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar_sat_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar_sat_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar_sat_rtn(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar_sat_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar_sat_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar_sat_rtp(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar_sat_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int8_t
 __spirv_ConvertFToS_Rchar_sat_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rchar_sat_rtz(as_half(args_0));
+  return __spirv_ConvertFToS_Rchar_sat_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint(as_half(args_0));
+  return __spirv_ConvertFToS_Rint(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16_rte(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16_rtn(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16_rtp(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16_rtz(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16_sat(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16_sat(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16_sat(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16_sat_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16_sat_rte(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16_sat_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16_sat_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16_sat_rtn(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16_sat_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16_sat_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16_sat_rtp(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16_sat_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ConvertFToS_Rint16_sat_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint16_sat_rtz(as_half16(args_0));
+  return __spirv_ConvertFToS_Rint16_sat_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2_rte(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2_rtn(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2_rtp(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2_rtz(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2_sat(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2_sat(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2_sat(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2_sat_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2_sat_rte(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2_sat_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2_sat_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2_sat_rtn(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2_sat_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2_sat_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2_sat_rtp(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2_sat_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ConvertFToS_Rint2_sat_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint2_sat_rtz(as_half2(args_0));
+  return __spirv_ConvertFToS_Rint2_sat_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3_rte(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3_rtn(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3_rtp(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3_rtz(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3_sat(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3_sat(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3_sat(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3_sat_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3_sat_rte(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3_sat_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3_sat_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3_sat_rtn(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3_sat_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3_sat_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3_sat_rtp(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3_sat_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ConvertFToS_Rint3_sat_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint3_sat_rtz(as_half3(args_0));
+  return __spirv_ConvertFToS_Rint3_sat_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4_rte(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4_rtn(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4_rtp(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4_rtz(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4_sat(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4_sat(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4_sat(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4_sat_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4_sat_rte(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4_sat_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4_sat_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4_sat_rtn(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4_sat_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4_sat_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4_sat_rtp(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4_sat_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ConvertFToS_Rint4_sat_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint4_sat_rtz(as_half4(args_0));
+  return __spirv_ConvertFToS_Rint4_sat_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8_rte(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8_rtn(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8_rtp(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8_rtz(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8_sat(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8_sat(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8_sat(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8_sat_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8_sat_rte(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8_sat_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8_sat_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8_sat_rtn(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8_sat_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8_sat_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8_sat_rtp(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8_sat_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ConvertFToS_Rint8_sat_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint8_sat_rtz(as_half8(args_0));
+  return __spirv_ConvertFToS_Rint8_sat_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint_rte(as_half(args_0));
+  return __spirv_ConvertFToS_Rint_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint_rtn(as_half(args_0));
+  return __spirv_ConvertFToS_Rint_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint_rtp(as_half(args_0));
+  return __spirv_ConvertFToS_Rint_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint_rtz(as_half(args_0));
+  return __spirv_ConvertFToS_Rint_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint_sat(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint_sat(as_half(args_0));
+  return __spirv_ConvertFToS_Rint_sat(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint_sat_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint_sat_rte(as_half(args_0));
+  return __spirv_ConvertFToS_Rint_sat_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint_sat_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint_sat_rtn(as_half(args_0));
+  return __spirv_ConvertFToS_Rint_sat_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint_sat_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint_sat_rtp(as_half(args_0));
+  return __spirv_ConvertFToS_Rint_sat_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ConvertFToS_Rint_sat_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rint_sat_rtz(as_half(args_0));
+  return __spirv_ConvertFToS_Rint_sat_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16_rte(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16_rtn(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16_rtp(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16_rtz(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16_sat(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16_sat(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16_sat(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16_sat_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16_sat_rte(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16_sat_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16_sat_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16_sat_rtn(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16_sat_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16_sat_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16_sat_rtp(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16_sat_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int64_t
 __spirv_ConvertFToS_Rlong16_sat_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong16_sat_rtz(as_half16(args_0));
+  return __spirv_ConvertFToS_Rlong16_sat_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2_rte(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2_rtn(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2_rtp(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2_rtz(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2_sat(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2_sat(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2_sat(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2_sat_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2_sat_rte(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2_sat_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2_sat_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2_sat_rtn(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2_sat_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2_sat_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2_sat_rtp(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2_sat_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int64_t
 __spirv_ConvertFToS_Rlong2_sat_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong2_sat_rtz(as_half2(args_0));
+  return __spirv_ConvertFToS_Rlong2_sat_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3_rte(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3_rtn(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3_rtp(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3_rtz(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3_sat(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3_sat(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3_sat(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3_sat_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3_sat_rte(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3_sat_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3_sat_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3_sat_rtn(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3_sat_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3_sat_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3_sat_rtp(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3_sat_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int64_t
 __spirv_ConvertFToS_Rlong3_sat_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong3_sat_rtz(as_half3(args_0));
+  return __spirv_ConvertFToS_Rlong3_sat_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4_rte(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4_rtn(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4_rtp(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4_rtz(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4_sat(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4_sat(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4_sat(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4_sat_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4_sat_rte(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4_sat_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4_sat_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4_sat_rtn(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4_sat_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4_sat_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4_sat_rtp(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4_sat_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int64_t
 __spirv_ConvertFToS_Rlong4_sat_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong4_sat_rtz(as_half4(args_0));
+  return __spirv_ConvertFToS_Rlong4_sat_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8_rte(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8_rtn(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8_rtp(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8_rtz(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8_sat(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8_sat(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8_sat(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8_sat_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8_sat_rte(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8_sat_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8_sat_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8_sat_rtn(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8_sat_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8_sat_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8_sat_rtp(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8_sat_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int64_t
 __spirv_ConvertFToS_Rlong8_sat_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong8_sat_rtz(as_half8(args_0));
+  return __spirv_ConvertFToS_Rlong8_sat_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong_rte(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong_rtn(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong_rtp(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong_rtz(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong_sat(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong_sat(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong_sat(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong_sat_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong_sat_rte(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong_sat_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong_sat_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong_sat_rtn(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong_sat_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong_sat_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong_sat_rtp(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong_sat_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int64_t
 __spirv_ConvertFToS_Rlong_sat_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rlong_sat_rtz(as_half(args_0));
+  return __spirv_ConvertFToS_Rlong_sat_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16_rte(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16_rtn(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16_rtp(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16_rtz(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16_sat(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16_sat(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16_sat(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16_sat_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16_sat_rte(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16_sat_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16_sat_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16_sat_rtn(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16_sat_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16_sat_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16_sat_rtp(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16_sat_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int16_t
 __spirv_ConvertFToS_Rshort16_sat_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort16_sat_rtz(as_half16(args_0));
+  return __spirv_ConvertFToS_Rshort16_sat_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2_rte(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2_rtn(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2_rtp(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2_rtz(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2_sat(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2_sat(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2_sat(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2_sat_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2_sat_rte(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2_sat_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2_sat_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2_sat_rtn(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2_sat_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2_sat_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2_sat_rtp(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2_sat_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int16_t
 __spirv_ConvertFToS_Rshort2_sat_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort2_sat_rtz(as_half2(args_0));
+  return __spirv_ConvertFToS_Rshort2_sat_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3_rte(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3_rtn(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3_rtp(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3_rtz(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3_sat(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3_sat(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3_sat(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3_sat_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3_sat_rte(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3_sat_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3_sat_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3_sat_rtn(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3_sat_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3_sat_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3_sat_rtp(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3_sat_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int16_t
 __spirv_ConvertFToS_Rshort3_sat_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort3_sat_rtz(as_half3(args_0));
+  return __spirv_ConvertFToS_Rshort3_sat_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4_rte(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4_rtn(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4_rtp(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4_rtz(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4_sat(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4_sat(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4_sat(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4_sat_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4_sat_rte(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4_sat_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4_sat_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4_sat_rtn(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4_sat_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4_sat_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4_sat_rtp(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4_sat_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int16_t
 __spirv_ConvertFToS_Rshort4_sat_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort4_sat_rtz(as_half4(args_0));
+  return __spirv_ConvertFToS_Rshort4_sat_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8_rte(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8_rtn(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8_rtp(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8_rtz(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8_sat(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8_sat(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8_sat(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8_sat_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8_sat_rte(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8_sat_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8_sat_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8_sat_rtn(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8_sat_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8_sat_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8_sat_rtp(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8_sat_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int16_t
 __spirv_ConvertFToS_Rshort8_sat_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort8_sat_rtz(as_half8(args_0));
+  return __spirv_ConvertFToS_Rshort8_sat_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort_rte(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort_rtn(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort_rtp(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort_rtz(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort_sat(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort_sat(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort_sat(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort_sat_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort_sat_rte(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort_sat_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort_sat_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort_sat_rtn(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort_sat_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort_sat_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort_sat_rtp(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort_sat_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int16_t
 __spirv_ConvertFToS_Rshort_sat_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToS_Rshort_sat_rtz(as_half(args_0));
+  return __spirv_ConvertFToS_Rshort_sat_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16_rte(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16_rtn(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16_rtp(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16_rtz(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16_sat(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16_sat(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16_sat(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16_sat_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16_sat_rte(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16_sat_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16_sat_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16_sat_rtn(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16_sat_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16_sat_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16_sat_rtp(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16_sat_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint8_t
 __spirv_ConvertFToU_Ruchar16_sat_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar16_sat_rtz(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruchar16_sat_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2_rte(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2_rtn(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2_rtp(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2_rtz(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2_sat(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2_sat(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2_sat(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2_sat_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2_sat_rte(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2_sat_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2_sat_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2_sat_rtn(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2_sat_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2_sat_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2_sat_rtp(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2_sat_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint8_t
 __spirv_ConvertFToU_Ruchar2_sat_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar2_sat_rtz(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruchar2_sat_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3_rte(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3_rtn(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3_rtp(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3_rtz(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3_sat(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3_sat(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3_sat(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3_sat_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3_sat_rte(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3_sat_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3_sat_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3_sat_rtn(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3_sat_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3_sat_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3_sat_rtp(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3_sat_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint8_t
 __spirv_ConvertFToU_Ruchar3_sat_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar3_sat_rtz(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruchar3_sat_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4_rte(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4_rtn(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4_rtp(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4_rtz(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4_sat(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4_sat(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4_sat(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4_sat_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4_sat_rte(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4_sat_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4_sat_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4_sat_rtn(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4_sat_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4_sat_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4_sat_rtp(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4_sat_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint8_t
 __spirv_ConvertFToU_Ruchar4_sat_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar4_sat_rtz(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruchar4_sat_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8_rte(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8_rtn(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8_rtp(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8_rtz(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8_sat(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8_sat(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8_sat(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8_sat_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8_sat_rte(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8_sat_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8_sat_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8_sat_rtn(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8_sat_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8_sat_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8_sat_rtp(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8_sat_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint8_t
 __spirv_ConvertFToU_Ruchar8_sat_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar8_sat_rtz(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruchar8_sat_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar_rte(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar_rtn(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar_rtp(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar_rtz(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar_sat(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar_sat(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar_sat(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar_sat_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar_sat_rte(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar_sat_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar_sat_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar_sat_rtn(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar_sat_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar_sat_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar_sat_rtp(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar_sat_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint8_t
 __spirv_ConvertFToU_Ruchar_sat_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruchar_sat_rtz(as_half(args_0));
+  return __spirv_ConvertFToU_Ruchar_sat_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16_rte(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16_rtn(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16_rtp(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16_rtz(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16_sat(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16_sat(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16_sat(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16_sat_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16_sat_rte(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16_sat_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16_sat_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16_sat_rtn(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16_sat_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16_sat_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16_sat_rtp(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16_sat_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint32_t
 __spirv_ConvertFToU_Ruint16_sat_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint16_sat_rtz(as_half16(args_0));
+  return __spirv_ConvertFToU_Ruint16_sat_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2_rte(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2_rtn(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2_rtp(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2_rtz(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2_sat(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2_sat(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2_sat(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2_sat_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2_sat_rte(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2_sat_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2_sat_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2_sat_rtn(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2_sat_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2_sat_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2_sat_rtp(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2_sat_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint32_t
 __spirv_ConvertFToU_Ruint2_sat_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint2_sat_rtz(as_half2(args_0));
+  return __spirv_ConvertFToU_Ruint2_sat_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3_rte(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3_rtn(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3_rtp(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3_rtz(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3_sat(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3_sat(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3_sat(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3_sat_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3_sat_rte(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3_sat_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3_sat_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3_sat_rtn(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3_sat_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3_sat_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3_sat_rtp(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3_sat_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint32_t
 __spirv_ConvertFToU_Ruint3_sat_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint3_sat_rtz(as_half3(args_0));
+  return __spirv_ConvertFToU_Ruint3_sat_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4_rte(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4_rtn(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4_rtp(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4_rtz(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4_sat(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4_sat(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4_sat(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4_sat_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4_sat_rte(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4_sat_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4_sat_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4_sat_rtn(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4_sat_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4_sat_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4_sat_rtp(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4_sat_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint32_t
 __spirv_ConvertFToU_Ruint4_sat_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint4_sat_rtz(as_half4(args_0));
+  return __spirv_ConvertFToU_Ruint4_sat_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8_rte(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8_rtn(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8_rtp(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8_rtz(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8_sat(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8_sat(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8_sat(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8_sat_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8_sat_rte(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8_sat_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8_sat_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8_sat_rtn(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8_sat_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8_sat_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8_sat_rtp(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8_sat_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint32_t
 __spirv_ConvertFToU_Ruint8_sat_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint8_sat_rtz(as_half8(args_0));
+  return __spirv_ConvertFToU_Ruint8_sat_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint_rte(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint_rtn(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint_rtp(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint_rtz(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint_sat(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint_sat(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint_sat(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint_sat_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint_sat_rte(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint_sat_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint_sat_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint_sat_rtn(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint_sat_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint_sat_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint_sat_rtp(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint_sat_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint32_t
 __spirv_ConvertFToU_Ruint_sat_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Ruint_sat_rtz(as_half(args_0));
+  return __spirv_ConvertFToU_Ruint_sat_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16_rte(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16_rtn(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16_rtp(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16_rtz(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16_sat(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16_sat(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16_sat(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16_sat_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16_sat_rte(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16_sat_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16_sat_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16_sat_rtn(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16_sat_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16_sat_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16_sat_rtp(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16_sat_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint64_t
 __spirv_ConvertFToU_Rulong16_sat_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong16_sat_rtz(as_half16(args_0));
+  return __spirv_ConvertFToU_Rulong16_sat_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2_rte(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2_rtn(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2_rtp(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2_rtz(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2_sat(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2_sat(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2_sat(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2_sat_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2_sat_rte(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2_sat_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2_sat_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2_sat_rtn(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2_sat_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2_sat_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2_sat_rtp(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2_sat_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint64_t
 __spirv_ConvertFToU_Rulong2_sat_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong2_sat_rtz(as_half2(args_0));
+  return __spirv_ConvertFToU_Rulong2_sat_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3_rte(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3_rtn(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3_rtp(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3_rtz(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3_sat(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3_sat(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3_sat(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3_sat_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3_sat_rte(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3_sat_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3_sat_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3_sat_rtn(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3_sat_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3_sat_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3_sat_rtp(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3_sat_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint64_t
 __spirv_ConvertFToU_Rulong3_sat_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong3_sat_rtz(as_half3(args_0));
+  return __spirv_ConvertFToU_Rulong3_sat_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4_rte(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4_rtn(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4_rtp(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4_rtz(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4_sat(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4_sat(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4_sat(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4_sat_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4_sat_rte(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4_sat_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4_sat_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4_sat_rtn(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4_sat_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4_sat_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4_sat_rtp(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4_sat_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint64_t
 __spirv_ConvertFToU_Rulong4_sat_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong4_sat_rtz(as_half4(args_0));
+  return __spirv_ConvertFToU_Rulong4_sat_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8_rte(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8_rtn(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8_rtp(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8_rtz(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8_sat(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8_sat(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8_sat(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8_sat_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8_sat_rte(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8_sat_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8_sat_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8_sat_rtn(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8_sat_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8_sat_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8_sat_rtp(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8_sat_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint64_t
 __spirv_ConvertFToU_Rulong8_sat_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong8_sat_rtz(as_half8(args_0));
+  return __spirv_ConvertFToU_Rulong8_sat_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong_rte(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong_rtn(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong_rtp(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong_rtz(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong_sat(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong_sat(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong_sat(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong_sat_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong_sat_rte(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong_sat_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong_sat_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong_sat_rtn(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong_sat_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong_sat_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong_sat_rtp(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong_sat_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint64_t
 __spirv_ConvertFToU_Rulong_sat_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rulong_sat_rtz(as_half(args_0));
+  return __spirv_ConvertFToU_Rulong_sat_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16_rte(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16_rtn(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16_rtp(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16_rtz(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16_sat(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16_sat(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16_sat(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16_sat_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16_sat_rte(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16_sat_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16_sat_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16_sat_rtn(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16_sat_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16_sat_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16_sat_rtp(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16_sat_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_uint16_t
 __spirv_ConvertFToU_Rushort16_sat_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort16_sat_rtz(as_half16(args_0));
+  return __spirv_ConvertFToU_Rushort16_sat_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2_rte(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2_rtn(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2_rtp(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2_rtz(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2_sat(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2_sat(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2_sat(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2_sat_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2_sat_rte(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2_sat_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2_sat_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2_sat_rtn(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2_sat_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2_sat_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2_sat_rtp(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2_sat_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_uint16_t
 __spirv_ConvertFToU_Rushort2_sat_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort2_sat_rtz(as_half2(args_0));
+  return __spirv_ConvertFToU_Rushort2_sat_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3_rte(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3_rtn(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3_rtp(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3_rtz(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3_sat(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3_sat(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3_sat(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3_sat_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3_sat_rte(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3_sat_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3_sat_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3_sat_rtn(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3_sat_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3_sat_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3_sat_rtp(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3_sat_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_uint16_t
 __spirv_ConvertFToU_Rushort3_sat_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort3_sat_rtz(as_half3(args_0));
+  return __spirv_ConvertFToU_Rushort3_sat_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4_rte(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4_rtn(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4_rtp(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4_rtz(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4_sat(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4_sat(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4_sat(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4_sat_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4_sat_rte(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4_sat_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4_sat_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4_sat_rtn(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4_sat_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4_sat_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4_sat_rtp(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4_sat_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_uint16_t
 __spirv_ConvertFToU_Rushort4_sat_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort4_sat_rtz(as_half4(args_0));
+  return __spirv_ConvertFToU_Rushort4_sat_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8_rte(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8_rtn(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8_rtp(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8_rtz(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8_sat(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8_sat(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8_sat(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8_sat_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8_sat_rte(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8_sat_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8_sat_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8_sat_rtn(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8_sat_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8_sat_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8_sat_rtp(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8_sat_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_uint16_t
 __spirv_ConvertFToU_Rushort8_sat_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort8_sat_rtz(as_half8(args_0));
+  return __spirv_ConvertFToU_Rushort8_sat_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort_rte(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort_rtn(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort_rtp(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort_rtz(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort_sat(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort_sat(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort_sat(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort_sat_rte(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort_sat_rte(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort_sat_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort_sat_rtn(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort_sat_rtn(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort_sat_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort_sat_rtp(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort_sat_rtp(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort_sat_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_uint16_t
 __spirv_ConvertFToU_Rushort_sat_rtz(__clc_float16_t args_0) {
-  return __spirv_ConvertFToU_Rushort_sat_rtz(as_half(args_0));
+  return __spirv_ConvertFToU_Rushort_sat_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_Dot(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_Dot(as_half2(args_0), as_half2(args_1));
+  return __spirv_Dot(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_Dot(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_Dot(as_half3(args_0), as_half3(args_1));
+  return __spirv_Dot(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_Dot(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_Dot(as_half4(args_0), as_half4(args_1));
+  return __spirv_Dot(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_Dot(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_Dot(as_half8(args_0), as_half8(args_1));
+  return __spirv_Dot(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_Dot(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_Dot(as_half16(args_0), as_half16(args_1));
+  return __spirv_Dot(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp64_t
 __spirv_FConvert_Rdouble(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rdouble(as_half(args_0));
+  return __spirv_FConvert_Rdouble(__clc_as_half(args_0));
 }
 
 #endif
@@ -2453,7 +2453,7 @@ __spirv_FConvert_Rdouble(__clc_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp64_t
 __spirv_FConvert_Rdouble16(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rdouble16(as_half16(args_0));
+  return __spirv_FConvert_Rdouble16(__clc_as_half16(args_0));
 }
 
 #endif
@@ -2461,7 +2461,7 @@ __spirv_FConvert_Rdouble16(__clc_vec16_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp64_t
 __spirv_FConvert_Rdouble16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rdouble16_rte(as_half16(args_0));
+  return __spirv_FConvert_Rdouble16_rte(__clc_as_half16(args_0));
 }
 
 #endif
@@ -2469,7 +2469,7 @@ __spirv_FConvert_Rdouble16_rte(__clc_vec16_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp64_t
 __spirv_FConvert_Rdouble16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rdouble16_rtn(as_half16(args_0));
+  return __spirv_FConvert_Rdouble16_rtn(__clc_as_half16(args_0));
 }
 
 #endif
@@ -2477,7 +2477,7 @@ __spirv_FConvert_Rdouble16_rtn(__clc_vec16_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp64_t
 __spirv_FConvert_Rdouble16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rdouble16_rtp(as_half16(args_0));
+  return __spirv_FConvert_Rdouble16_rtp(__clc_as_half16(args_0));
 }
 
 #endif
@@ -2485,7 +2485,7 @@ __spirv_FConvert_Rdouble16_rtp(__clc_vec16_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp64_t
 __spirv_FConvert_Rdouble16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rdouble16_rtz(as_half16(args_0));
+  return __spirv_FConvert_Rdouble16_rtz(__clc_as_half16(args_0));
 }
 
 #endif
@@ -2493,7 +2493,7 @@ __spirv_FConvert_Rdouble16_rtz(__clc_vec16_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp64_t
 __spirv_FConvert_Rdouble2(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rdouble2(as_half2(args_0));
+  return __spirv_FConvert_Rdouble2(__clc_as_half2(args_0));
 }
 
 #endif
@@ -2501,7 +2501,7 @@ __spirv_FConvert_Rdouble2(__clc_vec2_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp64_t
 __spirv_FConvert_Rdouble2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rdouble2_rte(as_half2(args_0));
+  return __spirv_FConvert_Rdouble2_rte(__clc_as_half2(args_0));
 }
 
 #endif
@@ -2509,7 +2509,7 @@ __spirv_FConvert_Rdouble2_rte(__clc_vec2_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp64_t
 __spirv_FConvert_Rdouble2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rdouble2_rtn(as_half2(args_0));
+  return __spirv_FConvert_Rdouble2_rtn(__clc_as_half2(args_0));
 }
 
 #endif
@@ -2517,7 +2517,7 @@ __spirv_FConvert_Rdouble2_rtn(__clc_vec2_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp64_t
 __spirv_FConvert_Rdouble2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rdouble2_rtp(as_half2(args_0));
+  return __spirv_FConvert_Rdouble2_rtp(__clc_as_half2(args_0));
 }
 
 #endif
@@ -2525,7 +2525,7 @@ __spirv_FConvert_Rdouble2_rtp(__clc_vec2_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp64_t
 __spirv_FConvert_Rdouble2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rdouble2_rtz(as_half2(args_0));
+  return __spirv_FConvert_Rdouble2_rtz(__clc_as_half2(args_0));
 }
 
 #endif
@@ -2533,7 +2533,7 @@ __spirv_FConvert_Rdouble2_rtz(__clc_vec2_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp64_t
 __spirv_FConvert_Rdouble3(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rdouble3(as_half3(args_0));
+  return __spirv_FConvert_Rdouble3(__clc_as_half3(args_0));
 }
 
 #endif
@@ -2541,7 +2541,7 @@ __spirv_FConvert_Rdouble3(__clc_vec3_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp64_t
 __spirv_FConvert_Rdouble3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rdouble3_rte(as_half3(args_0));
+  return __spirv_FConvert_Rdouble3_rte(__clc_as_half3(args_0));
 }
 
 #endif
@@ -2549,7 +2549,7 @@ __spirv_FConvert_Rdouble3_rte(__clc_vec3_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp64_t
 __spirv_FConvert_Rdouble3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rdouble3_rtn(as_half3(args_0));
+  return __spirv_FConvert_Rdouble3_rtn(__clc_as_half3(args_0));
 }
 
 #endif
@@ -2557,7 +2557,7 @@ __spirv_FConvert_Rdouble3_rtn(__clc_vec3_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp64_t
 __spirv_FConvert_Rdouble3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rdouble3_rtp(as_half3(args_0));
+  return __spirv_FConvert_Rdouble3_rtp(__clc_as_half3(args_0));
 }
 
 #endif
@@ -2565,7 +2565,7 @@ __spirv_FConvert_Rdouble3_rtp(__clc_vec3_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp64_t
 __spirv_FConvert_Rdouble3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rdouble3_rtz(as_half3(args_0));
+  return __spirv_FConvert_Rdouble3_rtz(__clc_as_half3(args_0));
 }
 
 #endif
@@ -2573,7 +2573,7 @@ __spirv_FConvert_Rdouble3_rtz(__clc_vec3_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp64_t
 __spirv_FConvert_Rdouble4(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rdouble4(as_half4(args_0));
+  return __spirv_FConvert_Rdouble4(__clc_as_half4(args_0));
 }
 
 #endif
@@ -2581,7 +2581,7 @@ __spirv_FConvert_Rdouble4(__clc_vec4_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp64_t
 __spirv_FConvert_Rdouble4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rdouble4_rte(as_half4(args_0));
+  return __spirv_FConvert_Rdouble4_rte(__clc_as_half4(args_0));
 }
 
 #endif
@@ -2589,7 +2589,7 @@ __spirv_FConvert_Rdouble4_rte(__clc_vec4_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp64_t
 __spirv_FConvert_Rdouble4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rdouble4_rtn(as_half4(args_0));
+  return __spirv_FConvert_Rdouble4_rtn(__clc_as_half4(args_0));
 }
 
 #endif
@@ -2597,7 +2597,7 @@ __spirv_FConvert_Rdouble4_rtn(__clc_vec4_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp64_t
 __spirv_FConvert_Rdouble4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rdouble4_rtp(as_half4(args_0));
+  return __spirv_FConvert_Rdouble4_rtp(__clc_as_half4(args_0));
 }
 
 #endif
@@ -2605,7 +2605,7 @@ __spirv_FConvert_Rdouble4_rtp(__clc_vec4_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp64_t
 __spirv_FConvert_Rdouble4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rdouble4_rtz(as_half4(args_0));
+  return __spirv_FConvert_Rdouble4_rtz(__clc_as_half4(args_0));
 }
 
 #endif
@@ -2613,7 +2613,7 @@ __spirv_FConvert_Rdouble4_rtz(__clc_vec4_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp64_t
 __spirv_FConvert_Rdouble8(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rdouble8(as_half8(args_0));
+  return __spirv_FConvert_Rdouble8(__clc_as_half8(args_0));
 }
 
 #endif
@@ -2621,7 +2621,7 @@ __spirv_FConvert_Rdouble8(__clc_vec8_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp64_t
 __spirv_FConvert_Rdouble8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rdouble8_rte(as_half8(args_0));
+  return __spirv_FConvert_Rdouble8_rte(__clc_as_half8(args_0));
 }
 
 #endif
@@ -2629,7 +2629,7 @@ __spirv_FConvert_Rdouble8_rte(__clc_vec8_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp64_t
 __spirv_FConvert_Rdouble8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rdouble8_rtn(as_half8(args_0));
+  return __spirv_FConvert_Rdouble8_rtn(__clc_as_half8(args_0));
 }
 
 #endif
@@ -2637,7 +2637,7 @@ __spirv_FConvert_Rdouble8_rtn(__clc_vec8_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp64_t
 __spirv_FConvert_Rdouble8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rdouble8_rtp(as_half8(args_0));
+  return __spirv_FConvert_Rdouble8_rtp(__clc_as_half8(args_0));
 }
 
 #endif
@@ -2645,7 +2645,7 @@ __spirv_FConvert_Rdouble8_rtp(__clc_vec8_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp64_t
 __spirv_FConvert_Rdouble8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rdouble8_rtz(as_half8(args_0));
+  return __spirv_FConvert_Rdouble8_rtz(__clc_as_half8(args_0));
 }
 
 #endif
@@ -2653,7 +2653,7 @@ __spirv_FConvert_Rdouble8_rtz(__clc_vec8_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp64_t
 __spirv_FConvert_Rdouble_rte(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rdouble_rte(as_half(args_0));
+  return __spirv_FConvert_Rdouble_rte(__clc_as_half(args_0));
 }
 
 #endif
@@ -2661,7 +2661,7 @@ __spirv_FConvert_Rdouble_rte(__clc_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp64_t
 __spirv_FConvert_Rdouble_rtn(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rdouble_rtn(as_half(args_0));
+  return __spirv_FConvert_Rdouble_rtn(__clc_as_half(args_0));
 }
 
 #endif
@@ -2669,7 +2669,7 @@ __spirv_FConvert_Rdouble_rtn(__clc_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp64_t
 __spirv_FConvert_Rdouble_rtp(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rdouble_rtp(as_half(args_0));
+  return __spirv_FConvert_Rdouble_rtp(__clc_as_half(args_0));
 }
 
 #endif
@@ -2677,536 +2677,536 @@ __spirv_FConvert_Rdouble_rtp(__clc_float16_t args_0) {
 #ifdef cl_khr_fp64
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp64_t
 __spirv_FConvert_Rdouble_rtz(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rdouble_rtz(as_half(args_0));
+  return __spirv_FConvert_Rdouble_rtz(__clc_as_half(args_0));
 }
 
 #endif
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp32_t
 __spirv_FConvert_Rfloat(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rfloat(as_half(args_0));
+  return __spirv_FConvert_Rfloat(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp32_t
 __spirv_FConvert_Rfloat16(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rfloat16(as_half16(args_0));
+  return __spirv_FConvert_Rfloat16(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp32_t
 __spirv_FConvert_Rfloat16_rte(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rfloat16_rte(as_half16(args_0));
+  return __spirv_FConvert_Rfloat16_rte(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp32_t
 __spirv_FConvert_Rfloat16_rtn(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rfloat16_rtn(as_half16(args_0));
+  return __spirv_FConvert_Rfloat16_rtn(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp32_t
 __spirv_FConvert_Rfloat16_rtp(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rfloat16_rtp(as_half16(args_0));
+  return __spirv_FConvert_Rfloat16_rtp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp32_t
 __spirv_FConvert_Rfloat16_rtz(__clc_vec16_float16_t args_0) {
-  return __spirv_FConvert_Rfloat16_rtz(as_half16(args_0));
+  return __spirv_FConvert_Rfloat16_rtz(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp32_t
 __spirv_FConvert_Rfloat2(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rfloat2(as_half2(args_0));
+  return __spirv_FConvert_Rfloat2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp32_t
 __spirv_FConvert_Rfloat2_rte(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rfloat2_rte(as_half2(args_0));
+  return __spirv_FConvert_Rfloat2_rte(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp32_t
 __spirv_FConvert_Rfloat2_rtn(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rfloat2_rtn(as_half2(args_0));
+  return __spirv_FConvert_Rfloat2_rtn(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp32_t
 __spirv_FConvert_Rfloat2_rtp(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rfloat2_rtp(as_half2(args_0));
+  return __spirv_FConvert_Rfloat2_rtp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp32_t
 __spirv_FConvert_Rfloat2_rtz(__clc_vec2_float16_t args_0) {
-  return __spirv_FConvert_Rfloat2_rtz(as_half2(args_0));
+  return __spirv_FConvert_Rfloat2_rtz(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp32_t
 __spirv_FConvert_Rfloat3(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rfloat3(as_half3(args_0));
+  return __spirv_FConvert_Rfloat3(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp32_t
 __spirv_FConvert_Rfloat3_rte(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rfloat3_rte(as_half3(args_0));
+  return __spirv_FConvert_Rfloat3_rte(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp32_t
 __spirv_FConvert_Rfloat3_rtn(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rfloat3_rtn(as_half3(args_0));
+  return __spirv_FConvert_Rfloat3_rtn(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp32_t
 __spirv_FConvert_Rfloat3_rtp(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rfloat3_rtp(as_half3(args_0));
+  return __spirv_FConvert_Rfloat3_rtp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp32_t
 __spirv_FConvert_Rfloat3_rtz(__clc_vec3_float16_t args_0) {
-  return __spirv_FConvert_Rfloat3_rtz(as_half3(args_0));
+  return __spirv_FConvert_Rfloat3_rtz(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp32_t
 __spirv_FConvert_Rfloat4(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rfloat4(as_half4(args_0));
+  return __spirv_FConvert_Rfloat4(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp32_t
 __spirv_FConvert_Rfloat4_rte(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rfloat4_rte(as_half4(args_0));
+  return __spirv_FConvert_Rfloat4_rte(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp32_t
 __spirv_FConvert_Rfloat4_rtn(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rfloat4_rtn(as_half4(args_0));
+  return __spirv_FConvert_Rfloat4_rtn(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp32_t
 __spirv_FConvert_Rfloat4_rtp(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rfloat4_rtp(as_half4(args_0));
+  return __spirv_FConvert_Rfloat4_rtp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp32_t
 __spirv_FConvert_Rfloat4_rtz(__clc_vec4_float16_t args_0) {
-  return __spirv_FConvert_Rfloat4_rtz(as_half4(args_0));
+  return __spirv_FConvert_Rfloat4_rtz(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp32_t
 __spirv_FConvert_Rfloat8(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rfloat8(as_half8(args_0));
+  return __spirv_FConvert_Rfloat8(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp32_t
 __spirv_FConvert_Rfloat8_rte(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rfloat8_rte(as_half8(args_0));
+  return __spirv_FConvert_Rfloat8_rte(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp32_t
 __spirv_FConvert_Rfloat8_rtn(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rfloat8_rtn(as_half8(args_0));
+  return __spirv_FConvert_Rfloat8_rtn(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp32_t
 __spirv_FConvert_Rfloat8_rtp(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rfloat8_rtp(as_half8(args_0));
+  return __spirv_FConvert_Rfloat8_rtp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp32_t
 __spirv_FConvert_Rfloat8_rtz(__clc_vec8_float16_t args_0) {
-  return __spirv_FConvert_Rfloat8_rtz(as_half8(args_0));
+  return __spirv_FConvert_Rfloat8_rtz(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp32_t
 __spirv_FConvert_Rfloat_rte(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rfloat_rte(as_half(args_0));
+  return __spirv_FConvert_Rfloat_rte(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp32_t
 __spirv_FConvert_Rfloat_rtn(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rfloat_rtn(as_half(args_0));
+  return __spirv_FConvert_Rfloat_rtn(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp32_t
 __spirv_FConvert_Rfloat_rtp(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rfloat_rtp(as_half(args_0));
+  return __spirv_FConvert_Rfloat_rtp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp32_t
 __spirv_FConvert_Rfloat_rtz(__clc_float16_t args_0) {
-  return __spirv_FConvert_Rfloat_rtz(as_half(args_0));
+  return __spirv_FConvert_Rfloat_rtz(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FOrdEqual(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FOrdEqual(as_half(args_0), as_half(args_1));
+  return __spirv_FOrdEqual(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_FOrdEqual(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_FOrdEqual(as_half2(args_0), as_half2(args_1));
+  return __spirv_FOrdEqual(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_FOrdEqual(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_FOrdEqual(as_half3(args_0), as_half3(args_1));
+  return __spirv_FOrdEqual(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_FOrdEqual(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_FOrdEqual(as_half4(args_0), as_half4(args_1));
+  return __spirv_FOrdEqual(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_FOrdEqual(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_FOrdEqual(as_half8(args_0), as_half8(args_1));
+  return __spirv_FOrdEqual(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_FOrdEqual(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_FOrdEqual(as_half16(args_0), as_half16(args_1));
+  return __spirv_FOrdEqual(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FOrdGreaterThan(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FOrdGreaterThan(as_half(args_0), as_half(args_1));
+  return __spirv_FOrdGreaterThan(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t __spirv_FOrdGreaterThan(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_FOrdGreaterThan(as_half2(args_0), as_half2(args_1));
+  return __spirv_FOrdGreaterThan(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t __spirv_FOrdGreaterThan(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_FOrdGreaterThan(as_half3(args_0), as_half3(args_1));
+  return __spirv_FOrdGreaterThan(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t __spirv_FOrdGreaterThan(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_FOrdGreaterThan(as_half4(args_0), as_half4(args_1));
+  return __spirv_FOrdGreaterThan(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t __spirv_FOrdGreaterThan(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_FOrdGreaterThan(as_half8(args_0), as_half8(args_1));
+  return __spirv_FOrdGreaterThan(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t __spirv_FOrdGreaterThan(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_FOrdGreaterThan(as_half16(args_0), as_half16(args_1));
+  return __spirv_FOrdGreaterThan(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FOrdGreaterThanEqual(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FOrdGreaterThanEqual(as_half(args_0), as_half(args_1));
+  return __spirv_FOrdGreaterThanEqual(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_FOrdGreaterThanEqual(__clc_vec2_float16_t args_0,
                              __clc_vec2_float16_t args_1) {
-  return __spirv_FOrdGreaterThanEqual(as_half2(args_0), as_half2(args_1));
+  return __spirv_FOrdGreaterThanEqual(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_FOrdGreaterThanEqual(__clc_vec3_float16_t args_0,
                              __clc_vec3_float16_t args_1) {
-  return __spirv_FOrdGreaterThanEqual(as_half3(args_0), as_half3(args_1));
+  return __spirv_FOrdGreaterThanEqual(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_FOrdGreaterThanEqual(__clc_vec4_float16_t args_0,
                              __clc_vec4_float16_t args_1) {
-  return __spirv_FOrdGreaterThanEqual(as_half4(args_0), as_half4(args_1));
+  return __spirv_FOrdGreaterThanEqual(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_FOrdGreaterThanEqual(__clc_vec8_float16_t args_0,
                              __clc_vec8_float16_t args_1) {
-  return __spirv_FOrdGreaterThanEqual(as_half8(args_0), as_half8(args_1));
+  return __spirv_FOrdGreaterThanEqual(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_FOrdGreaterThanEqual(__clc_vec16_float16_t args_0,
                              __clc_vec16_float16_t args_1) {
-  return __spirv_FOrdGreaterThanEqual(as_half16(args_0), as_half16(args_1));
+  return __spirv_FOrdGreaterThanEqual(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FOrdLessThan(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FOrdLessThan(as_half(args_0), as_half(args_1));
+  return __spirv_FOrdLessThan(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_FOrdLessThan(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_FOrdLessThan(as_half2(args_0), as_half2(args_1));
+  return __spirv_FOrdLessThan(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_FOrdLessThan(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_FOrdLessThan(as_half3(args_0), as_half3(args_1));
+  return __spirv_FOrdLessThan(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_FOrdLessThan(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_FOrdLessThan(as_half4(args_0), as_half4(args_1));
+  return __spirv_FOrdLessThan(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_FOrdLessThan(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_FOrdLessThan(as_half8(args_0), as_half8(args_1));
+  return __spirv_FOrdLessThan(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t __spirv_FOrdLessThan(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_FOrdLessThan(as_half16(args_0), as_half16(args_1));
+  return __spirv_FOrdLessThan(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FOrdLessThanEqual(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FOrdLessThanEqual(as_half(args_0), as_half(args_1));
+  return __spirv_FOrdLessThanEqual(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t __spirv_FOrdLessThanEqual(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_FOrdLessThanEqual(as_half2(args_0), as_half2(args_1));
+  return __spirv_FOrdLessThanEqual(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t __spirv_FOrdLessThanEqual(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_FOrdLessThanEqual(as_half3(args_0), as_half3(args_1));
+  return __spirv_FOrdLessThanEqual(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t __spirv_FOrdLessThanEqual(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_FOrdLessThanEqual(as_half4(args_0), as_half4(args_1));
+  return __spirv_FOrdLessThanEqual(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t __spirv_FOrdLessThanEqual(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_FOrdLessThanEqual(as_half8(args_0), as_half8(args_1));
+  return __spirv_FOrdLessThanEqual(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_FOrdLessThanEqual(__clc_vec16_float16_t args_0,
                           __clc_vec16_float16_t args_1) {
-  return __spirv_FOrdLessThanEqual(as_half16(args_0), as_half16(args_1));
+  return __spirv_FOrdLessThanEqual(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FOrdNotEqual(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FOrdNotEqual(as_half(args_0), as_half(args_1));
+  return __spirv_FOrdNotEqual(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_FOrdNotEqual(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_FOrdNotEqual(as_half2(args_0), as_half2(args_1));
+  return __spirv_FOrdNotEqual(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_FOrdNotEqual(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_FOrdNotEqual(as_half3(args_0), as_half3(args_1));
+  return __spirv_FOrdNotEqual(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_FOrdNotEqual(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_FOrdNotEqual(as_half4(args_0), as_half4(args_1));
+  return __spirv_FOrdNotEqual(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_FOrdNotEqual(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_FOrdNotEqual(as_half8(args_0), as_half8(args_1));
+  return __spirv_FOrdNotEqual(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t __spirv_FOrdNotEqual(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_FOrdNotEqual(as_half16(args_0), as_half16(args_1));
+  return __spirv_FOrdNotEqual(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FUnordEqual(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FUnordEqual(as_half(args_0), as_half(args_1));
+  return __spirv_FUnordEqual(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_FUnordEqual(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_FUnordEqual(as_half2(args_0), as_half2(args_1));
+  return __spirv_FUnordEqual(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_FUnordEqual(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_FUnordEqual(as_half3(args_0), as_half3(args_1));
+  return __spirv_FUnordEqual(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_FUnordEqual(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_FUnordEqual(as_half4(args_0), as_half4(args_1));
+  return __spirv_FUnordEqual(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_FUnordEqual(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_FUnordEqual(as_half8(args_0), as_half8(args_1));
+  return __spirv_FUnordEqual(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t __spirv_FUnordEqual(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_FUnordEqual(as_half16(args_0), as_half16(args_1));
+  return __spirv_FUnordEqual(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FUnordGreaterThan(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FUnordGreaterThan(as_half(args_0), as_half(args_1));
+  return __spirv_FUnordGreaterThan(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t __spirv_FUnordGreaterThan(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_FUnordGreaterThan(as_half2(args_0), as_half2(args_1));
+  return __spirv_FUnordGreaterThan(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t __spirv_FUnordGreaterThan(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_FUnordGreaterThan(as_half3(args_0), as_half3(args_1));
+  return __spirv_FUnordGreaterThan(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t __spirv_FUnordGreaterThan(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_FUnordGreaterThan(as_half4(args_0), as_half4(args_1));
+  return __spirv_FUnordGreaterThan(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t __spirv_FUnordGreaterThan(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_FUnordGreaterThan(as_half8(args_0), as_half8(args_1));
+  return __spirv_FUnordGreaterThan(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_FUnordGreaterThan(__clc_vec16_float16_t args_0,
                           __clc_vec16_float16_t args_1) {
-  return __spirv_FUnordGreaterThan(as_half16(args_0), as_half16(args_1));
+  return __spirv_FUnordGreaterThan(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FUnordGreaterThanEqual(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FUnordGreaterThanEqual(as_half(args_0), as_half(args_1));
+  return __spirv_FUnordGreaterThanEqual(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_FUnordGreaterThanEqual(__clc_vec2_float16_t args_0,
                                __clc_vec2_float16_t args_1) {
-  return __spirv_FUnordGreaterThanEqual(as_half2(args_0), as_half2(args_1));
+  return __spirv_FUnordGreaterThanEqual(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_FUnordGreaterThanEqual(__clc_vec3_float16_t args_0,
                                __clc_vec3_float16_t args_1) {
-  return __spirv_FUnordGreaterThanEqual(as_half3(args_0), as_half3(args_1));
+  return __spirv_FUnordGreaterThanEqual(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_FUnordGreaterThanEqual(__clc_vec4_float16_t args_0,
                                __clc_vec4_float16_t args_1) {
-  return __spirv_FUnordGreaterThanEqual(as_half4(args_0), as_half4(args_1));
+  return __spirv_FUnordGreaterThanEqual(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_FUnordGreaterThanEqual(__clc_vec8_float16_t args_0,
                                __clc_vec8_float16_t args_1) {
-  return __spirv_FUnordGreaterThanEqual(as_half8(args_0), as_half8(args_1));
+  return __spirv_FUnordGreaterThanEqual(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_FUnordGreaterThanEqual(__clc_vec16_float16_t args_0,
                                __clc_vec16_float16_t args_1) {
-  return __spirv_FUnordGreaterThanEqual(as_half16(args_0), as_half16(args_1));
+  return __spirv_FUnordGreaterThanEqual(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FUnordLessThan(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FUnordLessThan(as_half(args_0), as_half(args_1));
+  return __spirv_FUnordLessThan(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t __spirv_FUnordLessThan(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_FUnordLessThan(as_half2(args_0), as_half2(args_1));
+  return __spirv_FUnordLessThan(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t __spirv_FUnordLessThan(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_FUnordLessThan(as_half3(args_0), as_half3(args_1));
+  return __spirv_FUnordLessThan(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t __spirv_FUnordLessThan(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_FUnordLessThan(as_half4(args_0), as_half4(args_1));
+  return __spirv_FUnordLessThan(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t __spirv_FUnordLessThan(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_FUnordLessThan(as_half8(args_0), as_half8(args_1));
+  return __spirv_FUnordLessThan(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t __spirv_FUnordLessThan(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_FUnordLessThan(as_half16(args_0), as_half16(args_1));
+  return __spirv_FUnordLessThan(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FUnordLessThanEqual(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FUnordLessThanEqual(as_half(args_0), as_half(args_1));
+  return __spirv_FUnordLessThanEqual(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_FUnordLessThanEqual(__clc_vec2_float16_t args_0,
                             __clc_vec2_float16_t args_1) {
-  return __spirv_FUnordLessThanEqual(as_half2(args_0), as_half2(args_1));
+  return __spirv_FUnordLessThanEqual(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_FUnordLessThanEqual(__clc_vec3_float16_t args_0,
                             __clc_vec3_float16_t args_1) {
-  return __spirv_FUnordLessThanEqual(as_half3(args_0), as_half3(args_1));
+  return __spirv_FUnordLessThanEqual(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_FUnordLessThanEqual(__clc_vec4_float16_t args_0,
                             __clc_vec4_float16_t args_1) {
-  return __spirv_FUnordLessThanEqual(as_half4(args_0), as_half4(args_1));
+  return __spirv_FUnordLessThanEqual(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_FUnordLessThanEqual(__clc_vec8_float16_t args_0,
                             __clc_vec8_float16_t args_1) {
-  return __spirv_FUnordLessThanEqual(as_half8(args_0), as_half8(args_1));
+  return __spirv_FUnordLessThanEqual(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_FUnordLessThanEqual(__clc_vec16_float16_t args_0,
                             __clc_vec16_float16_t args_1) {
-  return __spirv_FUnordLessThanEqual(as_half16(args_0), as_half16(args_1));
+  return __spirv_FUnordLessThanEqual(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_FUnordNotEqual(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_FUnordNotEqual(as_half(args_0), as_half(args_1));
+  return __spirv_FUnordNotEqual(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t __spirv_FUnordNotEqual(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_FUnordNotEqual(as_half2(args_0), as_half2(args_1));
+  return __spirv_FUnordNotEqual(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t __spirv_FUnordNotEqual(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_FUnordNotEqual(as_half3(args_0), as_half3(args_1));
+  return __spirv_FUnordNotEqual(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t __spirv_FUnordNotEqual(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_FUnordNotEqual(as_half4(args_0), as_half4(args_1));
+  return __spirv_FUnordNotEqual(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t __spirv_FUnordNotEqual(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_FUnordNotEqual(as_half8(args_0), as_half8(args_1));
+  return __spirv_FUnordNotEqual(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t __spirv_FUnordNotEqual(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_FUnordNotEqual(as_half16(args_0), as_half16(args_1));
+  return __spirv_FUnordNotEqual(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONVERGENT __clc_event_t __spirv_GroupAsyncCopy(
@@ -3319,2564 +3319,2564 @@ _CLC_OVERLOAD _CLC_DEF _CLC_CONVERGENT __clc_event_t __spirv_GroupAsyncCopy(
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_IsFinite(__clc_float16_t args_0) {
-  return __spirv_IsFinite(as_half(args_0));
+  return __spirv_IsFinite(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_IsFinite(__clc_vec2_float16_t args_0) {
-  return __spirv_IsFinite(as_half2(args_0));
+  return __spirv_IsFinite(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_IsFinite(__clc_vec3_float16_t args_0) {
-  return __spirv_IsFinite(as_half3(args_0));
+  return __spirv_IsFinite(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_IsFinite(__clc_vec4_float16_t args_0) {
-  return __spirv_IsFinite(as_half4(args_0));
+  return __spirv_IsFinite(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_IsFinite(__clc_vec8_float16_t args_0) {
-  return __spirv_IsFinite(as_half8(args_0));
+  return __spirv_IsFinite(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_IsFinite(__clc_vec16_float16_t args_0) {
-  return __spirv_IsFinite(as_half16(args_0));
+  return __spirv_IsFinite(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_IsInf(__clc_float16_t args_0) {
-  return __spirv_IsInf(as_half(args_0));
+  return __spirv_IsInf(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_IsInf(__clc_vec2_float16_t args_0) {
-  return __spirv_IsInf(as_half2(args_0));
+  return __spirv_IsInf(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_IsInf(__clc_vec3_float16_t args_0) {
-  return __spirv_IsInf(as_half3(args_0));
+  return __spirv_IsInf(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_IsInf(__clc_vec4_float16_t args_0) {
-  return __spirv_IsInf(as_half4(args_0));
+  return __spirv_IsInf(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_IsInf(__clc_vec8_float16_t args_0) {
-  return __spirv_IsInf(as_half8(args_0));
+  return __spirv_IsInf(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_IsInf(__clc_vec16_float16_t args_0) {
-  return __spirv_IsInf(as_half16(args_0));
+  return __spirv_IsInf(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_IsNan(__clc_float16_t args_0) {
-  return __spirv_IsNan(as_half(args_0));
+  return __spirv_IsNan(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_IsNan(__clc_vec2_float16_t args_0) {
-  return __spirv_IsNan(as_half2(args_0));
+  return __spirv_IsNan(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_IsNan(__clc_vec3_float16_t args_0) {
-  return __spirv_IsNan(as_half3(args_0));
+  return __spirv_IsNan(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_IsNan(__clc_vec4_float16_t args_0) {
-  return __spirv_IsNan(as_half4(args_0));
+  return __spirv_IsNan(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_IsNan(__clc_vec8_float16_t args_0) {
-  return __spirv_IsNan(as_half8(args_0));
+  return __spirv_IsNan(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_IsNan(__clc_vec16_float16_t args_0) {
-  return __spirv_IsNan(as_half16(args_0));
+  return __spirv_IsNan(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_IsNormal(__clc_float16_t args_0) {
-  return __spirv_IsNormal(as_half(args_0));
+  return __spirv_IsNormal(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_IsNormal(__clc_vec2_float16_t args_0) {
-  return __spirv_IsNormal(as_half2(args_0));
+  return __spirv_IsNormal(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_IsNormal(__clc_vec3_float16_t args_0) {
-  return __spirv_IsNormal(as_half3(args_0));
+  return __spirv_IsNormal(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_IsNormal(__clc_vec4_float16_t args_0) {
-  return __spirv_IsNormal(as_half4(args_0));
+  return __spirv_IsNormal(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_IsNormal(__clc_vec8_float16_t args_0) {
-  return __spirv_IsNormal(as_half8(args_0));
+  return __spirv_IsNormal(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_IsNormal(__clc_vec16_float16_t args_0) {
-  return __spirv_IsNormal(as_half16(args_0));
+  return __spirv_IsNormal(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_LessOrGreater(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_LessOrGreater(as_half(args_0), as_half(args_1));
+  return __spirv_LessOrGreater(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t __spirv_LessOrGreater(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_LessOrGreater(as_half2(args_0), as_half2(args_1));
+  return __spirv_LessOrGreater(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t __spirv_LessOrGreater(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_LessOrGreater(as_half3(args_0), as_half3(args_1));
+  return __spirv_LessOrGreater(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t __spirv_LessOrGreater(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_LessOrGreater(as_half4(args_0), as_half4(args_1));
+  return __spirv_LessOrGreater(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t __spirv_LessOrGreater(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_LessOrGreater(as_half8(args_0), as_half8(args_1));
+  return __spirv_LessOrGreater(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t __spirv_LessOrGreater(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_LessOrGreater(as_half16(args_0), as_half16(args_1));
+  return __spirv_LessOrGreater(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_Ordered(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_Ordered(as_half(args_0), as_half(args_1));
+  return __spirv_Ordered(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_Ordered(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_Ordered(as_half2(args_0), as_half2(args_1));
+  return __spirv_Ordered(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_Ordered(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_Ordered(as_half3(args_0), as_half3(args_1));
+  return __spirv_Ordered(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_Ordered(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_Ordered(as_half4(args_0), as_half4(args_1));
+  return __spirv_Ordered(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_Ordered(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_Ordered(as_half8(args_0), as_half8(args_1));
+  return __spirv_Ordered(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_Ordered(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_Ordered(as_half16(args_0), as_half16(args_1));
+  return __spirv_Ordered(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_SignBitSet(__clc_float16_t args_0) {
-  return __spirv_SignBitSet(as_half(args_0));
+  return __spirv_SignBitSet(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_SignBitSet(__clc_vec2_float16_t args_0) {
-  return __spirv_SignBitSet(as_half2(args_0));
+  return __spirv_SignBitSet(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_SignBitSet(__clc_vec3_float16_t args_0) {
-  return __spirv_SignBitSet(as_half3(args_0));
+  return __spirv_SignBitSet(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_SignBitSet(__clc_vec4_float16_t args_0) {
-  return __spirv_SignBitSet(as_half4(args_0));
+  return __spirv_SignBitSet(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_SignBitSet(__clc_vec8_float16_t args_0) {
-  return __spirv_SignBitSet(as_half8(args_0));
+  return __spirv_SignBitSet(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_SignBitSet(__clc_vec16_float16_t args_0) {
-  return __spirv_SignBitSet(as_half16(args_0));
+  return __spirv_SignBitSet(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_bool_t
 __spirv_Unordered(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_Unordered(as_half(args_0), as_half(args_1));
+  return __spirv_Unordered(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int8_t
 __spirv_Unordered(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_Unordered(as_half2(args_0), as_half2(args_1));
+  return __spirv_Unordered(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int8_t
 __spirv_Unordered(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_Unordered(as_half3(args_0), as_half3(args_1));
+  return __spirv_Unordered(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int8_t
 __spirv_Unordered(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_Unordered(as_half4(args_0), as_half4(args_1));
+  return __spirv_Unordered(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int8_t
 __spirv_Unordered(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_Unordered(as_half8(args_0), as_half8(args_1));
+  return __spirv_Unordered(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int8_t
 __spirv_Unordered(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_Unordered(as_half16(args_0), as_half16(args_1));
+  return __spirv_Unordered(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_VectorTimesScalar(__clc_vec2_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_VectorTimesScalar(as_half2(args_0), as_half(args_1));
+  return __spirv_VectorTimesScalar(__clc_as_half2(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_VectorTimesScalar(__clc_vec3_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_VectorTimesScalar(as_half3(args_0), as_half(args_1));
+  return __spirv_VectorTimesScalar(__clc_as_half3(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_VectorTimesScalar(__clc_vec4_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_VectorTimesScalar(as_half4(args_0), as_half(args_1));
+  return __spirv_VectorTimesScalar(__clc_as_half4(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_VectorTimesScalar(__clc_vec8_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_VectorTimesScalar(as_half8(args_0), as_half(args_1));
+  return __spirv_VectorTimesScalar(__clc_as_half8(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_VectorTimesScalar(__clc_vec16_float16_t args_0,
                           __clc_float16_t args_1) {
-  return __spirv_VectorTimesScalar(as_half16(args_0), as_half(args_1));
+  return __spirv_VectorTimesScalar(__clc_as_half16(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_acos(__clc_float16_t args_0) {
-  return __spirv_ocl_acos(as_half(args_0));
+  return __spirv_ocl_acos(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_acos(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_acos(as_half2(args_0));
+  return __spirv_ocl_acos(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_acos(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_acos(as_half3(args_0));
+  return __spirv_ocl_acos(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_acos(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_acos(as_half4(args_0));
+  return __spirv_ocl_acos(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_acos(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_acos(as_half8(args_0));
+  return __spirv_ocl_acos(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_acos(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_acos(as_half16(args_0));
+  return __spirv_ocl_acos(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_acosh(__clc_float16_t args_0) {
-  return __spirv_ocl_acosh(as_half(args_0));
+  return __spirv_ocl_acosh(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_acosh(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_acosh(as_half2(args_0));
+  return __spirv_ocl_acosh(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_acosh(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_acosh(as_half3(args_0));
+  return __spirv_ocl_acosh(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_acosh(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_acosh(as_half4(args_0));
+  return __spirv_ocl_acosh(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_acosh(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_acosh(as_half8(args_0));
+  return __spirv_ocl_acosh(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_acosh(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_acosh(as_half16(args_0));
+  return __spirv_ocl_acosh(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_acospi(__clc_float16_t args_0) {
-  return __spirv_ocl_acospi(as_half(args_0));
+  return __spirv_ocl_acospi(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_acospi(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_acospi(as_half2(args_0));
+  return __spirv_ocl_acospi(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_acospi(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_acospi(as_half3(args_0));
+  return __spirv_ocl_acospi(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_acospi(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_acospi(as_half4(args_0));
+  return __spirv_ocl_acospi(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_acospi(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_acospi(as_half8(args_0));
+  return __spirv_ocl_acospi(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_acospi(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_acospi(as_half16(args_0));
+  return __spirv_ocl_acospi(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_asin(__clc_float16_t args_0) {
-  return __spirv_ocl_asin(as_half(args_0));
+  return __spirv_ocl_asin(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_asin(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_asin(as_half2(args_0));
+  return __spirv_ocl_asin(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_asin(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_asin(as_half3(args_0));
+  return __spirv_ocl_asin(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_asin(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_asin(as_half4(args_0));
+  return __spirv_ocl_asin(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_asin(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_asin(as_half8(args_0));
+  return __spirv_ocl_asin(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_asin(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_asin(as_half16(args_0));
+  return __spirv_ocl_asin(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_asinh(__clc_float16_t args_0) {
-  return __spirv_ocl_asinh(as_half(args_0));
+  return __spirv_ocl_asinh(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_asinh(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_asinh(as_half2(args_0));
+  return __spirv_ocl_asinh(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_asinh(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_asinh(as_half3(args_0));
+  return __spirv_ocl_asinh(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_asinh(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_asinh(as_half4(args_0));
+  return __spirv_ocl_asinh(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_asinh(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_asinh(as_half8(args_0));
+  return __spirv_ocl_asinh(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_asinh(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_asinh(as_half16(args_0));
+  return __spirv_ocl_asinh(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_asinpi(__clc_float16_t args_0) {
-  return __spirv_ocl_asinpi(as_half(args_0));
+  return __spirv_ocl_asinpi(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_asinpi(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_asinpi(as_half2(args_0));
+  return __spirv_ocl_asinpi(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_asinpi(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_asinpi(as_half3(args_0));
+  return __spirv_ocl_asinpi(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_asinpi(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_asinpi(as_half4(args_0));
+  return __spirv_ocl_asinpi(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_asinpi(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_asinpi(as_half8(args_0));
+  return __spirv_ocl_asinpi(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_asinpi(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_asinpi(as_half16(args_0));
+  return __spirv_ocl_asinpi(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_atan(__clc_float16_t args_0) {
-  return __spirv_ocl_atan(as_half(args_0));
+  return __spirv_ocl_atan(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_atan(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_atan(as_half2(args_0));
+  return __spirv_ocl_atan(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_atan(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_atan(as_half3(args_0));
+  return __spirv_ocl_atan(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_atan(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_atan(as_half4(args_0));
+  return __spirv_ocl_atan(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_atan(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_atan(as_half8(args_0));
+  return __spirv_ocl_atan(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_atan(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_atan(as_half16(args_0));
+  return __spirv_ocl_atan(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_atan2(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_atan2(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_atan2(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_atan2(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_atan2(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_atan2(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_atan2(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_atan2(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_atan2(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_atan2(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_atan2(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_atan2(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_atan2(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_atan2(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_atan2(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_atan2(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_atan2(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_atan2(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_atan2pi(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_atan2pi(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_atan2pi(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_atan2pi(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_atan2pi(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_atan2pi(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_atan2pi(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_atan2pi(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_atan2pi(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_atan2pi(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_atan2pi(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_atan2pi(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_atan2pi(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_atan2pi(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_atan2pi(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t __spirv_ocl_atan2pi(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_atan2pi(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_atan2pi(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_atanh(__clc_float16_t args_0) {
-  return __spirv_ocl_atanh(as_half(args_0));
+  return __spirv_ocl_atanh(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_atanh(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_atanh(as_half2(args_0));
+  return __spirv_ocl_atanh(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_atanh(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_atanh(as_half3(args_0));
+  return __spirv_ocl_atanh(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_atanh(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_atanh(as_half4(args_0));
+  return __spirv_ocl_atanh(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_atanh(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_atanh(as_half8(args_0));
+  return __spirv_ocl_atanh(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_atanh(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_atanh(as_half16(args_0));
+  return __spirv_ocl_atanh(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_atanpi(__clc_float16_t args_0) {
-  return __spirv_ocl_atanpi(as_half(args_0));
+  return __spirv_ocl_atanpi(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_atanpi(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_atanpi(as_half2(args_0));
+  return __spirv_ocl_atanpi(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_atanpi(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_atanpi(as_half3(args_0));
+  return __spirv_ocl_atanpi(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_atanpi(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_atanpi(as_half4(args_0));
+  return __spirv_ocl_atanpi(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_atanpi(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_atanpi(as_half8(args_0));
+  return __spirv_ocl_atanpi(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_atanpi(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_atanpi(as_half16(args_0));
+  return __spirv_ocl_atanpi(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t __spirv_ocl_bitselect(
     __clc_float16_t args_0, __clc_float16_t args_1, __clc_float16_t args_2) {
-  return __spirv_ocl_bitselect(as_half(args_0), as_half(args_1),
-                               as_half(args_2));
+  return __spirv_ocl_bitselect(__clc_as_half(args_0), __clc_as_half(args_1),
+                               __clc_as_half(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_bitselect(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                       __clc_vec2_float16_t args_2) {
-  return __spirv_ocl_bitselect(as_half2(args_0), as_half2(args_1),
-                               as_half2(args_2));
+  return __spirv_ocl_bitselect(__clc_as_half2(args_0), __clc_as_half2(args_1),
+                               __clc_as_half2(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_bitselect(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                       __clc_vec3_float16_t args_2) {
-  return __spirv_ocl_bitselect(as_half3(args_0), as_half3(args_1),
-                               as_half3(args_2));
+  return __spirv_ocl_bitselect(__clc_as_half3(args_0), __clc_as_half3(args_1),
+                               __clc_as_half3(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_bitselect(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                       __clc_vec4_float16_t args_2) {
-  return __spirv_ocl_bitselect(as_half4(args_0), as_half4(args_1),
-                               as_half4(args_2));
+  return __spirv_ocl_bitselect(__clc_as_half4(args_0), __clc_as_half4(args_1),
+                               __clc_as_half4(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_bitselect(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                       __clc_vec8_float16_t args_2) {
-  return __spirv_ocl_bitselect(as_half8(args_0), as_half8(args_1),
-                               as_half8(args_2));
+  return __spirv_ocl_bitselect(__clc_as_half8(args_0), __clc_as_half8(args_1),
+                               __clc_as_half8(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t __spirv_ocl_bitselect(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
     __clc_vec16_float16_t args_2) {
-  return __spirv_ocl_bitselect(as_half16(args_0), as_half16(args_1),
-                               as_half16(args_2));
+  return __spirv_ocl_bitselect(__clc_as_half16(args_0), __clc_as_half16(args_1),
+                               __clc_as_half16(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_cbrt(__clc_float16_t args_0) {
-  return __spirv_ocl_cbrt(as_half(args_0));
+  return __spirv_ocl_cbrt(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_cbrt(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_cbrt(as_half2(args_0));
+  return __spirv_ocl_cbrt(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_cbrt(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_cbrt(as_half3(args_0));
+  return __spirv_ocl_cbrt(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_cbrt(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_cbrt(as_half4(args_0));
+  return __spirv_ocl_cbrt(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_cbrt(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_cbrt(as_half8(args_0));
+  return __spirv_ocl_cbrt(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_cbrt(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_cbrt(as_half16(args_0));
+  return __spirv_ocl_cbrt(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_ceil(__clc_float16_t args_0) {
-  return __spirv_ocl_ceil(as_half(args_0));
+  return __spirv_ocl_ceil(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_ceil(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_ceil(as_half2(args_0));
+  return __spirv_ocl_ceil(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_ceil(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_ceil(as_half3(args_0));
+  return __spirv_ocl_ceil(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_ceil(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_ceil(as_half4(args_0));
+  return __spirv_ocl_ceil(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_ceil(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_ceil(as_half8(args_0));
+  return __spirv_ocl_ceil(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_ceil(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_ceil(as_half16(args_0));
+  return __spirv_ocl_ceil(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_copysign(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_copysign(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_copysign(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_copysign(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_copysign(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_copysign(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_copysign(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_copysign(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_copysign(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_copysign(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_copysign(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_copysign(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_copysign(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_copysign(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_copysign(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t __spirv_ocl_copysign(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_copysign(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_copysign(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_cos(__clc_float16_t args_0) {
-  return __spirv_ocl_cos(as_half(args_0));
+  return __spirv_ocl_cos(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_cos(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_cos(as_half2(args_0));
+  return __spirv_ocl_cos(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_cos(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_cos(as_half3(args_0));
+  return __spirv_ocl_cos(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_cos(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_cos(as_half4(args_0));
+  return __spirv_ocl_cos(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_cos(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_cos(as_half8(args_0));
+  return __spirv_ocl_cos(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_cos(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_cos(as_half16(args_0));
+  return __spirv_ocl_cos(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_cosh(__clc_float16_t args_0) {
-  return __spirv_ocl_cosh(as_half(args_0));
+  return __spirv_ocl_cosh(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_cosh(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_cosh(as_half2(args_0));
+  return __spirv_ocl_cosh(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_cosh(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_cosh(as_half3(args_0));
+  return __spirv_ocl_cosh(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_cosh(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_cosh(as_half4(args_0));
+  return __spirv_ocl_cosh(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_cosh(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_cosh(as_half8(args_0));
+  return __spirv_ocl_cosh(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_cosh(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_cosh(as_half16(args_0));
+  return __spirv_ocl_cosh(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_cospi(__clc_float16_t args_0) {
-  return __spirv_ocl_cospi(as_half(args_0));
+  return __spirv_ocl_cospi(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_cospi(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_cospi(as_half2(args_0));
+  return __spirv_ocl_cospi(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_cospi(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_cospi(as_half3(args_0));
+  return __spirv_ocl_cospi(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_cospi(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_cospi(as_half4(args_0));
+  return __spirv_ocl_cospi(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_cospi(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_cospi(as_half8(args_0));
+  return __spirv_ocl_cospi(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_cospi(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_cospi(as_half16(args_0));
+  return __spirv_ocl_cospi(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_cross(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_cross(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_cross(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_cross(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_cross(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_cross(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_degrees(__clc_float16_t args_0) {
-  return __spirv_ocl_degrees(as_half(args_0));
+  return __spirv_ocl_degrees(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_degrees(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_degrees(as_half2(args_0));
+  return __spirv_ocl_degrees(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_degrees(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_degrees(as_half3(args_0));
+  return __spirv_ocl_degrees(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_degrees(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_degrees(as_half4(args_0));
+  return __spirv_ocl_degrees(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_degrees(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_degrees(as_half8(args_0));
+  return __spirv_ocl_degrees(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_degrees(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_degrees(as_half16(args_0));
+  return __spirv_ocl_degrees(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_distance(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_distance(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_distance(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_distance(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_distance(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_distance(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_distance(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_distance(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_distance(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_distance(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_distance(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_distance(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_erf(__clc_float16_t args_0) {
-  return __spirv_ocl_erf(as_half(args_0));
+  return __spirv_ocl_erf(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_erf(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_erf(as_half2(args_0));
+  return __spirv_ocl_erf(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_erf(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_erf(as_half3(args_0));
+  return __spirv_ocl_erf(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_erf(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_erf(as_half4(args_0));
+  return __spirv_ocl_erf(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_erf(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_erf(as_half8(args_0));
+  return __spirv_ocl_erf(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_erf(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_erf(as_half16(args_0));
+  return __spirv_ocl_erf(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_erfc(__clc_float16_t args_0) {
-  return __spirv_ocl_erfc(as_half(args_0));
+  return __spirv_ocl_erfc(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_erfc(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_erfc(as_half2(args_0));
+  return __spirv_ocl_erfc(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_erfc(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_erfc(as_half3(args_0));
+  return __spirv_ocl_erfc(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_erfc(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_erfc(as_half4(args_0));
+  return __spirv_ocl_erfc(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_erfc(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_erfc(as_half8(args_0));
+  return __spirv_ocl_erfc(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_erfc(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_erfc(as_half16(args_0));
+  return __spirv_ocl_erfc(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_exp(__clc_float16_t args_0) {
-  return __spirv_ocl_exp(as_half(args_0));
+  return __spirv_ocl_exp(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_exp(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_exp(as_half2(args_0));
+  return __spirv_ocl_exp(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_exp(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_exp(as_half3(args_0));
+  return __spirv_ocl_exp(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_exp(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_exp(as_half4(args_0));
+  return __spirv_ocl_exp(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_exp(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_exp(as_half8(args_0));
+  return __spirv_ocl_exp(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_exp(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_exp(as_half16(args_0));
+  return __spirv_ocl_exp(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_exp10(__clc_float16_t args_0) {
-  return __spirv_ocl_exp10(as_half(args_0));
+  return __spirv_ocl_exp10(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_exp10(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_exp10(as_half2(args_0));
+  return __spirv_ocl_exp10(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_exp10(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_exp10(as_half3(args_0));
+  return __spirv_ocl_exp10(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_exp10(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_exp10(as_half4(args_0));
+  return __spirv_ocl_exp10(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_exp10(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_exp10(as_half8(args_0));
+  return __spirv_ocl_exp10(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_exp10(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_exp10(as_half16(args_0));
+  return __spirv_ocl_exp10(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_exp2(__clc_float16_t args_0) {
-  return __spirv_ocl_exp2(as_half(args_0));
+  return __spirv_ocl_exp2(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_exp2(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_exp2(as_half2(args_0));
+  return __spirv_ocl_exp2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_exp2(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_exp2(as_half3(args_0));
+  return __spirv_ocl_exp2(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_exp2(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_exp2(as_half4(args_0));
+  return __spirv_ocl_exp2(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_exp2(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_exp2(as_half8(args_0));
+  return __spirv_ocl_exp2(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_exp2(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_exp2(as_half16(args_0));
+  return __spirv_ocl_exp2(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __clc_native_exp2(__clc_float16_t args_0) {
-  return __clc_native_exp2(as_half(args_0));
+  return __clc_native_exp2(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __clc_native_exp2(__clc_vec2_float16_t args_0) {
-  return __clc_native_exp2(as_half2(args_0));
+  return __clc_native_exp2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __clc_native_exp2(__clc_vec3_float16_t args_0) {
-  return __clc_native_exp2(as_half3(args_0));
+  return __clc_native_exp2(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __clc_native_exp2(__clc_vec4_float16_t args_0) {
-  return __clc_native_exp2(as_half4(args_0));
+  return __clc_native_exp2(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __clc_native_exp2(__clc_vec8_float16_t args_0) {
-  return __clc_native_exp2(as_half8(args_0));
+  return __clc_native_exp2(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __clc_native_exp2(__clc_vec16_float16_t args_0) {
-  return __clc_native_exp2(as_half16(args_0));
+  return __clc_native_exp2(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_expm1(__clc_float16_t args_0) {
-  return __spirv_ocl_expm1(as_half(args_0));
+  return __spirv_ocl_expm1(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_expm1(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_expm1(as_half2(args_0));
+  return __spirv_ocl_expm1(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_expm1(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_expm1(as_half3(args_0));
+  return __spirv_ocl_expm1(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_expm1(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_expm1(as_half4(args_0));
+  return __spirv_ocl_expm1(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_expm1(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_expm1(as_half8(args_0));
+  return __spirv_ocl_expm1(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_expm1(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_expm1(as_half16(args_0));
+  return __spirv_ocl_expm1(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_fabs(__clc_float16_t args_0) {
-  return __spirv_ocl_fabs(as_half(args_0));
+  return __spirv_ocl_fabs(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_fabs(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_fabs(as_half2(args_0));
+  return __spirv_ocl_fabs(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_fabs(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_fabs(as_half3(args_0));
+  return __spirv_ocl_fabs(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_fabs(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_fabs(as_half4(args_0));
+  return __spirv_ocl_fabs(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_fabs(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_fabs(as_half8(args_0));
+  return __spirv_ocl_fabs(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_fabs(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_fabs(as_half16(args_0));
+  return __spirv_ocl_fabs(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t __spirv_ocl_fclamp(
     __clc_float16_t args_0, __clc_float16_t args_1, __clc_float16_t args_2) {
-  return __spirv_ocl_fclamp(as_half(args_0), as_half(args_1), as_half(args_2));
+  return __spirv_ocl_fclamp(__clc_as_half(args_0), __clc_as_half(args_1), __clc_as_half(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_fclamp(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                    __clc_vec2_float16_t args_2) {
-  return __spirv_ocl_fclamp(as_half2(args_0), as_half2(args_1),
-                            as_half2(args_2));
+  return __spirv_ocl_fclamp(__clc_as_half2(args_0), __clc_as_half2(args_1),
+                            __clc_as_half2(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_fclamp(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                    __clc_vec3_float16_t args_2) {
-  return __spirv_ocl_fclamp(as_half3(args_0), as_half3(args_1),
-                            as_half3(args_2));
+  return __spirv_ocl_fclamp(__clc_as_half3(args_0), __clc_as_half3(args_1),
+                            __clc_as_half3(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_fclamp(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                    __clc_vec4_float16_t args_2) {
-  return __spirv_ocl_fclamp(as_half4(args_0), as_half4(args_1),
-                            as_half4(args_2));
+  return __spirv_ocl_fclamp(__clc_as_half4(args_0), __clc_as_half4(args_1),
+                            __clc_as_half4(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_fclamp(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                    __clc_vec8_float16_t args_2) {
-  return __spirv_ocl_fclamp(as_half8(args_0), as_half8(args_1),
-                            as_half8(args_2));
+  return __spirv_ocl_fclamp(__clc_as_half8(args_0), __clc_as_half8(args_1),
+                            __clc_as_half8(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_fclamp(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                    __clc_vec16_float16_t args_2) {
-  return __spirv_ocl_fclamp(as_half16(args_0), as_half16(args_1),
-                            as_half16(args_2));
+  return __spirv_ocl_fclamp(__clc_as_half16(args_0), __clc_as_half16(args_1),
+                            __clc_as_half16(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_fdim(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_fdim(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_fdim(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_fdim(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_fdim(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_fdim(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_fdim(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_fdim(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_fdim(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_fdim(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_fdim(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_fdim(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_fdim(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_fdim(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_fdim(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_fdim(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_fdim(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_fdim(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_floor(__clc_float16_t args_0) {
-  return __spirv_ocl_floor(as_half(args_0));
+  return __spirv_ocl_floor(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_floor(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_floor(as_half2(args_0));
+  return __spirv_ocl_floor(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_floor(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_floor(as_half3(args_0));
+  return __spirv_ocl_floor(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_floor(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_floor(as_half4(args_0));
+  return __spirv_ocl_floor(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_floor(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_floor(as_half8(args_0));
+  return __spirv_ocl_floor(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_floor(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_floor(as_half16(args_0));
+  return __spirv_ocl_floor(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t __spirv_ocl_fma(
     __clc_float16_t args_0, __clc_float16_t args_1, __clc_float16_t args_2) {
-  return __spirv_ocl_fma(as_half(args_0), as_half(args_1), as_half(args_2));
+  return __spirv_ocl_fma(__clc_as_half(args_0), __clc_as_half(args_1), __clc_as_half(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_fma(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                 __clc_vec2_float16_t args_2) {
-  return __spirv_ocl_fma(as_half2(args_0), as_half2(args_1), as_half2(args_2));
+  return __spirv_ocl_fma(__clc_as_half2(args_0), __clc_as_half2(args_1), __clc_as_half2(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_fma(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                 __clc_vec3_float16_t args_2) {
-  return __spirv_ocl_fma(as_half3(args_0), as_half3(args_1), as_half3(args_2));
+  return __spirv_ocl_fma(__clc_as_half3(args_0), __clc_as_half3(args_1), __clc_as_half3(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_fma(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                 __clc_vec4_float16_t args_2) {
-  return __spirv_ocl_fma(as_half4(args_0), as_half4(args_1), as_half4(args_2));
+  return __spirv_ocl_fma(__clc_as_half4(args_0), __clc_as_half4(args_1), __clc_as_half4(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_fma(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                 __clc_vec8_float16_t args_2) {
-  return __spirv_ocl_fma(as_half8(args_0), as_half8(args_1), as_half8(args_2));
+  return __spirv_ocl_fma(__clc_as_half8(args_0), __clc_as_half8(args_1), __clc_as_half8(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_fma(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                 __clc_vec16_float16_t args_2) {
-  return __spirv_ocl_fma(as_half16(args_0), as_half16(args_1),
-                         as_half16(args_2));
+  return __spirv_ocl_fma(__clc_as_half16(args_0), __clc_as_half16(args_1),
+                         __clc_as_half16(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_fmax(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_fmax(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_fmax(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_fmax(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_fmax(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_fmax(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_fmax(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_fmax(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_fmax(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_fmax(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_fmax(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_fmax(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_fmax(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_fmax(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_fmax(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_fmax(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_fmax(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_fmax(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_fmax_common(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_fmax_common(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_fmax_common(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t __spirv_ocl_fmax_common(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_fmax_common(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_fmax_common(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t __spirv_ocl_fmax_common(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_fmax_common(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_fmax_common(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t __spirv_ocl_fmax_common(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_fmax_common(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_fmax_common(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t __spirv_ocl_fmax_common(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_fmax_common(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_fmax_common(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t __spirv_ocl_fmax_common(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_fmax_common(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_fmax_common(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_fmin(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_fmin(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_fmin(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_fmin(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_fmin(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_fmin(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_fmin(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_fmin(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_fmin(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_fmin(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_fmin(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_fmin(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_fmin(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_fmin(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_fmin(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_fmin(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_fmin(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_fmin(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_fmin_common(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_fmin_common(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_fmin_common(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t __spirv_ocl_fmin_common(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_fmin_common(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_fmin_common(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t __spirv_ocl_fmin_common(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_fmin_common(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_fmin_common(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t __spirv_ocl_fmin_common(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_fmin_common(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_fmin_common(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t __spirv_ocl_fmin_common(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_fmin_common(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_fmin_common(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t __spirv_ocl_fmin_common(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_fmin_common(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_fmin_common(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_fmod(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_fmod(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_fmod(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_fmod(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_fmod(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_fmod(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_fmod(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_fmod(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_fmod(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_fmod(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_fmod(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_fmod(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_fmod(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_fmod(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_fmod(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_fmod(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_fmod(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_fmod(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_fract(__clc_float16_t args_0, __clc_float16_t __private *args_1) {
-  return __spirv_ocl_fract(as_half(args_0), (__clc_fp16_t __private *)(args_1));
+  return __spirv_ocl_fract(__clc_as_half(args_0), (__clc_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_fract(__clc_float16_t args_0, __clc_float16_t __local *args_1) {
-  return __spirv_ocl_fract(as_half(args_0), (__clc_fp16_t __local *)(args_1));
+  return __spirv_ocl_fract(__clc_as_half(args_0), (__clc_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_fract(__clc_float16_t args_0, __clc_float16_t __global *args_1) {
-  return __spirv_ocl_fract(as_half(args_0), (__clc_fp16_t __global *)(args_1));
+  return __spirv_ocl_fract(__clc_as_half(args_0), (__clc_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_fract(__clc_float16_t args_0, __clc_float16_t __generic *args_1) {
-  return __spirv_ocl_fract(as_half(args_0), (__clc_fp16_t __generic *)(args_1));
+  return __spirv_ocl_fract(__clc_as_half(args_0), (__clc_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_fract(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __private *args_1) {
-  return __spirv_ocl_fract(as_half2(args_0),
+  return __spirv_ocl_fract(__clc_as_half2(args_0),
                            (__clc_vec2_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_fract(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __local *args_1) {
-  return __spirv_ocl_fract(as_half2(args_0),
+  return __spirv_ocl_fract(__clc_as_half2(args_0),
                            (__clc_vec2_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_fract(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __global *args_1) {
-  return __spirv_ocl_fract(as_half2(args_0),
+  return __spirv_ocl_fract(__clc_as_half2(args_0),
                            (__clc_vec2_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_fract(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __generic *args_1) {
-  return __spirv_ocl_fract(as_half2(args_0),
+  return __spirv_ocl_fract(__clc_as_half2(args_0),
                            (__clc_vec2_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_fract(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __private *args_1) {
-  return __spirv_ocl_fract(as_half3(args_0),
+  return __spirv_ocl_fract(__clc_as_half3(args_0),
                            (__clc_vec3_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_fract(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __local *args_1) {
-  return __spirv_ocl_fract(as_half3(args_0),
+  return __spirv_ocl_fract(__clc_as_half3(args_0),
                            (__clc_vec3_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_fract(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __global *args_1) {
-  return __spirv_ocl_fract(as_half3(args_0),
+  return __spirv_ocl_fract(__clc_as_half3(args_0),
                            (__clc_vec3_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_fract(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __generic *args_1) {
-  return __spirv_ocl_fract(as_half3(args_0),
+  return __spirv_ocl_fract(__clc_as_half3(args_0),
                            (__clc_vec3_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_fract(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __private *args_1) {
-  return __spirv_ocl_fract(as_half4(args_0),
+  return __spirv_ocl_fract(__clc_as_half4(args_0),
                            (__clc_vec4_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_fract(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __local *args_1) {
-  return __spirv_ocl_fract(as_half4(args_0),
+  return __spirv_ocl_fract(__clc_as_half4(args_0),
                            (__clc_vec4_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_fract(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __global *args_1) {
-  return __spirv_ocl_fract(as_half4(args_0),
+  return __spirv_ocl_fract(__clc_as_half4(args_0),
                            (__clc_vec4_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_fract(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __generic *args_1) {
-  return __spirv_ocl_fract(as_half4(args_0),
+  return __spirv_ocl_fract(__clc_as_half4(args_0),
                            (__clc_vec4_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_fract(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __private *args_1) {
-  return __spirv_ocl_fract(as_half8(args_0),
+  return __spirv_ocl_fract(__clc_as_half8(args_0),
                            (__clc_vec8_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_fract(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __local *args_1) {
-  return __spirv_ocl_fract(as_half8(args_0),
+  return __spirv_ocl_fract(__clc_as_half8(args_0),
                            (__clc_vec8_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_fract(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __global *args_1) {
-  return __spirv_ocl_fract(as_half8(args_0),
+  return __spirv_ocl_fract(__clc_as_half8(args_0),
                            (__clc_vec8_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_fract(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __generic *args_1) {
-  return __spirv_ocl_fract(as_half8(args_0),
+  return __spirv_ocl_fract(__clc_as_half8(args_0),
                            (__clc_vec8_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_fract(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __private *args_1) {
-  return __spirv_ocl_fract(as_half16(args_0),
+  return __spirv_ocl_fract(__clc_as_half16(args_0),
                            (__clc_vec16_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_fract(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __local *args_1) {
-  return __spirv_ocl_fract(as_half16(args_0),
+  return __spirv_ocl_fract(__clc_as_half16(args_0),
                            (__clc_vec16_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_fract(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __global *args_1) {
-  return __spirv_ocl_fract(as_half16(args_0),
+  return __spirv_ocl_fract(__clc_as_half16(args_0),
                            (__clc_vec16_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_fract(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __generic *args_1) {
-  return __spirv_ocl_fract(as_half16(args_0),
+  return __spirv_ocl_fract(__clc_as_half16(args_0),
                            (__clc_vec16_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_frexp(__clc_float16_t args_0, __clc_int32_t __private *args_1) {
-  return __spirv_ocl_frexp(as_half(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_frexp(__clc_float16_t args_0, __clc_int32_t __local *args_1) {
-  return __spirv_ocl_frexp(as_half(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_frexp(__clc_float16_t args_0, __clc_int32_t __global *args_1) {
-  return __spirv_ocl_frexp(as_half(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_frexp(__clc_float16_t args_0, __clc_int32_t __generic *args_1) {
-  return __spirv_ocl_frexp(as_half(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_frexp(
     __clc_vec2_float16_t args_0, __clc_vec2_int32_t __private *args_1) {
-  return __spirv_ocl_frexp(as_half2(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_frexp(
     __clc_vec2_float16_t args_0, __clc_vec2_int32_t __local *args_1) {
-  return __spirv_ocl_frexp(as_half2(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_frexp(
     __clc_vec2_float16_t args_0, __clc_vec2_int32_t __global *args_1) {
-  return __spirv_ocl_frexp(as_half2(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half2(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_frexp(
     __clc_vec2_float16_t args_0, __clc_vec2_int32_t __generic *args_1) {
-  return __spirv_ocl_frexp(as_half2(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half2(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_frexp(
     __clc_vec3_float16_t args_0, __clc_vec3_int32_t __private *args_1) {
-  return __spirv_ocl_frexp(as_half3(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half3(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_frexp(
     __clc_vec3_float16_t args_0, __clc_vec3_int32_t __local *args_1) {
-  return __spirv_ocl_frexp(as_half3(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half3(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_frexp(
     __clc_vec3_float16_t args_0, __clc_vec3_int32_t __global *args_1) {
-  return __spirv_ocl_frexp(as_half3(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half3(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_frexp(
     __clc_vec3_float16_t args_0, __clc_vec3_int32_t __generic *args_1) {
-  return __spirv_ocl_frexp(as_half3(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half3(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_frexp(
     __clc_vec4_float16_t args_0, __clc_vec4_int32_t __private *args_1) {
-  return __spirv_ocl_frexp(as_half4(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_frexp(
     __clc_vec4_float16_t args_0, __clc_vec4_int32_t __local *args_1) {
-  return __spirv_ocl_frexp(as_half4(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_frexp(
     __clc_vec4_float16_t args_0, __clc_vec4_int32_t __global *args_1) {
-  return __spirv_ocl_frexp(as_half4(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half4(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_frexp(
     __clc_vec4_float16_t args_0, __clc_vec4_int32_t __generic *args_1) {
-  return __spirv_ocl_frexp(as_half4(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half4(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_frexp(
     __clc_vec8_float16_t args_0, __clc_vec8_int32_t __private *args_1) {
-  return __spirv_ocl_frexp(as_half8(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_frexp(
     __clc_vec8_float16_t args_0, __clc_vec8_int32_t __local *args_1) {
-  return __spirv_ocl_frexp(as_half8(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_frexp(
     __clc_vec8_float16_t args_0, __clc_vec8_int32_t __global *args_1) {
-  return __spirv_ocl_frexp(as_half8(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half8(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_frexp(
     __clc_vec8_float16_t args_0, __clc_vec8_int32_t __generic *args_1) {
-  return __spirv_ocl_frexp(as_half8(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half8(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_frexp(
     __clc_vec16_float16_t args_0, __clc_vec16_int32_t __private *args_1) {
-  return __spirv_ocl_frexp(as_half16(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_frexp(
     __clc_vec16_float16_t args_0, __clc_vec16_int32_t __local *args_1) {
-  return __spirv_ocl_frexp(as_half16(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_frexp(
     __clc_vec16_float16_t args_0, __clc_vec16_int32_t __global *args_1) {
-  return __spirv_ocl_frexp(as_half16(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half16(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_frexp(
     __clc_vec16_float16_t args_0, __clc_vec16_int32_t __generic *args_1) {
-  return __spirv_ocl_frexp(as_half16(args_0), args_1);
+  return __spirv_ocl_frexp(__clc_as_half16(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_hypot(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_hypot(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_hypot(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_hypot(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_hypot(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_hypot(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_hypot(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_hypot(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_hypot(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_hypot(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_hypot(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_hypot(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_hypot(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_hypot(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_hypot(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_hypot(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_hypot(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_hypot(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_int32_t
 __spirv_ocl_ilogb(__clc_float16_t args_0) {
-  return __spirv_ocl_ilogb(as_half(args_0));
+  return __spirv_ocl_ilogb(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_int32_t
 __spirv_ocl_ilogb(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_ilogb(as_half2(args_0));
+  return __spirv_ocl_ilogb(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_int32_t
 __spirv_ocl_ilogb(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_ilogb(as_half3(args_0));
+  return __spirv_ocl_ilogb(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_int32_t
 __spirv_ocl_ilogb(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_ilogb(as_half4(args_0));
+  return __spirv_ocl_ilogb(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_int32_t
 __spirv_ocl_ilogb(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_ilogb(as_half8(args_0));
+  return __spirv_ocl_ilogb(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_int32_t
 __spirv_ocl_ilogb(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_ilogb(as_half16(args_0));
+  return __spirv_ocl_ilogb(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_ldexp(__clc_float16_t args_0, __clc_int32_t args_1) {
-  return __spirv_ocl_ldexp(as_half(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_ldexp(__clc_float16_t args_0, __clc_uint32_t args_1) {
-  return __spirv_ocl_ldexp(as_half(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_ldexp(__clc_vec2_float16_t args_0, __clc_vec2_int32_t args_1) {
-  return __spirv_ocl_ldexp(as_half2(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_ldexp(__clc_vec2_float16_t args_0, __clc_vec2_uint32_t args_1) {
-  return __spirv_ocl_ldexp(as_half2(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_ldexp(__clc_vec3_float16_t args_0, __clc_vec3_int32_t args_1) {
-  return __spirv_ocl_ldexp(as_half3(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half3(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_ldexp(__clc_vec3_float16_t args_0, __clc_vec3_uint32_t args_1) {
-  return __spirv_ocl_ldexp(as_half3(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half3(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_ldexp(__clc_vec4_float16_t args_0, __clc_vec4_int32_t args_1) {
-  return __spirv_ocl_ldexp(as_half4(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_ldexp(__clc_vec4_float16_t args_0, __clc_vec4_uint32_t args_1) {
-  return __spirv_ocl_ldexp(as_half4(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_ldexp(__clc_vec8_float16_t args_0, __clc_vec8_int32_t args_1) {
-  return __spirv_ocl_ldexp(as_half8(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_ldexp(__clc_vec8_float16_t args_0, __clc_vec8_uint32_t args_1) {
-  return __spirv_ocl_ldexp(as_half8(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_ldexp(__clc_vec16_float16_t args_0, __clc_vec16_int32_t args_1) {
-  return __spirv_ocl_ldexp(as_half16(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_ldexp(__clc_vec16_float16_t args_0, __clc_vec16_uint32_t args_1) {
-  return __spirv_ocl_ldexp(as_half16(args_0), args_1);
+  return __spirv_ocl_ldexp(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_length(__clc_float16_t args_0) {
-  return __spirv_ocl_length(as_half(args_0));
+  return __spirv_ocl_length(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_length(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_length(as_half2(args_0));
+  return __spirv_ocl_length(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_length(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_length(as_half3(args_0));
+  return __spirv_ocl_length(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_length(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_length(as_half4(args_0));
+  return __spirv_ocl_length(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_lgamma(__clc_float16_t args_0) {
-  return __spirv_ocl_lgamma(as_half(args_0));
+  return __spirv_ocl_lgamma(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_lgamma(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_lgamma(as_half2(args_0));
+  return __spirv_ocl_lgamma(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_lgamma(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_lgamma(as_half3(args_0));
+  return __spirv_ocl_lgamma(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_lgamma(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_lgamma(as_half4(args_0));
+  return __spirv_ocl_lgamma(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_lgamma(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_lgamma(as_half8(args_0));
+  return __spirv_ocl_lgamma(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_lgamma(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_lgamma(as_half16(args_0));
+  return __spirv_ocl_lgamma(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_lgamma_r(__clc_float16_t args_0, __clc_int32_t __private *args_1) {
-  return __spirv_ocl_lgamma_r(as_half(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_lgamma_r(__clc_float16_t args_0, __clc_int32_t __local *args_1) {
-  return __spirv_ocl_lgamma_r(as_half(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_lgamma_r(__clc_float16_t args_0, __clc_int32_t __global *args_1) {
-  return __spirv_ocl_lgamma_r(as_half(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_lgamma_r(__clc_float16_t args_0, __clc_int32_t __generic *args_1) {
-  return __spirv_ocl_lgamma_r(as_half(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec2_float16_t args_0, __clc_vec2_int32_t __private *args_1) {
-  return __spirv_ocl_lgamma_r(as_half2(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec2_float16_t args_0, __clc_vec2_int32_t __local *args_1) {
-  return __spirv_ocl_lgamma_r(as_half2(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec2_float16_t args_0, __clc_vec2_int32_t __global *args_1) {
-  return __spirv_ocl_lgamma_r(as_half2(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half2(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec2_float16_t args_0, __clc_vec2_int32_t __generic *args_1) {
-  return __spirv_ocl_lgamma_r(as_half2(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half2(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec3_float16_t args_0, __clc_vec3_int32_t __private *args_1) {
-  return __spirv_ocl_lgamma_r(as_half3(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half3(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec3_float16_t args_0, __clc_vec3_int32_t __local *args_1) {
-  return __spirv_ocl_lgamma_r(as_half3(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half3(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec3_float16_t args_0, __clc_vec3_int32_t __global *args_1) {
-  return __spirv_ocl_lgamma_r(as_half3(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half3(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec3_float16_t args_0, __clc_vec3_int32_t __generic *args_1) {
-  return __spirv_ocl_lgamma_r(as_half3(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half3(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec4_float16_t args_0, __clc_vec4_int32_t __private *args_1) {
-  return __spirv_ocl_lgamma_r(as_half4(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec4_float16_t args_0, __clc_vec4_int32_t __local *args_1) {
-  return __spirv_ocl_lgamma_r(as_half4(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec4_float16_t args_0, __clc_vec4_int32_t __global *args_1) {
-  return __spirv_ocl_lgamma_r(as_half4(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half4(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec4_float16_t args_0, __clc_vec4_int32_t __generic *args_1) {
-  return __spirv_ocl_lgamma_r(as_half4(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half4(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec8_float16_t args_0, __clc_vec8_int32_t __private *args_1) {
-  return __spirv_ocl_lgamma_r(as_half8(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec8_float16_t args_0, __clc_vec8_int32_t __local *args_1) {
-  return __spirv_ocl_lgamma_r(as_half8(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec8_float16_t args_0, __clc_vec8_int32_t __global *args_1) {
-  return __spirv_ocl_lgamma_r(as_half8(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half8(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec8_float16_t args_0, __clc_vec8_int32_t __generic *args_1) {
-  return __spirv_ocl_lgamma_r(as_half8(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half8(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec16_float16_t args_0, __clc_vec16_int32_t __private *args_1) {
-  return __spirv_ocl_lgamma_r(as_half16(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec16_float16_t args_0, __clc_vec16_int32_t __local *args_1) {
-  return __spirv_ocl_lgamma_r(as_half16(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec16_float16_t args_0, __clc_vec16_int32_t __global *args_1) {
-  return __spirv_ocl_lgamma_r(as_half16(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half16(args_0), args_1);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_lgamma_r(
     __clc_vec16_float16_t args_0, __clc_vec16_int32_t __generic *args_1) {
-  return __spirv_ocl_lgamma_r(as_half16(args_0), args_1);
+  return __spirv_ocl_lgamma_r(__clc_as_half16(args_0), args_1);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_log(__clc_float16_t args_0) {
-  return __spirv_ocl_log(as_half(args_0));
+  return __spirv_ocl_log(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_log(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_log(as_half2(args_0));
+  return __spirv_ocl_log(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_log(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_log(as_half3(args_0));
+  return __spirv_ocl_log(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_log(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_log(as_half4(args_0));
+  return __spirv_ocl_log(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_log(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_log(as_half8(args_0));
+  return __spirv_ocl_log(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_log(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_log(as_half16(args_0));
+  return __spirv_ocl_log(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_log10(__clc_float16_t args_0) {
-  return __spirv_ocl_log10(as_half(args_0));
+  return __spirv_ocl_log10(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_log10(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_log10(as_half2(args_0));
+  return __spirv_ocl_log10(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_log10(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_log10(as_half3(args_0));
+  return __spirv_ocl_log10(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_log10(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_log10(as_half4(args_0));
+  return __spirv_ocl_log10(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_log10(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_log10(as_half8(args_0));
+  return __spirv_ocl_log10(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_log10(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_log10(as_half16(args_0));
+  return __spirv_ocl_log10(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_log1p(__clc_float16_t args_0) {
-  return __spirv_ocl_log1p(as_half(args_0));
+  return __spirv_ocl_log1p(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_log1p(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_log1p(as_half2(args_0));
+  return __spirv_ocl_log1p(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_log1p(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_log1p(as_half3(args_0));
+  return __spirv_ocl_log1p(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_log1p(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_log1p(as_half4(args_0));
+  return __spirv_ocl_log1p(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_log1p(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_log1p(as_half8(args_0));
+  return __spirv_ocl_log1p(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_log1p(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_log1p(as_half16(args_0));
+  return __spirv_ocl_log1p(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_log2(__clc_float16_t args_0) {
-  return __spirv_ocl_log2(as_half(args_0));
+  return __spirv_ocl_log2(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_log2(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_log2(as_half2(args_0));
+  return __spirv_ocl_log2(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_log2(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_log2(as_half3(args_0));
+  return __spirv_ocl_log2(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_log2(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_log2(as_half4(args_0));
+  return __spirv_ocl_log2(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_log2(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_log2(as_half8(args_0));
+  return __spirv_ocl_log2(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_log2(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_log2(as_half16(args_0));
+  return __spirv_ocl_log2(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_logb(__clc_float16_t args_0) {
-  return __spirv_ocl_logb(as_half(args_0));
+  return __spirv_ocl_logb(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_logb(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_logb(as_half2(args_0));
+  return __spirv_ocl_logb(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_logb(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_logb(as_half3(args_0));
+  return __spirv_ocl_logb(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_logb(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_logb(as_half4(args_0));
+  return __spirv_ocl_logb(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_logb(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_logb(as_half8(args_0));
+  return __spirv_ocl_logb(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_logb(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_logb(as_half16(args_0));
+  return __spirv_ocl_logb(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t __spirv_ocl_mad(
     __clc_float16_t args_0, __clc_float16_t args_1, __clc_float16_t args_2) {
-  return __spirv_ocl_mad(as_half(args_0), as_half(args_1), as_half(args_2));
+  return __spirv_ocl_mad(__clc_as_half(args_0), __clc_as_half(args_1), __clc_as_half(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_mad(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                 __clc_vec2_float16_t args_2) {
-  return __spirv_ocl_mad(as_half2(args_0), as_half2(args_1), as_half2(args_2));
+  return __spirv_ocl_mad(__clc_as_half2(args_0), __clc_as_half2(args_1), __clc_as_half2(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_mad(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                 __clc_vec3_float16_t args_2) {
-  return __spirv_ocl_mad(as_half3(args_0), as_half3(args_1), as_half3(args_2));
+  return __spirv_ocl_mad(__clc_as_half3(args_0), __clc_as_half3(args_1), __clc_as_half3(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_mad(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                 __clc_vec4_float16_t args_2) {
-  return __spirv_ocl_mad(as_half4(args_0), as_half4(args_1), as_half4(args_2));
+  return __spirv_ocl_mad(__clc_as_half4(args_0), __clc_as_half4(args_1), __clc_as_half4(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_mad(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                 __clc_vec8_float16_t args_2) {
-  return __spirv_ocl_mad(as_half8(args_0), as_half8(args_1), as_half8(args_2));
+  return __spirv_ocl_mad(__clc_as_half8(args_0), __clc_as_half8(args_1), __clc_as_half8(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_mad(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                 __clc_vec16_float16_t args_2) {
-  return __spirv_ocl_mad(as_half16(args_0), as_half16(args_1),
-                         as_half16(args_2));
+  return __spirv_ocl_mad(__clc_as_half16(args_0), __clc_as_half16(args_1),
+                         __clc_as_half16(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_maxmag(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_maxmag(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_maxmag(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_maxmag(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_maxmag(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_maxmag(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_maxmag(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_maxmag(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_maxmag(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_maxmag(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_maxmag(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_maxmag(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_maxmag(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_maxmag(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_maxmag(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_maxmag(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_maxmag(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_maxmag(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_minmag(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_minmag(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_minmag(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_minmag(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_minmag(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_minmag(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_minmag(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_minmag(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_minmag(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_minmag(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_minmag(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_minmag(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_minmag(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_minmag(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_minmag(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_minmag(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_minmag(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_minmag(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t __spirv_ocl_mix(
     __clc_float16_t args_0, __clc_float16_t args_1, __clc_float16_t args_2) {
-  return __spirv_ocl_mix(as_half(args_0), as_half(args_1), as_half(args_2));
+  return __spirv_ocl_mix(__clc_as_half(args_0), __clc_as_half(args_1), __clc_as_half(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_mix(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                 __clc_vec2_float16_t args_2) {
-  return __spirv_ocl_mix(as_half2(args_0), as_half2(args_1), as_half2(args_2));
+  return __spirv_ocl_mix(__clc_as_half2(args_0), __clc_as_half2(args_1), __clc_as_half2(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_mix(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                 __clc_vec3_float16_t args_2) {
-  return __spirv_ocl_mix(as_half3(args_0), as_half3(args_1), as_half3(args_2));
+  return __spirv_ocl_mix(__clc_as_half3(args_0), __clc_as_half3(args_1), __clc_as_half3(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_mix(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                 __clc_vec4_float16_t args_2) {
-  return __spirv_ocl_mix(as_half4(args_0), as_half4(args_1), as_half4(args_2));
+  return __spirv_ocl_mix(__clc_as_half4(args_0), __clc_as_half4(args_1), __clc_as_half4(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_mix(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                 __clc_vec8_float16_t args_2) {
-  return __spirv_ocl_mix(as_half8(args_0), as_half8(args_1), as_half8(args_2));
+  return __spirv_ocl_mix(__clc_as_half8(args_0), __clc_as_half8(args_1), __clc_as_half8(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_mix(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                 __clc_vec16_float16_t args_2) {
-  return __spirv_ocl_mix(as_half16(args_0), as_half16(args_1),
-                         as_half16(args_2));
+  return __spirv_ocl_mix(__clc_as_half16(args_0), __clc_as_half16(args_1),
+                         __clc_as_half16(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_modf(__clc_float16_t args_0, __clc_float16_t __private *args_1) {
-  return __spirv_ocl_modf(as_half(args_0), (__clc_fp16_t __private *)(args_1));
+  return __spirv_ocl_modf(__clc_as_half(args_0), (__clc_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_modf(__clc_float16_t args_0, __clc_float16_t __local *args_1) {
-  return __spirv_ocl_modf(as_half(args_0), (__clc_fp16_t __local *)(args_1));
+  return __spirv_ocl_modf(__clc_as_half(args_0), (__clc_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_modf(__clc_float16_t args_0, __clc_float16_t __global *args_1) {
-  return __spirv_ocl_modf(as_half(args_0), (__clc_fp16_t __global *)(args_1));
+  return __spirv_ocl_modf(__clc_as_half(args_0), (__clc_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_modf(__clc_float16_t args_0, __clc_float16_t __generic *args_1) {
-  return __spirv_ocl_modf(as_half(args_0), (__clc_fp16_t __generic *)(args_1));
+  return __spirv_ocl_modf(__clc_as_half(args_0), (__clc_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_modf(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __private *args_1) {
-  return __spirv_ocl_modf(as_half2(args_0),
+  return __spirv_ocl_modf(__clc_as_half2(args_0),
                           (__clc_vec2_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_modf(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __local *args_1) {
-  return __spirv_ocl_modf(as_half2(args_0),
+  return __spirv_ocl_modf(__clc_as_half2(args_0),
                           (__clc_vec2_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_modf(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __global *args_1) {
-  return __spirv_ocl_modf(as_half2(args_0),
+  return __spirv_ocl_modf(__clc_as_half2(args_0),
                           (__clc_vec2_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_modf(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __generic *args_1) {
-  return __spirv_ocl_modf(as_half2(args_0),
+  return __spirv_ocl_modf(__clc_as_half2(args_0),
                           (__clc_vec2_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_modf(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __private *args_1) {
-  return __spirv_ocl_modf(as_half3(args_0),
+  return __spirv_ocl_modf(__clc_as_half3(args_0),
                           (__clc_vec3_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_modf(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __local *args_1) {
-  return __spirv_ocl_modf(as_half3(args_0),
+  return __spirv_ocl_modf(__clc_as_half3(args_0),
                           (__clc_vec3_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_modf(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __global *args_1) {
-  return __spirv_ocl_modf(as_half3(args_0),
+  return __spirv_ocl_modf(__clc_as_half3(args_0),
                           (__clc_vec3_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_modf(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __generic *args_1) {
-  return __spirv_ocl_modf(as_half3(args_0),
+  return __spirv_ocl_modf(__clc_as_half3(args_0),
                           (__clc_vec3_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_modf(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __private *args_1) {
-  return __spirv_ocl_modf(as_half4(args_0),
+  return __spirv_ocl_modf(__clc_as_half4(args_0),
                           (__clc_vec4_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_modf(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __local *args_1) {
-  return __spirv_ocl_modf(as_half4(args_0),
+  return __spirv_ocl_modf(__clc_as_half4(args_0),
                           (__clc_vec4_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_modf(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __global *args_1) {
-  return __spirv_ocl_modf(as_half4(args_0),
+  return __spirv_ocl_modf(__clc_as_half4(args_0),
                           (__clc_vec4_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_modf(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __generic *args_1) {
-  return __spirv_ocl_modf(as_half4(args_0),
+  return __spirv_ocl_modf(__clc_as_half4(args_0),
                           (__clc_vec4_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_modf(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __private *args_1) {
-  return __spirv_ocl_modf(as_half8(args_0),
+  return __spirv_ocl_modf(__clc_as_half8(args_0),
                           (__clc_vec8_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_modf(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __local *args_1) {
-  return __spirv_ocl_modf(as_half8(args_0),
+  return __spirv_ocl_modf(__clc_as_half8(args_0),
                           (__clc_vec8_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_modf(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __global *args_1) {
-  return __spirv_ocl_modf(as_half8(args_0),
+  return __spirv_ocl_modf(__clc_as_half8(args_0),
                           (__clc_vec8_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_modf(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __generic *args_1) {
-  return __spirv_ocl_modf(as_half8(args_0),
+  return __spirv_ocl_modf(__clc_as_half8(args_0),
                           (__clc_vec8_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_modf(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __private *args_1) {
-  return __spirv_ocl_modf(as_half16(args_0), (__clc_vec16_fp16_t __private *)(args_1));
+  return __spirv_ocl_modf(__clc_as_half16(args_0), (__clc_vec16_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_modf(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __local *args_1) {
-  return __spirv_ocl_modf(as_half16(args_0),
+  return __spirv_ocl_modf(__clc_as_half16(args_0),
                           (__clc_vec16_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_modf(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __global *args_1) {
-  return __spirv_ocl_modf(as_half16(args_0),
+  return __spirv_ocl_modf(__clc_as_half16(args_0),
                           (__clc_vec16_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_modf(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __generic *args_1) {
-  return __spirv_ocl_modf(as_half16(args_0),
+  return __spirv_ocl_modf(__clc_as_half16(args_0),
                           (__clc_vec16_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_nextafter(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_nextafter(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_nextafter(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t __spirv_ocl_nextafter(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_nextafter(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_nextafter(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t __spirv_ocl_nextafter(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_nextafter(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_nextafter(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t __spirv_ocl_nextafter(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_nextafter(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_nextafter(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t __spirv_ocl_nextafter(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_nextafter(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_nextafter(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t __spirv_ocl_nextafter(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_nextafter(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_nextafter(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_normalize(__clc_float16_t args_0) {
-  return __spirv_ocl_normalize(as_half(args_0));
+  return __spirv_ocl_normalize(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_normalize(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_normalize(as_half2(args_0));
+  return __spirv_ocl_normalize(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_normalize(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_normalize(as_half3(args_0));
+  return __spirv_ocl_normalize(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_normalize(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_normalize(as_half4(args_0));
+  return __spirv_ocl_normalize(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_pow(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_pow(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_pow(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_pow(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_pow(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_pow(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_pow(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_pow(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_pow(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_pow(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_pow(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_pow(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_pow(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_pow(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_pow(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_pow(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_pow(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_pow(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_pown(__clc_float16_t args_0, __clc_int32_t args_1) {
-  return __spirv_ocl_pown(as_half(args_0), args_1);
+  return __spirv_ocl_pown(__clc_as_half(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_pown(__clc_vec2_float16_t args_0, __clc_vec2_int32_t args_1) {
-  return __spirv_ocl_pown(as_half2(args_0), args_1);
+  return __spirv_ocl_pown(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_pown(__clc_vec3_float16_t args_0, __clc_vec3_int32_t args_1) {
-  return __spirv_ocl_pown(as_half3(args_0), args_1);
+  return __spirv_ocl_pown(__clc_as_half3(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_pown(__clc_vec4_float16_t args_0, __clc_vec4_int32_t args_1) {
-  return __spirv_ocl_pown(as_half4(args_0), args_1);
+  return __spirv_ocl_pown(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_pown(__clc_vec8_float16_t args_0, __clc_vec8_int32_t args_1) {
-  return __spirv_ocl_pown(as_half8(args_0), args_1);
+  return __spirv_ocl_pown(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_pown(__clc_vec16_float16_t args_0, __clc_vec16_int32_t args_1) {
-  return __spirv_ocl_pown(as_half16(args_0), args_1);
+  return __spirv_ocl_pown(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_powr(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_powr(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_powr(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_powr(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_powr(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_powr(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_powr(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_powr(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_powr(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_powr(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_powr(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_powr(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_powr(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_powr(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_powr(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_powr(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_powr(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_powr(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
@@ -5917,1134 +5917,1134 @@ __spirv_ocl_prefetch(__clc_vec16_float16_t const __global *args_0,
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_radians(__clc_float16_t args_0) {
-  return __spirv_ocl_radians(as_half(args_0));
+  return __spirv_ocl_radians(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_radians(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_radians(as_half2(args_0));
+  return __spirv_ocl_radians(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_radians(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_radians(as_half3(args_0));
+  return __spirv_ocl_radians(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_radians(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_radians(as_half4(args_0));
+  return __spirv_ocl_radians(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_radians(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_radians(as_half8(args_0));
+  return __spirv_ocl_radians(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_radians(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_radians(as_half16(args_0));
+  return __spirv_ocl_radians(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_remainder(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_remainder(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_remainder(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t __spirv_ocl_remainder(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_remainder(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_remainder(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t __spirv_ocl_remainder(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_remainder(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_remainder(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t __spirv_ocl_remainder(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_remainder(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_remainder(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t __spirv_ocl_remainder(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_remainder(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_remainder(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t __spirv_ocl_remainder(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_remainder(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_remainder(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_remquo(__clc_float16_t args_0, __clc_float16_t args_1,
                    __clc_int32_t __private *args_2) {
-  return __spirv_ocl_remquo(as_half(args_0), as_half(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half(args_0), __clc_as_half(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_remquo(__clc_float16_t args_0, __clc_float16_t args_1,
                    __clc_int32_t __local *args_2) {
-  return __spirv_ocl_remquo(as_half(args_0), as_half(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half(args_0), __clc_as_half(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_remquo(__clc_float16_t args_0, __clc_float16_t args_1,
                    __clc_int32_t __global *args_2) {
-  return __spirv_ocl_remquo(as_half(args_0), as_half(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half(args_0), __clc_as_half(args_1), args_2);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_remquo(__clc_float16_t args_0, __clc_float16_t args_1,
                    __clc_int32_t __generic *args_2) {
-  return __spirv_ocl_remquo(as_half(args_0), as_half(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half(args_0), __clc_as_half(args_1), args_2);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t
 __spirv_ocl_remquo(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                    __clc_vec2_int32_t __private *args_2) {
-  return __spirv_ocl_remquo(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t
 __spirv_ocl_remquo(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                    __clc_vec2_int32_t __local *args_2) {
-  return __spirv_ocl_remquo(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t
 __spirv_ocl_remquo(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                    __clc_vec2_int32_t __global *args_2) {
-  return __spirv_ocl_remquo(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t
 __spirv_ocl_remquo(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                    __clc_vec2_int32_t __generic *args_2) {
-  return __spirv_ocl_remquo(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t
 __spirv_ocl_remquo(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                    __clc_vec3_int32_t __private *args_2) {
-  return __spirv_ocl_remquo(as_half3(args_0), as_half3(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half3(args_0), __clc_as_half3(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t
 __spirv_ocl_remquo(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                    __clc_vec3_int32_t __local *args_2) {
-  return __spirv_ocl_remquo(as_half3(args_0), as_half3(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half3(args_0), __clc_as_half3(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t
 __spirv_ocl_remquo(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                    __clc_vec3_int32_t __global *args_2) {
-  return __spirv_ocl_remquo(as_half3(args_0), as_half3(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half3(args_0), __clc_as_half3(args_1), args_2);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t
 __spirv_ocl_remquo(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                    __clc_vec3_int32_t __generic *args_2) {
-  return __spirv_ocl_remquo(as_half3(args_0), as_half3(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half3(args_0), __clc_as_half3(args_1), args_2);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t
 __spirv_ocl_remquo(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                    __clc_vec4_int32_t __private *args_2) {
-  return __spirv_ocl_remquo(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t
 __spirv_ocl_remquo(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                    __clc_vec4_int32_t __local *args_2) {
-  return __spirv_ocl_remquo(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t
 __spirv_ocl_remquo(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                    __clc_vec4_int32_t __global *args_2) {
-  return __spirv_ocl_remquo(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t
 __spirv_ocl_remquo(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                    __clc_vec4_int32_t __generic *args_2) {
-  return __spirv_ocl_remquo(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t
 __spirv_ocl_remquo(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                    __clc_vec8_int32_t __private *args_2) {
-  return __spirv_ocl_remquo(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t
 __spirv_ocl_remquo(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                    __clc_vec8_int32_t __local *args_2) {
-  return __spirv_ocl_remquo(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t
 __spirv_ocl_remquo(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                    __clc_vec8_int32_t __global *args_2) {
-  return __spirv_ocl_remquo(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t
 __spirv_ocl_remquo(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                    __clc_vec8_int32_t __generic *args_2) {
-  return __spirv_ocl_remquo(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t
 __spirv_ocl_remquo(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                    __clc_vec16_int32_t __private *args_2) {
-  return __spirv_ocl_remquo(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t
 __spirv_ocl_remquo(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                    __clc_vec16_int32_t __local *args_2) {
-  return __spirv_ocl_remquo(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t
 __spirv_ocl_remquo(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                    __clc_vec16_int32_t __global *args_2) {
-  return __spirv_ocl_remquo(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t
 __spirv_ocl_remquo(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                    __clc_vec16_int32_t __generic *args_2) {
-  return __spirv_ocl_remquo(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_remquo(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_rint(__clc_float16_t args_0) {
-  return __spirv_ocl_rint(as_half(args_0));
+  return __spirv_ocl_rint(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_rint(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_rint(as_half2(args_0));
+  return __spirv_ocl_rint(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_rint(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_rint(as_half3(args_0));
+  return __spirv_ocl_rint(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_rint(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_rint(as_half4(args_0));
+  return __spirv_ocl_rint(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_rint(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_rint(as_half8(args_0));
+  return __spirv_ocl_rint(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_rint(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_rint(as_half16(args_0));
+  return __spirv_ocl_rint(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_rootn(__clc_float16_t args_0, __clc_int32_t args_1) {
-  return __spirv_ocl_rootn(as_half(args_0), args_1);
+  return __spirv_ocl_rootn(__clc_as_half(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_rootn(__clc_vec2_float16_t args_0, __clc_vec2_int32_t args_1) {
-  return __spirv_ocl_rootn(as_half2(args_0), args_1);
+  return __spirv_ocl_rootn(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_rootn(__clc_vec3_float16_t args_0, __clc_vec3_int32_t args_1) {
-  return __spirv_ocl_rootn(as_half3(args_0), args_1);
+  return __spirv_ocl_rootn(__clc_as_half3(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_rootn(__clc_vec4_float16_t args_0, __clc_vec4_int32_t args_1) {
-  return __spirv_ocl_rootn(as_half4(args_0), args_1);
+  return __spirv_ocl_rootn(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_rootn(__clc_vec8_float16_t args_0, __clc_vec8_int32_t args_1) {
-  return __spirv_ocl_rootn(as_half8(args_0), args_1);
+  return __spirv_ocl_rootn(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_rootn(__clc_vec16_float16_t args_0, __clc_vec16_int32_t args_1) {
-  return __spirv_ocl_rootn(as_half16(args_0), args_1);
+  return __spirv_ocl_rootn(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_round(__clc_float16_t args_0) {
-  return __spirv_ocl_round(as_half(args_0));
+  return __spirv_ocl_round(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_round(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_round(as_half2(args_0));
+  return __spirv_ocl_round(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_round(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_round(as_half3(args_0));
+  return __spirv_ocl_round(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_round(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_round(as_half4(args_0));
+  return __spirv_ocl_round(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_round(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_round(as_half8(args_0));
+  return __spirv_ocl_round(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_round(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_round(as_half16(args_0));
+  return __spirv_ocl_round(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_rsqrt(__clc_float16_t args_0) {
-  return __spirv_ocl_rsqrt(as_half(args_0));
+  return __spirv_ocl_rsqrt(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_rsqrt(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_rsqrt(as_half2(args_0));
+  return __spirv_ocl_rsqrt(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_rsqrt(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_rsqrt(as_half3(args_0));
+  return __spirv_ocl_rsqrt(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_rsqrt(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_rsqrt(as_half4(args_0));
+  return __spirv_ocl_rsqrt(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_rsqrt(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_rsqrt(as_half8(args_0));
+  return __spirv_ocl_rsqrt(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_rsqrt(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_rsqrt(as_half16(args_0));
+  return __spirv_ocl_rsqrt(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t __spirv_ocl_select(
     __clc_float16_t args_0, __clc_float16_t args_1, __clc_int16_t args_2) {
-  return __spirv_ocl_select(as_half(args_0), as_half(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half(args_0), __clc_as_half(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t __spirv_ocl_select(
     __clc_float16_t args_0, __clc_float16_t args_1, __clc_uint16_t args_2) {
-  return __spirv_ocl_select(as_half(args_0), as_half(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half(args_0), __clc_as_half(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_select(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                    __clc_vec2_int16_t args_2) {
-  return __spirv_ocl_select(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_select(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                    __clc_vec2_uint16_t args_2) {
-  return __spirv_ocl_select(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_select(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                    __clc_vec3_int16_t args_2) {
-  return __spirv_ocl_select(as_half3(args_0), as_half3(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half3(args_0), __clc_as_half3(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_select(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                    __clc_vec3_uint16_t args_2) {
-  return __spirv_ocl_select(as_half3(args_0), as_half3(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half3(args_0), __clc_as_half3(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_select(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                    __clc_vec4_int16_t args_2) {
-  return __spirv_ocl_select(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_select(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                    __clc_vec4_uint16_t args_2) {
-  return __spirv_ocl_select(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_select(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                    __clc_vec8_int16_t args_2) {
-  return __spirv_ocl_select(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_select(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                    __clc_vec8_uint16_t args_2) {
-  return __spirv_ocl_select(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_select(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                    __clc_vec16_int16_t args_2) {
-  return __spirv_ocl_select(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_select(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                    __clc_vec16_uint16_t args_2) {
-  return __spirv_ocl_select(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_select(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_shuffle(__clc_vec2_float16_t args_0, __clc_vec2_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half2(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_shuffle(__clc_vec4_float16_t args_0, __clc_vec2_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half4(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_shuffle(__clc_vec8_float16_t args_0, __clc_vec2_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half8(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_shuffle(__clc_vec16_float16_t args_0, __clc_vec2_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half16(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_shuffle(__clc_vec2_float16_t args_0, __clc_vec4_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half2(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_shuffle(__clc_vec4_float16_t args_0, __clc_vec4_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half4(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_shuffle(__clc_vec8_float16_t args_0, __clc_vec4_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half8(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_shuffle(__clc_vec16_float16_t args_0, __clc_vec4_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half16(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_shuffle(__clc_vec2_float16_t args_0, __clc_vec8_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half2(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_shuffle(__clc_vec4_float16_t args_0, __clc_vec8_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half4(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_shuffle(__clc_vec8_float16_t args_0, __clc_vec8_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half8(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_shuffle(__clc_vec16_float16_t args_0, __clc_vec8_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half16(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_shuffle(__clc_vec2_float16_t args_0, __clc_vec16_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half2(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half2(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_shuffle(__clc_vec4_float16_t args_0, __clc_vec16_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half4(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half4(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_shuffle(__clc_vec8_float16_t args_0, __clc_vec16_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half8(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half8(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_shuffle(__clc_vec16_float16_t args_0, __clc_vec16_uint16_t args_1) {
-  return __spirv_ocl_shuffle(as_half16(args_0), args_1);
+  return __spirv_ocl_shuffle(__clc_as_half16(args_0), args_1);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_shuffle2(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                      __clc_vec2_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_shuffle2(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                      __clc_vec2_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_shuffle2(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                      __clc_vec2_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_shuffle2(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                      __clc_vec2_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_shuffle2(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                      __clc_vec4_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_shuffle2(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                      __clc_vec4_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_shuffle2(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                      __clc_vec4_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_shuffle2(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                      __clc_vec4_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_shuffle2(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                      __clc_vec8_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_shuffle2(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                      __clc_vec8_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_shuffle2(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                      __clc_vec8_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_shuffle2(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                      __clc_vec8_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_shuffle2(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                      __clc_vec16_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half2(args_0), as_half2(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half2(args_0), __clc_as_half2(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_shuffle2(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                      __clc_vec16_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half4(args_0), as_half4(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half4(args_0), __clc_as_half4(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_shuffle2(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                      __clc_vec16_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half8(args_0), as_half8(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half8(args_0), __clc_as_half8(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_shuffle2(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
                      __clc_vec16_uint16_t args_2) {
-  return __spirv_ocl_shuffle2(as_half16(args_0), as_half16(args_1), args_2);
+  return __spirv_ocl_shuffle2(__clc_as_half16(args_0), __clc_as_half16(args_1), args_2);
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_sign(__clc_float16_t args_0) {
-  return __spirv_ocl_sign(as_half(args_0));
+  return __spirv_ocl_sign(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_sign(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_sign(as_half2(args_0));
+  return __spirv_ocl_sign(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_sign(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_sign(as_half3(args_0));
+  return __spirv_ocl_sign(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_sign(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_sign(as_half4(args_0));
+  return __spirv_ocl_sign(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_sign(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_sign(as_half8(args_0));
+  return __spirv_ocl_sign(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_sign(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_sign(as_half16(args_0));
+  return __spirv_ocl_sign(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_sin(__clc_float16_t args_0) {
-  return __spirv_ocl_sin(as_half(args_0));
+  return __spirv_ocl_sin(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_sin(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_sin(as_half2(args_0));
+  return __spirv_ocl_sin(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_sin(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_sin(as_half3(args_0));
+  return __spirv_ocl_sin(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_sin(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_sin(as_half4(args_0));
+  return __spirv_ocl_sin(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_sin(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_sin(as_half8(args_0));
+  return __spirv_ocl_sin(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_sin(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_sin(as_half16(args_0));
+  return __spirv_ocl_sin(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_sincos(__clc_float16_t args_0, __clc_float16_t __private *args_1) {
-  return __spirv_ocl_sincos(as_half(args_0),
+  return __spirv_ocl_sincos(__clc_as_half(args_0),
                             (__clc_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_sincos(__clc_float16_t args_0, __clc_float16_t __local *args_1) {
-  return __spirv_ocl_sincos(as_half(args_0), (__clc_fp16_t __local *)(args_1));
+  return __spirv_ocl_sincos(__clc_as_half(args_0), (__clc_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_sincos(__clc_float16_t args_0, __clc_float16_t __global *args_1) {
-  return __spirv_ocl_sincos(as_half(args_0), (__clc_fp16_t __global *)(args_1));
+  return __spirv_ocl_sincos(__clc_as_half(args_0), (__clc_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_fp16_t
 __spirv_ocl_sincos(__clc_float16_t args_0, __clc_float16_t __generic *args_1) {
-  return __spirv_ocl_sincos(as_half(args_0),
+  return __spirv_ocl_sincos(__clc_as_half(args_0),
                             (__clc_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_sincos(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __private *args_1) {
-  return __spirv_ocl_sincos(as_half2(args_0), (__clc_vec2_fp16_t __private *)(args_1));
+  return __spirv_ocl_sincos(__clc_as_half2(args_0), (__clc_vec2_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_sincos(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __local *args_1) {
-  return __spirv_ocl_sincos(as_half2(args_0),
+  return __spirv_ocl_sincos(__clc_as_half2(args_0),
                             (__clc_vec2_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_sincos(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __global *args_1) {
-  return __spirv_ocl_sincos(as_half2(args_0),
+  return __spirv_ocl_sincos(__clc_as_half2(args_0),
                             (__clc_vec2_fp16_t __global *)(args_1));
 }
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec2_fp16_t __spirv_ocl_sincos(
     __clc_vec2_float16_t args_0, __clc_vec2_float16_t __generic *args_1) {
-  return __spirv_ocl_sincos(as_half2(args_0), (__clc_vec2_fp16_t __generic *)(args_1));
+  return __spirv_ocl_sincos(__clc_as_half2(args_0), (__clc_vec2_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_sincos(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __private *args_1) {
-  return __spirv_ocl_sincos(as_half3(args_0), (__clc_vec3_fp16_t __private *)(args_1));
+  return __spirv_ocl_sincos(__clc_as_half3(args_0), (__clc_vec3_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_sincos(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __local *args_1) {
-  return __spirv_ocl_sincos(as_half3(args_0),
+  return __spirv_ocl_sincos(__clc_as_half3(args_0),
                             (__clc_vec3_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_sincos(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __global *args_1) {
-  return __spirv_ocl_sincos(as_half3(args_0),
+  return __spirv_ocl_sincos(__clc_as_half3(args_0),
                             (__clc_vec3_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec3_fp16_t __spirv_ocl_sincos(
     __clc_vec3_float16_t args_0, __clc_vec3_float16_t __generic *args_1) {
-  return __spirv_ocl_sincos(as_half3(args_0), (__clc_vec3_fp16_t __generic *)(args_1));
+  return __spirv_ocl_sincos(__clc_as_half3(args_0), (__clc_vec3_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t
 __spirv_ocl_sincos(__clc_vec4_float16_t args_0, __clc_vec4_float16_t __private *args_1) {
-  return __spirv_ocl_sincos(as_half4(args_0),
+  return __spirv_ocl_sincos(__clc_as_half4(args_0),
                             (__clc_vec4_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_sincos(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __local *args_1) {
-  return __spirv_ocl_sincos(as_half4(args_0),
+  return __spirv_ocl_sincos(__clc_as_half4(args_0),
                             (__clc_vec4_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t __spirv_ocl_sincos(
     __clc_vec4_float16_t args_0, __clc_vec4_float16_t __global *args_1) {
-  return __spirv_ocl_sincos(as_half4(args_0),
+  return __spirv_ocl_sincos(__clc_as_half4(args_0),
                             (__clc_vec4_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec4_fp16_t
 __spirv_ocl_sincos(__clc_vec4_float16_t args_0, __clc_vec4_float16_t __generic *args_1) {
-  return __spirv_ocl_sincos(as_half4(args_0),
+  return __spirv_ocl_sincos(__clc_as_half4(args_0),
                             (__clc_vec4_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_sincos(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __private *args_1) {
-  return __spirv_ocl_sincos(as_half8(args_0),
+  return __spirv_ocl_sincos(__clc_as_half8(args_0),
                             (__clc_vec8_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_sincos(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __local *args_1) {
-  return __spirv_ocl_sincos(as_half8(args_0),
+  return __spirv_ocl_sincos(__clc_as_half8(args_0),
                             (__clc_vec8_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_sincos(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __global *args_1) {
-  return __spirv_ocl_sincos(as_half8(args_0),
+  return __spirv_ocl_sincos(__clc_as_half8(args_0),
                             (__clc_vec8_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec8_fp16_t __spirv_ocl_sincos(
     __clc_vec8_float16_t args_0, __clc_vec8_float16_t __generic *args_1) {
-  return __spirv_ocl_sincos(as_half8(args_0),
+  return __spirv_ocl_sincos(__clc_as_half8(args_0),
                             (__clc_vec8_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_sincos(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __private *args_1) {
-  return __spirv_ocl_sincos(as_half16(args_0),
+  return __spirv_ocl_sincos(__clc_as_half16(args_0),
                             (__clc_vec16_fp16_t __private *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_sincos(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __local *args_1) {
-  return __spirv_ocl_sincos(as_half16(args_0),
+  return __spirv_ocl_sincos(__clc_as_half16(args_0),
                             (__clc_vec16_fp16_t __local *)(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_sincos(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __global *args_1) {
-  return __spirv_ocl_sincos(as_half16(args_0),
+  return __spirv_ocl_sincos(__clc_as_half16(args_0),
                             (__clc_vec16_fp16_t __global *)(args_1));
 }
 
 #if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
 _CLC_OVERLOAD _CLC_DEF __clc_vec16_fp16_t __spirv_ocl_sincos(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t __generic *args_1) {
-  return __spirv_ocl_sincos(as_half16(args_0),
+  return __spirv_ocl_sincos(__clc_as_half16(args_0),
                             (__clc_vec16_fp16_t __generic *)(args_1));
 }
 #endif
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_sinh(__clc_float16_t args_0) {
-  return __spirv_ocl_sinh(as_half(args_0));
+  return __spirv_ocl_sinh(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_sinh(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_sinh(as_half2(args_0));
+  return __spirv_ocl_sinh(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_sinh(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_sinh(as_half3(args_0));
+  return __spirv_ocl_sinh(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_sinh(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_sinh(as_half4(args_0));
+  return __spirv_ocl_sinh(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_sinh(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_sinh(as_half8(args_0));
+  return __spirv_ocl_sinh(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_sinh(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_sinh(as_half16(args_0));
+  return __spirv_ocl_sinh(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_sinpi(__clc_float16_t args_0) {
-  return __spirv_ocl_sinpi(as_half(args_0));
+  return __spirv_ocl_sinpi(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_sinpi(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_sinpi(as_half2(args_0));
+  return __spirv_ocl_sinpi(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_sinpi(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_sinpi(as_half3(args_0));
+  return __spirv_ocl_sinpi(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_sinpi(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_sinpi(as_half4(args_0));
+  return __spirv_ocl_sinpi(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_sinpi(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_sinpi(as_half8(args_0));
+  return __spirv_ocl_sinpi(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_sinpi(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_sinpi(as_half16(args_0));
+  return __spirv_ocl_sinpi(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t __spirv_ocl_smoothstep(
     __clc_float16_t args_0, __clc_float16_t args_1, __clc_float16_t args_2) {
-  return __spirv_ocl_smoothstep(as_half(args_0), as_half(args_1),
-                                as_half(args_2));
+  return __spirv_ocl_smoothstep(__clc_as_half(args_0), __clc_as_half(args_1),
+                                __clc_as_half(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_smoothstep(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1,
                        __clc_vec2_float16_t args_2) {
-  return __spirv_ocl_smoothstep(as_half2(args_0), as_half2(args_1),
-                                as_half2(args_2));
+  return __spirv_ocl_smoothstep(__clc_as_half2(args_0), __clc_as_half2(args_1),
+                                __clc_as_half2(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_smoothstep(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1,
                        __clc_vec3_float16_t args_2) {
-  return __spirv_ocl_smoothstep(as_half3(args_0), as_half3(args_1),
-                                as_half3(args_2));
+  return __spirv_ocl_smoothstep(__clc_as_half3(args_0), __clc_as_half3(args_1),
+                                __clc_as_half3(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_smoothstep(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1,
                        __clc_vec4_float16_t args_2) {
-  return __spirv_ocl_smoothstep(as_half4(args_0), as_half4(args_1),
-                                as_half4(args_2));
+  return __spirv_ocl_smoothstep(__clc_as_half4(args_0), __clc_as_half4(args_1),
+                                __clc_as_half4(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_smoothstep(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1,
                        __clc_vec8_float16_t args_2) {
-  return __spirv_ocl_smoothstep(as_half8(args_0), as_half8(args_1),
-                                as_half8(args_2));
+  return __spirv_ocl_smoothstep(__clc_as_half8(args_0), __clc_as_half8(args_1),
+                                __clc_as_half8(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t __spirv_ocl_smoothstep(
     __clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1,
     __clc_vec16_float16_t args_2) {
-  return __spirv_ocl_smoothstep(as_half16(args_0), as_half16(args_1),
-                                as_half16(args_2));
+  return __spirv_ocl_smoothstep(__clc_as_half16(args_0), __clc_as_half16(args_1),
+                                __clc_as_half16(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_sqrt(__clc_float16_t args_0) {
-  return __spirv_ocl_sqrt(as_half(args_0));
+  return __spirv_ocl_sqrt(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_sqrt(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_sqrt(as_half2(args_0));
+  return __spirv_ocl_sqrt(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_sqrt(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_sqrt(as_half3(args_0));
+  return __spirv_ocl_sqrt(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_sqrt(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_sqrt(as_half4(args_0));
+  return __spirv_ocl_sqrt(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_sqrt(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_sqrt(as_half8(args_0));
+  return __spirv_ocl_sqrt(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_sqrt(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_sqrt(as_half16(args_0));
+  return __spirv_ocl_sqrt(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_step(__clc_float16_t args_0, __clc_float16_t args_1) {
-  return __spirv_ocl_step(as_half(args_0), as_half(args_1));
+  return __spirv_ocl_step(__clc_as_half(args_0), __clc_as_half(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_step(__clc_vec2_float16_t args_0, __clc_vec2_float16_t args_1) {
-  return __spirv_ocl_step(as_half2(args_0), as_half2(args_1));
+  return __spirv_ocl_step(__clc_as_half2(args_0), __clc_as_half2(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_step(__clc_vec3_float16_t args_0, __clc_vec3_float16_t args_1) {
-  return __spirv_ocl_step(as_half3(args_0), as_half3(args_1));
+  return __spirv_ocl_step(__clc_as_half3(args_0), __clc_as_half3(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_step(__clc_vec4_float16_t args_0, __clc_vec4_float16_t args_1) {
-  return __spirv_ocl_step(as_half4(args_0), as_half4(args_1));
+  return __spirv_ocl_step(__clc_as_half4(args_0), __clc_as_half4(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_step(__clc_vec8_float16_t args_0, __clc_vec8_float16_t args_1) {
-  return __spirv_ocl_step(as_half8(args_0), as_half8(args_1));
+  return __spirv_ocl_step(__clc_as_half8(args_0), __clc_as_half8(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_step(__clc_vec16_float16_t args_0, __clc_vec16_float16_t args_1) {
-  return __spirv_ocl_step(as_half16(args_0), as_half16(args_1));
+  return __spirv_ocl_step(__clc_as_half16(args_0), __clc_as_half16(args_1));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_tan(__clc_float16_t args_0) {
-  return __spirv_ocl_tan(as_half(args_0));
+  return __spirv_ocl_tan(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_tan(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_tan(as_half2(args_0));
+  return __spirv_ocl_tan(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_tan(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_tan(as_half3(args_0));
+  return __spirv_ocl_tan(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_tan(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_tan(as_half4(args_0));
+  return __spirv_ocl_tan(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_tan(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_tan(as_half8(args_0));
+  return __spirv_ocl_tan(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_tan(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_tan(as_half16(args_0));
+  return __spirv_ocl_tan(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_tanh(__clc_float16_t args_0) {
-  return __spirv_ocl_tanh(as_half(args_0));
+  return __spirv_ocl_tanh(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_tanh(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_tanh(as_half2(args_0));
+  return __spirv_ocl_tanh(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_tanh(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_tanh(as_half3(args_0));
+  return __spirv_ocl_tanh(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_tanh(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_tanh(as_half4(args_0));
+  return __spirv_ocl_tanh(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_tanh(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_tanh(as_half8(args_0));
+  return __spirv_ocl_tanh(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_tanh(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_tanh(as_half16(args_0));
+  return __spirv_ocl_tanh(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __clc_native_tanh(__clc_float16_t args_0) {
-  return __clc_native_tanh(as_half(args_0));
+  return __clc_native_tanh(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __clc_native_tanh(__clc_vec2_float16_t args_0) {
-  return __clc_native_tanh(as_half2(args_0));
+  return __clc_native_tanh(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __clc_native_tanh(__clc_vec3_float16_t args_0) {
-  return __clc_native_tanh(as_half3(args_0));
+  return __clc_native_tanh(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __clc_native_tanh(__clc_vec4_float16_t args_0) {
-  return __clc_native_tanh(as_half4(args_0));
+  return __clc_native_tanh(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __clc_native_tanh(__clc_vec8_float16_t args_0) {
-  return __clc_native_tanh(as_half8(args_0));
+  return __clc_native_tanh(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __clc_native_tanh(__clc_vec16_float16_t args_0) {
-  return __clc_native_tanh(as_half16(args_0));
+  return __clc_native_tanh(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_tanpi(__clc_float16_t args_0) {
-  return __spirv_ocl_tanpi(as_half(args_0));
+  return __spirv_ocl_tanpi(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_tanpi(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_tanpi(as_half2(args_0));
+  return __spirv_ocl_tanpi(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_tanpi(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_tanpi(as_half3(args_0));
+  return __spirv_ocl_tanpi(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_tanpi(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_tanpi(as_half4(args_0));
+  return __spirv_ocl_tanpi(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_tanpi(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_tanpi(as_half8(args_0));
+  return __spirv_ocl_tanpi(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_tanpi(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_tanpi(as_half16(args_0));
+  return __spirv_ocl_tanpi(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_tgamma(__clc_float16_t args_0) {
-  return __spirv_ocl_tgamma(as_half(args_0));
+  return __spirv_ocl_tgamma(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_tgamma(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_tgamma(as_half2(args_0));
+  return __spirv_ocl_tgamma(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_tgamma(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_tgamma(as_half3(args_0));
+  return __spirv_ocl_tgamma(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_tgamma(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_tgamma(as_half4(args_0));
+  return __spirv_ocl_tgamma(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_tgamma(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_tgamma(as_half8(args_0));
+  return __spirv_ocl_tgamma(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_tgamma(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_tgamma(as_half16(args_0));
+  return __spirv_ocl_tgamma(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_fp16_t
 __spirv_ocl_trunc(__clc_float16_t args_0) {
-  return __spirv_ocl_trunc(as_half(args_0));
+  return __spirv_ocl_trunc(__clc_as_half(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec2_fp16_t
 __spirv_ocl_trunc(__clc_vec2_float16_t args_0) {
-  return __spirv_ocl_trunc(as_half2(args_0));
+  return __spirv_ocl_trunc(__clc_as_half2(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec3_fp16_t
 __spirv_ocl_trunc(__clc_vec3_float16_t args_0) {
-  return __spirv_ocl_trunc(as_half3(args_0));
+  return __spirv_ocl_trunc(__clc_as_half3(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec4_fp16_t
 __spirv_ocl_trunc(__clc_vec4_float16_t args_0) {
-  return __spirv_ocl_trunc(as_half4(args_0));
+  return __spirv_ocl_trunc(__clc_as_half4(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec8_fp16_t
 __spirv_ocl_trunc(__clc_vec8_float16_t args_0) {
-  return __spirv_ocl_trunc(as_half8(args_0));
+  return __spirv_ocl_trunc(__clc_as_half8(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONSTFN __clc_vec16_fp16_t
 __spirv_ocl_trunc(__clc_vec16_float16_t args_0) {
-  return __spirv_ocl_trunc(as_half16(args_0));
+  return __spirv_ocl_trunc(__clc_as_half16(args_0));
 }
 
 _CLC_OVERLOAD _CLC_DEF __clc_fp32_t
@@ -8335,100 +8335,100 @@ __spirv_ocl_vstorea_halfn_r(__clc_vec16_fp64_t args_0, __clc_size_t args_1,
 _CLC_OVERLOAD _CLC_DEF void __spirv_ocl_vstoren(__clc_vec2_float16_t args_0,
                                                 __clc_size_t args_1,
                                                 __clc_float16_t *args_2) {
-  __spirv_ocl_vstoren(as_half2(args_0), args_1, (__clc_fp16_t *)(args_2));
+  __spirv_ocl_vstoren(__clc_as_half2(args_0), args_1, (__clc_fp16_t *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec2_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __local *args_2) {
-  __spirv_ocl_vstoren(as_half2(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half2(args_0), args_1,
                       (__clc_fp16_t __local *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec2_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __global *args_2) {
-  __spirv_ocl_vstoren(as_half2(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half2(args_0), args_1,
                       (__clc_fp16_t __global *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void __spirv_ocl_vstoren(__clc_vec3_float16_t args_0,
                                                 __clc_size_t args_1,
                                                 __clc_float16_t *args_2) {
-  __spirv_ocl_vstoren(as_half3(args_0), args_1, (__clc_fp16_t *)(args_2));
+  __spirv_ocl_vstoren(__clc_as_half3(args_0), args_1, (__clc_fp16_t *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec3_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __local *args_2) {
-  __spirv_ocl_vstoren(as_half3(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half3(args_0), args_1,
                       (__clc_fp16_t __local *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec3_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __global *args_2) {
-  __spirv_ocl_vstoren(as_half3(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half3(args_0), args_1,
                       (__clc_fp16_t __global *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void __spirv_ocl_vstoren(__clc_vec4_float16_t args_0,
                                                 __clc_size_t args_1,
                                                 __clc_float16_t *args_2) {
-  __spirv_ocl_vstoren(as_half4(args_0), args_1, (__clc_fp16_t *)(args_2));
+  __spirv_ocl_vstoren(__clc_as_half4(args_0), args_1, (__clc_fp16_t *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec4_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __local *args_2) {
-  __spirv_ocl_vstoren(as_half4(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half4(args_0), args_1,
                       (__clc_fp16_t __local *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec4_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __global *args_2) {
-  __spirv_ocl_vstoren(as_half4(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half4(args_0), args_1,
                       (__clc_fp16_t __global *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void __spirv_ocl_vstoren(__clc_vec8_float16_t args_0,
                                                 __clc_size_t args_1,
                                                 __clc_float16_t *args_2) {
-  __spirv_ocl_vstoren(as_half8(args_0), args_1, (__clc_fp16_t *)(args_2));
+  __spirv_ocl_vstoren(__clc_as_half8(args_0), args_1, (__clc_fp16_t *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec8_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __local *args_2) {
-  __spirv_ocl_vstoren(as_half8(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half8(args_0), args_1,
                       (__clc_fp16_t __local *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec8_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __global *args_2) {
-  __spirv_ocl_vstoren(as_half8(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half8(args_0), args_1,
                       (__clc_fp16_t __global *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void __spirv_ocl_vstoren(__clc_vec16_float16_t args_0,
                                                 __clc_size_t args_1,
                                                 __clc_float16_t *args_2) {
-  __spirv_ocl_vstoren(as_half16(args_0), args_1, (__clc_fp16_t *)(args_2));
+  __spirv_ocl_vstoren(__clc_as_half16(args_0), args_1, (__clc_fp16_t *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec16_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __local *args_2) {
-  __spirv_ocl_vstoren(as_half16(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half16(args_0), args_1,
                       (__clc_fp16_t __local *)(args_2));
 }
 
 _CLC_OVERLOAD _CLC_DEF void
 __spirv_ocl_vstoren(__clc_vec16_float16_t args_0, __clc_size_t args_1,
                     __clc_float16_t __global *args_2) {
-  __spirv_ocl_vstoren(as_half16(args_0), args_1,
+  __spirv_ocl_vstoren(__clc_as_half16(args_0), args_1,
                       (__clc_fp16_t __global *)(args_2));
 }
 

--- a/libclc/libspirv/lib/generic/gen_core_convert.py
+++ b/libclc/libspirv/lib/generic/gen_core_convert.py
@@ -85,6 +85,7 @@ print(
 */
 
 #include <core/clc_core.h>
+#include <clc/clc_as_type.h>
 #include <clc/integer/clc_abs.h>
 #include <clc/shared/clc_clamp.h>
 #include <clc/shared/clc_max.h>
@@ -226,7 +227,7 @@ def generate_saturated_conversion(src, dst, size):
     # the unsigned type.
     bool_conv_fn = clc_core_fn_name(bool_type[dst], size=size)
     if dst in unsigned_types:
-        bool_prefix = "as_{DST}{N}({BOOL_CONV_FN}".format(
+        bool_prefix = "__clc_as_{DST}{N}({BOOL_CONV_FN}".format(
             DST=dst, BOOL_CONV_FN=bool_conv_fn, N=size
         )
         bool_suffix = ")"

--- a/libclc/libspirv/lib/generic/math/acosh.cl
+++ b/libclc/libspirv/lib/generic/math/acosh.cl
@@ -13,7 +13,7 @@
 #include <clc/math/math.h>
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_acosh(float x) {
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
 
   // Arguments greater than 1/sqrt(epsilon) in magnitude are
   // approximated by acosh(x) = ln(2) + ln(x)
@@ -30,7 +30,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_acosh(float x) {
   float z = __spirv_ocl_log1p(v) + (high ? 0x1.62e430p-1f : 0.0f);
 
   z = ux >= PINFBITPATT_SP32 ? x : z;
-  z = x < 1.0f ? as_float(QNANBITPATT_SP32) : z;
+  z = x < 1.0f ? __clc_as_float(QNANBITPATT_SP32) : z;
 
   return z;
 }
@@ -99,13 +99,13 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_acosh(double x) {
   // For arguments 1.13 <= x <= 1.5 the log1p function is good enough
   double ret2 = __spirv_ocl_log1p(t);
 
-  ulong ux = as_ulong(x);
+  ulong ux = __clc_as_ulong(x);
   double ret = x >= 128.0 ? ret1 : ret2;
 
   ret = ux >= 0x7FF0000000000000 ? x : ret;
   ret = x == 1.0 ? 0.0 : ret;
   ret =
-      (ux & SIGNBIT_DP64) != 0UL || x < 1.0 ? as_double(QNANBITPATT_DP64) : ret;
+      (ux & SIGNBIT_DP64) != 0UL || x < 1.0 ? __clc_as_double(QNANBITPATT_DP64) : ret;
 
   return ret;
 }

--- a/libclc/libspirv/lib/generic/math/acospi.cl
+++ b/libclc/libspirv/lib/generic/math/acospi.cl
@@ -32,12 +32,12 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_acospi(float x) {
   const float piby2_head = 1.5707963267948965580e+00f;  /* 0x3ff921fb54442d18 */
   const float piby2_tail = 6.12323399573676603587e-17f; /* 0x3c91a62633145c07 */
 
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint aux = ux & ~SIGNBIT_SP32;
   int xneg = ux != aux;
   int xexp = (int)(aux >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
 
-  float y = as_float(aux);
+  float y = __clc_as_float(aux);
 
   // transform if |x| >= 0.5
   int transform = xexp >= -1;
@@ -60,7 +60,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_acospi(float x) {
 
   float s = __spirv_ocl_sqrt(r);
   y = s;
-  float s1 = as_float(as_uint(s) & 0xffff0000);
+  float s1 = __clc_as_float(__clc_as_uint(s) & 0xffff0000);
   float c = MATH_DIVIDE(r - s1 * s1, s + s1);
   // float rettn = 1.0f - MATH_DIVIDE(2.0f * (s + (y * u - piby2_tail)), pi);
   float rettn =
@@ -73,7 +73,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_acospi(float x) {
       MATH_DIVIDE(piby2_head - (x - __spirv_ocl_mad(x, -u, piby2_tail)), pi);
 
   ret = transform ? rett : ret;
-  ret = aux > 0x3f800000U ? as_float(QNANBITPATT_SP32) : ret;
+  ret = aux > 0x3f800000U ? __clc_as_float(QNANBITPATT_SP32) : ret;
   ret = ux == 0x3f800000U ? 0.0f : ret;
   ret = ux == 0xbf800000U ? 1.0f : ret;
   ret = xexp < -26 ? 0.5f : ret;
@@ -105,8 +105,8 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_acospi(double x) {
   const double piby2_tail = 6.12323399573676603587e-17; /* 0x3c91a62633145c07 */
 
   double y = __spirv_ocl_fabs(x);
-  int xneg = as_int2(x).hi < 0;
-  int xexp = (as_int2(y).hi >> 20) - EXPBIAS_DP64;
+  int xneg = __clc_as_int2(x).hi < 0;
+  int xexp = (__clc_as_int2(y).hi >> 20) - EXPBIAS_DP64;
 
   // abs(x) >= 0.5
   int transform = xexp >= -1;
@@ -150,7 +150,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_acospi(double x) {
   // Reconstruct acos carefully in transformed region
   double res1 = __spirv_ocl_fma(
       -2.0, MATH_DIVIDE(s + __spirv_ocl_fma(y, u, -piby2_tail), pi), 1.0);
-  double s1 = as_double(as_ulong(s) & 0xffffffff00000000UL);
+  double s1 = __clc_as_double(__clc_as_ulong(s) & 0xffffffff00000000UL);
   double c = MATH_DIVIDE(__spirv_ocl_fma(-s1, s1, r), s + s1);
   double res2 = MATH_DIVIDE(
       __spirv_ocl_fma(2.0, s1, __spirv_ocl_fma(2.0, c, 2.0 * y * u)), pi);
@@ -158,7 +158,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_acospi(double x) {
   res2 = 0.5 - __spirv_ocl_fma(x, u, x) / pi;
   res1 = transform ? res1 : res2;
 
-  const double qnan = as_double(QNANBITPATT_DP64);
+  const double qnan = __clc_as_double(QNANBITPATT_DP64);
   res2 = x == 1.0 ? 0.0 : qnan;
   res2 = x == -1.0 ? 1.0 : res2;
   res1 = xexp >= 0 ? res2 : res1;

--- a/libclc/libspirv/lib/generic/math/asinh.cl
+++ b/libclc/libspirv/lib/generic/math/asinh.cl
@@ -13,7 +13,7 @@
 #include <clc/math/math.h>
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_asinh(float x) {
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint ax = ux & EXSIGNBIT_SP32;
   uint xsgn = ax ^ ux;
 
@@ -51,12 +51,12 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_asinh(float x) {
   // approximated by asinhf(x) = ln(abs(x) + sqrt(x*x+1))
   // with the sign of x (see Abramowitz and Stegun 4.6.20)
 
-  float absx = as_float(ax);
+  float absx = __clc_as_float(ax);
   int hi = ax > 0x46000000U;
   float y = MATH_SQRT(absx * absx + 1.0f) + absx;
   y = hi ? absx : y;
   float r = __spirv_ocl_log(y) + (hi ? 0x1.62e430p-1f : 0.0f);
-  float z2 = as_float(xsgn | as_uint(r));
+  float z2 = __clc_as_float(xsgn | __clc_as_uint(r));
 
   float z = ax <= 0x40000000 ? z1 : z2;
   z = ax < 0x39800000U || ax >= PINFBITPATT_SP32 ? x : z;
@@ -187,9 +187,9 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_asinh(double x) {
   const double log2_lead = 0x1.62e42ep-1;
   const double log2_tail = 0x1.efa39ef35793cp-25;
 
-  ulong ux = as_ulong(x);
+  ulong ux = __clc_as_ulong(x);
   ulong ax = ux & ~SIGNBIT_DP64;
-  double absx = as_double(ax);
+  double absx = __clc_as_double(ax);
 
   double t = x * x;
   double pn, tn, pd, td;

--- a/libclc/libspirv/lib/generic/math/asinpi.cl
+++ b/libclc/libspirv/lib/generic/math/asinpi.cl
@@ -30,14 +30,14 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_asinpi(float x) {
   const float piby2_tail = 7.5497894159e-08F;  /* 0x33a22168 */
   const float hpiby2_head = 7.8539812565e-01F; /* 0x3f490fda */
 
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint aux = ux & EXSIGNBIT_SP32;
   uint xs = ux ^ aux;
-  float shalf = as_float(xs | as_uint(0.5f));
+  float shalf = __clc_as_float(xs | __clc_as_uint(0.5f));
 
   int xexp = (int)(aux >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
 
-  float y = as_float(aux);
+  float y = __clc_as_float(aux);
 
   // abs(x) >= 0.5
   int transform = xexp >= -1;
@@ -59,7 +59,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_asinpi(float x) {
   float u = r * MATH_DIVIDE(a, b);
 
   float s = MATH_SQRT(r);
-  float s1 = as_float(as_uint(s) & 0xffff0000);
+  float s1 = __clc_as_float(__clc_as_uint(s) & 0xffff0000);
   float c = MATH_DIVIDE(__spirv_ocl_mad(-s1, s1, r), s + s1);
   float p =
       __spirv_ocl_mad(2.0f * s, u, -__spirv_ocl_mad(c, -2.0f, piby2_tail));
@@ -70,8 +70,8 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_asinpi(float x) {
   v = MATH_DIVIDE(v, pi);
   float xbypi = MATH_DIVIDE(x, pi);
 
-  float ret = as_float(xs | as_uint(v));
-  ret = aux > 0x3f800000U ? as_float(QNANBITPATT_SP32) : ret;
+  float ret = __clc_as_float(xs | __clc_as_uint(v));
+  ret = aux > 0x3f800000U ? __clc_as_float(QNANBITPATT_SP32) : ret;
   ret = aux == 0x3f800000U ? shalf : ret;
   ret = xexp < -14 ? xbypi : ret;
 
@@ -103,8 +103,8 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_asinpi(double x) {
   const double hpiby2_head = 7.8539816339744831e-01; /* 0x3fe921fb54442d18 */
 
   double y = __spirv_ocl_fabs(x);
-  int xneg = as_int2(x).hi < 0;
-  int xexp = (as_int2(y).hi >> 20) - EXPBIAS_DP64;
+  int xneg = __clc_as_int2(x).hi < 0;
+  int xexp = (__clc_as_int2(y).hi >> 20) - EXPBIAS_DP64;
 
   // abs(x) >= 0.5
   int transform = xexp >= -1;
@@ -144,7 +144,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_asinpi(double x) {
 
   // Reconstruct asin carefully in transformed region
   double s = __spirv_ocl_sqrt(r);
-  double sh = as_double(as_ulong(s) & 0xffffffff00000000UL);
+  double sh = __clc_as_double(__clc_as_ulong(s) & 0xffffffff00000000UL);
   double c = MATH_DIVIDE(__spirv_ocl_fma(-sh, sh, r), s + sh);
   double p = __spirv_ocl_fma(2.0 * s, u, -__spirv_ocl_fma(-2.0, c, piby2_tail));
   double q = __spirv_ocl_fma(-2.0, sh, hpiby2_head);
@@ -154,7 +154,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_asinpi(double x) {
 
   v = xexp < -28 ? y : v;
   v = MATH_DIVIDE(v, pi);
-  v = xexp >= 0 ? as_double(QNANBITPATT_DP64) : v;
+  v = xexp >= 0 ? __clc_as_double(QNANBITPATT_DP64) : v;
   v = y == 1.0 ? 0.5 : v;
   return xneg ? -v : v;
 }

--- a/libclc/libspirv/lib/generic/math/atan.cl
+++ b/libclc/libspirv/lib/generic/math/atan.cl
@@ -14,13 +14,13 @@
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_atan(float x) {
   const float piby2 = 1.5707963267948966f; // 0x3ff921fb54442d18
 
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint aux = ux & EXSIGNBIT_SP32;
   uint sx = ux ^ aux;
 
-  float spiby2 = as_float(sx | as_uint(piby2));
+  float spiby2 = __clc_as_float(sx | __clc_as_uint(piby2));
 
-  float v = as_float(aux);
+  float v = __clc_as_float(aux);
 
   // Return for NaN
   float ret = x;
@@ -75,12 +75,12 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_atan(float x) {
   float q = x * s * MATH_DIVIDE(a, b);
 
   float z = c - (q - x);
-  float zs = as_float(sx | as_uint(z));
+  float zs = __clc_as_float(sx | __clc_as_uint(z));
 
   ret = aux < 0x4c800000 ? zs : ret;
 
   // |x| < 2^-19
-  ret = aux < 0x36000000 ? as_float(ux) : ret;
+  ret = aux < 0x36000000 ? __clc_as_float(ux) : ret;
   return ret;
 }
 

--- a/libclc/libspirv/lib/generic/math/atan2.cl
+++ b/libclc/libspirv/lib/generic/math/atan2.cl
@@ -60,7 +60,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_atan2(float y, float x) {
   a = x < 0.0F ? at : a;
 
   // y == 0 => 0 for x >= 0, pi for x < 0
-  at = as_int(x) < 0 ? pi : 0.0f;
+  at = __clc_as_int(x) < 0 ? pi : 0.0f;
   a = y == 0.0f ? at : a;
 
   // if (!FINITE_ONLY()) {
@@ -69,7 +69,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_atan2(float y, float x) {
   a = ax == INFINITY && ay == INFINITY ? at : a;
 
   // x or y is NaN
-  a = __spirv_IsNan(x) || __spirv_IsNan(y) ? as_float(QNANBITPATT_SP32) : a;
+  a = __spirv_IsNan(x) || __spirv_IsNan(y) ? __clc_as_float(QNANBITPATT_SP32) : a;
   // }
 
   // Fixup sign and return
@@ -94,21 +94,21 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_atan2(double y, double x) {
   const double piby2_tail = 6.1232339957367660e-17;  /* 0x3c91a62633145c07 */
 
   double x2 = x;
-  int xneg = as_int2(x).hi < 0;
-  int xexp = (as_int2(x).hi >> 20) & 0x7ff;
+  int xneg = __clc_as_int2(x).hi < 0;
+  int xexp = (__clc_as_int2(x).hi >> 20) & 0x7ff;
 
   double y2 = y;
-  int yneg = as_int2(y).hi < 0;
-  int yexp = (as_int2(y).hi >> 20) & 0x7ff;
+  int yneg = __clc_as_int2(y).hi < 0;
+  int yexp = (__clc_as_int2(y).hi >> 20) & 0x7ff;
 
   int cond2 = (xexp < 1021) & (yexp < 1021);
   int diffexp = yexp - xexp;
 
   // Scale up both x and y if they are both below 1/4
   double x1 = __spirv_ocl_ldexp(x, 1024);
-  int xexp1 = (as_int2(x1).hi >> 20) & 0x7ff;
+  int xexp1 = (__clc_as_int2(x1).hi >> 20) & 0x7ff;
   double y1 = __spirv_ocl_ldexp(y, 1024);
-  int yexp1 = (as_int2(y1).hi >> 20) & 0x7ff;
+  int yexp1 = (__clc_as_int2(y1).hi >> 20) & 0x7ff;
   int diffexp1 = yexp1 - xexp1;
 
   diffexp = cond2 ? diffexp1 : diffexp;
@@ -140,14 +140,14 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_atan2(double y, double x) {
 
     // We're going to scale u and v by 2^(-u_exponent) to bring them close to 1
     // u_exponent could be EMAX so we have to do it in 2 steps
-    int m = -((int)(as_ulong(u) >> EXPSHIFTBITS_DP64) - EXPBIAS_DP64);
+    int m = -((int)(__clc_as_ulong(u) >> EXPSHIFTBITS_DP64) - EXPBIAS_DP64);
     // double um = __amdil_ldexp_f64(u, m);
     // double vm = __amdil_ldexp_f64(v, m);
     double um = __spirv_ocl_ldexp(u, m);
     double vm = __spirv_ocl_ldexp(v, m);
 
     // 26 leading bits of u
-    double u1 = as_double(as_ulong(um) & 0xfffffffff8000000UL);
+    double u1 = __clc_as_double(__clc_as_ulong(um) & 0xfffffffff8000000UL);
     double u2 = um - u1;
 
     double r = MATH_DIVIDE(__spirv_ocl_fma(-c, u2, __spirv_ocl_fma(-c, u1, vm)),
@@ -168,9 +168,9 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_atan2(double y, double x) {
 
   double q5, q6;
   {
-    double u1 = as_double(as_ulong(u) & 0xffffffff00000000UL);
+    double u1 = __clc_as_double(__clc_as_ulong(u) & 0xffffffff00000000UL);
     double u2 = u - u1;
-    double vu1 = as_double(as_ulong(vbyu) & 0xffffffff00000000UL);
+    double vu1 = __clc_as_double(__clc_as_ulong(vbyu) & 0xffffffff00000000UL);
     double vu2 = vbyu - vu1;
 
     q5 = 0.0;

--- a/libclc/libspirv/lib/generic/math/atan2pi.cl
+++ b/libclc/libspirv/lib/generic/math/atan2pi.cl
@@ -43,7 +43,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_atan2pi(float y, float x) {
   a = x < 0.0F ? at : a;
 
   // y == 0 => 0 for x >= 0, pi for x < 0
-  at = as_int(x) < 0 ? 1.0f : 0.0f;
+  at = __clc_as_int(x) < 0 ? 1.0f : 0.0f;
   a = y == 0.0f ? at : a;
 
   // if (!FINITE_ONLY()) {
@@ -52,7 +52,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_atan2pi(float y, float x) {
   a = ax == INFINITY && ay == INFINITY ? at : a;
 
   // x or y is NaN
-  a = __spirv_IsNan(x) || __spirv_IsNan(y) ? as_float(QNANBITPATT_SP32) : a;
+  a = __spirv_IsNan(x) || __spirv_IsNan(y) ? __clc_as_float(QNANBITPATT_SP32) : a;
   // }
 
   // Fixup sign and return
@@ -73,21 +73,21 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_atan2pi(double y, double x) {
   const double piby2_tail = 6.1232339957367660e-17; /* 0x3c91a62633145c07 */
 
   double x2 = x;
-  int xneg = as_int2(x).hi < 0;
-  int xexp = (as_int2(x).hi >> 20) & 0x7ff;
+  int xneg = __clc_as_int2(x).hi < 0;
+  int xexp = (__clc_as_int2(x).hi >> 20) & 0x7ff;
 
   double y2 = y;
-  int yneg = as_int2(y).hi < 0;
-  int yexp = (as_int2(y).hi >> 20) & 0x7ff;
+  int yneg = __clc_as_int2(y).hi < 0;
+  int yexp = (__clc_as_int2(y).hi >> 20) & 0x7ff;
 
   int cond2 = (xexp < 1021) & (yexp < 1021);
   int diffexp = yexp - xexp;
 
   // Scale up both x and y if they are both below 1/4
   double x1 = __spirv_ocl_ldexp(x, 1024);
-  int xexp1 = (as_int2(x1).hi >> 20) & 0x7ff;
+  int xexp1 = (__clc_as_int2(x1).hi >> 20) & 0x7ff;
   double y1 = __spirv_ocl_ldexp(y, 1024);
-  int yexp1 = (as_int2(y1).hi >> 20) & 0x7ff;
+  int yexp1 = (__clc_as_int2(y1).hi >> 20) & 0x7ff;
   int diffexp1 = yexp1 - xexp1;
 
   diffexp = cond2 ? diffexp1 : diffexp;
@@ -119,12 +119,12 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_atan2pi(double y, double x) {
 
     // We're going to scale u and v by 2^(-u_exponent) to bring them close to 1
     // u_exponent could be EMAX so we have to do it in 2 steps
-    int m = -((int)(as_ulong(u) >> EXPSHIFTBITS_DP64) - EXPBIAS_DP64);
+    int m = -((int)(__clc_as_ulong(u) >> EXPSHIFTBITS_DP64) - EXPBIAS_DP64);
     double um = __spirv_ocl_ldexp(u, m);
     double vm = __spirv_ocl_ldexp(v, m);
 
     // 26 leading bits of u
-    double u1 = as_double(as_ulong(um) & 0xfffffffff8000000UL);
+    double u1 = __clc_as_double(__clc_as_ulong(um) & 0xfffffffff8000000UL);
     double u2 = um - u1;
 
     double r = MATH_DIVIDE(__spirv_ocl_fma(-c, u2, __spirv_ocl_fma(-c, u1, vm)),
@@ -145,9 +145,9 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_atan2pi(double y, double x) {
 
   double q5, q6;
   {
-    double u1 = as_double(as_ulong(u) & 0xffffffff00000000UL);
+    double u1 = __clc_as_double(__clc_as_ulong(u) & 0xffffffff00000000UL);
     double u2 = u - u1;
-    double vu1 = as_double(as_ulong(vbyu) & 0xffffffff00000000UL);
+    double vu1 = __clc_as_double(__clc_as_ulong(vbyu) & 0xffffffff00000000UL);
     double vu2 = vbyu - vu1;
 
     q5 = 0.0;

--- a/libclc/libspirv/lib/generic/math/atanh.cl
+++ b/libclc/libspirv/lib/generic/math/atanh.cl
@@ -12,22 +12,22 @@
 #include <clc/math/math.h>
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_atanh(float x) {
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint ax = ux & EXSIGNBIT_SP32;
   uint xs = ux ^ ax;
 
   // |x| > 1 or NaN
-  float z = as_float(QNANBITPATT_SP32);
+  float z = __clc_as_float(QNANBITPATT_SP32);
 
   // |x| == 1
-  float t = as_float(xs | PINFBITPATT_SP32);
+  float t = __clc_as_float(xs | PINFBITPATT_SP32);
   z = ax == 0x3f800000U ? t : z;
 
   // 1/2 <= |x| < 1
-  t = as_float(ax);
+  t = __clc_as_float(ax);
   t = MATH_DIVIDE(2.0f * t, 1.0f - t);
   t = 0.5f * __spirv_ocl_log1p(t);
-  t = as_float(xs | as_uint(t));
+  t = __clc_as_float(xs | __clc_as_uint(t));
   z = ax < 0x3f800000U ? t : z;
 
   // |x| < 1/2
@@ -57,7 +57,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_atanh(double x) {
   double absx = __spirv_ocl_fabs(x);
 
   double ret =
-      absx == 1.0 ? as_double(PINFBITPATT_DP64) : as_double(QNANBITPATT_DP64);
+      absx == 1.0 ? __clc_as_double(PINFBITPATT_DP64) : __clc_as_double(QNANBITPATT_DP64);
 
   // |x| >= 0.5
   // Note that atanh(x) = 0.5 * ln((1+x)/(1-x))

--- a/libclc/libspirv/lib/generic/math/atanpi.cl
+++ b/libclc/libspirv/lib/generic/math/atanpi.cl
@@ -14,14 +14,14 @@
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_atanpi(float x) {
   const float pi = 3.1415926535897932f;
 
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint aux = ux & EXSIGNBIT_SP32;
   uint sx = ux ^ aux;
 
   float xbypi = MATH_DIVIDE(x, pi);
-  float shalf = as_float(sx | as_uint(0.5f));
+  float shalf = __clc_as_float(sx | __clc_as_uint(0.5f));
 
-  float v = as_float(aux);
+  float v = __clc_as_float(aux);
 
   // Return for NaN
   float ret = x;
@@ -77,7 +77,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_atanpi(float x) {
 
   float z = c - (q - x);
   z = MATH_DIVIDE(z, pi);
-  float zs = as_float(sx | as_uint(z));
+  float zs = __clc_as_float(sx | __clc_as_uint(z));
 
   ret = aux < 0x4c800000 ? zs : ret;
 

--- a/libclc/libspirv/lib/generic/math/cbrt.cl
+++ b/libclc/libspirv/lib/generic/math/cbrt.cl
@@ -14,7 +14,7 @@
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cbrt(float x) {
 
-  uint xi = as_uint(x);
+  uint xi = __clc_as_uint(x);
   uint axi = xi & EXSIGNBIT_SP32;
   uint xsign = axi ^ xi;
   xi = axi;
@@ -22,7 +22,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cbrt(float x) {
   int m = (xi >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
 
   // Treat subnormals
-  uint xisub = as_uint(as_float(xi | 0x3f800000) - 1.0f);
+  uint xisub = __clc_as_uint(__clc_as_float(xi | 0x3f800000) - 1.0f);
   int msub = (xisub >> EXPSHIFTBITS_SP32) - 253;
   int c = m == -127;
   xi = c ? xisub : xi;
@@ -30,11 +30,11 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cbrt(float x) {
 
   int m3 = m / 3;
   int rem = m - m3 * 3;
-  float mf = as_float((m3 + EXPBIAS_SP32) << EXPSHIFTBITS_SP32);
+  float mf = __clc_as_float((m3 + EXPBIAS_SP32) << EXPSHIFTBITS_SP32);
 
   uint indx = (xi & 0x007f0000) + ((xi & 0x00008000) << 1);
   float f =
-      as_float((xi & MANTBITS_SP32) | 0x3f000000) - as_float(indx | 0x3f000000);
+      __clc_as_float((xi & MANTBITS_SP32) | 0x3f000000) - __clc_as_float(indx | 0x3f000000);
 
   indx >>= 16;
   float r = f * USE_TABLE(log_inv_tbl, indx);
@@ -68,7 +68,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cbrt(float x) {
 
   float z = __spirv_ocl_mad(poly, bH, __spirv_ocl_mad(poly, bT, bT)) + bH;
   z *= mf;
-  z = as_float(as_uint(z) | xsign);
+  z = __clc_as_float(__clc_as_uint(z) | xsign);
   c = axi >= EXPBITS_SP32 | axi == 0;
   z = c ? x : z;
   return z;
@@ -82,12 +82,12 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, __spirv_ocl_cbrt, float);
 _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_cbrt(double x) {
 
   int return_x = __spirv_IsInf(x) | __spirv_IsNan(x) | x == 0.0;
-  ulong ux = as_ulong(__spirv_ocl_fabs(x));
-  int m = (as_int2(ux).hi >> 20) - 1023;
+  ulong ux = __clc_as_ulong(__spirv_ocl_fabs(x));
+  int m = (__clc_as_int2(ux).hi >> 20) - 1023;
 
   // Treat subnormals
-  ulong uxs = as_ulong(as_double(0x3ff0000000000000UL | ux) - 1.0);
-  int ms = m + (as_int2(uxs).hi >> 20) - 1022;
+  ulong uxs = __clc_as_ulong(__clc_as_double(0x3ff0000000000000UL | ux) - 1.0);
+  int ms = m + (__clc_as_int2(uxs).hi >> 20) - 1022;
 
   int c = m == -1023;
   ux = c ? uxs : ux;
@@ -96,13 +96,13 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_cbrt(double x) {
   int mby3 = m / 3;
   int rem = m - 3 * mby3;
 
-  double mf = as_double((ulong)(mby3 + 1023) << 52);
+  double mf = __clc_as_double((ulong)(mby3 + 1023) << 52);
 
   ux &= 0x000fffffffffffffUL;
-  double Y = as_double(0x3fe0000000000000UL | ux);
+  double Y = __clc_as_double(0x3fe0000000000000UL | ux);
 
   // nearest integer
-  int index = as_int2(ux).hi >> 11;
+  int index = __clc_as_int2(ux).hi >> 11;
   index = (0x100 | (index >> 1)) + (index & 1);
   double F = (double)index * 0x1.0p-9;
 

--- a/libclc/libspirv/lib/generic/math/clc_exp10.cl
+++ b/libclc/libspirv/lib/generic/math/clc_exp10.cl
@@ -90,11 +90,11 @@ _CLC_DEF _CLC_OVERLOAD float __clc_exp10(float x) {
   float two_to_jby64 = USE_TABLE(exp_tbl, j);
   z2 = __clc_mad(two_to_jby64, z2, two_to_jby64);
 
-  float z2s = z2 * as_float(0x1 << (m + 149));
-  float z2n = as_float(as_int(z2) + m2);
+  float z2s = z2 * __clc_as_float(0x1 << (m + 149));
+  float z2n = __clc_as_float(__clc_as_int(z2) + m2);
   z2 = m <= -126 ? z2s : z2n;
 
-  z2 = return_inf ? as_float(PINFBITPATT_SP32) : z2;
+  z2 = return_inf ? __clc_as_float(PINFBITPATT_SP32) : z2;
   z2 = return_zero ? 0.0f : z2;
   z2 = return_nan ? x : z2;
   return z2;
@@ -149,15 +149,15 @@ _CLC_DEF _CLC_OVERLOAD double __clc_exp10(double x) {
 
   int n1 = m >> 2;
   int n2 = m - n1;
-  double z3 = z2 * as_double(((long)n1 + 1023) << 52);
-  z3 *= as_double(((long)n2 + 1023) << 52);
+  double z3 = z2 * __clc_as_double(((long)n1 + 1023) << 52);
+  z3 *= __clc_as_double(((long)n2 + 1023) << 52);
 
   z2 = __spirv_ocl_ldexp(z2, m);
   z2 = small_value ? z3 : z2;
 
   z2 = __clc_isnan(x) ? x : z2;
 
-  z2 = x > X_MAX ? as_double(PINFBITPATT_DP64) : z2;
+  z2 = x > X_MAX ? __clc_as_double(PINFBITPATT_DP64) : z2;
   z2 = x < X_MIN ? 0.0 : z2;
 
   return z2;

--- a/libclc/libspirv/lib/generic/math/clc_fma.cl
+++ b/libclc/libspirv/lib/generic/math/clc_fma.cl
@@ -56,17 +56,17 @@ _CLC_DEF _CLC_OVERLOAD float __clc_sw_fma(float a, float b, float c) {
 
   struct fp st_a, st_b, st_c;
 
-  st_a.exponent = a == .0f ? 0 : ((as_uint(a) & 0x7f800000) >> 23) - 127;
-  st_b.exponent = b == .0f ? 0 : ((as_uint(b) & 0x7f800000) >> 23) - 127;
-  st_c.exponent = c == .0f ? 0 : ((as_uint(c) & 0x7f800000) >> 23) - 127;
+  st_a.exponent = a == .0f ? 0 : ((__clc_as_uint(a) & 0x7f800000) >> 23) - 127;
+  st_b.exponent = b == .0f ? 0 : ((__clc_as_uint(b) & 0x7f800000) >> 23) - 127;
+  st_c.exponent = c == .0f ? 0 : ((__clc_as_uint(c) & 0x7f800000) >> 23) - 127;
 
-  st_a.mantissa = a == .0f ? 0 : (as_uint(a) & 0x7fffff) | 0x800000;
-  st_b.mantissa = b == .0f ? 0 : (as_uint(b) & 0x7fffff) | 0x800000;
-  st_c.mantissa = c == .0f ? 0 : (as_uint(c) & 0x7fffff) | 0x800000;
+  st_a.mantissa = a == .0f ? 0 : (__clc_as_uint(a) & 0x7fffff) | 0x800000;
+  st_b.mantissa = b == .0f ? 0 : (__clc_as_uint(b) & 0x7fffff) | 0x800000;
+  st_c.mantissa = c == .0f ? 0 : (__clc_as_uint(c) & 0x7fffff) | 0x800000;
 
-  st_a.sign = as_uint(a) & 0x80000000;
-  st_b.sign = as_uint(b) & 0x80000000;
-  st_c.sign = as_uint(c) & 0x80000000;
+  st_a.sign = __clc_as_uint(a) & 0x80000000;
+  st_b.sign = __clc_as_uint(b) & 0x80000000;
+  st_c.sign = __clc_as_uint(c) & 0x80000000;
 
   // Multiplication.
   // Move the product to the highest bits to maximize precision
@@ -155,13 +155,13 @@ _CLC_DEF _CLC_OVERLOAD float __clc_sw_fma(float a, float b, float c) {
 
   // Flating point range limit
   if (st_fma.exponent > 127)
-    return as_float(as_uint(INFINITY) | st_fma.sign);
+    return __clc_as_float(__clc_as_uint(INFINITY) | st_fma.sign);
 
   // Flush denormals
   if (st_fma.exponent <= -127)
-    return as_float(st_fma.sign);
+    return __clc_as_float(st_fma.sign);
 
-  return as_float(st_fma.sign | ((st_fma.exponent + 127) << 23) |
+  return __clc_as_float(st_fma.sign | ((st_fma.exponent + 127) << 23) |
                   ((uint)st_fma.mantissa & 0x7fffff));
 }
 _CLC_TERNARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_sw_fma, float,

--- a/libclc/libspirv/lib/generic/math/clc_fmod.cl
+++ b/libclc/libspirv/lib/generic/math/clc_fmod.cl
@@ -14,19 +14,19 @@
 #include <clc/math/math.h>
 
 _CLC_DEF _CLC_OVERLOAD float __clc_fmod(float x, float y) {
-  int ux = as_int(x);
+  int ux = __clc_as_int(x);
   int ax = ux & EXSIGNBIT_SP32;
-  float xa = as_float(ax);
+  float xa = __clc_as_float(ax);
   int sx = ux ^ ax;
   int ex = ax >> EXPSHIFTBITS_SP32;
 
-  int uy = as_int(y);
+  int uy = __clc_as_int(y);
   int ay = uy & EXSIGNBIT_SP32;
-  float ya = as_float(ay);
+  float ya = __clc_as_float(ay);
   int ey = ay >> EXPSHIFTBITS_SP32;
 
-  float xr = as_float(0x3f800000 | (ax & 0x007fffff));
-  float yr = as_float(0x3f800000 | (ay & 0x007fffff));
+  float xr = __clc_as_float(0x3f800000 | (ax & 0x007fffff));
+  float yr = __clc_as_float(0x3f800000 | (ay & 0x007fffff));
   int c;
   int k = ex - ey;
 
@@ -45,17 +45,17 @@ _CLC_DEF _CLC_OVERLOAD float __clc_fmod(float x, float y) {
   xr = lt ? xa : xr;
   yr = lt ? ya : yr;
 
-  float s = as_float(ey << EXPSHIFTBITS_SP32);
+  float s = __clc_as_float(ey << EXPSHIFTBITS_SP32);
   xr *= lt ? 1.0f : s;
 
   c = ax == ay;
   xr = c ? 0.0f : xr;
 
-  xr = as_float(sx ^ as_int(xr));
+  xr = __clc_as_float(sx ^ __clc_as_int(xr));
 
   c = ax > PINFBITPATT_SP32 | ay > PINFBITPATT_SP32 | ax == PINFBITPATT_SP32 |
       ay == 0;
-  xr = c ? as_float(QNANBITPATT_SP32) : xr;
+  xr = c ? __clc_as_float(QNANBITPATT_SP32) : xr;
 
   return xr;
 }
@@ -63,17 +63,17 @@ _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_fmod, float, float);
 
 #ifdef cl_khr_fp64
 _CLC_DEF _CLC_OVERLOAD double __clc_fmod(double x, double y) {
-  ulong ux = as_ulong(x);
+  ulong ux = __clc_as_ulong(x);
   ulong ax = ux & ~SIGNBIT_DP64;
   ulong xsgn = ux ^ ax;
-  double dx = as_double(ax);
+  double dx = __clc_as_double(ax);
   int xexp = __spirv_SatConvertUToS_Rint(ax >> EXPSHIFTBITS_DP64);
   int xexp1 = 11 - (int)__spirv_ocl_clz(ax & MANTBITS_DP64);
   xexp1 = xexp < 1 ? xexp1 : xexp;
 
-  ulong uy = as_ulong(y);
+  ulong uy = __clc_as_ulong(y);
   ulong ay = uy & ~SIGNBIT_DP64;
-  double dy = as_double(ay);
+  double dy = __clc_as_double(ay);
   int yexp = __spirv_SatConvertUToS_Rint(ay >> EXPSHIFTBITS_DP64);
   int yexp1 = 11 - (int)__spirv_ocl_clz(ay & MANTBITS_DP64);
   yexp1 = yexp < 1 ? yexp1 : yexp;
@@ -134,12 +134,12 @@ _CLC_DEF _CLC_OVERLOAD double __clc_fmod(double x, double y) {
   dx += i ? w : 0.0;
 
   // At this point, dx lies in the range [0,dy)
-  double ret = as_double(xsgn ^ as_ulong(dx));
-  dx = as_double(ax);
+  double ret = __clc_as_double(xsgn ^ __clc_as_ulong(dx));
+  dx = __clc_as_double(ax);
 
   // Now handle |x| == |y|
   int c = dx == dy;
-  t = as_double(xsgn);
+  t = __clc_as_double(xsgn);
   ret = c ? t : ret;
 
   // Next, handle |x| < |y|
@@ -150,7 +150,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_fmod(double x, double y) {
 
   // |y| is 0
   c = dy == 0.0;
-  ret = c ? as_double(QNANBITPATT_DP64) : ret;
+  ret = c ? __clc_as_double(QNANBITPATT_DP64) : ret;
 
   // y is +-Inf, NaN
   c = yexp > BIASEDEMAX_DP64;
@@ -159,7 +159,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_fmod(double x, double y) {
 
   // x is +=Inf, NaN
   c = xexp > BIASEDEMAX_DP64;
-  ret = c ? as_double(QNANBITPATT_DP64) : ret;
+  ret = c ? __clc_as_double(QNANBITPATT_DP64) : ret;
 
   return ret;
 }

--- a/libclc/libspirv/lib/generic/math/clc_hypot.cl
+++ b/libclc/libspirv/lib/generic/math/clc_hypot.cl
@@ -21,9 +21,9 @@
 // Returns sqrt(x*x + y*y) with no overflow or underflow unless the result
 // warrants it
 _CLC_DEF _CLC_OVERLOAD float __clc_hypot(float x, float y) {
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint aux = ux & EXSIGNBIT_SP32;
-  uint uy = as_uint(y);
+  uint uy = __clc_as_uint(y);
   uint auy = uy & EXSIGNBIT_SP32;
   float retval;
   int c = aux > auy;
@@ -32,15 +32,15 @@ _CLC_DEF _CLC_OVERLOAD float __clc_hypot(float x, float y) {
 
   int xexp =
       __clc_clamp((int)(ux >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32, -126, 126);
-  float fx_exp = as_float((xexp + EXPBIAS_SP32) << EXPSHIFTBITS_SP32);
-  float fi_exp = as_float((-xexp + EXPBIAS_SP32) << EXPSHIFTBITS_SP32);
-  float fx = as_float(ux) * fi_exp;
-  float fy = as_float(uy) * fi_exp;
+  float fx_exp = __clc_as_float((xexp + EXPBIAS_SP32) << EXPSHIFTBITS_SP32);
+  float fi_exp = __clc_as_float((-xexp + EXPBIAS_SP32) << EXPSHIFTBITS_SP32);
+  float fx = __clc_as_float(ux) * fi_exp;
+  float fy = __clc_as_float(uy) * fi_exp;
   retval = __spirv_ocl_sqrt(__clc_mad(fx, fx, fy * fy)) * fx_exp;
 
-  retval = ux > PINFBITPATT_SP32 || uy == 0 ? as_float(ux) : retval;
+  retval = ux > PINFBITPATT_SP32 || uy == 0 ? __clc_as_float(ux) : retval;
   retval = ux == PINFBITPATT_SP32 || uy == PINFBITPATT_SP32
-               ? as_float(PINFBITPATT_SP32)
+               ? __clc_as_float(PINFBITPATT_SP32)
                : retval;
   return retval;
 }
@@ -48,13 +48,13 @@ _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_hypot, float, float)
 
 #ifdef cl_khr_fp64
 _CLC_DEF _CLC_OVERLOAD double __clc_hypot(double x, double y) {
-  ulong ux = as_ulong(x) & ~SIGNBIT_DP64;
+  ulong ux = __clc_as_ulong(x) & ~SIGNBIT_DP64;
   int xexp = ux >> EXPSHIFTBITS_DP64;
-  x = as_double(ux);
+  x = __clc_as_double(ux);
 
-  ulong uy = as_ulong(y) & ~SIGNBIT_DP64;
+  ulong uy = __clc_as_ulong(y) & ~SIGNBIT_DP64;
   int yexp = uy >> EXPSHIFTBITS_DP64;
-  y = as_double(uy);
+  y = __clc_as_double(uy);
 
   int c = xexp > EXPBIAS_DP64 + 500 | yexp > EXPBIAS_DP64 + 500;
   double preadjust = c ? 0x1.0p-600 : 1.0;
@@ -78,11 +78,11 @@ _CLC_DEF _CLC_OVERLOAD double __clc_hypot(double x, double y) {
   // Check for NaN
   // c = x != x | y != y;
   c = __clc_isnan(x) | __clc_isnan(y);
-  r = c ? as_double(QNANBITPATT_DP64) : r;
+  r = c ? __clc_as_double(QNANBITPATT_DP64) : r;
 
   // If either is Inf, we must return Inf
-  c = x == as_double(PINFBITPATT_DP64) | y == as_double(PINFBITPATT_DP64);
-  r = c ? as_double(PINFBITPATT_DP64) : r;
+  c = x == __clc_as_double(PINFBITPATT_DP64) | y == __clc_as_double(PINFBITPATT_DP64);
+  r = c ? __clc_as_double(PINFBITPATT_DP64) : r;
 
   return r;
 }

--- a/libclc/libspirv/lib/generic/math/clc_ldexp.cl
+++ b/libclc/libspirv/lib/generic/math/clc_ldexp.cl
@@ -35,7 +35,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
   if (!__clc_fp32_subnormals_supported()) {
 
     // This treats subnormals as zeros
-    int i = as_int(x);
+    int i = __clc_as_int(x);
     int e = (i >> 23) & 0xff;
     int m = i & 0x007fffff;
     int s = i & 0x80000000;
@@ -46,7 +46,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
     mr = c ? m : mr;
     int er = c ? e : v;
     er = e ? er : e;
-    return as_float(s | (er << 23) | mr);
+    return __clc_as_float(s | (er << 23) | mr);
   }
 
   /* supports denormal values */
@@ -55,7 +55,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
   uint val_ui;
   uint sign;
   int exponent;
-  val_ui = as_uint(x);
+  val_ui = __clc_as_uint(x);
   sign = val_ui & 0x80000000;
   val_ui = val_ui & 0x7fffffff; /* remove the sign bit */
   int val_x = val_ui;
@@ -65,7 +65,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
 
   /* denormal support */
   int fbh =
-      127 - (as_uint((float)(as_float(val_ui | 0x3f800000) - 1.0f)) >> 23);
+      127 - (__clc_as_uint((float)(__clc_as_float(val_ui | 0x3f800000) - 1.0f)) >> 23);
   int dexponent = 25 - fbh;
   uint dval_ui = (((val_ui << fbh) & 0x007fffff) | (dexponent << 23));
   int ex = dexponent + n - multiplier;
@@ -78,7 +78,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
   dval_ui = dexponent > 254 ? 0x7f800000 : dval_ui; /*overflow*/
   dval_ui = dexponent < -multiplier ? 0 : dval_ui;  /*underflow*/
   dval_ui = dval_ui | sign;
-  val_f = as_float(dval_ui);
+  val_f = __clc_as_float(dval_ui);
 
   exponent += n;
 
@@ -92,7 +92,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
   val_ui = val_ui | sign;
 
   val_ui = dexp == 0 ? dval_ui : val_ui;
-  val_f = as_float(val_ui);
+  val_f = __clc_as_float(val_ui);
 
   val_f = __clc_isnan(x) || __clc_isinf(x) || val_x == 0 ? x : val_f;
   return val_f;
@@ -103,11 +103,11 @@ _CLC_DEF _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
 _CLC_DEF _CLC_OVERLOAD double __clc_ldexp(double x, int n) {
-  long l = as_ulong(x);
+  long l = __clc_as_ulong(x);
   int e = (l >> 52) & 0x7ff;
   long s = l & 0x8000000000000000;
 
-  ulong ux = as_ulong(x * 0x1.0p+53);
+  ulong ux = __clc_as_ulong(x * 0x1.0p+53);
   int de = ((int)(ux >> 52) & 0x7ff) - 53;
   int c = e == 0;
   e = c ? de : e;
@@ -119,13 +119,13 @@ _CLC_DEF _CLC_OVERLOAD double __clc_ldexp(double x, int n) {
 
   ux &= ~EXPBITS_DP64;
 
-  double mr = as_double(ux | ((ulong)(v + 53) << 52));
+  double mr = __clc_as_double(ux | ((ulong)(v + 53) << 52));
   mr = mr * 0x1.0p-53;
 
-  mr = v > 0 ? as_double(ux | ((ulong)v << 52)) : mr;
+  mr = v > 0 ? __clc_as_double(ux | ((ulong)v << 52)) : mr;
 
-  mr = v == 0x7ff ? as_double(s | PINFBITPATT_DP64) : mr;
-  mr = v < -53 ? as_double(s) : mr;
+  mr = v == 0x7ff ? __clc_as_double(s | PINFBITPATT_DP64) : mr;
+  mr = v < -53 ? __clc_as_double(s) : mr;
 
   mr = ((n == 0) | __clc_isinf(x) | (x == 0)) ? x : mr;
   return mr;

--- a/libclc/libspirv/lib/generic/math/clc_pow.cl
+++ b/libclc/libspirv/lib/generic/math/clc_pow.cl
@@ -69,18 +69,18 @@
 
 _CLC_DEF _CLC_OVERLOAD float __clc_pow(float x, float y) {
 
-  int ix = as_int(x);
+  int ix = __clc_as_int(x);
   int ax = ix & EXSIGNBIT_SP32;
   int xpos = ix == ax;
 
-  int iy = as_int(y);
+  int iy = __clc_as_int(y);
   int ay = iy & EXSIGNBIT_SP32;
   int ypos = iy == ay;
 
   /* Extra precise log calculation
    *  First handle case that x is close to 1
    */
-  float r = 1.0f - as_float(ax);
+  float r = 1.0f - __clc_as_float(ax);
   int near1 = __spirv_ocl_fabs(r) < 0x1.0p-4f;
   float r2 = r * r;
 
@@ -104,7 +104,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pow(float x, float y) {
   /* Computations for x not near 1 */
   int m = (int)(ax >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
   float mf = (float)m;
-  int ixs = as_int(as_float(ax | 0x3f800000) - 1.0f);
+  int ixs = __clc_as_int(__clc_as_float(ax | 0x3f800000) - 1.0f);
   float mfs = (float)((ixs >> EXPSHIFTBITS_SP32) - 253);
   int c = m == -127;
   int ixn = c ? ixs : ax;
@@ -113,8 +113,8 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pow(float x, float y) {
   int indx = (ixn & 0x007f0000) + ((ixn & 0x00008000) << 1);
 
   /* F - Y */
-  float f = as_float(0x3f000000 | indx) -
-            as_float(0x3f000000 | (ixn & MANTBITS_SP32));
+  float f = __clc_as_float(0x3f000000 | indx) -
+            __clc_as_float(0x3f000000 | (ixn & MANTBITS_SP32));
 
   indx = indx >> 16;
   float2 tv = USE_TABLE(log_inv_tbl_ep, indx);
@@ -142,10 +142,10 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pow(float x, float y) {
   lh = near1 ? lh_near1 : lh;
   l = near1 ? l_near1 : l;
 
-  float gh = as_float(as_int(l) & 0xfffff000);
+  float gh = __clc_as_float(__clc_as_int(l) & 0xfffff000);
   float gt = ((ltt - (lt - lth)) + ((lh - l) + lt)) + (l - gh);
 
-  float yh = as_float(iy & 0xfffff000);
+  float yh = __clc_as_float(iy & 0xfffff000);
 
   float yt = y - yh;
 
@@ -179,14 +179,14 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pow(float x, float y) {
 
   float expylogx =
       __clc_mad(tv.s0, poly, __clc_mad(tv.s1, poly, tv.s1)) + tv.s0;
-  float sexpylogx = expylogx * as_float(0x1 << (m + 149));
-  float texpylogx = as_float(as_int(expylogx) + m2);
+  float sexpylogx = expylogx * __clc_as_float(0x1 << (m + 149));
+  float texpylogx = __clc_as_float(__clc_as_int(expylogx) + m2);
   expylogx = m < -125 ? sexpylogx : texpylogx;
 
   /* Result is +-Inf if (ylogx + ylogx_t) > 128*log2 */
   expylogx = (ylogx > 0x1.62e430p+6f) |
                      (ylogx == 0x1.62e430p+6f & ylogx_t > -0x1.05c610p-22f)
-                 ? as_float(PINFBITPATT_SP32)
+                 ? __clc_as_float(PINFBITPATT_SP32)
                  : expylogx;
 
   /* Result is 0 if ylogx < -149*log2 */
@@ -206,9 +206,9 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pow(float x, float y) {
   inty = yexp < 1 ? 0 : inty;
   inty = yexp > 24 ? 2 : inty;
 
-  float signval = as_float((as_uint(expylogx) ^ SIGNBIT_SP32));
+  float signval = __clc_as_float((__clc_as_uint(expylogx) ^ SIGNBIT_SP32));
   expylogx = ((inty == 1) & !xpos) ? signval : expylogx;
-  int ret = as_int(expylogx);
+  int ret = __clc_as_int(expylogx);
 
   /* Corner case handling */
   ret = (!xpos & (inty == 0)) ? QNANBITPATT_SP32 : ret;
@@ -237,7 +237,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pow(float x, float y) {
   ret = ay == 0 ? 0x3f800000 : ret;
   ret = ix == 0x3f800000 ? 0x3f800000 : ret;
 
-  return as_float(ret);
+  return __clc_as_float(ret);
 }
 _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_pow, float, float)
 
@@ -246,11 +246,11 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pow(double x, double y) {
   const double real_log2_tail = 5.76999904754328540596e-08;
   const double real_log2_lead = 6.93147122859954833984e-01;
 
-  long ux = as_long(x);
+  long ux = __clc_as_long(x);
   long ax = ux & (~SIGNBIT_DP64);
   int xpos = ax == ux;
 
-  long uy = as_long(y);
+  long uy = __clc_as_long(y);
   long ay = uy & (~SIGNBIT_DP64);
   int ypos = ay == uy;
 
@@ -262,7 +262,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pow(double x, double y) {
     double xexp = (double)exp;
     long mantissa = ax & 0x000FFFFFFFFFFFFFL;
 
-    long temp_ux = as_long(as_double(0x3ff0000000000000L | mantissa) - 1.0);
+    long temp_ux = __clc_as_long(__clc_as_double(0x3ff0000000000000L | mantissa) - 1.0);
     exp = ((temp_ux & 0x7FF0000000000000L) >> 52) - 2045;
     double xexp1 = (double)exp;
     long mantissa1 = temp_ux & 0x000FFFFFFFFFFFFFL;
@@ -274,14 +274,14 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pow(double x, double y) {
                ((mantissa & 0x0000080000000000) << 1);
     int index = rax >> 44;
 
-    double F = as_double(rax | 0x3FE0000000000000L);
-    double Y = as_double(mantissa | 0x3FE0000000000000L);
+    double F = __clc_as_double(rax | 0x3FE0000000000000L);
+    double Y = __clc_as_double(mantissa | 0x3FE0000000000000L);
     double f = F - Y;
     double2 tv = USE_TABLE(log_f_inv_tbl, index);
     double log_h = tv.s0;
     double log_t = tv.s1;
     double f_inv = (log_h + log_t) * f;
-    double r1 = as_double(as_long(f_inv) & 0xfffffffff8000000L);
+    double r1 = __clc_as_double(__clc_as_long(f_inv) & 0xfffffffff8000000L);
     double r2 = __spirv_ocl_fma(-F, r1, f) * (log_h + log_t);
     double r = r1 + r2;
 
@@ -311,11 +311,11 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pow(double x, double y) {
     double resT_h = poly0h;
 
     double H = resT + resH;
-    double H_h = as_double(as_long(H) & 0xfffffffff8000000L);
+    double H_h = __clc_as_double(__clc_as_long(H) & 0xfffffffff8000000L);
     double T = (resH - H + resT) + (resT_t - (resT + resT_h)) + (H - H_h);
     H = H_h;
 
-    double y_head = as_double(uy & 0xfffffffff8000000L);
+    double y_head = __clc_as_double(uy & 0xfffffffff8000000L);
     double y_tail = y - y_head;
 
     double temp =
@@ -364,7 +364,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pow(double x, double y) {
     expv = __spirv_ocl_fma(f, q, f2) + f1;
     expv = __spirv_ocl_ldexp(expv, m);
 
-    expv = v > max_exp_arg ? as_double(0x7FF0000000000000L) : expv;
+    expv = v > max_exp_arg ? __clc_as_double(0x7FF0000000000000L) : expv;
     expv = v < min_exp_arg ? 0.0 : expv;
   }
 
@@ -386,7 +386,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pow(double x, double y) {
 
   expv *= (inty == 1) & !xpos ? -1.0 : 1.0;
 
-  long ret = as_long(expv);
+  long ret = __clc_as_long(expv);
 
   // Now all the edge cases
   ret = !xpos & (inty == 0) ? QNANBITPATT_DP64 : ret;
@@ -420,7 +420,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pow(double x, double y) {
   ret = ay == 0L ? 0x3ff0000000000000L : ret;
   ret = ux == 0x3ff0000000000000L ? 0x3ff0000000000000L : ret;
 
-  return as_double(ret);
+  return __clc_as_double(ret);
 }
 _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_pow, double, double)
 #endif

--- a/libclc/libspirv/lib/generic/math/clc_pown.cl
+++ b/libclc/libspirv/lib/generic/math/clc_pown.cl
@@ -52,17 +52,17 @@
 _CLC_DEF _CLC_OVERLOAD float __clc_pown(float x, int ny) {
   float y = (float)ny;
 
-  int ix = as_int(x);
+  int ix = __clc_as_int(x);
   int ax = ix & EXSIGNBIT_SP32;
   int xpos = ix == ax;
 
-  int iy = as_int(y);
+  int iy = __clc_as_int(y);
   int ay = iy & EXSIGNBIT_SP32;
   int ypos = iy == ay;
 
   // Extra precise log calculation
   // First handle case that x is close to 1
-  float r = 1.0f - as_float(ax);
+  float r = 1.0f - __clc_as_float(ax);
   int near1 = __spirv_ocl_fabs(r) < 0x1.0p-4f;
   float r2 = r * r;
 
@@ -87,7 +87,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pown(float x, int ny) {
   // Computations for x not near 1
   int m = (int)(ax >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
   float mf = (float)m;
-  int ixs = as_int(as_float(ax | 0x3f800000) - 1.0f);
+  int ixs = __clc_as_int(__clc_as_float(ax | 0x3f800000) - 1.0f);
   float mfs = (float)((ixs >> EXPSHIFTBITS_SP32) - 253);
   int c = m == -127;
   int ixn = c ? ixs : ax;
@@ -96,8 +96,8 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pown(float x, int ny) {
   int indx = (ixn & 0x007f0000) + ((ixn & 0x00008000) << 1);
 
   // F - Y
-  float f = as_float(0x3f000000 | indx) -
-            as_float(0x3f000000 | (ixn & MANTBITS_SP32));
+  float f = __clc_as_float(0x3f000000 | indx) -
+            __clc_as_float(0x3f000000 | (ixn & MANTBITS_SP32));
 
   indx = indx >> 16;
   float2 tv = USE_TABLE(log_inv_tbl_ep, indx);
@@ -126,10 +126,10 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pown(float x, int ny) {
   lh = near1 ? lh_near1 : lh;
   l = near1 ? l_near1 : l;
 
-  float gh = as_float(as_int(l) & 0xfffff000);
+  float gh = __clc_as_float(__clc_as_int(l) & 0xfffff000);
   float gt = ((ltt - (lt - lth)) + ((lh - l) + lt)) + (l - gh);
 
-  float yh = as_float(iy & 0xfffff000);
+  float yh = __clc_as_float(iy & 0xfffff000);
 
   float yt = (float)(ny - (int)yh);
 
@@ -163,14 +163,14 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pown(float x, int ny) {
 
   float expylogx =
       __spirv_ocl_mad(tv.s0, poly, __spirv_ocl_mad(tv.s1, poly, tv.s1)) + tv.s0;
-  float sexpylogx = expylogx * as_float(0x1 << (m + 149));
-  float texpylogx = as_float(as_int(expylogx) + m2);
+  float sexpylogx = expylogx * __clc_as_float(0x1 << (m + 149));
+  float texpylogx = __clc_as_float(__clc_as_int(expylogx) + m2);
   expylogx = m < -125 ? sexpylogx : texpylogx;
 
   // Result is +-Inf if (ylogx + ylogx_t) > 128*log2
   expylogx = ((ylogx > 0x1.62e430p+6f) |
               (ylogx == 0x1.62e430p+6f & ylogx_t > -0x1.05c610p-22f))
-                 ? as_float(PINFBITPATT_SP32)
+                 ? __clc_as_float(PINFBITPATT_SP32)
                  : expylogx;
 
   // Result is 0 if ylogx < -149*log2
@@ -183,9 +183,9 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pown(float x, int ny) {
 
   int inty = 2 - (ny & 1);
 
-  float signval = as_float((as_uint(expylogx) ^ SIGNBIT_SP32));
+  float signval = __clc_as_float((__clc_as_uint(expylogx) ^ SIGNBIT_SP32));
   expylogx = ((inty == 1) & !xpos) ? signval : expylogx;
-  int ret = as_int(expylogx);
+  int ret = __clc_as_int(expylogx);
 
   // Corner case handling
   int xinf = xpos ? PINFBITPATT_SP32 : NINFBITPATT_SP32;
@@ -205,7 +205,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_pown(float x, int ny) {
   ret = ax > PINFBITPATT_SP32 ? ix : ret;
   ret = ny == 0 ? 0x3f800000 : ret;
 
-  return as_float(ret);
+  return __clc_as_float(ret);
 }
 _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_pown, float, int)
 
@@ -216,11 +216,11 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pown(double x, int ny) {
 
   double y = (double)ny;
 
-  long ux = as_long(x);
+  long ux = __clc_as_long(x);
   long ax = ux & (~SIGNBIT_DP64);
   int xpos = ax == ux;
 
-  long uy = as_long(y);
+  long uy = __clc_as_long(y);
   long ay = uy & (~SIGNBIT_DP64);
   int ypos = ay == uy;
 
@@ -232,7 +232,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pown(double x, int ny) {
     double xexp = (double)exp;
     long mantissa = ax & 0x000FFFFFFFFFFFFFL;
 
-    long temp_ux = as_long(as_double(0x3ff0000000000000L | mantissa) - 1.0);
+    long temp_ux = __clc_as_long(__clc_as_double(0x3ff0000000000000L | mantissa) - 1.0);
     exp = ((temp_ux & 0x7FF0000000000000L) >> 52) - 2045;
     double xexp1 = (double)exp;
     long mantissa1 = temp_ux & 0x000FFFFFFFFFFFFFL;
@@ -244,14 +244,14 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pown(double x, int ny) {
                ((mantissa & 0x0000080000000000) << 1);
     int index = rax >> 44;
 
-    double F = as_double(rax | 0x3FE0000000000000L);
-    double Y = as_double(mantissa | 0x3FE0000000000000L);
+    double F = __clc_as_double(rax | 0x3FE0000000000000L);
+    double Y = __clc_as_double(mantissa | 0x3FE0000000000000L);
     double f = F - Y;
     double2 tv = USE_TABLE(log_f_inv_tbl, index);
     double log_h = tv.s0;
     double log_t = tv.s1;
     double f_inv = (log_h + log_t) * f;
-    double r1 = as_double(as_long(f_inv) & 0xfffffffff8000000L);
+    double r1 = __clc_as_double(__clc_as_long(f_inv) & 0xfffffffff8000000L);
     double r2 = __spirv_ocl_fma(-F, r1, f) * (log_h + log_t);
     double r = r1 + r2;
 
@@ -281,11 +281,11 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pown(double x, int ny) {
     double resT_h = poly0h;
 
     double H = resT + resH;
-    double H_h = as_double(as_long(H) & 0xfffffffff8000000L);
+    double H_h = __clc_as_double(__clc_as_long(H) & 0xfffffffff8000000L);
     double T = (resH - H + resT) + (resT_t - (resT + resT_h)) + (H - H_h);
     H = H_h;
 
-    double y_head = as_double(uy & 0xfffffffff8000000L);
+    double y_head = __clc_as_double(uy & 0xfffffffff8000000L);
     double y_tail = y - y_head;
 
     int mask_2_24 = ay > 0x4170000000000000; // 2^24
@@ -340,7 +340,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pown(double x, int ny) {
     expv = __spirv_ocl_fma(f, q, f2) + f1;
     expv = __spirv_ocl_ldexp(expv, m);
 
-    expv = v > max_exp_arg ? as_double(0x7FF0000000000000L) : expv;
+    expv = v > max_exp_arg ? __clc_as_double(0x7FF0000000000000L) : expv;
     expv = v < min_exp_arg ? 0.0 : expv;
   }
 
@@ -353,7 +353,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pown(double x, int ny) {
 
   expv *= ((inty == 1) & !xpos) ? -1.0 : 1.0;
 
-  long ret = as_long(expv);
+  long ret = __clc_as_long(expv);
 
   // Now all the edge cases
   long xinf = xpos ? PINFBITPATT_DP64 : NINFBITPATT_DP64;
@@ -374,7 +374,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pown(double x, int ny) {
   ret = ax > PINFBITPATT_DP64 ? ux : ret;
   ret = ny == 0 ? 0x3ff0000000000000L : ret;
 
-  return as_double(ret);
+  return __clc_as_double(ret);
 }
 _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_pown, double, int)
 #endif

--- a/libclc/libspirv/lib/generic/math/clc_powr.cl
+++ b/libclc/libspirv/lib/generic/math/clc_powr.cl
@@ -50,17 +50,17 @@
 // ((((expT * poly) + expT) + expH*poly) + expH)
 
 _CLC_DEF _CLC_OVERLOAD float __clc_powr(float x, float y) {
-  int ix = as_int(x);
+  int ix = __clc_as_int(x);
   int ax = ix & EXSIGNBIT_SP32;
   int xpos = ix == ax;
 
-  int iy = as_int(y);
+  int iy = __clc_as_int(y);
   int ay = iy & EXSIGNBIT_SP32;
   int ypos = iy == ay;
 
   // Extra precise log calculation
   // First handle case that x is close to 1
-  float r = 1.0f - as_float(ax);
+  float r = 1.0f - __clc_as_float(ax);
   int near1 = __spirv_ocl_fabs(r) < 0x1.0p-4f;
   float r2 = r * r;
 
@@ -85,7 +85,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_powr(float x, float y) {
   // Computations for x not near 1
   int m = (int)(ax >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
   float mf = (float)m;
-  int ixs = as_int(as_float(ax | 0x3f800000) - 1.0f);
+  int ixs = __clc_as_int(__clc_as_float(ax | 0x3f800000) - 1.0f);
   float mfs = (float)((ixs >> EXPSHIFTBITS_SP32) - 253);
   int c = m == -127;
   int ixn = c ? ixs : ax;
@@ -94,8 +94,8 @@ _CLC_DEF _CLC_OVERLOAD float __clc_powr(float x, float y) {
   int indx = (ixn & 0x007f0000) + ((ixn & 0x00008000) << 1);
 
   // F - Y
-  float f = as_float(0x3f000000 | indx) -
-            as_float(0x3f000000 | (ixn & MANTBITS_SP32));
+  float f = __clc_as_float(0x3f000000 | indx) -
+            __clc_as_float(0x3f000000 | (ixn & MANTBITS_SP32));
 
   indx = indx >> 16;
   float2 tv = USE_TABLE(log_inv_tbl_ep, indx);
@@ -124,10 +124,10 @@ _CLC_DEF _CLC_OVERLOAD float __clc_powr(float x, float y) {
   lh = near1 ? lh_near1 : lh;
   l = near1 ? l_near1 : l;
 
-  float gh = as_float(as_int(l) & 0xfffff000);
+  float gh = __clc_as_float(__clc_as_int(l) & 0xfffff000);
   float gt = ((ltt - (lt - lth)) + ((lh - l) + lt)) + (l - gh);
 
-  float yh = as_float(iy & 0xfffff000);
+  float yh = __clc_as_float(iy & 0xfffff000);
 
   float yt = y - yh;
 
@@ -161,14 +161,14 @@ _CLC_DEF _CLC_OVERLOAD float __clc_powr(float x, float y) {
 
   float expylogx =
       __spirv_ocl_mad(tv.s0, poly, __spirv_ocl_mad(tv.s1, poly, tv.s1)) + tv.s0;
-  float sexpylogx = expylogx * as_float(0x1 << (m + 149));
-  float texpylogx = as_float(as_int(expylogx) + m2);
+  float sexpylogx = expylogx * __clc_as_float(0x1 << (m + 149));
+  float texpylogx = __clc_as_float(__clc_as_int(expylogx) + m2);
   expylogx = m < -125 ? sexpylogx : texpylogx;
 
   // Result is +-Inf if (ylogx + ylogx_t) > 128*log2
   expylogx = ((ylogx > 0x1.62e430p+6f) |
               (ylogx == 0x1.62e430p+6f & ylogx_t > -0x1.05c610p-22f))
-                 ? as_float(PINFBITPATT_SP32)
+                 ? __clc_as_float(PINFBITPATT_SP32)
                  : expylogx;
 
   // Result is 0 if ylogx < -149*log2
@@ -187,9 +187,9 @@ _CLC_DEF _CLC_OVERLOAD float __clc_powr(float x, float y) {
   inty = yexp < 1 ? 0 : inty;
   inty = yexp > 24 ? 2 : inty;
 
-  float signval = as_float((as_uint(expylogx) ^ SIGNBIT_SP32));
+  float signval = __clc_as_float((__clc_as_uint(expylogx) ^ SIGNBIT_SP32));
   expylogx = ((inty == 1) & !xpos) ? signval : expylogx;
-  int ret = as_int(expylogx);
+  int ret = __clc_as_int(expylogx);
 
   // Corner case handling
   ret = ax < 0x3f800000 && iy == NINFBITPATT_SP32 ? PINFBITPATT_SP32 : ret;
@@ -211,7 +211,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_powr(float x, float y) {
   ret = ax > PINFBITPATT_SP32 ? ix : ret;
   ret = ay > PINFBITPATT_SP32 ? iy : ret;
 
-  return as_float(ret);
+  return __clc_as_float(ret);
 }
 _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_powr, float, float)
 
@@ -220,11 +220,11 @@ _CLC_DEF _CLC_OVERLOAD double __clc_powr(double x, double y) {
   const double real_log2_tail = 5.76999904754328540596e-08;
   const double real_log2_lead = 6.93147122859954833984e-01;
 
-  long ux = as_long(x);
+  long ux = __clc_as_long(x);
   long ax = ux & (~SIGNBIT_DP64);
   int xpos = ax == ux;
 
-  long uy = as_long(y);
+  long uy = __clc_as_long(y);
   long ay = uy & (~SIGNBIT_DP64);
   int ypos = ay == uy;
 
@@ -236,7 +236,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_powr(double x, double y) {
     double xexp = (double)exp;
     long mantissa = ax & 0x000FFFFFFFFFFFFFL;
 
-    long temp_ux = as_long(as_double(0x3ff0000000000000L | mantissa) - 1.0);
+    long temp_ux = __clc_as_long(__clc_as_double(0x3ff0000000000000L | mantissa) - 1.0);
     exp = ((temp_ux & 0x7FF0000000000000L) >> 52) - 2045;
     double xexp1 = (double)exp;
     long mantissa1 = temp_ux & 0x000FFFFFFFFFFFFFL;
@@ -248,14 +248,14 @@ _CLC_DEF _CLC_OVERLOAD double __clc_powr(double x, double y) {
                ((mantissa & 0x0000080000000000) << 1);
     int index = rax >> 44;
 
-    double F = as_double(rax | 0x3FE0000000000000L);
-    double Y = as_double(mantissa | 0x3FE0000000000000L);
+    double F = __clc_as_double(rax | 0x3FE0000000000000L);
+    double Y = __clc_as_double(mantissa | 0x3FE0000000000000L);
     double f = F - Y;
     double2 tv = USE_TABLE(log_f_inv_tbl, index);
     double log_h = tv.s0;
     double log_t = tv.s1;
     double f_inv = (log_h + log_t) * f;
-    double r1 = as_double(as_long(f_inv) & 0xfffffffff8000000L);
+    double r1 = __clc_as_double(__clc_as_long(f_inv) & 0xfffffffff8000000L);
     double r2 = __spirv_ocl_fma(-F, r1, f) * (log_h + log_t);
     double r = r1 + r2;
 
@@ -285,11 +285,11 @@ _CLC_DEF _CLC_OVERLOAD double __clc_powr(double x, double y) {
     double resT_h = poly0h;
 
     double H = resT + resH;
-    double H_h = as_double(as_long(H) & 0xfffffffff8000000L);
+    double H_h = __clc_as_double(__clc_as_long(H) & 0xfffffffff8000000L);
     double T = (resH - H + resT) + (resT_t - (resT + resT_h)) + (H - H_h);
     H = H_h;
 
-    double y_head = as_double(uy & 0xfffffffff8000000L);
+    double y_head = __clc_as_double(uy & 0xfffffffff8000000L);
     double y_tail = y - y_head;
 
     double temp =
@@ -338,7 +338,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_powr(double x, double y) {
     expv = __spirv_ocl_fma(f, q, f2) + f1;
     expv = __spirv_ocl_ldexp(expv, m);
 
-    expv = v > max_exp_arg ? as_double(0x7FF0000000000000L) : expv;
+    expv = v > max_exp_arg ? __clc_as_double(0x7FF0000000000000L) : expv;
     expv = v < min_exp_arg ? 0.0 : expv;
   }
 
@@ -360,7 +360,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_powr(double x, double y) {
 
   expv *= ((inty == 1) & !xpos) ? -1.0 : 1.0;
 
-  long ret = as_long(expv);
+  long ret = __clc_as_long(expv);
 
   // Now all the edge cases
   ret = ax < 0x3ff0000000000000L && uy == NINFBITPATT_DP64 ? PINFBITPATT_DP64
@@ -386,7 +386,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_powr(double x, double y) {
   ret = ax > PINFBITPATT_DP64 ? ux : ret;
   ret = ay > PINFBITPATT_DP64 ? uy : ret;
 
-  return as_double(ret);
+  return __clc_as_double(ret);
 }
 _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_powr, double,
                       double)

--- a/libclc/libspirv/lib/generic/math/clc_remainder.cl
+++ b/libclc/libspirv/lib/generic/math/clc_remainder.cl
@@ -14,19 +14,19 @@
 #include <clc/math/math.h>
 
 _CLC_DEF _CLC_OVERLOAD float __clc_remainder(float x, float y) {
-  int ux = as_int(x);
+  int ux = __clc_as_int(x);
   int ax = ux & EXSIGNBIT_SP32;
-  float xa = as_float(ax);
+  float xa = __clc_as_float(ax);
   int sx = ux ^ ax;
   int ex = ax >> EXPSHIFTBITS_SP32;
 
-  int uy = as_int(y);
+  int uy = __clc_as_int(y);
   int ay = uy & EXSIGNBIT_SP32;
-  float ya = as_float(ay);
+  float ya = __clc_as_float(ay);
   int ey = ay >> EXPSHIFTBITS_SP32;
 
-  float xr = as_float(0x3f800000 | (ax & 0x007fffff));
-  float yr = as_float(0x3f800000 | (ay & 0x007fffff));
+  float xr = __clc_as_float(0x3f800000 | (ax & 0x007fffff));
+  float yr = __clc_as_float(0x3f800000 | (ay & 0x007fffff));
   int c;
   int k = ex - ey;
 
@@ -54,17 +54,17 @@ _CLC_DEF _CLC_OVERLOAD float __clc_remainder(float x, float y) {
   xr -= c ? yr : 0.0f;
   q += c;
 
-  float s = as_float(ey << EXPSHIFTBITS_SP32);
+  float s = __clc_as_float(ey << EXPSHIFTBITS_SP32);
   xr *= lt ? 1.0f : s;
 
   c = ax == ay;
   xr = c ? 0.0f : xr;
 
-  xr = as_float(sx ^ as_int(xr));
+  xr = __clc_as_float(sx ^ __clc_as_int(xr));
 
   c = ax > PINFBITPATT_SP32 | ay > PINFBITPATT_SP32 | ax == PINFBITPATT_SP32 |
       ay == 0;
-  xr = c ? as_float(QNANBITPATT_SP32) : xr;
+  xr = c ? __clc_as_float(QNANBITPATT_SP32) : xr;
 
   return xr;
 }
@@ -73,17 +73,17 @@ _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_remainder, float,
 
 #ifdef cl_khr_fp64
 _CLC_DEF _CLC_OVERLOAD double __clc_remainder(double x, double y) {
-  ulong ux = as_ulong(x);
+  ulong ux = __clc_as_ulong(x);
   ulong ax = ux & ~SIGNBIT_DP64;
   ulong xsgn = ux ^ ax;
-  double dx = as_double(ax);
+  double dx = __clc_as_double(ax);
   int xexp = __spirv_SatConvertUToS_Rint(ax >> EXPSHIFTBITS_DP64);
   int xexp1 = 11 - (int)__spirv_ocl_clz(ax & MANTBITS_DP64);
   xexp1 = xexp < 1 ? xexp1 : xexp;
 
-  ulong uy = as_ulong(y);
+  ulong uy = __clc_as_ulong(y);
   ulong ay = uy & ~SIGNBIT_DP64;
-  double dy = as_double(ay);
+  double dy = __clc_as_double(ay);
   int yexp = __spirv_SatConvertUToS_Rint(ay >> EXPSHIFTBITS_DP64);
   int yexp1 = 11 - (int)__spirv_ocl_clz(ay & MANTBITS_DP64);
   yexp1 = yexp < 1 ? yexp1 : yexp;
@@ -164,12 +164,12 @@ _CLC_DEF _CLC_OVERLOAD double __clc_remainder(double x, double y) {
 
   dx = dy < 0x1.0p+1022 ? dxl : dxg;
 
-  double ret = as_double(xsgn ^ as_ulong(dx));
-  dx = as_double(ax);
+  double ret = __clc_as_double(xsgn ^ __clc_as_ulong(dx));
+  dx = __clc_as_double(ax);
 
   // Now handle |x| == |y|
   int c = dx == dy;
-  t = as_double(xsgn);
+  t = __clc_as_double(xsgn);
   ret = c ? t : ret;
 
   // Next, handle |x| < |y|
@@ -186,7 +186,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_remainder(double x, double y) {
 
   // |y| is 0
   c = dy == 0.0;
-  ret = c ? as_double(QNANBITPATT_DP64) : ret;
+  ret = c ? __clc_as_double(QNANBITPATT_DP64) : ret;
 
   // y is +-Inf, NaN
   c = yexp > BIASEDEMAX_DP64;
@@ -195,7 +195,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_remainder(double x, double y) {
 
   // x is +=Inf, NaN
   c = xexp > BIASEDEMAX_DP64;
-  ret = c ? as_double(QNANBITPATT_DP64) : ret;
+  ret = c ? __clc_as_double(QNANBITPATT_DP64) : ret;
 
   return ret;
 }

--- a/libclc/libspirv/lib/generic/math/clc_remquo.cl
+++ b/libclc/libspirv/lib/generic/math/clc_remquo.cl
@@ -17,20 +17,20 @@ _CLC_DEF _CLC_OVERLOAD float __clc_remquo(float x, float y,
                                           __private int *quo) {
   x = __clc_flush_denormal_if_not_supported(x);
   y = __clc_flush_denormal_if_not_supported(y);
-  int ux = as_int(x);
+  int ux = __clc_as_int(x);
   int ax = ux & EXSIGNBIT_SP32;
-  float xa = as_float(ax);
+  float xa = __clc_as_float(ax);
   int sx = ux ^ ax;
   int ex = ax >> EXPSHIFTBITS_SP32;
 
-  int uy = as_int(y);
+  int uy = __clc_as_int(y);
   int ay = uy & EXSIGNBIT_SP32;
-  float ya = as_float(ay);
+  float ya = __clc_as_float(ay);
   int sy = uy ^ ay;
   int ey = ay >> EXPSHIFTBITS_SP32;
 
-  float xr = as_float(0x3f800000 | (ax & 0x007fffff));
-  float yr = as_float(0x3f800000 | (ay & 0x007fffff));
+  float xr = __clc_as_float(0x3f800000 | (ax & 0x007fffff));
+  float yr = __clc_as_float(0x3f800000 | (ay & 0x007fffff));
   int c;
   int k = ex - ey;
 
@@ -58,7 +58,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_remquo(float x, float y,
   xr -= c ? yr : 0.0f;
   q += c;
 
-  float s = as_float(ey << EXPSHIFTBITS_SP32);
+  float s = __clc_as_float(ey << EXPSHIFTBITS_SP32);
   xr *= lt ? 1.0f : s;
 
   int qsgn = sx == sy ? 1 : -1;
@@ -68,12 +68,12 @@ _CLC_DEF _CLC_OVERLOAD float __clc_remquo(float x, float y,
   quot = c ? qsgn : quot;
   xr = c ? 0.0f : xr;
 
-  xr = as_float(sx ^ as_int(xr));
+  xr = __clc_as_float(sx ^ __clc_as_int(xr));
 
   c = ax > PINFBITPATT_SP32 | ay > PINFBITPATT_SP32 | ax == PINFBITPATT_SP32 |
       ay == 0;
   quot = c ? 0 : quot;
-  xr = c ? as_float(QNANBITPATT_SP32) : xr;
+  xr = c ? __clc_as_float(QNANBITPATT_SP32) : xr;
 
   *quo = quot;
 
@@ -100,17 +100,17 @@ __VEC_REMQUO(float, 16, 8)
 #ifdef cl_khr_fp64
 _CLC_DEF _CLC_OVERLOAD double __clc_remquo(double x, double y,
                                            __private int *pquo) {
-  ulong ux = as_ulong(x);
+  ulong ux = __clc_as_ulong(x);
   ulong ax = ux & ~SIGNBIT_DP64;
   ulong xsgn = ux ^ ax;
-  double dx = as_double(ax);
+  double dx = __clc_as_double(ax);
   int xexp = __spirv_SatConvertUToS_Rint(ax >> EXPSHIFTBITS_DP64);
   int xexp1 = 11 - (int)__spirv_ocl_clz(ax & MANTBITS_DP64);
   xexp1 = xexp < 1 ? xexp1 : xexp;
 
-  ulong uy = as_ulong(y);
+  ulong uy = __clc_as_ulong(y);
   ulong ay = uy & ~SIGNBIT_DP64;
-  double dy = as_double(ay);
+  double dy = __clc_as_double(ay);
   int yexp = __spirv_SatConvertUToS_Rint(ay >> EXPSHIFTBITS_DP64);
   int yexp1 = 11 - (int)__spirv_ocl_clz(ay & MANTBITS_DP64);
   yexp1 = yexp < 1 ? yexp1 : yexp;
@@ -193,12 +193,12 @@ _CLC_DEF _CLC_OVERLOAD double __clc_remquo(double x, double y,
   lt += dy < 0x1.0p+1022 ? al : ag;
   int quo = ((int)lt & 0x7f) * qsgn;
 
-  double ret = as_double(xsgn ^ as_ulong(dx));
-  dx = as_double(ax);
+  double ret = __clc_as_double(xsgn ^ __clc_as_ulong(dx));
+  dx = __clc_as_double(ax);
 
   // Now handle |x| == |y|
   int c = dx == dy;
-  t = as_double(xsgn);
+  t = __clc_as_double(xsgn);
   quo = c ? qsgn : quo;
   ret = c ? t : ret;
 
@@ -219,7 +219,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_remquo(double x, double y,
   // |y| is 0
   c = dy == 0.0;
   quo = c ? 0 : quo;
-  ret = c ? as_double(QNANBITPATT_DP64) : ret;
+  ret = c ? __clc_as_double(QNANBITPATT_DP64) : ret;
 
   // y is +-Inf, NaN
   c = yexp > BIASEDEMAX_DP64;
@@ -230,7 +230,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_remquo(double x, double y,
   // x is +=Inf, NaN
   c = xexp > BIASEDEMAX_DP64;
   quo = c ? 0 : quo;
-  ret = c ? as_double(QNANBITPATT_DP64) : ret;
+  ret = c ? __clc_as_double(QNANBITPATT_DP64) : ret;
 
   *pquo = quo;
   return ret;

--- a/libclc/libspirv/lib/generic/math/clc_rootn.cl
+++ b/libclc/libspirv/lib/generic/math/clc_rootn.cl
@@ -52,17 +52,17 @@
 _CLC_DEF _CLC_OVERLOAD float __clc_rootn(float x, int ny) {
   float y = MATH_RECIP((float)ny);
 
-  int ix = as_int(x);
+  int ix = __clc_as_int(x);
   int ax = ix & EXSIGNBIT_SP32;
   int xpos = ix == ax;
 
-  int iy = as_int(y);
+  int iy = __clc_as_int(y);
   int ay = iy & EXSIGNBIT_SP32;
   int ypos = iy == ay;
 
   // Extra precise log calculation
   // First handle case that x is close to 1
-  float r = 1.0f - as_float(ax);
+  float r = 1.0f - __clc_as_float(ax);
   int near1 = __spirv_ocl_fabs(r) < 0x1.0p-4f;
   float r2 = r * r;
 
@@ -87,7 +87,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_rootn(float x, int ny) {
   // Computations for x not near 1
   int m = (int)(ax >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
   float mf = (float)m;
-  int ixs = as_int(as_float(ax | 0x3f800000) - 1.0f);
+  int ixs = __clc_as_int(__clc_as_float(ax | 0x3f800000) - 1.0f);
   float mfs = (float)((ixs >> EXPSHIFTBITS_SP32) - 253);
   int c = m == -127;
   int ixn = c ? ixs : ax;
@@ -96,8 +96,8 @@ _CLC_DEF _CLC_OVERLOAD float __clc_rootn(float x, int ny) {
   int indx = (ixn & 0x007f0000) + ((ixn & 0x00008000) << 1);
 
   // F - Y
-  float f = as_float(0x3f000000 | indx) -
-            as_float(0x3f000000 | (ixn & MANTBITS_SP32));
+  float f = __clc_as_float(0x3f000000 | indx) -
+            __clc_as_float(0x3f000000 | (ixn & MANTBITS_SP32));
 
   indx = indx >> 16;
   float2 tv = USE_TABLE(log_inv_tbl_ep, indx);
@@ -126,13 +126,13 @@ _CLC_DEF _CLC_OVERLOAD float __clc_rootn(float x, int ny) {
   lh = near1 ? lh_near1 : lh;
   l = near1 ? l_near1 : l;
 
-  float gh = as_float(as_int(l) & 0xfffff000);
+  float gh = __clc_as_float(__clc_as_int(l) & 0xfffff000);
   float gt = ((ltt - (lt - lth)) + ((lh - l) + lt)) + (l - gh);
 
-  float yh = as_float(iy & 0xfffff000);
+  float yh = __clc_as_float(iy & 0xfffff000);
 
   float fny = (float)ny;
-  float fnyh = as_float(as_int(fny) & 0xfffff000);
+  float fnyh = __clc_as_float(__clc_as_int(fny) & 0xfffff000);
   float fnyt = (float)(ny - (int)fnyh);
   float yt = MATH_DIVIDE(
       __spirv_ocl_mad(-fnyt, yh, __spirv_ocl_mad(-fnyh, yh, 1.0f)), fny);
@@ -168,16 +168,16 @@ _CLC_DEF _CLC_OVERLOAD float __clc_rootn(float x, int ny) {
   float expylogx =
       __spirv_ocl_mad(tv.s0, poly, __spirv_ocl_mad(tv.s1, poly, tv.s1)) + tv.s0;
   float sexpylogx = __clc_fp32_subnormals_supported()
-                        ? expylogx * as_float(0x1 << (m + 149))
+                        ? expylogx * __clc_as_float(0x1 << (m + 149))
                         : 0.0f;
 
-  float texpylogx = as_float(as_int(expylogx) + m2);
+  float texpylogx = __clc_as_float(__clc_as_int(expylogx) + m2);
   expylogx = m < -125 ? sexpylogx : texpylogx;
 
   // Result is +-Inf if (ylogx + ylogx_t) > 128*log2
   expylogx = ((ylogx > 0x1.62e430p+6f) |
               (ylogx == 0x1.62e430p+6f & ylogx_t > -0x1.05c610p-22f))
-                 ? as_float(PINFBITPATT_SP32)
+                 ? __clc_as_float(PINFBITPATT_SP32)
                  : expylogx;
 
   // Result is 0 if ylogx < -149*log2
@@ -190,9 +190,9 @@ _CLC_DEF _CLC_OVERLOAD float __clc_rootn(float x, int ny) {
 
   int inty = 2 - (ny & 1);
 
-  float signval = as_float((as_uint(expylogx) ^ SIGNBIT_SP32));
+  float signval = __clc_as_float((__clc_as_uint(expylogx) ^ SIGNBIT_SP32));
   expylogx = ((inty == 1) & !xpos) ? signval : expylogx;
-  int ret = as_int(expylogx);
+  int ret = __clc_as_int(expylogx);
 
   // Corner case handling
   ret = (!xpos & (inty == 2)) ? QNANBITPATT_SP32 : ret;
@@ -210,7 +210,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_rootn(float x, int ny) {
   ret = ax > PINFBITPATT_SP32 ? ix : ret;
   ret = ny == 0 ? QNANBITPATT_SP32 : ret;
 
-  return as_float(ret);
+  return __clc_as_float(ret);
 }
 _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_rootn, float, int)
 
@@ -222,11 +222,11 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
   double dny = (double)ny;
   double y = 1.0 / dny;
 
-  long ux = as_long(x);
+  long ux = __clc_as_long(x);
   long ax = ux & (~SIGNBIT_DP64);
   int xpos = ax == ux;
 
-  long uy = as_long(y);
+  long uy = __clc_as_long(y);
   long ay = uy & (~SIGNBIT_DP64);
   int ypos = ay == uy;
 
@@ -238,7 +238,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
     double xexp = (double)exp;
     long mantissa = ax & 0x000FFFFFFFFFFFFFL;
 
-    long temp_ux = as_long(as_double(0x3ff0000000000000L | mantissa) - 1.0);
+    long temp_ux = __clc_as_long(__clc_as_double(0x3ff0000000000000L | mantissa) - 1.0);
     exp = ((temp_ux & 0x7FF0000000000000L) >> 52) - 2045;
     double xexp1 = (double)exp;
     long mantissa1 = temp_ux & 0x000FFFFFFFFFFFFFL;
@@ -250,14 +250,14 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
                ((mantissa & 0x0000080000000000) << 1);
     int index = rax >> 44;
 
-    double F = as_double(rax | 0x3FE0000000000000L);
-    double Y = as_double(mantissa | 0x3FE0000000000000L);
+    double F = __clc_as_double(rax | 0x3FE0000000000000L);
+    double Y = __clc_as_double(mantissa | 0x3FE0000000000000L);
     double f = F - Y;
     double2 tv = USE_TABLE(log_f_inv_tbl, index);
     double log_h = tv.s0;
     double log_t = tv.s1;
     double f_inv = (log_h + log_t) * f;
-    double r1 = as_double(as_long(f_inv) & 0xfffffffff8000000L);
+    double r1 = __clc_as_double(__clc_as_long(f_inv) & 0xfffffffff8000000L);
     double r2 = __spirv_ocl_fma(-F, r1, f) * (log_h + log_t);
     double r = r1 + r2;
 
@@ -287,14 +287,14 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
     double resT_h = poly0h;
 
     double H = resT + resH;
-    double H_h = as_double(as_long(H) & 0xfffffffff8000000L);
+    double H_h = __clc_as_double(__clc_as_long(H) & 0xfffffffff8000000L);
     double T = (resH - H + resT) + (resT_t - (resT + resT_h)) + (H - H_h);
     H = H_h;
 
-    double y_head = as_double(uy & 0xfffffffff8000000L);
+    double y_head = __clc_as_double(uy & 0xfffffffff8000000L);
     double y_tail = y - y_head;
 
-    double fnyh = as_double(as_long(dny) & 0xfffffffffff00000);
+    double fnyh = __clc_as_double(__clc_as_long(dny) & 0xfffffffffff00000);
     double fnyt = (double)(ny - (int)(long)fnyh);
     y_tail =
         __spirv_ocl_fma(-fnyt, y_head, __spirv_ocl_fma(-fnyh, y_head, 1.0)) /
@@ -346,7 +346,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
     expv = __spirv_ocl_fma(f, q, f2) + f1;
     expv = __spirv_ocl_ldexp(expv, m);
 
-    expv = v > max_exp_arg ? as_double(0x7FF0000000000000L) : expv;
+    expv = v > max_exp_arg ? __clc_as_double(0x7FF0000000000000L) : expv;
     expv = v < min_exp_arg ? 0.0 : expv;
   }
 
@@ -359,7 +359,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
 
   expv *= ((inty == 1) & !xpos) ? -1.0 : 1.0;
 
-  long ret = as_long(expv);
+  long ret = __clc_as_long(expv);
 
   // Now all the edge cases
   ret = (!xpos & (inty == 2)) ? QNANBITPATT_DP64 : ret;
@@ -377,7 +377,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
   ret = ((ux == PINFBITPATT_DP64) & ypos) ? PINFBITPATT_DP64 : ret;
   ret = ax > PINFBITPATT_DP64 ? ux : ret;
   ret = ny == 0 ? QNANBITPATT_DP64 : ret;
-  return as_double(ret);
+  return __clc_as_double(ret);
 }
 _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_rootn, double, int)
 #endif

--- a/libclc/libspirv/lib/generic/math/clc_tan.cl
+++ b/libclc/libspirv/lib/generic/math/clc_tan.cl
@@ -31,17 +31,17 @@
 #include <clc/math/tables.h>
 
 _CLC_DEF _CLC_OVERLOAD float __clc_tan(float x) {
-  int ix = as_int(x);
+  int ix = __clc_as_int(x);
   int ax = ix & 0x7fffffff;
-  float dx = as_float(ax);
+  float dx = __clc_as_float(ax);
 
   float r0, r1;
   int regn = __clc_argReductionS(&r0, &r1, dx);
 
   float t = __clc_tanf_piby4(r0 + r1, regn);
-  t = as_float(as_int(t) ^ (ix ^ ax));
+  t = __clc_as_float(__clc_as_int(t) ^ (ix ^ ax));
 
-  t = ax >= PINFBITPATT_SP32 ? as_float(QNANBITPATT_SP32) : t;
+  t = ax >= PINFBITPATT_SP32 ? __clc_as_float(QNANBITPATT_SP32) : t;
   // Take care of subnormals
   t = (x == 0.0f) ? x : t;
   return t;
@@ -64,11 +64,11 @@ _CLC_DEF _CLC_OVERLOAD double __clc_tan(double x) {
 
   double2 tt = __clc_tan_piby4(r, rr);
 
-  int2 t = as_int2(regn & 1 ? tt.y : tt.x);
+  int2 t = __clc_as_int2(regn & 1 ? tt.y : tt.x);
   t.hi ^= (x < 0.0) << 31;
 
-  return __clc_isnan(x) || __clc_isinf(x) ? as_double(QNANBITPATT_DP64)
-                                          : as_double(t);
+  return __clc_isnan(x) || __clc_isinf(x) ? __clc_as_double(QNANBITPATT_DP64)
+                                          : __clc_as_double(t);
 }
 _CLC_UNARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_tan, double);
 

--- a/libclc/libspirv/lib/generic/math/clc_tanpi.cl
+++ b/libclc/libspirv/lib/generic/math/clc_tanpi.cl
@@ -29,11 +29,11 @@
 
 _CLC_DEF _CLC_OVERLOAD float __clc_tanpi(float x)
 {
-    int ix = as_int(x);
+    int ix = __clc_as_int(x);
     int xsgn = ix & 0x80000000;
     int xnsgn = xsgn ^ 0x80000000;
     ix ^= xsgn;
-    float ax = as_float(ix);
+    float ax = __clc_as_float(ix);
     int iax = (int)ax;
     float r = ax - iax;
     int xodd = xsgn ^ (iax & 0x1 ? 0x80000000 : 0);
@@ -73,13 +73,13 @@ _CLC_DEF _CLC_OVERLOAD float __clc_tanpi(float x)
 
     float t = __clc_tanf_piby4(a * M_PI_F, 0);
     float tr = -__spirv_ocl_native_recip(t);
-    int jr = s ^ as_int(e ? tr : t);
+    int jr = s ^ __clc_as_int(e ? tr : t);
 
     jr = r == 0.5f ? xodd | 0x7f800000 : jr;
 
     ir = ix < 0x4b000000 ? jr : ir;
 
-    return as_float(ir);
+    return __clc_as_float(ir);
 }
 _CLC_UNARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_tanpi, float);
 
@@ -88,11 +88,11 @@ _CLC_UNARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_tanpi, float);
 
 _CLC_DEF _CLC_OVERLOAD double __clc_tanpi(double x)
 {
-    long ix = as_long(x);
+    long ix = __clc_as_long(x);
     long xsgn = ix & 0x8000000000000000L;
     long xnsgn = xsgn ^ 0x8000000000000000L;
     ix ^= xsgn;
-    double ax = as_double(ix);
+    double ax = __clc_as_double(ix);
     long iax = (long)ax;
     double r = ax - iax;
     long xodd = xsgn ^ (iax & 0x1 ? 0x8000000000000000L : 0L);
@@ -134,14 +134,14 @@ _CLC_DEF _CLC_OVERLOAD double __clc_tanpi(double x)
 
     double api = a * M_PI;
     double2 tt = __clc_tan_piby4(api, 0.0);
-    long jr = s ^ as_long(e ? tt.hi : tt.lo);
+    long jr = s ^ __clc_as_long(e ? tt.hi : tt.lo);
 
     long si = xodd | 0x7ff0000000000000L;
     jr = r == 0.5 ? si : jr;
 
     ir = ix < 0x4330000000000000L ? jr : ir;
 
-    return as_double(ir);
+    return __clc_as_double(ir);
 }
 _CLC_UNARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_tanpi, double);
 #endif

--- a/libclc/libspirv/lib/generic/math/cos.cl
+++ b/libclc/libspirv/lib/generic/math/cos.cl
@@ -14,9 +14,9 @@
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cos(float x)
 {
-    int ix = as_int(x);
+    int ix = __clc_as_int(x);
     int ax = ix & 0x7fffffff;
-    float dx = as_float(ax);
+    float dx = __clc_as_float(ax);
 
     float r0, r1;
     int regn = __clc_argReductionS(&r0, &r1, dx);
@@ -25,9 +25,9 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cos(float x)
     float cc =  __clc_cosf_piby4(r0, r1);
 
     float c =  (regn & 1) != 0 ? ss : cc;
-    c = as_float(as_int(c) ^ ((regn > 1) << 31));
+    c = __clc_as_float(__clc_as_int(c) ^ ((regn > 1) << 31));
 
-    c = ax >= PINFBITPATT_SP32 ? as_float(QNANBITPATT_SP32) : c;
+    c = ax >= PINFBITPATT_SP32 ? __clc_as_float(QNANBITPATT_SP32) : c;
 
     return c;
 }
@@ -52,11 +52,11 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_cos(double x) {
     double2 sc = __clc_sincos_piby4(r, rr);
     sc.lo = -sc.lo;
 
-    int2 c = as_int2(regn & 1 ? sc.lo : sc.hi);
+    int2 c = __clc_as_int2(regn & 1 ? sc.lo : sc.hi);
     c.hi ^= (regn > 1) << 31;
 
-    return __spirv_IsNan(x) || __spirv_IsInf(x) ? as_double(QNANBITPATT_DP64)
-                                                : as_double(c);
+    return __spirv_IsNan(x) || __spirv_IsInf(x) ? __clc_as_double(QNANBITPATT_DP64)
+                                                : __clc_as_double(c);
 }
 
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_cos, double);

--- a/libclc/libspirv/lib/generic/math/cosh.cl
+++ b/libclc/libspirv/lib/generic/math/cosh.cl
@@ -25,9 +25,9 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cosh(float x) {
   const float max_cosh_arg = 0x1.65a9fap+6f;
   const float small_threshold = 0x1.0a2b24p+3f;
 
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint aux = ux & EXSIGNBIT_SP32;
-  float y = as_float(aux);
+  float y = __clc_as_float(aux);
 
   // Find the integer part y0 of y and the increment dy = y - y0. We then
   // compute z = sinh(y) = sinh(y0)cosh(dy) + cosh(y0)sinh(dy) z = cosh(y) =
@@ -87,8 +87,8 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cosh(float x) {
   z = y >= small_threshold ? zsmall : z;
 
   // Corner cases
-  z = y >= max_cosh_arg ? as_float(PINFBITPATT_SP32) : z;
-  z = aux > PINFBITPATT_SP32 ? as_float(QNANBITPATT_SP32) : z;
+  z = y >= max_cosh_arg ? __clc_as_float(PINFBITPATT_SP32) : z;
+  z = aux > PINFBITPATT_SP32 ? __clc_as_float(QNANBITPATT_SP32) : z;
   z = aux < 0x38800000 ? 1.0f : z;
 
   return z;
@@ -199,7 +199,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_cosh(double x) {
   t = __spirv_ocl_fma(t, -0x1.ef35793c76641p-45, t);
   z = y >= small_threshold ? t : z;
 
-  z = y >= max_cosh_arg ? as_double(PINFBITPATT_DP64) : z;
+  z = y >= max_cosh_arg ? __clc_as_double(PINFBITPATT_DP64) : z;
 
   z = __spirv_IsInf(x) || __spirv_IsNan(x) ? y : z;
 

--- a/libclc/libspirv/lib/generic/math/cospi.cl
+++ b/libclc/libspirv/lib/generic/math/cospi.cl
@@ -18,8 +18,8 @@
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cospi(float x)
 {
-    int ix = as_int(x) & 0x7fffffff;
-    float ax = as_float(ix);
+    int ix = __clc_as_int(x) & 0x7fffffff;
+    float ax = __clc_as_float(ix);
     int iax = (int)ax;
     float r = ax - iax;
     int xodd = iax & 0x1 ? 0x80000000 : 0;
@@ -56,11 +56,11 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_cospi(float x)
     e = c ? 1 : e;
 
     float2 t = __libclc__sincosf_piby4(a * M_PI_F);
-    int jr = s ^ as_int(e ? t.hi : t.lo);
+    int jr = s ^ __clc_as_int(e ? t.hi : t.lo);
 
     ir = ix < 0x4b000000 ? jr : ir;
 
-    return as_float(ir);
+    return __clc_as_float(ir);
 }
 
 
@@ -72,8 +72,8 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, __spirv_ocl_cospi, float);
 
 _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_cospi(double x) {
 
-    long ix = as_long(x) & 0x7fffffffffffffffL;
-    double ax = as_double(ix);
+    long ix = __clc_as_long(x) & 0x7fffffffffffffffL;
+    double ax = __clc_as_double(ix);
     long iax = (long)ax;
     double r = ax - (double)iax;
     long xodd = iax & 0x1L ? 0x8000000000000000L : 0L;
@@ -112,11 +112,11 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_cospi(double x) {
     e = c ? 1 : e;
 
     double2 sc = __libclc__sincos_piby4(a * M_PI, 0.0);
-    long jr = s ^ as_long(e ? sc.hi : sc.lo);
+    long jr = s ^ __clc_as_long(e ? sc.hi : sc.lo);
 
     ir = ax < 0x1.0p+52 ? jr : ir;
 
-    return as_double(ir);
+    return __clc_as_double(ir);
 }
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_cospi, double);
 #endif

--- a/libclc/libspirv/lib/generic/math/ep_log.cl
+++ b/libclc/libspirv/lib/generic/math/ep_log.cl
@@ -34,15 +34,15 @@ _CLC_DEF void __clc_ep_log(double x, int *xexp, double *r1, double *r2) {
   // Volume 16, Issue 4 (December 1990)
   int near_one = x >= 0x1.e0faap-1 & x <= 0x1.1082cp+0;
 
-  ulong ux = as_ulong(x);
-  ulong uxs = as_ulong(as_double(0x03d0000000000000UL | ux) - 0x1.0p-962);
+  ulong ux = __clc_as_ulong(x);
+  ulong uxs = __clc_as_ulong(__clc_as_double(0x03d0000000000000UL | ux) - 0x1.0p-962);
   int c = ux < IMPBIT_DP64;
   ux = c ? uxs : ux;
   int expadjust = c ? 60 : 0;
 
   // Store the exponent of x in xexp and put f into the range [0.5,1)
-  int xexp1 = ((as_int2(ux).hi >> 20) & 0x7ff) - EXPBIAS_DP64 - expadjust;
-  double f = as_double(HALFEXPBITS_DP64 | (ux & MANTBITS_DP64));
+  int xexp1 = ((__clc_as_int2(ux).hi >> 20) & 0x7ff) - EXPBIAS_DP64 - expadjust;
+  double f = __clc_as_double(HALFEXPBITS_DP64 | (ux & MANTBITS_DP64));
   *xexp = near_one ? 0 : xexp1;
 
   double r = x - 1.0;
@@ -50,7 +50,7 @@ _CLC_DEF void __clc_ep_log(double x, int *xexp, double *r1, double *r2) {
   double ru1 = -r * u1;
   u1 = u1 + u1;
 
-  int index = as_int2(ux).hi >> 13;
+  int index = __clc_as_int2(ux).hi >> 13;
   index = ((0x80 | (index & 0x7e)) >> 1) + (index & 0x1);
 
   double f1 = index * 0x1.0p-7;

--- a/libclc/libspirv/lib/generic/math/erf.cl
+++ b/libclc/libspirv/lib/generic/math/erf.cl
@@ -93,9 +93,9 @@
 #define sb7 -2.2440952301e+01f /* 0xc1b38712 */
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_erf(float x) {
-  int hx = as_uint(x);
+  int hx = __clc_as_uint(x);
   int ix = hx & 0x7fffffff;
-  float absx = as_float(ix);
+  float absx = __clc_as_float(ix);
 
   float x2 = absx * absx;
   float t = 1.0f / x2;
@@ -206,7 +206,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_erf(float x) {
   float ret = 1.0f;
 
   // |x| < 6
-  float z = as_float(ix & 0xfffff000);
+  float z = __clc_as_float(ix & 0xfffff000);
   float r = __spirv_ocl_exp(__spirv_ocl_mad(-z, z, -0.5625f)) *
             __spirv_ocl_exp(__spirv_ocl_mad(z - absx, z + absx, q));
   r = 1.0f - MATH_DIVIDE(r, absx);
@@ -215,7 +215,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_erf(float x) {
   r = erx + q;
   ret = absx < 1.25f ? r : ret;
 
-  ret = as_float((hx & 0x80000000) | as_int(ret));
+  ret = __clc_as_float((hx & 0x80000000) | __clc_as_int(ret));
 
   r = __spirv_ocl_mad(x, q, x);
   ret = absx < 0.84375f ? r : ret;
@@ -517,7 +517,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_erf(double y) {
   double q = u / v;
 
   // Compute results
-  double z = as_double(as_long(x) & 0xffffffff00000000L);
+  double z = __clc_as_double(__clc_as_long(x) & 0xffffffff00000000L);
   double r =
       __spirv_ocl_exp(-z * z - 0.5625) * __spirv_ocl_exp((z - x) * (z + x) + q);
   r = 1.0 - r / x;

--- a/libclc/libspirv/lib/generic/math/erfc.cl
+++ b/libclc/libspirv/lib/generic/math/erfc.cl
@@ -93,9 +93,9 @@
 #define sb7 -2.2440952301e+01f /* 0xc1b38712 */
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_erfc(float x) {
-  int hx = as_int(x);
+  int hx = __clc_as_int(x);
   int ix = hx & 0x7fffffff;
-  float absx = as_float(ix);
+  float absx = __clc_as_float(ix);
 
   // Argument for polys
   float x2 = absx * absx;
@@ -207,7 +207,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_erfc(float x) {
 
   float ret = 0.0f;
 
-  float z = as_float(ix & 0xfffff000);
+  float z = __clc_as_float(ix & 0xfffff000);
   float r = __spirv_ocl_exp(__spirv_ocl_mad(-z, z, -0.5625f)) *
             __spirv_ocl_exp(__spirv_ocl_mad(z - absx, z + absx, q));
   r = MATH_DIVIDE(r, absx);
@@ -403,9 +403,9 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, __spirv_ocl_erfc, float);
 #define DV4 -3.96022827877536812320e-06
 
 _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_erfc(double x) {
-  long lx = as_long(x);
+  long lx = __clc_as_long(x);
   long ax = lx & 0x7fffffffffffffffL;
-  double absx = as_double(ax);
+  double absx = __clc_as_double(ax);
   int xneg = lx != ax;
 
   // Poly arg
@@ -521,7 +521,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_erfc(double x) {
   // Evaluate return value
 
   // |x| < 28
-  double z = as_double(ax & 0xffffffff00000000UL);
+  double z = __clc_as_double(ax & 0xffffffff00000000UL);
   double ret = __spirv_ocl_exp(-z * z - 0.5625) *
                __spirv_ocl_exp((z - absx) * (z + absx) + q) / absx;
   t = 2.0 - ret;

--- a/libclc/libspirv/lib/generic/math/exp.cl
+++ b/libclc/libspirv/lib/generic/math/exp.cl
@@ -40,13 +40,13 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_exp(float x) {
     float y = 1.0f - (((-lo) - MATH_DIVIDE(t * v, 2.0f - v)) - hi);
 
     // Scale by 2^p
-    float r =  as_float(as_int(y) + (p << 23));
+    float r =  __clc_as_float(__clc_as_int(y) + (p << 23));
 
     const float ulim =  0x1.62e430p+6f; // ln(largest_normal) = 88.72283905206835305366
     const float llim = -0x1.5d589ep+6f; // ln(smallest_normal) = -87.33654475055310898657
 
     r = x < llim ? 0.0f : r;
-    r = x < ulim ? r : as_float(0x7f800000);
+    r = x < ulim ? r : __clc_as_float(0x7f800000);
     return __spirv_IsNan(x) ? x : r;
 }
 

--- a/libclc/libspirv/lib/generic/math/exp2.cl
+++ b/libclc/libspirv/lib/generic/math/exp2.cl
@@ -39,13 +39,13 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_exp2(float x) {
     float y = 1.0f - (((-lo) - MATH_DIVIDE(t * v, 2.0f - v)) - hi);
 
     // Scale by 2^p
-    float r =  as_float(as_int(y) + (p << 23));
+    float r =  __clc_as_float(__clc_as_int(y) + (p << 23));
 
     const float ulim =  128.0f;
     const float llim = -126.0f;
 
     r = x < llim ? 0.0f : r;
-    r = x < ulim ? r : as_float(0x7f800000);
+    r = x < ulim ? r : __clc_as_float(0x7f800000);
     return __spirv_IsNan(x) ? x : r;
 }
 

--- a/libclc/libspirv/lib/generic/math/exp_helper.cl
+++ b/libclc/libspirv/lib/generic/math/exp_helper.cl
@@ -51,15 +51,15 @@ _CLC_DEF double __clc_exp_helper(double x, double x_min, double x_max, double r,
 
     int n1 = m >> 2;
     int n2 = m-n1;
-    double z3= z2 * as_double(((long)n1 + 1023) << 52);
-    z3 *= as_double(((long)n2 + 1023) << 52);
+    double z3= z2 * __clc_as_double(((long)n1 + 1023) << 52);
+    z3 *= __clc_as_double(((long)n2 + 1023) << 52);
 
     z2 = __spirv_ocl_ldexp(z2, m);
     z2 = small_value ? z3: z2;
 
     z2 = __spirv_IsNan(x) ? x : z2;
 
-    z2 = x > x_max ? as_double(PINFBITPATT_DP64) : z2;
+    z2 = x > x_max ? __clc_as_double(PINFBITPATT_DP64) : z2;
     z2 = x < x_min ? 0.0 : z2;
 
     return z2;

--- a/libclc/libspirv/lib/generic/math/expm1.cl
+++ b/libclc/libspirv/lib/generic/math/expm1.cl
@@ -22,7 +22,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_expm1(float x) {
     const float R_LOG2_BY_64_LD = 0x1.620000p-7f;  // log2/64 lead: 0.0108032227
     const float R_LOG2_BY_64_TL = 0x1.c85fdep-16f; // log2/64 tail: 0.0000272020388
 
-    uint xi = as_uint(x);
+    uint xi = __clc_as_uint(x);
     int n = (int)(x * R_64_BY_LOG2);
     float fn = (float)n;
 
@@ -35,7 +35,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_expm1(float x) {
     float z2 = __spirv_ocl_mad(r*r, __spirv_ocl_mad(r,
         __spirv_ocl_mad(r, 0x1.555556p-5f,  0x1.555556p-3f), 0.5f), r);
 
-    float m2 = as_float((m + EXPBIAS_SP32) << EXPSHIFTBITS_SP32);
+    float m2 = __clc_as_float((m + EXPBIAS_SP32) << EXPSHIFTBITS_SP32);
     float2 tv = USE_TABLE(exp_tbl_ep, j);
 
     float two_to_jby64_h = tv.s0 * m2;
@@ -46,7 +46,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_expm1(float x) {
 	//Make subnormals work
     z2 = x == 0.f ? x : z2;
     z2 = x < X_MIN || m < -24 ? -1.0f : z2;
-    z2 = x > X_MAX ? as_float(PINFBITPATT_SP32) : z2;
+    z2 = x > X_MAX ? __clc_as_float(PINFBITPATT_SP32) : z2;
     z2 = __spirv_IsNan(x) ? x : z2;
 
     return z2;
@@ -70,7 +70,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_expm1(double x) {
     const double lnof2_by_64_tail = 2.5728046223276688e-14;     //0x3d1cf79abc9e3b39
 
     // First, assume log(1-1/4) < x < log(1+1/4) i.e  -0.28768 < x < 0.22314
-    double u = as_double(as_ulong(x) & 0xffffffffff000000UL);
+    double u = __clc_as_double(__clc_as_ulong(x) & 0xffffffffff000000UL);
     double v = x - u;
     double y = u * u * 0.5;
     double z = v * (x + u) * 0.5;
@@ -118,15 +118,15 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_expm1(double x) {
 	     5.00000000000000008883e-01);
     q = __spirv_ocl_fma(r*r, q, r);
 
-    double twopm = as_double((long)(m + EXPBIAS_DP64) << EXPSHIFTBITS_DP64);
-    double twopmm = as_double((long)(EXPBIAS_DP64 - m) << EXPSHIFTBITS_DP64);
+    double twopm = __clc_as_double((long)(m + EXPBIAS_DP64) << EXPSHIFTBITS_DP64);
+    double twopmm = __clc_as_double((long)(EXPBIAS_DP64 - m) << EXPSHIFTBITS_DP64);
 
     // Computations for m > 52, including where result is close to Inf
-    ulong uval = as_ulong(0x1.0p+1023 * (f1 + (f * q + (f2))));
+    ulong uval = __clc_as_ulong(0x1.0p+1023 * (f1 + (f * q + (f2))));
     int e = (int)(uval >> EXPSHIFTBITS_DP64) + 1;
 
-    double zme1024 = as_double(((long)e << EXPSHIFTBITS_DP64) | (uval & MANTBITS_DP64));
-    zme1024 = e == 2047 ? as_double(PINFBITPATT_DP64) : zme1024;
+    double zme1024 = __clc_as_double(((long)e << EXPSHIFTBITS_DP64) | (uval & MANTBITS_DP64));
+    zme1024 = e == 2047 ? __clc_as_double(PINFBITPATT_DP64) : zme1024;
 
     double zmg52 = twopm * (f1 + __spirv_ocl_fma(f, q, f2 - twopmm));
     zmg52 = m == 1024 ? zme1024 : zmg52;
@@ -140,7 +140,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_expm1(double x) {
     z = m < 53 ? zml53 : zmg52;
     z = m < -7 ? zmln7 : z;
     z = x > log_OneMinus_OneByFour && x < log_OnePlus_OneByFour ? z1 : z;
-    z = x > max_expm1_arg ? as_double(PINFBITPATT_DP64) : z;
+    z = x > max_expm1_arg ? __clc_as_double(PINFBITPATT_DP64) : z;
     z = x < min_expm1_arg ? -1.0 : z;
 
     return z;

--- a/libclc/libspirv/lib/generic/math/fdim.inc
+++ b/libclc/libspirv/lib/generic/math/fdim.inc
@@ -24,8 +24,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __spirv_ocl_fdim(__CLC_GENTYPE x,
     int##width n = ~((x == x) & (y == y)) & QNANBITPATT_SP32;                  \
     /* Calculate x-y if x>y, otherwise positive 0, again taking */             \
     /* advantage of vector true being all-bits-set. */                         \
-    int##width r = (x > y) & __clc_as_int##width(x - y);                             \
-    return __clc_as_float##width(n | r);                                             \
+    int##width r = (x > y) & __clc_as_int##width(x - y);                       \
+    return __clc_as_float##width(n | r);                                       \
   }
 __CLC_FDIM_VEC(2)
 __CLC_FDIM_VEC(3)
@@ -49,8 +49,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __spirv_ocl_fdim(__CLC_GENTYPE x,
                                                         double##width y) {     \
     /* See comment in float implementation for explanation. */                 \
     long##width n = ~((x == x) & (y == y)) & QNANBITPATT_DP64;                 \
-    long##width r = (x > y) & __clc_as_long##width(x - y);                           \
-    return __clc_as_double##width(n | r);                                            \
+    long##width r = (x > y) & __clc_as_long##width(x - y);                     \
+    return __clc_as_double##width(n | r);                                      \
   }
 __CLC_FDIM_VEC(2)
 __CLC_FDIM_VEC(3)

--- a/libclc/libspirv/lib/generic/math/fdim.inc
+++ b/libclc/libspirv/lib/generic/math/fdim.inc
@@ -11,7 +11,7 @@
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __spirv_ocl_fdim(__CLC_GENTYPE x,
                                                       __CLC_GENTYPE y) {
   if (__builtin_isnan(x) || __builtin_isnan(y))
-    return as_float(QNANBITPATT_SP32);
+    return __clc_as_float(QNANBITPATT_SP32);
   return __spirv_ocl_fmax(x - y, 0.0f);
 }
 #define __CLC_FDIM_VEC(width)                                                  \
@@ -24,8 +24,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __spirv_ocl_fdim(__CLC_GENTYPE x,
     int##width n = ~((x == x) & (y == y)) & QNANBITPATT_SP32;                  \
     /* Calculate x-y if x>y, otherwise positive 0, again taking */             \
     /* advantage of vector true being all-bits-set. */                         \
-    int##width r = (x > y) & as_int##width(x - y);                             \
-    return as_float##width(n | r);                                             \
+    int##width r = (x > y) & __clc_as_int##width(x - y);                             \
+    return __clc_as_float##width(n | r);                                             \
   }
 __CLC_FDIM_VEC(2)
 __CLC_FDIM_VEC(3)
@@ -41,16 +41,16 @@ __CLC_FDIM_VEC(16)
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __spirv_ocl_fdim(__CLC_GENTYPE x,
                                                       private __CLC_GENTYPE y) {
   long n = -(__spirv_IsNan(x) | __spirv_IsNan(y)) & QNANBITPATT_DP64;
-  long r = -(x > y) & as_long(x - y);
-  return as_double(n | r);
+  long r = -(x > y) & __clc_as_long(x - y);
+  return __clc_as_double(n | r);
 }
 #define __CLC_FDIM_VEC(width)                                                  \
   _CLC_OVERLOAD _CLC_DEF double##width __spirv_ocl_fdim(double##width x,       \
                                                         double##width y) {     \
     /* See comment in float implementation for explanation. */                 \
     long##width n = ~((x == x) & (y == y)) & QNANBITPATT_DP64;                 \
-    long##width r = (x > y) & as_long##width(x - y);                           \
-    return as_double##width(n | r);                                            \
+    long##width r = (x > y) & __clc_as_long##width(x - y);                           \
+    return __clc_as_double##width(n | r);                                            \
   }
 __CLC_FDIM_VEC(2)
 __CLC_FDIM_VEC(3)

--- a/libclc/libspirv/lib/generic/math/frexp.inc
+++ b/libclc/libspirv/lib/generic/math/frexp.inc
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_AS_GENTYPE __CLC_XCONCAT(as_, __CLC_GENTYPE)
-#define __CLC_AS_INTN __CLC_XCONCAT(as_, __CLC_INTN)
+#define __CLC_AS_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)
+#define __CLC_AS_INTN __CLC_XCONCAT(__clc_as_, __CLC_INTN)
 
 #if __CLC_FPSIZE == 32
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE
@@ -29,11 +29,11 @@ __spirv_ocl_frexp(__CLC_GENTYPE x, __CLC_ADDRESS_SPACE __CLC_INTN *ep) {
 
 #if __CLC_FPSIZE == 64
 #ifdef __CLC_SCALAR
-#define __CLC_AS_LONGN as_long
+#define __CLC_AS_LONGN __clc_as_long
 #define __CLC_LONGN long
 #define __CLC_CONVERT_INTN __spirv_SConvert_Rint
 #else
-#define __CLC_AS_LONGN __CLC_XCONCAT(as_long, __CLC_VECSIZE)
+#define __CLC_AS_LONGN __CLC_XCONCAT(__clc_as_long, __CLC_VECSIZE)
 #define __CLC_LONGN __CLC_XCONCAT(long, __CLC_VECSIZE)
 #define __CLC_CONVERT_INTN __CLC_XCONCAT(__spirv_SConvert_Rint, __CLC_VECSIZE)
 #endif

--- a/libclc/libspirv/lib/generic/math/ilogb.cl
+++ b/libclc/libspirv/lib/generic/math/ilogb.cl
@@ -12,7 +12,7 @@
 #include <clc/math/math.h>
 
 _CLC_OVERLOAD _CLC_DEF int __spirv_ocl_ilogb(float x) {
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint ax = ux & EXSIGNBIT_SP32;
   int rs = -118 - (int)__spirv_ocl_clz(ux & MANTBITS_SP32);
   int r = (int)(ax >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
@@ -28,7 +28,7 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, int, __spirv_ocl_ilogb, float);
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
 _CLC_OVERLOAD _CLC_DEF int __spirv_ocl_ilogb(double x) {
-  ulong ux = as_ulong(x);
+  ulong ux = __clc_as_ulong(x);
   ulong ax = ux & ~SIGNBIT_DP64;
   int r = (int)(ax >> EXPSHIFTBITS_DP64) - EXPBIAS_DP64;
   int rs = -1011 - (int)__spirv_ocl_clz(ax & MANTBITS_DP64);

--- a/libclc/libspirv/lib/generic/math/lgamma_r.cl
+++ b/libclc/libspirv/lib/generic/math/lgamma_r.cl
@@ -96,9 +96,9 @@
 #define w6_f -1.6309292987e-03f /* 0xbad5c4e8 */
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_lgamma_r(float x, private int *signp) {
-  int hx = as_int(x);
+  int hx = __clc_as_int(x);
   int ix = hx & 0x7fffffff;
-  float absx = as_float(ix);
+  float absx = __clc_as_float(ix);
 
   if (ix >= 0x7f800000) {
     *signp = 1;
@@ -292,7 +292,7 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_lgamma_r(float x, private int *signp) {
   if (x < 0.0f) {
     float t = __spirv_ocl_sinpi(x);
     r = __spirv_ocl_log(pi_f / __spirv_ocl_fabs(t * x)) - r;
-    r = t == 0.0f ? as_float(PINFBITPATT_SP32) : r;
+    r = t == 0.0f ? __clc_as_float(PINFBITPATT_SP32) : r;
     s = t < 0.0f ? -1 : s;
   }
 
@@ -451,9 +451,9 @@ _CLC_V_V_VP_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, __spirv_ocl_lgamma_r,
 #define w6 -1.63092934096575273989e-03 /* 0xBF5AB89D, 0x0B9E43E4 */
 
 _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_lgamma_r(double x, private int *ip) {
-  ulong ux = as_ulong(x);
+  ulong ux = __clc_as_ulong(x);
   ulong ax = ux & EXSIGNBIT_DP64;
-  double absx = as_double(ax);
+  double absx = __clc_as_double(ax);
 
   if (ax >= 0x7ff0000000000000UL) {
     // +-Inf, NaN
@@ -625,7 +625,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_lgamma_r(double x, private int *ip) {
   if (x < 0.0) {
     double t = __spirv_ocl_sinpi(x);
     r = __spirv_ocl_log(pi / __spirv_ocl_fabs(t * x)) - r;
-    r = t == 0.0 ? as_double(PINFBITPATT_DP64) : r;
+    r = t == 0.0 ? __clc_as_double(PINFBITPATT_DP64) : r;
     *ip = t < 0.0 ? -1 : 1;
   } else
     *ip = 1;

--- a/libclc/libspirv/lib/generic/math/log1p.cl
+++ b/libclc/libspirv/lib/generic/math/log1p.cl
@@ -14,7 +14,7 @@
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_log1p(float x) {
   float w = x;
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint ax = ux & EXSIGNBIT_SP32;
 
   // |x| < 2^-4
@@ -28,23 +28,23 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_log1p(float x) {
       x;
 
   // |x| >= 2^-4
-  ux = as_uint(x + 1.0f);
+  ux = __clc_as_uint(x + 1.0f);
 
   int m = (int)((ux >> EXPSHIFTBITS_SP32) & 0xff) - EXPBIAS_SP32;
   float mf = (float)m;
   uint indx = (ux & 0x007f0000) + ((ux & 0x00008000) << 1);
-  float F = as_float(indx | 0x3f000000);
+  float F = __clc_as_float(indx | 0x3f000000);
 
   // x > 2^24
-  float fg24 = F - as_float(0x3f000000 | (ux & MANTBITS_SP32));
+  float fg24 = F - __clc_as_float(0x3f000000 | (ux & MANTBITS_SP32));
 
   // x <= 2^24
   uint xhi = ux & 0xffff8000;
-  float xh = as_float(xhi);
+  float xh = __clc_as_float(xhi);
   float xt = (1.0f - xh) + w;
   uint xnm = ((~(xhi & 0x7f800000)) - 0x00800000) & 0x7f800000;
-  xt = xt * as_float(xnm) * 0.5f;
-  float fl24 = F - as_float(0x3f000000 | (xhi & MANTBITS_SP32)) - xt;
+  xt = xt * __clc_as_float(xnm) * 0.5f;
+  float fl24 = F - __clc_as_float(0x3f000000 | (xhi & MANTBITS_SP32)) - xt;
 
   float f = mf > 24.0f ? fg24 : fl24;
 
@@ -67,8 +67,8 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_log1p(float x) {
 
   // Edge cases
   z = ax >= PINFBITPATT_SP32 ? w : z;
-  z = w < -1.0f ? as_float(QNANBITPATT_SP32) : z;
-  z = w == -1.0f ? as_float(NINFBITPATT_SP32) : z;
+  z = w < -1.0f ? __clc_as_float(QNANBITPATT_SP32) : z;
+  z = w == -1.0f ? __clc_as_float(NINFBITPATT_SP32) : z;
   // fix subnormals
   z = ax < 0x33800000 ? x : z;
 
@@ -93,17 +93,17 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_log1p(double x) {
   // for the kernel approximation.
 
   // Process Inside the threshold now
-  ulong ux = as_ulong(1.0 + x);
-  int xexp = ((as_int2(ux).hi >> 20) & 0x7ff) - EXPBIAS_DP64;
-  double f = as_double(ONEEXPBITS_DP64 | (ux & MANTBITS_DP64));
+  ulong ux = __clc_as_ulong(1.0 + x);
+  int xexp = ((__clc_as_int2(ux).hi >> 20) & 0x7ff) - EXPBIAS_DP64;
+  double f = __clc_as_double(ONEEXPBITS_DP64 | (ux & MANTBITS_DP64));
 
-  int j = as_int2(ux).hi >> 13;
+  int j = __clc_as_int2(ux).hi >> 13;
   j = ((0x80 | (j & 0x7e)) >> 1) + (j & 0x1);
   double f1 = (double)j * 0x1.0p-6;
   j -= 64;
 
   double f2temp = f - f1;
-  double m2 = as_double(__spirv_SatConvertSToU_Rulong(0x3ff - xexp)
+  double m2 = __clc_as_double(__spirv_SatConvertSToU_Rulong(0x3ff - xexp)
                         << EXPSHIFTBITS_DP64);
   double f2l = __spirv_ocl_fma(m2, x, m2 - f1);
   double f2g = __spirv_ocl_fma(m2, x, -f1) + m2;
@@ -158,8 +158,8 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_log1p(double x) {
   result2 = x < log1p_thresh1 || x > log1p_thresh2 ? result1 : result2;
 
   result2 = __spirv_IsInf(x) ? x : result2;
-  result2 = x < -1.0 ? as_double(QNANBITPATT_DP64) : result2;
-  result2 = x == -1.0 ? as_double(NINFBITPATT_DP64) : result2;
+  result2 = x < -1.0 ? __clc_as_double(QNANBITPATT_DP64) : result2;
+  result2 = x == -1.0 ? __clc_as_double(NINFBITPATT_DP64) : result2;
   return result2;
 }
 

--- a/libclc/libspirv/lib/generic/math/log_base.h
+++ b/libclc/libspirv/lib/generic/math/log_base.h
@@ -102,7 +102,7 @@ __spirv_ocl_log(float x)
   const float LOG2_TAIL = 0x1.0bfbe8p-15f; // 0.0000319461833
 #endif
 
-  uint xi = as_uint(x);
+  uint xi = __clc_as_uint(x);
   uint ax = xi & EXSIGNBIT_SP32;
 
   // Calculations for |x-1| < 2^-4
@@ -119,14 +119,14 @@ __spirv_ocl_log(float x)
       u, __spirv_ocl_mad(v, 0x1.99999ap-7f, 0x1.555556p-4f) * v, -corr);
 
 #if defined(COMPILING_LOG2)
-  z1 = as_float(as_int(r) & 0xffff0000);
+  z1 = __clc_as_float(__clc_as_int(r) & 0xffff0000);
   z2 = z2 + (r - z1);
   znear1 = __spirv_ocl_mad(
       z1, LOG2E_HEAD,
       __spirv_ocl_mad(z2, LOG2E_HEAD,
                       __spirv_ocl_mad(z1, LOG2E_TAIL, z2 * LOG2E_TAIL)));
 #elif defined(COMPILING_LOG10)
-  z1 = as_float(as_int(r) & 0xffff0000);
+  z1 = __clc_as_float(__clc_as_int(r) & 0xffff0000);
   z2 = z2 + (r - z1);
   znear1 = __spirv_ocl_mad(
       z1, LOG10E_HEAD,
@@ -140,7 +140,7 @@ __spirv_ocl_log(float x)
   int m = (int)(xi >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
 
   // Normalize subnormal
-  uint xis = as_uint(as_float(xi | 0x3f800000) - 1.0f);
+  uint xis = __clc_as_uint(__clc_as_float(xi | 0x3f800000) - 1.0f);
   int ms = (int)(xis >> EXPSHIFTBITS_SP32) - 253;
   int c = m == -127;
   m = c ? ms : m;
@@ -150,8 +150,8 @@ __spirv_ocl_log(float x)
   uint indx = (xin & 0x007f0000) + ((xin & 0x00008000) << 1);
 
   // F - Y
-  float f = as_float(0x3f000000 | indx) -
-            as_float(0x3f000000 | (xin & MANTBITS_SP32));
+  float f = __clc_as_float(0x3f000000 | indx) -
+            __clc_as_float(0x3f000000 | (xin & MANTBITS_SP32));
 
   indx = indx >> 16;
   r = f * USE_TABLE(log_inv_tbl, indx);
@@ -179,8 +179,8 @@ __spirv_ocl_log(float x)
 
   // Corner cases
   z = ax >= PINFBITPATT_SP32 ? x : z;
-  z = xi != ax ? as_float(QNANBITPATT_SP32) : z;
-  z = ax == 0 ? as_float(NINFBITPATT_SP32) : z;
+  z = xi != ax ? __clc_as_float(QNANBITPATT_SP32) : z;
+  z = ax == 0 ? __clc_as_float(NINFBITPATT_SP32) : z;
 
   return z;
 }
@@ -245,7 +245,7 @@ __spirv_ocl_log(double x)
 
 #if defined(COMPILING_LOG10)
   r = r1;
-  r1 = as_double(as_ulong(r1) & 0xffffffff00000000);
+  r1 = __clc_as_double(__clc_as_ulong(r1) & 0xffffffff00000000);
   r2 = r2 + (r - r1);
   double ret_near = __spirv_ocl_fma(
       log10e_lead, r1,
@@ -253,7 +253,7 @@ __spirv_ocl_log(double x)
                       __spirv_ocl_fma(log10e_tail, r1, log10e_tail * r2)));
 #elif defined(COMPILING_LOG2)
   r = r1;
-  r1 = as_double(as_ulong(r1) & 0xffffffff00000000);
+  r1 = __clc_as_double(__clc_as_ulong(r1) & 0xffffffff00000000);
   r2 = r2 + (r - r1);
   double ret_near = __spirv_ocl_fma(
       log2e_lead, r1,
@@ -266,15 +266,15 @@ __spirv_ocl_log(double x)
   // This is the far from 1 code
 
   // Deal with subnormal
-  ulong ux = as_ulong(x);
-  ulong uxs = as_ulong(as_double(0x03d0000000000000UL | ux) - 0x1.0p-962);
+  ulong ux = __clc_as_ulong(x);
+  ulong uxs = __clc_as_ulong(__clc_as_double(0x03d0000000000000UL | ux) - 0x1.0p-962);
   int c = ux < IMPBIT_DP64;
   ux = c ? uxs : ux;
   int expadjust = c ? 60 : 0;
 
-  int xexp = ((as_int2(ux).hi >> 20) & 0x7ff) - EXPBIAS_DP64 - expadjust;
-  double f = as_double(HALFEXPBITS_DP64 | (ux & MANTBITS_DP64));
-  int index = as_int2(ux).hi >> 13;
+  int xexp = ((__clc_as_int2(ux).hi >> 20) & 0x7ff) - EXPBIAS_DP64 - expadjust;
+  double f = __clc_as_double(HALFEXPBITS_DP64 | (ux & MANTBITS_DP64));
+  int index = __clc_as_int2(ux).hi >> 13;
   index = ((0x80 | (index & 0x7e)) >> 1) + (index & 0x1);
 
   double2 tv = USE_TABLE(ln_tbl, index - 64);
@@ -315,9 +315,9 @@ __spirv_ocl_log(double x)
 
   double ret = is_near ? ret_near : ret_far;
 
-  ret = __spirv_IsInf(x) ? as_double(PINFBITPATT_DP64) : ret;
-  ret = __spirv_IsNan(x) || (x < 0.0) ? as_double(QNANBITPATT_DP64) : ret;
-  ret = x == 0.0 ? as_double(NINFBITPATT_DP64) : ret;
+  ret = __spirv_IsInf(x) ? __clc_as_double(PINFBITPATT_DP64) : ret;
+  ret = __spirv_IsNan(x) || (x < 0.0) ? __clc_as_double(QNANBITPATT_DP64) : ret;
+  ret = x == 0.0 ? __clc_as_double(NINFBITPATT_DP64) : ret;
   return ret;
 }
 

--- a/libclc/libspirv/lib/generic/math/log_base.h
+++ b/libclc/libspirv/lib/generic/math/log_base.h
@@ -267,7 +267,8 @@ __spirv_ocl_log(double x)
 
   // Deal with subnormal
   ulong ux = __clc_as_ulong(x);
-  ulong uxs = __clc_as_ulong(__clc_as_double(0x03d0000000000000UL | ux) - 0x1.0p-962);
+  ulong uxs =
+      __clc_as_ulong(__clc_as_double(0x03d0000000000000UL | ux) - 0x1.0p-962);
   int c = ux < IMPBIT_DP64;
   ux = c ? uxs : ux;
   int expadjust = c ? 60 : 0;

--- a/libclc/libspirv/lib/generic/math/logb.cl
+++ b/libclc/libspirv/lib/generic/math/logb.cl
@@ -12,12 +12,12 @@
 #include <clc/math/math.h>
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_logb(float x) {
-    int ax = as_int(x) & EXSIGNBIT_SP32;
+    int ax = __clc_as_int(x) & EXSIGNBIT_SP32;
     float s = -118 - __spirv_ocl_clz(ax);
     float r = (ax >> EXPSHIFTBITS_SP32) - EXPBIAS_SP32;
-    r = ax >= PINFBITPATT_SP32 ? as_float(ax) : r;
+    r = ax >= PINFBITPATT_SP32 ? __clc_as_float(ax) : r;
     r = ax < 0x00800000 ? s : r;
-    r = ax == 0 ? as_float(NINFBITPATT_SP32) : r;
+    r = ax == 0 ? __clc_as_float(NINFBITPATT_SP32) : r;
     return r;
 }
 
@@ -27,12 +27,12 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, __spirv_ocl_logb, float);
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
 _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_logb(double x) {
-    long ax = as_long(x) & EXSIGNBIT_DP64;
+    long ax = __clc_as_long(x) & EXSIGNBIT_DP64;
     double s = -1011L - __spirv_ocl_clz(ax);
     double r = (int) (ax >> EXPSHIFTBITS_DP64) - EXPBIAS_DP64;
-    r = ax >= PINFBITPATT_DP64 ? as_double(ax) : r;
+    r = ax >= PINFBITPATT_DP64 ? __clc_as_double(ax) : r;
     r = ax < 0x0010000000000000L ? s : r;
-    r = ax == 0L ? as_double(NINFBITPATT_DP64) : r;
+    r = ax == 0L ? __clc_as_double(NINFBITPATT_DP64) : r;
     return r;
 }
 

--- a/libclc/libspirv/lib/generic/math/nan.cl
+++ b/libclc/libspirv/lib/generic/math/nan.cl
@@ -9,8 +9,8 @@
 #include <libspirv/spirv.h>
 #include <clc/utils.h>
 
-#define __CLC_AS_GENTYPE __CLC_XCONCAT(as_, __CLC_GENTYPE)
+#define __CLC_AS_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)
 #define __CLC_AS_UNSIGNED(TYPE)                                                \
-  __CLC_XCONCAT(as_, __CLC_XCONCAT(TYPE, __CLC_VECSIZE))
+  __CLC_XCONCAT(__clc_as_, __CLC_XCONCAT(TYPE, __CLC_VECSIZE))
 #define __CLC_BODY <nan.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/sin.cl
+++ b/libclc/libspirv/lib/generic/math/sin.cl
@@ -14,9 +14,9 @@
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_sin(float x)
 {
-    int ix = as_int(x);
+    int ix = __clc_as_int(x);
     int ax = ix & 0x7fffffff;
-    float dx = as_float(ax);
+    float dx = __clc_as_float(ax);
 
     float r0, r1;
     int regn = __clc_argReductionS(&r0, &r1, dx);
@@ -25,9 +25,9 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_sin(float x)
     float cc = __clc_cosf_piby4(r0, r1);
 
     float s = (regn & 1) != 0 ? cc : ss;
-    s = as_float(as_int(s) ^ ((regn > 1) << 31) ^ (ix ^ ax));
+    s = __clc_as_float(__clc_as_int(s) ^ ((regn > 1) << 31) ^ (ix ^ ax));
 
-    s = ax >= PINFBITPATT_SP32 ? as_float(QNANBITPATT_SP32) : s;
+    s = ax >= PINFBITPATT_SP32 ? __clc_as_float(QNANBITPATT_SP32) : s;
 
     //Subnormals
     s = x == 0.0f ? x : s;
@@ -54,11 +54,11 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_sin(double x) {
 
     double2 sc = __clc_sincos_piby4(r, rr);
 
-    int2 s = as_int2(regn & 1 ? sc.hi : sc.lo);
+    int2 s = __clc_as_int2(regn & 1 ? sc.hi : sc.lo);
     s.hi ^= ((regn > 1) << 31) ^ ((x < 0.0) << 31);
 
-    return __spirv_IsInf(x) || __spirv_IsNan(x) ? as_double(QNANBITPATT_DP64)
-                                                : as_double(s);
+    return __spirv_IsInf(x) || __spirv_IsNan(x) ? __clc_as_double(QNANBITPATT_DP64)
+                                                : __clc_as_double(s);
 }
 
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_sin, double);

--- a/libclc/libspirv/lib/generic/math/sincosD_piby4.h
+++ b/libclc/libspirv/lib/generic/math/sincosD_piby4.h
@@ -132,10 +132,10 @@ _CLC_INLINE double2 __clc_tan_piby4(double x, double xx) {
   double tp = t1 + t2;
 
   // Compute -1.0/(t1 + t2) accurately
-  double z1 = as_double(as_long(tp) & 0xffffffff00000000L);
+  double z1 = __clc_as_double(__clc_as_long(tp) & 0xffffffff00000000L);
   double z2 = t2 - (z1 - t1);
   double trec = -MATH_RECIP(tp);
-  double trec_top = as_double(as_long(trec) & 0xffffffff00000000L);
+  double trec_top = __clc_as_double(__clc_as_long(trec) & 0xffffffff00000000L);
 
   double tpr = __spirv_ocl_fma(
       __spirv_ocl_fma(trec_top, z2, __spirv_ocl_fma(trec_top, z1, 1.0)), trec,

--- a/libclc/libspirv/lib/generic/math/sincos_helpers.cl
+++ b/libclc/libspirv/lib/generic/math/sincos_helpers.cl
@@ -91,10 +91,10 @@ _CLC_DEF float __clc_cosf_piby4(float x, float y) {
   // if |x| < 0.3
   float qx = 0.0f;
 
-  int ix = as_int(x) & EXSIGNBIT_SP32;
+  int ix = __clc_as_int(x) & EXSIGNBIT_SP32;
 
   //  0.78125 > |x| >= 0.3
-  float xby4 = as_float(ix - 0x01000000);
+  float xby4 = __clc_as_float(ix - 0x01000000);
   qx = (ix >= 0x3e99999a) && (ix <= 0x3f480000) ? xby4 : qx;
 
   // x > 0.78125
@@ -131,7 +131,7 @@ _CLC_DEF void __clc_fullMulS(float *hi, float *lo, float a, float b, float bh,
     *hi = ph;
     *lo = __spirv_ocl_fma(a, b, -ph);
   } else {
-    float ah = as_float(as_uint(a) & 0xfffff000U);
+    float ah = __clc_as_float(__clc_as_uint(a) & 0xfffff000U);
     float at = a - ah;
     float ph = a * b;
     float pt = __spirv_ocl_mad(
@@ -196,8 +196,8 @@ _CLC_DEF int __clc_argReductionSmallS(float *r, float *rr, float x) {
   HI += LO < C
 
 _CLC_DEF int __clc_argReductionLargeS(float *r, float *rr, float x) {
-  int xe = (int)(as_uint(x) >> 23) - 127;
-  uint xm = 0x00800000U | (as_uint(x) & 0x7fffffU);
+  int xe = (int)(__clc_as_uint(x) >> 23) - 127;
+  uint xm = 0x00800000U | (__clc_as_uint(x) & 0x7fffffU);
 
   // 224 bits of 2/PI: . A2F9836E 4E441529 FC2757D1 F534DDC0 DB629599 3C439041
   // FE5163AB
@@ -292,7 +292,7 @@ _CLC_DEF int __clc_argReductionLargeS(float *r, float *rr, float x) {
   p6 = bitalign(p6, p5, shift);
 
   // Most significant part of fraction
-  float q1 = as_float(sign | ((127 - xe) << 23) | (p7 >> 9));
+  float q1 = __clc_as_float(sign | ((127 - xe) << 23) | (p7 >> 9));
 
   // Shift out bits we captured on q1
   p7 = bitalign(p7, p6, 32 - 23);
@@ -301,7 +301,7 @@ _CLC_DEF int __clc_argReductionLargeS(float *r, float *rr, float x) {
   // of zeroes here
   int xxe = __spirv_ocl_clz(p7) + 1;
   p7 = bitalign(p7, p6, 32 - xxe);
-  float q0 = as_float(sign | ((127 - (xe + 23 + xxe)) << 23) | (p7 >> 9));
+  float q0 = __clc_as_float(sign | ((127 - (xe + 23 + xxe)) << 23) | (p7 >> 9));
 
   // At this point, the fraction q1 + q0 is correct to at least 48 bits
   // Now we need to multiply the fraction by pi/2
@@ -320,7 +320,7 @@ _CLC_DEF int __clc_argReductionLargeS(float *r, float *rr, float x) {
     rt = __spirv_ocl_fma(
         q0, pio2h, __spirv_ocl_fma(q1, pio2t, __spirv_ocl_fma(q1, pio2h, -rh)));
   } else {
-    float q1h = as_float(as_uint(q1) & 0xfffff000);
+    float q1h = __clc_as_float(__clc_as_uint(q1) & 0xfffff000);
     float q1t = q1 - q1h;
     rh = q1 * pio2h;
     rt = __spirv_ocl_mad(
@@ -399,7 +399,7 @@ _CLC_DEF void __clc_remainder_piby2_medium(double x, double *r, double *rr,
 _CLC_DEF void __clc_remainder_piby2_large(double x, double *r, double *rr,
                                           int *regn) {
 
-  long ux = as_long(x);
+  long ux = __clc_as_long(x);
   int e = (int)(ux >> 52) - 1023;
   int i = __clc_max(23, (e >> 3) + 17);
   int j = 150 - i;
@@ -460,17 +460,17 @@ _CLC_DEF void __clc_remainder_piby2_large(double x, double *r, double *rr,
   i -= i > 1018 ? 136 : 0;
 
   uint ua = (uint)(1023 + 52 - i) << 20;
-  double a = as_double((uint2)(0, ua));
-  double p0 = as_double((uint2)(v0, ua | (v1 & 0xffffU))) - a;
+  double a = __clc_as_double((uint2)(0, ua));
+  double p0 = __clc_as_double((uint2)(v0, ua | (v1 & 0xffffU))) - a;
   ua += 0x03000000U;
-  a = as_double((uint2)(0, ua));
-  double p1 = as_double((uint2)((v2 << 16) | (v1 >> 16), ua | (v2 >> 16))) - a;
+  a = __clc_as_double((uint2)(0, ua));
+  double p1 = __clc_as_double((uint2)((v2 << 16) | (v1 >> 16), ua | (v2 >> 16))) - a;
   ua += 0x03000000U;
-  a = as_double((uint2)(0, ua));
-  double p2 = as_double((uint2)(v3, ua | (v4 & 0xffffU))) - a;
+  a = __clc_as_double((uint2)(0, ua));
+  double p2 = __clc_as_double((uint2)(v3, ua | (v4 & 0xffffU))) - a;
   ua += 0x03000000U;
-  a = as_double((uint2)(0, ua));
-  double p3 = as_double((uint2)((v5 << 16) | (v4 >> 16), ua | (v5 >> 16))) - a;
+  a = __clc_as_double((uint2)(0, ua));
+  double p3 = __clc_as_double((uint2)((v5 << 16) | (v4 >> 16), ua | (v5 >> 16))) - a;
 
   // Exact multiply
   double f0h = p0 * x;

--- a/libclc/libspirv/lib/generic/math/sinh.cl
+++ b/libclc/libspirv/lib/generic/math/sinh.cl
@@ -23,10 +23,10 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_sinh(float x) {
   const float max_sinh_arg = 0x1.65a9fap+6f;
   const float small_threshold = 0x1.0a2b24p+3f;
 
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint aux = ux & EXSIGNBIT_SP32;
   uint xs = ux ^ aux;
-  float y = as_float(aux);
+  float y = __clc_as_float(aux);
 
   // We find the integer part y0 of y and the increment dy = y - y0. We then
   // compute z = sinh(y) = sinh(y0)cosh(dy) + cosh(y0)sinh(dy) where sinh(y0)
@@ -77,17 +77,17 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_sinh(float x) {
 
   float2 tv = USE_TABLE(sinhcosh_tbl, ind);
   float z = __spirv_ocl_mad(tv.s1, sdy, tv.s0 * cdy);
-  z = as_float(xs | as_uint(z));
+  z = __clc_as_float(xs | __clc_as_uint(z));
 
   // When y is large enough so that the negative exponential is negligible,
   // so sinh(y) is approximated by sign(x)*exp(y)/2.
   float t = __spirv_ocl_exp(y - 0x1.62e500p-1f);
   float zsmall = __spirv_ocl_mad(0x1.a0210ep-18f, t, t);
-  zsmall = as_float(xs | as_uint(zsmall));
+  zsmall = __clc_as_float(xs | __clc_as_uint(zsmall));
   z = y >= small_threshold ? zsmall : z;
 
   // Corner cases
-  float zinf = as_float(PINFBITPATT_SP32 | xs);
+  float zinf = __clc_as_float(PINFBITPATT_SP32 | xs);
   z = y >= max_sinh_arg ? zinf : z;
   z = aux > PINFBITPATT_SP32 || aux < 0x38800000U ? x : z;
 
@@ -172,7 +172,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_sinh(double x) {
 
   // At this point sinh(dy) is approximated by dy + sdy.
   // Shift some significant bits from dy to sdy.
-  double sdy1 = as_double(as_ulong(dy) & 0xfffffffff8000000UL);
+  double sdy1 = __clc_as_double(__clc_as_ulong(dy) & 0xfffffffff8000000UL);
   double sdy2 = sdy + (dy - sdy1);
 
   double2 tv = USE_TABLE(cosh_tbl, ind);
@@ -199,7 +199,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_sinh(double x) {
   double t = __spirv_ocl_exp(y - 0x1.62e42fefa3800p-1);
   t = __spirv_ocl_fma(t, -0x1.ef35793c76641p-45, t);
   z = y >= small_threshold ? t : z;
-  z = y >= max_sinh_arg ? as_double(PINFBITPATT_DP64) : z;
+  z = y >= max_sinh_arg ? __clc_as_double(PINFBITPATT_DP64) : z;
 
   return __spirv_ocl_copysign(z, x);
 }

--- a/libclc/libspirv/lib/generic/math/sinpi.cl
+++ b/libclc/libspirv/lib/generic/math/sinpi.cl
@@ -17,10 +17,10 @@
 
 _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_sinpi(float x)
 {
-    int ix = as_int(x);
+    int ix = __clc_as_int(x);
     int xsgn = ix & 0x80000000;
     ix ^= xsgn;
-    float ax = as_float(ix);
+    float ax = __clc_as_float(ix);
     int iax = (int)ax;
     float r = ax - iax;
     int xodd = xsgn ^ (iax & 0x1 ? 0x80000000 : 0);
@@ -52,11 +52,11 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_sinpi(float x)
     e = c ? 0 : e;
 
     float2 t = __libclc__sincosf_piby4(a * M_PI_F);
-    int jr = xodd ^ as_int(e ? t.hi : t.lo);
+    int jr = xodd ^ __clc_as_int(e ? t.hi : t.lo);
 
     ir = ix < 0x4b000000 ? jr : ir;
 
-    return as_float(ir);
+    return __clc_as_float(ir);
 }
 
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, __spirv_ocl_sinpi, float);
@@ -67,10 +67,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, __spirv_ocl_sinpi, float);
 
 _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_sinpi(double x)
 {
-    long ix = as_long(x);
+    long ix = __clc_as_long(x);
     long xsgn = ix & 0x8000000000000000L;
     ix ^= xsgn;
-    double ax = as_double(ix);
+    double ax = __clc_as_double(ix);
     long iax = (long)ax;
     double r = ax - (double)iax;
     long xodd = xsgn ^ (iax & 0x1L ? 0x8000000000000000L : 0L);
@@ -105,11 +105,11 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_sinpi(double x)
 
     double api = a * M_PI;
     double2 sc = __libclc__sincos_piby4(api, 0.0);
-    long jr = xodd ^ as_long(e ? sc.hi : sc.lo);
+    long jr = xodd ^ __clc_as_long(e ? sc.hi : sc.lo);
 
     ir = ax < 0x1.0p+52 ? jr : ir;
 
-    return as_double(ir);
+    return __clc_as_double(ir);
 }
 
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_sinpi, double)

--- a/libclc/libspirv/lib/generic/math/tanh.cl
+++ b/libclc/libspirv/lib/generic/math/tanh.cl
@@ -21,11 +21,11 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_tanh(float x) {
 
   const float large_threshold = 0x1.0a2b24p+3f;
 
-  uint ux = as_uint(x);
+  uint ux = __clc_as_uint(x);
   uint aux = ux & EXSIGNBIT_SP32;
   uint xs = ux ^ aux;
 
-  float y = as_float(aux);
+  float y = __clc_as_float(aux);
   float y2 = y * y;
 
   float a1 = __spirv_ocl_mad(
@@ -51,10 +51,10 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_tanh(float x) {
   float zhi = 1.0F - MATH_DIVIDE(2.0F, p);
 
   float z = y <= 1.0f ? zlo : zhi;
-  z = as_float(xs | as_uint(z));
+  z = __clc_as_float(xs | __clc_as_uint(z));
 
   // Edge cases
-  float sone = as_float(0x3f800000U | xs);
+  float sone = __clc_as_float(0x3f800000U | xs);
   z = y > large_threshold ? sone : z;
   z = aux < 0x39000000 || aux > 0x7f800000 ? x : z;
 
@@ -78,10 +78,10 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_tanh(double x) {
   // The point at which e^-x is insignificant compared to e^x = ln(2^27)
   const double large_threshold = 0x1.2b708872320e2p+4;
 
-  ulong ux = as_ulong(x);
+  ulong ux = __clc_as_ulong(x);
   ulong ax = ux & ~SIGNBIT_DP64;
   ulong sx = ux ^ ax;
-  double y = as_double(ax);
+  double y = __clc_as_double(ax);
   double y2 = y * y;
 
   // y < 0.9
@@ -134,7 +134,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_tanh(double x) {
 
   z = y > large_threshold ? 1.0 : z;
 
-  return as_double(sx | as_ulong(z));
+  return __clc_as_double(sx | __clc_as_ulong(z));
 }
 
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, __spirv_ocl_tanh, double);

--- a/libclc/libspirv/lib/generic/math/tgamma.cl
+++ b/libclc/libspirv/lib/generic/math/tgamma.cl
@@ -21,8 +21,8 @@ _CLC_OVERLOAD _CLC_DEF float __spirv_ocl_tgamma(float x) {
     float z = __spirv_ocl_sinpi(x);
     g = g * ax * z;
     g = pi / g;
-    g = g == 0 ? as_float(PINFBITPATT_SP32) : g;
-    g = z == 0 ? as_float(QNANBITPATT_SP32) : g;
+    g = g == 0 ? __clc_as_float(PINFBITPATT_SP32) : g;
+    g = z == 0 ? __clc_as_float(QNANBITPATT_SP32) : g;
   }
 
   return g;
@@ -44,8 +44,8 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_tgamma(double x) {
     double z = __spirv_ocl_sinpi(x);
     g = g * ax * z;
     g = pi / g;
-    g = g == 0 ? as_double(PINFBITPATT_DP64) : g;
-    g = z == 0 ? as_double(QNANBITPATT_DP64) : g;
+    g = g == 0 ? __clc_as_double(PINFBITPATT_DP64) : g;
+    g = z == 0 ? __clc_as_double(QNANBITPATT_DP64) : g;
   }
 
   return g;

--- a/libclc/libspirv/lib/generic/shared/vstore.cl
+++ b/libclc/libspirv/lib/generic/shared/vstore.cl
@@ -184,7 +184,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_noop(float x) { return x; }
 _CLC_DEF _CLC_OVERLOAD float __clc_rtz(float x) {
   /* Remove lower 13 bits to make sure the number is rounded down */
   int mask = 0xffffe000;
-  const int exp = (as_uint(x) >> 23 & 0xff) - 127;
+  const int exp = ( __clc_as_uint(x) >> 23 & 0xff) - 127;
   /* Denormals cannot be flushed, and they use different bit for rounding */
   if (exp < -14)
     mask <<= __spirv_ocl_s_min(-(exp + 14), 10);
@@ -194,32 +194,32 @@ _CLC_DEF _CLC_OVERLOAD float __clc_rtz(float x) {
   /* Handle nan corner case */
   if (__spirv_IsNan(x))
     return x;
-  return as_float(as_uint(x) & mask);
+  return  __clc_as_float( __clc_as_uint(x) & mask);
 }
 _CLC_DEF _CLC_OVERLOAD float __clc_rti(float x) {
   const float inf = __spirv_ocl_copysign(INFINITY, x);
   /* Set lower 13 bits */
   int mask = (1 << 13) - 1;
-  const int exp = (as_uint(x) >> 23 & 0xff) - 127;
+  const int exp = ( __clc_as_uint(x) >> 23 & 0xff) - 127;
   /* Denormals cannot be flushed, and they use different bit for rounding */
   if (exp < -14)
     mask = (1 << (13 + __spirv_ocl_s_min(-(exp + 14), 10))) - 1;
   /* Handle nan corner case */
   if (__spirv_IsNan(x))
     return x;
-  const float next = __spirv_ocl_nextafter(as_float(as_uint(x) | mask), inf);
-  return ((as_uint(x) & mask) == 0) ? x : next;
+  const float next = __spirv_ocl_nextafter(__clc_as_float(__clc_as_uint(x) | mask), inf);
+  return ((__clc_as_uint(x) & mask) == 0) ? x : next;
 }
 _CLC_DEF _CLC_OVERLOAD float __clc_rtn(float x) {
-  return ((as_uint(x) & 0x80000000) == 0) ? __clc_rtz(x) : __clc_rti(x);
+  return ((__clc_as_uint(x) & 0x80000000) == 0) ? __clc_rtz(x) : __clc_rti(x);
 }
 _CLC_DEF _CLC_OVERLOAD float __clc_rtp(float x) {
-  return ((as_uint(x) & 0x80000000) == 0) ? __clc_rti(x) : __clc_rtz(x);
+  return ((__clc_as_uint(x) & 0x80000000) == 0) ? __clc_rti(x) : __clc_rtz(x);
 }
 _CLC_DEF _CLC_OVERLOAD float __clc_rte(float x) {
   /* Mantisa + implicit bit */
-  const uint mantissa = (as_uint(x) & 0x7fffff) | (1u << 23);
-  const int exp = (as_uint(x) >> 23 & 0xff) - 127;
+  const uint mantissa = (__clc_as_uint(x) & 0x7fffff) | (1u << 23);
+  const int exp = (__clc_as_uint(x) >> 23 & 0xff) - 127;
   int shift = 13;
   if (exp < -14) {
     /* The default assumes lower 13 bits are rounded,
@@ -242,7 +242,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_noop(double x) { return x; }
 _CLC_DEF _CLC_OVERLOAD double __clc_rtz(double x) {
   /* Remove lower 42 bits to make sure the number is rounded down */
   ulong mask = 0xfffffc0000000000UL;
-  const int exp = (as_ulong(x) >> 52 & 0x7ff) - 1023;
+  const int exp = (__clc_as_ulong(x) >> 52 & 0x7ff) - 1023;
   /* Denormals cannot be flushed, and they use different bit for rounding */
   if (exp < -14)
     mask <<= __spirv_ocl_s_min(-(exp + 14), 10);
@@ -252,34 +252,34 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rtz(double x) {
   /* Handle nan corner case */
   if (__spirv_IsNan(x))
     return x;
-  return as_double(as_ulong(x) & mask);
+  return __clc_as_double(__clc_as_ulong(x) & mask);
 }
 _CLC_DEF _CLC_OVERLOAD double __clc_rti(double x) {
   const double inf = __spirv_ocl_copysign((double)INFINITY, x);
   /* Set lower 42 bits */
   long mask = (1UL << 42UL) - 1UL;
-  const int exp = (as_ulong(x) >> 52 & 0x7ff) - 1023;
+  const int exp = (__clc_as_ulong(x) >> 52 & 0x7ff) - 1023;
   /* Denormals cannot be flushed, and they use different bit for rounding */
   if (exp < -14)
     mask = (1UL << (42UL + __spirv_ocl_s_min(-(exp + 14), 10))) - 1;
   /* Handle nan corner case */
   if (__spirv_IsNan(x))
     return x;
-  const double next = __spirv_ocl_nextafter(as_double(as_ulong(x) | mask), inf);
-  return ((as_ulong(x) & mask) == 0) ? x : next;
+  const double next = __spirv_ocl_nextafter(__clc_as_double(__clc_as_ulong(x) | mask), inf);
+  return ((__clc_as_ulong(x) & mask) == 0) ? x : next;
 }
 _CLC_DEF _CLC_OVERLOAD double __clc_rtn(double x) {
-  return ((as_ulong(x) & 0x8000000000000000UL) == 0) ? __clc_rtz(x)
+  return ((__clc_as_ulong(x) & 0x8000000000000000UL) == 0) ? __clc_rtz(x)
                                                      : __clc_rti(x);
 }
 _CLC_DEF _CLC_OVERLOAD double __clc_rtp(double x) {
-  return ((as_ulong(x) & 0x8000000000000000UL) == 0) ? __clc_rti(x)
+  return ((__clc_as_ulong(x) & 0x8000000000000000UL) == 0) ? __clc_rti(x)
                                                      : __clc_rtz(x);
 }
 _CLC_DEF _CLC_OVERLOAD double __clc_rte(double x) {
   /* Mantisa + implicit bit */
-  const ulong mantissa = (as_ulong(x) & 0xfffffffffffff) | (1UL << 52);
-  const int exp = (as_ulong(x) >> 52 & 0x7ff) - 1023;
+  const ulong mantissa = (__clc_as_ulong(x) & 0xfffffffffffff) | (1UL << 52);
+  const int exp = (__clc_as_ulong(x) >> 52 & 0x7ff) - 1023;
   int shift = 42;
   if (exp < -14) {
     /* The default assumes lower 13 bits are rounded,

--- a/libclc/libspirv/lib/ptx-nvidiacl/group/collectives.cl
+++ b/libclc/libspirv/lib/ptx-nvidiacl/group/collectives.cl
@@ -69,20 +69,20 @@ __CLC_SUBGROUP_SHUFFLE_I32(uint);
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT ulong __clc__SubgroupShuffle(ulong x,
                                                                     uint idx) {
-  uint2 y = as_uint2(x);
+  uint2 y = __clc_as_uint2(x);
   y.lo = __nvvm_shfl_sync_idx_i32(__clc__membermask(), y.lo, idx, 0x1f);
   y.hi = __nvvm_shfl_sync_idx_i32(__clc__membermask(), y.hi, idx, 0x1f);
-  return as_ulong(y);
+  return __clc_as_ulong(y);
 }
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT long __clc__SubgroupShuffle(long x,
                                                                    uint idx) {
-  return as_long(__clc__SubgroupShuffle(as_ulong(x), idx));
+  return __clc_as_long(__clc__SubgroupShuffle(__clc_as_ulong(x), idx));
 }
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT half __clc__SubgroupShuffle(half x,
                                                                    uint idx) {
-  return as_half(__clc__SubgroupShuffle(as_short(x), idx));
+  return __clc_as_half(__clc__SubgroupShuffle(__clc_as_short(x), idx));
 }
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT float __clc__SubgroupShuffle(float x,
@@ -92,7 +92,7 @@ _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT float __clc__SubgroupShuffle(float x,
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT double __clc__SubgroupShuffle(double x,
                                                                      uint idx) {
-  return as_double(__clc__SubgroupShuffle(as_ulong(x), idx));
+  return __clc_as_double(__clc__SubgroupShuffle(__clc_as_ulong(x), idx));
 }
 
 typedef union {
@@ -150,20 +150,20 @@ __CLC_SUBGROUP_SHUFFLEUP_I32(uint);
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT ulong
 __clc__SubgroupShuffleUp(ulong x, uint delta) {
-  uint2 y = as_uint2(x);
+  uint2 y = __clc_as_uint2(x);
   y.lo = __nvvm_shfl_sync_up_i32(__clc__membermask(), y.lo, delta, 0);
   y.hi = __nvvm_shfl_sync_up_i32(__clc__membermask(), y.hi, delta, 0);
-  return as_ulong(y);
+  return __clc_as_ulong(y);
 }
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT long
 __clc__SubgroupShuffleUp(long x, uint delta) {
-  return as_long(__clc__SubgroupShuffleUp(as_ulong(x), delta));
+  return __clc_as_long(__clc__SubgroupShuffleUp(__clc_as_ulong(x), delta));
 }
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT half
 __clc__SubgroupShuffleUp(half x, uint delta) {
-  return as_half(__clc__SubgroupShuffleUp(as_short(x), delta));
+  return __clc_as_half(__clc__SubgroupShuffleUp(__clc_as_short(x), delta));
 }
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT float
@@ -173,7 +173,7 @@ __clc__SubgroupShuffleUp(float x, uint delta) {
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT double
 __clc__SubgroupShuffleUp(double x, uint delta) {
-  return as_double(__clc__SubgroupShuffleUp(as_ulong(x), delta));
+  return __clc_as_double(__clc__SubgroupShuffleUp(__clc_as_ulong(x), delta));
 }
 
 _CLC_DEF _CLC_OVERLOAD _CLC_CONVERGENT complex_half

--- a/libclc/libspirv/lib/ptx-nvidiacl/images/image.cl
+++ b/libclc/libspirv/lib/ptx-nvidiacl/images/image.cl
@@ -198,8 +198,8 @@ typedef float4 pixelf32;
 typedef half fp16;
 typedef float fp32;
 
-pixelf16 as_pixelf16(short4 v) { return as_half4(v); }
-pixelf32 as_pixelf32(int4 v) { return as_float4(v); }
+pixelf16 as_pixelf16(short4 v) { return __clc_as_half4(v); }
+pixelf32 as_pixelf32(int4 v) { return __clc_as_float4(v); }
 
 #define _DEFINE_VEC4_CAST(from_t, to_t)                                        \
   inline to_t##4 cast_##from_t##4_to_##to_t##4(from_t##4 from) {               \
@@ -367,7 +367,7 @@ _DEFINE_READ_3D_PIXELF(16, clamp)
   _CLC_DEF                                                                          \
   elem_t##4 _Z17__spirv_ImageReadIDv4_##elem_t_mangled##14ocl_image1d_roiET_T0_T1_( \
       read_only image1d_t image, int x) {                                           \
-    return as_##elem_t##4(                                                          \
+    return __clc_as_##elem_t##4(                                                    \
         __nvvm_suld_1d_v4i##elem_size##_clamp(image, x * sizeof(elem_t##4)));       \
   }
 
@@ -375,7 +375,7 @@ _DEFINE_READ_3D_PIXELF(16, clamp)
   _CLC_DEF                                                                              \
   elem_t##4 _Z17__spirv_ImageReadIDv4_##elem_t_mangled##14ocl_image2d_roDv2_iET_T0_T1_( \
       read_only image2d_t image, int2 coord) {                                          \
-    return as_##elem_t##4(__nvvm_suld_2d_v4i##elem_size##_clamp(                        \
+    return __clc_as_##elem_t##4(__nvvm_suld_2d_v4i##elem_size##_clamp(                  \
         image, coord.x * sizeof(elem_t##4), coord.y));                                  \
   }
 
@@ -384,7 +384,7 @@ _DEFINE_READ_3D_PIXELF(16, clamp)
   _CLC_DEF                                                                                          \
   elem_t##4 _Z17__spirv_ImageReadIDv4_##elem_t_mangled##14ocl_image3d_ro##coord_mangled##ET_T0_T1_( \
       read_only image3d_t image, int4 coord) {                                                      \
-    return as_##elem_t##4(__nvvm_suld_3d_v4i##elem_size##_clamp(                                    \
+    return __clc_as_##elem_t##4(__nvvm_suld_3d_v4i##elem_size##_clamp(                              \
         image, coord.x * sizeof(elem_t##4), coord.y, coord.z));                                     \
   }
 
@@ -394,8 +394,8 @@ _DEFINE_READ_3D_PIXELF(16, clamp)
       _Z18__spirv_ImageWriteI14ocl_image1d_woiDv4_##elem_t_mangled##EvT_T0_T1_( \
           write_only image1d_t image, int x, elem_t##4 c) {                     \
     __nvvm_sust_1d_v4i##elem_size##_clamp(                                      \
-        image, x * sizeof(elem_t##4), as_##int_rep(c.x), as_##int_rep(c.y),     \
-        as_##int_rep(c.z), as_##int_rep(c.w));                                  \
+        image, x * sizeof(elem_t##4), __clc_as_##int_rep(c.x), __clc_as_##int_rep(c.y),     \
+        __clc_as_##int_rep(c.z), __clc_as_##int_rep(c.w));                                  \
   }
 
 #define _CLC_DEFINE_IMAGE2D_WRITE_BUILTIN(elem_t, elem_t_mangled, elem_size,        \
@@ -404,19 +404,19 @@ _DEFINE_READ_3D_PIXELF(16, clamp)
       _Z18__spirv_ImageWriteI14ocl_image2d_woDv2_iDv4_##elem_t_mangled##EvT_T0_T1_( \
           write_only image2d_t image, int2 coord, elem_t##4 c) {                    \
     __nvvm_sust_2d_v4i##elem_size##_clamp(                                          \
-        image, coord.x * sizeof(elem_t##4), coord.y, as_##int_rep(c.x),             \
-        as_##int_rep(c.y), as_##int_rep(c.z), as_##int_rep(c.w));                   \
+        image, coord.x * sizeof(elem_t##4), coord.y, __clc_as_##int_rep(c.x),       \
+        __clc_as_##int_rep(c.y), __clc_as_##int_rep(c.z), __clc_as_##int_rep(c.w)); \
   }
 
-#define _CLC_DEFINE_IMAGE3D_WRITE_BUILTIN(elem_t, elem_t_mangled, elem_size,   \
-                                          int_rep, val_mangled)                \
-  _CLC_DEF void                                                                \
-      _Z18__spirv_ImageWriteI14ocl_image3d_woDv4_i##val_mangled##EvT_T0_T1_(   \
-          write_only image3d_t image, int4 coord, elem_t##4 c) {               \
-    __nvvm_sust_3d_v4i##elem_size##_clamp(                                     \
-        image, coord.x * sizeof(elem_t##4), coord.y, coord.z,                  \
-        as_##int_rep(c.x), as_##int_rep(c.y), as_##int_rep(c.z),               \
-        as_##int_rep(c.w));                                                    \
+#define _CLC_DEFINE_IMAGE3D_WRITE_BUILTIN(elem_t, elem_t_mangled, elem_size,       \
+                                          int_rep, val_mangled)                    \
+  _CLC_DEF void                                                                    \
+      _Z18__spirv_ImageWriteI14ocl_image3d_woDv4_i##val_mangled##EvT_T0_T1_(       \
+          write_only image3d_t image, int4 coord, elem_t##4 c) {                   \
+    __nvvm_sust_3d_v4i##elem_size##_clamp(                                         \
+        image, coord.x * sizeof(elem_t##4), coord.y, coord.z,                      \
+        __clc_as_##int_rep(c.x), __clc_as_##int_rep(c.y), __clc_as_##int_rep(c.z), \
+        __clc_as_##int_rep(c.w));                                                  \
   }
 
 _CLC_DEFINE_IMAGE1D_READ_BUILTIN(float, f, 32)
@@ -503,7 +503,7 @@ float4 unnormalized_coord_3d(float4 coord, long image) {
       float coord, long image, int sampler) {                                  \
     if (is_nearest_filter_mode(sampler)) {                                     \
       int i = (int)__spirv_ocl_floor(coord);                                   \
-      return as_##elem_t##4(                                                   \
+      return __clc_as_##elem_t##4(                                             \
           __nvvm_suld_1d_v4i##elem_size##_##cuda_address_mode##_s(             \
               image, i * sizeof(elem_t##4)));                                  \
     } else {                                                                   \
@@ -527,7 +527,7 @@ float4 unnormalized_coord_3d(float4 coord, long image) {
     if (is_nearest_filter_mode(sampler)) {                                     \
       int i = (int)__spirv_ocl_floor(coord.x);                                 \
       int j = (int)__spirv_ocl_floor(coord.y);                                 \
-      return as_##elem_t##4(                                                   \
+      return __clc_as_##elem_t##4(                                             \
           __nvvm_suld_2d_v4i##elem_size##_##cuda_address_mode##_s(             \
               image, i * sizeof(elem_t##4), j));                               \
     } else {                                                                   \
@@ -560,7 +560,7 @@ float4 unnormalized_coord_3d(float4 coord, long image) {
       int i = (int)__spirv_ocl_floor(coord.x);                                 \
       int j = (int)__spirv_ocl_floor(coord.y);                                 \
       int k = (int)__spirv_ocl_floor(coord.z);                                 \
-      return as_##elem_t##4(                                                   \
+      return __clc_as_##elem_t##4(                                             \
           __nvvm_suld_3d_v4i##elem_size##_##cuda_address_mode##_s(             \
               image, i * sizeof(elem_t##4), j, k));                            \
     } else {                                                                   \
@@ -610,7 +610,7 @@ float4 unnormalized_coord_3d(float4 coord, long image) {
       if (i > width - 1) {                                                     \
         i = i - width;                                                         \
       }                                                                        \
-      return as_##elem_t##4(__nvvm_suld_1d_v4i##elem_size##_trap_s(            \
+      return __clc_as_##elem_t##4(__nvvm_suld_1d_v4i##elem_size##_trap_s(      \
           image, i * sizeof(elem_t##4)));                                      \
     } else {                                                                   \
       int i0, i1;                                                              \
@@ -649,7 +649,7 @@ float4 unnormalized_coord_3d(float4 coord, long image) {
       if (j > height - 1) {                                                    \
         j = j - height;                                                        \
       }                                                                        \
-      return as_##elem_t##4(__nvvm_suld_2d_v4i##elem_size##_trap_s(            \
+      return __clc_as_##elem_t##4(__nvvm_suld_2d_v4i##elem_size##_trap_s(      \
           image, i * sizeof(elem_t##4), j));                                   \
     } else {                                                                   \
       int i0, i1, j0, j1;                                                      \
@@ -706,7 +706,7 @@ float4 unnormalized_coord_3d(float4 coord, long image) {
       if (k > depth - 1) {                                                     \
         k = k - depth;                                                         \
       }                                                                        \
-      return as_##elem_t##4(__nvvm_suld_3d_v4i##elem_size##_trap_s(            \
+      return __clc_as_##elem_t##4(__nvvm_suld_3d_v4i##elem_size##_trap_s(      \
           image, i * sizeof(elem_t##4), j, k));                                \
     } else {                                                                   \
       int i0, i1, j0, j1, k0, k1;                                              \
@@ -775,7 +775,7 @@ float4 unnormalized_coord_3d(float4 coord, long image) {
       int i = (int)__spirv_ocl_floor(u);                                       \
       i = __spirv_ocl_s_min(i, width - 1);                                     \
                                                                                \
-      return as_##elem_t##4(__nvvm_suld_1d_v4i##elem_size##_trap_s(            \
+      return __clc_as_##elem_t##4(__nvvm_suld_1d_v4i##elem_size##_trap_s(      \
           image, i * sizeof(elem_t##4)));                                      \
     } else {                                                                   \
       int i0, i1;                                                              \
@@ -811,7 +811,7 @@ float4 unnormalized_coord_3d(float4 coord, long image) {
       int j = (int)__spirv_ocl_floor(v);                                       \
       j = __spirv_ocl_s_min(j, height - 1);                                    \
                                                                                \
-      return as_##elem_t##4(__nvvm_suld_2d_v4i##elem_size##_trap_s(            \
+      return __clc_as_##elem_t##4(__nvvm_suld_2d_v4i##elem_size##_trap_s(      \
           image, i * sizeof(elem_t##4), j));                                   \
     } else {                                                                   \
       int i0, i1, j0, j1;                                                      \
@@ -861,7 +861,7 @@ float4 unnormalized_coord_3d(float4 coord, long image) {
       int k = (int)__spirv_ocl_floor(w);                                       \
       k = __spirv_ocl_s_min(k, depth - 1);                                     \
                                                                                \
-      return as_##elem_t##4(__nvvm_suld_3d_v4i##elem_size##_trap_s(            \
+      return __clc_as_##elem_t##4(__nvvm_suld_3d_v4i##elem_size##_trap_s(      \
           image, i * sizeof(elem_t##4), j, k));                                \
     } else {                                                                   \
       int i0, i1, j0, j1, k0, k1;                                              \
@@ -1067,31 +1067,31 @@ int2 __nvvm_suld_3d_v2i32_clamp_s(long imageHandle, int x, int y, int z) {
 
 // unsigned int
 unsigned int __nvvm_suld_1d_j32_clamp_s(long imageHandle, int coord) {
-  return as_uint(__nvvm_suld_1d_i32_clamp_s(imageHandle, coord));
+  return __clc_as_uint(__nvvm_suld_1d_i32_clamp_s(imageHandle, coord));
 }
 unsigned int __nvvm_suld_2d_j32_clamp_s(long imageHandle, int x, int y) {
-  return as_uint(__nvvm_suld_2d_i32_clamp_s(imageHandle, x, y));
+  return __clc_as_uint(__nvvm_suld_2d_i32_clamp_s(imageHandle, x, y));
 }
 unsigned int __nvvm_suld_3d_j32_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_uint(__nvvm_suld_3d_i32_clamp_s(imageHandle, x, y, z));
+  return __clc_as_uint(__nvvm_suld_3d_i32_clamp_s(imageHandle, x, y, z));
 }
 uint2 __nvvm_suld_1d_v2j32_clamp_s(long imageHandle, int coord) {
-  return as_uint2(__nvvm_suld_1d_v2i32_clamp_s(imageHandle, coord));
+  return __clc_as_uint2(__nvvm_suld_1d_v2i32_clamp_s(imageHandle, coord));
 }
 uint2 __nvvm_suld_2d_v2j32_clamp_s(long imageHandle, int x, int y) {
-  return as_uint2(__nvvm_suld_2d_v2i32_clamp_s(imageHandle, x, y));
+  return __clc_as_uint2(__nvvm_suld_2d_v2i32_clamp_s(imageHandle, x, y));
 }
 uint2 __nvvm_suld_3d_v2j32_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_uint2(__nvvm_suld_3d_v2i32_clamp_s(imageHandle, x, y, z));
+  return __clc_as_uint2(__nvvm_suld_3d_v2i32_clamp_s(imageHandle, x, y, z));
 }
 uint4 __nvvm_suld_1d_v4j32_clamp_s(long imageHandle, int coord) {
-  return as_uint4(__nvvm_suld_1d_v4i32_clamp_s(imageHandle, coord));
+  return __clc_as_uint4(__nvvm_suld_1d_v4i32_clamp_s(imageHandle, coord));
 }
 uint4 __nvvm_suld_2d_v4j32_clamp_s(long imageHandle, int x, int y) {
-  return as_uint4(__nvvm_suld_2d_v4i32_clamp_s(imageHandle, x, y));
+  return __clc_as_uint4(__nvvm_suld_2d_v4i32_clamp_s(imageHandle, x, y));
 }
 uint4 __nvvm_suld_3d_v4j32_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_uint4(__nvvm_suld_3d_v4i32_clamp_s(imageHandle, x, y, z));
+  return __clc_as_uint4(__nvvm_suld_3d_v4i32_clamp_s(imageHandle, x, y, z));
 }
 
 // short -- short4 already defined
@@ -1119,53 +1119,53 @@ short2 __nvvm_suld_3d_v2i16_clamp_s(long imageHandle, int x, int y, int z) {
 
 // unsigned short
 unsigned short __nvvm_suld_1d_t16_clamp_s(long imageHandle, int coord) {
-  return as_ushort(__nvvm_suld_1d_i16_clamp_s(imageHandle, coord));
+  return __clc_as_ushort(__nvvm_suld_1d_i16_clamp_s(imageHandle, coord));
 }
 unsigned short __nvvm_suld_2d_t16_clamp_s(long imageHandle, int x, int y) {
-  return as_ushort(__nvvm_suld_2d_i16_clamp_s(imageHandle, x, y));
+  return __clc_as_ushort(__nvvm_suld_2d_i16_clamp_s(imageHandle, x, y));
 }
 unsigned short __nvvm_suld_3d_t16_clamp_s(long imageHandle, int x, int y,
                                           int z) {
-  return as_ushort(__nvvm_suld_3d_i16_clamp_s(imageHandle, x, y, z));
+  return __clc_as_ushort(__nvvm_suld_3d_i16_clamp_s(imageHandle, x, y, z));
 }
 ushort2 __nvvm_suld_1d_v2t16_clamp_s(long imageHandle, int coord) {
-  return as_ushort2(__nvvm_suld_1d_v2i16_clamp_s(imageHandle, coord));
+  return __clc_as_ushort2(__nvvm_suld_1d_v2i16_clamp_s(imageHandle, coord));
 }
 ushort2 __nvvm_suld_2d_v2t16_clamp_s(long imageHandle, int x, int y) {
-  return as_ushort2(__nvvm_suld_2d_v2i16_clamp_s(imageHandle, x, y));
+  return __clc_as_ushort2(__nvvm_suld_2d_v2i16_clamp_s(imageHandle, x, y));
 }
 ushort2 __nvvm_suld_3d_v2t16_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_ushort2(__nvvm_suld_3d_v2i16_clamp_s(imageHandle, x, y, z));
+  return __clc_as_ushort2(__nvvm_suld_3d_v2i16_clamp_s(imageHandle, x, y, z));
 }
 ushort4 __nvvm_suld_1d_v4t16_clamp_s(long imageHandle, int coord) {
-  return as_ushort4(__nvvm_suld_1d_v4i16_clamp_s(imageHandle, coord));
+  return __clc_as_ushort4(__nvvm_suld_1d_v4i16_clamp_s(imageHandle, coord));
 }
 ushort4 __nvvm_suld_2d_v4t16_clamp_s(long imageHandle, int x, int y) {
-  return as_ushort4(__nvvm_suld_2d_v4i16_clamp_s(imageHandle, x, y));
+  return __clc_as_ushort4(__nvvm_suld_2d_v4i16_clamp_s(imageHandle, x, y));
 }
 ushort4 __nvvm_suld_3d_v4t16_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_ushort4(__nvvm_suld_3d_v4i16_clamp_s(imageHandle, x, y, z));
+  return __clc_as_ushort4(__nvvm_suld_3d_v4i16_clamp_s(imageHandle, x, y, z));
 }
 
 // signed char
 short __nvvm_suld_1d_i8_clamp_s_helper(long,
                                        int) __asm("llvm.nvvm.suld.1d.i8.clamp");
 signed char __nvvm_suld_1d_i8_clamp_s(long imageHandle, int coord) {
-  return as_char(
+  return __clc_as_char(
       (signed char)__nvvm_suld_1d_i8_clamp_s_helper(imageHandle, coord));
 }
 
 short __nvvm_suld_2d_i8_clamp_s_helper(long, int,
                                        int) __asm("llvm.nvvm.suld.2d.i8.clamp");
 signed char __nvvm_suld_2d_i8_clamp_s(long imageHandle, int x, int y) {
-  return as_char(
+  return __clc_as_char(
       (signed char)__nvvm_suld_2d_i8_clamp_s_helper(imageHandle, x, y));
 }
 
 short __nvvm_suld_3d_i8_clamp_s_helper(long, int, int,
                                        int) __asm("llvm.nvvm.suld.3d.i8.clamp");
 signed char __nvvm_suld_3d_i8_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_char(
+  return __clc_as_char(
       (signed char)__nvvm_suld_3d_i8_clamp_s_helper(imageHandle, x, y, z));
 }
 
@@ -1215,7 +1215,7 @@ char4 __nvvm_suld_3d_v4i8_clamp_s(long imageHandle, int x, int y, int z) {
 unsigned short
 __nvvm_suld_1d_h8_clamp_s_helper(long, int) __asm("llvm.nvvm.suld.1d.i8.clamp");
 unsigned char __nvvm_suld_1d_h8_clamp_s(long imageHandle, int coord) {
-  return as_uchar(
+  return __clc_as_uchar(
       (unsigned char)__nvvm_suld_1d_h8_clamp_s_helper(imageHandle, coord));
 }
 
@@ -1223,7 +1223,7 @@ unsigned short
 __nvvm_suld_2d_h8_clamp_s_helper(long, int,
                                  int) __asm("llvm.nvvm.suld.2d.i8.clamp");
 unsigned char __nvvm_suld_2d_h8_clamp_s(long imageHandle, int x, int y) {
-  return as_uchar(
+  return __clc_as_uchar(
       (unsigned char)__nvvm_suld_2d_h8_clamp_s_helper(imageHandle, x, y));
 }
 
@@ -1232,7 +1232,7 @@ __nvvm_suld_3d_h8_clamp_s_helper(long, int, int,
                                  int) __asm("llvm.nvvm.suld.3d.i8.clamp");
 
 unsigned char __nvvm_suld_3d_h8_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_uchar(
+  return __clc_as_uchar(
       (unsigned char)__nvvm_suld_3d_h8_clamp_s_helper(imageHandle, x, y, z));
 }
 
@@ -1268,60 +1268,60 @@ uchar4 __nvvm_suld_3d_v4h8_clamp_s(long imageHandle, int x, int y, int z) {
 
 // float
 float __nvvm_suld_1d_f32_clamp_s(long imageHandle, int coord) {
-  return as_float(__nvvm_suld_1d_i32_clamp_s(imageHandle, coord));
+  return __clc_as_float(__nvvm_suld_1d_i32_clamp_s(imageHandle, coord));
 }
 float __nvvm_suld_2d_f32_clamp_s(long imageHandle, int x, int y) {
-  return as_float(__nvvm_suld_2d_i32_clamp_s(imageHandle, x, y));
+  return __clc_as_float(__nvvm_suld_2d_i32_clamp_s(imageHandle, x, y));
 }
 float __nvvm_suld_3d_f32_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_float(__nvvm_suld_3d_i32_clamp_s(imageHandle, x, y, z));
+  return __clc_as_float(__nvvm_suld_3d_i32_clamp_s(imageHandle, x, y, z));
 }
 float2 __nvvm_suld_1d_v2f32_clamp_s(long imageHandle, int coord) {
-  return as_float2(__nvvm_suld_1d_v2i32_clamp_s(imageHandle, coord));
+  return __clc_as_float2(__nvvm_suld_1d_v2i32_clamp_s(imageHandle, coord));
 }
 float2 __nvvm_suld_2d_v2f32_clamp_s(long imageHandle, int x, int y) {
-  return as_float2(__nvvm_suld_2d_v2i32_clamp_s(imageHandle, x, y));
+  return __clc_as_float2(__nvvm_suld_2d_v2i32_clamp_s(imageHandle, x, y));
 }
 float2 __nvvm_suld_3d_v2f32_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_float2(__nvvm_suld_3d_v2i32_clamp_s(imageHandle, x, y, z));
+  return __clc_as_float2(__nvvm_suld_3d_v2i32_clamp_s(imageHandle, x, y, z));
 }
 float4 __nvvm_suld_1d_v4f32_clamp_s(long imageHandle, int coord) {
-  return as_float4(__nvvm_suld_1d_v4i32_clamp_s(imageHandle, coord));
+  return __clc_as_float4(__nvvm_suld_1d_v4i32_clamp_s(imageHandle, coord));
 }
 float4 __nvvm_suld_2d_v4f32_clamp_s(long imageHandle, int x, int y) {
-  return as_float4(__nvvm_suld_2d_v4i32_clamp_s(imageHandle, x, y));
+  return __clc_as_float4(__nvvm_suld_2d_v4i32_clamp_s(imageHandle, x, y));
 }
 float4 __nvvm_suld_3d_v4f32_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_float4(__nvvm_suld_3d_v4i32_clamp_s(imageHandle, x, y, z));
+  return __clc_as_float4(__nvvm_suld_3d_v4i32_clamp_s(imageHandle, x, y, z));
 }
 
 // half
 half __nvvm_suld_1d_f16_clamp_s(long imageHandle, int coord) {
-  return as_half(__nvvm_suld_1d_i16_clamp_s(imageHandle, coord));
+  return __clc_as_half(__nvvm_suld_1d_i16_clamp_s(imageHandle, coord));
 }
 half __nvvm_suld_2d_f16_clamp_s(long imageHandle, int x, int y) {
-  return as_half(__nvvm_suld_2d_i16_clamp_s(imageHandle, x, y));
+  return __clc_as_half(__nvvm_suld_2d_i16_clamp_s(imageHandle, x, y));
 }
 half __nvvm_suld_3d_f16_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_half(__nvvm_suld_3d_i16_clamp_s(imageHandle, x, y, z));
+  return __clc_as_half(__nvvm_suld_3d_i16_clamp_s(imageHandle, x, y, z));
 }
 half2 __nvvm_suld_1d_v2f16_clamp_s(long imageHandle, int coord) {
-  return as_half2(__nvvm_suld_1d_v2i16_clamp_s(imageHandle, coord));
+  return __clc_as_half2(__nvvm_suld_1d_v2i16_clamp_s(imageHandle, coord));
 }
 half2 __nvvm_suld_2d_v2f16_clamp_s(long imageHandle, int x, int y) {
-  return as_half2(__nvvm_suld_2d_v2i16_clamp_s(imageHandle, x, y));
+  return __clc_as_half2(__nvvm_suld_2d_v2i16_clamp_s(imageHandle, x, y));
 }
 half2 __nvvm_suld_3d_v2f16_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_half2(__nvvm_suld_3d_v2i16_clamp_s(imageHandle, x, y, z));
+  return __clc_as_half2(__nvvm_suld_3d_v2i16_clamp_s(imageHandle, x, y, z));
 }
 half4 __nvvm_suld_1d_v4f16_clamp_s(long imageHandle, int coord) {
-  return as_half4(__nvvm_suld_1d_v4i16_clamp_s(imageHandle, coord));
+  return __clc_as_half4(__nvvm_suld_1d_v4i16_clamp_s(imageHandle, coord));
 }
 half4 __nvvm_suld_2d_v4f16_clamp_s(long imageHandle, int x, int y) {
-  return as_half4(__nvvm_suld_2d_v4i16_clamp_s(imageHandle, x, y));
+  return __clc_as_half4(__nvvm_suld_2d_v4i16_clamp_s(imageHandle, x, y));
 }
 half4 __nvvm_suld_3d_v4f16_clamp_s(long imageHandle, int x, int y, int z) {
-  return as_half4(__nvvm_suld_3d_v4i16_clamp_s(imageHandle, x, y, z));
+  return __clc_as_half4(__nvvm_suld_3d_v4i16_clamp_s(imageHandle, x, y, z));
 }
 
 // Generated funcs -- WRITES
@@ -1349,46 +1349,46 @@ void __nvvm_sust_3d_v4i32_clamp_s(unsigned long, int, int, int, int, int, int,
 // unsigned int
 void __nvvm_sust_1d_j32_clamp_s(unsigned long imageHandle, int coord,
                                 unsigned int a) {
-  return __nvvm_sust_1d_i32_clamp_s(imageHandle, coord, as_int(a));
+  return __nvvm_sust_1d_i32_clamp_s(imageHandle, coord, __clc_as_int(a));
 }
 void __nvvm_sust_2d_j32_clamp_s(unsigned long imageHandle, int x, int y,
                                 unsigned int a) {
-  return __nvvm_sust_2d_i32_clamp_s(imageHandle, x, y, as_int(a));
+  return __nvvm_sust_2d_i32_clamp_s(imageHandle, x, y, __clc_as_int(a));
 }
 void __nvvm_sust_3d_j32_clamp_s(unsigned long imageHandle, int x, int y, int z,
                                 unsigned int a) {
-  return __nvvm_sust_3d_i32_clamp_s(imageHandle, x, y, z, as_int(a));
+  return __nvvm_sust_3d_i32_clamp_s(imageHandle, x, y, z, __clc_as_int(a));
 }
 void __nvvm_sust_1d_v2j32_clamp_s(unsigned long imageHandle, int coord,
                                   unsigned int a, unsigned int b) {
-  return __nvvm_sust_1d_v2i32_clamp_s(imageHandle, coord, as_int(a), as_int(b));
+  return __nvvm_sust_1d_v2i32_clamp_s(imageHandle, coord, __clc_as_int(a), __clc_as_int(b));
 }
 void __nvvm_sust_2d_v2j32_clamp_s(unsigned long imageHandle, int x, int y,
                                   unsigned int a, unsigned int b) {
-  return __nvvm_sust_2d_v2i32_clamp_s(imageHandle, x, y, as_int(a), as_int(b));
+  return __nvvm_sust_2d_v2i32_clamp_s(imageHandle, x, y, __clc_as_int(a), __clc_as_int(b));
 }
 void __nvvm_sust_3d_v2j32_clamp_s(unsigned long imageHandle, int x, int y,
                                   int z, unsigned int a, unsigned int b) {
-  return __nvvm_sust_3d_v2i32_clamp_s(imageHandle, x, y, z, as_int(a),
-                                      as_int(b));
+  return __nvvm_sust_3d_v2i32_clamp_s(imageHandle, x, y, z, __clc_as_int(a),
+                                      __clc_as_int(b));
 }
 void __nvvm_sust_1d_v4j32_clamp_s(unsigned long imageHandle, int coord,
                                   unsigned int a, unsigned int b,
                                   unsigned int c, unsigned int d) {
-  return __nvvm_sust_1d_v4i32_clamp_s(imageHandle, coord, as_int(a), as_int(b),
-                                      as_int(c), as_int(d));
+  return __nvvm_sust_1d_v4i32_clamp_s(imageHandle, coord, __clc_as_int(a), __clc_as_int(b),
+                                      __clc_as_int(c), __clc_as_int(d));
 }
 void __nvvm_sust_2d_v4j32_clamp_s(unsigned long imageHandle, int x, int y,
                                   unsigned int a, unsigned int b,
                                   unsigned int c, unsigned int d) {
-  return __nvvm_sust_2d_v4i32_clamp_s(imageHandle, x, y, as_int(a), as_int(b),
-                                      as_int(c), as_int(d));
+  return __nvvm_sust_2d_v4i32_clamp_s(imageHandle, x, y, __clc_as_int(a), __clc_as_int(b),
+                                      __clc_as_int(c), __clc_as_int(d));
 }
 void __nvvm_sust_3d_v4j32_clamp_s(unsigned long imageHandle, int x, int y,
                                   int z, unsigned int a, unsigned int b,
                                   unsigned int c, unsigned int d) {
-  return __nvvm_sust_3d_v4i32_clamp_s(imageHandle, x, y, z, as_int(a),
-                                      as_int(b), as_int(c), as_int(d));
+  return __nvvm_sust_3d_v4i32_clamp_s(imageHandle, x, y, z, __clc_as_int(a),
+                                      __clc_as_int(b), __clc_as_int(c), __clc_as_int(d));
 }
 
 // short
@@ -1418,48 +1418,48 @@ void __nvvm_sust_3d_v4i16_clamp_s(
 // unsigned short
 void __nvvm_sust_1d_t16_clamp_s(unsigned long imageHandle, int coord,
                                 unsigned short a) {
-  return __nvvm_sust_1d_i16_clamp_s(imageHandle, coord, as_ushort(a));
+  return __nvvm_sust_1d_i16_clamp_s(imageHandle, coord, __clc_as_ushort(a));
 }
 void __nvvm_sust_2d_t16_clamp_s(unsigned long imageHandle, int x, int y,
                                 unsigned short a) {
-  return __nvvm_sust_2d_i16_clamp_s(imageHandle, x, y, as_ushort(a));
+  return __nvvm_sust_2d_i16_clamp_s(imageHandle, x, y, __clc_as_ushort(a));
 }
 void __nvvm_sust_3d_t16_clamp_s(unsigned long imageHandle, int x, int y, int z,
                                 unsigned short a) {
-  return __nvvm_sust_3d_i16_clamp_s(imageHandle, x, y, z, as_ushort(a));
+  return __nvvm_sust_3d_i16_clamp_s(imageHandle, x, y, z, __clc_as_ushort(a));
 }
 void __nvvm_sust_1d_v2t16_clamp_s(unsigned long imageHandle, int coord,
                                   unsigned short a, unsigned short b) {
-  return __nvvm_sust_1d_v2i16_clamp_s(imageHandle, coord, as_ushort(a),
-                                      as_ushort(b));
+  return __nvvm_sust_1d_v2i16_clamp_s(imageHandle, coord, __clc_as_ushort(a),
+                                      __clc_as_ushort(b));
 }
 void __nvvm_sust_2d_v2t16_clamp_s(unsigned long imageHandle, int x, int y,
                                   unsigned short a, unsigned short b) {
-  return __nvvm_sust_2d_v2i16_clamp_s(imageHandle, x, y, as_ushort(a),
-                                      as_ushort(b));
+  return __nvvm_sust_2d_v2i16_clamp_s(imageHandle, x, y, __clc_as_ushort(a),
+                                      __clc_as_ushort(b));
 }
 void __nvvm_sust_3d_v2t16_clamp_s(unsigned long imageHandle, int x, int y,
                                   int z, unsigned short a, unsigned short b) {
-  return __nvvm_sust_3d_v2i16_clamp_s(imageHandle, x, y, z, as_ushort(a),
-                                      as_ushort(b));
+  return __nvvm_sust_3d_v2i16_clamp_s(imageHandle, x, y, z, __clc_as_ushort(a),
+                                      __clc_as_ushort(b));
 }
 void __nvvm_sust_1d_v4t16_clamp_s(unsigned long imageHandle, int coord,
                                   unsigned short a, unsigned short b,
                                   unsigned short c, unsigned short d) {
-  return __nvvm_sust_1d_v4i16_clamp_s(imageHandle, coord, as_ushort(a),
-                                      as_ushort(b), as_short(c), as_ushort(d));
+  return __nvvm_sust_1d_v4i16_clamp_s(imageHandle, coord, __clc_as_ushort(a),
+                                      __clc_as_ushort(b), __clc_as_short(c), __clc_as_ushort(d));
 }
 void __nvvm_sust_2d_v4t16_clamp_s(unsigned long imageHandle, int x, int y,
                                   unsigned short a, unsigned short b,
                                   unsigned short c, unsigned short d) {
-  return __nvvm_sust_2d_v4i16_clamp_s(imageHandle, x, y, as_ushort(a),
-                                      as_ushort(b), as_short(c), as_ushort(d));
+  return __nvvm_sust_2d_v4i16_clamp_s(imageHandle, x, y, __clc_as_ushort(a),
+                                      __clc_as_ushort(b), __clc_as_short(c), __clc_as_ushort(d));
 }
 void __nvvm_sust_3d_v4t16_clamp_s(unsigned long imageHandle, int x, int y,
                                   int z, unsigned short a, unsigned short b,
                                   unsigned short c, unsigned short d) {
-  return __nvvm_sust_3d_v4i16_clamp_s(imageHandle, x, y, z, as_ushort(a),
-                                      as_ushort(b), as_short(c), as_ushort(d));
+  return __nvvm_sust_3d_v4i16_clamp_s(imageHandle, x, y, z, __clc_as_ushort(a),
+                                      __clc_as_ushort(b), __clc_as_short(c), __clc_as_ushort(d));
 }
 
 // char  -- i8 intrinsic returns i16, requires helper
@@ -1584,86 +1584,86 @@ void __nvvm_sust_3d_v4h8_clamp_s(unsigned long imageHandle, int x, int y, int z,
 
 // float
 void __nvvm_sust_1d_f32_clamp_s(unsigned long imageHandle, int coord, float a) {
-  return __nvvm_sust_1d_i32_clamp_s(imageHandle, coord, as_int(a));
+  return __nvvm_sust_1d_i32_clamp_s(imageHandle, coord, __clc_as_int(a));
 }
 void __nvvm_sust_2d_f32_clamp_s(unsigned long imageHandle, int x, int y,
                                 float a) {
-  return __nvvm_sust_2d_i32_clamp_s(imageHandle, x, y, as_int(a));
+  return __nvvm_sust_2d_i32_clamp_s(imageHandle, x, y, __clc_as_int(a));
 }
 void __nvvm_sust_3d_f32_clamp_s(unsigned long imageHandle, int x, int y, int z,
                                 float a) {
-  return __nvvm_sust_3d_i32_clamp_s(imageHandle, x, y, z, as_int(a));
+  return __nvvm_sust_3d_i32_clamp_s(imageHandle, x, y, z, __clc_as_int(a));
 }
 void __nvvm_sust_1d_v2f32_clamp_s(unsigned long imageHandle, int coord, float a,
                                   float b) {
-  return __nvvm_sust_1d_v2i32_clamp_s(imageHandle, coord, as_int(a), as_int(b));
+  return __nvvm_sust_1d_v2i32_clamp_s(imageHandle, coord, __clc_as_int(a), __clc_as_int(b));
 }
 void __nvvm_sust_2d_v2f32_clamp_s(unsigned long imageHandle, int x, int y,
                                   float a, float b) {
-  return __nvvm_sust_2d_v2i32_clamp_s(imageHandle, x, y, as_int(a), as_int(b));
+  return __nvvm_sust_2d_v2i32_clamp_s(imageHandle, x, y, __clc_as_int(a), __clc_as_int(b));
 }
 void __nvvm_sust_3d_v2f32_clamp_s(unsigned long imageHandle, int x, int y,
                                   int z, float a, float b) {
-  return __nvvm_sust_3d_v2i32_clamp_s(imageHandle, x, y, z, as_int(a),
-                                      as_int(b));
+  return __nvvm_sust_3d_v2i32_clamp_s(imageHandle, x, y, z, __clc_as_int(a),
+                                      __clc_as_int(b));
 }
 void __nvvm_sust_1d_v4f32_clamp_s(unsigned long imageHandle, int coord, float a,
                                   float b, float c, float d) {
-  return __nvvm_sust_1d_v4i32_clamp_s(imageHandle, coord, as_int(a), as_int(b),
-                                      as_int(c), as_int(d));
+  return __nvvm_sust_1d_v4i32_clamp_s(imageHandle, coord, __clc_as_int(a), __clc_as_int(b),
+                                      __clc_as_int(c), __clc_as_int(d));
 }
 void __nvvm_sust_2d_v4f32_clamp_s(unsigned long imageHandle, int x, int y,
                                   float a, float b, float c, float d) {
-  return __nvvm_sust_2d_v4i32_clamp_s(imageHandle, x, y, as_int(a), as_int(b),
-                                      as_int(c), as_int(d));
+  return __nvvm_sust_2d_v4i32_clamp_s(imageHandle, x, y, __clc_as_int(a), __clc_as_int(b),
+                                      __clc_as_int(c), __clc_as_int(d));
 }
 void __nvvm_sust_3d_v4f32_clamp_s(unsigned long imageHandle, int x, int y,
                                   int z, float a, float b, float c, float d) {
-  return __nvvm_sust_3d_v4i32_clamp_s(imageHandle, x, y, z, as_int(a),
-                                      as_int(b), as_int(c), as_int(d));
+  return __nvvm_sust_3d_v4i32_clamp_s(imageHandle, x, y, z, __clc_as_int(a),
+                                      __clc_as_int(b), __clc_as_int(c), __clc_as_int(d));
 }
 
 // half
 void __nvvm_sust_1d_f16_clamp_s(unsigned long imageHandle, int coord, half a) {
-  return __nvvm_sust_1d_i16_clamp_s(imageHandle, coord, as_short(a));
+  return __nvvm_sust_1d_i16_clamp_s(imageHandle, coord, __clc_as_short(a));
 }
 void __nvvm_sust_2d_f16_clamp_s(unsigned long imageHandle, int x, int y,
                                 half a) {
-  return __nvvm_sust_2d_i16_clamp_s(imageHandle, x, y, as_short(a));
+  return __nvvm_sust_2d_i16_clamp_s(imageHandle, x, y, __clc_as_short(a));
 }
 void __nvvm_sust_3d_f16_clamp_s(unsigned long imageHandle, int x, int y, int z,
                                 half a) {
-  return __nvvm_sust_3d_i16_clamp_s(imageHandle, x, y, z, as_short(a));
+  return __nvvm_sust_3d_i16_clamp_s(imageHandle, x, y, z, __clc_as_short(a));
 }
 void __nvvm_sust_1d_v2f16_clamp_s(unsigned long imageHandle, int coord, half a,
                                   half b) {
-  return __nvvm_sust_1d_v2i16_clamp_s(imageHandle, coord, as_short(a),
-                                      as_short(b));
+  return __nvvm_sust_1d_v2i16_clamp_s(imageHandle, coord, __clc_as_short(a),
+                                      __clc_as_short(b));
 }
 void __nvvm_sust_2d_v2f16_clamp_s(unsigned long imageHandle, int x, int y,
                                   half a, half b) {
-  return __nvvm_sust_2d_v2i16_clamp_s(imageHandle, x, y, as_short(a),
-                                      as_short(b));
+  return __nvvm_sust_2d_v2i16_clamp_s(imageHandle, x, y, __clc_as_short(a),
+                                      __clc_as_short(b));
 }
 void __nvvm_sust_3d_v2f16_clamp_s(unsigned long imageHandle, int x, int y,
                                   int z, half a, half b) {
-  return __nvvm_sust_3d_v2i16_clamp_s(imageHandle, x, y, z, as_short(a),
-                                      as_short(b));
+  return __nvvm_sust_3d_v2i16_clamp_s(imageHandle, x, y, z, __clc_as_short(a),
+                                      __clc_as_short(b));
 }
 void __nvvm_sust_1d_v4f16_clamp_s(unsigned long imageHandle, int coord, half a,
                                   half b, half c, half d) {
-  return __nvvm_sust_1d_v4i16_clamp_s(imageHandle, coord, as_short(a),
-                                      as_short(b), as_short(c), as_short(d));
+  return __nvvm_sust_1d_v4i16_clamp_s(imageHandle, coord, __clc_as_short(a),
+                                      __clc_as_short(b), __clc_as_short(c), __clc_as_short(d));
 }
 void __nvvm_sust_2d_v4f16_clamp_s(unsigned long imageHandle, int x, int y,
                                   half a, half b, half c, half d) {
-  return __nvvm_sust_2d_v4i16_clamp_s(imageHandle, x, y, as_short(a),
-                                      as_short(b), as_short(c), as_short(d));
+  return __nvvm_sust_2d_v4i16_clamp_s(imageHandle, x, y, __clc_as_short(a),
+                                      __clc_as_short(b), __clc_as_short(c), __clc_as_short(d));
 }
 void __nvvm_sust_3d_v4f16_clamp_s(unsigned long imageHandle, int x, int y,
                                   int z, half a, half b, half c, half d) {
-  return __nvvm_sust_3d_v4i16_clamp_s(imageHandle, x, y, z, as_short(a),
-                                      as_short(b), as_short(c), as_short(d));
+  return __nvvm_sust_3d_v4i16_clamp_s(imageHandle, x, y, z, __clc_as_short(a),
+                                      __clc_as_short(b), __clc_as_short(c), __clc_as_short(d));
 }
 
 #define _CLC_DEFINE_IMAGE_BINDLESS_FETCH_BUILTIN(                              \
@@ -3615,13 +3615,13 @@ BINDLESS_INTRINSIC_FUNC_ALL(float, f, f, 32, )
                                                    int idx, int x) {           \
     fetch_elem_t a = __nvvm_suld_1d_array_##fetch_vec_size##_clamp_s##helper(  \
         imageHandle, idx, x);                                                  \
-    return as_##elem_t(cast_##fetch_elem_t##_to_##cast_to_elem_t(a));          \
+    return __clc_as_##elem_t(cast_##fetch_elem_t##_to_##cast_to_elem_t(a));          \
   }                                                                            \
   elem_t __nvvm_suld_2d_array_##vec_size##_clamp_s(unsigned long imageHandle,  \
                                                    int idx, int x, int y) {    \
     fetch_elem_t a = __nvvm_suld_2d_array_##fetch_vec_size##_clamp_s##helper(  \
         imageHandle, idx, x, y);                                               \
-    return as_##elem_t(cast_##fetch_elem_t##_to_##cast_to_elem_t(a));          \
+    return __clc_as_##elem_t(cast_##fetch_elem_t##_to_##cast_to_elem_t(a));          \
   }
 
 _CLC_DEFINE_SURFACE_ARRAY_BINDLESS_THUNK_READS_BUILTIN(uint, int, uint, j32, i32, )
@@ -3656,10 +3656,10 @@ _CLC_DEFINE_SURFACE_ARRAY_BINDLESS_THUNK_READS_BUILTIN(half4, short4, short4, v4
 #define COLOR_INPUT_2_CHANNEL(elem_t) elem_t a, elem_t b
 #define COLOR_INPUT_4_CHANNEL(elem_t) elem_t a, elem_t b, elem_t c, elem_t d
 
-#define COLOR_PARAMS_1_CHANNEL_AS_TYPE(elem_t) as_##elem_t(a)
-#define COLOR_PARAMS_2_CHANNEL_AS_TYPE(elem_t) as_##elem_t(a), as_##elem_t(b)
+#define COLOR_PARAMS_1_CHANNEL_AS_TYPE(elem_t) __clc_as_##elem_t(a)
+#define COLOR_PARAMS_2_CHANNEL_AS_TYPE(elem_t) __clc_as_##elem_t(a), __clc_as_##elem_t(b)
 #define COLOR_PARAMS_4_CHANNEL_AS_TYPE(elem_t)                                 \
-  as_##elem_t(a), as_##elem_t(b), as_##elem_t(c), as_##elem_t(d)
+  __clc_as_##elem_t(a), __clc_as_##elem_t(b), __clc_as_##elem_t(c), __clc_as_##elem_t(d)
 
 #define COLOR_PARAMS_1_CHANNEL_C_CAST(elem_t) (elem_t) a
 #define COLOR_PARAMS_2_CHANNEL_C_CAST(elem_t) (elem_t) a, (elem_t)b
@@ -3722,25 +3722,25 @@ _CLC_DEFINE_SURFACE_ARRAY_BINDLESS_THUNK_WRITES_BUILTIN(half, short, v4f16, v4i1
       unsigned long imageHandle, int idx, int x) {                             \
     fetch_elem_t a = __nvvm_tex_unified_1d_array_##fetch_vec_size##_i32(       \
         imageHandle, idx, x) index;                                            \
-    return as_##elem_t(cast_##fetch_elem_t##_to_##elem_t(a));          \
+    return __clc_as_##elem_t(cast_##fetch_elem_t##_to_##elem_t(a));          \
   }                                                                            \
   elem_t __nvvm_tex_unified_1d_array_##vec_size##_f32(                         \
       unsigned long imageHandle, int idx, float x) {                           \
     fetch_elem_t a = __nvvm_tex_unified_1d_array_##fetch_vec_size##_f32(       \
         imageHandle, idx, x) index;                                            \
-    return as_##elem_t(cast_##fetch_elem_t##_to_##elem_t(a));          \
+    return __clc_as_##elem_t(cast_##fetch_elem_t##_to_##elem_t(a));          \
   }                                                                            \
   elem_t __nvvm_tex_unified_2d_array_##vec_size##_i32(                         \
       unsigned long imageHandle, int idx, int x, int y) {                      \
     fetch_elem_t a = __nvvm_tex_unified_2d_array_##fetch_vec_size##_i32(       \
         imageHandle, idx, x, y) index;                                         \
-    return as_##elem_t(cast_##fetch_elem_t##_to_##elem_t(a));          \
+    return __clc_as_##elem_t(cast_##fetch_elem_t##_to_##elem_t(a));          \
   }                                                                            \
   elem_t __nvvm_tex_unified_2d_array_##vec_size##_f32(                         \
       unsigned long imageHandle, int idx, float x, float y) {                  \
     fetch_elem_t a = __nvvm_tex_unified_2d_array_##fetch_vec_size##_f32(       \
         imageHandle, idx, x, y) index;                                         \
-    return as_##elem_t(cast_##fetch_elem_t##_to_##elem_t(a));          \
+    return __clc_as_##elem_t(cast_##fetch_elem_t##_to_##elem_t(a));          \
   }
 
 // int4 handled above


### PR DESCRIPTION
This removes one dependency on OpenCL library.