### PR TITLE
[UR] ASan layer fix and test update

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -332,7 +332,7 @@ AsanInterceptor::getOrCreateShadowMemory(ur_device_handle_t Device,
     }
     std::shared_ptr<ContextInfo> CI;
     insertContext(InternalContext, CI);
-    m_ShadowMap[Type] = GetShadowMemory(InternalContext, Device, Type);
+    m_ShadowMap[Type] = CreateShadowMemory(InternalContext, Device, Type);
     m_ShadowMap[Type]->Setup();
   }
   return m_ShadowMap[Type];

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
@@ -20,21 +20,15 @@
 namespace ur_sanitizer_layer {
 namespace asan {
 
-std::shared_ptr<ShadowMemory> GetShadowMemory(ur_context_handle_t Context,
-                                              ur_device_handle_t Device,
-                                              DeviceType Type) {
+std::shared_ptr<ShadowMemory> CreateShadowMemory(ur_context_handle_t Context,
+                                                 ur_device_handle_t Device,
+                                                 DeviceType Type) {
   if (Type == DeviceType::CPU) {
-    static std::shared_ptr<ShadowMemory> ShadowCPU =
-        std::make_shared<ShadowMemoryCPU>(Context, Device);
-    return ShadowCPU;
+    return std::make_shared<ShadowMemoryCPU>(Context, Device);
   } else if (Type == DeviceType::GPU_PVC) {
-    static std::shared_ptr<ShadowMemory> ShadowPVC =
-        std::make_shared<ShadowMemoryPVC>(Context, Device);
-    return ShadowPVC;
+    return std::make_shared<ShadowMemoryPVC>(Context, Device);
   } else if (Type == DeviceType::GPU_DG2) {
-    static std::shared_ptr<ShadowMemory> ShadowDG2 =
-        std::make_shared<ShadowMemoryDG2>(Context, Device);
-    return ShadowDG2;
+    return std::make_shared<ShadowMemoryDG2>(Context, Device);
   } else {
     getContext()->logger.error("Unsupport device type");
     return nullptr;

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.hpp
@@ -163,9 +163,9 @@ struct ShadowMemoryDG2 final : public ShadowMemoryGPU {
   size_t GetShadowSize() override { return 0x100000000000ULL; }
 };
 
-std::shared_ptr<ShadowMemory> GetShadowMemory(ur_context_handle_t Context,
-                                              ur_device_handle_t Device,
-                                              DeviceType Type);
+std::shared_ptr<ShadowMemory> CreateShadowMemory(ur_context_handle_t Context,
+                                                 ur_device_handle_t Device,
+                                                 DeviceType Type);
 
 } // namespace asan
 } // namespace ur_sanitizer_layer

--- a/unified-runtime/test/layers/sanitizer/asan.cpp
+++ b/unified-runtime/test/layers/sanitizer/asan.cpp
@@ -26,30 +26,47 @@ TEST(DeviceAsan, Initialization) {
   status = urLoaderInit(0, loaderConfig);
   ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  ur_adapter_handle_t adapter;
-  status = urAdapterGet(1, &adapter, nullptr);
+  uint32_t num_adapters;
+  status = urAdapterGet(0, nullptr, &num_adapters);
   ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  ur_platform_handle_t platform;
-  status = urPlatformGet(&adapter, 1, 1, &platform, nullptr);
+  std::vector<ur_adapter_handle_t> adapters;
+  adapters.resize(num_adapters);
+  status = urAdapterGet(num_adapters, adapters.data(), nullptr);
   ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  ur_device_handle_t device;
-  status = urDeviceGet(platform, UR_DEVICE_TYPE_DEFAULT, 1, &device, nullptr);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+  for (auto adapter : adapters) {
+    ur_adapter_backend_t backend;
+    status = urAdapterGetInfo(adapter, UR_ADAPTER_INFO_BACKEND, sizeof(backend),
+                              &backend, nullptr);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    if (backend == UR_ADAPTER_BACKEND_OPENCL ||
+        backend == UR_ADAPTER_BACKEND_HIP) {
+      // Helper methods are unsupported
+      continue;
+    }
 
-  ur_context_handle_t context;
-  status = urContextCreate(1, &device, nullptr, &context);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    ur_platform_handle_t platform;
+    status = urPlatformGet(&adapter, 1, 1, &platform, nullptr);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  status = urContextRelease(context);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    ur_device_handle_t device;
+    status = urDeviceGet(platform, UR_DEVICE_TYPE_DEFAULT, 1, &device, nullptr);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  status = urDeviceRelease(device);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    ur_context_handle_t context;
+    status = urContextCreate(1, &device, nullptr, &context);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  status = urAdapterRelease(adapter);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    status = urContextRelease(context);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+
+    status = urDeviceRelease(device);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+
+    status = urAdapterRelease(adapter);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+  }
 
   status = urLoaderTearDown();
   ASSERT_EQ(status, UR_RESULT_SUCCESS);
@@ -70,49 +87,67 @@ TEST(DeviceAsan, UnsupportedFeature) {
   status = urLoaderInit(0, loaderConfig);
   ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  ur_adapter_handle_t adapter;
-  status = urAdapterGet(1, &adapter, nullptr);
+  uint32_t num_adapters;
+  status = urAdapterGet(0, nullptr, &num_adapters);
   ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  ur_platform_handle_t platform;
-  status = urPlatformGet(&adapter, 1, 1, &platform, nullptr);
+  std::vector<ur_adapter_handle_t> adapters;
+  adapters.resize(num_adapters);
+  status = urAdapterGet(num_adapters, adapters.data(), nullptr);
   ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  ur_device_handle_t device;
-  status = urDeviceGet(platform, UR_DEVICE_TYPE_DEFAULT, 1, &device, nullptr);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+  for (auto adapter : adapters) {
+    ur_adapter_backend_t backend;
+    status = urAdapterGetInfo(adapter, UR_ADAPTER_INFO_BACKEND, sizeof(backend),
+                              &backend, nullptr);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    SCOPED_TRACE(backend);
+    if (backend == UR_ADAPTER_BACKEND_OPENCL ||
+        backend == UR_ADAPTER_BACKEND_HIP) {
+      // Helper methods are unsupported
+      continue;
+    }
 
-  ur_context_handle_t context;
-  status = urContextCreate(1, &device, nullptr, &context);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    ur_platform_handle_t platform;
+    status = urPlatformGet(&adapter, 1, 1, &platform, nullptr);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  // Check for explict unsupported features
-  ur_bool_t isSupported;
-  status = urDeviceGetInfo(device, UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT,
-                           sizeof(isSupported), &isSupported, nullptr);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
-  ASSERT_EQ(isSupported, 0);
+    ur_device_handle_t device;
+    status = urDeviceGet(platform, UR_DEVICE_TYPE_DEFAULT, 1, &device, nullptr);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  status = urDeviceGetInfo(device, UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP,
-                           sizeof(isSupported), &isSupported, nullptr);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
-  ASSERT_EQ(isSupported, 0);
+    ur_context_handle_t context;
+    status = urContextCreate(1, &device, nullptr, &context);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
 
-  ur_device_command_buffer_update_capability_flags_t update_flag;
-  status = urDeviceGetInfo(
-      device, UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_CAPABILITIES_EXP,
-      sizeof(update_flag), &update_flag, nullptr);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
-  ASSERT_EQ(update_flag, 0);
+    // Check for explict unsupported features
+    ur_bool_t isSupported;
+    status = urDeviceGetInfo(device, UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT,
+                             sizeof(isSupported), &isSupported, nullptr);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    ASSERT_EQ(isSupported, 0);
 
-  status = urContextRelease(context);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    status = urDeviceGetInfo(device, UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP,
+                             sizeof(isSupported), &isSupported, nullptr);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    ASSERT_EQ(isSupported, 0);
 
-  status = urDeviceRelease(device);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    ur_device_command_buffer_update_capability_flags_t update_flag;
+    status = urDeviceGetInfo(
+        device, UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_CAPABILITIES_EXP,
+        sizeof(update_flag), &update_flag, nullptr);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    ASSERT_EQ(update_flag, 0);
 
-  status = urAdapterRelease(adapter);
-  ASSERT_EQ(status, UR_RESULT_SUCCESS);
+    status = urContextRelease(context);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+
+    status = urDeviceRelease(device);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+
+    status = urAdapterRelease(adapter);
+    ASSERT_EQ(status, UR_RESULT_SUCCESS);
+  }
 
   status = urLoaderTearDown();
   ASSERT_EQ(status, UR_RESULT_SUCCESS);


### PR DESCRIPTION
Two fixes for asan:
* The test has been updated to run on all adapters and also skip HIP
  and OpenCL (which don't support the required VirtualMem functions).
* GetShadowMemory has been changed to CreateShadowMemory. Previously,
  shadow memory had a static lifetime, while the Context that was used
  to construct it only had a lifetime of the `AsanInterceptor` object.
  It has been changed and now each `AsanInterceptor` creates its own
  shadow memory.
