### PR TITLE
[AsyncAlloc][SYCL][Exp] Remove unused handler members

### DIFF
--- a/sycl/source/detail/async_alloc.cpp
+++ b/sycl/source/detail/async_alloc.cpp
@@ -65,7 +65,6 @@ void *async_malloc(sycl::handler &h, sycl::usm::alloc kind, size_t size) {
   // Async malloc must return a void* immediately.
   // Set up CommandGroup which is a no-op and pass the
   // event from the alloc.
-  h.impl->MAllocSize = size;
   h.impl->MAsyncAllocEvent = Event;
   h.setType(detail::CGType::AsyncAlloc);
 
@@ -112,8 +111,6 @@ __SYCL_EXPORT void *async_malloc_from_pool(sycl::handler &h, size_t size,
 
   // Async malloc must return a void* immediately.
   // Set up CommandGroup which is a no-op and pass the event from the alloc.
-  h.impl->MAllocSize = size;
-  h.impl->MMemPool = memPoolImpl;
   h.impl->MAsyncAllocEvent = Event;
   h.setType(detail::CGType::AsyncAlloc);
 

--- a/sycl/source/detail/cg.hpp
+++ b/sycl/source/detail/cg.hpp
@@ -671,29 +671,14 @@ public:
 /// "Async Alloc" command group class.
 class CGAsyncAlloc : public CG {
 
-  // These members are unused but kept in case of logging.
-  size_t MSize;
-  std::shared_ptr<ext::oneapi::experimental::detail::memory_pool_impl> MMemPool;
-
   // Resulting event carried from async alloc execution.
   ur_event_handle_t MEvent;
 
 public:
-  CGAsyncAlloc(
-      size_t size,
-      std::shared_ptr<ext::oneapi::experimental::detail::memory_pool_impl>
-          MemPool,
-      ur_event_handle_t event, CG::StorageInitHelper CGData,
-      detail::code_location loc = {})
-      : CG(CGType::AsyncAlloc, std::move(CGData), std::move(loc)), MSize(size),
-        MMemPool(std::move(MemPool)), MEvent(event) {}
-
-  std::shared_ptr<ext::oneapi::experimental::detail::memory_pool_impl>
-  getMemPool() const {
-    return MMemPool;
-  }
-
-  size_t getSize() const { return MSize; }
+  CGAsyncAlloc(ur_event_handle_t event, CG::StorageInitHelper CGData,
+               detail::code_location loc = {})
+      : CG(CGType::AsyncAlloc, std::move(CGData), std::move(loc)),
+        MEvent(event) {}
 
   ur_event_handle_t getEvent() const { return MEvent; }
 };

--- a/sycl/source/detail/handler_impl.hpp
+++ b/sycl/source/detail/handler_impl.hpp
@@ -203,11 +203,7 @@ public:
   ext::oneapi::experimental::event_mode_enum MEventMode =
       ext::oneapi::experimental::event_mode_enum::none;
 
-  /// Memory pool and allocation size for asynchronous allocation - held for
-  /// potential logging.
   /// Event computed from async alloc which is passed through for processing.
-  std::shared_ptr<ext::oneapi::experimental::detail::memory_pool_impl> MMemPool;
-  size_t MAllocSize = 0;
   ur_event_handle_t MAsyncAllocEvent = nullptr;
 
   // Allocation ptr to be freed asynchronously.

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -725,8 +725,7 @@ event handler::finalize() {
     break;
   case detail::CGType::AsyncAlloc:
     CommandGroup.reset(new detail::CGAsyncAlloc(
-        impl->MAllocSize, impl->MMemPool, impl->MAsyncAllocEvent,
-        std::move(impl->CGData), MCodeLoc));
+        impl->MAsyncAllocEvent, std::move(impl->CGData), MCodeLoc));
     break;
   case detail::CGType::AsyncFree:
     CommandGroup.reset(new detail::CGAsyncFree(


### PR DESCRIPTION
This patch removes unused handler_impl members.