### PR TITLE
[SYCL][CI] do not set ZE_DEBUG when running UR tests

### DIFF
--- a/.github/workflows/ur-build-hw.yml
+++ b/.github/workflows/ur-build-hw.yml
@@ -143,7 +143,6 @@ jobs:
     - name: Test adapter specific
       env:
         ZE_ENABLE_LOADER_DEBUG_TRACE: 1
-        ZE_DEBUG: 1
       run: ctest -C ${{matrix.build_type}} --test-dir ${{github.workspace}}/build --output-on-failure -L "adapter-specific" -E "memcheck" --timeout 600 -VV
       # Don't run adapter specific tests when building multiple adapters
       if: ${{ matrix.adapter.other_name == '' }}
@@ -151,7 +150,6 @@ jobs:
     - name: Test adapters
       env:
         ZE_ENABLE_LOADER_DEBUG_TRACE: 1
-        ZE_DEBUG: 1
       run: env UR_CTS_ADAPTER_PLATFORM="${{matrix.adapter.platform}}" ctest -C ${{matrix.build_type}} --test-dir ${{github.workspace}}/build --output-on-failure -L "conformance" --timeout 600 -VV
 
     - name: Get information about platform


### PR DESCRIPTION
Setting ZE_DEBUG impacts test execution time and introduces delays that can hide problems in the UR adapters.

Also, with ZE_DEBUG logs generated by CI jobs are tens of megabytes in size which makes it difficult to analyze then (at least online).