### PR TITLE
[UR][E2E] add missing zeInit calls to interop tests

### DIFF
--- a/sycl/test-e2e/Basic/interop/get_native_ze.cpp
+++ b/sycl/test-e2e/Basic/interop/get_native_ze.cpp
@@ -12,6 +12,14 @@ constexpr auto BE = sycl::backend::ext_oneapi_level_zero;
 class TestKernel;
 
 int main() {
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
+
   sycl::queue Q;
 
   if (0) {

--- a/sycl/test-e2e/Graph/Inputs/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/Inputs/interop-level-zero-get-native-mem.cpp
@@ -21,6 +21,14 @@ bool is_discrete(const device &Device) {
 }
 
 int main() {
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
+
   try {
     platform Plt{gpu_selector_v};
 

--- a/sycl/test-e2e/Graph/Inputs/interop-level-zero-launch-kernel.cpp
+++ b/sycl/test-e2e/Graph/Inputs/interop-level-zero-launch-kernel.cpp
@@ -37,6 +37,13 @@ std::vector<uint8_t> loadSpirvFromFile(std::string FileName) {
 }
 
 int main(int, char **argv) {
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
 
   device Device;
   if (!getDevice(Device, backend::ext_oneapi_level_zero)) {

--- a/sycl/test-e2e/Graph/NativeCommand/level-zero_usm.cpp
+++ b/sycl/test-e2e/Graph/NativeCommand/level-zero_usm.cpp
@@ -14,6 +14,14 @@ namespace exp_ext = sycl::ext::oneapi::experimental;
 using namespace sycl;
 
 int main() {
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
+
   queue Queue;
 
   const size_t Size = 128;

--- a/sycl/test-e2e/Graph/NativeCommand/level-zero_usm_D2H_copy.cpp
+++ b/sycl/test-e2e/Graph/NativeCommand/level-zero_usm_D2H_copy.cpp
@@ -21,6 +21,14 @@ namespace exp_ext = sycl::ext::oneapi::experimental;
 using namespace sycl;
 
 int main() {
+  // Initialize Level Zero driver is required if this test is linked
+  // statically with Level Zero loader, the driver will not be init otherwise.
+  ze_result_t result = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+  if (result != ZE_RESULT_SUCCESS) {
+    std::cout << "zeInit failed\n";
+    return 1;
+  }
+
   queue Queue{{sycl::property::queue::in_order{}}};
 
   const size_t Size = 128;


### PR DESCRIPTION
Continuation of: https://github.com/intel/llvm/pull/17699