### PR TITLE
[SYCL][Driver] '-fsycl-unnamed-lambda' is not supported with '-fsycl-host-compiler'

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5885,8 +5885,16 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-ffine-grained-bitfield-accesses");
     }
 
-    if (!Args.hasFlag(options::OPT_fsycl_unnamed_lambda,
-                      options::OPT_fno_sycl_unnamed_lambda, true))
+    // '-fsycl-unnamed-lambda' is not supported with '-fsycl-host-compiler'
+    if (Args.hasArg(options::OPT_fsycl_host_compiler_EQ)) {
+      if (Args.hasFlag(options::OPT_fsycl_unnamed_lambda,
+                       options::OPT_fno_sycl_unnamed_lambda, false))
+        D.Diag(diag::err_drv_cannot_mix_options) << "-fsycl-host-compiler"
+                                                 << "-fsycl-unnamed-lambda";
+      else // '-fsycl-host-compiler' implies '-fno-sycl-unnamed-lambda'
+        CmdArgs.push_back("-fno-sycl-unnamed-lambda");
+    } else if (!Args.hasFlag(options::OPT_fsycl_unnamed_lambda,
+                             options::OPT_fno_sycl_unnamed_lambda, true))
       CmdArgs.push_back("-fno-sycl-unnamed-lambda");
 
     if (!Args.hasFlag(options::OPT_fsycl_esimd_force_stateless_mem,

--- a/clang/test/Driver/sycl-host-compiler-old-model.cpp
+++ b/clang/test/Driver/sycl-host-compiler-old-model.cpp
@@ -62,6 +62,16 @@
 // RUN:  | FileCheck -check-prefix=HOST_COMPILER_NOARG %s
 // HOST_COMPILER_NOARG: missing argument to '-fsycl-host-compiler='
 
+/// error for -fsycl-host-compiler and -fsycl-unnamed-lambda combination 
+// RUN: not %clangxx -fsycl --no-offload-new-driver -fsycl-host-compiler=g++ -fsycl-unnamed-lambda -c -### %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=HOST_COMPILER_AND_UNNAMED_LAMBDA %s
+// HOST_COMPILER_AND_UNNAMED_LAMBDA: error: cannot specify '-fsycl-unnamed-lambda' along with '-fsycl-host-compiler'
+
+// -fsycl-host-compiler implies -fno-sycl-unnamed-lambda
+// RUN: %clangxx -### -fsycl --no-offload-new-driver -fsycl-host-compiler=g++ -c -### %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=IMPLY-NO-SYCL-UNNAMED-LAMBDA %s
+// IMPLY-NO-SYCL-UNNAMED-LAMBDA: clang{{.*}} "-fno-sycl-unnamed-lambda"
+
 /// Warning should not be emitted when using -fsycl-host-compiler when linking
 // RUN: touch %t.o
 // RUN: %clangxx -fsycl --no-offload-new-driver -fsycl-host-compiler=g++ %t.o -### 2>&1 \


### PR DESCRIPTION
Addresses https://github.com/intel/llvm/issues/15120

This patch emits an error when `-fsycl-unnamed-lambda` is used in conjunction with `-fsycl-host-compiler`
Also, use of `-fsycl-host-compiler` implicitly adds `-fno-sycl-unnamed-lambda` to the list of command line arg strings.