### PR TITLE
[UR][L0] Address issue with unnecessary event for barrier

### DIFF
--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -2351,16 +2351,6 @@ ur_queue_handle_t_::insertActiveBarriers(ur_command_list_ptr_t &CmdList,
     ActiveBarriers.add(Event);
   }
 
-  ur_event_handle_t Event = nullptr;
-  if (auto Res = createEventAndAssociateQueue(
-          reinterpret_cast<ur_queue_handle_t>(this), &Event,
-          UR_EXT_COMMAND_TYPE_USER, CmdList,
-          /* IsInternal */ true, /* IsMultiDevice */ true))
-    return Res;
-
-  Event->WaitList = ActiveBarriersWaitList;
-  Event->OwnNativeHandle = true;
-
   // If there are more active barriers, insert a barrier on the command-list. We
   // do not need an event for finishing so we pass nullptr.
   ZE2UR_CALL(zeCommandListAppendBarrier,


### PR DESCRIPTION
- Remove creation of an event that is not used in the barrier as a signal event and simply is added to the cache. This leaks an event resource when this is called. The event creation in this case has been removed.