### PR TITLE
Disable fill test for command buffer v2

### DIFF
--- a/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
@@ -16,6 +16,7 @@ struct urCommandBufferFillCommandsTest
   void SetUp() override {
     // This test fails due to a bug in the Level-Zero driver, it can be
     // reenabled after CI machines get their drivers updated
+    // https://github.com/intel/llvm/issues/17856
     UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
 
     UUR_RETURN_ON_FATAL_FAILURE(

--- a/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
@@ -14,6 +14,8 @@ struct testParametersFill {
 struct urCommandBufferFillCommandsTest
     : uur::command_buffer::urCommandBufferExpTestWithParam<testParametersFill> {
   void SetUp() override {
+    // This test fails due to a bug in the Level-Zero driver, it can be
+    // reenabled after CI machines get their drivers updated
     UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
 
     UUR_RETURN_ON_FATAL_FAILURE(

--- a/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
@@ -14,6 +14,8 @@ struct testParametersFill {
 struct urCommandBufferFillCommandsTest
     : uur::command_buffer::urCommandBufferExpTestWithParam<testParametersFill> {
   void SetUp() override {
+    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
+
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::command_buffer::urCommandBufferExpTestWithParam<
             testParametersFill>::SetUp());


### PR DESCRIPTION
This PR disables flaky fill test for command buffer that was enabled in https://github.com/intel/llvm/pull/17709. 
The issue is connected to the bug in the driver that is patched in new version, but the CI machines still have the old one, which causes it to sometimes fail (for example https://github.com/intel/llvm/actions/runs/14250564960/job/39942652796?pr=17836)