### PR TITLE
[SYCL][Graph] Disable L0 native command tests on V2

### DIFF
--- a/sycl/test-e2e/Graph/NativeCommand/level-zero_usm.cpp
+++ b/sycl/test-e2e/Graph/NativeCommand/level-zero_usm.cpp
@@ -4,6 +4,9 @@
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 // REQUIRES: level_zero, level_zero_dev_kit
 
+// UNSUPPORTED: level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17847
+
 #include <level_zero/ze_api.h>
 #include <sycl/backend.hpp>
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test-e2e/Graph/NativeCommand/level-zero_usm_D2H_copy.cpp
+++ b/sycl/test-e2e/Graph/NativeCommand/level-zero_usm_D2H_copy.cpp
@@ -9,6 +9,9 @@
 //
 // REQUIRES: aspect-usm_host_allocations
 
+// UNSUPPORTED: level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17847
+
 #include <level_zero/ze_api.h>
 #include <sycl/backend.hpp>
 #include <sycl/ext/oneapi/experimental/graph.hpp>


### PR DESCRIPTION
The 2 L0 native command tests for SYCL-Graphs timeout when run with the L0 v2 adapter.

Disable until they can be investigated in https://github.com/intel/llvm/issues/17847