### PR TITLE
[UR] Bump googletest version

### DIFF
--- a/unified-runtime/test/CMakeLists.txt
+++ b/unified-runtime/test/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.12.1
+  GIT_TAG        v1.13.0
 )
 
 set(UR_TEST_DEVICES_COUNT 1 CACHE STRING "Count of devices on which conformance and adapters tests will be run")


### PR DESCRIPTION
This contains a fix for https://github.com/google/googletest/pull/4036 ,
which we encounter if we are outputting JSON and the test runner finds
no adapters.
