### PR TITLE
[Benchmarks][CI] add UR SubmitGraph benchmark

### DIFF
--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -46,7 +46,7 @@ class ComputeBench(Suite):
         return "https://github.com/intel/compute-benchmarks.git"
 
     def git_hash(self) -> str:
-        return "b5cc46acf61766ab00da04e85bd4da4f7591eb21"
+        return "c10baa895b4364899e253e44127ff128a8efa5d5"
 
     def setup(self):
         if options.sycl is None:
@@ -145,7 +145,7 @@ class ComputeBench(Suite):
             benches.append(UllsKernelSwitch(self, runtime, 8, 200, 0, 0, 1, 1))
 
         # Add GraphApiSubmitGraph benchmarks
-        for runtime in self.enabled_runtimes([RUNTIMES.SYCL]):
+        for runtime in self.enabled_runtimes([RUNTIMES.SYCL, RUNTIMES.UR]):
             for in_order_queue in [0, 1]:
                 for num_kernels in [4, 10, 32]:
                     for measure_completion_time in [0, 1]:


### PR DESCRIPTION
```
running graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 0 measureCompletion 0, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 0 measureCompletion 0 complete (graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 0 measureCompletion 0: 14.738 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 0 measureCompletion 1, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 0 measureCompletion 1 complete (graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 0 measureCompletion 1: 15.132 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 0 measureCompletion 0, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 0 measureCompletion 0 complete (graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 0 measureCompletion 0: 29.481 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 0 measureCompletion 1, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 0 measureCompletion 1 complete (graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 0 measureCompletion 1: 30.309 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 0 measureCompletion 0, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 0 measureCompletion 0 complete (graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 0 measureCompletion 0: 85.288 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 0 measureCompletion 1, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 0 measureCompletion 1 complete (graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 0 measureCompletion 1: 85.948 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 1 measureCompletion 0, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 1 measureCompletion 0 complete (graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 1 measureCompletion 0: 15.483 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 1 measureCompletion 1, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 1 measureCompletion 1 complete (graph_api_benchmark_sycl SubmitGraph numKernels:4 ioq 1 measureCompletion 1: 16.589 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 1 measureCompletion 0, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 1 measureCompletion 0 complete (graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 1 measureCompletion 0: 31.217 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 1 measureCompletion 1, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 1 measureCompletion 1 complete (graph_api_benchmark_sycl SubmitGraph numKernels:10 ioq 1 measureCompletion 1: 31.615 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 1 measureCompletion 0, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 1 measureCompletion 0 complete (graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 1 measureCompletion 0: 86.204 μs).
running graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 1 measureCompletion 1, iteration 0... 
graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 1 measureCompletion 1 complete (graph_api_benchmark_sycl SubmitGraph numKernels:32 ioq 1 measureCompletion 1: 86.468 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 0 measureCompletion 0, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 0 measureCompletion 0 complete (graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 0 measureCompletion 0: 11.087 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 0 measureCompletion 1, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 0 measureCompletion 1 complete (graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 0 measureCompletion 1: 11.178 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 0 measureCompletion 0, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 0 measureCompletion 0 complete (graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 0 measureCompletion 0: 21.347 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 0 measureCompletion 1, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 0 measureCompletion 1 complete (graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 0 measureCompletion 1: 22.886 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 0 measureCompletion 0, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 0 measureCompletion 0 complete (graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 0 measureCompletion 0: 61.907 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 0 measureCompletion 1, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 0 measureCompletion 1 complete (graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 0 measureCompletion 1: 63.073 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 1 measureCompletion 0, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 1 measureCompletion 0 complete (graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 1 measureCompletion 0: 11.016 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 1 measureCompletion 1, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 1 measureCompletion 1 complete (graph_api_benchmark_ur SubmitGraph numKernels:4 ioq 1 measureCompletion 1: 14.501 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 1 measureCompletion 0, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 1 measureCompletion 0 complete (graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 1 measureCompletion 0: 21.556 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 1 measureCompletion 1, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 1 measureCompletion 1 complete (graph_api_benchmark_ur SubmitGraph numKernels:10 ioq 1 measureCompletion 1: 21.254 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 1 measureCompletion 0, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 1 measureCompletion 0 complete (graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 1 measureCompletion 0: 67.115 μs).
running graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 1 measureCompletion 1, iteration 0... 
graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 1 measureCompletion 1 complete (graph_api_benchmark_ur SubmitGraph numKernels:32 ioq 1 measureCompletion 1: 63.078 μs).
```