### PR TITLE
[UR] Track handles from enqueue functions in validation layer

### DIFF
--- a/unified-runtime/scripts/templates/valddi.cpp.mako
+++ b/unified-runtime/scripts/templates/valddi.cpp.mako
@@ -11,7 +11,7 @@ from templates import helper as th
     handle_create_get_retain_release_funcs=th.get_handle_create_get_retain_release_functions(specs, n, tags)
 %>/*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
  * Exceptions.
@@ -117,9 +117,14 @@ namespace ur_validation_layer
         <%
             tp_handle_funcs = next((hf for hf in handle_create_get_retain_release_funcs if th.subt(n, tags, tp['type']) in [hf['handle'], hf['handle'] + "*"]), None)
             is_handle_to_adapter = ("_adapter_handle_t" in tp['type'])
+            is_handle_to_event = ("_event_handle_t" in tp['type'])
         %>
         %if func_name in tp_handle_funcs['create']:
-        if( getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS )
+        if( getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS
+        %if is_handle_to_event:
+            && ${tp['name']}
+        %endif
+        )
         {
             getContext()->refCountContext->createRefCount(*${tp['name']});
         }
@@ -236,7 +241,7 @@ namespace ur_validation_layer
         if (enableLeakChecking) {
             getContext()->refCountContext->logInvalidReferences();
         }
-        
+
         return ${X}_RESULT_SUCCESS;
     }
 

--- a/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
+++ b/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
  * Exceptions.
@@ -4344,7 +4344,8 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
   ur_result_t result =
       pfnCreateWithNativeHandle(hNativeEvent, hContext, pProperties, phEvent);
 
-  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS) {
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
     getContext()->refCountContext->createRefCount(*phEvent);
   }
 
@@ -4474,6 +4475,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
       hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
       pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -4526,6 +4532,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
   ur_result_t result =
       pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -4580,6 +4591,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
   ur_result_t result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
                                                 phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -4662,6 +4678,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
       pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
                        numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -4742,6 +4763,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
   ur_result_t result =
       pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
                         numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -4866,6 +4892,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
       hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region,
       bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
       numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -4992,6 +5023,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
       bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
       numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -5084,6 +5120,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
   ur_result_t result =
       pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset,
                        size, numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -5215,6 +5256,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
       srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList,
       phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -5311,6 +5357,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
       pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size,
                        numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -5400,6 +5451,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
       hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst,
       numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -5488,6 +5544,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
   ur_result_t result = pfnMemImageWrite(
       hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc,
       numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -5588,6 +5649,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
       pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin,
                       region, numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -5675,6 +5741,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
       pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size,
                       numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -5741,6 +5812,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
   ur_result_t result = pfnMemUnmap(
       hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -5826,6 +5902,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
       pfnUSMFill(hQueue, pMem, patternSize, pPattern, size, numEventsInWaitList,
                  phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -5910,6 +5991,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
       pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList,
                    phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -5984,6 +6070,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
   ur_result_t result = pfnUSMPrefetch(
       hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -6034,6 +6125,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
   }
 
   ur_result_t result = pfnUSMAdvise(hQueue, pMem, size, advice, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -6325,6 +6421,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
       hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
       numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -6405,6 +6506,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
   ur_result_t result = pfnDeviceGlobalVariableRead(
       hQueue, hProgram, name, blockingRead, count, offset, pDst,
       numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -6487,6 +6593,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
   ur_result_t result =
       pfnReadHostPipe(hQueue, hProgram, pipe_symbol, blocking, pDst, size,
                       numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -6571,6 +6682,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
       pfnWriteHostPipe(hQueue, hProgram, pipe_symbol, blocking, pSrc, size,
                        numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -6636,6 +6752,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMDeviceAllocExp(
   ur_result_t result = pfnUSMDeviceAllocExp(hQueue, pPool, size, pProperties,
                                             numEventsInWaitList,
                                             phEventWaitList, ppMem, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -6703,6 +6824,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMSharedAllocExp(
                                             numEventsInWaitList,
                                             phEventWaitList, ppMem, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -6769,6 +6895,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMHostAllocExp(
       pfnUSMHostAllocExp(hQueue, pPool, size, pProperties, numEventsInWaitList,
                          phEventWaitList, ppMem, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -6824,6 +6955,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFreeExp(
 
   ur_result_t result = pfnUSMFreeExp(hQueue, pPool, pMem, numEventsInWaitList,
                                      phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -9501,6 +9637,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCommandBufferExp(
   ur_result_t result = pfnCommandBufferExp(
       hQueue, hCommandBuffer, numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -9766,6 +9907,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
       hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
       pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -9890,6 +10036,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
   ur_result_t result = pfnTimestampRecordingExp(
       hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -9977,6 +10128,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
       hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
       pLocalWorkSize, numPropsInLaunchPropList, launchPropList,
       numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }
@@ -10364,6 +10520,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
   ur_result_t result = pfnEventsWaitWithBarrierExt(
       hQueue, pProperties, numEventsInWaitList, phEventWaitList, phEvent);
 
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
+
   return result;
 }
 
@@ -10434,6 +10595,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
   ur_result_t result = pfnNativeCommandExp(
       hQueue, pfnNativeEnqueue, data, numMemsInMemList, phMemList, pProperties,
       numEventsInWaitList, phEventWaitList, phEvent);
+
+  if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
+      phEvent) {
+    getContext()->refCountContext->createRefCount(*phEvent);
+  }
 
   return result;
 }

--- a/unified-runtime/test/layers/validation/leaks.out.match
+++ b/unified-runtime/test/layers/validation/leaks.out.match
@@ -79,3 +79,42 @@
 <VALIDATION>[ERROR]: Retained -1 reference(s) to handle {{[0-9xa-fA-F]+}}
 <VALIDATION>[ERROR]: Handle {{[0-9xa-fA-F]+}} was recorded for first time here:
 {{IGNORE}}
+[ RUN      ] queueLeakTest.testUrEnqueueSuccess
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+{{IGNORE}}
+[ RUN      ] queueLeakTest.testUrEnqueueLeak
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[ERROR]: Retained 1 reference(s) to handle {{[0-9xa-fA-F]+}}
+<VALIDATION>[ERROR]: Handle {{[0-9xa-fA-F]+}} was recorded for first time here:
+{{IGNORE}}
+[ RUN      ] queueLeakTest.testUrEventReleaseNonexistent
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 1
+<VALIDATION>[ERROR]: Attempting to release nonexistent handle {{[0-9xa-fA-F]+}}
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to -1
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[DEBUG]: Reference count for handle {{[0-9xa-fA-F]+}} changed to 0
+<VALIDATION>[ERROR]: Retained -1 reference(s) to handle {{[0-9xa-fA-F]+}}
+<VALIDATION>[ERROR]: Handle {{[0-9xa-fA-F]+}} was recorded for first time here:
+{{IGNORE}}


### PR DESCRIPTION
On handle release, the validation layer reports event handles obtained via enqueue functions as invalid. This patch should fix this behavior.