### PR TITLE
[SYCL][NativeCPU] Update OCK.

### DIFF
--- a/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
+++ b/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
@@ -35,15 +35,15 @@ endif()
 if(NATIVECPU_USE_OCK)
   if(NATIVECPU_OCK_USE_FETCHCONTENT)
     set(OCK_GIT_INTERNAL_REPO "https://github.com/uxlfoundation/oneapi-construction-kit.git")
-    # commit 652f9943b0bfcf61123a0f82b2bdd499738c5391
-    # Merge: c24c971bcb e0f02ae739
-    # Author: Colin Davidson <colin.davidson@codeplay.com>
-    # Date:   Fri Feb 28 15:59:50 2025 +0000
+    # commit ffef31717750d3f15bfd2f18d9cd7f4677fe9d3e
+    # Merge: 574307afde 0b00238554
+    # Author: Harald van Dijk <harald.vandijk@codeplay.com>
+    # Date:   Fri Apr 4 16:26:38 2025 +0100
     # 
-    #     Merge pull request #677 from coldav/colin/build_installed_llvm
+    #     Merge pull request #751 from hvdijk/llvm21-address-space
     #     
-    #     Change llvm over to a choice of install or cache, default PRs to install
-    set(OCK_GIT_INTERNAL_TAG 652f9943b0bfcf61123a0f82b2bdd499738c5391)
+    #     [LLVM 21] Take address space into account for legality.
+    set(OCK_GIT_INTERNAL_TAG ffef31717750d3f15bfd2f18d9cd7f4677fe9d3e)
 
     # Overwrite OCK_GIT_INTERNAL_REPO/OCK_GIT_INTERNAL_TAG if the corresponding options are set
     if(OCK_GIT_REPO)


### PR DESCRIPTION
This commit updates OCK to apply a code generation fix that will affect upcoming NativeCPU changes, as well as a forward compatibility fix to prevent issues with the next LLVM pulldown or the one thereafter.