### PR TITLE
[AsyncAlloc][CUDA] Change memory pool max size error to a warning

### DIFF
--- a/unified-runtime/source/adapters/cuda/usm.cpp
+++ b/unified-runtime/source/adapters/cuda/usm.cpp
@@ -440,14 +440,12 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
                                    // only reserved when it's needed for the
                                    // first time (cuMemAllocFromPoolAsync).
 #else
-      // Only error if the user set a value >0 for the maximum size.
+      // Only warn if the user set a value >0 for the maximum size.
       // Otherwise, do nothing.
-      if (Limits->maxPoolableSize > 0) {
-        setErrorMessage(
-            "The memory pool maximum size feature requires CUDA 12.2 or later.",
-            UR_RESULT_ERROR_ADAPTER_SPECIFIC);
-        throw UsmAllocationException(UR_RESULT_ERROR_ADAPTER_SPECIFIC);
-      }
+      // Set maximum size is effectively ignored.
+      if (Limits->maxPoolableSize > 0)
+        logger::warning("The memory pool maximum size feature requires CUDA "
+                        "12.2 or later.\n");
 #endif
       maxSize = Limits->maxPoolableSize;
       size_t chunkSize = 33554432; // 32MB


### PR DESCRIPTION
Warn users over setting the memory pool maximum size property instead of error.

This should aid CI which is affected by the memory_pool.cpp e2e test which expects to be able to set this property despite DPC++ being built with a CUDA version that is too old.

See this CI error: https://github.com/intel/llvm/pull/17757#issuecomment-2778601572