### PR TITLE
[SYCL] Fix `traceKernel` function to avoid temporary string creation

### DIFF
--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -340,15 +340,15 @@ public:
 
   // Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is
   // set.
-  static inline void traceKernel(const std::string &Msg,
-                                 const std::string &KernelName,
+  static inline void traceKernel(std::string_view Msg,
+                                 std::string_view KernelName,
                                  bool IsKernelFastCache = false) {
     if (!SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache())
       return;
 
     std::string Identifier =
         "[IsFastCache: " + std::to_string(IsKernelFastCache) +
-        "][Key:{Name = " + KernelName + "}]: ";
+        "][Key:{Name = " + KernelName.data() + "}]: ";
 
     std::cerr << "[In-Memory Cache][Thread Id:" << std::this_thread::get_id()
               << "][Kernel Cache]" << Identifier << Msg << std::endl;


### PR DESCRIPTION
When the `traceKernel` function is called with a C-string as a parameter, a temporary `std::string` object is created. This PR change the `traceKernel` function to accept `std::string_view` instead `const std::string &`.