### PR TITLE
[CI] Change artifact for Ubuntu 22 build in pre-commit

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -69,7 +69,7 @@ jobs:
     with:
       build_ref: ${{ github.sha }}
       build_cache_root: "/__w/"
-      build_artifact_suffix: "default"
+      build_artifact_suffix: "ubuntu22"
       build_cache_suffix: "default"
       build_image: "ghcr.io/intel/llvm/ubuntu2204_build:latest"
       changes: ${{ needs.detect_changes.outputs.filters }}


### PR DESCRIPTION
Currently, in precommit, both Ubuntu 24 and Ubuntu 22, upload build artifact with the same name. This causes upload job to fail. For example: https://github.com/intel/llvm/actions/runs/14293545650/job/40057838391?pr=17710

This PR changes the suffix of the build archive for Ubuntu 22 build.