### PR TITLE
[CI][Benchmarks] update compute runtime and fix IGC build

### DIFF
--- a/devops/scripts/benchmarks/options.py
+++ b/devops/scripts/benchmarks/options.py
@@ -40,7 +40,7 @@ class Options:
     build_compute_runtime: bool = False
     extra_ld_libraries: list[str] = field(default_factory=list)
     extra_env_vars: dict = field(default_factory=dict)
-    compute_runtime_tag: str = "25.09.32961.7"
+    compute_runtime_tag: str = "25.09.32961.8"
     build_igc: bool = False
     current_run_name: str = "This PR"
     preset: str = "Full"

--- a/devops/scripts/benchmarks/utils/compute_runtime.py
+++ b/devops/scripts/benchmarks/utils/compute_runtime.py
@@ -135,6 +135,8 @@ class ComputeRuntime:
         self.igc_install = os.path.join(options.workdir, "igc-install")
         configure_command = [
             "cmake",
+            "-DCMAKE_C_FLAGS=-Wno-error",
+            "-DCMAKE_CXX_FLAGS=-Wno-error",
             f"-B {self.igc_build}",
             f"-S {self.igc_repo}",
             f"-DCMAKE_INSTALL_PREFIX={self.igc_install}",


### PR DESCRIPTION
Latest IGC doesn't build on the compilers on the perf testing systems due to warnings. This patch bumps up the driver to latest and also adds -Wno-error when building IGC.

Nightly is broken: https://github.com/oneapi-src/unified-runtime/actions/runs/14297928864, this fixes it. Please prioritize this @intel/llvm-reviewers-benchmarking.