### PR TITLE
[SYCL] Get platform_impl shared_ptr directly

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -369,8 +369,8 @@ static void appendCompileOptionsFromImage(std::string &CompileOpts,
 
   appendCompileOptionsForGRFSizeProperties(CompileOpts, Img, isEsimdImage);
 
-  platform Platform = Devs[0].get_platform();
-  const auto &PlatformImpl = detail::getSyclObjImpl(Platform);
+  const detail::DeviceImplPtr &DeviceImpl = detail::getSyclObjImpl(Devs[0]);
+  const detail::PlatformImplPtr &PlatformImpl = DeviceImpl->getPlatformImpl();
 
   // Add optimization flags.
   auto str = getUint32PropAsOptStr(Img, "optLevel");


### PR DESCRIPTION
Avoid constructing a platform object to get the platform_impl shared_ptr.