### PR TITLE
[CI][Benchmarks] update llama.cpp and requirements to latest

### DIFF
--- a/devops/scripts/benchmarks/utils/oneapi.py
+++ b/devops/scripts/benchmarks/utils/oneapi.py
@@ -16,16 +16,10 @@ class OneAPI:
         Path(self.oneapi_dir).mkdir(parents=True, exist_ok=True)
         self.oneapi_instance_id = self.generate_unique_oneapi_id(self.oneapi_dir)
 
-        # can we just hardcode these links?
         self.install_package(
-            "dnnl",
-            "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/87e117ab-039b-437d-9c80-dcd5c9e675d5/intel-onednn-2025.0.0.862_offline.sh",
-            "6866feb5b8dfefd6ff45d6bfabed44f01d7fba8fd452480ae1fd86b92e9481ae052c24842da14f112f672f5c4859945b",
-        )
-        self.install_package(
-            "mkl",
-            "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/79153e0f-74d7-45af-b8c2-258941adf58a/intel-onemkl-2025.0.0.940_offline.sh",
-            "122bb84cf943ea27753cb399c81ab2ae218ebd51b789c74d273240157722925ab4d5a43cb0b5de41b854f2c5a59a4002",
+            "base",
+            "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/cca951e1-31e7-485e-b300-fe7627cb8c08/intel-oneapi-base-toolkit-2025.1.0.651_offline.sh",
+            "98cad2489f2c90a2b328568a59371cf35855a3338643f61a9fc2d16a265d29f22feb2d673916dd7be18fa12a5e6d2475",
         )
         return
 

--- a/devops/scripts/benchmarks/utils/utils.py
+++ b/devops/scripts/benchmarks/utils/utils.py
@@ -9,10 +9,11 @@ import shutil
 import subprocess
 
 import tarfile
-import urllib  # nosec B404
 from options import options
 from pathlib import Path
 import hashlib
+from urllib.request import urlopen  # nosec B404
+from shutil import copyfileobj
 
 
 def run(
@@ -147,7 +148,9 @@ def download(dir, url, file, untar=False, unzip=False, checksum=""):
     data_file = os.path.join(dir, file)
     if not Path(data_file).exists():
         print(f"{data_file} does not exist, downloading")
-        urllib.request.urlretrieve(url, data_file)
+        with urlopen(url) as in_stream, open(data_file, "wb") as out_file:
+            copyfileobj(in_stream, out_file)
+
         calculated_checksum = calculate_checksum(data_file)
         if calculated_checksum != checksum:
             print(


### PR DESCRIPTION
This patch updates llama.cpp to the latest available version, uses a new, more relevant, GGUF model, and updates oneAPI to 2025.1.

I was trying to avoid updating oneAPI, but the latest llama.cpp internal pooling logic seems to be broken on 2025.0, resulting in double-free errors when using older oneAPI components.

The utils.download function also had to be updated, because it was using a deprecated features and didn't work on some configurations.