### PR TITLE
[CI][Benchmarks] add mako to requirements

### DIFF
--- a/devops/scripts/benchmarks/requirements.txt
+++ b/devops/scripts/benchmarks/requirements.txt
@@ -2,3 +2,4 @@ matplotlib==3.9.2
 mpld3==0.5.10
 dataclasses-json==0.6.7
 PyYAML==6.0.1
+Mako==1.3.0


### PR DESCRIPTION
Mako is required for building IGC from source.