### PR TITLE
[Matrix][E2E] Include `chrono` in Matrix test on Windows

### DIFF
--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_bf16_fill_k_cache_impl.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_bf16_fill_k_cache_impl.hpp
@@ -9,6 +9,10 @@
 #include <random>
 #include <sycl/usm.hpp>
 
+#ifdef _WIN32
+#include <chrono>
+#endif
+
 #ifdef SLM
 #include "slm_utils.hpp"
 #endif


### PR DESCRIPTION
Fixes #17516

Tests that include `joint_matrix_bf16_fill_k_cache_impl.hpp` may fail on windows with the following message `error: no member named 'high_resolution_clock' in namespace 'std::chrono'`. Including chrono resolves this.