### PR TITLE
[UR][L0] Update L0 static loader to fix dynamic tracing

### DIFF
--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -43,7 +43,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
         set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
     endif()
     if (UR_LEVEL_ZERO_LOADER_TAG STREQUAL "")
-        set(UR_LEVEL_ZERO_LOADER_TAG ecfe375b30cc04265b20ac1b7996a85d0910f3ed)
+        set(UR_LEVEL_ZERO_LOADER_TAG 01c9bad362b1981ed8fb287235e50d2d903a72cc)
     endif()
 
     # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104

--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -43,7 +43,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
         set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
     endif()
     if (UR_LEVEL_ZERO_LOADER_TAG STREQUAL "")
-        set(UR_LEVEL_ZERO_LOADER_TAG 01c9bad362b1981ed8fb287235e50d2d903a72cc)
+        set(UR_LEVEL_ZERO_LOADER_TAG 782ba0ef068e7a9b6a73cf1779e2ca46dc01781c)
     endif()
 
     # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104


### PR DESCRIPTION
- Fix to use the version of the L0 Loader which addresses the issues with dynamically enabling the tracing layer during execution. Previously, this path was not working correctly to allow intercepting the UR calls. 