### PR TITLE
[SYCL][UR][CTS] Mark known failure on L0 v2

### DIFF
--- a/unified-runtime/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
@@ -46,7 +46,7 @@ void common_check(ur_event_handle_t event) {
 }
 
 TEST_P(urEnqueueTimestampRecordingExpTest, Success) {
-  UUR_KNOWN_FAILURE_ON(uur::HIP{}, uur::CUDA{});
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{}, uur::HIP{}, uur::CUDA{});
 
   ur_event_handle_t event = nullptr;
   ASSERT_SUCCESS(


### PR DESCRIPTION
The test is flaky on V2, similarly to
urEnqueueTimestampRecordingExpTest.SuccessBlocking