### PR TITLE
[UR] Fix two issues flagged by coverity

### DIFF
--- a/unified-runtime/source/adapters/opencl/device.hpp
+++ b/unified-runtime/source/adapters/opencl/device.hpp
@@ -28,8 +28,9 @@ struct ur_device_handle_t_ {
     if (Parent) {
       Type = Parent->Type;
     } else {
-      clGetDeviceInfo(CLDevice, CL_DEVICE_TYPE, sizeof(cl_device_type), &Type,
-                      nullptr);
+      [[maybe_unused]] auto Res = clGetDeviceInfo(
+          CLDevice, CL_DEVICE_TYPE, sizeof(cl_device_type), &Type, nullptr);
+      assert(Res == CL_SUCCESS);
     }
   }
 


### PR DESCRIPTION
* When creating a command buffer, we might encounter errors and leaked
  the queue. Now it is released if required.
* When creating a device, we assert that getting the type was
  successful. This should never be false since none of the errors apply
  (it shouldn't allocate any memory either).
