### PR TITLE
[CI] Disable assertions for linux_shared_build in sycl-linux-build.yml

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -32,9 +32,6 @@ on:
       build_artifact_suffix:
         type: string
         required: true
-      build_with_assertions:
-        type: string
-        default: false
       artifact_archive_name:
         type: string
         default: llvm_sycl.tar.zst
@@ -173,7 +170,6 @@ jobs:
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults ${{ inputs.build_configure_extra_args }} \
-          ${{ !inputs.build_with_assertions == "true" ? "--no-assertions" | "" }} \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DLLVM_INSTALL_UTILS=ON \

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -32,6 +32,9 @@ on:
       build_artifact_suffix:
         type: string
         required: true
+      build_with_assertions:
+        type: string
+        default: false
       artifact_archive_name:
         type: string
         default: llvm_sycl.tar.zst
@@ -170,6 +173,7 @@ jobs:
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults ${{ inputs.build_configure_extra_args }} \
+          ${{ !inputs.build_with_assertions == "true" ? "--no-assertions" | "" }} \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DLLVM_INSTALL_UTILS=ON \

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -15,7 +15,7 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      build_configure_extra_args: '--hip --cuda --no-assertions'
+      build_configure_extra_args: '--hip --cuda'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       retention-days: 90
 

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -15,7 +15,7 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      build_configure_extra_args: '--hip --cuda'
+      build_configure_extra_args: '--hip --cuda --no-assertions'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       retention-days: 90
 
@@ -23,6 +23,7 @@ jobs:
       # prefer widespread gzip compression.
       artifact_archive_name: sycl_linux.tar.gz
 
+  # Build used for performance testing only: not intended for testing
   linux_shared_build:
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl-linux-build.yml
@@ -31,7 +32,7 @@ jobs:
       build_cache_root: "/__w/"
       build_cache_suffix: sprod_shared
       build_artifact_suffix: sprod_shared
-      build_configure_extra_args: '--shared-libs --hip --cuda --native_cpu'
+      build_configure_extra_args: '--shared-libs --hip --cuda --native_cpu --no-assertions'
 
       artifact_archive_name: sycl_linux_shared.tar.zst
 


### PR DESCRIPTION
This PR addresses https://github.com/intel/llvm/issues/17609, which introduces `--no-assertions` for the archive `sprod_shared`/`linux_shared_build`.

This archive is currently not used anywhere: The intention is that we could leverage it for CI runs where performance matters (e.g. benchmarking).