### PR TITLE
[DevTSAN] Sync thread clocks before/after barrier call

### DIFF
--- a/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/instrument_barrier.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/instrument_barrier.ll
@@ -1,0 +1,28 @@
+; RUN: opt < %s -passes='function(tsan),module(tsan-module)' -tsan-instrument-func-entry-exit=0 -tsan-instrument-memintrinsics=0 -S | FileCheck %s
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @CheckDeviceBarrier() {
+; CHECK-LABEL: void @CheckDeviceBarrier
+entry:
+  call spir_func void @_Z22__spirv_ControlBarrieriii(i32 noundef 1, i32 noundef 1, i32 noundef 912)
+  ; CHECK: call void @__tsan_device_barrier
+  br label %exit
+
+exit: ; preds = %entry
+  ret void
+}
+
+define spir_kernel void @CheckGroupBarrier() {
+; CHECK-LABEL: void @CheckGroupBarrier
+entry:
+  call spir_func void @_Z22__spirv_ControlBarrieriii(i32 noundef 2, i32 noundef 2, i32 noundef 912)
+  ; CHECK: call void @__tsan_group_barrier
+  br label %exit
+
+exit: ; preds = %entry
+  ret void
+}
+
+declare spir_func void @_Z22__spirv_ControlBarrieriii(i32 noundef, i32 noundef, i32 noundef)
+

--- a/sycl/test-e2e/ThreadSanitizer/check_device_barrier.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_device_barrier.cpp
@@ -2,6 +2,7 @@
 // RUN: %{build} %device_tsan_flags -O2 -g -o %t1.out
 // RUN: %{run} %t1.out 2>&1 | FileCheck %s
 // UNSUPPORTED: cpu
+// UNSUPPORTED-TRACKER: CMPLRLLVM-66827
 #include "sycl/detail/core.hpp"
 #include "sycl/ext/oneapi/experimental/root_group.hpp"
 #include "sycl/group_barrier.hpp"

--- a/sycl/test-e2e/ThreadSanitizer/check_device_barrier.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_device_barrier.cpp
@@ -1,0 +1,59 @@
+// REQUIRES: linux, cpu || (gpu && level_zero)
+// RUN: %{build} %device_tsan_flags -O2 -g -o %t1.out
+// RUN: %{run} %t1.out 2>&1 | FileCheck %s
+// UNSUPPORTED: cpu
+#include "sycl/detail/core.hpp"
+#include "sycl/ext/oneapi/experimental/root_group.hpp"
+#include "sycl/group_barrier.hpp"
+#include "sycl/usm.hpp"
+
+const size_t N = 32;
+
+struct TestKernel {
+  int *m_array;
+  TestKernel(int *array) : m_array(array) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    auto root = item.ext_oneapi_get_root_group();
+    if (item.get_group_linear_id() == 0 && item.get_local_linear_id() == 0)
+      m_array[0]++;
+
+    sycl::group_barrier(root);
+
+    if (item.get_group_linear_id() == 1 && item.get_local_linear_id() == 0)
+      m_array[0]++;
+
+    sycl::group_barrier(root);
+
+    if (item.get_group_linear_id() == 2 && item.get_local_linear_id() == 0)
+      m_array[0]++;
+
+    sycl::group_barrier(root);
+
+    if (item.get_group_linear_id() == 3 && item.get_local_linear_id() == 0)
+      m_array[0]++;
+  }
+
+  auto get(sycl::ext::oneapi::experimental::properties_tag) const {
+    return sycl::ext::oneapi::experimental::properties{
+        sycl::ext::oneapi::experimental::use_root_sync};
+  }
+};
+
+int main() {
+  sycl::queue queue;
+  int *array = sycl::malloc_shared<int>(1, queue);
+  array[0] = 0;
+
+  queue
+      .submit([&](sycl::handler &h) {
+        h.parallel_for<class Test>(sycl::nd_range<1>(N, N / 4),
+                                   TestKernel(array));
+      })
+      .wait();
+  // CHECK-NOT: WARNING: DeviceSanitizer: data race
+
+  assert(array[0] == 4);
+
+  return 0;
+}

--- a/sycl/test-e2e/ThreadSanitizer/check_group_barrier.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_group_barrier.cpp
@@ -1,0 +1,64 @@
+// REQUIRES: linux, cpu || (gpu && level_zero)
+// RUN: %{build} %device_tsan_flags -O2 -g -o %t1.out
+// RUN: %{run} %t1.out 2>&1 | FileCheck %s
+#include "sycl/detail/core.hpp"
+#include "sycl/sub_group.hpp"
+#include "sycl/usm.hpp"
+#include <algorithm>
+
+int main() {
+  sycl::queue queue;
+  constexpr size_t reqd_sg_size = 32;
+  constexpr size_t N = reqd_sg_size * 4;
+
+  auto device = queue.get_device();
+  auto supported_sg_sizes =
+      device.get_info<sycl::info::device::sub_group_sizes>();
+  if (std::none_of(supported_sg_sizes.begin(), supported_sg_sizes.end(),
+                   [](size_t size) { return size == reqd_sg_size; }))
+    return 0;
+
+  int *array = sycl::malloc_shared<int>(1, queue);
+  array[0] = 0;
+
+  queue
+      .submit([&](sycl::handler &h) {
+        h.parallel_for<class Test>(
+            sycl::nd_range<1>(N, N),
+            [=](sycl::nd_item<1> item)
+                [[sycl::reqd_sub_group_size(reqd_sg_size)]] {
+                  auto sg = item.get_sub_group();
+                  if (item.get_group_linear_id() == 0 &&
+                      sg.get_group_linear_id() == 0 &&
+                      sg.get_local_linear_id() == 0)
+                    array[0]++;
+
+                  item.barrier();
+
+                  if (item.get_group_linear_id() == 0 &&
+                      sg.get_group_linear_id() == 1 &&
+                      sg.get_local_linear_id() == 0)
+                    array[0]++;
+
+                  item.barrier();
+
+                  if (item.get_group_linear_id() == 0 &&
+                      sg.get_group_linear_id() == 2 &&
+                      sg.get_local_linear_id() == 0)
+                    array[0]++;
+
+                  item.barrier();
+
+                  if (item.get_group_linear_id() == 0 &&
+                      sg.get_group_linear_id() == 3 &&
+                      sg.get_local_linear_id() == 0)
+                    array[0]++;
+                });
+      })
+      .wait();
+  // CHECK-NOT: WARNING: DeviceSanitizer: data race
+
+  assert(array[0] == 4);
+
+  return 0;
+}

--- a/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_ddi.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_ddi.cpp
@@ -1159,6 +1159,53 @@ ur_result_t urEnqueueKernelLaunch(
   return UR_RESULT_SUCCESS;
 }
 
+ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
+    /// [in] handle of the queue object
+    ur_queue_handle_t hQueue,
+    /// [in] handle of the kernel object
+    ur_kernel_handle_t hKernel,
+    /// [in] number of dimensions, from 1 to 3, to specify the global and
+    /// work-group work-items
+    uint32_t workDim,
+    /// [in] pointer to an array of workDim unsigned values that specify the
+    /// offset used to calculate the global ID of a work-item
+    const size_t *pGlobalWorkOffset,
+    /// [in] pointer to an array of workDim unsigned values that specify the
+    /// number of global work-items in workDim that will execute the kernel
+    /// function
+    const size_t *pGlobalWorkSize,
+    /// [in][optional] pointer to an array of workDim unsigned values that
+    /// specify the number of local work-items forming a work-group that will
+    /// execute the kernel function.
+    /// If nullptr, the runtime implementation will choose the work-group size.
+    const size_t *pLocalWorkSize,
+    /// [in] size of the event wait list
+    uint32_t numEventsInWaitList,
+    /// [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    /// events that must be complete before the kernel execution.
+    /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    /// event.
+    const ur_event_handle_t *phEventWaitList,
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
+    ur_event_handle_t *phEvent) {
+  getContext()->logger.debug("==== urEnqueueCooperativeKernelLaunchExp");
+
+  LaunchInfo LaunchInfo(GetContext(hQueue), GetDevice(hQueue));
+
+  UR_CALL(getTsanInterceptor()->preLaunchKernel(hKernel, hQueue, LaunchInfo));
+
+  UR_CALL(getContext()->urDdiTable.EnqueueExp.pfnCooperativeKernelLaunchExp(
+      hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
+      pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent));
+
+  UR_CALL(getTsanInterceptor()->postLaunchKernel(hKernel, hQueue, LaunchInfo));
+
+  return UR_RESULT_SUCCESS;
+}
+
 ur_result_t urCheckVersion(ur_api_version_t version) {
   if (UR_MAJOR_VERSION(ur_sanitizer_layer::getContext()->version) !=
           UR_MAJOR_VERSION(version) ||
@@ -1337,6 +1384,25 @@ __urdlllocal ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's EnqueueExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+__urdlllocal ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
+    /// [in,out] pointer to table of DDI function pointers
+    ur_enqueue_exp_dditable_t *pDdiTable) {
+  if (nullptr == pDdiTable) {
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+  }
+
+  pDdiTable->pfnCooperativeKernelLaunchExp =
+      ur_sanitizer_layer::tsan::urEnqueueCooperativeKernelLaunchExp;
+  return UR_RESULT_SUCCESS;
+}
+
 } // namespace tsan
 
 ur_result_t initTsanDDITable(ur_dditable_t *dditable) {
@@ -1379,6 +1445,11 @@ ur_result_t initTsanDDITable(ur_dditable_t *dditable) {
   if (UR_RESULT_SUCCESS == result) {
     result =
         ur_sanitizer_layer::tsan::urGetEnqueueProcAddrTable(&dditable->Enqueue);
+  }
+
+  if (UR_RESULT_SUCCESS == result) {
+    result = ur_sanitizer_layer::tsan::urGetEnqueueExpProcAddrTable(
+        &dditable->EnqueueExp);
   }
 
   if (result != UR_RESULT_SUCCESS) {

--- a/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_libdevice.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_libdevice.hpp
@@ -81,7 +81,8 @@ struct TsanRuntimeData {
 
   uintptr_t GlobalShadowOffsetEnd = 0;
 
-  VectorClock Clock[kThreadSlotCount];
+  // The last one is to record global state
+  VectorClock Clock[kThreadSlotCount + 1];
 
   DeviceType DeviceTy = DeviceType::UNKNOWN;
 


### PR DESCRIPTION
Barrier instructions will synchronize work items execution status, we
need to sync thread clocks before/after barrier call to avoid false
positive reports.