### PR TITLE
[libclc] Fix data races in libclc/libspirv LIT tests

### DIFF
--- a/libclc/test/CMakeLists.txt
+++ b/libclc/test/CMakeLists.txt
@@ -19,7 +19,7 @@ set(LIBCLC_TEST_DEPS
 add_custom_target(check-libclc)
 
 foreach( t ${LIBCLC_TARGET_TO_TEST} )
-	foreach( d ${${t}_devices} )
+  foreach( d ${${t}_devices} )
     if( ${d} STREQUAL "none" )
       set( mcpu )
       set( arch_suffix "${t}" )
@@ -29,11 +29,13 @@ foreach( t ${LIBCLC_TARGET_TO_TEST} )
     endif()
     message( " Testing : ${arch_suffix}" )
 
-    add_lit_testsuite(check-libclc-spirv-${arch_suffix} "Running libclc spirv-${arch_suffix} regression tests"
+    add_lit_testsuite(check-libclc-spirv-${arch_suffix}
+      "Running libclc spirv-${arch_suffix} regression tests"
       ${CMAKE_CURRENT_BINARY_DIR}
       ARGS
         --verbose
-      PARAMS "target=${t}" ${mcpu} "builtins=libspirv-${arch_suffix}.bc"
+      PARAMS "target=${t}" ${mcpu} "libclc-arch-suffix=${arch_suffix}"
+             "builtins=libspirv-${arch_suffix}.bc"
       DEPENDS
         ${LIBCLC_TEST_DEPS}
         libspirv-builtins

--- a/libclc/test/lit.cfg.py
+++ b/libclc/test/lit.cfg.py
@@ -37,7 +37,7 @@ libclc_arch_suffix = lit_config.params.get("libclc-arch-suffix", "")
 # test_exec_root: The root path where tests should be run. We create a unique
 # test directory per libclc target to test to avoid data races when multiple
 # targets try and access the the same libclc test files.
-config.test_exec_root = os.path.join(config.test_run_dir, 'test', libclc_arch_suffix)
+config.test_exec_root = os.path.join(config.test_run_dir, "test", libclc_arch_suffix)
 
 llvm_config.use_default_substitutions()
 

--- a/libclc/test/lit.cfg.py
+++ b/libclc/test/lit.cfg.py
@@ -26,15 +26,18 @@ config.excludes = ["CMakeLists.txt"]
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.join(os.path.dirname(__file__), "binding")
 
-# test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.test_run_dir, "test")
-
 libclc_inc = os.path.join(config.libclc_root, "libspirv", "include")
 
 target = lit_config.params.get("target", "")
 builtins = lit_config.params.get("builtins", "")
 cpu = lit_config.params.get("cpu", "")
 cpu = [] if cpu == "" else ["-mcpu=" + cpu]
+libclc_arch_suffix = lit_config.params.get("libclc-arch-suffix", "")
+
+# test_exec_root: The root path where tests should be run. We create a unique
+# test directory per libclc target to test to avoid data races when multiple
+# targets try and access the the same libclc test files.
+config.test_exec_root = os.path.join(config.test_run_dir, 'test', libclc_arch_suffix)
 
 llvm_config.use_default_substitutions()
 


### PR DESCRIPTION
Multiple libclc test targets were running essentially the same test suite in parallel. This could result in data races when one target writes a file another target is reading.

This commit fixes the issue by creating a unique test execution directory per target. We already have a unique libclc target known as an 'arch suffix' in CMake. This suffix is used as the unique builtins file name. We pass this through to LIT via a parameter to create the execution directory. Note this use of LIT (i.e., having one suite called multiple times in different configurations) is unconventional so there aren't many similar examples in LLVM.

Patch proposed by @bader.