### PR TITLE
[CODEOWNERS] Assign sycl/cts_exclude_filters to devops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,6 +123,7 @@ sycl/test-e2e/InvokeSimd/ @intel/dpcpp-esimd-reviewers
 .github/ @intel/dpcpp-devops-reviewers
 buildbot/ @intel/dpcpp-devops-reviewers
 devops/ @intel/dpcpp-devops-reviewers
+sycl/cts_exclude_filter/ @intel/dpcpp-devops-reviewers
 
 # dev-igc driver update
 devops/dependencies-igc-dev.json @intel/sycl-matrix-reviewers @intel/dpcpp-esimd-reviewers @intel/dpcpp-devops-reviewers


### PR DESCRIPTION
Changes in the cts_exclude_filter dir only affect CI.