### PR TITLE
[SYCL] Fix `ProgramManager::kernelUsesAssert` to avoid tmp string creation

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1824,10 +1824,6 @@ void ProgramManager::cacheKernelUsesAssertInfo(RTDeviceBinaryImage &Img) {
       m_KernelUsesAssert.insert(Prop->Name);
 }
 
-bool ProgramManager::kernelUsesAssert(const std::string &KernelName) const {
-  return m_KernelUsesAssert.find(KernelName) != m_KernelUsesAssert.end();
-}
-
 void ProgramManager::cacheKernelImplicitLocalArg(RTDeviceBinaryImage &Img) {
   const RTDeviceBinaryImage::PropertyRange &ImplicitLocalArgRange =
       Img.getImplicitLocalArg();

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -360,7 +360,10 @@ public:
   ProgramManager();
   ~ProgramManager() = default;
 
-  bool kernelUsesAssert(const std::string &KernelName) const;
+  template <typename NameT>
+  bool kernelUsesAssert(const NameT &KernelName) const {
+    return m_KernelUsesAssert.find(KernelName) != m_KernelUsesAssert.end();
+  }
 
   SanitizerType kernelUsesSanitizer() const { return m_SanitizerFoundInImage; }
 
@@ -503,7 +506,12 @@ protected:
   bool m_UseSpvFile = false;
   RTDeviceBinaryImageUPtr m_SpvFileImage;
 
-  std::set<std::string> m_KernelUsesAssert;
+  // std::less<> is a transparent comparator that enabled comparison between
+  // different types without temporary key_type object creation. This includes
+  // standard overloads, such as comparison between std::string and
+  // std::string_view or just char*.
+  using KernelUsesAssertSet = std::set<std::string, std::less<>>;
+  KernelUsesAssertSet m_KernelUsesAssert;
   std::unordered_map<std::string, int> m_KernelImplicitLocalArgPos;
 
   // Sanitizer type used in device image

--- a/sycl/unittests/program_manager/Cleanup.cpp
+++ b/sycl/unittests/program_manager/Cleanup.cpp
@@ -64,7 +64,7 @@ public:
     return m_EliminatedKernelArgMasks;
   }
 
-  std::set<std::string> &getKernelUsesAssert() { return m_KernelUsesAssert; }
+  KernelUsesAssertSet &getKernelUsesAssert() { return m_KernelUsesAssert; }
 
   std::unordered_map<std::string, int> &getKernelImplicitLocalArgPos() {
     return m_KernelImplicitLocalArgPos;


### PR DESCRIPTION
The handler calls the `ProgramManager::kernelUsesAssert` with `const char *` argument. It resulted in a temporary `std::string` creation. This PR changes the `ProgramManager::kernelUsesAssert` to accept template parameter and uses heterogeneous lookup feature of `std::set`