### PR TITLE
[SYCL][Clang] Fix compilation with --offload-compress and missing zstd

### DIFF
--- a/sycl/test-e2e/Compression/no_zstd_warning.cpp
+++ b/sycl/test-e2e/Compression/no_zstd_warning.cpp
@@ -1,4 +1,4 @@
-// using --offload-compress without zstd should throw an error.
+// using --offload-compress without zstd should throw a warning.
 // REQUIRES: !zstd
-// RUN: not %{build} %O0 -g --offload-compress %S/Inputs/single_kernel.cpp -o %t_compress.out 2>&1 | FileCheck %s
+// RUN: %{build} %O0 -g --offload-compress %S/Inputs/single_kernel.cpp -o %t_compress.out 2>&1 | FileCheck %s
 // CHECK: '--offload-compress' option is specified but zstd is not available. The device image will not be compressed.


### PR DESCRIPTION
When using a compiler built without zstd support, it's preferable for --offload-compress option to lead to a warning instead of an error.