### PR TITLE
[SYCL][UR][L0 v2] Fix p2p access checking

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -25,7 +25,7 @@ filterP2PDevices(ur_device_handle_t hSourceDevice,
 
     ze_bool_t p2p;
     ZE2UR_CALL_THROWS(zeDeviceCanAccessPeer,
-                      (hSourceDevice->ZeDevice, device->ZeDevice, &p2p));
+                      (device->ZeDevice, hSourceDevice->ZeDevice, &p2p));
 
     if (p2p) {
       p2pDevices.push_back(device);


### PR DESCRIPTION
The order of arguments to zeDeviceCanAccessPeer was incorrect causing problems on platforms with both
discrete and integrated GPUs.

Relying on incorrecnt information zeContextMakeMemoryResident was being called for memory that was inaccesible on a device.