### PR TITLE
[SYCL][Coverity] Fix COPY_INSTEAD_OF_MOVE hit in Coverity

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -1425,7 +1425,8 @@ void exec_graph_impl::update(
     // other scheduler commands
     auto UpdateEvent =
         sycl::detail::Scheduler::getInstance().addCommandGraphUpdate(
-            this, Nodes, AllocaQueue, UpdateRequirements, MExecutionEvents);
+            this, Nodes, AllocaQueue, std::move(UpdateRequirements),
+            MExecutionEvents);
 
     MExecutionEvents.push_back(UpdateEvent);
 


### PR DESCRIPTION
Fix coverity hit regarding an opportunity in `graph_impl` to use `std::move` instead of implicitly copying.