### PR TITLE
[SYCL][Coverity] Fix invalid iterator coverity hit

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2190,8 +2190,8 @@ void ProgramManager::removeImages(sycl_device_binaries DeviceBinary) {
 
       if (auto It = m_KernelName2KernelIDs.find(EntriesIt->GetName());
           It != m_KernelName2KernelIDs.end()) {
-        m_KernelName2KernelIDs.erase(It);
         m_KernelIDs2BinImage.erase(It->second);
+        m_KernelName2KernelIDs.erase(It);
       }
     }
 


### PR DESCRIPTION
In `ProgramManager::removeImages`, we cleanup our KernelName2KernelID mapping, before using that exact mapping retrieve KernelIDs in order to clean up our KernelIDs2BinImage mapping. This PR cleans up `m_KernelID2BinImage` mapping before cleaning up `m_KernelName2KernelIDs` maping.

This is inteded to fix a hit raised by Coverity.