### PR TITLE
[UR] Add UR_DEVICE_INFO_VALIDATES_ON_LAUNCH

### DIFF
--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -2243,6 +2243,9 @@ typedef enum ur_device_info_t {
   UR_DEVICE_INFO_MAX_POWER_LIMIT = 126,
   /// [::ur_bool_t] support for native bfloat16 conversions
   UR_DEVICE_INFO_BFLOAT16_CONVERSIONS_NATIVE = 127,
+  /// [::ur_bool_t] ::urEnqueueKernelLaunch may return
+  /// ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS
+  UR_DEVICE_INFO_VALIDATES_ON_LAUNCH = 128,
   /// [::ur_bool_t] Returns true if the device supports the use of
   /// command-buffers.
   UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP = 0x1000,
@@ -7548,6 +7551,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
+/// @details
+///     - Adapters must perform validation on provided kernel arguments when
+///       launching them if they report `::UR_DEVICE_INFO_VALIDATES_ON_LAUNCH`
+///       as true for the appropriate device. If this is reported as false, then
+///       launching a kernel with invalid arguments is Undefined Behavior.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueNDRangeKernel**
@@ -7575,8 +7584,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS - "The kernel argument values
-///     have not been specified."
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS
+///         + The kernel argument values are not valid and
+///         `::UR_DEVICE_INFO_VALIDATES_ON_LAUNCH` is true for the device
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(

--- a/unified-runtime/include/ur_print.hpp
+++ b/unified-runtime/include/ur_print.hpp
@@ -2969,6 +2969,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
   case UR_DEVICE_INFO_BFLOAT16_CONVERSIONS_NATIVE:
     os << "UR_DEVICE_INFO_BFLOAT16_CONVERSIONS_NATIVE";
     break;
+  case UR_DEVICE_INFO_VALIDATES_ON_LAUNCH:
+    os << "UR_DEVICE_INFO_VALIDATES_ON_LAUNCH";
+    break;
   case UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP:
     os << "UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP";
     break;
@@ -4702,6 +4705,19 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr,
     os << ")";
   } break;
   case UR_DEVICE_INFO_BFLOAT16_CONVERSIONS_NATIVE: {
+    const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+    if (sizeof(ur_bool_t) > size) {
+      os << "invalid size (is: " << size
+         << ", expected: >=" << sizeof(ur_bool_t) << ")";
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    os << (const void *)(tptr) << " (";
+
+    os << *tptr;
+
+    os << ")";
+  } break;
+  case UR_DEVICE_INFO_VALIDATES_ON_LAUNCH: {
     const ur_bool_t *tptr = (const ur_bool_t *)ptr;
     if (sizeof(ur_bool_t) > size) {
       os << "invalid size (is: " << size

--- a/unified-runtime/scripts/core/device.yml
+++ b/unified-runtime/scripts/core/device.yml
@@ -462,6 +462,8 @@ etors:
       desc: "[int32_t][optional-query] return max power limit in milliwatts."
     - name: BFLOAT16_CONVERSIONS_NATIVE
       desc: "[$x_bool_t] support for native bfloat16 conversions"
+    - name: VALIDATES_ON_LAUNCH
+      desc: "[$x_bool_t] $xEnqueueKernelLaunch may return $X_RESULT_ERROR_INVALID_KERNEL_ARGS"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves various information about device"

--- a/unified-runtime/scripts/core/enqueue.yml
+++ b/unified-runtime/scripts/core/enqueue.yml
@@ -16,6 +16,10 @@ type: function
 desc: "Enqueue a command to execute a kernel"
 class: $xEnqueue
 name: KernelLaunch
+details:
+    - "Adapters must perform validation on provided kernel arguments when launching them if they report
+      `$X_DEVICE_INFO_VALIDATES_ON_LAUNCH` as true for the appropriate device. If this is reported as false, then
+      launching a kernel with invalid arguments is Undefined Behavior."
 ordinal: "0"
 analogue:
     - "**clEnqueueNDRangeKernel**"
@@ -65,8 +69,8 @@ returns:
     - $X_RESULT_ERROR_INVALID_WORK_DIMENSION
     - $X_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
     - $X_RESULT_ERROR_INVALID_VALUE
-    - $X_RESULT_ERROR_INVALID_KERNEL_ARGS
-        - "The kernel argument values have not been specified."
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGS:
+        - "The kernel argument values are not valid and `$X_DEVICE_INFO_VALIDATES_ON_LAUNCH` is true for the device"
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------

--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -1188,6 +1188,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(false);
   case UR_DEVICE_INFO_ASYNC_USM_ALLOCATIONS_SUPPORT_EXP:
     return ReturnValue(true);
+  case UR_DEVICE_INFO_VALIDATES_ON_LAUNCH:
+    return ReturnValue(false);
   default:
     break;
   }

--- a/unified-runtime/source/adapters/hip/device.cpp
+++ b/unified-runtime/source/adapters/hip/device.cpp
@@ -1095,6 +1095,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(true);
   case UR_DEVICE_INFO_MULTI_DEVICE_COMPILE_SUPPORT_EXP:
     return ReturnValue(false);
+  case UR_DEVICE_INFO_VALIDATES_ON_LAUNCH:
+    return ReturnValue(false);
   default:
     break;
   }

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1335,6 +1335,8 @@ ur_result_t urDeviceGetInfo(
       return ReturnValue(int32_t{PowerProperties.maxLimit});
     }
   }
+  case UR_DEVICE_INFO_VALIDATES_ON_LAUNCH:
+    return ReturnValue(false);
   default:
     logger::error("Unsupported ParamName in urGetDeviceInfo");
     logger::error("ParamNameParamName={}(0x{})", ParamName,

--- a/unified-runtime/source/adapters/native_cpu/device.cpp
+++ b/unified-runtime/source/adapters/native_cpu/device.cpp
@@ -456,6 +456,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_VARIABLE_SUPPORT:
     return ReturnValue(false);
 
+  case UR_DEVICE_INFO_VALIDATES_ON_LAUNCH:
+    return ReturnValue(false);
+
   default:
     DIE_NO_IMPLEMENTATION;
   }

--- a/unified-runtime/source/adapters/opencl/device.cpp
+++ b/unified-runtime/source/adapters/opencl/device.cpp
@@ -1427,6 +1427,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(true);
   case UR_DEVICE_INFO_MULTI_DEVICE_COMPILE_SUPPORT_EXP:
     return ReturnValue(false);
+  case UR_DEVICE_INFO_VALIDATES_ON_LAUNCH:
+    return ReturnValue(true);
   // TODO: We can't query to check if these are supported, they will need to be
   // manually updated if support is ever implemented.
   case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS:

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -4983,6 +4983,12 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
+/// @details
+///     - Adapters must perform validation on provided kernel arguments when
+///       launching them if they report `::UR_DEVICE_INFO_VALIDATES_ON_LAUNCH`
+///       as true for the appropriate device. If this is reported as false, then
+///       launching a kernel with invalid arguments is Undefined Behavior.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueNDRangeKernel**
@@ -5010,8 +5016,9 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS - "The kernel argument values
-///     have not been specified."
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS
+///         + The kernel argument values are not valid and
+///         `::UR_DEVICE_INFO_VALIDATES_ON_LAUNCH` is true for the device
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urEnqueueKernelLaunch(

--- a/unified-runtime/source/ur_api.cpp
+++ b/unified-runtime/source/ur_api.cpp
@@ -4349,6 +4349,12 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
+/// @details
+///     - Adapters must perform validation on provided kernel arguments when
+///       launching them if they report `::UR_DEVICE_INFO_VALIDATES_ON_LAUNCH`
+///       as true for the appropriate device. If this is reported as false, then
+///       launching a kernel with invalid arguments is Undefined Behavior.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueNDRangeKernel**
@@ -4376,8 +4382,9 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS - "The kernel argument values
-///     have not been specified."
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS
+///         + The kernel argument values are not valid and
+///         `::UR_DEVICE_INFO_VALIDATES_ON_LAUNCH` is true for the device
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urEnqueueKernelLaunch(

--- a/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
@@ -2662,6 +2662,20 @@ TEST_P(urDeviceGetInfoTest, SuccessMinPowerLimit) {
                              property_value);
 }
 
+TEST_P(urDeviceGetInfoTest, SuccessValidatesOnLaunch) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_VALIDATES_ON_LAUNCH;
+
+  ASSERT_SUCCESS(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = 0;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+}
+
 TEST_P(urDeviceGetInfoTest, InvalidNullHandleDevice) {
   ur_device_type_t device_type;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -154,19 +154,13 @@ TEST_P(urEnqueueKernelLaunchTest, InvalidWorkGroupSize) {
 }
 
 TEST_P(urEnqueueKernelLaunchTest, InvalidKernelArgs) {
-  // Cuda and hip both lack any way to validate kernel args
-  UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
-  UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
+  ur_bool_t validates;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_VALIDATES_ON_LAUNCH,
+                                 sizeof(validates), &validates, nullptr));
 
-  ur_platform_backend_t backend;
-  ASSERT_SUCCESS(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
-                                   sizeof(ur_platform_backend_t), &backend,
-                                   nullptr));
-
-  if (backend == UR_PLATFORM_BACKEND_CUDA ||
-      backend == UR_PLATFORM_BACKEND_HIP ||
-      backend == UR_PLATFORM_BACKEND_LEVEL_ZERO) {
-    GTEST_FAIL() << "AMD, L0 and Nvidia can't check kernel arguments.";
+  if (!validates) {
+    GTEST_SKIP() << "Adapter can't check kernel arguments.";
+    return;
   }
 
   // Enqueue kernel without setting any args

--- a/unified-runtime/tools/urinfo/urinfo.hpp
+++ b/unified-runtime/tools/urinfo/urinfo.hpp
@@ -344,6 +344,8 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
   printDeviceInfo<ur_bool_t>(hDevice,
                              UR_DEVICE_INFO_BFLOAT16_CONVERSIONS_NATIVE);
   std::cout << prefix;
+  printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_VALIDATES_ON_LAUNCH);
+  std::cout << prefix;
   printDeviceInfo<ur_bool_t>(hDevice,
                              UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP);
   std::cout << prefix;


### PR DESCRIPTION
This device info is used to specify whether a given device can validate
arguments passed to a kernel when it is launched. This also updates the
spec to specify that if this value is not set, then running a kernel
with invalid arguments is UB.

This does not imply any behavior changes in adapters themselves; they
already UB-ed anyway. This just writes it into the spec and makes
some conformance tests not fail them for it.
