### PR TITLE
[SYCL] Add test for free function kernels extension that checks emitted diagnostics if kernel violates restrictions

### DIFF
--- a/sycl/test/extensions/free_function_kernels/free_function_kernels_diagnostics.cpp
+++ b/sycl/test/extensions/free_function_kernels/free_function_kernels_diagnostics.cpp
@@ -1,0 +1,29 @@
+// RUN: %clangxx -fsyntax-only -fsycl-device-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+#include <sycl/sycl.hpp>
+
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+// expected-error@+2 {{'int &' cannot be used as the type of a kernel parameter}}
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::single_task_kernel)
+void singleTaskKernelReference(int &Ref) {}
+
+// expected-error@+2 {{'int &' cannot be used as the type of a kernel parameter}}
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<2>)
+void ndRangeKernelReference(int &Ref) {}
+
+// Diagnostic for these violations of the restrictions haven't been implemented yet.
+// TODO: Add expected error when it will be implemented.
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::single_task_kernel)
+void singleTaskKernelVariadic(...) {}
+
+// TODO: Add expected error when it will be implemented.
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<3>)
+void ndRangeKernelVariadic(...) {}
+
+// TODO: Add expected error when it will be implemented.
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::single_task_kernel)
+void singleTaskKernelDefaultValues(int Value = 1) {}
+
+// TODO: Add expected error when it will be implemented.
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<1>)
+void ndRangeKernelDefaultValues(int Value = 1) {}


### PR DESCRIPTION
This PR adds test for free function kernels extension that checks emitted diagnostics if kernel violates restrictions specified in spec for declaration of free function kernel.
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc#defining-a-free-function-kernel

Test introduced based on test plan: https://github.com/intel/llvm/pull/17886