### PR TITLE
[SYCL] Require building with zstd library

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -64,7 +64,6 @@ def do_configure(args, passthrough_args):
 
     sycl_enable_xpti_tracing = "ON"
     xpti_enable_werror = "OFF"
-    llvm_enable_zstd = "ON"
     spirv_enable_dis = "OFF"
 
     if sys.platform != "darwin":
@@ -188,7 +187,7 @@ def do_configure(args, passthrough_args):
         "-DLLVM_ENABLE_PROJECTS={}".format(llvm_enable_projects),
         "-DSYCL_BUILD_PI_HIP_PLATFORM={}".format(sycl_build_pi_hip_platform),
         "-DLLVM_BUILD_TOOLS=ON",
-        "-DLLVM_ENABLE_ZSTD={}".format(llvm_enable_zstd),
+        "-DLLVM_ENABLE_ZSTD=FORCE_ON",  # Required by SYCL device image compression.
         "-DLLVM_USE_STATIC_ZSTD=ON",
         "-DSYCL_ENABLE_WERROR={}".format(sycl_werror),
         "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),


### PR DESCRIPTION
SYCL device image compression requires zstd.
Running `clang++ -fsycl --offload-compress` with a version of the compiler compiled without zstd leads to an error.
Instead of complicating the handling of device image compression to also make it optional, it's cleaner to avoid compiling without zstd library, and to make it a required dependency for SYCL.
Using LLVM_ENABLE_ZSTD=FORCE_ON prevents from compiling without zstd.

An alternative has been discussed in https://github.com/intel/llvm/pull/17914