### PR TITLE
[SYCL] Stop emission of modf intrinsic for NVPTX/AMDGCN

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3154,9 +3154,10 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       GenerateIntrinsics =
           ConstWithoutErrnoOrExceptions && ErrnoOverridenToFalseWithOpt;
   }
-  if (GenerateIntrinsics &&
+  GenerateIntrinsics &=
       !(getLangOpts().SYCLIsDevice && (getTarget().getTriple().isNVPTX() ||
-                                       getTarget().getTriple().isAMDGCN()))) {
+                                       getTarget().getTriple().isAMDGCN()));
+  if (GenerateIntrinsics) {
     switch (BuiltinIDIfNoAsmLabel) {
     case Builtin::BIacos:
     case Builtin::BIacosf:
@@ -4256,7 +4257,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_modf:
   case Builtin::BI__builtin_modff:
   case Builtin::BI__builtin_modfl:
-    if (Builder.getIsFPConstrained())
+    if (Builder.getIsFPConstrained() || !GenerateIntrinsics)
       break; // TODO: Emit constrained modf intrinsic once one exists.
     return RValue::get(emitModfBuiltin(*this, E, Intrinsic::modf));
   case Builtin::BI__builtin_isgreater:

--- a/sycl/test-e2e/DeviceLib/cmath_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_test.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: true
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17813
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 
 // RUN: %{build} -fno-builtin %{mathflags} -o %t1.out


### PR DESCRIPTION
A recent change in #126750 changed the lowering of the modf builtin(s) to lower to the llvm.modf intrinsic. Certain SYCL targets such as NVPTX and AMDGCN cannot currently handle this intrinsic in the backend because they don't have the necessary target library info. Even if they did, the SYCL device libraries are linked in earlier at the IR level so we'd be left with an unresolved symbol.

We have been working around this at clang codegen time by avoiding the emission of intrinsics altogether by (ab)using a guard on math intrinsics.

The problem with us hooking into GenerateIntrinsics like this is that SYCL is wanting to use it as a guarantee that (a certain subset of) intrinsics won't be emitted if GenerateIntrinsics is false, whereas upstream does not make this guarantee: it's an opt-in toggle for a more optimal lowering strategy. Thus we're always going to be liable to this sort of upstream change.

This doesn't feel like the right mechanism for SYCL to handle these builtins (or intrinsics) long term, but this fix restores the previous behaviour without making things much worse.

Fixes #17813