### PR TITLE
[SYCL][E2E] Disable MemorySanitizer tests failing on OCL CPU

### DIFF
--- a/sycl/test-e2e/MemorySanitizer/check_large_access.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_large_access.cpp
@@ -7,6 +7,9 @@
 // XFAIL: spirv-backend
 // XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/122075
 
+// XFAIL: linux && cpu && run-mode
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17959
+
 #include "sycl/detail/core.hpp"
 #include <sycl/vector.hpp>
 

--- a/sycl/test-e2e/MemorySanitizer/local/parallel_for_work_group.cpp
+++ b/sycl/test-e2e/MemorySanitizer/local/parallel_for_work_group.cpp
@@ -9,6 +9,9 @@
 // XFAIL: spirv-backend && gpu && run-mode
 // XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/122075
 
+// XFAIL: linux && cpu && run-mode
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17959
+
 #include <sycl/group.hpp>
 #include <sycl/usm.hpp>
 


### PR DESCRIPTION
[Failing](https://github.com/intel/llvm/issues/17959) in nightly 