### PR TITLE
[UR][SYCL] Fix cmake LIST cache variables - LIST is not a valid cache type.

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -33,7 +33,7 @@ set(UR_BUILD_XPTI_LIBS OFF)
 set(UR_ENABLE_SYMBOLIZER ON CACHE BOOL "Enable symbolizer for sanitizer layer.")
 set(UR_ENABLE_TRACING ON)
 
-set(UR_EXTERNAL_DEPENDENCIES "sycl-headers" CACHE LIST
+set(UR_EXTERNAL_DEPENDENCIES "sycl-headers" CACHE STRING
   "List of external CMake targets for executables/libraries to depend on" FORCE)
 
 if("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)

--- a/unified-runtime/CMakeLists.txt
+++ b/unified-runtime/CMakeLists.txt
@@ -56,7 +56,7 @@ option(UR_BUILD_XPTI_LIBS "Build the XPTI libraries when tracing is enabled" ON)
 option(UR_STATIC_LOADER "Build loader as a static library" OFF)
 option(UR_FORCE_LIBSTDCXX "Force use of libstdc++ in a build using libc++ on Linux" OFF)
 option(UR_ENABLE_LATENCY_HISTOGRAM "Enable latncy histogram" OFF)
-set(UR_EXTERNAL_DEPENDENCIES "" CACHE LIST
+set(UR_EXTERNAL_DEPENDENCIES "" CACHE STRING
     "List of external CMake targets for executables/libraries to depend on")
 set(UR_DPCXX "" CACHE FILEPATH "Path of the DPC++ compiler executable")
 set(UR_DPCXX_BUILD_FLAGS "" CACHE STRING "Build flags to pass to DPC++ when compiling device programs")


### PR DESCRIPTION
This doesn't affect the behaviour of UR_EXTERNAL_DEPENDENCIES - since it gets used as a list, if you try to set it to a string that cmake can't convert to a list you get a fatal error (e.g. doing `set(UR_EXTERNAL_DEPENDENCIES "my-dep my-other-dep")` rather than `set(UR_EXTERNAL_DEPENDENCIES "my-dep;my-other-dep")`).

The list of valid cache variable types is here https://cmake.org/cmake/help/latest/prop_cache/TYPE.html