### PR TITLE
[UR] Fix use of old global CL adapter handle.

### DIFF
--- a/unified-runtime/source/adapters/opencl/adapter.cpp
+++ b/unified-runtime/source/adapters/opencl/adapter.cpp
@@ -130,21 +130,21 @@ urAdapterGetInfo(ur_adapter_handle_t hAdapter, ur_adapter_info_t propName,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
-    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    ur_adapter_handle_t hAdapter, ur_logger_callback_t pfnLoggerCallback,
     void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
 
-  if (adapter) {
-    adapter->log.setCallbackSink(pfnLoggerCallback, pUserData, level);
+  if (hAdapter) {
+    hAdapter->log.setCallbackSink(pfnLoggerCallback, pUserData, level);
   }
 
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t, ur_logger_level_t level) {
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    ur_adapter_handle_t hAdapter, ur_logger_level_t level) {
 
-  if (adapter) {
-    adapter->log.setCallbackLevel(level);
+  if (hAdapter) {
+    hAdapter->log.setCallbackLevel(level);
   }
 
   return UR_RESULT_SUCCESS;


### PR DESCRIPTION
This was introduced by unfortunate merge timing.