### PR TITLE
[clang][Sema][SYCL] Fix SYCL AMDGPU compilation on Windows

### DIFF
--- a/clang/test/SemaSYCL/Inputs/vectorcall.hpp
+++ b/clang/test/SemaSYCL/Inputs/vectorcall.hpp
@@ -1,0 +1,18 @@
+
+template <typename F> struct A{};
+
+template <typename Ret, typename C, typename... Args> struct A<Ret (             C::*)(Args...) noexcept> { static constexpr int value = 0; };
+template <typename Ret, typename C, typename... Args> struct A<Ret (__vectorcall C::*)(Args...) noexcept> { static constexpr int value = 1; };
+
+template <typename F> constexpr int A_v = A<F>::value;
+
+struct B
+{
+    void f() noexcept {}
+    void __vectorcall g() noexcept {}
+};
+
+int main()
+{
+    return A_v<decltype(&B::f)> + A_v<decltype(&B::g)>;
+}

--- a/clang/test/SemaSYCL/sycl-cconv-win.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv-win.cpp
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -isystem %S/Inputs/ -fsycl-is-device -triple amdgcn-amd-hsa -aux-triple x86_64-pc-windows-msvc -fsyntax-only -verify %s
+
+// expected-no-diagnostics
+
+#include <vectorcall.hpp>


### PR DESCRIPTION
The MSVC STL includes specializations of `_Is_memfunptr` for every function pointer type, including every calling convention.

The problem is the AMDGPU target doesn't support the `vectorcall` calling convention so clang sets it to the default CC. This ends up clashing with the already-existing overload for the default CC, so we get a duplicate definiton error when including `type_traits` (which we heavily use in the SYCL STL) and compiling for AMDGPU on Windows.

This doesn't happen for pure AMDGPU non-SYCL because it doesn't include the C++ STL, and it doesn't happen for CUDA/HIP because a similar workaround was done upstream [here](https://github.com/llvm/llvm-project/commit/fa49c3a888e816969b5ed68cd5c47efc3eb9419f).

I am submitting this here as opposed to upstream as upstream SYCL doesn't hit the issue due to lacking AMDGPU SYCL support.

I am not an expert in Sema, so I tried to make the fix extremely targeted. If there is a better fix let me know. As far as I can tell we can't do exactly the same fix that was done for CUDA because we can't differentiate between device and host code so easily.

Closes: https://github.com/intel/llvm/issues/7738