### PR TITLE
[UR][CUDA][HIP] Remove duplicated parameter checking

### DIFF
--- a/unified-runtime/source/adapters/cuda/image.cpp
+++ b/unified-runtime/source/adapters/cuda/image.cpp
@@ -269,7 +269,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPitchedAllocExp(
   std::ignore = pUSMDesc;
   std::ignore = pool;
 
-  UR_ASSERT((widthInBytes > 0), UR_RESULT_ERROR_INVALID_VALUE);
   UR_ASSERT((height > 0), UR_RESULT_ERROR_INVALID_VALUE);
   UR_ASSERT((elementSizeBytes > 0), UR_RESULT_ERROR_INVALID_VALUE);
 

--- a/unified-runtime/source/adapters/cuda/kernel.cpp
+++ b/unified-runtime/source/adapters/cuda/kernel.cpp
@@ -473,8 +473,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
             UR_RESULT_ERROR_INVALID_KERNEL);
   UR_ASSERT(workDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
   UR_ASSERT(workDim < 4, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
-  UR_ASSERT(pSuggestedLocalWorkSize != nullptr,
-            UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
   ur_device_handle_t Device = hQueue->Device;
   ur_result_t Result = UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/cuda/memory.cpp
+++ b/unified-runtime/source/adapters/cuda/memory.cpp
@@ -24,14 +24,6 @@
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ur_mem_flags_t flags, size_t size,
     const ur_buffer_properties_t *pProperties, ur_mem_handle_t *phBuffer) {
-  // Validate flags
-  if (flags &
-      (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) {
-    UR_ASSERT(pProperties && pProperties->pHost,
-              UR_RESULT_ERROR_INVALID_HOST_PTR);
-  }
-  UR_ASSERT(size != 0, UR_RESULT_ERROR_INVALID_BUFFER_SIZE);
-
   // Currently, USE_HOST_PTR is not implemented using host register
   // since this triggers a weird segfault after program ends.
   // Setting this constant to true enables testing that behavior.
@@ -201,18 +193,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     ur_context_handle_t hContext, ur_mem_flags_t flags,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     void *pHost, ur_mem_handle_t *phMem) {
-  if (flags &
-      (UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER | UR_MEM_FLAG_USE_HOST_POINTER)) {
-    UR_ASSERT(pHost, UR_RESULT_ERROR_INVALID_HOST_PTR);
-  }
   const bool PerformInitialCopy =
       (flags & UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER) ||
       ((flags & UR_MEM_FLAG_USE_HOST_POINTER));
-
-  UR_ASSERT(pImageDesc->stype == UR_STRUCTURE_TYPE_IMAGE_DESC,
-            UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-  UR_ASSERT(pImageDesc->type <= UR_MEM_TYPE_IMAGE1D_ARRAY,
-            UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
 
   // We only support RBGA channel order
   // TODO: check SYCL CTS and spec. May also have to support BGRA
@@ -363,9 +346,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
     ur_mem_handle_t hBuffer, ur_mem_flags_t flags,
     ur_buffer_create_type_t bufferCreateType, const ur_buffer_region_t *pRegion,
     ur_mem_handle_t *phMem) {
-  UR_ASSERT(hBuffer, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-  UR_ASSERT((flags & UR_MEM_FLAGS_MASK) == 0,
-            UR_RESULT_ERROR_INVALID_ENUMERATION);
   UR_ASSERT(hBuffer->isBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
   UR_ASSERT(!hBuffer->isSubBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
@@ -386,13 +366,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
     UR_ASSERT(!(flags & (UR_MEM_FLAG_READ_WRITE | UR_MEM_FLAG_WRITE_ONLY)),
               UR_RESULT_ERROR_INVALID_VALUE);
   }
-
-  UR_ASSERT(bufferCreateType == UR_BUFFER_CREATE_TYPE_REGION,
-            UR_RESULT_ERROR_INVALID_ENUMERATION);
-  UR_ASSERT(pRegion != nullptr, UR_RESULT_ERROR_INVALID_NULL_POINTER);
-  UR_ASSERT(phMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
-
-  UR_ASSERT(pRegion->size != 0u, UR_RESULT_ERROR_INVALID_BUFFER_SIZE);
 
   auto &BufferImpl = std::get<BufferMem>(hBuffer->Mem);
   UR_ASSERT(((pRegion->origin + pRegion->size) <= BufferImpl.getSize()),

--- a/unified-runtime/source/adapters/cuda/memory.cpp
+++ b/unified-runtime/source/adapters/cuda/memory.cpp
@@ -343,9 +343,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
 /// A buffer partition (or a sub-buffer, in OpenCL terms) is simply implemented
 /// as an offset over an existing CUDA allocation.
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
-    ur_mem_handle_t hBuffer, ur_mem_flags_t flags,
-    ur_buffer_create_type_t bufferCreateType, const ur_buffer_region_t *pRegion,
-    ur_mem_handle_t *phMem) {
+    ur_mem_handle_t hBuffer, ur_mem_flags_t flags, ur_buffer_create_type_t,
+    const ur_buffer_region_t *pRegion, ur_mem_handle_t *phMem) {
   UR_ASSERT(hBuffer->isBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
   UR_ASSERT(!hBuffer->isSubBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 

--- a/unified-runtime/source/adapters/cuda/platform.cpp
+++ b/unified-runtime/source/adapters/cuda/platform.cpp
@@ -79,7 +79,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform, ur_platform_info_t PlatformInfoType,
     size_t Size, void *pPlatformInfo, size_t *pSizeRet) {
 
-  UR_ASSERT(hPlatform, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UrReturnHelper ReturnValue(Size, pPlatformInfo, pSizeRet);
 
   switch (PlatformInfoType) {
@@ -119,9 +118,6 @@ urPlatformGet(ur_adapter_handle_t, uint32_t NumEntries,
   try {
     static std::once_flag InitFlag;
     static uint32_t NumPlatforms = 1;
-
-    UR_ASSERT(phPlatforms || pNumPlatforms, UR_RESULT_ERROR_INVALID_VALUE);
-    UR_ASSERT(!phPlatforms || NumEntries > 0, UR_RESULT_ERROR_INVALID_SIZE);
 
     ur_result_t Result = UR_RESULT_SUCCESS;
 

--- a/unified-runtime/source/adapters/cuda/platform.cpp
+++ b/unified-runtime/source/adapters/cuda/platform.cpp
@@ -75,10 +75,9 @@ CreateDeviceMemoryProvidersPools(ur_platform_handle_t_ *Platform) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetInfo(
-    ur_platform_handle_t hPlatform, ur_platform_info_t PlatformInfoType,
-    size_t Size, void *pPlatformInfo, size_t *pSizeRet) {
-
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetInfo(ur_platform_handle_t, ur_platform_info_t PlatformInfoType,
+                  size_t Size, void *pPlatformInfo, size_t *pSizeRet) {
   UrReturnHelper ReturnValue(Size, pPlatformInfo, pSizeRet);
 
   switch (PlatformInfoType) {
@@ -113,8 +112,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetInfo(
 /// Triggers the CUDA Driver initialization (cuInit) the first time, so this
 /// must be the first PI API called.
 UR_APIEXPORT ur_result_t UR_APICALL
-urPlatformGet(ur_adapter_handle_t, uint32_t NumEntries,
-              ur_platform_handle_t *phPlatforms, uint32_t *pNumPlatforms) {
+urPlatformGet(ur_adapter_handle_t, uint32_t, ur_platform_handle_t *phPlatforms,
+              uint32_t *pNumPlatforms) {
   try {
     static std::once_flag InitFlag;
     static uint32_t NumPlatforms = 1;

--- a/unified-runtime/source/adapters/cuda/usm.cpp
+++ b/unified-runtime/source/adapters/cuda/usm.cpp
@@ -35,6 +35,10 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
                ur_usm_pool_handle_t hPool, size_t size, void **ppMem) {
   auto alignment = pUSMDesc ? pUSMDesc->align : 0u;
+  UR_ASSERT(!pUSMDesc ||
+                (alignment == 0 || ((alignment & (alignment - 1)) == 0)),
+            UR_RESULT_ERROR_INVALID_VALUE);
+
   if (!hPool) {
     return USMHostAllocImpl(ppMem, hContext, /* flags */ 0, size, alignment);
   }
@@ -55,6 +59,10 @@ urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
                  const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t hPool,
                  size_t size, void **ppMem) {
   auto alignment = pUSMDesc ? pUSMDesc->align : 0u;
+  UR_ASSERT(!pUSMDesc ||
+                (alignment == 0 || ((alignment & (alignment - 1)) == 0)),
+            UR_RESULT_ERROR_INVALID_VALUE);
+
   if (!hPool) {
     return USMDeviceAllocImpl(ppMem, hContext, hDevice, /* flags */ 0, size,
                               alignment);
@@ -76,6 +84,10 @@ urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
                  const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t hPool,
                  size_t size, void **ppMem) {
   auto alignment = pUSMDesc ? pUSMDesc->align : 0u;
+  UR_ASSERT(!pUSMDesc ||
+                (alignment == 0 || ((alignment & (alignment - 1)) == 0)),
+            UR_RESULT_ERROR_INVALID_VALUE);
+
   if (!hPool) {
     return USMSharedAllocImpl(ppMem, hContext, hDevice, /*host flags*/ 0,
                               /*device flags*/ 0, size, alignment);

--- a/unified-runtime/source/adapters/cuda/usm.cpp
+++ b/unified-runtime/source/adapters/cuda/usm.cpp
@@ -35,10 +35,6 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
                ur_usm_pool_handle_t hPool, size_t size, void **ppMem) {
   auto alignment = pUSMDesc ? pUSMDesc->align : 0u;
-  UR_ASSERT(!pUSMDesc ||
-                (alignment == 0 || ((alignment & (alignment - 1)) == 0)),
-            UR_RESULT_ERROR_INVALID_VALUE);
-
   if (!hPool) {
     return USMHostAllocImpl(ppMem, hContext, /* flags */ 0, size, alignment);
   }
@@ -59,10 +55,6 @@ urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
                  const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t hPool,
                  size_t size, void **ppMem) {
   auto alignment = pUSMDesc ? pUSMDesc->align : 0u;
-  UR_ASSERT(!pUSMDesc ||
-                (alignment == 0 || ((alignment & (alignment - 1)) == 0)),
-            UR_RESULT_ERROR_INVALID_VALUE);
-
   if (!hPool) {
     return USMDeviceAllocImpl(ppMem, hContext, hDevice, /* flags */ 0, size,
                               alignment);
@@ -84,10 +76,6 @@ urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
                  const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t hPool,
                  size_t size, void **ppMem) {
   auto alignment = pUSMDesc ? pUSMDesc->align : 0u;
-  UR_ASSERT(!pUSMDesc ||
-                (alignment == 0 || ((alignment & (alignment - 1)) == 0)),
-            UR_RESULT_ERROR_INVALID_VALUE);
-
   if (!hPool) {
     return USMSharedAllocImpl(ppMem, hContext, hDevice, /*host flags*/ 0,
                               /*device flags*/ 0, size, alignment);
@@ -269,18 +257,14 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
   return Result;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMImportExp(ur_context_handle_t Context,
-                                                   void *HostPtr, size_t Size) {
-  UR_ASSERT(Context, UR_RESULT_ERROR_INVALID_CONTEXT);
-  UR_ASSERT(!HostPtr, UR_RESULT_ERROR_INVALID_VALUE);
+UR_APIEXPORT ur_result_t UR_APICALL urUSMImportExp(ur_context_handle_t, void *,
+                                                   size_t Size) {
   UR_ASSERT(Size > 0, UR_RESULT_ERROR_INVALID_VALUE);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMReleaseExp(ur_context_handle_t Context,
-                                                    void *HostPtr) {
-  UR_ASSERT(Context, UR_RESULT_ERROR_INVALID_CONTEXT);
-  UR_ASSERT(!HostPtr, UR_RESULT_ERROR_INVALID_VALUE);
+UR_APIEXPORT ur_result_t UR_APICALL urUSMReleaseExp(ur_context_handle_t,
+                                                    void *) {
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/hip/command_buffer.cpp
+++ b/unified-runtime/source/adapters/hip/command_buffer.cpp
@@ -302,9 +302,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
   UR_ASSERT(workDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
   UR_ASSERT(workDim < 4, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
 
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
   for (uint32_t i = 0; i < numKernelAlternatives; ++i) {
     UR_ASSERT(phKernelAlternatives[i] != hKernel,
               UR_RESULT_ERROR_INVALID_VALUE);
@@ -397,9 +394,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
   try {
     UR_CHECK_ERROR(getNodesFromSyncPoints(
         hCommandBuffer, numSyncPointsInWaitList, pSyncPointWaitList, DepsList));
@@ -433,8 +427,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
   UR_ASSERT(size + dstOffset <= std::get<BufferMem>(hDstMem->Mem).getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
   UR_ASSERT(size + srcOffset <= std::get<BufferMem>(hSrcMem->Mem).getSize(),
@@ -481,9 +473,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
   try {
     UR_CHECK_ERROR(getNodesFromSyncPoints(
         hCommandBuffer, numSyncPointsInWaitList, pSyncPointWaitList, DepsList));
@@ -529,9 +518,6 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
   try {
     UR_CHECK_ERROR(getNodesFromSyncPoints(
         hCommandBuffer, numSyncPointsInWaitList, pSyncPointWaitList, DepsList));
@@ -568,9 +554,6 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
   std::ignore = phCommand;
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
-
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   try {
     UR_CHECK_ERROR(getNodesFromSyncPoints(
@@ -611,9 +594,6 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
   std::ignore = phCommand;
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
-
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   try {
     UR_CHECK_ERROR(getNodesFromSyncPoints(
@@ -660,9 +640,6 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
   try {
     UR_CHECK_ERROR(getNodesFromSyncPoints(
         hCommandBuffer, numSyncPointsInWaitList, pSyncPointWaitList, DepsList));
@@ -707,9 +684,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
 
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
   try {
     UR_CHECK_ERROR(getNodesFromSyncPoints(
         hCommandBuffer, numSyncPointsInWaitList, pSyncPointWaitList, DepsList));
@@ -745,9 +719,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
   // We implement it as an empty node to enforce dependencies.
   hipGraphNode_t GraphNode;
   std::vector<hipGraphNode_t> DepsList;
-
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   try {
     UR_CHECK_ERROR(getNodesFromSyncPoints(
@@ -790,8 +761,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
   UR_ASSERT(ArgsAreMultiplesOfPatternSize && PatternIsValid &&
                 PatternSizeIsValid,
             UR_RESULT_ERROR_INVALID_SIZE);
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   auto DstDevice = std::get<BufferMem>(hBuffer->Mem)
                        .getPtrWithOffset(hCommandBuffer->Device, offset);
@@ -819,8 +788,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
   auto PatternSizeIsValid = ((patternSize & (patternSize - 1)) == 0) &&
                             (patternSize > 0); // is a positive power of two
 
-  UR_ASSERT(!(pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
   UR_ASSERT(PatternIsValid && PatternSizeIsValid, UR_RESULT_ERROR_INVALID_SIZE);
   return enqueueCommandBufferFillHelper(
       hCommandBuffer, pPtr, hipMemoryTypeUnified, pPattern, patternSize, size,

--- a/unified-runtime/source/adapters/hip/device.cpp
+++ b/unified-runtime/source/adapters/hip/device.cpp
@@ -1133,8 +1133,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(ur_platform_handle_t hPlatform,
   size_t NumDevices = ReturnDevices ? hPlatform->Devices.size() : 0;
 
   try {
-    UR_ASSERT(pNumDevices || phDevices, UR_RESULT_ERROR_INVALID_VALUE);
-
     if (pNumDevices) {
       *pNumDevices = NumDevices;
     }
@@ -1215,9 +1213,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceSelectBinary(ur_device_handle_t, const ur_device_binary_t *pBinaries,
                      uint32_t NumBinaries, uint32_t *pSelectedBinary) {
-  // Ignore unused parameter
-  UR_ASSERT(NumBinaries > 0, UR_RESULT_ERROR_INVALID_ARGUMENT);
-
   // Look for an image for the HIP target, and return the first one that is
   // found
 #if defined(__HIP_PLATFORM_AMD__)

--- a/unified-runtime/source/adapters/hip/enqueue.cpp
+++ b/unified-runtime/source/adapters/hip/enqueue.cpp
@@ -151,11 +151,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingWrite,
     size_t offset, size_t size, const void *pSrc, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  UR_ASSERT(!(phEventWaitList == NULL && numEventsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  UR_ASSERT(!(phEventWaitList != NULL && numEventsInWaitList == 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  UR_ASSERT(hBuffer->isBuffer(), UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+  UR_ASSERT(hBuffer->isBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
   hBuffer->setLastQueueWritingToMemObj(hQueue);
@@ -199,11 +195,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
     ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingRead,
     size_t offset, size_t size, void *pDst, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  UR_ASSERT(!(phEventWaitList == NULL && numEventsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  UR_ASSERT(!(phEventWaitList != NULL && numEventsInWaitList == 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  UR_ASSERT(hBuffer->isBuffer(), UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+  UR_ASSERT(hBuffer->isBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
@@ -367,10 +359,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  UR_ASSERT(!(phEventWaitList == NULL && numEventsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST)
-  UR_ASSERT(!(phEventWaitList != NULL && numEventsInWaitList == 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST)
 
   try {
     ScopedDevice Active(hQueue->getDevice());
@@ -503,27 +491,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     size_t hostRowPitch, size_t hostSlicePitch, void *pDst,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
-  UR_ASSERT(!(phEventWaitList == NULL && numEventsInWaitList > 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  UR_ASSERT(!(phEventWaitList != NULL && numEventsInWaitList == 0),
-            UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  UR_ASSERT(!(region.width == 0 || region.height == 0 || region.width == 0),
-            UR_RESULT_ERROR_INVALID_SIZE);
-  UR_ASSERT(!(bufferRowPitch != 0 && bufferRowPitch < region.width),
-            UR_RESULT_ERROR_INVALID_SIZE);
-  UR_ASSERT(!(hostRowPitch != 0 && hostRowPitch < region.width),
-            UR_RESULT_ERROR_INVALID_SIZE);
-  UR_ASSERT(!(bufferSlicePitch != 0 &&
-              bufferSlicePitch < region.height * bufferRowPitch),
-            UR_RESULT_ERROR_INVALID_SIZE);
-  UR_ASSERT(!(bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0),
-            UR_RESULT_ERROR_INVALID_SIZE);
-  UR_ASSERT(
-      !(hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch),
-      UR_RESULT_ERROR_INVALID_SIZE);
-  UR_ASSERT(!(hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0),
-            UR_RESULT_ERROR_INVALID_SIZE);
-
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
   try {
@@ -1441,7 +1408,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
                    ur_usm_advice_flags_t advice, ur_event_handle_t *phEvent) {
-  UR_ASSERT(pMem && size > 0, UR_RESULT_ERROR_INVALID_VALUE);
   void *HIPDevicePtr = const_cast<void *>(pMem);
   ur_device_handle_t Device = hQueue->getDevice();
 

--- a/unified-runtime/source/adapters/hip/image.cpp
+++ b/unified-runtime/source/adapters/hip/image.cpp
@@ -260,7 +260,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPitchedAllocExp(
   std::ignore = pUSMDesc;
   std::ignore = pool;
 
-  UR_ASSERT((widthInBytes > 0), UR_RESULT_ERROR_INVALID_VALUE);
   UR_ASSERT((height > 0), UR_RESULT_ERROR_INVALID_VALUE);
   UR_ASSERT((elementSizeBytes > 0), UR_RESULT_ERROR_INVALID_VALUE);
 

--- a/unified-runtime/source/adapters/hip/kernel.cpp
+++ b/unified-runtime/source/adapters/hip/kernel.cpp
@@ -385,8 +385,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
             UR_RESULT_ERROR_INVALID_QUEUE);
   UR_ASSERT(workDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
   UR_ASSERT(workDim < 4, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
-  UR_ASSERT(pSuggestedLocalWorkSize != nullptr,
-            UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
   size_t MaxThreadsPerBlock[3];
   size_t ThreadsPerBlock[3] = {32u, 1u, 1u};

--- a/unified-runtime/source/adapters/hip/memory.cpp
+++ b/unified-runtime/source/adapters/hip/memory.cpp
@@ -155,9 +155,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
 /// A buffer partition (or a sub-buffer, in OpenCL terms) is simply implemented
 /// as an offset over an existing HIP allocation.
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
-    ur_mem_handle_t hBuffer, ur_mem_flags_t flags,
-    ur_buffer_create_type_t bufferCreateType, const ur_buffer_region_t *pRegion,
-    ur_mem_handle_t *phMem) {
+    ur_mem_handle_t hBuffer, ur_mem_flags_t flags, ur_buffer_create_type_t,
+    const ur_buffer_region_t *pRegion, ur_mem_handle_t *phMem) {
   UR_ASSERT(hBuffer->isBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
   UR_ASSERT(!hBuffer->isSubBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 

--- a/unified-runtime/source/adapters/hip/memory.cpp
+++ b/unified-runtime/source/adapters/hip/memory.cpp
@@ -95,17 +95,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ur_mem_flags_t flags, size_t size,
     const ur_buffer_properties_t *pProperties, ur_mem_handle_t *phBuffer) {
-  // Validate flags
-  UR_ASSERT((flags & UR_MEM_FLAGS_MASK) == 0,
-            UR_RESULT_ERROR_INVALID_ENUMERATION);
-  if (flags &
-      (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) {
-    UR_ASSERT(pProperties && pProperties->pHost,
-              UR_RESULT_ERROR_INVALID_HOST_PTR);
-  }
-  // Need input memory object
-  UR_ASSERT(size != 0, UR_RESULT_ERROR_INVALID_BUFFER_SIZE);
-
   // Currently, USE_HOST_PTR is not implemented using host register
   // since this triggers a weird segfault after program ends.
   // Setting this constant to true enables testing that behavior.
@@ -169,8 +158,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
     ur_mem_handle_t hBuffer, ur_mem_flags_t flags,
     ur_buffer_create_type_t bufferCreateType, const ur_buffer_region_t *pRegion,
     ur_mem_handle_t *phMem) {
-  UR_ASSERT((flags & UR_MEM_FLAGS_MASK) == 0,
-            UR_RESULT_ERROR_INVALID_ENUMERATION);
   UR_ASSERT(hBuffer->isBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
   UR_ASSERT(!hBuffer->isSubBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
@@ -191,11 +178,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
     UR_ASSERT(!(flags & (UR_MEM_FLAG_READ_WRITE | UR_MEM_FLAG_WRITE_ONLY)),
               UR_RESULT_ERROR_INVALID_VALUE);
   }
-
-  UR_ASSERT(bufferCreateType == UR_BUFFER_CREATE_TYPE_REGION,
-            UR_RESULT_ERROR_INVALID_ENUMERATION);
-
-  UR_ASSERT(pRegion->size != 0u, UR_RESULT_ERROR_INVALID_BUFFER_SIZE);
 
   auto &BufferImpl = std::get<BufferMem>(hBuffer->Mem);
   UR_ASSERT(((pRegion->origin + pRegion->size) <= BufferImpl.getSize()),
@@ -351,15 +333,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     ur_context_handle_t hContext, ur_mem_flags_t flags,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     void *pHost, ur_mem_handle_t *phMem) {
-
-  // Need input memory object
-  UR_ASSERT((flags & UR_MEM_FLAGS_MASK) == 0,
-            UR_RESULT_ERROR_INVALID_ENUMERATION);
-  if (flags &
-      (UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER | UR_MEM_FLAG_USE_HOST_POINTER)) {
-    UR_ASSERT(pHost, UR_RESULT_ERROR_INVALID_HOST_PTR);
-  }
-
   const bool PerformInitialCopy =
       (flags & UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER) ||
       ((flags & UR_MEM_FLAG_USE_HOST_POINTER));

--- a/unified-runtime/source/adapters/hip/platform.cpp
+++ b/unified-runtime/source/adapters/hip/platform.cpp
@@ -50,9 +50,8 @@ urPlatformGetInfo(ur_platform_handle_t, ur_platform_info_t propName,
 /// Triggers the HIP Driver initialization (hipInit) the first time, so this
 /// must be the first UR API called.
 UR_APIEXPORT ur_result_t UR_APICALL
-urPlatformGet(ur_adapter_handle_t, uint32_t NumEntries,
-              ur_platform_handle_t *phPlatforms, uint32_t *pNumPlatforms) {
-
+urPlatformGet(ur_adapter_handle_t, uint32_t, ur_platform_handle_t *phPlatforms,
+              uint32_t *pNumPlatforms) {
   try {
     static std::once_flag InitFlag;
     static uint32_t NumPlatforms = 1;

--- a/unified-runtime/source/adapters/hip/platform.cpp
+++ b/unified-runtime/source/adapters/hip/platform.cpp
@@ -57,9 +57,6 @@ urPlatformGet(ur_adapter_handle_t, uint32_t NumEntries,
     static std::once_flag InitFlag;
     static uint32_t NumPlatforms = 1;
 
-    UR_ASSERT(phPlatforms || pNumPlatforms, UR_RESULT_ERROR_INVALID_VALUE);
-    UR_ASSERT(!phPlatforms || NumEntries > 0, UR_RESULT_ERROR_INVALID_VALUE);
-
     ur_result_t Result = UR_RESULT_SUCCESS;
 
     std::call_once(

--- a/unified-runtime/source/adapters/hip/usm.cpp
+++ b/unified-runtime/source/adapters/hip/usm.cpp
@@ -245,18 +245,14 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMImportExp(ur_context_handle_t Context,
-                                                   void *HostPtr, size_t Size) {
-  UR_ASSERT(Context, UR_RESULT_ERROR_INVALID_CONTEXT);
-  UR_ASSERT(!HostPtr, UR_RESULT_ERROR_INVALID_VALUE);
+UR_APIEXPORT ur_result_t UR_APICALL urUSMImportExp(ur_context_handle_t, void *,
+                                                   size_t Size) {
   UR_ASSERT(Size > 0, UR_RESULT_ERROR_INVALID_VALUE);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMReleaseExp(ur_context_handle_t Context,
-                                                    void *HostPtr) {
-  UR_ASSERT(Context, UR_RESULT_ERROR_INVALID_CONTEXT);
-  UR_ASSERT(!HostPtr, UR_RESULT_ERROR_INVALID_VALUE);
+UR_APIEXPORT ur_result_t UR_APICALL urUSMReleaseExp(ur_context_handle_t,
+                                                    void *) {
   return UR_RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
Most of the parameter checking is done in the UR validation layer, so we don't need to re-do it in the adapters.

The adapters should only do parameter checking that can't be done in the validation layer.