### PR TITLE
[SYCL][E2E] Fix CUDA/HIP options on Windows

### DIFF
--- a/sycl/test-e2e/E2EExpr.py
+++ b/sycl/test-e2e/E2EExpr.py
@@ -34,6 +34,8 @@ class E2EExpr(BooleanExpression):
         "hip_dev_kit",
         "zstd",
         "vulkan",
+        "hip_options",
+        "cuda_options",
         "true",
         "false",
     }

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -434,7 +434,7 @@ config.cuda_include = quote_path(
     )
 )
 
-cuda_options = cuda_options = (
+cuda_options = (
     (" -L" + config.cuda_libs_dir if config.cuda_libs_dir else "")
     + " -lcuda "
     + " -I"
@@ -446,6 +446,10 @@ if cl_options:
         + (config.cuda_libs_dir + "/cuda.lib " if config.cuda_libs_dir else "cuda.lib")
         + " /I"
         + config.cuda_include
+    )
+if platform.system() == "Windows":
+    cuda_options += (
+        " --cuda-path=" + os.path.dirname(os.path.dirname(config.cuda_libs_dir)) + f'"'
     )
 
 config.substitutions.append(("%cuda_options", cuda_options))
@@ -483,7 +487,7 @@ config.hip_include = quote_path(
     )
 )
 
-hip_options = hip_options = (
+hip_options = (
     (" -L" + config.hip_libs_dir if config.hip_libs_dir else "")
     + " -lamdhip64 "
     + " -I"
@@ -500,7 +504,8 @@ if cl_options:
         + " /I"
         + config.hip_include
     )
-
+if platform.system() == "Windows":
+    hip_options += " --rocm-path=" + os.path.dirname(config.hip_libs_dir) + f'"'
 with test_env():
     sp = subprocess.getstatusoutput(
         config.dpcpp_compiler + " -fsycl  " + check_hip_file + hip_options


### PR DESCRIPTION
We need to set `cuda-path`/`hip-path` on Windows as the autodetection isn't implemented upstream, it seems only implemented for Linux.

Also fix a double assign and a missed update in `E2EExpr`

This was tested with some other pending changes [here](https://github.com/intel/llvm/actions/runs/14389689524/job/40353640119?pr=14114) and [here](https://github.com/intel/llvm/actions/runs/14389689487/job/40353627543?pr=14114).