### PR TITLE
[SYCL][Driver] Revert -O0 as the default SYCL device optimization if -g is passed.

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5757,27 +5757,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-Wno-sycl-strict");
       }
 
-      // If no optimization controlling flags (-O) are provided, check if
-      // any debug information flags(-g) are passed.
-      // "-fintelfpga" implies "-g" and we preserve the default optimization for
-      // this flow(-O2).
-      // if "-g" is explicitly passed from the command-line, set default
-      // optimization to -O0.
-
-      if (!Args.hasArgNoClaim(options::OPT_O_Group, options::OPT__SLASH_O)) {
-        StringRef OptLevel = "-O2";
-        const Arg *DebugInfoGroup = Args.getLastArg(options::OPT_g_Group);
-        // -fintelfpga -g case
-        if ((Args.hasArg(options::OPT_fintelfpga) &&
-             Args.hasMultipleArgs(options::OPT_g_Group)) ||
-            /* -fsycl -g case */ (!Args.hasArg(options::OPT_fintelfpga) &&
-                                  DebugInfoGroup)) {
-          if (!DebugInfoGroup->getOption().matches(options::OPT_g0)) {
-            OptLevel = "-O0";
-          }
-        }
-        CmdArgs.push_back(OptLevel.data());
-      }
+      // Set O2 optimization level by default
+      if (!Args.getLastArg(options::OPT_O_Group))
+        CmdArgs.push_back("-O2");
 
       // Add the integration header option to generate the header.
       StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
@@ -11083,25 +11065,7 @@ static std::string getSYCLPostLinkOptimizationLevel(const ArgList &Args) {
                     [=](char c) { return c == S[0]; }))
       return std::string("-O") + S[0];
   }
-  // If no optimization controlling flags (-O) are provided, check if
-  // any debug information flags(-g) are passed.
-  // "-fintelfpga" implies "-g" and we preserve the default optimization for
-  // this flow(-O2).
-  // if "-g" is explicitly passed from the command-line, set default
-  // optimization to -O0.
 
-  if (!Args.hasArg(options::OPT_O_Group)) {
-    const Arg *DebugInfoGroup = Args.getLastArg(options::OPT_g_Group);
-    // -fintelfpga -g case
-    if ((Args.hasArg(options::OPT_fintelfpga) &&
-         Args.hasMultipleArgs(options::OPT_g_Group)) ||
-        /* -fsycl -g case */
-        (!Args.hasArg(options::OPT_fintelfpga) && DebugInfoGroup)) {
-      if (!DebugInfoGroup->getOption().matches(options::OPT_g0)) {
-        return "-O0";
-      }
-    }
-  }
   // The default for SYCL device code optimization
   return "-O2";
 }

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -46,24 +46,4 @@
 // RUN:   | FileCheck -check-prefix=CHECK-NO-THRESH %s
 // CHECK-NO-THRESH-NOT: "-mllvm" "-inline-threshold
 
-/// Check that optimizations for sycl device are disabled with -g passed:
-// RUN:   %clang -### -fsycl -g %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEBUG %s
-// RUN:   %clang_cl -### -fsycl -g %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-DEBUG %s
-// CHECK-DEBUG: clang{{.*}} "-fsycl-is-device{{.*}}" "-O0"
-// CHECK-DEBUG: sycl-post-link{{.*}} "-O0"
-// CHECK-DEBUG-NOT: "-O2"
 
-/// Check that optimizations for sycl device are enabled with -g and O2 passed:
-// RUN:   %clang -### -fsycl -O2 -g %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-G-O2 %s
-// For clang_cl, -O2 maps to -O3
-// RUN:   %clang_cl -### -fsycl -O2 -g %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-G-O3 %s
-// CHECK-G-O2: clang{{.*}} "-fsycl-is-device{{.*}}" "-O2"
-// CHECK-G-O2: sycl-post-link{{.*}} "-O2"
-// CHECK-G-O2-NOT: "-O0"
-// CHECK-G-O3: clang{{.*}} "-fsycl-is-device{{.*}}" "-O3"
-// CHECK-G-O3: sycl-post-link{{.*}} "-O3"
-// CHECK-G-O3-NOT: "-O0"

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/debug_symbols.cpp
@@ -1,5 +1,5 @@
 // Check that full compilation works:
-// RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -O2 %S/../debug_symbols.cpp -o %t.out
+// RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g %S/../debug_symbols.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //
 // VISALTO enable run

--- a/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
@@ -1,5 +1,5 @@
 // Check that full compilation works:
-// RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -O2 -o %t.out
+// RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //
 // VISALTO enable run


### PR DESCRIPTION
Reverts https://github.com/intel/llvm/pull/16408