### PR TITLE
[DeviceSanitizer][Coverity] Fix uncaught exception issue

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
@@ -20,7 +20,9 @@ context_t *getContext() {
   try {
     return context_t::get_direct();
   } catch (...) {
-    die("Failed to get sanitizer context.");
+    // Cannot write logger here as that would also introduce a potential
+    // exception
+    std::terminate();
   }
 }
 


### PR DESCRIPTION
`die()` would write to the logger, bringing the potential exception. 