### PR TITLE
[NFC][SYCL][Graph][Doc] Clarify aspect relationship

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -321,6 +321,9 @@ devices with full graph support are more prevalent.
 
 |===
 
+A device which reports `aspect::ext_oneapi_graph` must also report
+`aspect::ext_oneapi_limited_graph`, as `aspect::ext_oneapi_graph` is a
+superset of the limited aspect.
 
 === Node
 


### PR DESCRIPTION
SYCL-Graph contains two aspects for a device to report extension support. Make the relationship between the two aspects clearer to readers, as it wasn't immediately obvious to reviewers of an [application PR](https://github.com/ggml-org/llama.cpp/pull/12873) using these aspects.