### PR TITLE
[SYCL][clang-linker-wrapper] Replace -lto-emit-asm option with -S for cuda pipeline

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1546,7 +1546,7 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
     CmdArgs.push_back("-Wl,--no-undefined");
 
   if (IsSYCLKind && Triple.isNVPTX())
-    CmdArgs.push_back("-Wl,--lto-emit-asm");
+    CmdArgs.push_back("-S");
   for (StringRef InputFile : InputFiles)
     CmdArgs.push_back(InputFile);
 

--- a/sycl/test-e2e/NewOffloadDriver/multisource.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/multisource.cpp
@@ -5,8 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: true
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17812
 // Separate kernel sources and host code sources
 // Test with `--offload-new-driver`
 // RUN: %{build} --offload-new-driver -c -o %t.kernel.o -DINIT_KERNEL -DCALC_KERNEL

--- a/sycl/test-e2e/NewOffloadDriver/split-per-source-main.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/split-per-source-main.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: true
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17812 
 // RUN: %{build} -Wno-error=unused-command-line-argument -fsycl-device-code-split=per_source -I %S/Inputs -o %t.out %S/Inputs/split-per-source-second-file.cpp \
 // RUN: --offload-new-driver -fsycl-dead-args-optimization
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/NewOffloadDriver/sycl-external-with-optional-features.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/sycl-external-with-optional-features.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: true
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17812
 // Test with `--offload-new-driver`
 // RUN: %{build} -DSOURCE1 --offload-new-driver -c -o %t1.o
 // RUN: %{build} -DSOURCE2 --offload-new-driver -c -o %t2.o


### PR DESCRIPTION
`-lto-emit-asm` was used previously for cuda kernels pipeline when `-flto` was also used to generate ptx assembly. But after removing lto for cuda kernels, we don't need this option, instead we should use `-S` clang option to generate the ptx assembly for cuda kernels.

Fixing issue [17812](https://github.com/intel/llvm/issues/17812)