### PR TITLE
[SYCL] do not store last event as a dendency for in-order queues

### DIFF
--- a/sycl/test-e2e/InOrderEventsExt/get_last_event.cpp
+++ b/sycl/test-e2e/InOrderEventsExt/get_last_event.cpp
@@ -36,10 +36,6 @@ int Check(const sycl::queue &Q, const char *CheckName, const F &CheckFunc) {
               << std::endl;
     return 1;
   }
-  if (*E != *LastEvent) {
-    std::cout << "Failed " << CheckName << std::endl;
-    return 1;
-  }
   return 0;
 }
 


### PR DESCRIPTION
For in-order queues, the ordering is guaranteed by UR. The only expception is Host Task - if the last event is a host task, then enqueue a barrier.