### PR TITLE
[SYCL][UR] Ignore errors in logger callback

### DIFF
--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -79,7 +79,9 @@ ur_code_location_t codeLocationCallback(void *);
 
 void urLoggerCallback([[maybe_unused]] ur_logger_level_t level, const char *msg,
                       [[maybe_unused]] void *userData) {
-  std::cerr << msg << std::endl;
+  if (level == UR_LOGGER_LEVEL_WARN) {
+    std::cerr << msg << std::endl;
+  }
 }
 
 namespace ur {


### PR DESCRIPTION
Fixes #18012 by having the `urLoggerCallback()` ignore messages which are not warnings as errors should be handled via other mechanisms, i.e. UR error codes translated into exception messages or by explicitly enabling logging.
