### PR TITLE
[L0v2] remove host synchronize around cmdbuf enqueue

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -910,16 +910,11 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueGenericCommandListsExp(
   auto [pWaitEvents, numWaitEvents] =
       getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList,
                       additionalWaitEvent);
-  // zeCommandListImmediateAppendCommandListsExp is not working with in-order
-  // immediate lists what causes problems with synchronization
-  // TODO: remove synchronization when it is not needed
-  ZE_CALL_NOCHECK(zeCommandListHostSynchronize,
-                  (commandListLocked->getZeCommandList(), UINT64_MAX));
+
   ZE2UR_CALL(zeCommandListImmediateAppendCommandListsExp,
              (commandListLocked->getZeCommandList(), numCommandLists,
               phCommandLists, zeSignalEvent, numWaitEvents, pWaitEvents));
-  ZE_CALL_NOCHECK(zeCommandListHostSynchronize,
-                  (commandListLocked->getZeCommandList(), UINT64_MAX));
+
   return UR_RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
This was used as a workaround for a driver bug that was already fixed.