### PR TITLE
[CI] Bump L0 version and fix dpkg dep issue

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -13,15 +13,15 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {
-      "github_tag": "cmclang-1.0.144",
-      "version": "1.0.144",
-      "url": "https://github.com/intel/cm-compiler/releases/tag/cmclang-1.0.144",
+      "github_tag": "cmclang-1.0.119",
+      "version": "1.0.119",
+      "url": "https://github.com/intel/cm-compiler/releases/tag/cmclang-1.0.119",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.20.2",
-      "version": "v1.20.2",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.20.2",
+      "github_tag": "v1.21.9",
+      "version": "v1.21.9",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.21.9",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {

--- a/devops/scripts/update_drivers.py
+++ b/devops/scripts/update_drivers.py
@@ -69,10 +69,12 @@ def uplift_linux_igfx_driver(config, platform_tag, igc_dev_only):
             "https://github.com/intel/intel-graphics-compiler/releases/tag/" + ver
         )
 
-    cm = get_latest_release('intel/cm-compiler', allow_prerelease=False)
-    config[platform_tag]['cm']['github_tag'] = cm['tag_name']
-    config[platform_tag]['cm']['version'] = cm['tag_name'].replace('cmclang-', '')
-    config[platform_tag]['cm']['url'] = 'https://github.com/intel/cm-compiler/releases/tag/' + cm['tag_name']
+    cm = get_latest_release("intel/cm-compiler", allow_prerelease=False)
+    config[platform_tag]["cm"]["github_tag"] = cm["tag_name"]
+    config[platform_tag]["cm"]["version"] = cm["tag_name"].replace("cmclang-", "")
+    config[platform_tag]["cm"]["url"] = (
+        "https://github.com/intel/cm-compiler/releases/tag/" + cm["tag_name"]
+    )
 
     level_zero = get_latest_release("oneapi-src/level-zero", allow_prerelease=False)
     config[platform_tag]["level_zero"]["github_tag"] = level_zero["tag_name"]

--- a/devops/scripts/update_drivers.py
+++ b/devops/scripts/update_drivers.py
@@ -69,7 +69,7 @@ def uplift_linux_igfx_driver(config, platform_tag, igc_dev_only):
             "https://github.com/intel/intel-graphics-compiler/releases/tag/" + ver
         )
 
-    cm = get_latest_release('intel/cm-compiler')
+    cm = get_latest_release('intel/cm-compiler', allow_prerelease=False)
     config[platform_tag]['cm']['github_tag'] = cm['tag_name']
     config[platform_tag]['cm']['version'] = cm['tag_name'].replace('cmclang-', '')
     config[platform_tag]['cm']['url'] = 'https://github.com/intel/cm-compiler/releases/tag/' + cm['tag_name']


### PR DESCRIPTION
Level Zero had a new full-quality release and it has binaries so we can use it now.

Also, we've had this issue forever:
```
The following packages have unmet dependencies:
 intel-igc-cm : Depends: intel-igc-core (>= 1.0.9995) but it is not installabl
```

The problem was the prerelease version of CM has bad dependencies, use the latest released version which works fine, and we don't really use CM anyway.

Formatter made me fix some unrelated areas again.