### PR TITLE
[SYCL] Remove handler overload that accept PrimaryQueue

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -447,9 +447,6 @@ private:
           std::shared_ptr<detail::queue_impl> SecondaryQueue,
           bool CallerNeedsEvent);
 #endif
-  __SYCL_DLL_LOCAL handler(std::shared_ptr<detail::queue_impl> Queue,
-                           detail::queue_impl *PrimaryQueue,
-                           bool CallerNeedsEvent);
 
   /// Constructs SYCL handler from Graph.
   ///

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -352,14 +352,13 @@ void queue_impl::addSharedEvent(const event &Event) {
   MEventsShared.push_back(Event);
 }
 
-event queue_impl::submit_impl(const detail::type_erased_cgfo_ty &CGF,
-                              const std::shared_ptr<queue_impl> &Self,
-                              const std::shared_ptr<queue_impl> &PrimaryQueue,
-                              bool CallerNeedsEvent,
-                              const detail::code_location &Loc,
-                              bool IsTopCodeLoc,
-                              const SubmissionInfo &SubmitInfo) {
-  handler Handler(Self, PrimaryQueue.get(), CallerNeedsEvent);
+event queue_impl::submit_impl(
+    const detail::type_erased_cgfo_ty &CGF,
+    const std::shared_ptr<queue_impl> &Self,
+    [[maybe_unused]] const std::shared_ptr<queue_impl> &PrimaryQueue,
+    bool CallerNeedsEvent, const detail::code_location &Loc, bool IsTopCodeLoc,
+    const SubmissionInfo &SubmitInfo) {
+  handler Handler(Self, CallerNeedsEvent);
   auto &HandlerImpl = detail::getSyclObjImpl(Handler);
   if (xptiTraceEnabled()) {
     Handler.saveCodeLoc(Loc, IsTopCodeLoc);
@@ -394,7 +393,7 @@ event queue_impl::submit_impl(const detail::type_erased_cgfo_ty &CGF,
     };
     detail::type_erased_cgfo_ty CGF{L};
     event FlushEvent =
-        submit_impl(CGF, Self, PrimaryQueue,
+        submit_impl(CGF, Self, nullptr,
                     /*CallerNeedsEvent*/ true, Loc, IsTopCodeLoc, {});
     EventImpl->attachEventToCompleteWeak(detail::getSyclObjImpl(FlushEvent));
     registerStreamServiceEvent(detail::getSyclObjImpl(FlushEvent));

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -331,12 +331,6 @@ handler::handler(
       MQueue(Queue) {}
 #endif
 
-handler::handler(std::shared_ptr<detail::queue_impl> Queue,
-                 detail::queue_impl *PrimaryQueue, bool CallerNeedsEvent)
-    : impl(std::make_shared<detail::handler_impl>(PrimaryQueue,
-                                                  CallerNeedsEvent)),
-      MQueue(std::move(Queue)) {}
-
 handler::handler(
     std::shared_ptr<ext::oneapi::experimental::detail::graph_impl> Graph)
     : impl(std::make_shared<detail::handler_impl>(Graph)) {}


### PR DESCRIPTION
Follow-up of https://github.com/intel/llvm/pull/18047
This function is not used anymore.