### PR TITLE
[DeviceSanitizer][NFC] Remove unnecessary warning for asan libdevice

### DIFF
--- a/libdevice/sanitizer/asan_rtl.cpp
+++ b/libdevice/sanitizer/asan_rtl.cpp
@@ -339,6 +339,7 @@ void __asan_exit(ErrorType error_type) {
     __devicelib_exit();
     break;
   default:
+    break;
   }
 }
 


### PR DESCRIPTION
The latest asan libdevice source triggers a compiler warning: llvm/libdevice/sanitizer/asan_rtl.cpp:342:3: warning: label at end of compound statement is a C++23 extension [-Wc++23-extensions]
This trivial pr removes it.