### PR TITLE
[SYCL][CUDA] Include CUPTI as system headers

### DIFF
--- a/sycl/tools/sycl-trace/CMakeLists.txt
+++ b/sycl/tools/sycl-trace/CMakeLists.txt
@@ -107,7 +107,7 @@ if(SYCL_BUILD_BACKEND_CUDA)
   endif()
 
   target_include_directories(cuda_trace_collector
-    PRIVATE
+    SYSTEM PRIVATE
     ${CUDAToolkit_CUPTI_INCLUDE_DIR}
   )
 

--- a/unified-runtime/source/adapters/cuda/CMakeLists.txt
+++ b/unified-runtime/source/adapters/cuda/CMakeLists.txt
@@ -102,6 +102,8 @@ if (UR_ENABLE_TRACING AND UNIX)
 
   target_include_directories(${TARGET_NAME} PRIVATE
     ${XPTI_INCLUDES}
+  )
+  target_include_directories(${TARGET_NAME} SYSTEM PRIVATE
     ${CUDAToolkit_CUPTI_INCLUDE_DIR}
   )
   target_sources(${TARGET_NAME} PRIVATE ${XPTI_PROXY_SRC})


### PR DESCRIPTION
This suppresses warnings coming from CUPTI headers, like `-Wnested-anon-types`.