### PR TITLE
More std::ignore cleanups after 82d8ed7b1e

### DIFF
--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -1079,12 +1079,11 @@ ur_result_t urCommandBufferAppendKernelLaunchExp(
     uint32_t NumKernelAlternatives, ur_kernel_handle_t *KernelAlternatives,
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *RetSyncPoint, ur_event_handle_t *Event,
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *RetSyncPoint,
+    ur_event_handle_t * /*Event*/,
     ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
 
   UR_ASSERT(Kernel->Program, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   // Command handles can only be obtained from updatable command-buffers
@@ -1157,13 +1156,11 @@ ur_result_t urCommandBufferAppendUSMMemcpyExp(
     ur_exp_command_buffer_handle_t CommandBuffer, void *Dst, const void *Src,
     size_t Size, uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *SyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *SyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
 
   return enqueueCommandBufferMemCopyHelper(
       UR_COMMAND_USM_MEMCPY, CommandBuffer, Dst, Src, Size,
@@ -1177,13 +1174,11 @@ ur_result_t urCommandBufferAppendMemBufferCopyExp(
     ur_mem_handle_t DstMem, size_t SrcOffset, size_t DstOffset, size_t Size,
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *SyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *SyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
   auto SrcBuffer = ur_cast<_ur_buffer *>(SrcMem);
   auto DstBuffer = ur_cast<_ur_buffer *>(DstMem);
 
@@ -1215,13 +1210,11 @@ ur_result_t urCommandBufferAppendMemBufferCopyRectExp(
     size_t SrcSlicePitch, size_t DstRowPitch, size_t DstSlicePitch,
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *SyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *SyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
   auto SrcBuffer = ur_cast<_ur_buffer *>(SrcMem);
   auto DstBuffer = ur_cast<_ur_buffer *>(DstMem);
 
@@ -1252,13 +1245,11 @@ ur_result_t urCommandBufferAppendMemBufferWriteExp(
     size_t Offset, size_t Size, const void *Src,
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *SyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *SyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
   std::scoped_lock<ur_shared_mutex> Lock(Buffer->Mutex);
 
   char *ZeHandleDst = nullptr;
@@ -1282,13 +1273,11 @@ ur_result_t urCommandBufferAppendMemBufferWriteRectExp(
     size_t HostRowPitch, size_t HostSlicePitch, void *Src,
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *SyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *SyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
   std::scoped_lock<ur_shared_mutex> Lock(Buffer->Mutex);
 
   char *ZeHandleDst = nullptr;
@@ -1310,13 +1299,11 @@ ur_result_t urCommandBufferAppendMemBufferReadExp(
     ur_exp_command_buffer_handle_t CommandBuffer, ur_mem_handle_t Buffer,
     size_t Offset, size_t Size, void *Dst, uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *SyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *SyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
   std::scoped_lock<ur_shared_mutex> SrcLock(Buffer->Mutex);
 
   char *ZeHandleSrc = nullptr;
@@ -1339,13 +1326,11 @@ ur_result_t urCommandBufferAppendMemBufferReadRectExp(
     size_t HostRowPitch, size_t HostSlicePitch, void *Dst,
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *SyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *SyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
   std::scoped_lock<ur_shared_mutex> SrcLock(Buffer->Mutex);
 
   char *ZeHandleSrc;
@@ -1364,16 +1349,13 @@ ur_result_t urCommandBufferAppendMemBufferReadRectExp(
 
 ur_result_t urCommandBufferAppendUSMPrefetchExp(
     ur_exp_command_buffer_handle_t CommandBuffer, const void *Mem, size_t Size,
-    ur_usm_migration_flags_t Flags, uint32_t NumSyncPointsInWaitList,
+    ur_usm_migration_flags_t /*Flags*/, uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *RetSyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
-  std::ignore = Flags;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *RetSyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
 
   std::vector<ze_event_handle_t> ZeEventList;
   ze_event_handle_t ZeLaunchEvent = nullptr;
@@ -1407,13 +1389,11 @@ ur_result_t urCommandBufferAppendUSMAdviseExp(
     ur_exp_command_buffer_handle_t CommandBuffer, const void *Mem, size_t Size,
     ur_usm_advice_flags_t Advice, uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *RetSyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *RetSyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
   // A memory chunk can be advised with muliple memory advices
   // We therefore prefer if statements to switch cases to combine all potential
   // flags
@@ -1473,13 +1453,11 @@ ur_result_t urCommandBufferAppendMemBufferFillExp(
     const void *Pattern, size_t PatternSize, size_t Offset, size_t Size,
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *SyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *SyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
 
   std::scoped_lock<ur_shared_mutex> Lock(Buffer->Mutex);
 
@@ -1500,13 +1478,11 @@ ur_result_t urCommandBufferAppendUSMFillExp(
     const void *Pattern, size_t PatternSize, size_t Size,
     uint32_t NumSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_exp_command_buffer_sync_point_t *SyncPoint, ur_event_handle_t *Event,
-    ur_exp_command_buffer_command_handle_t *Command) {
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
-  std::ignore = Event;
-  std::ignore = Command;
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/,
+    ur_exp_command_buffer_sync_point_t *SyncPoint,
+    ur_event_handle_t * /*Event*/,
+    ur_exp_command_buffer_command_handle_t * /*Command*/) {
 
   return enqueueCommandBufferFillHelper(
       UR_COMMAND_MEM_BUFFER_FILL, CommandBuffer, Ptr,
@@ -2304,18 +2280,15 @@ ur_result_t urCommandBufferUpdateKernelLaunchExp(
 }
 
 ur_result_t urCommandBufferUpdateSignalEventExp(
-    ur_exp_command_buffer_command_handle_t Command, ur_event_handle_t *Event) {
-  std::ignore = Command;
-  std::ignore = Event;
+    ur_exp_command_buffer_command_handle_t /*Command*/,
+    ur_event_handle_t * /*Event*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urCommandBufferUpdateWaitEventsExp(
-    ur_exp_command_buffer_command_handle_t Command,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList) {
-  std::ignore = Command;
-  std::ignore = NumEventsInWaitList;
-  std::ignore = EventWaitList;
+    ur_exp_command_buffer_command_handle_t /*Command*/,
+    uint32_t /*NumEventsInWaitList*/,
+    const ur_event_handle_t * /*EventWaitList*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -27,10 +27,9 @@ ur_result_t urContextCreate(
     /// [in][range(0, DeviceCount)] array of handle of devices.
     const ur_device_handle_t *Devices,
     /// [in][optional] pointer to context creation properties.
-    const ur_context_properties_t *Properties,
+    const ur_context_properties_t * /*Properties*/,
     /// [out] pointer to handle of context object created
     ur_context_handle_t *RetContext) {
-  std::ignore = Properties;
 
   ur_platform_handle_t Platform = Devices[0]->Platform;
   ZeStruct<ze_context_desc_t> ContextDesc{};
@@ -163,14 +162,11 @@ ur_result_t urContextCreateWithNativeHandle(
 
 ur_result_t urContextSetExtendedDeleter(
     /// [in] handle of the context.
-    ur_context_handle_t Context,
+    ur_context_handle_t /*Context*/,
     /// [in] Function pointer to extended deleter.
-    ur_context_extended_deleter_t Deleter,
+    ur_context_extended_deleter_t /*Deleter*/,
     /// [in][out][optional] pointer to data to be passed to callback.
-    void *UserData) {
-  std::ignore = Context;
-  std::ignore = Deleter;
-  std::ignore = UserData;
+    void * /*UserData*/) {
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1448,7 +1448,7 @@ ur_result_t urDevicePartition(
 
 ur_result_t urDeviceSelectBinary(
     /// [in] handle of the device to select binary for.
-    ur_device_handle_t Device,
+    ur_device_handle_t /*Device*/,
     /// [in] the array of binaries to select from.
     const ur_device_binary_t *Binaries,
     /// [in] the number of binaries passed in ppBinaries. Must greater than or
@@ -1458,7 +1458,6 @@ ur_result_t urDeviceSelectBinary(
     /// binaries. If a suitable binary was not found the function returns
     /// ${X}_INVALID_BINARY.
     uint32_t *SelectedBinary) {
-  std::ignore = Device;
   // TODO: this is a bare-bones implementation for choosing a device image
   // that would be compatible with the targeted device. An AOT-compiled
   // image is preferred over SPIR-V for known devices (i.e. Intel devices)

--- a/unified-runtime/source/adapters/level_zero/enqueue_native.cpp
+++ b/unified-runtime/source/adapters/level_zero/enqueue_native.cpp
@@ -8,9 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <tuple>
 #include <ur_api.h>
-#include <utility>
 
 namespace ur::level_zero {
 

--- a/unified-runtime/source/adapters/level_zero/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/usm.hpp
@@ -187,17 +187,13 @@ public:
     return UMF_RESULT_SUCCESS;
   }
   void *malloc(size_t Size) noexcept { return aligned_malloc(Size, 0); }
-  void *calloc(size_t Num, size_t Size) noexcept {
-    std::ignore = Num;
-    std::ignore = Size;
+  void *calloc(size_t /*Num*/, size_t /*Size*/) noexcept {
 
     // Currently not needed
     umf::getPoolLastStatusRef<USMProxyPool>() = UMF_RESULT_ERROR_NOT_SUPPORTED;
     return nullptr;
   }
-  void *realloc(void *Ptr, size_t Size) noexcept {
-    std::ignore = Ptr;
-    std::ignore = Size;
+  void *realloc(void * /*Ptr*/, size_t /*Size*/) noexcept {
 
     // Currently not needed
     umf::getPoolLastStatusRef<USMProxyPool>() = UMF_RESULT_ERROR_NOT_SUPPORTED;
@@ -211,8 +207,7 @@ public:
     }
     return Ptr;
   }
-  size_t malloc_usable_size(void *Ptr) noexcept {
-    std::ignore = Ptr;
+  size_t malloc_usable_size(void * /*Ptr*/) noexcept {
 
     // Currently not needed
     return 0;

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -283,12 +283,10 @@ ur_result_t ur_command_list_manager::appendUSMFill(
 }
 
 ur_result_t ur_command_list_manager::appendUSMPrefetch(
-    const void *pMem, size_t size, ur_usm_migration_flags_t flags,
+    const void *pMem, size_t size, ur_usm_migration_flags_t /*flags*/,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
   TRACK_SCOPE_LATENCY("ur_command_list_manager::appendUSMPrefetch");
-
-  std::ignore = flags;
 
   auto zeSignalEvent = getSignalEvent(phEvent, UR_COMMAND_USM_PREFETCH);
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_create.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_create.cpp
@@ -15,9 +15,6 @@
 #include "queue_handle.hpp"
 #include "queue_immediate_in_order.hpp"
 
-#include <tuple>
-#include <utility>
-
 namespace ur::level_zero {
 ur_result_t urQueueCreate(ur_context_handle_t hContext,
                           ur_device_handle_t hDevice,

--- a/unified-runtime/source/adapters/native_cpu/context.cpp
+++ b/unified-runtime/source/adapters/native_cpu/context.cpp
@@ -9,7 +9,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <memory>
-#include <tuple>
 
 #include "ur/ur.hpp"
 #include "ur_api.h"

--- a/unified-runtime/test/adapters/hip/test_event.cpp
+++ b/unified-runtime/test/adapters/hip/test_event.cpp
@@ -16,7 +16,7 @@ struct RAIIHipEvent {
 
   ~RAIIHipEvent() {
     if (handle) {
-      std::ignore = hipEventDestroy(handle);
+      (void)hipEventDestroy(handle);
     }
   }
 

--- a/unified-runtime/test/conformance/testing/include/uur/known_failure.h
+++ b/unified-runtime/test/conformance/testing/include/uur/known_failure.h
@@ -11,7 +11,6 @@
 #include "uur/utils.h"
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <vector>
 
 namespace uur {


### PR DESCRIPTION
I missed several-many invalid uses of `std::ignore = unused_variable` in the level zero adapter in 82d8ed7b. This brings us up to date. I've additionally removed the unnecessary inclusion of `<tuple>` or `<utility>` where they're no longer needed.

Plus a bonus (void) of a nodiscard function in a hip test.