### PR TITLE
[UR] Implement `getProviderNativeError` in CUDA adptr. tests

### DIFF
--- a/unified-runtime/source/adapters/cuda/common.cpp
+++ b/unified-runtime/source/adapters/cuda/common.cpp
@@ -166,3 +166,13 @@ void setPluginSpecificMessage(CUresult cu_res) {
   setErrorMessage(message, UR_RESULT_ERROR_ADAPTER_SPECIFIC);
   free(message);
 }
+
+namespace umf {
+ur_result_t getProviderNativeError(const char *providerName, int32_t error) {
+  if (strcmp(providerName, "CUDA") == 0) {
+    return mapErrorUR(static_cast<CUresult>(error));
+  }
+
+  return UR_RESULT_ERROR_UNKNOWN;
+}
+} // namespace umf

--- a/unified-runtime/source/adapters/cuda/usm.cpp
+++ b/unified-runtime/source/adapters/cuda/usm.cpp
@@ -22,16 +22,6 @@
 
 #include <cuda.h>
 
-namespace umf {
-ur_result_t getProviderNativeError(const char *providerName, int32_t error) {
-  if (strcmp(providerName, "CUDA") == 0) {
-    return mapErrorUR(static_cast<CUresult>(error));
-  }
-
-  return UR_RESULT_ERROR_UNKNOWN;
-}
-} // namespace umf
-
 /// USM: Implements USM Host allocations using CUDA Pinned Memory
 /// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#page-locked-host-memory
 UR_APIEXPORT ur_result_t UR_APICALL


### PR DESCRIPTION
This fixes debug builds of UR with CUDA enabled; in that configuration
the `test-adapter-cuda` emits a call to `umf::umf2urResult` which
requires an implementaiton of `umf::getProviderNativeError`.
