### PR TITLE
[SYCL][SPIR-V] Move GenericCastToPtrExplicit and GenericCastToPtr into clang headers

### DIFF
--- a/clang/include/clang/Basic/BuiltinsSPIRV.td
+++ b/clang/include/clang/Basic/BuiltinsSPIRV.td
@@ -8,6 +8,15 @@
 
 include "clang/Basic/BuiltinsBase.td"
 
+class SPIRVBuiltin<string prototype, list<Attribute> Attr> : Builtin {
+  let Spellings = ["__builtin_spirv_" # NAME];
+  let Prototype = prototype;
+  let Attributes = !listconcat([NoThrow], Attr);
+}
+
+class SPIRVBuiltinWithCustomChecks<list<Attribute> Attr = []> :
+     SPIRVBuiltin<"void(...)", !listconcat([CustomTypeChecking], Attr)>;
+
 def SPIRVDistance : Builtin {
   let Spellings = ["__builtin_spirv_distance"];
   let Attributes = [NoThrow, Const];
@@ -25,3 +34,6 @@ def SPIRVReflect : Builtin {
   let Attributes = [NoThrow, Const];
   let Prototype = "void(...)";
 }
+
+def generic_cast_to_ptr_explicit :
+  SPIRVBuiltin<"void*(void*, int)", [CustomTypeChecking, NoThrow, Const]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4718,7 +4718,7 @@ def err_attribute_preferred_name_arg_invalid : Error<
   "argument %0 to 'preferred_name' attribute is not a typedef for "
   "a specialization of %1">;
 def err_attribute_builtin_alias : Error<
-  "%0 attribute can only be applied to a ARM, HLSL, SYCL or RISC-V builtin">;
+  "%0 attribute can only be applied to a ARM, HLSL, SPIR-V, SYCL or RISC-V builtin">;
 
 // called-once attribute diagnostics.
 def err_called_once_attribute_wrong_type : Error<
@@ -12990,6 +12990,15 @@ def warn_sycl_old_and_new_kernel_attributes : Warning<
   "are ignored">, InGroup<IgnoredAttributes>;
 def err_attribute_argument_is_not_valid : Error<
   "%0 attribute requires integer constant value 0 or 1">;
+
+// errors SPIR-V builtins
+def err_spirv_builtin_generic_cast_invalid_arg : Error<
+  "expecting a pointer argument to the generic address space">;
+def err_spirv_enum_not_int : Error<
+   "%0{storage class} argument for SPIR-V builtin is not a 32-bits integer">;
+def err_spirv_enum_not_valid : Error<
+   "invalid value for %select{storage class}0 argument">;
+
 
 // errors of expect.with.probability
 def err_probability_not_constant_float : Error<

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -9988,6 +9988,11 @@ bool ASTContext::canBuiltinBeRedeclared(const FunctionDecl *FD) const {
   if (LangOpts.HLSL && FD->getBuiltinID() != Builtin::NotBuiltin &&
       BuiltinInfo.hasCustomTypechecking(FD->getBuiltinID()))
     return true;
+  // Allow redecl custom type checking builtin for SPIR-V.
+  if (getTargetInfo().getTriple().isSPIRV() &&
+      FD->getBuiltinID() != Builtin::NotBuiltin &&
+      BuiltinInfo.hasCustomTypechecking(FD->getBuiltinID()))
+    return true;
   return BuiltinInfo.canBeRedeclared(FD->getBuiltinID());
 }
 

--- a/clang/lib/Basic/Targets/SPIR.cpp
+++ b/clang/lib/Basic/Targets/SPIR.cpp
@@ -35,7 +35,7 @@ static constexpr Builtin::Info BuiltinInfos[] = {
 static_assert(std::size(BuiltinInfos) == NumBuiltins);
 
 llvm::SmallVector<Builtin::InfosShard>
-SPIRVTargetInfo::getTargetBuiltins() const {
+BaseSPIRVTargetInfo::getTargetBuiltins() const {
   return {{&BuiltinStrings, BuiltinInfos}};
 }
 

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -405,6 +405,8 @@ public:
     return Feature == "spirv";
   }
 
+  llvm::SmallVector<Builtin::InfosShard> getTargetBuiltins() const override;
+
   void getTargetDefines(const LangOptions &Opts,
                         MacroBuilder &Builder) const override;
 };
@@ -428,8 +430,6 @@ public:
     resetDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-"
                     "v256:256-v512:512-v1024:1024-n8:16:32:64-G1");
   }
-
-  llvm::SmallVector<Builtin::InfosShard> getTargetBuiltins() const override;
 
   void getTargetDefines(const LangOptions &Opts,
                         MacroBuilder &Builder) const override;

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -188,6 +188,8 @@ void SYCLInstallationDetector::addSYCLIncludeArgs(
   CC1Args.push_back(DriverArgs.MakeArgString(STLWrappersPath));
   CC1Args.push_back("-internal-isystem");
   CC1Args.push_back(DriverArgs.MakeArgString(IncludePath));
+  CC1Args.push_back("-include");
+  CC1Args.push_back("__clang_spirv_builtins.h");
 }
 
 void SYCLInstallationDetector::print(llvm::raw_ostream &OS) const {

--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -129,6 +129,10 @@ set(riscv_files
   sifive_vector.h
   )
 
+set(spirv_files
+  __clang_spirv_builtins.h
+  )
+
 set(systemz_files
   s390intrin.h
   vecintrin.h
@@ -435,7 +439,7 @@ endfunction(clang_generate_header)
 # Copy header files from the source directory to the build directory
 foreach( f ${files} ${cuda_wrapper_files} ${cuda_wrapper_bits_files}
            ${ppc_wrapper_files} ${openmp_wrapper_files} ${zos_wrapper_files} ${hlsl_files}
-	   ${llvm_libc_wrapper_files} ${llvm_offload_wrapper_files})
+	   ${llvm_libc_wrapper_files} ${llvm_offload_wrapper_files} ${spirv_files})
   copy_header_to_output_dir(${CMAKE_CURRENT_SOURCE_DIR} ${f})
 endforeach( f )
 
@@ -526,6 +530,7 @@ add_dependencies("clang-resource-headers"
                  "ppc-resource-headers"
                  "ppc-htm-resource-headers"
                  "riscv-resource-headers"
+                 "spirv-resource-headers"
                  "systemz-resource-headers"
                  "ve-resource-headers"
                  "webassembly-resource-headers"
@@ -559,6 +564,7 @@ add_header_target("gpu-resource-headers" "${gpu_files}")
 
 # Other header groupings
 add_header_target("hlsl-resource-headers" ${hlsl_files})
+add_header_target("spirv-resource-headers" ${spirv_files})
 add_header_target("opencl-resource-headers" ${opencl_files})
 add_header_target("llvm-libc-resource-headers" ${llvm_libc_wrapper_files})
 add_header_target("openmp-resource-headers" ${openmp_wrapper_files})
@@ -765,6 +771,12 @@ install(
   COMPONENT hlsl-resource-headers)
 
 install(
+  FILES ${spirv_files}
+  DESTINATION ${header_install_dir}
+  EXCLUDE_FROM_ALL
+  COMPONENT spirv-resource-headers)
+
+install(
   FILES ${opencl_files}
   DESTINATION ${header_install_dir}
   EXCLUDE_FROM_ALL
@@ -833,6 +845,9 @@ if (NOT LLVM_ENABLE_IDE)
   add_llvm_install_targets(install-riscv-resource-headers
                            DEPENDS riscv-resource-headers
                            COMPONENT riscv-resource-headers)
+  add_llvm_install_targets(install-spirv-resource-headers
+                           DEPENDS spirv-resource-headers
+                           COMPONENT spirv-resource-headers)
   add_llvm_install_targets(install-systemz-resource-headers
                            DEPENDS systemz-resource-headers
                            COMPONENT systemz-resource-headers)

--- a/clang/lib/Headers/__clang_spirv_builtins.h
+++ b/clang/lib/Headers/__clang_spirv_builtins.h
@@ -1,0 +1,174 @@
+/*===---- spirv_builtin_vars.h - SPIR-V built-in ---------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __SPIRV_BUILTIN_VARS_H
+#define __SPIRV_BUILTIN_VARS_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsycl-strict"
+
+#define __SPIRV_overloadable __attribute__((overloadable))
+#define __SPIRV_convergent __attribute__((convergent))
+#define __SPIRV_inline __attribute__((always_inline))
+
+#define __SPIRV_purefn __attribute__((pure))
+#define __SPIRV_cnfn __attribute__((const))
+
+#define __global __attribute__((opencl_global))
+#define __local __attribute__((opencl_local))
+#define __private __attribute__((opencl_private))
+#define __constant __attribute__((opencl_constant))
+#ifdef __SYCL_DEVICE_ONLY__
+#define __generic
+#else
+#define __generic __attribute__((opencl_generic))
+#endif
+
+#ifdef __SYCL_DEVICE_ONLY__
+#else
+#endif
+
+// Check if SPIR-V builtins are supported.
+// As the translator doesn't use the LLVM intrinsics (which would be emitted if
+// we use the SPIR-V builtins) we can't rely on the SPIRV32/SPIRV64 etc macros
+// to establish if we can use the builtin alias. We disable builtin altogether if we do not
+// intent to use the backend.
+// So instead of use target macros, rely on a __has_builtin test.
+#if (__has_builtin(__builtin_spirv_generic_cast_to_ptr_explicit))
+#define _SPIRV_BUILTIN_ALIAS(builtin)                                          \
+  __attribute__((clang_builtin_alias(builtin)))
+#else
+#define _SPIRV_BUILTIN_ALIAS(builtin)
+#endif
+#define _SPIRV_AVAILABILITY(platform, version)                                 \
+  __attribute__((availability(platform, introduced = version)))
+#define _SPIRV_AVAILABILITY_STAGE(platform, version, stage)                    \
+  __attribute__((                                                              \
+      availability(platform, introduced = version, environment = stage)))
+
+// OpGenericCastToPtrExplicit
+
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__global void *__spirv_GenericCastToPtrExplicit_ToGlobal(__generic void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__global const void *
+__spirv_GenericCastToPtrExplicit_ToGlobal(__generic const void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__global volatile void *
+__spirv_GenericCastToPtrExplicit_ToGlobal(__generic volatile void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__global const volatile void *
+__spirv_GenericCastToPtrExplicit_ToGlobal(__generic const volatile void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__local void *__spirv_GenericCastToPtrExplicit_ToLocal(__generic void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__local const void *
+__spirv_GenericCastToPtrExplicit_ToLocal(__generic const void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__local volatile void *
+__spirv_GenericCastToPtrExplicit_ToLocal(__generic volatile void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__local const volatile void *
+__spirv_GenericCastToPtrExplicit_ToLocal(__generic const volatile void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__private void *__spirv_GenericCastToPtrExplicit_ToPrivate(__generic void *,
+                                                           int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__private const void *
+__spirv_GenericCastToPtrExplicit_ToPrivate(__generic const void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__private volatile void *
+__spirv_GenericCastToPtrExplicit_ToPrivate(__generic volatile void *, int);
+__SPIRV_overloadable
+_SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
+__private const volatile void *
+__spirv_GenericCastToPtrExplicit_ToPrivate(__generic const volatile void *,
+                                           int);
+
+// OpGenericCastToPtr
+
+__SPIRV_overloadable __SPIRV_inline __global void *
+__spirv_GenericCastToPtr_ToGlobal(__generic void *p, int) {
+  return (__global void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __global const void *
+__spirv_GenericCastToPtr_ToGlobal(__generic const void *p, int) {
+  return (__global const void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __global volatile void *
+__spirv_GenericCastToPtr_ToGlobal(__generic volatile void *p, int) {
+  return (__global volatile void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __global const volatile void *
+__spirv_GenericCastToPtr_ToGlobal(__generic const volatile void *p, int) {
+  return (__global const volatile void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __local void *
+__spirv_GenericCastToPtr_ToLocal(__generic void *p, int) {
+  return (__local void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __local const void *
+__spirv_GenericCastToPtr_ToLocal(__generic const void *p, int) {
+  return (__local const void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __local volatile void *
+__spirv_GenericCastToPtr_ToLocal(__generic volatile void *p, int) {
+  return (__local volatile void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __local const volatile void *
+__spirv_GenericCastToPtr_ToLocal(__generic const volatile void *p, int) {
+  return (__local const volatile void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __private void *
+__spirv_GenericCastToPtr_ToPrivate(__generic void *p, int) {
+  return (__private void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __private const void *
+__spirv_GenericCastToPtr_ToPrivate(__generic const void *p, int) {
+  return (__private const void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __private volatile void *
+__spirv_GenericCastToPtr_ToPrivate(__generic volatile void *p, int) {
+  return (__private volatile void *)p;
+}
+__SPIRV_overloadable __SPIRV_inline __private const volatile void *
+__spirv_GenericCastToPtr_ToPrivate(__generic const volatile void *p, int) {
+  return (__private const volatile void *)p;
+}
+
+#undef __SPIRV_overloadable
+#undef __SPIRV_convergent
+#undef __SPIRV_inline
+
+#undef __SPIRV_purefn
+#undef __SPIRV_cnfn
+
+#undef __global
+#undef __local
+#undef __constant
+#undef __generic
+
+#undef _SPIRV_BUILTIN_ALIAS
+#undef _SPIRV_AVAILABILITY
+#undef _SPIRV_AVAILABILITY_STAGE
+
+#pragma clang diagnostic pop
+
+#endif /* __SPIRV_BUILTIN_VARS_H */

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1942,6 +1942,8 @@ bool Sema::CheckTSBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
   case llvm::Triple::mips64el:
     return MIPS().CheckMipsBuiltinFunctionCall(TI, BuiltinID, TheCall);
   case llvm::Triple::spirv:
+  case llvm::Triple::spirv32:
+  case llvm::Triple::spirv64:
     return SPIRV().CheckSPIRVBuiltinFunctionCall(BuiltinID, TheCall);
   case llvm::Triple::systemz:
     return SystemZ().CheckSystemZBuiltinFunctionCall(BuiltinID, TheCall);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -53,6 +53,7 @@
 #include "clang/Sema/SemaOpenCL.h"
 #include "clang/Sema/SemaOpenMP.h"
 #include "clang/Sema/SemaRISCV.h"
+#include "clang/Sema/SemaSPIRV.h"
 #include "clang/Sema/SemaSYCL.h"
 #include "clang/Sema/SemaSwift.h"
 #include "clang/Sema/SemaWasm.h"
@@ -5856,14 +5857,16 @@ static void handleBuiltinAliasAttr(Sema &S, Decl *D,
   bool IsAArch64 = S.Context.getTargetInfo().getTriple().isAArch64();
   bool IsARM = S.Context.getTargetInfo().getTriple().isARM();
   bool IsRISCV = S.Context.getTargetInfo().getTriple().isRISCV();
+  bool IsSPIRV = S.Context.getTargetInfo().getTriple().isSPIRV();
   bool IsHLSL = S.Context.getLangOpts().HLSL;
   bool IsSYCL = S.Context.getLangOpts().isSYCL();
+  bool IsTSBuiltin = S.Context.BuiltinInfo.isTSBuiltin(BuiltinID);
   if ((IsAArch64 && !S.ARM().SveAliasValid(BuiltinID, AliasName)) ||
       (IsARM && !S.ARM().MveAliasValid(BuiltinID, AliasName) &&
        !S.ARM().CdeAliasValid(BuiltinID, AliasName)) ||
       (IsRISCV && !S.RISCV().isAliasValid(BuiltinID, AliasName)) ||
-      (IsSYCL && !SYCLAliasValid(S.Context, BuiltinID)) ||
-      (!IsAArch64 && !IsARM && !IsRISCV && !IsHLSL && !IsSYCL)) {
+      (IsSYCL && !IsTSBuiltin && !SYCLAliasValid(S.Context, BuiltinID)) ||
+      (!IsAArch64 && !IsARM && !IsRISCV && !IsHLSL && !IsSYCL && !IsSPIRV)) {
     S.Diag(AL.getLoc(), diag::err_attribute_builtin_alias) << AL;
     return;
   }

--- a/clang/lib/Sema/SemaSPIRV.cpp
+++ b/clang/lib/Sema/SemaSPIRV.cpp
@@ -12,9 +12,113 @@
 #include "clang/Basic/TargetBuiltins.h"
 #include "clang/Sema/Sema.h"
 
+// SPIR-V enumerants. Enums have only the required entries, see SPIR-V specs for
+// values.
+// FIXME: either use the SPIRV-Headers or generate a custom header using the
+// grammar (like done with MLIR).
+namespace spirv {
+enum class StorageClass : int {
+  Workgroup = 4,
+  CrossWorkgroup = 5,
+  Function = 7
+};
+}
+
 namespace clang {
 
 SemaSPIRV::SemaSPIRV(Sema &S) : SemaBase(S) {}
+
+static std::optional<int>
+processConstant32BitIntArgument(Sema &SemaRef, CallExpr *Call, int Argument) {
+  ExprResult Arg =
+      SemaRef.DefaultFunctionArrayLvalueConversion(Call->getArg(Argument));
+  if (Arg.isInvalid())
+    return true;
+  Call->setArg(Argument, Arg.get());
+
+  const Expr *IntArg = Arg.get();
+  SmallVector<PartialDiagnosticAt, 8> Notes;
+  Expr::EvalResult Eval;
+  Eval.Diag = &Notes;
+  if ((!IntArg->EvaluateAsConstantExpr(Eval, SemaRef.getASTContext())) ||
+      !Eval.Val.isInt() || Eval.Val.getInt().getBitWidth() > 32) {
+    SemaRef.Diag(IntArg->getBeginLoc(), diag::err_spirv_enum_not_int)
+        << 0 << IntArg->getSourceRange();
+    for (const PartialDiagnosticAt &PDiag : Notes)
+      SemaRef.Diag(PDiag.first, PDiag.second);
+    return true;
+  }
+  return {Eval.Val.getInt().getZExtValue()};
+}
+
+static bool checkGenericCastToPtr(Sema &SemaRef, CallExpr *Call) {
+  if (SemaRef.checkArgCount(Call, 2))
+    return true;
+
+  {
+    ExprResult Arg =
+        SemaRef.DefaultFunctionArrayLvalueConversion(Call->getArg(0));
+    if (Arg.isInvalid())
+      return true;
+    Call->setArg(0, Arg.get());
+
+    QualType Ty = Arg.get()->getType();
+    const auto *PtrTy = Ty->getAs<PointerType>();
+    auto AddressSpaceNotInGeneric = [&](LangAS AS) {
+      if (SemaRef.LangOpts.OpenCL)
+        return AS != LangAS::opencl_generic;
+      return AS != LangAS::Default;
+    };
+    if (!PtrTy ||
+        AddressSpaceNotInGeneric(PtrTy->getPointeeType().getAddressSpace())) {
+      SemaRef.Diag(Arg.get()->getBeginLoc(),
+                   diag::err_spirv_builtin_generic_cast_invalid_arg)
+          << Call->getSourceRange();
+      return true;
+    }
+  }
+
+  spirv::StorageClass StorageClass;
+  if (std::optional<int> SCInt =
+          processConstant32BitIntArgument(SemaRef, Call, 1);
+      SCInt.has_value()) {
+    StorageClass = static_cast<spirv::StorageClass>(SCInt.value());
+    if (StorageClass != spirv::StorageClass::CrossWorkgroup &&
+        StorageClass != spirv::StorageClass::Workgroup &&
+        StorageClass != spirv::StorageClass::Function) {
+      SemaRef.Diag(Call->getArg(1)->getBeginLoc(),
+                   diag::err_spirv_enum_not_valid)
+          << 0 << Call->getArg(1)->getSourceRange();
+      return true;
+    }
+  } else {
+    return true;
+  }
+  auto RT = Call->getArg(0)->getType();
+  RT = RT->getPointeeType();
+  auto Qual = RT.getQualifiers();
+  LangAS AddrSpace;
+  switch (static_cast<spirv::StorageClass>(StorageClass)) {
+  case spirv::StorageClass::CrossWorkgroup:
+    AddrSpace = LangAS::opencl_global;
+    break;
+  case spirv::StorageClass::Workgroup:
+    AddrSpace = LangAS::opencl_local;
+    break;
+  case spirv::StorageClass::Function:
+    AddrSpace = LangAS::opencl_private;
+    break;
+  default:
+    llvm_unreachable("Invalid builtin function");
+  }
+  if (SemaRef.LangOpts.isSYCL())
+    AddrSpace = asSYCLLangAS(AddrSpace);
+  Qual.setAddressSpace(AddrSpace);
+  Call->setType(SemaRef.getASTContext().getPointerType(
+      SemaRef.getASTContext().getQualifiedType(RT.getUnqualifiedType(), Qual)));
+
+  return false;
+}
 
 bool SemaSPIRV::CheckSPIRVBuiltinFunctionCall(unsigned BuiltinID,
                                               CallExpr *TheCall) {
@@ -100,6 +204,9 @@ bool SemaSPIRV::CheckSPIRVBuiltinFunctionCall(unsigned BuiltinID,
     QualType RetTy = ArgTyA;
     TheCall->setType(RetTy);
     break;
+  }
+  case SPIRV::BI__builtin_spirv_generic_cast_to_ptr_explicit: {
+    return checkGenericCastToPtr(SemaRef, TheCall);
   }
   }
   return false;

--- a/clang/test/CodeGenSPIRV/Builtins/generic_cast_to_ptr_explicit.c
+++ b/clang/test/CodeGenSPIRV/Builtins/generic_cast_to_ptr_explicit.c
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -O1 -triple spirv64 -fsycl-is-device %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -O1 -triple spirv64 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s
+
+#ifdef __OPENCL_C_VERSION__
+#define SYCL_DEVICE
+#else
+#define SYCL_DEVICE __attribute__((sycl_device))
+#endif
+
+// CHECK-LABEL: define spir_func noundef ptr @test_cast_to_private(
+// CHECK-SAME: ptr addrspace(4) noundef readnone [[P:%.*]]
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[SPV_CAST:%.*]] = tail call noundef ptr @llvm.spv.generic.cast.to.ptr.explicit.p0(ptr addrspace(4) %p)
+// CHECK-NEXT:    ret ptr [[SPV_CAST]]
+//
+__attribute__((sycl_device))
+__attribute__((opencl_private)) int* test_cast_to_private(int* p) {
+    return __builtin_spirv_generic_cast_to_ptr_explicit(p, 7);
+}
+
+// CHECK-LABEL: define spir_func noundef ptr addrspace(1) @test_cast_to_global(
+// CHECK-SAME: ptr addrspace(4) noundef readnone [[P:%.*]]
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[SPV_CAST:%.*]] = tail call noundef ptr addrspace(1) @llvm.spv.generic.cast.to.ptr.explicit.p1(ptr addrspace(4) %p)
+// CHECK-NEXT:    ret ptr addrspace(1) [[SPV_CAST]]
+//
+__attribute__((sycl_device))
+__attribute__((opencl_global)) int* test_cast_to_global(int* p) {
+    return __builtin_spirv_generic_cast_to_ptr_explicit(p, 5);
+}
+
+// CHECK-LABEL: define spir_func noundef ptr addrspace(3) @test_cast_to_local(
+// CHECK-SAME: ptr addrspace(4) noundef readnone [[P:%.*]]
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[SPV_CAST:%.*]] = tail call noundef ptr addrspace(3) @llvm.spv.generic.cast.to.ptr.explicit.p3(ptr addrspace(4) %p)
+// CHECK-NEXT:    ret ptr addrspace(3) [[SPV_CAST]]
+//
+__attribute__((sycl_device))
+__attribute__((opencl_local)) int* test_cast_to_local(int* p) {
+    return __builtin_spirv_generic_cast_to_ptr_explicit(p, 4);
+}

--- a/clang/test/Headers/spirv_functions.cpp
+++ b/clang/test/Headers/spirv_functions.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -Wno-unused-value -O0 -internal-isystem %S/../../lib/Headers -include __clang_spirv_builtins.h -triple spirv64 -emit-llvm %s -fsycl-is-device -o - | FileCheck %s
+
+
+// CHECK: define spir_func void @_Z9test_castPi
+// CHECK: call noundef ptr addrspace(1) @llvm.spv.generic.cast.to.ptr.explicit.p1.p4
+// CHECK: call noundef ptr addrspace(3) @llvm.spv.generic.cast.to.ptr.explicit.p3.p4
+// CHECK: call noundef ptr @llvm.spv.generic.cast.to.ptr.explicit.p0.p4
+// CHECK: addrspacecast ptr addrspace(4) %{{.*}} to ptr addrspace(1)
+// CHECK: addrspacecast ptr addrspace(4) %{{.*}} to ptr addrspace(3)
+// CHECK: addrspacecast ptr addrspace(4) %{{.*}} to ptr
+__attribute__((sycl_device))
+void test_cast(int* p) {
+  __spirv_GenericCastToPtrExplicit_ToGlobal(p, 5);
+  __spirv_GenericCastToPtrExplicit_ToLocal(p, 4);
+  __spirv_GenericCastToPtrExplicit_ToPrivate(p, 7);
+  __spirv_GenericCastToPtr_ToGlobal(p, 5);
+  __spirv_GenericCastToPtr_ToLocal(p, 4);
+  __spirv_GenericCastToPtr_ToPrivate(p, 7);
+}

--- a/clang/test/SemaSPIRV/BuiltIns/generic_cast_to_ptr_explicit.c
+++ b/clang/test/SemaSPIRV/BuiltIns/generic_cast_to_ptr_explicit.c
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -O1 -triple spirv64 -fsycl-is-device -verify %s -o -
+// RUN: %clang_cc1 -O1 -triple spirv64 -verify %s -cl-std=CL3.0 -x cl -o -
+
+#ifdef __OPENCL_C_VERSION__
+#define SYCL_DEVICE
+#else
+#define SYCL_DEVICE __attribute__((sycl_device))
+#endif
+
+SYCL_DEVICE
+void test_missing_arguments(int* p) {
+  __builtin_spirv_generic_cast_to_ptr_explicit(p); 
+  // expected-error@-1 {{too few arguments to function call, expected 2, have 1}}
+  __builtin_spirv_generic_cast_to_ptr_explicit(p, 7, p); 
+  // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
+}
+
+SYCL_DEVICE
+void test_wrong_flag_value(int* p) {
+  __builtin_spirv_generic_cast_to_ptr_explicit(p, 14); 
+  // expected-error@-1 {{invalid value for storage class argument}}
+}
+
+SYCL_DEVICE
+void test_wrong_address_space(__attribute__((opencl_local)) int* p) {
+  __builtin_spirv_generic_cast_to_ptr_explicit(p, 14); 
+  // expected-error@-1 {{expecting a pointer argument to the generic address space}}
+}
+
+SYCL_DEVICE
+void test_not_a_pointer(int p) {
+  __builtin_spirv_generic_cast_to_ptr_explicit(p, 14); 
+  // expected-error@-1 {{expecting a pointer argument to the generic address space}}
+}

--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+def generic_ptr_ty : LLVMQualPointerType<4>;
+
 let TargetPrefix = "spv" in {
   def int_spv_assign_type : Intrinsic<[], [llvm_any_ty, llvm_metadata_ty]>;
   def int_spv_assign_ptr_type : Intrinsic<[], [llvm_any_ty, llvm_metadata_ty, llvm_i32_ty], [ImmArg<ArgIndex<2>>]>;
@@ -143,4 +145,9 @@ let TargetPrefix = "spv" in {
 
   // FPMaxErrorDecorationINTEL
   def int_spv_assign_fpmaxerror_decoration: Intrinsic<[], [llvm_any_ty, llvm_metadata_ty]>;
+
+  // Convert between the generic storage class and a concrete one.
+  def int_spv_generic_cast_to_ptr_explicit
+    : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [generic_ptr_ty],
+       [IntrNoMem, NoUndef<RetIndex>]>;
 }

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -26,6 +26,7 @@
 #include "llvm/IR/IntrinsicsR600.h"
 #include "llvm/IR/IntrinsicsRISCV.h"
 #include "llvm/IR/IntrinsicsS390.h"
+#include "llvm/IR/IntrinsicsSPIRV.h"
 #include "llvm/IR/IntrinsicsVE.h"
 #include "llvm/IR/IntrinsicsX86.h"
 #include "llvm/IR/IntrinsicsXCore.h"

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -3131,6 +3131,19 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
                .addUse(MemSemReg)
                .constrainAllUses(TII, TRI, RBI);
   }
+  case Intrinsic::spv_generic_cast_to_ptr_explicit: {
+    bool Result = true;
+    Register PtrReg = I.getOperand(I.getNumExplicitDefs() + 1).getReg();
+    SPIRV::StorageClass::StorageClass ResSC = GR.getPointerStorageClass(ResType);
+    Result &= isGenericCastablePtr(ResSC);
+    return Result && BuildMI(BB, I, I.getDebugLoc(),
+                             TII.get(SPIRV::OpGenericCastToPtrExplicit))
+                         .addDef(ResVReg)
+                         .addUse(GR.getSPIRVTypeID(ResType))
+                         .addUse(PtrReg)
+                         .addImm(ResSC)
+                         .constrainAllUses(TII, TRI, RBI);
+  }
   case Intrinsic::spv_lifetime_start:
   case Intrinsic::spv_lifetime_end: {
     unsigned Op = IID == Intrinsic::spv_lifetime_start ? SPIRV::OpLifetimeStart

--- a/llvm/test/CodeGen/SPIRV/pointers/generic_cast_to_ptr_explicit.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/generic_cast_to_ptr_explicit.ll
@@ -1,0 +1,44 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Make sure SPIRV operation function calls for generic_cast_to_ptr_explicit are lowered correctly.
+
+; CHECK: %[[#Char:]] = OpTypeInt 8 0
+; CHECK: %[[#GenericPtr:]] = OpTypePointer Generic %[[#Char]]
+; CHECK: %[[#GlobalPtr:]] = OpTypePointer CrossWorkgroup %[[#Char]]
+; CHECK: %[[#LocalPtr:]] = OpTypePointer Workgroup %[[#Char]]
+; CHECK: %[[#PrivatePtr:]] = OpTypePointer Function %[[#Char]]
+
+; CHECK: OpFunction %[[#GlobalPtr]]
+; CHECK-NEXT: %[[#Arg:]] = OpFunctionParameter %[[#GenericPtr]]
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: OpGenericCastToPtrExplicit %[[#GlobalPtr]] %[[#Arg]] CrossWorkgroup
+define ptr addrspace(1) @test_to_global(ptr addrspace(4) noundef %ptr) {
+entry:
+  %cast = call spir_func noundef ptr addrspace(1) @llvm.spv.generic.cast.to.ptr.explicit.p1(ptr addrspace(4) noundef %ptr)
+  ret ptr addrspace(1) %cast
+}
+
+; CHECK: OpFunction %[[#LocalPtr]]
+; CHECK-NEXT: %[[#Arg:]] = OpFunctionParameter %[[#GenericPtr]]
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: OpGenericCastToPtrExplicit %[[#LocalPtr]] %[[#Arg]] Workgroup
+define ptr addrspace(3) @test_to_local(ptr addrspace(4) noundef %ptr) {
+entry:
+  %cast = call spir_func noundef ptr addrspace(3) @llvm.spv.generic.cast.to.ptr.explicit.p3(ptr addrspace(4) noundef %ptr)
+  ret ptr addrspace(3) %cast
+}
+
+; CHECK: OpFunction %[[#PrivatePtr]]
+; CHECK-NEXT: %[[#Arg:]] = OpFunctionParameter %[[#GenericPtr]]
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: OpGenericCastToPtrExplicit %[[#PrivatePtr]] %[[#Arg]] Function
+define ptr @test_to_private(ptr addrspace(4) noundef %ptr) {
+entry:
+  %cast = call spir_func noundef ptr @llvm.spv.generic.cast.to.ptr.explicit.p0(ptr addrspace(4) noundef %ptr)
+  ret ptr %cast
+}
+
+declare noundef ptr @llvm.spv.generic.cast.to.ptr.explicit.p0(ptr addrspace(4))
+declare noundef ptr addrspace(1) @llvm.spv.generic.cast.to.ptr.explicit.p1(ptr addrspace(4))
+declare noundef ptr addrspace(3) @llvm.spv.generic.cast.to.ptr.explicit.p3(ptr addrspace(4))


### PR DESCRIPTION
The patch introduce new intrinsics and builtins allowing the __spirv_* builtin function to be mapped to backend intrinsics. The enables also better diagnostics.