### PR TITLE
[UR] For non-standalone builds, use built DPCXX/Extractor

### DIFF
--- a/unified-runtime/CMakeLists.txt
+++ b/unified-runtime/CMakeLists.txt
@@ -59,6 +59,7 @@ set(UR_EXTERNAL_DEPENDENCIES "" CACHE STRING
     "List of external CMake targets for executables/libraries to depend on")
 set(UR_DPCXX "" CACHE FILEPATH "Path of the DPC++ compiler executable")
 set(UR_DPCXX_BUILD_FLAGS "" CACHE STRING "Build flags to pass to DPC++ when compiling device programs")
+set(UR_DEVICE_CODE_EXTRACTOR "" CACHE PATH "Path to clang-offload-extract")
 set(UR_SYCL_LIBRARY_DIR "" CACHE PATH
     "Path of the SYCL runtime library directory")
 set(UR_CONFORMANCE_TARGET_TRIPLES "" CACHE STRING
@@ -140,6 +141,21 @@ if(NOT MSVC)
         # is available we still need to link this library.
         link_libraries(stdc++fs)
     endif()
+endif()
+
+if(NOT UR_STANDALONE_BUILD AND "${UR_DPCXX}" STREQUAL "")
+    set(UR_FOUND_DPCXX "$<TARGET_FILE:clang>")
+    set(UR_FOUND_DEVICE_CODE_EXTRACTOR "$<TARGET_FILE:clang-offload-extract>")
+    set(UR_DPCXX_DEPS "sycl-toolchain;")
+else()
+    set(UR_FOUND_DPCXX "${UR_DPCXX}")
+    if(UR_DEVICE_CODE_EXTRACTOR)
+        set(UR_FOUND_DEVICE_CODE_EXTRACTOR "${UR_DEVICE_CODE_EXTRACTOR}")
+    else()
+        cmake_path(GET UR_FOUND_DPCXX EXTENSION EXE)
+        cmake_path(REPLACE_FILENAME UR_FOUND_DPCXX "clang-offload-extract${EXE}" OUTPUT_VARIABLE UR_FOUND_DEVICE_CODE_EXTRACTOR)
+    endif()
+    set(UR_DPCXX_DEPS "")
 endif()
 
 if(UR_ENABLE_TRACING)

--- a/unified-runtime/test/adapters/cuda/CMakeLists.txt
+++ b/unified-runtime/test/adapters/cuda/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-if(NOT UR_DPCXX)
+if(NOT UR_FOUND_DPCXX)
     message(WARNING
         "UR_DPCXX is not defined, skipping adapter-specific tests for Cuda")
     return()

--- a/unified-runtime/test/adapters/hip/CMakeLists.txt
+++ b/unified-runtime/test/adapters/hip/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-if(NOT UR_DPCXX)
+if(NOT UR_FOUND_DPCXX)
     message(WARNING
         "UR_DPCXX is not defined, skipping adapter-specific tests for HIP")
     return()

--- a/unified-runtime/test/adapters/level_zero/CMakeLists.txt
+++ b/unified-runtime/test/adapters/level_zero/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 function(add_adapter_tests adapter)
-    if(NOT UR_DPCXX)
+    if(NOT UR_FOUND_DPCXX)
         # Tests that require kernels can't be used if we aren't generating
         # device binaries
         message(WARNING

--- a/unified-runtime/test/adapters/level_zero/v2/CMakeLists.txt
+++ b/unified-runtime/test/adapters/level_zero/v2/CMakeLists.txt
@@ -63,7 +63,7 @@ add_adapter_test(level_zero_memory_residency
 )
 
 if(NOT WIN32)
-    if (NOT UR_DPCXX)
+    if (NOT UR_FOUND_DPCXX)
         # Tests that require kernels can't be used if we aren't generating
         # device binaries
         message(WARNING

--- a/unified-runtime/test/conformance/CMakeLists.txt
+++ b/unified-runtime/test/conformance/CMakeLists.txt
@@ -117,7 +117,7 @@ set(TEST_SUBDIRECTORIES_DPCXX
     "usm"
 )
 
-if(UR_DPCXX)
+if(UR_FOUND_DPCXX)
     add_custom_target(generate_device_binaries)
 
     set(UR_CONFORMANCE_DEVICE_BINARIES_DIR

--- a/unified-runtime/test/conformance/device_code/CMakeLists.txt
+++ b/unified-runtime/test/conformance/device_code/CMakeLists.txt
@@ -16,10 +16,6 @@ else()
   set(NULDEV /dev/null)
 endif()
 
-cmake_path(GET UR_DPCXX EXTENSION EXE)
-cmake_path(REPLACE_FILENAME UR_DPCXX "clang-offload-extract${EXE}" OUTPUT_VARIABLE DEFAULT_EXTRACTOR_NAME)
-set(UR_DEVICE_CODE_EXTRACTOR "${DEFAULT_EXTRACTOR_NAME}" CACHE PATH "Path to clang-offload-extract")
-
 if("${AMD_ARCH}" STREQUAL "" AND "${TARGET_TRIPLES}" MATCHES "amd")
     find_package(RocmAgentEnumerator)
     if(NOT ROCM_AGENT_ENUMERATOR_FOUND)
@@ -110,15 +106,15 @@ macro(add_device_binary SOURCE_FILE)
 
         add_custom_command(OUTPUT ${BIN_PATH}
             COMMAND LD_LIBRARY_PATH=${UR_SYCL_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH} 
-            ${UR_DPCXX} -fsycl -fsycl-targets=${TRIPLE} 
-            -fsycl-device-code-split=off ${AMD_TARGET_BACKEND} 
-            ${AMD_OFFLOAD_ARCH} ${AMD_NOGPULIB} ${DPCXX_BUILD_FLAGS_LIST} 
+            ${UR_FOUND_DPCXX} -fsycl -fsycl-targets=${TRIPLE}
+            -fsycl-device-code-split=off ${AMD_TARGET_BACKEND}
+            ${AMD_OFFLOAD_ARCH} ${AMD_NOGPULIB} ${DPCXX_BUILD_FLAGS_LIST}
             ${SOURCE_FILE} -o ${EXE_PATH}
 
-            COMMAND ${CMAKE_COMMAND} -E env ${EXTRA_ENV} ${UR_DEVICE_CODE_EXTRACTOR} -q --stem="${TRIPLE}.bin" ${EXE_PATH}
+            COMMAND ${CMAKE_COMMAND} -E env ${EXTRA_ENV} ${UR_FOUND_DEVICE_CODE_EXTRACTOR} -q --stem="${TRIPLE}.bin" ${EXE_PATH}
 
             WORKING_DIRECTORY "${DEVICE_BINARY_DIR}"
-            DEPENDS ${SOURCE_FILE}
+            DEPENDS ${SOURCE_FILE} ${UR_DPCXX_DEPS}
         )
         add_custom_target(generate_${KERNEL_NAME}_${TRIPLE} DEPENDS ${BIN_PATH})
         add_dependencies(generate_device_binaries generate_${KERNEL_NAME}_${TRIPLE})
@@ -126,7 +122,7 @@ macro(add_device_binary SOURCE_FILE)
 
     set(IH_PATH "${DEVICE_BINARY_DIR}/${KERNEL_NAME}.ih")
     add_custom_command(OUTPUT "${IH_PATH}"
-        COMMAND ${UR_DPCXX} -fsycl -fsycl-device-code-split=off
+        COMMAND ${UR_FOUND_DPCXX} -fsycl -fsycl-device-code-split=off
         -fsycl-device-only -c -Xclang -fsycl-int-header="${IH_PATH}"
         ${DPCXX_BUILD_FLAGS_LIST} ${SOURCE_FILE} -o ${NULDEV}
 


### PR DESCRIPTION
If we are not a standalone build (that is, we are built as part of
intel/llvm) and `UR_DPCXX` is not specified as part of the cmake
options, we use the `clang` built by `intel/llvm` to generate device
binaries.

Likewise, if no `UR_DEVICE_CODE_EXTRACTOR` is specified and we are
not standalone, the `clang-offload-extractor` from intel/llvm is used.

This change should not affect CI, but does mean that the UR testing
targets can be built in an intel/llvm local build.
