### PR TITLE
[SYCL][UR][L0 v2] fix urMemBufferCreateWithNativeHandle for host memory

### DIFF
--- a/sycl/test-e2e/Adapters/interop-level-zero-buffer.cpp
+++ b/sycl/test-e2e/Adapters/interop-level-zero-buffer.cpp
@@ -62,6 +62,8 @@ int main() {
     // Check API
     void *HostBuffer1 = nullptr;
     zeMemAllocHost(ZeContext, &HostDesc, 10, 1, &HostBuffer1);
+    std::fill(static_cast<char *>(HostBuffer1),
+              static_cast<char *>(HostBuffer1) + 10, 'a');
 
     backend_input_t<backend::ext_oneapi_level_zero, buffer<char, 1>>
         HostBufferInteropInput1 = {
@@ -74,6 +76,9 @@ int main() {
 
     void *HostBuffer2 = nullptr;
     zeMemAllocHost(ZeContext, &HostDesc, 12 * sizeof(int), 1, &HostBuffer2);
+    std::fill(static_cast<int *>(HostBuffer2),
+              static_cast<int *>(HostBuffer2) + 12, 1);
+
     backend_input_t<backend::ext_oneapi_level_zero, buffer<int, 1>>
         HostBufferInteropInput2 = {
             HostBuffer2, ext::oneapi::level_zero::ownership::transfer};
@@ -89,11 +94,11 @@ int main() {
 
       CGH.single_task<class SimpleKernel1>([=]() {
         for (int i = 0; i < 10; i++) {
-          Acc1[i] = 'a';
+          Acc1[i] += 1;
         }
 
         for (int i = 0; i < 12; i++) {
-          Acc2[i] = 10;
+          Acc2[i] += 10;
         }
       });
     });
@@ -102,12 +107,12 @@ int main() {
     {
       auto HostAcc1 = HostBufferInterop1.get_host_access();
       for (int i = 0; i < 10; i++) {
-        assert(HostAcc1[i] == 'a');
+        assert(HostAcc1[i] == 'b');
       }
 
       auto HostAcc2 = HostBufferInterop2.get_host_access();
       for (int i = 0; i < 12; i++) {
-        assert(HostAcc2[i] == 10);
+        assert(HostAcc2[i] == 11);
       }
     }
 
@@ -216,6 +221,8 @@ int main() {
     void *SharedBuffer = nullptr;
     zeMemAllocShared(ZeContext, &DeviceDesc, &HostDesc, 12 * sizeof(int), 1,
                      nullptr, &SharedBuffer);
+    std::fill(static_cast<int *>(SharedBuffer),
+              static_cast<int *>(SharedBuffer) + 12, 1);
 
     backend_input_t<backend::ext_oneapi_level_zero, buffer<int, 1>>
         SharedBufferInteropInput = {
@@ -242,7 +249,7 @@ int main() {
           DeviceBufferInterop.get_access<sycl::access::mode::read_write>(CGH);
       CGH.single_task<class SimpleKernel5>([=]() {
         for (int i = 0; i < 12; i++) {
-          Acc1[i] = 77;
+          Acc1[i] += 77;
         }
         for (int i = 0; i < 12; i++) {
           Acc2[i] = 99;
@@ -253,7 +260,7 @@ int main() {
     {
       auto HostAcc1 = SharedBufferInterop.get_host_access();
       for (int i = 0; i < 12; i++) {
-        assert(HostAcc1[i] == 77);
+        assert(HostAcc1[i] == 78);
       }
       auto HostAcc2 = DeviceBufferInterop.get_host_access();
       for (int i = 0; i < 12; i++) {

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -205,16 +205,19 @@ ur_discrete_buffer_handle_t::ur_discrete_buffer_handle_t(
 
 ur_discrete_buffer_handle_t::ur_discrete_buffer_handle_t(
     ur_context_handle_t hContext, ur_device_handle_t hDevice, void *devicePtr,
-    size_t size, device_access_mode_t accessMode, void *writeBackMemory,
-    bool ownZePtr)
+    size_t size, device_access_mode_t accessMode, void *hostPtr, bool ownZePtr)
     : ur_mem_buffer_t(hContext, size, accessMode),
       deviceAllocations(hContext->getPlatform()->getNumDevices()),
-      activeAllocationDevice(hDevice), writeBackPtr(writeBackMemory),
+      activeAllocationDevice(hDevice), writeBackPtr(hostPtr),
       hostAllocations() {
 
   if (!devicePtr) {
     hDevice = hDevice ? hDevice : hContext->getDevices()[0];
     devicePtr = allocateOnDevice(hDevice, size);
+
+    if (hostPtr) {
+      UR_CALL_THROWS(migrateBufferTo(hDevice, hostPtr, size));
+    }
   } else {
     assert(hDevice);
     deviceAllocations[hDevice->Id.value()] = usm_unique_ptr_t(


### PR DESCRIPTION
In case of creating a buffer from native host memory pointer, there was a missing initialization step. Host memory content was not being copied to the underlying buffer device memory.