### PR TITLE
[SYCL][UR][L0 v2] fix use after free on queue

### DIFF
--- a/unified-runtime/scripts/templates/queue_api.hpp.mako
+++ b/unified-runtime/scripts/templates/queue_api.hpp.mako
@@ -31,6 +31,7 @@ struct ur_queue_t_ {
 
     virtual void deferEventFree(ur_event_handle_t hEvent) = 0;
 
+    virtual void setURHandle(ur_queue_handle_t_*) = 0;
     %for obj in th.get_queue_related_functions(specs, n, tags):
     %if not 'Release' in obj['name'] and not 'Retain' in obj['name']:
     virtual ${x}_result_t ${th.transform_queue_related_function_name(n, tags, obj, format=["type"])} = 0;

--- a/unified-runtime/source/adapters/level_zero/v2/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.hpp
@@ -24,9 +24,11 @@ class event_pool;
 }
 
 struct event_profiling_data_t {
-  event_profiling_data_t(ze_event_handle_t hZeEvent) : hZeEvent(hZeEvent) {}
+  event_profiling_data_t(ze_event_handle_t hZeEvent,
+                         ur_queue_handle_t_ *hURQueue,
+                         ur_device_handle_t hDevice);
+  ~event_profiling_data_t();
 
-  void recordStartTimestamp(ur_device_handle_t hDevice);
   uint64_t getEventStartTimestmap() const;
 
   uint64_t getEventEndTimestamp();
@@ -37,6 +39,7 @@ struct event_profiling_data_t {
 
 private:
   ze_event_handle_t hZeEvent;
+  ur_queue_handle_t_ *hURQueue;
 
   uint64_t adjustedEventStartTimestamp = 0;
   uint64_t recordEventEndTimestamp = 0;
@@ -89,6 +92,9 @@ public:
   // Queue associated with this event. Can be nullptr (for native events)
   ur_queue_t_ *getQueue() const;
 
+  // Device associated with this event. Can be nullptr (for native events)
+  ur_device_handle_t getDevice() const;
+
   // Context associated with this event
   ur_context_handle_t getContext() const;
 
@@ -98,7 +104,7 @@ public:
   // Record the start timestamp of the event, to be obtained by
   // urEventGetProfilingInfo. resetQueueAndCommand should be
   // called before this.
-  void recordStartTimestamp();
+  void recordStartTimestamp(ur_queue_handle_t_ *hURQueue);
 
   // Get pointer to the end timestamp, and ze event handle.
   // Caller is responsible for signaling the event once the timestamp is ready.
@@ -121,8 +127,9 @@ protected:
   // queue and commandType that this event is associated with, set by enqueue
   // commands
   ur_queue_t_ *hQueue = nullptr;
+  ur_device_handle_t hDevice = nullptr;
   ur_command_t commandType = UR_COMMAND_FORCE_UINT32;
 
   v2::event_flags_t flags;
-  event_profiling_data_t profilingData;
+  std::optional<event_profiling_data_t> profilingData;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/queue_api.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_api.hpp
@@ -23,6 +23,7 @@ struct ur_queue_t_ {
 
   virtual void deferEventFree(ur_event_handle_t hEvent) = 0;
 
+  virtual void setURHandle(ur_queue_handle_t_ *) = 0;
   virtual ur_result_t queueGetInfo(ur_queue_info_t, size_t, void *,
                                    size_t *) = 0;
   virtual ur_result_t queueGetNativeHandle(ur_queue_native_desc_t *,

--- a/unified-runtime/source/adapters/level_zero/v2/queue_create.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_create.cpp
@@ -30,6 +30,7 @@ ur_result_t urQueueCreate(ur_context_handle_t hContext,
   // TODO: For now, always use immediate, in-order
   *phQueue = ur_queue_handle_t_::create<v2::ur_queue_immediate_in_order_t>(
       hContext, hDevice, pProperties);
+  (*phQueue)->get().setURHandle(*phQueue);
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -60,6 +61,7 @@ ur_result_t urQueueCreateWithNativeHandle(
 
   *phQueue = ur_queue_handle_t_::create<v2::ur_queue_immediate_in_order_t>(
       hContext, hDevice, hNativeQueue, flags, ownNativeHandle);
+  (*phQueue)->get().setURHandle(*phQueue);
 
   return UR_RESULT_SUCCESS;
 } catch (...) {

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -98,6 +98,10 @@ ze_event_handle_t ur_queue_immediate_in_order_t::getSignalEvent(
   return commandList->getSignalEvent(hUserEvent, commandType);
 }
 
+void ur_queue_immediate_in_order_t::setURHandle(ur_queue_handle_t_ *hURQueue) {
+  this->hURQueue = hURQueue;
+}
+
 ur_result_t
 ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
                                             size_t propSize, void *pPropValue,
@@ -840,7 +844,7 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueTimestampRecordingExp(
   auto [pWaitEvents, numWaitEvents] =
       getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
-  (*phEvent)->recordStartTimestamp();
+  (*phEvent)->recordStartTimestamp(hURQueue);
 
   auto [timestampPtr, zeSignalEvent] =
       (*phEvent)->getEventEndTimestampAndHandle();

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -23,6 +23,8 @@
 #include "command_list_manager.hpp"
 #include "lockable.hpp"
 
+struct ur_queue_handle_t_;
+
 namespace v2 {
 
 using queue_group_type = ur_device_handle_t_::queue_group_info_t::type;
@@ -32,6 +34,10 @@ private:
   ur_context_handle_t hContext;
   ur_device_handle_t hDevice;
   ur_queue_flags_t flags;
+
+  // Needed for operations that call urQueueRetain/urQueueRelease
+  // TODO: using virtual destructor instead of relying on variant
+  ur_queue_handle_t_ *hURQueue;
 
   lockable<ur_command_list_manager> commandListManager;
   std::vector<ur_event_handle_t> deferredEvents;
@@ -76,6 +82,7 @@ public:
 
   ~ur_queue_immediate_in_order_t();
 
+  void setURHandle(ur_queue_handle_t_ *hURQueue);
   ur_result_t queueGetInfo(ur_queue_info_t propName, size_t propSize,
                            void *pPropValue, size_t *pPropSizeRet) override;
   ur_result_t queueGetNativeHandle(ur_queue_native_desc_t *pDesc,


### PR DESCRIPTION
It is possible for queue to be released before all events associated with that queue are released. To avoid use-after free, avoid calling any function on queue and instead rely on a device handle (which will be alive until adapter is destroyed).

The only place where we still call a function on the queue is in event release in case the timestamp is not ready. This should be safe - if the queue is released then the timestamp must have been written to the event already so this path should never be taken. However, there is a potential race: if getEventEndTimestamp returns false and just after that the queue finishes and is dstroyed. To avoid that, retain the queue when starting the recording, and release whenever profiling data is destroyed (on resetQueue and event release).