### PR TITLE
[CI] Fix defaults values in benchmark CI

### DIFF
--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -114,18 +114,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - ref: |
-              ${{ 
-                inputs.commit_hash != '' && inputs.commit_hash ||
-                inputs.pr_no != '' && format('refs/pull/{0}/head', inputs.pr_no) ||
-                github.ref
-              }}
-            save_name: |
-              ${{
-                inputs.commit_hash != '' && format('Commit{0}', inputs.commit_hash) ||
-                inputs.pr_no != '' && format('PR{0}', inputs.pr_no) ||
-                'Baseline'
-              }}
+          - ref: ${{ inputs.commit_hash != '' && inputs.commit_hash || inputs.pr_no != '' && format('refs/pull/{0}/head', inputs.pr_no) || github.ref }}
+            save_name: ${{ inputs.commit_hash != '' && format('Commit{0}', inputs.commit_hash) || inputs.pr_no != '' && format('PR{0}', inputs.pr_no) || 'Baseline' }}
             # Set default values if not specified:
             runner: ${{ inputs.runner || '["PVC_PERF"]' }}
             backend: ${{ inputs.backend || 'level_zero:gpu' }}

--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -114,8 +114,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - ref: ${{ inputs.commit_hash != '' && inputs.commit_hash || format('refs/pull/{0}/head', inputs.pr_no) }}
-            save_name: ${{ inputs.commit_hash != '' && format('Commit{0}', inputs.commit_hash) || format('PR{0}', inputs.pr_no) }}
+          - ref: |
+              ${{ 
+                inputs.commit_hash != '' && inputs.commit_hash ||
+                inputs.pr_no != '' && format('refs/pull/{0}/head', inputs.pr_no) ||
+                github.ref
+              }}
+            save_name: |
+              ${{
+                inputs.commit_hash != '' && format('Commit{0}', inputs.commit_hash) ||
+                inputs.pr_no != '' && format('PR{0}', inputs.pr_no) ||
+                'Baseline'
+              }}
             # Set default values if not specified:
             runner: ${{ inputs.runner || '["PVC_PERF"]' }}
             backend: ${{ inputs.backend || 'level_zero:gpu' }}


### PR DESCRIPTION
This PR:
- Fixes missing default values for benchmarking CI manual trigger
- When splitting conditionals into multiple lines, if there is a newline at the end of the expression the github yml appends a newline if you use `|` or `>` (which, by definition, should have gotten rid of the newline): This PR folds the conditional expression back into 1 line 