### PR TITLE
[Benchmark] Sanitize --save input and strip strip while validating

### DIFF
--- a/devops/scripts/benchmarks/main.py
+++ b/devops/scripts/benchmarks/main.py
@@ -356,7 +356,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--save",
-        type=str,
+        type=lambda save: Validate.save_name(
+            save,
+            throw=argparse.ArgumentTypeError(
+                "Specified save name is not within characters [a-zA-Z0-9_-]."
+            ),
+        ),
         help="Save the results for comparison under a specified name.",
     )
     parser.add_argument(

--- a/devops/scripts/benchmarks/utils/validate.py
+++ b/devops/scripts/benchmarks/utils/validate.py
@@ -26,7 +26,17 @@ class Validate:
         """
         Returns True if runner_name is clean (no illegal characters).
         """
-        return validate_on_re(runner_name, r"^[a-zA-Z0-9_]+$", throw=throw)
+        return validate_on_re(runner_name.strip(), r"^[a-zA-Z0-9_]+$", throw=throw)
+
+    @staticmethod
+    def save_name(save: str, throw: Exception = None):
+        """
+        Returns True if save is within [a-zA-Z0-9_-].
+
+        If throw argument is specified: return save as is if save satisfies
+        aforementioned regex, otherwise raise error defined by throw.
+        """
+        return validate_on_re(save.strip(), r"^[a-zA-Z0-9_-]+$", throw=throw)
 
     @staticmethod
     def timestamp(t: str, throw: Exception = None):
@@ -37,7 +47,7 @@ class Validate:
         format, otherwise raise error defined by throw.
         """
         return validate_on_re(
-            t,
+            t.strip(),
             r"^\d{4}(0[1-9]|1[0-2])([0-2][0-9]|3[01])_([01][0-9]|2[0-3])[0-5][0-9][0-5][0-9]$",
             throw=throw,
         )
@@ -51,7 +61,7 @@ class Validate:
         aforementioned format, otherwise raise error defined by throw.
         """
         return validate_on_re(
-            re.sub(r"^https?://github.com/", "", repo),
+            re.sub(r"^https?://github.com/", "", repo.strip()),
             r"^[a-zA-Z0-9_-]{1,39}/[a-zA-Z0-9_.-]{1,100}$",
             throw=throw,
         )
@@ -67,6 +77,6 @@ class Validate:
         """
         commit_re = r"^[a-f0-9]{7,40}$"
         if throw is None:
-            return validate_on_re(commit, commit_re)
+            return validate_on_re(commit.strip(), commit_re)
         else:
-            return validate_on_re(commit, commit_re, throw=throw)[:trunc]
+            return validate_on_re(commit.strip(), commit_re, throw=throw)[:trunc]


### PR DESCRIPTION
This PR adds a sanitation check for the `--save` flag: Improper `--save` names may result in bad linux filenames.

Additionally, this PR applies `strip()` on inputs in order to prevent extra spaces or newlines in filenames