### PR TITLE
[SYCL][Benchmark] Enable computeBench for cuda

### DIFF
--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -115,6 +115,10 @@ class ComputeBench(Suite):
         if options.ur is None:
             runtimes = [r for r in runtimes if r != RUNTIMES.UR]
 
+        # Filter out L0 if cuda backend
+        if options.ur_adapter == "cuda":
+            runtimes = [r for r in runtimes if r != RUNTIMES.LEVEL_ZERO]
+
         return runtimes
 
     def benchmarks(self) -> list[Benchmark]:

--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -70,6 +70,9 @@ class ComputeBench(Suite):
             f"-DALLOW_WARNINGS=ON",
         ]
 
+        if options.ur_adapter == "cuda":
+            configure_command += ["-DBUILD_SYCL_WITH_CUDA=ON"]
+
         if options.ur is not None:
             configure_command += [
                 f"-DBUILD_UR=ON",
@@ -118,7 +121,7 @@ class ComputeBench(Suite):
         if options.sycl is None:
             return []
 
-        if options.ur_adapter == "cuda" or options.ur_adapter == "hip":
+        if options.ur_adapter == "hip":
             return []
 
         benches = []


### PR DESCRIPTION
Enable computeBench to run on sycl with cuda backend via the benchmarking scripts.