### PR TITLE
[Driver][NFC][FPGA] Remove remaining FPGA offload support in driver

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7145,10 +7145,13 @@ defm sycl_force_inline_kernel_lambda
           NegFlag<SetFalse, [], [ClangOption, CLOption], "Disallow">,
           BothFlags<[], [ClangOption, CLOption, CC1Option], " force inline "
                     "SYCL kernels lambda in entry point">>;
-def fsycl_help_EQ : Joined<["-"], "fsycl-help=">, Flags<[NoXarchOption]>,
-  HelpText<"Emit help information from the related offline compilation tool. "
-           "Valid values: all, fpga, gen, x86_64.">,
-  Values<"all,fpga,gen,x86_64">;
+def fsycl_help_EQ
+    : Joined<["-"], "fsycl-help=">,
+      Flags<[NoXarchOption]>,
+      HelpText<
+          "Emit help information from the related offline compilation tool. "
+          "Valid values: all, gen, x86_64.">,
+      Values<"all,gen,x86_64">;
 def fsycl_help : Flag<["-"], "fsycl-help">, Alias<fsycl_help_EQ>,
   Flags<[NoXarchOption]>, AliasArgs<["all"]>,
   HelpText<"Emit help information from all of the offline compilation tools">;

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -125,7 +125,6 @@ TYPE("tempfiletable",            Tempfiletable,INVALID,         "table",  phases
 TYPE("tempAOCOfilelist",         TempAOCOfilelist, INVALID,     "txt",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("archive",                  Archive,      INVALID,         "a",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("wholearchive",             WholeArchive, INVALID,         "a",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
-TYPE("fpga_dep",                 FPGA_Dependencies, INVALID,    "d",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("host_dep_image",           Host_Dependencies_Image, INVALID, "out", phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("api-information",          API_INFO,     INVALID,         "json",   phases::Precompile)
 TYPE("dx-container",             DX_CONTAINER, INVALID,         "dxo",    phases::Compile, phases::Backend)

--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -154,8 +154,8 @@ bool OffloadTargetInfo::hasHostKind() const {
 
 bool OffloadTargetInfo::isOffloadKindValid() const {
   return OffloadKind == "host" || OffloadKind == "openmp" ||
-         OffloadKind == "sycl" || OffloadKind == "fpga" ||
-         OffloadKind == "hip" || OffloadKind == "hipv4";
+         OffloadKind == "sycl" || OffloadKind == "hip" ||
+         OffloadKind == "hipv4";
 }
 
 bool OffloadTargetInfo::isOffloadKindCompatible(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1035,7 +1035,6 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
                                     const InputInfo &Output,
                                     const InputInfoList &Inputs) const {
   const bool IsIAMCU = getToolChain().getTriple().isOSIAMCU();
-  const bool IsIntelFPGA = Args.hasArg(options::OPT_fintelfpga);
   bool SYCLDeviceCompilation = JA.isOffloading(Action::OFK_SYCL) &&
                                JA.isDeviceOffloading(Action::OFK_SYCL);
 
@@ -1058,16 +1057,6 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
   else
     ArgM = ArgMD;
 
-  auto createFPGATempDepFile = [&](const char *&DepFile) {
-    // Generate dependency files as temporary. These will be used for the
-    // aoc call/bundled during fat object creation
-    std::string BaseName(Clang::getBaseInputName(Args, Inputs[0]));
-    std::string DepTmpName =
-        C.getDriver().GetTemporaryPath(llvm::sys::path::stem(BaseName), "d");
-    DepFile = C.addTempFile(C.getArgs().MakeArgString(DepTmpName));
-    C.getDriver().addFPGATempDepFile(DepFile, BaseName);
-  };
-
   if (ArgM) {
     if (!JA.isDeviceOffloading(Action::OFK_HIP)) {
       // Determine the output location.
@@ -1077,15 +1066,10 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
         C.addFailureResultFile(DepFile, &JA);
         // Populate the named dependency file to be used in the bundle
         // or passed to the offline compilation.
-        if (IsIntelFPGA && JA.isDeviceOffloading(Action::OFK_SYCL))
-          C.getDriver().addFPGATempDepFile(
-               DepFile, Clang::getBaseInputName(Args, Inputs[0]));
       } else if (Output.getType() == types::TY_Dependencies) {
         DepFile = Output.getFilename();
       } else if (!ArgMD) {
         DepFile = "-";
-      } else if (IsIntelFPGA && JA.isDeviceOffloading(Action::OFK_SYCL)) {
-        createFPGATempDepFile(DepFile);
       } else {
         DepFile = getDependencyFileName(Args, Inputs);
         C.addFailureResultFile(DepFile, &JA);
@@ -1139,21 +1123,6 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
          !Args.hasArg(options::OPT_fno_module_file_deps)) ||
         Args.hasArg(options::OPT_fmodule_file_deps))
       CmdArgs.push_back("-module-file-deps");
-  }
-
-  if (!ArgM && IsIntelFPGA && JA.isDeviceOffloading(Action::OFK_SYCL)) {
-    // No dep generation option was provided, add all of the needed options
-    // to ensure a successful dep generation.
-    const char *DepFile;
-    createFPGATempDepFile(DepFile);
-    CmdArgs.push_back("-dependency-file");
-    CmdArgs.push_back(DepFile);
-    CmdArgs.push_back("-MT");
-    SmallString<128> P(Inputs[0].getBaseInput());
-    llvm::sys::path::replace_extension(P, "o");
-    SmallString<128> Quoted;
-    quoteMakeTarget(llvm::sys::path::filename(P), Quoted);
-    CmdArgs.push_back(Args.MakeArgString(Quoted));
   }
 
   if (Args.hasArg(options::OPT_MG)) {
@@ -5511,8 +5480,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       Args.hasFlag(options::OPT_fgpu_rdc, options::OPT_fno_gpu_rdc, IsSYCL);
   auto LTOMode = IsDeviceOffloadAction ? D.getOffloadLTOMode() : D.getLTOMode();
   bool IsUsingLTO = LTOMode != LTOK_None;
-  bool IsFPGASYCLOffloadDevice =
-      IsSYCLDevice && Triple.getSubArch() == llvm::Triple::SPIRSubArch_fpga;
   const bool IsSYCLCUDACompat = isSYCLCudaCompatEnabled(Args);
 
   // Perform the SYCL host compilation using an external compiler if the user
@@ -5689,10 +5656,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       if (!Args.getLastArg(options::OPT_O_Group))
         CmdArgs.push_back("-O2");
 
-      // Default value for FPGA is false, for all other targets is true.
       if (!Args.hasFlag(options::OPT_fsycl_early_optimizations,
-                        options::OPT_fno_sycl_early_optimizations,
-                        !IsFPGASYCLOffloadDevice))
+                        options::OPT_fno_sycl_early_optimizations, true))
         CmdArgs.push_back("-fno-sycl-early-optimizations");
       else if (RawTriple.isSPIROrSPIRV()) {
         // Set `sycl-opt` option to configure LLVM passes for SPIR/SPIR-V target
@@ -5909,8 +5874,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     // At -O0, disable the inlining for debugging purposes.
     if (!Args.hasFlag(options::OPT_fsycl_force_inline_kernel_lambda,
                       options::OPT_fno_sycl_force_inline_kernel_lambda,
-                      !DisableSYCLForceInlineKernelLambda &&
-                          !IsFPGASYCLOffloadDevice))
+                      !DisableSYCLForceInlineKernelLambda))
       CmdArgs.push_back("-fno-sycl-force-inline-kernel-lambda");
 
     // Add -ffine-grained-bitfield-accesses option. This will be added
@@ -5955,9 +5919,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back(
           Args.MakeArgString(Twine("-fsycl-unique-prefix=") + UniqueID));
 
-    // Disable parallel for range-rounding for anything involving FPGA
     auto SYCLTCRange = C.getOffloadToolChains<Action::OFK_SYCL>();
-    bool HasFPGA = false;
     for (auto TI = SYCLTCRange.first, TE = SYCLTCRange.second; TI != TE; ++TI) {
       llvm::Triple SYCLTriple = TI->second->getTriple();
       if (SYCLTriple.isNVPTX() && IsSYCLCUDACompat && !IsSYCLDevice) {
@@ -5973,14 +5935,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
               CudaVersionToString(CTC->CudaInstallation.version())));
         break;
       }
-      if (SYCLTriple.getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
-        HasFPGA = true;
-        if (!IsSYCLDevice) {
-          CmdArgs.push_back("-aux-triple");
-          CmdArgs.push_back(Args.MakeArgString(SYCLTriple.getTriple()));
-        }
-        break;
-      }
     }
     // At -O0, imply -fsycl-disable-range-rounding.
     bool DisableRangeRounding = false;
@@ -5991,13 +5945,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         if (!Args.getLastArg(options::OPT_fsycl_range_rounding_EQ))
           DisableRangeRounding = true;
     }
-    if (DisableRangeRounding || HasFPGA)
+    if (DisableRangeRounding)
       CmdArgs.push_back("-fsycl-range-rounding=disable");
-
-    if (HasFPGA) {
-      // Pass -fintelfpga to both the host and device SYCL compilations if set.
-      CmdArgs.push_back("-fintelfpga");
-    }
 
     const auto DeviceTraitsMacrosArgs = D.getDeviceTraitsMacrosArgs();
     for (const auto &Arg : DeviceTraitsMacrosArgs) {
@@ -6423,8 +6372,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Discard value names in assert builds unless otherwise specified.
   if (Args.hasFlag(options::OPT_fdiscard_value_names,
-                   options::OPT_fno_discard_value_names,
-                   !IsAssertBuild && !IsFPGASYCLOffloadDevice)) {
+                   options::OPT_fno_discard_value_names, !IsAssertBuild)) {
     if (Args.hasArg(options::OPT_fdiscard_value_names) &&
         llvm::any_of(Inputs, [](const clang::driver::InputInfo &II) {
           return types::isLLVMIR(II.getType());
@@ -9971,24 +9919,6 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
       Triples += GPUArchName.str();
     }
   }
-  // If we see we are bundling for FPGA using -fintelfpga, add the
-  // dependency bundle
-  bool IsFPGADepBundle = TCArgs.hasArg(options::OPT_fintelfpga) &&
-                         Output.getType() == types::TY_Object &&
-                         !TCArgs.hasArg(options::OPT_fsycl_link_EQ);
-
-  // For spir64_fpga target, when bundling objects we also want to bundle up the
-  // named dependency file.
-  // TODO - We are currently using the target triple inputs to slot a location
-  // of the dependency information into the bundle.  It would be good to
-  // separate this out to an explicit option in the bundler for the dependency
-  // file as it does not match the type being bundled.
-  if (IsFPGADepBundle) {
-    Triples += ',';
-    Triples += Action::GetOffloadKindName(Action::OFK_SYCL);
-    Triples += '-';
-    Triples += types::getTypeName(types::TY_FPGA_Dependencies);
-  }
   CmdArgs.push_back(TCArgs.MakeArgString(Triples));
 
   // Get bundled file command.
@@ -10014,14 +9944,6 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
       UB += CurTC->getInputFilename(Inputs[I]);
     }
     CmdArgs.push_back(TCArgs.MakeArgString(UB));
-  }
-  // For -fintelfpga, when bundling objects we also want to bundle up the
-  // named dependency file.
-  if (IsFPGADepBundle) {
-    const char *BaseName = Clang::getBaseInputName(TCArgs, Inputs[0]);
-    SmallString<128> DepFile(C.getDriver().getFPGATempDepFile(BaseName));
-    if (!DepFile.empty())
-      CmdArgs.push_back(TCArgs.MakeArgString("-input=" + DepFile));
   }
   addOffloadCompressArgs(TCArgs, CmdArgs);
   // All the inputs are encoded as commands.
@@ -10052,12 +9974,9 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   const char *TypeArg = types::getTypeTempSuffix(Input.getType());
   const char *InputFileName = Input.getFilename();
   types::ID InputType(Input.getType());
-  bool IsFPGADepUnbundle = JA.getType() == types::TY_FPGA_Dependencies;
   InputInfoList ForeachInputs;
   if (InputType == types::TY_Tempfilelist)
     ForeachInputs.push_back(Input);
-  if (IsFPGADepUnbundle)
-    TypeArg = "o";
 
   bool HasSPIRTarget = false;
   auto SYCLTCRange = C.getOffloadToolChains<Action::OFK_SYCL>();
@@ -10142,15 +10061,6 @@ void OffloadBundler::ConstructJobMultipleOutputs(
       Triples += GPUArchName.str();
     }
   }
-  if (IsFPGADepUnbundle) {
-    // TODO - We are currently using the target triple inputs to slot a location
-    // of the dependency information into the bundle.  It would be good to
-    // separate this out to an explicit option in the bundler for the dependency
-    // file as it does not match the type being bundled.
-    Triples += Action::GetOffloadKindName(Action::OFK_SYCL);
-    Triples += '-';
-    Triples += types::getTypeName(types::TY_FPGA_Dependencies);
-  }
   std::string TargetString(UA.getTargetString());
   if (!TargetString.empty()) {
     // The target string was provided, we will override the defaults and use
@@ -10167,21 +10077,11 @@ void OffloadBundler::ConstructJobMultipleOutputs(
       TCArgs.MakeArgString(Twine("-input=") + InputFileName));
 
   // Get unbundled files command.
-  // When dealing with -fintelfpga, there is an additional unbundle step
-  // that occurs for the dependency file.  In that case, do not use the
-  // dependent information, but just the output file.
-  if (IsFPGADepUnbundle) {
+  for (unsigned I = 0; I < Outputs.size(); ++I) {
     SmallString<128> UB;
     UB += "-output=";
-    UB += Outputs[0].getFilename();
+    UB += DepInfo[I].DependentToolChain->getInputFilename(Outputs[I]);
     CmdArgs.push_back(TCArgs.MakeArgString(UB));
-  } else {
-    for (unsigned I = 0; I < Outputs.size(); ++I) {
-      SmallString<128> UB;
-      UB += "-output=";
-      UB += DepInfo[I].DependentToolChain->getInputFilename(Outputs[I]);
-      CmdArgs.push_back(TCArgs.MakeArgString(UB));
-    }
   }
   CmdArgs.push_back("-unbundle");
   CmdArgs.push_back("-allow-missing-bundles");
@@ -10342,18 +10242,10 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     const InputInfo &I = Inputs[0];
     assert(I.isFilename() && "Invalid input.");
 
-    // TODO: The embedded compilation step after the wrapping step restricts
-    // the ability to control the 'for each' methodology used when performing
-    // device code splitting.  We set the individual wrap behavior when we know
-    // the wrapping and compile step should be done individually.  Ideally this
-    // would be controlled at the JobAction creation, but we cannot do that
-    // until the compilation of the wrap is it's own JobAction.
-    bool IndividualWrapCompile = WrapperJob.getWrapIndividualFiles();
     const InputInfo TempOutput(types::TY_LLVM_BC, WrapperFileName,
                                WrapperFileName);
-    if (!IndividualWrapCompile &&
-        (I.getType() == types::TY_Tempfiletable ||
-         I.getType() == types::TY_Tempfilelist || IsEmbeddedIR))
+    if (I.getType() == types::TY_Tempfiletable ||
+        I.getType() == types::TY_Tempfilelist || IsEmbeddedIR)
       // Input files are passed via the batch job file table.
       WrapperArgs.push_back(C.getArgs().MakeArgString("-batch"));
     WrapperArgs.push_back(C.getArgs().MakeArgString(I.getFilename()));
@@ -10362,17 +10254,7 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         JA, *this, ResponseFileSupport::None(),
         TCArgs.MakeArgString(getToolChain().GetProgramPath(getShortName())),
         WrapperArgs, std::nullopt);
-
-    if (IndividualWrapCompile) {
-      // When wrapping FPGA device binaries for FPGA archives, create individual
-      // wrapped and compiled entries for the archive.
-      StringRef ParallelJobs =
-          C.getArgs().getLastArgValue(options::OPT_fsycl_max_parallel_jobs_EQ);
-      clang::driver::tools::SYCL::constructLLVMForeachCommand(
-          C, JA, std::move(Cmd), Inputs, TempOutput, this, "", "bc",
-          ParallelJobs);
-    } else
-      C.addCommand(std::move(Cmd));
+    C.addCommand(std::move(Cmd));
 
     if (WrapperCompileEnabled) {
       // TODO Use TC.SelectTool().
@@ -10398,16 +10280,7 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       auto PostWrapCompileCmd =
           std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
                                     Clang, ClangArgs, std::nullopt);
-      if (IndividualWrapCompile) {
-        StringRef ParallelJobs = C.getArgs().getLastArgValue(
-            options::OPT_fsycl_max_parallel_jobs_EQ);
-        InputInfoList Inputs;
-        Inputs.push_back(TempOutput);
-        clang::driver::tools::SYCL::constructLLVMForeachCommand(
-            C, JA, std::move(PostWrapCompileCmd), Inputs, Output, this, "",
-            "bc", ParallelJobs);
-      } else
-        C.addCommand(std::move(PostWrapCompileCmd));
+      C.addCommand(std::move(PostWrapCompileCmd));
     }
     return;
   } // end of SYCL flavor of offload wrapper command creation
@@ -10431,44 +10304,15 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   if (OffloadingKind == Action::OFK_None &&
       C.getArgs().hasArg(options::OPT_fsycl_link_EQ)) {
 
-    // For FPGA, we wrap the host objects before archiving them when using
-    // -fsycl-link.  This allows for better extraction control from the
-    // archive when we need the host objects for subsequent compilations.
-    if (C.getArgs().hasArg(options::OPT_fintelfpga)) {
-
-      // Add offload targets and inputs.
-      CmdArgs.push_back(C.getArgs().MakeArgString(
-          Twine("-kind=") + Action::GetOffloadKindName(OffloadingKind)));
-      CmdArgs.push_back(
-          TCArgs.MakeArgString(Twine("-target=") + Triple.getTriple()));
-
-      if (Inputs[0].getType() == types::TY_Tempfiletable ||
-          Inputs[0].getType() == types::TY_Tempfilelist)
-        // Input files are passed via the batch job file table.
-        CmdArgs.push_back(C.getArgs().MakeArgString("-batch"));
-
-      // Add input.
-      assert(Inputs[0].isFilename() && "Invalid input.");
-      CmdArgs.push_back(TCArgs.MakeArgString(Inputs[0].getFilename()));
-
-      C.addCommand(std::make_unique<Command>(
-          JA, *this, ResponseFileSupport::None(),
-          TCArgs.MakeArgString(getToolChain().GetProgramPath(getShortName())),
-          CmdArgs, Inputs));
-      return;
-    } else {
-      // When compiling and linking separately, we need to propagate the
-      // compression related CLI options to offload-wrapper. Don't propagate
-      // these options when wrapping objects for FPGA.
-      if (C.getInputArgs().getLastArg(options::OPT_offload_compress)) {
-        CmdArgs.push_back(
-            C.getArgs().MakeArgString(Twine("-offload-compress")));
-        // -offload-compression-level=<>
-        if (Arg *A = C.getInputArgs().getLastArg(
-                options::OPT_offload_compression_level_EQ))
-          CmdArgs.push_back(C.getArgs().MakeArgString(
-              Twine("-offload-compression-level=") + A->getValue()));
-      }
+    // When compiling and linking separately, we need to propagate the
+    // compression related CLI options to offload-wrapper.
+    if (C.getInputArgs().getLastArg(options::OPT_offload_compress)) {
+      CmdArgs.push_back(C.getArgs().MakeArgString(Twine("-offload-compress")));
+      // -offload-compression-level=<>
+      if (Arg *A = C.getInputArgs().getLastArg(
+              options::OPT_offload_compression_level_EQ))
+        CmdArgs.push_back(C.getArgs().MakeArgString(
+            Twine("-offload-compression-level=") + A->getValue()));
     }
   }
 
@@ -10742,17 +10586,7 @@ static void getTripleBasedSPIRVTransOpts(Compilation &C,
                                          ArgStringList &TranslatorArgs) {
   bool IsCPU = Triple.isSPIR() &&
                Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64;
-  // Enable NonSemanticShaderDebugInfo.200 for non-FPGA targets.
-  const bool EnableNonSemanticDebug = !C.getDriver().IsFPGAHWMode();
-  if (EnableNonSemanticDebug) {
-    TranslatorArgs.push_back(
-        "-spirv-debug-info-version=nonsemantic-shader-200");
-  } else {
-    TranslatorArgs.push_back("-spirv-debug-info-version=ocl-100");
-    // Prevent crash in the translator if input IR contains DIExpression
-    // operations which don't have mapping to OpenCL.DebugInfo.100 spec.
-    TranslatorArgs.push_back("-spirv-allow-extra-diexpressions");
-  }
+  TranslatorArgs.push_back("-spirv-debug-info-version=nonsemantic-shader-200");
   std::string UnknownIntrinsics("-spirv-allow-unknown-intrinsics=llvm.genx.");
   if (IsCPU)
     UnknownIntrinsics += ",llvm.fpbuiltin";
@@ -10789,25 +10623,17 @@ static void getTripleBasedSPIRVTransOpts(Compilation &C,
       ",+SPV_INTEL_bindless_images"
       ",+SPV_INTEL_task_sequence";
   ExtArg = ExtArg + DefaultExtArg + INTELExtArg;
-  if (C.getDriver().IsFPGAHWMode())
-    // Enable several extensions on FPGA H/W exclusively
-    ExtArg += ",+SPV_INTEL_usm_storage_classes,+SPV_INTEL_runtime_aligned"
-              ",+SPV_INTEL_fpga_cluster_attributes,+SPV_INTEL_loop_fuse"
-              ",+SPV_INTEL_fpga_dsp_control,+SPV_INTEL_fpga_memory_accesses"
-              ",+SPV_INTEL_fpga_memory_attributes";
-  else
-    // Don't enable several freshly added extensions on FPGA H/W
-    ExtArg += ",+SPV_INTEL_bfloat16_conversion"
-              ",+SPV_INTEL_joint_matrix"
-              ",+SPV_INTEL_hw_thread_queries"
-              ",+SPV_KHR_uniform_group_instructions"
-              ",+SPV_INTEL_masked_gather_scatter"
-              ",+SPV_INTEL_tensor_float32_conversion"
-              ",+SPV_INTEL_optnone"
-              ",+SPV_KHR_non_semantic_info"
-              ",+SPV_KHR_cooperative_matrix"
-              ",+SPV_EXT_shader_atomic_float16_add"
-              ",+SPV_INTEL_fp_max_error";
+  ExtArg += ",+SPV_INTEL_bfloat16_conversion"
+            ",+SPV_INTEL_joint_matrix"
+            ",+SPV_INTEL_hw_thread_queries"
+            ",+SPV_KHR_uniform_group_instructions"
+            ",+SPV_INTEL_masked_gather_scatter"
+            ",+SPV_INTEL_tensor_float32_conversion"
+            ",+SPV_INTEL_optnone"
+            ",+SPV_KHR_non_semantic_info"
+            ",+SPV_KHR_cooperative_matrix"
+            ",+SPV_EXT_shader_atomic_float16_add"
+            ",+SPV_INTEL_fp_max_error";
 
   TranslatorArgs.push_back(TCArgs.MakeArgString(ExtArg));
 }
@@ -11075,8 +10901,7 @@ static void getTripleBasedSYCLPostLinkOpts(const ToolChain &TC,
   // See if device code splitting is requested.  The logic here works along side
   // the behavior in getNonTripleBasedSYCLPostLinkOpts, where the option is
   // added based on the user setting of -fsycl-device-code-split.
-  if (!TCArgs.hasArg(options::OPT_fsycl_device_code_split_EQ) &&
-      (Triple.getArchName() != "spir64_fpga"))
+  if (!TCArgs.hasArg(options::OPT_fsycl_device_code_split_EQ))
     addArgs(PostLinkArgs, TCArgs, {"-split=auto"});
 
   if (shouldEmitOnlyKernelsAsEntryPoints(TC, TCArgs, Triple))
@@ -11106,7 +10931,6 @@ static void getTripleBasedSYCLPostLinkOpts(const ToolChain &TC,
     addArgs(PostLinkArgs, TCArgs, {"-lower-esimd"});
   }
   bool IsAOT = Triple.isNVPTX() || Triple.isAMDGCN() ||
-               Triple.getSubArch() == llvm::Triple::SPIRSubArch_fpga ||
                Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen ||
                Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64;
   if (TCArgs.hasFlag(options::OPT_fsycl_add_default_spec_consts_image,

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -308,42 +308,6 @@ static bool getStatic(const ArgList &Args) {
       !Args.hasArg(options::OPT_static_pie);
 }
 
-// Create an archive with llvm-ar.  This is used to create an archive that
-// contains host objects and the wrapped FPGA device binary
-void tools::gnutools::Linker::constructLLVMARCommand(
-    Compilation &C, const JobAction &JA, const InputInfo &Output,
-    const InputInfoList &Input, const ArgList &Args) const {
-  ArgStringList CmdArgs;
-  // Use 'cqL' to create the archive.  This allows for any fat archives that
-  // are passed on the command line to be added via contents instead of the
-  // full archive.  Any usage of the generated archive will then have full
-  // access to resolve any dependencies.
-  CmdArgs.push_back("cqL");
-  const char *OutputFilename = Output.getFilename();
-  if (llvm::sys::fs::exists(OutputFilename)) {
-    C.getDriver().Diag(clang::diag::warn_drv_existing_archive_append)
-        << OutputFilename;
-  }
-  CmdArgs.push_back(OutputFilename);
-  for (const auto &II : Input) {
-    if (II.getType() == types::TY_Tempfilelist) {
-      // Take the list file and pass it in with '@'.
-      std::string FileName(II.getFilename());
-      const char *ArgFile = Args.MakeArgString("@" + FileName);
-      CmdArgs.push_back(ArgFile);
-      continue;
-    }
-    if (II.isFilename())
-      CmdArgs.push_back(II.getFilename());
-  }
-
-  SmallString<128> LLVMARPath(C.getDriver().Dir);
-  llvm::sys::path::append(LLVMARPath, "llvm-ar");
-  const char *Exec = C.getArgs().MakeArgString(LLVMARPath);
-  C.addCommand(std::make_unique<Command>(
-      JA, *this, ResponseFileSupport::None(), Exec, CmdArgs, std::nullopt));
-}
-
 void tools::gnutools::StaticLibTool::ConstructJob(
     Compilation &C, const JobAction &JA, const InputInfo &Output,
     const InputInfoList &Inputs, const ArgList &Args,
@@ -413,12 +377,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       ToolChain.getTriple().hasEnvironment() ||
       (ToolChain.getTriple().getVendor() != llvm::Triple::MipsTechnologies);
 
-  // Use of -fsycl-link creates an archive.
-  if (Args.hasArg(options::OPT_fsycl_link_EQ) &&
-      JA.getType() == types::TY_Archive) {
-    constructLLVMARCommand(C, JA, Output, Inputs, Args);
-    return;
-  }
   ArgStringList CmdArgs;
 
   // Silence warning for "clang -g foo.o -o foo"

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -739,10 +739,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         else
           CmdArgs.push_back("-lsycl");
         CmdArgs.push_back("-lsycl-devicelib-host");
-        // Use of -fintelfpga implies -lOpenCL.
-        // FIXME: Adjust to use plugin interface when available.
-        if (Args.hasArg(options::OPT_fintelfpga))
-          CmdArgs.push_back("-lOpenCL");
       }
 
       // LLVM support for atomics on 32-bit SPARC V8+ is incomplete, so

--- a/clang/lib/Driver/ToolChains/Gnu.h
+++ b/clang/lib/Driver/ToolChains/Gnu.h
@@ -63,12 +63,6 @@ public:
                     const InputInfo &Output, const InputInfoList &Inputs,
                     const llvm::opt::ArgList &TCArgs,
                     const char *LinkingOutput) const override;
-
-private:
-  void constructLLVMARCommand(Compilation &C, const JobAction &JA,
-                              const InputInfo &Output,
-                              const InputInfoList &InputFiles,
-                              const llvm::opt::ArgList &Args) const;
 };
 
 class LLVM_LIBRARY_VISIBILITY StaticLibTool : public Tool {

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -65,51 +65,12 @@ static std::string FindVisualStudioExecutable(const ToolChain &TC,
   return std::string(canExecute(TC.getVFS(), FilePath) ? FilePath.str() : Exe);
 }
 
-// Add a call to lib.exe to create an archive.  This is used to embed host
-// objects into the bundled fat FPGA device binary.
-void visualstudio::Linker::constructMSVCLibCommand(Compilation &C,
-                                                   const JobAction &JA,
-                                                   const InputInfo &Output,
-                                                   const InputInfoList &Input,
-                                                   const ArgList &Args) const {
-  ArgStringList CmdArgs;
-  for (const auto &II : Input) {
-    if (II.getType() == types::TY_Tempfilelist) {
-      // Take the list file and pass it in with '@'.
-      std::string FileName(II.getFilename());
-      const char *ArgFile = Args.MakeArgString("@" + FileName);
-      CmdArgs.push_back(ArgFile);
-      continue;
-    }
-    CmdArgs.push_back(II.getFilename());
-  }
-
-  // Suppress multiple section warning LNK4078
-  if (Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false))
-    CmdArgs.push_back("/IGNORE:4078");
-
-  CmdArgs.push_back(
-      C.getArgs().MakeArgString(Twine("-OUT:") + Output.getFilename()));
-
-  SmallString<128> ExecPath(getToolChain().GetProgramPath("lib.exe"));
-  const char *Exec = C.getArgs().MakeArgString(ExecPath);
-  C.addCommand(std::make_unique<Command>(
-      JA, *this, ResponseFileSupport::AtFileUTF16(), Exec, CmdArgs, std::nullopt));
-}
-
 void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                         const InputInfo &Output,
                                         const InputInfoList &Inputs,
                                         const ArgList &Args,
                                         const char *LinkingOutput) const {
   ArgStringList CmdArgs;
-
-  // Create a library with -fsycl-link
-  if (Args.hasArg(options::OPT_fsycl_link_EQ) &&
-      JA.getType() == types::TY_Archive) {
-    constructMSVCLibCommand(C, JA, Output, Inputs, Args);
-    return;
-  }
 
   auto &TC = static_cast<const toolchains::MSVCToolChain &>(getToolChain());
 

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -83,9 +83,6 @@ void visualstudio::Linker::constructMSVCLibCommand(Compilation &C,
     }
     CmdArgs.push_back(II.getFilename());
   }
-  if (Args.hasArg(options::OPT_fsycl_link_EQ) &&
-      Args.hasArg(options::OPT_fintelfpga))
-    CmdArgs.push_back("/IGNORE:4221");
 
   // Suppress multiple section warning LNK4078
   if (Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false))

--- a/clang/lib/Driver/ToolChains/MSVC.h
+++ b/clang/lib/Driver/ToolChains/MSVC.h
@@ -36,12 +36,6 @@ public:
                     const InputInfo &Output, const InputInfoList &Inputs,
                     const llvm::opt::ArgList &TCArgs,
                     const char *LinkingOutput) const override;
-
-private:
-  void constructMSVCLibCommand(Compilation &C, const JobAction &JA,
-                               const InputInfo &Output,
-                               const InputInfoList &InputFiles,
-                               const llvm::opt::ArgList &Args) const;
 };
 } // end namespace visualstudio
 

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -199,17 +199,6 @@ void SYCLInstallationDetector::print(llvm::raw_ostream &OS) const {
   }
 }
 
-static void addFPGATimingDiagnostic(std::unique_ptr<Command> &Cmd,
-                                    Compilation &C) {
-  const char *Msg = C.getArgs().MakeArgString(
-      "The FPGA image generated during this compile contains timing violations "
-      "and may produce functional errors if used. Refer to the Intel oneAPI "
-      "DPC++ FPGA Optimization Guide section on Timing Failures for more "
-      "information.");
-  Cmd->addDiagForErrorCode(/*ErrorCode*/ 42, Msg);
-  Cmd->addExitForErrorCode(/*ErrorCode*/ 42, false);
-}
-
 void SYCL::constructLLVMForeachCommand(Compilation &C, const JobAction &JA,
                                        std::unique_ptr<Command> InputCommand,
                                        const InputInfoList &InputFiles,
@@ -292,10 +281,6 @@ void SYCL::constructLLVMForeachCommand(Compilation &C, const JobAction &JA,
 
   auto Cmd = std::make_unique<Command>(JA, *T, ResponseFileSupport::None(),
                                        Foreach, ForeachArgs, std::nullopt);
-  // FIXME: Add the FPGA specific timing diagnostic to the foreach call.
-  // The foreach call obscures the return codes from the tool it is calling
-  // to the compiler itself.
-  addFPGATimingDiagnostic(Cmd, C);
   C.addCommand(std::move(Cmd));
 }
 
@@ -373,14 +358,12 @@ static bool selectBfloatLibs(const llvm::Triple &Triple, const Compilation &C,
       // When "-device XXX" is applied to specify GPU type, user can still
       // add -fsycl-targets=intel_gpu_pvc..., native bfloat16 devicelib can
       // only be linked when all GPU types specified support.
-      // We need to filter CPU and FPGA target here and only focus on GPU
-      // device.
+      // We need to filter CPU target here and only focus on GPU device.
       if (Arg *SYCLTarget = Args.getLastArg(options::OPT_fsycl_targets_EQ)) {
         for (auto TargetsV : SYCLTarget->getValues()) {
           if (!checkSpirvJIT(StringRef(TargetsV)) &&
               !StringRef(TargetsV).starts_with("spir64_gen") &&
               !StringRef(TargetsV).starts_with("spir64_x86_64") &&
-              !StringRef(TargetsV).starts_with("spir64_fpga") &&
               !GPUArchsWithNBF16.contains(StringRef(TargetsV))) {
             UseNative = false;
             break;
@@ -630,10 +613,6 @@ SYCL::getDeviceLibraries(const Compilation &C, const llvm::Triple &TargetTriple,
       C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment();
   bool IsNewOffload = C.getDriver().getUseNewOffloadingDriver();
   StringRef LibSuffix = ".bc";
-  if (TargetTriple.isSPIR() &&
-      TargetTriple.getSubArch() == llvm::Triple::SPIRSubArch_fpga)
-    // For FPGA, we are unbundling objects.
-    LibSuffix = IsWindowsMSVCEnv ? ".obj" : ".o";
   if (IsNewOffload)
     // For new offload model, we use packaged .bc files.
     LibSuffix = IsWindowsMSVCEnv ? ".new.obj" : ".new.o";
@@ -960,16 +939,7 @@ const char *SYCL::Linker::constructLLVMLinkCommand(
       const bool IsAMDGCN = this->getToolChain().getTriple().isAMDGCN();
       const bool IsSYCLNativeCPU =
           isSYCLNativeCPU(this->getToolChain().getTriple());
-      const bool IsFPGA = this->getToolChain().getTriple().isSPIR() &&
-                          this->getToolChain().getTriple().getSubArch() ==
-                              llvm::Triple::SPIRSubArch_fpga;
       StringRef LibPostfix = ".bc";
-      if (IsFPGA) {
-        LibPostfix = ".o";
-        if (HostTC->getTriple().isWindowsMSVCEnvironment() &&
-            C.getDriver().IsCLMode())
-          LibPostfix = ".obj";
-      }
       StringRef NewLibPostfix = ".new.o";
       if (HostTC->getTriple().isWindowsMSVCEnvironment() &&
           C.getDriver().IsCLMode())
@@ -1154,201 +1124,6 @@ static const char *makeExeName(Compilation &C, StringRef Name) {
   if (HostTC->getTriple().isWindowsMSVCEnvironment())
     ExeName.append(".exe");
   return C.getArgs().MakeArgString(ExeName);
-}
-
-void SYCL::fpga::BackendCompiler::constructOpenCLAOTCommand(
-    Compilation &C, const JobAction &JA, const InputInfo &Output,
-    const InputInfoList &Inputs, const ArgList &Args) const {
-  // Construct opencl-aot command. This is used for FPGA AOT compilations
-  // when performing emulation.  Input file will be a SPIR-V binary which
-  // will be compiled to an aocx file.
-  InputInfoList ForeachInputs;
-  InputInfoList FPGADepFiles;
-  ArgStringList CmdArgs{"-device=fpga_fast_emu"};
-
-  for (const auto &II : Inputs) {
-    if (II.getType() == types::TY_FPGA_Dependencies)
-      continue;
-    if (II.getType() == types::TY_Tempfilelist)
-      ForeachInputs.push_back(II);
-    CmdArgs.push_back(
-        C.getArgs().MakeArgString("-spv=" + Twine(II.getFilename())));
-  }
-  CmdArgs.push_back(
-      C.getArgs().MakeArgString("-ir=" + Twine(Output.getFilename())));
-
-  StringRef ForeachExt = "aocx";
-  if (Arg *A = Args.getLastArg(options::OPT_fsycl_link_EQ))
-    if (A->getValue() == StringRef("early"))
-      ForeachExt = "aocr";
-
-  // Add any implied arguments before user defined arguments.
-  const toolchains::SYCLToolChain &TC =
-      static_cast<const toolchains::SYCLToolChain &>(getToolChain());
-  const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
-  llvm::Triple CPUTriple("spir64_x86_64");
-  TC.AddImpliedTargetArgs(CPUTriple, Args, CmdArgs, JA, *HostTC);
-  // Add the target args passed in
-  TC.TranslateBackendTargetArgs(CPUTriple, Args, CmdArgs);
-  TC.TranslateLinkerTargetArgs(CPUTriple, Args, CmdArgs);
-
-  SmallString<128> ExecPath(
-      getToolChain().GetProgramPath(makeExeName(C, "opencl-aot")));
-  const char *Exec = C.getArgs().MakeArgString(ExecPath);
-  auto Cmd = std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
-                                       Exec, CmdArgs, std::nullopt);
-  if (!ForeachInputs.empty()) {
-    StringRef ParallelJobs =
-        Args.getLastArgValue(options::OPT_fsycl_max_parallel_jobs_EQ);
-    constructLLVMForeachCommand(C, JA, std::move(Cmd), ForeachInputs, Output,
-                                this, "", ForeachExt, ParallelJobs);
-  } else
-    C.addCommand(std::move(Cmd));
-}
-
-void SYCL::fpga::BackendCompiler::ConstructJob(
-    Compilation &C, const JobAction &JA, const InputInfo &Output,
-    const InputInfoList &Inputs, const ArgList &Args,
-    const char *LinkingOutput) const {
-  assert(getToolChain().getTriple().isSPIROrSPIRV() && "Unsupported target");
-
-  // Grab the -Xsycl-target* options.
-  const toolchains::SYCLToolChain &TC =
-      static_cast<const toolchains::SYCLToolChain &>(getToolChain());
-  ArgStringList TargetArgs;
-  TC.TranslateBackendTargetArgs(TC.getTriple(), Args, TargetArgs);
-
-  // When performing emulation compilations for FPGA AOT, we want to use
-  // opencl-aot instead of aoc.
-  if (C.getDriver().IsFPGAEmulationMode()) {
-    constructOpenCLAOTCommand(C, JA, Output, Inputs, Args);
-    return;
-  }
-
-  InputInfoList ForeachInputs;
-  InputInfoList FPGADepFiles;
-  StringRef CreatedReportName;
-  ArgStringList CmdArgs{"-o", Output.getFilename()};
-  for (const auto &II : Inputs) {
-    std::string Filename(II.getFilename());
-    if (II.getType() == types::TY_Tempfilelist)
-      ForeachInputs.push_back(II);
-    else if (II.getType() == types::TY_FPGA_Dependencies)
-      FPGADepFiles.push_back(II);
-    else
-      CmdArgs.push_back(C.getArgs().MakeArgString(Filename));
-    StringRef Ext(llvm::sys::path::extension(Filename));
-    if (Ext.empty())
-      continue;
-  }
-  CmdArgs.push_back("-sycl");
-
-  StringRef ForeachExt = "aocx";
-  if (Arg *A = Args.getLastArg(options::OPT_fsycl_link_EQ))
-    if (A->getValue() == StringRef("early")) {
-      CmdArgs.push_back("-rtl");
-      ForeachExt = "aocr";
-    }
-
-  for (auto *A : Args) {
-    // Any input file is assumed to have a dependency file associated and
-    // the report folder can also be named based on the first input.
-    if (A->getOption().getKind() != Option::InputClass)
-      continue;
-    SmallString<128> ArgName(A->getSpelling());
-    StringRef Ext(llvm::sys::path::extension(ArgName));
-    if (Ext.empty())
-      continue;
-    types::ID Ty = getToolChain().LookupTypeForExtension(Ext.drop_front());
-    if (Ty == types::TY_INVALID)
-      continue;
-    if (types::isSrcFile(Ty) || Ty == types::TY_Object) {
-      // The project report is created in CWD, so strip off any directory
-      // information if provided with the input file.
-      StringRef TrimmedArgName = llvm::sys::path::filename(ArgName);
-      if (types::isSrcFile(Ty)) {
-        SmallString<128> DepName(
-            C.getDriver().getFPGATempDepFile(std::string(TrimmedArgName)));
-        if (!DepName.empty())
-          FPGADepFiles.push_back(InputInfo(types::TY_Dependencies,
-                                           Args.MakeArgString(DepName),
-                                           Args.MakeArgString(DepName)));
-      }
-      if (CreatedReportName.empty()) {
-        // Project report should be saved into CWD, so strip off any
-        // directory information if provided with the input file.
-        llvm::sys::path::replace_extension(ArgName, "prj");
-        CreatedReportName = Args.MakeArgString(ArgName);
-      }
-    }
-  }
-
-  // Add any dependency files.
-  if (!FPGADepFiles.empty()) {
-    SmallString<128> DepOpt("-dep-files=");
-    for (unsigned I = 0; I < FPGADepFiles.size(); ++I) {
-      if (I)
-        DepOpt += ',';
-      DepOpt += FPGADepFiles[I].getFilename();
-    }
-    CmdArgs.push_back(C.getArgs().MakeArgString(DepOpt));
-  }
-
-  // Depending on output file designations, set the report folder
-  SmallString<128> ReportOptArg;
-  if (Arg *FinalOutput = Args.getLastArg(options::OPT_o, options::OPT__SLASH_o,
-                                         options::OPT__SLASH_Fe)) {
-    SmallString<128> FN(FinalOutput->getValue());
-    // For "-o file.xxx" where the option value has an extension, if the
-    // extension is one of .a .o .out .lib .obj .exe, the output project
-    // directory name will be file.proj which omits the extension. Otherwise
-    // the output project directory name will be file.xxx.prj which keeps
-    // the original extension.
-    StringRef Ext = llvm::sys::path::extension(FN);
-    SmallVector<StringRef, 6> Exts = {".o",   ".a",   ".out",
-                                      ".obj", ".lib", ".exe"};
-    if (std::find(Exts.begin(), Exts.end(), Ext) != Exts.end())
-      llvm::sys::path::replace_extension(FN, "prj");
-    else
-      FN.append(".prj");
-    const char *FolderName = Args.MakeArgString(FN);
-    ReportOptArg += FolderName;
-  } else {
-    // Default output directory should match default output executable name
-    ReportOptArg += "a.prj";
-  }
-  if (!ReportOptArg.empty())
-    CmdArgs.push_back(C.getArgs().MakeArgString(
-        Twine("-output-report-folder=") + ReportOptArg));
-
-  // Add any implied arguments before user defined arguments.
-  const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
-  TC.AddImpliedTargetArgs(getToolChain().getTriple(), Args, CmdArgs, JA,
-                          *HostTC);
-
-  // Add -Xsycl-target* options.
-  TC.TranslateBackendTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
-  TC.TranslateLinkerTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
-
-  // Look for -reuse-exe=XX option
-  if (Arg *A = Args.getLastArg(options::OPT_reuse_exe_EQ)) {
-    Args.ClaimAllArgs(options::OPT_reuse_exe_EQ);
-    CmdArgs.push_back(Args.MakeArgString(A->getAsString(Args)));
-  }
-
-  SmallString<128> ExecPath(
-      getToolChain().GetProgramPath(makeExeName(C, "aoc")));
-  const char *Exec = C.getArgs().MakeArgString(ExecPath);
-  auto Cmd = std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
-                                       Exec, CmdArgs, std::nullopt);
-  addFPGATimingDiagnostic(Cmd, C);
-  if (!ForeachInputs.empty()) {
-    StringRef ParallelJobs =
-        Args.getLastArgValue(options::OPT_fsycl_max_parallel_jobs_EQ);
-    constructLLVMForeachCommand(C, JA, std::move(Cmd), ForeachInputs, Output,
-                                this, ReportOptArg, ForeachExt, ParallelJobs);
-  } else
-    C.addCommand(std::move(Cmd));
 }
 
 // Determine if any of the given arguments contain any PVC based values for
@@ -1786,10 +1561,6 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
     if (IsNewDAL)
       DAL->append(A);
   }
-  // Strip out -O0 for FPGA Hardware device compilation.
-  if (getDriver().IsFPGAHWMode() &&
-      getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga)
-    DAL->eraseArg(options::OPT_O0);
 
   const OptTable &Opts = getDriver().getOpts();
   if (!BoundArch.empty()) {
@@ -1909,7 +1680,6 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
                                          StringRef Device) const {
   // Current implied args are for debug information and disabling of
   // optimizations.  They are passed along to the respective areas as follows:
-  // FPGA:  -g -cl-opt-disable
   // Default device AOT: -g -cl-opt-disable
   // Default device JIT: -g (-O0 is handled by the runtime)
   // GEN:  -options "-g -O0"
@@ -1998,14 +1768,6 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
                                             ":" + BackendOptName));
     }
   }
-  // only pass -vpfp-relaxed for aoc with -fintelfpga and -fp-model=fast
-  if (Args.hasArg(options::OPT_fintelfpga) && getDriver().IsFPGAHWMode() &&
-      Triple.getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
-    if (Arg *A = Args.getLastArg(options::OPT_ffp_model_EQ)) {
-      if (StringRef(A->getValue()) == "fast")
-        BeArgs.push_back("-vpfp-relaxed");
-    }
-  }
   if (IsGen) {
     // For GEN (spir64_gen) we have implied -device settings given usage
     // of intel_gpu_ as a target.  Handle those here, and also check that no
@@ -2070,8 +1832,7 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
   }
   if (BeArgs.empty())
     return;
-  if (Triple.getSubArch() == llvm::Triple::NoSubArch ||
-      Triple.getSubArch() == llvm::Triple::SPIRSubArch_fpga) {
+  if (Triple.getSubArch() == llvm::Triple::NoSubArch) {
     for (StringRef A : BeArgs)
       CmdArgs.push_back(Args.MakeArgString(A));
     return;
@@ -2150,8 +1911,6 @@ void SYCLToolChain::TranslateLinkerTargetArgs(const llvm::Triple &Triple,
 }
 
 Tool *SYCLToolChain::buildBackendCompiler() const {
-  if (getTriple().getSubArch() == llvm::Triple::SPIRSubArch_fpga)
-    return new tools::SYCL::fpga::BackendCompiler(*this);
   if (getTriple().getSubArch() == llvm::Triple::SPIRSubArch_gen)
     return new tools::SYCL::gen::BackendCompiler(*this);
   // fall through is CPU.

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -190,30 +190,6 @@ private:
                                        const InputInfoList &InputFiles) const;
 };
 
-/// Directly call FPGA Compiler and Linker
-namespace fpga {
-
-class LLVM_LIBRARY_VISIBILITY BackendCompiler : public Tool {
-public:
-  BackendCompiler(const ToolChain &TC)
-      : Tool("fpga::BackendCompiler", "fpga compiler", TC) {}
-
-  bool hasIntegratedCPP() const override { return false; }
-
-  void ConstructJob(Compilation &C, const JobAction &JA,
-                    const InputInfo &Output, const InputInfoList &Inputs,
-                    const llvm::opt::ArgList &TCArgs,
-                    const char *LinkingOutput) const override;
-
-private:
-  void constructOpenCLAOTCommand(Compilation &C, const JobAction &JA,
-                                 const InputInfo &Output,
-                                 const InputInfoList &InputFiles,
-                                 const llvm::opt::ArgList &Args) const;
-};
-
-} // end namespace fpga
-
 namespace gen {
 
 class LLVM_LIBRARY_VISIBILITY BackendCompiler : public Tool {

--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -63,14 +63,14 @@
 // RUN:  | FileCheck %s -check-prefix UNSUPPORTED_FPGA -DBADOPT=-fsycl-targets=spir64_fpga
 // RUN: not %clangxx -fsycl -fsycl-targets=spir64_fpga-unknown-unknown -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix UNSUPPORTED_FPGA -DBADOPT=-fsycl-targets=spir64_fpga-unknown-unknown
-// RUN: not %clangxx -fintelfpga -reuse-exe=exe -### %s 2>&1 \
+// RUN: not %clangxx -fsycl -reuse-exe=exe -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix UNSUPPORTED_FPGA -DBADOPT=-reuse-exe=exe
 // RUN: not %clangxx -fsycl-help=fpga -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix UNSUPPORTED_FPGA -DBADOPT=-fsycl-help=fpga
 // RUN: not %clangxx -fsycl -fintelfpga -Xsycl-target-backend=spir64_fpga "-backend_opts" -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix UNSUPPORTED_FPGA -DBADOPT=-Xsycl-target-backend=spir64_fpga
-// RUN: not %clangxx -fintelfpga -fsycl-link=early -### %s 2>&1 \
+// RUN: not %clangxx -fsycl -fsycl-link=early -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix UNSUPPORTED_FPGA -DBADOPT=-fsycl-link=early
-// RUN: not %clangxx -fintelfpga -fsycl-link=image -### %s 2>&1 \
+// RUN: not %clangxx -fsycl -fsycl-link=image -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix UNSUPPORTED_FPGA -DBADOPT=-fsycl-link=image
 // UNSUPPORTED_FPGA: option '[[BADOPT]]' is not supported and has been removed from the compiler. Please see the compiler documentation for more details


### PR DESCRIPTION
Following https://github.com/intel/llvm/commit/491915b2ac92caf76f611e804644abce30e148ae, remove the remaining items in the driver that support FPGA.

Small exceptions to this include any specific diagnostic behaviors that inform the user of option usage that is not supported due to the removal of FPGA.  Cleanup of those items can occur following a later major release.  The extension enabling options for the `sycl-post-link` tool specific for fpga also remain for now.