### PR TITLE
[SYCL] Cache device aspects during `shared_ptr<device_impl>` creation

### DIFF
--- a/sycl/include/sycl/aspects.hpp
+++ b/sycl/include/sycl/aspects.hpp
@@ -7,9 +7,9 @@
 // ===--------------------------------------------------------------------=== //
 #pragma once
 
+#include <algorithm>
 #include <sycl/detail/defines.hpp>            // for __SYCL_TYPE
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
-#include <algorithm>
 
 namespace sycl {
 inline namespace _V1 {

--- a/sycl/include/sycl/aspects.hpp
+++ b/sycl/include/sycl/aspects.hpp
@@ -28,7 +28,7 @@ enum class __SYCL_TYPE(aspect) aspect {
 #undef __SYCL_ASPECT
 
 namespace detail {
-constexpr int max_aspect_id = std::max({0
+constexpr int max_aspect_id = (std::max)({0
 #define __SYCL_ASPECT(ASPECT, ID) , ID
 #define __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE) , ID
 // Alias isn't necessary as it will be handled by base entry.

--- a/sycl/include/sycl/aspects.hpp
+++ b/sycl/include/sycl/aspects.hpp
@@ -9,6 +9,7 @@
 
 #include <sycl/detail/defines.hpp>            // for __SYCL_TYPE
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
+#include <algorithm>
 
 namespace sycl {
 inline namespace _V1 {
@@ -25,6 +26,18 @@ enum class __SYCL_TYPE(aspect) aspect {
 #undef __SYCL_ASPECT_DEPRECATED_ALIAS
 #undef __SYCL_ASPECT_DEPRECATED
 #undef __SYCL_ASPECT
+
+namespace detail {
+constexpr int max_aspect_id = std::max({0
+#define __SYCL_ASPECT(ASPECT, ID) , ID
+#define __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE) , ID
+// Alias isn't necessary as it will be handled by base entry.
+#include <sycl/info/aspects.def>
+#include <sycl/info/aspects_deprecated.def>
+#undef __SYCL_ASPECT_DEPRECATED
+#undef __SYCL_ASPECT
+});
+} // namespace detail
 
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -762,7 +762,7 @@ bool device_impl::compute_has_aspect(aspect Aspect) const {
         UR_DEVICE_COMMAND_BUFFER_UPDATE_CAPABILITY_FLAG_GLOBAL_WORK_OFFSET |
         UR_DEVICE_COMMAND_BUFFER_UPDATE_CAPABILITY_FLAG_KERNEL_HANDLE;
 
-    return has(aspect::ext_oneapi_limited_graph) &&
+    return compute_has_aspect(aspect::ext_oneapi_limited_graph) &&
            (UpdateCapabilities & RequiredCapabilities) == RequiredCapabilities;
   }
   case aspect::ext_oneapi_limited_graph: {

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -838,7 +838,8 @@ void device_impl::init_aspects() {
   if (MIsMock)
     return;
 
-#define __SYCL_ASPECT(ASPECT, ID) MAspects[ID] = compute_has_aspect(sycl::aspect::ASPECT);
+#define __SYCL_ASPECT(ASPECT, ID)                                              \
+  MAspects[ID] = compute_has_aspect(sycl::aspect::ASPECT);
 #define __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE) __SYCL_ASPECT(ASPECT, ID)
 // Alias isn't necessary as it will be handled by base entry.
 #include <sycl/info/aspects.def>

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -298,10 +298,12 @@ public:
   /// Get device architecture
   ext::oneapi::experimental::architecture getDeviceArch() const;
 
+  void init_aspects();
 private:
   explicit device_impl(ur_native_handle_t InteropDevice,
                        ur_device_handle_t Device, PlatformImplPtr Platform,
                        const AdapterPtr &Adapter);
+  bool compute_has_aspect(aspect Aspect) const;
 
   ur_device_handle_t MDevice = 0;
   ur_device_type_t MType;
@@ -313,6 +315,13 @@ private:
   mutable ext::oneapi::experimental::architecture MDeviceArch{};
   mutable std::once_flag MDeviceArchFlag;
   std::pair<uint64_t, uint64_t> MDeviceHostBaseTime{0, 0};
+
+  // Cache aspects during `DeviceImplPtr` creation (because that's what APIs in
+  // `device_info.hpp` accept and we need those to compute aspects). Also, mock
+  // implementations don't iplement all the aspects, so avoid such caching for
+  // the mock device.
+  std::array<bool, detail::max_aspect_id + 1> MAspects{false};
+  bool MIsMock = false;
 }; // class device_impl
 
 } // namespace detail

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -299,6 +299,7 @@ public:
   ext::oneapi::experimental::architecture getDeviceArch() const;
 
   void init_aspects();
+
 private:
   explicit device_impl(ur_native_handle_t InteropDevice,
                        ur_device_handle_t Device, PlatformImplPtr Platform,

--- a/sycl/test-e2e/USM/usm_pooling.cpp
+++ b/sycl/test-e2e/USM/usm_pooling.cpp
@@ -110,7 +110,6 @@ int main(int argc, char *argv[]) {
 }
 
 // CHECK-NOPOOL: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
-// CHECK-NOPOOL-NEXT:  zeDeviceGetMemoryAccessProperties
 // CHECK-NOPOOL-NEXT:  [[API]](
 // CHECK-NOPOOL-NEXT:  [[API]](
 // CHECK-NOPOOL-NEXT:  zeMemFree
@@ -120,7 +119,6 @@ int main(int argc, char *argv[]) {
 // CHECK-NOPOOL-NEXT:  [[API]](
 
 // CHECK-12345: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
-// CHECK-12345-NEXT:  zeDeviceGetMemoryAccessProperties
 // CHECK-12345-NEXT:  [[API]](
 // CHECK-12345-NEXT:  [[API]](
 // CHECK-12345-NEXT:  zeMemFree
@@ -130,7 +128,6 @@ int main(int argc, char *argv[]) {
 // CHECK-12345-NEXT:  [[API]](
 
 // CHECK-1245: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
-// CHECK-1245-NEXT:  zeDeviceGetMemoryAccessProperties
 // CHECK-1245-NEXT:  [[API]](
 // CHECK-1245-NEXT:  [[API]](
 // CHECK-1245-NEXT:  zeMemFree
@@ -138,7 +135,6 @@ int main(int argc, char *argv[]) {
 // CHECK-1245-NEXT:  [[API]](
 
 // CHECK-15: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
-// CHECK-15-NEXT:  zeDeviceGetMemoryAccessProperties
 // CHECK-15-NEXT:  [[API]](
 // CHECK-15-NEXT:  [[API]](
 // CHECK-15-NEXT:  zeMemFree


### PR DESCRIPTION
Computing some aspects requires string comparison or even heap allocations of strings (for `device_impl::has_extension`) and caching that on lower levels (e.g., UR) doesn't look reasonable. On the other hand, SYCL aspects don't change for the entire lifetime of a device, so it makes sense to compute them just once.

The overhead of such compute is about 36us on my machine. It's significant compared to the `device_impl` creation, but we do create all the root devices together with the platforms and those are orders of magnitude more expensive than computing the aspects (~100ms).

Implementation-wise there are two things worth mentioning:

  * `device_info.hpp` APIs take `DeviceImplPtr` and not `device_impl` ptr/ref and are needed to compute some of the aspects. As such, we can't pre-compute everything in the `device_impl` ctor and have to do that in `platform_impl::getOrMakeDeviceImpl`
  * Mock devices in unittests don't implement queries for all the aspects, so pre-computing them leads to crashes. I've decided to simply disable such caching for the devices named "Mock device".