### PR TITLE
[SYCL][NFC] Avoid double allocation in `device_impl::get_device_info_string`

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -208,11 +208,13 @@ device_impl::get_device_info_string(ur_device_info_t InfoCode) const {
   if (resultSize == 0) {
     return std::string();
   }
-  std::unique_ptr<char[]> result(new char[resultSize]);
+  std::string result;
+  // C++23's `resize_and_overwrite` would be better...
+  result.resize(resultSize);
   getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-      getHandleRef(), InfoCode, resultSize, result.get(), nullptr);
+      getHandleRef(), InfoCode, resultSize, result.data(), nullptr);
 
-  return std::string(result.get());
+  return result;
 }
 
 // Specialization for string return type, variable return size

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -210,7 +210,10 @@ device_impl::get_device_info_string(ur_device_info_t InfoCode) const {
   }
   std::string result;
   // C++23's `resize_and_overwrite` would be better...
-  result.resize(resultSize);
+  //
+  // UR counts null terminator in the size, std::string doesn't. Adjust by "-1"
+  // for that.
+  result.resize(resultSize - 1);
   getAdapter()->call<UrApiKind::urDeviceGetInfo>(
       getHandleRef(), InfoCode, resultSize, result.data(), nullptr);
 


### PR DESCRIPTION
Before the change: two allocations plus copy between them, after: one allocation plus zero-init of it so should be a strict improvement.