### PR TITLE
[DeviceSanitizer] Fix Generic pointer convert bug

### DIFF
--- a/libdevice/include/sanitizer_defs.hpp
+++ b/libdevice/include/sanitizer_defs.hpp
@@ -64,4 +64,19 @@ __SYCL_PRIVATE__ void *ToPrivate(void *ptr) {
   return __spirv_GenericCastToPtrExplicit_ToPrivate(ptr, 7);
 }
 
+inline void ConvertGenericPointer(uptr &addr, uint32_t &as) {
+  auto old = addr;
+  if ((addr = (uptr)ToPrivate((void *)old))) {
+    as = ADDRESS_SPACE_PRIVATE;
+  } else if ((addr = (uptr)ToLocal((void *)old))) {
+    as = ADDRESS_SPACE_LOCAL;
+  } else if ((addr = (uptr)ToGlobal((void *)old))) {
+    as = ADDRESS_SPACE_GLOBAL;
+  } else {
+    as = ADDRESS_SPACE_GENERIC;
+    addr = old;
+  }
+}
+
+
 #endif // __SPIR__ || __SPIRV__

--- a/libdevice/sanitizer/asan_rtl.cpp
+++ b/libdevice/sanitizer/asan_rtl.cpp
@@ -71,10 +71,10 @@ inline uptr MemToShadow_CPU(uptr addr) {
     if (as == ADDRESS_SPACE_GENERIC) {                                         \
       uptr old = addr;                                                         \
       ConvertGenericPointer(addr, as);                                         \
-      ASAN_DEBUG(__spirv_ocl_printf(__generic_to, old, addr, as));
-} // namespace                                                                          \
-    if (as == ADDRESS_SPACE_GENERIC) {                                         \
-      return 0;                                                                \
+      ASAN_DEBUG(__spirv_ocl_printf(__generic_to, old, addr, as));             \
+      if (as == ADDRESS_SPACE_GENERIC) {                                       \
+        return 0;                                                              \
+      }                                                                        \
     }                                                                          \
   } while (0)
 

--- a/libdevice/sanitizer/msan_rtl.cpp
+++ b/libdevice/sanitizer/msan_rtl.cpp
@@ -142,12 +142,12 @@ inline uptr __msan_get_shadow_cpu(uptr addr) {
 #define CONVERT_GENERIC_PTR_EARLY_RETURN(addr, as)                             \
   do {                                                                         \
     if (as == ADDRESS_SPACE_GENERIC) {                                         \
-      auto old = addr;                                                      \
+      auto old = addr;                                                         \
       ConvertGenericPointer(addr, as);                                         \
-      MSAN_DEBUG(__spirv_ocl_printf(__msan_print_generic_to, old, addr, as)); \
-    }                                                                          \
-    if (as == ADDRESS_SPACE_GENERIC) {                                         \
-      return GetMsanLaunchInfo->CleanShadow;                                   \
+      MSAN_DEBUG(__spirv_ocl_printf(__msan_print_generic_to, old, addr, as));  \
+      if (as == ADDRESS_SPACE_GENERIC) {                                       \
+        return GetMsanLaunchInfo->CleanShadow;                                 \
+      }                                                                        \
     }                                                                          \
   } while (0)
 

--- a/libdevice/sanitizer/tsan_rtl.cpp
+++ b/libdevice/sanitizer/tsan_rtl.cpp
@@ -60,21 +60,6 @@ inline constexpr uptr RoundDownTo(uptr x, uptr boundary) {
 
 inline constexpr uptr Min(uptr a, uptr b) { return a < b ? a : b; }
 
-inline void ConvertGenericPointer(uptr &addr, uint32_t &as) {
-  auto old = addr;
-  if ((addr = (uptr)ToPrivate((void *)old))) {
-    as = ADDRESS_SPACE_PRIVATE;
-  } else if ((addr = (uptr)ToLocal((void *)old))) {
-    as = ADDRESS_SPACE_LOCAL;
-  } else {
-    // FIXME: I'm not sure if we need to check ADDRESS_SPACE_CONSTANT,
-    // but this can really simplify the generic pointer conversion logic
-    as = ADDRESS_SPACE_GLOBAL;
-    addr = old;
-  }
-  TSAN_DEBUG(__spirv_ocl_printf(__tsan_print_generic_to, old, addr, as));
-}
-
 inline Epoch IncrementEpoch(Sid sid) {
   return atomicAdd(&TsanLaunchInfo->Clock[sid].clk_[sid], 1);
 }
@@ -85,10 +70,20 @@ inline __SYCL_GLOBAL__ RawShadow *MemToShadow_CPU(uptr addr, uint32_t) {
       TsanLaunchInfo->GlobalShadowOffset);
 }
 
+#define CONVERT_GENERIC_PTR_EARLY_RETURN(addr, as)                             \
+  do {                                                                         \
+    if (as == ADDRESS_SPACE_GENERIC) {                                         \
+      auto old = addr;                                                      \
+      ConvertGenericPointer(addr, as);                                         \
+      TSAN_DEBUG(__spirv_ocl_printf(__tsan_print_generic_to, old, addr, as)); \
+    }                                                                          \
+    if (as == ADDRESS_SPACE_GENERIC) {                                         \
+      return nullptr;                                                          \
+    }                                                                          \
+  } while (0)
+
 inline __SYCL_GLOBAL__ RawShadow *MemToShadow_PVC(uptr addr, uint32_t as) {
-  if (as == ADDRESS_SPACE_GENERIC) {
-    ConvertGenericPointer(addr, as);
-  }
+  CONVERT_GENERIC_PTR_EARLY_RETURN(addr, as);
 
   if (as != ADDRESS_SPACE_GLOBAL)
     return nullptr;

--- a/libdevice/sanitizer/tsan_rtl.cpp
+++ b/libdevice/sanitizer/tsan_rtl.cpp
@@ -73,12 +73,12 @@ inline __SYCL_GLOBAL__ RawShadow *MemToShadow_CPU(uptr addr, uint32_t) {
 #define CONVERT_GENERIC_PTR_EARLY_RETURN(addr, as)                             \
   do {                                                                         \
     if (as == ADDRESS_SPACE_GENERIC) {                                         \
-      auto old = addr;                                                      \
+      auto old = addr;                                                         \
       ConvertGenericPointer(addr, as);                                         \
-      TSAN_DEBUG(__spirv_ocl_printf(__tsan_print_generic_to, old, addr, as)); \
-    }                                                                          \
-    if (as == ADDRESS_SPACE_GENERIC) {                                         \
-      return nullptr;                                                          \
+      TSAN_DEBUG(__spirv_ocl_printf(__tsan_print_generic_to, old, addr, as));  \
+      if (as == ADDRESS_SPACE_GENERIC) {                                       \
+        return nullptr;                                                        \
+      }                                                                        \
     }                                                                          \
   } while (0)
 


### PR DESCRIPTION
Currently, the internal `ConvertGenericPointer()` is not well implemented. We cannot simply default the pointer to global when they are not a local or private pointer, as there are other possibilities (like the pointer is ill-formed, IGC code gen bug). This patch addresses that problem by skipping checking the pointer when the conversion fails.