### PR TITLE
[SYCL][BINDLESS] Fix mem_image_free for gather array

### DIFF
--- a/sycl/source/detail/bindless_images.cpp
+++ b/sycl/source/detail/bindless_images.cpp
@@ -234,16 +234,10 @@ __SYCL_EXPORT void free_image_mem(image_mem_handle memHandle,
       Adapter->call<sycl::errc::memory_allocation,
                     sycl::detail::UrApiKind::urBindlessImagesMipmapFreeExp>(
           C, Device, memHandle.raw_handle);
-    } else if (imageType == image_type::standard ||
-               imageType == image_type::array ||
-               imageType == image_type::cubemap ||
-               imageType == image_type::gather) {
+    } else {
       Adapter->call<sycl::errc::memory_allocation,
                     sycl::detail::UrApiKind::urBindlessImagesImageFreeExp>(
           C, Device, memHandle.raw_handle);
-    } else {
-      throw sycl::exception(sycl::make_error_code(sycl::errc::invalid),
-                            "Invalid image type to free");
     }
   }
 }


### PR DESCRIPTION
The case of `image_type::gather` would lead to an exception being thrown in `free_image_mem`/ `std::terminate` in `~image_mem_impl`. I missed this in https://github.com/intel/llvm/pull/17322.
This fixes that.

Note that this doesn't fully address https://github.com/intel/llvm/issues/16331 since the call to UR could still throw in theory. However, in order to avoid such a UR call in a destructor the implementation would have to be completely changed. As it is, if for some unusual circumstance the image free did fail in UR, I think there is at least an argument it be better that this does lead to `std::terminate`. So I'm leaving this for discussion.