### PR TITLE
[libspirv] Remove scalar Dot, All and Any built-ins

### DIFF
--- a/libclc/libspirv/lib/generic/geometric/dot.cl
+++ b/libclc/libspirv/lib/generic/geometric/dot.cl
@@ -10,7 +10,7 @@
 #include <libspirv/spirv.h>
 
 #define _CLC_GEN_DOT(DECLSPEC, TYPE)                                           \
-  DECLSPEC TYPE __spirv_Dot(TYPE x, TYPE y) { return x * y; }                  \
+  DECLSPEC static TYPE __spirv_Dot(TYPE x, TYPE y) { return x * y; }           \
   DECLSPEC TYPE __spirv_Dot(TYPE##2 x, TYPE##2 y) {                            \
     return __spirv_Dot(x.x, y.x) + __spirv_Dot(x.y, y.y);                      \
   }                                                                            \

--- a/libclc/libspirv/lib/generic/relational/all.cl
+++ b/libclc/libspirv/lib/generic/relational/all.cl
@@ -22,8 +22,6 @@
 
 #define ALL_ID(TYPE) _CLC_OVERLOAD _CLC_DEF bool __spirv_All(TYPE v)
 
-bool __spirv_All(bool v) { return v; }
-
 #define ALL_VECTORIZE(TYPE)                                                    \
   ALL_ID(TYPE##2) { return _CLC_ALL2(v); }                                     \
   ALL_ID(TYPE##3) { return _CLC_ALL3(v); }                                     \

--- a/libclc/libspirv/lib/generic/relational/any.cl
+++ b/libclc/libspirv/lib/generic/relational/any.cl
@@ -22,8 +22,6 @@
 
 #define ANY_ID(TYPE) _CLC_OVERLOAD _CLC_DEF bool __spirv_Any(TYPE v)
 
-bool __spirv_Any(bool v) { return v; }
-
 #define ANY_VECTORIZE(TYPE)                                                    \
   ANY_ID(TYPE##2) { return _CLC_ANY2(v); }                                     \
   ANY_ID(TYPE##3) { return _CLC_ANY3(v); }                                     \


### PR DESCRIPTION
They only accept vector input per SPIR-V spec.