### PR TITLE
[SYCL][Bindless][E2E] Add missing wait in test between copy and verification

### DIFF
--- a/sycl/test-e2e/bindless_images/examples/example_1_1D_read_write.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_1_1D_read_write.cpp
@@ -67,6 +67,9 @@ int main() {
   // Copy data written to imgOut to host
   q.ext_oneapi_copy(imgMemoryOut.get_handle(), dataOut.data(), desc);
 
+  // Ensure copying data from the device to host is finished before validate
+  q.wait_and_throw();
+
   // Cleanup
   sycl::ext::oneapi::experimental::destroy_image_handle(imgIn, q);
   sycl::ext::oneapi::experimental::destroy_image_handle(imgOut, q);


### PR DESCRIPTION
Fixes #16923 'example_1_1D_read_write.cpp' has a sporadic failure on battlemage where it fails to validate the data. This is likely due to a missing 'q.wait_and_throw()' between copying the data from the device to host and verifying it. Adding the wait should fix this failure.