### PR TITLE
[SYCL][E2E] Enable is_compatible_amdgcn.cpp on Windows

### DIFF
--- a/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_amdgcn.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_amdgcn.cpp
@@ -1,9 +1,5 @@
 // REQUIRES: hip_dev_kit
 
-// UNSUPPORTED: windows
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17515
-// ROCm libraries are not installed correctly.
-
-// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1030 %S/Inputs/is_compatible_with_env.cpp -o %t.out
+// RUN: %clangxx %hip_options -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1030 %S/Inputs/is_compatible_with_env.cpp -o %t.out
 
 // RUN: %if !hip %{ not %} %{run} %t.out


### PR DESCRIPTION
It's fixed now.

Closes: https://github.com/intel/llvm/issues/17515