### PR TITLE
[SYCL][NFCI] Remove unnecessary partial specializations

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -227,12 +227,6 @@ template <typename Param> struct get_device_info_impl<std::string, Param> {
   }
 };
 
-// Specialization for parent device
-template <typename ReturnT>
-struct get_device_info_impl<ReturnT, info::device::parent_device> {
-  static ReturnT get(const DeviceImplPtr &Dev);
-};
-
 // Specialization for fp_config types, checks the corresponding fp type support
 template <typename Param>
 struct get_device_info_impl<std::vector<info::fp_config>, Param> {
@@ -248,14 +242,6 @@ struct get_device_info_impl<std::vector<info::fp_config>, Param> {
         Dev->getHandleRef(), UrInfoCode<Param>::value, sizeof(result), &result,
         nullptr);
     return read_fp_bitfield(result);
-  }
-};
-
-// Specialization for device version
-template <> struct get_device_info_impl<std::string, info::device::version> {
-  static std::string get(const DeviceImplPtr &Dev) {
-    return Dev->get_device_info_string(
-        UrInfoCode<info::device::version>::value);
   }
 };
 


### PR DESCRIPTION
`parent_device` declaration isn't used because we have even more specialized `get_device_info_impl<device, info::device::parent_device>`. One can argue that it intends to catch "wrong" uses with incorrect return type, but that kind of handling isn't done to any other device descriptor in the file, don't see any reason to have one here.

`device_version` isn't necessary because `std::string` return type partial specialization handles that scenario.