### PR TITLE
[UR] Fix Windows build of urDeviceGetSelected tests

### DIFF
--- a/unified-runtime/test/conformance/device/urDeviceGetSelected.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetSelected.cpp
@@ -6,6 +6,29 @@
 
 #include <uur/fixtures.h>
 
+#ifdef _MSC_VER
+#include <Windows.h>
+#endif
+
+namespace uur {
+static int set_env(const char *name, const char *value) {
+#ifdef _MSC_VER
+  return _putenv_s(name, value);
+#else
+  return setenv(name, value, 1);
+#endif
+}
+
+static int unset_env(const char *name) {
+#ifdef _MSC_VER
+  return _putenv_s(name, "");
+#else
+  return unsetenv(name);
+#endif
+}
+
+} // namespace uur
+
 using urDeviceGetSelectedTest = uur::urPlatformTest;
 UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urDeviceGetSelectedTest);
 
@@ -13,7 +36,7 @@ UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urDeviceGetSelectedTest);
  * specific adapter */
 
 TEST_P(urDeviceGetSelectedTest, Success) {
-  unsetenv("ONEAPI_DEVICE_SELECTOR");
+  uur::unset_env("ONEAPI_DEVICE_SELECTOR");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -27,7 +50,7 @@ TEST_P(urDeviceGetSelectedTest, Success) {
 }
 
 TEST_P(urDeviceGetSelectedTest, SuccessSubsetOfDevices) {
-  unsetenv("ONEAPI_DEVICE_SELECTOR");
+  uur::unset_env("ONEAPI_DEVICE_SELECTOR");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -38,13 +61,13 @@ TEST_P(urDeviceGetSelectedTest, SuccessSubsetOfDevices) {
   std::vector<ur_device_handle_t> devices(count - 1);
   ASSERT_SUCCESS(urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, count - 1,
                                      devices.data(), nullptr));
-  for (auto device : devices) {
+  for (auto *device : devices) {
     ASSERT_NE(nullptr, device);
   }
 }
 
 TEST_P(urDeviceGetSelectedTest, SuccessSelected_StarColonStar) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:*", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:*");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -74,7 +97,7 @@ TEST_P(urDeviceGetSelectedTest, SuccessSelected_StarColonStar) {
 }
 
 TEST_P(urDeviceGetSelectedTest, SuccessSelected_StarColonZero) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:0", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:0");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -88,7 +111,7 @@ TEST_P(urDeviceGetSelectedTest, SuccessSelected_StarColonZero) {
 }
 
 TEST_P(urDeviceGetSelectedTest, SuccessSelected_StarColonZeroCommaStar) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:0,*", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:0,*");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -102,7 +125,7 @@ TEST_P(urDeviceGetSelectedTest, SuccessSelected_StarColonZeroCommaStar) {
 }
 
 TEST_P(urDeviceGetSelectedTest, SuccessSelected_DiscardStarColonStar) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "!*:*", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "!*:*");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -110,7 +133,7 @@ TEST_P(urDeviceGetSelectedTest, SuccessSelected_DiscardStarColonStar) {
 }
 
 TEST_P(urDeviceGetSelectedTest, SuccessSelected_SelectAndDiscard) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:0;!*:*", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:0;!*:*");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -119,7 +142,7 @@ TEST_P(urDeviceGetSelectedTest, SuccessSelected_SelectAndDiscard) {
 
 TEST_P(urDeviceGetSelectedTest,
        SuccessSelected_SelectSomethingAndDiscardSomethingElse) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:0;!*:1", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:0;!*:1");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -133,7 +156,7 @@ TEST_P(urDeviceGetSelectedTest,
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidNullHandlePlatform) {
-  unsetenv("ONEAPI_DEVICE_SELECTOR");
+  uur::unset_env("ONEAPI_DEVICE_SELECTOR");
   uint32_t count = 0;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_NULL_HANDLE,
@@ -141,7 +164,7 @@ TEST_P(urDeviceGetSelectedTest, InvalidNullHandlePlatform) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidEnumerationDevicesType) {
-  unsetenv("ONEAPI_DEVICE_SELECTOR");
+  uur::unset_env("ONEAPI_DEVICE_SELECTOR");
   uint32_t count = 0;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                    urDeviceGetSelected(platform, UR_DEVICE_TYPE_FORCE_UINT32, 0,
@@ -149,7 +172,7 @@ TEST_P(urDeviceGetSelectedTest, InvalidEnumerationDevicesType) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidValueNumEntries) {
-  unsetenv("ONEAPI_DEVICE_SELECTOR");
+  uur::unset_env("ONEAPI_DEVICE_SELECTOR");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -161,7 +184,7 @@ TEST_P(urDeviceGetSelectedTest, InvalidValueNumEntries) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidMissingBackend) {
-  setenv("ONEAPI_DEVICE_SELECTOR", ":garbage", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", ":garbage");
   uint32_t count = 0;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_UNKNOWN,
@@ -170,7 +193,7 @@ TEST_P(urDeviceGetSelectedTest, InvalidMissingBackend) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidGarbageBackendString) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "garbage:0", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "garbage:0");
   uint32_t count = 0;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_VALUE,
@@ -179,20 +202,20 @@ TEST_P(urDeviceGetSelectedTest, InvalidGarbageBackendString) {
 }
 
 TEST_P(urDeviceGetSelectedTest, SuccessCaseSensitive) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "OpEnCl:0", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "OpEnCl:0");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidMissingFilterStrings) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*");
   uint32_t count = 0;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_VALUE,
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
   ASSERT_EQ(count, 0);
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:");
   uint32_t count2 = 0;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_VALUE,
@@ -201,7 +224,7 @@ TEST_P(urDeviceGetSelectedTest, InvalidMissingFilterStrings) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidMissingFilterString) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:0,,2", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:0,,2");
   uint32_t count = 0;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_UNKNOWN,
@@ -210,7 +233,7 @@ TEST_P(urDeviceGetSelectedTest, InvalidMissingFilterString) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidTooManyDotsInFilterString) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:0.1.2.3", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:0.1.2.3");
   uint32_t count = 0;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_VALUE,
@@ -219,13 +242,13 @@ TEST_P(urDeviceGetSelectedTest, InvalidTooManyDotsInFilterString) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidBadWildardInFilterString) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:*.", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:*.");
   uint32_t count = 0;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_VALUE,
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
   ASSERT_EQ(count, 0);
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:*.0", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:*.0");
   uint32_t count2 = 0;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_VALUE,
@@ -234,7 +257,7 @@ TEST_P(urDeviceGetSelectedTest, InvalidBadWildardInFilterString) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidSelectingNonexistentDevice) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:4321", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:4321");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -242,7 +265,7 @@ TEST_P(urDeviceGetSelectedTest, InvalidSelectingNonexistentDevice) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidSelectingNonexistentSubDevice) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:0.4321", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:0.4321");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -250,7 +273,7 @@ TEST_P(urDeviceGetSelectedTest, InvalidSelectingNonexistentSubDevice) {
 }
 
 TEST_P(urDeviceGetSelectedTest, InvalidSelectingNonexistentSubSubDevice) {
-  setenv("ONEAPI_DEVICE_SELECTOR", "*:0.0.4321", 1);
+  uur::set_env("ONEAPI_DEVICE_SELECTOR", "*:0.0.4321");
   uint32_t count = 0;
   ASSERT_SUCCESS(
       urDeviceGetSelected(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));


### PR DESCRIPTION
The `setenv` and `unsetenv` functions are not available on Windows, instead use `_putenv_s` wrapped in our own interfaces to fix the UR CTS build on Windows.
