### PR TITLE
[SYCL][Graph] Improve in-order test coverage and output

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/ext_oneapi_enqueue_functions.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/ext_oneapi_enqueue_functions.cpp
@@ -52,7 +52,7 @@ int main() {
 
   for (size_t i = 0; i < Size; i++) {
     T Ref = Pattern * i;
-    assert(Output[i] == Ref);
+    assert(check_value(i, Ref, Output[i], "Output"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -67,14 +67,15 @@ int main() {
   // memcpy from 2.0 Y values to Z
   Queue.submit([&](handler &CGH) { CGH.memcpy(Z, Y, N * sizeof(int)); });
 
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), Z, N * sizeof(int));
+
   Graph.end_recording();
 
   auto ExecGraph = Graph.finalize();
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
-
-  std::vector<int> Output(N);
-  Queue.memcpy(Output.data(), Z, N * sizeof(int)).wait();
+  Queue.wait_and_throw();
 
   const int Expected = 2;
   for (size_t i = 0; i < N; i++) {

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -49,9 +49,9 @@ int main() {
   // Shouldn't be captured in graph as a dependency
   Queue.submit([&](handler &CGH) {
     CGH.parallel_for(N, [=](id<1> it) {
-      X[it] += 0.5f;
-      Y[it] += 0.5f;
-      Z[it] += 0.5f;
+      X[it] += 1.0f;
+      Y[it] += 1.0f;
+      Z[it] += 1.0f;
     });
   });
 


### PR DESCRIPTION
This patch improves coverage for recording a `memcpy` by modifying an existing test.