### PR TITLE
[UR][CUDA][HIP] Cleanup use of assertions and die

### DIFF
--- a/unified-runtime/source/adapters/cuda/common.cpp
+++ b/unified-runtime/source/adapters/cuda/common.cpp
@@ -134,11 +134,6 @@ std::string getCudaVersionString() {
   return stream.str();
 }
 
-void detail::ur::assertion(bool Condition, const char *Message) {
-  if (!Condition)
-    die(Message);
-}
-
 // Global variables for ZER_EXT_RESULT_ADAPTER_SPECIFIC_ERROR
 thread_local ur_result_t ErrorMessageCode = UR_RESULT_SUCCESS;
 thread_local char ErrorMessage[MaxMessageSize]{};

--- a/unified-runtime/source/adapters/cuda/common.hpp
+++ b/unified-runtime/source/adapters/cuda/common.hpp
@@ -64,8 +64,6 @@ namespace ur {
 // Reports error messages
 void cuPrint(const char *Message);
 
-void assertion(bool Condition, const char *Message = nullptr);
-
 } // namespace ur
 } // namespace detail
 

--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -72,15 +72,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxX, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, hDevice->get()));
-    detail::ur::assertion(MaxX >= 0);
+    assert(MaxX >= 0);
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxY, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, hDevice->get()));
-    detail::ur::assertion(MaxY >= 0);
+    assert(MaxY >= 0);
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, hDevice->get()));
-    detail::ur::assertion(MaxZ >= 0);
+    assert(MaxZ >= 0);
 
     ReturnSizes.Sizes[0] = size_t(MaxX);
     ReturnSizes.Sizes[1] = size_t(MaxY);
@@ -95,15 +95,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxX, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, hDevice->get()));
-    detail::ur::assertion(MaxX >= 0);
+    assert(MaxX >= 0);
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxY, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y, hDevice->get()));
-    detail::ur::assertion(MaxY >= 0);
+    assert(MaxY >= 0);
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z, hDevice->get()));
-    detail::ur::assertion(MaxZ >= 0);
+    assert(MaxZ >= 0);
 
     ReturnSizes.Sizes[0] = size_t(MaxX);
     ReturnSizes.Sizes[1] = size_t(MaxY);
@@ -116,8 +116,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxWorkGroupSize, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
         hDevice->get()));
-
-    detail::ur::assertion(MaxWorkGroupSize >= 0);
+    assert(MaxWorkGroupSize >= 0);
 
     return ReturnValue(size_t(MaxWorkGroupSize));
   }
@@ -268,7 +267,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int ClockFreq = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ClockFreq, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, hDevice->get()));
-    detail::ur::assertion(ClockFreq >= 0);
+    assert(ClockFreq >= 0);
     return ReturnValue(static_cast<uint32_t>(ClockFreq) / 1000u);
   }
   case UR_DEVICE_INFO_ADDRESS_BITS: {
@@ -314,12 +313,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT,
         hDevice->get()));
-    detail::ur::assertion(TexHeight >= 0);
+    assert(TexHeight >= 0);
     int SurfHeight = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT,
         hDevice->get()));
-    detail::ur::assertion(SurfHeight >= 0);
+    assert(SurfHeight >= 0);
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -331,12 +330,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    assert(TexWidth >= 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    assert(SurfWidth >= 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -348,12 +347,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT,
         hDevice->get()));
-    detail::ur::assertion(TexHeight >= 0);
+    assert(TexHeight >= 0);
     int SurfHeight = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT,
         hDevice->get()));
-    detail::ur::assertion(SurfHeight >= 0);
+    assert(SurfHeight >= 0);
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -365,12 +364,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    assert(TexWidth >= 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    assert(SurfWidth >= 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -382,12 +381,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH,
         hDevice->get()));
-    detail::ur::assertion(TexDepth >= 0);
+    assert(TexDepth >= 0);
     int SurfDepth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH,
         hDevice->get()));
-    detail::ur::assertion(SurfDepth >= 0);
+    assert(SurfDepth >= 0);
 
     int Min = std::min(TexDepth, SurfDepth);
 
@@ -399,12 +398,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    assert(TexWidth >= 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    assert(SurfWidth >= 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -473,15 +472,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int CacheSize = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &CacheSize, CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, hDevice->get()));
-    detail::ur::assertion(CacheSize >= 0);
+    assert(CacheSize >= 0);
     // The L2 cache is global to the GPU.
     return ReturnValue(static_cast<uint64_t>(CacheSize));
   }
   case UR_DEVICE_INFO_GLOBAL_MEM_SIZE: {
     size_t Bytes = 0;
     // Runtime API has easy access to this value, driver API info is scarse.
-    detail::ur::assertion(cuDeviceTotalMem(&Bytes, hDevice->get()) ==
-                          CUDA_SUCCESS);
+    UR_CHECK_ERROR(cuDeviceTotalMem(&Bytes, hDevice->get()));
     return ReturnValue(uint64_t{Bytes});
   }
   case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE: {
@@ -489,7 +487,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ConstantMemory, CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY,
         hDevice->get()));
-    detail::ur::assertion(ConstantMemory >= 0);
+    assert(ConstantMemory >= 0);
 
     return ReturnValue(static_cast<uint64_t>(ConstantMemory));
   }
@@ -519,7 +517,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ECCEnabled, CU_DEVICE_ATTRIBUTE_ECC_ENABLED, hDevice->get()));
 
-    detail::ur::assertion((ECCEnabled == 0) | (ECCEnabled == 1));
+    assert((ECCEnabled == 0) | (ECCEnabled == 1));
     auto Result = static_cast<bool>(ECCEnabled);
     return ReturnValue(Result);
   }
@@ -528,7 +526,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &IsIntegrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, hDevice->get()));
 
-    detail::ur::assertion((IsIntegrated == 0) | (IsIntegrated == 1));
+    assert((IsIntegrated == 0) | (IsIntegrated == 1));
     auto result = static_cast<bool>(IsIntegrated);
     return ReturnValue(result);
   }
@@ -800,16 +798,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
     size_t FreeMemory = 0;
     size_t TotalMemory = 0;
-    detail::ur::assertion(cuMemGetInfo(&FreeMemory, &TotalMemory) ==
-                              CUDA_SUCCESS,
-                          "failed cuMemGetInfo() API.");
+    UR_CHECK_ERROR(cuMemGetInfo(&FreeMemory, &TotalMemory));
     return ReturnValue(FreeMemory);
   }
   case UR_DEVICE_INFO_MEMORY_CLOCK_RATE: {
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &Value, CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    assert(Value >= 0);
     // Convert kilohertz to megahertz when returning.
     return ReturnValue(Value / 1000);
   }
@@ -817,7 +813,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &Value, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    assert(Value >= 0);
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES: {
@@ -953,17 +949,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &Value, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    assert(Value >= 0);
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_UUID: {
     CUuuid UUID;
 #if (CUDA_VERSION >= 11040)
-    detail::ur::assertion(cuDeviceGetUuid_v2(&UUID, hDevice->get()) ==
-                          CUDA_SUCCESS);
+    UR_CHECK_ERROR(cuDeviceGetUuid_v2(&UUID, hDevice->get()));
 #else
-    detail::ur::assertion(cuDeviceGetUuid(&UUID, hDevice->get()) ==
-                          CUDA_SUCCESS);
+    UR_CHECK_ERROR(cuDeviceGetUuid(&UUID, hDevice->get()));
 #endif
     std::array<unsigned char, 16> Name;
     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());
@@ -1046,7 +1040,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         &MaxRegisters, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
         hDevice->get()));
 
-    detail::ur::assertion(MaxRegisters >= 0);
+    assert(MaxRegisters >= 0);
 
     return ReturnValue(static_cast<uint32_t>(MaxRegisters));
   }
@@ -1060,7 +1054,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(
         cuDeviceGetPCIBusId(AddressBuffer, AddressBufferSize, hDevice->get()));
     // CUDA API (8.x - 12.1) guarantees 12 bytes + \0 are written
-    detail::ur::assertion(strnlen(AddressBuffer, AddressBufferSize) == 12);
+    assert(strnlen(AddressBuffer, AddressBufferSize) == 12);
     return ReturnValue(AddressBuffer,
                        strnlen(AddressBuffer, AddressBufferSize - 1) + 1);
   }

--- a/unified-runtime/source/adapters/cuda/enqueue.cpp
+++ b/unified-runtime/source/adapters/cuda/enqueue.cpp
@@ -1103,9 +1103,11 @@ static size_t imageElementByteSize(CUDA_ARRAY_DESCRIPTOR ArrayDesc) {
   case CU_AD_FORMAT_FLOAT:
     return 4;
   default:
-    die("Invalid image format.");
-    return 0;
+    setErrorMessage("Invalid CUDA format specifier",
+                    UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+    throw UR_RESULT_ERROR_ADAPTER_SPECIFIC;
   }
+  return 0;
 }
 
 /// General ND memory copy operation for images.

--- a/unified-runtime/source/adapters/cuda/event.cpp
+++ b/unified-runtime/source/adapters/cuda/event.cpp
@@ -250,8 +250,9 @@ urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
   const auto RefCount = hEvent->incrementReferenceCount();
 
-  detail::ur::assertion(RefCount != 0,
-                        "Reference count overflow detected in urEventRetain.");
+  if (RefCount == 0) {
+    return UR_RESULT_ERROR_OUT_OF_RESOURCES;
+  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -259,8 +260,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  detail::ur::assertion(hEvent->getReferenceCount() != 0,
-                        "Reference count overflow detected in urEventRelease.");
+  if (hEvent->getReferenceCount() == 0) {
+    return UR_RESULT_ERROR_INVALID_EVENT;
+  }
 
   // decrement ref count. If it is 0, delete the event.
   if (hEvent->decrementReferenceCount() == 0) {

--- a/unified-runtime/source/adapters/cuda/image.cpp
+++ b/unified-runtime/source/adapters/cuda/image.cpp
@@ -988,7 +988,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
       ChannelOrder = UR_IMAGE_CHANNEL_ORDER_RGBA;
       break;
     default:
-      die("Unexpected NumChannels returned by CUDA");
+      setErrorMessage("Unexpected NumChannels returned by CUDA",
+                      UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
     }
     if (pPropValue) {
       ((ur_image_format_t *)pPropValue)->channelType = ChannelType;

--- a/unified-runtime/source/adapters/cuda/kernel.cpp
+++ b/unified-runtime/source/adapters/cuda/kernel.cpp
@@ -210,7 +210,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     UR_CHECK_ERROR(cuOccupancyMaxActiveBlocksPerMultiprocessor(
         &MaxNumActiveGroupsPerCU, hKernel->get(), localWorkSize,
         dynamicSharedMemorySize));
-    detail::ur::assertion(MaxNumActiveGroupsPerCU >= 0);
+    assert(MaxNumActiveGroupsPerCU >= 0);
     // Handle the case where we can't have all SMs active with at least 1 group
     // per SM. In that case, the device is still able to run 1 work-group, hence
     // we will manually check if it is possible with the available HW resources.

--- a/unified-runtime/source/adapters/cuda/memory.cpp
+++ b/unified-runtime/source/adapters/cuda/memory.cpp
@@ -110,7 +110,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
     // error for which it is unclear if the function that reported it succeeded
     // or not. Either way, the state of the program is compromised and likely
     // unrecoverable.
-    die("Unrecoverable program state reached in urMemRelease");
+    setErrorMessage("Error in native free, program state may be "
+                    "compromised.",
+                    UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
   }
 
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/cuda/queue.cpp
+++ b/unified-runtime/source/adapters/cuda/queue.cpp
@@ -195,12 +195,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   UR_CHECK_ERROR(cuStreamGetFlags(CuStream, &CuFlags));
 
   ur_queue_flags_t Flags = 0;
-  if (CuFlags == CU_STREAM_DEFAULT)
+  if (CuFlags == CU_STREAM_DEFAULT) {
     Flags = UR_QUEUE_FLAG_USE_DEFAULT_STREAM;
-  else if (CuFlags == CU_STREAM_NON_BLOCKING)
+  } else if (CuFlags == CU_STREAM_NON_BLOCKING) {
     Flags = UR_QUEUE_FLAG_SYNC_WITH_DEFAULT_STREAM;
-  else
-    die("Unknown cuda stream");
+  } else {
+    setErrorMessage("Incorrect native stream flags, expecting "
+                    "CU_STREAM_DEFAULT or CU_STREAM_NON_BLOCKING",
+                    UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+  }
 
   auto isNativeHandleOwned =
       pProperties ? pProperties->isNativeHandleOwned : false;

--- a/unified-runtime/source/adapters/cuda/sampler.cpp
+++ b/unified-runtime/source/adapters/cuda/sampler.cpp
@@ -103,9 +103,9 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  detail::ur::assertion(
-      hSampler->getReferenceCount() != 0,
-      "Reference count overflow detected in urSamplerRelease.");
+  if (hSampler->getReferenceCount() == 0) {
+    return UR_RESULT_ERROR_INVALID_SAMPLER;
+  }
 
   // decrement ref count. If it is 0, delete the sampler.
   if (hSampler->decrementReferenceCount() == 0) {

--- a/unified-runtime/source/adapters/hip/common.cpp
+++ b/unified-runtime/source/adapters/hip/common.cpp
@@ -156,11 +156,6 @@ hipError_t getHipVersionString(std::string &Version) {
   return Result;
 }
 
-void detail::ur::assertion(bool Condition, const char *pMessage) {
-  if (!Condition)
-    die(pMessage);
-}
-
 // Global variables for UR_RESULT_ADAPTER_SPECIFIC_ERROR
 thread_local ur_result_t ErrorMessageCode = UR_RESULT_SUCCESS;
 thread_local char ErrorMessage[MaxMessageSize]{};

--- a/unified-runtime/source/adapters/hip/common.hpp
+++ b/unified-runtime/source/adapters/hip/common.hpp
@@ -120,8 +120,6 @@ namespace ur {
 // Reports error messages
 void hipPrint(const char *pMessage);
 
-void assertion(bool Condition, const char *pMessage = nullptr);
-
 } // namespace ur
 } // namespace detail
 

--- a/unified-runtime/source/adapters/hip/device.cpp
+++ b/unified-runtime/source/adapters/hip/device.cpp
@@ -63,7 +63,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int ComputeUnits = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &ComputeUnits, hipDeviceAttributeMultiprocessorCount, hDevice->get()));
-    detail::ur::assertion(ComputeUnits >= 0);
+    assert(ComputeUnits >= 0);
     return ReturnValue(static_cast<uint32_t>(ComputeUnits));
   }
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS: {
@@ -77,15 +77,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxX, hipDeviceAttributeMaxBlockDimX,
                                          hDevice->get()));
-    detail::ur::assertion(MaxX >= 0);
+    assert(MaxX >= 0);
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxY, hipDeviceAttributeMaxBlockDimY,
                                          hDevice->get()));
-    detail::ur::assertion(MaxY >= 0);
+    assert(MaxY >= 0);
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxZ, hipDeviceAttributeMaxBlockDimZ,
                                          hDevice->get()));
-    detail::ur::assertion(MaxZ >= 0);
+    assert(MaxZ >= 0);
 
     return_sizes.sizes[0] = size_t(MaxX);
     return_sizes.sizes[1] = size_t(MaxY);
@@ -101,15 +101,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxX, hipDeviceAttributeMaxGridDimX,
                                          hDevice->get()));
-    detail::ur::assertion(MaxX >= 0);
+    assert(MaxX >= 0);
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxY, hipDeviceAttributeMaxGridDimY,
                                          hDevice->get()));
-    detail::ur::assertion(MaxY >= 0);
+    assert(MaxY >= 0);
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxZ, hipDeviceAttributeMaxGridDimZ,
                                          hDevice->get()));
-    detail::ur::assertion(MaxZ >= 0);
+    assert(MaxZ >= 0);
 
     return_sizes.sizes[0] = size_t(MaxX);
     return_sizes.sizes[1] = size_t(MaxY);
@@ -123,7 +123,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
                                          hipDeviceAttributeMaxThreadsPerBlock,
                                          hDevice->get()));
 
-    detail::ur::assertion(MaxWorkGroupSize >= 0);
+    assert(MaxWorkGroupSize >= 0);
 
     return ReturnValue(size_t(MaxWorkGroupSize));
   }
@@ -200,7 +200,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int ClockFreq = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &ClockFreq, hipDeviceAttributeClockRate, hDevice->get()));
-    detail::ur::assertion(ClockFreq >= 0);
+    assert(ClockFreq >= 0);
     return ReturnValue(static_cast<uint32_t>(ClockFreq) / 1000u);
   }
   case UR_DEVICE_INFO_ADDRESS_BITS: {
@@ -215,8 +215,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // CL_DEVICE_TYPE_CUSTOM.
 
     size_t Global = 0;
-    detail::ur::assertion(hipDeviceTotalMem(&Global, hDevice->get()) ==
-                          hipSuccess);
+    UR_CHECK_ERROR(hipDeviceTotalMem(&Global, hDevice->get()));
 
     auto QuarterGlobal = static_cast<uint32_t>(Global / 4u);
 
@@ -252,11 +251,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
-    detail::ur::assertion(TexHeight >= 0);
+    assert(TexHeight >= 0);
     int SurfHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
-    detail::ur::assertion(SurfHeight >= 0);
+    assert(SurfHeight >= 0);
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -267,11 +266,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    assert(TexWidth >= 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    assert(SurfWidth >= 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -282,11 +281,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
-    detail::ur::assertion(TexHeight >= 0);
+    assert(TexHeight >= 0);
     int SurfHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
-    detail::ur::assertion(SurfHeight >= 0);
+    assert(SurfHeight >= 0);
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -297,11 +296,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    assert(TexWidth >= 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    assert(SurfWidth >= 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -312,11 +311,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexDepth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
-    detail::ur::assertion(TexDepth >= 0);
+    assert(TexDepth >= 0);
     int SurfDepth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
-    detail::ur::assertion(SurfDepth >= 0);
+    assert(SurfDepth >= 0);
 
     int Min = std::min(TexDepth, SurfDepth);
 
@@ -327,11 +326,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    assert(TexWidth >= 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    assert(SurfWidth >= 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -394,7 +393,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int CacheSize = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &CacheSize, hipDeviceAttributeL2CacheSize, hDevice->get()));
-    detail::ur::assertion(CacheSize >= 0);
+    assert(CacheSize >= 0);
     // The L2 cache is global to the GPU.
     return ReturnValue(static_cast<uint64_t>(CacheSize));
   }
@@ -414,7 +413,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(&ConstantMemory,
                                          hipDeviceAttributeTotalConstantMemory,
                                          hDevice->get()));
-    detail::ur::assertion(ConstantMemory >= 0);
+    assert(ConstantMemory >= 0);
 
     return ReturnValue(static_cast<uint64_t>(ConstantMemory));
   }
@@ -435,7 +434,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &LocalMemSize, hipDeviceAttributeMaxSharedMemoryPerBlock,
         hDevice->get()));
-    detail::ur::assertion(LocalMemSize >= 0);
+    assert(LocalMemSize >= 0);
     return ReturnValue(static_cast<uint64_t>(LocalMemSize));
   }
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
@@ -443,7 +442,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &EccEnabled, hipDeviceAttributeEccEnabled, hDevice->get()));
 
-    detail::ur::assertion((EccEnabled == 0) | (EccEnabled == 1));
+    assert((EccEnabled == 0) | (EccEnabled == 1));
     auto Result = static_cast<bool>(EccEnabled);
     return ReturnValue(Result);
   }
@@ -452,7 +451,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &IsIntegrated, hipDeviceAttributeIntegrated, hDevice->get()));
 
-    detail::ur::assertion((IsIntegrated == 0) | (IsIntegrated == 1));
+    assert((IsIntegrated == 0) | (IsIntegrated == 1));
     auto Result = static_cast<bool>(IsIntegrated);
     return ReturnValue(Result);
   }
@@ -507,8 +506,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // name instead, this is also what AMD OpenCL devices return.
     if (strlen(Name) == 0) {
       hipDeviceProp_t Props;
-      detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                            hipSuccess);
+      UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
 
       return ReturnValue(Props.gcnArchName, strlen(Props.gcnArchName) + 1);
     }
@@ -532,8 +530,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     std::stringstream S;
 
     hipDeviceProp_t Props;
-    detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                          hipSuccess);
+    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
 #if defined(__HIP_PLATFORM_NVIDIA__)
     S << Props.major << "." << Props.minor;
 #elif defined(__HIP_PLATFORM_AMD__)
@@ -550,8 +547,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     std::string SupportedExtensions = "";
 
     hipDeviceProp_t Props;
-    detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                          hipSuccess);
+    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
 
     if (Props.arch.hasDoubles) {
       SupportedExtensions += "cl_khr_fp64 ";
@@ -711,8 +707,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
   case UR_DEVICE_INFO_ATOMIC_64: {
     hipDeviceProp_t Props;
-    detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                          hipSuccess);
+    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
     return ReturnValue(Props.arch.hasGlobalInt64Atomics &&
                        Props.arch.hasSharedInt64Atomics);
   }
@@ -739,7 +734,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &Value, hipDeviceAttributeMemoryClockRate, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    assert(Value >= 0);
     // Convert kilohertz to megahertz when returning.
     return ReturnValue(Value / 1000);
   }
@@ -748,7 +743,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &Value, hipDeviceAttributeMemoryBusWidth, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    assert(Value >= 0);
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES: {
@@ -786,7 +781,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &tex_pitch_align, hipDeviceAttributeTexturePitchAlignment,
         hDevice->get()));
-    detail::ur::assertion(tex_pitch_align >= 0);
+    assert(tex_pitch_align >= 0);
     return ReturnValue(static_cast<uint32_t>(tex_pitch_align));
   }
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP: {
@@ -956,7 +951,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(&Value, hipDeviceAttributePciDeviceId,
                                          hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    assert(Value >= 0);
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_UUID: {
@@ -964,8 +959,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
      HIP_VERSION_MAJOR > 5)
     hipUUID UUID = {};
     // Supported since 5.2+
-    detail::ur::assertion(hipDeviceGetUuid(&UUID, hDevice->get()) ==
-                          hipSuccess);
+    UR_CHECK_ERROR(hipDeviceGetUuid(&UUID, hDevice->get()));
     std::array<unsigned char, 16> Name;
     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());
     return ReturnValue(Name.data(), 16);
@@ -980,7 +974,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &MaxRegisters, hipDeviceAttributeMaxRegistersPerBlock, hDevice->get()));
 
-    detail::ur::assertion(MaxRegisters >= 0);
+    assert(MaxRegisters >= 0);
 
     return ReturnValue(static_cast<uint32_t>(MaxRegisters));
   }
@@ -998,7 +992,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // at least in 5.3-5.5. To be on the safe side, we make sure the terminating
     // \0 is set.
     AddressBuffer[AddressBufferSize - 1] = '\0';
-    detail::ur::assertion(strnlen(AddressBuffer, AddressBufferSize) > 0);
+    assert(strnlen(AddressBuffer, AddressBufferSize) > 0);
     return ReturnValue(AddressBuffer,
                        strnlen(AddressBuffer, AddressBufferSize - 1) + 1);
   }

--- a/unified-runtime/source/adapters/hip/device.hpp
+++ b/unified-runtime/source/adapters/hip/device.hpp
@@ -62,7 +62,7 @@ public:
     int Ret{};
     UR_CHECK_ERROR(
         hipDeviceGetAttribute(&Ret, hipDeviceAttributeImageSupport, HIPDevice));
-    detail::ur::assertion(Ret == 0 || Ret == 1);
+    assert(Ret == 0 || Ret == 1);
     HardwareImageSupport = Ret == 1;
   }
 

--- a/unified-runtime/source/adapters/hip/event.cpp
+++ b/unified-runtime/source/adapters/hip/event.cpp
@@ -251,8 +251,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
   const auto RefCount = hEvent->incrementReferenceCount();
 
-  detail::ur::assertion(RefCount != 0,
-                        "Reference count overflow detected in urEventRetain.");
+  if (RefCount == 0) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -260,8 +261,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  detail::ur::assertion(hEvent->getReferenceCount() != 0,
-                        "Reference count overflow detected in urEventRelease.");
+  if (hEvent->getReferenceCount() == 0) {
+    return UR_RESULT_ERROR_INVALID_EVENT;
+  }
 
   // decrement ref count. If it is 0, delete the event.
   if (hEvent->decrementReferenceCount() == 0) {

--- a/unified-runtime/source/adapters/hip/image.cpp
+++ b/unified-runtime/source/adapters/hip/image.cpp
@@ -985,7 +985,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
       ChannelOrder = UR_IMAGE_CHANNEL_ORDER_RGBA;
       break;
     default:
-      die("Unexpected NumChannels returned by HIP");
+      setErrorMessage("Unexpected NumChannels returned by HIP",
+                      UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
     }
     if (pPropValue) {
       (static_cast<ur_image_format_t *>(pPropValue))->channelType = ChannelType;

--- a/unified-runtime/source/adapters/hip/kernel.cpp
+++ b/unified-runtime/source/adapters/hip/kernel.cpp
@@ -321,8 +321,7 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
       if (Format != HIP_AD_FORMAT_UNSIGNED_INT32 &&
           Format != HIP_AD_FORMAT_SIGNED_INT32 &&
           Format != HIP_AD_FORMAT_HALF && Format != HIP_AD_FORMAT_FLOAT) {
-        die("UR HIP kernels only support images with channel types int32, "
-            "uint32, float, and half.");
+        return UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT;
       }
       hipSurfaceObject_t hipSurf =
           std::get<SurfaceMem>(hArgValue->Mem).getSurface(Device);

--- a/unified-runtime/source/adapters/hip/memory.cpp
+++ b/unified-runtime/source/adapters/hip/memory.cpp
@@ -28,7 +28,9 @@ size_t imageElementByteSize(hipArray_Format ArrayFormat) {
   case HIP_AD_FORMAT_FLOAT:
     return 4;
   default:
-    die("Invalid HIP format specifier");
+    setErrorMessage("Invalid HIP format specifier",
+                    UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+    throw UR_RESULT_ERROR_ADAPTER_SPECIFIC;
   }
   return 0;
 }
@@ -82,7 +84,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
     // error for which it is unclear if the function that reported it succeeded
     // or not. Either way, the state of the program is compromised and likely
     // unrecoverable.
-    die("Unrecoverable program state reached in urMemRelease");
+    setErrorMessage("Error in native free, program state may be "
+                    "compromised.",
+                    UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
   }
 
   return UR_RESULT_SUCCESS;
@@ -408,9 +413,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
         return UR_IMAGE_CHANNEL_TYPE_HALF_FLOAT;
       case HIP_AD_FORMAT_FLOAT:
         return UR_IMAGE_CHANNEL_TYPE_FLOAT;
-
       default:
-        die("Invalid Hip format specified.");
+        throw UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT;
       }
     };
 

--- a/unified-runtime/source/adapters/hip/memory.hpp
+++ b/unified-runtime/source/adapters/hip/memory.hpp
@@ -249,7 +249,7 @@ public:
       break;
     default:
       // urMemImageCreate given unsupported image_channel_data_type
-      die("Bad image format given to ur_image_ constructor");
+      throw UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT;
     }
   }
 

--- a/unified-runtime/source/adapters/hip/program.cpp
+++ b/unified-runtime/source/adapters/hip/program.cpp
@@ -165,8 +165,7 @@ ur_result_t ur_program_handle_t_::finalizeRelocatable() {
 
   std::string ISA = "amdgcn-amd-amdhsa--";
   hipDeviceProp_t Props;
-  detail::ur::assertion(hipGetDeviceProperties(&Props, getDevice()->get()) ==
-                        hipSuccess);
+  UR_CHECK_ERROR(hipGetDeviceProperties(&Props, getDevice()->get()));
   ISA += Props.gcnArchName;
   UR_CHECK_ERROR(amd_comgr_action_info_set_isa_name(Action, ISA.data()));
 
@@ -266,8 +265,6 @@ ur_result_t ur_program_handle_t_::getGlobalVariablePointer(
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramCreateWithIL(ur_context_handle_t, const void *, size_t,
                       const ur_program_properties_t *, ur_program_handle_t *) {
-  die("urProgramCreateWithIL not implemented for HIP adapter"
-      " please use urProgramCreateWithBinary instead");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/hip/queue.cpp
+++ b/unified-runtime/source/adapters/hip/queue.cpp
@@ -231,12 +231,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   UR_CHECK_ERROR(hipStreamGetFlags(HIPStream, &HIPFlags));
 
   ur_queue_flags_t Flags = 0;
-  if (HIPFlags == hipStreamDefault)
+  if (HIPFlags == hipStreamDefault) {
     Flags = UR_QUEUE_FLAG_USE_DEFAULT_STREAM;
-  else if (HIPFlags == hipStreamNonBlocking)
+  } else if (HIPFlags == hipStreamNonBlocking) {
     Flags = UR_QUEUE_FLAG_SYNC_WITH_DEFAULT_STREAM;
-  else
-    die("Unknown hip stream");
+  } else {
+    setErrorMessage("Incorrect native stream flags, expecting "
+                    "hipStreamDefault or hipStreamNonBlocking",
+                    UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+  }
 
   auto isNativeHandleOwned =
       pProperties ? pProperties->isNativeHandleOwned : false;

--- a/unified-runtime/source/adapters/hip/sampler.cpp
+++ b/unified-runtime/source/adapters/hip/sampler.cpp
@@ -74,9 +74,9 @@ ur_result_t urSamplerRetain(ur_sampler_handle_t hSampler) {
 ur_result_t urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  detail::ur::assertion(
-      hSampler->getReferenceCount() != 0,
-      "Reference count overflow detected in urSamplerRelease.");
+  if (hSampler->getReferenceCount() == 0) {
+    return UR_RESULT_ERROR_INVALID_SAMPLER;
+  }
 
   // decrement ref count. If it is 0, delete the sampler.
   if (hSampler->decrementReferenceCount() == 0) {


### PR DESCRIPTION
This patch cleans up most of the uses of `die()` in the CUDA and HIP adapters, it was replaced by:

* Using regular `assert()`
* Using `UR_CHECK_ERROR`
* Returning an appropriate error code
* Throw an appropriate error code
* Return an adapter specific error code with a message