### PR TITLE
[UR][CL] Use regular malloc where clHostMemAllocINTEL_fn is not supported for USM allocs.

### DIFF
--- a/unified-runtime/source/adapters/opencl/usm.cpp
+++ b/unified-runtime/source/adapters/opencl/usm.cpp
@@ -294,7 +294,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
   // not a power of 2, we need to do on the host side and copy it into the
   // target allocation.
   clHostMemAllocINTEL_fn HostMemAlloc = nullptr;
-  bool HostAllocSupported =
+  ur_result_t HostAllocSupported =
       cl_ext::getExtFuncFromContext<clHostMemAllocINTEL_fn>(
           CLContext, ur::cl::getAdapter()->fnCache.clHostMemAllocINTELCache,
           cl_ext::HostMemAllocName, &HostMemAlloc);
@@ -313,10 +313,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
   uint8_t *HostBuffer = nullptr;
   AllocDeleterCallbackInfoBase *Info = nullptr;
 
-  if (HostAllocSupported) {
+  if (HostAllocSupported == UR_RESULT_SUCCESS) {
     HostBuffer = static_cast<uint8_t *>(
         HostMemAlloc(CLContext, nullptr, size, 0, &ClErr));
-    Info = new AllocDeleterCallbackInfoIntel(USMFree, CLContext, HostBuffer);
+    Info = new AllocDeleterCallbackInfoUSM(USMFree, CLContext, HostBuffer);
   } else {
     HostBuffer = new uint8_t[size];
     Info = new AllocDeleterCallbackInfo(CLContext, HostBuffer);

--- a/unified-runtime/source/adapters/opencl/usm.hpp
+++ b/unified-runtime/source/adapters/opencl/usm.hpp
@@ -27,7 +27,7 @@ struct AllocDeleterCallbackInfoBase {
     clRetainContext(CLContext);
   }
 
-  virtual ~AllocDeleterCallbackInfoBase() = 0;
+  virtual ~AllocDeleterCallbackInfoBase() { clReleaseContext(CLContext); }
 
   AllocDeleterCallbackInfoBase(const AllocDeleterCallbackInfoBase &) = delete;
   AllocDeleterCallbackInfoBase &
@@ -37,10 +37,6 @@ protected:
   cl_context CLContext;
   uint8_t *Allocation;
 };
-
-inline AllocDeleterCallbackInfoBase::~AllocDeleterCallbackInfoBase() {
-  clReleaseContext(CLContext);
-}
 
 struct AllocDeleterCallbackInfo : AllocDeleterCallbackInfoBase {
   AllocDeleterCallbackInfo(cl_context CLContext, uint8_t *Allocation)
@@ -58,13 +54,14 @@ struct AllocDeleterCallbackInfoUSM : AllocDeleterCallbackInfoBase {
   clMemBlockingFreeINTEL_fn USMFree;
 };
 
-struct AllocDeleterCallbackInfoWithQueue : AllocDeleterCallbackInfoUSM {
-  AllocDeleterCallbackInfoWithQueue(clMemBlockingFreeINTEL_fn USMFree,
-                                    cl_context CLContext, uint8_t *Allocation,
-                                    cl_command_queue CLQueue)
+struct AllocDeleterCallbackInfoUSMWithQueue : AllocDeleterCallbackInfoUSM {
+  AllocDeleterCallbackInfoUSMWithQueue(clMemBlockingFreeINTEL_fn USMFree,
+                                       cl_context CLContext,
+                                       uint8_t *Allocation,
+                                       cl_command_queue CLQueue)
       : AllocDeleterCallbackInfoUSM(USMFree, CLContext, Allocation),
         CLQueue(CLQueue) {}
-  ~AllocDeleterCallbackInfoWithQueue() override {
+  ~AllocDeleterCallbackInfoUSMWithQueue() override {
     clReleaseCommandQueue(CLQueue);
   }
 

--- a/unified-runtime/source/adapters/opencl/usm.hpp
+++ b/unified-runtime/source/adapters/opencl/usm.hpp
@@ -17,7 +17,7 @@
 //
 // Example usage:
 //
-// auto Info = new AllocDeleterCallbackInfoIntel(USMFreeFuncPtr, Context,
+// auto Info = new AllocDeleterCallbackInfoUSM(USMFreeFuncPtr, Context,
 // Allocation); clSetEventCallback(USMOpEvent, CL_COMPLETE,
 // AllocDeleterCallback, Info);
 
@@ -49,20 +49,20 @@ struct AllocDeleterCallbackInfo : AllocDeleterCallbackInfoBase {
   ~AllocDeleterCallbackInfo() override { delete[] Allocation; }
 };
 
-struct AllocDeleterCallbackInfoIntel : AllocDeleterCallbackInfoBase {
-  AllocDeleterCallbackInfoIntel(clMemBlockingFreeINTEL_fn USMFree,
-                                cl_context CLContext, uint8_t *Allocation)
+struct AllocDeleterCallbackInfoUSM : AllocDeleterCallbackInfoBase {
+  AllocDeleterCallbackInfoUSM(clMemBlockingFreeINTEL_fn USMFree,
+                              cl_context CLContext, uint8_t *Allocation)
       : AllocDeleterCallbackInfoBase(CLContext, Allocation), USMFree(USMFree) {}
-  ~AllocDeleterCallbackInfoIntel() override { USMFree(CLContext, Allocation); }
+  ~AllocDeleterCallbackInfoUSM() override { USMFree(CLContext, Allocation); }
 
   clMemBlockingFreeINTEL_fn USMFree;
 };
 
-struct AllocDeleterCallbackInfoWithQueue : AllocDeleterCallbackInfoIntel {
+struct AllocDeleterCallbackInfoWithQueue : AllocDeleterCallbackInfoUSM {
   AllocDeleterCallbackInfoWithQueue(clMemBlockingFreeINTEL_fn USMFree,
                                     cl_context CLContext, uint8_t *Allocation,
                                     cl_command_queue CLQueue)
-      : AllocDeleterCallbackInfoIntel(USMFree, CLContext, Allocation),
+      : AllocDeleterCallbackInfoUSM(USMFree, CLContext, Allocation),
         CLQueue(CLQueue) {}
   ~AllocDeleterCallbackInfoWithQueue() override {
     clReleaseCommandQueue(CLQueue);
@@ -72,4 +72,4 @@ struct AllocDeleterCallbackInfoWithQueue : AllocDeleterCallbackInfoIntel {
 };
 
 template <class T>
-uint8_t AllocDeleterCallback(cl_event event, cl_int, uint8_t *pUserData);
+void AllocDeleterCallback(cl_event event, cl_int, uint8_t *pUserData);


### PR DESCRIPTION
Fixes https://github.com/oneapi-src/unified-runtime/issues/1837

The UR OpenCL adapter expects patterns of 2 for USM allocs, and fallsback to using clHostMemAllocINTEL_fn for non patterns of 2. Some devices/platforms don't support this extension so we can just use a regular malloc instead.