### PR TITLE
[NFCI][SYCL] Change `get_device_info_impl` to operate on `device_impl`

### DIFF
--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -428,18 +428,20 @@ void applyAllowList(std::vector<ur_device_handle_t> &UrDevices,
     }
     // get DeviceVendorId value and put it to DeviceDesc
     uint32_t DeviceVendorIdUInt =
-        sycl::detail::get_device_info<info::device::vendor_id>(DeviceImpl);
+        sycl::detail::get_device_info<info::device::vendor_id>(
+            *DeviceImpl.get());
     std::stringstream DeviceVendorIdHexStringStream;
     DeviceVendorIdHexStringStream << "0x" << std::hex << DeviceVendorIdUInt;
     const auto &DeviceVendorIdValue = DeviceVendorIdHexStringStream.str();
     DeviceDesc[DeviceVendorIdKeyName] = DeviceVendorIdValue;
     // get DriverVersion value and put it to DeviceDesc
     const std::string &DriverVersionValue =
-        sycl::detail::get_device_info<info::device::driver_version>(DeviceImpl);
+        sycl::detail::get_device_info<info::device::driver_version>(
+            *DeviceImpl.get());
     DeviceDesc[DriverVersionKeyName] = DriverVersionValue;
     // get DeviceName value and put it to DeviceDesc
     const std::string &DeviceNameValue =
-        sycl::detail::get_device_info<info::device::name>(DeviceImpl);
+        sycl::detail::get_device_info<info::device::name>(*DeviceImpl.get());
     DeviceDesc[DeviceNameKeyName] = DeviceNameValue;
 
     // check if we can allow device with such device description DeviceDesc

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -109,8 +109,7 @@ platform device_impl::get_platform() const {
 
 template <typename Param>
 typename Param::return_type device_impl::get_info() const {
-  return get_device_info<Param>(
-      MPlatform->getOrMakeDeviceImpl(MDevice, MPlatform));
+  return get_device_info<Param>(*this);
 }
 // Explicitly instantiate all device info traits
 #define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, PiCode)              \
@@ -401,17 +400,17 @@ bool device_impl::has(aspect Aspect) const {
   case aspect::ext_oneapi_cuda_cluster_group:
     return get_info<info::device::ext_oneapi_cuda_cluster_group>();
   case aspect::usm_atomic_host_allocations:
-    return (get_device_info_impl<ur_device_usm_access_capability_flags_t,
-                                 info::device::usm_host_allocations>::
-                get(MPlatform->getDeviceImpl(MDevice)) &
-            UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_CONCURRENT_ACCESS);
+    return (
+        get_device_info_impl<ur_device_usm_access_capability_flags_t,
+                             info::device::usm_host_allocations>::get(*this) &
+        UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_CONCURRENT_ACCESS);
   case aspect::usm_shared_allocations:
     return get_info<info::device::usm_shared_allocations>();
   case aspect::usm_atomic_shared_allocations:
-    return (get_device_info_impl<ur_device_usm_access_capability_flags_t,
-                                 info::device::usm_shared_allocations>::
-                get(MPlatform->getDeviceImpl(MDevice)) &
-            UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_CONCURRENT_ACCESS);
+    return (
+        get_device_info_impl<ur_device_usm_access_capability_flags_t,
+                             info::device::usm_shared_allocations>::get(*this) &
+        UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_CONCURRENT_ACCESS);
   case aspect::usm_restricted_shared_allocations:
     return get_info<info::device::usm_restricted_shared_allocations>();
   case aspect::usm_system_allocations:

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -174,10 +174,10 @@ template <> struct check_fp_support<info::device::double_fp_config> {
 // TODO: get rid of remaining uses of OpenCL directly
 
 template <typename ReturnT, typename Param> struct get_device_info_impl {
-  static ReturnT get(const DeviceImplPtr &Dev) {
+  static ReturnT get(const device_impl &Dev) {
     typename sycl_to_ur<ReturnT>::type result;
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(), UrInfoCode<Param>::value, sizeof(result), &result,
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(), UrInfoCode<Param>::value, sizeof(result), &result,
         nullptr);
     return ReturnT(result);
   }
@@ -185,14 +185,14 @@ template <typename ReturnT, typename Param> struct get_device_info_impl {
 
 // Specialization for platform
 template <typename Param> struct get_device_info_impl<platform, Param> {
-  static platform get(const DeviceImplPtr &Dev) {
+  static platform get(const device_impl &Dev) {
     // TODO: Change UrDevice to device_impl.
     // Use the Adapter from the device_impl class after adapter details
     // are added to the class.
     return createSyclObjFromImpl<platform>(platform_impl::getOrMakePlatformImpl(
         get_device_info_impl<typename sycl_to_ur<platform>::type, Param>::get(
             Dev),
-        Dev->getAdapter()));
+        Dev.getAdapter()));
   }
 };
 
@@ -220,15 +220,15 @@ device_impl::get_device_info_string(ur_device_info_t InfoCode) const {
 
 // Specialization for string return type, variable return size
 template <typename Param> struct get_device_info_impl<std::string, Param> {
-  static std::string get(const DeviceImplPtr &Dev) {
-    return Dev->get_device_info_string(UrInfoCode<Param>::value);
+  static std::string get(const device_impl &Dev) {
+    return Dev.get_device_info_string(UrInfoCode<Param>::value);
   }
 };
 
 // Specialization for fp_config types, checks the corresponding fp type support
 template <typename Param>
 struct get_device_info_impl<std::vector<info::fp_config>, Param> {
-  static std::vector<info::fp_config> get(const DeviceImplPtr &Dev) {
+  static std::vector<info::fp_config> get(const device_impl &Dev) {
     // Check if fp type is supported
     if (!get_device_info_impl<
             typename check_fp_support<Param>::type::return_type,
@@ -244,7 +244,7 @@ struct get_device_info_impl<std::vector<info::fp_config>, Param> {
 template <>
 struct get_device_info_impl<std::vector<info::fp_config>,
                             info::device::single_fp_config> {
-  static std::vector<info::fp_config> get(const DeviceImplPtr &Dev) {
+  static std::vector<info::fp_config> get(const device_impl &Dev) {
     return read_fp_bitfield(
         get_device_info_impl<ur_device_fp_capability_flags_t,
                              info::device::single_fp_config>::get(Dev));
@@ -255,7 +255,7 @@ struct get_device_info_impl<std::vector<info::fp_config>,
 // urDeviceGetGlobalTimestamps is not supported, command_submit, command_start,
 // command_end will be calculated. See MFallbackProfiling
 template <> struct get_device_info_impl<bool, info::device::queue_profiling> {
-  static bool get(const DeviceImplPtr &Dev) {
+  static bool get(const device_impl &Dev) {
     return get_device_info_impl<ur_queue_flags_t,
                                 info::device::queue_profiling>::get(Dev) &
            UR_QUEUE_FLAG_PROFILING_ENABLE;
@@ -266,7 +266,7 @@ template <> struct get_device_info_impl<bool, info::device::queue_profiling> {
 template <>
 struct get_device_info_impl<std::vector<memory_order>,
                             info::device::atomic_memory_order_capabilities> {
-  static std::vector<memory_order> get(const DeviceImplPtr &Dev) {
+  static std::vector<memory_order> get(const device_impl &Dev) {
     return readMemoryOrderBitfield(
         get_device_info_impl<
             ur_memory_order_capability_flag_t,
@@ -278,7 +278,7 @@ struct get_device_info_impl<std::vector<memory_order>,
 template <>
 struct get_device_info_impl<std::vector<memory_order>,
                             info::device::atomic_fence_order_capabilities> {
-  static std::vector<memory_order> get(const DeviceImplPtr &Dev) {
+  static std::vector<memory_order> get(const device_impl &Dev) {
     return readMemoryOrderBitfield(
         get_device_info_impl<
             ur_memory_order_capability_flag_t,
@@ -290,7 +290,7 @@ struct get_device_info_impl<std::vector<memory_order>,
 template <>
 struct get_device_info_impl<std::vector<memory_scope>,
                             info::device::atomic_memory_scope_capabilities> {
-  static std::vector<memory_scope> get(const DeviceImplPtr &Dev) {
+  static std::vector<memory_scope> get(const device_impl &Dev) {
     return readMemoryScopeBitfield(
         get_device_info_impl<
             size_t, info::device::atomic_memory_scope_capabilities>::get(Dev));
@@ -301,7 +301,7 @@ struct get_device_info_impl<std::vector<memory_scope>,
 template <>
 struct get_device_info_impl<std::vector<memory_scope>,
                             info::device::atomic_fence_scope_capabilities> {
-  static std::vector<memory_scope> get(const DeviceImplPtr &Dev) {
+  static std::vector<memory_scope> get(const device_impl &Dev) {
     return readMemoryScopeBitfield(
         get_device_info_impl<
             size_t, info::device::atomic_fence_scope_capabilities>::get(Dev));
@@ -311,11 +311,11 @@ struct get_device_info_impl<std::vector<memory_scope>,
 // Specialization for cuda cluster group
 template <>
 struct get_device_info_impl<bool, info::device::ext_oneapi_cuda_cluster_group> {
-  static bool get(const DeviceImplPtr &Dev) {
+  static bool get(const device_impl &Dev) {
     bool result = false;
-    if (Dev->getBackend() == backend::ext_oneapi_cuda) {
-      auto Err = Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-          Dev->getHandleRef(),
+    if (Dev.getBackend() == backend::ext_oneapi_cuda) {
+      auto Err = Dev.getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+          Dev.getHandleRef(),
           UrInfoCode<info::device::ext_oneapi_cuda_cluster_group>::value,
           sizeof(result), &result, nullptr);
       if (Err != UR_RESULT_SUCCESS) {
@@ -330,8 +330,8 @@ struct get_device_info_impl<bool, info::device::ext_oneapi_cuda_cluster_group> {
 template <>
 struct get_device_info_impl<std::vector<info::execution_capability>,
                             info::device::execution_capabilities> {
-  static std::vector<info::execution_capability> get(const DeviceImplPtr &Dev) {
-    if (Dev->getBackend() != backend::opencl)
+  static std::vector<info::execution_capability> get(const device_impl &Dev) {
+    if (Dev.getBackend() != backend::opencl)
       throw exception(make_error_code(errc::invalid),
                       "info::device::execution_capabilities is available for "
                       "backend::opencl only");
@@ -346,8 +346,8 @@ struct get_device_info_impl<std::vector<info::execution_capability>,
 template <>
 struct get_device_info_impl<std::vector<kernel_id>,
                             info::device::built_in_kernel_ids> {
-  static std::vector<kernel_id> get(const DeviceImplPtr &Dev) {
-    std::string result = Dev->get_device_info_string(
+  static std::vector<kernel_id> get(const device_impl &Dev) {
+    std::string result = Dev.get_device_info_string(
         UrInfoCode<info::device::built_in_kernels>::value);
     auto names = split_string(result, ';');
 
@@ -364,8 +364,8 @@ struct get_device_info_impl<std::vector<kernel_id>,
 template <>
 struct get_device_info_impl<std::vector<std::string>,
                             info::device::built_in_kernels> {
-  static std::vector<std::string> get(const DeviceImplPtr &Dev) {
-    std::string result = Dev->get_device_info_string(
+  static std::vector<std::string> get(const device_impl &Dev) {
+    std::string result = Dev.get_device_info_string(
         UrInfoCode<info::device::built_in_kernels>::value);
     return split_string(result, ';');
   }
@@ -375,7 +375,7 @@ struct get_device_info_impl<std::vector<std::string>,
 template <>
 struct get_device_info_impl<std::vector<std::string>,
                             info::device::extensions> {
-  static std::vector<std::string> get(const DeviceImplPtr &Dev) {
+  static std::vector<std::string> get(const device_impl &Dev) {
     std::string result =
         get_device_info_impl<std::string, info::device::extensions>::get(Dev);
     return split_string(result, ' ');
@@ -398,13 +398,13 @@ static bool is_sycl_partition_property(info::partition_property PP) {
 template <>
 struct get_device_info_impl<std::vector<info::partition_property>,
                             info::device::partition_properties> {
-  static std::vector<info::partition_property> get(const DeviceImplPtr &Dev) {
+  static std::vector<info::partition_property> get(const device_impl &Dev) {
     auto info_partition = UrInfoCode<info::device::partition_properties>::value;
-    const auto &Adapter = Dev->getAdapter();
+    const auto &Adapter = Dev.getAdapter();
 
     size_t resultSize;
     Adapter->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(), info_partition, 0, nullptr, &resultSize);
+        Dev.getHandleRef(), info_partition, 0, nullptr, &resultSize);
 
     size_t arrayLength = resultSize / sizeof(ur_device_partition_t);
     if (arrayLength == 0) {
@@ -412,7 +412,7 @@ struct get_device_info_impl<std::vector<info::partition_property>,
     }
     std::unique_ptr<ur_device_partition_t[]> arrayResult(
         new ur_device_partition_t[arrayLength]);
-    Adapter->call<UrApiKind::urDeviceGetInfo>(Dev->getHandleRef(),
+    Adapter->call<UrApiKind::urDeviceGetInfo>(Dev.getHandleRef(),
                                               info_partition, resultSize,
                                               arrayResult.get(), nullptr);
 
@@ -434,7 +434,7 @@ template <>
 struct get_device_info_impl<std::vector<info::partition_affinity_domain>,
                             info::device::partition_affinity_domains> {
   static std::vector<info::partition_affinity_domain>
-  get(const DeviceImplPtr &Dev) {
+  get(const device_impl &Dev) {
     return read_domain_bitfield(
         get_device_info_impl<
             ur_device_affinity_domain_flags_t,
@@ -447,11 +447,11 @@ struct get_device_info_impl<std::vector<info::partition_affinity_domain>,
 template <>
 struct get_device_info_impl<info::partition_affinity_domain,
                             info::device::partition_type_affinity_domain> {
-  static info::partition_affinity_domain get(const DeviceImplPtr &Dev) {
+  static info::partition_affinity_domain get(const device_impl &Dev) {
     std::vector<ur_device_partition_property_t> PartitionProperties;
     size_t PropertiesSize = 0;
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(),
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(),
         UrInfoCode<info::device::partition_type_affinity_domain>::value, 0,
         nullptr, &PropertiesSize);
     if (PropertiesSize == 0)
@@ -460,8 +460,8 @@ struct get_device_info_impl<info::partition_affinity_domain,
     PartitionProperties.resize(PropertiesSize /
                                sizeof(ur_device_partition_property_t));
 
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(),
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(),
         UrInfoCode<info::device::partition_type_affinity_domain>::value,
         PropertiesSize, PartitionProperties.data(), nullptr);
 
@@ -479,11 +479,11 @@ struct get_device_info_impl<info::partition_affinity_domain,
 template <>
 struct get_device_info_impl<info::partition_property,
                             info::device::partition_type_property> {
-  static info::partition_property get(const DeviceImplPtr &Dev) {
+  static info::partition_property get(const device_impl &Dev) {
     std::vector<ur_device_partition_property_t> PartitionProperties;
     size_t PropertiesSize = 0;
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(),
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(),
         UrInfoCode<info::device::partition_type_affinity_domain>::value, 0,
         nullptr, &PropertiesSize);
     if (PropertiesSize == 0)
@@ -492,8 +492,8 @@ struct get_device_info_impl<info::partition_property,
     PartitionProperties.resize(PropertiesSize /
                                sizeof(ur_device_partition_property_t));
 
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(),
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(),
         UrInfoCode<info::device::partition_type_affinity_domain>::value,
         PropertiesSize, PartitionProperties.data(), nullptr);
     // The old UR implementation also just checked the first element, is that
@@ -506,15 +506,15 @@ struct get_device_info_impl<info::partition_property,
 template <>
 struct get_device_info_impl<std::vector<size_t>,
                             info::device::sub_group_sizes> {
-  static std::vector<size_t> get(const DeviceImplPtr &Dev) {
+  static std::vector<size_t> get(const device_impl &Dev) {
     size_t resultSize = 0;
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(), UrInfoCode<info::device::sub_group_sizes>::value,
-        0, nullptr, &resultSize);
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(), UrInfoCode<info::device::sub_group_sizes>::value, 0,
+        nullptr, &resultSize);
 
     std::vector<uint32_t> result32(resultSize / sizeof(uint32_t));
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(), UrInfoCode<info::device::sub_group_sizes>::value,
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(), UrInfoCode<info::device::sub_group_sizes>::value,
         resultSize, result32.data(), nullptr);
 
     std::vector<size_t> result;
@@ -531,7 +531,7 @@ struct get_device_info_impl<std::vector<size_t>,
 // enum for global pipes feature.
 template <>
 struct get_device_info_impl<bool, info::device::kernel_kernel_pipe_support> {
-  static bool get(const DeviceImplPtr &Dev) {
+  static bool get(const device_impl &Dev) {
     // We claim, that all Intel FPGA devices support kernel to kernel pipe
     // feature (at least at the scope of SYCL_INTEL_data_flow_pipes extension).
     platform plt =
@@ -567,10 +567,10 @@ template <> inline range<3> construct_range<3>(size_t *values) {
 template <int Dimensions>
 struct get_device_info_impl<range<Dimensions>,
                             info::device::max_work_item_sizes<Dimensions>> {
-  static range<Dimensions> get(const DeviceImplPtr &Dev) {
+  static range<Dimensions> get(const device_impl &Dev) {
     size_t result[3];
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(),
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(),
         UrInfoCode<info::device::max_work_item_sizes<Dimensions>>::value,
         sizeof(result), &result, nullptr);
     return construct_range<Dimensions>(result);
@@ -701,14 +701,14 @@ template <>
 struct get_device_info_impl<
     ext::oneapi::experimental::architecture,
     ext::oneapi::experimental::info::device::architecture> {
-  static ext::oneapi::experimental::architecture get(const DeviceImplPtr &Dev) {
-    backend CurrentBackend = Dev->getBackend();
+  static ext::oneapi::experimental::architecture get(const device_impl &Dev) {
+    backend CurrentBackend = Dev.getBackend();
     auto LookupIPVersion = [&](auto &ArchList)
         -> std::optional<ext::oneapi::experimental::architecture> {
       uint32_t DeviceIp;
       ur_result_t Err =
-          Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-              Dev->getHandleRef(),
+          Dev.getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+              Dev.getHandleRef(),
               UrInfoCode<
                   ext::oneapi::experimental::info::device::architecture>::value,
               sizeof(DeviceIp), &DeviceIp, nullptr);
@@ -716,7 +716,7 @@ struct get_device_info_impl<
         // Not all devices support this device info query
         return std::nullopt;
       }
-      Dev->getAdapter()->checkUrResult(Err);
+      Dev.getAdapter()->checkUrResult(Err);
 
       for (const auto &Item : ArchList) {
         if (Item.first == static_cast<int>(DeviceIp))
@@ -725,12 +725,12 @@ struct get_device_info_impl<
       return std::nullopt;
     };
 
-    if (Dev->is_gpu() && (backend::ext_oneapi_level_zero == CurrentBackend ||
-                          backend::opencl == CurrentBackend)) {
+    if (Dev.is_gpu() && (backend::ext_oneapi_level_zero == CurrentBackend ||
+                         backend::opencl == CurrentBackend)) {
       return LookupIPVersion(IntelGPUArchitectures)
           .value_or(ext::oneapi::experimental::architecture::unknown);
-    } else if (Dev->is_gpu() && (backend::ext_oneapi_cuda == CurrentBackend ||
-                                 backend::ext_oneapi_hip == CurrentBackend)) {
+    } else if (Dev.is_gpu() && (backend::ext_oneapi_cuda == CurrentBackend ||
+                                backend::ext_oneapi_hip == CurrentBackend)) {
       auto MapArchIDToArchName = [](const char *arch) {
         for (const auto &Item : NvidiaAmdGPUArchitectures) {
           if (std::string_view(Item.first) == arch)
@@ -739,18 +739,18 @@ struct get_device_info_impl<
         return ext::oneapi::experimental::architecture::unknown;
       };
       size_t ResultSize = 0;
-      Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-          Dev->getHandleRef(), UrInfoCode<info::device::version>::value, 0,
+      Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+          Dev.getHandleRef(), UrInfoCode<info::device::version>::value, 0,
           nullptr, &ResultSize);
       std::unique_ptr<char[]> DeviceArch(new char[ResultSize]);
-      Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-          Dev->getHandleRef(), UrInfoCode<info::device::version>::value,
+      Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+          Dev.getHandleRef(), UrInfoCode<info::device::version>::value,
           ResultSize, DeviceArch.get(), nullptr);
       std::string DeviceArchCopy(DeviceArch.get());
       std::string DeviceArchSubstr =
           DeviceArchCopy.substr(0, DeviceArchCopy.find(":"));
       return MapArchIDToArchName(DeviceArchSubstr.data());
-    } else if (Dev->is_cpu() && backend::opencl == CurrentBackend) {
+    } else if (Dev.is_cpu() && backend::opencl == CurrentBackend) {
       return LookupIPVersion(IntelCPUArchitectures)
           .value_or(ext::oneapi::experimental::architecture::x86_64);
     } // else is not needed
@@ -764,10 +764,10 @@ struct get_device_info_impl<
     std::vector<ext::oneapi::experimental::matrix::combination>,
     ext::oneapi::experimental::info::device::matrix_combinations> {
   static std::vector<ext::oneapi::experimental::matrix::combination>
-  get(const DeviceImplPtr &Dev) {
+  get(const device_impl &Dev) {
     using namespace ext::oneapi::experimental::matrix;
     using namespace ext::oneapi::experimental;
-    backend CurrentBackend = Dev->getBackend();
+    backend CurrentBackend = Dev.getBackend();
     auto get_current_architecture = [&Dev]() -> std::optional<architecture> {
       // this helper lambda ignores all runtime-related exceptions from
       // quering the device architecture. For instance, if device architecture
@@ -1083,21 +1083,21 @@ struct get_device_info_impl<
 template <>
 struct get_device_info_impl<
     size_t, ext::oneapi::experimental::info::device::max_global_work_groups> {
-  static size_t get(const DeviceImplPtr) {
+  static size_t get(const device_impl &) {
     return static_cast<size_t>((std::numeric_limits<int>::max)());
   }
 };
 template <int Dims>
 struct get_device_info_impl<
     id<Dims>, ext::oneapi::experimental::info::device::max_work_groups<Dims>> {
-  static id<Dims> get(const DeviceImplPtr &Dev) {
+  static id<Dims> get(const device_impl &Dev) {
     size_t Limit =
         get_device_info_impl<size_t, ext::oneapi::experimental::info::device::
                                          max_global_work_groups>::get(Dev);
 
     size_t result[3];
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(),
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(),
         UrInfoCode<
             ext::oneapi::experimental::info::device::max_work_groups<3>>::value,
         sizeof(result), &result, nullptr);
@@ -1117,7 +1117,7 @@ struct get_device_info_impl<
 template <>
 struct get_device_info_impl<size_t,
                             info::device::ext_oneapi_max_global_work_groups> {
-  static size_t get(const DeviceImplPtr &Dev) {
+  static size_t get(const device_impl &Dev) {
     return get_device_info_impl<size_t,
                                 ext::oneapi::experimental::info::device::
                                     max_global_work_groups>::get(Dev);
@@ -1129,7 +1129,7 @@ struct get_device_info_impl<size_t,
 template <>
 struct get_device_info_impl<id<1>,
                             info::device::ext_oneapi_max_work_groups_1d> {
-  static id<1> get(const DeviceImplPtr &Dev) {
+  static id<1> get(const device_impl &Dev) {
     return get_device_info_impl<
         id<1>,
         ext::oneapi::experimental::info::device::max_work_groups<1>>::get(Dev);
@@ -1141,7 +1141,7 @@ struct get_device_info_impl<id<1>,
 template <>
 struct get_device_info_impl<id<2>,
                             info::device::ext_oneapi_max_work_groups_2d> {
-  static id<2> get(const DeviceImplPtr &Dev) {
+  static id<2> get(const device_impl &Dev) {
     return get_device_info_impl<
         id<2>,
         ext::oneapi::experimental::info::device::max_work_groups<2>>::get(Dev);
@@ -1153,7 +1153,7 @@ struct get_device_info_impl<id<2>,
 template <>
 struct get_device_info_impl<id<3>,
                             info::device::ext_oneapi_max_work_groups_3d> {
-  static id<3> get(const DeviceImplPtr &Dev) {
+  static id<3> get(const device_impl &Dev) {
     return get_device_info_impl<
         id<3>,
         ext::oneapi::experimental::info::device::max_work_groups<3>>::get(Dev);
@@ -1162,16 +1162,16 @@ struct get_device_info_impl<id<3>,
 
 // Specialization for parent device
 template <> struct get_device_info_impl<device, info::device::parent_device> {
-  static device get(const DeviceImplPtr &Dev) {
+  static device get(const device_impl &Dev) {
     typename sycl_to_ur<device>::type result;
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(), UrInfoCode<info::device::parent_device>::value,
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(), UrInfoCode<info::device::parent_device>::value,
         sizeof(result), &result, nullptr);
     if (result == nullptr)
       throw exception(make_error_code(errc::invalid),
                       "No parent for device because it is not a subdevice");
 
-    const auto &Platform = Dev->getPlatformImpl();
+    const auto &Platform = Dev.getPlatformImpl();
     return createSyclObjFromImpl<device>(
         Platform->getOrMakeDeviceImpl(result, Platform));
   }
@@ -1179,7 +1179,7 @@ template <> struct get_device_info_impl<device, info::device::parent_device> {
 
 // Specialization for image_support
 template <> struct get_device_info_impl<bool, info::device::image_support> {
-  static bool get(const DeviceImplPtr &) {
+  static bool get(const device_impl &) {
     // No devices currently support SYCL 2020 images.
     return false;
   }
@@ -1191,11 +1191,11 @@ template <> struct get_device_info_impl<bool, info::device::image_support> {
 
 template <>
 struct get_device_info_impl<bool, info::device::usm_device_allocations> {
-  static bool get(const DeviceImplPtr &Dev) {
+  static bool get(const device_impl &Dev) {
     ur_device_usm_access_capability_flags_t caps;
     ur_result_t Err =
-        Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-            Dev->getHandleRef(),
+        Dev.getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+            Dev.getHandleRef(),
             UrInfoCode<info::device::usm_device_allocations>::value,
             sizeof(ur_device_usm_access_capability_flags_t), &caps, nullptr);
 
@@ -1209,11 +1209,11 @@ struct get_device_info_impl<bool, info::device::usm_device_allocations> {
 
 template <>
 struct get_device_info_impl<bool, info::device::usm_host_allocations> {
-  static bool get(const DeviceImplPtr &Dev) {
+  static bool get(const device_impl &Dev) {
     ur_device_usm_access_capability_flags_t caps;
     ur_result_t Err =
-        Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-            Dev->getHandleRef(),
+        Dev.getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+            Dev.getHandleRef(),
             UrInfoCode<info::device::usm_host_allocations>::value,
             sizeof(ur_device_usm_access_capability_flags_t), &caps, nullptr);
 
@@ -1226,11 +1226,11 @@ struct get_device_info_impl<bool, info::device::usm_host_allocations> {
 // Specialization for shared usm query.
 template <>
 struct get_device_info_impl<bool, info::device::usm_shared_allocations> {
-  static bool get(const DeviceImplPtr &Dev) {
+  static bool get(const device_impl &Dev) {
     ur_device_usm_access_capability_flags_t caps;
     ur_result_t Err =
-        Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-            Dev->getHandleRef(),
+        Dev.getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+            Dev.getHandleRef(),
             UrInfoCode<info::device::usm_shared_allocations>::value,
             sizeof(ur_device_usm_access_capability_flags_t), &caps, nullptr);
     return (Err != UR_RESULT_SUCCESS)
@@ -1243,11 +1243,11 @@ struct get_device_info_impl<bool, info::device::usm_shared_allocations> {
 template <>
 struct get_device_info_impl<bool,
                             info::device::usm_restricted_shared_allocations> {
-  static bool get(const DeviceImplPtr &Dev) {
+  static bool get(const device_impl &Dev) {
     ur_device_usm_access_capability_flags_t caps;
     ur_result_t Err =
-        Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-            Dev->getHandleRef(),
+        Dev.getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+            Dev.getHandleRef(),
             UrInfoCode<info::device::usm_restricted_shared_allocations>::value,
             sizeof(ur_device_usm_access_capability_flags_t), &caps, nullptr);
     // Check that we don't support any cross device sharing
@@ -1262,11 +1262,11 @@ struct get_device_info_impl<bool,
 // Specialization for system usm query
 template <>
 struct get_device_info_impl<bool, info::device::usm_system_allocations> {
-  static bool get(const DeviceImplPtr &Dev) {
+  static bool get(const device_impl &Dev) {
     ur_device_usm_access_capability_flags_t caps;
     ur_result_t Err =
-        Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-            Dev->getHandleRef(),
+        Dev.getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+            Dev.getHandleRef(),
             UrInfoCode<info::device::usm_system_allocations>::value,
             sizeof(ur_device_usm_access_capability_flags_t), &caps, nullptr);
     return (Err != UR_RESULT_SUCCESS)
@@ -1280,7 +1280,7 @@ struct get_device_info_impl<bool, info::device::usm_system_allocations> {
 template <>
 struct get_device_info_impl<
     bool, ext::codeplay::experimental::info::device::supports_fusion> {
-  static bool get(const DeviceImplPtr &Dev) {
+  static bool get(const device_impl &Dev) {
     (void)Dev;
     return false;
   }
@@ -1291,10 +1291,10 @@ template <>
 struct get_device_info_impl<
     uint32_t,
     ext::codeplay::experimental::info::device::max_registers_per_work_group> {
-  static uint32_t get(const DeviceImplPtr &Dev) {
+  static uint32_t get(const device_impl &Dev) {
     uint32_t maxRegsPerWG;
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(),
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(),
         UrInfoCode<ext::codeplay::experimental::info::device::
                        max_registers_per_work_group>::value,
         sizeof(maxRegsPerWG), &maxRegsPerWG, nullptr);
@@ -1307,12 +1307,12 @@ template <>
 struct get_device_info_impl<
     std::vector<sycl::device>,
     ext::oneapi::experimental::info::device::component_devices> {
-  static std::vector<sycl::device> get(const DeviceImplPtr &Dev) {
+  static std::vector<sycl::device> get(const device_impl &Dev) {
     size_t ResultSize = 0;
     // First call to get DevCount.
     ur_result_t Err =
-        Dev->getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-            Dev->getHandleRef(),
+        Dev.getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+            Dev.getHandleRef(),
             UrInfoCode<ext::oneapi::experimental::info::device::
                            component_devices>::value,
             0, nullptr, &ResultSize);
@@ -1325,19 +1325,19 @@ struct get_device_info_impl<
 
     // Otherwise, if there was an error from UR it is unexpected and we should
     // handle it accordingly.
-    Dev->getAdapter()->checkUrResult(Err);
+    Dev.getAdapter()->checkUrResult(Err);
 
     size_t DevCount = ResultSize / sizeof(ur_device_handle_t);
 
     // Second call to get the list.
     std::vector<ur_device_handle_t> Devs(DevCount);
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(),
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(),
         UrInfoCode<
             ext::oneapi::experimental::info::device::component_devices>::value,
         ResultSize, Devs.data(), nullptr);
     std::vector<sycl::device> Result;
-    const auto &Platform = Dev->getPlatformImpl();
+    const auto &Platform = Dev.getPlatformImpl();
     for (const auto &d : Devs)
       Result.push_back(createSyclObjFromImpl<device>(
           Platform->getOrMakeDeviceImpl(d, Platform)));
@@ -1349,21 +1349,21 @@ struct get_device_info_impl<
 template <>
 struct get_device_info_impl<
     sycl::device, ext::oneapi::experimental::info::device::composite_device> {
-  static sycl::device get(const DeviceImplPtr &Dev) {
-    if (!Dev->has(sycl::aspect::ext_oneapi_is_component))
+  static sycl::device get(const device_impl &Dev) {
+    if (!Dev.has(sycl::aspect::ext_oneapi_is_component))
       throw sycl::exception(make_error_code(errc::invalid),
                             "Only devices with aspect::ext_oneapi_is_component "
                             "can call this function.");
 
     typename sycl_to_ur<device>::type Result;
-    Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-        Dev->getHandleRef(),
+    Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+        Dev.getHandleRef(),
         UrInfoCode<
             ext::oneapi::experimental::info::device::composite_device>::value,
         sizeof(Result), &Result, nullptr);
 
     if (Result) {
-      const auto &Platform = Dev->getPlatformImpl();
+      const auto &Platform = Dev.getPlatformImpl();
       return createSyclObjFromImpl<device>(
           Platform->getOrMakeDeviceImpl(Result, Platform));
     }
@@ -1374,7 +1374,7 @@ struct get_device_info_impl<
 };
 
 template <typename Param>
-typename Param::return_type get_device_info(const DeviceImplPtr &Dev) {
+typename Param::return_type get_device_info(const device_impl &Dev) {
   static_assert(is_device_info_desc<Param>::value,
                 "Invalid device information descriptor");
   return get_device_info_impl<typename Param::return_type, Param>::get(Dev);
@@ -1383,8 +1383,8 @@ typename Param::return_type get_device_info(const DeviceImplPtr &Dev) {
 template <>
 inline typename info::device::preferred_interop_user_sync::return_type
 get_device_info<info::device::preferred_interop_user_sync>(
-    const DeviceImplPtr &Dev) {
-  if (Dev->getBackend() != backend::opencl) {
+    const device_impl &Dev) {
+  if (Dev.getBackend() != backend::opencl) {
     throw sycl::exception(
         errc::invalid,
         "the info::device::preferred_interop_user_sync info descriptor can "
@@ -1396,8 +1396,8 @@ get_device_info<info::device::preferred_interop_user_sync>(
 
 template <>
 inline typename info::device::profile::return_type
-get_device_info<info::device::profile>(const DeviceImplPtr &Dev) {
-  if (Dev->getBackend() != backend::opencl) {
+get_device_info<info::device::profile>(const device_impl &Dev) {
+  if (Dev.getBackend() != backend::opencl) {
     throw sycl::exception(errc::invalid,
                           "the info::device::profile info descriptor can "
                           "only be queried with an OpenCL backend");
@@ -1408,8 +1408,8 @@ get_device_info<info::device::profile>(const DeviceImplPtr &Dev) {
 
 template <>
 inline ext::intel::info::device::device_id::return_type
-get_device_info<ext::intel::info::device::device_id>(const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_device_id))
+get_device_info<ext::intel::info::device::device_id>(const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_device_id))
     throw exception(make_error_code(errc::feature_not_supported),
                     "The device does not have the ext_intel_device_id aspect");
   using Param = ext::intel::info::device::device_id;
@@ -1418,8 +1418,8 @@ get_device_info<ext::intel::info::device::device_id>(const DeviceImplPtr &Dev) {
 
 template <>
 inline ext::intel::info::device::uuid::return_type
-get_device_info<ext::intel::info::device::uuid>(const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_device_info_uuid))
+get_device_info<ext::intel::info::device::uuid>(const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_device_info_uuid))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_device_info_uuid aspect");
@@ -1429,9 +1429,8 @@ get_device_info<ext::intel::info::device::uuid>(const DeviceImplPtr &Dev) {
 
 template <>
 inline ext::intel::info::device::pci_address::return_type
-get_device_info<ext::intel::info::device::pci_address>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_pci_address))
+get_device_info<ext::intel::info::device::pci_address>(const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_pci_address))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_pci_address aspect");
@@ -1442,8 +1441,8 @@ get_device_info<ext::intel::info::device::pci_address>(
 template <>
 inline ext::intel::info::device::gpu_eu_simd_width::return_type
 get_device_info<ext::intel::info::device::gpu_eu_simd_width>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_gpu_eu_simd_width))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_gpu_eu_simd_width))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_gpu_eu_simd_width aspect");
@@ -1454,8 +1453,8 @@ get_device_info<ext::intel::info::device::gpu_eu_simd_width>(
 template <>
 inline ext::intel::info::device::gpu_eu_count::return_type
 get_device_info<ext::intel::info::device::gpu_eu_count>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_gpu_eu_count))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_gpu_eu_count))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_gpu_eu_count aspect");
@@ -1465,9 +1464,8 @@ get_device_info<ext::intel::info::device::gpu_eu_count>(
 
 template <>
 inline ext::intel::info::device::gpu_slices::return_type
-get_device_info<ext::intel::info::device::gpu_slices>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_gpu_slices))
+get_device_info<ext::intel::info::device::gpu_slices>(const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_gpu_slices))
     throw exception(make_error_code(errc::feature_not_supported),
                     "The device does not have the ext_intel_gpu_slices aspect");
   using Param = ext::intel::info::device::gpu_slices;
@@ -1477,8 +1475,8 @@ get_device_info<ext::intel::info::device::gpu_slices>(
 template <>
 inline ext::intel::info::device::gpu_subslices_per_slice::return_type
 get_device_info<ext::intel::info::device::gpu_subslices_per_slice>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_gpu_subslices_per_slice))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_gpu_subslices_per_slice))
     throw exception(make_error_code(errc::feature_not_supported),
                     "The device does not have the "
                     "ext_intel_gpu_subslices_per_slice aspect");
@@ -1489,8 +1487,8 @@ get_device_info<ext::intel::info::device::gpu_subslices_per_slice>(
 template <>
 inline ext::intel::info::device::gpu_eu_count_per_subslice::return_type
 get_device_info<ext::intel::info::device::gpu_eu_count_per_subslice>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_gpu_eu_count_per_subslice))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_gpu_eu_count_per_subslice))
     throw exception(make_error_code(errc::feature_not_supported),
                     "The device does not have the "
                     "ext_intel_gpu_eu_count_per_subslice aspect");
@@ -1501,8 +1499,8 @@ get_device_info<ext::intel::info::device::gpu_eu_count_per_subslice>(
 template <>
 inline ext::intel::info::device::gpu_hw_threads_per_eu::return_type
 get_device_info<ext::intel::info::device::gpu_hw_threads_per_eu>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_gpu_hw_threads_per_eu))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_gpu_hw_threads_per_eu))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_gpu_hw_threads_per_eu aspect");
@@ -1513,8 +1511,8 @@ get_device_info<ext::intel::info::device::gpu_hw_threads_per_eu>(
 template <>
 inline ext::intel::info::device::max_mem_bandwidth::return_type
 get_device_info<ext::intel::info::device::max_mem_bandwidth>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_max_mem_bandwidth))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_max_mem_bandwidth))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_max_mem_bandwidth aspect");
@@ -1524,9 +1522,8 @@ get_device_info<ext::intel::info::device::max_mem_bandwidth>(
 
 template <>
 inline ext::intel::info::device::free_memory::return_type
-get_device_info<ext::intel::info::device::free_memory>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_free_memory))
+get_device_info<ext::intel::info::device::free_memory>(const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_free_memory))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_free_memory aspect");
@@ -1537,8 +1534,8 @@ get_device_info<ext::intel::info::device::free_memory>(
 template <>
 inline ext::intel::info::device::memory_clock_rate::return_type
 get_device_info<ext::intel::info::device::memory_clock_rate>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_memory_clock_rate))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_memory_clock_rate))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_memory_clock_rate aspect");
@@ -1549,8 +1546,8 @@ get_device_info<ext::intel::info::device::memory_clock_rate>(
 template <>
 inline ext::intel::info::device::memory_bus_width::return_type
 get_device_info<ext::intel::info::device::memory_bus_width>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_memory_bus_width))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_memory_bus_width))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_memory_bus_width aspect");
@@ -1561,13 +1558,13 @@ get_device_info<ext::intel::info::device::memory_bus_width>(
 template <>
 inline ext::intel::esimd::info::device::has_2d_block_io_support::return_type
 get_device_info<ext::intel::esimd::info::device::has_2d_block_io_support>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_esimd))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_esimd))
     return false;
 
   ur_exp_device_2d_block_array_capability_flags_t BlockArrayCapabilities;
-  Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-      Dev->getHandleRef(),
+  Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+      Dev.getHandleRef(),
       UrInfoCode<
           ext::intel::esimd::info::device::has_2d_block_io_support>::value,
       sizeof(BlockArrayCapabilities), &BlockArrayCapabilities, nullptr);
@@ -1580,15 +1577,15 @@ get_device_info<ext::intel::esimd::info::device::has_2d_block_io_support>(
 template <>
 inline ext::intel::info::device::current_clock_throttle_reasons::return_type
 get_device_info<ext::intel::info::device::current_clock_throttle_reasons>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_current_clock_throttle_reasons))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_current_clock_throttle_reasons))
     throw exception(make_error_code(errc::feature_not_supported),
                     "The device does not have the "
                     "ext_intel_current_clock_throttle_reasons aspect");
 
   ur_device_throttle_reasons_flags_t UrThrottleReasons;
-  Dev->getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-      Dev->getHandleRef(),
+  Dev.getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+      Dev.getHandleRef(),
       UrInfoCode<
           ext::intel::info::device::current_clock_throttle_reasons>::value,
       sizeof(UrThrottleReasons), &UrThrottleReasons, nullptr);
@@ -1620,8 +1617,8 @@ get_device_info<ext::intel::info::device::current_clock_throttle_reasons>(
 
 template <>
 inline ext::intel::info::device::fan_speed::return_type
-get_device_info<ext::intel::info::device::fan_speed>(const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_fan_speed))
+get_device_info<ext::intel::info::device::fan_speed>(const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_fan_speed))
     throw exception(make_error_code(errc::feature_not_supported),
                     "The device does not have the ext_intel_fan_speed aspect");
   using Param = ext::intel::info::device::fan_speed;
@@ -1631,8 +1628,8 @@ get_device_info<ext::intel::info::device::fan_speed>(const DeviceImplPtr &Dev) {
 template <>
 inline ext::intel::info::device::max_power_limit::return_type
 get_device_info<ext::intel::info::device::max_power_limit>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_power_limits))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_power_limits))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_power_limits aspect");
@@ -1643,8 +1640,8 @@ get_device_info<ext::intel::info::device::max_power_limit>(
 template <>
 inline ext::intel::info::device::min_power_limit::return_type
 get_device_info<ext::intel::info::device::min_power_limit>(
-    const DeviceImplPtr &Dev) {
-  if (!Dev->has(aspect::ext_intel_power_limits))
+    const device_impl &Dev) {
+  if (!Dev.has(aspect::ext_intel_power_limits))
     throw exception(
         make_error_code(errc::feature_not_supported),
         "The device does not have the ext_intel_power_limits aspect");
@@ -1664,11 +1661,11 @@ struct get_device_info_impl<
     ReturnT,
     ext::oneapi::experimental::info::device::work_group_progress_capabilities<
         ext::oneapi::experimental::execution_scope::root_group>> {
-  static ReturnT get(const DeviceImplPtr &Dev) {
+  static ReturnT get(const device_impl &Dev) {
     using execution_scope = ext::oneapi::experimental::execution_scope;
     return device_impl::getProgressGuaranteesUpTo<ReturnT>(
-        Dev->getProgressGuarantee(execution_scope::work_group,
-                                  execution_scope::root_group));
+        Dev.getProgressGuarantee(execution_scope::work_group,
+                                 execution_scope::root_group));
   }
 };
 template <typename ReturnT>
@@ -1676,11 +1673,11 @@ struct get_device_info_impl<
     ReturnT,
     ext::oneapi::experimental::info::device::sub_group_progress_capabilities<
         ext::oneapi::experimental::execution_scope::root_group>> {
-  static ReturnT get(const DeviceImplPtr &Dev) {
+  static ReturnT get(const device_impl &Dev) {
     using execution_scope = ext::oneapi::experimental::execution_scope;
     return device_impl::getProgressGuaranteesUpTo<ReturnT>(
-        Dev->getProgressGuarantee(execution_scope::sub_group,
-                                  execution_scope::root_group));
+        Dev.getProgressGuarantee(execution_scope::sub_group,
+                                 execution_scope::root_group));
   }
 };
 
@@ -1689,12 +1686,12 @@ struct get_device_info_impl<
     ReturnT,
     ext::oneapi::experimental::info::device::sub_group_progress_capabilities<
         ext::oneapi::experimental::execution_scope::work_group>> {
-  static ReturnT get(const DeviceImplPtr &Dev) {
+  static ReturnT get(const device_impl &Dev) {
 
     using execution_scope = ext::oneapi::experimental::execution_scope;
     return device_impl::getProgressGuaranteesUpTo<ReturnT>(
-        Dev->getProgressGuarantee(execution_scope::sub_group,
-                                  execution_scope::work_group));
+        Dev.getProgressGuarantee(execution_scope::sub_group,
+                                 execution_scope::work_group));
   }
 };
 
@@ -1703,12 +1700,12 @@ struct get_device_info_impl<
     ReturnT,
     ext::oneapi::experimental::info::device::work_item_progress_capabilities<
         ext::oneapi::experimental::execution_scope::root_group>> {
-  static ReturnT get(const DeviceImplPtr &Dev) {
+  static ReturnT get(const device_impl &Dev) {
 
     using execution_scope = ext::oneapi::experimental::execution_scope;
     return device_impl::getProgressGuaranteesUpTo<ReturnT>(
-        Dev->getProgressGuarantee(execution_scope::work_item,
-                                  execution_scope::root_group));
+        Dev.getProgressGuarantee(execution_scope::work_item,
+                                 execution_scope::root_group));
   }
 };
 template <typename ReturnT>
@@ -1716,12 +1713,12 @@ struct get_device_info_impl<
     ReturnT,
     ext::oneapi::experimental::info::device::work_item_progress_capabilities<
         ext::oneapi::experimental::execution_scope::work_group>> {
-  static ReturnT get(const DeviceImplPtr &Dev) {
+  static ReturnT get(const device_impl &Dev) {
 
     using execution_scope = ext::oneapi::experimental::execution_scope;
     return device_impl::getProgressGuaranteesUpTo<ReturnT>(
-        Dev->getProgressGuarantee(execution_scope::work_item,
-                                  execution_scope::work_group));
+        Dev.getProgressGuarantee(execution_scope::work_item,
+                                 execution_scope::work_group));
   }
 };
 
@@ -1730,12 +1727,12 @@ struct get_device_info_impl<
     ReturnT,
     ext::oneapi::experimental::info::device::work_item_progress_capabilities<
         ext::oneapi::experimental::execution_scope::sub_group>> {
-  static ReturnT get(const DeviceImplPtr &Dev) {
+  static ReturnT get(const device_impl &Dev) {
 
     using execution_scope = ext::oneapi::experimental::execution_scope;
     return device_impl::getProgressGuaranteesUpTo<ReturnT>(
-        Dev->getProgressGuarantee(execution_scope::work_item,
-                                  execution_scope::sub_group));
+        Dev.getProgressGuarantee(execution_scope::work_item,
+                                 execution_scope::sub_group));
   }
 };
 


### PR DESCRIPTION
Previously, it used `DeviceImplPtr` (`std::shared_ptr<device_impl>`) but that isn't necessary and was preventing a future change to initialzie device aspects when creating `device_impl` object.

Also, searching for a correct `std::shared_ptr` via `getOrMakeDeviceImpl` (e.g., in `device_impl::get_info`) is just wasteful.