### PR TITLE
[SYCL] fix for cache tests interacting with multi tile devices

### DIFF
--- a/sycl/test-e2e/KernelCompiler/sycl_cache.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_cache.cpp
@@ -58,7 +58,6 @@ int test_persistent_cache() {
   sycl::context ctx{d};
   sycl::queue q{ctx, d};
 
-
   bool ok =
       q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl);
   if (!ok) {

--- a/sycl/test-e2e/KernelCompiler/sycl_cache.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_cache.cpp
@@ -51,8 +51,13 @@ int test_persistent_cache() {
   using source_kb = sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source>;
   using exe_kb = sycl::kernel_bundle<sycl::bundle_state::executable>;
 
-  sycl::queue q;
-  sycl::context ctx = q.get_context();
+  // This test uses a very small cache eviction threshold,
+  // so we make a queue with a context of exactly one device
+  // not "all devices" like the default context might have.
+  sycl::device d;
+  sycl::context ctx{d};
+  sycl::queue q{ctx, d};
+
 
   bool ok =
       q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl);


### PR DESCRIPTION
cache eviction might occur earlier than test expects on multi-tile systems. Solution is to use a context of just one device. 