### PR TITLE
[SYCL] Coverity scan fixes for #17380

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -66,6 +66,9 @@ public:
 
   ManagedDeviceGlobalsRegistry(const ManagedDeviceGlobalsRegistry &) = delete;
 
+  ManagedDeviceGlobalsRegistry &
+  operator=(const ManagedDeviceGlobalsRegistry &) = delete;
+
   ~ManagedDeviceGlobalsRegistry() {
     try {
       unregisterDeviceGlobalsFromContext();
@@ -127,6 +130,8 @@ public:
       : MBinaries{Binaries} {}
 
   ManagedDeviceBinaries(const ManagedDeviceBinaries &) = delete;
+
+  ManagedDeviceBinaries &operator=(const ManagedDeviceBinaries &) = delete;
 
   ~ManagedDeviceBinaries() {
     try {
@@ -518,7 +523,7 @@ public:
     return MProgram;
   }
 
-  const RTDeviceBinaryImage *const &get_bin_image_ref() const noexcept {
+  const RTDeviceBinaryImage *const &get_bin_image_ref() const {
     return std::get<const RTDeviceBinaryImage *>(MBinImage);
   }
 


### PR DESCRIPTION
Changes in #17380 introduced some Coverity detected issues. This commit fixes the following issues:
 1. Removes noexcept from get_bin_image_ref as it can now potentially throw through std::variant interfaces.
 2. Adheres to rule-of-three in ManagedDeviceGlobalsRegistry and ManagedDeviceBinaries.