### PR TITLE
[UR] Change names starting in `_ur_` -> `ur_`

### DIFF
--- a/unified-runtime/source/adapters/level_zero/async_alloc.cpp
+++ b/unified-runtime/source/adapters/level_zero/async_alloc.cpp
@@ -64,7 +64,7 @@ static ur_result_t enqueueUSMAllocHelper(
   }
 
   bool UseCopyEngine = false;
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -206,7 +206,7 @@ ur_result_t urEnqueueUSMFreeExp(
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
   bool UseCopyEngine = false;
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -1179,8 +1179,8 @@ ur_result_t urCommandBufferAppendMemBufferCopyExp(
     ur_exp_command_buffer_sync_point_t *SyncPoint,
     ur_event_handle_t * /*Event*/,
     ur_exp_command_buffer_command_handle_t * /*Command*/) {
-  auto SrcBuffer = ur_cast<_ur_buffer *>(SrcMem);
-  auto DstBuffer = ur_cast<_ur_buffer *>(DstMem);
+  auto SrcBuffer = ur_cast<ur_buffer *>(SrcMem);
+  auto DstBuffer = ur_cast<ur_buffer *>(DstMem);
 
   std::shared_lock<ur_shared_mutex> SrcLock(SrcBuffer->Mutex, std::defer_lock);
   std::scoped_lock<std::shared_lock<ur_shared_mutex>, ur_shared_mutex> LockAll(
@@ -1215,8 +1215,8 @@ ur_result_t urCommandBufferAppendMemBufferCopyRectExp(
     ur_exp_command_buffer_sync_point_t *SyncPoint,
     ur_event_handle_t * /*Event*/,
     ur_exp_command_buffer_command_handle_t * /*Command*/) {
-  auto SrcBuffer = ur_cast<_ur_buffer *>(SrcMem);
-  auto DstBuffer = ur_cast<_ur_buffer *>(DstMem);
+  auto SrcBuffer = ur_cast<ur_buffer *>(SrcMem);
+  auto DstBuffer = ur_cast<ur_buffer *>(DstMem);
 
   std::shared_lock<ur_shared_mutex> SrcLock(SrcBuffer->Mutex, std::defer_lock);
   std::scoped_lock<std::shared_lock<ur_shared_mutex>, ur_shared_mutex> LockAll(
@@ -1462,7 +1462,7 @@ ur_result_t urCommandBufferAppendMemBufferFillExp(
   std::scoped_lock<ur_shared_mutex> Lock(Buffer->Mutex);
 
   char *ZeHandleDst = nullptr;
-  _ur_buffer *UrBuffer = reinterpret_cast<_ur_buffer *>(Buffer);
+  ur_buffer *UrBuffer = reinterpret_cast<ur_buffer *>(Buffer);
   UR_CALL(UrBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
                                 CommandBuffer->Device, nullptr, 0u));
 
@@ -1542,7 +1542,7 @@ ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
   const bool UseCopyEngine = false;
   bool MustSignalWaitEvent = true;
   if (NumEventsInWaitList) {
-    _ur_ze_event_list_t TmpWaitList;
+    ur_ze_event_list_t TmpWaitList;
     UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
         NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -1636,7 +1636,7 @@ ur_result_t enqueueImmediateAppendPath(
   assert(CommandListHelper->second.IsImmediate);
   assert(Platform->ZeCommandListImmediateAppendExt.Supported);
 
-  _ur_ze_event_list_t UrZeEventList;
+  ur_ze_event_list_t UrZeEventList;
   if (NumEventsInWaitList) {
     UR_CALL(UrZeEventList.createAndRetainUrZeEventList(
         NumEventsInWaitList, EventWaitList, Queue, false));

--- a/unified-runtime/source/adapters/level_zero/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.hpp
@@ -26,7 +26,7 @@ struct command_buffer_profiling_t {
   ze_kernel_timestamp_result_t *Timestamps;
 };
 
-struct ur_exp_command_buffer_handle_t_ : public _ur_object {
+struct ur_exp_command_buffer_handle_t_ : public ur_object {
   ur_exp_command_buffer_handle_t_(
       ur_context_handle_t Context, ur_device_handle_t Device,
       ze_command_list_handle_t CommandList,
@@ -149,7 +149,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
       CommandHandles;
 };
 
-struct ur_exp_command_buffer_command_handle_t_ : public _ur_object {
+struct ur_exp_command_buffer_command_handle_t_ : public ur_object {
   ur_exp_command_buffer_command_handle_t_(
       ur_exp_command_buffer_handle_t CommandBuffer, uint64_t CommandId)
       : CommandBuffer(CommandBuffer), CommandId(CommandId) {}

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -256,8 +256,8 @@ private:
 };
 
 // Base class to store common data
-struct _ur_object {
-  _ur_object() : RefCount{} {}
+struct ur_object {
+  ur_object() : RefCount{} {}
 
   // Must be atomic to prevent data race when incrementing/decrementing.
   ReferenceCounter RefCount;
@@ -284,7 +284,7 @@ struct _ur_object {
 
 // Record for a memory allocation. This structure is used to keep information
 // for each memory allocation.
-struct MemAllocRecord : _ur_object {
+struct MemAllocRecord : ur_object {
   MemAllocRecord(ur_context_handle_t Context, bool OwnZeMemHandle = true)
       : Context(Context) {
     OwnNativeHandle = OwnZeMemHandle;

--- a/unified-runtime/source/adapters/level_zero/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/context.hpp
@@ -54,7 +54,7 @@ typedef struct _ze_intel_event_sync_mode_exp_desc_t {
 
 extern const bool UseUSMAllocator;
 
-struct ur_context_handle_t_ : _ur_object {
+struct ur_context_handle_t_ : ur_object {
   ur_context_handle_t_(ze_context_handle_t ZeContext, uint32_t NumDevices,
                        const ur_device_handle_t *Devs, bool OwnZeContext)
       : ZeContext{ZeContext}, Devices{Devs, Devs + NumDevices},

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -56,7 +56,7 @@ struct ur_ze_external_memory_data {
   size_t size;
 };
 
-struct ur_device_handle_t_ : _ur_object {
+struct ur_device_handle_t_ : ur_object {
   ur_device_handle_t_(ze_device_handle_t Device, ur_platform_handle_t Plt,
                       ur_device_handle_t ParentDevice = nullptr)
       : ZeDevice{Device}, Platform{Plt}, RootDevice{ParentDevice},

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -21,7 +21,7 @@
 #include "ur_interface_loader.hpp"
 #include "ur_level_zero.hpp"
 
-void printZeEventList(const _ur_ze_event_list_t &UrZeEventList) {
+void printZeEventList(const ur_ze_event_list_t &UrZeEventList) {
   if (UrL0Debug & UR_L0_DEBUG_BASIC) {
     std::stringstream ss;
     ss << "  NumEventsInWaitList " << UrZeEventList.Length << ":";
@@ -81,7 +81,7 @@ ur_result_t urEnqueueEventsWait(
     // Lock automatically releases when this goes out of scope.
     std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
-    _ur_ze_event_list_t TmpWaitList = {};
+    ur_ze_event_list_t TmpWaitList = {};
     UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
         NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -198,9 +198,9 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
 
   // Helper function for appending a barrier to a command list.
   auto insertBarrierIntoCmdList =
-      [&Queue](ur_command_list_ptr_t CmdList,
-               _ur_ze_event_list_t &EventWaitList, ur_event_handle_t &Event,
-               bool IsInternal, bool InterruptBasedEventsEnabled) {
+      [&Queue](ur_command_list_ptr_t CmdList, ur_ze_event_list_t &EventWaitList,
+               ur_event_handle_t &Event, bool IsInternal,
+               bool InterruptBasedEventsEnabled) {
         UR_CALL(createEventAndAssociateQueue(
             Queue, &Event, UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, CmdList,
             IsInternal, InterruptBasedEventsEnabled));
@@ -281,7 +281,7 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
   if (NumEventsInWaitList || !UseMultipleCmdlistBarriers ||
       Queue->isInOrderQueue()) {
     // Retain the events as they will be owned by the result event.
-    _ur_ze_event_list_t TmpWaitList;
+    ur_ze_event_list_t TmpWaitList;
     UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
         NumEventsInWaitList, EventWaitList, Queue, false /*UseCopyEngine=*/));
 
@@ -377,7 +377,7 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
     // command-lists.
     std::vector<ur_event_handle_t> EventWaitVector(CmdLists.size());
     for (size_t I = 0; I < CmdLists.size(); ++I) {
-      _ur_ze_event_list_t waitlist;
+      ur_ze_event_list_t waitlist;
       UR_CALL(insertBarrierIntoCmdList(CmdLists[I], waitlist,
                                        EventWaitVector[I], true /*IsInternal*/,
                                        InterruptBasedEventsEnabled));
@@ -390,7 +390,7 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
 
     // Create an event list. It will take ownership over all relevant events so
     // we relinquish ownership and let it keep all events it needs.
-    _ur_ze_event_list_t BaseWaitList;
+    ur_ze_event_list_t BaseWaitList;
     UR_CALL(BaseWaitList.createAndRetainUrZeEventList(
         EventWaitVector.size(),
         reinterpret_cast<const ur_event_handle_t *>(EventWaitVector.data()),
@@ -406,7 +406,7 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
     // If there is only a single queue then insert a barrier and the single
     // result event can be used as our active barrier and used as the return
     // event. Take into account whether output event is discarded or not.
-    _ur_ze_event_list_t waitlist;
+    ur_ze_event_list_t waitlist;
     UR_CALL(insertBarrierIntoCmdList(CmdLists[0], waitlist, ResultEvent,
                                      IsInternal, InterruptBasedEventsEnabled));
   }
@@ -743,7 +743,7 @@ ur_result_t urEnqueueTimestampRecordingExp(
   ur_device_handle_t Device = Queue->Device;
 
   bool UseCopyEngine = false;
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -1438,7 +1438,7 @@ ur_result_t ur_event_handle_t_::reset() {
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
+ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
     uint32_t EventListLength, const ur_event_handle_t *EventList,
     ur_queue_handle_t CurQueue, bool UseCopyEngine) {
   this->Length = 0;
@@ -1697,7 +1697,7 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t _ur_ze_event_list_t::insert(_ur_ze_event_list_t &Other) {
+ur_result_t ur_ze_event_list_t::insert(ur_ze_event_list_t &Other) {
   if (this != &Other) {
     // save of the previous object values
     uint32_t PreLength = this->Length;
@@ -1735,7 +1735,7 @@ ur_result_t _ur_ze_event_list_t::insert(_ur_ze_event_list_t &Other) {
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t _ur_ze_event_list_t::collectEventsForReleaseAndDestroyUrZeEventList(
+ur_result_t ur_ze_event_list_t::collectEventsForReleaseAndDestroyUrZeEventList(
     std::list<ur_event_handle_t> &EventsToBeReleased) {
   // event wait lists are owned by events, this function is called with owning
   // event lock taken, hence it is thread safe

--- a/unified-runtime/source/adapters/level_zero/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/event.hpp
@@ -68,7 +68,7 @@ const bool FilterEventWaitList = [] {
   return RetVal;
 }();
 
-struct _ur_ze_event_list_t {
+struct ur_ze_event_list_t {
   // List of level zero events for this event list.
   ze_event_handle_t *ZeEventList = {nullptr};
 
@@ -95,7 +95,7 @@ struct _ur_ze_event_list_t {
                                            bool UseCopyEngine);
 
   // Add all the events in this object's UrEventList to the end
-  // of the list EventsToBeReleased. Destroy ur_ze_event_list_t data
+  // of the list EventsToBeReleased. Destroy ur_ze_event_list_t_t data
   // structure fields making it look empty.
   ur_result_t collectEventsForReleaseAndDestroyUrZeEventList(
       std::list<ur_event_handle_t> &EventsToBeReleased);
@@ -103,7 +103,7 @@ struct _ur_ze_event_list_t {
   // Had to create custom assignment operator because the mutex is
   // not assignment copyable. Just field by field copy of the other
   // fields.
-  _ur_ze_event_list_t &operator=(const _ur_ze_event_list_t &other) {
+  ur_ze_event_list_t &operator=(const ur_ze_event_list_t &other) {
     if (this != &other) {
       this->ZeEventList = other.ZeEventList;
       this->UrEventList = other.UrEventList;
@@ -112,19 +112,19 @@ struct _ur_ze_event_list_t {
     return *this;
   }
 
-  // This function allows to merge two _ur_ze_event_lists
+  // This function allows to merge two ur_ze_event_lists
   // The ur_ze_event_list "other" is added to the caller list.
   // Note that new containers are allocated to contains the additional elements.
   // Elements are moved to the new containers.
   // other list can not be used after the call to this function.
-  ur_result_t insert(_ur_ze_event_list_t &Other);
+  ur_result_t insert(ur_ze_event_list_t &Other);
 
   bool isEmpty() const { return (this->ZeEventList == nullptr); }
 };
 
-void printZeEventList(const _ur_ze_event_list_t &PiZeEventList);
+void printZeEventList(const ur_ze_event_list_t &PiZeEventList);
 
-struct ur_event_handle_t_ : _ur_object {
+struct ur_event_handle_t_ : ur_object {
   ur_event_handle_t_(ze_event_handle_t ZeEvent,
                      ze_event_pool_handle_t ZeEventPool,
                      ur_context_handle_t Context, ur_command_t CommandType,
@@ -179,7 +179,7 @@ struct ur_event_handle_t_ : _ur_object {
   // signal this event.  These events must be retained when the command is
   // enqueued, and must then be released when this event has signalled.
   // This list must be destroyed once the event has signalled.
-  _ur_ze_event_list_t WaitList;
+  ur_ze_event_list_t WaitList;
 
   // Tracks if the needed cleanup was already performed for
   // a completed event. This allows to control that some cleanup
@@ -220,7 +220,7 @@ struct ur_event_handle_t_ : _ur_object {
   uint64_t RecordEventEndTimestamp = 0;
 
   // Besides each PI object keeping a total reference count in
-  // _ur_object::RefCount we keep special track of the event *external*
+  // ur_object::RefCount we keep special track of the event *external*
   // references. This way we are able to tell when the event is not referenced
   // externally anymore, i.e. it can't be passed as a dependency event to
   // piEnqueue* functions and explicitly waited meaning that we can do some

--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -204,7 +204,7 @@ ur_result_t bindlessImagesCreateImpl(ur_context_handle_t hContext,
              (hContext->ZeContext, reinterpret_cast<const void *>(hImageMem),
               &MemAllocProperties, nullptr));
   if (MemAllocProperties.type == ZE_MEMORY_TYPE_UNKNOWN) {
-    _ur_image *UrImage = reinterpret_cast<_ur_image *>(hImageMem);
+    ur_image *UrImage = reinterpret_cast<ur_image *>(hImageMem);
 
     ZE2UR_CALL(zeImageViewCreateExt,
                (hContext->ZeContext, hDevice->ZeDevice, &ZeImageDesc,
@@ -429,7 +429,7 @@ ur_result_t urBindlessImagesImageCopyExp(
     UseCopyEngine = false;
   }
 
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       numEventsInWaitList, phEventWaitList, hQueue, UseCopyEngine));
 
@@ -467,7 +467,7 @@ ur_result_t urBindlessImagesImageCopyExp(
       ze_image_region_t DstRegion;
       UR_CALL(getImageRegionHelper(ZeImageDesc, &pCopyRegion->dstOffset,
                                    &pCopyRegion->copyExtent, DstRegion));
-      auto *UrImage = static_cast<_ur_image *>(pDst);
+      auto *UrImage = static_cast<ur_image *>(pDst);
       const char *SrcPtr =
           static_cast<const char *>(pSrc) +
           pCopyRegion->srcOffset.z * SrcSlicePitch +
@@ -507,7 +507,7 @@ ur_result_t urBindlessImagesImageCopyExp(
       ze_image_region_t SrcRegion;
       UR_CALL(getImageRegionHelper(ZeImageDesc, &pCopyRegion->srcOffset,
                                    &pCopyRegion->copyExtent, SrcRegion));
-      auto *UrImage = static_cast<const _ur_image *>(pSrc);
+      auto *UrImage = static_cast<const ur_image *>(pSrc);
       char *DstPtr =
           static_cast<char *>(pDst) + pCopyRegion->dstOffset.z * DstSlicePitch +
           pCopyRegion->dstOffset.y * DstRowPitch +
@@ -544,8 +544,8 @@ ur_result_t urBindlessImagesImageCopyExp(
     ze_image_region_t SrcRegion;
     UR_CALL(getImageRegionHelper(ZeImageDesc, &pCopyRegion->srcOffset,
                                  &pCopyRegion->copyExtent, SrcRegion));
-    auto *UrImageDst = static_cast<_ur_image *>(pDst);
-    auto *UrImageSrc = static_cast<const _ur_image *>(pSrc);
+    auto *UrImageDst = static_cast<ur_image *>(pDst);
+    auto *UrImageSrc = static_cast<const ur_image *>(pSrc);
     ZE2UR_CALL(zeCommandListAppendImageCopyRegion,
                (ZeCommandList, UrImageDst->ZeImage, UrImageSrc->ZeImage,
                 &DstRegion, &SrcRegion, ZeEvent, WaitList.Length,
@@ -568,7 +568,7 @@ ur_result_t urBindlessImagesImageGetInfoExp(
             UR_RESULT_ERROR_INVALID_ENUMERATION);
   UR_ASSERT(pPropValue || pPropSizeRet, UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
-  auto *UrImage = reinterpret_cast<_ur_image *>(hImageMem);
+  auto *UrImage = reinterpret_cast<ur_image *>(hImageMem);
   ze_image_desc_t &Desc = UrImage->ZeImageDesc;
   switch (propName) {
   case UR_IMAGE_INFO_WIDTH:
@@ -963,7 +963,7 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
   // We want to batch these commands to avoid extra submissions (costly)
   bool OkToBatch = true;
 
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       numEventsInWaitList, phEventWaitList, hQueue, UseCopyEngine));
 
@@ -1047,7 +1047,7 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
   // We want to batch these commands to avoid extra submissions (costly)
   bool OkToBatch = true;
 
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       numEventsInWaitList, phEventWaitList, hQueue, UseCopyEngine));
 

--- a/unified-runtime/source/adapters/level_zero/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.cpp
@@ -125,7 +125,7 @@ ur_result_t urEnqueueKernelLaunch(
   ZE2UR_CALL(zeKernelSetGroupSize, (ZeKernel, WG[0], WG[1], WG[2]));
 
   bool UseCopyEngine = false;
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -385,7 +385,7 @@ ur_result_t urEnqueueCooperativeKernelLaunchExp(
   ZE2UR_CALL(zeKernelSetGroupSize, (ZeKernel, WG[0], WG[1], WG[2]));
 
   bool UseCopyEngine = false;
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 

--- a/unified-runtime/source/adapters/level_zero/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.hpp
@@ -13,7 +13,7 @@
 #include "memory.hpp"
 #include <unordered_set>
 
-struct ur_kernel_handle_t_ : _ur_object {
+struct ur_kernel_handle_t_ : ur_object {
   ur_kernel_handle_t_(bool OwnZeHandle, ur_program_handle_t Program)
       : Context{nullptr}, Program{Program}, ZeKernel{nullptr},
         SubmissionsCount{0}, MemAllocs{} {

--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -90,7 +90,7 @@ ur_result_t enqueueMemCopyHelper(ur_command_t CommandType,
                                  bool PreferCopyEngine) {
   bool UseCopyEngine = Queue->useCopyEngine(PreferCopyEngine);
 
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -143,7 +143,7 @@ ur_result_t enqueueMemCopyRectHelper(
     ur_event_handle_t *OutEvent, bool PreferCopyEngine) {
   bool UseCopyEngine = Queue->useCopyEngine(PreferCopyEngine);
 
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -227,7 +227,7 @@ static ur_result_t enqueueMemFillHelper(ur_command_t CommandType,
         UR_RESULT_ERROR_INVALID_VALUE);
   }
 
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -344,7 +344,7 @@ static ur_result_t enqueueMemImageCommandHelper(
     bool PreferCopyEngine = false) {
   bool UseCopyEngine = Queue->useCopyEngine(PreferCopyEngine);
 
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -372,7 +372,7 @@ static ur_result_t enqueueMemImageCommandHelper(
   const auto &WaitList = (*Event)->WaitList;
 
   if (CommandType == UR_COMMAND_MEM_IMAGE_READ) {
-    _ur_image *SrcMem = ur_cast<_ur_image *>(const_cast<void *>(Src));
+    ur_image *SrcMem = ur_cast<ur_image *>(const_cast<void *>(Src));
 
     ze_image_region_t ZeSrcRegion;
     UR_CALL(getImageRegionHelper(SrcMem->ZeImageDesc, SrcOrigin, Region,
@@ -407,7 +407,7 @@ static ur_result_t enqueueMemImageCommandHelper(
                (ZeCommandList, Dst, ur_cast<ze_image_handle_t>(ZeHandleSrc),
                 &ZeSrcRegion, ZeEvent, WaitList.Length, WaitList.ZeEventList));
   } else if (CommandType == UR_COMMAND_MEM_IMAGE_WRITE) {
-    _ur_image *DstMem = ur_cast<_ur_image *>(Dst);
+    ur_image *DstMem = ur_cast<ur_image *>(Dst);
     ze_image_region_t ZeDstRegion;
     UR_CALL(getImageRegionHelper(DstMem->ZeImageDesc, DstOrigin, Region,
                                  ZeDstRegion));
@@ -417,7 +417,7 @@ static ur_result_t enqueueMemImageCommandHelper(
     UR_ASSERT(DstMem->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
 #ifndef NDEBUG
-    auto DstImage = static_cast<_ur_image *>(DstMem);
+    auto DstImage = static_cast<ur_image *>(DstMem);
     const ze_image_desc_t &ZeImageDesc = DstImage->ZeImageDesc;
     UR_ASSERT(
         RowPitch == 0 ||
@@ -441,8 +441,8 @@ static ur_result_t enqueueMemImageCommandHelper(
                (ZeCommandList, ur_cast<ze_image_handle_t>(ZeHandleDst), Src,
                 &ZeDstRegion, ZeEvent, WaitList.Length, WaitList.ZeEventList));
   } else if (CommandType == UR_COMMAND_MEM_IMAGE_COPY) {
-    _ur_image *SrcImage = ur_cast<_ur_image *>(const_cast<void *>(Src));
-    _ur_image *DstImage = ur_cast<_ur_image *>(Dst);
+    ur_image *SrcImage = ur_cast<ur_image *>(const_cast<void *>(Src));
+    ur_image *DstImage = ur_cast<ur_image *>(Dst);
 
     ze_image_region_t ZeSrcRegion;
     UR_CALL(getImageRegionHelper(SrcImage->ZeImageDesc, SrcOrigin, Region,
@@ -681,8 +681,8 @@ ur_result_t urEnqueueMemBufferCopy(
     /// [in,out][optional] return an event object that identifies this
     /// particular command instance.
     ur_event_handle_t *OutEvent) {
-  _ur_buffer *SrcBuffer = ur_cast<_ur_buffer *>(BufferSrc);
-  _ur_buffer *DstBuffer = ur_cast<_ur_buffer *>(BufferDst);
+  ur_buffer *SrcBuffer = ur_cast<ur_buffer *>(BufferSrc);
+  ur_buffer *DstBuffer = ur_cast<ur_buffer *>(BufferDst);
 
   UR_ASSERT(!SrcBuffer->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
   UR_ASSERT(!DstBuffer->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
@@ -746,8 +746,8 @@ ur_result_t urEnqueueMemBufferCopyRect(
     /// [in,out][optional] return an event object that identifies this
     /// particular command instance.
     ur_event_handle_t *OutEvent) {
-  _ur_buffer *SrcBuffer = ur_cast<_ur_buffer *>(BufferSrc);
-  _ur_buffer *DstBuffer = ur_cast<_ur_buffer *>(BufferDst);
+  ur_buffer *SrcBuffer = ur_cast<ur_buffer *>(BufferSrc);
+  ur_buffer *DstBuffer = ur_cast<ur_buffer *>(BufferDst);
 
   UR_ASSERT(!SrcBuffer->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
   UR_ASSERT(!DstBuffer->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
@@ -805,7 +805,7 @@ ur_result_t urEnqueueMemBufferFill(
                                                           Buffer->Mutex);
 
   char *ZeHandleDst = nullptr;
-  _ur_buffer *UrBuffer = reinterpret_cast<_ur_buffer *>(Buffer);
+  ur_buffer *UrBuffer = reinterpret_cast<ur_buffer *>(Buffer);
   UR_CALL(UrBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
                                 Queue->Device, EventWaitList,
                                 NumEventsInWaitList));
@@ -957,7 +957,7 @@ ur_result_t urEnqueueMemBufferMap(
     /// [in,out] return mapped pointer. TODO: move it before
     /// numEventsInWaitList?
     void **RetMap) {
-  auto Buffer = ur_cast<_ur_buffer *>(Buf);
+  auto Buffer = ur_cast<ur_buffer *>(Buf);
 
   UR_ASSERT(!Buffer->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
@@ -971,7 +971,7 @@ ur_result_t urEnqueueMemBufferMap(
     // Lock automatically releases when this goes out of scope.
     std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
-    _ur_ze_event_list_t TmpWaitList;
+    ur_ze_event_list_t TmpWaitList;
     UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
         NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -1127,7 +1127,7 @@ ur_result_t urEnqueueMemUnmap(
     ur_event_handle_t *OutEvent) {
   UR_ASSERT(!Mem->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
-  auto Buffer = ur_cast<_ur_buffer *>(Mem);
+  auto Buffer = ur_cast<ur_buffer *>(Mem);
 
   bool UseCopyEngine = false;
 
@@ -1139,7 +1139,7 @@ ur_result_t urEnqueueMemUnmap(
     // Lock automatically releases when this goes out of scope.
     std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
-    _ur_ze_event_list_t TmpWaitList;
+    ur_ze_event_list_t TmpWaitList;
     UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
         NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -1150,7 +1150,7 @@ ur_result_t urEnqueueMemUnmap(
     (*Event)->WaitList = TmpWaitList;
   }
 
-  _ur_buffer::Mapping MapInfo = {};
+  ur_buffer::Mapping MapInfo = {};
   {
     // Lock automatically releases when this goes out of scope.
     std::scoped_lock<ur_shared_mutex> Guard(Buffer->Mutex);
@@ -1299,7 +1299,7 @@ ur_result_t urEnqueueUSMPrefetch(
   // The createAndRetainUrZeEventList() has the proper side-effect
   // of submitting batches with dependent events.
   //
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
 
@@ -1359,7 +1359,7 @@ ur_result_t urEnqueueUSMAdvise(
 
   bool UseCopyEngine = false;
 
-  _ur_ze_event_list_t TmpWaitList;
+  ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(0, nullptr, Queue,
                                                    UseCopyEngine));
 
@@ -1583,12 +1583,12 @@ ur_result_t urMemBufferCreate(
         maybeImportUSM(Context->getPlatform()->ZeDriverHandleExpTranslated,
                        Context->ZeContext, Host, Size);
 
-  _ur_buffer *Buffer = nullptr;
+  ur_buffer *Buffer = nullptr;
   auto HostPtrOrNull = (Flags & UR_MEM_FLAG_USE_HOST_POINTER)
                            ? reinterpret_cast<char *>(Host)
                            : nullptr;
   try {
-    Buffer = new _ur_buffer(Context, Size, HostPtrOrNull, HostPtrImported);
+    Buffer = new ur_buffer(Context, Size, HostPtrOrNull, HostPtrImported);
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
@@ -1645,7 +1645,7 @@ ur_result_t urMemRelease(
 
   if (Mem->isImage()) {
     char *ZeHandleImage;
-    auto Image = static_cast<_ur_image *>(Mem);
+    auto Image = static_cast<ur_image *>(Mem);
     if (Image->OwnNativeHandle) {
       UR_CALL(Mem->getZeHandle(ZeHandleImage, ur_mem_handle_t_::write_only,
                                nullptr, nullptr, 0u));
@@ -1663,7 +1663,7 @@ ur_result_t urMemRelease(
     }
     delete Image;
   } else {
-    auto Buffer = reinterpret_cast<_ur_buffer *>(Mem);
+    auto Buffer = reinterpret_cast<ur_buffer *>(Mem);
     Buffer->free();
     delete Buffer;
   }
@@ -1684,7 +1684,7 @@ ur_result_t urMemBufferPartition(
     /// [out] pointer to the handle of sub buffer created
     ur_mem_handle_t *RetMem) {
   UR_ASSERT(Buffer && !Buffer->isImage() &&
-                !(static_cast<_ur_buffer *>(Buffer))->isSubBuffer(),
+                !(static_cast<ur_buffer *>(Buffer))->isSubBuffer(),
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
   std::shared_lock<ur_shared_mutex> Guard(Buffer->Mutex);
@@ -1696,8 +1696,8 @@ ur_result_t urMemBufferPartition(
 
   try {
     auto partitionedBuffer =
-        new _ur_buffer(static_cast<_ur_buffer *>(Buffer),
-                       BufferCreateInfo->origin, BufferCreateInfo->size);
+        new ur_buffer(static_cast<ur_buffer *>(Buffer),
+                      BufferCreateInfo->origin, BufferCreateInfo->size);
     *RetMem = reinterpret_cast<ur_mem_handle_t>(partitionedBuffer);
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
@@ -1759,10 +1759,10 @@ ur_result_t urMemBufferCreateWithNativeHandle(
     UR_ASSERT(Context->isValidDevice(Device), UR_RESULT_ERROR_INVALID_CONTEXT);
   }
 
-  _ur_buffer *Buffer = nullptr;
+  ur_buffer *Buffer = nullptr;
   try {
-    Buffer = new _ur_buffer(Context, Size, Device, ur_cast<char *>(NativeMem),
-                            OwnNativeHandle);
+    Buffer = new ur_buffer(Context, Size, Device, ur_cast<char *>(NativeMem),
+                           OwnNativeHandle);
     *Mem = reinterpret_cast<ur_mem_handle_t>(Buffer);
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
@@ -1833,7 +1833,7 @@ ur_result_t urMemGetInfo(
     /// [out][optional] pointer to the actual size in bytes of data queried by
     /// pMemInfo.
     size_t *PropSizeRet) {
-  auto Buffer = reinterpret_cast<_ur_buffer *>(Memory);
+  auto Buffer = reinterpret_cast<ur_buffer *>(Memory);
   std::shared_lock<ur_shared_mutex> Lock(Buffer->Mutex);
   UrReturnHelper ReturnValue(PropSize, MemInfo, PropSizeRet);
 
@@ -1972,11 +1972,11 @@ static ur_result_t ZeDeviceMemAllocHelper(void **ResultPtr,
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t _ur_buffer::getBufferZeHandle(char *&ZeHandle,
-                                          access_mode_t AccessMode,
-                                          ur_device_handle_t Device,
-                                          const ur_event_handle_t *phWaitEvents,
-                                          uint32_t numWaitEvents) {
+ur_result_t ur_buffer::getBufferZeHandle(char *&ZeHandle,
+                                         access_mode_t AccessMode,
+                                         ur_device_handle_t Device,
+                                         const ur_event_handle_t *phWaitEvents,
+                                         uint32_t numWaitEvents) {
 
   // NOTE: There might be no valid allocation at all yet and we get
   // here from piEnqueueKernelLaunch that would be doing the buffer
@@ -2098,7 +2098,7 @@ ur_result_t _ur_buffer::getBufferZeHandle(char *&ZeHandle,
     if (NeedCopy) {
       // Wait on all dependency events passed in to ensure that the memory which
       // is being init is updated correctly.
-      _ur_ze_event_list_t waitlist;
+      ur_ze_event_list_t waitlist;
       waitlist.ZeEventList = nullptr;
       waitlist.Length = 0;
       uint32_t EventListIndex = 0;
@@ -2198,7 +2198,7 @@ ur_result_t _ur_buffer::getBufferZeHandle(char *&ZeHandle,
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t _ur_buffer::free() {
+ur_result_t ur_buffer::free() {
   for (auto &Alloc : Allocations) {
     auto &ZeHandle = Alloc.second.ZeHandle;
     // It is possible that the real allocation wasn't made if the buffer
@@ -2238,7 +2238,7 @@ ur_result_t _ur_buffer::free() {
           UrContext->getPlatform()->ZeDriverHandleExpTranslated, ZeHandle);
       break;
     default:
-      die("_ur_buffer::free(): Unhandled release action");
+      die("ur_buffer::free(): Unhandled release action");
     }
     ZeHandle = nullptr; // don't leave hanging pointers
     this->isFreed = true;
@@ -2247,8 +2247,8 @@ ur_result_t _ur_buffer::free() {
 }
 
 // Buffer constructor
-_ur_buffer::_ur_buffer(ur_context_handle_t Context, size_t Size, char *HostPtr,
-                       bool ImportedHostPtr = false)
+ur_buffer::ur_buffer(ur_context_handle_t Context, size_t Size, char *HostPtr,
+                     bool ImportedHostPtr = false)
     : ur_mem_handle_t_(mem_type_t::buffer, Context), Size(Size) {
 
   // We treat integrated devices (physical memory shared with the CPU)
@@ -2268,7 +2268,7 @@ _ur_buffer::_ur_buffer(ur_context_handle_t Context, size_t Size, char *HostPtr,
     if (ImportedHostPtr) {
       Allocations[nullptr].ZeHandle = HostPtr;
       Allocations[nullptr].Valid = true;
-      Allocations[nullptr].ReleaseAction = _ur_buffer::allocation_t::unimport;
+      Allocations[nullptr].ReleaseAction = ur_buffer::allocation_t::unimport;
     }
   }
 
@@ -2276,14 +2276,14 @@ _ur_buffer::_ur_buffer(ur_context_handle_t Context, size_t Size, char *HostPtr,
   LastDeviceWithValidAllocation = nullptr;
 }
 
-_ur_buffer::_ur_buffer(ur_context_handle_t Context, ur_device_handle_t Device,
-                       size_t Size)
+ur_buffer::ur_buffer(ur_context_handle_t Context, ur_device_handle_t Device,
+                     size_t Size)
     : ur_mem_handle_t_(mem_type_t::buffer, Context, Device), Size(Size) {}
 
 // Interop-buffer constructor
-_ur_buffer::_ur_buffer(ur_context_handle_t Context, size_t Size,
-                       ur_device_handle_t Device, char *ZeMemHandle,
-                       bool OwnZeMemHandle)
+ur_buffer::ur_buffer(ur_context_handle_t Context, size_t Size,
+                     ur_device_handle_t Device, char *ZeMemHandle,
+                     bool OwnZeMemHandle)
     : ur_mem_handle_t_(mem_type_t::buffer, Context, Device), Size(Size) {
 
   // Device == nullptr means host allocation
@@ -2305,7 +2305,7 @@ _ur_buffer::_ur_buffer(ur_context_handle_t Context, size_t Size,
   LastDeviceWithValidAllocation = Device;
 }
 
-_ur_buffer::~_ur_buffer() {
+ur_buffer::~ur_buffer() {
   if (isSubBuffer())
     ur::level_zero::urMemRelease(SubBuffer->Parent);
 }
@@ -2316,10 +2316,10 @@ ur_result_t ur_mem_handle_t_::getZeHandle(char *&ZeHandle, access_mode_t mode,
                                           uint32_t numWaitEvents) {
   switch (mem_type) {
   case ur_mem_handle_t_::image:
-    return reinterpret_cast<_ur_image *>(this)->getImageZeHandle(
+    return reinterpret_cast<ur_image *>(this)->getImageZeHandle(
         ZeHandle, mode, Device, phWaitEvents, numWaitEvents);
   case ur_mem_handle_t_::buffer:
-    return reinterpret_cast<_ur_buffer *>(this)->getBufferZeHandle(
+    return reinterpret_cast<ur_buffer *>(this)->getBufferZeHandle(
         ZeHandle, mode, Device, phWaitEvents, numWaitEvents);
   }
   ur::unreachable();
@@ -2330,16 +2330,16 @@ ur_result_t ur_mem_handle_t_::getZeHandlePtr(
     const ur_event_handle_t *phWaitEvents, uint32_t numWaitEvents) {
   switch (mem_type) {
   case ur_mem_handle_t_::image:
-    return reinterpret_cast<_ur_image *>(this)->getImageZeHandlePtr(
+    return reinterpret_cast<ur_image *>(this)->getImageZeHandlePtr(
         ZeHandlePtr, mode, Device, phWaitEvents, numWaitEvents);
   case ur_mem_handle_t_::buffer:
-    return reinterpret_cast<_ur_buffer *>(this)->getBufferZeHandlePtr(
+    return reinterpret_cast<ur_buffer *>(this)->getBufferZeHandlePtr(
         ZeHandlePtr, mode, Device, phWaitEvents, numWaitEvents);
   }
   ur::unreachable();
 }
 
-ur_result_t _ur_buffer::getBufferZeHandlePtr(
+ur_result_t ur_buffer::getBufferZeHandlePtr(
     char **&ZeHandlePtr, access_mode_t AccessMode, ur_device_handle_t Device,
     const ur_event_handle_t *phWaitEvents, uint32_t numWaitEvents) {
   char *ZeHandle;
@@ -2349,7 +2349,7 @@ ur_result_t _ur_buffer::getBufferZeHandlePtr(
   return UR_RESULT_SUCCESS;
 }
 
-size_t _ur_buffer::getAlignment() const {
+size_t ur_buffer::getAlignment() const {
   // Choose an alignment that is at most 64 and is the next power of 2
   // for sizes less than 64.
   auto Alignment = Size;

--- a/unified-runtime/source/adapters/level_zero/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/memory.hpp
@@ -63,7 +63,7 @@ ur_result_t enqueueMemCopyRectHelper(
     uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
     ur_event_handle_t *OutEvent, bool PreferCopyEngine = false);
 
-struct ur_mem_handle_t_ : _ur_object {
+struct ur_mem_handle_t_ : ur_object {
   // Keeps the PI context of this memory handle.
   ur_context_handle_t UrContext;
 
@@ -102,21 +102,21 @@ protected:
                    ur_device_handle_t Device)
       : UrContext{Context}, UrDevice(Device), mem_type(type) {}
 
-  // Since the destructor isn't virtual, callers must destruct it via _ur_buffer
-  // or _ur_image
+  // Since the destructor isn't virtual, callers must destruct it via ur_buffer
+  // or ur_image
   ~ur_mem_handle_t_() {};
 };
 
-struct _ur_buffer final : ur_mem_handle_t_ {
+struct ur_buffer final : ur_mem_handle_t_ {
   // Buffer constructor
-  _ur_buffer(ur_context_handle_t Context, ur_device_handle_t UrDevice,
-             size_t Size);
+  ur_buffer(ur_context_handle_t Context, ur_device_handle_t UrDevice,
+            size_t Size);
 
-  _ur_buffer(ur_context_handle_t Context, size_t Size, char *HostPtr,
-             bool ImportedHostPtr);
+  ur_buffer(ur_context_handle_t Context, size_t Size, char *HostPtr,
+            bool ImportedHostPtr);
 
   // Sub-buffer constructor
-  _ur_buffer(_ur_buffer *Parent, size_t Origin, size_t Size)
+  ur_buffer(ur_buffer *Parent, size_t Origin, size_t Size)
       : ur_mem_handle_t_(mem_type_t::buffer, Parent->UrContext), Size(Size),
         SubBuffer{{Parent, Origin}} {
     // Retain the Parent Buffer due to the Creation of the SubBuffer.
@@ -124,10 +124,10 @@ struct _ur_buffer final : ur_mem_handle_t_ {
   }
 
   // Interop-buffer constructor
-  _ur_buffer(ur_context_handle_t Context, size_t Size,
-             ur_device_handle_t Device, char *ZeMemHandle, bool OwnZeMemHandle);
+  ur_buffer(ur_context_handle_t Context, size_t Size, ur_device_handle_t Device,
+            char *ZeMemHandle, bool OwnZeMemHandle);
 
-  ~_ur_buffer();
+  ~ur_buffer();
 
   // Returns a pointer to the USM allocation representing this PI buffer
   // on the specified Device. If Device is nullptr then the returned
@@ -205,19 +205,19 @@ struct _ur_buffer final : ur_mem_handle_t_ {
   size_t getAlignment() const;
 
   struct SubBuffer_t {
-    _ur_buffer *Parent;
+    ur_buffer *Parent;
     size_t Origin;
   };
   std::optional<SubBuffer_t> SubBuffer;
 };
 
-struct _ur_image final : ur_mem_handle_t_ {
+struct ur_image final : ur_mem_handle_t_ {
   // Image constructor
-  _ur_image(ur_context_handle_t UrContext, ze_image_handle_t ZeImage)
+  ur_image(ur_context_handle_t UrContext, ze_image_handle_t ZeImage)
       : ur_mem_handle_t_(mem_type_t::image, UrContext), ZeImage{ZeImage} {}
 
-  _ur_image(ur_context_handle_t UrContext, ze_image_handle_t ZeImage,
-            bool OwnZeMemHandle)
+  ur_image(ur_context_handle_t UrContext, ze_image_handle_t ZeImage,
+           bool OwnZeMemHandle)
       : ur_mem_handle_t_(mem_type_t::image, UrContext), ZeImage{ZeImage} {
     OwnNativeHandle = OwnZeMemHandle;
   }
@@ -250,7 +250,7 @@ createUrMemFromZeImage(ur_context_handle_t Context, ze_image_handle_t ZeImage,
                        bool OwnZeMemHandle,
                        const ZeStruct<ze_image_desc_t> &ZeImageDesc, T *UrMem) {
   try {
-    auto UrImage = new _ur_image(Context, ZeImage, OwnZeMemHandle);
+    auto UrImage = new ur_image(Context, ZeImage, OwnZeMemHandle);
     UrImage->ZeImageDesc = ZeImageDesc;
     *UrMem = reinterpret_cast<T>(UrImage);
   } catch (const std::bad_alloc &) {

--- a/unified-runtime/source/adapters/level_zero/physical_mem.hpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.hpp
@@ -11,7 +11,7 @@
 
 #include "common.hpp"
 
-struct ur_physical_mem_handle_t_ : _ur_object {
+struct ur_physical_mem_handle_t_ : ur_object {
   ur_physical_mem_handle_t_(ze_physical_mem_handle_t ZePhysicalMem,
                             ur_context_handle_t Context)
       : ZePhysicalMem{ZePhysicalMem}, Context{Context} {}

--- a/unified-runtime/source/adapters/level_zero/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/platform.hpp
@@ -25,7 +25,7 @@ struct ur_zes_device_handle_data_t {
   ze_bool_t SubDevice = false;
 };
 
-struct ur_platform_handle_t_ : public _ur_platform {
+struct ur_platform_handle_t_ : public ur_platform {
   ur_platform_handle_t_(ze_driver_handle_t Driver)
       : ZeDriver{Driver}, ZeApiVersion{ZE_API_VERSION_CURRENT} {}
   // Performs initialization of a newly constructed PI platform.

--- a/unified-runtime/source/adapters/level_zero/program.hpp
+++ b/unified-runtime/source/adapters/level_zero/program.hpp
@@ -12,7 +12,7 @@
 #include "common.hpp"
 #include "device.hpp"
 
-struct ur_program_handle_t_ : _ur_object {
+struct ur_program_handle_t_ : ur_object {
   // ur_program_handle_t_() {}
 
   typedef enum {

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -2337,7 +2337,7 @@ ur_queue_handle_t_::insertActiveBarriers(ur_command_list_ptr_t &CmdList,
     return UR_RESULT_SUCCESS;
 
   // Create a wait-list and retain events.
-  _ur_ze_event_list_t ActiveBarriersWaitList;
+  ur_ze_event_list_t ActiveBarriersWaitList;
   UR_CALL(ActiveBarriersWaitList.createAndRetainUrZeEventList(
       ActiveBarriers.vector().size(), ActiveBarriers.vector().data(),
       reinterpret_cast<ur_queue_handle_t>(this), UseCopyEngine));

--- a/unified-runtime/source/adapters/level_zero/queue.hpp
+++ b/unified-runtime/source/adapters/level_zero/queue.hpp
@@ -224,7 +224,7 @@ using ur_command_list_map_t =
 // The iterator pointing to a specific command-list in use.
 using ur_command_list_ptr_t = ur_command_list_map_t::iterator;
 
-struct ur_queue_handle_t_ : _ur_object {
+struct ur_queue_handle_t_ : ur_object {
   ur_queue_handle_t_(std::vector<ze_command_queue_handle_t> &ComputeQueues,
                      std::vector<ze_command_queue_handle_t> &CopyQueues,
                      ur_context_handle_t Context, ur_device_handle_t Device,
@@ -420,7 +420,7 @@ struct ur_queue_handle_t_ : _ur_object {
   active_barriers ActiveBarriers;
 
   // Besides each PI object keeping a total reference count in
-  // _ur_object::RefCount we keep special track of the queue *external*
+  // ur_object::RefCount we keep special track of the queue *external*
   // references. This way we are able to tell when the queue is being finished
   // externally, and can wait for internal references to complete, and do proper
   // cleanup of the queue.

--- a/unified-runtime/source/adapters/level_zero/sampler.hpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.hpp
@@ -11,7 +11,7 @@
 
 #include "common.hpp"
 
-struct ur_sampler_handle_t_ : _ur_object {
+struct ur_sampler_handle_t_ : ur_object {
   ur_sampler_handle_t_(ze_sampler_handle_t Sampler) : ZeSampler{Sampler} {}
 
   // Level Zero sampler handle.

--- a/unified-runtime/source/adapters/level_zero/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/usm.hpp
@@ -25,7 +25,7 @@ struct UsmPool {
   EnqueuedPool AsyncPool;
 };
 
-struct ur_usm_pool_handle_t_ : _ur_object {
+struct ur_usm_pool_handle_t_ : ur_object {
   ur_usm_pool_handle_t_(ur_context_handle_t Context,
                         ur_usm_pool_desc_t *PoolDesc, bool IsProxy = false);
   ur_usm_pool_handle_t_(ur_context_handle_t Context, ur_device_handle_t Device,

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -17,7 +17,7 @@
 #include "queue_api.hpp"
 #include <ze_api.h>
 
-struct ur_exp_command_buffer_handle_t_ : public _ur_object {
+struct ur_exp_command_buffer_handle_t_ : public ur_object {
   ur_exp_command_buffer_handle_t_(
       ur_context_handle_t context, ur_device_handle_t device,
       v2::raii::command_list_unique_handle &&commandList,
@@ -44,7 +44,7 @@ private:
   ur_event_handle_t currentExecution = nullptr;
 };
 
-struct ur_exp_command_buffer_command_handle_t_ : public _ur_object {
+struct ur_exp_command_buffer_command_handle_t_ : public ur_object {
   ur_exp_command_buffer_command_handle_t_(ur_exp_command_buffer_handle_t,
                                           uint64_t);
 

--- a/unified-runtime/source/adapters/level_zero/v2/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.hpp
@@ -17,7 +17,7 @@
 #include "event_pool_cache.hpp"
 #include "usm.hpp"
 
-struct ur_context_handle_t_ : _ur_object {
+struct ur_context_handle_t_ : ur_object {
   ur_context_handle_t_(ze_context_handle_t hContext, uint32_t numDevices,
                        const ur_device_handle_t *phDevices, bool ownZeContext);
 

--- a/unified-runtime/source/adapters/level_zero/v2/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.hpp
@@ -46,7 +46,7 @@ private:
   uint64_t timestampMaxValue = 0;
 };
 
-struct ur_event_handle_t_ : _ur_object {
+struct ur_event_handle_t_ : ur_object {
 public:
   // cache_borrowed_event is used for pooled events, whilst ze_event_handle_t is
   // used for native events

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
@@ -25,7 +25,7 @@ struct ur_single_device_kernel_t {
   mutable ZeCache<ZeStruct<ze_kernel_properties_t>> zeKernelProperties;
 };
 
-struct ur_kernel_handle_t_ : _ur_object {
+struct ur_kernel_handle_t_ : ur_object {
 private:
   struct pending_memory_allocation_t;
 

--- a/unified-runtime/source/adapters/level_zero/v2/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.hpp
@@ -19,7 +19,7 @@
 
 using usm_unique_ptr_t = std::unique_ptr<void, std::function<void(void *)>>;
 
-struct ur_mem_buffer_t : _ur_object {
+struct ur_mem_buffer_t : ur_object {
 
   enum class device_access_mode_t { read_write, read_only, write_only };
 
@@ -197,7 +197,7 @@ private:
   size_t offset;
 };
 
-struct ur_mem_image_t : _ur_object {
+struct ur_mem_image_t : ur_object {
   ur_mem_image_t(ur_context_handle_t hContext, ur_mem_flags_t flags,
                  const ur_image_format_t *pImageFormat,
                  const ur_image_desc_t *pImageDesc, void *pHost);
@@ -262,10 +262,10 @@ struct ur_mem_handle_t_ {
         mem);
   }
 
-  _ur_object *getObject() {
+  ur_object *getObject() {
     return std::visit(
-        [](auto &&arg) -> _ur_object * {
-          return static_cast<_ur_object *>(&arg);
+        [](auto &&arg) -> ur_object * {
+          return static_cast<ur_object *>(&arg);
         },
         mem);
   }

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -27,7 +27,7 @@ namespace v2 {
 
 using queue_group_type = ur_device_handle_t_::queue_group_info_t::type;
 
-struct ur_queue_immediate_in_order_t : _ur_object, public ur_queue_t_ {
+struct ur_queue_immediate_in_order_t : ur_object, public ur_queue_t_ {
 private:
   ur_context_handle_t hContext;
   ur_device_handle_t hDevice;

--- a/unified-runtime/source/adapters/level_zero/v2/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.hpp
@@ -15,7 +15,7 @@
 #include "common.hpp"
 #include "ur_pool_manager.hpp"
 
-struct ur_usm_pool_handle_t_ : _ur_object {
+struct ur_usm_pool_handle_t_ : ur_object {
   ur_usm_pool_handle_t_(ur_context_handle_t hContext,
                         ur_usm_pool_desc_t *pPoolDes);
 

--- a/unified-runtime/source/adapters/native_cpu/common.hpp
+++ b/unified-runtime/source/adapters/native_cpu/common.hpp
@@ -50,7 +50,7 @@ struct RefCounted {
 };
 
 // Base class to store common data
-struct _ur_object : RefCounted {
+struct ur_object : RefCounted {
   ur_shared_mutex Mutex;
 };
 

--- a/unified-runtime/source/adapters/native_cpu/memory.cpp
+++ b/unified-runtime/source/adapters/native_cpu/memory.cpp
@@ -46,11 +46,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
   ur_mem_handle_t_ *retMem;
 
   if (useHostPtr) {
-    retMem = new _ur_buffer(hContext, pProperties->pHost);
+    retMem = new ur_buffer(hContext, pProperties->pHost);
   } else if (copyHostPtr) {
-    retMem = new _ur_buffer(hContext, pProperties->pHost, size);
+    retMem = new ur_buffer(hContext, pProperties->pHost, size);
   } else {
-    retMem = new _ur_buffer(hContext, size);
+    retMem = new ur_buffer(hContext, size);
   }
 
   *phBuffer = retMem;
@@ -75,7 +75,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
     const ur_buffer_region_t *pRegion, ur_mem_handle_t *phMem) {
 
   UR_ASSERT(hBuffer && !hBuffer->isImage() &&
-                !(static_cast<_ur_buffer *>(hBuffer))->isSubBuffer(),
+                !(static_cast<ur_buffer *>(hBuffer))->isSubBuffer(),
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
   std::shared_lock<ur_shared_mutex> Guard(hBuffer->Mutex);
@@ -86,8 +86,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
   }
 
   try {
-    auto partitionedBuffer = new _ur_buffer(static_cast<_ur_buffer *>(hBuffer),
-                                            pRegion->origin, pRegion->size);
+    auto partitionedBuffer = new ur_buffer(static_cast<ur_buffer *>(hBuffer),
+                                           pRegion->origin, pRegion->size);
     *phMem = reinterpret_cast<ur_mem_handle_t>(partitionedBuffer);
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;

--- a/unified-runtime/source/adapters/native_cpu/memory.hpp
+++ b/unified-runtime/source/adapters/native_cpu/memory.hpp
@@ -17,7 +17,7 @@
 #include "common.hpp"
 #include "context.hpp"
 
-struct ur_mem_handle_t_ : _ur_object {
+struct ur_mem_handle_t_ : ur_object {
   ur_mem_handle_t_(size_t Size, bool _IsImage)
       : _mem{static_cast<char *>(malloc(Size))}, _ownsMem{true},
         IsImage{_IsImage} {}
@@ -48,15 +48,15 @@ private:
   const bool IsImage;
 };
 
-struct _ur_buffer final : ur_mem_handle_t_ {
+struct ur_buffer final : ur_mem_handle_t_ {
   // Buffer constructor
-  _ur_buffer(ur_context_handle_t /* Context*/, void *HostPtr)
+  ur_buffer(ur_context_handle_t /* Context*/, void *HostPtr)
       : ur_mem_handle_t_(HostPtr, false) {}
-  _ur_buffer(ur_context_handle_t /* Context*/, void *HostPtr, size_t Size)
+  ur_buffer(ur_context_handle_t /* Context*/, void *HostPtr, size_t Size)
       : ur_mem_handle_t_(HostPtr, Size, false) {}
-  _ur_buffer(ur_context_handle_t /* Context*/, size_t Size)
+  ur_buffer(ur_context_handle_t /* Context*/, size_t Size)
       : ur_mem_handle_t_(Size, false) {}
-  _ur_buffer(_ur_buffer *b, size_t Offset, size_t /*Size*/)
+  ur_buffer(ur_buffer *b, size_t Offset, size_t /*Size*/)
       : ur_mem_handle_t_(b->_mem + Offset, false), SubBuffer(b) {
     SubBuffer.Origin = Offset;
   }
@@ -64,9 +64,9 @@ struct _ur_buffer final : ur_mem_handle_t_ {
   bool isSubBuffer() const { return SubBuffer.Parent != nullptr; }
 
   struct BB {
-    BB(_ur_buffer *b) : Parent(b), Origin(0) {}
+    BB(ur_buffer *b) : Parent(b), Origin(0) {}
     BB() : BB(nullptr) {}
-    _ur_buffer *const Parent;
+    ur_buffer *const Parent;
     size_t Origin; // only valid if Parent != nullptr
   } SubBuffer;
 };

--- a/unified-runtime/source/ur/ur.hpp
+++ b/unified-runtime/source/ur/ur.hpp
@@ -372,7 +372,7 @@ template <class T> struct ZeCache : private T {
 };
 
 // TODO: populate with target agnostic handling of UR platforms
-struct _ur_platform {};
+struct ur_platform {};
 
 // Controls tracing UR calls from within the UR itself.
 extern bool PrintTrace;


### PR DESCRIPTION
Identifiers starting with an underscore in the global scope are reserved
names, so change them to not do that.
