### PR TITLE
[SYCL] Fix Win path handling in lit config

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -251,7 +251,7 @@ def check_igc_tag_and_add_feature():
 
 def quote_path(path):
     if platform.system() == "Windows":
-        return f'"{path}"'
+        return f'"{path}"' if path else ""
     return shlex.quote(path)
 
 # Call the function to perform the check and add the feature


### PR DESCRIPTION
Fixes consequence of https://github.com/intel/llvm/commit/4150bdff5eaae27d5b99ad46042412cd39ad8fa1
f'"{path}"' converts empty string to the string with quotes and length == 2. Fixes that.