### PR TITLE
[NFCI][SYCL] Make sure `platform_impl` could only be owned by `GlobalHandler`

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -50,8 +50,13 @@ platform_impl::getOrMakePlatformImpl(ur_platform_handle_t UrPlatform,
         return PlatImpl;
     }
 
-    // Otherwise make the impl
-    Result = std::make_shared<platform_impl>(UrPlatform, Adapter);
+    // Otherwise make the impl. Our ctor/dtor are private, so std::make_shared
+    // needs a bit of help...
+    struct creator : platform_impl {
+      creator(ur_platform_handle_t APlatform, const AdapterPtr &AAdapter)
+          : platform_impl(APlatform, AAdapter) {}
+    };
+    Result = std::make_shared<creator>(UrPlatform, Adapter);
     PlatformCache.emplace_back(Result);
   }
 

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -32,11 +32,13 @@ class device_impl;
 // TODO: implement extension management for host device
 // TODO: implement parameters treatment for host device
 class platform_impl {
-public:
   /// Constructs platform_impl from a UR platform handle.
   ///
   /// \param APlatform is a raw plug-in platform handle.
   /// \param AAdapter is a plug-in handle.
+  //
+  // Platforms can only be created under `GlobalHandler`'s ownership via
+  // `platform_impl::getOrMakePlatformImpl` method.
   explicit platform_impl(ur_platform_handle_t APlatform,
                          const std::shared_ptr<Adapter> &AAdapter)
       : MPlatform(APlatform), MAdapter(AAdapter) {
@@ -50,6 +52,7 @@ public:
 
   ~platform_impl() = default;
 
+public:
   /// Checks if this platform supports extension.
   ///
   /// \param ExtensionName is a string containing extension name.


### PR DESCRIPTION
This is a pre-requisite to eliminate `PlatformImplPtr` and use `platform_impl` by raw pointer/reference throught the SYCL RT library.