### PR TITLE
[SYCL] Less `shared_ptr` for `platform_impl`

### DIFF
--- a/sycl/gdb/libsycl.so-gdb.py
+++ b/sycl/gdb/libsycl.so-gdb.py
@@ -376,7 +376,7 @@ class SYCLDevice(SYCLValue):
 
     IMPL_OFFSET_TO_DEVICE_TYPE = 0x8
     IMPL_OFFSET_TO_PLATFORM = 0x18
-    PLATFORM_OFFSET_TO_BACKEND = 0x10
+    PLATFORM_OFFSET_TO_BACKEND = 0x20
 
     def __init__(self, gdb_value):
         super().__init__(gdb_value)

--- a/sycl/include/sycl/detail/impl_utils.hpp
+++ b/sycl/include/sycl/detail/impl_utils.hpp
@@ -50,6 +50,14 @@ T createSyclObjFromImpl(
   return T(ImplObj);
 }
 
+template <class T>
+T createSyclObjFromImpl(
+    std::add_lvalue_reference_t<typename std::remove_reference_t<
+        decltype(getSyclObjImpl(std::declval<T>()))>::element_type>
+        ImplRef) {
+  return createSyclObjFromImpl<T>(ImplRef.shared_from_this());
+}
+
 } // namespace detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -89,9 +89,9 @@ __SYCL_EXPORT device make_device(ur_native_handle_t NativeHandle,
       NativeHandle, Adapter->getUrAdapter(), nullptr, &UrDevice);
 
   // Construct the SYCL device from UR device.
-  auto Platform = platform_impl::getPlatformFromUrDevice(UrDevice, Adapter);
   return detail::createSyclObjFromImpl<device>(
-      Platform->getOrMakeDeviceImpl(UrDevice, Platform));
+      platform_impl::getPlatformFromUrDevice(UrDevice, Adapter)
+          .getOrMakeDeviceImpl(UrDevice));
 }
 
 __SYCL_EXPORT context make_context(ur_native_handle_t NativeHandle,
@@ -288,10 +288,9 @@ make_kernel_bundle(ur_native_handle_t NativeHandle,
   std::transform(
       ProgramDevices.begin(), ProgramDevices.end(), std::back_inserter(Devices),
       [&Adapter](const auto &Dev) {
-        auto Platform =
-            detail::platform_impl::getPlatformFromUrDevice(Dev, Adapter);
-        auto DeviceImpl = Platform->getOrMakeDeviceImpl(Dev, Platform);
-        return createSyclObjFromImpl<device>(DeviceImpl);
+        return createSyclObjFromImpl<device>(
+            detail::platform_impl::getPlatformFromUrDevice(Dev, Adapter)
+                .getOrMakeDeviceImpl(Dev));
       });
 
   // Unlike SYCL, other backends, like OpenCL or Level Zero, may not support

--- a/sycl/source/backend/level_zero.cpp
+++ b/sycl/source/backend/level_zero.cpp
@@ -20,14 +20,13 @@ using namespace sycl::detail;
 __SYCL_EXPORT device make_device(const platform &Platform,
                                  ur_native_handle_t NativeHandle) {
   const auto &Adapter = ur::getAdapter<backend::ext_oneapi_level_zero>();
-  const auto &PlatformImpl = getSyclObjImpl(Platform);
   // Create UR device first.
   ur_device_handle_t UrDevice;
   Adapter->call<UrApiKind::urDeviceCreateWithNativeHandle>(
       NativeHandle, Adapter->getUrAdapter(), nullptr, &UrDevice);
 
   return detail::createSyclObjFromImpl<device>(
-      PlatformImpl->getOrMakeDeviceImpl(UrDevice, PlatformImpl));
+      getSyclObjImpl(Platform)->getOrMakeDeviceImpl(UrDevice));
 }
 
 } // namespace ext::oneapi::level_zero::detail

--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -375,8 +375,9 @@ void applyAllowList(std::vector<ur_device_handle_t> &UrDevices,
 
   // Get platform's backend and put it to DeviceDesc
   DeviceDescT DeviceDesc;
-  auto PlatformImpl = platform_impl::getOrMakePlatformImpl(UrPlatform, Adapter);
-  backend Backend = PlatformImpl->getBackend();
+  platform_impl &PlatformImpl =
+      platform_impl::getOrMakePlatformImpl(UrPlatform, Adapter);
+  backend Backend = PlatformImpl.getBackend();
 
   for (const auto &SyclBe : getSyclBeMap()) {
     if (SyclBe.second == Backend) {
@@ -395,7 +396,7 @@ void applyAllowList(std::vector<ur_device_handle_t> &UrDevices,
 
   int InsertIDx = 0;
   for (ur_device_handle_t Device : UrDevices) {
-    auto DeviceImpl = PlatformImpl->getOrMakeDeviceImpl(Device, PlatformImpl);
+    auto DeviceImpl = PlatformImpl.getOrMakeDeviceImpl(Device);
     // get DeviceType value and put it to DeviceDesc
     ur_device_type_t UrDevType = UR_DEVICE_TYPE_ALL;
     Adapter->call<UrApiKind::urDeviceGetInfo>(

--- a/sycl/source/detail/buffer_impl.cpp
+++ b/sycl/source/detail/buffer_impl.cpp
@@ -79,12 +79,11 @@ buffer_impl::getNativeVector(backend BackendName) const {
     // doesn't have context and platform
     if (!Ctx)
       continue;
-    const PlatformImplPtr &Platform = Ctx->getPlatformImpl();
-    assert(Platform && "Platform must be present for device context");
-    if (Platform->getBackend() != BackendName)
+    const platform_impl &Platform = Ctx->getPlatformImpl();
+    if (Platform.getBackend() != BackendName)
       continue;
 
-    auto Adapter = Platform->getAdapter();
+    auto Adapter = Platform.getAdapter();
 
     ur_native_handle_t Handle = 0;
     // When doing buffer interop we don't know what device the memory should be
@@ -94,7 +93,7 @@ buffer_impl::getNativeVector(backend BackendName) const {
                                                    &Handle);
     Handles.push_back(Handle);
 
-    if (Platform->getBackend() == backend::opencl) {
+    if (Platform.getBackend() == backend::opencl) {
       __SYCL_OCL_CALL(clRetainMemObject, ur::cast<cl_mem>(Handle));
     }
   }

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -29,7 +29,6 @@ inline namespace _V1 {
 // Forward declaration
 class device;
 namespace detail {
-using PlatformImplPtr = std::shared_ptr<detail::platform_impl>;
 class context_impl {
 public:
   /// Constructs a context_impl using a single SYCL devices.
@@ -90,7 +89,7 @@ public:
   const AdapterPtr &getAdapter() const { return MPlatform->getAdapter(); }
 
   /// \return the PlatformImpl associated with this context.
-  const PlatformImplPtr &getPlatformImpl() const { return MPlatform; }
+  platform_impl &getPlatformImpl() const { return *MPlatform; }
 
   /// Queries this context for information.
   ///
@@ -257,7 +256,8 @@ private:
   async_handler MAsyncHandler;
   std::vector<device> MDevices;
   ur_context_handle_t MContext;
-  PlatformImplPtr MPlatform;
+  // TODO: Make it a reference instead, but that needs a bit more refactoring:
+  std::shared_ptr<platform_impl> MPlatform;
   property_list MPropList;
   CachedLibProgramsT MCachedLibPrograms;
   std::mutex MCachedLibProgramsMutex;

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -30,14 +30,13 @@ namespace detail {
 
 // Forward declaration
 class platform_impl;
-using PlatformImplPtr = std::shared_ptr<platform_impl>;
 
 // TODO: Make code thread-safe
 class device_impl {
 public:
   /// Constructs a SYCL device instance using the provided
   /// UR device instance.
-  explicit device_impl(ur_device_handle_t Device, PlatformImplPtr Platform);
+  explicit device_impl(ur_device_handle_t Device, platform_impl &Platform);
 
   ~device_impl();
 
@@ -279,8 +278,7 @@ public:
   backend getBackend() const { return MPlatform->getBackend(); }
 
   /// @brief  Get the platform impl serving this device
-  /// @return PlatformImplPtr
-  const PlatformImplPtr &getPlatformImpl() const { return MPlatform; }
+  platform_impl &getPlatformImpl() const { return *MPlatform; }
 
   /// Get device info string
   std::string get_device_info_string(ur_device_info_t InfoCode) const;
@@ -292,7 +290,7 @@ private:
   ur_device_handle_t MDevice = 0;
   ur_device_type_t MType;
   ur_device_handle_t MRootDevice = nullptr;
-  PlatformImplPtr MPlatform;
+  std::shared_ptr<platform_impl> MPlatform;
   bool MUseNativeAssert = false;
   mutable std::string MDeviceName;
   mutable std::once_flag MDeviceNameFlag;

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -35,7 +35,6 @@
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
-
 inline std::vector<memory_order>
 readMemoryOrderBitfield(ur_memory_order_capability_flags_t bits) {
   std::vector<memory_order> result;
@@ -1171,9 +1170,8 @@ template <> struct get_device_info_impl<device, info::device::parent_device> {
       throw exception(make_error_code(errc::invalid),
                       "No parent for device because it is not a subdevice");
 
-    const auto &Platform = Dev.getPlatformImpl();
     return createSyclObjFromImpl<device>(
-        Platform->getOrMakeDeviceImpl(result, Platform));
+        Dev.getPlatformImpl().getOrMakeDeviceImpl(result));
   }
 };
 
@@ -1337,10 +1335,10 @@ struct get_device_info_impl<
             ext::oneapi::experimental::info::device::component_devices>::value,
         ResultSize, Devs.data(), nullptr);
     std::vector<sycl::device> Result;
-    const auto &Platform = Dev.getPlatformImpl();
+    platform_impl &Platform = Dev.getPlatformImpl();
     for (const auto &d : Devs)
-      Result.push_back(createSyclObjFromImpl<device>(
-          Platform->getOrMakeDeviceImpl(d, Platform)));
+      Result.push_back(
+          createSyclObjFromImpl<device>(Platform.getOrMakeDeviceImpl(d)));
 
     return Result;
   }
@@ -1363,9 +1361,8 @@ struct get_device_info_impl<
         sizeof(Result), &Result, nullptr);
 
     if (Result) {
-      const auto &Platform = Dev.getPlatformImpl();
       return createSyclObjFromImpl<device>(
-          Platform->getOrMakeDeviceImpl(Result, Platform));
+          Dev.getPlatformImpl().getOrMakeDeviceImpl(Result));
     }
     throw sycl::exception(make_error_code(errc::invalid),
                           "A component with aspect::ext_oneapi_is_component "

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -184,7 +184,7 @@ ProgramManager &GlobalHandler::getProgramManager() {
   return PM;
 }
 
-std::unordered_map<PlatformImplPtr, ContextImplPtr> &
+std::unordered_map<platform_impl *, ContextImplPtr> &
 GlobalHandler::getPlatformToDefaultContextCache() {
   // The optimization with static reference is not done because
   // there are public methods of the GlobalHandler
@@ -205,8 +205,8 @@ Sync &GlobalHandler::getSync() {
   return sync;
 }
 
-std::vector<PlatformImplPtr> &GlobalHandler::getPlatformCache() {
-  static std::vector<PlatformImplPtr> &PlatformCache =
+std::vector<std::shared_ptr<platform_impl>> &GlobalHandler::getPlatformCache() {
+  static std::vector<std::shared_ptr<platform_impl>> &PlatformCache =
       getOrCreate(MPlatformCache);
   return PlatformCache;
 }

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -27,7 +27,6 @@ class ods_target_list;
 class XPTIRegistry;
 class ThreadPool;
 
-using PlatformImplPtr = std::shared_ptr<platform_impl>;
 using ContextImplPtr = std::shared_ptr<context_impl>;
 using AdapterPtr = std::shared_ptr<Adapter>;
 
@@ -60,9 +59,9 @@ public:
   bool isSchedulerAlive() const;
   ProgramManager &getProgramManager();
   Sync &getSync();
-  std::vector<PlatformImplPtr> &getPlatformCache();
+  std::vector<std::shared_ptr<platform_impl>> &getPlatformCache();
 
-  std::unordered_map<PlatformImplPtr, ContextImplPtr> &
+  std::unordered_map<platform_impl *, ContextImplPtr> &
   getPlatformToDefaultContextCache();
 
   std::mutex &getPlatformToDefaultContextCacheMutex();
@@ -117,8 +116,8 @@ private:
   InstWithLock<Scheduler> MScheduler;
   InstWithLock<ProgramManager> MProgramManager;
   InstWithLock<Sync> MSync;
-  InstWithLock<std::vector<PlatformImplPtr>> MPlatformCache;
-  InstWithLock<std::unordered_map<PlatformImplPtr, ContextImplPtr>>
+  InstWithLock<std::vector<std::shared_ptr<platform_impl>>> MPlatformCache;
+  InstWithLock<std::unordered_map<platform_impl *, ContextImplPtr>>
       MPlatformToDefaultContextCache;
   InstWithLock<std::mutex> MPlatformToDefaultContextCacheMutex;
   InstWithLock<std::mutex> MPlatformMapMutex;

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -126,7 +126,7 @@ void kernel_impl::checkIfValidForNumArgsInfoQuery() const {
 }
 
 void kernel_impl::enableUSMIndirectAccess() const {
-  if (!MContext->getPlatformImpl()->supports_usm())
+  if (!MContext->getPlatformImpl().supports_usm())
     return;
 
   // Some UR Adapters (like OpenCL) require this call to enable USM

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -31,23 +31,21 @@ namespace sycl {
 inline namespace _V1 {
 namespace detail {
 
-using PlatformImplPtr = std::shared_ptr<platform_impl>;
-
-PlatformImplPtr
+platform_impl &
 platform_impl::getOrMakePlatformImpl(ur_platform_handle_t UrPlatform,
                                      const AdapterPtr &Adapter) {
-  PlatformImplPtr Result;
+  std::shared_ptr<platform_impl> Result;
   {
     const std::lock_guard<std::mutex> Guard(
         GlobalHandler::instance().getPlatformMapMutex());
 
-    std::vector<PlatformImplPtr> &PlatformCache =
+    std::vector<std::shared_ptr<platform_impl>> &PlatformCache =
         GlobalHandler::instance().getPlatformCache();
 
     // If we've already seen this platform, return the impl
     for (const auto &PlatImpl : PlatformCache) {
       if (PlatImpl->getHandleRef() == UrPlatform)
-        return PlatImpl;
+        return *PlatImpl;
     }
 
     // Otherwise make the impl. Our ctor/dtor are private, so std::make_shared
@@ -60,10 +58,10 @@ platform_impl::getOrMakePlatformImpl(ur_platform_handle_t UrPlatform,
     PlatformCache.emplace_back(Result);
   }
 
-  return Result;
+  return *Result;
 }
 
-PlatformImplPtr
+platform_impl &
 platform_impl::getPlatformFromUrDevice(ur_device_handle_t UrDevice,
                                        const AdapterPtr &Adapter) {
   ur_platform_handle_t Plt =
@@ -297,9 +295,8 @@ platform_impl::getDeviceImpl(ur_device_handle_t UrDevice) {
   return getDeviceImplHelper(UrDevice);
 }
 
-std::shared_ptr<device_impl> platform_impl::getOrMakeDeviceImpl(
-    ur_device_handle_t UrDevice,
-    const std::shared_ptr<platform_impl> &PlatformImpl) {
+std::shared_ptr<device_impl>
+platform_impl::getOrMakeDeviceImpl(ur_device_handle_t UrDevice) {
   const std::lock_guard<std::mutex> Guard(MDeviceMapMutex);
   // If we've already seen this device, return the impl
   std::shared_ptr<device_impl> Result = getDeviceImplHelper(UrDevice);
@@ -307,7 +304,7 @@ std::shared_ptr<device_impl> platform_impl::getOrMakeDeviceImpl(
     return Result;
 
   // Otherwise make the impl
-  Result = std::make_shared<device_impl>(UrDevice, PlatformImpl);
+  Result = std::make_shared<device_impl>(UrDevice, *this);
   MDeviceCache.emplace_back(Result);
 
   return Result;
@@ -335,7 +332,7 @@ static bool supportsPartitionProperty(const device &dev,
 static std::vector<device> amendDeviceAndSubDevices(
     backend PlatformBackend, std::vector<device> &DeviceList,
     ods_target_list *OdsTargetList, const std::vector<int> &original_indices,
-    PlatformImplPtr PlatformImpl) {
+    platform_impl &PlatformImpl) {
   constexpr info::partition_property partitionProperty =
       info::partition_property::partition_by_affinity_domain;
   constexpr info::partition_affinity_domain affinityDomain =
@@ -344,7 +341,7 @@ static std::vector<device> amendDeviceAndSubDevices(
   std::vector<device> FinalResult;
   // (Only) when amending sub-devices for ONEAPI_DEVICE_SELECTOR, all
   // sub-devices are treated as root.
-  TempAssignGuard<bool> TAG(PlatformImpl->MAlwaysRootDevice, true);
+  TempAssignGuard<bool> TAG(PlatformImpl.MAlwaysRootDevice, true);
 
   for (unsigned i = 0; i < DeviceList.size(); i++) {
     // device has already been screened. The question is whether it should be a
@@ -528,13 +525,12 @@ platform_impl::get_devices(info::device_type DeviceType) const {
 
   // The next step is to inflate the filtered UrDevices into SYCL Device
   // objects.
-  PlatformImplPtr PlatformImpl = getOrMakePlatformImpl(MPlatform, MAdapter);
-  std::transform(
-      UrDevices.begin(), UrDevices.end(), std::back_inserter(Res),
-      [PlatformImpl](const ur_device_handle_t UrDevice) -> device {
-        return detail::createSyclObjFromImpl<device>(
-            PlatformImpl->getOrMakeDeviceImpl(UrDevice, PlatformImpl));
-      });
+  platform_impl &PlatformImpl = getOrMakePlatformImpl(MPlatform, MAdapter);
+  std::transform(UrDevices.begin(), UrDevices.end(), std::back_inserter(Res),
+                 [&PlatformImpl](const ur_device_handle_t UrDevice) -> device {
+                   return detail::createSyclObjFromImpl<device>(
+                       PlatformImpl.getOrMakeDeviceImpl(UrDevice));
+                 });
 
   // The reference counter for handles, that we used to create sycl objects, is
   // incremented, so we need to call release here.

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -31,7 +31,7 @@ class device_impl;
 
 // TODO: implement extension management for host device
 // TODO: implement parameters treatment for host device
-class platform_impl {
+class platform_impl : public std::enable_shared_from_this<platform_impl> {
   /// Constructs platform_impl from a UR platform handle.
   ///
   /// \param APlatform is a raw plug-in platform handle.
@@ -171,9 +171,7 @@ public:
   /// \param PlatormImpl is the Platform for that Device
   ///
   /// \return a shared_ptr<device_impl> corresponding to the device
-  std::shared_ptr<device_impl>
-  getOrMakeDeviceImpl(ur_device_handle_t UrDevice,
-                      const std::shared_ptr<platform_impl> &PlatformImpl);
+  std::shared_ptr<device_impl> getOrMakeDeviceImpl(ur_device_handle_t UrDevice);
 
   /// Queries the cache to see if the specified UR platform has been seen
   /// before.  If so, return the cached platform_impl, otherwise create a new
@@ -182,9 +180,8 @@ public:
   /// \param UrPlatform is the UR Platform handle representing the platform
   /// \param Adapter is the UR adapter providing the backend for the platform
   /// \return the platform_impl representing the UR platform
-  static std::shared_ptr<platform_impl>
-  getOrMakePlatformImpl(ur_platform_handle_t UrPlatform,
-                        const AdapterPtr &Adapter);
+  static platform_impl &getOrMakePlatformImpl(ur_platform_handle_t UrPlatform,
+                                              const AdapterPtr &Adapter);
 
   /// Queries the cache for the specified platform based on an input device.
   /// If found, returns the the cached platform_impl, otherwise creates a new
@@ -195,9 +192,8 @@ public:
   /// \param Adapter is the UR adapter providing the backend for the device and
   /// platform
   /// \return the platform_impl that contains the input device
-  static std::shared_ptr<platform_impl>
-  getPlatformFromUrDevice(ur_device_handle_t UrDevice,
-                          const AdapterPtr &Adapter);
+  static platform_impl &getPlatformFromUrDevice(ur_device_handle_t UrDevice,
+                                                const AdapterPtr &Adapter);
 
   // when getting sub-devices for ONEAPI_DEVICE_SELECTOR we may temporarily
   // ensure every device is a root one.

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -592,10 +592,8 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
 
   // The device is not necessarily a member of the context, it could be a
   // member's descendant instead. Fetch the corresponding device from the cache.
-  const std::shared_ptr<detail::platform_impl> &PltImpl =
-      detail::getSyclObjImpl(Ctxt)->getPlatformImpl();
   std::shared_ptr<detail::device_impl> DevImpl =
-      PltImpl->getDeviceImpl(DeviceId);
+      detail::getSyclObjImpl(Ctxt)->getPlatformImpl().getDeviceImpl(DeviceId);
   if (DevImpl)
     return detail::createSyclObjFromImpl<device>(DevImpl);
   throw exception(make_error_code(errc::runtime),

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -40,9 +40,8 @@ device::device(cl_device_id DeviceId) {
   Adapter->call<detail::UrApiKind::urDeviceCreateWithNativeHandle>(
       detail::ur::cast<ur_native_handle_t>(DeviceId), Adapter->getUrAdapter(),
       nullptr, &Device);
-  auto Platform =
-      detail::platform_impl::getPlatformFromUrDevice(Device, Adapter);
-  impl = Platform->getOrMakeDeviceImpl(Device, Platform);
+  impl = detail::platform_impl::getPlatformFromUrDevice(Device, Adapter)
+             .getOrMakeDeviceImpl(Device);
   __SYCL_OCL_CALL(clRetainDevice, DeviceId);
 }
 

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -29,7 +29,8 @@ platform::platform(cl_platform_id PlatformId) {
   Adapter->call<detail::UrApiKind::urPlatformCreateWithNativeHandle>(
       detail::ur::cast<ur_native_handle_t>(PlatformId), Adapter->getUrAdapter(),
       /* pProperties = */ nullptr, &UrPlatform);
-  impl = detail::platform_impl::getOrMakePlatformImpl(UrPlatform, Adapter);
+  impl = detail::platform_impl::getOrMakePlatformImpl(UrPlatform, Adapter)
+             .shared_from_this();
 }
 
 // protected constructor for internal use
@@ -90,7 +91,7 @@ platform::get_backend_info() const {
 context platform::khr_get_default_context() const {
   // Keeping the default context for platforms in the global cache to avoid
   // shared_ptr based circular dependency between platform and context classes
-  std::unordered_map<detail::PlatformImplPtr, detail::ContextImplPtr>
+  std::unordered_map<detail::platform_impl *, detail::ContextImplPtr>
       &PlatformToDefaultContextCache =
           detail::GlobalHandler::instance().getPlatformToDefaultContextCache();
 
@@ -98,10 +99,10 @@ context platform::khr_get_default_context() const {
       detail::GlobalHandler::instance()
           .getPlatformToDefaultContextCacheMutex()};
 
-  auto It = PlatformToDefaultContextCache.find(impl);
+  auto It = PlatformToDefaultContextCache.find(impl.get());
   if (PlatformToDefaultContextCache.end() == It)
     std::tie(It, std::ignore) = PlatformToDefaultContextCache.insert(
-        {impl, detail::getSyclObjImpl(context{get_devices()})});
+        {impl.get(), detail::getSyclObjImpl(context{get_devices()})});
 
   return detail::createSyclObjFromImpl<context>(It->second);
 }

--- a/sycl/test/gdb/printers.cpp
+++ b/sycl/test/gdb/printers.cpp
@@ -60,7 +60,7 @@ sycl::range<1> r(3);
 // CHECK:       120 |     void * MUserPtr
 
 // CHECK:         0 | class sycl::detail::platform_impl
-// CHECK:        16 |   backend MBackend
+// CHECK:        32 |   backend MBackend
 
 // CHECK:         0 | class sycl::detail::device_impl
 // CHECK:         8 |   ur_device_type_t MType

--- a/sycl/unittests/program_manager/SubDevices.cpp
+++ b/sycl/unittests/program_manager/SubDevices.cpp
@@ -105,7 +105,7 @@ TEST(SubDevices, DISABLED_BuildProgramForSubdevices) {
   // Initialize root device
   rootDevice = sycl::detail::getSyclObjImpl(device)->getHandleRef();
   // Initialize sub-devices
-  auto PltImpl = sycl::detail::getSyclObjImpl(Plt);
+  sycl::detail::platform_impl &PltImpl = *sycl::detail::getSyclObjImpl(Plt);
   auto subDev1 =
       std::make_shared<sycl::detail::device_impl>(urSubDev1, PltImpl);
   auto subDev2 =

--- a/sycl/unittests/queue/DeviceCheck.cpp
+++ b/sycl/unittests/queue/DeviceCheck.cpp
@@ -117,8 +117,9 @@ TEST(QueueDeviceCheck, CheckDeviceRestriction) {
   {
     ParentDevice = nullptr;
     device Device = detail::createSyclObjFromImpl<device>(
-        std::make_shared<detail::device_impl>(reinterpret_cast<ur_device_handle_t>(0x01),
-                                              detail::getSyclObjImpl(Plt)));
+        std::make_shared<detail::device_impl>(
+            reinterpret_cast<ur_device_handle_t>(0x01),
+            *detail::getSyclObjImpl(Plt)));
     queue Q{Device};
     EXPECT_NE(Q.get_context(), DefaultCtx);
     try {


### PR DESCRIPTION
`GlobalHandler::MPlatformCache` keeps (shared) ownership of `platform_impl` objects, so none of them could be destroyed until SYCL RT library shutdown/unload process. As such, using raw pointers/reference to `platform_impl` throughout the SYCL RT is totally fine and would avoid extra costs of `std::shared_ptr`. However, our unittests don't work the same way and lifetimes are actually managed by all the data member `std::shared_ptr`s (e.g., see `CurrentDevice.cpp` as the most obvious case), so simply switching all `PlatformImplPtr` to raw pointer/reference doesn't work right now. I think it will be possible with an ABI break if we'd remove all the shared pointers but the one in the `GlobalHandler`.

What I'm doing here instead is the following:
  * Try to keep lifetime management the same, i.e., all data member pointers are still "smart"
  * Inherit from `std::enable_shared_from_this()` so that we could pass raw references around and only actually create smart pointers when absolutely necessary.
  * Change internal APIs to operate more using plain references

This should make it much harder to write something like this:
```
  // BAD: Should have been `auto &`, extra atomic counter
  // increment/decrement without it.
  auto PlatformImpl = d.getPlatformImplPtr();
```