### PR TITLE
[SYCL] Fix use-after-release kernel issue

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -1474,11 +1474,10 @@ void exec_graph_impl::populateURKernelUpdateStructs(
   ur_kernel_handle_t UrKernel = nullptr;
   auto Kernel = ExecCG.MSyclKernel;
   auto KernelBundleImplPtr = ExecCG.MKernelBundle;
-  std::shared_ptr<sycl::detail::kernel_impl> SyclKernelImpl = nullptr;
   const sycl::detail::KernelArgMask *EliminatedArgMask = nullptr;
 
   if (auto SyclKernelImpl = KernelBundleImplPtr
-                                ? KernelBundleImplPtr->tryGetKernel(
+                                ? KernelBundleImplPtr->tryGetOfflineKernel(
                                       ExecCG.MKernelName, KernelBundleImplPtr)
                                 : std::shared_ptr<kernel_impl>{nullptr}) {
     UrKernel = SyclKernelImpl->getHandleRef();

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2523,8 +2523,8 @@ getCGKernelInfo(const CGExecKernel &CommandGroup, ContextImplPtr ContextImpl,
 
   if (auto SyclKernelImpl =
           KernelBundleImplPtr
-              ? KernelBundleImplPtr->tryGetKernel(CommandGroup.MKernelName,
-                                                  KernelBundleImplPtr)
+              ? KernelBundleImplPtr->tryGetOfflineKernel(
+                    CommandGroup.MKernelName, KernelBundleImplPtr)
               : std::shared_ptr<kernel_impl>{nullptr}) {
     UrKernel = SyclKernelImpl->getHandleRef();
     DeviceImageImpl = SyclKernelImpl->getDeviceImage();

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -445,10 +445,8 @@ event handler::finalize() {
       // Make sure implicit non-interop kernel bundles have the kernel
       if (!impl->isStateExplicitKernelBundle() &&
           !(MKernel && MKernel->isInterop()) &&
-          (KernelBundleImpPtr->empty() ||
-           KernelBundleImpPtr->hasSYCLOfflineImages()) &&
-          !KernelBundleImpPtr->tryGetKernel(MKernelName.data(),
-                                            KernelBundleImpPtr)) {
+          !KernelBundleImpPtr->tryGetOfflineKernel(MKernelName.data(),
+                                                   KernelBundleImpPtr)) {
         auto Dev =
             impl->MGraph ? impl->MGraph->getDevice() : MQueue->get_device();
         kernel_id KernelID =


### PR DESCRIPTION
After the changes in #17380, kernels looked up from a kernel bundle could cause lifetime issues, as the lifetime of the returned objects had to be handled differently based on the path taken. These changes move back to only look up non-source-based kernels and use the stored kernel objects otherwise.