### PR TITLE
[SYCL] Use defined(__SPIRV__) instead of !defined(all other targets) (NFC)

### DIFF
--- a/sycl/include/sycl/__spirv/spirv_vars.hpp
+++ b/sycl/include/sycl/__spirv/spirv_vars.hpp
@@ -18,7 +18,7 @@
 
 #define __SPIRV_VAR_QUALIFIERS extern "C" const
 
-#if defined(__NVPTX__) || defined(__AMDGCN__) || defined(__SYCL_NATIVE_CPU__)
+#if !(defined(__SPIR__) || defined(__SPIRV__))
 
 __DPCPP_SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_x();
 __DPCPP_SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_y();
@@ -54,7 +54,7 @@ __DPCPP_SYCL_EXTERNAL uint32_t __spirv_NumSubgroups();
 __DPCPP_SYCL_EXTERNAL uint32_t __spirv_SubgroupId();
 __DPCPP_SYCL_EXTERNAL uint32_t __spirv_SubgroupLocalInvocationId();
 
-#else // defined(__NVPTX__) || defined(__AMDGCN__)
+#else // !(defined(__SPIR__) || defined(__SPIRV__))
 
 typedef size_t size_t_vec __attribute__((ext_vector_type(3)));
 __SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInGlobalSize;
@@ -163,7 +163,7 @@ __DPCPP_SYCL_EXTERNAL inline uint32_t __spirv_SubgroupLocalInvocationId() {
   return __spirv_BuiltInSubgroupLocalInvocationId;
 }
 
-#endif // defined(__NVPTX__) || defined(__AMDGCN__)
+#endif // !(defined(__SPIR__) || defined(__SPIRV__))
 
 #undef __SPIRV_VAR_QUALIFIERS
 


### PR DESCRIPTION
This is a simpler logic, the `#else` branch already assumes built-in SPIR-V variables anyway, so any future target would not want to take it. Also this removes one point that needs to be modified if new targets were to be added.

NOTE:
I could have flipped the logic to make the `#if` positive, but I didn't that to make this a smaller diff. Let me know if that would be preferable.