### PR TITLE
[DeviceMSAN] Fix e2e tests crashed on OpenCL CPU

### DIFF
--- a/libdevice/sanitizer/msan_rtl.cpp
+++ b/libdevice/sanitizer/msan_rtl.cpp
@@ -215,6 +215,11 @@ inline uptr __msan_get_shadow_pvc(uptr addr, uint32_t as) {
   return GetMsanLaunchInfo->CleanShadow;
 }
 
+inline void __msan_exit() {
+  if (!GetMsanLaunchInfo->IsRecover)
+    __devicelib_exit();
+}
+
 } // namespace
 
 #define MSAN_MAYBE_WARNING(type, size)                                         \
@@ -225,7 +230,7 @@ inline uptr __msan_get_shadow_pvc(uptr addr, uint32_t as) {
       return;                                                                  \
     if (UNLIKELY(s)) {                                                         \
       __msan_report_error(size, file, line, func, o);                          \
-      __devicelib_exit();                                                      \
+      __msan_exit();                                                           \
     }                                                                          \
   }
 
@@ -237,15 +242,19 @@ MSAN_MAYBE_WARNING(u64, 8)
 DEVICE_EXTERN_C_NOINLINE void
 __msan_warning(const char __SYCL_CONSTANT__ *file, uint32_t line,
                const char __SYCL_CONSTANT__ *func) {
+  if (!GetMsanLaunchInfo)
+    return;
   __msan_report_error(1, file, line, func);
-  __devicelib_exit();
+  __msan_exit();
 }
 
 DEVICE_EXTERN_C_NOINLINE void
 __msan_warning_noreturn(const char __SYCL_CONSTANT__ *file, uint32_t line,
                         const char __SYCL_CONSTANT__ *func) {
+  if (!GetMsanLaunchInfo)
+    return;
   __msan_internal_report_save(1, file, line, func, 0);
-  __devicelib_exit();
+  __msan_exit();
 }
 
 // For mapping detail, ref to

--- a/libdevice/sanitizer/msan_rtl.cpp
+++ b/libdevice/sanitizer/msan_rtl.cpp
@@ -225,6 +225,7 @@ inline uptr __msan_get_shadow_pvc(uptr addr, uint32_t as) {
       return;                                                                  \
     if (UNLIKELY(s)) {                                                         \
       __msan_report_error(size, file, line, func, o);                          \
+      __devicelib_exit();                                                      \
     }                                                                          \
   }
 
@@ -237,12 +238,14 @@ DEVICE_EXTERN_C_NOINLINE void
 __msan_warning(const char __SYCL_CONSTANT__ *file, uint32_t line,
                const char __SYCL_CONSTANT__ *func) {
   __msan_report_error(1, file, line, func);
+  __devicelib_exit();
 }
 
 DEVICE_EXTERN_C_NOINLINE void
 __msan_warning_noreturn(const char __SYCL_CONSTANT__ *file, uint32_t line,
                         const char __SYCL_CONSTANT__ *func) {
   __msan_internal_report_save(1, file, line, func, 0);
+  __devicelib_exit();
 }
 
 // For mapping detail, ref to

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -467,6 +467,7 @@ ur_result_t MsanInterceptor::prepareLaunch(
 
   LaunchInfo.Data.Host.DeviceTy = DeviceInfo->Type;
   LaunchInfo.Data.Host.Debug = getContext()->Options.Debug ? 1 : 0;
+  LaunchInfo.Data.Host.IsRecover = getContext()->Options.Recover ? 1 : 0;
 
   // Clean shadow
   // Its content is always zero, and is used for unsupport memory types

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_options.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_options.cpp
@@ -46,6 +46,7 @@ void SanitizerOptions::Init(const std::string &EnvName,
   Parser.ParseBool("print_stats", PrintStats);
   Parser.ParseBool("detect_leaks", DetectLeaks);
   Parser.ParseBool("halt_on_error", HaltOnError);
+  Parser.ParseBool("recover", Recover);
 
   Parser.ParseUint64("quarantine_size_mb", MaxQuarantineSizeMB, 0, UINT32_MAX);
   Parser.ParseUint64("redzone", MinRZSize, 16);

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_options.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_options.hpp
@@ -31,6 +31,7 @@ struct SanitizerOptions {
   bool DetectKernelArguments = true;
   bool DetectLeaks = true;
   bool HaltOnError = true;
+  bool Recover = false;
 
   void Init(const std::string &EnvName, logger::Logger &Logger);
 };


### PR DESCRIPTION
Unlike ASAN, MSAN needs "__devicelib_exit()" because if "j" is an uninitialized value in "data[j]", this will cause memory crash on CPU.
But sometimes "__devicelib_exit()" will hang on OpenMP (GPU), so I added a new option "recover" to control it.