### PR TITLE
[SYCL][E2E] Re-enable test-e2e/USM/fill_any_size.cpp for OpenCL as it now passes

### DIFF
--- a/sycl/test-e2e/USM/fill_any_size.cpp
+++ b/sycl/test-e2e/USM/fill_any_size.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
 // clang-format off
-// UNSUPPORTED: opencl
-// UNSUPPORTED-TRACKER: https://github.com/oneapi-src/unified-runtime/issues/2440
 // clang-format on
 
 /**


### PR DESCRIPTION
Closes https://github.com/oneapi-src/unified-runtime/issues/2440