### PR TITLE
[UR][OpenCL][Graph] Set simultaneous-use property

### DIFF
--- a/unified-runtime/source/adapters/opencl/command_buffer.cpp
+++ b/unified-runtime/source/adapters/opencl/command_buffer.cpp
@@ -60,9 +60,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  cl_command_buffer_properties_khr Properties[3] = {
-      CL_COMMAND_BUFFER_FLAGS_KHR,
-      IsUpdatable ? CL_COMMAND_BUFFER_MUTABLE_KHR : 0u, 0};
+  // OpenCL command-buffer must be simultaneous use to match expectation of UR
+  // command-buffer specification.
+  cl_command_buffer_flags_khr Flags = CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR;
+  if (IsUpdatable) {
+    Flags |= CL_COMMAND_BUFFER_MUTABLE_KHR;
+  }
+
+  cl_command_buffer_properties_khr Properties[3] = {CL_COMMAND_BUFFER_FLAGS_KHR,
+                                                    Flags, 0};
 
   ur_queue_handle_t Queue = nullptr;
   ur_queue_properties_t QueueProperties = {UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,


### PR DESCRIPTION
The merged PR https://github.com/intel/llvm/pull/17658 added the requirement for OpenCL cl_khr_command_buffer implementations to support the simultaneous use capability in order to support UR command-buffers.

There was an oversight in this PR where the simultaneous use property wasn't set on command-buffer creation in the OpenCL adapter. This is rectified in this patch.