### PR TITLE
[SYCL] Use `platform_impl::getOrMakeDeviceImpl` in `make_device`

### DIFF
--- a/sycl/include/sycl/backend.hpp
+++ b/sycl/include/sycl/backend.hpp
@@ -305,16 +305,6 @@ std::enable_if_t<detail::InteropFeatureSupportMap<Backend>::MakeDevice == true,
                  device>
 make_device(const typename backend_traits<Backend>::template input_type<device>
                 &BackendObject) {
-  for (auto p : platform::get_platforms()) {
-    if (p.get_backend() != Backend)
-      continue;
-
-    for (auto d : p.get_devices()) {
-      if (get_native<Backend>(d) == BackendObject)
-        return d;
-    }
-  }
-
   return detail::make_device(
       detail::ur::cast<ur_native_handle_t>(BackendObject), Backend);
 }

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -87,9 +87,11 @@ __SYCL_EXPORT device make_device(ur_native_handle_t NativeHandle,
   ur_device_handle_t UrDevice = nullptr;
   Adapter->call<UrApiKind::urDeviceCreateWithNativeHandle>(
       NativeHandle, Adapter->getUrAdapter(), nullptr, &UrDevice);
+
   // Construct the SYCL device from UR device.
+  auto Platform = platform_impl::getPlatformFromUrDevice(UrDevice, Adapter);
   return detail::createSyclObjFromImpl<device>(
-      std::make_shared<device_impl>(UrDevice, Adapter));
+      Platform->getOrMakeDeviceImpl(UrDevice, Platform));
 }
 
 __SYCL_EXPORT context make_context(ur_native_handle_t NativeHandle,

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -35,19 +35,9 @@ using PlatformImplPtr = std::shared_ptr<platform_impl>;
 // TODO: Make code thread-safe
 class device_impl {
 public:
-  /// Constructs a SYCL device instance as a host device.
-  device_impl();
-
-  /// Constructs a SYCL device instance using the provided raw device handle.
-  explicit device_impl(ur_native_handle_t, const AdapterPtr &Adapter);
-
   /// Constructs a SYCL device instance using the provided
   /// UR device instance.
   explicit device_impl(ur_device_handle_t Device, PlatformImplPtr Platform);
-
-  /// Constructs a SYCL device instance using the provided
-  /// UR device instance.
-  explicit device_impl(ur_device_handle_t Device, const AdapterPtr &Adapter);
 
   ~device_impl();
 
@@ -299,10 +289,6 @@ public:
   ext::oneapi::experimental::architecture getDeviceArch() const;
 
 private:
-  explicit device_impl(ur_native_handle_t InteropDevice,
-                       ur_device_handle_t Device, PlatformImplPtr Platform,
-                       const AdapterPtr &Adapter);
-
   ur_device_handle_t MDevice = 0;
   ur_device_type_t MType;
   ur_device_handle_t MRootDevice = nullptr;


### PR DESCRIPTION
This effectively reverts part of the changes made in https://github.com/intel/llvm/pull/13483 in favor of a simpler solution. The tests added there are unchanged and are verifying this PR.

This made one `device_impl` ctor overload unused with another already dead prior to this. Removing them both here and making some other simplifications following from that removal.