### PR TITLE
[SYCL][E2E] Disable memory_management_test1_usmnone.cpp on Gen12 Linux

### DIFF
--- a/sycl/test-e2e/syclcompat/memory/memory_management_test1_usmnone.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test1_usmnone.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// UNSUPPORTED: linux && gpu-intel-gen12 && (!build-mode && run-mode)
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17966
+
 #define SYCLCOMPAT_USM_LEVEL_NONE
 #include <sycl/detail/core.hpp>
 #include <syclcompat/memory.hpp>


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/17966