### PR TITLE
[NFC][SYCL] Introduce `get_ur_handles` helper

### DIFF
--- a/sycl/source/detail/bindless_images.cpp
+++ b/sycl/source/detail/bindless_images.cpp
@@ -112,18 +112,12 @@ image_mem::get_mip_level_mem_handle(const unsigned int level) const {
 __SYCL_EXPORT void destroy_image_handle(unsampled_image_handle &imageHandle,
                                         const sycl::device &syclDevice,
                                         const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   Adapter->call<
       sycl::errc::runtime,
       sycl::detail::UrApiKind::urBindlessImagesUnsampledImageHandleDestroyExp>(
-      C, Device, imageHandle.raw_handle);
+      urCtx, urDevice, imageHandle.raw_handle);
 }
 
 __SYCL_EXPORT void destroy_image_handle(unsampled_image_handle &imageHandle,
@@ -135,18 +129,12 @@ __SYCL_EXPORT void destroy_image_handle(unsampled_image_handle &imageHandle,
 __SYCL_EXPORT void destroy_image_handle(sampled_image_handle &imageHandle,
                                         const sycl::device &syclDevice,
                                         const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   Adapter->call<
       sycl::errc::runtime,
       sycl::detail::UrApiKind::urBindlessImagesSampledImageHandleDestroyExp>(
-      C, Device, imageHandle.raw_handle);
+      urCtx, urDevice, imageHandle.raw_handle);
 }
 
 __SYCL_EXPORT void destroy_image_handle(sampled_image_handle &imageHandle,
@@ -160,13 +148,7 @@ alloc_image_mem(const image_descriptor &desc, const sycl::device &syclDevice,
                 const sycl::context &syclContext) {
   desc.verify();
 
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -177,7 +159,7 @@ alloc_image_mem(const image_descriptor &desc, const sycl::device &syclDevice,
   // Call impl.
   Adapter->call<sycl::errc::memory_allocation,
                 sycl::detail::UrApiKind::urBindlessImagesImageAllocateExp>(
-      C, Device, &urFormat, &urDesc,
+      urCtx, urDevice, &urFormat, &urDesc,
       reinterpret_cast<ur_exp_image_mem_native_handle_t *>(
           &retHandle.raw_handle));
 
@@ -193,19 +175,13 @@ __SYCL_EXPORT image_mem_handle get_mip_level_mem_handle(
     const image_mem_handle mipMem, unsigned int level,
     const sycl::device &syclDevice, const sycl::context &syclContext) {
 
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   // Call impl.
   image_mem_handle individual_image = {};
   Adapter->call<sycl::errc::runtime,
                 sycl::detail::UrApiKind::urBindlessImagesMipmapGetLevelExp>(
-      C, Device, mipMem.raw_handle, level, &individual_image.raw_handle);
+      urCtx, urDevice, mipMem.raw_handle, level, &individual_image.raw_handle);
 
   return individual_image;
 }
@@ -221,23 +197,17 @@ __SYCL_EXPORT void free_image_mem(image_mem_handle memHandle,
                                   image_type imageType,
                                   const sycl::device &syclDevice,
                                   const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   if (memHandle.raw_handle != 0) {
     if (imageType == image_type::mipmap) {
       Adapter->call<sycl::errc::memory_allocation,
                     sycl::detail::UrApiKind::urBindlessImagesMipmapFreeExp>(
-          C, Device, memHandle.raw_handle);
+          urCtx, urDevice, memHandle.raw_handle);
     } else {
       Adapter->call<sycl::errc::memory_allocation,
                     sycl::detail::UrApiKind::urBindlessImagesImageFreeExp>(
-          C, Device, memHandle.raw_handle);
+          urCtx, urDevice, memHandle.raw_handle);
     }
   }
 }
@@ -267,13 +237,7 @@ create_image(image_mem_handle memHandle, const image_descriptor &desc,
              const sycl::device &syclDevice, const sycl::context &syclContext) {
   desc.verify();
 
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -284,7 +248,8 @@ create_image(image_mem_handle memHandle, const image_descriptor &desc,
   Adapter
       ->call<sycl::errc::runtime,
              sycl::detail::UrApiKind::urBindlessImagesUnsampledImageCreateExp>(
-          C, Device, memHandle.raw_handle, &urFormat, &urDesc, &urImageHandle);
+          urCtx, urDevice, memHandle.raw_handle, &urFormat, &urDesc,
+          &urImageHandle);
 
   return unsampled_image_handle{urImageHandle};
 }
@@ -372,13 +337,7 @@ create_image(void *devPtr, size_t pitch, const bindless_image_sampler &sampler,
              const sycl::context &syclContext) {
   desc.verify();
 
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_sampler_desc_t UrSamplerProps{
       UR_STRUCTURE_TYPE_SAMPLER_DESC, nullptr,
@@ -410,7 +369,7 @@ create_image(void *devPtr, size_t pitch, const bindless_image_sampler &sampler,
 
   ur_sampler_handle_t urSampler = nullptr;
   Adapter->call<sycl::errc::runtime, sycl::detail::UrApiKind::urSamplerCreate>(
-      C, &UrSamplerProps, &urSampler);
+      urCtx, &UrSamplerProps, &urSampler);
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -420,8 +379,9 @@ create_image(void *devPtr, size_t pitch, const bindless_image_sampler &sampler,
   ur_exp_image_mem_native_handle_t urImageHandle = 0;
   Adapter->call<sycl::errc::runtime,
                 sycl::detail::UrApiKind::urBindlessImagesSampledImageCreateExp>(
-      C, Device, reinterpret_cast<ur_exp_image_mem_native_handle_t>(devPtr),
-      &urFormat, &urDesc, urSampler, &urImageHandle);
+      urCtx, urDevice,
+      reinterpret_cast<ur_exp_image_mem_native_handle_t>(devPtr), &urFormat,
+      &urDesc, urSampler, &urImageHandle);
 
   return sampled_image_handle{urImageHandle};
 }
@@ -437,13 +397,7 @@ template <>
 __SYCL_EXPORT external_mem import_external_memory<resource_fd>(
     external_mem_descriptor<resource_fd> externalMemDesc,
     const sycl::device &syclDevice, const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_exp_external_mem_handle_t urExternalMem = nullptr;
   ur_exp_file_descriptor_t urFileDescriptor = {};
@@ -459,7 +413,7 @@ __SYCL_EXPORT external_mem import_external_memory<resource_fd>(
   Adapter
       ->call<sycl::errc::invalid,
              sycl::detail::UrApiKind::urBindlessImagesImportExternalMemoryExp>(
-          C, Device, externalMemDesc.size_in_bytes,
+          urCtx, urDevice, externalMemDesc.size_in_bytes,
           UR_EXP_EXTERNAL_MEM_TYPE_OPAQUE_FD, &urExternalMemDescriptor,
           &urExternalMem);
 
@@ -478,13 +432,7 @@ template <>
 __SYCL_EXPORT external_mem import_external_memory<resource_win32_handle>(
     external_mem_descriptor<resource_win32_handle> externalMemDesc,
     const sycl::device &syclDevice, const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_exp_external_mem_handle_t urExternalMem = nullptr;
   ur_exp_win32_handle_t urWin32Handle = {};
@@ -511,7 +459,7 @@ __SYCL_EXPORT external_mem import_external_memory<resource_win32_handle>(
   Adapter
       ->call<sycl::errc::invalid,
              sycl::detail::UrApiKind::urBindlessImagesImportExternalMemoryExp>(
-          C, Device, externalMemDesc.size_in_bytes, urHandleType,
+          urCtx, urDevice, externalMemDesc.size_in_bytes, urHandleType,
           &urExternalMemDescriptor, &urExternalMem);
 
   return external_mem{urExternalMem};
@@ -532,13 +480,7 @@ image_mem_handle map_external_image_memory(external_mem extMem,
                                            const sycl::context &syclContext) {
   desc.verify();
 
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -549,7 +491,8 @@ image_mem_handle map_external_image_memory(external_mem extMem,
   image_mem_handle retHandle = {};
   Adapter->call<sycl::errc::invalid,
                 sycl::detail::UrApiKind::urBindlessImagesMapExternalArrayExp>(
-      C, Device, &urFormat, &urDesc, urExternalMem, &retHandle.raw_handle);
+      urCtx, urDevice, &urFormat, &urDesc, urExternalMem,
+      &retHandle.raw_handle);
 
   return image_mem_handle{retHandle};
 }
@@ -566,13 +509,7 @@ __SYCL_EXPORT
 void *map_external_linear_memory(external_mem extMem, uint64_t offset,
                                  uint64_t size, const sycl::device &syclDevice,
                                  const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_exp_external_mem_handle_t urExternalMem{extMem.raw_handle};
 
@@ -580,7 +517,7 @@ void *map_external_linear_memory(external_mem extMem, uint64_t offset,
   Adapter->call<
       sycl::errc::invalid,
       sycl::detail::UrApiKind::urBindlessImagesMapExternalLinearMemoryExp>(
-      C, Device, offset, size, urExternalMem, &retMemory);
+      urCtx, urDevice, offset, size, urExternalMem, &retMemory);
 
   return retMemory;
 }
@@ -595,18 +532,12 @@ void *map_external_linear_memory(external_mem extMem, uint64_t offset,
 __SYCL_EXPORT void release_external_memory(external_mem extMem,
                                            const sycl::device &syclDevice,
                                            const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   Adapter
       ->call<sycl::errc::invalid,
              sycl::detail::UrApiKind::urBindlessImagesReleaseExternalMemoryExp>(
-          C, Device, extMem.raw_handle);
+          urCtx, urDevice, extMem.raw_handle);
 }
 
 __SYCL_EXPORT void release_external_memory(external_mem extMem,
@@ -619,13 +550,7 @@ template <>
 __SYCL_EXPORT external_semaphore import_external_semaphore(
     external_semaphore_descriptor<resource_fd> externalSemaphoreDesc,
     const sycl::device &syclDevice, const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_exp_external_semaphore_handle_t urExternalSemaphore = nullptr;
   ur_exp_file_descriptor_t urFileDescriptor = {};
@@ -656,7 +581,7 @@ __SYCL_EXPORT external_semaphore import_external_semaphore(
   Adapter->call<
       sycl::errc::invalid,
       sycl::detail::UrApiKind::urBindlessImagesImportExternalSemaphoreExp>(
-      C, Device, urHandleType, &urExternalSemDesc, &urExternalSemaphore);
+      urCtx, urDevice, urHandleType, &urExternalSemDesc, &urExternalSemaphore);
 
   return external_semaphore{urExternalSemaphore,
                             externalSemaphoreDesc.handle_type};
@@ -674,13 +599,7 @@ template <>
 __SYCL_EXPORT external_semaphore import_external_semaphore(
     external_semaphore_descriptor<resource_win32_handle> externalSemaphoreDesc,
     const sycl::device &syclDevice, const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_exp_external_semaphore_handle_t urExternalSemaphore = nullptr;
   ur_exp_win32_handle_t urWin32Handle = {};
@@ -710,7 +629,7 @@ __SYCL_EXPORT external_semaphore import_external_semaphore(
   Adapter->call<
       sycl::errc::invalid,
       sycl::detail::UrApiKind::urBindlessImagesImportExternalSemaphoreExp>(
-      C, Device, urHandleType, &urExternalSemDesc, &urExternalSemaphore);
+      urCtx, urDevice, urHandleType, &urExternalSemDesc, &urExternalSemaphore);
 
   return external_semaphore{urExternalSemaphore,
                                   externalSemaphoreDesc.handle_type};
@@ -728,18 +647,12 @@ __SYCL_EXPORT void
 release_external_semaphore(external_semaphore externalSemaphore,
                            const sycl::device &syclDevice,
                            const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   Adapter->call<
       sycl::errc::invalid,
       sycl::detail::UrApiKind::urBindlessImagesReleaseExternalSemaphoreExp>(
-      C, Device, externalSemaphore.raw_handle);
+      urCtx, urDevice, externalSemaphore.raw_handle);
 }
 
 __SYCL_EXPORT void
@@ -752,27 +665,22 @@ release_external_semaphore(external_semaphore externalSemaphore,
 __SYCL_EXPORT sycl::range<3> get_image_range(const image_mem_handle memHandle,
                                              const sycl::device &syclDevice,
                                              const sycl::context &syclContext) {
-  std::ignore = syclDevice;
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  (void)syclDevice;
+  auto [urCtx, Adapter] = get_ur_handles(syclContext);
 
   size_t Width = 0, Height = 0, Depth = 0;
 
   Adapter->call<sycl::errc::invalid,
                 sycl::detail::UrApiKind::urBindlessImagesImageGetInfoExp>(
-      CtxImpl->getHandleRef(), memHandle.raw_handle, UR_IMAGE_INFO_WIDTH,
-      &Width, nullptr);
+      urCtx, memHandle.raw_handle, UR_IMAGE_INFO_WIDTH, &Width, nullptr);
 
   Adapter->call<sycl::errc::invalid,
                 sycl::detail::UrApiKind::urBindlessImagesImageGetInfoExp>(
-      CtxImpl->getHandleRef(), memHandle.raw_handle, UR_IMAGE_INFO_HEIGHT,
-      &Height, nullptr);
+      urCtx, memHandle.raw_handle, UR_IMAGE_INFO_HEIGHT, &Height, nullptr);
 
   Adapter->call<sycl::errc::invalid,
                 sycl::detail::UrApiKind::urBindlessImagesImageGetInfoExp>(
-      CtxImpl->getHandleRef(), memHandle.raw_handle, UR_IMAGE_INFO_DEPTH,
-      &Depth, nullptr);
+      urCtx, memHandle.raw_handle, UR_IMAGE_INFO_DEPTH, &Depth, nullptr);
 
   return {Width, Height, Depth};
 }
@@ -787,17 +695,14 @@ __SYCL_EXPORT sycl::image_channel_type
 get_image_channel_type(const image_mem_handle memHandle,
                        const sycl::device &syclDevice,
                        const sycl::context &syclContext) {
-  std::ignore = syclDevice;
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  (void)syclDevice;
+  auto [urCtx, Adapter] = get_ur_handles(syclContext);
 
   ur_image_format_t URFormat = {};
 
   Adapter->call<sycl::errc::invalid,
                 sycl::detail::UrApiKind::urBindlessImagesImageGetInfoExp>(
-      CtxImpl->getHandleRef(), memHandle.raw_handle, UR_IMAGE_INFO_FORMAT,
-      &URFormat, nullptr);
+      urCtx, memHandle.raw_handle, UR_IMAGE_INFO_FORMAT, &URFormat, nullptr);
 
   image_channel_type ChannelType =
       sycl::detail::convertChannelType(URFormat.channelType);
@@ -823,18 +728,12 @@ __SYCL_EXPORT void *pitched_alloc_device(size_t *resultPitch,
                           "Cannot allocate pitched memory with zero size!");
   }
 
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-
-  ur_context_handle_t UrContext = CtxImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
-  ur_device_handle_t UrDevice =
-      sycl::detail::getSyclObjImpl(syclDevice)->getHandleRef();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   Adapter->call<sycl::errc::memory_allocation,
                 sycl::detail::UrApiKind::urUSMPitchedAllocExp>(
-      UrContext, UrDevice, nullptr, nullptr, widthInBytes, height,
-      elementSizeBytes, &RetVal, resultPitch);
+      urCtx, urDevice, nullptr, nullptr, widthInBytes, height, elementSizeBytes,
+      &RetVal, resultPitch);
 
   return RetVal;
 }
@@ -873,17 +772,13 @@ __SYCL_EXPORT unsigned int
 get_image_num_channels(const image_mem_handle memHandle,
                        const sycl::device &syclDevice,
                        const sycl::context &syclContext) {
-  std::ignore = syclDevice;
-
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  (void)syclDevice;
+  auto [urCtx, Adapter] = get_ur_handles(syclContext);
   ur_image_format_t URFormat = {};
 
   Adapter->call<sycl::errc::runtime,
                 sycl::detail::UrApiKind::urBindlessImagesImageGetInfoExp>(
-      CtxImpl->getHandleRef(), memHandle.raw_handle, UR_IMAGE_INFO_FORMAT,
-      &URFormat, nullptr);
+      urCtx, memHandle.raw_handle, UR_IMAGE_INFO_FORMAT, &URFormat, nullptr);
 
   image_channel_order Order =
       sycl::detail::convertChannelOrder(URFormat.channelOrder);

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -341,5 +341,21 @@ void GetCapabilitiesIntersectionSet(const std::vector<sycl::device> &Devices,
 }
 
 } // namespace detail
+
+// We're under sycl/source and these won't be exported but it's way more
+// convenient to be able to reference them without extra `detail::`.
+inline auto get_ur_handles(const sycl::context &syclContext) {
+  sycl::detail::context_impl &Ctx = *sycl::detail::getSyclObjImpl(syclContext);
+  ur_context_handle_t urCtx = Ctx.getHandleRef();
+  const sycl::detail::Adapter *Adapter = Ctx.getAdapter().get();
+  return std::tuple{urCtx, Adapter};
+}
+inline auto get_ur_handles(const sycl::device &syclDevice,
+                           const sycl::context &syclContext) {
+  auto [urCtx, Adapter] = get_ur_handles(syclContext);
+  ur_device_handle_t urDevice =
+      sycl::detail::getSyclObjImpl(syclDevice)->getHandleRef();
+  return std::tuple{urDevice, urCtx, Adapter};
+}
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/detail/memory_pool_impl.cpp
+++ b/sycl/source/detail/memory_pool_impl.cpp
@@ -24,14 +24,7 @@ ur_usm_pool_handle_t
 create_memory_pool_device(const sycl::context &ctx, const sycl::device &dev,
                           const size_t threshold, const size_t maxSize,
                           const bool readOnly, const bool zeroInit) {
-
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(ctx);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(dev);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(dev, ctx);
 
   ur_usm_pool_limits_desc_t LimitsDesc{UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC,
                                        nullptr, maxSize, threshold};
@@ -49,25 +42,18 @@ create_memory_pool_device(const sycl::context &ctx, const sycl::device &dev,
 
   Adapter
       ->call<sycl::errc::runtime, sycl::detail::UrApiKind::urUSMPoolCreateExp>(
-          C, Device, &PoolDesc, &poolHandle);
+          urCtx, urDevice, &PoolDesc, &poolHandle);
 
   return poolHandle;
 }
 
 void destroy_memory_pool(const sycl::context &ctx, const sycl::device &dev,
                          ur_usm_pool_handle_t &poolHandle) {
-
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(ctx);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(dev);
-  ur_device_handle_t Device = DevImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(dev, ctx);
 
   Adapter
       ->call<sycl::errc::runtime, sycl::detail::UrApiKind::urUSMPoolDestroyExp>(
-          C, Device, poolHandle);
+          urCtx, urDevice, poolHandle);
 }
 } // namespace
 

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -62,10 +62,7 @@ void *alignedAllocHost(size_t Alignment, size_t Size, const sycl::context &Ctxt,
   if (Size == 0)
     return nullptr;
 
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(Ctxt);
-  ur_context_handle_t C = CtxImpl->getHandleRef();
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  auto [urCtx, Adapter] = get_ur_handles(Ctxt);
   ur_result_t Error = UR_RESULT_ERROR_INVALID_VALUE;
 
     ur_usm_desc_t UsmDesc{};
@@ -87,7 +84,7 @@ void *alignedAllocHost(size_t Alignment, size_t Size, const sycl::context &Ctxt,
     }
 
     Error = Adapter->call_nocheck<sycl::detail::UrApiKind::urUSMHostAlloc>(
-        C, &UsmDesc,
+        urCtx, &UsmDesc,
         /* pool= */ nullptr, Size, &RetVal);
 
     // Error is for debugging purposes.
@@ -525,16 +522,13 @@ alloc get_pointer_type(const void *Ptr, const context &Ctxt) {
   if (!Ptr)
     return alloc::unknown;
 
-  std::shared_ptr<detail::context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
-
-  ur_context_handle_t URCtx = CtxImpl->getHandleRef();
+  auto [urCtx, Adapter] = get_ur_handles(Ctxt);
   ur_usm_type_t AllocTy;
 
   // query type using UR function
-  const detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
   ur_result_t Err =
       Adapter->call_nocheck<detail::UrApiKind::urUSMGetMemAllocInfo>(
-          URCtx, Ptr, UR_USM_ALLOC_INFO_TYPE, sizeof(ur_usm_type_t), &AllocTy,
+          urCtx, Ptr, UR_USM_ALLOC_INFO_TYPE, sizeof(ur_usm_type_t), &AllocTy,
           nullptr);
 
   // UR_RESULT_ERROR_INVALID_VALUE means USM doesn't know about this ptr
@@ -576,11 +570,11 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
     throw exception(make_error_code(errc::invalid),
                     "Ptr not a valid USM allocation!");
 
-  std::shared_ptr<detail::context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
+  auto [urCtx, Adapter] = get_ur_handles(Ctxt);
 
   // Check if ptr is a host allocation
   if (get_pointer_type(Ptr, Ctxt) == alloc::host) {
-    auto Devs = CtxImpl->getDevices();
+    auto Devs = detail::getSyclObjImpl(Ctxt)->getDevices();
     if (Devs.size() == 0)
       throw exception(make_error_code(errc::invalid),
                       "No devices in passed context!");
@@ -589,19 +583,17 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
     return Devs[0];
   }
 
-  ur_context_handle_t URCtx = CtxImpl->getHandleRef();
   ur_device_handle_t DeviceId;
 
   // query device using UR function
-  const detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
   Adapter->call<detail::UrApiKind::urUSMGetMemAllocInfo>(
-      URCtx, Ptr, UR_USM_ALLOC_INFO_DEVICE, sizeof(ur_device_handle_t),
+      urCtx, Ptr, UR_USM_ALLOC_INFO_DEVICE, sizeof(ur_device_handle_t),
       &DeviceId, nullptr);
 
   // The device is not necessarily a member of the context, it could be a
   // member's descendant instead. Fetch the corresponding device from the cache.
   const std::shared_ptr<detail::platform_impl> &PltImpl =
-      CtxImpl->getPlatformImpl();
+      detail::getSyclObjImpl(Ctxt)->getPlatformImpl();
   std::shared_ptr<detail::device_impl> DevImpl =
       PltImpl->getDeviceImpl(DeviceId);
   if (DevImpl)
@@ -614,20 +606,16 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
 
 static void prepare_for_usm_device_copy(const void *Ptr, size_t Size,
                                         const context &Ctxt) {
-  std::shared_ptr<detail::context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
-  ur_context_handle_t URCtx = CtxImpl->getHandleRef();
+  auto [urCtx, Adapter] = get_ur_handles(Ctxt);
   // Call the UR function
-  const detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
   Adapter->call<detail::UrApiKind::urUSMImportExp>(
-      URCtx, const_cast<void *>(Ptr), Size);
+      urCtx, const_cast<void *>(Ptr), Size);
 }
 
 static void release_from_usm_device_copy(const void *Ptr, const context &Ctxt) {
-  std::shared_ptr<detail::context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
-  ur_context_handle_t URCtx = CtxImpl->getHandleRef();
+  auto [urCtx, Adapter] = get_ur_handles(Ctxt);
   // Call the UR function
-  const detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
-  Adapter->call<detail::UrApiKind::urUSMReleaseExp>(URCtx,
+  Adapter->call<detail::UrApiKind::urUSMReleaseExp>(urCtx,
                                                     const_cast<void *>(Ptr));
 }
 


### PR DESCRIPTION
To reduce the amount of boilerplate code necessary without it. As a nice side effect avoids creation of temporary `std::shared_ptr` where using references would have been enough.