### PR TITLE
[SYCL] Hide inline definitions of stdio functions

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1547,6 +1547,13 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
       Builder.defineMacro("__ENABLE_USM_ADDR_SPACE__");
       Builder.defineMacro("SYCL_DISABLE_FALLBACK_ASSERT");
     }
+
+    // Despite the name, DeviceTriple is not necessarily the device triple.
+    if (DeviceTriple.isWindowsMSVCEnvironment()) {
+      // MSVC inline definitions of stdio functions should not be used for SYCL
+      // device code.
+      Builder.defineMacro("_NO_CRT_STDIO_INLINE");
+    }
   } else if (LangOpts.SYCLIsHost && LangOpts.SYCLESIMDBuildHostCode) {
     Builder.defineMacro("__ESIMD_BUILD_HOST_CODE");
   }

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1535,21 +1535,21 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     if (LangOpts.GPURelocatableDeviceCode)
       Builder.defineMacro("SYCL_EXTERNAL", "__attribute__((sycl_device))");
 
-    const llvm::Triple &DeviceTriple = TI.getTriple();
-    const llvm::Triple::SubArchType DeviceSubArch = DeviceTriple.getSubArch();
-    if (DeviceTriple.isNVPTX() || DeviceTriple.isAMDGPU() ||
-        (DeviceTriple.isSPIR() &&
-         DeviceSubArch != llvm::Triple::SPIRSubArch_fpga) ||
+    // This gets called twice, once with TI set to the host TargetInfo, once
+    // with TI set to the device TargetInfo.
+    const llvm::Triple &Triple = TI.getTriple();
+    const llvm::Triple::SubArchType SubArch = Triple.getSubArch();
+    if (Triple.isNVPTX() || Triple.isAMDGPU() ||
+        (Triple.isSPIR() && SubArch != llvm::Triple::SPIRSubArch_fpga) ||
         LangOpts.SYCLIsNativeCPU)
       Builder.defineMacro("SYCL_USE_NATIVE_FP_ATOMICS");
     // Enable generation of USM address spaces for FPGA.
-    if (DeviceSubArch == llvm::Triple::SPIRSubArch_fpga) {
+    if (SubArch == llvm::Triple::SPIRSubArch_fpga) {
       Builder.defineMacro("__ENABLE_USM_ADDR_SPACE__");
       Builder.defineMacro("SYCL_DISABLE_FALLBACK_ASSERT");
     }
 
-    // Despite the name, DeviceTriple is not necessarily the device triple.
-    if (DeviceTriple.isWindowsMSVCEnvironment()) {
+    if (Triple.isWindowsMSVCEnvironment()) {
       // MSVC inline definitions of stdio functions should not be used for SYCL
       // device code.
       Builder.defineMacro("_NO_CRT_STDIO_INLINE");


### PR DESCRIPTION
MSVC's inline definitions of stdio functions such as printf() are only meant for host code; device code cannot call them. Device code can, however, call ext::oneapi::experimental::printf() which depending on the target is implemented as a call to the global printf(). The availability of a definition of the global host printf() makes it more difficult to handle in device code, so hide it.