### PR TITLE
[UR][L0 v2] Do not use logger::error in queue dtor

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -178,7 +178,7 @@ ur_queue_immediate_in_order_t::~ur_queue_immediate_in_order_t() {
   try {
     UR_CALL_THROWS(queueFinish());
   } catch (...) {
-    logger::error("Failed to finish queue on destruction");
+    // Ignore errors during destruction
   }
 }
 


### PR DESCRIPTION
The logger might throw leading to an abort.

The error message will be printed anyway if the PrintTrace is set.