### PR TITLE
[UR][OpenCL] Add missing mapping for CL_INVALID_KERNEL to UR OpenCL adapter and handle CL_INVALID_KERNEL_DEFINITION in urKernelCreate

### DIFF
--- a/unified-runtime/source/adapters/opencl/common.cpp
+++ b/unified-runtime/source/adapters/opencl/common.cpp
@@ -102,6 +102,8 @@ ur_result_t mapCLErrorToUR(cl_int Result) {
     return UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE;
   case CL_INVALID_SPEC_ID:
     return UR_RESULT_ERROR_INVALID_SPEC_ID;
+  case CL_INVALID_KERNEL:
+    return UR_RESULT_ERROR_INVALID_KERNEL;
   default:
     return UR_RESULT_ERROR_UNKNOWN;
   }

--- a/unified-runtime/source/adapters/opencl/kernel.cpp
+++ b/unified-runtime/source/adapters/opencl/kernel.cpp
@@ -70,8 +70,7 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
 
     if (CLResult == CL_INVALID_KERNEL_DEFINITION) {
       cl_adapter::setErrorMessage(
-          "urKernelCreate failing with CL_INVALID_KERNEL_DEFINITION",
-          UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+          "clCreateKernel failed with CL_INVALID_KERNEL_DEFINITION", CLResult);
       return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
     }
 

--- a/unified-runtime/source/adapters/opencl/kernel.cpp
+++ b/unified-runtime/source/adapters/opencl/kernel.cpp
@@ -67,6 +67,14 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
     cl_int CLResult;
     cl_kernel Kernel =
         clCreateKernel(hProgram->CLProgram, pKernelName, &CLResult);
+
+    if (CLResult == CL_INVALID_KERNEL_DEFINITION) {
+      cl_adapter::setErrorMessage(
+          "urKernelCreate failing with CL_INVALID_KERNEL_DEFINITION",
+          UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+    }
+
     CL_RETURN_ON_FAILURE(CLResult);
     auto URKernel = std::make_unique<ur_kernel_handle_t_>(Kernel, hProgram,
                                                           hProgram->Context);


### PR DESCRIPTION
Fixes https://github.com/oneapi-src/unified-runtime/issues/2555

Also handles checking for CL_INVALID_KERNEL_DEFINITION inside urKernelCreate.