### PR TITLE
[UR][Graph] command-buffer unsupported OpenCL CTS tests

### DIFF
--- a/unified-runtime/test/conformance/exp_command_buffer/commands.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/commands.cpp
@@ -56,12 +56,18 @@ struct urCommandBufferCommandsTest
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferCommandsTest);
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMMemcpyExp) {
+  // No USM memcpy command in cl_khr_command_buffer
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   ASSERT_SUCCESS(urCommandBufferAppendUSMMemcpyExp(
       cmd_buf_handle, device_ptrs[0], device_ptrs[1], allocation_size, 0,
       nullptr, 0, nullptr, nullptr, nullptr, nullptr));
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMFillExp) {
+  // No USM fill command in cl_khr_command_buffer
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   uint32_t pattern = 42;
   ASSERT_SUCCESS(urCommandBufferAppendUSMFillExp(
       cmd_buf_handle, device_ptrs[0], &pattern, sizeof(pattern),
@@ -83,6 +89,10 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferCopyRectExp) {
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferReadExp) {
+  // No buffer read command in cl_khr_command_buffer
+  // See https://github.com/KhronosGroup/OpenCL-Docs/issues/1281
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   std::array<uint32_t, elements> host_data{};
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferReadExp(
       cmd_buf_handle, buffers[0], 0, allocation_size, host_data.data(), 0,
@@ -90,6 +100,10 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferReadExp) {
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferReadRectExp) {
+  // No buffer read command in cl_khr_command_buffer
+  // See https://github.com/KhronosGroup/OpenCL-Docs/issues/1281
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   std::array<uint32_t, elements> host_data{};
   ur_rect_offset_t origin{0, 0, 0};
   ur_rect_region_t region{4, 4, 1};
@@ -99,6 +113,10 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferReadRectExp) {
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferWriteExp) {
+  // No buffer write command in cl_khr_command_buffer
+  // See https://github.com/KhronosGroup/OpenCL-Docs/issues/1281
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   std::array<uint32_t, elements> host_data{};
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferWriteExp(
       cmd_buf_handle, buffers[0], 0, allocation_size, host_data.data(), 0,
@@ -107,6 +125,10 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferWriteExp) {
 
 TEST_P(urCommandBufferCommandsTest,
        urCommandBufferAppendMemBufferWriteRectExp) {
+  // No buffer write command in cl_khr_command_buffer
+  // See https://github.com/KhronosGroup/OpenCL-Docs/issues/1281
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   std::array<uint32_t, elements> host_data{};
   ur_rect_offset_t origin{0, 0, 0};
   ur_rect_region_t region{4, 4, 1};
@@ -123,12 +145,18 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferFillExp) {
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMPrefetchExp) {
+  // No Prefetch command in cl_khr_command_buffer
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   ASSERT_SUCCESS(urCommandBufferAppendUSMPrefetchExp(
       cmd_buf_handle, device_ptrs[0], allocation_size, 0, 0, nullptr, 0,
       nullptr, nullptr, nullptr, nullptr));
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMAdviseExp) {
+  // No advise command in cl_khr_command_buffer
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   ASSERT_SUCCESS(urCommandBufferAppendUSMAdviseExp(
       cmd_buf_handle, device_ptrs[0], allocation_size, 0, 0, nullptr, 0,
       nullptr, nullptr, nullptr, nullptr));

--- a/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
@@ -109,6 +109,9 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     printFillTestString<urCommandBufferFillCommandsTest>);
 
 TEST_P(urCommandBufferFillCommandsTest, Buffer) {
+  // No buffer read command in cl_khr_command_buffer
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferFillExp(
       cmd_buf_handle, buffer, pattern.data(), pattern_size, 0, size, 0, nullptr,
       0, nullptr, &sync_point, nullptr, nullptr));
@@ -128,6 +131,9 @@ TEST_P(urCommandBufferFillCommandsTest, Buffer) {
 }
 
 TEST_P(urCommandBufferFillCommandsTest, ExecuteTwice) {
+  // No buffer read command in cl_khr_command_buffer
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferFillExp(
       cmd_buf_handle, buffer, pattern.data(), pattern_size, 0, size, 0, nullptr,
       0, nullptr, &sync_point, nullptr, nullptr));
@@ -149,6 +155,9 @@ TEST_P(urCommandBufferFillCommandsTest, ExecuteTwice) {
 }
 
 TEST_P(urCommandBufferFillCommandsTest, USM) {
+  // No USM fill command in cl_khr_command_buffer
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   ASSERT_SUCCESS(urCommandBufferAppendUSMFillExp(
       cmd_buf_handle, device_ptr, pattern.data(), pattern_size, size, 0,
       nullptr, 0, nullptr, &sync_point, nullptr, nullptr));


### PR DESCRIPTION
There are currently limitations on what commands can be added to a SYCL-Graph that we document in the [design doc](https://github.com/intel/llvm/blob/sycl/sycl/doc/design/CommandGraph.md#opencl) and mark as unsupported in Graph E2E tests.

However, we never marked the equivalent UR command-buffer commands as unsupported in the CTS, so they will currently fail when testing against an OpenCL backend with support for the extension. Address this by marking CTS tests which use these commands as unsupported.

Note that this will conflict with https://github.com/intel/llvm/pull/18177 in that some CTS tests can be re-enabled, but I can resolve that based on whatever merges first.