### PR TITLE
[SYCL] Reintroduce secondary queue by reverting #18045 and #17967

### DIFF
--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -86,10 +86,8 @@ public:
   sycl::detail::optional<SubmitPostProcessF> &PostProcessorFunc();
   const sycl::detail::optional<SubmitPostProcessF> &PostProcessorFunc() const;
 
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   std::shared_ptr<detail::queue_impl> &SecondaryQueue();
   const std::shared_ptr<detail::queue_impl> &SecondaryQueue() const;
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   ext::oneapi::experimental::event_mode_enum &EventMode();
   const ext::oneapi::experimental::event_mode_enum &EventMode() const;
@@ -3620,11 +3618,13 @@ private:
   template <bool UseFallbackAssert, typename PropertiesT>
   event submit_with_event(
       PropertiesT Props, const detail::type_erased_cgfo_ty &CGF,
-      [[maybe_unused]] queue *SecondaryQueuePtr,
+      queue *SecondaryQueuePtr,
       const detail::code_location &CodeLoc = detail::code_location::current()) {
     detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
     detail::SubmissionInfo SI{};
     ProcessSubmitProperties(Props, SI);
+    if (SecondaryQueuePtr)
+      SI.SecondaryQueue() = detail::getSyclObjImpl(*SecondaryQueuePtr);
     if constexpr (UseFallbackAssert)
       SI.PostProcessorFunc() =
           [this, &SecondaryQueuePtr,

--- a/sycl/source/detail/handler_impl.hpp
+++ b/sycl/source/detail/handler_impl.hpp
@@ -31,8 +31,10 @@ enum class HandlerSubmissionState : std::uint8_t {
 
 class handler_impl {
 public:
-  handler_impl(queue_impl *SubmissionPrimaryQueue, bool EventNeeded)
+  handler_impl(queue_impl *SubmissionPrimaryQueue,
+               queue_impl *SubmissionSecondaryQueue, bool EventNeeded)
       : MSubmissionPrimaryQueue(SubmissionPrimaryQueue),
+        MSubmissionSecondaryQueue(SubmissionSecondaryQueue),
         MEventNeeded(EventNeeded) {};
 
   handler_impl(
@@ -71,6 +73,12 @@ public:
   /// the queue associated with the handler if the corresponding submission is
   /// a fallback from a previous submission.
   queue_impl *MSubmissionPrimaryQueue = nullptr;
+
+  /// Shared pointer to the secondary queue implementation. Nullptr if no
+  /// secondary queue fallback was given in the associated submission. This is
+  /// equal to the queue associated with the handler if the corresponding
+  /// submission is a fallback from a previous submission.
+  queue_impl *MSubmissionSecondaryQueue = nullptr;
 
   /// Bool stores information about whether the event resulting from the
   /// corresponding work is required.

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -70,9 +70,7 @@ enum QueueOrder { Ordered, OOO };
 // Implementation of the submission information storage.
 struct SubmissionInfoImpl {
   optional<detail::SubmitPostProcessF> MPostProcessorFunc = std::nullopt;
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   std::shared_ptr<detail::queue_impl> MSecondaryQueue = nullptr;
-#endif
   ext::oneapi::experimental::event_mode_enum MEventMode =
       ext::oneapi::experimental::event_mode_enum::none;
 };
@@ -342,11 +340,12 @@ public:
   /// group is being enqueued on.
   event submit(const detail::type_erased_cgfo_ty &CGF,
                const std::shared_ptr<queue_impl> &Self,
-               [[maybe_unused]] const std::shared_ptr<queue_impl> &SecondQueue,
+               const std::shared_ptr<queue_impl> &SecondQueue,
                const detail::code_location &Loc, bool IsTopCodeLoc,
                const SubmitPostProcessF *PostProcess = nullptr) {
     event ResEvent;
     SubmissionInfo SI{};
+    SI.SecondaryQueue() = SecondQueue;
     if (PostProcess)
       SI.PostProcessorFunc() = *PostProcess;
     return submit_with_event(CGF, Self, SI, Loc, IsTopCodeLoc);
@@ -365,6 +364,21 @@ public:
                           const std::shared_ptr<queue_impl> &Self,
                           const SubmissionInfo &SubmitInfo,
                           const detail::code_location &Loc, bool IsTopCodeLoc) {
+    if (SubmitInfo.SecondaryQueue()) {
+      event ResEvent;
+      const std::shared_ptr<queue_impl> &SecondQueue =
+          SubmitInfo.SecondaryQueue();
+      try {
+        ResEvent = submit_impl(CGF, Self, Self, SecondQueue,
+                               /*CallerNeedsEvent=*/true, Loc, IsTopCodeLoc,
+                               SubmitInfo);
+      } catch (...) {
+        ResEvent = SecondQueue->submit_impl(CGF, SecondQueue, Self, SecondQueue,
+                                            /*CallerNeedsEvent=*/true, Loc,
+                                            IsTopCodeLoc, SubmitInfo);
+      }
+      return ResEvent;
+    }
     event ResEvent =
         submit_impl(CGF, Self, Self, nullptr,
                     /*CallerNeedsEvent=*/true, Loc, IsTopCodeLoc, SubmitInfo);
@@ -376,8 +390,21 @@ public:
                             const SubmissionInfo &SubmitInfo,
                             const detail::code_location &Loc,
                             bool IsTopCodeLoc) {
-    submit_impl(CGF, Self, Self, nullptr, /*CallerNeedsEvent=*/false, Loc,
-                IsTopCodeLoc, SubmitInfo);
+    if (SubmitInfo.SecondaryQueue()) {
+      const std::shared_ptr<queue_impl> SecondQueue =
+          SubmitInfo.SecondaryQueue();
+      try {
+        submit_impl(CGF, Self, Self, SecondQueue,
+                    /*CallerNeedsEvent=*/false, Loc, IsTopCodeLoc, SubmitInfo);
+      } catch (...) {
+        SecondQueue->submit_impl(CGF, SecondQueue, Self, SecondQueue,
+                                 /*CallerNeedsEvent=*/false, Loc, IsTopCodeLoc,
+                                 SubmitInfo);
+      }
+    } else {
+      submit_impl(CGF, Self, Self, nullptr, /*CallerNeedsEvent=*/false, Loc,
+                  IsTopCodeLoc, SubmitInfo);
+    }
   }
 
   /// Performs a blocking wait for the completion of all enqueued tasks in the

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -314,28 +314,26 @@ fill_copy_args(detail::handler_impl *impl,
 
 handler::handler(std::shared_ptr<detail::queue_impl> Queue,
                  bool CallerNeedsEvent)
-    : impl(std::make_shared<detail::handler_impl>(Queue.get(),
+    : impl(std::make_shared<detail::handler_impl>(Queue.get(), nullptr,
                                                   CallerNeedsEvent)),
       MQueue(std::move(Queue)) {}
 
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 // TODO: This function is not used anymore, remove it in the next
 // ABI-breaking window.
-handler::handler(
-    std::shared_ptr<detail::queue_impl> Queue,
-    std::shared_ptr<detail::queue_impl> PrimaryQueue,
-    [[maybe_unused]] std::shared_ptr<detail::queue_impl> SecondaryQueue,
-    bool CallerNeedsEvent)
-    : impl(std::make_shared<detail::handler_impl>(PrimaryQueue.get(),
-                                                  CallerNeedsEvent)),
+handler::handler(std::shared_ptr<detail::queue_impl> Queue,
+                 std::shared_ptr<detail::queue_impl> PrimaryQueue,
+                 std::shared_ptr<detail::queue_impl> SecondaryQueue,
+                 bool CallerNeedsEvent)
+    : impl(std::make_shared<detail::handler_impl>(
+          PrimaryQueue.get(), SecondaryQueue.get(), CallerNeedsEvent)),
       MQueue(Queue) {}
 #endif
 
 handler::handler(std::shared_ptr<detail::queue_impl> Queue,
                  detail::queue_impl *PrimaryQueue,
-                 [[maybe_unused]] detail::queue_impl *SecondaryQueue,
-                 bool CallerNeedsEvent)
-    : impl(std::make_shared<detail::handler_impl>(PrimaryQueue,
+                 detail::queue_impl *SecondaryQueue, bool CallerNeedsEvent)
+    : impl(std::make_shared<detail::handler_impl>(PrimaryQueue, SecondaryQueue,
                                                   CallerNeedsEvent)),
       MQueue(std::move(Queue)) {}
 
@@ -1777,6 +1775,14 @@ void handler::use_kernel_bundle(
         "Context associated with the primary queue is different from the "
         "context associated with the kernel bundle");
 
+  if (impl->MSubmissionSecondaryQueue &&
+      impl->MSubmissionSecondaryQueue->get_context() !=
+          ExecBundle.get_context())
+    throw sycl::exception(
+        make_error_code(errc::invalid),
+        "Context associated with the secondary queue is different from the "
+        "context associated with the kernel bundle");
+
   setStateExplicitKernelBundle();
   setHandlerKernelBundle(detail::getSyclObjImpl(ExecBundle));
 }
@@ -1922,28 +1928,34 @@ void handler::verifyDeviceHasProgressGuarantee(
 }
 
 bool handler::supportsUSMMemcpy2D() {
-  auto &PrimQueue = impl->MSubmissionPrimaryQueue;
-  if (PrimQueue)
-    return checkContextSupports(PrimQueue->getContextImplPtr(),
-                                UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT);
-  else
-    // Return true when handler_impl is constructed with a graph.
-    return true;
+  for (detail::queue_impl *QueueImpl :
+       {impl->MSubmissionPrimaryQueue, impl->MSubmissionSecondaryQueue}) {
+    if (QueueImpl &&
+        !checkContextSupports(QueueImpl->getContextImplPtr(),
+                              UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT))
+      return false;
+  }
+  return true;
 }
 
 bool handler::supportsUSMFill2D() {
-  auto &PrimQueue = impl->MSubmissionPrimaryQueue;
-  if (PrimQueue)
-    return checkContextSupports(PrimQueue->getContextImplPtr(),
-                                UR_CONTEXT_INFO_USM_FILL2D_SUPPORT);
-  else
-    // Return true when handler_impl is constructed with a graph.
-    return true;
+  for (detail::queue_impl *QueueImpl :
+       {impl->MSubmissionPrimaryQueue, impl->MSubmissionSecondaryQueue}) {
+    if (QueueImpl && !checkContextSupports(QueueImpl->getContextImplPtr(),
+                                           UR_CONTEXT_INFO_USM_FILL2D_SUPPORT))
+      return false;
+  }
+  return true;
 }
 
 bool handler::supportsUSMMemset2D() {
-  // memset use the same UR check as fill2D.
-  return supportsUSMFill2D();
+  for (detail::queue_impl *QueueImpl :
+       {impl->MSubmissionPrimaryQueue, impl->MSubmissionSecondaryQueue}) {
+    if (QueueImpl && !checkContextSupports(QueueImpl->getContextImplPtr(),
+                                           UR_CONTEXT_INFO_USM_FILL2D_SUPPORT))
+      return false;
+  }
+  return true;
 }
 
 id<2> handler::computeFallbackKernelBounds(size_t Width, size_t Height) {

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -32,7 +32,6 @@ const optional<SubmitPostProcessF> &SubmissionInfo::PostProcessorFunc() const {
   return impl->MPostProcessorFunc;
 }
 
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 std::shared_ptr<detail::queue_impl> &SubmissionInfo::SecondaryQueue() {
   return impl->MSecondaryQueue;
 }
@@ -41,7 +40,6 @@ const std::shared_ptr<detail::queue_impl> &
 SubmissionInfo::SecondaryQueue() const {
   return impl->MSecondaryQueue;
 }
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 ext::oneapi::experimental::event_mode_enum &SubmissionInfo::EventMode() {
   return impl->MEventMode;


### PR DESCRIPTION
Reverts #18045 and #17967

I'll create a follow-up PR to:
1. Remove Secondary queue from fallback (which is legal)
2. Have separate code paths, one when user specifies secondary queue and one without it.