### PR TITLE
[Driver][SYCL] Remove object upon failure

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2711,8 +2711,8 @@ int Driver::ExecuteCompilation(
       // When performing offload compilations, the result files may not match
       // the JobAction that fails.  In that case, do not pass in the JobAction
       // to allow for the proper resulting file to be removed upon failure.
-      C.CleanupFileMap(C.getResultFiles(), C.getActiveOffloadKinds()
-                       ? nullptr : JA, true);
+      C.CleanupFileMap(C.getResultFiles(),
+                       C.getActiveOffloadKinds() ? nullptr : JA, true);
 
       // Failure result files are valid unless we crashed.
       if (CommandRes < 0)

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2708,7 +2708,11 @@ int Driver::ExecuteCompilation(
     // Remove result files if we're not saving temps.
     if (!isSaveTempsEnabled()) {
       const JobAction *JA = cast<JobAction>(&FailingCommand->getSource());
-      C.CleanupFileMap(C.getResultFiles(), JA, true);
+      // When performing offload compilations, the result files may not match
+      // the JobAction that fails.  In that case, do not pass in the JobAction
+      // to allow for the proper resulting file to be removed upon failure.
+      C.CleanupFileMap(C.getResultFiles(), C.getActiveOffloadKinds()
+                       ? nullptr : JA, true);
 
       // Failure result files are valid unless we crashed.
       if (CommandRes < 0)

--- a/clang/test/Driver/sycl-obj-remove.cpp
+++ b/clang/test/Driver/sycl-obj-remove.cpp
@@ -2,15 +2,25 @@
 
 // REQUIRES: system-linux
 
+/// Force failure during device compilation
 // RUN: touch %t.o
-// RUN: not %clangxx -fsycl -Xsycl-target-frontend -DCOMPILE_HOST_FAIL=1 -o %t.o %s
+// RUN: not %clangxx -fsycl -Xsycl-target-frontend -DCOMPILE_FAIL=1 -c -o %t.o %s
 // RUN: not ls %t.o
 
 // RUN: touch %t.o
-// RUN: not %clangxx --offload-new-driver -fsycl -Xsycl-target-frontend -DCOMPILE_HOST_FAIL=1 -o %t.o %s
+// RUN: not %clangxx --offload-new-driver -fsycl -Xsycl-target-frontend -DCOMPILE_FAIL=1 -c -o %t.o %s
+// RUN: not ls %t.o
+
+/// Force failure during compilation
+// RUN: touch %t.o
+// RUN: not %clangxx -fsycl -DCOMPILE_FAIL=1 -c -o %t.o %s
+// RUN: not ls %t.o
+
+// RUN: touch %t.o
+// RUN: not %clangxx --offload-new-driver -fsycl -DCOMPILE_FAIL=1 -c -o %t.o %s
 // RUN: not ls %t.o
 
 void func(){};
-#ifdef COMPILE_HOST_FAIL
+#ifdef COMPILE_FAIL
 #error FAIL
-#endif // COMPILE_HOST_FAIL
+#endif // COMPILE_FAIL

--- a/clang/test/Driver/sycl-obj-remove.cpp
+++ b/clang/test/Driver/sycl-obj-remove.cpp
@@ -1,0 +1,16 @@
+/// Verify object removal when the offload compilation fails.
+
+// REQUIRES: system-linux
+
+// RUN: touch %t.o
+// RUN: not %clangxx -fsycl -Xsycl-target-frontend -DCOMPILE_HOST_FAIL=1 -o %t.o %s
+// RUN: not ls %t.o
+
+// RUN: touch %t.o
+// RUN: not %clangxx --offload-new-driver -fsycl -Xsycl-target-frontend -DCOMPILE_HOST_FAIL=1 -o %t.o %s
+// RUN: not ls %t.o
+
+void func(){};
+#ifdef COMPILE_HOST_FAIL
+#error FAIL
+#endif // COMPILE_HOST_FAIL


### PR DESCRIPTION
Typical behaviors when the compilation fails is to have the resulting output object to be removed. Due to the fact that there are multiple compilations that occur during an offload compilation, the actual final output object may not be directly associated with the compile causing it to not be removed.

Update the cleanup file list to remove the output result file regardless of the associated job action when we are performing offload.