### PR TITLE
[SYCL] Do not lock event_impl when it not shared with other threads

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -570,14 +570,18 @@ void event_impl::cleanupDependencyEvents() {
   MPreparedHostDepsEvents.clear();
 }
 
-void event_impl::cleanDepEventsThroughOneLevel() {
-  std::lock_guard<std::mutex> Lock(MMutex);
+void event_impl::cleanDepEventsThroughOneLevelUnlocked() {
   for (auto &Event : MPreparedDepsEvents) {
     Event->cleanupDependencyEvents();
   }
   for (auto &Event : MPreparedHostDepsEvents) {
     Event->cleanupDependencyEvents();
   }
+}
+
+void event_impl::cleanDepEventsThroughOneLevel() {
+  std::lock_guard<std::mutex> Lock(MMutex);
+  cleanDepEventsThroughOneLevelUnlocked();
 }
 
 void event_impl::setSubmissionTime() {

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -217,6 +217,9 @@ public:
   /// Cleans dependencies of this event's dependencies.
   void cleanDepEventsThroughOneLevel();
 
+  /// Cleans dependencies of this event's dependencies w/o locking MMutex.
+  void cleanDepEventsThroughOneLevelUnlocked();
+
   /// Checks if this event is discarded by SYCL implementation.
   ///
   /// \return true if this event is discarded.

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -439,7 +439,8 @@ event queue_impl::submitMemOpHelper(const std::shared_ptr<queue_impl> &Self,
             ExpandedDepEventImplPtrs.push_back(
                 detail::getSyclObjImpl(DepEvent));
 
-          EventImpl->cleanDepEventsThroughOneLevel();
+          // EventImpl is local for current thread, no need to lock
+          EventImpl->cleanDepEventsThroughOneLevelUnlocked();
         }
       }
 

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -439,7 +439,7 @@ event queue_impl::submitMemOpHelper(const std::shared_ptr<queue_impl> &Self,
             ExpandedDepEventImplPtrs.push_back(
                 detail::getSyclObjImpl(DepEvent));
 
-          // EventImpl is local for current thread, no need to lock
+          // EventImpl is local for current thread, no need to lock.
           EventImpl->cleanDepEventsThroughOneLevelUnlocked();
         }
       }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -578,7 +578,7 @@ event handler::finalize() {
           LastEventImpl->getPreparedDepsEvents() =
               std::move(impl->CGData.MEvents);
           // LastEventImpl is local for current thread, no need to lock
-          LastEventImpl->cleanDepEventsThroughOneLevel();
+          LastEventImpl->cleanDepEventsThroughOneLevelUnlocked();
         }
       }
       return MLastEvent;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -574,7 +574,9 @@ event handler::finalize() {
         LastEventImpl->setEnqueued();
         // connect returned event with dependent events
         if (!MQueue->isInOrder()) {
-          LastEventImpl->getPreparedDepsEvents() = impl->CGData.MEvents;
+          // MEvents is not used anymore, so can move
+          LastEventImpl->getPreparedDepsEvents() = std::move(impl->CGData.MEvents);
+          // LastEventImpl is local for current thread, no need to lock
           LastEventImpl->cleanDepEventsThroughOneLevel();
         }
       }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -577,7 +577,7 @@ event handler::finalize() {
           // MEvents is not used anymore, so can move.
           LastEventImpl->getPreparedDepsEvents() =
               std::move(impl->CGData.MEvents);
-          // LastEventImpl is local for current thread, no need to lock
+          // LastEventImpl is local for current thread, no need to lock.
           LastEventImpl->cleanDepEventsThroughOneLevelUnlocked();
         }
       }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -574,7 +574,7 @@ event handler::finalize() {
         LastEventImpl->setEnqueued();
         // connect returned event with dependent events
         if (!MQueue->isInOrder()) {
-          // MEvents is not used anymore, so can move
+          // MEvents is not used anymore, so can move.
           LastEventImpl->getPreparedDepsEvents() =
               std::move(impl->CGData.MEvents);
           // LastEventImpl is local for current thread, no need to lock

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -575,7 +575,8 @@ event handler::finalize() {
         // connect returned event with dependent events
         if (!MQueue->isInOrder()) {
           // MEvents is not used anymore, so can move
-          LastEventImpl->getPreparedDepsEvents() = std::move(impl->CGData.MEvents);
+          LastEventImpl->getPreparedDepsEvents() =
+              std::move(impl->CGData.MEvents);
           // LastEventImpl is local for current thread, no need to lock
           LastEventImpl->cleanDepEventsThroughOneLevel();
         }


### PR DESCRIPTION
The code was added in 64546e7, but locks are superfluous.