### PR TITLE
[SYCL] Re-enable math tests for spirv

### DIFF
--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: spirv-backend
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17813
 // REQUIRES: aspect-fp64
 // UNSUPPORTED: target-amd || target-nvidia
 

--- a/sycl/test-e2e/DeviceLib/cmath_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_test.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: spirv-backend
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17813
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 
 // RUN: %{build} -fno-builtin %{mathflags} -o %t1.out

--- a/sycl/test-e2e/DeviceLib/math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_fp64_test.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: spirv-backend
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17813
 // REQUIRES: aspect-fp64
 
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}

--- a/sycl/test-e2e/DeviceLib/math_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_test.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: spirv-backend
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17813
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 
 // RUN: %{build} %{mathflags} -o %t1.out


### PR DESCRIPTION
The last LLVM-SPIRV pulldown brought in the fix for modf.