### PR TITLE
[SYCL] Fix bindless images tests with windows cl

### DIFF
--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled_semaphore.cpp
@@ -4,7 +4,8 @@
 // XFAIL: run-mode
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15851
 
-// RUN: %{build} -l d3d12 -l dxgi -l dxguid -o %t.out
+// DEFINE: %{link-flags}=%if cl_options %{ /clang:-ld3d12 /clang:-ldxgi /clang:-ldxguid %} %else %{ -ld3d12 -ldxgi -ldxguid %}
+// RUN: %{build} %{link-flags} -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out
 
 #define TEST_SEMAPHORE_IMPORT

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -586,18 +586,16 @@ else:
 config.substitutions.append(("%vulkan_include_dir", config.vulkan_include_dir))
 config.substitutions.append(("%vulkan_lib", config.vulkan_lib))
 
+link_vulkan = "-I %s " % (config.vulkan_include_dir)
 if platform.system() == "Windows":
-    config.substitutions.append(
-        ("%link-vulkan", "-l %s -I %s" % (config.vulkan_lib, config.vulkan_include_dir))
-    )
+    if cl_options:
+        link_vulkan += "/clang:-l%s" % (config.vulkan_lib)
+    else:
+        link_vulkan += "-l %s" % (config.vulkan_lib)
 else:
     vulkan_lib_path = os.path.dirname(config.vulkan_lib)
-    config.substitutions.append(
-        (
-            "%link-vulkan",
-            "-L %s -lvulkan -I %s" % (vulkan_lib_path, config.vulkan_include_dir),
-        )
-    )
+    link_vulkan += "-L %s -lvulkan" % (vulkan_lib_path)
+config.substitutions.append(("%link-vulkan", link_vulkan))
 
 if config.vulkan_found == "TRUE":
     config.available_features.add("vulkan")


### PR DESCRIPTION
These tests were failing on Windows when using a msvc-like compiler such as `clang-cl`, so this patch makes sure we're using the correct style of options depending on the compiler.