### PR TITLE
[SYCL][E2E] Re-enable tests hanging on Windows BMG

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/eager_init.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/eager_init.cpp
@@ -3,9 +3,6 @@
 // UNSUPPORTED-INTENDED: ze_debug UR emits summary of leaks that contains
 // function names that we match in the test.
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18067
-
 // RUN: %{build} -Wno-error=deprecated-declarations %level_zero_options -o %t.out
 // RUN: env UR_L0_DEBUG=1 SYCL_EAGER_INIT=1 %{run} %t.out 2>&1 | FileCheck %s
 //

--- a/sycl/test-e2e/Reduction/reduction_ctor.cpp
+++ b/sycl/test-e2e/Reduction/reduction_ctor.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21 && (!build-mode && run-mode)
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17582
-
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows
 

--- a/sycl/test-e2e/USM/hmemll.cpp
+++ b/sycl/test-e2e/USM/hmemll.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21 && (!build-mode && run-mode)
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17582
-
 //==------------------- hmemll.cpp - Host Memory Linked List test ----------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
Fixes #18067 and #17582 

These were fixed with the Windows driver being updated.