### PR TITLE
[SYCL] Revert  (#17871), enqueue status reset.  

### DIFF
--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -84,13 +84,6 @@ bool Scheduler::GraphProcessor::enqueueCommand(
     return false;
   }
 
-  // Reset enqueue status if reattempting
-
-  if (!Cmd->isHostTask() &&
-      Cmd->MEnqueueStatus == EnqueueResultT::SyclEnqueueFailed) {
-    Cmd->MEnqueueStatus = EnqueueResultT::SyclEnqueueReady;
-  }
-
   // Recursively enqueue all the implicit + explicit backend level dependencies
   // first and exit immediately if any of the commands cannot be enqueued.
   for (const EventImplPtr &Event : Cmd->getPreparedDepsEvents()) {

--- a/sycl/unittests/scheduler/FailedCommands.cpp
+++ b/sycl/unittests/scheduler/FailedCommands.cpp
@@ -20,14 +20,13 @@ TEST_F(SchedulerTest, FailedDependency) {
   queue Queue(context(Plt), default_selector_v);
 
   detail::Requirement MockReq = getMockRequirement();
-  MockCommand MDepFail(
-      false, detail::getSyclObjImpl(Queue)); // <-- will fail to enqueue
+  MockCommand MDep(detail::getSyclObjImpl(Queue));
   MockCommand MUser(detail::getSyclObjImpl(Queue));
-  MDepFail.addUser(&MUser);
+  MDep.addUser(&MUser);
   std::vector<detail::Command *> ToCleanUp;
-  (void)MUser.addDep(detail::DepDesc{&MDepFail, &MockReq, nullptr}, ToCleanUp);
+  (void)MUser.addDep(detail::DepDesc{&MDep, &MockReq, nullptr}, ToCleanUp);
   MUser.MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueReady;
-  MDepFail.MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueReady;
+  MDep.MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueFailed;
 
   MockScheduler MS;
   auto Lock = MS.acquireGraphReadLock();
@@ -36,13 +35,13 @@ TEST_F(SchedulerTest, FailedDependency) {
       MockScheduler::enqueueCommand(&MUser, Res, detail::NON_BLOCKING);
 
   ASSERT_FALSE(Enqueued) << "Enqueue process must fail\n";
-  ASSERT_EQ(Res.MCmd, &MDepFail) << "Wrong failed command\n";
+  ASSERT_EQ(Res.MCmd, &MDep) << "Wrong failed command\n";
   ASSERT_EQ(Res.MResult, detail::EnqueueResultT::SyclEnqueueFailed)
       << "Enqueue process must fail\n";
   ASSERT_EQ(MUser.MEnqueueStatus, detail::EnqueueResultT::SyclEnqueueReady)
       << "MUser shouldn't be marked as failed\n";
-  ASSERT_EQ(MDepFail.MEnqueueStatus, detail::EnqueueResultT::SyclEnqueueFailed)
-      << "MDepFail should be marked as failed\n";
+  ASSERT_EQ(MDep.MEnqueueStatus, detail::EnqueueResultT::SyclEnqueueFailed)
+      << "MDep should be marked as failed\n";
 }
 
 void RunWithFailedCommandsAndCheck(bool SyncExceptionExpected,

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -54,17 +54,6 @@ public:
     EXPECT_CALL(*this, enqueue).Times(AnyNumber());
   }
 
-  // This Mock will fail to enqueue.
-  MockCommand(
-      bool, sycl::detail::QueueImplPtr Queue,
-      sycl::detail::Command::CommandType Type = sycl::detail::Command::RUN_CG)
-      : Command{Type, Queue}, MRequirement{std::move(getMockRequirement())} {
-    using namespace testing;
-    ON_CALL(*this, enqueue)
-        .WillByDefault(Invoke(this, &MockCommand::enqueueFail));
-    EXPECT_CALL(*this, enqueue).Times(AnyNumber());
-  }
-
   void printDot(std::ostream &) const override {}
   void emitInstrumentationData() override {}
 
@@ -81,14 +70,6 @@ public:
                      sycl::detail::BlockingT Blocking,
                      std::vector<sycl::detail::Command *> &ToCleanUp) {
     return sycl::detail::Command::enqueue(EnqueueResult, Blocking, ToCleanUp);
-  }
-  bool enqueueFail(sycl::detail::EnqueueResultT &EnqueueResult,
-                   sycl::detail::BlockingT Blocking,
-                   std::vector<sycl::detail::Command *> &ToCleanUp) {
-    this->MEnqueueStatus = sycl::detail::EnqueueResultT::SyclEnqueueFailed;
-    EnqueueResult = {sycl::detail::EnqueueResultT::SyclEnqueueFailed, this};
-    ToCleanUp.push_back(this);
-    return false;
   }
 
   ur_result_t MRetVal = UR_RESULT_SUCCESS;


### PR DESCRIPTION
reverting "[SYCL] reset enqueue status so that buffer can be used after …failure is addressed (#17871)"

This PR accidentally introduced a very subtle flaky failure/seg fault. I quickly tried the immediate and obvious fixes but no luck. Given that the original problem is lower priority, I'm reverting the commit before we cement in the instability.

Addresses issue: https://github.com/intel/llvm/issues/17965

This reverts commit a827836a167c3e075db0916421c176cbe5c176ce.