### PR TITLE
[SYCL][UR][L0 v2] fix wait_list_view contruction

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -20,9 +20,12 @@ struct wait_list_view {
   ze_event_handle_t *handles;
   uint32_t num;
 
+  wait_list_view(ze_event_handle_t *handles, uint32_t num)
+      : handles(num > 0 ? handles : nullptr), num(num) {}
+
   operator bool() const {
     assert((handles != nullptr) == (num > 0));
-    return handles != nullptr;
+    return num > 0;
   }
 
   void clear() {


### PR DESCRIPTION
getWaitListView assumed that calling data() on ane empty vector will return nullptr - this is not guaranteed.

This lead to assert in operator bool() trigerring.

Implement a constructor for wait_list_view that will set the handles to NULL if num is 0.