### PR TITLE
[SYCL] Fix missing xpti ifdefs

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -501,8 +501,8 @@ graph_impl::add(std::function<void(handler &)> CGF,
   sycl::handler Handler{shared_from_this()};
 
 #if XPTI_ENABLE_INSTRUMENTATION
-  // save code location if one was set in TLS.
-  // idealy it would be nice to capture user's call code location
+  // Save code location if one was set in TLS.
+  // Ideally it would be nice to capture user's call code location
   // by adding a parameter to the graph.add function, but this will
   // break the API. At least capture code location from TLS, user
   // can set it before calling graph.add

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -500,6 +500,7 @@ graph_impl::add(std::function<void(handler &)> CGF,
   (void)Args;
   sycl::handler Handler{shared_from_this()};
 
+#if XPTI_ENABLE_INSTRUMENTATION
   // save code location if one was set in TLS.
   // idealy it would be nice to capture user's call code location
   // by adding a parameter to the graph.add function, but this will
@@ -509,6 +510,7 @@ graph_impl::add(std::function<void(handler &)> CGF,
     sycl::detail::tls_code_loc_t Tls;
     Handler.saveCodeLoc(Tls.query(), Tls.isToplevel());
   }
+#endif
 
   CGF(Handler);
 

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -321,9 +321,12 @@ event queue_impl::submit_impl(const detail::type_erased_cgfo_ty &CGF,
   handler Handler(Self, PrimaryQueue.get(), SecondaryQueue.get(),
                   CallerNeedsEvent);
   auto &HandlerImpl = detail::getSyclObjImpl(Handler);
+
+#if XPTI_ENABLE_INSTRUMENTATION
   if (xptiTraceEnabled()) {
     Handler.saveCodeLoc(Loc, IsTopCodeLoc);
   }
+#endif
 
   {
     NestedCallsTracker tracker;


### PR DESCRIPTION
This fixes the build with `SYCL_ENABLE_XPTI_TRACING=OFF`.