### PR TITLE
[SYCL] [Graph] Reduce number of queue_impl creation

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -834,13 +834,6 @@ ur_exp_command_buffer_sync_point_t exec_graph_impl::enqueueNode(
     ur_exp_command_buffer_handle_t CommandBuffer,
     std::shared_ptr<node_impl> Node) {
 
-  // Queue which will be used for allocation operations for accessors.
-  // Will also be used in native commands to return to the user in
-  // `interop_handler::get_native_queue()` calls.
-  auto AllocaQueue = std::make_shared<sycl::detail::queue_impl>(
-      DeviceImpl, sycl::detail::getSyclObjImpl(Ctx), sycl::async_handler{},
-      sycl::property_list{});
-
   std::vector<ur_exp_command_buffer_sync_point_t> Deps;
   for (auto &N : Node->MPredecessors) {
     findRealDeps(Deps, N.lock(), MPartitionNodes[Node]);
@@ -848,8 +841,8 @@ ur_exp_command_buffer_sync_point_t exec_graph_impl::enqueueNode(
 
   sycl::detail::EventImplPtr Event =
       sycl::detail::Scheduler::getInstance().addCG(
-          Node->getCGCopy(), AllocaQueue, /*EventNeeded=*/true, CommandBuffer,
-          Deps);
+          Node->getCGCopy(), MQueueImpl,
+          /*EventNeeded=*/true, CommandBuffer, Deps);
 
   if (MIsUpdatable) {
     MCommandMap[Node] = Event->getCommandBufferCommand();
@@ -922,6 +915,10 @@ exec_graph_impl::exec_graph_impl(sycl::context Context,
                                  const std::shared_ptr<graph_impl> &GraphImpl,
                                  const property_list &PropList)
     : MSchedule(), MGraphImpl(GraphImpl), MSyncPoints(),
+      MQueueImpl(std::make_shared<sycl::detail::queue_impl>(
+          sycl::detail::getSyclObjImpl(GraphImpl->getDevice()),
+          sycl::detail::getSyclObjImpl(Context), sycl::async_handler{},
+          sycl::property_list{})),
       MDevice(GraphImpl->getDevice()), MContext(Context), MRequirements(),
       MExecutionEvents(),
       MIsUpdatable(PropList.has_property<property::graph::updatable>()),
@@ -1360,16 +1357,11 @@ void exec_graph_impl::update(
       ++It;
     }
 
-    auto AllocaQueue = std::make_shared<sycl::detail::queue_impl>(
-        sycl::detail::getSyclObjImpl(MGraphImpl->getDevice()),
-        sycl::detail::getSyclObjImpl(MGraphImpl->getContext()),
-        sycl::async_handler{}, sycl::property_list{});
-
     // Track the event for the update command since execution may be blocked by
     // other scheduler commands
     auto UpdateEvent =
         sycl::detail::Scheduler::getInstance().addCommandGraphUpdate(
-            this, Nodes, AllocaQueue, std::move(UpdateRequirements),
+            this, Nodes, MQueueImpl, std::move(UpdateRequirements),
             MExecutionEvents);
 
     MExecutionEvents.push_back(UpdateEvent);

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -829,10 +829,9 @@ exec_graph_impl::enqueueNodeDirect(sycl::context Ctx,
   return NewSyncPoint;
 }
 
-ur_exp_command_buffer_sync_point_t exec_graph_impl::enqueueNode(
-    sycl::context Ctx, std::shared_ptr<sycl::detail::device_impl> DeviceImpl,
-    ur_exp_command_buffer_handle_t CommandBuffer,
-    std::shared_ptr<node_impl> Node) {
+ur_exp_command_buffer_sync_point_t
+exec_graph_impl::enqueueNode(ur_exp_command_buffer_handle_t CommandBuffer,
+                             std::shared_ptr<node_impl> Node) {
 
   std::vector<ur_exp_command_buffer_sync_point_t> Deps;
   for (auto &N : Node->MPredecessors) {
@@ -887,8 +886,7 @@ void exec_graph_impl::createCommandBuffers(
       MSyncPoints[Node] =
           enqueueNodeDirect(MContext, DeviceImpl, OutCommandBuffer, Node);
     } else {
-      MSyncPoints[Node] =
-          enqueueNode(MContext, DeviceImpl, OutCommandBuffer, Node);
+      MSyncPoints[Node] = enqueueNode(OutCommandBuffer, Node);
     }
 
     // Append Node requirements to overall graph requirements

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "detail/queue_impl.hpp"
 #include <sycl/detail/cg_types.hpp>
 #include <sycl/detail/os_util.hpp>
 #include <sycl/ext/oneapi/experimental/graph.hpp>
@@ -1442,6 +1443,8 @@ private:
   std::unordered_map<std::shared_ptr<node_impl>,
                      ur_exp_command_buffer_sync_point_t>
       MSyncPoints;
+  /// Sycl queue impl ptr associated with this graph.
+  std::shared_ptr<sycl::detail::queue_impl> MQueueImpl;
   /// Map of nodes in the exec graph to the partition number to which they
   /// belong.
   std::unordered_map<std::shared_ptr<node_impl>, int> MPartitionNodes;

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -1344,8 +1344,7 @@ private:
   /// @param Node The node being enqueued.
   /// @return UR sync point created for this node in the command-buffer.
   ur_exp_command_buffer_sync_point_t
-  enqueueNode(sycl::context Ctx, sycl::detail::DeviceImplPtr DeviceImpl,
-              ur_exp_command_buffer_handle_t CommandBuffer,
+  enqueueNode(ur_exp_command_buffer_handle_t CommandBuffer,
               std::shared_ptr<node_impl> Node);
 
   /// Enqueue a node directly to the command-buffer without going through the

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -1338,8 +1338,6 @@ public:
 private:
   /// Create a command-group for the node and add it to command-buffer by going
   /// through the scheduler.
-  /// @param Ctx Context to use.
-  /// @param DeviceImpl Device associated with the enqueue.
   /// @param CommandBuffer Command-buffer to add node to as a command.
   /// @param Node The node being enqueued.
   /// @return UR sync point created for this node in the command-buffer.


### PR DESCRIPTION
We were creating queue_impl each time we were enqueueing a node or updating it. It makes sense to cache queue_impl as a private member of `exec_graph_impl`.