### PR TITLE
[SYCL] Addrspacecast needed even in non-alloca sret

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5346,13 +5346,14 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
       // chosen IndirectAS can happen e.g. when passing the this pointer through
       // a chain involving stores to / loads from the DefaultAS; we address this
       // here, symmetrically with the handling we have for normal pointer args.
-      if (CGM.getCodeGenOpts().UseAllocaASForSrets &&
-          (SRetPtr.getAddressSpace() != RetAI.getIndirectAddrSpace())) {
+      unsigned RetAddrSpace = CGM.getCodeGenOpts().UseAllocaASForSrets
+                                  ? RetAI.getIndirectAddrSpace()
+                                  : CGM.getTypes().getTargetAddressSpace(RetTy);
+      if (SRetPtr.getAddressSpace() != RetAddrSpace) {
         llvm::Value *V = SRetPtr.getBasePointer();
         LangAS SAS = getLangASFromTargetAS(SRetPtr.getAddressSpace());
-        LangAS DAS = getLangASFromTargetAS(RetAI.getIndirectAddrSpace());
-        llvm::Type *Ty = llvm::PointerType::get(getLLVMContext(),
-                                                RetAI.getIndirectAddrSpace());
+        LangAS DAS = getLangASFromTargetAS(RetAddrSpace);
+        llvm::Type *Ty = llvm::PointerType::get(getLLVMContext(), RetAddrSpace);
 
         SRetPtr = SRetPtr.withPointer(
             getTargetHooks().performAddrSpaceCast(*this, V, SAS, DAS, Ty, true),


### PR DESCRIPTION
This is a follow up to #17976 

In EmitCall, we assumed that the address space mismatch between the return type argument
and the corresponding function parameter will not occur when UseAllocaASForSrets is not in effect.
Extended testing demonstrated that it is needed then too.