### PR TITLE
[SYCL] reenable Win BMG tests .o…

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/events_caching.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/events_caching.cpp
@@ -2,9 +2,6 @@
 // UNSUPPORTED: level_zero_v2_adapter
 // UNSUPPORTED-INTENDED: v2 adapter does not allow disabling caching
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17255
-
 // RUN: %{build}  -o %t.out
 
 // RUN: %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --check-prefixes=CACHING-ENABLED %s

--- a/sycl/test-e2e/Adapters/level_zero/events_caching_leak.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/events_caching_leak.cpp
@@ -7,9 +7,6 @@
 // Check that events and pools are not leaked when event caching is
 // enabled/disabled.
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17916
-
 #include <array>
 #include <sycl/detail/core.hpp>
 


### PR DESCRIPTION
There have been Win teardown fixes ( https://github.com/intel/llvm/issues/17916 )  and the BMG drivers have been updated.  

Tested on one of our Win BMG machines and the tests run promptly and pass.

also see https://github.com/intel/llvm/pull/18204  for other hanging BMG tests now being successfully reenabled.