### PR TITLE
[NFC][SYCL] fix flaky build fail in ze_trace_collector target

### DIFF
--- a/sycl/tools/sycl-trace/CMakeLists.txt
+++ b/sycl/tools/sycl-trace/CMakeLists.txt
@@ -18,6 +18,9 @@ if ("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)
     ze_trace_collector
   )
   add_dependencies(sycl-trace ze_trace_collector)
+  target_include_directories(ze_trace_collector PRIVATE
+    "${sycl_inc_dir}"
+  )
 endif()
 
 if ("cuda" IN_LIST SYCL_ENABLE_BACKENDS)


### PR DESCRIPTION
sycl/detail/spinlock.hpp is included in ze_trace_collector.cpp. ze_trace_collector target should either depend on sycl-headers target or include sycl_inc_dir.