### PR TITLE
[SYCL] Fix syclbin-dump build on non clang/gcc compilers

### DIFF
--- a/sycl/tools/syclbin-dump/CMakeLists.txt
+++ b/sycl/tools/syclbin-dump/CMakeLists.txt
@@ -12,7 +12,10 @@ if (WIN32 AND "${build_type_lower}" MATCHES "debug")
 endif()
 target_link_libraries(syclbin-dump PRIVATE ${sycl_lib})
 
-target_compile_options(syclbin-dump PRIVATE -fno-rtti)
+if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
+    (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+  target_compile_options(syclbin-dump PRIVATE -fno-rtti)
+endif()
 
 add_dependencies(sycl-toolchain syclbin-dump)
 


### PR DESCRIPTION
This commit avoids a warning produced by
https://github.com/intel/llvm/pull/16873 when building syclbin-dump using compilers other than gcc and clang, where the -fno-rtti option isn't available.