### PR TITLE
[SYCL] Add missing xpti ifdef

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -318,9 +318,11 @@ event queue_impl::submit_impl(const detail::type_erased_cgfo_ty &CGF,
                               const SubmissionInfo &SubmitInfo) {
   handler Handler(Self, SecondaryQueue, CallerNeedsEvent);
   auto &HandlerImpl = detail::getSyclObjImpl(Handler);
+#ifdef XPTI_ENABLE_INSTRUMENTATION
   if (xptiTraceEnabled()) {
     Handler.saveCodeLoc(Loc, IsTopCodeLoc);
   }
+#endif
 
   {
     NestedCallsTracker tracker;


### PR DESCRIPTION
`xptiTraceEnabled` is only available when `XPTI_ENABLE_INSTRUMENTATION` is on.