### PR TITLE
[SYCL][E2E] Add missing sg-32 requires

### DIFF
--- a/sycl/test-e2e/SubGroup/attributes_cuda_hip.cpp
+++ b/sycl/test-e2e/SubGroup/attributes_cuda_hip.cpp
@@ -9,6 +9,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// REQUIRES: sg-32
 
 #include "attributes_helper.hpp"
 

--- a/sycl/test-e2e/syclcompat/launch/launch_policy.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy.cpp
@@ -19,6 +19,7 @@
  *  Description:
  *     launch<F> with config tests
  **************************************************************************/
+// REQUIRES: sg-32
 
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
These tests are using `redq_sub_group_size(32)` so they should require the feature.

This is visible on certain AMD GPUs that use a 64 thread sub-group size instead of 32 threads.