### PR TITLE
[Bindless][UR][LevelZero] Fix memory leak caused by not destroying sampler handles

### DIFF
--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -237,6 +237,10 @@ struct ur_device_handle_t_ : ur_object {
   std::unordered_map<ur_exp_image_native_handle_t, ze_image_handle_t>
       ZeOffsetToImageHandleMap;
 
+  // Map (sampled) bindless image handle to its corresponding sampler.
+  std::unordered_map<ur_exp_image_native_handle_t, ze_sampler_handle_t>
+      ZeImageToSamplerMap;
+
   // unique ephemeral identifer of the device in the adapter
   std::optional<DeviceId> Id;
 };

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -237,9 +237,9 @@ struct ur_device_handle_t_ : ur_object {
   std::unordered_map<ur_exp_image_native_handle_t, ze_image_handle_t>
       ZeOffsetToImageHandleMap;
 
-  // Map (sampled) bindless image handle to its corresponding sampler.
-  std::unordered_map<ur_exp_image_native_handle_t, ze_sampler_handle_t>
-      ZeImageToSamplerMap;
+  // Map (sampled) bindless image handle to its corresponding sampler handle.
+  std::unordered_map<ur_exp_image_native_handle_t, ur_sampler_handle_t>
+      UrImageToSamplerMap;
 
   // unique ephemeral identifer of the device in the adapter
   std::optional<DeviceId> Id;

--- a/unified-runtime/source/adapters/level_zero/sampler.hpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.hpp
@@ -19,3 +19,7 @@ struct ur_sampler_handle_t_ : ur_object {
 
   ZeStruct<ze_sampler_desc_t> ZeSamplerDesc;
 };
+
+ur_result_t releaseSamplerHandle(
+    /// [in] handle of the sampler object to release
+    ur_sampler_handle_t Sampler);


### PR DESCRIPTION
This PR fixes memory leaks where both UR and LevelZero sampler handles weren't being released and memory wasn't cleaned up appropriately when the bindless images object gets destroyed. The old SYCL 2020 images' sampler implementation is different as it is a self-managed RAII object which is not true for bindless images, hence we need to ensure, depending on the requirements of the backend/adapter API, to manage the lifetime of the sampler associated to the bindless image accordingly.