### PR TITLE
[SYCL] Pass NULL instead of {0, 0, 0} offset

### DIFF
--- a/sycl/source/detail/cg.hpp
+++ b/sycl/source/detail/cg.hpp
@@ -134,6 +134,13 @@ public:
       ClusterDimensions[I] = (I < Dims) ? N[I] : 1;
   }
 
+  bool hasOffset() const {
+    bool HasOffset = false;
+    for (int I = 0; I < 3; ++I)
+      HasOffset |= GlobalOffset[I];
+    return HasOffset;
+  }
+
   NDRDescT &operator=(const NDRDescT &Desc) = default;
   NDRDescT &operator=(NDRDescT &&Desc) = default;
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2431,6 +2431,10 @@ static ur_result_t SetKernelParamsAndLaunch(
 
   size_t RequiredWGSize[3] = {0, 0, 0};
   size_t *LocalSize = nullptr;
+  size_t *GlobalOffset = nullptr;
+
+  if (NDRDesc.hasOffset())
+    GlobalOffset = &NDRDesc.GlobalOffset[0];
 
   if (HasLocalSize)
     LocalSize = &NDRDesc.LocalSize[0];
@@ -2478,9 +2482,9 @@ static ur_result_t SetKernelParamsAndLaunch(
     ur_event_handle_t UREvent = nullptr;
     ur_result_t Error =
         Adapter->call_nocheck<UrApiKind::urEnqueueKernelLaunchCustomExp>(
-            Queue->getHandleRef(), Kernel, NDRDesc.Dims,
-            &NDRDesc.GlobalOffset[0], &NDRDesc.GlobalSize[0], LocalSize,
-            property_list.size(), property_list.data(), RawEvents.size(),
+            Queue->getHandleRef(), Kernel, NDRDesc.Dims, GlobalOffset,
+            &NDRDesc.GlobalSize[0], LocalSize, property_list.size(),
+            property_list.data(), RawEvents.size(),
             RawEvents.empty() ? nullptr : &RawEvents[0],
             OutEventImpl ? &UREvent : nullptr);
     if ((Error == UR_RESULT_SUCCESS) && OutEventImpl) {
@@ -2497,7 +2501,7 @@ static ur_result_t SetKernelParamsAndLaunch(
                   Args...);
         }
         return Adapter->call_nocheck<UrApiKind::urEnqueueKernelLaunch>(Args...);
-      }(Queue->getHandleRef(), Kernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],
+      }(Queue->getHandleRef(), Kernel, NDRDesc.Dims, GlobalOffset,
         &NDRDesc.GlobalSize[0], LocalSize, RawEvents.size(),
         RawEvents.empty() ? nullptr : &RawEvents[0],
         OutEventImpl ? &UREvent : nullptr);
@@ -2605,6 +2609,10 @@ ur_result_t enqueueImpCommandBufferKernel(
 
   size_t RequiredWGSize[3] = {0, 0, 0};
   size_t *LocalSize = nullptr;
+  size_t *GlobalOffset = nullptr;
+
+  if (NDRDesc.hasOffset())
+    GlobalOffset = &NDRDesc.GlobalOffset[0];
 
   if (HasLocalSize)
     LocalSize = &NDRDesc.LocalSize[0];
@@ -2633,7 +2641,7 @@ ur_result_t enqueueImpCommandBufferKernel(
 
   ur_result_t Res =
       Adapter->call_nocheck<UrApiKind::urCommandBufferAppendKernelLaunchExp>(
-          CommandBuffer, UrKernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],
+          CommandBuffer, UrKernel, NDRDesc.Dims, GlobalOffset,
           &NDRDesc.GlobalSize[0], LocalSize, AltUrKernels.size(),
           AltUrKernels.size() ? AltUrKernels.data() : nullptr,
           SyncPoints.size(), SyncPoints.size() ? SyncPoints.data() : nullptr, 0,


### PR DESCRIPTION
UR adapters check against NULL to avoid setting an offset, so passing NULL should improve performance.