### PR TITLE
[SYCL] tighten known_identity to finite_math macro

### DIFF
--- a/sycl/include/sycl/known_identity.hpp
+++ b/sycl/include/sycl/known_identity.hpp
@@ -263,6 +263,8 @@ struct known_identity_impl<BinaryOperation, AccumulatorT,
   // Finite math only (-ffast-math,  -fno-honor-infinities) improves
   // performance, but does not affect ::has_infinity (which is correct behavior,
   // if unexpected). Use ::max() instead of ::infinity().
+  // Note that if someone uses -fno-honor-infinities WITHOUT -fno-honor-nans
+  // they'll end up using ::infinity(). This is a very unlikely occurence
   static constexpr AccumulatorT value =
       (std::numeric_limits<AccumulatorT>::max)();
 #else

--- a/sycl/include/sycl/known_identity.hpp
+++ b/sycl/include/sycl/known_identity.hpp
@@ -258,16 +258,11 @@ template <typename BinaryOperation, typename AccumulatorT>
 struct known_identity_impl<BinaryOperation, AccumulatorT,
                            std::enable_if_t<IsMinimumIdentityOp<
                                AccumulatorT, BinaryOperation>::value>> {
-// TODO: detect -fno-honor-infinities instead of -ffast-math
-// See https://github.com/intel/llvm/issues/13813
-// This workaround is a vast improvement, but still falls short.
-// To correct it properly, we need to detect -fno-honor-infinities usage,
-// perhaps via a driver inserted macro.
-// See similar below in known_identity_impl<IsMaximumIdentityOp>
-#ifdef __FAST_MATH__
-  // -ffast-math implies -fno-honor-infinities,
-  // but neither affect ::has_infinity (which is correct behavior, if
-  // unexpected)
+
+#if defined(__FINITE_MATH_ONLY__) && (__FINITE_MATH_ONLY__ == 1)
+  // Finite math only (-ffast-math,  -fno-honor-infinities) improves
+  // performance, but does not affect ::has_infinity (which is correct behavior,
+  // if unexpected). Use ::max() instead of ::infinity().
   static constexpr AccumulatorT value =
       (std::numeric_limits<AccumulatorT>::max)();
 #else
@@ -309,10 +304,8 @@ template <typename BinaryOperation, typename AccumulatorT>
 struct known_identity_impl<BinaryOperation, AccumulatorT,
                            std::enable_if_t<IsMaximumIdentityOp<
                                AccumulatorT, BinaryOperation>::value>> {
-// TODO: detect -fno-honor-infinities instead of -ffast-math
-// See https://github.com/intel/llvm/issues/13813
-// and comments above in known_identity_impl<IsMinimumIdentityOp>
-#ifdef __FAST_MATH__
+// See comment above in known_identity_impl<IsMinimumIdentityOp>
+#if defined(__FINITE_MATH_ONLY__) && (__FINITE_MATH_ONLY__ == 1)
   static constexpr AccumulatorT value =
       (std::numeric_limits<AccumulatorT>::lowest)();
 #else

--- a/sycl/include/sycl/known_identity.hpp
+++ b/sycl/include/sycl/known_identity.hpp
@@ -264,7 +264,10 @@ struct known_identity_impl<BinaryOperation, AccumulatorT,
   // performance, but does not affect ::has_infinity (which is correct behavior,
   // if unexpected). Use ::max() instead of ::infinity().
   // Note that if someone uses -fno-honor-infinities WITHOUT -fno-honor-nans
-  // they'll end up using ::infinity(). This is a very unlikely occurence
+  // they'll end up using ::infinity(). There is no reasonable case where one of
+  // the flags would be used without the other and therefore
+  // __FINITE_MATH_ONLY__ is sufficient for this problem ( and superior to the
+  // __FAST_MATH__ macro we were using before).
   static constexpr AccumulatorT value =
       (std::numeric_limits<AccumulatorT>::max)();
 #else


### PR DESCRIPTION
Some time ago we fixed a bug in `sycl::known_identity` where it was incorrectly using `std::numeric_limits<T>::infinity()` even in cases where `::infinity()` should not have been available. At the time, the fix was to simply test for `__FAST_MATH__`.  

That worked, but was not ideal. Now we are tightening this to use the `__FINITE_MATH_ONLY__` macro which is more accurate.  
see https://github.com/intel/llvm/issues/13813

`__FINITE_MATH_ONLY__`  will be set when both the `-fno-honor-infinities` and `-fno-honor-nans` flags are used. It was felt by the FE team that there is no reasonable case where one of the flags would be used without the other and therefore `__FINITE_MATH_ONLY__` is sufficient for this problem ( and superior to the `__FAST_MATH__` macro we were using before).

