### PR TITLE
[SYCL] Remove usage of LLVMGenXIntrinsics CMake target

### DIFF
--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -47,9 +47,6 @@ if (NOT TARGET LLVMGenXIntrinsics)
  endif()
 endif (NOT TARGET LLVMGenXIntrinsics)
 
-set_property(GLOBAL PROPERTY LLVMGenXIntrinsics_SOURCE_PROP ${LLVMGenXIntrinsics_SOURCE_DIR})
-set_property(GLOBAL PROPERTY LLVMGenXIntrinsics_BINARY_PROP ${LLVMGenXIntrinsics_BINARY_DIR})
-
 add_llvm_component_library(LLVMSYCLLowerIR
   ESIMD/ESIMDOptimizeVecArgCallConv.cpp
   ESIMD/ESIMDUtils.cpp

--- a/llvm/tools/sycl-post-link/CMakeLists.txt
+++ b/llvm/tools/sycl-post-link/CMakeLists.txt
@@ -16,25 +16,12 @@ set(LLVM_LINK_COMPONENTS
   Analysis
   )
 
-get_property(LLVMGenXIntrinsics_SOURCE_DIR GLOBAL PROPERTY LLVMGenXIntrinsics_SOURCE_PROP)
-get_property(LLVMGenXIntrinsics_BINARY_DIR GLOBAL PROPERTY LLVMGenXIntrinsics_BINARY_PROP)
-
-include_directories(
-  ${LLVMGenXIntrinsics_SOURCE_DIR}/GenXIntrinsics/include
-  ${LLVMGenXIntrinsics_BINARY_DIR}/GenXIntrinsics/include)
-
 add_llvm_tool(sycl-post-link
   sycl-post-link.cpp
-  ADDITIONAL_HEADER_DIRS
-  ${LLVMGenXIntrinsics_SOURCE_DIR}/GenXIntrinsics/include
-  ${LLVMGenXIntrinsics_BINARY_DIR}/GenXIntrinsics/include
 
   DEPENDS
   intrinsics_gen
-  LLVMGenXIntrinsics
   )
 
 setup_host_tool(sycl-post-link SYCL_POST_LINK
   sycl-post-link_exe sycl-post-link_target)
-
-target_link_libraries(sycl-post-link PRIVATE LLVMGenXIntrinsics)

--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -35,7 +35,6 @@ add_llvm_library(sycl-jit
    MC
    SYCLLowerIR
    SYCLPostLink
-   GenXIntrinsics
    ${LLVM_TARGETS_TO_BUILD}
 
    LINK_LIBS


### PR DESCRIPTION
The target isn't defined when using `find_package` to use the preinstalled version, and we don't need it even when using `FetchContent`.