### PR TITLE
[SYCL] Add lit parameter to pass extra system env vars

### DIFF
--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -293,6 +293,9 @@ configure specific single test execution in the command line:
 * **extra_environment** - comma-separated list of variables with values to be
   added to test environment. Can be also set by LIT_EXTRA_ENVIRONMENT variable
   in CMake.
+* **extra_system_environment** - comma-separated list of variables to be
+  propagated from the host environment to test environment. Can be also set by
+  LIT_EXTRA_SYSTEM_ENVIRONMENT variable in CMake.
 * **level_zero_include** - directory containing Level_Zero native headers, can
   be also set by CMake variable LEVEL_ZERO_INCLUDE.
 * **level_zero_libs_dir** - directory containing Level_Zero native libraries,

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -121,6 +121,14 @@ llvm_config.with_system_environment(
     ]
 )
 
+# Take into account extra system environment variables if provided via parameter.
+if config.extra_system_environment:
+    lit_config.note("Extra system variables to propagate value from: " + config.extra_system_environment)
+    extra_env_vars = config.extra_system_environment.split(",")
+    for var in extra_env_vars:
+        if var in os.environ:
+            llvm_config.with_system_environment(var)
+
 llvm_config.with_environment("PATH", config.lit_tools_dir, append_path=True)
 
 # Configure LD_LIBRARY_PATH or corresponding os-specific alternatives

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -38,6 +38,7 @@ config.sycl_build_targets = set("target-" + t for t in lit_config.params.get(
 config.amd_arch = lit_config.params.get("amd_arch", "@AMD_ARCH@")
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'
 config.extra_environment = lit_config.params.get("extra_environment", "@LIT_EXTRA_ENVIRONMENT@")
+config.extra_system_environment = lit_config.params.get("extra_system_environment", "@LIT_EXTRA_SYSTEM_ENVIRONMENT@")
 config.cxx_flags = lit_config.params.get("cxx_flags", "@SYCL_E2E_CLANG_CXX_FLAGS@")
 config.c_flags = "@CMAKE_C_FLAGS@"
 config.external_tests = "@SYCL_EXTERNAL_TESTS@"


### PR DESCRIPTION
Add lit parameter to which allows to pass comma-separated list of variables to be propagated from the host environment to test environment.