### PR TITLE
[SYCL] Keep `platform_impl`'s `device_impl`s alive until shutdown

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -211,6 +211,14 @@ std::vector<std::shared_ptr<platform_impl>> &GlobalHandler::getPlatformCache() {
   return PlatformCache;
 }
 
+void GlobalHandler::clearPlatforms() {
+  if (!MPlatformCache.Inst)
+    return;
+  for (auto &PltSmartPtr : *MPlatformCache.Inst)
+    PltSmartPtr->MDevices.clear();
+  MPlatformCache.Inst->clear();
+}
+
 std::mutex &GlobalHandler::getPlatformMapMutex() {
   static std::mutex &PlatformMapMutex = getOrCreate(MPlatformMapMutex);
   return PlatformMapMutex;
@@ -366,6 +374,7 @@ void shutdown_late() {
 #endif
 
   // First, release resources, that may access adapters.
+  Handler->clearPlatforms(); // includes dropping platforms' devices ownership.
   Handler->MPlatformCache.Inst.reset(nullptr);
   Handler->MScheduler.Inst.reset(nullptr);
   Handler->MProgramManager.Inst.reset(nullptr);

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -61,6 +61,8 @@ public:
   Sync &getSync();
   std::vector<std::shared_ptr<platform_impl>> &getPlatformCache();
 
+  void clearPlatforms();
+
   std::unordered_map<platform_impl *, ContextImplPtr> &
   getPlatformToDefaultContextCache();
 

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -306,7 +306,7 @@ platform_impl::getOrMakeDeviceImpl(ur_device_handle_t UrDevice) {
   // Otherwise make the impl
   Result = std::make_shared<device_impl>(UrDevice, *this,
                                          device_impl::private_tag{});
-  MDeviceCache.emplace_back(Result);
+  MDevices.emplace_back(Result);
 
   return Result;
 }
@@ -637,11 +637,9 @@ bool platform_impl::has(aspect Aspect) const {
 
 std::shared_ptr<device_impl>
 platform_impl::getDeviceImplHelper(ur_device_handle_t UrDevice) {
-  for (const std::weak_ptr<device_impl> &DeviceWP : MDeviceCache) {
-    if (std::shared_ptr<device_impl> Device = DeviceWP.lock()) {
-      if (Device->getHandleRef() == UrDevice)
-        return Device;
-    }
+  for (const std::shared_ptr<device_impl> &Device : MDevices) {
+    if (Device->getHandleRef() == UrDevice)
+      return Device;
   }
   return nullptr;
 }

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -217,7 +217,8 @@ private:
 
   AdapterPtr MAdapter;
 
-  std::vector<std::weak_ptr<device_impl>> MDeviceCache;
+  std::vector<std::shared_ptr<device_impl>> MDevices;
+  friend class GlobalHandler;
   std::mutex MDeviceMapMutex;
 };
 

--- a/sycl/unittests/context_device/DeviceRefCounter.cpp
+++ b/sycl/unittests/context_device/DeviceRefCounter.cpp
@@ -31,7 +31,6 @@ static ur_result_t redefinedDeviceReleaseAfter(void *) {
 TEST(DevRefCounter, DevRefCounter) {
   {
     sycl::unittest::UrMock<> Mock;
-    sycl::platform Plt = sycl::platform();
 
     mock::getCallbacks().set_after_callback("urDeviceGet",
                                             &redefinedDevicesGetAfter);
@@ -39,6 +38,7 @@ TEST(DevRefCounter, DevRefCounter) {
                                             &redefinedDeviceRetainAfter);
     mock::getCallbacks().set_after_callback("urDeviceRelease",
                                             &redefinedDeviceReleaseAfter);
+    sycl::platform Plt = sycl::platform();
 
     Plt.get_devices();
   }

--- a/sycl/unittests/helpers/UrMock.hpp
+++ b/sycl/unittests/helpers/UrMock.hpp
@@ -612,7 +612,11 @@ public:
     // clear platform cache in case subsequent tests want a different backend,
     // this forces platforms to be reconstructed (and thus queries about UR
     // backend info to be called again)
-    detail::GlobalHandler::instance().getPlatformCache().clear();
+    //
+    // This also erases each platform's devices (normally done in the library
+    // shutdown) so that platforms/devices' lifetimes could work in unittests
+    // scenario.
+    detail::GlobalHandler::instance().clearPlatforms();
     mock::getCallbacks().resetCallbacks();
   }
 


### PR DESCRIPTION
After that devices are never destroyed until the SYCL RT library shutdown. In practice, that means that before the change a simple

```
int main() { sycl::device d; }
```

went into `platform` ctor, then queried all the platform's devices to check that it has some, returned from ctor and those `sycl::device`s created on stack were already destroyed. After that, when creating user's `sycl::device d` we were re-creating device hierarchy for the platform at SYCL level again (including some calls to `urDeviceGetInfo` during `device_impl` creation).

After the changes, devices created when veryfing that platform isn't empty are preserved inside the `platform_impl` object and this existing SYCL devices hierarchy is used when creating user's device object.

A note on the implementation: `device_impl` has an `std::shared_ptr<platform_impl>` inside so we can't rely on automatic resource management just by the nature of `std::shared_ptr` everywhere (and we haven't changed this aspect in https://github.com/intel/llvm/pull/18143). As such, we have to perform some explicit resource release during shutdown procedure (or in `~UrMock()` for unittests).