### PR TITLE
[Driver][SYCL] Do not set workaround predefines with /MDd

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5366,11 +5366,6 @@ static void ProcessVSRuntimeLibrary(const ToolChain &TC, const ArgList &Args,
       CmdArgs.push_back("-D_MT");
     if (Defines & addDLL && !isSPIROrSPIRV)
       CmdArgs.push_back("-D_DLL");
-    // for /MDd with spir targets
-    if ((Defines & addDLL) && (Defines & addDEBUG) && isSPIROrSPIRV) {
-      CmdArgs.push_back("-D_CONTAINER_DEBUG_LEVEL=0");
-      CmdArgs.push_back("-D_ITERATOR_DEBUG_LEVEL=0");
-    }
   };
   StringRef FlagForCRT;
   switch (RTOptionID) {

--- a/clang/test/Driver/sycl-MD-default.cpp
+++ b/clang/test/Driver/sycl-MD-default.cpp
@@ -8,12 +8,10 @@
 // RUN: %clang_cl -### -fsycl -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DEFAULT-CL %s
 // RUN: %clang_cl -### -MD -fsycl -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=CHK-DEFAULT-CL,CHK-DEFAULT-CL-MD %s
+// RUN:   | FileCheck -check-prefixes=CHK-DEFAULT-CL %s
 // RUN: %clang_cl -### -MDd -fsycl -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=CHK-DEFAULT-CL,CHK-DEFAULT-CL-MDd %s
+// RUN:   | FileCheck -check-prefixes=CHK-DEFAULT-CL %s
 // CHK-DEFAULT-CL-NOT: "-fsycl-is-device" {{.*}} "-D_MT" "-D_DLL"
-// CHK-DEFAULT-CL-MD-NOT: "-D_CONTAINER_DEBUG_LEVEL=0" "-D_ITERATOR_DEBUG_LEVEL=0"
-// CHK-DEFAULT-CL-MDd: "-D_CONTAINER_DEBUG_LEVEL=0" "-D_ITERATOR_DEBUG_LEVEL=0"
 // CHK-DEFAULT-CL: "-fsycl-is-host"{{.*}} "-D_MT" "-D_DLL" "--dependent-lib=msvcrt{{d*}}"
 
 // RUN: not %clang_cl -### -MT -fsycl -c %s 2>&1 \


### PR DESCRIPTION
We are currently setting 2 pre-defines which workaound a compilation issue:  -D_CONTAINER_DEBUG_LEVEL=0 and -D_ITERATOR_DEBUG_LEVEL=0.  We can no longer rely on these macros as _CONTAINER_DEBUG_LEVEL will be going away with a future release of Visual Studio.

The issues that this worked around are detailed in our release notes as a known issue: https://github.com/intel/llvm/blob/aa2c876f529f942943afaf9395694fe07a7f6121/sycl/ReleaseNotes.md?plain=1#L2700

Remove these workarounds in preparation for the upcoming MSVS release.