### PR TITLE
[UR][CUDA][HIP] Fix nullptr offset in graph enqueue

### DIFF
--- a/unified-runtime/source/adapters/cuda/command_buffer.cpp
+++ b/unified-runtime/source/adapters/cuda/command_buffer.cpp
@@ -107,7 +107,11 @@ kernel_command_data::kernel_command_data(
     ur_kernel_handle_t *KernelAlternatives)
     : Kernel(Kernel), Params(Params), WorkDim(WorkDim) {
   const size_t CopySize = sizeof(size_t) * WorkDim;
-  std::memcpy(GlobalWorkOffset, GlobalWorkOffsetPtr, CopySize);
+  if (GlobalWorkOffsetPtr) {
+    std::memcpy(GlobalWorkOffset, GlobalWorkOffsetPtr, CopySize);
+  } else {
+    std::memset(GlobalWorkOffset, 0, CopySize);
+  }
   std::memcpy(GlobalWorkSize, GlobalWorkSizePtr, CopySize);
   // Local work size may be nullptr
   if (LocalWorkSizePtr) {

--- a/unified-runtime/source/adapters/hip/command_buffer.cpp
+++ b/unified-runtime/source/adapters/hip/command_buffer.cpp
@@ -53,7 +53,11 @@ ur_exp_command_buffer_command_handle_t_::
     : CommandBuffer(CommandBuffer), Kernel(Kernel), Node(Node), Params(Params),
       WorkDim(WorkDim) {
   const size_t CopySize = sizeof(size_t) * WorkDim;
-  std::memcpy(GlobalWorkOffset, GlobalWorkOffsetPtr, CopySize);
+  if (GlobalWorkOffsetPtr) {
+    std::memcpy(GlobalWorkOffset, GlobalWorkOffsetPtr, CopySize);
+  } else {
+    std::memset(GlobalWorkOffset, 0, CopySize);
+  }
   std::memcpy(GlobalWorkSize, GlobalWorkSizePtr, CopySize);
   // Local work size may be nullptr
   if (LocalWorkSizePtr) {


### PR DESCRIPTION
In theory kernel launch UR entry points don't accept null pointer offsets, but the regular kernel launch entry points are checking it.