### PR TITLE
[SYCL][UR] Update setErrorMessage to use int32_t instead of ur_result_t for the urAdapterGetLastError entry point

### DIFF
--- a/sycl/source/detail/adapter.hpp
+++ b/sycl/source/detail/adapter.hpp
@@ -71,7 +71,14 @@ public:
       int32_t adapter_error = 0;
       ur_result = call_nocheck<UrApiKind::urAdapterGetLastError>(
           MAdapter, &message, &adapter_error);
-      std::cerr << message << " (error code " << adapter_error << ")\n";
+      throw sycl::detail::set_ur_error(
+          sycl::exception(
+              sycl::make_error_code(errc),
+              __SYCL_UR_ERROR_REPORT + sycl::detail::codeToString(ur_result) +
+                  (message ? "\n" + std::string(message) + "(adapter error )" +
+                                 std::to_string(adapter_error) + "\n"
+                           : std::string{})),
+          ur_result);
     }
     if (ur_result != UR_RESULT_SUCCESS) {
       throw sycl::detail::set_ur_error(

--- a/sycl/source/detail/adapter.hpp
+++ b/sycl/source/detail/adapter.hpp
@@ -71,17 +71,7 @@ public:
       int32_t adapter_error = 0;
       ur_result = call_nocheck<UrApiKind::urAdapterGetLastError>(
           MAdapter, &message, &adapter_error);
-
-      // If the warning level is greater then 2 emit the message
-      if (message != nullptr &&
-          detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() >= 2) {
-        std::clog << message << std::endl;
-      }
-
-      // If it is a warning do not throw code
-      if (ur_result == UR_RESULT_SUCCESS) {
-        return;
-      }
+      std::cerr << message << " (error code " << adapter_error << ")\n";
     }
     if (ur_result != UR_RESULT_SUCCESS) {
       throw sycl::detail::set_ur_error(

--- a/sycl/source/interop_handle.cpp
+++ b/sycl/source/interop_handle.cpp
@@ -79,7 +79,7 @@ ur_native_handle_t interop_handle::getNativeGraph() const {
   }
 
   auto Adapter = MQueue->getAdapter();
-  ur_native_handle_t Handle;
+  ur_native_handle_t Handle = 0;
   Adapter->call<detail::UrApiKind::urCommandBufferGetNativeHandleExp>(Graph,
                                                                       &Handle);
   return Handle;

--- a/unified-runtime/source/adapters/cuda/adapter.cpp
+++ b/unified-runtime/source/adapters/cuda/adapter.cpp
@@ -90,9 +90,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
-    ur_adapter_handle_t, const char **ppMessage, int32_t * /*pError*/) {
+    ur_adapter_handle_t, const char **ppMessage, int32_t *pError) {
   *ppMessage = ErrorMessage;
-  return ErrorMessageCode;
+  *pError = ErrorMessageCode;
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,

--- a/unified-runtime/source/adapters/cuda/common.cpp
+++ b/unified-runtime/source/adapters/cuda/common.cpp
@@ -135,12 +135,11 @@ std::string getCudaVersionString() {
 }
 
 // Global variables for ZER_EXT_RESULT_ADAPTER_SPECIFIC_ERROR
-thread_local ur_result_t ErrorMessageCode = UR_RESULT_SUCCESS;
+thread_local int32_t ErrorMessageCode = UR_RESULT_SUCCESS;
 thread_local char ErrorMessage[MaxMessageSize]{};
 
 // Utility function for setting a message and warning
-[[maybe_unused]] void setErrorMessage(const char *pMessage,
-                                      ur_result_t ErrorCode) {
+[[maybe_unused]] void setErrorMessage(const char *pMessage, int32_t ErrorCode) {
   assert(strlen(pMessage) < MaxMessageSize);
   // Copy at most MaxMessageSize - 1 bytes to ensure the resultant string is
   // always null terminated.

--- a/unified-runtime/source/adapters/cuda/common.cpp
+++ b/unified-runtime/source/adapters/cuda/common.cpp
@@ -135,7 +135,7 @@ std::string getCudaVersionString() {
 }
 
 // Global variables for ZER_EXT_RESULT_ADAPTER_SPECIFIC_ERROR
-thread_local int32_t ErrorMessageCode = UR_RESULT_SUCCESS;
+thread_local int32_t ErrorMessageCode = 0;
 thread_local char ErrorMessage[MaxMessageSize]{};
 
 // Utility function for setting a message and warning

--- a/unified-runtime/source/adapters/cuda/common.hpp
+++ b/unified-runtime/source/adapters/cuda/common.hpp
@@ -48,12 +48,11 @@ void checkErrorUR(ur_result_t Result, const char *Function, int Line,
 std::string getCudaVersionString();
 
 constexpr size_t MaxMessageSize = 256;
-extern thread_local ur_result_t ErrorMessageCode;
+extern thread_local int32_t ErrorMessageCode;
 extern thread_local char ErrorMessage[MaxMessageSize];
 
 // Utility function for setting a message and warning
-[[maybe_unused]] void setErrorMessage(const char *pMessage,
-                                      ur_result_t ErrorCode);
+[[maybe_unused]] void setErrorMessage(const char *pMessage, int32_t ErrorCode);
 
 void setPluginSpecificMessage(CUresult cu_res);
 

--- a/unified-runtime/source/adapters/cuda/enqueue.cpp
+++ b/unified-runtime/source/adapters/cuda/enqueue.cpp
@@ -1682,10 +1682,9 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
   UR_CHECK_ERROR(cuPointerGetAttribute(
       &IsManaged, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)pMem));
   if (!IsManaged) {
-    setErrorMessage(
-        "Memory advice ignored as memory advices only works with USM",
-        UR_RESULT_SUCCESS);
-    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+    logger::warning(
+        "Memory advice ignored as memory advices only works with USM.");
+    return UR_RESULT_SUCCESS;
   }
 
   ur_result_t Result = UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/hip/common.cpp
+++ b/unified-runtime/source/adapters/hip/common.cpp
@@ -157,7 +157,7 @@ hipError_t getHipVersionString(std::string &Version) {
 }
 
 // Global variables for UR_RESULT_ADAPTER_SPECIFIC_ERROR
-thread_local int32_t ErrorMessageCode = UR_RESULT_SUCCESS;
+thread_local int32_t ErrorMessageCode = 0;
 thread_local char ErrorMessage[MaxMessageSize]{};
 
 // Utility function for setting a message and warning

--- a/unified-runtime/source/adapters/hip/common.cpp
+++ b/unified-runtime/source/adapters/hip/common.cpp
@@ -157,22 +157,14 @@ hipError_t getHipVersionString(std::string &Version) {
 }
 
 // Global variables for UR_RESULT_ADAPTER_SPECIFIC_ERROR
-thread_local ur_result_t ErrorMessageCode = UR_RESULT_SUCCESS;
+thread_local int32_t ErrorMessageCode = UR_RESULT_SUCCESS;
 thread_local char ErrorMessage[MaxMessageSize]{};
 
 // Utility function for setting a message and warning
-[[maybe_unused]] void setErrorMessage(const char *pMessage,
-                                      ur_result_t ErrorCode) {
+[[maybe_unused]] void setErrorMessage(const char *pMessage, int32_t ErrorCode) {
   assert(strlen(pMessage) < MaxMessageSize);
   // Copy at most MaxMessageSize - 1 bytes to ensure the resultant string is
   // always null terminated.
   strncpy(ErrorMessage, pMessage, MaxMessageSize - 1);
   ErrorMessageCode = ErrorCode;
-}
-
-// Returns plugin specific error and warning messages; common implementation
-// that can be shared between adapters
-ur_result_t urGetLastResult(ur_platform_handle_t, const char **ppMessage) {
-  *ppMessage = &ErrorMessage[0];
-  return ErrorMessageCode;
 }

--- a/unified-runtime/source/adapters/hip/common.hpp
+++ b/unified-runtime/source/adapters/hip/common.hpp
@@ -106,12 +106,11 @@ void checkErrorUR(ur_result_t Result, const char *Function, int Line,
 hipError_t getHipVersionString(std::string &Version);
 
 constexpr size_t MaxMessageSize = 256;
-extern thread_local ur_result_t ErrorMessageCode;
+extern thread_local int32_t ErrorMessageCode;
 extern thread_local char ErrorMessage[MaxMessageSize];
 
 // Utility function for setting a message and warning
-[[maybe_unused]] void setErrorMessage(const char *Message,
-                                      ur_result_t ErrorCode);
+[[maybe_unused]] void setErrorMessage(const char *Message, int32_t ErrorCode);
 
 /// ------ Error handling, matching OpenCL plugin semantics.
 namespace detail {

--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -712,7 +712,7 @@ ur_result_t urAdapterGetLastError(
   *Message = ErrorMessage;
   *Error = ErrorAdapterNativeCode;
 
-  return ErrorMessageCode;
+  return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urAdapterGetInfo(ur_adapter_handle_t, ur_adapter_info_t PropName,

--- a/unified-runtime/source/adapters/level_zero/common.cpp
+++ b/unified-runtime/source/adapters/level_zero/common.cpp
@@ -342,13 +342,12 @@ getZeStructureType<ze_intel_device_block_array_exp_properties_t>() {
 #endif // ZE_INTEL_DEVICE_BLOCK_ARRAY_EXP_NAME
 
 // Global variables for ZER_EXT_RESULT_ADAPTER_SPECIFIC_ERROR
-thread_local ur_result_t ErrorMessageCode = UR_RESULT_SUCCESS;
+thread_local int32_t ErrorMessageCode = 0;
 thread_local char ErrorMessage[MaxMessageSize]{};
 thread_local int32_t ErrorAdapterNativeCode;
 
 // Utility function for setting a message and warning
-[[maybe_unused]] void setErrorMessage(const char *pMessage,
-                                      ur_result_t ErrorCode,
+[[maybe_unused]] void setErrorMessage(const char *pMessage, int32_t ErrorCode,
                                       int32_t AdapterErrorCode) {
   assert(strlen(pMessage) < MaxMessageSize);
   // Copy at most MaxMessageSize - 1 bytes to ensure the resultant string is
@@ -356,9 +355,4 @@ thread_local int32_t ErrorAdapterNativeCode;
   strncpy(ErrorMessage, pMessage, MaxMessageSize - 1);
   ErrorMessageCode = ErrorCode;
   ErrorAdapterNativeCode = AdapterErrorCode;
-}
-
-ur_result_t zerPluginGetLastError(char **message) {
-  *message = &ErrorMessage[0];
-  return ErrorMessageCode;
 }

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -373,11 +373,10 @@ constexpr char ZE_SUPPORTED_EXTENSIONS[] =
 
 // Global variables for ZER_EXT_RESULT_ADAPTER_SPECIFIC_ERROR
 constexpr size_t MaxMessageSize = 256;
-extern thread_local ur_result_t ErrorMessageCode;
+extern thread_local int32_t ErrorMessageCode;
 extern thread_local char ErrorMessage[MaxMessageSize];
 extern thread_local int32_t ErrorAdapterNativeCode;
 
 // Utility function for setting a message and warning
-[[maybe_unused]] void setErrorMessage(const char *pMessage,
-                                      ur_result_t ErrorCode,
+[[maybe_unused]] void setErrorMessage(const char *pMessage, int32_t ErrorCode,
                                       int32_t AdapterErrorCode);

--- a/unified-runtime/source/adapters/native_cpu/common.cpp
+++ b/unified-runtime/source/adapters/native_cpu/common.cpp
@@ -11,21 +11,14 @@
 #include "common.hpp"
 
 // Global variables for UR_RESULT_ADAPTER_SPECIFIC_ERROR
-// See urGetLastResult
-thread_local ur_result_t ErrorMessageCode = UR_RESULT_SUCCESS;
+thread_local int32_t ErrorMessageCode;
 thread_local char ErrorMessage[MaxMessageSize]{};
 
 // Utility function for setting a message and warning
-[[maybe_unused]] void setErrorMessage(const char *pMessage,
-                                      ur_result_t ErrorCode) {
+[[maybe_unused]] void setErrorMessage(const char *pMessage, int32_t ErrorCode) {
   assert(strlen(pMessage) < MaxMessageSize);
   // Copy at most MaxMessageSize - 1 bytes to ensure the resultant string is
   // always null terminated.
   strncpy(ErrorMessage, pMessage, MaxMessageSize - 1);
   ErrorMessageCode = ErrorCode;
-}
-
-ur_result_t urGetLastResult(ur_platform_handle_t, const char **ppMessage) {
-  *ppMessage = &ErrorMessage[0];
-  return ErrorMessageCode;
 }

--- a/unified-runtime/source/adapters/native_cpu/common.cpp
+++ b/unified-runtime/source/adapters/native_cpu/common.cpp
@@ -11,7 +11,7 @@
 #include "common.hpp"
 
 // Global variables for UR_RESULT_ADAPTER_SPECIFIC_ERROR
-thread_local int32_t ErrorMessageCode;
+thread_local int32_t ErrorMessageCode = 0;
 thread_local char ErrorMessage[MaxMessageSize]{};
 
 // Utility function for setting a message and warning

--- a/unified-runtime/source/adapters/native_cpu/common.hpp
+++ b/unified-runtime/source/adapters/native_cpu/common.hpp
@@ -16,7 +16,7 @@
 
 constexpr size_t MaxMessageSize = 256;
 
-extern thread_local ur_result_t ErrorMessageCode;
+extern thread_local int32_t ErrorMessageCode;
 extern thread_local char ErrorMessage[MaxMessageSize];
 
 #define DIE_NO_IMPLEMENTATION                                                  \

--- a/unified-runtime/source/adapters/opencl/common.cpp
+++ b/unified-runtime/source/adapters/opencl/common.cpp
@@ -16,6 +16,15 @@ namespace cl_adapter {
 thread_local int32_t ErrorMessageCode = 0;
 thread_local char ErrorMessage[MaxMessageSize]{};
 
+[[maybe_unused]] void setErrorMessage(const char *Message, int32_t ErrorCode) {
+  assert(strlen(Message) < cl_adapter::MaxMessageSize);
+  // Copy at most MaxMessageSize - 1 bytes to ensure the resultant string is
+  // always null terminated.
+  strncpy(cl_adapter::ErrorMessage, Message, MaxMessageSize - 1);
+
+  ErrorMessageCode = ErrorCode;
+}
+
 } // namespace cl_adapter
 
 ur_result_t mapCLErrorToUR(cl_int Result) {

--- a/unified-runtime/source/adapters/opencl/common.hpp
+++ b/unified-runtime/source/adapters/opencl/common.hpp
@@ -154,8 +154,7 @@ extern thread_local int32_t ErrorMessageCode;
 extern thread_local char ErrorMessage[MaxMessageSize];
 
 // Utility function for setting a message and warning
-[[maybe_unused]] void setErrorMessage(const char *Message,
-                                      ur_result_t ErrorCode);
+[[maybe_unused]] void setErrorMessage(const char *Message, int32_t ErrorCode);
 } // namespace cl_adapter
 
 namespace cl_ext {

--- a/unified-runtime/source/adapters/opencl/kernel.cpp
+++ b/unified-runtime/source/adapters/opencl/kernel.cpp
@@ -71,7 +71,6 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
     auto URKernel = std::make_unique<ur_kernel_handle_t_>(Kernel, hProgram,
                                                           hProgram->Context);
     *phKernel = URKernel.release();
-    // todo update here
   } catch (std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_RESOURCES;
   } catch (...) {

--- a/unified-runtime/source/adapters/opencl/kernel.cpp
+++ b/unified-runtime/source/adapters/opencl/kernel.cpp
@@ -71,6 +71,7 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
     auto URKernel = std::make_unique<ur_kernel_handle_t_>(Kernel, hProgram,
                                                           hProgram->Context);
     *phKernel = URKernel.release();
+    // todo update here
   } catch (std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_RESOURCES;
   } catch (...) {


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/issues/18260

Also updates `checkUrResult` in SYCL RT to remove warning level check as `urAdapterGetLastError` is now only used for errors.