### PR TITLE
[SYCL] Fix build with XPTI disabled

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -359,6 +359,12 @@ if (NOT WIN32)
     COMPONENT sycl-headers-extras)
 endif()
 
+if(SYCL_ENABLE_XPTI_TRACING AND
+    DEFINED LLVM_EXTERNAL_PROJECTS AND
+    (NOT "xpti" IN_LIST LLVM_EXTERNAL_PROJECTS OR NOT "xptifw" IN_LIST LLVM_EXTERNAL_PROJECTS))
+  message(FATAL_ERROR "SYCL_ENABLE_XPTI_TRACING=ON but XPTI is not going to be built")
+endif()
+
 if (SYCL_ENABLE_XPTI_TRACING)
   if (MSVC)
     set(XPTIFW_LIBS xpti xptid xptifw xptifwd)

--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -29,9 +29,9 @@ set(UR_BUILD_TESTS "${SYCL_UR_BUILD_TESTS}" CACHE BOOL "" FORCE)
 set(UR_BUILD_EXAMPLES "${SYCL_UR_BUILD_TESTS}" CACHE BOOL "" FORCE)
 
 # Here we override the defaults to unified-runtime
-set(UR_BUILD_XPTI_LIBS OFF)
+set(UR_BUILD_XPTI_LIBS OFF CACHE BOOL "")
 set(UR_ENABLE_SYMBOLIZER ON CACHE BOOL "Enable symbolizer for sanitizer layer.")
-set(UR_ENABLE_TRACING ON)
+set(UR_ENABLE_TRACING ON CACHE BOOL "")
 
 set(UR_EXTERNAL_DEPENDENCIES "sycl-headers" CACHE STRING
   "List of external CMake targets for executables/libraries to depend on" FORCE)

--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -57,7 +57,7 @@ if (LLVM_ENABLE_ZSTD)
 endif()
 
 # TODO Enable xpti tests for Windows
-if (NOT WIN32)
+if (SYCL_ENABLE_XPTI_TRACING AND NOT WIN32)
     add_subdirectory(xpti_trace)
 endif()
 add_subdirectory(sampler)

--- a/unified-runtime/CMakeLists.txt
+++ b/unified-runtime/CMakeLists.txt
@@ -159,6 +159,13 @@ else()
     set(UR_DPCXX_DEPS "")
 endif()
 
+if(NOT UR_STANDALONE_BUILD AND
+    UR_ENABLE_TRACING AND
+    DEFINED LLVM_EXTERNAL_PROJECTS AND
+    (NOT "xpti" IN_LIST LLVM_EXTERNAL_PROJECTS OR NOT "xptifw" IN_LIST LLVM_EXTERNAL_PROJECTS))
+  message(FATAL_ERROR "UR_ENABLE_TRACING=ON but XPTI is not going to be built")
+endif()
+
 if(UR_ENABLE_TRACING)
     add_compile_definitions(UR_ENABLE_TRACING)
 


### PR DESCRIPTION
There were two issues:
1) Setting `UR_ENABLE_TRACING` on the command line didn't work because the SYCL code calling the FetchUR CMake files didn't use `CACHE`, also fixed two other vars with the same problem.
2) XPTI SYCL tests were built even if XPTI wasn't built, causing a build failure.

Also add two errors so the problem isn't discovered in a build failure.