### PR TITLE
[NFC][SYCL] Don't use `fprintf` as deemed "unsafe"

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -236,7 +236,8 @@ template <typename... Ts>
 void cannot_be_called_on_host([[maybe_unused]] const char *API,
                               Ts &&.../* ignore */) {
 #ifndef __SYCL_DEVICE_ONLY__
-  std::fprintf(stderr, "%s cannot be called on host!\n", API);
+  fputs(API, stderr);
+  fputs(" cannot be called on host!\n", stderr);
   std::abort();
 #endif
 }

--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -236,8 +236,7 @@ template <typename... Ts>
 void cannot_be_called_on_host([[maybe_unused]] const char *API,
                               Ts &&.../* ignore */) {
 #ifndef __SYCL_DEVICE_ONLY__
-  fputs(API, stderr);
-  fputs(" cannot be called on host!\n", stderr);
+  std::cerr << API << " cannot be called on host!" << std::endl;
   std::abort();
 #endif
 }


### PR DESCRIPTION
Some customers complained that having `fprintf` used in our library makes their security policy trigger an error.