### PR TITLE
[UR] Use pre-installed compute-runtime L0 headers if found

### DIFF
--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -106,9 +106,15 @@ target_include_directories(LevelZeroLoader-Headers
               "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-# Fetch only if UR_COMPUTE_RUNTIME_FETCH_REPO is set to ON.
-if (UR_COMPUTE_RUNTIME_FETCH_REPO)
-
+find_path(L0_COMPUTE_RUNTIME_HEADERS
+  NAMES "ze_intel_gpu.h"
+  PATH_SUFFIXES "level_zero"
+)
+if(NOT UR_COMPUTE_RUNTIME_REPO AND L0_COMPUTE_RUNTIME_HEADERS)
+    set(COMPUTE_RUNTIME_LEVEL_ZERO_INCLUDE "${L0_COMPUTE_RUNTIME_HEADERS}")
+    set(COMPUTE_RUNTIME_REPO_PATH "${L0_COMPUTE_RUNTIME_HEADERS}")
+elseif (UR_COMPUTE_RUNTIME_FETCH_REPO)
+    # Fetch only if UR_COMPUTE_RUNTIME_FETCH_REPO is set to ON.
     if (UR_COMPUTE_RUNTIME_REPO STREQUAL "")
         set(UR_COMPUTE_RUNTIME_REPO "https://github.com/intel/compute-runtime.git")
     endif()

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -31,7 +31,7 @@
 #include <ze_api.h>
 #include <zes_api.h>
 
-#include <level_zero/include/level_zero/ze_intel_gpu.h>
+#include <level_zero/ze_intel_gpu.h>
 #include <umf_pools/disjoint_pool_config_parser.hpp>
 
 #include "logger/ur_logger.hpp"


### PR DESCRIPTION
I'm trying to make dpcpp more friendly to packaging by Linux distros, and we should be using system-installed dependencies by default.

Find the system-installed compute-runtime headers and use them if they exist instead of downloading the upstream repo.

Also fix an include that doesn't work with system headers.