### PR TITLE
[UR][Test] Explicit target name in KernelsEnvironment::LoadSource (NFCI)

### DIFF
--- a/unified-runtime/test/conformance/source/environment.cpp
+++ b/unified-runtime/test/conformance/source/environment.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <fstream>
 #include <sstream>
+#include <string>
 
 #include "ur_api.h"
 #include "ur_filesystem_resolved.hpp"
@@ -190,15 +191,13 @@ KernelsEnvironment::parseKernelOptions(int argc, char **argv,
   return options;
 }
 
-std::string KernelsEnvironment::getTargetName(ur_platform_handle_t platform) {
-  std::stringstream IL;
-
+std::string
+KernelsEnvironment::getDefaultTargetName(ur_platform_handle_t platform) {
   if (instance->GetDevices().size() == 0) {
     error = "no devices available on the platform";
     return {};
   }
 
-  // special case for AMD as it doesn't support IL.
   ur_platform_backend_t backend;
   if (urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND, sizeof(backend),
                         &backend, nullptr)) {
@@ -206,7 +205,6 @@ std::string KernelsEnvironment::getTargetName(ur_platform_handle_t platform) {
     return {};
   }
 
-  std::string target = "";
   switch (backend) {
   case UR_PLATFORM_BACKEND_OPENCL:
   case UR_PLATFORM_BACKEND_LEVEL_ZERO:
@@ -226,17 +224,10 @@ std::string KernelsEnvironment::getTargetName(ur_platform_handle_t platform) {
 
 std::string
 KernelsEnvironment::getKernelSourcePath(const std::string &kernel_name,
-                                        ur_platform_handle_t platform) {
+                                        const std::string &target_name) {
   std::stringstream path;
-  path << kernel_options.kernel_directory << "/" << kernel_name;
-
-  std::string target_name = getTargetName(platform);
-  if (target_name.empty()) {
-    return {};
-  }
-
-  path << "/" << target_name << ".bin.0";
-
+  path << kernel_options.kernel_directory << "/" << kernel_name << "/"
+       << target_name << ".bin.0";
   return path.str();
 }
 
@@ -246,12 +237,19 @@ void KernelsEnvironment::LoadSource(
   // We don't have a way to build device code for native cpu yet.
   UUR_KNOWN_FAILURE_ON_PARAM(platform, uur::NativeCPU{});
 
-  std::string source_path =
-      instance->getKernelSourcePath(kernel_name, platform);
-
-  if (source_path.empty()) {
+  std::string target_name = getDefaultTargetName(platform);
+  if (target_name.empty()) {
     FAIL() << error;
   }
+
+  return LoadSource(kernel_name, target_name, binary_out);
+}
+
+void KernelsEnvironment::LoadSource(
+    const std::string &kernel_name, const std::string &target_name,
+    std::shared_ptr<std::vector<char>> &binary_out) {
+  std::string source_path =
+      instance->getKernelSourcePath(kernel_name, target_name);
 
   if (cached_kernels.find(source_path) != cached_kernels.end()) {
     binary_out = cached_kernels[source_path];

--- a/unified-runtime/test/conformance/testing/include/uur/environment.h
+++ b/unified-runtime/test/conformance/testing/include/uur/environment.h
@@ -71,6 +71,10 @@ struct KernelsEnvironment : DevicesEnvironment {
   void LoadSource(const std::string &kernel_name, ur_platform_handle_t platform,
                   std::shared_ptr<std::vector<char>> &binary_out);
 
+  void LoadSource(const std::string &kernel_name,
+                  const std::string &target_name,
+                  std::shared_ptr<std::vector<char>> &binary_out);
+
   void CreateProgram(ur_platform_handle_t hPlatform,
                      ur_context_handle_t hContext, ur_device_handle_t hDevice,
                      const std::vector<char> &binary,
@@ -85,8 +89,8 @@ private:
   KernelOptions parseKernelOptions(int argc, char **argv,
                                    const std::string &kernels_default_dir);
   std::string getKernelSourcePath(const std::string &kernel_name,
-                                  ur_platform_handle_t platform);
-  std::string getTargetName(ur_platform_handle_t platform);
+                                  const std::string &target_name);
+  std::string getDefaultTargetName(ur_platform_handle_t platform);
 
   KernelOptions kernel_options;
   // mapping between kernels (full_path + kernel_name) and their saved source.


### PR DESCRIPTION
Allow explicitly overriding the name of the target to load kernel sources for. This is useful if the backend supports multiple targets, and a test wants to load the source for a specific one. Multiple targets might for example be SPIR-V and native binary format for the OpenCL or Level Zero backend, or future vendor specific intermediate representations.

The overload taking a platform is unchanged, it will load a the source for the "default" target for the backend, which is the same as before.