### PR TITLE
[UR][Test] Expose UR_CONFORMANCE_TARGET_TRIPLES to tests

### DIFF
--- a/unified-runtime/test/conformance/CMakeLists.txt
+++ b/unified-runtime/test/conformance/CMakeLists.txt
@@ -91,6 +91,28 @@ function(add_conformance_test_with_platform_environment name)
     target_compile_definitions("test-${name}" PRIVATE PLATFORM_ENVIRONMENT)
 endfunction()
 
+if(UR_FOUND_DPCXX)
+    add_custom_target(generate_device_binaries)
+
+    set(UR_CONFORMANCE_DEVICE_BINARIES_DIR
+        "${CMAKE_CURRENT_BINARY_DIR}/device_binaries" CACHE INTERNAL UR_CONFORMANCE_DEVICE_BINARIES_DIR)
+    file(MAKE_DIRECTORY ${UR_CONFORMANCE_DEVICE_BINARIES_DIR})
+
+    if("${UR_CONFORMANCE_TARGET_TRIPLES}" STREQUAL "")
+        if(UR_BUILD_ADAPTER_L0 OR UR_BUILD_ADAPTER_L0_V2 OR UR_BUILD_ADAPTER_OPENCL OR UR_BUILD_ADAPTER_ALL)
+            list(APPEND TARGET_TRIPLES "spir64")
+        endif()
+        if(UR_BUILD_ADAPTER_CUDA OR UR_BUILD_ADAPTER_ALL)
+            list(APPEND TARGET_TRIPLES "nvptx64-nvidia-cuda")
+        endif()
+        if(UR_BUILD_ADAPTER_HIP OR UR_BUILD_ADAPTER_ALL)
+            list(APPEND TARGET_TRIPLES "amdgcn-amd-amdhsa")
+        endif()
+    else()
+        string(REPLACE "," ";" TARGET_TRIPLES ${UR_CONFORMANCE_TARGET_TRIPLES})
+    endif()
+endif()
+
 add_subdirectory(testing)
 
 add_subdirectory(adapter)
@@ -118,26 +140,6 @@ set(TEST_SUBDIRECTORIES_DPCXX
 )
 
 if(UR_FOUND_DPCXX)
-    add_custom_target(generate_device_binaries)
-
-    set(UR_CONFORMANCE_DEVICE_BINARIES_DIR
-        "${CMAKE_CURRENT_BINARY_DIR}/device_binaries" CACHE INTERNAL UR_CONFORMANCE_DEVICE_BINARIES_DIR)
-    file(MAKE_DIRECTORY ${UR_CONFORMANCE_DEVICE_BINARIES_DIR})
-
-    if("${UR_CONFORMANCE_TARGET_TRIPLES}" STREQUAL "")
-        if(UR_BUILD_ADAPTER_L0 OR UR_BUILD_ADAPTER_L0_V2 OR UR_BUILD_ADAPTER_OPENCL OR UR_BUILD_ADAPTER_ALL)
-            list(APPEND TARGET_TRIPLES "spir64")
-        endif()
-        if(UR_BUILD_ADAPTER_CUDA OR UR_BUILD_ADAPTER_ALL)
-            list(APPEND TARGET_TRIPLES "nvptx64-nvidia-cuda")
-        endif()
-        if(UR_BUILD_ADAPTER_HIP OR UR_BUILD_ADAPTER_ALL)
-            list(APPEND TARGET_TRIPLES "amdgcn-amd-amdhsa")
-        endif()
-    else()
-        string(REPLACE "," ";" TARGET_TRIPLES ${UR_CONFORMANCE_TARGET_TRIPLES})
-    endif()
-
     foreach(dir ${TEST_SUBDIRECTORIES_DPCXX})
         add_subdirectory(${dir})
     endforeach()

--- a/unified-runtime/test/conformance/source/environment.cpp
+++ b/unified-runtime/test/conformance/source/environment.cpp
@@ -20,6 +20,7 @@
 
 #include <ur_util.hpp>
 #include <uur/environment.h>
+#include <uur/targets.h>
 #include <uur/utils.h>
 
 namespace uur {
@@ -238,6 +239,14 @@ KernelsEnvironment::getKernelSourcePath(const std::string &kernel_name,
   path << "/" << target_name << ".bin.0";
 
   return path.str();
+}
+
+bool KernelsEnvironment::HaveSourcesForTarget(const std::string &target_name) {
+  auto it = std::find_if(
+      std::begin(uur::UR_CONFORMANCE_TARGET_TRIPLES),
+      std::end(uur::UR_CONFORMANCE_TARGET_TRIPLES),
+      [&target_name](const char *triple) { return target_name == triple; });
+  return it != std::end(uur::UR_CONFORMANCE_TARGET_TRIPLES);
 }
 
 void KernelsEnvironment::LoadSource(

--- a/unified-runtime/test/conformance/testing/CMakeLists.txt
+++ b/unified-runtime/test/conformance/testing/CMakeLists.txt
@@ -3,10 +3,32 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+function(configure_targets_header input output)
+    cmake_parse_arguments(PARSE_ARGV 2 ARG "" VAR_PREFIX TARGETS)
+    if (ARG_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unexpected arguments \"${ARG_UNPARSED_ARGUMENTS}\"")
+    endif()
+
+    list(LENGTH ARG_TARGETS "${ARG_VAR_PREFIX}_NUM")
+    list(TRANSFORM ARG_TARGETS PREPEND "\"")
+    list(TRANSFORM ARG_TARGETS APPEND "\"")
+    list(JOIN ARG_TARGETS ",\n" "${ARG_VAR_PREFIX}_INITIALIZER")
+
+    configure_file(${input} ${output} @ONLY)
+endfunction()
+
+configure_targets_header(
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/uur/targets.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/include/uur/targets.h
+    VAR_PREFIX UR_CONFORMANCE_TARGET_TRIPLES
+    TARGETS ${TARGET_TRIPLES})
+
 add_ur_library(ur_testing STATIC 
     source/utils.cpp
     source/fixtures.cpp)
-target_include_directories(ur_testing PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(ur_testing PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_link_libraries(ur_testing PRIVATE
     gtest_main
     ${PROJECT_NAME}::common

--- a/unified-runtime/test/conformance/testing/include/uur/environment.h
+++ b/unified-runtime/test/conformance/testing/include/uur/environment.h
@@ -68,6 +68,8 @@ struct KernelsEnvironment : DevicesEnvironment {
   virtual void SetUp() override;
   virtual void TearDown() override;
 
+  static bool HaveSourcesForTarget(const std::string &target_name);
+
   void LoadSource(const std::string &kernel_name, ur_platform_handle_t platform,
                   std::shared_ptr<std::vector<char>> &binary_out);
 

--- a/unified-runtime/test/conformance/testing/include/uur/targets.h.in
+++ b/unified-runtime/test/conformance/testing/include/uur/targets.h.in
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See LICENSE.TXT
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef UR_CONFORMANCE_INCLUDE_TARGETS_H_INCLUDED
+#define UR_CONFORMANCE_INCLUDE_TARGETS_H_INCLUDED
+
+#include <array>
+
+namespace uur {
+// clang-format off
+constexpr std::array<const char *, @UR_CONFORMANCE_TARGET_TRIPLES_NUM@> UR_CONFORMANCE_TARGET_TRIPLES = {
+@UR_CONFORMANCE_TARGET_TRIPLES_INITIALIZER@
+};
+// clang-format on
+} // namespace uur
+
+#endif // UR_CONFORMANCE_INCLUDE_TARGETS_H_INCLUDED


### PR DESCRIPTION
Forward the value of UR_CONFORMANCE_TARGET_TRIPLES as an array to the conformance tests, and make it available to tests via `KernelsEnvironment::HaveSourcesForTarget(target_name)`. This allows tests to require specific targets to be available.