### PR TITLE
[UR][Docs] Transform reference to macros in specs to links

### DIFF
--- a/unified-runtime/scripts/generate_docs.py
+++ b/unified-runtime/scripts/generate_docs.py
@@ -58,7 +58,7 @@ def _find_enum_from_etor(etor, meta):
 
 def _make_ref(symbol, symbol_type, meta):
     """make restructedtext reference from symbol."""
-    if not re.match(r"function|struct|union|enum|etor", symbol_type):
+    if not re.match(r"function|struct|union|enum|etor|macro", symbol_type):
         return ""
 
     ref = _fixup_tag(symbol)
@@ -180,7 +180,7 @@ def _generate_valid_rst(fin, fout, namespace, tags, ver, rev, meta, fast_mode):
                         line = tuple[2]
                     else:
                         # ignore reference links for specific types that have no API documentation for them.
-                        if not re.match(r"env|handle|typedef|macro", symbol_type):
+                        if not re.match(r"env|handle|typedef", symbol_type):
                             print(
                                 "%s(%s) : warning : reference link %s (type=%s) not used."
                                 % (fin, iline + 1, symbol, symbol_type)


### PR DESCRIPTION
Contrary to the comment in the code macros do have API documentation, so they should be linked to. Currently there seems to be no macros in the rst sources, but I noticed this while working on an extension that would add one.