### PR TITLE
[SYCL][E2E] Re-enable Windows BMG tests that are no longer slow/hanging

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/events_caching.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/events_caching.cpp
@@ -2,9 +2,6 @@
 // UNSUPPORTED: level_zero_v2_adapter
 // UNSUPPORTED-INTENDED: v2 adapter does not allow disabling caching
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17255
-
 // RUN: %{build}  -o %t.out
 
 // RUN: %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --check-prefixes=CACHING-ENABLED %s

--- a/sycl/test-e2e/Adapters/level_zero/events_caching_leak.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/events_caching_leak.cpp
@@ -7,9 +7,6 @@
 // Check that events and pools are not leaked when event caching is
 // enabled/disabled.
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17916
-
 #include <array>
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/KernelCompiler/sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl.cpp
@@ -12,9 +12,6 @@
 // UNSUPPORTED: accelerator
 // UNSUPPORTED-INTENDED: while accelerator is AoT only, this cannot run there.
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17255
-
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out
 

--- a/sycl/test-e2e/Regression/static-buffer-dtor.cpp
+++ b/sycl/test-e2e/Regression/static-buffer-dtor.cpp
@@ -18,9 +18,6 @@
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17255
-
 #include <sycl/detail/core.hpp>
 
 int main() {


### PR DESCRIPTION
Fixes #17255
Fixes #17916

These are no longer slow after updating the drivers