### PR TITLE
[SYCL] UR enum values are already typed, avoid explicit casts

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -82,6 +82,13 @@ template <typename Param>
 typename Param::return_type device_impl::get_info() const {
   return get_device_info<Param>(*this);
 }
+template <>
+info::device::opencl_c_version::return_type
+device_impl::get_info<info::device::opencl_c_version>() const {
+  throw sycl::exception(
+      errc::feature_not_supported,
+      "Deprecated interface that hasn't been working for some time already");
+}
 // Explicitly instantiate all device info traits
 #define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, PiCode)              \
   template ReturnT device_impl::get_info<info::device::Desc>() const;

--- a/sycl/source/detail/ur_info_code.hpp
+++ b/sycl/source/detail/ur_info_code.hpp
@@ -19,66 +19,30 @@ template <typename T> struct UrInfoCode;
 
 #define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
   template <> struct UrInfoCode<info::DescType::Desc> {                        \
-    static constexpr ur_##DescType##_info_t value =                            \
-        static_cast<ur_##DescType##_info_t>(UrCode);                           \
+    static constexpr auto value = UrCode;                                      \
   };
 #include <sycl/info/context_traits.def>
+#include <sycl/info/event_profiling_traits.def>
 #include <sycl/info/event_traits.def>
+#include <sycl/info/kernel_device_specific_traits.def>
 #include <sycl/info/kernel_traits.def>
 #include <sycl/info/platform_traits.def>
 #include <sycl/info/queue_traits.def>
-#undef __SYCL_PARAM_TRAITS_SPEC
-
-#define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
-  template <> struct UrInfoCode<info::DescType::Desc> {                        \
-    static constexpr ur_profiling_info_t value = UrCode;                       \
-  };
-#include <sycl/info/event_profiling_traits.def>
-#undef __SYCL_PARAM_TRAITS_SPEC
-
-#define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
-  template <> struct UrInfoCode<info::DescType::Desc> {                        \
-    static constexpr typename std::conditional<                                \
-        IsSubGroupInfo<info::DescType::Desc>::value,                           \
-        ur_kernel_sub_group_info_t,                                            \
-        std::conditional<IsKernelInfo<info::DescType::Desc>::value,            \
-                         ur_kernel_info_t,                                     \
-                         ur_kernel_group_info_t>::type>::type value = UrCode;  \
-  };
-#include <sycl/info/kernel_device_specific_traits.def>
-#undef __SYCL_PARAM_TRAITS_SPEC
-
-#define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
-  template <> struct UrInfoCode<info::DescType::Desc> {                        \
-    static constexpr ur_device_info_t value =                                  \
-        static_cast<ur_device_info_t>(UrCode);                                 \
-  };
 #define __SYCL_PARAM_TRAITS_SPEC_SPECIALIZED(DescType, Desc, ReturnT, PiCode)  \
   __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, PiCode)
-
 #include <sycl/info/device_traits.def>
-
-#undef __SYCL_PARAM_TRAITS_SPEC
 #undef __SYCL_PARAM_TRAITS_SPEC_SPECIALIZED
+#undef __SYCL_PARAM_TRAITS_SPEC
 
 #define __SYCL_PARAM_TRAITS_SPEC(Namespace, DescType, Desc, ReturnT, UrCode)   \
   template <> struct UrInfoCode<Namespace::info::DescType::Desc> {             \
-    static constexpr ur_device_info_t value =                                  \
-        static_cast<ur_device_info_t>(UrCode);                                 \
+    static constexpr auto value = UrCode;                                      \
   };
 
 #include <sycl/info/ext_codeplay_device_traits.def>
 #include <sycl/info/ext_intel_device_traits.def>
-#include <sycl/info/ext_oneapi_device_traits.def>
-#undef __SYCL_PARAM_TRAITS_SPEC
-
-#define __SYCL_PARAM_TRAITS_SPEC(Namespace, DescType, Desc, ReturnT, UrCode)   \
-  template <> struct UrInfoCode<Namespace::info::DescType::Desc> {             \
-    static constexpr ur_kernel_info_t value =                                  \
-        static_cast<ur_kernel_info_t>(UrCode);                                 \
-  };
-
 #include <sycl/info/ext_intel_kernel_info_traits.def>
+#include <sycl/info/ext_oneapi_device_traits.def>
 #undef __SYCL_PARAM_TRAITS_SPEC
 
 } // namespace detail


### PR DESCRIPTION
Apparently, `get_info<info::device::opencl_c_version>` was returning garbage because its `UrCode` is `__SYCL_TRAIT_HANDLED_IN_RT` while no special handling was in fact done for it. Since it's deprecated anyway I'm not trying to fix that but just throw an exception instead.