### PR TITLE
[SYCL][E2E] Remove UB kernel launch in sycl_join

### DIFF
--- a/sycl/test-e2e/KernelCompiler/sycl_join.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_join.cpp
@@ -210,25 +210,12 @@ int main() {
       ++Failed;
     }
 
-    Q.submit([&](sycl::handler &CGH) {
-       CGH.set_args(IntPtr);
-       CGH.single_task(RegularSYCLK);
-     }).wait_and_throw();
-
-    if (*IntPtr != RegularSYCLKernelWriteValue) {
-      std::cout << "Regular SYCL kernel (explicit) in joined mixed executable "
-                   "bundles failed: "
-                << *IntPtr << " != " << RegularSYCLKernelWriteValue << "\n";
-      ++Failed;
-    }
-    *IntPtr = 0;
-
     RunRegularSYCLKernel(Q, KBExeJoined, IntPtr);
 
     if (*IntPtr != RegularSYCLKernelWriteValue) {
-      std::cout << "Regular SYCL kernel (implicit) in joined mixed executable "
-                   "bundles failed: "
-                << *IntPtr << " != " << RegularSYCLKernelWriteValue << "\n";
+      std::cout
+          << "Regular SYCL kernel in joined mixed executable bundles failed: "
+          << *IntPtr << " != " << RegularSYCLKernelWriteValue << "\n";
       ++Failed;
     }
 


### PR DESCRIPTION
This commit removes the explicit kernel launch in sycl_join, as the use of the set_args assumes the layout of arguments in the kernel, which is not guaranteed to be as expected.