### PR TITLE
[SYCL][SYCLLowerIR] Fix shared library build

### DIFF
--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -115,5 +115,9 @@ add_llvm_component_library(LLVMSYCLLowerIR
   )
 
 target_include_directories(LLVMSYCLLowerIR
-  PRIVATE ${LLVM_MAIN_SRC_DIR}/projects/vc-intrinsics/GenXIntrinsics/include
-  PRIVATE ${LLVM_BINARY_DIR}/projects/vc-intrinsics/GenXIntrinsics/include)
+  PUBLIC $<BUILD_INTERFACE:${LLVMGenXIntrinsics_SOURCE_DIR}/GenXIntrinsics/include/>
+  PUBLIC $<BUILD_INTERFACE:${LLVMGenXIntrinsics_BINARY_DIR}>
+  )
+target_link_libraries(LLVMSYCLLowerIR
+  PUBLIC LLVMGenXIntrinsics
+  )


### PR DESCRIPTION
Shared library build is currently failing due to my change [here](https://github.com/intel/llvm/pull/18249).

The problem is the public build target dependencies of SYCLLowerIR didn't add the vc-intrinsics headers/binaries so the include/link fails.

This wasn't happening before because users of SYCLLowerIR manually added the missing dependencies in their targets.

Manually verified this on static/shared library build on both preinstalled vc-intrinsics and system vc-intrinsics.