### PR TITLE
[LIBCLC] Drop AMD code object version from libclc

### DIFF
--- a/libclc/utils/prepare-builtins.cpp
+++ b/libclc/utils/prepare-builtins.cpp
@@ -89,16 +89,32 @@ int main(int argc, char **argv) {
   if (NamedMDNode *OCLVersion = M->getNamedMetadata("opencl.ocl.version"))
       M->eraseNamedMetadata(OCLVersion);
 
+  SmallVector<Metadata *, 2> BannedFlags;
   // wchar_size flag can cause a mismatch between libclc libraries and
   // modules using them. Since wchar is not used by libclc we drop the flag
-  if (M->getModuleFlag("wchar_size")) {
+  if (Metadata *F = M->getModuleFlag("wchar_size")) {
+    BannedFlags.push_back(F);
+  }
+
+  // amdhsa_code_object_version will be provided by the kernel module and may
+  // be changed by a command line flag.
+  if (Metadata *F = M->getModuleFlag("amdhsa_code_object_version")) {
+    BannedFlags.push_back(F);
+  }
+
+  // Re-write module flags but skip banned flags
+  if (!BannedFlags.empty()) {
     SmallVector<Module::ModuleFlagEntry, 4> ModuleFlags;
     M->getModuleFlagsMetadata(ModuleFlags);
     M->getModuleFlagsMetadata()->clearOperands();
-    for (const Module::ModuleFlagEntry ModuleFlag : ModuleFlags)
-      if (ModuleFlag.Key->getString() != "wchar_size")
-        M->addModuleFlag(ModuleFlag.Behavior, ModuleFlag.Key->getString(),
-                         ModuleFlag.Val);
+    for (const Module::ModuleFlagEntry ModuleFlag : ModuleFlags) {
+      if (BannedFlags.end() !=
+          std::find(BannedFlags.begin(), BannedFlags.end(), ModuleFlag.Val)) {
+        continue;
+      }
+      M->addModuleFlag(ModuleFlag.Behavior, ModuleFlag.Key->getString(),
+                       ModuleFlag.Val);
+    }
   }
 
   // Set linkage of every external definition to linkonce_odr.


### PR DESCRIPTION
Upstream recently bumped the default AMD code object version to 6, which is only supported by ROCm 6.3 and above.

There is a flag `-mcode-object-version=` to make the compiler use an older version. But before this patch it broke at the libclc linking stage since libclc had the default value in a module flag.

So this patch makes the prepare builtin tool remove this module flag from the libclc bitcode libraries.