### PR TITLE
[SYCL][E2E] Mark failing interop native mem tests as UNSUPPORTED

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
@@ -2,6 +2,7 @@
 // L0 adapter incorrectly reports memory leaks because it doesn't take into
 // account direct calls to L0 API.
 // UNSUPPORTED: ze_debug
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18299
 // UNSUPPORTED: linux && gpu-intel-dg2 && run-mode && !igc-dev
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
 // RUN: %{build} %level_zero_options -o %t.out

--- a/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
@@ -2,8 +2,8 @@
 // L0 adapter incorrectly reports memory leaks because it doesn't take into
 // account direct calls to L0 API.
 // UNSUPPORTED: ze_debug
-// XFAIL: linux && gpu-intel-dg2 && run-mode && !igc-dev
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18273
+// UNSUPPORTED: linux && gpu-intel-dg2 && run-mode && !igc-dev
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
@@ -2,6 +2,7 @@
 // L0 adapter incorrectly reports memory leaks because it doesn't take into
 // account direct calls to L0 API.
 // UNSUPPORTED: ze_debug
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18299
 // UNSUPPORTED: linux && gpu-intel-dg2 && run-mode && !igc-dev
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
 // RUN: %{build} %level_zero_options -o %t.out

--- a/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
@@ -2,8 +2,8 @@
 // L0 adapter incorrectly reports memory leaks because it doesn't take into
 // account direct calls to L0 API.
 // UNSUPPORTED: ze_debug
-// XFAIL: linux && gpu-intel-dg2 && run-mode && !igc-dev
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18273
+// UNSUPPORTED: linux && gpu-intel-dg2 && run-mode && !igc-dev
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
@@ -2,8 +2,8 @@
 // L0 adapter incorrectly reports memory leaks because it doesn't take into
 // account direct calls to L0 API.
 // UNSUPPORTED: ze_debug
-// XFAIL: linux && gpu-intel-dg2 && run-mode && !igc-dev
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18273
+// UNSUPPORTED: linux && gpu-intel-dg2 && run-mode && !igc-dev
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for immediate-command-list in Level Zero

--- a/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
@@ -2,6 +2,7 @@
 // L0 adapter incorrectly reports memory leaks because it doesn't take into
 // account direct calls to L0 API.
 // UNSUPPORTED: ze_debug
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18299
 // UNSUPPORTED: linux && gpu-intel-dg2 && run-mode && !igc-dev
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
 // RUN: %{build} %level_zero_options -o %t.out

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -69,7 +69,6 @@
 // CHECK-NEXT: Adapters/level_zero/interop-buffer-ownership.cpp
 // CHECK-NEXT: Adapters/level_zero/interop-buffer.cpp
 // CHECK-NEXT: Adapters/level_zero/interop-direct.cpp
-// CHECK-NEXT: Adapters/level_zero/interop-get-native-mem.cpp
 // CHECK-NEXT: Adapters/level_zero/interop-image-get-native-mem.cpp
 // CHECK-NEXT: Adapters/level_zero/interop-image-ownership.cpp
 // CHECK-NEXT: Adapters/level_zero/interop-image-ownership.cpp
@@ -159,7 +158,6 @@
 // CHECK-NEXT: Graph/Explicit/buffer_copy_target2host_offset.cpp
 // CHECK-NEXT: Graph/Explicit/host_task2_multiple_roots.cpp
 // CHECK-NEXT: Graph/Explicit/host_task_multiple_roots.cpp
-// CHECK-NEXT: Graph/Explicit/interop-level-zero-get-native-mem.cpp
 // CHECK-NEXT: Graph/Explicit/interop-level-zero-launch-kernel.cpp
 // CHECK-NEXT: Graph/Explicit/memadvise.cpp
 // CHECK-NEXT: Graph/Explicit/prefetch.cpp
@@ -174,7 +172,6 @@
 // CHECK-NEXT: Graph/RecordReplay/buffer_copy_target2host_offset.cpp
 // CHECK-NEXT: Graph/RecordReplay/host_task2_multiple_roots.cpp
 // CHECK-NEXT: Graph/RecordReplay/host_task_multiple_roots.cpp
-// CHECK-NEXT: Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
 // CHECK-NEXT: Graph/RecordReplay/interop-level-zero-launch-kernel.cpp
 // CHECK-NEXT: Graph/RecordReplay/memadvise.cpp
 // CHECK-NEXT: Graph/RecordReplay/prefetch.cpp

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 261
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 258
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.


### PR DESCRIPTION
[XPASSing](https://github.com/intel/llvm/actions/runs/14787981688) in the nightly for some reason but failing in postcommit, so make them `UNSUPPORTED`.