### PR TITLE
[NFC][SYCL] Move `platform_impl::get_info` impl to the header

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -11,7 +11,6 @@
 #include <detail/device_impl.hpp>
 #include <detail/global_handler.hpp>
 #include <detail/platform_impl.hpp>
-#include <detail/split_string.hpp>
 #include <detail/ur_info_code.hpp>
 #include <sycl/backend_types.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
@@ -565,17 +564,6 @@ ur_native_handle_t platform_impl::getNative() const {
   return Handle;
 }
 
-template <typename Param>
-typename Param::return_type platform_impl::get_info() const {
-  std::string InfoStr = urGetInfoString<UrApiKind::urPlatformGetInfo>(
-      *this, detail::UrInfoCode<Param>::value);
-  if constexpr (std::is_same_v<Param, info::platform::extensions>) {
-    return split_string(InfoStr, ' ');
-  } else {
-    return InfoStr;
-  }
-}
-
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 typename info::platform::version::return_type
@@ -644,12 +632,6 @@ device_impl *platform_impl::getDeviceImplHelper(ur_device_handle_t UrDevice) {
   }
   return nullptr;
 }
-
-#define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, PiCode)              \
-  template ReturnT platform_impl::get_info<info::platform::Desc>() const;
-
-#include <sycl/info/platform_traits.def>
-#undef __SYCL_PARAM_TRAITS_SPEC
 
 } // namespace detail
 } // namespace _V1

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <detail/adapter.hpp>
+#include <detail/split_string.hpp>
 #include <detail/ur.hpp>
 #include <detail/ur_info_code.hpp>
 #include <sycl/backend_types.hpp>
@@ -79,7 +80,15 @@ public:
   /// Queries this SYCL platform for info.
   ///
   /// The return type depends on information being queried.
-  template <typename Param> typename Param::return_type get_info() const;
+  template <typename Param> typename Param::return_type get_info() const {
+    std::string InfoStr = urGetInfoString<UrApiKind::urPlatformGetInfo>(
+        *this, detail::UrInfoCode<Param>::value);
+    if constexpr (std::is_same_v<Param, info::platform::extensions>) {
+      return split_string(InfoStr, ' ');
+    } else {
+      return InfoStr;
+    }
+  }
 
   /// Queries this SYCL platform for SYCL backend-specific information.
   ///


### PR DESCRIPTION
So that we wouldn't need explicit instantiations. Instead, `platform.cpp` would implicitly instantiate all of them when processing explicit ones for `platform::get_info`.