### PR TITLE
[NFC][UR] Remove unused print functions

### DIFF
--- a/unified-runtime/source/adapters/cuda/common.hpp
+++ b/unified-runtime/source/adapters/cuda/common.hpp
@@ -57,16 +57,6 @@ extern thread_local char ErrorMessage[MaxMessageSize];
 
 void setPluginSpecificMessage(CUresult cu_res);
 
-/// ------ Error handling, matching OpenCL plugin semantics.
-namespace detail {
-namespace ur {
-
-// Reports error messages
-void cuPrint(const char *Message);
-
-} // namespace ur
-} // namespace detail
-
 namespace umf {
 
 inline umf_result_t setCUMemoryProviderParams(

--- a/unified-runtime/source/adapters/hip/common.hpp
+++ b/unified-runtime/source/adapters/hip/common.hpp
@@ -113,16 +113,6 @@ extern thread_local char ErrorMessage[MaxMessageSize];
 [[maybe_unused]] void setErrorMessage(const char *Message,
                                       ur_result_t ErrorCode);
 
-/// ------ Error handling, matching OpenCL plugin semantics.
-namespace detail {
-namespace ur {
-
-// Reports error messages
-void hipPrint(const char *pMessage);
-
-} // namespace ur
-} // namespace detail
-
 // Helper method to return a (non-null) pointer's attributes, or std::nullopt in
 // the case that the pointer is unknown to the HIP subsystem.
 inline static std::optional<hipPointerAttribute_t>


### PR DESCRIPTION
`cuPrint` and `hipPrint` were deleted but the declaration wasn't, these aren't used anywhere, they were replaced by the UR logger.