### PR TITLE
[SYCL][CL] Fix ownership of native handle in sycl::make_queue

### DIFF
--- a/sycl/include/sycl/backend.hpp
+++ b/sycl/include/sycl/backend.hpp
@@ -327,18 +327,16 @@ std::enable_if_t<detail::InteropFeatureSupportMap<Backend>::MakeQueue == true,
 make_queue(const typename backend_traits<Backend>::template input_type<queue>
                &BackendObject,
            const context &TargetContext, const async_handler Handler = {}) {
-  auto KeepOwnership =
-      Backend == backend::ext_oneapi_cuda || Backend == backend::ext_oneapi_hip;
   if constexpr (Backend == backend::ext_oneapi_level_zero) {
     return detail::make_queue(
         detail::ur::cast<ur_native_handle_t>(
             std::get<ze_command_queue_handle_t>(BackendObject.NativeHandle)),
-        false, TargetContext, nullptr, KeepOwnership, {}, Handler, Backend);
-  }
-  if constexpr (Backend != backend::ext_oneapi_level_zero) {
+        false, TargetContext, nullptr, /*KeepOwnership*/ false, {}, Handler,
+        Backend);
+  } else {
     return detail::make_queue(
         detail::ur::cast<ur_native_handle_t>(BackendObject), false,
-        TargetContext, nullptr, KeepOwnership, {}, Handler, Backend);
+        TargetContext, nullptr, /*KeepOwnership*/ true, {}, Handler, Backend);
   }
 }
 


### PR DESCRIPTION
Level Zero is the only backend which has any explicit ownership transfer controls when creating SYCL objects from native handles.

The CUDA and HIP backends already had the default to not transferring ownership of native handles.

Up until this patch the OpenCL backend was transferring ownership when creating with a native handle, when combined with the changes to the OpenCL adapter in https://github.com/intel/llvm/pull/17572 this caused crashes in existing workloads which expect to manage ownership of the OpenCL native handles.

Fixes URT-905.