### PR TITLE
[CI] Use the build label for all Windows builds

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -249,7 +249,7 @@ jobs:
     uses: ./.github/workflows/sycl-windows-run-tests.yml
     with:
       name: Build SYCL-CTS for Windows
-      runner: '["Windows", "build-e2e"]'
+      runner: '["Windows", "build"]'
       cts_testing_mode: 'build-only'
       tests_selector: cts
       repo_ref: ${{ github.sha }}

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -81,7 +81,7 @@ permissions: read-all
 jobs:
   build:
     name: Build + LIT
-    runs-on: [Windows, build-e2e]
+    runs-on: [Windows, build]
     environment: WindowsCILock
     outputs:
       build_conclusion: ${{ steps.build.conclusion }}


### PR DESCRIPTION
After I merge this I'll remove the `build` label from the slow machines and remove all runners using the `build-e2e` label.