### PR TITLE
Use refs to device_impl in ProgramManager

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -583,8 +583,7 @@ static const char *getUrDeviceTarget(const char *URDeviceTarget) {
 }
 
 static bool compatibleWithDevice(RTDeviceBinaryImage *BinImage,
-                                 const device &Dev) {
-  detail::device_impl &DeviceImpl = *detail::getSyclObjImpl(Dev);
+                                 const device_impl &DeviceImpl) {
   auto &Adapter = DeviceImpl.getAdapter();
 
   const ur_device_handle_t &URDeviceHandle = DeviceImpl.getHandleRef();
@@ -621,7 +620,7 @@ bool ProgramManager::isSpecialDeviceImage(RTDeviceBinaryImage *BinImage) {
 }
 
 bool ProgramManager::isSpecialDeviceImageShouldBeUsed(
-    RTDeviceBinaryImage *BinImage, const device &Dev) {
+    RTDeviceBinaryImage *BinImage, const device_impl &DeviceImpl) {
   // Decide whether a devicelib image should be used.
   int Bfloat16DeviceLibVersion = -1;
   if (m_Bfloat16DeviceLibImages[0].get() == BinImage)
@@ -640,7 +639,6 @@ bool ProgramManager::isSpecialDeviceImageShouldBeUsed(
     // more devicelib images in this way.
     enum { DEVICELIB_FALLBACK = 0, DEVICELIB_NATIVE };
     ur_bool_t NativeBF16Supported = false;
-    detail::device_impl &DeviceImpl = *detail::getSyclObjImpl(Dev);
     ur_result_t CallSuccessful =
         DeviceImpl.getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
             DeviceImpl.getHandleRef(),
@@ -658,7 +656,7 @@ bool ProgramManager::isSpecialDeviceImageShouldBeUsed(
   return false;
 }
 
-static bool checkLinkingSupport(const device &Dev,
+static bool checkLinkingSupport(const device_impl &DeviceImpl,
                                 const RTDeviceBinaryImage &Img) {
   const char *Target = Img.getRawData().DeviceTargetSpec;
   // TODO replace with extension checks once implemented in UR.
@@ -666,7 +664,7 @@ static bool checkLinkingSupport(const device &Dev,
     return true;
   }
   if (strcmp(Target, __SYCL_DEVICE_BINARY_TARGET_SPIRV64_GEN) == 0) {
-    return Dev.is_gpu() && Dev.get_backend() == backend::opencl;
+    return DeviceImpl.is_gpu() && DeviceImpl.getBackend() == backend::opencl;
   }
   return false;
 }
@@ -701,7 +699,8 @@ ProgramManager::collectDeviceImageDepsForImportedSymbols(
     HandledSymbols.insert(ISProp->Name);
   }
   ur::DeviceBinaryType Format = MainImg.getFormat();
-  if (!WorkList.empty() && !checkLinkingSupport(Dev, MainImg))
+  if (!WorkList.empty() &&
+      !checkLinkingSupport(*getSyclObjImpl(Dev).get(), MainImg))
     throw exception(make_error_code(errc::feature_not_supported),
                     "Cannot resolve external symbols, linking is unsupported "
                     "for the backend");
@@ -715,10 +714,10 @@ ProgramManager::collectDeviceImageDepsForImportedSymbols(
       RTDeviceBinaryImage *Img = It->second;
       if (Img->getFormat() != Format ||
           !doesDevSupportDeviceRequirements(Dev, *Img) ||
-          !compatibleWithDevice(Img, Dev))
+          !compatibleWithDevice(Img, *getSyclObjImpl(Dev).get()))
         continue;
       if (isSpecialDeviceImage(Img) &&
-          !isSpecialDeviceImageShouldBeUsed(Img, Dev))
+          !isSpecialDeviceImageShouldBeUsed(Img, *getSyclObjImpl(Dev).get()))
         continue;
       DeviceImagesToLink.insert(Img);
       Found = true;
@@ -2415,14 +2414,14 @@ kernel_id ProgramManager::getSYCLKernelID(KernelNameStrRefT KernelName) {
                   "No kernel found with the specified name");
 }
 
-bool ProgramManager::hasCompatibleImage(const device &Dev) {
+bool ProgramManager::hasCompatibleImage(const device_impl &DeviceImpl) {
   std::lock_guard<std::mutex> Guard(m_KernelIDsMutex);
 
   return std::any_of(
       m_BinImg2KernelIDs.cbegin(), m_BinImg2KernelIDs.cend(),
       [&](std::pair<RTDeviceBinaryImage *,
                     std::shared_ptr<std::vector<kernel_id>>>
-              Elem) { return compatibleWithDevice(Elem.first, Dev); });
+              Elem) { return compatibleWithDevice(Elem.first, DeviceImpl); });
 }
 
 std::vector<kernel_id> ProgramManager::getAllSYCLKernelIDs() {
@@ -2555,7 +2554,7 @@ device_image_plain ProgramManager::getDeviceImageFromBinaryImage(
     RTDeviceBinaryImage *BinImage, const context &Ctx, const device &Dev) {
   const bundle_state ImgState = getBinImageState(BinImage);
 
-  assert(compatibleWithDevice(BinImage, Dev));
+  assert(compatibleWithDevice(BinImage, *getSyclObjImpl(Dev).get()));
 
   std::shared_ptr<std::vector<sycl::kernel_id>> KernelIDs;
   // Collect kernel names for the image.
@@ -2640,7 +2639,7 @@ ProgramManager::getSYCLDeviceImagesWithCompatibleState(
         KernelImageMap.insert({KernelID, {}});
 
     for (RTDeviceBinaryImage *BinImage : BinImages) {
-      if (!compatibleWithDevice(BinImage, Dev) ||
+      if (!compatibleWithDevice(BinImage, *getSyclObjImpl(Dev).get()) ||
           !doesDevSupportDeviceRequirements(Dev, *BinImage))
         continue;
 

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -254,7 +254,7 @@ public:
                                   const char *UniqueId);
 
   // Returns true if any available image is compatible with the device Dev.
-  bool hasCompatibleImage(const device &Dev);
+  bool hasCompatibleImage(const device_impl &DeviceImpl);
 
   // The function gets a device_global entry identified by the pointer to the
   // device_global object from the device_global map.
@@ -406,7 +406,7 @@ private:
 
   bool isSpecialDeviceImage(RTDeviceBinaryImage *BinImage);
   bool isSpecialDeviceImageShouldBeUsed(RTDeviceBinaryImage *BinImage,
-                                        const device &Dev);
+                                        const device_impl &DeviceImpl);
 
 protected:
   /// The three maps below are used during kernel resolution. Any kernel is

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -33,15 +33,14 @@ namespace detail {
 // itself, so only matching devices will be scored.
 static int getDevicePreference(const device &Device) {
   int Score = 0;
-
+  const device_impl &DeviceImpl = *getSyclObjImpl(Device).get();
   // Strongly prefer devices with available images.
   auto &program_manager = sycl::detail::ProgramManager::getInstance();
-  if (program_manager.hasCompatibleImage(Device))
+  if (program_manager.hasCompatibleImage(DeviceImpl))
     Score += 1000;
 
   // Prefer level_zero backend devices.
-  if (detail::getSyclObjImpl(Device)->getBackend() ==
-      backend::ext_oneapi_level_zero)
+  if (DeviceImpl.getBackend() == backend::ext_oneapi_level_zero)
     Score += 50;
 
   return Score;


### PR DESCRIPTION
Refactored the `ProgramManager` to use refs to `device_impl` instead of `const std::shared_ptr<device_impl> &`