### PR TITLE
Event pool cache leak fix

### DIFF
--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -407,14 +407,71 @@ ur_result_t ur_context_handle_t_::getFreeSlotInExistingOrNewPool(
     bool ProfilingEnabled, ur_device_handle_t Device,
     bool CounterBasedEventEnabled, bool UsingImmCmdList,
     bool InterruptBasedEventEnabled) {
-  // Lock while updating event pool machinery.
-  std::scoped_lock<ur_mutex> Lock(ZeEventPoolCacheMutex);
 
   ze_device_handle_t ZeDevice = nullptr;
-
   if (Device) {
     ZeDevice = Device->ZeDevice;
   }
+
+  if (DisableEventsCaching) {
+    // Skip all cache handling, always create a new pool
+    ze_event_pool_counter_based_exp_desc_t counterBasedExt = {
+        ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC, nullptr, 0};
+
+    ze_intel_event_sync_mode_exp_desc_t eventSyncMode = {
+        ZE_INTEL_STRUCTURE_TYPE_EVENT_SYNC_MODE_EXP_DESC, nullptr, 0};
+    eventSyncMode.syncModeFlags =
+        ZE_INTEL_EVENT_SYNC_MODE_EXP_FLAG_LOW_POWER_WAIT |
+        ZE_INTEL_EVENT_SYNC_MODE_EXP_FLAG_SIGNAL_INTERRUPT;
+
+    ZeStruct<ze_event_pool_desc_t> ZeEventPoolDesc;
+    ZeEventPoolDesc.count = MaxNumEventsPerPool;
+    ZeEventPoolDesc.flags = 0;
+    ZeEventPoolDesc.pNext = nullptr;
+    if (HostVisible)
+      ZeEventPoolDesc.flags |= ZE_EVENT_POOL_FLAG_HOST_VISIBLE;
+    if (ProfilingEnabled)
+      ZeEventPoolDesc.flags |= ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP;
+    UR_LOG(DEBUG, "ze_event_pool_desc_t flags set to: {}",
+           ZeEventPoolDesc.flags);
+    if (CounterBasedEventEnabled) {
+      if (UsingImmCmdList) {
+        counterBasedExt.flags = ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE;
+      } else {
+        counterBasedExt.flags =
+            ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_NON_IMMEDIATE;
+      }
+      UR_LOG(DEBUG, "ze_event_pool_desc_t counter based flags set to: {}",
+             counterBasedExt.flags);
+      if (InterruptBasedEventEnabled) {
+        counterBasedExt.pNext = &eventSyncMode;
+      }
+      ZeEventPoolDesc.pNext = &counterBasedExt;
+    } else if (InterruptBasedEventEnabled) {
+      ZeEventPoolDesc.pNext = &eventSyncMode;
+    }
+
+    std::vector<ze_device_handle_t> ZeDevices;
+    if (ZeDevice) {
+      ZeDevices.push_back(ZeDevice);
+    } else {
+      std::for_each(Devices.begin(), Devices.end(),
+                    [&](const ur_device_handle_t &D) {
+                      ZeDevices.push_back(D->ZeDevice);
+                    });
+    }
+
+    ZE2UR_CALL(zeEventPoolCreate, (ZeContext, &ZeEventPoolDesc,
+                                   ZeDevices.size(), &ZeDevices[0], &Pool));
+    Index = 0;
+    NumEventsAvailableInEventPool[Pool] = MaxNumEventsPerPool - 1;
+    NumEventsUnreleasedInEventPool[Pool] = 1;
+    return UR_RESULT_SUCCESS;
+  }
+
+  // --- Normal cache-based logic below ---
+  std::scoped_lock<ur_mutex> Lock(ZeEventPoolCacheMutex);
+
   std::list<ze_event_pool_handle_t> *ZePoolCache = getZeEventPoolCache(
       HostVisible, ProfilingEnabled, CounterBasedEventEnabled, UsingImmCmdList,
       InterruptBasedEventEnabled, ZeDevice);

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -423,9 +423,7 @@ ur_result_t ur_context_handle_t_::getFreeSlotInExistingOrNewPool(
     if (NumEventsAvailableInEventPool[ZePoolCache->front()] == 0) {
       if (DisableEventsCaching) {
         // Remove full pool from the cache if events caching is disabled.
-        for (auto &ZePool : *ZePoolCache) {
-          ZE_CALL_NOCHECK(zeEventPoolDestroy, (ZePool));
-        }
+        ZE_CALL_NOCHECK(zeEventPoolDestroy, (ZePoolCache->front()));
         ZePoolCache->erase(ZePoolCache->begin());
       } else {
         // If event caching is enabled then we don't destroy events so there is

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -423,6 +423,9 @@ ur_result_t ur_context_handle_t_::getFreeSlotInExistingOrNewPool(
     if (NumEventsAvailableInEventPool[ZePoolCache->front()] == 0) {
       if (DisableEventsCaching) {
         // Remove full pool from the cache if events caching is disabled.
+        for (auto &ZePool : *ZePoolCache) {
+          ZE_CALL_NOCHECK(zeEventPoolDestroy, (ZePool));
+        }
         ZePoolCache->erase(ZePoolCache->begin());
       } else {
         // If event caching is enabled then we don't destroy events so there is


### PR DESCRIPTION
addresses event pool leak when SYCL_PI_LEVEL_ZERO_DISABLE_EVENTS_CACHING is set to 1