### PR TITLE
[UR][L0] Move async pool cleanup after queue sync

### DIFF
--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -615,8 +615,6 @@ ur_result_t urQueueRelease(
       return UR_RESULT_SUCCESS;
     }
 
-    Queue->Context->AsyncPool.cleanupPoolsForQueue(Queue);
-
     // When external reference count goes to zero it is still possible
     // that internal references still exists, e.g. command-lists that
     // are not yet completed. So do full queue synchronization here
@@ -629,6 +627,9 @@ ur_result_t urQueueRelease(
     // Make sure all commands get executed.
     if (Res == UR_RESULT_SUCCESS)
       UR_CALL(Queue->synchronize());
+
+    // Cleanup the allocations from 'AsyncPool' made by this queue.
+    Queue->Context->AsyncPool.cleanupPoolsForQueue(Queue);
 
     // Destroy all the fences created associated with this queue.
     for (auto it = Queue->CommandListMap.begin();


### PR DESCRIPTION
In a scenario where the AsyncPool freelist contains an entry tied to a free event that hasn't completed yet, performing freelist cleanup before queue sync can result in freeing memory that's actively in use.