### PR TITLE
[CI][Perf] Fix BenchmarkRun 'NoneType' warning

### DIFF
--- a/devops/scripts/benchmarks/history.py
+++ b/devops/scripts/benchmarks/history.py
@@ -120,7 +120,7 @@ class BenchmarkHistory:
             )
 
         compute_runtime = (
-            options.compute_runtime_tag if options.build_compute_runtime else None
+            options.compute_runtime_tag if options.build_compute_runtime else ""
         )
 
         return BenchmarkRun(


### PR DESCRIPTION
Fix the following warning during benchmarks run:
```
RuntimeWarning: 'NoneType' object value of non-optional type compute_runtime detected when decoding BenchmarkRun.
```
https://github.com/intel/llvm/actions/runs/14850915457/job/41694529398#step:19:810

