### PR TITLE
[SYCL][E2E] Fix LIT requires vulkan directive

### DIFF
--- a/sycl/test-e2e/bindless_images/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/lit.local.cfg
@@ -22,6 +22,3 @@ if platform.system() == "Windows":
     if cl_options:
         dx12libs = ['/clang:' + l for l in dx12libs]
     config.substitutions.append(("%link-directx", ' '.join(dx12libs)))
-
-if config.vulkan_found == "TRUE":
-    config.available_features.add("vulkan")

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -605,6 +605,10 @@ if "verbose-print" in lit_config.params:
 else:
     config.substitutions.append(("%verbose_print", ""))
 
+# Enable `vulkan` feature if Vulkan was found.
+if config.vulkan_found == "TRUE":
+    config.available_features.add("vulkan")
+
 if not config.gpu_aot_target_opts:
     config.gpu_aot_target_opts = '"-device *"'
 


### PR DESCRIPTION
The addition of "vulkan" to `config.available_features` was moved to `bindless_images/lit.local.cfg` in #18220. This broke the `// REQUIRES: vulkan` directive, and tests were reporting as being unsupported despite vulkan being available on the system.

This patch moves the check and addition of vulkan to the available features back to `test-e2e/lit.cfg.py` to fix the issue.