### PR TITLE
[SYCL][UR][L0 v2] add missing offset calculation to

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -47,16 +47,16 @@ ur_usm_handle_t::ur_usm_handle_t(ur_context_handle_t hContext, size_t size,
 
 void *ur_usm_handle_t::getDevicePtr(
     ur_device_handle_t /*hDevice*/, device_access_mode_t /*access*/,
-    size_t /*offset*/, size_t /*size*/,
+    size_t offset, size_t /*size*/,
     std::function<void(void *src, void *dst, size_t)> /*migrate*/) {
-  return ptr;
+  return ur_cast<char *>(ptr) + offset;
 }
 
 void *
-ur_usm_handle_t::mapHostPtr(ur_map_flags_t /*flags*/, size_t /*offset*/,
+ur_usm_handle_t::mapHostPtr(ur_map_flags_t /*flags*/, size_t offset,
                             size_t /*size*/,
                             std::function<void(void *src, void *dst, size_t)>) {
-  return ptr;
+  return ur_cast<char *>(ptr) + offset;
 }
 
 void ur_usm_handle_t::unmapHostPtr(


### PR DESCRIPTION
getDevicePtr and mapHostPtr for ur_usm_handle_t.

We never actually use the handle with non-zero offset but we may change that in future.