### PR TITLE
[CI][Benchmarks] update compute-benchmarks

### DIFF
--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -49,7 +49,7 @@ class ComputeBench(Suite):
         return "https://github.com/intel/compute-benchmarks.git"
 
     def git_hash(self) -> str:
-        return "5e4e39cabd0f74422754890ff8e362789c714543"
+        return "015019f815f73e308171145a48b63d57c1263e45"
 
     def setup(self):
         if options.sycl is None:


### PR DESCRIPTION
This fixes api_overhead_benchmark_ur after #18242.