### PR TITLE
[UR] Use std::move so vector is not copied in validation layer RefRuntimeInfo struct

### DIFF
--- a/unified-runtime/source/loader/layers/validation/ur_leak_check.hpp
+++ b/unified-runtime/source/loader/layers/validation/ur_leak_check.hpp
@@ -27,7 +27,7 @@ private:
 
     RefRuntimeInfo(int64_t refCount, std::type_index type,
                    std::vector<BacktraceLine> backtrace)
-        : refCount(refCount), type(type), backtrace(backtrace) {}
+        : refCount(refCount), type(type), backtrace(std::move(backtrace)) {}
   };
 
   enum RefCountUpdateType {


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/issues/18341