### PR TITLE
[SYCL][host_task] Align host_task event submission clock with start/end clock

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -581,9 +581,9 @@ void event_impl::setSubmissionTime() {
   } else {
     // Returning host time
     using namespace std::chrono;
-    MSubmitTime =
-        duration_cast<nanoseconds>(steady_clock::now().time_since_epoch())
-            .count();
+    MSubmitTime = duration_cast<nanoseconds>(
+                      high_resolution_clock::now().time_since_epoch())
+                      .count();
   }
 }
 


### PR DESCRIPTION
The submission time for host_task events was previously obtained using `std::chrono::steady_clock`, while the command start and end times were derived from `high_resolution_clock`. This discrepancy in clock epochs led to meaningless duration calculations when users used submission time as a reference.

This update standardizes the clock source by switching the submission time to use `high_resolution_clock`, ensuring consistent and meaningful timing results for host_task events.

Note: `steady_clock` is not related to wall clock. See https://en.cppreference.com/w/cpp/chrono/steady_clock