### PR TITLE
[CI][UR] Fix UR pre-commit after lit migration

### DIFF
--- a/.github/workflows/ur-precommit.yml
+++ b/.github/workflows/ur-precommit.yml
@@ -94,7 +94,6 @@ jobs:
       runner_name: ${{ matrix.runner }}
       static_loader: ${{ matrix.static || 'OFF' }}
       static_adapter: ${{ matrix.static || 'OFF' }}
-      platform: ${{ matrix.platform || '' }}
       other_adapter_name: ${{ matrix.other_adapter || '' }}
       docker_image: ${{ matrix.docker_image || 'ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps'}}
       image_options: ${{ matrix.image_options || '' }}


### PR DESCRIPTION
The UR pre-commit has been failing since: https://github.com/intel/llvm/pull/17998

With:
```
Invalid workflow file: .github/workflows/ur-precommit.yml#L97
The workflow is not valid. .github/workflows/ur-precommit.yml (Line: 97, Col: 17): Invalid input, platform is not defined in the referenced workflow.
```

It seems the PR missed a use of the `platform` variable, so this patch is removing it, as it's also no longer used anywhere.