### PR TITLE
[UR][L0] Correctly destroy images

### DIFF
--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -28,8 +28,9 @@ ur_result_t
 urBindlessImagesImageFreeExp(ur_context_handle_t /*hContext*/,
                              ur_device_handle_t /*hDevice*/,
                              ur_exp_image_mem_native_handle_t hImageMem) {
-  UR_CALL(ur::level_zero::urMemRelease(
-      reinterpret_cast<ur_mem_handle_t>(hImageMem)));
+  auto Native = reinterpret_cast<ur_bindless_mem_handle_t *>(hImageMem);
+  delete Native;
+
   return UR_RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
`ur_exp_image_mem_native_handle_t` is a `ur_bindless_mem_handle_t *`,
but was incorrectly being treated as a `ur_mem_handle_t` on destruction.
