### PR TITLE
[UR] Remove references to CTS_ADAPTER_PLATFORM in CI/docs

### DIFF
--- a/.github/workflows/ur-build-hw.yml
+++ b/.github/workflows/ur-build-hw.yml
@@ -13,11 +13,6 @@ on:
       runner_name:
         required: true
         type: string
-      platform:
-        description: "Platform string, `UR_CTS_ADAPTER_PLATFORM` will be set to this."
-        required: false
-        type: string
-        default: ""
       static_loader:
         required: false
         type: string
@@ -46,11 +41,6 @@ on:
       runner_name:
         required: true
         type: string
-      platform:
-        description: "Platform string, `UR_CTS_ADAPTER_PLATFORM` will be set to this."
-        required: false
-        type: string
-        default: ""
       static_loader:
         required: false
         type: string
@@ -89,7 +79,6 @@ jobs:
           {
             name: "${{inputs.adapter_name}}",
             other_name: "${{inputs.other_adapter_name}}",
-            platform: "${{inputs.platform}}",
             static_Loader: "${{inputs.static_loader}}",
             static_adapter: "${{inputs.static_loader}}"
           }
@@ -105,7 +94,6 @@ jobs:
     steps:
     # TODO:
     # - investigate if DUR_CONFORMANCE_AMD_ARCH could be removed
-    # - find better way to handle platform param (e.g. "Intel(R) OpenCL" -> "opencl")
     # - switch to Ninja generator in CMake
     # - downloading DPC++ should be integrated somehow; most likely use nightly release.
     #
@@ -184,7 +172,7 @@ jobs:
     - name: Test adapters
       env:
         ZE_ENABLE_LOADER_DEBUG_TRACE: 1
-      run: env UR_CTS_ADAPTER_PLATFORM="${{matrix.adapter.platform}}" ctest -C ${{matrix.build_type}} --test-dir build --output-on-failure -L "conformance" --timeout 600 -VV
+      run: ctest -C ${{matrix.build_type}} --test-dir build --output-on-failure -L "conformance" --timeout 600 -VV
 
     - name: Get information about platform
       if: ${{ always() }}

--- a/.github/workflows/ur-precommit.yml
+++ b/.github/workflows/ur-precommit.yml
@@ -77,12 +77,10 @@ jobs:
             image_options: -u 1001 --privileged --cap-add SYS_ADMIN --gpus all
           - name: OPENCL
             runner: UR_OPENCL
-            platform: "Intel(R) OpenCL"
             docker_image: "ghcr.io/intel/llvm/ubuntu2204_build:latest"
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd --privileged --cap-add SYS_ADMIN
           - name: OPENCL
             runner: UR_OPENCL
-            platform: "OPENCL:Intel(R) OpenCL"
             other_adapter: NATIVE_CPU
             docker_image: "ghcr.io/intel/llvm/ubuntu2204_build:latest"
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd --privileged --cap-add SYS_ADMIN
@@ -96,7 +94,6 @@ jobs:
       runner_name: ${{ matrix.runner }}
       static_loader: ${{ matrix.static || 'OFF' }}
       static_adapter: ${{ matrix.static || 'OFF' }}
-      platform: ${{ matrix.platform || '' }}
       other_adapter_name: ${{ matrix.other_adapter || '' }}
       docker_image: ${{ matrix.docker_image || 'ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps'}}
       image_options: ${{ matrix.image_options || '' }}

--- a/unified-runtime/scripts/core/INTRO.rst
+++ b/unified-runtime/scripts/core/INTRO.rst
@@ -420,20 +420,6 @@ framework should run on. This can be used during development and testing to run 
 are available. If both filters are specified, then they both must match a platform for it to be selected. If there are
 no valid platforms, then the tests will fail. Command line arguments take priority over these variables.
 
-.. envvar:: UR_CTS_ADAPTER_PLATFORM
-
-    A specifier list in the form of `[(backend):](platform name)[;[(backend)]:(platform name)]...`. If a backend
-    specific specifier is present in the list and the test is running for that backend, the device with the given name
-    is chosen. Otherwise, it must match the name of the specifier from the list with no backend. Backend names are case-
-    insensitive, however platform names must match exactly.
-
-    For example, if the test device has multiple platforms and you want to run tests on the "ABC Corp" backend when
-    testing OpenCL and "XYZ Org" when testing level zero, you'd use `OPENCL:ABC Corp;LEVEL_ZERO:XYZ Org`. This form is
-    useful when running the `build` target with a build with multiple backends.
-
-    For testing only one platform, the backend can be omitted. For example, just `ABC Corp` is sufficient if the tests
-    are only going to be testing OpenCL.
-
 .. envvar:: UR_CTS_BACKEND
 
     A (case insensitive) backend to force the test to use. For example, `opencl`, `level_zero`, `hip` and so on.


### PR DESCRIPTION
This variable isn't actually read anywhere.
