### PR TITLE
[UR][CTS] Flip command-buffer assert condition

### DIFF
--- a/unified-runtime/test/conformance/exp_command_buffer/copy.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/copy.cpp
@@ -25,8 +25,8 @@ struct urCommandBufferMemcpyCommandsTest
     offset_src = std::get<1>(GetParam()).offset_src;
     offset_dst = std::get<1>(GetParam()).offset_dst;
     copy_size = std::get<1>(GetParam()).copy_size;
-    assert(size <= offset_src + copy_size);
-    assert(size <= offset_dst + copy_size);
+    assert(size >= offset_src + copy_size);
+    assert(size >= offset_dst + copy_size);
     // Allocate USM pointers
     ASSERT_SUCCESS(
         urUSMDeviceAlloc(context, device, nullptr, nullptr, size, &device_ptr));

--- a/unified-runtime/test/conformance/exp_command_buffer/read.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/read.cpp
@@ -22,7 +22,7 @@ struct urCommandBufferReadCommandsTest
     size = std::get<1>(GetParam()).size;
     offset = std::get<1>(GetParam()).offset;
     read_size = std::get<1>(GetParam()).read_size;
-    assert(size <= offset + read_size);
+    assert(size >= offset + read_size);
     // Allocate USM pointers
     ASSERT_SUCCESS(
         urUSMDeviceAlloc(context, device, nullptr, nullptr, size, &device_ptr));

--- a/unified-runtime/test/conformance/exp_command_buffer/write.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/write.cpp
@@ -23,7 +23,7 @@ struct urCommandBufferWriteCommandsTest
     size = std::get<1>(GetParam()).size;
     offset = std::get<1>(GetParam()).offset;
     write_size = std::get<1>(GetParam()).write_size;
-    assert(size <= offset + write_size);
+    assert(size >= offset + write_size);
     // Allocate USM pointers
     ASSERT_SUCCESS(
         urUSMDeviceAlloc(context, device, nullptr, nullptr, size, &device_ptr));


### PR DESCRIPTION
The comparison on the assert conditions was incorrect, and should be flipped to verify that the allocation size is greater than or equal to the bytes being copied/read/written. Discovered during local testing with a debug build

```
[ RUN      ] urCommandBufferMemcpyCommandsTest.Buffer/NVIDIA_CUDA_BACKEND__NVIDIA_GeForce_GT_1030_ID0ID______W_________B______size__256__offset_src__127__offset_src__127__copy_size__128
test-exp_command_buffer: unified-runtime/test/conformance/exp_command_buffer/copy.cpp:28: virtual void urCommandBufferMemcpyCommandsTest::SetUp(): Assertion `size <= offset_src + copy_size' failed.
Aborted (core dumped)
```

We could just remove these asserts, as they are not present in other CTS tests, but I think they do add some value in catching programmer error when adding additional parameterized gtest cases, so kept the corrected version around