### PR TITLE
[SYCL][Docs] Move sycl_ext_intel_event_mode to experimental

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_intel_event_mode.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_intel_event_mode.asciidoc
@@ -52,11 +52,12 @@ This extension also depends on the following other SYCL extensions:
 
 == Status
 
-This is a proposed extension specification, intended to gather community
-feedback.  Interfaces defined in this specification may not be implemented yet
-or may be in a preliminary state.  The specification itself may also change in
-incompatible ways before it is finalized.  *Shipping software products should
-not rely on APIs defined in this specification.*
+This is an experimental extension specification, intended to provide early
+access to features and gather community feedback.  Interfaces defined in this
+specification are implemented in {dpcpp}, but they are not finalized and may
+change incompatibly in future versions of {dpcpp} without prior notice.
+*Shipping software products should not rely on APIs defined in this
+specification.*
 
 
 == Overview
@@ -71,6 +72,9 @@ possible, yield the thread that the `wait()` member function is called on and
 only wake up occasionally to check if the event has finished. This reduces the
 time the CPU spends checking finish condition of the wait, at the cost of
 latency.
+
+This extension exists to solve a specific problem, and a general solution is
+still being evaluated.  It is not recommended for general usage.
 
 
 == Specification

--- a/sycl/source/feature_test.hpp.in
+++ b/sycl/source/feature_test.hpp.in
@@ -120,6 +120,7 @@ inline namespace _V1 {
 // In progress yet
 #define SYCL_EXT_ONEAPI_ATOMIC16 0
 #define SYCL_KHR_DEFAULT_CONTEXT 1
+#define SYCL_EXT_INTEL_EVENT_MODE 1
 
 #ifndef __has_include
 #define __has_include(x) 0


### PR DESCRIPTION
This commit moves the sycl_ext_intel_event_mode extension to the experimental namespace and defines the corresponding feature test macro.