### PR TITLE
[libspirv][ptx-nvidiacl] Change __clc__group_scratch size to 32 x i128

### DIFF
--- a/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives_helpers.ll
+++ b/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives_helpers.ll
@@ -1,9 +1,9 @@
 ; 32 storage locations is sufficient for all current-generation AMD GPUs
-@__clc__group_scratch_i1 = internal addrspace(3) global [32 x i1] undef, align 1
-@__clc__group_scratch_i8 = internal addrspace(3) global [32 x i8] undef, align 1
-@__clc__group_scratch_i16 = internal addrspace(3) global [32 x i16] undef, align 2
-@__clc__group_scratch_i32 = internal addrspace(3) global [32 x i32] undef, align 4
-@__clc__group_scratch_i64 = internal addrspace(3) global [32 x i64] undef, align 8
+@__clc__group_scratch_i1 = internal addrspace(3) global [32 x i1] poison, align 1
+@__clc__group_scratch_i8 = internal addrspace(3) global [32 x i8] poison, align 1
+@__clc__group_scratch_i16 = internal addrspace(3) global [32 x i16] poison, align 2
+@__clc__group_scratch_i32 = internal addrspace(3) global [32 x i32] poison, align 4
+@__clc__group_scratch_i64 = internal addrspace(3) global [32 x i64] poison, align 8
 
 define ptr addrspace(3) @__clc__get_group_scratch_bool() nounwind alwaysinline {
 entry:

--- a/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives_helpers.ll
+++ b/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives_helpers.ll
@@ -20,9 +20,9 @@ entry:
   ret ptr addrspace(3) @__clc__group_scratch_i16
 }
 
-define i32 addrspace(3)* @__clc__get_group_scratch_int() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_int() nounwind alwaysinline {
 entry:
-  ret i32 addrspace(3)* @__clc__group_scratch_i32
+  ret ptr addrspace(3) @__clc__group_scratch_i32
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_long() nounwind alwaysinline {

--- a/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives_helpers.ll
+++ b/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives_helpers.ll
@@ -7,49 +7,41 @@
 
 define ptr addrspace(3) @__clc__get_group_scratch_bool() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i1], ptr addrspace(3) @__clc__group_scratch_i1, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i1
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_char() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i8], ptr addrspace(3) @__clc__group_scratch_i8, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i8
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_short() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i16], ptr addrspace(3) @__clc__group_scratch_i16, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i16
 }
 
 define i32 addrspace(3)* @__clc__get_group_scratch_int() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
-  ret i32 addrspace(3)* %0
+  ret i32 addrspace(3)* @__clc__group_scratch_i32
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_long() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i64
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_half() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i16], ptr addrspace(3) @__clc__group_scratch_i16, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i16
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_float() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i32
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_double() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i64
 }
 

--- a/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives_helpers.ll
+++ b/libclc/libspirv/lib/amdgcn-amdhsa/group/collectives_helpers.ll
@@ -1,62 +1,55 @@
 ; 32 storage locations is sufficient for all current-generation AMD GPUs
-; 64 bits per wavefront is sufficient for all fundamental data types
-; Reducing storage for small data types or increasing it for user-defined types
-; will likely require an additional pass to track group algorithm usage
-@__clc__group_scratch = internal addrspace(3) global [32 x i64] undef, align 1
+@__clc__group_scratch_i1 = internal addrspace(3) global [32 x i1] undef, align 1
+@__clc__group_scratch_i8 = internal addrspace(3) global [32 x i8] undef, align 1
+@__clc__group_scratch_i16 = internal addrspace(3) global [32 x i16] undef, align 2
+@__clc__group_scratch_i32 = internal addrspace(3) global [32 x i32] undef, align 4
+@__clc__group_scratch_i64 = internal addrspace(3) global [32 x i64] undef, align 8
 
-define i8 addrspace(3)* @__clc__get_group_scratch_bool() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_bool() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i64], [32 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
-  ret i8 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i1], ptr addrspace(3) @__clc__group_scratch_i1, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define i8 addrspace(3)* @__clc__get_group_scratch_char() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_char() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i64], [32 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
-  ret i8 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i8], ptr addrspace(3) @__clc__group_scratch_i8, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define i16 addrspace(3)* @__clc__get_group_scratch_short() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_short() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i64], [32 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i16 addrspace(3)*
-  ret i16 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i16], ptr addrspace(3) @__clc__group_scratch_i16, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
 define i32 addrspace(3)* @__clc__get_group_scratch_int() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i64], [32 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i32 addrspace(3)*
-  ret i32 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
+  ret i32 addrspace(3)* %0
 }
 
-define i64 addrspace(3)* @__clc__get_group_scratch_long() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_long() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i64], [32 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i64 addrspace(3)*
-  ret i64 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define half addrspace(3)* @__clc__get_group_scratch_half() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_half() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i64], [32 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to half addrspace(3)*
-  ret half addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i16], ptr addrspace(3) @__clc__group_scratch_i16, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define float addrspace(3)* @__clc__get_group_scratch_float() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_float() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i64], [32 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to float addrspace(3)*
-  ret float addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define double addrspace(3)* @__clc__get_group_scratch_double() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_double() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i64], [32 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to double addrspace(3)*
-  ret double addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 

--- a/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
+++ b/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
@@ -2,60 +2,60 @@
 ; 128 bits per warp is sufficient for all fundamental data types and complex
 ; Reducing storage for small data types or increasing it for user-defined types
 ; will likely require an additional pass to track group algorithm usage
-@__clc__group_scratch = internal addrspace(3) global [128 x i64] undef, align 1
+@__clc__group_scratch = internal addrspace(3) global [32 x i128] undef, align 1
 
 define i8 addrspace(3)* @__clc__get_group_scratch_bool() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
   ret i8 addrspace(3)* %cast
 }
 
 define i8 addrspace(3)* @__clc__get_group_scratch_char() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
   ret i8 addrspace(3)* %cast
 }
 
 define i16 addrspace(3)* @__clc__get_group_scratch_short() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to i16 addrspace(3)*
   ret i16 addrspace(3)* %cast
 }
 
 define i32 addrspace(3)* @__clc__get_group_scratch_int() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to i32 addrspace(3)*
   ret i32 addrspace(3)* %cast
 }
 
 define i64 addrspace(3)* @__clc__get_group_scratch_long() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to i64 addrspace(3)*
   ret i64 addrspace(3)* %cast
 }
 
 define half addrspace(3)* @__clc__get_group_scratch_half() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to half addrspace(3)*
   ret half addrspace(3)* %cast
 }
 
 define float addrspace(3)* @__clc__get_group_scratch_float() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to float addrspace(3)*
   ret float addrspace(3)* %cast
 }
 
 define double addrspace(3)* @__clc__get_group_scratch_double() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to double addrspace(3)*
   ret double addrspace(3)* %cast
 }
@@ -77,21 +77,21 @@ entry:
 
 define %complex_half addrspace(3)* @__clc__get_group_scratch_complex_half() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to %complex_half addrspace(3)*
   ret %complex_half addrspace(3)* %cast
 }
 
 define %complex_float addrspace(3)* @__clc__get_group_scratch_complex_float() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to %complex_float addrspace(3)*
   ret %complex_float addrspace(3)* %cast
 }
 
 define %complex_double addrspace(3)* @__clc__get_group_scratch_complex_double() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [128 x i64], [128 x i64] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
+  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
   %cast = bitcast i64 addrspace(3)* %ptr to %complex_double addrspace(3)*
   ret %complex_double addrspace(3)* %cast
 }

--- a/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
+++ b/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
@@ -1,97 +1,73 @@
 ; 32 storage locations is sufficient for all current-generation NVIDIA GPUs
-; 128 bits per warp is sufficient for all fundamental data types and complex
-; Reducing storage for small data types or increasing it for user-defined types
-; will likely require an additional pass to track group algorithm usage
-@__clc__group_scratch = internal addrspace(3) global [32 x i128] undef, align 1
+@__clc__group_scratch_i1 = internal addrspace(3) global [32 x i1] undef, align 1
+@__clc__group_scratch_i8 = internal addrspace(3) global [32 x i8] undef, align 1
+@__clc__group_scratch_i16 = internal addrspace(3) global [32 x i16] undef, align 2
+@__clc__group_scratch_i32 = internal addrspace(3) global [32 x i32] undef, align 4
+@__clc__group_scratch_i64 = internal addrspace(3) global [32 x i64] undef, align 8
+@__clc__group_scratch_i128 = internal addrspace(3) global [32 x i128] undef, align 8
 
-define i8 addrspace(3)* @__clc__get_group_scratch_bool() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_bool() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
-  ret i8 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i1], ptr addrspace(3) @__clc__group_scratch_i1, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define i8 addrspace(3)* @__clc__get_group_scratch_char() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_char() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i8 addrspace(3)*
-  ret i8 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i8], ptr addrspace(3) @__clc__group_scratch_i8, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define i16 addrspace(3)* @__clc__get_group_scratch_short() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_short() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i16 addrspace(3)*
-  ret i16 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i16], ptr addrspace(3) @__clc__group_scratch_i16, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
 define i32 addrspace(3)* @__clc__get_group_scratch_int() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i32 addrspace(3)*
-  ret i32 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
+  ret i32 addrspace(3)* %0
 }
 
-define i64 addrspace(3)* @__clc__get_group_scratch_long() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_long() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to i64 addrspace(3)*
-  ret i64 addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define half addrspace(3)* @__clc__get_group_scratch_half() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_half() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to half addrspace(3)*
-  ret half addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i16], ptr addrspace(3) @__clc__group_scratch_i16, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define float addrspace(3)* @__clc__get_group_scratch_float() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_float() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to float addrspace(3)*
-  ret float addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define double addrspace(3)* @__clc__get_group_scratch_double() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_double() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to double addrspace(3)*
-  ret double addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-%complex_half = type {
-  half,
-  half
-}
-
-%complex_float = type {
-  float,
-  float
-}
-
-%complex_double = type {
-  double,
-  double
-}
-
-define %complex_half addrspace(3)* @__clc__get_group_scratch_complex_half() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_complex_half() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to %complex_half addrspace(3)*
-  ret %complex_half addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define %complex_float addrspace(3)* @__clc__get_group_scratch_complex_float() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_complex_float() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to %complex_float addrspace(3)*
-  ret %complex_float addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }
 
-define %complex_double addrspace(3)* @__clc__get_group_scratch_complex_double() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_complex_double() nounwind alwaysinline {
 entry:
-  %ptr = getelementptr inbounds [32 x i128], [32 x i128] addrspace(3)* @__clc__group_scratch, i64 0, i64 0
-  %cast = bitcast i64 addrspace(3)* %ptr to %complex_double addrspace(3)*
-  ret %complex_double addrspace(3)* %cast
+  %0 = getelementptr inbounds [32 x i128], ptr addrspace(3) @__clc__group_scratch_i128, i64 0, i64 0
+  ret ptr addrspace(3) %0
 }

--- a/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
+++ b/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
@@ -1,10 +1,10 @@
 ; 32 storage locations is sufficient for all current-generation NVIDIA GPUs
-@__clc__group_scratch_i1 = internal addrspace(3) global [32 x i1] undef, align 1
-@__clc__group_scratch_i8 = internal addrspace(3) global [32 x i8] undef, align 1
-@__clc__group_scratch_i16 = internal addrspace(3) global [32 x i16] undef, align 2
-@__clc__group_scratch_i32 = internal addrspace(3) global [32 x i32] undef, align 4
-@__clc__group_scratch_i64 = internal addrspace(3) global [32 x i64] undef, align 8
-@__clc__group_scratch_i128 = internal addrspace(3) global [32 x i128] undef, align 8
+@__clc__group_scratch_i1 = internal addrspace(3) global [32 x i1] poison, align 1
+@__clc__group_scratch_i8 = internal addrspace(3) global [32 x i8] poison, align 1
+@__clc__group_scratch_i16 = internal addrspace(3) global [32 x i16] poison, align 2
+@__clc__group_scratch_i32 = internal addrspace(3) global [32 x i32] poison, align 4
+@__clc__group_scratch_i64 = internal addrspace(3) global [32 x i64] poison, align 8
+@__clc__group_scratch_i128 = internal addrspace(3) global [32 x i128] poison, align 8
 
 define ptr addrspace(3) @__clc__get_group_scratch_bool() nounwind alwaysinline {
 entry:

--- a/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
+++ b/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
@@ -8,66 +8,55 @@
 
 define ptr addrspace(3) @__clc__get_group_scratch_bool() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i1], ptr addrspace(3) @__clc__group_scratch_i1, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i1
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_char() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i8], ptr addrspace(3) @__clc__group_scratch_i8, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i8
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_short() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i16], ptr addrspace(3) @__clc__group_scratch_i16, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i16
 }
 
 define i32 addrspace(3)* @__clc__get_group_scratch_int() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
-  ret i32 addrspace(3)* %0
+  ret i32 addrspace(3)* @__clc__group_scratch_i32
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_long() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i64
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_half() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i16], ptr addrspace(3) @__clc__group_scratch_i16, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i16
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_float() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i32
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_double() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i64
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_complex_half() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i32], ptr addrspace(3) @__clc__group_scratch_i32, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i32
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_complex_float() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i64], ptr addrspace(3) @__clc__group_scratch_i64, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i64
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_complex_double() nounwind alwaysinline {
 entry:
-  %0 = getelementptr inbounds [32 x i128], ptr addrspace(3) @__clc__group_scratch_i128, i64 0, i64 0
-  ret ptr addrspace(3) %0
+  ret ptr addrspace(3) @__clc__group_scratch_i128
 }

--- a/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
+++ b/libclc/libspirv/lib/ptx-nvidiacl/group/collectives_helpers.ll
@@ -21,9 +21,9 @@ entry:
   ret ptr addrspace(3) @__clc__group_scratch_i16
 }
 
-define i32 addrspace(3)* @__clc__get_group_scratch_int() nounwind alwaysinline {
+define ptr addrspace(3) @__clc__get_group_scratch_int() nounwind alwaysinline {
 entry:
-  ret i32 addrspace(3)* @__clc__group_scratch_i32
+  ret ptr addrspace(3) @__clc__group_scratch_i32
 }
 
 define ptr addrspace(3) @__clc__get_group_scratch_long() nounwind alwaysinline {


### PR DESCRIPTION
To align with the comment in the file that specifies 32 storage locations and 128 bits per warp.
Change file to opaque pointer mode.
Add more global variables for different sizes to resolve `Reducing storage for small data types`.