### PR TITLE
[NFC][SYCL] Auto-deduce return type for `device_impl::get_info_impl*`

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -28,14 +28,13 @@ device_impl::device_impl(ur_device_handle_t Device, platform_impl &Platform,
   const AdapterPtr &Adapter = Platform.getAdapter();
 
   // TODO catch an exception and put it to list of asynchronous exceptions
-  MType = get_info_impl<ur_device_type_t, UR_DEVICE_INFO_TYPE>();
+  MType = get_info_impl<UR_DEVICE_INFO_TYPE>();
 
   // No need to set MRootDevice when MAlwaysRootDevice is true
   // TODO: Is get_info aligned with this?
   if (!Platform.MAlwaysRootDevice) {
     // TODO catch an exception and put it to list of asynchronous exceptions
-    MRootDevice =
-        get_info_impl<ur_device_handle_t, UR_DEVICE_INFO_PARENT_DEVICE>();
+    MRootDevice = get_info_impl<UR_DEVICE_INFO_PARENT_DEVICE>();
   }
 
   // TODO catch an exception and put it to list of asynchronous exceptions
@@ -43,8 +42,7 @@ device_impl::device_impl(ur_device_handle_t Device, platform_impl &Platform,
   // urDeviceCreateWithNativeHandle.
   Adapter->call<UrApiKind::urDeviceRetain>(MDevice);
 
-  MUseNativeAssert =
-      get_info_impl<ur_bool_t, UR_DEVICE_INFO_USE_NATIVE_ASSERT>();
+  MUseNativeAssert = get_info_impl<UR_DEVICE_INFO_USE_NATIVE_ASSERT>();
 }
 
 device_impl::~device_impl() {
@@ -119,8 +117,7 @@ device_impl::get_backend_info<info::device::backend_version>() const {
 #endif
 
 bool device_impl::has_extension(const std::string &ExtensionName) const {
-  std::string AllExtensionNames =
-      get_info_impl<std::string, UR_DEVICE_INFO_EXTENSIONS>();
+  std::string AllExtensionNames = get_info_impl<UR_DEVICE_INFO_EXTENSIONS>();
 
   return (AllExtensionNames.find(ExtensionName) != std::string::npos);
 }
@@ -370,14 +367,12 @@ bool device_impl::has(aspect Aspect) const {
   case aspect::ext_oneapi_cuda_cluster_group:
     return get_info<info::device::ext_oneapi_cuda_cluster_group>();
   case aspect::usm_atomic_host_allocations:
-    return (get_info_impl<ur_device_usm_access_capability_flags_t,
-                          UR_DEVICE_INFO_USM_HOST_SUPPORT>() &
+    return (get_info_impl<UR_DEVICE_INFO_USM_HOST_SUPPORT>() &
             UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_CONCURRENT_ACCESS);
   case aspect::usm_shared_allocations:
     return get_info<info::device::usm_shared_allocations>();
   case aspect::usm_atomic_shared_allocations:
-    return (get_info_impl<ur_device_usm_access_capability_flags_t,
-                          UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT>() &
+    return (get_info_impl<UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT>() &
             UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_CONCURRENT_ACCESS);
   case aspect::usm_restricted_shared_allocations:
     return get_info<info::device::usm_restricted_shared_allocations>();
@@ -422,129 +417,113 @@ bool device_impl::has(aspect Aspect) const {
   case aspect::ext_oneapi_native_assert:
     return useNativeAssert();
   case aspect::ext_oneapi_cuda_async_barrier: {
-    return get_info_impl_nocheck<ur_bool_t, UR_DEVICE_INFO_ASYNC_BARRIER>()
-        .value_or(0);
+    return get_info_impl_nocheck<UR_DEVICE_INFO_ASYNC_BARRIER>().value_or(0);
   }
   case aspect::ext_intel_legacy_image: {
-    return get_info_impl_nocheck<ur_bool_t, UR_DEVICE_INFO_IMAGE_SUPPORT>()
-        .value_or(0);
+    return get_info_impl_nocheck<UR_DEVICE_INFO_IMAGE_SUPPORT>().value_or(0);
   }
   case aspect::ext_oneapi_bindless_images: {
-    return get_info_impl_nocheck<ur_bool_t,
-                                 UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP>()
+    return get_info_impl_nocheck<UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_images_shared_usm: {
     return get_info_impl_nocheck<
-               ur_bool_t,
                UR_DEVICE_INFO_BINDLESS_IMAGES_SHARED_USM_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_images_1d_usm: {
     return get_info_impl_nocheck<
-               ur_bool_t, UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP>()
+               UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_images_2d_usm: {
     return get_info_impl_nocheck<
-               ur_bool_t, UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP>()
+               UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_external_memory_import: {
     return get_info_impl_nocheck<
-               ur_bool_t, UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP>()
+               UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_external_semaphore_import: {
     return get_info_impl_nocheck<
-               ur_bool_t,
                UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_mipmap: {
-    return get_info_impl_nocheck<ur_bool_t, UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP>()
-        .value_or(0);
+    return get_info_impl_nocheck<UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP>().value_or(
+        0);
   }
   case aspect::ext_oneapi_mipmap_anisotropy: {
-    return get_info_impl_nocheck<ur_bool_t,
-                                 UR_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP>()
+    return get_info_impl_nocheck<UR_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_mipmap_level_reference: {
     return get_info_impl_nocheck<
-               ur_bool_t, UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP>()
+               UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_sampled_image_fetch_1d_usm: {
     return get_info_impl_nocheck<
-               ur_bool_t,
                UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_1D_USM_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_sampled_image_fetch_1d: {
     return get_info_impl_nocheck<
-               ur_bool_t,
                UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_1D_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_sampled_image_fetch_2d_usm: {
     return get_info_impl_nocheck<
-               ur_bool_t,
                UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_2D_USM_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_sampled_image_fetch_2d: {
     return get_info_impl_nocheck<
-               ur_bool_t,
                UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_2D_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_sampled_image_fetch_3d: {
     return get_info_impl_nocheck<
-               ur_bool_t,
                UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_3D_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_images_gather: {
     return get_info_impl_nocheck<
-               ur_bool_t, UR_DEVICE_INFO_BINDLESS_IMAGES_GATHER_SUPPORT_EXP>()
+               UR_DEVICE_INFO_BINDLESS_IMAGES_GATHER_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_cubemap: {
-    return get_info_impl_nocheck<ur_bool_t,
-                                 UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP>()
-        .value_or(0);
+    return get_info_impl_nocheck<UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP>().value_or(
+        0);
   }
   case aspect::ext_oneapi_cubemap_seamless_filtering: {
     return get_info_impl_nocheck<
-               ur_bool_t,
                UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_image_array: {
-    return get_info_impl_nocheck<ur_bool_t,
-                                 UR_DEVICE_INFO_IMAGE_ARRAY_SUPPORT_EXP>()
+    return get_info_impl_nocheck<UR_DEVICE_INFO_IMAGE_ARRAY_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_unique_addressing_per_dim: {
     return get_info_impl_nocheck<
-               ur_bool_t,
                UR_DEVICE_INFO_BINDLESS_UNIQUE_ADDRESSING_PER_DIM_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_images_sample_1d_usm: {
     return get_info_impl_nocheck<
-               ur_bool_t, UR_DEVICE_INFO_BINDLESS_SAMPLE_1D_USM_SUPPORT_EXP>()
+               UR_DEVICE_INFO_BINDLESS_SAMPLE_1D_USM_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_bindless_images_sample_2d_usm: {
     return get_info_impl_nocheck<
-               ur_bool_t, UR_DEVICE_INFO_BINDLESS_SAMPLE_2D_USM_SUPPORT_EXP>()
+               UR_DEVICE_INFO_BINDLESS_SAMPLE_2D_USM_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_intel_esimd: {
-    return get_info_impl_nocheck<ur_bool_t, UR_DEVICE_INFO_ESIMD_SUPPORT>()
-        .value_or(0);
+    return get_info_impl_nocheck<UR_DEVICE_INFO_ESIMD_SUPPORT>().value_or(0);
   }
   case aspect::ext_oneapi_ballot_group:
   case aspect::ext_oneapi_fixed_size_group:
@@ -587,9 +566,8 @@ bool device_impl::has(aspect Aspect) const {
     return components.size() >= 2;
   }
   case aspect::ext_oneapi_is_component: {
-    return get_info_impl_nocheck<ur_device_handle_t,
-                                 UR_DEVICE_INFO_COMPOSITE_DEVICE>()
-               .value_or(nullptr) != nullptr;
+    return get_info_impl_nocheck<UR_DEVICE_INFO_COMPOSITE_DEVICE>().value_or(
+               nullptr) != nullptr;
   }
   case aspect::ext_oneapi_graph: {
     ur_device_command_buffer_update_capability_flags_t UpdateCapabilities;
@@ -635,12 +613,11 @@ bool device_impl::has(aspect Aspect) const {
   }
   case aspect::ext_oneapi_queue_profiling_tag: {
     return get_info_impl_nocheck<
-               ur_bool_t, UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP>()
+               UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP>()
         .value_or(0);
   }
   case aspect::ext_oneapi_virtual_mem: {
-    return get_info_impl_nocheck<ur_bool_t,
-                                 UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT>()
+    return get_info_impl_nocheck<UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT>()
         .value_or(0);
   }
   case aspect::ext_intel_fpga_task_sequence: {
@@ -664,7 +641,7 @@ bool device_impl::has(aspect Aspect) const {
   }
   case aspect::ext_oneapi_async_memory_alloc: {
     return get_info_impl_nocheck<
-               ur_bool_t, UR_DEVICE_INFO_ASYNC_USM_ALLOCATIONS_SUPPORT_EXP>()
+               UR_DEVICE_INFO_ASYNC_USM_ALLOCATIONS_SUPPORT_EXP>()
         .value_or(0);
   }
   }

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -66,6 +66,107 @@ class device_impl : public std::enable_shared_from_this<device_impl> {
   };
   friend class platform_impl;
 
+  bool has_info_desc(ur_device_info_t Desc) const {
+    size_t return_size = 0;
+    return getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+               MDevice, Desc, 0, nullptr, &return_size) == UR_RESULT_SUCCESS;
+  }
+
+  template <ur_device_info_t Desc> static constexpr auto ur_ret_type_impl() {
+    if constexpr (false) {
+    }
+#define MAP(VALUE, ...) else if constexpr (Desc == VALUE) return __VA_ARGS__{};
+#include "ur_device_info_ret_types.inc"
+#undef MAP
+  }
+
+  template <ur_device_info_t Desc>
+  using ur_ret_type = decltype(ur_ret_type_impl<Desc>());
+
+  // This should really be
+  //   std::expected<ReturnT, ur_result_t>
+  // but we don't have C++23. Emulate close enough with as little code as
+  // possible.
+  template <typename T, typename E>
+  struct expected : public std::variant<T, E> {
+    using base = std::variant<T, E>;
+    using base::base;
+
+    bool has_val() const { return this->index() == 0; }
+    template <typename U> T value_or(U &&default_value) const {
+      if (auto *p = std::get_if<0>(static_cast<const base *>(this)))
+        return *p;
+      else
+        return std::forward<U>(default_value);
+    }
+    template <typename G> E error_or(G &&default_error) const {
+      if (auto *p = std::get_if<1>(static_cast<const base *>(this)))
+        return *p;
+      else
+        return std::forward<G>(default_error);
+    }
+    T value() const { return std::get<0>(*static_cast<const base *>(this)); }
+    E error() const { return std::get<1>(*static_cast<const base *>(this)); }
+  };
+
+  template <ur_device_info_t Desc>
+  expected<ur_ret_type<Desc>, ur_result_t> get_info_impl_nocheck() const {
+    using ur_ret_t = ur_ret_type<Desc>;
+    static_assert(!std::is_same_v<ur_ret_t, std::string>,
+                  "Wasn't needed before.");
+    if constexpr (is_std_vector_v<ur_ret_t>) {
+      static_assert(
+          !check_type_in_v<typename ur_ret_t::value_type, bool, std::string>);
+      size_t ResultSize = 0;
+      ur_result_t Error =
+          getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+              getHandleRef(), Desc, 0, nullptr, &ResultSize);
+      if (Error != UR_RESULT_SUCCESS)
+        return {Error};
+      if (ResultSize == 0)
+        return {ur_ret_t{}};
+
+      ur_ret_t Result(ResultSize / sizeof(typename ur_ret_t::value_type));
+      Error = getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+          getHandleRef(), Desc, ResultSize, Result.data(), nullptr);
+      if (Error != UR_RESULT_SUCCESS)
+        return {Error};
+      return {Result};
+    } else {
+      ur_ret_t Result;
+      ur_result_t Error =
+          getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
+              getHandleRef(), Desc, sizeof(Result), &Result, nullptr);
+      if (Error == UR_RESULT_SUCCESS)
+        return {Result};
+      else
+        return {Error};
+    }
+  }
+
+  template <ur_device_info_t Desc> ur_ret_type<Desc> get_info_impl() const {
+    using ur_ret_t = ur_ret_type<Desc>;
+    if constexpr (std::is_same_v<ur_ret_t, std::string>) {
+      return urGetInfoString<UrApiKind::urDeviceGetInfo>(*this, Desc);
+    } else if constexpr (is_std_vector_v<ur_ret_t>) {
+      size_t ResultSize = 0;
+      getAdapter()->call<UrApiKind::urDeviceGetInfo>(getHandleRef(), Desc, 0,
+                                                     nullptr, &ResultSize);
+      if (ResultSize == 0)
+        return {};
+
+      ur_ret_t Result(ResultSize / sizeof(typename ur_ret_t::value_type));
+      getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+          getHandleRef(), Desc, ResultSize, Result.data(), nullptr);
+      return Result;
+    } else {
+      ur_ret_t Result;
+      getAdapter()->call<UrApiKind::urDeviceGetInfo>(
+          getHandleRef(), Desc, sizeof(Result), &Result, nullptr);
+      return Result;
+    }
+  }
+
 public:
   /// Constructs a SYCL device instance using the provided
   /// UR device instance.
@@ -222,7 +323,6 @@ public:
   template <typename Param>
   typename Param::return_type get_info_abi_workaround() const {
 #endif
-    using return_type = typename Param::return_type;
     using execution_scope = ext::oneapi::experimental::execution_scope;
 #define CASE(PARAM) else if constexpr (std::is_same_v<Param, PARAM>)
     if constexpr (false) {
@@ -232,7 +332,7 @@ public:
 
     CASE(info::device::device_type) {
       using device_type = info::device_type;
-      switch (get_info_impl<ur_device_type_t, UR_DEVICE_INFO_TYPE>()) {
+      switch (get_info_impl<UR_DEVICE_INFO_TYPE>()) {
       case UR_DEVICE_TYPE_DEFAULT:
         return device_type::automatic;
       case UR_DEVICE_TYPE_ALL:
@@ -255,8 +355,7 @@ public:
     }
 
     CASE(info::device::max_work_item_sizes<3>) {
-      auto result = get_info_impl<std::array<size_t, 3>,
-                                  UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES>();
+      auto result = get_info_impl<UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES>();
       return range<3>{result[2], result[1], result[0]};
     }
     CASE(info::device::max_work_item_sizes<2>) {
@@ -270,8 +369,7 @@ public:
 
     CASE(info::device::sub_group_sizes) {
       std::vector<uint32_t> ur_result =
-          get_info_impl<std::vector<uint32_t>,
-                        UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL>();
+          get_info_impl<UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL>();
       std::vector<size_t> result;
       result.reserve(ur_result.size());
       std::copy(ur_result.begin(), ur_result.end(), std::back_inserter(result));
@@ -296,8 +394,7 @@ public:
                        UR_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE},
                       {cache::none, cache::read_only, cache::read_write}));
       return static_cast<cache>(
-          get_info_impl<ur_device_mem_cache_type_t,
-                        UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE>());
+          get_info_impl<UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE>());
     }
 
     CASE(info::device::local_mem_type) {
@@ -306,29 +403,24 @@ public:
                                  UR_DEVICE_LOCAL_MEM_TYPE_LOCAL,
                                  UR_DEVICE_LOCAL_MEM_TYPE_GLOBAL},
                                 {mem::none, mem::local, mem::global}));
-      return static_cast<mem>(get_info_impl<ur_device_local_mem_type_t,
-                                            UR_DEVICE_INFO_LOCAL_MEM_TYPE>());
+      return static_cast<mem>(get_info_impl<UR_DEVICE_INFO_LOCAL_MEM_TYPE>());
     }
 
     CASE(info::device::atomic_memory_order_capabilities) {
       return readMemoryOrderBitfield(
-          get_info_impl<ur_memory_order_capability_flags_t,
-                        UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES>());
+          get_info_impl<UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES>());
     }
     CASE(info::device::atomic_fence_order_capabilities) {
       return readMemoryOrderBitfield(
-          get_info_impl<ur_memory_order_capability_flags_t,
-                        UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES>());
+          get_info_impl<UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES>());
     }
     CASE(info::device::atomic_memory_scope_capabilities) {
       return readMemoryScopeBitfield(
-          get_info_impl<ur_memory_scope_capability_flags_t,
-                        UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES>());
+          get_info_impl<UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES>());
     }
     CASE(info::device::atomic_fence_scope_capabilities) {
       return readMemoryScopeBitfield(
-          get_info_impl<ur_memory_scope_capability_flags_t,
-                        UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES>());
+          get_info_impl<UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES>());
     }
 
     CASE(info::device::execution_capabilities) {
@@ -338,8 +430,7 @@ public:
                         "backend::opencl only");
 
       ur_device_exec_capability_flags_t bits =
-          get_info_impl<ur_device_exec_capability_flags_t,
-                        UR_DEVICE_INFO_EXECUTION_CAPABILITIES>();
+          get_info_impl<UR_DEVICE_INFO_EXECUTION_CAPABILITIES>();
       std::vector<info::execution_capability> result;
       if (bits & UR_DEVICE_EXEC_CAPABILITY_FLAG_KERNEL)
         result.push_back(info::execution_capability::exec_kernel);
@@ -353,14 +444,13 @@ public:
       // profiling, urDeviceGetGlobalTimestamps is not supported,
       // command_submit, command_start, command_end will be calculated. See
       // MFallbackProfiling
-      return get_info_impl<ur_queue_flags_t,
-                           UR_DEVICE_INFO_QUEUE_PROPERTIES>() &
+      return get_info_impl<UR_DEVICE_INFO_QUEUE_PROPERTIES>() &
              UR_QUEUE_FLAG_PROFILING_ENABLE;
     }
 
     CASE(info::device::built_in_kernels) {
-      return split_string(
-          get_info_impl<std::string, UR_DEVICE_INFO_BUILT_IN_KERNELS>(), ';');
+      return split_string(get_info_impl<UR_DEVICE_INFO_BUILT_IN_KERNELS>(),
+                          ';');
     }
     CASE(info::device::built_in_kernel_ids) {
       auto names = CALL_GET_INFO<info::device::built_in_kernels>();
@@ -378,8 +468,7 @@ public:
     CASE(info::device::platform) {
       return createSyclObjFromImpl<platform>(
           platform_impl::getOrMakePlatformImpl(
-              get_info_impl<ur_platform_handle_t, UR_DEVICE_INFO_PLATFORM>(),
-              getAdapter()));
+              get_info_impl<UR_DEVICE_INFO_PLATFORM>(), getAdapter()));
     }
 
     CASE(info::device::profile) {
@@ -388,12 +477,11 @@ public:
                               "the info::device::profile info descriptor can "
                               "only be queried with an OpenCL backend");
 
-      return get_info_impl<std::string, UR_DEVICE_INFO_PROFILE>();
+      return get_info_impl<UR_DEVICE_INFO_PROFILE>();
     }
 
     CASE(info::device::extensions) {
-      return split_string(
-          get_info_impl<std::string, UR_DEVICE_INFO_EXTENSIONS>(), ' ');
+      return split_string(get_info_impl<UR_DEVICE_INFO_EXTENSIONS>(), ' ');
     }
 
     CASE(info::device::preferred_interop_user_sync) {
@@ -403,14 +491,12 @@ public:
             "the info::device::preferred_interop_user_sync info descriptor can "
             "only be queried with an OpenCL backend");
 
-      return get_info_impl<ur_bool_t,
-                           UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC>();
+      return get_info_impl<UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC>();
     }
 
     CASE(info::device::partition_properties) {
       std::vector<ur_device_partition_t> ur_dev_partitions =
-          get_info_impl<std::vector<ur_device_partition_t>,
-                        UR_DEVICE_INFO_SUPPORTED_PARTITIONS>();
+          get_info_impl<UR_DEVICE_INFO_SUPPORTED_PARTITIONS>();
       std::vector<info::partition_property> result;
       result.reserve(ur_dev_partitions.size());
       for (auto &entry : ur_dev_partitions) {
@@ -431,8 +517,7 @@ public:
     }
     CASE(info::device::partition_affinity_domains) {
       ur_device_affinity_domain_flags_t bits =
-          get_info_impl<ur_device_affinity_domain_flags_t,
-                        UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN>();
+          get_info_impl<UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN>();
       std::vector<info::partition_affinity_domain> result;
       using domain = info::partition_affinity_domain;
       constexpr std::pair<ur_device_affinity_domain_flags_t, domain> mapping[] =
@@ -451,8 +536,7 @@ public:
     }
     CASE(info::device::partition_type_property) {
       std::vector<ur_device_partition_property_t> PartitionProperties =
-          get_info_impl<std::vector<ur_device_partition_property_t>,
-                        UR_DEVICE_INFO_PARTITION_TYPE>();
+          get_info_impl<UR_DEVICE_INFO_PARTITION_TYPE>();
       if (PartitionProperties.empty())
         return info::partition_property::no_partition;
       // The old UR implementation also just checked the first element, is that
@@ -461,8 +545,7 @@ public:
     }
     CASE(info::device::partition_type_affinity_domain) {
       std::vector<ur_device_partition_property_t> PartitionProperties =
-          get_info_impl<std::vector<ur_device_partition_property_t>,
-                        UR_DEVICE_INFO_PARTITION_TYPE>();
+          get_info_impl<UR_DEVICE_INFO_PARTITION_TYPE>();
       if (PartitionProperties.empty())
         return info::partition_affinity_domain::not_applicable;
       for (const auto &PartitionProp : PartitionProperties) {
@@ -475,8 +558,7 @@ public:
     }
 
     CASE(info::device::parent_device) {
-      auto ur_parent_dev =
-          get_info_impl<ur_device_handle_t, UR_DEVICE_INFO_PARENT_DEVICE>();
+      auto ur_parent_dev = get_info_impl<UR_DEVICE_INFO_PARENT_DEVICE>();
       if (ur_parent_dev == nullptr)
         throw exception(make_error_code(errc::invalid),
                         "No parent for device because it is not a subdevice");
@@ -507,27 +589,23 @@ public:
     }
 
     CASE(info::device::usm_device_allocations) {
-      return get_info_impl_nocheck<ur_device_usm_access_capability_flags_t,
-                                   UR_DEVICE_INFO_USM_DEVICE_SUPPORT>()
+      return get_info_impl_nocheck<UR_DEVICE_INFO_USM_DEVICE_SUPPORT>()
                  .value_or(0) &
              UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS;
     }
     CASE(info::device::usm_host_allocations) {
-      return get_info_impl_nocheck<ur_device_usm_access_capability_flags_t,
-                                   UR_DEVICE_INFO_USM_HOST_SUPPORT>()
-                 .value_or(0) &
+      return get_info_impl_nocheck<UR_DEVICE_INFO_USM_HOST_SUPPORT>().value_or(
+                 0) &
              UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS;
     }
     CASE(info::device::usm_shared_allocations) {
-      return get_info_impl_nocheck<ur_device_usm_access_capability_flags_t,
-                                   UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT>()
+      return get_info_impl_nocheck<UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT>()
                  .value_or(0) &
              UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS;
     }
     CASE(info::device::usm_restricted_shared_allocations) {
       auto cap_flags =
-          get_info_impl_nocheck<ur_device_usm_access_capability_flags_t,
-                                UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT>();
+          get_info_impl_nocheck<UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT>();
       if (!cap_flags.has_val())
         return false;
       // Check that we don't support any cross device sharing
@@ -536,8 +614,7 @@ public:
                 UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_CONCURRENT_ACCESS));
     }
     CASE(info::device::usm_system_allocations) {
-      return get_info_impl_nocheck<ur_device_usm_access_capability_flags_t,
-                                   UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT>()
+      return get_info_impl_nocheck<UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT>()
                  .value_or(0) &
              UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS;
     }
@@ -553,7 +630,7 @@ public:
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_max_mem_bandwidth aspect");
-      return get_info_impl<uint64_t, UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH>();
+      return get_info_impl<UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH>();
     }
 
     CASE(info::device::ext_oneapi_max_global_work_groups) {
@@ -581,8 +658,7 @@ public:
       if (getBackend() != backend::ext_oneapi_cuda)
         return false;
 
-      return get_info_impl_nocheck<ur_bool_t,
-                                   UR_DEVICE_INFO_CLUSTER_LAUNCH_SUPPORT_EXP>()
+      return get_info_impl_nocheck<UR_DEVICE_INFO_CLUSTER_LAUNCH_SUPPORT_EXP>()
           .value_or(0);
     }
 
@@ -663,13 +739,12 @@ public:
 
     CASE(ext::oneapi::experimental::info::device::mipmap_max_anisotropy) {
       // Implicit conversion:
-      return get_info_impl<uint32_t,
-                           UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP>();
+      return get_info_impl<UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP>();
     }
 
     CASE(ext::oneapi::experimental::info::device::component_devices) {
-      auto Devs = get_info_impl_nocheck<std::vector<ur_device_handle_t>,
-                                        UR_DEVICE_INFO_COMPONENT_DEVICES>();
+      expected<std::vector<ur_device_handle_t>, ur_result_t> Devs =
+          get_info_impl_nocheck<UR_DEVICE_INFO_COMPONENT_DEVICES>();
       if (!Devs.has_val()) {
         ur_result_t Err = Devs.error();
         if (Err == UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION)
@@ -693,8 +768,7 @@ public:
             "can call this function.");
 
       if (ur_device_handle_t Result =
-              get_info_impl<ur_device_handle_t,
-                            UR_DEVICE_INFO_COMPOSITE_DEVICE>())
+              get_info_impl<UR_DEVICE_INFO_COMPOSITE_DEVICE>())
         return createSyclObjFromImpl<device>(
             MPlatform->getOrMakeDeviceImpl(Result));
 
@@ -704,7 +778,7 @@ public:
     }
     CASE(ext::oneapi::info::device::num_compute_units) {
       // uint32_t -> size_t
-      return get_info_impl<uint32_t, UR_DEVICE_INFO_NUM_COMPUTE_UNITS>();
+      return get_info_impl<UR_DEVICE_INFO_NUM_COMPUTE_UNITS>();
     }
 
     // ext_intel_device_traits.def
@@ -714,57 +788,56 @@ public:
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_device_id aspect");
-      return get_info_impl<uint32_t, UR_DEVICE_INFO_DEVICE_ID>();
+      return get_info_impl<UR_DEVICE_INFO_DEVICE_ID>();
     }
     CASE(ext::intel::info::device::pci_address) {
       if (!has(aspect::ext_intel_pci_address))
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_pci_address aspect");
-      return get_info_impl<std::string, UR_DEVICE_INFO_PCI_ADDRESS>();
+      return get_info_impl<UR_DEVICE_INFO_PCI_ADDRESS>();
     }
     CASE(ext::intel::info::device::gpu_eu_count) {
       if (!has(aspect::ext_intel_gpu_eu_count))
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_gpu_eu_count aspect");
-      return get_info_impl<uint32_t, UR_DEVICE_INFO_GPU_EU_COUNT>();
+      return get_info_impl<UR_DEVICE_INFO_GPU_EU_COUNT>();
     }
     CASE(ext::intel::info::device::gpu_eu_simd_width) {
       if (!has(aspect::ext_intel_gpu_eu_simd_width))
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_gpu_eu_simd_width aspect");
-      return get_info_impl<uint32_t, UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH>();
+      return get_info_impl<UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH>();
     }
     CASE(ext::intel::info::device::gpu_slices) {
       if (!has(aspect::ext_intel_gpu_slices))
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_gpu_slices aspect");
-      return get_info_impl<uint32_t, UR_DEVICE_INFO_GPU_EU_SLICES>();
+      return get_info_impl<UR_DEVICE_INFO_GPU_EU_SLICES>();
     }
     CASE(ext::intel::info::device::gpu_subslices_per_slice) {
       if (!has(aspect::ext_intel_gpu_subslices_per_slice))
         throw exception(make_error_code(errc::feature_not_supported),
                         "The device does not have the "
                         "ext_intel_gpu_subslices_per_slice aspect");
-      return get_info_impl<uint32_t, UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE>();
+      return get_info_impl<UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE>();
     }
     CASE(ext::intel::info::device::gpu_eu_count_per_subslice) {
       if (!has(aspect::ext_intel_gpu_eu_count_per_subslice))
         throw exception(make_error_code(errc::feature_not_supported),
                         "The device does not have the "
                         "ext_intel_gpu_eu_count_per_subslice aspect");
-      return get_info_impl<uint32_t,
-                           UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE>();
+      return get_info_impl<UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE>();
     }
     CASE(ext::intel::info::device::gpu_hw_threads_per_eu) {
       if (!has(aspect::ext_intel_gpu_hw_threads_per_eu))
         throw exception(make_error_code(errc::feature_not_supported),
                         "The device does not have the "
                         "ext_intel_gpu_hw_threads_per_eu aspect");
-      return get_info_impl<uint32_t, UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU>();
+      return get_info_impl<UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU>();
     }
     CASE(ext::intel::info::device::uuid) {
       if (!has(aspect::ext_intel_device_info_uuid))
@@ -773,40 +846,38 @@ public:
             "The device does not have the ext_intel_device_info_uuid aspect");
       // TODO: we're essentially memcpy'ing here...
       static_assert(std::is_same_v<uuid_type, std::array<unsigned char, 16>>);
-      return get_info_impl<uuid_type, UR_DEVICE_INFO_UUID>();
+      return get_info_impl<UR_DEVICE_INFO_UUID>();
     }
     CASE(ext::intel::info::device::free_memory) {
       if (!has(aspect::ext_intel_free_memory))
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_free_memory aspect");
-      return get_info_impl<uint64_t, UR_DEVICE_INFO_GLOBAL_MEM_FREE>();
+      return get_info_impl<UR_DEVICE_INFO_GLOBAL_MEM_FREE>();
     }
     CASE(ext::intel::info::device::memory_clock_rate) {
       if (!has(aspect::ext_intel_memory_clock_rate))
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_memory_clock_rate aspect");
-      return get_info_impl<uint32_t, UR_DEVICE_INFO_MEMORY_CLOCK_RATE>();
+      return get_info_impl<UR_DEVICE_INFO_MEMORY_CLOCK_RATE>();
     }
     CASE(ext::intel::info::device::memory_bus_width) {
       if (!has(aspect::ext_intel_memory_bus_width))
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_memory_bus_width aspect");
-      return get_info_impl<uint32_t, UR_DEVICE_INFO_MEMORY_BUS_WIDTH>();
+      return get_info_impl<UR_DEVICE_INFO_MEMORY_BUS_WIDTH>();
     }
     CASE(ext::intel::info::device::max_compute_queue_indices) {
       // uint32_t->int implicit conversion.
-      return get_info_impl<uint32_t,
-                           UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES>();
+      return get_info_impl<UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES>();
     }
     CASE(ext::intel::esimd::info::device::has_2d_block_io_support) {
       if (!has(aspect::ext_intel_esimd))
         return false;
       ur_exp_device_2d_block_array_capability_flags_t BlockArrayCapabilities =
-          get_info_impl<ur_exp_device_2d_block_array_capability_flags_t,
-                        UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP>();
+          get_info_impl<UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP>();
       return (BlockArrayCapabilities &
               UR_EXP_DEVICE_2D_BLOCK_ARRAY_CAPABILITY_FLAG_LOAD) &&
              (BlockArrayCapabilities &
@@ -819,8 +890,7 @@ public:
                         "ext_intel_current_clock_throttle_reasons aspect");
 
       ur_device_throttle_reasons_flags_t UrThrottleReasons =
-          get_info_impl<ur_device_throttle_reasons_flags_t,
-                        UR_DEVICE_INFO_CURRENT_CLOCK_THROTTLE_REASONS>();
+          get_info_impl<UR_DEVICE_INFO_CURRENT_CLOCK_THROTTLE_REASONS>();
       std::vector<ext::intel::throttle_reason> ThrottleReasons;
       using reason = ext::intel::throttle_reason;
       constexpr std::pair<ur_device_throttle_reasons_flags_t, reason>
@@ -847,25 +917,25 @@ public:
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_fan_speed aspect");
-      return get_info_impl<int32_t, UR_DEVICE_INFO_FAN_SPEED>();
+      return get_info_impl<UR_DEVICE_INFO_FAN_SPEED>();
     }
     CASE(ext::intel::info::device::max_power_limit) {
       if (!has(aspect::ext_intel_power_limits))
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_power_limits aspect");
-      return get_info_impl<int32_t, UR_DEVICE_INFO_MAX_POWER_LIMIT>();
+      return get_info_impl<UR_DEVICE_INFO_MAX_POWER_LIMIT>();
     }
     CASE(ext::intel::info::device::min_power_limit) {
       if (!has(aspect::ext_intel_power_limits))
         throw exception(
             make_error_code(errc::feature_not_supported),
             "The device does not have the ext_intel_power_limits aspect");
-      return get_info_impl<int32_t, UR_DEVICE_INFO_MIN_POWER_LIMIT>();
+      return get_info_impl<UR_DEVICE_INFO_MIN_POWER_LIMIT>();
     }
     else {
       constexpr auto Desc = UrInfoCode<Param>::value;
-      return get_info_impl<return_type, Desc>();
+      return get_info_impl<Desc>();
     }
 #undef CASE
   }
@@ -980,119 +1050,6 @@ public:
   /// Get device architecture
   ext::oneapi::experimental::architecture getDeviceArch() const;
 
-private:
-  bool has_info_desc(ur_device_info_t Desc) const {
-    size_t return_size = 0;
-    return getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-               MDevice, Desc, 0, nullptr, &return_size) == UR_RESULT_SUCCESS;
-  }
-
-  template <ur_device_info_t Desc> static constexpr auto ur_ret_type_impl() {
-    if constexpr (false) {
-    }
-#define MAP(VALUE, ...) else if constexpr (Desc == VALUE) return __VA_ARGS__{};
-#include "ur_device_info_ret_types.inc"
-#undef MAP
-  }
-
-  template <ur_device_info_t Desc>
-  using ur_ret_type = decltype(ur_ret_type_impl<Desc>());
-
-  // This should really be
-  //   std::expected<ReturnT, ur_result_t>
-  // but we don't have C++23. Emulate close enough with as little code as
-  // possible.
-  template <typename T, typename E>
-  struct expected : public std::variant<T, E> {
-    using base = std::variant<T, E>;
-    using base::base;
-
-    bool has_val() const { return this->index() == 0; }
-    template <typename U> T value_or(U &&default_value) const {
-      if (auto *p = std::get_if<0>(static_cast<const base *>(this)))
-        return *p;
-      else
-        return std::forward<U>(default_value);
-    }
-    template <typename G> E error_or(G &&default_error) const {
-      if (auto *p = std::get_if<1>(static_cast<const base *>(this)))
-        return *p;
-      else
-        return std::forward<G>(default_error);
-    }
-    T value() const { return std::get<0>(*static_cast<const base *>(this)); }
-    E error() const { return std::get<1>(*static_cast<const base *>(this)); }
-  };
-
-  template <typename ReturnT, ur_device_info_t Desc>
-  expected<ReturnT, ur_result_t> get_info_impl_nocheck() const {
-    using ur_ret_t = ur_ret_type<Desc>;
-    static_assert(!std::is_same_v<ReturnT, std::string>,
-                  "Wasn't needed before.");
-    if constexpr (std::is_same_v<ReturnT, bool>) {
-      return get_info_impl_nocheck<ur_bool_t, Desc>();
-    } else {
-      static_assert(std::is_same_v<ur_ret_t, ReturnT>);
-      if constexpr (is_std_vector_v<ReturnT>) {
-        static_assert(
-            !check_type_in_v<typename ReturnT::value_type, bool, std::string>);
-        size_t ResultSize = 0;
-        ur_result_t Error =
-            getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-                getHandleRef(), Desc, 0, nullptr, &ResultSize);
-        if (Error != UR_RESULT_SUCCESS)
-          return {Error};
-        if (ResultSize == 0)
-          return {ReturnT{}};
-
-        ReturnT Result(ResultSize / sizeof(typename ReturnT::value_type));
-        Error = getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-            getHandleRef(), Desc, ResultSize, Result.data(), nullptr);
-        if (Error != UR_RESULT_SUCCESS)
-          return {Error};
-        return {Result};
-      } else {
-        ReturnT Result;
-        ur_result_t Error =
-            getAdapter()->call_nocheck<UrApiKind::urDeviceGetInfo>(
-                getHandleRef(), Desc, sizeof(Result), &Result, nullptr);
-        if (Error == UR_RESULT_SUCCESS)
-          return {Result};
-        else
-          return {Error};
-      }
-    }
-  }
-
-  template <typename ReturnT, ur_device_info_t Desc>
-  ReturnT get_info_impl() const {
-    using ur_ret_t = ur_ret_type<Desc>;
-    if constexpr (std::is_same_v<ReturnT, bool>) {
-      return get_info_impl<ur_bool_t, Desc>();
-    } else {
-      static_assert(std::is_same_v<ur_ret_t, ReturnT>);
-      if constexpr (std::is_same_v<ReturnT, std::string>) {
-        return urGetInfoString<UrApiKind::urDeviceGetInfo>(*this, Desc);
-      } else if constexpr (is_std_vector_v<ReturnT>) {
-        size_t ResultSize = 0;
-        getAdapter()->call<UrApiKind::urDeviceGetInfo>(getHandleRef(), Desc, 0,
-                                                       nullptr, &ResultSize);
-        if (ResultSize == 0)
-          return {};
-
-        ReturnT Result(ResultSize / sizeof(typename ReturnT::value_type));
-        getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-            getHandleRef(), Desc, ResultSize, Result.data(), nullptr);
-        return Result;
-      } else {
-        ReturnT Result;
-        getAdapter()->call<UrApiKind::urDeviceGetInfo>(
-            getHandleRef(), Desc, sizeof(Result), &Result, nullptr);
-        return Result;
-      }
-    }
-  }
-
   template <ur_device_info_t Desc>
   std::vector<info::fp_config> get_fp_config() const {
     if (Desc == UR_DEVICE_INFO_HALF_FP_CONFIG &&
@@ -1101,7 +1058,7 @@ private:
     if (Desc == UR_DEVICE_INFO_DOUBLE_FP_CONFIG &&
         !get_info<info::device::native_vector_width_double>())
       return {};
-    auto bits = get_info_impl<ur_device_fp_capability_flags_t, Desc>();
+    auto bits = get_info_impl<Desc>();
 
     std::vector<info::fp_config> result;
     using cfg = info::fp_config;
@@ -1276,8 +1233,7 @@ private:
     backend CurrentBackend = getBackend();
     auto LookupIPVersion = [&, this](auto &ArchList)
         -> std::optional<ext::oneapi::experimental::architecture> {
-      auto DeviceIp =
-          get_info_impl_nocheck<uint32_t, UR_DEVICE_INFO_IP_VERSION>();
+      auto DeviceIp = get_info_impl_nocheck<UR_DEVICE_INFO_IP_VERSION>();
       if (!DeviceIp.has_val()) {
         ur_result_t Err = DeviceIp.error();
         if (Err == UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {
@@ -1309,8 +1265,7 @@ private:
         return ext::oneapi::experimental::architecture::unknown;
       };
       std::string DeviceArch =
-          get_info_impl<std::string,
-                        UrInfoCode<info::device::version>::value>();
+          get_info_impl<UrInfoCode<info::device::version>::value>();
       std::string_view DeviceArchSubstr =
           std::string_view{DeviceArch}.substr(0, DeviceArch.find(":"));
       return MapArchIDToArchName(DeviceArchSubstr.data());


### PR DESCRIPTION
https://github.com/intel/llvm/pull/18425 has ensured that current manually specified return type and the auto-deduced one are the same.