### PR TITLE
[Driver][SYCL] Pass as system headers for external SYCL host compilation

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5282,6 +5282,12 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
     HostCompileArgs.push_back(TCArgs.MakeArgString(*CWD));
   }
 
+  // Add /external:W0 for MSVC based compilation. We are using /external:I
+  // which requires /external:Wn upon usage. Use of /external:W0 disables
+  // warnings from headers that are included with /external:I.
+  if (IsMSVCHostCompiler)
+    HostCompileArgs.push_back("/external:W0");
+
   // Add default header search directories.
   SmallString<128> BaseDir(C.getDriver().Dir);
   llvm::sys::path::append(BaseDir, "..", "include");
@@ -5294,11 +5300,11 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
   llvm::sys::path::append(STLWrappersDir, "stl_wrappers");
   // Add the SYCL specific header directories as system directories for non
   // MSVC compilers.
-  HostCompileArgs.push_back(IsMSVCHostCompiler ? "-I" : "-isystem");
+  HostCompileArgs.push_back(IsMSVCHostCompiler ? "/external:I" : "-isystem");
   HostCompileArgs.push_back(TCArgs.MakeArgString(SYCLDir));
-  HostCompileArgs.push_back(IsMSVCHostCompiler ? "-I" : "-isystem");
+  HostCompileArgs.push_back(IsMSVCHostCompiler ? "/external:I" : "-isystem");
   HostCompileArgs.push_back(TCArgs.MakeArgString(STLWrappersDir));
-  HostCompileArgs.push_back(IsMSVCHostCompiler ? "-I" : "-isystem");
+  HostCompileArgs.push_back(IsMSVCHostCompiler ? "/external:I" : "-isystem");
   HostCompileArgs.push_back(TCArgs.MakeArgString(BaseDir));
 
   if (!OutputAdded) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5292,11 +5292,13 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
   // STL headers in their programs (e.g., <complex>).
   SmallString<128> STLWrappersDir(SYCLDir);
   llvm::sys::path::append(STLWrappersDir, "stl_wrappers");
-  HostCompileArgs.push_back("-I");
+  // Add the SYCL specific header directories as system directories for non
+  // MSVC compilers.
+  HostCompileArgs.push_back(IsMSVCHostCompiler ? "-I" : "-isystem");
   HostCompileArgs.push_back(TCArgs.MakeArgString(SYCLDir));
-  HostCompileArgs.push_back("-I");
+  HostCompileArgs.push_back(IsMSVCHostCompiler ? "-I" : "-isystem");
   HostCompileArgs.push_back(TCArgs.MakeArgString(STLWrappersDir));
-  HostCompileArgs.push_back("-I");
+  HostCompileArgs.push_back(IsMSVCHostCompiler ? "-I" : "-isystem");
   HostCompileArgs.push_back(TCArgs.MakeArgString(BaseDir));
 
   if (!OutputAdded) {

--- a/clang/test/Driver/sycl-host-compiler-old-model.cpp
+++ b/clang/test/Driver/sycl-host-compiler-old-model.cpp
@@ -16,9 +16,10 @@
 // RUN:  | FileCheck -check-prefix=HOST_COMPILER_CL %s
 // HOST_COMPILER_CL: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer={{.*}}"
 // HOST_COMPILER_CL: cl{{.*}} "-c" "-Fo[[HOSTOBJ:.+\.obj]]" "-FI" "[[INTHEADER]]"
-// HOST_COMPILER_CL-SAME: "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"
-// HOST_COMPILER_CL-SAME: "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"
-// HOST_COMPILER_CL-SAME: "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
+// HOST_COMPILER_CL-SAME: "/external:W0"
+// HOST_COMPILER_CL-SAME: "/external:I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"
+// HOST_COMPILER_CL-SAME: "/external:I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"
+// HOST_COMPILER_CL-SAME: "/external:I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
 // HOST_COMPILER_CL: link{{.*}} "[[HOSTOBJ]]"
 
 /// check for additional host options

--- a/clang/test/Driver/sycl-host-compiler-old-model.cpp
+++ b/clang/test/Driver/sycl-host-compiler-old-model.cpp
@@ -4,13 +4,21 @@
 // RUN: %clangxx -fsycl --no-offload-new-driver -fsycl-host-compiler=/some/dir/g++ %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_COMPILER %s
 // HOST_COMPILER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer={{.*}}"
-// HOST_COMPILER: g++{{.*}} "-c" "-include" "[[INTHEADER]]" "-iquote" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"{{.*}} "-o" "[[HOSTOBJ:.+\.o]]"{{.*}}
+// HOST_COMPILER: g++{{.*}} "-c" "-include" "[[INTHEADER]]"
+// HOST_COMPILER-SAME: "-iquote"
+// HOST_COMPILER-SAME: "-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"
+// HOST_COMPILER-SAME: "-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"
+// HOST_COMPILER-SAME: "-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
+// HOST_COMPILER-SAME: "-o" "[[HOSTOBJ:.+\.o]]"
 // HOST_COMPILER: ld{{.*}} "[[HOSTOBJ]]"
 
 // RUN: %clang_cl -fsycl --no-offload-new-driver -fsycl-host-compiler=/some/dir/cl %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_COMPILER_CL %s
 // HOST_COMPILER_CL: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer={{.*}}"
-// HOST_COMPILER_CL: cl{{.*}} "-c" "-Fo[[HOSTOBJ:.+\.obj]]" "-FI" "[[INTHEADER]]"{{.*}} "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"{{.*}}
+// HOST_COMPILER_CL: cl{{.*}} "-c" "-Fo[[HOSTOBJ:.+\.obj]]" "-FI" "[[INTHEADER]]"
+// HOST_COMPILER_CL-SAME: "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl"
+// HOST_COMPILER_CL-SAME: "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"
+// HOST_COMPILER_CL-SAME: "-I" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
 // HOST_COMPILER_CL: link{{.*}} "[[HOSTOBJ]]"
 
 /// check for additional host options


### PR DESCRIPTION
The use of `-fsycl-host-compiler=arg` allows a user to specify a 3rd party compiler to perform host compilation when using `-fsycl`.  The compilation will also include the SYCL specific headers.  Pass in these headers as system headers with `-isystem` so they are treated as system headers as opposed to user headers.