### PR TITLE
[SYCL] Use `inline` in device definition of `_invalid_parameter`

### DIFF
--- a/sycl/include/sycl/stl_wrappers/corecrt.h
+++ b/sycl/include/sycl/stl_wrappers/corecrt.h
@@ -28,9 +28,8 @@
 #if defined(__SYCL_DEVICE_ONLY__) && defined(_DEBUG)
 
 #include <cstdint>                            // For uintptr_t
-#include <sycl/detail/defines_elementary.hpp> // For __DPCPP_SYCL_EXTERNAL
 
-extern "C" __DPCPP_SYCL_EXTERNAL void __cdecl _invalid_parameter(
+extern "C" inline void __cdecl _invalid_parameter(
     wchar_t const *, wchar_t const *, wchar_t const *, unsigned int,
     uintptr_t) {
   // Do nothing when called in device code

--- a/sycl/include/sycl/stl_wrappers/corecrt.h
+++ b/sycl/include/sycl/stl_wrappers/corecrt.h
@@ -29,9 +29,10 @@
 
 #include <cstdint>                            // For uintptr_t
 
-extern "C" inline void __cdecl _invalid_parameter(
-    wchar_t const *, wchar_t const *, wchar_t const *, unsigned int,
-    uintptr_t) {
+extern "C" inline void __cdecl _invalid_parameter(wchar_t const *,
+                                                  wchar_t const *,
+                                                  wchar_t const *, unsigned int,
+                                                  uintptr_t) {
   // Do nothing when called in device code
 }
 

--- a/sycl/include/sycl/stl_wrappers/corecrt.h
+++ b/sycl/include/sycl/stl_wrappers/corecrt.h
@@ -27,7 +27,7 @@
 
 #if defined(__SYCL_DEVICE_ONLY__) && defined(_DEBUG)
 
-#include <cstdint>                            // For uintptr_t
+#include <cstdint> // For uintptr_t
 
 extern "C" inline void __cdecl _invalid_parameter(wchar_t const *,
                                                   wchar_t const *,


### PR DESCRIPTION
Header definitions should be `inline` to avoid multiple definitions error.