### PR TITLE
[XPTI][INFRA] Fixes minor standalone build and code issues

### DIFF
--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.5)
 
-set(XPTI_VERSION 1.0.0)
+set(XPTI_VERSION 1.0.1)
 
 project (xptifw VERSION "${XPTI_VERSION}" LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
@@ -74,8 +74,8 @@ endif()
 
 if (XPTI_BUILD_SAMPLES)
   add_subdirectory(samples/basic_collector)
-  add_subdirectory(samples/syclpi_collector)
   add_subdirectory(samples/sycl_perf_collector)
+  add_subdirectory(samples/syclur_collector)
   add_subdirectory(basic_test)
 endif()
 

--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20.0)
 
 set(XPTI_VERSION 1.0.1)
 

--- a/xptifw/CMakeLists.txt.in
+++ b/xptifw/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.20.0)
 
 project(googletest-download NONE)
 

--- a/xptifw/src/CMakeLists.txt
+++ b/xptifw/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Fetch third party headers
+include(FetchContent)
 set(EMHASH_REPO https://github.com/ktprime/emhash)
 message(STATUS "Will fetch emhash from ${EMHASH_REPO}")
 FetchContent_Declare(emhash-headers

--- a/xptifw/src/xpti_trace_framework.cpp
+++ b/xptifw/src/xpti_trace_framework.cpp
@@ -1387,7 +1387,7 @@ public:
   /// @brief Maps a trace type to its associated callback entries.
   /// @details This unordered map uses a uint16_t as the key to represent the
   /// trace point type, and cb_entries_t to store the associated callbacks.
-  using cb_t = std::unordered_map<uint16_t, cb_entries_t>;
+  using cb_t = emhash7::HashMap<uint16_t, cb_entries_t>;
 
   /// @typedef stream_cb_t
   /// @brief Maps a stream ID to its corresponding callbacks for different
@@ -1395,7 +1395,7 @@ public:
   /// @details This unordered map uses a uint16_t as the key for the stream
   /// ID, and cb_t to map the stream to registered callbacks for each trace
   /// type
-  using stream_cb_t = std::unordered_map<uint16_t, cb_t>;
+  using stream_cb_t = emhash7::HashMap<uint16_t, cb_t>;
 
   /// @typedef statistics_t
   /// @brief Keeps track of statistics, typically counts, associated with
@@ -1404,13 +1404,13 @@ public:
   /// the type of statistical data and usually not defined by default. To
   /// enable it, XPTI_STATISTICS has to be defined while compiling the
   /// frmaework library.
-  using statistics_t = std::unordered_map<uint16_t, uint64_t>;
+  using statistics_t = emhash7::HashMap<uint16_t, uint64_t>;
   /// @typedef trace_flags_t
   /// @brief Maps an trace type to a boolean flag indicating its state.
   /// @details This unordered map uses a uint16_t as the key for the trace
   /// type, and a boolean value to indicate whether callbacks are registered
   /// for this trace type (e.g., registered or unregisterted/no callback).
-  using trace_flags_t = std::unordered_map<uint16_t, bool>;
+  using trace_flags_t = emhash7::HashMap<uint16_t, bool>;
 
   /// @typedef stream_flags_t
   /// @brief Maps a stream ID to its corresponding trace flags for different
@@ -1419,7 +1419,7 @@ public:
   /// and trace_flags_t to map the trace type to their boolean that indiciates
   /// whether a callback has been registered for this trace type in the given
   /// stream.
-  using stream_flags_t = std::unordered_map<uint8_t, trace_flags_t>;
+  using stream_flags_t = emhash7::HashMap<uint8_t, trace_flags_t>;
 
   /// @brief Registers a callback function for a specific trace type and stream
   /// ID.

--- a/xptifw/unit_test/CMakeLists.txt
+++ b/xptifw/unit_test/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${XPTI_DIR}/include)
 if (NOT DEFINED LLVM_EXTERNAL_XPTIFW_SOURCE_DIR)
   message(STATUS "Building XPTI outside of LLVM Project...")
   # Download and unpack googletest at configure time
-  configure_file(../CMakeLists.txt.in googletest-download/CMakeLists.txt)
+  configure_file(${XPTIFW_DIR}/CMakeLists.txt.in googletest-download/CMakeLists.txt)
   execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )


### PR DESCRIPTION
This PR is first of many XPTI changes to address the performance issues that have been reported.

(1) xpti::Framework::instance() - testing the use of std::call_once against current implementation 
(2) Added cleanup for default stream "xpti.framework"
(3) Switched to EmHash instead of std::unordered_map that improve notification performance by 10%

Most of the performance overheads are from xptiRegisterObject() and xptiAddMetadata(). This requires changes in the SYCL runtime an will be addressed in a subsequent PR