### PR TITLE
[UR][CUDA] Fix command-buffer handle inheritance

### DIFF
--- a/unified-runtime/source/adapters/cuda/command_buffer.cpp
+++ b/unified-runtime/source/adapters/cuda/command_buffer.cpp
@@ -57,7 +57,7 @@ ur_result_t commandHandleDestroy(
 
 ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     ur_context_handle_t Context, ur_device_handle_t Device, bool IsUpdatable)
-    : Context(Context), Device(Device), IsUpdatable(IsUpdatable),
+    : handle_base(), Context(Context), Device(Device), IsUpdatable(IsUpdatable),
       CudaGraph{nullptr}, CudaGraphExec{nullptr}, RefCount{1},
       NextSyncPoint{0} {
   urContextRetain(Context);

--- a/unified-runtime/source/adapters/cuda/command_buffer.hpp
+++ b/unified-runtime/source/adapters/cuda/command_buffer.hpp
@@ -128,7 +128,7 @@ struct ur_exp_command_buffer_command_handle_t_ : ur::cuda::handle_base {
   command_data_type_t CommandData;
 };
 
-struct ur_exp_command_buffer_handle_t_ {
+struct ur_exp_command_buffer_handle_t_ : ur::cuda::handle_base {
 
   ur_exp_command_buffer_handle_t_(ur_context_handle_t Context,
                                   ur_device_handle_t Device, bool IsUpdatable);


### PR DESCRIPTION
The `ur_exp_command_buffer_handle_t_` definition in the CUDA adapter was missed in https://github.com/intel/llvm/pull/17118 in the changes to inherit from a base handle.

Discovered by seeing segfaults in the UR CTS tests locally, and git bisecting back to that change.