### PR TITLE
[SYCL-E2E] Disable Basic/std_array.cpp for GEN12 on Windows

### DIFF
--- a/sycl/test-e2e/Basic/std_array.cpp
+++ b/sycl/test-e2e/Basic/std_array.cpp
@@ -1,6 +1,8 @@
 // Check that std::array is supported on device in debug mode on Windows.
 
 // REQUIRES: windows
+// UNSUPPORTED: gpu-intel-gen12
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18458
 
 // RUN: %clangxx --driver-mode=cl -fsycl -o %t.exe %s /Od /MDd /Zi /EHsc
 // RUN: %{run} %t.exe


### PR DESCRIPTION
Post-commit failure introduced by https://github.com/intel/llvm/pull/18400 and tracked in https://github.com/intel/llvm/issues/18458.
