### PR TITLE
Transfer opt level to clang target options

### DIFF
--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -1084,6 +1084,24 @@ void CudaToolChain::addClangTargetOptions(
                                    GpuArch, /*isBitCodeSDL=*/true,
                                    /*postClangLink=*/true);
   }
+  const Arg *A = DriverArgs.getLastArg(options::OPT_O_Group);
+  StringRef OOpt = "3";
+  if (A->getOption().matches(options::OPT_O4) ||
+      A->getOption().matches(options::OPT_Ofast))
+    OOpt = "3";
+  else if (A->getOption().matches(options::OPT_O0))
+    OOpt = "0";
+  else if (A->getOption().matches(options::OPT_O)) {
+    // -Os, -Oz, and -O(anything else) map to -O2, for lack of better options.
+    OOpt = llvm::StringSwitch<const char *>(A->getValue())
+                .Case("1", "1")
+                .Case("2", "2")
+                .Case("3", "3")
+                .Case("s", "2")
+                .Case("z", "2")
+                .Default("2");
+  }
+  CC1Args.push_back(DriverArgs.MakeArgString(llvm::Twine("-O") + OOpt));
 }
 
 llvm::DenormalMode CudaToolChain::getDefaultDenormalModeForType(


### PR DESCRIPTION
Currently, without transferring the opt level to clang target options if we called: 
```
clang -O3 -fsycl -fsycl-targets=nvptx64-nvidia-cuda a.cpp -o b
```
 it will not transfer this `-O3` to the clang command underneath that compiles the nvptx kernels:
```
clang -cc1 -triple nvptx64-nvidia-cuda ...
``` 

This for some reason was not a problem on linux platforms as they already compiled the kernels with -O3, but on windows and on calling `clang-cl.exe` it was using `-O0`. This PR would make them consistent by explicitly transfer driver opt level called to CC1 args, so it would be in the above case:
```
clang -cc1 -triple nvptx64-nvidia-cuda -O3 ...
```