### PR TITLE
[SYCL][NFC] Remove unused host kernel member in CGExecKernel

### DIFF
--- a/sycl/source/detail/cg.hpp
+++ b/sycl/source/detail/cg.hpp
@@ -252,7 +252,6 @@ class CGExecKernel : public CG {
 public:
   /// Stores ND-range description.
   NDRDescT MNDRDesc;
-  std::shared_ptr<HostKernelBase> MHostKernel;
   std::shared_ptr<detail::kernel_impl> MSyclKernel;
   std::shared_ptr<detail::kernel_bundle_impl> MKernelBundle;
   std::vector<ArgDesc> MArgs;
@@ -267,7 +266,7 @@ public:
   bool MKernelUsesClusterLaunch = false;
   size_t MKernelWorkGroupMemorySize = 0;
 
-  CGExecKernel(NDRDescT NDRDesc, std::shared_ptr<HostKernelBase> HKernel,
+  CGExecKernel(NDRDescT NDRDesc,
                std::shared_ptr<detail::kernel_impl> SyclKernel,
                std::shared_ptr<detail::kernel_bundle_impl> KernelBundle,
                CG::StorageInitHelper CGData, std::vector<ArgDesc> Args,
@@ -278,8 +277,7 @@ public:
                bool KernelIsCooperative, bool MKernelUsesClusterLaunch,
                size_t KernelWorkGroupMemorySize, detail::code_location loc = {})
       : CG(Type, std::move(CGData), std::move(loc)),
-        MNDRDesc(std::move(NDRDesc)), MHostKernel(std::move(HKernel)),
-        MSyclKernel(std::move(SyclKernel)),
+        MNDRDesc(std::move(NDRDesc)), MSyclKernel(std::move(SyclKernel)),
         MKernelBundle(std::move(KernelBundle)), MArgs(std::move(Args)),
         MKernelName(std::move(KernelName)), MStreams(std::move(Streams)),
         MAuxiliaryResources(std::move(AuxiliaryResources)),

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -611,7 +611,7 @@ event handler::finalize() {
     // running of this method by reductions implementation. This allows for
     // assert feature to check if kernel uses assertions
     CommandGroup.reset(new detail::CGExecKernel(
-        std::move(impl->MNDRDesc), std::move(MHostKernel), std::move(MKernel),
+        std::move(impl->MNDRDesc), std::move(MKernel),
         std::move(impl->MKernelBundle), std::move(impl->CGData),
         std::move(impl->MArgs), MKernelName.data(), std::move(MStreamStorage),
         std::move(impl->MAuxiliaryResources), getType(),

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -126,13 +126,13 @@ public:
     switch (getType()) {
     case sycl::detail::CGType::Kernel: {
       CommandGroup.reset(new sycl::detail::CGExecKernel(
-          std::move(impl->MNDRDesc), std::move(CGH->MHostKernel),
-          std::move(CGH->MKernel), std::move(impl->MKernelBundle),
-          std::move(impl->CGData), std::move(impl->MArgs),
-          CGH->MKernelName.data(), std::move(CGH->MStreamStorage),
-          std::move(impl->MAuxiliaryResources), impl->MCGType, {},
-          impl->MKernelIsCooperative, impl->MKernelUsesClusterLaunch,
-          impl->MKernelWorkGroupMemorySize, CGH->MCodeLoc));
+          std::move(impl->MNDRDesc), std::move(CGH->MKernel),
+          std::move(impl->MKernelBundle), std::move(impl->CGData),
+          std::move(impl->MArgs), CGH->MKernelName.data(),
+          std::move(CGH->MStreamStorage), std::move(impl->MAuxiliaryResources),
+          impl->MCGType, {}, impl->MKernelIsCooperative,
+          impl->MKernelUsesClusterLaunch, impl->MKernelWorkGroupMemorySize,
+          CGH->MCodeLoc));
       break;
     }
     default:

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -234,9 +234,6 @@ public:
   std::vector<std::shared_ptr<sycl::detail::stream_impl>> &getStreamStorage() {
     return MStreamStorage;
   }
-  std::unique_ptr<sycl::detail::HostKernelBase> &getHostKernel() {
-    return MHostKernel;
-  }
   std::vector<std::vector<char>> &getArgsStorage() {
     return impl->CGData.MArgsStorage;
   }
@@ -299,10 +296,9 @@ public:
     switch (getType()) {
     case sycl::detail::CGType::Kernel: {
       CommandGroup.reset(new sycl::detail::CGExecKernel(
-          getNDRDesc(), std::move(getHostKernel()), getKernel(),
-          std::move(impl->MKernelBundle), std::move(CGData), getArgs(),
-          getKernelName(), getStreamStorage(), impl->MAuxiliaryResources,
-          getType(), {}, impl->MKernelIsCooperative,
+          getNDRDesc(), getKernel(), std::move(impl->MKernelBundle),
+          std::move(CGData), getArgs(), getKernelName(), getStreamStorage(),
+          impl->MAuxiliaryResources, getType(), {}, impl->MKernelIsCooperative,
           impl->MKernelUsesClusterLaunch, impl->MKernelWorkGroupMemorySize,
           getCodeLoc()));
       break;

--- a/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
+++ b/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
@@ -29,8 +29,7 @@ public:
     switch (getType()) {
     case detail::CGType::Kernel: {
       CommandGroup.reset(new detail::CGExecKernel(
-          getNDRDesc(), std::move(getHostKernel()), getKernel(),
-          std::move(impl->MKernelBundle),
+          getNDRDesc(), getKernel(), std::move(impl->MKernelBundle),
           detail::CG::StorageInitHelper(getArgsStorage(), getAccStorage(),
                                         getSharedPtrStorage(),
                                         getRequirements(), getEvents()),


### PR DESCRIPTION
The MHostKernel member in CGExecKernel was unused, so this commit removes it.