### PR TITLE
[SYCL][E2E] Use `ROCM_PATH` from the system environment

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -541,6 +541,10 @@ with test_env():
     else:
         config.substitutions.append(("%hip_options", ""))
 
+# Add ROCM_PATH from system environment, this is used by clang to find ROCm
+# libraries in non-standard installation locations.
+llvm_config.with_system_environment("ROCM_PATH")
+
 # Check for OpenCL ICD
 if config.opencl_libs_dir:
     config.opencl_libs_dir = quote_path(config.opencl_libs_dir)


### PR DESCRIPTION
For ROCm installations that aren't just in `/opt/rocm`, `clang` uses `ROCM_PATH` at runtime to find the ROCm device libraries, and this is done even in regular SYCL compilation. So this is needed for lit tests in certain configurations.

This was accidentally removed in https://github.com/intel/llvm/pull/17692 it doesn't cause any issues in the CI because the CI has ROCm installed in the standard `/opt/rocm`, but it causes issues on local setups.