### PR TITLE
[SYCL][Graph]Fix coverity issues by passing shared pointer by reference.

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -139,7 +139,7 @@ void propagatePartitionUp(std::shared_ptr<node_impl> Node, int PartitionNum) {
 /// @param HostTaskList List of host tasks that have already been processed and
 /// are encountered as successors to the node Node.
 void propagatePartitionDown(
-    std::shared_ptr<node_impl> Node, int PartitionNum,
+    const std::shared_ptr<node_impl> &Node, int PartitionNum,
     std::list<std::shared_ptr<node_impl>> &HostTaskList) {
   if (Node->MCGType == sycl::detail::CGType::CodeplayHostTask) {
     if (Node->MPartitionNum != -1) {
@@ -753,7 +753,7 @@ std::vector<sycl::detail::EventImplPtr> graph_impl::getExitNodesEvents(
 }
 
 void graph_impl::beginRecording(
-    std::shared_ptr<sycl::detail::queue_impl> Queue) {
+    const std::shared_ptr<sycl::detail::queue_impl> &Queue) {
   graph_impl::WriteLock Lock(MMutex);
   if (!Queue->hasCommandGraph()) {
     Queue->setCommandGraph(shared_from_this());
@@ -1024,7 +1024,7 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
       for (std::vector<sycl::detail::EventImplPtr>::iterator It =
                MExecutionEvents.begin();
            It != MExecutionEvents.end();) {
-        auto Event = *It;
+        std::shared_ptr<event_impl> &Event = *It;
         if (!Event->isCompleted()) {
           auto &AttachedEventsList = Event->getPostCompleteEvents();
           CGData.MEvents.reserve(CGData.MEvents.size() +

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -1024,9 +1024,10 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
       for (std::vector<sycl::detail::EventImplPtr>::iterator It =
                MExecutionEvents.begin();
            It != MExecutionEvents.end();) {
-        std::shared_ptr<event_impl> &Event = *It;
+        EventImplPtr &Event = *It;
         if (!Event->isCompleted()) {
-          auto &AttachedEventsList = Event->getPostCompleteEvents();
+          const std::vector<EventImplPtr> &AttachedEventsList =
+              Event->getPostCompleteEvents();
           CGData.MEvents.reserve(CGData.MEvents.size() +
                                  AttachedEventsList.size() + 1);
           CGData.MEvents.push_back(Event);

--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -895,7 +895,7 @@ public:
   /// @param EventImpl Event to associate with a node in map.
   /// @param NodeImpl Node to associate with event in map.
   void addEventForNode(std::shared_ptr<sycl::detail::event_impl> EventImpl,
-                       std::shared_ptr<node_impl> NodeImpl) {
+                       const std::shared_ptr<node_impl> &NodeImpl) {
     if (!(EventImpl->hasCommandGraph()))
       EventImpl->setCommandGraph(shared_from_this());
     MEventsMap[EventImpl] = NodeImpl;
@@ -1145,7 +1145,7 @@ public:
   /// Sets the Queue state to queue_state::recording. Adds the queue to the list
   /// of recording queues associated with this graph.
   /// @param[in] Queue The queue to be recorded from.
-  void beginRecording(std::shared_ptr<sycl::detail::queue_impl> Queue);
+  void beginRecording(const std::shared_ptr<sycl::detail::queue_impl> &Queue);
 
   /// Store the last barrier node that was submitted to the queue.
   /// @param[in] Queue The queue the barrier was recorded from.
@@ -1212,7 +1212,7 @@ private:
   /// added as a root node.
   /// @param Node The node to add deps for
   /// @param Deps List of dependent nodes
-  void addDepsToNode(std::shared_ptr<node_impl> Node,
+  void addDepsToNode(const std::shared_ptr<node_impl> &Node,
                      std::vector<std::shared_ptr<node_impl>> &Deps) {
     if (!Deps.empty()) {
       for (auto &N : Deps) {


### PR DESCRIPTION
Changes some functions in the sycl graph implementation to pass shared pointers by reference instead of by value.

Fixes: #18412