### PR TITLE
Revert "[SYCL][E2E] XFAIL failing DG2 tests"

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/cache_env_vars.cpp
+++ b/sycl/test-e2e/KernelAndProgram/cache_env_vars.cpp
@@ -1,7 +1,5 @@
 // No JITing for host devices.
 // REQUIRES: opencl || level_zero
-// XFAIL: run-mode && linux && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18416
 // RUN: %{run-aux} rm -rf %t/cache_dir
 // RUN: %{build} -o %t.out -DTARGET_IMAGE=INC100
 // Build program and add item to cache

--- a/sycl/test-e2e/KernelAndProgram/cache_env_vars_lin.cpp
+++ b/sycl/test-e2e/KernelAndProgram/cache_env_vars_lin.cpp
@@ -1,8 +1,7 @@
 // No JITing for host devices and diffrent environment variables on linux and
 // windows.
 // REQUIRES: (level_zero || opencl) && linux
-// XFAIL: run-mode && linux && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18416
+
 // RUN: %{run-aux} rm -rf %t/cache_dir
 // RUN: %{build} -o %t.out -DTARGET_IMAGE=INC100
 

--- a/sycl/test-e2e/KernelCompiler/opencl.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: ocloc && (opencl || level_zero)
-// XFAIL: run-mode && linux && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18416
 // UNSUPPORTED: accelerator
 // UNSUPPORTED-INTENDED: while accelerator is AoT only, this cannot run there.
 

--- a/sycl/test-e2e/KernelCompiler/sycl_cache_pm.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_cache_pm.cpp
@@ -8,8 +8,7 @@
 
 // REQUIRES: (opencl || level_zero)
 // REQUIRES: aspect-usm_device_allocations
-// XFAIL: run-mode && linux && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18416
+
 // UNSUPPORTED: accelerator
 // UNSUPPORTED-INTENDED: while accelerator is AoT only, this cannot run there.
 


### PR DESCRIPTION
Reverts intel/llvm#18445

The root cause for the test failure was fixed in https://github.com/intel/llvm/pull/18420.

This now leads to unexpectedly passing tests.