### PR TITLE
[Benchmark] Switch off L0 for computeBench on SYCL for CUDA

### DIFF
--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -74,7 +74,11 @@ class ComputeBench(Suite):
         ]
 
         if options.ur_adapter == "cuda":
-            configure_command += ["-DBUILD_SYCL_WITH_CUDA=ON"]
+            configure_command += [
+                "-DBUILD_SYCL_WITH_CUDA=ON",
+                "-DBUILD_L0=OFF",
+                "-DBUILD_OCL=OFF",
+            ]
 
         if options.ur is not None:
             configure_command += [


### PR DESCRIPTION
Currently L0/opencl benchmarks is still built on computeBench even when we specify that we need to benchmark sycl on top of cuda that creates an error sometimes when the execution environment doesn't have L0 setup. That PR will close building L0/opencl benchmarks on computeBench when we specify cuda target for benchmarking.