### PR TITLE
[CI] Turn on security flags in Nightly builds

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -15,7 +15,7 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      build_configure_extra_args: '--hip --cuda'
+      build_configure_extra_args: '--hip --cuda --add_security_flags=default -DCMAKE_POSITION_INDEPENDENT_CODE=ON'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
       retention-days: 90
 
@@ -150,7 +150,7 @@ jobs:
       # functionality, make sure Linux/Windows names follow the same pattern.
       artifact_archive_name: sycl_windows.tar.gz
       # Disable the spirv-dis requirement as to not require SPIR-V Tools.
-      build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off
+      build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off --add_security_flags=default -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
   e2e-win:
     needs: build-win

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -51,19 +51,13 @@ endif()
 
 macro(append_common_extra_security_flags)
   # Compiler Warnings and Error Detection
-  # Note: in intel/llvm we build both linux and win with --ci-defaults.
-  # This flag also enables -Werror or /WX.
-  if(is_gcc
-     OR is_clang
-     OR (is_icpx AND MSVC))
-    add_compile_option_ext("-Wall" WALL)
-    add_compile_option_ext("-Wextra" WEXTRA)
-  elseif(is_icpx)
-    add_compile_option_ext("/Wall" WALL)
-  elseif(is_msvc)
-    add_compile_option_ext("/W4" WALL)
-  endif()
 
+  # Notes:
+  # -Wall -Wextra or /W4 flags are enabled for the sycl project by default.
+
+  # In intel/llvm we build both linux and win with --ci-defaults, this flag also
+  # enables -Werror or /WX. Otherwise the "--werror" flag of the configure.py
+  # script can be applied.
   if(CMAKE_BUILD_TYPE MATCHES "Release")
     if(is_gcc
        OR is_clang
@@ -125,6 +119,7 @@ macro(append_common_extra_security_flags)
   if(is_gcc
      OR is_clang
      OR (is_icpx AND MSVC))
+     # The project should be configured with -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     add_compile_option_ext("-fPIC" FPIC)
   elseif(is_msvc)
     add_compile_option_ext("/Gy" GY)
@@ -134,7 +129,6 @@ macro(append_common_extra_security_flags)
   if(is_gcc
      OR is_clang
      OR (is_icpx AND MSVC))
-    # The project should be configured with -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     add_compile_option_ext("-fPIE" FPIE)
     add_link_option_ext("-pie" PIE CMAKE_EXE_LINKER_FLAGS
                         CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)


### PR DESCRIPTION
These flags are needed for release binaries, so we need to regularly verify that we can build the compiler with them.