### PR TITLE
[UR][L0] Add L0 teardown notification support and simply teardown with proxy loader support

### DIFF
--- a/sycl/ur_win_proxy_loader/ur_win_proxy_loader.cpp
+++ b/sycl/ur_win_proxy_loader/ur_win_proxy_loader.cpp
@@ -168,6 +168,11 @@ void preloadLibraries() {
   loadAdapter(UR_LIBRARY_NAME(adapter_cuda));
   loadAdapter(UR_LIBRARY_NAME(adapter_hip));
   loadAdapter(UR_LIBRARY_NAME(adapter_native_cpu));
+  // Load the Level Zero loader dynamic library to ensure it is loaded during
+  // the runtime. This is necessary to avoid the level zero loader from being
+  // unloaded prematurely. the Only trusted loader is the one that is loaded
+  // from the system32 directory.
+  LoadLibraryExW(L"ze_loader.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
   // Restore system error handling.
   (void)SetErrorMode(SavedMode);

--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -47,7 +47,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
         set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
     endif()
     if (UR_LEVEL_ZERO_LOADER_TAG STREQUAL "")
-        set(UR_LEVEL_ZERO_LOADER_TAG abc68a57e5d536a449a5e45f1aef85285fa70088)
+        set(UR_LEVEL_ZERO_LOADER_TAG 35c037cdf4aa9a2e6df34b6f1ce1bdc86ac5422f)
     endif()
 
     # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104


### PR DESCRIPTION
- Add support for L0 teardown notification in the static L0 loader.
- Add loading of the L0 dynamic loader in the windows proxy loader to ensure that the L0 dynamic loader is usable during teardown.