### PR TITLE
[WIP][SYCL][HostTask] Optimize blocked users tracking

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -837,6 +837,7 @@ protected:
     /// \param EnqueueResult is set to specific status if enqueue failed.
     /// \param ToCleanUp container for commands that can be cleaned up.
     /// \param RootCommand top level command enqueueCommand is called for.
+    /// \param TrackBlockedUser whether to track Cmd as a blocked user of its host task dependencies.
     /// \return true if the command is successfully enqueued.
     ///
     /// The function may unlock and lock GraphReadLock as needed. Upon return
@@ -845,7 +846,8 @@ protected:
                                EnqueueResultT &EnqueueResult,
                                std::vector<Command *> &ToCleanUp,
                                Command *RootCommand,
-                               BlockingT Blocking = NON_BLOCKING);
+                               BlockingT Blocking = NON_BLOCKING,
+                               bool TrackBlockedUser = true);
 
     /// Check if successfully enqueued command is expected to be blocking for
     /// the dependent commands before its completion.
@@ -858,9 +860,11 @@ protected:
     /// no dependencies to be blocked yet.
     /// \param Blocking mode for enqueue, we do not report command as blocking
     /// if it is true and allow to wait for command completion in enqueueImp.
+    /// \param TrackBlockedUser whether to track Cmd as a blocked user of blocking RootCommand.
     /// \return true if we should continue enqueue process.
     static bool handleBlockingCmd(Command *Cmd, EnqueueResultT &EnqueueResult,
-                                  Command *RootCommand, BlockingT Blocking);
+                                  Command *RootCommand, BlockingT Blocking,
+                                  bool TrackBlockedUser = true);
   };
 
   /// This function waits on all of the graph leaves which somehow use the


### PR DESCRIPTION
This commit partially addresses a performance issue observed when submitting consecutive host tasks to an in-order queue without explicit `wait()`. The execution time of each host task was found to increase significantly as the number of submissions grew:
https://github.com/intel/llvm/issues/18500.

The major cause was identified as the unnecessary tracking of indirect blocking dependencies in `MBlockedUsers`. Previously, all direct and indirect blocking relations between enqueued commands were tracked, causing a siginificant increase in notification time upon task completion. For example, in a sequence of tasks `A, B, C, D`, `A.MBlockedUsers` would redundantly include `{C, D}`, even though these tasks are already blocked by `B`.

To resolve this, the `enqueueCommand` function was enhanced to include a `TrackBlockedUser` flag during recursion enqueueing. This change prevents excessive growth in the size of `Cmd->MBlockedUsers` in long dependency chains by only tracking the host task immediate dominator in the dependency tree, thereby reducing notification time upon command completion.