### PR TITLE
[SYCL][libdevice] Move common group utils from sanitizer specific header

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -245,6 +245,7 @@ if (NOT MSVC AND UR_SANITIZER_INCLUDE_DIR)
     include/asan_rtl.hpp
     include/sanitizer_defs.hpp
     include/spir_global_var.hpp
+    include/group_utils.hpp
     ${sycl-compiler_deps})
 
   set(sanitizer_generic_compile_opts ${compile_opts}
@@ -303,6 +304,7 @@ if (NOT MSVC AND UR_SANITIZER_INCLUDE_DIR)
     include/msan_rtl.hpp
     include/sanitizer_defs.hpp
     include/spir_global_var.hpp
+    include/group_utils.hpp
     sycl-compiler)
 
   set(tsan_obj_deps
@@ -311,6 +313,7 @@ if (NOT MSVC AND UR_SANITIZER_INCLUDE_DIR)
     include/tsan_rtl.hpp
     include/sanitizer_defs.hpp
     include/spir_global_var.hpp
+    include/group_utils.hpp
     sycl-compiler)
 endif()
 

--- a/libdevice/include/group_utils.hpp
+++ b/libdevice/include/group_utils.hpp
@@ -1,0 +1,33 @@
+//==------------------ group_utils.hpp - utils for group -------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "spirv_vars.h"
+
+#if defined(__SPIR__) || defined(__SPIRV__)
+
+size_t WorkGroupLinearId() {
+  return __spirv_BuiltInWorkgroupId.x * __spirv_BuiltInNumWorkgroups.y *
+             __spirv_BuiltInNumWorkgroups.z +
+         __spirv_BuiltInWorkgroupId.y * __spirv_BuiltInNumWorkgroups.z +
+         __spirv_BuiltInWorkgroupId.z;
+}
+
+// For GPU device, each sub group is a hardware thread
+size_t SubGroupLinearId() {
+  return __spirv_BuiltInGlobalLinearId / __spirv_BuiltInSubgroupSize;
+}
+
+void SubGroupBarrier() {
+  __spirv_ControlBarrier(__spv::Scope::Subgroup, __spv::Scope::Subgroup,
+                         __spv::MemorySemanticsMask::SequentiallyConsistent |
+                             __spv::MemorySemanticsMask::CrossWorkgroupMemory |
+                             __spv::MemorySemanticsMask::WorkgroupMemory);
+}
+
+#endif // __SPIR__ || __SPIRV__

--- a/libdevice/include/group_utils.hpp
+++ b/libdevice/include/group_utils.hpp
@@ -11,7 +11,7 @@
 
 #if defined(__SPIR__) || defined(__SPIRV__)
 
-size_t WorkGroupLinearId() {
+static inline size_t WorkGroupLinearId() {
   return __spirv_BuiltInWorkgroupId.x * __spirv_BuiltInNumWorkgroups.y *
              __spirv_BuiltInNumWorkgroups.z +
          __spirv_BuiltInWorkgroupId.y * __spirv_BuiltInNumWorkgroups.z +
@@ -19,11 +19,11 @@ size_t WorkGroupLinearId() {
 }
 
 // For GPU device, each sub group is a hardware thread
-size_t SubGroupLinearId() {
+static inline size_t SubGroupLinearId() {
   return __spirv_BuiltInGlobalLinearId / __spirv_BuiltInSubgroupSize;
 }
 
-void SubGroupBarrier() {
+static inline void SubGroupBarrier() {
   __spirv_ControlBarrier(__spv::Scope::Subgroup, __spv::Scope::Subgroup,
                          __spv::MemorySemanticsMask::SequentiallyConsistent |
                              __spv::MemorySemanticsMask::CrossWorkgroupMemory |

--- a/libdevice/include/sanitizer_defs.hpp
+++ b/libdevice/include/sanitizer_defs.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 #include "atomic.hpp"
+#include "group_utils.hpp"
 #include "spir_global_var.hpp"
-#include "spirv_vars.h"
 #include <cstdint>
 
 using uptr = uintptr_t;
@@ -64,25 +64,6 @@ __SYCL_LOCAL__ void *ToLocal(void *ptr) {
 }
 __SYCL_PRIVATE__ void *ToPrivate(void *ptr) {
   return __spirv_GenericCastToPtrExplicit_ToPrivate(ptr, 7);
-}
-
-size_t WorkGroupLinearId() {
-  return __spirv_BuiltInWorkgroupId.x * __spirv_BuiltInNumWorkgroups.y *
-             __spirv_BuiltInNumWorkgroups.z +
-         __spirv_BuiltInWorkgroupId.y * __spirv_BuiltInNumWorkgroups.z +
-         __spirv_BuiltInWorkgroupId.z;
-}
-
-// For GPU device, each sub group is a hardware thread
-size_t SubGroupLinearId() {
-  return __spirv_BuiltInGlobalLinearId / __spirv_BuiltInSubgroupSize;
-}
-
-void SubGroupBarrier() {
-  __spirv_ControlBarrier(__spv::Scope::Subgroup, __spv::Scope::Subgroup,
-                         __spv::MemorySemanticsMask::SequentiallyConsistent |
-                             __spv::MemorySemanticsMask::CrossWorkgroupMemory |
-                             __spv::MemorySemanticsMask::WorkgroupMemory);
 }
 
 #endif // __SPIR__ || __SPIRV__


### PR DESCRIPTION
We defined some group/subgroup util functions in device sanitizer specific headers, these functions will be used by other libdevice functions, so move them to a separate header.