### PR TITLE
[SYCL] Add UR error code when throwing exception from Scheduler::enqueueCommandForCG

### DIFF
--- a/sycl/source/detail/adapter.hpp
+++ b/sycl/source/detail/adapter.hpp
@@ -66,8 +66,8 @@ public:
   /// \throw SYCL 2020 exception(errc) if ur_result is not UR_RESULT_SUCCESS
   template <sycl::errc errc = sycl::errc::runtime>
   void checkUrResult(ur_result_t ur_result) const {
-    const char *message = nullptr;
     if (ur_result == UR_RESULT_ERROR_ADAPTER_SPECIFIC) {
+      const char *message = nullptr;
       int32_t adapter_error = 0;
       ur_result = call_nocheck<UrApiKind::urAdapterGetLastError>(
           MAdapter, &message, &adapter_error);
@@ -84,9 +84,7 @@ public:
       throw sycl::detail::set_ur_error(
           sycl::exception(sycl::make_error_code(errc),
                           __SYCL_UR_ERROR_REPORT +
-                              sycl::detail::codeToString(ur_result) +
-                              (message ? "\n" + std::string(message) + "\n"
-                                       : std::string{})),
+                              sycl::detail::codeToString(ur_result)),
           ur_result);
     }
   }

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -188,9 +188,14 @@ void Scheduler::enqueueCommandForCG(EventImplPtr NewEvent,
       try {
         bool Enqueued = GraphProcessor::enqueueCommand(
             NewCmd, Lock, Res, ToCleanUp, NewCmd, Blocking);
-        if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-          throw exception(make_error_code(errc::runtime),
-                          "Enqueue process failed.");
+        if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult) {
+          throw sycl::detail::set_ur_error(
+              sycl::exception(sycl::make_error_code(errc::runtime),
+                              std::string("Enqueue process failed.\n") +
+                                  __SYCL_UR_ERROR_REPORT +
+                                  sycl::detail::codeToString(Res.MErrCode)),
+              Res.MErrCode);
+        }
       } catch (...) {
         // enqueueCommand() func and if statement above may throw an exception,
         // so destroy required resources to avoid memory leak


### PR DESCRIPTION
Add UR error code when throwing exception from Scheduler::enqueueCommandForCG.
Remove message string from non adapter specific error exception in checkUrResult as it's only used in the adapter specific error path.

This is related to https://github.com/oneapi-src/unified-runtime/issues/2440 and https://github.com/intel/llvm/pull/18423 where `clEnqueueMemFillINTEL` was failing with -30 (`CL_INVALID_VALUE`) but no detail was provided in the log:
```
terminate called after throwing an instance of 'sycl::_V1::exception'
  what():  Enqueue process failed.
Aborted (core dumped)
```
This is because the first exception thrown from `checkUrResult` was being hidden by a second exception thrown from `Scheduler::enqueueCommandForCG`. I've modified this second exception to include the UR result. The output now looks like:
```
terminate called after throwing an instance of 'sycl::_V1::exception'
  what():  Enqueue process failed.
Native API failed. Native API returns: 4 (UR_RESULT_ERROR_INVALID_VALUE)
```