### PR TITLE
[SYCL][UR][L0 v2] fix ur_queue_handle_t_ after #17118

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -259,7 +259,9 @@ ur_result_t urEventGetInfo(ur_event_handle_t hEvent, ur_event_info_t propName,
     return returnValue(hEvent->RefCount.load());
   }
   case UR_EVENT_INFO_COMMAND_QUEUE: {
-    return returnValue(hEvent->getQueue());
+    auto urQueueHandle = reinterpret_cast<uintptr_t>(hEvent->getQueue()) -
+                         ur_queue_handle_t_::queue_offset;
+    return returnValue(urQueueHandle);
   }
   case UR_EVENT_INFO_CONTEXT: {
     return returnValue(hEvent->getContext());

--- a/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
@@ -13,17 +13,24 @@
 
 #pragma once
 
+#include "../common.hpp"
 #include "queue_immediate_in_order.hpp"
 #include <ur_api.h>
 #include <variant>
 
-struct ur_queue_handle_t_ {
+struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   using data_variant = std::variant<v2::ur_queue_immediate_in_order_t>;
   data_variant queue_data;
 
   template <typename T, class... Args>
+  ur_queue_handle_t_(std::in_place_type_t<T>, Args &&...args)
+      : ur::handle_base<ur::level_zero::ddi_getter>(),
+        queue_data(std::in_place_type<T>, std::forward<Args>(args)...) {}
+
+  template <typename T, class... Args>
   static ur_queue_handle_t_ *create(Args &&...args) {
-    return new ur_queue_handle_t_{data_variant{std::in_place_type<T>, args...}};
+    return new ur_queue_handle_t_(std::in_place_type<T>,
+                                  std::forward<Args>(args)...);
   }
 
   ur_queue_t_ &get() {

--- a/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
@@ -22,10 +22,18 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   using data_variant = std::variant<v2::ur_queue_immediate_in_order_t>;
   data_variant queue_data;
 
+  static constexpr uintptr_t queue_offset =
+      sizeof(ur::handle_base<ur::level_zero::ddi_getter>);
+
   template <typename T, class... Args>
   ur_queue_handle_t_(std::in_place_type_t<T>, Args &&...args)
       : ur::handle_base<ur::level_zero::ddi_getter>(),
-        queue_data(std::in_place_type<T>, std::forward<Args>(args)...) {}
+        queue_data(std::in_place_type<T>, std::forward<Args>(args)...) {
+    assert(queue_offset ==
+           (std::visit([](auto &q) { return reinterpret_cast<uintptr_t>(&q); },
+                       queue_data) -
+            reinterpret_cast<uintptr_t>(this)));
+  }
 
   template <typename T, class... Args>
   static ur_queue_handle_t_ *create(Args &&...args) {


### PR DESCRIPTION
ur_queue_handle_t_ was not inheriting from ur::handle_base resulting in *reinterpret_cast<ur_dditable_t **>(hQueue) not working correctly.

For some reason this worked on some platforms, and only manifested on PVC.