### PR TITLE
[SYCL][Driver] Allow -gline-tables-only for the SYCL host compilation only.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -141,9 +141,10 @@ def warn_drv_unsupported_option_for_offload_arch_req_feature : Warning<
   "ignoring '%0' option for offload arch '%1' as it is not currently supported "
   "there. Use it with an offload arch containing '%2' instead">,
   InGroup<OptionIgnored>;
-def warn_drv_unsupported_option_for_target : Warning<
-  "ignoring '%0' option as it is not currently supported for target '%1'">,
-  InGroup<OptionIgnored>;
+def warn_drv_unsupported_option_for_target
+    : Warning<"ignoring '%0' option as it is not currently supported for "
+              "target '%1'%select{|;only supported for host compilation}2">,
+      InGroup<OptionIgnored>;
 def warn_drv_unsupported_option_for_flang : Warning<
   "the argument '%0' is not supported for option '%1'. Mapping to '%1%2'">,
   InGroup<OptionIgnored>;

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -143,7 +143,7 @@ def warn_drv_unsupported_option_for_offload_arch_req_feature : Warning<
   InGroup<OptionIgnored>;
 def warn_drv_unsupported_option_for_target
     : Warning<"ignoring '%0' option as it is not currently supported for "
-              "target '%1'%select{|;only supported for host compilation}2">,
+              "target '%1'%select{|; only supported for host compilation}2">,
       InGroup<OptionIgnored>;
 def warn_drv_unsupported_option_for_flang : Warning<
   "the argument '%0' is not supported for option '%1'. Mapping to '%1%2'">,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1560,7 +1560,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
         continue;
       }
       Diag(diag::warn_drv_unsupported_option_for_target)
-          << "-fno-sycl-libspirv" << TT.getTriple();
+          << "-fno-sycl-libspirv" << TT.getTriple() << 0;
     }
   }
   // -fsycl-fp64-conv-emu is valid only for AOT compilation with an Intel GPU

--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1309,7 +1309,7 @@ void SanitizerArgs::addArgs(const ToolChain &TC, const llvm::opt::ArgList &Args,
 
     if (!SanitizeArg.empty())
       TC.getDriver().Diag(diag::warn_drv_unsupported_option_for_target)
-          << SanitizeArg << TC.getTripleString();
+          << SanitizeArg << TC.getTripleString() << 0;
 #endif
     return;
   }

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -164,7 +164,7 @@ public:
           parseSanitizerValue(A->getValue(), /*Allow Groups*/ false);
       if (K != SanitizerKind::Address)
         Diags.Report(clang::diag::warn_drv_unsupported_option_for_target)
-            << A->getAsString(Args) << getTriple().str();
+            << A->getAsString(Args) << getTriple().str() << 0;
     }
   }
 };

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3858,7 +3858,7 @@ static void RenderSSPOptions(const Driver &D, const ToolChain &TC,
 
     if (EffectiveTriple.isBPF() && StackProtectorLevel != LangOptions::SSPOff) {
       D.Diag(diag::warn_drv_unsupported_option_for_target)
-          << A->getSpelling() << EffectiveTriple.getTriple();
+          << A->getSpelling() << EffectiveTriple.getTriple() << 0;
       StackProtectorLevel = DefaultStackProtectorLevel;
     }
   } else {

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1472,6 +1472,7 @@ static ArrayRef<options::ID> getUnsupportedOpts() {
       options::OPT_fprofile_instr_use_EQ, // -fprofile-instr-use
       options::OPT_fcs_profile_generate,  // -fcs-profile-generate
       options::OPT_fcs_profile_generate_EQ,
+      options::OPT_gline_tables_only, // -gline-tables-only
   };
   return UnsupportedOpts;
 }
@@ -1517,7 +1518,7 @@ SYCLToolChain::SYCLToolChain(const Driver &D, const llvm::Triple &Triple,
           continue;
       }
       D.Diag(clang::diag::warn_drv_unsupported_option_for_target)
-          << A->getAsString(Args) << getTriple().str();
+          << A->getAsString(Args) << getTriple().str() << 1;
     }
   }
 }

--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -9,6 +9,16 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fcf-protection -### %s 2>&1 \
 // RUN:  | FileCheck %s -DARCH=spir64_x86_64 -DOPT=-fcf-protection
 
+// Check to make sure -gline-tables-only is passed to -fsycl-is-host invocation only.
+// RUN: %clangxx -### -fsycl -gline-tables-only %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-gline-tables-only \
+// RUN:    -DOPT_CC1=-debug-info-kind=line-tables-only \
+// RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
+// RUN: %clang_cl -### -fsycl -gline-tables-only %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-gline-tables-only \
+// RUN:    -DOPT_CC1=-debug-info-kind=line-tables-only \
+// RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
+
 // RUN: %clangxx -fsycl -fprofile-instr-generate -### %s 2>&1 \
 // RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-fprofile-instr-generate \
 // RUN:    -DOPT_CC1=-fprofile-instrument=clang \
@@ -46,11 +56,11 @@
 // RUN:    -DOPT_CC1=-fprofile-instrument=clang \
 // RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
 
-// CHECK: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}' [-Woption-ignored]
+// CHECK: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}';only supported for host compilation [-Woption-ignored]
 // CHECK-NOT: clang{{.*}} "-fsycl-is-device"{{.*}} "[[OPT]]{{.*}}"
 // CHECK: clang{{.*}} "-fsycl-is-host"{{.*}} "[[OPT]]{{.*}}"
 
-// UNSUPPORTED_OPT_DIAG: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}' [-Woption-ignored]
+// UNSUPPORTED_OPT_DIAG: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}';only supported for host compilation [-Woption-ignored]
 // UNSUPPORTED_OPT-NOT: clang{{.*}} "-fsycl-is-device"{{.*}} "[[OPT_CC1]]{{.*}}"
 // UNSUPPORTED_OPT: clang{{.*}} "-fsycl-is-host"{{.*}} "[[OPT_CC1]]{{.*}}"
 

--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -56,11 +56,11 @@
 // RUN:    -DOPT_CC1=-fprofile-instrument=clang \
 // RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
 
-// CHECK: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}';only supported for host compilation [-Woption-ignored]
+// CHECK: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}'; only supported for host compilation [-Woption-ignored]
 // CHECK-NOT: clang{{.*}} "-fsycl-is-device"{{.*}} "[[OPT]]{{.*}}"
 // CHECK: clang{{.*}} "-fsycl-is-host"{{.*}} "[[OPT]]{{.*}}"
 
-// UNSUPPORTED_OPT_DIAG: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}';only supported for host compilation [-Woption-ignored]
+// UNSUPPORTED_OPT_DIAG: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}'; only supported for host compilation [-Woption-ignored]
 // UNSUPPORTED_OPT-NOT: clang{{.*}} "-fsycl-is-device"{{.*}} "[[OPT_CC1]]{{.*}}"
 // UNSUPPORTED_OPT: clang{{.*}} "-fsycl-is-host"{{.*}} "[[OPT_CC1]]{{.*}}"
 


### PR DESCRIPTION
Allow `-gline-tables-only` for the SYCL host compilation only, providing a warning that `-gline-tables-only` does not apply to device compilation.

Example:
```
clang++ -### -fsycl -gline-tables-only syclfile.cpp
ignoring `-gline-tables-only` option as it is not currently supported for target 'spir64';only supported for SYCL host compilation
```
