### PR TITLE
[SYCL][libdevice] Support std::__glibcxx_assert_fail in device code

### DIFF
--- a/libdevice/crt_wrapper.cpp
+++ b/libdevice/crt_wrapper.cpp
@@ -126,5 +126,20 @@ void __assert_fail(const char *expr, const char *file, unsigned int line,
       __spirv_LocalInvocationId_x(), __spirv_LocalInvocationId_y(),
       __spirv_LocalInvocationId_z());
 }
+
+// In GCC-15, std::__glibcxx_assert_fail is added to do runtime check for some
+// STL items such as std::array in debug mode, its behavior is same as assert,
+// so just handle it in the same way as '__assert_fail'.
+namespace std {
+DEVICE_EXTERN_CPP
+void __glibcxx_assert_fail(const char *file, int line, const char *func,
+                           const char *cond) {
+  __devicelib_assert_fail(
+      cond, file, line, func, __spirv_GlobalInvocationId_x(),
+      __spirv_GlobalInvocationId_y(), __spirv_GlobalInvocationId_z(),
+      __spirv_LocalInvocationId_x(), __spirv_LocalInvocationId_y(),
+      __spirv_LocalInvocationId_z());
+}
+} // namespace std
 #endif
 #endif // __SPIR__ || __SPIRV__ || __NVPTX__ || __AMDGCN__

--- a/libdevice/device.h
+++ b/libdevice/device.h
@@ -23,6 +23,7 @@
 #define DEVICE_EXTERNAL __attribute__((weak))
 #endif // __SYCL_DEVICE_ONLY__
 
+#define DEVICE_EXTERN_CPP DEVICE_EXTERNAL
 #define DEVICE_EXTERN_C DEVICE_EXTERNAL EXTERN_C
 #define DEVICE_EXTERN_C_INLINE                                                 \
   DEVICE_EXTERNAL EXTERN_C __attribute__((always_inline))

--- a/sycl/include/sycl/builtins.hpp
+++ b/sycl/include/sycl/builtins.hpp
@@ -633,6 +633,12 @@ __imf_vimin_s16x2_relu(unsigned int x, unsigned int y);
 extern __DPCPP_SYCL_EXTERNAL int __imf_vimin_s32_relu(int x, int y);
 }
 #ifdef __GLIBC__
+namespace std {
+extern __DPCPP_SYCL_EXTERNAL void __glibcxx_assert_fail(const char *file,
+                                                        int line,
+                                                        const char *func,
+                                                        const char *cond);
+} // namespace std
 extern "C" {
 extern __DPCPP_SYCL_EXTERNAL void __assert_fail(const char *expr,
                                                 const char *file,


### PR DESCRIPTION
GCC-15 introduced std::__glibcxx_assert_fail whose behavior is similar to normal assert. It is used extensively by libstdc++ to do some runtime check in some STL items such as std::array when "-O0" is used. We handle it in the same way as normal assert by calling __devicelib_assert_fail provide by IGC.