### PR TITLE
[SYCL] Update test for free function kernels extension that checks emitted diagnostics if kernel violates restrictions

### DIFF
--- a/sycl/test/extensions/free_function_kernels/free_function_kernels_diagnostics.cpp
+++ b/sycl/test/extensions/free_function_kernels/free_function_kernels_diagnostics.cpp
@@ -11,13 +11,11 @@ void singleTaskKernelReference(int &Ref) {}
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<2>)
 void ndRangeKernelReference(int &Ref) {}
 
-// expected-error@+2 {{a function with a default argument value cannot
-// be used to define SYCL free function kernel}}
+// expected-error@+2 {{a function with a default argument value cannot be used to define SYCL free function kernel}}
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::single_task_kernel)
 void singleTaskKernelDefaultParameterValue(int DefVal = 1024) {}
 
-// expected-error@+2 {{a function with a default argument value
-// cannot be used to define SYCL free function kernel}}
+// expected-error@+2 {{a function with a default argument value cannot be used to define SYCL free function kernel}}
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<3>)
 void ndRangeKernelReferenceDefaultParameterValue(int DefVal = 1024) {}
 

--- a/sycl/test/extensions/free_function_kernels/free_function_kernels_diagnostics.cpp
+++ b/sycl/test/extensions/free_function_kernels/free_function_kernels_diagnostics.cpp
@@ -11,10 +11,39 @@ void singleTaskKernelReference(int &Ref) {}
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<2>)
 void ndRangeKernelReference(int &Ref) {}
 
-// Diagnostic for these violations of the restrictions haven't been implemented
-// yet.
+// expected-error@+2 {{a function with a default argument value cannot
+// be used to define SYCL free function kernel}}
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::single_task_kernel)
+void singleTaskKernelDefaultParameterValue(int DefVal = 1024) {}
 
+// expected-error@+2 {{a function with a default argument value
+// cannot be used to define SYCL free function kernel}}
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<3>)
-void ndRangeKernelVariadic( // expected-error {{free function kernel cannot be a variadic function}}
-    ...) {}
+void ndRangeKernelReferenceDefaultParameterValue(int DefVal = 1024) {}
+
+// expected-error@+2 {{free function kernel cannot be a variadic function}}
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::single_task_kernel)
+void singleTaskKernelVariadic(...) {}
+
+// expected-error@+2 {{free function kernel cannot be a variadic function}}
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<1>)
+void ndRangeKernelVariadic(...) {}
+
+class DummyClass {
+public:
+  // Diagnostic for these violations of the restrictions haven't been
+  // implemented yet.
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::single_task_kernel)
+  void singleTaskKernelNonStaticMemberFunc(int *Ptr) {}
+
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<2>)
+  void ndRangeKernelNonStaticMemberFunc(float *Ptr) {}
+};
+
+// expected-error@+2 {{SYCL free function kernel should have return type 'void'}}
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::single_task_kernel)
+float singleTaskKernelNonVoid() { return 0.0F; }
+
+// expected-error@+2 {{SYCL free function kernel should have return type 'void'}}
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(syclexp::nd_range_kernel<3>)
+int ndRangeKernelNonVoid() { return 0; }


### PR DESCRIPTION
This PR updates test for free function kernels extension that checks emitted diagnostics if kernel violates restrictions specified in spec for declaration of free function kernel.
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc#defining-a-free-function-kernel

Test introduced based on test plan: https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/FreeFunctionKernels/test-plan.md