### PR TITLE
[SYCL][E2E] Fix error reporting in e2e lit config

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -864,7 +864,7 @@ def get_sycl_ls_verbose(sycl_device, env):
                 f"stdout:{sp.stdout}\n"
                 f"stderr:{sp.stderr}\n"
             )
-        return sp.stdout.splitlines()
+        return sp
 
 
 # A device filter such as level_zero:gpu can have multiple devices under it and
@@ -893,7 +893,7 @@ for sycl_device in config.sycl_devices:
 
     platform_devices = remove_level_zero_suffix(backend + ":*")
 
-    for line in get_sycl_ls_verbose(platform_devices, env):
+    for line in get_sycl_ls_verbose(platform_devices, env).stdout.splitlines():
         if re.match(r" *Architecture:", line):
             _, architecture = line.strip().split(":", 1)
             detected_architectures.append(architecture.strip())
@@ -952,7 +952,8 @@ for full_name, sycl_device in zip(
     # See format.py's parse_min_intel_driver_req for explanation.
     is_intel_driver = False
     intel_driver_ver = {}
-    for line in get_sycl_ls_verbose(sycl_device, env):
+    sycl_ls_sp = get_sycl_ls_verbose(sycl_device, env)
+    for line in sycl_ls_sp.stdout.splitlines():
         if re.match(r" *Vendor *: Intel\(R\) Corporation", line):
             is_intel_driver = True
         if re.match(r" *Driver *:", line):
@@ -989,7 +990,7 @@ for full_name, sycl_device in zip(
     if dev_aspects == []:
         lit_config.error(
             "Cannot detect device aspect for {}\nstdout:\n{}\nstderr:\n{}".format(
-                sycl_device, sp.stdout, sp.stderr
+                sycl_device, sycl_ls_sp.stdout, sycl_ls_sp.stderr
             )
         )
         dev_aspects.append(set())
@@ -1001,7 +1002,7 @@ for full_name, sycl_device in zip(
     if dev_sg_sizes == []:
         lit_config.error(
             "Cannot detect device SG sizes for {}\nstdout:\n{}\nstderr:\n{}".format(
-                sycl_device, sp.stdout, sp.stderr
+                sycl_device, sycl_ls_sp.stdout, sycl_ls_sp.stderr
             )
         )
         dev_sg_sizes.append(set())
@@ -1024,7 +1025,7 @@ for full_name, sycl_device in zip(
             if not config.allow_unknown_arch:
                 lit_config.error(
                     "Cannot detect architecture for {}\nstdout:\n{}\nstderr:\n{}".format(
-                        sycl_device, sp.stdout, sp.stderr
+                        sycl_device, sycl_ls_sp.stdout, sycl_ls_sp.stderr
                     )
                 )
             architectures = set()


### PR DESCRIPTION
Checking the output of `get_sycl_ls_verbose` expected the function to
update a global `sp` variable. Since it didn't do that, this resulted
in an error when trying to print the command output.

This patch changes the function to return the subprocess directly, which
is used during error message generation.
