### PR TITLE
[SYCL][NATIVECPU] use ur_memory_scope_capability_flags_t in NativeCPU adapter

### DIFF
--- a/unified-runtime/source/adapters/native_cpu/device.cpp
+++ b/unified-runtime/source/adapters/native_cpu/device.cpp
@@ -396,10 +396,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES:
   case UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES: {
-    uint64_t Capabilities = UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_ITEM |
-                            UR_MEMORY_SCOPE_CAPABILITY_FLAG_SUB_GROUP |
-                            UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_GROUP |
-                            UR_MEMORY_SCOPE_CAPABILITY_FLAG_DEVICE;
+    ur_memory_scope_capability_flags_t Capabilities =
+        UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_ITEM |
+        UR_MEMORY_SCOPE_CAPABILITY_FLAG_SUB_GROUP |
+        UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_GROUP |
+        UR_MEMORY_SCOPE_CAPABILITY_FLAG_DEVICE;
     return ReturnValue(Capabilities);
   }
   case UR_DEVICE_INFO_ESIMD_SUPPORT:


### PR DESCRIPTION
A fix for the NativeCPU adapter to use ur_memory_scope_capability_flags_t instead of uint64_t.

Required for NativeCPU to pass AtomicRef -related e2e and SYCL-CTS tests.
