### PR TITLE
[SYCL] Cache kernel assert usage

### DIFF
--- a/sycl/source/detail/kernel_name_based_cache_t.hpp
+++ b/sycl/source/detail/kernel_name_based_cache_t.hpp
@@ -12,6 +12,7 @@
 #include <sycl/detail/ur.hpp>
 
 #include <mutex>
+#include <optional>
 
 #include <boost/unordered/unordered_flat_map.hpp>
 
@@ -36,6 +37,7 @@ struct FastKernelSubcacheT {
 
 struct KernelNameBasedCacheT {
   FastKernelSubcacheT FastKernelSubcache;
+  std::optional<bool> UsesAssert;
 };
 
 } // namespace detail

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -12,6 +12,7 @@
 #include <detail/device_global_map_entry.hpp>
 #include <detail/host_pipe_map_entry.hpp>
 #include <detail/kernel_arg_mask.hpp>
+#include <detail/kernel_name_based_cache_t.hpp>
 #include <detail/spec_constant_impl.hpp>
 #include <sycl/detail/cg_types.hpp>
 #include <sycl/detail/common.hpp>
@@ -359,8 +360,16 @@ public:
   ~ProgramManager() = default;
 
   template <typename NameT>
-  bool kernelUsesAssert(const NameT &KernelName) const {
-    return m_KernelUsesAssert.find(KernelName) != m_KernelUsesAssert.end();
+  bool kernelUsesAssert(const NameT &KernelName,
+                        KernelNameBasedCacheT *KernelNameBasedCachePtr) const {
+    if (!KernelNameBasedCachePtr)
+      return m_KernelUsesAssert.find(KernelName) != m_KernelUsesAssert.end();
+
+    std::optional<bool> &UsesAssert = KernelNameBasedCachePtr->UsesAssert;
+    if (!UsesAssert.has_value())
+      UsesAssert =
+          m_KernelUsesAssert.find(KernelName) != m_KernelUsesAssert.end();
+    return UsesAssert.value();
   }
 
   SanitizerType kernelUsesSanitizer() const { return m_SanitizerFoundInImage; }

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -777,7 +777,8 @@ protected:
       KernelUsesAssert =
           (!Handler.MKernel || Handler.MKernel->hasSYCLMetadata()) &&
           ProgramManager::getInstance().kernelUsesAssert(
-              Handler.MKernelName.data());
+              Handler.MKernelName.data(),
+              Handler.impl->MKernelNameBasedCachePtr);
 
     auto Event = MIsInorder ? finalizeHandlerInOrder(Handler)
                             : finalizeHandlerOutOfOrder(Handler);

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3268,7 +3268,8 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
       // Kernel only uses assert if it's non interop one
       bool KernelUsesAssert =
           (!SyclKernel || SyclKernel->hasSYCLMetadata()) &&
-          ProgramManager::getInstance().kernelUsesAssert(KernelName);
+          ProgramManager::getInstance().kernelUsesAssert(
+              KernelName, ExecKernel->MKernelNameBasedCachePtr);
       if (KernelUsesAssert) {
         EventImpl = MEvent.get();
       }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -541,7 +541,7 @@ event handler::finalize() {
         bool KernelUsesAssert =
             !(MKernel && MKernel->isInterop()) &&
             detail::ProgramManager::getInstance().kernelUsesAssert(
-                MKernelName.data());
+                MKernelName.data(), impl->MKernelNameBasedCachePtr);
         DiscardEvent = !KernelUsesAssert;
       }
 


### PR DESCRIPTION
Cache whether a kernel uses assertions or not to avoid a set lookup.