### PR TITLE
[SYCL] Get rid of vector reallocations for kernel name caches

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -254,12 +254,10 @@ ThreadPool &GlobalHandler::getHostTaskThreadPool() {
 }
 
 KernelNameBasedCacheT *GlobalHandler::createKernelNameBasedCache() {
-  static std::vector<std::unique_ptr<KernelNameBasedCacheT>>
-      &KernelNameBasedCaches = getOrCreate(MKernelNameBasedCaches);
+  static std::deque<KernelNameBasedCacheT> &KernelNameBasedCaches =
+      getOrCreate(MKernelNameBasedCaches);
   LockGuard LG{MKernelNameBasedCaches.Lock};
-  return KernelNameBasedCaches
-      .emplace_back(std::make_unique<KernelNameBasedCacheT>())
-      .get();
+  return &KernelNameBasedCaches.emplace_back();
 }
 
 void GlobalHandler::releaseDefaultContexts() {

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -11,6 +11,7 @@
 #include <sycl/detail/spinlock.hpp>
 #include <sycl/detail/util.hpp>
 
+#include <deque>
 #include <memory>
 #include <unordered_map>
 
@@ -130,8 +131,7 @@ private:
   InstWithLock<XPTIRegistry> MXPTIRegistry;
   // Thread pool for host task and event callbacks execution
   InstWithLock<ThreadPool> MHostTaskThreadPool;
-  InstWithLock<std::vector<std::unique_ptr<KernelNameBasedCacheT>>>
-      MKernelNameBasedCaches;
+  InstWithLock<std::deque<KernelNameBasedCacheT>> MKernelNameBasedCaches;
 };
 } // namespace detail
 } // namespace _V1


### PR DESCRIPTION
A follow up on the code review of https://github.com/intel/llvm/pull/18081