### PR TITLE
[SYCL][E2E][CI] Disable `std_array.cpp` at CI level

### DIFF
--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -120,6 +120,8 @@ jobs:
       target_devices: "level_zero:gpu"
       sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
       cxx: icx
+      # https://github.com/intel/llvm/issues/18458
+      env: "{'LIT_FILTER_OUT':'std_array.cpp'}"
 
   macos_default:
     name: macOS

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -121,7 +121,7 @@ jobs:
       sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
       cxx: icx
       # https://github.com/intel/llvm/issues/18458
-      env: "{'LIT_FILTER_OUT':'std_array.cpp'}"
+      env: "{'LIT_FILTER_OUT':'std_array.cpp|compile_on_win_with_mdd.cpp'}"
 
   macos_default:
     name: macOS

--- a/devops/actions/run-tests/windows/e2e/action.yml
+++ b/devops/actions/run-tests/windows/e2e/action.yml
@@ -77,9 +77,6 @@ runs:
       LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time ${{ inputs.e2e_testing_mode == 'run-only' && 1200 || 3600 }} --time-tests --param print_features=True --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} ${{ inputs.extra_lit_opts }}
     run: |
       # Run E2E tests.
-      if [[ ${{ inputs.cxx }} == 'icx' ]]; then
-         export LIT_FILTER_OUT="compile_on_win_with_mdd"
-      fi
       cmake --build build-e2e --target check-sycl-e2e > e2e.log 2>&1
 
       exit_code=$?

--- a/sycl/test-e2e/Basic/std_array.cpp
+++ b/sycl/test-e2e/Basic/std_array.cpp
@@ -1,8 +1,6 @@
 // Check that std::array is supported on device in debug mode on Windows.
 
 // REQUIRES: windows
-// UNSUPPORTED: gpu-intel-gen12
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18458
 
 // RUN: %clangxx --driver-mode=cl -fsycl -o %t.exe %s /Od /MDd /Zi /EHsc
 // RUN: %{run} %t.exe


### PR DESCRIPTION
The issue is specific to the post-commit CI using OneAPI compiler to build SYCL RT (see https://github.com/intel/llvm/issues/18458). Ideally, we'd like to use `/Qno-intel-lib` during such build but OneAPI seems to have a bug related to that (reported internally). It will take an official release for it to reach this CI even after it's implemented, so we need to disable the test on that specific configuration only for the time being.