### PR TITLE
[SYCL] fix for std::locale::global interfering with allowlist check

### DIFF
--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -428,6 +428,8 @@ void applyAllowList(std::vector<ur_device_handle_t> &UrDevices,
     uint32_t DeviceVendorIdUInt =
         DeviceImpl.get_info<info::device::vendor_id>();
     std::stringstream DeviceVendorIdHexStringStream;
+    // To avoid commas or other locale-specific modifications, call imbue().
+    DeviceVendorIdHexStringStream.imbue(std::locale::classic());
     DeviceVendorIdHexStringStream << "0x" << std::hex << DeviceVendorIdUInt;
     const auto &DeviceVendorIdValue = DeviceVendorIdHexStringStream.str();
     DeviceDesc[DeviceVendorIdKeyName] = DeviceVendorIdValue;

--- a/sycl/unittests/allowlist/DeviceIsAllowed.cpp
+++ b/sycl/unittests/allowlist/DeviceIsAllowed.cpp
@@ -91,14 +91,20 @@ TEST(DeviceIsAllowedTests, CheckLocalizationDoesNotImpact) {
   // We want to make sure that DeviceVenderId doesn't have a comma
   // inserted (ie "0x8,086" ), which will break the platform retrieval.
 
-  auto previous = std::locale::global(std::locale("en_US.UTF-8"));
-  setenv("SYCL_DEVICE_ALLOWLIST", SyclDeviceAllowList, 1);
+  try {
+    auto previous = std::locale::global(std::locale("en_US.UTF-8"));
+    setenv("SYCL_DEVICE_ALLOWLIST", SyclDeviceAllowList, 1);
 
-  auto post_platforms = sycl::platform::get_platforms();
-  std::locale::global(previous);
-  unsetenv("SYCL_DEVICE_ALLOWLIST");
+    auto post_platforms = sycl::platform::get_platforms();
+    std::locale::global(previous);
+    unsetenv("SYCL_DEVICE_ALLOWLIST");
 
-  EXPECT_NE(size_t{0}, post_platforms.size());
+    EXPECT_NE(size_t{0}, post_platforms.size());
+  } catch (...) {
+    // It is possible that the en_US locale is not available.
+    // In this case, we just skip the test.
+    GTEST_SKIP() << "Locale en_US.UTF-8 not available.";
+  }
 }
 
 TEST(DeviceIsAllowedTests, CheckSupportedOpenCLCPUDeviceIsAllowed) {

--- a/sycl/unittests/allowlist/DeviceIsAllowed.cpp
+++ b/sycl/unittests/allowlist/DeviceIsAllowed.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <detail/allowlist.hpp>
+#include <sycl/platform.hpp>
 
 #include <gtest/gtest.h>
 
@@ -83,6 +84,21 @@ TEST(DeviceIsAllowedTests, CheckSupportedOpenCLGPUDeviceIsAllowed) {
   bool Actual = sycl::detail::deviceIsAllowed(
       OpenCLGPUDeviceDesc, sycl::detail::parseAllowList(SyclDeviceAllowList));
   EXPECT_EQ(Actual, true);
+}
+
+TEST(DeviceIsAllowedTests, CheckLocalizationDoesNotImpact) {
+  // The localization can affect std::stringstream output.
+  // We want to make sure that DeviceVenderId doesn't have a comma
+  // inserted (ie "0x8,086" ), which will break the platform retrieval.
+
+  auto previous = std::locale::global(std::locale("en_US.UTF-8"));
+  setenv("SYCL_DEVICE_ALLOWLIST", SyclDeviceAllowList, 1);
+
+  auto post_platforms = sycl::platform::get_platforms();
+  std::locale::global(previous);
+  unsetenv("SYCL_DEVICE_ALLOWLIST");
+
+  EXPECT_NE(size_t{0}, post_platforms.size());
 }
 
 TEST(DeviceIsAllowedTests, CheckSupportedOpenCLCPUDeviceIsAllowed) {


### PR DESCRIPTION
`std::locale::global()` is a very common way for apps to initialize string localization for numeric and monetary values.  Unfortunately, it is global. 
In this very limited fix, we are preventing it from interfering with the allowlist check which uses `std::stringstream`.  The insertion of commas into numbers for the locale support messes with the expected values.
We'll probably have to audit the other uses of std streams to see if they would be similarly vulnerable. 