### PR TITLE
[libspirv] Avoid duplicating builtins during remangling

### DIFF
--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -837,6 +837,13 @@ private:
       CloneeName = OriginalName;
     }
 
+    // If the clone name already exists in the module then we have to assume it
+    // does the right thing already. We're only going to end up creating a copy
+    // of that function without external users being able to reach it.
+    if (M->getFunction(CloneName)) {
+      return true;
+    }
+
     if (Function *Clonee = M->getFunction(CloneeName)) {
       ValueToValueMapTy Dummy;
       Function *NewF = CloneFunction(Clonee, Dummy);
@@ -883,6 +890,15 @@ private:
         errs() << "Test run failure!\n";
         return false;
       }
+
+      // If the remangled name already exists in the module then we have to
+      // assume it does the right thing already. We're only going to end up
+      // creating a copy of that function without external users being able to
+      // reach it.
+      if (M->getFunction(RemangledName)) {
+        return true;
+      }
+
       Func.setName(RemangledName);
 
       // Make a clone of a suitable function using the old name if there is a


### PR DESCRIPTION
This commit adds some checks to the remangler. It prevents it from generating clones or renaming functions if a function with the target name already exists in the module.

This can happen if the libspirv source provides, e.g., both a char and a signed char version of a builtin and the remangler wants to remangle char to signed char.

In such cases we'd previously generate new unreachable builtins as to avoid the naming clash LLVM would give them a random suffix like renaming _Z3fooi to _Z3fooi24234. We can't know that the functions are equivalent but this situtation is no worse than before - we'd be calling into the 'wrong' builtin in any case.

This removes around 2000 unreachable builtins from the 'l64' remangled libraries and 300 from the 'l32' ones.

This commit does introduce some new builtins too. Some builtins like _Z17__spirv_ocl_s_minDv16_cS_ are now in the 'unsigned char' module which I believe is okay; any user calling 'char' builtins on an char-is-unsigned-char platform would be calling into the unsigned char versions ('h') anyway. These builtins are now included because they are in the source module and left alone when the remangler detects that the remangled version already exists.