### PR TITLE
[UR] Include the backend name in the platform string for testing

### DIFF
--- a/unified-runtime/test/conformance/testing/include/uur/utils.h
+++ b/unified-runtime/test/conformance/testing/include/uur/utils.h
@@ -169,8 +169,11 @@ std::string GetAdapterBackendName(ur_adapter_handle_t hAdapter);
 inline std::string GetPlatformName(ur_platform_handle_t hPlatform) {
   std::string platform_name;
   GetPlatformInfo<std::string>(hPlatform, UR_PLATFORM_INFO_NAME, platform_name);
-  return GTestSanitizeString(
-      std::string(platform_name.data(), platform_name.size()));
+  ur_adapter_handle_t adapter = nullptr;
+  GetPlatformInfo<ur_adapter_handle_t>(hPlatform, UR_PLATFORM_INFO_ADAPTER,
+                                       adapter);
+  std::string full_name = GetAdapterBackendName(adapter) + "__" + platform_name;
+  return GTestSanitizeString(std::string(full_name.data(), full_name.size()));
 }
 
 inline std::string GetPlatformNameWithID(ur_platform_handle_t hPlatform) {


### PR DESCRIPTION
For ease of debugging, the platform name also prepends the name of the
adapter, resulting in test names like:
`urEventGetProfilingInfoTest/ReleaseEventAfterQueueRelease/UR_BACKEND_OPENCL__AMD_Accelerated_Parallel_Processing__gfx1100_ID5ID_` .
