### PR TITLE
[UR] In CTS, "AllDevices" test now skip if the platform has no devices

### DIFF
--- a/unified-runtime/test/conformance/testing/include/uur/fixtures.h
+++ b/unified-runtime/test/conformance/testing/include/uur/fixtures.h
@@ -66,7 +66,7 @@ struct urAllDevicesTest : urPlatformTest {
     UUR_RETURN_ON_FATAL_FAILURE(urPlatformTest::SetUp());
     auto devicesPair = GetDevices(platform);
     if (!devicesPair.first) {
-      FAIL() << "Failed to get devices";
+      GTEST_SKIP() << "No devices available";
     }
     devices = std::move(devicesPair.second);
   }
@@ -133,7 +133,7 @@ struct urAllDevicesTestWithParam : urPlatformTestWithParam<T> {
     UUR_RETURN_ON_FATAL_FAILURE(urPlatformTestWithParam<T>::SetUp());
     auto devicesPair = GetDevices(this->platform);
     if (!devicesPair.first) {
-      FAIL() << "Failed to get devices";
+      GTEST_SKIP() << "No devices available";
     }
     devices = std::move(devicesPair.second);
   }

--- a/unified-runtime/test/layers/validation/fixtures.hpp
+++ b/unified-runtime/test/layers/validation/fixtures.hpp
@@ -104,7 +104,8 @@ struct valAllDevicesTest : valPlatformTest {
     uint32_t count = 0;
     if (urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count) ||
         count == 0) {
-      FAIL() << "Failed to get devices";
+      GTEST_SKIP() << "No devices available";
+      return;
     }
 
     devices.resize(count);


### PR DESCRIPTION
Some platforms don't provide any devices. For test fixtures that provide
a device list to the test itself, this used to result in a failure. Now
the test is just skipped.
