### PR TITLE
Revert "[SYCL] Link and include LLVMSupport in SYCL library"

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -91,8 +91,15 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
 
   # Feature-specific compilation and link step setup
 
+  # Unlike for sycl library, for LLVMSupport we have only one version for a given build,
+  # so, we link LLVMSupport lib to matching sycl version only.
   if (SYCL_ENABLE_STACK_PRINTING)
-    target_compile_definitions(${LIB_OBJ_NAME} PUBLIC ENABLE_STACK_TRACE)
+    if(NOT MSVC OR (CMAKE_BUILD_TYPE STREQUAL "Debug" AND ARG_COMPILE_OPTIONS MATCHES ".*MDd.*") OR
+      (NOT CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT ARG_COMPILE_OPTIONS MATCHES ".*MDd.*"))
+        add_dependencies(${LIB_NAME} LLVMSupport)
+        target_compile_definitions(${LIB_OBJ_NAME} PUBLIC ENABLE_STACK_TRACE)
+        target_link_libraries(${LIB_NAME} PRIVATE LLVMSupport)
+    endif()
   endif()
 
   # TODO: Enabled for MSVC
@@ -185,11 +192,6 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
       target_link_libraries(${LIB_NAME} PRIVATE ${CMAKE_DL_LIBS})
     endif()
   endif()
-
-  # Link with LLVMSupport for shared utilities.
-  add_dependencies(${LIB_NAME} LLVMSupport)
-  target_link_libraries(${LIB_NAME} PRIVATE LLVMSupport)
-  target_include_directories(${LIB_OBJ_NAME} SYSTEM PRIVATE ${LLVM_MAIN_INCLUDE_DIR})
 
   check_linker_flag(CXX "-Wl,--gc-sections" LINKER_SUPPORTS_WL_GC_SECTIONS)
   if(LINKER_SUPPORTS_WL_GC_SECTIONS)

--- a/sycl/source/detail/compiler.hpp
+++ b/sycl/source/detail/compiler.hpp
@@ -35,6 +35,45 @@
 #define __SYCL_DEVICE_BINARY_TARGET_LLVM_NVPTX64 "llvm_nvptx64"
 #define __SYCL_DEVICE_BINARY_TARGET_LLVM_AMDGCN "llvm_amdgcn"
 
+/// Device binary image property set names recognized by the SYCL runtime.
+/// Name must be consistent with
+/// PropertySetRegistry::SYCL_SPECIALIZATION_CONSTANTS defined in
+/// PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SPEC_CONST_MAP "SYCL/specialization constants"
+/// PropertySetRegistry::SYCL_SPEC_CONSTANTS_DEFAULT_VALUES defined in
+/// PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SPEC_CONST_DEFAULT_VALUES_MAP                      \
+  "SYCL/specialization constants default values"
+/// TODO: remove req mask when sycl devicelib online linking path is removed.
+/// PropertySetRegistry::SYCL_DEVICELIB_REQ_MASK defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_DEVICELIB_REQ_MASK "SYCL/devicelib req mask"
+/// PropertySetRegistry::SYCL_DEVICELIB_METADATA defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_DEVICELIB_METADATA "SYCL/devicelib metadata"
+/// PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO "SYCL/kernel param opt"
+/// PropertySetRegistry::SYCL_KERNEL_PROGRAM_METADATA defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_PROGRAM_METADATA "SYCL/program metadata"
+/// PropertySetRegistry::SYCL_MISC_PROP defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_MISC_PROP "SYCL/misc properties"
+/// PropertySetRegistry::SYCL_ASSERT_USED defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_ASSERT_USED "SYCL/assert used"
+/// PropertySetRegistry::SYCL_EXPORTED_SYMBOLS defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS "SYCL/exported symbols"
+/// PropertySetRegistry::SYCL_IMPORTED_SYMBOLS defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_IMPORTED_SYMBOLS "SYCL/imported symbols"
+/// PropertySetRegistry::SYCL_DEVICE_GLOBALS defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS "SYCL/device globals"
+/// PropertySetRegistry::SYCL_DEVICE_REQUIREMENTS defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_DEVICE_REQUIREMENTS "SYCL/device requirements"
+/// PropertySetRegistry::SYCL_HOST_PIPES defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_HOST_PIPES "SYCL/host pipes"
+/// PropertySetRegistry::SYCL_VIRTUAL_FUNCTIONS defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_VIRTUAL_FUNCTIONS "SYCL/virtual functions"
+/// PropertySetRegistry::SYCL_IMPLICIT_LOCAL_ARG defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_IMPLICIT_LOCAL_ARG "SYCL/implicit local arg"
+/// PropertySetRegistry::SYCL_REGISTERED_KERNELS defined in PropertySetIO.h
+#define __SYCL_PROPERTY_SET_SYCL_REGISTERED_KERNELS "SYCL/registered kernels"
+
 /// Program metadata tags recognized by the PI backends. For kernels the tag
 /// must appear after the kernel name.
 #define __SYCL_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE "@reqd_work_group_size"

--- a/sycl/source/detail/device_binary_image.cpp
+++ b/sycl/source/detail/device_binary_image.cpp
@@ -12,8 +12,6 @@
 // For device image compression.
 #include <detail/compression.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
@@ -187,39 +185,28 @@ void RTDeviceBinaryImage::init(sycl_device_binary Bin) {
     // try to determine the format; may remain "NONE"
     Format = ur::getBinaryImageFormat(Bin->BinaryStart, getSize());
 
-  SpecConstIDMap.init(
-      Bin, llvm::util::PropertySetRegistry::SYCL_SPECIALIZATION_CONSTANTS);
+  SpecConstIDMap.init(Bin, __SYCL_PROPERTY_SET_SPEC_CONST_MAP);
   SpecConstDefaultValuesMap.init(
-      Bin, llvm::util::PropertySetRegistry::SYCL_SPEC_CONSTANTS_DEFAULT_VALUES);
-  DeviceLibReqMask.init(
-      Bin, llvm::util::PropertySetRegistry::SYCL_DEVICELIB_REQ_MASK);
-  DeviceLibMetadata.init(
-      Bin, llvm::util::PropertySetRegistry::SYCL_DEVICELIB_METADATA);
-  KernelParamOptInfo.init(
-      Bin, llvm::util::PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO);
-  AssertUsed.init(Bin, llvm::util::PropertySetRegistry::SYCL_ASSERT_USED);
-  ImplicitLocalArg.init(
-      Bin, llvm::util::PropertySetRegistry::SYCL_IMPLICIT_LOCAL_ARG);
-  ProgramMetadata.init(Bin,
-                       llvm::util::PropertySetRegistry::SYCL_PROGRAM_METADATA);
+      Bin, __SYCL_PROPERTY_SET_SPEC_CONST_DEFAULT_VALUES_MAP);
+  DeviceLibReqMask.init(Bin, __SYCL_PROPERTY_SET_DEVICELIB_REQ_MASK);
+  DeviceLibMetadata.init(Bin, __SYCL_PROPERTY_SET_DEVICELIB_METADATA);
+  KernelParamOptInfo.init(Bin, __SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
+  AssertUsed.init(Bin, __SYCL_PROPERTY_SET_SYCL_ASSERT_USED);
+  ImplicitLocalArg.init(Bin, __SYCL_PROPERTY_SET_SYCL_IMPLICIT_LOCAL_ARG);
+  ProgramMetadata.init(Bin, __SYCL_PROPERTY_SET_PROGRAM_METADATA);
   // Convert ProgramMetadata into the UR format
   for (const auto &Prop : ProgramMetadata) {
     ProgramMetadataUR.push_back(
         ur::mapDeviceBinaryPropertyToProgramMetadata(Prop));
   }
-  ExportedSymbols.init(Bin,
-                       llvm::util::PropertySetRegistry::SYCL_EXPORTED_SYMBOLS);
-  ImportedSymbols.init(Bin,
-                       llvm::util::PropertySetRegistry::SYCL_IMPORTED_SYMBOLS);
-  DeviceGlobals.init(Bin, llvm::util::PropertySetRegistry::SYCL_DEVICE_GLOBALS);
-  DeviceRequirements.init(
-      Bin, llvm::util::PropertySetRegistry::SYCL_DEVICE_REQUIREMENTS);
-  HostPipes.init(Bin, llvm::util::PropertySetRegistry::SYCL_HOST_PIPES);
-  VirtualFunctions.init(
-      Bin, llvm::util::PropertySetRegistry::SYCL_VIRTUAL_FUNCTIONS);
-  RegisteredKernels.init(
-      Bin, llvm::util::PropertySetRegistry::SYCL_REGISTERED_KERNELS);
-  Misc.init(Bin, llvm::util::PropertySetRegistry::SYCL_MISC_PROP);
+  ExportedSymbols.init(Bin, __SYCL_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS);
+  ImportedSymbols.init(Bin, __SYCL_PROPERTY_SET_SYCL_IMPORTED_SYMBOLS);
+  DeviceGlobals.init(Bin, __SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS);
+  DeviceRequirements.init(Bin, __SYCL_PROPERTY_SET_SYCL_DEVICE_REQUIREMENTS);
+  HostPipes.init(Bin, __SYCL_PROPERTY_SET_SYCL_HOST_PIPES);
+  VirtualFunctions.init(Bin, __SYCL_PROPERTY_SET_SYCL_VIRTUAL_FUNCTIONS);
+  RegisteredKernels.init(Bin, __SYCL_PROPERTY_SET_SYCL_REGISTERED_KERNELS);
+  Misc.init(Bin, __SYCL_PROPERTY_SET_SYCL_MISC_PROP);
 }
 
 std::atomic<uintptr_t> RTDeviceBinaryImage::ImageCounter = 1;

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -12,8 +12,6 @@
 #include <sycl/detail/os_util.hpp>
 #include <sycl/detail/ur.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
@@ -267,7 +265,7 @@ sycl_device_binaries jit_compiler::createDeviceBinaries(
 
     for (const auto &FPS : DevImgInfo.Properties) {
       bool IsDeviceGlobalsPropSet =
-          FPS.Name == llvm::util::PropertySetRegistry::SYCL_DEVICE_GLOBALS;
+          FPS.Name == __SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS;
       PropertySetContainer PropSet{FPS.Name.c_str()};
       for (const auto &FPV : FPS.Values) {
         if (FPV.IsUIntValue) {

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -34,8 +34,6 @@
 
 #include <sycl/ext/oneapi/matrix/query-types.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
@@ -1865,8 +1863,7 @@ static bool isBfloat16DeviceLibImage(sycl_device_binary RawImg,
   for (ImgPS = RawImg->PropertySetsBegin; ImgPS != RawImg->PropertySetsEnd;
        ++ImgPS) {
     if (ImgPS->Name &&
-        !strcmp(llvm::util::PropertySetRegistry::SYCL_DEVICELIB_METADATA,
-                ImgPS->Name)) {
+        !strcmp(__SYCL_PROPERTY_SET_DEVICELIB_METADATA, ImgPS->Name)) {
       if (!LibVersion)
         return true;
 
@@ -1894,8 +1891,7 @@ getExportedSymbolPS(sycl_device_binary RawImg) {
   for (ImgPS = RawImg->PropertySetsBegin; ImgPS != RawImg->PropertySetsEnd;
        ++ImgPS) {
     if (ImgPS->Name &&
-        !strcmp(llvm::util::PropertySetRegistry::SYCL_EXPORTED_SYMBOLS,
-                ImgPS->Name))
+        !strcmp(__SYCL_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS, ImgPS->Name))
       return ImgPS;
   }
 

--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -16,7 +16,6 @@ set(SYCL_THREADS_LIB ${CMAKE_THREAD_LIBS_INIT})
 # TEST_INCLUDE_PATH is used for syntax-only verification of type information.
 list(APPEND test_includes ${SYCL_INCLUDE})
 list(APPEND test_includes ${SYCL_SOURCE_DIR}/source)
-list(APPEND test_includes ${LLVM_MAIN_INCLUDE_DIR})
 list(APPEND test_includes ${BOOST_UNORDERED_INCLUDE_DIRS})
 if(SYCL_ENABLE_EXTENSION_JIT)
   list(APPEND test_includes ${LLVM_EXTERNAL_SYCL_JIT_SOURCE_DIR}/jit-compiler/include)

--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -8,8 +8,6 @@
 
 #include <sycl/sycl.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 #include "detail/context_impl.hpp"
 #include "detail/kernel_program_cache.hpp"
 
@@ -66,7 +64,7 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImage() {
   MockPropertySet PropSet;
   MockProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalName, sizeof(int) * 2, 0);
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_DEVICE_GLOBALS,
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
                  std::vector<MockProperty>{std::move(DevGlobInfo)});
 
   std::vector<MockOffloadEntry> Entries =
@@ -89,7 +87,7 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImgScopeImage() {
   MockPropertySet PropSet;
   MockProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalImgScopeName, sizeof(int) * 2, 1);
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_DEVICE_GLOBALS,
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
                  std::vector<MockProperty>{std::move(DevGlobInfo)});
 
   std::vector<MockOffloadEntry> Entries =

--- a/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
+++ b/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
@@ -2,8 +2,6 @@
 #include "ur_mock_helpers.hpp"
 #include <sycl/sycl.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 #include <helpers/MockDeviceImage.hpp>
 #include <helpers/MockKernelInfo.hpp>
 #include <helpers/RuntimeLinkingCommon.hpp>
@@ -67,8 +65,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
                                     SYCL_PROPERTY_TYPE_BYTE_ARRAY);
 
   Props.push_back(Prop);
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_VIRTUAL_FUNCTIONS,
-                 std::move(Props));
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_VIRTUAL_FUNCTIONS, std::move(Props));
 
   std::vector<unsigned char> Bin{Magic};
 

--- a/sycl/unittests/helpers/MockDeviceImage.hpp
+++ b/sycl/unittests/helpers/MockDeviceImage.hpp
@@ -20,8 +20,6 @@
 
 #include <sycl/detail/defines_elementary.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 namespace sycl {
 inline namespace _V1 {
 namespace unittest {
@@ -193,8 +191,7 @@ public:
     // Value must be an all-zero 32-bit mask, which would mean that no fallback
     // libraries are needed to be loaded.
     MockProperty DeviceLibReqMask("", Data, SYCL_PROPERTY_TYPE_UINT32);
-    insert(llvm::util::PropertySetRegistry::SYCL_DEVICELIB_REQ_MASK,
-           std::move(DeviceLibReqMask));
+    insert(__SYCL_PROPERTY_SET_DEVICELIB_REQ_MASK, std::move(DeviceLibReqMask));
   }
 
   /// Adds a new property to the set.
@@ -464,8 +461,7 @@ inline void setKernelUsesAssert(const std::vector<std::string> &Names,
   std::vector<MockProperty> Value;
   for (const std::string &N : Names)
     Value.push_back({N, {0, 0, 0, 0}, SYCL_PROPERTY_TYPE_UINT32});
-  Set.insert(llvm::util::PropertySetRegistry::SYCL_ASSERT_USED,
-             std::move(Value));
+  Set.insert(__SYCL_PROPERTY_SET_SYCL_ASSERT_USED, std::move(Value));
 }
 
 /// Utility function to add specialization constants to property set.
@@ -474,14 +470,12 @@ inline void setKernelUsesAssert(const std::vector<std::string> &Names,
 inline void addSpecConstants(std::vector<MockProperty> &&SpecConstants,
                              std::vector<char> ValData,
                              MockPropertySet &Props) {
-  Props.insert(llvm::util::PropertySetRegistry::SYCL_SPECIALIZATION_CONSTANTS,
-               std::move(SpecConstants));
+  Props.insert(__SYCL_PROPERTY_SET_SPEC_CONST_MAP, std::move(SpecConstants));
 
   MockProperty Prop{"all", std::move(ValData), SYCL_PROPERTY_TYPE_BYTE_ARRAY};
 
-  Props.insert(
-      llvm::util::PropertySetRegistry::SYCL_SPEC_CONSTANTS_DEFAULT_VALUES,
-      std::move(Prop));
+  Props.insert(__SYCL_PROPERTY_SET_SPEC_CONST_DEFAULT_VALUES_MAP,
+               std::move(Prop));
 }
 
 /// Utility function to add ESIMD kernel flag to property set.
@@ -490,8 +484,7 @@ inline void addESIMDFlag(MockPropertySet &Props) {
   ValData[0] = 1;
   MockProperty Prop{"isEsimdImage", ValData, SYCL_PROPERTY_TYPE_UINT32};
 
-  Props.insert(llvm::util::PropertySetRegistry::SYCL_MISC_PROP,
-               std::move(Prop));
+  Props.insert(__SYCL_PROPERTY_SET_SYCL_MISC_PROP, std::move(Prop));
 }
 
 /// Utility function to generate offload entries for kernels without arguments.
@@ -604,8 +597,7 @@ addDeviceRequirementsProps(MockPropertySet &Props,
   std::vector<MockProperty> Value{makeAspectsProp(Aspects)};
   if (!ReqdWGSize.empty())
     Value.push_back(makeReqdWGSizeProp(ReqdWGSize));
-  Props.insert(llvm::util::PropertySetRegistry::SYCL_DEVICE_REQUIREMENTS,
-               std::move(Value));
+  Props.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_REQUIREMENTS, std::move(Value));
 }
 
 inline MockDeviceImage

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -9,8 +9,6 @@
 #include <cstring>
 #include <sycl/sycl.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 #include <detail/device_binary_image.hpp>
 #include <detail/host_pipe_map_entry.hpp>
 #include <gtest/gtest.h>
@@ -40,7 +38,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   MockPropertySet PropSet;
   MockProperty HostPipeInfo =
       makeHostPipeInfo("test_host_pipe_unique_id", sizeof(int));
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_HOST_PIPES,
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_HOST_PIPES,
                  std::vector<MockProperty>{std::move(HostPipeInfo)});
 
   std::vector<MockOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});

--- a/sycl/unittests/program_manager/Cleanup.cpp
+++ b/sycl/unittests/program_manager/Cleanup.cpp
@@ -169,29 +169,28 @@ sycl::unittest::MockDeviceImage generateImage(const std::string &ImageId) {
                                              KernelEAM);
   std::vector<sycl::unittest::MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_EXPORTED_SYMBOLS,
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS,
                  createPropertySet(ExportedSymbols));
 
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_IMPORTED_SYMBOLS,
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_IMPORTED_SYMBOLS,
                  createPropertySet(ImportedSymbols));
 
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_VIRTUAL_FUNCTIONS,
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_VIRTUAL_FUNCTIONS,
                  createVFPropertySet(VirtualFunctions));
   setKernelUsesAssert(std::vector<std::string>{KernelNames.begin()[0]},
                       PropSet);
 
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_IMPLICIT_LOCAL_ARG,
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_IMPLICIT_LOCAL_ARG,
                  createPropertySet(ImplicitLocalArg));
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO,
-                 std::move(ImgKPOI));
+  PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   PropSet.insert(
-      llvm::util::PropertySetRegistry::SYCL_DEVICE_GLOBALS,
+      __SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
       std::vector<sycl::unittest::MockProperty>{
           sycl::unittest::makeDeviceGlobalInfo(
               generateRefName(ImageId, "DeviceGlobal"), sizeof(int), 0)});
 
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_HOST_PIPES,
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_HOST_PIPES,
                  std::vector<sycl::unittest::MockProperty>{
                      sycl::unittest::makeHostPipeInfo(
                          generateRefName(ImageId, "HostPipe"), sizeof(int))});

--- a/sycl/unittests/program_manager/CompileTarget.cpp
+++ b/sycl/unittests/program_manager/CompileTarget.cpp
@@ -9,8 +9,6 @@
 #include <helpers/MockKernelInfo.hpp>
 #include <helpers/UrMock.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 #include <gtest/gtest.h>
 
 using namespace sycl;
@@ -26,7 +24,7 @@ generateImageWithCompileTarget(std::string KernelName,
   MockProperty CompileTargetProperty("compile_target", Data,
                                      SYCL_PROPERTY_TYPE_BYTE_ARRAY);
   MockPropertySet PropSet;
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_DEVICE_REQUIREMENTS,
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_REQUIREMENTS,
                  std::move(CompileTargetProperty));
 
   std::vector<unsigned char> Bin(CompileTarget.begin(), CompileTarget.end());

--- a/sycl/unittests/program_manager/DynamicLinking/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking/DynamicLinking.cpp
@@ -1,7 +1,5 @@
 #include <sycl/sycl.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 #include <detail/device_image_impl.hpp>
 #include <helpers/MockDeviceImage.hpp>
 #include <helpers/MockKernelInfo.hpp>
@@ -78,10 +76,10 @@ generateImage(std::initializer_list<std::string> KernelNames,
               const char *DeviceTargetSpec,
               sycl::unittest::MockPropertySet PropSet) {
   if (!ExportedSymbols.empty())
-    PropSet.insert(llvm::util::PropertySetRegistry::SYCL_EXPORTED_SYMBOLS,
+    PropSet.insert(__SYCL_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS,
                    createPropertySet(ExportedSymbols));
   if (!ImportedSymbols.empty())
-    PropSet.insert(llvm::util::PropertySetRegistry::SYCL_IMPORTED_SYMBOLS,
+    PropSet.insert(__SYCL_PROPERTY_SET_SYCL_IMPORTED_SYMBOLS,
                    createPropertySet(ImportedSymbols));
 
   std::vector<unsigned char> Bin{Magic};

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -14,8 +14,6 @@
 #include <detail/scheduler/commands.hpp>
 #include <sycl/sycl.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 #include <helpers/MockDeviceImage.hpp>
 #include <helpers/MockKernelInfo.hpp>
 #include <helpers/ScopedEnvVar.hpp>
@@ -84,8 +82,7 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernelImage() {
   std::vector<MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   MockPropertySet PropSet;
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO,
-                 std::move(ImgKPOI));
+  PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   std::vector<MockOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
 
@@ -104,8 +101,7 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernel3Image() {
   std::vector<MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   MockPropertySet PropSet;
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO,
-                 std::move(ImgKPOI));
+  PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   std::vector<MockOffloadEntry> Entries =
       makeEmptyKernels({EAMTestKernel3Name});

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -14,8 +14,6 @@
 #include <helpers/MockKernelInfo.hpp>
 #include <helpers/UrMock.hpp>
 
-#include <llvm/Support/PropertySetIO.h>
-
 #include <gtest/gtest.h>
 
 std::string current_link_options, current_compile_options, current_build_opts;
@@ -69,8 +67,7 @@ generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
   std::vector<MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   MockPropertySet PropSet;
-  PropSet.insert(llvm::util::PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO,
-                 std::move(ImgKPOI));
+  PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 


### PR DESCRIPTION
Reverts intel/llvm#16763 - Turns out UCRT is causing a problem for this on Windows. We need https://github.com/intel/llvm/pull/18200 before we can reintroduce it.