### PR TITLE
[SYCL][E2E] Fix `Config/select_device.cpp` when using GCC 15

### DIFF
--- a/sycl/test-e2e/Config/select_device.cpp
+++ b/sycl/test-e2e/Config/select_device.cpp
@@ -111,7 +111,7 @@ static std::vector<DevDescT> getAllowListDesc(std::string_view allowList) {
     auto result =  allowList.substr(0, pattern_end);
     allowList.remove_prefix(pattern_end + 2);
 
-    if (allowList[0] == ',')
+    if (!allowList.empty() && allowList[0] == ',')
       allowList.remove_prefix(1);
     return {std::string{result}};
   };


### PR DESCRIPTION
The allowList can be empty when performing the check on the line changed. This is usually not an issue, as it ends up evaluating to false, however when using GCC 15, and compiling with `-O0` this will crash instead. Adding the empty check to avoid this crash.