### PR TITLE
[SYCL] protect against possible data corruption cause by std::locale side effect

### DIFF
--- a/sycl/include/syclcompat/kernel.hpp
+++ b/sycl/include/syclcompat/kernel.hpp
@@ -112,6 +112,7 @@ static inline fs::path write_data_to_file(char const *const data, size_t size) {
 
   // create private directory
   std::stringstream directory;
+  directory.imbue(std::locale::classic()); // avoid locale issues, like commas
   fs::path directory_path;
   constexpr int max_attempts = 5;
   int i;
@@ -134,6 +135,7 @@ static inline fs::path write_data_to_file(char const *const data, size_t size) {
 
   // random filename in private directory
   std::stringstream filename;
+  filename.imbue(std::locale::classic());
   filename << std::hex << rand(prng);
 #ifdef _WIN32
   auto filepath = directory_path / (filename.str() + ".dll");

--- a/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
+++ b/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
@@ -144,6 +144,7 @@ void SetupLibrary(voidPtr &oclocInvokeHandle, voidPtr &oclocFreeOutputHandle,
 
 std::string IPVersionsToString(const std::vector<uint32_t> IPVersionVec) {
   std::stringstream ss;
+  ss.imbue(std::locale::classic());
   bool amFirst = true;
   for (uint32_t ipVersion : IPVersionVec) {
     // if any device is not intelGPU, bail.

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -362,6 +362,8 @@ public:
 
     int ImageId = CacheKey.first.second;
     std::stringstream DeviceList;
+    DeviceList.imbue(
+        std::locale::classic()); // avoid locale issues, like commas
     std::vector<unsigned char> SerializedObjVec = CacheKey.first.first;
 
     // Convert spec constants to string. Spec constants are stored as

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -180,6 +180,8 @@ static bool isDeviceBinaryTypeSupported(const ContextImplPtr &ContextImpl,
   return "unknown";
 }
 
+// The string produced by this function might be localized, with commas and
+// periods inserted. Presently, it is used only for user facing error output.
 [[maybe_unused]] auto VecToString = [](auto &Vec) -> std::string {
   std::ostringstream Out;
   Out << "{";


### PR DESCRIPTION
std::locale::global() in a user app can impact the SYCL library by side-effect, causing numbers (include hex) to be formatted with commas and periods where we might not expect such.  In most cases, our use of std streams is for user facing messages. But in some cases they are used in places where unexpected formatting could cause errors. This PR attempts to shore these places up.