### PR TITLE
[DevTSAN] Treat each work item as a thread for both CPU & GPU device

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -361,8 +361,7 @@ void ThreadSanitizerOnSpirv::appendDebugInfoToArgs(
   auto &Loc = I->getDebugLoc();
 
   // SPIR constant address space
-  PointerType *ConstASPtrTy =
-      PointerType::get(Type::getInt8Ty(C), kSpirOffloadConstantAS);
+  PointerType *ConstASPtrTy = PointerType::get(C, kSpirOffloadConstantAS);
 
   // File & Line
   if (Loc) {

--- a/sycl/test-e2e/ThreadSanitizer/aot/Inputs/usm_data_race.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/aot/Inputs/usm_data_race.cpp
@@ -1,16 +1,21 @@
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 
+__attribute__((noinline)) void foo(char *array, int val) { *array += val; }
+
 int main() {
   sycl::queue Q;
   auto *array = sycl::malloc_device<char>(1, Q);
   Q.submit([&](sycl::handler &h) {
-     h.parallel_for<class Test>(sycl::nd_range<1>(32, 8),
-                                [=](sycl::nd_item<1>) { array[0]++; });
+     h.parallel_for<class Test>(sycl::nd_range<1>(128, 8),
+                                [=](sycl::nd_item<1> it) {
+                                  *array += it.get_global_linear_id();
+                                  foo(array, it.get_local_linear_id());
+                                });
    }).wait();
   // CHECK: DeviceSanitizer: data race
   // CHECK-NEXT: When write of size 1 at 0x{{.*}} in kernel <{{.*}}Test>
-  // CHECK-NEXT: #0 {{.*}}usm_data_race.cpp:[[@LINE-4]]
+  // CHECK-NEXT: #0 {{.*}}usm_data_race.cpp
 
   sycl::free(array, Q);
   return 0;

--- a/sycl/test-e2e/ThreadSanitizer/check_buffer.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_buffer.cpp
@@ -21,8 +21,9 @@ int main() {
     sycl::buffer<int, 1> buf(v.data(), v.size());
     q.submit([&](sycl::handler &h) {
        auto A = buf.get_access<sycl::access::mode::read_write>(h);
-       h.parallel_for<class Test>(sycl::nd_range<1>(N, 1),
-                                  [=](sycl::nd_item<1>) { A[0]++; });
+       h.parallel_for<class Test>(
+           sycl::nd_range<1>(N, 1),
+           [=](sycl::nd_item<1> it) { A[0] += it.get_global_linear_id(); });
      }).wait();
     // CHECK: WARNING: DeviceSanitizer: data race
     // CHECK-NEXT: When write of size 4 at 0x{{.*}} in kernel <{{.*}}Test>

--- a/sycl/test-e2e/ThreadSanitizer/check_device_usm.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_device_usm.cpp
@@ -5,17 +5,22 @@
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 
+__attribute__((noinline)) void foo(char *array, int val) { *array += val; }
+
 int main() {
   sycl::queue Q;
   auto *array = sycl::malloc_device<char>(1, Q);
 
   Q.submit([&](sycl::handler &h) {
      h.parallel_for<class Test>(sycl::nd_range<1>(128, 8),
-                                [=](sycl::nd_item<1>) { array[0]++; });
+                                [=](sycl::nd_item<1> it) {
+                                  *array += it.get_global_linear_id();
+                                  foo(array, it.get_local_linear_id());
+                                });
    }).wait();
   // CHECK: WARNING: DeviceSanitizer: data race
   // CHECK-NEXT: When write of size 1 at 0x{{.*}} in kernel <{{.*}}Test>
-  // CHECK-NEXT: #0 {{.*}}check_device_usm.cpp:[[@LINE-4]]
+  // CHECK-NEXT: #0 {{.*}}check_device_usm.cpp
 
   sycl::free(array, Q);
   return 0;

--- a/sycl/test-e2e/ThreadSanitizer/check_host_usm.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_host_usm.cpp
@@ -5,17 +5,22 @@
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 
+__attribute__((noinline)) void foo(char *array, int val) { *array += val; }
+
 int main() {
   sycl::queue Q;
   auto *array = sycl::malloc_host<char>(1, Q);
 
   Q.submit([&](sycl::handler &h) {
      h.parallel_for<class Test>(sycl::nd_range<1>(128, 8),
-                                [=](sycl::nd_item<1>) { array[0]++; });
+                                [=](sycl::nd_item<1> it) {
+                                  *array += it.get_global_linear_id();
+                                  foo(array, it.get_local_linear_id());
+                                });
    }).wait();
   // CHECK: WARNING: DeviceSanitizer: data race
   // CHECK-NEXT: When write of size 1 at 0x{{.*}} in kernel <{{.*}}Test>
-  // CHECK-NEXT: #0 {{.*}}check_host_usm.cpp:[[@LINE-4]]
+  // CHECK-NEXT: #0 {{.*}}check_host_usm.cpp
 
   sycl::free(array, Q);
   return 0;

--- a/sycl/test-e2e/ThreadSanitizer/check_no_race.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_no_race.cpp
@@ -14,7 +14,7 @@ int main() {
   Q.submit([&](sycl::handler &h) {
      h.parallel_for<class MyKernelR_4>(
          sycl::nd_range<1>(N, 8),
-         [=](sycl::nd_item<1> item) { array[item.get_group_linear_id()]++; });
+         [=](sycl::nd_item<1> item) { array[item.get_global_linear_id()]++; });
    }).wait();
   // CHECK-NOT: WARNING: DeviceSanitizer: data race
 

--- a/sycl/test-e2e/ThreadSanitizer/check_shared_usm.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_shared_usm.cpp
@@ -5,17 +5,22 @@
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 
+__attribute__((noinline)) void foo(char *array, int val) { *array += val; }
+
 int main() {
   sycl::queue Q;
   auto *array = sycl::malloc_shared<char>(1, Q);
 
   Q.submit([&](sycl::handler &h) {
      h.parallel_for<class Test>(sycl::nd_range<1>(128, 8),
-                                [=](sycl::nd_item<1>) { array[0]++; });
+                                [=](sycl::nd_item<1> it) {
+                                  *array += it.get_global_linear_id();
+                                  foo(array, it.get_local_linear_id());
+                                });
    }).wait();
   // CHECK: WARNING: DeviceSanitizer: data race
   // CHECK-NEXT: When write of size 1 at 0x{{.*}} in kernel <{{.*}}Test>
-  // CHECK-NEXT: #0 {{.*}}check_shared_usm.cpp:[[@LINE-4]]
+  // CHECK-NEXT: #0 {{.*}}check_shared_usm.cpp
 
   sycl::free(array, Q);
   return 0;

--- a/sycl/test-e2e/ThreadSanitizer/check_sub_buffer.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_sub_buffer.cpp
@@ -22,11 +22,13 @@ int main() {
     q.submit([&](sycl::handler &cgh) {
        auto accessor = sub_buf.get_access<sycl::access::mode::read_write>(cgh);
        cgh.parallel_for<class Test>(sycl::nd_range<1>(size_x / 2, 1),
-                                    [=](sycl::nd_item<1>) { accessor[0]++; });
+                                    [=](sycl::nd_item<1> it) {
+                                      accessor[0] += it.get_global_linear_id();
+                                    });
      }).wait();
     // CHECK: WARNING: DeviceSanitizer: data race
     // CHECK-NEXT: When write of size 4 at 0x{{.*}} in kernel <{{.*}}Test>
-    // CHECK-NEXT: #0 {{.*}}check_sub_buffer.cpp:[[@LINE-4]]
+    // CHECK-NEXT: #0 {{.*}}check_sub_buffer.cpp:[[@LINE-5]]
   }
 
   return 0;


### PR DESCRIPTION
According to sycl spec, these is no dependency between each work item. So we'd better treat each work item as a thread.

* Fix one minor bug to calculate thread id
* Make e2e tests more robust