### PR TITLE
[SYCL] Move `khr` extension definitions in `feature_test.hpp.in` under `__DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS`

### DIFF
--- a/sycl/source/feature_test.hpp.in
+++ b/sycl/source/feature_test.hpp.in
@@ -116,10 +116,15 @@ inline namespace _V1 {
 #define SYCL_EXT_ONEAPI_NUM_COMPUTE_UNITS 1
 #define SYCL_EXT_ONEAPI_DEVICE_IMAGE_BACKEND_CONTENT 1
 #define SYCL_EXT_ONEAPI_CURRENT_DEVICE 1
-#define SYCL_KHR_FREE_FUNCTION_COMMANDS 1
 // In progress yet
 #define SYCL_EXT_ONEAPI_ATOMIC16 0
+
+// Unfinished KHR extensions. These extensions are only available if the
+// __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS macro is defined.
+#ifdef __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS
+#define SYCL_KHR_FREE_FUNCTION_COMMANDS 1
 #define SYCL_KHR_DEFAULT_CONTEXT 1
+#endif 
 
 #ifndef __has_include
 #define __has_include(x) 0


### PR DESCRIPTION
Purpose of this PR is to move `khr` extension definitions in under `__DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS` because they are still unfinished. 