### PR TITLE
[libclc] Ensure CLC builtins see the generic addrspace

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -547,6 +547,8 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       -D${CLC_TARGET_DEFINE}
       # All libclc builtin libraries see CLC headers
       -I${CMAKE_CURRENT_SOURCE_DIR}/clc/include
+      # Error on undefined macros
+      -Werror=undef
     )
 
     if( NOT "${cpu}" STREQUAL "" )

--- a/libclc/clc/include/clc/clcfunc.h
+++ b/libclc/clc/include/clc/clcfunc.h
@@ -26,4 +26,20 @@
 #define _CLC_DEF __attribute__((always_inline))
 #endif
 
+#if __OPENCL_C_VERSION__ == CL_VERSION_2_0 ||                                  \
+    (__OPENCL_C_VERSION__ >= CL_VERSION_3_0 &&                                 \
+     defined(__opencl_c_generic_address_space))
+#define _CLC_GENERIC_AS_SUPPORTED 1
+// Note that we hard-code the assumption that a non-distinct address space means
+// that the target maps the generic address space to the private address space.
+#ifdef __CLC_DISTINCT_GENERIC_ADDRSPACE__
+#define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 1
+#else
+#define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 0
+#endif
+#else
+#define _CLC_GENERIC_AS_SUPPORTED 0
+#define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 0
+#endif
+
 #endif // __CLC_CLCFUNC_H_

--- a/libclc/generic/include/clc/clc.h
+++ b/libclc/generic/include/clc/clc.h
@@ -25,22 +25,6 @@
 
 #define __CLC_NO_SCHAR
 
-#if __OPENCL_C_VERSION__ == CL_VERSION_2_0 ||                                  \
-    (__OPENCL_C_VERSION__ >= CL_VERSION_3_0 &&                                 \
-     defined(__opencl_c_generic_address_space))
-#define _CLC_GENERIC_AS_SUPPORTED 1
-// Note that we hard-code the assumption that a non-distinct address space means
-// that the target maps the generic address space to the private address space.
-#ifdef __CLC_DISTINCT_GENERIC_ADDRSPACE__
-#define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 1
-#else
-#define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 0
-#endif
-#else
-#define _CLC_GENERIC_AS_SUPPORTED 0
-#define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 0
-#endif
-
 /* Function Attributes */
 #include <clc/clcfunc.h>
 

--- a/libclc/libspirv/include/libspirv/spirv.h
+++ b/libclc/libspirv/include/libspirv/spirv.h
@@ -20,22 +20,6 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 #endif
 
-#if __OPENCL_C_VERSION__ == CL_VERSION_2_0 ||                                  \
-    (__OPENCL_C_VERSION__ >= CL_VERSION_3_0 &&                                 \
-     defined(__opencl_c_generic_address_space))
-#define _CLC_GENERIC_AS_SUPPORTED 1
-// Note that we hard-code the assumption that a non-distinct address space means
-// that the target maps the generic address space to the private address space.
-#if __CLC_DISTINCT_GENERIC_ADDRSPACE__
-#define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 1
-#else
-#define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 0
-#endif
-#else
-#define _CLC_GENERIC_AS_SUPPORTED 0
-#define _CLC_DISTINCT_GENERIC_AS_SUPPORTED 0
-#endif
-
 /* Function Attributes */
 #include <clc/clcfunc.h>
 


### PR DESCRIPTION
Having the macros defined in either the SPIR-V headers or OpenCL headers left it easy for the generic address space macros to be undefined. What's worse is there was no warning or error that this was happening.

This commit moves the definition of these macros into a common shared header that all three builtin libraries see. It also ensures the build will fail on the use of any undefined macro. This mirrors how upstream will (likely) eventually place the code, though in all likelihood it will differ slightly.