### PR TITLE
[UR][Graph] Disable flaky PVC CTS test

### DIFF
--- a/unified-runtime/test/conformance/exp_command_buffer/in-order.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/in-order.cpp
@@ -16,6 +16,10 @@ struct urInOrderCommandBufferExpTest
   virtual void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(urCommandBufferExpExecutionTest::SetUp());
 
+    // Level-Zero bug https://github.com/intel/llvm/issues/18544
+    // Re-enable these tests once fixed
+    UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
+
     ur_exp_command_buffer_desc_t desc{
         UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC, // stype
         nullptr,                                   // pnext


### PR DESCRIPTION
CTS test `urInOrderUSMCommandBufferExpTest.WithHints` has been reported as failing on unrelated PRs on PVC in GitHub CI https://github.com/intel/llvm/issues/18544 which were added recently in #18444

Disable the UR CTS in-order tests on Level-Zero V1 adapter until this bug is investigated and resolved. I've disabled more than the specific test that fails, as the others UR tests inheriting from the base fixture are variants, and it is not unlikely that we'd end up seeing flaky fails in CI for them too.