### PR TITLE
[clang][SYCL] Remove redundant default opt level in clang toolchain

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5742,10 +5742,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-Wno-sycl-strict");
       }
 
-      // Set O2 optimization level by default
-      if (!Args.getLastArg(options::OPT_O_Group))
-        CmdArgs.push_back("-O2");
-
       // Add the integration header option to generate the header.
       StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
       if (!Header.empty()) {


### PR DESCRIPTION
This is defined in the a few lines before [here](https://github.com/intel/llvm/blob/e7ab07d4a827e1d3cb121a27acb2d519dd477465/clang/lib/Driver/ToolChains/Clang.cpp#L5676).