### PR TITLE
[SYCL] Fix `-Werror=unused-but-set-variable` warning with old gcc

### DIFF
--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -503,7 +503,7 @@ public:
     // descriptor first when defining the cache data member). For "CallOnce"
     // cache we want to be querying cached value so "false" is the right
     // template parameter for such delegation.
-    constexpr bool DependentFalse = InitializingCache && false;
+    [[maybe_unused]] constexpr bool DependentFalse = InitializingCache && false;
 
     if constexpr (decltype(MCache)::has<Param>() && !InitializingCache) {
       return MCache.get<Param>();


### PR DESCRIPTION
Follow-up for https://github.com/intel/llvm/pull/18477.