### PR TITLE
[SYCL][Driver] Update fsycl-dump-device-code option name.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7297,7 +7297,7 @@ defm sycl_allow_device_image_dependencies: BoolOptionWithoutMarshalling<"f", "sy
   PosFlag<SetTrue, [], [ClangOption], "Allow dependencies between device code images">,
   NegFlag<SetFalse, [], [ClangOption], "Do not allow dependencies between device code images (default)">>;
 
-def fsycl_dump_device_code_EQ : Joined<["-"], "fsycl-dump-device-code=">,
+def fdump_device_code_EQ : Joined<["-"], "fdump-device-code=">,
   Flags<[NoXarchOption]>,
   HelpText<"Dump device code into the user provided directory.">;
 def fsyclbin : Flag<["-"], "fsyclbin">,

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -182,10 +182,10 @@ bool Compilation::CleanupFile(const char *File, bool IssueErrors) const {
   // able to remove), or non-regular files. Underlying tools may have
   // intentionally not overwritten them.
 
-  // Save the device code files if -fsycl-dump-device-code option is enabled.
+  // Save the device code files if -fdump-device-code option is enabled.
   if (TheDriver.isDumpDeviceCodeEnabled()) {
     Arg *DumpDeviceCodeArg =
-        getArgs().getLastArg(options::OPT_fsycl_dump_device_code_EQ);
+        getArgs().getLastArg(options::OPT_fdump_device_code_EQ);
     std::string ExpectedDir =
         DumpDeviceCodeArg ? DumpDeviceCodeArg->getValue() : "";
     std::string ActualFile(File);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2098,7 +2098,7 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
                     .Default(SaveTempsCwd);
   }
 
-  if (Args.getLastArg(options::OPT_fsycl_dump_device_code_EQ))
+  if (Args.getLastArg(options::OPT_fdump_device_code_EQ))
     DumpDeviceCode = true;
 
   if (const Arg *A = Args.getLastArg(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10737,13 +10737,13 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
         TCArgs.MakeArgString("--out-file-list=" + OutputFileName));
     ForeachArgs.push_back(
         TCArgs.MakeArgString("--out-replace=" + OutputFileName));
-    // If fsycl-dump-device-code is passed, put the output files from llvm-spirv
-    // into the path provided in fsycl-dump-device-code.
+    // If fdump-device-code is passed, put the output files from llvm-spirv
+    // into the path provided in fdump-device-code.
     if (C.getDriver().isDumpDeviceCodeEnabled()) {
       SmallString<128> OutputDir;
 
       Arg *DumpDeviceCodeArg =
-          C.getArgs().getLastArg(options::OPT_fsycl_dump_device_code_EQ);
+          C.getArgs().getLastArg(options::OPT_fdump_device_code_EQ);
 
       OutputDir = (DumpDeviceCodeArg ? DumpDeviceCodeArg->getValue() : "");
 
@@ -11401,10 +11401,10 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
     if (C.getDriver().isDumpDeviceCodeEnabled()) {
       SmallString<128> DumpDir;
-      Arg *A = C.getArgs().getLastArg(options::OPT_fsycl_dump_device_code_EQ);
+      Arg *A = C.getArgs().getLastArg(options::OPT_fdump_device_code_EQ);
       DumpDir = A ? A->getValue() : "";
       CmdArgs.push_back(
-          Args.MakeArgString(Twine("-sycl-dump-device-code=") + DumpDir));
+          Args.MakeArgString(Twine("-dump-device-code=") + DumpDir));
     }
 
     auto appendOption = [](SmallString<128> &OptString, StringRef AddOpt) {

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -248,14 +248,14 @@ void SYCL::constructLLVMForeachCommand(Compilation &C, const JobAction &JA,
         C.getArgs().MakeArgString("--out-dir=" + OutputDirName));
   }
 
-  // If fsycl-dump-device-code is passed, put the PTX files
-  // into the path provided in fsycl-dump-device-code.
+  // If fdump-device-code is passed, put the PTX files
+  // into the path provided in fdump-device-code.
   if (T->getToolChain().getTriple().isNVPTX() &&
       C.getDriver().isDumpDeviceCodeEnabled() && Ext == "s") {
     SmallString<128> OutputDir;
 
     Arg *DumpDeviceCodeArg =
-        C.getArgs().getLastArg(options::OPT_fsycl_dump_device_code_EQ);
+        C.getArgs().getLastArg(options::OPT_fdump_device_code_EQ);
 
     OutputDir = (DumpDeviceCodeArg ? DumpDeviceCodeArg->getValue() : "");
 

--- a/clang/test/Driver/save-ptx-files.cpp
+++ b/clang/test/Driver/save-ptx-files.cpp
@@ -1,17 +1,17 @@
-// Save PTX files during PTX target processing using -fsycl-dump-device-code option.
+// Save PTX files during PTX target processing using -fdump-device-code option.
 
-// Verify that -fsycl-dump-device-code saves PTX files in the user provided directory
+// Verify that -fdump-device-code saves PTX files in the user provided directory
 // while targeting CUDA enabled GPUs.
 
 // Linux
-// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -fsycl-dump-device-code=/user/input/path %s 2>&1 \
+// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -fdump-device-code=/user/input/path %s 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHECK-PTX-FILES,CHECK-SPIRV-FILES
 
 // clang --driver-mode=g++
-// RUN: %clangxx -### -fsycl  -fsycl-targets=nvptx64-nvidia-cuda -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -fsycl-dump-device-code=/user/input/path %s 2>&1 \
+// RUN: %clangxx -### -fsycl  -fsycl-targets=nvptx64-nvidia-cuda -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -fdump-device-code=/user/input/path %s 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHECK-PTX-FILES
 
-// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -fsycl-dump-device-code= %s 2>&1 \
+// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -fdump-device-code= %s 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHECK-PTX-FILES-CWD,CHECK-SPIRV-FILES-CWD
 
 // CHECK-PTX-FILES: llvm-foreach{{.*}} "--out-ext=s"{{.*}} "--out-dir=/user/input/path{{(/|\\\\)}}" "--" "{{.*}}clang{{.*}}" {{.*}} "-fsycl-is-device" {{.*}}.s{{.*}}
@@ -22,20 +22,20 @@
 // Windows - Check if PTX files are saved in the user provided path.
 // RUN: %clang_cl -### -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
-// RUN: -fsycl-dump-device-code=/user/input/path %s 2>&1 \
+// RUN: -fdump-device-code=/user/input/path %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHECK-PTX-WIN %s
 
 // Windows - Check if PTX and SPV files are saved in user provided path.
 // RUN: %clang_cl -### -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
-// RUN: -fsycl-dump-device-code=/user/input/path %s 2>&1 \
+// RUN: -fdump-device-code=/user/input/path %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-PTX-WIN,CHECK-SPV-WIN %s
 
-// Windows - Check PTX files saved in current working directory when -fsycl-dump-device-code
+// Windows - Check PTX files saved in current working directory when -fdump-device-code
 // is empty. 
 // RUN: %clang_cl -### -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
-// RUN: -fsycl-dump-device-code= %s 2>&1 \
+// RUN: -fdump-device-code= %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHECK-PTX-WIN-CWD %s
 
 // CHECK-PTX-WIN: llvm-foreach{{.*}} "--out-ext=s"{{.*}} "--out-dir=/user/input/path{{(/|\\\\)}}" "--" "{{.*}}clang{{.*}}" {{.*}} "-fsycl-is-device" {{.*}}.asm{{.*}}

--- a/clang/test/Driver/sycl-dump-device-code-old-model.cpp
+++ b/clang/test/Driver/sycl-dump-device-code-old-model.cpp
@@ -1,35 +1,35 @@
-// SYCL offloading tests using -fsycl-dump-device-code
+// SYCL offloading tests using -fdump-device-code
 
-// Verify that -fsycl-dump-device-code puts the device code (.spv files)
+// Verify that -fdump-device-code puts the device code (.spv files)
 // in the user provided directory.
 
 // Linux
 // clang -fsycl --no-offload-new-driver -target x86_64-unknown-linux-gnu
-// RUN: %clang -fsycl --no-offload-new-driver -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -target x86_64-unknown-linux-gnu -fsycl-dump-device-code=/user/input/path %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE
+// RUN: %clang -fsycl --no-offload-new-driver -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -target x86_64-unknown-linux-gnu -fdump-device-code=/user/input/path %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE
 
 // clang -fsycl --no-offload-new-driver -fsycl-targets=spir64-unknown-unknown
-// RUN: %clang -fsycl --no-offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fsycl-dump-device-code=/user/input/path %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE
+// RUN: %clang -fsycl --no-offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fdump-device-code=/user/input/path %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE
 
 // clang --driver-mode=g++
-// RUN: %clangxx -fsycl --no-offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fsycl-dump-device-code=/user/input/path %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE
+// RUN: %clangxx -fsycl --no-offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fdump-device-code=/user/input/path %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE
 
 // Windows
-// RUN: %clang_cl -fsycl --no-offload-new-driver -fsycl-dump-device-code=/user/input/path %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE-WIN
+// RUN: %clang_cl -fsycl --no-offload-new-driver -fdump-device-code=/user/input/path %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE-WIN
 
-// CHK-FSYCL-DUMP-DEVICE-CODE: llvm-foreach{{.*}} "--out-dir=/user/input/path{{(/|\\\\)}}" "--" "{{.*}}llvm-spirv"
-// CHK-FSYCL-DUMP-DEVICE-CODE-WIN: llvm-foreach{{.*}} "--out-dir=/user/input/path{{(/|\\\\)}}" "--" "{{.*}}llvm-spirv"
+// CHK-FDUMP-DEVICE-CODE: llvm-foreach{{.*}} "--out-dir=/user/input/path{{(/|\\\\)}}" "--" "{{.*}}llvm-spirv"
+// CHK-FDUMP-DEVICE-CODE-WIN: llvm-foreach{{.*}} "--out-dir=/user/input/path{{(/|\\\\)}}" "--" "{{.*}}llvm-spirv"
 
 // Linux
-// RUN: %clang -fsycl --no-offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fsycl-dump-device-code= %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE-CWD
+// RUN: %clang -fsycl --no-offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fdump-device-code= %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE-CWD
 
 // Windows
-// RUN: %clang_cl -fsycl --no-offload-new-driver -fsycl-dump-device-code= %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE-WIN-CWD
+// RUN: %clang_cl -fsycl --no-offload-new-driver -fdump-device-code= %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE-WIN-CWD
 
-// CHK-FSYCL-DUMP-DEVICE-CODE-CWD: llvm-foreach{{.*}} "--out-dir=.{{(/|\\\\)}}" "--" "{{.*}}llvm-spirv"
-// CHK-FSYCL-DUMP-DEVICE-CODE-WIN-CWD: llvm-foreach{{.*}} "--out-dir=.{{(/|\\\\)}}" "--" "{{.*}}llvm-spirv"
+// CHK-FDUMP-DEVICE-CODE-CWD: llvm-foreach{{.*}} "--out-dir=.{{(/|\\\\)}}" "--" "{{.*}}llvm-spirv"
+// CHK-FDUMP-DEVICE-CODE-WIN-CWD: llvm-foreach{{.*}} "--out-dir=.{{(/|\\\\)}}" "--" "{{.*}}llvm-spirv"

--- a/clang/test/Driver/sycl-dump-device-code.cpp
+++ b/clang/test/Driver/sycl-dump-device-code.cpp
@@ -1,34 +1,34 @@
-// SYCL offloading tests using -fsycl-dump-device-code
+// SYCL offloading tests using -fdump-device-code
 
-// Verify that -fsycl-dump-device-code passes the option to
+// Verify that -fdump-device-code passes the option to
 // clang-linker-wrapper in the new offload model.
 
 // clang -fsycl --offload-new-driver -target x86_64-unknown-linux-gnu
-// RUN: %clang -fsycl --offload-new-driver -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -target x86_64-unknown-linux-gnu -fsycl-dump-device-code=/user/input/path %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE-NEW-OFFLOAD
+// RUN: %clang -fsycl --offload-new-driver -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -target x86_64-unknown-linux-gnu -fdump-device-code=/user/input/path %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE-NEW-OFFLOAD
 
 // clang -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown
-// RUN: %clang -fsycl --offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fsycl-dump-device-code=/user/input/path %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE-NEW-OFFLOAD
+// RUN: %clang -fsycl --offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fdump-device-code=/user/input/path %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE-NEW-OFFLOAD
 
 // clang --driver-mode=g++
-// RUN: %clangxx -fsycl --offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fsycl-dump-device-code=/user/input/path %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE-NEW-OFFLOAD
+// RUN: %clangxx -fsycl --offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fdump-device-code=/user/input/path %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE-NEW-OFFLOAD
 
 // Windows
-// RUN: %clang_cl -fsycl --offload-new-driver -fsycl-dump-device-code=/user/input/path %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE-WIN-NEW-OFFLOAD
+// RUN: %clang_cl -fsycl --offload-new-driver -fdump-device-code=/user/input/path %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE-WIN-NEW-OFFLOAD
 
-// CHK-FSYCL-DUMP-DEVICE-CODE-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code=/user/input/path"
-// CHK-FSYCL-DUMP-DEVICE-CODE-WIN-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code=/user/input/path"
+// CHK-FDUMP-DEVICE-CODE-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code=/user/input/path"
+// CHK-FDUMP-DEVICE-CODE-WIN-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code=/user/input/path"
 
 // Linux
-// RUN: %clang -fsycl --offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fsycl-dump-device-code= %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE-CWD-NEW-OFFLOAD
+// RUN: %clang -fsycl --offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -fdump-device-code= %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE-CWD-NEW-OFFLOAD
 
 // Windows
-// RUN: %clang_cl -fsycl --offload-new-driver -fsycl-dump-device-code= %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-DUMP-DEVICE-CODE-WIN-CWD-NEW-OFFLOAD
+// RUN: %clang_cl -fsycl --offload-new-driver -fdump-device-code= %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefixes=CHK-FDUMP-DEVICE-CODE-WIN-CWD-NEW-OFFLOAD
 
-// CHK-FSYCL-DUMP-DEVICE-CODE-CWD-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code="
-// CHK-FSYCL-DUMP-DEVICE-CODE-WIN-CWD-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code="
+// CHK-FDUMP-DEVICE-CODE-CWD-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code="
+// CHK-FDUMP-DEVICE-CODE-WIN-CWD-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code="


### PR DESCRIPTION
Update `-fsycl-dump-device-code` option name to a more generic name like `-fdump-device-code`, so it can be used to save device code IR files for all offloading models, not just SYCL.