### PR TITLE
[UR][Graph] Disable flaky CTS test on L0 v2

### DIFF
--- a/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
@@ -113,6 +113,9 @@ TEST_P(urEnqueueCommandBufferExpTest, SerializeAcrossQueues) {
 // Tests that submitting a command-buffer twice to an out-of-order queue
 // relying on implicit serialization semantics for dependencies.
 TEST_P(urEnqueueCommandBufferExpTest, SerializeOutofOrderQueue) {
+  // https://github.com/intel/llvm/issues/18610
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
+
   ASSERT_SUCCESS(urEnqueueCommandBufferExp(out_of_order_queue, cmd_buf_handle,
                                            0, nullptr, nullptr));
   ASSERT_SUCCESS(urEnqueueCommandBufferExp(out_of_order_queue, cmd_buf_handle,


### PR DESCRIPTION
As tracked in https://github.com/intel/llvm/issues/18610 there have been fails for the
`urEnqueueCommandBufferExpTest.SerializeOutofOrderQueue` UR CTS test on the Level-Zero V2 adapter on unrelated PRs.

Disabling test on V2 until issue can be investigated/resolved to help keep CI stable.