### PR TITLE
[DeviceASAN] Fix a UR_L0_LEAKS_DEBUG leak report

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -50,6 +50,7 @@ AsanInterceptor::~AsanInterceptor() {
   for (auto &[_, ShadowMemory] : m_ShadowMap) {
     ShadowMemory->Destory();
   }
+  m_ShadowMap.clear();
 
   for (auto Adapter : m_Adapters) {
     getContext()->urDdiTable.Global.pfnAdapterRelease(Adapter);


### PR DESCRIPTION
Some resource destruction is done in the destructor, but if we don't manually clear the map, then the destructor is called after the adapter release, which leads to the leak report and maybe some UB(trying to use adapter after it is released).