### PR TITLE
Revert "[CI] Set a time limit for sycl-cts (#18557)"

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -217,9 +217,6 @@ jobs:
   run-sycl-cts-linux:
     needs: [ubuntu2204_build, build-sycl-cts-linux]
     if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-    # Normally these jobs take less than 10m. But sometimes the job hangs up and
-    # reaches the 360m limit. Set a lower limit to free up the runner earlier.
-    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This reverts commit d1beb8e0ca8805d75c43e162aa49f243e7feede3.

`timeout-minutes:` parameter is not compatible with `uses` and `with`. It should probably be included in `.github/workflows/sycl-linux-run-tests.yml`. 