### PR TITLE
[libspirv] Align __clc_sincos with upstream

### DIFF
--- a/libclc/clc/lib/generic/math/clc_sincos.inc
+++ b/libclc/clc/lib/generic/math/clc_sincos.inc
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_DECLARE_SINCOS(ADDRSPACE, TYPE) \
-  _CLC_OVERLOAD _CLC_DEF TYPE sincos (TYPE x, ADDRSPACE TYPE * cosval) { \
-    return __spirv_ocl_sincos(x, cosval); \
+#define __CLC_DECLARE_SINCOS(ADDRSPACE, TYPE)                                  \
+  _CLC_OVERLOAD _CLC_DEF TYPE __clc_sincos(TYPE x, ADDRSPACE TYPE *cosval) {   \
+    *cosval = __clc_cos(x);                                                    \
+    return __clc_sin(x);                                                       \
   }
 
 __CLC_DECLARE_SINCOS(global, __CLC_GENTYPE)


### PR DESCRIPTION
Having CLC sincos call back to SPIR-V sincos would (in the 'generic' target) end up in a recursive loop as SPIR-V sincos defers to CLC sincos.