### PR TITLE
[UR][BINDLESS] Remove unnecessary stream wait after bindless copy

### DIFF
--- a/unified-runtime/source/adapters/cuda/image.cpp
+++ b/unified-runtime/source/adapters/cuda/image.cpp
@@ -918,11 +918,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
         cpy_desc.Depth = pCopyRegion->copyExtent.depth;
         UR_CHECK_ERROR(cuMemcpy3DAsync(&cpy_desc, Stream));
       }
-      // Synchronization is required here to handle the case of copying data
-      // from host to device, then device to device and finally device to host.
-      // Without it, there is a risk of the copies not being executed in the
-      // intended order.
-      cuStreamSynchronize(Stream);
     }
 
     if (phEvent) {

--- a/unified-runtime/source/adapters/hip/image.cpp
+++ b/unified-runtime/source/adapters/hip/image.cpp
@@ -906,11 +906,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
         // struct object which adds a little complexity (e.g. 'hipPitchedPtr').
         UR_CHECK_ERROR(hipDrvMemcpy3DAsync(&cpy_desc, Stream));
       }
-      // Synchronization is required here to handle the case of copying data
-      // from host to device, then device to device and finally device to host.
-      // Without it, there is a risk of the copies not being executed in the
-      // intended order.
-      UR_CHECK_ERROR(hipStreamSynchronize(Stream));
     }
 
     if (phEvent) {


### PR DESCRIPTION
Removes an unnecessary sync.

images are usm. It is the user responsibility to manage data dependencies, which the e2e tests account for. 
This will improve performance, particularly for out of order queues.