### PR TITLE
[libclc] Reduce diff with upstream in CLC headers

### DIFF
--- a/libclc/clc/include/clc/math/clc_exp.h
+++ b/libclc/clc/include/clc/math/clc_exp.h
@@ -12,7 +12,6 @@
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define __CLC_FUNCTION __clc_exp
 
-
 #include <clc/math/gentype.inc>
 
 #undef __CLC_FUNCTION

--- a/libclc/clc/include/clc/math/clc_fract.h
+++ b/libclc/clc/include/clc/math/clc_fract.h
@@ -9,8 +9,6 @@
 #ifndef __CLC_MATH_CLC_FRACT_H__
 #define __CLC_MATH_CLC_FRACT_H__
 
-#include <clc/internal/clc.h>
-
 #define __CLC_FUNCTION __clc_fract
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
 

--- a/libclc/clc/include/clc/math/clc_frexp.h
+++ b/libclc/clc/include/clc/math/clc_frexp.h
@@ -9,8 +9,6 @@
 #ifndef __CLC_MATH_CLC_FREXP_H__
 #define __CLC_MATH_CLC_FREXP_H__
 
-#include <clc/internal/clc.h>
-
 #define __CLC_FUNCTION __clc_frexp
 #define __CLC_BODY <clc/math/unary_decl_with_int_ptr.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/include/clc/math/clc_lgamma_r.h
+++ b/libclc/clc/include/clc/math/clc_lgamma_r.h
@@ -9,8 +9,6 @@
 #ifndef __CLC_MATH_CLC_LGAMMA_R_H__
 #define __CLC_MATH_CLC_LGAMMA_R_H__
 
-#include <clc/internal/clc.h>
-
 #define __CLC_FUNCTION __clc_lgamma_r
 #define __CLC_BODY <clc/math/unary_decl_with_int_ptr.inc>
 

--- a/libclc/clc/include/clc/math/clc_modf.h
+++ b/libclc/clc/include/clc/math/clc_modf.h
@@ -9,8 +9,6 @@
 #ifndef __CLC_MATH_CLC_MODF_H__
 #define __CLC_MATH_CLC_MODF_H__
 
-#include <clc/internal/clc.h>
-
 #define __CLC_FUNCTION __clc_modf
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/include/clc/math/clc_sincos.h
+++ b/libclc/clc/include/clc/math/clc_sincos.h
@@ -9,8 +9,6 @@
 #ifndef __CLC_MATH_CLC_SINCOS_H__
 #define __CLC_MATH_CLC_SINCOS_H__
 
-#include <clc/internal/clc.h>
-
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
 #define __CLC_FUNCTION __clc_sincos
 

--- a/libclc/clc/include/clc/relational/floatn.inc
+++ b/libclc/clc/include/clc/relational/floatn.inc
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
 #include <clc/clcfunc.h>
 #include <clc/clctypes.h>
 


### PR DESCRIPTION
In a recent sycl-web PR I mistakenly introduced extra includes to some CLC functions to account for the generic address space. This was because the macro defines weren't at that time being pulled in by math/gentype.inc (or any CLC headers) as they were in my upstream work.

After pulling in the upstream generic address space support, the defines are now in a common place across the whole of libclc and are automatically included by all of these files. Keeping the redundant includes around only serves to increases our diff with upstream.

This commit takes the opportunity to clean up some whitespace diffs at the same time.