### PR TITLE
[SYCL][E2E] Better handle the Intel Compiler in standalone build (NFC)

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -626,7 +626,9 @@ if config.dump_ir_supported:
 
 lit_config.note("Targeted devices: {}".format(", ".join(config.sycl_devices)))
 
-sycl_ls = FindTool("sycl-ls").resolve(llvm_config, config.llvm_tools_dir)
+sycl_ls = FindTool("sycl-ls").resolve(
+    llvm_config, os.pathsep.join([config.dpcpp_bin_dir, config.llvm_tools_dir])
+)
 if not sycl_ls:
     lit_config.fatal("can't find `sycl-ls`")
 
@@ -809,12 +811,14 @@ tools = [
     ToolSubst("sycl-ls", command=sycl_ls, unresolved="ignore"),
 ] + feature_tools
 
-# Try and find each of these tools in the llvm tools directory or the PATH, in
-# that order. If found, they will be added as substitutions with the full path
+# Try and find each of these tools in the DPC++ bin directory, in the llvm tools directory
+# or the PATH, in that order. If found, they will be added as substitutions with the full path
 # to the tool. This allows us to support both in-tree builds and standalone
 # builds, where the tools may be externally defined.
+# The DPC++ bin directory is different from the LLVM bin directory when using
+# the Intel Compiler (icx), which puts tools into $dpcpp_root_dir/bin/compiler
 llvm_config.add_tool_substitutions(
-    tools, [config.llvm_tools_dir, os.environ.get("PATH", "")]
+    tools, [config.dpcpp_bin_dir, config.llvm_tools_dir, os.environ.get("PATH", "")]
 )
 for tool in feature_tools:
     if tool.was_resolved:

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -2,6 +2,7 @@
 
 import sys
 import platform
+import subprocess
 
 import site
 
@@ -9,8 +10,15 @@ site.addsitedir("@CMAKE_CURRENT_SOURCE_DIR@")
 
 config.dpcpp_compiler = lit_config.params.get("dpcpp_compiler", "@SYCL_CXX_COMPILER@")
 config.dpcpp_root_dir= os.path.dirname(os.path.dirname(config.dpcpp_compiler))
+config.dpcpp_bin_dir = os.path.join(config.dpcpp_root_dir, 'bin')
 
-config.llvm_tools_dir = os.path.join(config.dpcpp_root_dir, 'bin')
+def get_dpcpp_tool_path(name):
+    try:
+        return subprocess.check_output([config.dpcpp_compiler, "-print-prog-name=" + name], text=True)
+    except CalledProcessError:
+        return os.path.join(config.dpcpp_bin_dir, tool)
+
+config.llvm_tools_dir = os.path.dirname(get_dpcpp_tool_path("llvm-config"))
 config.lit_tools_dir = os.path.dirname("@TEST_SUITE_LIT@")
 config.dump_ir_supported = lit_config.params.get("dump_ir", ("@DUMP_IR_SUPPORTED@" if "@DUMP_IR_SUPPORTED@" else False))
 config.sycl_tools_dir = config.llvm_tools_dir


### PR DESCRIPTION
The proprietary Intel Compiler (ICX) uses a different installation layout then clang. It puts tools into a bin/compiler subdirectory (to not expose them on the PATH by default). Handle this by not assuming that the compiler is in the same directory as other llvm tools. Ask the compiler for the path to `llvm-config` for the tools directory, using the `-print-prog-name` option.
`llvm-config` was choosen because lit already assumes it is in the tools directory see for example: [llvm/utils/lit/lit/llvm/config.py:285][1]

[1]: https://github.com/llvm/llvm-project/blob/9cac4bf485e64f7992f2c01bb9517f6379e58164/llvm/utils/lit/lit/llvm/config.py#L285