### PR TITLE
[UR] Ensure all CTS SetUp functions check their results

### DIFF
--- a/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunchAndMemcpyInOrder.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunchAndMemcpyInOrder.cpp
@@ -347,7 +347,8 @@ struct urEnqueueKernelLaunchIncrementMultiDeviceMultiThreadTest
     queuePerThread = std::get<1>(getParam()).value;
     // With !queuePerThread this becomes a test on a single device
     this->trueMultiDevice = queuePerThread;
-    urEnqueueKernelLaunchIncrementMultiDeviceTestWithParam<Param>::SetUp();
+    UUR_RETURN_ON_FATAL_FAILURE(
+        urEnqueueKernelLaunchIncrementMultiDeviceTestWithParam<Param>::SetUp());
   }
 
   bool useEvents;

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMAdvise.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMAdvise.cpp
@@ -46,7 +46,7 @@ TEST_P(urEnqueueUSMAdviseWithParamTest, Success) {
 struct urEnqueueUSMAdviseTest : uur::urUSMDeviceAllocTest {
   void SetUp() override {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-    uur::urUSMDeviceAllocTest::SetUp();
+    UUR_RETURN_ON_FATAL_FAILURE(uur::urUSMDeviceAllocTest::SetUp());
   }
 };
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueUSMAdviseTest);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
@@ -178,7 +178,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueUSMMemcpyTest);
 
 struct urEnqueueUSMMemcpyMultiDeviceTest : uur::urAllDevicesTest {
   void SetUp() override {
-    uur::urAllDevicesTest::SetUp();
+    UUR_RETURN_ON_FATAL_FAILURE(uur::urAllDevicesTest::SetUp());
     for (auto &device : devices) {
       ur_device_usm_access_capability_flags_t device_usm = 0;
       ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
@@ -13,7 +13,8 @@ struct urEnqueueUSMPrefetchWithParamTest
     // The setup for the parent fixture does a urQueueFlush, which isn't
     // supported by native cpu.
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-    uur::urUSMDeviceAllocTestWithParam<ur_usm_migration_flag_t>::SetUp();
+    UUR_RETURN_ON_FATAL_FAILURE(
+        uur::urUSMDeviceAllocTestWithParam<ur_usm_migration_flag_t>::SetUp());
   }
 };
 

--- a/unified-runtime/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
+++ b/unified-runtime/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
@@ -13,7 +13,7 @@ using T = uint32_t;
 
 struct urMultiDeviceContextTest : uur::urPlatformTest {
   void SetUp() {
-    uur::urPlatformTest::SetUp();
+    UUR_RETURN_ON_FATAL_FAILURE(uur::urPlatformTest::SetUp());
     ASSERT_SUCCESS(
         urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &num_devices));
     if (num_devices <= 1) {
@@ -52,7 +52,7 @@ struct urMultiDeviceContextTest : uur::urPlatformTest {
 
 struct urMultiDeviceContextMemBufferTest : urMultiDeviceContextTest {
   void SetUp() {
-    urMultiDeviceContextTest::SetUp();
+    UUR_RETURN_ON_FATAL_FAILURE(urMultiDeviceContextTest::SetUp());
     if (num_devices <= 1) {
       return;
     }

--- a/unified-runtime/test/conformance/memory/urMemGetInfo.cpp
+++ b/unified-runtime/test/conformance/memory/urMemGetInfo.cpp
@@ -113,7 +113,9 @@ TEST_P(urMemGetInfoTest, InvalidNullPointerPropSizeRet) {
 }
 
 struct urMemGetInfoImageTest : uur::urMemImageTest {
-  void SetUp() override { uur::urMemImageTest::SetUp(); }
+  void SetUp() override {
+    UUR_RETURN_ON_FATAL_FAILURE(uur::urMemImageTest::SetUp());
+  }
 };
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemGetInfoImageTest);
 

--- a/unified-runtime/test/conformance/queue/urQueueGetInfo.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueGetInfo.cpp
@@ -222,7 +222,7 @@ TEST_P(urQueueGetInfoTest, InvalidNullPointerPropSizeRet) {
 struct urQueueGetInfoDeviceQueueTestWithInfoParam : public uur::urQueueTest {
   void SetUp() {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-    urQueueGetInfoTest::SetUp();
+    UUR_RETURN_ON_FATAL_FAILURE(urQueueGetInfoTest::SetUp());
     ur_queue_flags_t deviceQueueCapabilities = 0;
     ASSERT_SUCCESS(urDeviceGetInfo(
         device, UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES,


### PR DESCRIPTION
Failing gtest doesn't fail right away. Wrap all calls to base class
"SetUp" methods in the `UUR_RETURN_ON_FATAL_FAILURE` macro.

This also includes cases where these functions were the last line in
the function, making it a NFC, but updating those for consistency.
