### PR TITLE
[UR][CUDA][HIP] Refactor event handling

### DIFF
--- a/unified-runtime/source/adapters/cuda/async_alloc.cpp
+++ b/unified-runtime/source/adapters/cuda/async_alloc.cpp
@@ -33,9 +33,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMDeviceAllocExp(
                                    phEventWaitList));
 
   if (phEvent) {
-    RetImplEvent = std::unique_ptr<ur_event_handle_t_>(
-        ur_event_handle_t_::makeNative(UR_COMMAND_ENQUEUE_USM_DEVICE_ALLOC_EXP,
-                                       hQueue, CuStream, StreamToken));
+    RetImplEvent = std::make_unique<ur_event_handle_t_>(
+        UR_COMMAND_ENQUEUE_USM_DEVICE_ALLOC_EXP, hQueue, CuStream, StreamToken);
     UR_CHECK_ERROR(RetImplEvent->start());
   }
 
@@ -91,9 +90,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFreeExp(
                                    phEventWaitList));
 
   if (phEvent) {
-    RetImplEvent =
-        std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-            UR_COMMAND_ENQUEUE_USM_FREE_EXP, hQueue, CuStream, StreamToken));
+    RetImplEvent = std::make_unique<ur_event_handle_t_>(
+        UR_COMMAND_ENQUEUE_USM_FREE_EXP, hQueue, CuStream, StreamToken);
     UR_CHECK_ERROR(RetImplEvent->start());
   }
 

--- a/unified-runtime/source/adapters/cuda/command_buffer.cpp
+++ b/unified-runtime/source/adapters/cuda/command_buffer.cpp
@@ -80,8 +80,7 @@ ur_exp_command_buffer_handle_t_::addSignalNode(CUgraphNode DepNode,
   UR_CHECK_ERROR(
       cuGraphAddEventRecordNode(&SignalNode, CudaGraph, &DepNode, 1, Event));
 
-  return std::unique_ptr<ur_event_handle_t_>(
-      ur_event_handle_t_::makeWithNative(Context, Event));
+  return std::make_unique<ur_event_handle_t_>(Context, Event);
 }
 
 ur_result_t ur_exp_command_buffer_handle_t_::addWaitNodes(
@@ -472,8 +471,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
             cuGraphAddEventRecordNode(&GraphNode, hCommandBuffer->CudaGraph,
                                       DepsList.data(), DepsList.size(), Event));
 
-        auto RetEventUP = std::unique_ptr<ur_event_handle_t_>(
-            ur_event_handle_t_::makeWithNative(hCommandBuffer->Context, Event));
+        auto RetEventUP = std::make_unique<ur_event_handle_t_>(
+            hCommandBuffer->Context, Event);
 
         *phEvent = RetEventUP.release();
       }
@@ -1163,9 +1162,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCommandBufferExp(
                                    phEventWaitList));
 
   if (phEvent) {
-    RetImplEvent = std::unique_ptr<ur_event_handle_t_>(
-        ur_event_handle_t_::makeNative(UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP,
-                                       hQueue, CuStream, StreamToken));
+    RetImplEvent = std::make_unique<ur_event_handle_t_>(
+        UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP, hQueue, CuStream, StreamToken);
     UR_CHECK_ERROR(RetImplEvent->start());
   }
 
@@ -1429,10 +1427,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
   UR_CHECK_ERROR(cuGraphEventRecordNodeGetEvent(SignalNode, &SignalEvent));
 
   if (phEvent) {
-    *phEvent = std::unique_ptr<ur_event_handle_t_>(
-                   ur_event_handle_t_::makeWithNative(CommandBuffer->Context,
-                                                      SignalEvent))
-                   .release();
+    *phEvent = new ur_event_handle_t_(CommandBuffer->Context, SignalEvent);
   }
 
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/cuda/enqueue.cpp
+++ b/unified-runtime/source/adapters/cuda/enqueue.cpp
@@ -341,8 +341,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     }
 
     if (phEvent) {
-      *phEvent = ur_event_handle_t_::makeNative(
-          UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, hQueue, CuStream, StreamToken);
+      *phEvent = new ur_event_handle_t_(UR_COMMAND_EVENTS_WAIT_WITH_BARRIER,
+                                        hQueue, CuStream, StreamToken);
       UR_CHECK_ERROR((*phEvent)->start());
       UR_CHECK_ERROR((*phEvent)->record());
     }
@@ -439,9 +439,8 @@ enqueueKernelLaunch(ur_queue_handle_t hQueue, ur_kernel_handle_t hKernel,
     }
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_KERNEL_LAUNCH, hQueue, CuStream, StreamToken));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_KERNEL_LAUNCH, hQueue, CuStream, StreamToken);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -627,9 +626,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     }
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_KERNEL_LAUNCH, hQueue, CuStream, StreamToken));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_KERNEL_LAUNCH, hQueue, CuStream, StreamToken);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -768,9 +766,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, Stream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, Stream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -817,9 +814,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_WRITE_RECT, hQueue, cuStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_WRITE_RECT, hQueue, cuStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -864,9 +860,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_COPY, hQueue, Stream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_COPY, hQueue, Stream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -910,9 +905,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_COPY_RECT, hQueue, CuStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_COPY_RECT, hQueue, CuStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1021,9 +1015,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_WRITE_RECT, hQueue, Stream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_WRITE_RECT, hQueue, Stream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1195,9 +1188,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
 
     std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_IMAGE_READ, hQueue, Stream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_IMAGE_READ, hQueue, Stream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
     if (ImgType == UR_MEM_TYPE_IMAGE1D) {
@@ -1261,9 +1253,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
     std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_IMAGE_WRITE, hQueue, CuStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_IMAGE_WRITE, hQueue, CuStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1338,9 +1329,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
     std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_IMAGE_COPY, hQueue, CuStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_IMAGE_COPY, hQueue, CuStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1409,8 +1399,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
     if (phEvent) {
       try {
-        *phEvent = ur_event_handle_t_::makeNative(
-            UR_COMMAND_MEM_BUFFER_MAP, hQueue, hQueue->getNextTransferStream());
+        *phEvent = new ur_event_handle_t_(UR_COMMAND_MEM_BUFFER_MAP, hQueue,
+                                          hQueue->getNextTransferStream());
         UR_CHECK_ERROR((*phEvent)->start());
         UR_CHECK_ERROR((*phEvent)->record());
       } catch (ur_result_t Err) {
@@ -1456,8 +1446,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
 
     if (phEvent) {
       try {
-        *phEvent = ur_event_handle_t_::makeNative(
-            UR_COMMAND_MEM_UNMAP, hQueue, hQueue->getNextTransferStream());
+        *phEvent = new ur_event_handle_t_(UR_COMMAND_MEM_UNMAP, hQueue,
+                                          hQueue->getNextTransferStream());
         UR_CHECK_ERROR((*phEvent)->start());
         UR_CHECK_ERROR((*phEvent)->record());
       } catch (ur_result_t Err) {
@@ -1485,9 +1475,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
     UR_CHECK_ERROR(enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
                                      phEventWaitList));
     if (phEvent) {
-      EventPtr =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_USM_FILL, hQueue, CuStream, StreamToken));
+      EventPtr = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_USM_FILL, hQueue, CuStream, StreamToken);
       UR_CHECK_ERROR(EventPtr->start());
     }
 
@@ -1535,9 +1524,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     UR_CHECK_ERROR(enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
                                      phEventWaitList));
     if (phEvent) {
-      EventPtr =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_USM_MEMCPY, hQueue, CuStream));
+      EventPtr = std::make_unique<ur_event_handle_t_>(UR_COMMAND_USM_MEMCPY,
+                                                      hQueue, CuStream);
       UR_CHECK_ERROR(EventPtr->start());
     }
     UR_CHECK_ERROR(
@@ -1576,9 +1564,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     UR_CHECK_ERROR(enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
                                      phEventWaitList));
     if (phEvent) {
-      EventPtr =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_COPY, hQueue, CuStream));
+      EventPtr = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_COPY, hQueue, CuStream);
       UR_CHECK_ERROR(EventPtr->start());
     }
 
@@ -1631,9 +1618,8 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
     ScopedContext Active(hQueue->getDevice());
 
     if (phEvent) {
-      EventPtr =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_USM_ADVISE, hQueue, hQueue->getNextTransferStream()));
+      EventPtr = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_USM_ADVISE, hQueue, hQueue->getNextTransferStream());
       UR_CHECK_ERROR(EventPtr->start());
     }
 
@@ -1722,9 +1708,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
     std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_COPY_RECT, hQueue, cuStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_COPY_RECT, hQueue, cuStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1785,9 +1770,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_READ, hQueue, Stream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_READ, hQueue, Stream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1835,9 +1819,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_WRITE, hQueue, CuStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_WRITE, hQueue, CuStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1953,9 +1936,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     UR_CHECK_ERROR(enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
                                      phEventWaitList));
 
-    RetImplEvent =
-        std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-            UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, CuStream));
+    // Make sure profiling stream is created if the queue
+    if (!(hQueue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE)) {
+      hQueue->createHostSubmitTimeStream();
+    }
+
+    RetImplEvent = std::make_unique<ur_event_handle_t_>(
+        UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, CuStream);
     UR_CHECK_ERROR(RetImplEvent->start());
     UR_CHECK_ERROR(RetImplEvent->record());
 

--- a/unified-runtime/source/adapters/cuda/enqueue_native.cpp
+++ b/unified-runtime/source/adapters/cuda/enqueue_native.cpp
@@ -37,9 +37,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     }
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_ENQUEUE_NATIVE_EXP, hQueue, ActiveStream.getStream()));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_ENQUEUE_NATIVE_EXP, hQueue, ActiveStream.getStream());
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 

--- a/unified-runtime/source/adapters/cuda/event.cpp
+++ b/unified-runtime/source/adapters/cuda/event.cpp
@@ -19,25 +19,31 @@
 #include <cuda.h>
 
 ur_event_handle_t_::ur_event_handle_t_(ur_command_t Type,
-                                       ur_context_handle_t Context,
-                                       ur_queue_handle_t Queue,
-                                       native_type EvEnd, native_type EvQueued,
-                                       native_type EvStart, CUstream Stream,
+                                       ur_queue_handle_t Queue, CUstream Stream,
                                        uint32_t StreamToken)
-    : handle_base(), CommandType{Type}, RefCount{1}, HasOwnership{true},
-      HasBeenWaitedOn{false}, IsRecorded{false}, IsStarted{false},
-      StreamToken{StreamToken}, EventID{0}, EvEnd{EvEnd}, EvStart{EvStart},
-      EvQueued{EvQueued}, Queue{Queue}, Stream{Stream}, Context{Context} {
+    : handle_base(), CommandType{Type}, StreamToken{StreamToken}, Queue{Queue},
+      Stream{Stream}, Context{Queue->getContext()} {
+  auto flag = CU_EVENT_DISABLE_TIMING;
+
+  // If profiling information is required
+  if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
+      Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP) {
+    HasProfiling = true;
+    flag = CU_EVENT_DEFAULT;
+    UR_CHECK_ERROR(cuEventCreate(&EvQueued, flag));
+    UR_CHECK_ERROR(cuEventCreate(&EvStart, flag));
+  }
+
+  UR_CHECK_ERROR(cuEventCreate(&EvEnd, flag));
+
   urQueueRetain(Queue);
   urContextRetain(Context);
 }
 
 ur_event_handle_t_::ur_event_handle_t_(ur_context_handle_t Context,
                                        CUevent EventNative)
-    : handle_base(), CommandType{UR_COMMAND_EVENTS_WAIT}, RefCount{1},
-      HasOwnership{false}, HasBeenWaitedOn{false}, IsRecorded{false},
-      IsStarted{false}, IsInterop{true},
-      StreamToken{std::numeric_limits<uint32_t>::max()}, EventID{0},
+    : handle_base(), CommandType{UR_COMMAND_EVENTS_WAIT}, HasProfiling{false},
+      IsInterop{true}, StreamToken{std::numeric_limits<uint32_t>::max()},
       EvEnd{EventNative}, EvStart{nullptr}, EvQueued{nullptr}, Queue{nullptr},
       Stream{nullptr}, Context{Context} {
   urContextRetain(Context);
@@ -50,12 +56,28 @@ ur_event_handle_t_::~ur_event_handle_t_() {
   urContextRelease(Context);
 }
 
+ur_result_t ur_event_handle_t_::release() {
+  if (!HasOwnership)
+    return UR_RESULT_SUCCESS;
+
+  assert(Queue != nullptr);
+
+  UR_CHECK_ERROR(cuEventDestroy(EvEnd));
+
+  if (HasProfiling) {
+    UR_CHECK_ERROR(cuEventDestroy(EvQueued));
+    UR_CHECK_ERROR(cuEventDestroy(EvStart));
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
 ur_result_t ur_event_handle_t_::start() {
   assert(!isStarted());
   ur_result_t Result = UR_RESULT_SUCCESS;
 
   try {
-    if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
+    if (HasProfiling) {
       UR_CHECK_ERROR(cuEventRecord(EvQueued, Queue->getHostSubmitTimeStream()));
       UR_CHECK_ERROR(cuEventRecord(EvStart, Stream));
     }
@@ -65,40 +87,6 @@ ur_result_t ur_event_handle_t_::start() {
 
   IsStarted = true;
   return Result;
-}
-
-bool ur_event_handle_t_::isCompleted() const noexcept try {
-  if (!IsRecorded) {
-    return false;
-  }
-  if (!HasBeenWaitedOn) {
-    const CUresult Result = cuEventQuery(EvEnd);
-    if (Result != CUDA_SUCCESS && Result != CUDA_ERROR_NOT_READY) {
-      UR_CHECK_ERROR(Result);
-      return false;
-    }
-    if (Result == CUDA_ERROR_NOT_READY) {
-      return false;
-    }
-  }
-  return true;
-} catch (...) {
-  return exceptionToResult(std::current_exception()) == UR_RESULT_SUCCESS;
-}
-
-uint64_t ur_event_handle_t_::getQueuedTime() const {
-  assert(isStarted());
-  return Queue->getDevice()->getElapsedTime(EvQueued);
-}
-
-uint64_t ur_event_handle_t_::getStartTime() const {
-  assert(isStarted());
-  return Queue->getDevice()->getElapsedTime(EvStart);
-}
-
-uint64_t ur_event_handle_t_::getEndTime() const {
-  assert(isStarted() && isRecorded());
-  return Queue->getDevice()->getElapsedTime(EvEnd);
 }
 
 ur_result_t ur_event_handle_t_::record() {
@@ -133,20 +121,38 @@ ur_result_t ur_event_handle_t_::wait() {
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t ur_event_handle_t_::release() {
-  if (!backendHasOwnership())
-    return UR_RESULT_SUCCESS;
-
-  assert(Queue != nullptr);
-
-  UR_CHECK_ERROR(cuEventDestroy(EvEnd));
-
-  if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
-    UR_CHECK_ERROR(cuEventDestroy(EvQueued));
-    UR_CHECK_ERROR(cuEventDestroy(EvStart));
+bool ur_event_handle_t_::isCompleted() const noexcept try {
+  if (!IsRecorded) {
+    return false;
   }
+  if (!HasBeenWaitedOn) {
+    const CUresult Result = cuEventQuery(EvEnd);
+    if (Result != CUDA_SUCCESS && Result != CUDA_ERROR_NOT_READY) {
+      UR_CHECK_ERROR(Result);
+      return false;
+    }
+    if (Result == CUDA_ERROR_NOT_READY) {
+      return false;
+    }
+  }
+  return true;
+} catch (...) {
+  return exceptionToResult(std::current_exception()) == UR_RESULT_SUCCESS;
+}
 
-  return UR_RESULT_SUCCESS;
+uint64_t ur_event_handle_t_::getQueuedTime() const {
+  assert(isStarted());
+  return Queue->getDevice()->getElapsedTime(EvQueued);
+}
+
+uint64_t ur_event_handle_t_::getStartTime() const {
+  assert(isStarted());
+  return Queue->getDevice()->getElapsedTime(EvStart);
+}
+
+uint64_t ur_event_handle_t_::getEndTime() const {
+  assert(isStarted() && isRecorded());
+  return Queue->getDevice()->getElapsedTime(EvEnd);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
@@ -192,8 +198,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
   UrReturnHelper ReturnValue(propValueSize, pPropValue, pPropValueSizeRet);
 
   ur_queue_handle_t Queue = hEvent->getQueue();
-  if (Queue == nullptr || (!(Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE) &&
-                           !hEvent->isTimestampEvent())) {
+  if (Queue == nullptr || !hEvent->hasProfiling()) {
     return UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE;
   }
 
@@ -287,9 +292,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
   std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
 
   try {
-    EventPtr =
-        std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeWithNative(
-            hContext, reinterpret_cast<CUevent>(hNativeEvent)));
+    EventPtr = std::make_unique<ur_event_handle_t_>(
+        hContext, reinterpret_cast<CUevent>(hNativeEvent));
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {

--- a/unified-runtime/source/adapters/cuda/event.hpp
+++ b/unified-runtime/source/adapters/cuda/event.hpp
@@ -16,39 +16,28 @@
 #include "queue.hpp"
 
 /// UR Event mapping to CUevent
-///
 struct ur_event_handle_t_ : ur::cuda::handle_base {
-public:
   using native_type = CUevent;
 
-  ur_result_t record();
-
-  ur_result_t wait();
+  ur_event_handle_t_(
+      ur_command_t Type, ur_queue_handle_t Queue, CUstream Stream,
+      uint32_t StreamToken = std::numeric_limits<uint32_t>::max());
+  ur_event_handle_t_(ur_context_handle_t Context, CUevent EventNative);
+  ~ur_event_handle_t_();
+  ur_result_t release();
 
   ur_result_t start();
-
-  native_type get() const noexcept { return EvEnd; };
-
-  ur_queue_handle_t getQueue() const noexcept { return Queue; }
-
-  CUstream getStream() const noexcept { return Stream; }
-
-  uint32_t getComputeStreamToken() const noexcept { return StreamToken; }
-
-  ur_command_t getCommandType() const noexcept { return CommandType; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  ur_result_t record();
+  ur_result_t wait();
 
   bool isRecorded() const noexcept { return IsRecorded; }
-
   bool isStarted() const noexcept { return IsStarted; }
-
   bool isCompleted() const noexcept;
 
-  bool isInterop() const noexcept { return IsInterop; };
-
+  uint64_t getQueuedTime() const;
+  uint64_t getStartTime() const;
+  uint64_t getEndTime() const;
   uint32_t getExecutionStatus() const noexcept {
-
     if (!isRecorded()) {
       return UR_EVENT_STATUS_SUBMITTED;
     }
@@ -59,102 +48,48 @@ public:
     return UR_EVENT_STATUS_COMPLETE;
   }
 
-  bool isTimestampEvent() const noexcept {
-    return getCommandType() == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
-  }
+  bool isInterop() const noexcept { return IsInterop; };
+  bool hasProfiling() const noexcept { return HasProfiling; }
 
+  // Basic getters.
+  native_type get() const noexcept { return EvEnd; };
+  ur_queue_handle_t getQueue() const noexcept { return Queue; }
+  CUstream getStream() const noexcept { return Stream; }
+  uint32_t getComputeStreamToken() const noexcept { return StreamToken; }
+  ur_command_t getCommandType() const noexcept { return CommandType; }
   ur_context_handle_t getContext() const noexcept { return Context; };
-
-  uint32_t incrementReferenceCount() { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() { return --RefCount; }
-
   uint32_t getEventID() const noexcept { return EventID; }
 
-  bool backendHasOwnership() const noexcept { return HasOwnership; }
-
-  // Returns the counter time when the associated command(s) were enqueued
-  //
-  uint64_t getQueuedTime() const;
-
-  // Returns the counter time when the associated command(s) started execution
-  //
-  uint64_t getStartTime() const;
-
-  // Returns the counter time when the associated command(s) completed
-  //
-  uint64_t getEndTime() const;
-
-  // construct a native CUDA. This maps closely to the underlying CUDA event.
-  static ur_event_handle_t
-  makeNative(ur_command_t Type, ur_queue_handle_t Queue, CUstream Stream,
-             uint32_t StreamToken = std::numeric_limits<uint32_t>::max()) {
-    const bool RequiresTimings =
-        Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
-        Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
-    if (RequiresTimings) {
-      Queue->createHostSubmitTimeStream();
-    }
-    native_type EvEnd = nullptr, EvQueued = nullptr, EvStart = nullptr;
-    UR_CHECK_ERROR(cuEventCreate(
-        &EvEnd, RequiresTimings ? CU_EVENT_DEFAULT : CU_EVENT_DISABLE_TIMING));
-
-    if (RequiresTimings) {
-      UR_CHECK_ERROR(cuEventCreate(&EvQueued, CU_EVENT_DEFAULT));
-      UR_CHECK_ERROR(cuEventCreate(&EvStart, CU_EVENT_DEFAULT));
-    }
-    return new ur_event_handle_t_(Type, Queue->getContext(), Queue, EvEnd,
-                                  EvQueued, EvStart, Stream, StreamToken);
-  }
-
-  static ur_event_handle_t makeWithNative(ur_context_handle_t context,
-                                          CUevent eventNative) {
-    return new ur_event_handle_t_(context, eventNative);
-  }
-
-  ur_result_t release();
-
-  ~ur_event_handle_t_();
+  // Reference counting.
+  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  uint32_t incrementReferenceCount() { return ++RefCount; }
+  uint32_t decrementReferenceCount() { return --RefCount; }
 
 private:
-  // This constructor is private to force programmers to use the makeNative /
-  // make_user static members in order to create a pi_event for CUDA.
-  ur_event_handle_t_(ur_command_t Type, ur_context_handle_t Context,
-                     ur_queue_handle_t Queue, native_type EvEnd,
-                     native_type EvQueued, native_type EvStart, CUstream Stream,
-                     uint32_t StreamToken);
-
-  // This constructor is private to force programmers to use the
-  // makeWithNative for event interop
-  ur_event_handle_t_(ur_context_handle_t Context, CUevent EventNative);
-
   ur_command_t CommandType; // The type of command associated with event.
 
-  std::atomic_uint32_t RefCount; // Event reference count.
+  std::atomic_uint32_t RefCount{1}; // Event reference count.
 
-  bool HasOwnership; // Signifies if event owns the native type.
+  bool HasOwnership{true};  // Signifies if event owns the native type.
+  bool HasProfiling{false}; // Signifies if event has profiling information.
 
-  bool HasBeenWaitedOn; // Signifies whether the event has been waited
-                        // on through a call to wait(), which implies
-                        // that it has completed.
+  bool HasBeenWaitedOn{false}; // Signifies whether the event has been waited
+                               // on through a call to wait(), which implies
+                               // that it has completed.
 
-  bool IsRecorded; // Signifies wether a native CUDA event has been recorded
-                   // yet.
-  bool IsStarted;  // Signifies wether the operation associated with the
-                   // UR event has started or not
+  bool IsRecorded{false}; // Signifies wether a native CUDA event has been
+                          // recorded yet.
+  bool IsStarted{false};  // Signifies wether the operation associated with the
+                          // UR event has started or not
 
   const bool IsInterop{false}; // Made with urEventCreateWithNativeHandle
 
   uint32_t StreamToken;
-  uint32_t EventID; // Queue identifier of the event.
+  uint32_t EventID{0}; // Queue identifier of the event.
 
-  native_type EvEnd; // CUDA event handle. If this ur_event_handle_t represents
-                     // a user event, this will be nullptr.
-
-  native_type EvStart; // CUDA event handle associated with the start
-
-  native_type EvQueued; // CUDA event handle associated with the time
-                        // the command was enqueued
+  native_type EvEnd;    // Native event if IsInterop.
+  native_type EvStart;  // Profiling event for command start.
+  native_type EvQueued; // Profiling even for command enqueue.
 
   ur_queue_handle_t Queue; // ur_queue_handle_t associated with the event. If
                            // this is a user event, this will be nullptr.

--- a/unified-runtime/source/adapters/cuda/image.cpp
+++ b/unified-runtime/source/adapters/cuda/image.cpp
@@ -965,8 +965,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     }
 
     if (phEvent) {
-      auto NewEvent = ur_event_handle_t_::makeNative(UR_COMMAND_MEM_IMAGE_COPY,
-                                                     hQueue, Stream);
+      auto NewEvent =
+          new ur_event_handle_t_(UR_COMMAND_MEM_IMAGE_COPY, hQueue, Stream);
       NewEvent->record();
       *phEvent = NewEvent;
     }
@@ -1773,7 +1773,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
         Stream));
 
     if (phEvent) {
-      auto NewEvent = ur_event_handle_t_::makeNative(
+      auto NewEvent = new ur_event_handle_t_(
           UR_COMMAND_EXTERNAL_SEMAPHORE_WAIT_EXP, hQueue, Stream);
       NewEvent->record();
       *phEvent = NewEvent;
@@ -1808,7 +1808,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
         1 /* numExtSems */, Stream));
 
     if (phEvent) {
-      auto NewEvent = ur_event_handle_t_::makeNative(
+      auto NewEvent = new ur_event_handle_t_(
           UR_COMMAND_EXTERNAL_SEMAPHORE_SIGNAL_EXP, hQueue, Stream);
       NewEvent->record();
       *phEvent = NewEvent;

--- a/unified-runtime/source/adapters/hip/command_buffer.cpp
+++ b/unified-runtime/source/adapters/hip/command_buffer.cpp
@@ -799,9 +799,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCommandBufferExp(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent = std::unique_ptr<ur_event_handle_t_>(
-          ur_event_handle_t_::makeNative(UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP,
-                                         hQueue, HIPStream, StreamToken));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_ENQUEUE_COMMAND_BUFFER_EXP, hQueue, HIPStream,
+          StreamToken);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 

--- a/unified-runtime/source/adapters/hip/enqueue.cpp
+++ b/unified-runtime/source/adapters/hip/enqueue.cpp
@@ -163,9 +163,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_WRITE, hQueue, HIPStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_WRITE, hQueue, HIPStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -217,9 +216,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_READ, hQueue, HIPStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_READ, hQueue, HIPStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -306,9 +304,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
     // If migration of mem across buffer is needed, an event must be associated
     // with this command, implicitly if phEvent is nullptr
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_KERNEL_LAUNCH, hQueue, HIPStream, StreamToken));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_KERNEL_LAUNCH, hQueue, HIPStream, StreamToken);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -409,8 +406,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     }
 
     if (phEvent) {
-      *phEvent = ur_event_handle_t_::makeNative(
-          UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, hQueue, HIPStream, StreamToken);
+      *phEvent = new ur_event_handle_t_(UR_COMMAND_EVENTS_WAIT_WITH_BARRIER,
+                                        hQueue, HIPStream, StreamToken);
       UR_CHECK_ERROR((*phEvent)->start());
       UR_CHECK_ERROR((*phEvent)->record());
     }
@@ -510,9 +507,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, HIPStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, HIPStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -558,9 +554,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_WRITE, hQueue, HIPStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_WRITE, hQueue, HIPStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -608,9 +603,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     }
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_COPY, hQueue, Stream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_COPY, hQueue, Stream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -654,9 +648,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
                                      phEventWaitList));
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_COPY_RECT, hQueue, HIPStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_COPY_RECT, hQueue, HIPStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -814,9 +807,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
     }
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_WRITE, hQueue, Stream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_WRITE, hQueue, Stream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -978,9 +970,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
 
     std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, HIPStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, HIPStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1039,9 +1030,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
     std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, HIPStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, HIPStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1113,9 +1103,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
     std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, HIPStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_MEM_BUFFER_READ_RECT, hQueue, HIPStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1174,8 +1163,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
       }
 
       if (phEvent) {
-        *phEvent = ur_event_handle_t_::makeNative(
-            UR_COMMAND_MEM_BUFFER_MAP, hQueue, hQueue->getNextTransferStream());
+        *phEvent = new ur_event_handle_t_(UR_COMMAND_MEM_BUFFER_MAP, hQueue,
+                                          hQueue->getNextTransferStream());
         UR_CHECK_ERROR((*phEvent)->start());
         UR_CHECK_ERROR((*phEvent)->record());
       }
@@ -1224,8 +1213,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
       }
 
       if (phEvent) {
-        *phEvent = ur_event_handle_t_::makeNative(
-            UR_COMMAND_MEM_UNMAP, hQueue, hQueue->getNextTransferStream());
+        *phEvent = new ur_event_handle_t_(UR_COMMAND_MEM_UNMAP, hQueue,
+                                          hQueue->getNextTransferStream());
         UR_CHECK_ERROR((*phEvent)->start());
         UR_CHECK_ERROR((*phEvent)->record());
       }
@@ -1253,9 +1242,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
     UR_CHECK_ERROR(enqueueEventsWait(hQueue, HIPStream, numEventsInWaitList,
                                      phEventWaitList));
     if (phEvent) {
-      EventPtr =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_USM_FILL, hQueue, HIPStream, StreamToken));
+      EventPtr = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_USM_FILL, hQueue, HIPStream, StreamToken);
       UR_CHECK_ERROR(EventPtr->start());
     }
 
@@ -1307,9 +1295,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     UR_CHECK_ERROR(enqueueEventsWait(hQueue, HIPStream, numEventsInWaitList,
                                      phEventWaitList));
     if (phEvent) {
-      EventPtr =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_USM_MEMCPY, hQueue, HIPStream));
+      EventPtr = std::make_unique<ur_event_handle_t_>(UR_COMMAND_USM_MEMCPY,
+                                                      hQueue, HIPStream);
       UR_CHECK_ERROR(EventPtr->start());
     }
     UR_CHECK_ERROR(
@@ -1356,9 +1343,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
 
     if (phEvent) {
-      EventPtr =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_USM_PREFETCH, hQueue, HIPStream));
+      EventPtr = std::make_unique<ur_event_handle_t_>(UR_COMMAND_USM_PREFETCH,
+                                                      hQueue, HIPStream);
       UR_CHECK_ERROR(EventPtr->start());
     }
 
@@ -1426,9 +1412,8 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
     std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
 
     if (phEvent) {
-      EventPtr =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_USM_ADVISE, hQueue, hQueue->getNextTransferStream()));
+      EventPtr = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_USM_ADVISE, hQueue, hQueue->getNextTransferStream());
       EventPtr->start();
     }
 
@@ -1560,9 +1545,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
     std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_USM_MEMCPY_2D, hQueue, HIPStream));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_USM_MEMCPY_2D, hQueue, HIPStream);
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
@@ -1905,9 +1889,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     UR_CHECK_ERROR(enqueueEventsWait(hQueue, HIPStream, numEventsInWaitList,
                                      phEventWaitList));
 
-    RetImplEvent =
-        std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-            UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, HIPStream));
+    RetImplEvent = std::make_unique<ur_event_handle_t_>(
+        UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, HIPStream);
     UR_CHECK_ERROR(RetImplEvent->start());
     UR_CHECK_ERROR(RetImplEvent->record());
 

--- a/unified-runtime/source/adapters/hip/enqueue_native.cpp
+++ b/unified-runtime/source/adapters/hip/enqueue_native.cpp
@@ -40,9 +40,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     }
 
     if (phEvent) {
-      RetImplEvent =
-          std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-              UR_COMMAND_ENQUEUE_NATIVE_EXP, hQueue, ActiveStream.getStream()));
+      RetImplEvent = std::make_unique<ur_event_handle_t_>(
+          UR_COMMAND_ENQUEUE_NATIVE_EXP, hQueue, ActiveStream.getStream());
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 

--- a/unified-runtime/source/adapters/hip/event.cpp
+++ b/unified-runtime/source/adapters/hip/event.cpp
@@ -14,25 +14,29 @@
 #include "platform.hpp"
 
 ur_event_handle_t_::ur_event_handle_t_(ur_command_t Type,
-                                       ur_context_handle_t Context,
                                        ur_queue_handle_t Queue,
-                                       hipEvent_t EvEnd, hipEvent_t EvQueued,
-                                       hipEvent_t EvStart, hipStream_t Stream,
-                                       uint32_t StreamToken)
-    : handle_base(), CommandType{Type}, RefCount{1}, HasOwnership{true},
-      HasBeenWaitedOn{false}, IsRecorded{false}, IsStarted{false},
-      StreamToken{StreamToken}, EventId{0}, EvEnd{EvEnd}, EvStart{EvStart},
-      EvQueued{EvQueued}, Queue{Queue}, Stream{Stream}, Context{Context} {
+                                       hipStream_t Stream, uint32_t StreamToken)
+    : handle_base(), CommandType{Type}, StreamToken{StreamToken}, Queue{Queue},
+      Stream{Stream}, Context{Queue->getContext()} {
+  auto flag = hipEventDisableTiming;
+  if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
+      Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP) {
+    flag = hipEventDefault;
+    HasProfiling = true;
+    UR_CHECK_ERROR(hipEventCreateWithFlags(&EvQueued, flag));
+    UR_CHECK_ERROR(hipEventCreateWithFlags(&EvStart, flag));
+  }
+
+  UR_CHECK_ERROR(hipEventCreateWithFlags(&EvEnd, flag));
+
   urQueueRetain(Queue);
   urContextRetain(Context);
 }
 
 ur_event_handle_t_::ur_event_handle_t_(ur_context_handle_t Context,
                                        hipEvent_t EventNative)
-    : handle_base(), CommandType{UR_COMMAND_EVENTS_WAIT}, RefCount{1},
-      HasOwnership{false}, HasBeenWaitedOn{false}, IsRecorded{false},
-      IsStarted{false}, IsInterop{true},
-      StreamToken{std::numeric_limits<uint32_t>::max()}, EventId{0},
+    : handle_base(), CommandType{UR_COMMAND_EVENTS_WAIT}, HasOwnership{false},
+      IsInterop{true}, StreamToken{std::numeric_limits<uint32_t>::max()},
       EvEnd{EventNative}, EvStart{nullptr}, EvQueued{nullptr}, Queue{nullptr},
       Stream{nullptr}, Context{Context} {
   urContextRetain(Context);
@@ -45,12 +49,27 @@ ur_event_handle_t_::~ur_event_handle_t_() {
   urContextRelease(Context);
 }
 
+ur_result_t ur_event_handle_t_::release() {
+  if (!HasOwnership)
+    return UR_RESULT_SUCCESS;
+
+  assert(Queue != nullptr);
+  UR_CHECK_ERROR(hipEventDestroy(EvEnd));
+
+  if (HasProfiling) {
+    UR_CHECK_ERROR(hipEventDestroy(EvQueued));
+    UR_CHECK_ERROR(hipEventDestroy(EvStart));
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
 ur_result_t ur_event_handle_t_::start() {
   assert(!isStarted());
   ur_result_t Result = UR_RESULT_SUCCESS;
 
   try {
-    if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
+    if (HasProfiling) {
       UR_CHECK_ERROR(
           hipEventRecord(EvQueued, Queue->getHostSubmitTimeStream()));
       UR_CHECK_ERROR(hipEventRecord(EvStart, Stream));
@@ -61,38 +80,6 @@ ur_result_t ur_event_handle_t_::start() {
 
   IsStarted = true;
   return Result;
-}
-
-bool ur_event_handle_t_::isCompleted() const {
-  if (!IsRecorded) {
-    return false;
-  }
-  if (!HasBeenWaitedOn) {
-    const hipError_t Result = hipEventQuery(EvEnd);
-    if (Result != hipSuccess && Result != hipErrorNotReady) {
-      UR_CHECK_ERROR(Result);
-      return false;
-    }
-    if (Result == hipErrorNotReady) {
-      return false;
-    }
-  }
-  return true;
-}
-
-uint64_t ur_event_handle_t_::getQueuedTime() const {
-  assert(isStarted());
-  return Queue->getDevice()->getElapsedTime(EvQueued);
-}
-
-uint64_t ur_event_handle_t_::getStartTime() const {
-  assert(isStarted());
-  return Queue->getDevice()->getElapsedTime(EvStart);
-}
-
-uint64_t ur_event_handle_t_::getEndTime() const {
-  assert(isStarted() && isRecorded());
-  return Queue->getDevice()->getElapsedTime(EvEnd);
 }
 
 ur_result_t ur_event_handle_t_::record() {
@@ -127,19 +114,36 @@ ur_result_t ur_event_handle_t_::wait() {
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t ur_event_handle_t_::release() {
-  if (!backendHasOwnership())
-    return UR_RESULT_SUCCESS;
-
-  assert(Queue != nullptr);
-  UR_CHECK_ERROR(hipEventDestroy(EvEnd));
-
-  if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
-    UR_CHECK_ERROR(hipEventDestroy(EvQueued));
-    UR_CHECK_ERROR(hipEventDestroy(EvStart));
+bool ur_event_handle_t_::isCompleted() const {
+  if (!IsRecorded) {
+    return false;
   }
+  if (!HasBeenWaitedOn) {
+    const hipError_t Result = hipEventQuery(EvEnd);
+    if (Result != hipSuccess && Result != hipErrorNotReady) {
+      UR_CHECK_ERROR(Result);
+      return false;
+    }
+    if (Result == hipErrorNotReady) {
+      return false;
+    }
+  }
+  return true;
+}
 
-  return UR_RESULT_SUCCESS;
+uint64_t ur_event_handle_t_::getQueuedTime() const {
+  assert(isStarted());
+  return Queue->getDevice()->getElapsedTime(EvQueued);
+}
+
+uint64_t ur_event_handle_t_::getStartTime() const {
+  assert(isStarted());
+  return Queue->getDevice()->getElapsedTime(EvStart);
+}
+
+uint64_t ur_event_handle_t_::getEndTime() const {
+  assert(isStarted() && isRecorded());
+  return Queue->getDevice()->getElapsedTime(EvEnd);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -211,8 +215,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
   UR_ASSERT(!(pPropValue && propValueSize == 0), UR_RESULT_ERROR_INVALID_VALUE);
 
   ur_queue_handle_t Queue = hEvent->getQueue();
-  if (Queue == nullptr || (!(Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE) &&
-                           !hEvent->isTimestampEvent())) {
+  if (Queue == nullptr || !hEvent->hasProfiling()) {
     return UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE;
   }
 
@@ -299,9 +302,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
   std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
 
   try {
-    EventPtr =
-        std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeWithNative(
-            hContext, reinterpret_cast<hipEvent_t>(hNativeEvent)));
+    EventPtr = std::make_unique<ur_event_handle_t_>(
+        hContext, reinterpret_cast<hipEvent_t>(hNativeEvent));
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {

--- a/unified-runtime/source/adapters/hip/event.hpp
+++ b/unified-runtime/source/adapters/hip/event.hpp
@@ -13,37 +13,27 @@
 #include "queue.hpp"
 
 /// UR Event mapping to hipEvent_t
-///
 struct ur_event_handle_t_ : ur::hip::handle_base {
-public:
   using native_type = hipEvent_t;
 
-  ur_result_t record();
-
-  ur_result_t wait();
+  ur_event_handle_t_(
+      ur_command_t Type, ur_queue_handle_t Queue, hipStream_t Stream,
+      uint32_t StreamToken = std::numeric_limits<uint32_t>::max());
+  ur_event_handle_t_(ur_context_handle_t Context, hipEvent_t EventNative);
+  ~ur_event_handle_t_();
+  ur_result_t release();
 
   ur_result_t start();
-
-  native_type get() const noexcept { return EvEnd; };
-
-  ur_queue_handle_t getQueue() const noexcept { return Queue; }
-
-  hipStream_t getStream() const noexcept { return Stream; }
-
-  uint32_t getComputeStreamToken() const noexcept { return StreamToken; }
-
-  ur_command_t getCommandType() const noexcept { return CommandType; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  ur_result_t record();
+  ur_result_t wait();
 
   bool isRecorded() const noexcept { return IsRecorded; }
-
   bool isStarted() const noexcept { return IsStarted; }
-
   bool isCompleted() const;
 
-  bool isInterop() const noexcept { return IsInterop; };
-
+  uint64_t getQueuedTime() const;
+  uint64_t getStartTime() const;
+  uint64_t getEndTime() const;
   uint32_t getExecutionStatus() const {
     if (!isRecorded()) {
       return UR_EVENT_STATUS_SUBMITTED;
@@ -55,100 +45,48 @@ public:
     return UR_EVENT_STATUS_COMPLETE;
   }
 
-  bool isTimestampEvent() const noexcept {
-    return getCommandType() == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
-  }
+  bool isInterop() const noexcept { return IsInterop; };
+  bool hasProfiling() const noexcept { return HasProfiling; }
 
+  // Basic getters.
+  native_type get() const noexcept { return EvEnd; };
+  ur_queue_handle_t getQueue() const noexcept { return Queue; }
+  hipStream_t getStream() const noexcept { return Stream; }
+  uint32_t getComputeStreamToken() const noexcept { return StreamToken; }
+  ur_command_t getCommandType() const noexcept { return CommandType; }
   ur_context_handle_t getContext() const noexcept { return Context; };
-
-  uint32_t incrementReferenceCount() { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() { return --RefCount; }
-
   uint32_t getEventId() const noexcept { return EventId; }
 
-  bool backendHasOwnership() const noexcept { return HasOwnership; }
-
-  // Returns the counter time when the associated command(s) were enqueued
-  uint64_t getQueuedTime() const;
-
-  // Returns the counter time when the associated command(s) started execution
-  uint64_t getStartTime() const;
-
-  // Returns the counter time when the associated command(s) completed
-  uint64_t getEndTime() const;
-
-  // construct a native HIP. This maps closely to the underlying HIP event.
-  static ur_event_handle_t
-  makeNative(ur_command_t Type, ur_queue_handle_t Queue, hipStream_t Stream,
-             uint32_t StreamToken = std::numeric_limits<uint32_t>::max()) {
-    const bool RequiresTimings =
-        Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
-        Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
-    if (RequiresTimings) {
-      Queue->createHostSubmitTimeStream();
-    }
-    native_type EvEnd{nullptr}, EvQueued{nullptr}, EvStart{nullptr};
-    UR_CHECK_ERROR(hipEventCreateWithFlags(
-        &EvEnd, RequiresTimings ? hipEventDefault : hipEventDisableTiming));
-
-    if (RequiresTimings) {
-      UR_CHECK_ERROR(hipEventCreateWithFlags(&EvQueued, hipEventDefault));
-      UR_CHECK_ERROR(hipEventCreateWithFlags(&EvStart, hipEventDefault));
-    }
-
-    return new ur_event_handle_t_(Type, Queue->getContext(), Queue, EvEnd,
-                                  EvQueued, EvStart, Stream, StreamToken);
-  }
-
-  static ur_event_handle_t makeWithNative(ur_context_handle_t context,
-                                          hipEvent_t eventNative) {
-    return new ur_event_handle_t_(context, eventNative);
-  }
-
-  ur_result_t release();
-
-  ~ur_event_handle_t_();
+  // Reference counting.
+  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  uint32_t incrementReferenceCount() { return ++RefCount; }
+  uint32_t decrementReferenceCount() { return --RefCount; }
 
 private:
-  // This constructor is private to force programmers to use the makeNative /
-  // make_user static members in order to create a ur_event_handle_t for HIP.
-  ur_event_handle_t_(ur_command_t Type, ur_context_handle_t Context,
-                     ur_queue_handle_t Queue, native_type EvEnd,
-                     native_type EvQueued, native_type EvStart,
-                     hipStream_t Stream, uint32_t StreamToken);
-
-  // This constructor is private to force programmers to use the
-  // makeWithNative for event interop
-  ur_event_handle_t_(ur_context_handle_t Context, hipEvent_t EventNative);
-
   ur_command_t CommandType; // The type of command associated with event.
 
-  std::atomic_uint32_t RefCount; // Event reference count.
+  std::atomic_uint32_t RefCount{1}; // Event reference count.
 
-  bool HasOwnership; // Signifies if event owns the native type.
+  bool HasOwnership{true};  // Signifies if event owns the native type.
+  bool HasProfiling{false}; // Signifies if event has profiling information.
 
-  bool HasBeenWaitedOn; // Signifies whether the event has been waited
-                        // on through a call to wait(), which implies
-                        // that it has completed.
+  bool HasBeenWaitedOn{false}; // Signifies whether the event has been waited
+                               // on through a call to wait(), which implies
+                               // that it has completed.
 
-  bool IsRecorded; // Signifies wether a native HIP event has been recorded
-                   // yet.
-  bool IsStarted;  // Signifies wether the operation associated with the
-                   // UR event has started or not
+  bool IsRecorded{false}; // Signifies wether a native HIP event has been
+                          // recorded yet.
+  bool IsStarted{false};  // Signifies wether the operation associated with the
+                          // UR event has started or not
 
   const bool IsInterop{false}; // Made with urEventCreateWithNativeHandle
 
   uint32_t StreamToken;
-  uint32_t EventId; // Queue identifier of the event.
+  uint32_t EventId{0}; // Queue identifier of the event.
 
-  native_type EvEnd; // HIP event handle. If this ur_event_handle_t_
-                     // represents a user event, this will be nullptr.
-
-  native_type EvStart; // HIP event handle associated with the start
-
-  native_type EvQueued; // HIP event handle associated with the time
-                        // the command was enqueued
+  native_type EvEnd;    // Native event if IsInterop.
+  native_type EvStart;  // Profiling event for command start.
+  native_type EvQueued; // Profiling even for command enqueue.
 
   ur_queue_handle_t Queue; // ur_queue_handle_t associated with the event. If
                            // this is a user event, this will be nullptr.

--- a/unified-runtime/source/adapters/hip/image.cpp
+++ b/unified-runtime/source/adapters/hip/image.cpp
@@ -963,8 +963,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     }
 
     if (phEvent) {
-      auto NewEvent = ur_event_handle_t_::makeNative(UR_COMMAND_MEM_IMAGE_COPY,
-                                                     hQueue, Stream);
+      auto NewEvent =
+          new ur_event_handle_t_(UR_COMMAND_MEM_IMAGE_COPY, hQueue, Stream);
       NewEvent->record();
       *phEvent = NewEvent;
     }
@@ -1597,7 +1597,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
         1 /* numExtSems */, Stream));
 
     if (phEvent) {
-      auto NewEvent = ur_event_handle_t_::makeNative(
+      auto NewEvent = new ur_event_handle_t_(
           UR_COMMAND_EXTERNAL_SEMAPHORE_WAIT_EXP, hQueue, Stream);
       NewEvent->record();
       *phEvent = NewEvent;
@@ -1632,7 +1632,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
         &SemSignalParams, 1 /* numExtSems */, Stream));
 
     if (phEvent) {
-      auto NewEvent = ur_event_handle_t_::makeNative(
+      auto NewEvent = new ur_event_handle_t_(
           UR_COMMAND_EXTERNAL_SEMAPHORE_SIGNAL_EXP, hQueue, Stream);
       NewEvent->record();
       *phEvent = NewEvent;

--- a/unified-runtime/source/common/cuda-hip/stream_queue.hpp
+++ b/unified-runtime/source/common/cuda-hip/stream_queue.hpp
@@ -76,6 +76,11 @@ struct stream_queue_t {
         Device{Device}, Flags(Flags), URFlags(URFlags), Priority(Priority),
         HasOwnership{true} {
     urContextRetain(Context);
+
+    // Create timing stream is profiling is enabled.
+    if (URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE) {
+      createHostSubmitTimeStream();
+    }
   }
 
   // Create a queue from a native handle
@@ -89,6 +94,11 @@ struct stream_queue_t {
         Device{Device}, NumComputeStreams{1}, Flags(Flags), URFlags(URFlags),
         Priority(0), HasOwnership{BackendOwns} {
     urContextRetain(Context);
+
+    // Create timing stream is profiling is enabled.
+    if (URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE) {
+      createHostSubmitTimeStream();
+    }
   }
 
   ~stream_queue_t() { urContextRelease(Context); }


### PR DESCRIPTION
- Use constructor instead of unnecessary makeNative function
- Move profiling stream constructor to queue and timestamp command
- Simplify even creation code
- Use make_unique
- Re-organize event.hpp and event.cpp

This is mostly NFC, the one behavior change is that we no longer create the profiling stream in event creation, it will be created either when we build a profiling queue, or when we enqueue a timestamp event. Which mostly means that it will be created a bit sooner for profiling queues.