### PR TITLE
[UR][Graph] Disable flaky CTS test on L0 v2

### DIFF
--- a/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
@@ -22,6 +22,9 @@ struct urEnqueueCommandBufferExpTest
     program_name = "increment";
     UUR_RETURN_ON_FATAL_FAILURE(urCommandBufferExpExecutionTest::SetUp());
 
+    // https://github.com/intel/llvm/issues/18610
+    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
+
     // Create an in-order queue
     ur_queue_properties_t queue_properties = {
         UR_STRUCTURE_TYPE_QUEUE_PROPERTIES, nullptr, 0};
@@ -113,9 +116,6 @@ TEST_P(urEnqueueCommandBufferExpTest, SerializeAcrossQueues) {
 // Tests that submitting a command-buffer twice to an out-of-order queue
 // relying on implicit serialization semantics for dependencies.
 TEST_P(urEnqueueCommandBufferExpTest, SerializeOutofOrderQueue) {
-  // https://github.com/intel/llvm/issues/18610
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
-
   ASSERT_SUCCESS(urEnqueueCommandBufferExp(out_of_order_queue, cmd_buf_handle,
                                            0, nullptr, nullptr));
   ASSERT_SUCCESS(urEnqueueCommandBufferExp(out_of_order_queue, cmd_buf_handle,


### PR DESCRIPTION
Hoists the `UUR_KNOWN_FAILURE_ON()` introduced in https://github.com/intel/llvm/pull/18611 up to the test fixture to also cover `urEnqueueCommandBufferExpTest.SerializeAcrossQueues` in addition to `urEnqueueCommandBufferExpTest.SerializeOutofOrderQueue`.
