### PR TITLE
[SYCL] optimize graph recording on in-order queue

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph/InOrderQueue.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/InOrderQueue.cpp
@@ -313,11 +313,11 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
 
   auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
   auto WaitList = EventLastImpl->getWaitList();
-  Lock.unlock();
   // Previous task is a host task. Explicit dependency is needed to enforce the
   // execution order.
   ASSERT_EQ(WaitList.size(), 1lu);
   ASSERT_EQ(WaitList[0], EventInitialImpl);
+  Lock.unlock();
   InOrderQueue.wait();
 }
 


### PR DESCRIPTION
Graphs already store dependencies internally (the logic is in handler.finalize()). There is no need to use lastEvent from queue to guarantee proper synchronization.