### PR TITLE
[SYCL] Add state arguments to SYCLBIN options

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7300,8 +7300,9 @@ defm sycl_allow_device_image_dependencies: BoolOptionWithoutMarshalling<"f", "sy
 def fsycl_dump_device_code_EQ : Joined<["-"], "fsycl-dump-device-code=">,
   Flags<[NoXarchOption]>,
   HelpText<"Dump device code into the user provided directory.">;
-def fsyclbin : Flag<["-"], "fsyclbin">,
-  HelpText<"Create a SYCLBIN file">;
+def fsyclbin_EQ : Joined<["-"], "fsyclbin=">,
+  HelpText<"Output in the SYCLBIN binary format in the state specified by <arg> (input, object or executable (default))">;
+def fsyclbin : Flag<["-"], "fsyclbin">, Alias<fsyclbin_EQ>;
 } // let Group = sycl_Group
 
 // FIXME: -fsycl-explicit-simd is deprecated. remove it when support is dropped.

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1230,7 +1230,8 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
   bool IsSYCL = C.getInputArgs().hasFlag(options::OPT_fsycl,
                                          options::OPT_fno_sycl, false) ||
                 C.getInputArgs().hasArgNoClaim(options::OPT_fsycl_device_only,
-                                               options::OPT_fsyclbin);
+                                               options::OPT_fsyclbin,
+                                               options::OPT_fsyclbin_EQ);
 
   auto argSYCLIncompatible = [&](OptSpecifier OptId) {
     if (!IsSYCL)
@@ -3470,7 +3471,8 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
   Arg *InputTypeArg = nullptr;
   bool IsSYCL =
       Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) ||
-      Args.hasArgNoClaim(options::OPT_fsycl_device_only, options::OPT_fsyclbin);
+      Args.hasArgNoClaim(options::OPT_fsycl_device_only, options::OPT_fsyclbin,
+                         options::OPT_fsyclbin_EQ);
 
   // The last /TC or /TP option sets the input type to C or C++ globally.
   if (Arg *TCTP = Args.getLastArgNoClaim(options::OPT__SLASH_TC,
@@ -7958,7 +7960,8 @@ Action *Driver::BuildOffloadingActions(Compilation &C,
     DDep.add(*FatbinAction, *C.getSingleOffloadToolChain<Action::OFK_HIP>(),
              nullptr, Action::OFK_HIP);
   } else if (C.isOffloadingHostKind(Action::OFK_SYCL) &&
-             Args.hasArg(options::OPT_fsyclbin)) {
+             (Args.hasArg(options::OPT_fsyclbin) ||
+              Args.hasArg(options::OPT_fsyclbin_EQ))) {
     // With '-fsyclbin', package all the offloading actions into a single output
     // that is sent to the clang-linker-wrapper.
     Action *PackagerAction =
@@ -9382,7 +9385,8 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
       return C.addResultFile(FinalOutput->getValue(), &JA);
     // Output to destination for -fsycl-device-only/-fsyclbin and Windows -o
     if ((offloadDeviceOnly() ||
-         C.getArgs().hasArgNoClaim(options::OPT_fsyclbin)) &&
+         C.getArgs().hasArgNoClaim(options::OPT_fsyclbin,
+                                   options::OPT_fsyclbin_EQ)) &&
         JA.getOffloadingDeviceKind() == Action::OFK_SYCL)
       if (Arg *FinalOutput = C.getArgs().getLastArg(options::OPT__SLASH_o))
         return C.addResultFile(FinalOutput->getValue(), &JA);
@@ -9556,7 +9560,8 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
   // resulting image.  A '.syclbin' extension is used to represent the resulting
   // output file.
   if (JA.getOffloadingDeviceKind() == Action::OFK_SYCL &&
-      C.getArgs().hasArgNoClaim(options::OPT_fsyclbin) &&
+      C.getArgs().hasArgNoClaim(options::OPT_fsyclbin,
+                                options::OPT_fsyclbin_EQ) &&
       JA.getType() == types::TY_Image) {
     SmallString<128> SYCLBinOutput(getDefaultImageName());
     if (IsCLMode())

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11508,8 +11508,14 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
             Args.MakeArgString("--sycl-target-link-options=" + LinkOptString));
     }
     // Add option to enable creating of the .syclbin file.
-    if (Args.hasArg(options::OPT_fsyclbin))
-      CmdArgs.push_back(Args.MakeArgString("--syclbin"));
+    if (Arg *A =
+            Args.getLastArg(options::OPT_fsyclbin, options::OPT_fsyclbin_EQ)) {
+      StringRef SYCLBINState = A->getValue();
+      if (SYCLBINState.empty())
+        SYCLBINState = "executable";
+      CmdArgs.push_back(
+          Args.MakeArgString("--syclbin=" + StringRef{SYCLBINState}));
+    }
   }
 
   // Construct the link job so we can wrap around it.

--- a/clang/test/Driver/fsyclbin.cpp
+++ b/clang/test/Driver/fsyclbin.cpp
@@ -15,16 +15,55 @@
 
 /// Check tool invocation contents.
 // RUN: %clangxx -fsycl -fsyclbin --offload-new-driver %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_DEFAULT
 // RUN: %clangxx -fsyclbin --offload-new-driver %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_DEFAULT
 // RUN: %clang_cl -fsycl -fsyclbin --offload-new-driver %s -### 2>&1 \
-// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS
-// CHECK_TOOLS: clang-offload-packager
-// CHECK_TOOLS-SAME: --image=file={{.*}}.bc,triple=spir64-unknown-unknown
-// CHECK_TOOLS-SAME: kind=sycl
-// CHECK_TOOLS: clang-linker-wrapper
-// CHECK_TOOLS-SAME: --syclbin
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_DEFAULT
+// CHECK_TOOLS_DEFAULT: clang-offload-packager
+// CHECK_TOOLS_DEFAULT-SAME: --image=file={{.*}}.bc,triple=spir64-unknown-unknown
+// CHECK_TOOLS_DEFAULT-SAME: kind=sycl
+// CHECK_TOOLS_DEFAULT: clang-linker-wrapper
+// CHECK_TOOLS_DEFAULT-SAME: --syclbin=executable
+
+/// Check tool invocation contents.
+// RUN: %clangxx -fsycl -fsyclbin=input --offload-new-driver %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_INPUT
+// RUN: %clangxx -fsyclbin=input --offload-new-driver %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_INPUT
+// RUN: %clang_cl -fsycl -fsyclbin=input --offload-new-driver %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_INPUT
+// CHECK_TOOLS_INPUT: clang-offload-packager
+// CHECK_TOOLS_INPUT-SAME: --image=file={{.*}}.bc,triple=spir64-unknown-unknown
+// CHECK_TOOLS_INPUT-SAME: kind=sycl
+// CHECK_TOOLS_INPUT: clang-linker-wrapper
+// CHECK_TOOLS_INPUT-SAME: --syclbin=input
+
+/// Check tool invocation contents.
+// RUN: %clangxx -fsycl -fsyclbin=object --offload-new-driver %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_OBJECT
+// RUN: %clangxx -fsyclbin=object --offload-new-driver %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_OBJECT
+// RUN: %clang_cl -fsycl -fsyclbin=object --offload-new-driver %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_OBJECT
+// CHECK_TOOLS_OBJECT: clang-offload-packager
+// CHECK_TOOLS_OBJECT-SAME: --image=file={{.*}}.bc,triple=spir64-unknown-unknown
+// CHECK_TOOLS_OBJECT-SAME: kind=sycl
+// CHECK_TOOLS_OBJECT: clang-linker-wrapper
+// CHECK_TOOLS_OBJECT-SAME: --syclbin=object
+
+/// Check tool invocation contents.
+// RUN: %clangxx -fsycl -fsyclbin=executable --offload-new-driver %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_EXECUTABLE
+// RUN: %clangxx -fsyclbin=executable --offload-new-driver %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_EXECUTABLE
+// RUN: %clang_cl -fsycl -fsyclbin=executable --offload-new-driver %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_EXECUTABLE
+// CHECK_TOOLS_EXECUTABLE: clang-offload-packager
+// CHECK_TOOLS_EXECUTABLE-SAME: --image=file={{.*}}.bc,triple=spir64-unknown-unknown
+// CHECK_TOOLS_EXECUTABLE-SAME: kind=sycl
+// CHECK_TOOLS_EXECUTABLE: clang-linker-wrapper
+// CHECK_TOOLS_EXECUTABLE-SAME: --syclbin=executable
 
 /// Check compilation phases, only device compile should be performed
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl -fsyclbin \

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -238,6 +238,6 @@ def sycl_allow_device_image_dependencies : Flag<["--", "-"], "sycl-allow-device-
   HelpText<"Allow dependencies between device code images">;
 
 // Options to force the output to be of the SYCLBIN format.
-def syclbin : Flag<["--", "-"], "syclbin">,
+def syclbin_EQ : Joined<["--", "-"], "syclbin=">,
   Flags<[WrapperOnlyOption]>,
-  HelpText<"Output in the SYCLBIN binary format">;
+  HelpText<"Output in the SYCLBIN binary format in the state specified by <arg> (input, object or executable)">;

--- a/sycl/test/syclbin/simple_kernel.cpp
+++ b/sycl/test/syclbin/simple_kernel.cpp
@@ -1,5 +1,11 @@
-// RUN: %clangxx --offload-new-driver -fsyclbin -o %t.syclbin %s
-// RUN: syclbin-dump %t.syclbin | FileCheck %s
+// RUN: %clangxx --offload-new-driver -fsyclbin=input -o %t.input.syclbin %s
+// RUN: %clangxx --offload-new-driver -fsyclbin=object -o %t.object.syclbin %s
+// RUN: %clangxx --offload-new-driver -fsyclbin=executable -o %t.executable.syclbin %s
+// RUN: %clangxx --offload-new-driver -fsyclbin -o %t.default.syclbin %s
+// RUN: syclbin-dump %t.input.syclbin | FileCheck %s --check-prefix CHECK-INPUT
+// RUN: syclbin-dump %t.object.syclbin | FileCheck %s --check-prefix CHECK-OBJECT
+// RUN: syclbin-dump %t.executable.syclbin | FileCheck %s --check-prefix CHECK-EXECUTABLE
+// RUN: syclbin-dump %t.default.syclbin | FileCheck %s --check-prefix CHECK-EXECUTABLE
 
 // Checks the generated SYCLBIN contents of a simple SYCL free function kernel.
 
@@ -14,17 +20,47 @@ void TestKernel(int *Ptr, int Size) {
 }
 }
 
-// CHECK:      Version: {{[1-9]+}}
-// CHECK-NEXT: Global metadata:
-// CHECK-NEXT:   SYCLBIN/global metadata:
-// CHECK-NEXT:     state: 0
-// CHECK-NEXT: Number of Abstract Modules: 1
-// CHECK-NEXT: Abstract Module 0:
-// CHECK-NEXT:   Metadata:
-// CHECK:      Number of IR Modules: 1
-// CHECK-NEXT:   IR module 0:
-// CHECK-NEXT:       Metadata:
-// CHECK-NEXT:         SYCLBIN/ir module metadata:
-// CHECK-NEXT:           type: 0
-// CHECK-NEXT:     Raw IR bytes: <Binary blob of {{.*}} bytes>
-// CHECK-NEXT:   Number of Native Device Code Images: 0
+// CHECK-INPUT:      Version: {{[1-9]+}}
+// CHECK-INPUT-NEXT: Global metadata:
+// CHECK-INPUT-NEXT:   SYCLBIN/global metadata:
+// CHECK-INPUT-NEXT:     state: 0
+// CHECK-INPUT-NEXT: Number of Abstract Modules: 1
+// CHECK-INPUT-NEXT: Abstract Module 0:
+// CHECK-INPUT-NEXT:   Metadata:
+// CHECK-INPUT:      Number of IR Modules: 1
+// CHECK-INPUT-NEXT:   IR module 0:
+// CHECK-INPUT-NEXT:       Metadata:
+// CHECK-INPUT-NEXT:         SYCLBIN/ir module metadata:
+// CHECK-INPUT-NEXT:           type: 0
+// CHECK-INPUT-NEXT:     Raw IR bytes: <Binary blob of {{.*}} bytes>
+// CHECK-INPUT-NEXT:   Number of Native Device Code Images: 0
+
+// CHECK-OBJECT:      Version: {{[1-9]+}}
+// CHECK-OBJECT-NEXT: Global metadata:
+// CHECK-OBJECT-NEXT:   SYCLBIN/global metadata:
+// CHECK-OBJECT-NEXT:     state: 1
+// CHECK-OBJECT-NEXT: Number of Abstract Modules: 1
+// CHECK-OBJECT-NEXT: Abstract Module 0:
+// CHECK-OBJECT-NEXT:   Metadata:
+// CHECK-OBJECT:      Number of IR Modules: 1
+// CHECK-OBJECT-NEXT:   IR module 0:
+// CHECK-OBJECT-NEXT:       Metadata:
+// CHECK-OBJECT-NEXT:         SYCLBIN/ir module metadata:
+// CHECK-OBJECT-NEXT:           type: 0
+// CHECK-OBJECT-NEXT:     Raw IR bytes: <Binary blob of {{.*}} bytes>
+// CHECK-OBJECT-NEXT:   Number of Native Device Code Images: 0
+
+// CHECK-EXECUTABLE:      Version: {{[1-9]+}}
+// CHECK-EXECUTABLE-NEXT: Global metadata:
+// CHECK-EXECUTABLE-NEXT:   SYCLBIN/global metadata:
+// CHECK-EXECUTABLE-NEXT:     state: 2
+// CHECK-EXECUTABLE-NEXT: Number of Abstract Modules: 1
+// CHECK-EXECUTABLE-NEXT: Abstract Module 0:
+// CHECK-EXECUTABLE-NEXT:   Metadata:
+// CHECK-EXECUTABLE:      Number of IR Modules: 1
+// CHECK-EXECUTABLE-NEXT:   IR module 0:
+// CHECK-EXECUTABLE-NEXT:       Metadata:
+// CHECK-EXECUTABLE-NEXT:         SYCLBIN/ir module metadata:
+// CHECK-EXECUTABLE-NEXT:           type: 0
+// CHECK-EXECUTABLE-NEXT:     Raw IR bytes: <Binary blob of {{.*}} bytes>
+// CHECK-EXECUTABLE-NEXT:   Number of Native Device Code Images: 0


### PR DESCRIPTION
This commit adds the bundle state as an argument to the -fsyclbin driver option (default to executable) and --syclbin clang-linker-wrapper option (no default). This argument is propagated to the SYCLBIN files.