### PR TITLE
[SYCL][NATIVECPU][CI] Enable Native CPU in Windows CI without OCK

### DIFF
--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -10,6 +10,7 @@ on:
       build_configure_extra_args:
         type: string
         required: false
+        default: "--native_cpu"
       changes:
         type: string
         description: 'Filter matches for the changed files in the PR'
@@ -58,6 +59,8 @@ on:
       build_configure_extra_args:
         type: string
         required: false
+        options:
+          - "--native_cpu"
       artifact_archive_name:
         type: choice
         options:
@@ -138,6 +141,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
           -DCMAKE_C_COMPILER_LAUNCHER=ccache ^
           -DLLVM_INSTALL_UTILS=ON ^
+          -DNATIVECPU_USE_OCK=Off ^
           -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
     - name: Build
       id: build


### PR DESCRIPTION
This PR enables NativeCPU partially in DPC++ Windows CI to enable similar testing we currently already have on Linux. This currently builds NativeCPU without the oneAPI Construction Kit (OCK) as a first step to gradually phase in CI for NativeCPU.   

In a subsequent PR we will then enable OCK in NativeCPU CI for Windows and Linux.   