### PR TITLE
[SYCL][E2E] Fix `XFAIL` statements that use negated device features

### DIFF
--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -393,4 +393,10 @@ class SYCLEndToEndTest(lit.formats.ShTest):
         if len(devices_for_test) == 1:
             device = devices_for_test[0]
             result.code = map_result(test.config.sycl_dev_features[device], result.code)
+
+        # Set this to empty so internal lit code won't change our result if it incorrectly
+        # thinks the test should XFAIL. This can happen when our XFAIL condition relies on
+        # device features, since the internal lit code doesn't have knowledge of these.
+        test.xfails = []
+
         return result


### PR DESCRIPTION
Because of device specific features we have to perform our own checks to see whether or not a test should XFAIL. However, a similar check is also done in internal lit code, but due to the fact that this bit of code only knows about the non device specific features there can be situations where it incorrectly reports a test as expected to fail (Like negating a device specific feature, like `XFAIL: !cpu`).

To avoid this we set the XFAIL conditions to an empty list before returning our result, this way `expected_to_fail` is always false in the code below, and our result is not altered.

https://github.com/intel/llvm/blob/d60cd271ccb330dd9da8158176404b68ff55baa9/llvm/utils/lit/lit/Test.py#L275-L292