### PR TITLE
[libspirv] Fix atomic_xchg declarations.

### DIFF
--- a/libclc/libspirv/include/libspirv/atomic/atomic_xchg.h
+++ b/libclc/libspirv/include/libspirv/atomic/atomic_xchg.h
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define __SPIRV_FUNCTION __spirv_AtomicExchange
 #define __SPIRV_FUNCTION_S __spirv_AtomicExchange
 #define __SPIRV_FUNCTION_U __spirv_AtomicExchange
 #define __SPIRV_INT64_BASE


### PR DESCRIPTION
This fixes build errors seen after #18613 in NativeCPU and AMD.