### PR TITLE
[UR][NFC] Squish some warnings in testing

### DIFF
--- a/unified-runtime/test/conformance/device/urDeviceGet.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGet.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 struct urDeviceGetTest : uur::urPlatformTest {
-  void SetUp() {
+  void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urPlatformTest::SetUp());
 
     // These tests require at least one device in the platform

--- a/unified-runtime/test/conformance/device/urDeviceGetSelected.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetSelected.cpp
@@ -30,7 +30,7 @@ static int unset_env(const char *name) {
 } // namespace uur
 
 struct urDeviceGetSelectedTest : uur::urPlatformTest {
-  void SetUp() {
+  void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urPlatformTest::SetUp());
 
     // These tests require at least one device in the platform

--- a/unified-runtime/test/conformance/exp_enqueue_native/enqueue_native_cuda.cpp
+++ b/unified-runtime/test/conformance/exp_enqueue_native/enqueue_native_cuda.cpp
@@ -12,7 +12,7 @@
 using T = uint32_t;
 
 struct urCudaEnqueueNativeCommandTest : uur::urQueueTest {
-  void SetUp() {
+  void SetUp() override {
     UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
 
     UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgLocal.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgLocal.cpp
@@ -9,7 +9,7 @@
 #include <uur/known_failure.h>
 
 struct urKernelSetArgLocalTest : uur::urKernelTest {
-  void SetUp() {
+  void SetUp() override {
     program_name = "mean";
     UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
   }

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgMemObj.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgMemObj.cpp
@@ -9,14 +9,14 @@
 #include <uur/known_failure.h>
 
 struct urKernelSetArgMemObjTest : uur::urKernelTest {
-  void SetUp() {
+  void SetUp() override {
     program_name = "fill";
     UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
                                      16 * sizeof(uint32_t), nullptr, &buffer));
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (buffer) {
       ASSERT_SUCCESS(urMemRelease(buffer));
     }

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgPointer.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgPointer.cpp
@@ -8,12 +8,12 @@
 #include <uur/known_failure.h>
 
 struct urKernelSetArgPointerTest : uur::urKernelExecutionTest {
-  void SetUp() {
+  void SetUp() override {
     program_name = "fill_usm";
     UUR_RETURN_ON_FATAL_FAILURE(urKernelExecutionTest::SetUp());
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (allocation) {
       ASSERT_SUCCESS(urUSMFree(context, allocation));
     }
@@ -126,7 +126,7 @@ struct urKernelSetArgPointerNegativeTest : urKernelSetArgPointerTest {
     }
   }
 
-  void SetUp() {
+  void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(urKernelSetArgPointerTest::SetUp());
     UUR_RETURN_ON_FATAL_FAILURE(SetUpAllocation());
     ASSERT_NE(allocation, nullptr);

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgSampler.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgSampler.cpp
@@ -9,7 +9,7 @@
 
 struct urKernelSetArgSamplerTestWithParam
     : uur::urBaseKernelTestWithParam<uur::SamplerCreateParamT> {
-  void SetUp() {
+  void SetUp() override {
     const auto param = getParam();
     const auto normalized = std::get<0>(param);
     const auto addr_mode = std::get<1>(param);
@@ -45,7 +45,7 @@ struct urKernelSetArgSamplerTestWithParam
         uur::urBaseKernelTestWithParam<uur::SamplerCreateParamT>::Build());
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (sampler) {
       ASSERT_SUCCESS(urSamplerRelease(sampler));
     }
@@ -75,7 +75,7 @@ TEST_P(urKernelSetArgSamplerTestWithParam, Success) {
 }
 
 struct urKernelSetArgSamplerTest : uur::urBaseKernelTest {
-  void SetUp() {
+  void SetUp() override {
     program_name = "image_copy";
     UUR_RETURN_ON_FATAL_FAILURE(urBaseKernelTest::SetUp());
 
@@ -104,7 +104,7 @@ struct urKernelSetArgSamplerTest : uur::urBaseKernelTest {
     Build();
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (sampler) {
       ASSERT_SUCCESS(urSamplerRelease(sampler));
     }

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgValue.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgValue.cpp
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 struct urKernelSetArgValueTest : uur::urKernelTest {
-  void SetUp() {
+  void SetUp() override {
     program_name = "fill";
     UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
   }

--- a/unified-runtime/test/conformance/kernel/urKernelSetExecInfo.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetExecInfo.cpp
@@ -44,12 +44,12 @@ TEST_P(urKernelSetExecInfoTest, InvalidNullPointerPropValue) {
 }
 
 struct urKernelSetExecInfoUSMPointersTest : uur::urKernelTest {
-  void SetUp() {
+  void SetUp() override {
     program_name = "fill";
     UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (allocation) {
       ASSERT_SUCCESS(urUSMFree(context, allocation));
     }

--- a/unified-runtime/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
+++ b/unified-runtime/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
@@ -12,7 +12,7 @@
 using T = uint32_t;
 
 struct urMultiDeviceContextTest : uur::urPlatformTest {
-  void SetUp() {
+  void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urPlatformTest::SetUp());
     ASSERT_SUCCESS(
         urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &num_devices));
@@ -32,7 +32,7 @@ struct urMultiDeviceContextTest : uur::urPlatformTest {
     }
   }
 
-  void TearDown() {
+  void TearDown() override {
     uur::urPlatformTest::TearDown();
     if (num_devices <= 1) {
       return;
@@ -51,7 +51,7 @@ struct urMultiDeviceContextTest : uur::urPlatformTest {
 };
 
 struct urMultiDeviceContextMemBufferTest : urMultiDeviceContextTest {
-  void SetUp() {
+  void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(urMultiDeviceContextTest::SetUp());
     if (num_devices <= 1) {
       return;
@@ -121,7 +121,7 @@ struct urMultiDeviceContextMemBufferTest : urMultiDeviceContextTest {
     }
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (num_devices > 1) {
       for (auto i = 0u; i < num_devices; ++i) {
         ASSERT_SUCCESS(urKernelRelease(kernels[i]));

--- a/unified-runtime/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
+++ b/unified-runtime/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
@@ -66,7 +66,7 @@ std::vector<ur_image_format_t> all_image_formats;
 
 struct urMemImageCreateTestWithImageFormatParam
     : uur::urContextTestWithParam<ur_image_format_t> {
-  void SetUp() {
+  void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::urContextTestWithParam<ur_image_format_t>::SetUp());
     bool image_support = false;
@@ -75,7 +75,7 @@ struct urMemImageCreateTestWithImageFormatParam
       GTEST_SKIP() << "Device doesn't support images";
     }
   }
-  void TearDown() {
+  void TearDown() override {
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::urContextTestWithParam<ur_image_format_t>::TearDown());
   }

--- a/unified-runtime/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
+++ b/unified-runtime/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
@@ -8,7 +8,9 @@
 #include <uur/known_failure.h>
 
 struct urMemImageCreateWithNativeHandleTest : uur::urMemImageTest {
-  void SetUp() { UUR_RETURN_ON_FATAL_FAILURE(urMemImageTest::SetUp()); }
+  void SetUp() override {
+    UUR_RETURN_ON_FATAL_FAILURE(urMemImageTest::SetUp());
+  }
 };
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemImageCreateWithNativeHandleTest);
 

--- a/unified-runtime/test/conformance/queue/urQueueGetInfo.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueGetInfo.cpp
@@ -220,7 +220,7 @@ TEST_P(urQueueGetInfoTest, InvalidNullPointerPropSizeRet) {
 }
 
 struct urQueueGetInfoDeviceQueueTestWithInfoParam : public uur::urQueueTest {
-  void SetUp() {
+  void SetUp() override {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
     UUR_RETURN_ON_FATAL_FAILURE(urQueueGetInfoTest::SetUp());
     ur_queue_flags_t deviceQueueCapabilities = 0;
@@ -233,7 +233,7 @@ struct urQueueGetInfoDeviceQueueTestWithInfoParam : public uur::urQueueTest {
     ASSERT_SUCCESS(urQueueCreate(context, device, &queueProperties, &queue));
   }
 
-  void TearDown() {
+  void TearDown() override {
     if (queue) {
       ASSERT_SUCCESS(urQueueRelease(queue));
     }

--- a/unified-runtime/test/conformance/testing/include/uur/fixtures.h
+++ b/unified-runtime/test/conformance/testing/include/uur/fixtures.h
@@ -1618,14 +1618,14 @@ private:
 
 template <class T>
 struct urKernelExecutionTestWithParam : urBaseKernelExecutionTestWithParam<T> {
-  void SetUp() {
+  void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(urBaseKernelExecutionTestWithParam<T>::SetUp());
     this->Build();
   }
 };
 
 struct urKernelExecutionTest : urBaseKernelExecutionTest {
-  void SetUp() {
+  void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(urBaseKernelExecutionTest::SetUp());
     Build();
   }
@@ -1647,7 +1647,7 @@ template <typename Derived> struct urGlobalVariableBaseTest : public Derived {
     // they rely on metadata set when creating the program.
     const std::string metadata_name = "_Z7dev_var@global_id_mapping";
     ur_program_metadata_value_t metadata_value;
-    metadata_value.pData = (void *)metadataData.c_str();
+    metadata_value.pData = (void *)metadataData.data();
     this->metadatas.push_back({metadata_name.c_str(),
                                UR_PROGRAM_METADATA_TYPE_BYTE_ARRAY,
                                metadataData.size(), metadata_value});

--- a/unified-runtime/test/conformance/usm/urUSMFree.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMFree.cpp
@@ -107,7 +107,7 @@ TEST_P(urUSMFreeTest, InvalidNullPtrMem) {
 // This goal of this test is to ensure urUSMFree blocks and waits for operations
 // accessing the given allocation to finish before actually freeing the memory.
 struct urUSMFreeDuringExecutionTest : uur::urKernelExecutionTest {
-  void SetUp() {
+  void SetUp() override {
     program_name = "fill_usm";
     UUR_RETURN_ON_FATAL_FAILURE(urKernelExecutionTest::SetUp());
   }

--- a/unified-runtime/test/conformance/usm/urUSMPoolCreate.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMPoolCreate.cpp
@@ -9,7 +9,7 @@
 #include <uur/known_failure.h>
 
 struct urUSMPoolCreateTest : uur::urContextTest {
-  void SetUp() {
+  void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urContextTest::SetUp());
     ur_bool_t poolSupport = false;
     ASSERT_SUCCESS(uur::GetDeviceUSMPoolSupport(device, poolSupport));

--- a/unified-runtime/test/unit/print.h
+++ b/unified-runtime/test/unit/print.h
@@ -210,12 +210,13 @@ struct UrDeviceGetInfoParamsEmpty : UrDeviceGetInfoParams {
 };
 
 struct UrDeviceGetInfoParamsName : UrDeviceGetInfoParams {
-  const char *name = "FOOBAR";
   UrDeviceGetInfoParamsName() : UrDeviceGetInfoParams() {
+    static std::string name{"FOOBAR"};
+
     propName = UR_DEVICE_INFO_NAME;
-    pPropValue = (void *)name;
-    propSize = strlen(name) + 1;
-    propSizeRet = strlen(name) + 1;
+    pPropValue = (void *)name.data();
+    propSize = name.length() + 1;
+    propSizeRet = name.length() + 1;
   }
   const char *get_expected() {
     return ".hDevice = nullptr, .propName = UR_DEVICE_INFO_NAME, .propSize "


### PR DESCRIPTION
When building UR tests in a dpcpp build (which is disabled by default),
some warnings are flagged, which this patch fixes. Specifically:

* Marking fixture functions as `override` where appropriate.
* Removing casts `const char *` -> `void *`.
