### PR TITLE
Fix leftover in sycl_ext_oneapi_tangle.asciidoc

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_tangle.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_tangle.asciidoc
@@ -318,7 +318,7 @@ branches to safely communicate between all work-items executing the same
 control flow.
 
 NOTE: This differs from the `fragment` returned by `get_opportunistic_group()`
-because a `tangle_group` requires the implementation to track group membership.
+because a `tangle` requires the implementation to track group membership.
 Which group type to use will depend on a combination of
 implementation/backend/device and programmer preference.
 


### PR DESCRIPTION
This PR cares about potential leftover / typo in  https://github.com/intel/llvm/edit/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_tangle.asciidoc#:~:text=320-,321,-322: as suggested by @AlexeySachkov here https://github.com/intel/llvm/pull/16151#discussion_r1868084750