### PR TITLE
[SYCL] Enable UR validation layer on SYCL RT e2e precommit jobs

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -309,6 +309,8 @@ jobs:
       if: inputs.tests_selector == 'e2e'
       uses: ./devops/actions/run-tests/e2e
       timeout-minutes: 60
+      env:
+        UR_ENABLE_LAYERS: UR_LAYER_FULL_VALIDATION
       with:
         ref: ${{ inputs.tests_ref || inputs.repo_ref || github.sha }}
         binaries_artifact: ${{ inputs.e2e_binaries_artifact }}


### PR DESCRIPTION
We would like to enable the validation layer in UR for the precommit e2e testing jobs. This layer is disabled currently to bypass the overhead of extra checks, but the same checks have propagated through to the UR adapters where they are not required. If the checks are removed from the adapters then some e2e tests will fail as some incorrect usage is not being caught by the validation layer. 

Docs on UR layers: https://oneapi-src.github.io/unified-runtime/core/INTRO.html#layers

Closes https://github.com/intel/llvm/issues/18257

