### PR TITLE
Update description of UR_LAYER_FULL_VALIDATION in docs to reflect behaviour in code

### DIFF
--- a/unified-runtime/scripts/core/INTRO.rst
+++ b/unified-runtime/scripts/core/INTRO.rst
@@ -310,7 +310,7 @@ By default, no layers are enabled. Layers currently included with the runtime ar
    * - UR_LAYER_LIFETIME_VALIDATION
      - Performs lifetime validation on objects (check if it was used within the scope of its creation and destruction) used in API calls. Automatically enables UR_LAYER_LEAK_CHECKING.
    * - UR_LAYER_FULL_VALIDATION
-     - Enables UR_LAYER_PARAMETER_VALIDATION and UR_LAYER_LEAK_CHECKING.
+     - Enables UR_LAYER_PARAMETER_VALIDATION, UR_LAYER_BOUNDS_CHECKING, UR_LAYER_LEAK_CHECKING, and UR_LAYER_LIFETIME_VALIDATION.
    * - UR_LAYER_TRACING
      - Enables the XPTI tracing layer, see Tracing_ for more detail.
    * - UR_LAYER_ASAN \| UR_LAYER_MSAN \| UR_LAYER_TSAN


### PR DESCRIPTION
Current documentation states the `UR_LAYER_FULL_VALIDATION ` env var enables `UR_LAYER_PARAMETER_VALIDATION` and `UR_LAYER_LEAK_CHECKING` but in the [code](https://github.com/intel/llvm/blob/375974ee85bef7e504550a0e7595d109bfe9bcd7/unified-runtime/source/loader/layers/validation/ur_valddi.cpp#L12313) it also enables `UR_LAYER_BOUNDS_CHECKING` and `UR_LAYER_LIFETIME_VALIDATION`.

