### PR TITLE
[SYCL][UR][L0 v2] get rid of std::function in memory.hpp

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -39,9 +39,9 @@ ur_result_t getMemPtr(ur_mem_handle_t memObj,
       urAccessMode =
           ur_mem_buffer_t::getDeviceAccessMode(properties->memoryAccess);
     }
-    ptr = ur_cast<char *>(
-        memBuffer->getDevicePtr(device, urAccessMode, 0, memBuffer->getSize(),
-                                [&](void *, void *, size_t) {}));
+    wait_list_view emptyWaitList(nullptr, 0);
+    ptr = ur_cast<char *>(memBuffer->getDevicePtr(
+        device, urAccessMode, 0, memBuffer->getSize(), nullptr, emptyWaitList));
   }
   assert(ptrStorage != nullptr);
   ptrStorage->push_back(std::make_unique<char *>(ptr));

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -14,6 +14,7 @@
 #include "../ur_interface_loader.hpp"
 #include "context.hpp"
 #include "kernel.hpp"
+#include "memory.hpp"
 
 ur_command_list_manager::ur_command_list_manager(
     ur_context_handle_t context, ur_device_handle_t device,
@@ -44,12 +45,7 @@ ur_result_t ur_command_list_manager::appendGenericFillUnlocked(
 
   auto pDst = ur_cast<char *>(dst->getDevicePtr(
       device, ur_mem_buffer_t::device_access_mode_t::read_only, offset, size,
-      [&](void *src, void *dst, size_t size) {
-        ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                          (zeCommandList.get(), dst, src, size, nullptr,
-                           waitListView.num, waitListView.handles));
-        waitListView.clear();
-      }));
+      zeCommandList.get(), waitListView));
 
   // PatternSize must be a power of two for zeCommandListAppendMemoryFill.
   // When it's not, the fill is emulated with zeCommandListAppendMemoryCopy.
@@ -87,21 +83,11 @@ ur_result_t ur_command_list_manager::appendGenericCopyUnlocked(
 
   auto pSrc = ur_cast<char *>(src->getDevicePtr(
       device, ur_mem_buffer_t::device_access_mode_t::read_only, srcOffset, size,
-      [&](void *src, void *dst, size_t size) {
-        ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                          (zeCommandList.get(), dst, src, size, nullptr,
-                           waitListView.num, waitListView.handles));
-        waitListView.clear();
-      }));
+      zeCommandList.get(), waitListView));
 
   auto pDst = ur_cast<char *>(dst->getDevicePtr(
       device, ur_mem_buffer_t::device_access_mode_t::write_only, dstOffset,
-      size, [&](void *src, void *dst, size_t size) {
-        ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                          (zeCommandList.get(), dst, src, size, nullptr,
-                           waitListView.num, waitListView.handles));
-        waitListView.clear();
-      }));
+      size, zeCommandList.get(), waitListView));
 
   ZE2UR_CALL(zeCommandListAppendMemoryCopy,
              (zeCommandList.get(), pDst, pSrc, size, zeSignalEvent,
@@ -130,20 +116,10 @@ ur_result_t ur_command_list_manager::appendRegionCopyUnlocked(
 
   auto pSrc = ur_cast<char *>(src->getDevicePtr(
       device, ur_mem_buffer_t::device_access_mode_t::read_only, 0,
-      src->getSize(), [&](void *src, void *dst, size_t size) {
-        ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                          (zeCommandList.get(), dst, src, size, nullptr,
-                           waitListView.num, waitListView.handles));
-        waitListView.clear();
-      }));
+      src->getSize(), zeCommandList.get(), waitListView));
   auto pDst = ur_cast<char *>(dst->getDevicePtr(
       device, ur_mem_buffer_t::device_access_mode_t::write_only, 0,
-      dst->getSize(), [&](void *src, void *dst, size_t size) {
-        ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                          (zeCommandList.get(), dst, src, size, nullptr,
-                           waitListView.num, waitListView.handles));
-        waitListView.clear();
-      }));
+      dst->getSize(), zeCommandList.get(), waitListView));
 
   ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
              (zeCommandList.get(), pDst, &zeParams.dstRegion, zeParams.dstPitch,
@@ -213,16 +189,9 @@ ur_result_t ur_command_list_manager::appendKernelLaunch(
 
   auto waitListView = getWaitListView(phEventWaitList, numEventsInWaitList);
 
-  auto memoryMigrate = [&](void *src, void *dst, size_t size) {
-    ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                      (zeCommandList.get(), dst, src, size, nullptr,
-                       waitListView.num, waitListView.handles));
-    waitListView.clear();
-  };
-
   UR_CALL(hKernel->prepareForSubmission(context, device, pGlobalWorkOffset,
                                         workDim, WG[0], WG[1], WG[2],
-                                        memoryMigrate));
+                                        zeCommandList.get(), waitListView));
 
   TRACK_SCOPE_LATENCY(
       "ur_command_list_manager::zeCommandListAppendLaunchKernel");

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -13,9 +13,10 @@
 #include "common.hpp"
 #include "context.hpp"
 #include "event_pool_cache.hpp"
-#include "memory.hpp"
 #include "queue_api.hpp"
 #include <ze_api.h>
+
+struct ur_mem_buffer_t;
 
 struct wait_list_view {
   ze_event_handle_t *handles;

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
@@ -277,7 +277,7 @@ ur_result_t ur_kernel_handle_t_::prepareForSubmission(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     const size_t *pGlobalWorkOffset, uint32_t workDim, uint32_t groupSizeX,
     uint32_t groupSizeY, uint32_t groupSizeZ,
-    std::function<void(void *, void *, size_t)> migrate) {
+    ze_command_list_handle_t commandList, wait_list_view &waitListView) {
   auto hZeKernel = getZeHandle(hDevice);
 
   if (pGlobalWorkOffset != NULL) {
@@ -293,8 +293,9 @@ ur_result_t ur_kernel_handle_t_::prepareForSubmission(
     if (pending.hMem) {
       if (!pending.hMem->isImage()) {
         auto hBuffer = pending.hMem->getBuffer();
-        zePtr = hBuffer->getDevicePtr(hDevice, pending.mode, 0,
-                                      hBuffer->getSize(), migrate);
+        zePtr =
+            hBuffer->getDevicePtr(hDevice, pending.mode, 0, hBuffer->getSize(),
+                                  commandList, waitListView);
       } else {
         auto hImage = static_cast<ur_mem_image_t *>(pending.hMem->getImage());
         zePtr = reinterpret_cast<void *>(hImage->getZeImage());

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
@@ -83,12 +83,13 @@ public:
 
   // Set all required values for the kernel before submission (including pending
   // memory allocations).
-  ur_result_t
-  prepareForSubmission(ur_context_handle_t hContext, ur_device_handle_t hDevice,
-                       const size_t *pGlobalWorkOffset, uint32_t workDim,
-                       uint32_t groupSizeX, uint32_t groupSizeY,
-                       uint32_t groupSizeZ,
-                       std::function<void(void *, void *, size_t)> migrate);
+  ur_result_t prepareForSubmission(ur_context_handle_t hContext,
+                                   ur_device_handle_t hDevice,
+                                   const size_t *pGlobalWorkOffset,
+                                   uint32_t workDim, uint32_t groupSizeX,
+                                   uint32_t groupSizeY, uint32_t groupSizeZ,
+                                   ze_command_list_handle_t cmdList,
+                                   wait_list_view &waitListView);
 
 private:
   // Keep the program of the kernel.

--- a/unified-runtime/source/adapters/level_zero/v2/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.hpp
@@ -17,7 +17,9 @@
 #include "../device.hpp"
 #include "../helpers/memory_helpers.hpp"
 #include "../image_common.hpp"
+#include "command_list_manager.hpp"
 #include "common.hpp"
+#include "lockable.hpp"
 
 using usm_unique_ptr_t = std::unique_ptr<void, std::function<void(void *)>>;
 
@@ -35,16 +37,15 @@ struct ur_mem_buffer_t : ur_object {
 
   // Returns pointer to the device memory. If device handle is NULL,
   // the buffer is allocated on the first device in the context.
-  virtual void *
-  getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
-               size_t size,
-               std::function<void(void *src, void *dst, size_t)> mecmpy) = 0;
-  virtual void *
-  mapHostPtr(ur_map_flags_t, size_t offset, size_t size,
-             std::function<void(void *src, void *dst, size_t)> memcpy) = 0;
-  virtual void
-  unmapHostPtr(void *pMappedPtr,
-               std::function<void(void *src, void *dst, size_t)> memcpy) = 0;
+  virtual void *getDevicePtr(ur_device_handle_t, device_access_mode_t,
+                             size_t offset, size_t size,
+                             ze_command_list_handle_t cmdList,
+                             wait_list_view &waitListView) = 0;
+  virtual void *mapHostPtr(ur_map_flags_t, size_t offset, size_t size,
+                           ze_command_list_handle_t cmdList,
+                           wait_list_view &waitListView) = 0;
+  virtual void unmapHostPtr(void *pMappedPtr, ze_command_list_handle_t cmdList,
+                            wait_list_view &waitListView) = 0;
 
   device_access_mode_t getDeviceAccessMode() const { return accessMode; }
   ur_context_handle_t getContext() const { return hContext; }
@@ -72,14 +73,14 @@ protected:
 struct ur_usm_handle_t : ur_mem_buffer_t {
   ur_usm_handle_t(ur_context_handle_t hContext, size_t size, const void *ptr);
 
-  void *
-  getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
-               size_t size,
-               std::function<void(void *src, void *dst, size_t)>) override;
+  void *getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
+                     size_t size, ze_command_list_handle_t cmdList,
+                     wait_list_view &waitListView) override;
   void *mapHostPtr(ur_map_flags_t, size_t offset, size_t size,
-                   std::function<void(void *src, void *dst, size_t)>) override;
-  void unmapHostPtr(void *pMappedPtr,
-                    std::function<void(void *src, void *dst, size_t)>) override;
+                   ze_command_list_handle_t cmdList,
+                   wait_list_view &waitListView) override;
+  void unmapHostPtr(void *pMappedPtr, ze_command_list_handle_t cmdList,
+                    wait_list_view &waitListView) override;
 
 private:
   void *ptr;
@@ -101,14 +102,14 @@ struct ur_integrated_buffer_handle_t : ur_mem_buffer_t {
 
   ~ur_integrated_buffer_handle_t();
 
-  void *
-  getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
-               size_t size,
-               std::function<void(void *src, void *dst, size_t)>) override;
+  void *getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
+                     size_t size, ze_command_list_handle_t cmdList,
+                     wait_list_view &waitListView) override;
   void *mapHostPtr(ur_map_flags_t, size_t offset, size_t size,
-                   std::function<void(void *src, void *dst, size_t)>) override;
-  void unmapHostPtr(void *pMappedPtr,
-                    std::function<void(void *src, void *dst, size_t)>) override;
+                   ze_command_list_handle_t cmdList,
+                   wait_list_view &waitListView) override;
+  void unmapHostPtr(void *pMappedPtr, ze_command_list_handle_t cmdList,
+                    wait_list_view &waitListView) override;
 
 private:
   usm_unique_ptr_t ptr;
@@ -142,14 +143,14 @@ struct ur_discrete_buffer_handle_t : ur_mem_buffer_t {
                               size_t size, device_access_mode_t accesMode,
                               void *writeBackMemory, bool ownDevicePtr);
 
-  void *
-  getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
-               size_t size,
-               std::function<void(void *src, void *dst, size_t)>) override;
+  void *getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
+                     size_t size, ze_command_list_handle_t cmdList,
+                     wait_list_view &waitListView) override;
   void *mapHostPtr(ur_map_flags_t, size_t offset, size_t size,
-                   std::function<void(void *src, void *dst, size_t)>) override;
-  void unmapHostPtr(void *pMappedPtr,
-                    std::function<void(void *src, void *dst, size_t)>) override;
+                   ze_command_list_handle_t cmdList,
+                   wait_list_view &waitListView) override;
+  void unmapHostPtr(void *pMappedPtr, ze_command_list_handle_t cmdList,
+                    wait_list_view &waitListView) override;
 
 private:
   void *getCurrentAllocation();
@@ -180,14 +181,14 @@ struct ur_shared_buffer_handle_t : ur_mem_buffer_t {
                             size_t size, device_access_mode_t accesMode,
                             bool ownDevicePtr);
 
-  void *
-  getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
-               size_t size,
-               std::function<void(void *src, void *dst, size_t)>) override;
+  void *getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
+                     size_t size, ze_command_list_handle_t cmdList,
+                     wait_list_view &waitListView) override;
   void *mapHostPtr(ur_map_flags_t, size_t offset, size_t size,
-                   std::function<void(void *src, void *dst, size_t)>) override;
-  void unmapHostPtr(void *pMappedPtr,
-                    std::function<void(void *src, void *dst, size_t)>) override;
+                   ze_command_list_handle_t cmdList,
+                   wait_list_view &waitListView) override;
+  void unmapHostPtr(void *pMappedPtr, ze_command_list_handle_t cmdList,
+                    wait_list_view &waitListView) override;
 
 private:
   usm_unique_ptr_t ptr;
@@ -198,14 +199,14 @@ struct ur_mem_sub_buffer_t : ur_mem_buffer_t {
                       device_access_mode_t accesMode);
   ~ur_mem_sub_buffer_t();
 
-  void *
-  getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
-               size_t size,
-               std::function<void(void *src, void *dst, size_t)>) override;
+  void *getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
+                     size_t size, ze_command_list_handle_t cmdList,
+                     wait_list_view &waitListView) override;
   void *mapHostPtr(ur_map_flags_t, size_t offset, size_t size,
-                   std::function<void(void *src, void *dst, size_t)>) override;
-  void unmapHostPtr(void *pMappedPtr,
-                    std::function<void(void *src, void *dst, size_t)>) override;
+                   ze_command_list_handle_t cmdList,
+                   wait_list_view &waitListView) override;
+  void unmapHostPtr(void *pMappedPtr, ze_command_list_handle_t cmdList,
+                    wait_list_view &waitListView) override;
 
   ur_shared_mutex &getMutex() override;
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -496,14 +496,9 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemBufferMap(
   auto waitListView =
       getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
-  auto pDst = ur_cast<char *>(hBuffer->mapHostPtr(
-      mapFlags, offset, size, [&](void *src, void *dst, size_t size) {
-        ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                          (commandListLocked->getZeCommandList(), dst, src,
-                           size, nullptr, waitListView.num,
-                           waitListView.handles));
-        waitListView.clear();
-      }));
+  auto pDst = ur_cast<char *>(
+      hBuffer->mapHostPtr(mapFlags, offset, size,
+                          commandListLocked->getZeCommandList(), waitListView));
   *ppRetMap = pDst;
 
   if (waitListView) {
@@ -549,11 +544,8 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueMemUnmap(
               waitListView.handles));
   waitListView.clear();
 
-  hBuffer->unmapHostPtr(pMappedPtr, [&](void *src, void *dst, size_t size) {
-    ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                      (commandListLocked->getZeCommandList(), dst, src, size,
-                       nullptr, waitListView.num, waitListView.handles));
-  });
+  hBuffer->unmapHostPtr(pMappedPtr, commandListLocked->getZeCommandList(),
+                        waitListView);
   if (zeSignalEvent) {
     ZE2UR_CALL(zeCommandListAppendSignalEvent,
                (commandListLocked->getZeCommandList(), zeSignalEvent));
@@ -931,16 +923,9 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueCooperativeKernelLaunchExp(
   auto waitListView =
       getWaitListView(commandListLocked, phEventWaitList, numEventsInWaitList);
 
-  auto memoryMigrate = [&](void *src, void *dst, size_t size) {
-    ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                      (commandListLocked->getZeCommandList(), dst, src, size,
-                       nullptr, waitListView.num, waitListView.handles));
-    waitListView.clear();
-  };
-
-  UR_CALL(hKernel->prepareForSubmission(hContext, hDevice, pGlobalWorkOffset,
-                                        workDim, WG[0], WG[1], WG[2],
-                                        memoryMigrate));
+  UR_CALL(hKernel->prepareForSubmission(
+      hContext, hDevice, pGlobalWorkOffset, workDim, WG[0], WG[1], WG[2],
+      commandListLocked->getZeCommandList(), waitListView));
 
   TRACK_SCOPE_LATENCY("ur_queue_immediate_in_order_t::"
                       "zeCommandListAppendLaunchCooperativeKernel");


### PR DESCRIPTION
There migration logic is always the same, there's no need to pass callback to every getDevicePtr/map/unmap function.