### PR TITLE
Only build libspirv for selected targets

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -413,23 +413,27 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     DIRS ${opencl_dirs}
   )
 
-  set( libspirv_lib_files )
-  set( libspirv_gen_files )
+  set( BUILD_LIBSPIRV_${t} FALSE )
+  if ( t STREQUAL amdgcn--amdhsa OR t STREQUAL nvptx64--nvidiacl OR t STREQUAL native_cpu )
+    set( libspirv_lib_files )
+    set( libspirv_gen_files )
+    set( BUILD_LIBSPIRV_${t} TRUE )
 
-  if( NOT ARCH STREQUAL spirv AND NOT ARCH STREQUAL spirv64 )
-    if( ARCH STREQUAL clspv OR ARCH STREQUAL clspv64 )
-      list( APPEND libspirv_gen_files clspv-convert.cl )
-    elseif ( NOT ENABLE_RUNTIME_SUBNORMAL )
-      list( APPEND libspirv_gen_files spirv-convert.cl )
-      list( APPEND libspirv_lib_files libspirv/lib/generic/subnormal_use_default.ll )
+    if( NOT ARCH STREQUAL spirv AND NOT ARCH STREQUAL spirv64 )
+      if( ARCH STREQUAL clspv OR ARCH STREQUAL clspv64 )
+        list( APPEND libspirv_gen_files clspv-convert.cl )
+      elseif ( NOT ENABLE_RUNTIME_SUBNORMAL )
+        list( APPEND libspirv_gen_files spirv-convert.cl )
+        list( APPEND libspirv_lib_files libspirv/lib/generic/subnormal_use_default.ll )
+      endif()
     endif()
-  endif()
 
-  libclc_configure_lib_source(
-    libspirv_lib_files
-    LIB_ROOT_DIR libspirv
-    DIRS ${libspirv_dirs} ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS}
-  )
+    libclc_configure_lib_source(
+      libspirv_lib_files
+      LIB_ROOT_DIR libspirv
+      DIRS ${libspirv_dirs} ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS}
+    )
+  endif()
 
   foreach( d ${${t}_devices} )
     get_libclc_device_info(
@@ -568,28 +572,30 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       GEN_FILES ${clc_gen_files}
     )
 
-    set( spirv_build_flags ${build_flags} )
-    list( APPEND spirv_build_flags
-      -I${CMAKE_CURRENT_SOURCE_DIR}/generic/include
-      -I${CMAKE_CURRENT_SOURCE_DIR}/libspirv/include/
-      # FIXME: Fix libspirv to not require disabling this noisy warning
-      -Wno-bitwise-conditional-parentheses
-    )
+    if( BUILD_LIBSPIRV_${t} )
+      set( spirv_build_flags ${build_flags} )
+      list( APPEND spirv_build_flags
+        -I${CMAKE_CURRENT_SOURCE_DIR}/generic/include
+        -I${CMAKE_CURRENT_SOURCE_DIR}/libspirv/include/
+        # FIXME: Fix libspirv to not require disabling this noisy warning
+        -Wno-bitwise-conditional-parentheses
+      )
 
-    add_libclc_builtin_set(
-      ARCH ${ARCH}
-      ARCH_SUFFIX libspirv-${arch_suffix}
-      TRIPLE ${clang_triple}
-      TARGET_ENV libspirv-
-      COMPILE_FLAGS ${spirv_build_flags}
-      OPT_FLAGS ${opt_flags}
-      LIB_FILES ${libspirv_lib_files}
-      GEN_FILES ${libspirv_gen_files}
-      ALIASES ${${d}_aliases}
-      PARENT_TARGET libspirv-builtins
-      # Link in the CLC builtins and internalize their symbols
-      INTERNAL_LINK_DEPENDENCIES builtins.link.clc-${arch_suffix}
-    )
+      add_libclc_builtin_set(
+        ARCH ${ARCH}
+        ARCH_SUFFIX libspirv-${arch_suffix}
+        TRIPLE ${clang_triple}
+        TARGET_ENV libspirv-
+        COMPILE_FLAGS ${spirv_build_flags}
+        OPT_FLAGS ${opt_flags}
+        LIB_FILES ${libspirv_lib_files}
+        GEN_FILES ${libspirv_gen_files}
+        ALIASES ${${d}_aliases}
+        PARENT_TARGET libspirv-builtins
+        # Link in the CLC builtins and internalize their symbols
+        INTERNAL_LINK_DEPENDENCIES builtins.link.clc-${arch_suffix}
+      )
+    endif()
 
     set( opencl_build_flags ${build_flags} )
     list( APPEND opencl_build_flags


### PR DESCRIPTION
In practice we only build (and thus test) three libclc targets: 'nvptx64--nvidiacl', 'amdgcn--amdhsa' and 'native_cpu'. All other upstream libclc targets are never built in our CI and would in fail to build.

This commit rectifies this by selectively building libspirv only for those three supported targets. More can be added in time if required.

There are still certain OpenCL libclc targets that can't be built with this commit. The r600 target, for example, can't build because we unconditionally enable the fp64 OpenCL extension across the board, but the r600 target doesn't support that.

The clspv and clspv64 targets also fail to build due to SOURCES files referencing missing files. This will be resolved in the next pulldown.