### PR TITLE
[UR] Fix logger use after move (Coverity)

### DIFF
--- a/unified-runtime/source/common/logger/ur_logger_details.hpp
+++ b/unified-runtime/source/common/logger/ur_logger_details.hpp
@@ -55,22 +55,19 @@ public:
            const char *filename, const char *lineno, const char *format,
            Args &&...args) {
     if (callbackSink && level >= this->callbackSinkLevel) {
-      callbackSink->log(level, filename, lineno, format,
-                        std::forward<Args>(args)...);
+      callbackSink->log(level, filename, lineno, format, args...);
     }
 
     if (standardSink) {
       if (isLegacySink) {
-        standardSink->log(level, filename, lineno, p.message,
-                          std::forward<Args>(args)...);
+        standardSink->log(level, filename, lineno, p.message, args...);
         return;
       }
 
       if (level < this->standardSinkLevel) {
         return;
       }
-      standardSink->log(level, filename, lineno, format,
-                        std::forward<Args>(args)...);
+      standardSink->log(level, filename, lineno, format, args...);
     }
   }
 


### PR DESCRIPTION
When the callback sink and the standard sink are both enabled using `std::forward<Args>(args)...` results in a use-after-move. This patches fixes the issue by letting the r-value references decay to l-value references when expanding the `args...` parameter pack and allowing the parameter pack to be passed to multiple functions. The `logger::log()` member function does not need to take ownership of the objects being passed in.
