### PR TITLE
[libspirv] Add include guards where appropriate

### DIFF
--- a/libclc/libspirv/include/libspirv/image/image.h
+++ b/libclc/libspirv/include/libspirv/image/image.h
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if defined(__opencl_c_images)
+
 _CLC_OVERLOAD _CLC_DECL float __spirv_ImageRead__Rfloat(image2d_t image,
                                                         int2 coord);
 _CLC_OVERLOAD _CLC_DECL float __spirv_ImageRead__Rfloat(image2d_t image,
@@ -112,4 +114,6 @@ _CLC_OVERLOAD _CLC_DECL void __spirv_ImageWrite(image2d_t image, int4 coord,
                                                 half4 texel);
 _CLC_OVERLOAD _CLC_DECL void __spirv_ImageWrite(image3d_t image, int4 coord,
                                                 half4 texel);
+#endif
+
 #endif

--- a/libclc/libspirv/include/libspirv/spirv_types.h
+++ b/libclc/libspirv/include/libspirv/spirv_types.h
@@ -50,12 +50,16 @@ typedef struct {
   float real, imag;
 } complex_float;
 
+#ifdef cl_khr_fp64
 typedef struct {
   double real, imag;
 } complex_double;
+#endif
 
+#ifdef cl_khr_fp16
 typedef struct {
   half real, imag;
 } complex_half;
+#endif
 
 #endif // CLC_SPIRV_TYPES


### PR DESCRIPTION
These are technically required by OpenCL but not observed since downstream we unconditionally build libclc with all extensions enabled. Since this won't fly upstream, this commit prepares the ground for a more correct building of these libraries.