### PR TITLE
[SYCL] Fix complex support for Cuda/HIP

### DIFF
--- a/libdevice/complex_wrapper.cpp
+++ b/libdevice/complex_wrapper.cpp
@@ -8,7 +8,8 @@
 
 #include "device_complex.h"
 
-#if defined(__SPIR__) || defined(__SPIRV__)
+#if defined(__SPIR__) || defined(__SPIRV__) || defined(__NVPTX__) ||           \
+    defined(__AMDGCN__)
 
 DEVICE_EXTERN_C_INLINE
 float cimagf(float __complex__ z) { return __devicelib_cimagf(z); }

--- a/libdevice/complex_wrapper_fp64.cpp
+++ b/libdevice/complex_wrapper_fp64.cpp
@@ -9,7 +9,8 @@
 
 #include "device_complex.h"
 
-#if defined(__SPIR__) || defined(__SPIRV__)
+#if defined(__SPIR__) || defined(__SPIRV__) || defined(__NVPTX__) ||           \
+    defined(__AMDGCN__)
 
 DEVICE_EXTERN_C_INLINE
 double cimag(double __complex__ z) { return __devicelib_cimag(z); }

--- a/libdevice/device_complex.h
+++ b/libdevice/device_complex.h
@@ -10,7 +10,8 @@
 
 #include "device.h"
 
-#if defined(__SPIR__) || defined(__SPIRV__)
+#if defined(__SPIR__) || defined(__SPIRV__) || defined(__NVPTX__) ||           \
+    defined(__AMDGCN__)
 
 // TODO: This needs to be more robust.
 // clang doesn't recognize the c11 CMPLX macro, but it does have

--- a/libdevice/fallback-complex-fp64.cpp
+++ b/libdevice/fallback-complex-fp64.cpp
@@ -9,7 +9,8 @@
 
 #include "device_complex.h"
 
-#if defined(__SPIR__) || defined(__SPIRV__)
+#if defined(__SPIR__) || defined(__SPIRV__) || defined(__NVPTX__) ||           \
+    defined(__AMDGCN__)
 #include <cmath>
 
 // To support fallback device libraries on-demand loading, please update the

--- a/libdevice/fallback-complex.cpp
+++ b/libdevice/fallback-complex.cpp
@@ -8,7 +8,8 @@
 
 #include "device_complex.h"
 
-#if defined(__SPIR__) || defined(__SPIRV__)
+#if defined(__SPIR__) || defined(__SPIRV__) || defined(__NVPTX__) ||           \
+    defined(__AMDGCN__)
 #include <cmath>
 
 // To support fallback device libraries on-demand loading, please update the

--- a/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: target-amd || target-nvidia
 // XFAIL: windows && arch-intel_gpu_bmg_g21
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/17165
 // RUN: %{build} -o %t1.out

--- a/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
@@ -1,5 +1,4 @@
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// UNSUPPORTED: target-amd || target-nvidia
 // RUN: %{build} %{mathflags} -o %t1.out
 // RUN: %{run} %t1.out
 

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 257
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 255
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
@@ -117,8 +117,6 @@
 // CHECK-NEXT: DeviceLib/imf_simd_emulate_test.cpp
 // CHECK-NEXT: DeviceLib/rand_test.cpp
 // CHECK-NEXT: DeviceLib/separate_compile_test.cpp
-// CHECK-NEXT: DeviceLib/std_complex_math_fp64_test.cpp
-// CHECK-NEXT: DeviceLib/std_complex_math_test.cpp
 // CHECK-NEXT: ESIMD/PerformanceTests/BitonicSortK.cpp
 // CHECK-NEXT: ESIMD/PerformanceTests/BitonicSortKv2.cpp
 // CHECK-NEXT: ESIMD/PerformanceTests/Stencil.cpp


### PR DESCRIPTION
The implementation was incorrectly kept behind SPIR-V ifdefs.