### PR TITLE
[libspirv] Avoid macro redefinition

### DIFF
--- a/libclc/libspirv/lib/ptx-nvidiacl/math/nextafter.cl
+++ b/libclc/libspirv/lib/ptx-nvidiacl/math/nextafter.cl
@@ -16,7 +16,8 @@
 #define __CLC_BUILTIN_F __CLC_XCONCAT(__CLC_BUILTIN, f)
 #define __CLC_BUILTIN_D __CLC_BUILTIN
 
-_CLC_DEFINE_BINARY_BUILTIN(float, __SPIRV_FUNCTION, __CLC_BUILTIN_F, float, float)
+_CLC_DEFINE_BINARY_BUILTIN(float, __SPIRV_FUNCTION, __CLC_BUILTIN_F, float,
+                           float)
 
 #ifndef __FLOAT_ONLY
 

--- a/libclc/libspirv/lib/ptx-nvidiacl/math/nextafter.cl
+++ b/libclc/libspirv/lib/ptx-nvidiacl/math/nextafter.cl
@@ -11,12 +11,12 @@
 #include <clc/utils.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_FUNCTION __spirv_ocl_nextafter
+#define __SPIRV_FUNCTION __spirv_ocl_nextafter
 #define __CLC_BUILTIN __nv_nextafter
 #define __CLC_BUILTIN_F __CLC_XCONCAT(__CLC_BUILTIN, f)
 #define __CLC_BUILTIN_D __CLC_BUILTIN
 
-_CLC_DEFINE_BINARY_BUILTIN(float, __CLC_FUNCTION, __CLC_BUILTIN_F, float, float)
+_CLC_DEFINE_BINARY_BUILTIN(float, __SPIRV_FUNCTION, __CLC_BUILTIN_F, float, float)
 
 #ifndef __FLOAT_ONLY
 
@@ -24,7 +24,7 @@ _CLC_DEFINE_BINARY_BUILTIN(float, __CLC_FUNCTION, __CLC_BUILTIN_F, float, float)
 
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
-_CLC_DEFINE_BINARY_BUILTIN(double, __CLC_FUNCTION, __CLC_BUILTIN_D, double,
+_CLC_DEFINE_BINARY_BUILTIN(double, __SPIRV_FUNCTION, __CLC_BUILTIN_D, double,
                            double)
 
 #endif


### PR DESCRIPTION
The macro __CLC_FUNCTION is special and is used in CLC headers. Defining it here in an implementation file - nextafter.cl - for another purpose then including half_nextafter.inc which pulls in the SPIR-V headers results in a macro redefinition, which is warned about.

Sicne the name isn't important and is local to this one file, this commit just changes the macro definition to fix the issue.