### PR TITLE
[SYCL][E2E] Add `local_accessor` and `accessor` e2e tests for `sycl_ext_oneapi_free_function_kernels` extension 

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/accessor_as_kernel_parameter.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/accessor_as_kernel_parameter.cpp
@@ -1,0 +1,80 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// This test verifies whether sycl::accessor can be used with free function
+// kernels extension.
+
+#include <sycl/ext/oneapi/free_function_queries.hpp>
+
+#include "helpers.hpp"
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::single_task_kernel))
+void globalScopeSingleFreeFunc(sycl::accessor<int, 1> Accessor,
+                               size_t NumOfElements, int Value) {
+  for (size_t i = 0; i < NumOfElements; ++i) {
+    Accessor[i] = Value;
+  }
+}
+
+namespace ns {
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<3>))
+void nsNdRangeFreeFunc(sycl::accessor<int, 1> Accessor, int Value) {
+  size_t Item =
+      syclext::this_work_item::get_nd_item<3>().get_global_linear_id();
+  Accessor[Item] = Value;
+}
+} // namespace ns
+
+// TODO: Need to add checks for a static member functions of a class as free
+// function kerenl
+
+int main() {
+
+  int Failed = 0;
+  sycl::queue Queue;
+  sycl::context Context = Queue.get_context();
+  constexpr size_t NumOfElements = 1024;
+  {
+    // Check that sycl::accessor is supported inside nd_range free function
+    // kernel.
+    std::vector<int> ResultHostData(NumOfElements, 0);
+    constexpr int ExpectedResultValue = 111;
+    {
+      sycl::buffer<int, 1> Buffer(ResultHostData);
+      sycl::kernel UsedKernel = getKernel<ns::nsNdRangeFreeFunc>(Context);
+      Queue.submit([&](sycl::handler &Handler) {
+        sycl::accessor<int, 1> Accessor{Buffer, Handler};
+        Handler.set_args(Accessor, ExpectedResultValue);
+        sycl::nd_range<3> Ndr{{4, 4, NumOfElements / 16}, {4, 4, 4}};
+        Handler.parallel_for(Ndr, UsedKernel);
+      });
+    }
+
+    Failed += performResultCheck(NumOfElements, ResultHostData.data(),
+                                 "ns::nsNdRangeFreeFunc with sycl::accessor",
+                                 ExpectedResultValue);
+  }
+
+  {
+    // Check that sycl::accessor is supported inside single_task free function
+    // kernel.
+    std::vector<int> ResultHostData(NumOfElements, 0);
+    constexpr int ExpectedResultValue = 222;
+    {
+      sycl::buffer<int, 1> Buffer(ResultHostData);
+      sycl::kernel UsedKernel = getKernel<globalScopeSingleFreeFunc>(Context);
+      Queue.submit([&](sycl::handler &Handler) {
+        sycl::accessor<int, 1> Accessor{Buffer, Handler};
+        Handler.set_arg(0, Accessor);
+        Handler.set_arg(1, NumOfElements);
+        Handler.set_arg(2, ExpectedResultValue);
+        Handler.single_task(UsedKernel);
+      });
+    }
+    Failed += performResultCheck(
+        NumOfElements, ResultHostData.data(),
+        "globalScopeSingleFreeFunc with sycl::accessor", ExpectedResultValue);
+  }
+
+  return Failed;
+}

--- a/sycl/test-e2e/FreeFunctionKernels/helpers.hpp
+++ b/sycl/test-e2e/FreeFunctionKernels/helpers.hpp
@@ -6,10 +6,10 @@
 namespace syclext = sycl::ext::oneapi;
 namespace syclexp = sycl::ext::oneapi::experimental;
 
-template <typename T>
+template <typename T, typename S>
 static int performResultCheck(size_t NumberOfElements, const T *ResultPtr,
                               std::string_view TestName,
-                              T ExpectedResultValue) {
+                              S ExpectedResultValue) {
   int IsSuccessful{0};
   for (size_t i = 0; i < NumberOfElements; i++) {
     if (ResultPtr[i] != ExpectedResultValue) {

--- a/sycl/test-e2e/FreeFunctionKernels/local_accessor_as_kernel_parameter.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/local_accessor_as_kernel_parameter.cpp
@@ -1,0 +1,93 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// This test verifies whether sycl::local_accessor can be used with free
+// function kernels extension.
+
+#include <sycl/atomic_ref.hpp>
+#include <sycl/ext/oneapi/free_function_queries.hpp>
+#include <sycl/group_barrier.hpp>
+
+#include "helpers.hpp"
+
+constexpr size_t BIN_SIZE = 4;
+constexpr size_t NUM_BINS = 4;
+constexpr size_t INPUT_SIZE = 1024;
+
+namespace ns {
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void nsNdRangeFreeFunc(sycl::accessor<int, 1> InputAccessor,
+                       sycl::accessor<int, 1> ResultAccessor,
+                       sycl::local_accessor<int, 1> LocalAccessor) {
+
+  size_t LocalWorkItemId =
+      syclext::this_work_item::get_nd_item<1>().get_local_id();
+  size_t GlobalWorkItemId =
+      syclext::this_work_item::get_nd_item<1>().get_global_id();
+  sycl::group<1> WorkGroup = syclext::this_work_item::get_work_group<1>();
+
+  if (LocalWorkItemId < BIN_SIZE)
+    LocalAccessor[LocalWorkItemId] = 0;
+
+  sycl::group_barrier(WorkGroup);
+
+  int Value = InputAccessor[GlobalWorkItemId];
+  sycl::atomic_ref<int, sycl::memory_order::relaxed,
+                   sycl::memory_scope::work_group>
+      AtomicRefLocal(LocalAccessor[Value]);
+  AtomicRefLocal++;
+  sycl::group_barrier(WorkGroup);
+
+  if (LocalWorkItemId < BIN_SIZE) {
+    sycl::atomic_ref<int, sycl::memory_order::relaxed,
+                     sycl::memory_scope::device>
+        AtomicRefGlobal(ResultAccessor[LocalWorkItemId]);
+    AtomicRefGlobal.fetch_add(LocalAccessor[LocalWorkItemId]);
+  }
+}
+} // namespace ns
+
+// TODO: Need to add checks for a static member functions of a class as free
+// function kerenl
+
+void FillWithData(std::vector<int> &Data, std::vector<int> &Values) {
+  constexpr size_t Offset = INPUT_SIZE / NUM_BINS;
+  for (size_t i = 0; i < NUM_BINS; ++i) {
+    std::fill(Data.begin() + i * Offset, Data.begin() + (i + 1) * Offset,
+              Values[i]);
+  }
+}
+int main() {
+
+  int Failed = 0;
+  sycl::queue Queue;
+  sycl::context Context = Queue.get_context();
+  {
+    // Check that sycl::local_accesor is supported inside nd_range free function
+    // kernel.
+    std::vector<int> ExpectedHistogramNumbers = {0, 1, 2, 3};
+    std::vector<int> ResultData(BIN_SIZE, 0);
+
+    std::vector<int> InputData(INPUT_SIZE);
+    FillWithData(InputData, ExpectedHistogramNumbers);
+    {
+      sycl::buffer<int, 1> InputBuffer(InputData);
+      sycl::buffer<int, 1> ResultBuffer(ResultData);
+      sycl::kernel UsedKernel = getKernel<ns::nsNdRangeFreeFunc>(Context);
+      Queue.submit([&](sycl::handler &Handler) {
+        sycl::accessor<int, 1> InputAccessor{InputBuffer, Handler};
+        sycl::accessor<int, 1> ResultsAccessor{ResultBuffer, Handler};
+        sycl::local_accessor<int> LocalMemPerWG(sycl::range<1>(BIN_SIZE),
+                                                Handler);
+        Handler.set_args(InputAccessor, ResultsAccessor, LocalMemPerWG);
+        sycl::nd_range<1> Ndr{INPUT_SIZE, INPUT_SIZE / NUM_BINS};
+        Handler.parallel_for(Ndr, UsedKernel);
+      });
+    }
+    Failed +=
+        performResultCheck(NUM_BINS, ResultData.data(),
+                           "sycl::nd_range_kernel with sycl::local_accessor",
+                           INPUT_SIZE / NUM_BINS);
+  }
+  return Failed;
+}


### PR DESCRIPTION
This PR adds new e2e tests for free function kernels extension based on test plan https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/FreeFunctionKernels/test-plan.md