### PR TITLE
[SYCL][NFC] Avoid unused variable AccTarget

### DIFF
--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -1234,10 +1234,9 @@ void handler::extractArgsAndReqsFromLambda(
     } else if (Kind == detail::kernel_param_kind_t::kind_dynamic_accessor) {
       // For args kind of accessor Size is information about accessor.
       // The first 11 bits of Size encodes the accessor target.
-      const access::target AccTarget =
-          static_cast<access::target>(Size & AccessTargetMask);
       // Only local targets are supported for dynamic accessors.
-      assert(AccTarget == access::target::local);
+      assert(static_cast<access::target>(Size & AccessTargetMask) ==
+             access::target::local);
 
       ext::oneapi::experimental::detail::dynamic_parameter_base
           *DynamicParamBase = static_cast<


### PR DESCRIPTION
After https://github.com/intel/llvm/pull/18437, the runtime library is producing a warning about an unused variable AccTarget in handler.cpp. This is due to the variable only being used in assert, which may in turn be removed when assertions are disabled. This commit removes the variable in favor of making the conversion inside the assert.