### PR TITLE
[E2E][BINDLESS] Remove unused `sycl::context` in e2e tests

### DIFF
--- a/sycl/test-e2e/bindless_images/array/fetch_sampled_array.cpp
+++ b/sycl/test-e2e/bindless_images/array/fetch_sampled_array.cpp
@@ -99,7 +99,6 @@ bool run_test(sycl::range<NDims> dims, sycl::range<NDims> localSize,
   using VecType = sycl::vec<DType, NChannels>;
 
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // skip half tests if not supported.
   if constexpr (std::is_same_v<DType, sycl::half>) {

--- a/sycl/test-e2e/bindless_images/array/read_sampled_array.cpp
+++ b/sycl/test-e2e/bindless_images/array/read_sampled_array.cpp
@@ -151,7 +151,6 @@ static bool runTest(sycl::range<NDims> dims, sycl::range<NDims> localSize,
   }
 
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   sycl::backend backend = dev.get_backend();
 

--- a/sycl/test-e2e/bindless_images/array/read_write_1d_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/array/read_write_1d_subregion.cpp
@@ -21,7 +21,6 @@ int main() {
 
   sycl::device dev;
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // declare image data
   size_t width = 4;

--- a/sycl/test-e2e/bindless_images/array/read_write_2d_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/array/read_write_2d_subregion.cpp
@@ -22,7 +22,6 @@ int main() {
 
   sycl::device dev;
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // declare image data
   size_t width = 6;

--- a/sycl/test-e2e/bindless_images/array/read_write_unsampled_array.cpp
+++ b/sycl/test-e2e/bindless_images/array/read_write_unsampled_array.cpp
@@ -128,7 +128,6 @@ bool run_test(sycl::range<NDims> dims, sycl::range<NDims> localSize,
   using VecType = sycl::vec<DType, NChannels>;
 
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // skip half tests if not supported.
   if constexpr (std::is_same_v<DType, sycl::half>) {

--- a/sycl/test-e2e/bindless_images/copies/device_to_device_copy.cpp
+++ b/sycl/test-e2e/bindless_images/copies/device_to_device_copy.cpp
@@ -232,7 +232,6 @@ int main() {
 
   sycl::device dev;
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // Standard images copies
   bool validated =

--- a/sycl/test-e2e/bindless_images/examples/example_1_1D_read_write.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_1_1D_read_write.cpp
@@ -12,7 +12,6 @@ int main() {
   // Set up device, queue, and context
   sycl::device dev;
   sycl::queue q(dev);
-  sycl::context ctxt = q.get_context();
 
   // Initialize input data
   constexpr size_t width = 512;

--- a/sycl/test-e2e/bindless_images/examples/example_2_2D_dynamic_read.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_2_2D_dynamic_read.cpp
@@ -10,7 +10,6 @@ int main() {
   // Set up device, queue, and context
   sycl::device dev;
   sycl::queue q(dev);
-  sycl::context ctxt = q.get_context();
 
   // declare image data
   size_t numImages = 5;

--- a/sycl/test-e2e/bindless_images/examples/example_3_1D_mipmap_anisotropic_filtering_and_levels.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_3_1D_mipmap_anisotropic_filtering_and_levels.cpp
@@ -13,7 +13,6 @@ int main() {
   // Set up device, queue, and context
   sycl::device dev;
   sycl::queue q(dev);
-  sycl::context ctxt = q.get_context();
 
   // declare image data
   constexpr size_t width = 16;

--- a/sycl/test-e2e/bindless_images/examples/example_6_import_memory_and_semaphores.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_6_import_memory_and_semaphores.cpp
@@ -16,7 +16,6 @@ int main() {
   // Set up device, queue, and context
   sycl::device dev;
   sycl::queue q(dev);
-  sycl::context ctxt = q.get_context();
 
   size_t width = 123 /* passed from external API */;
   size_t height = 123 /* passed from external API */;

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -143,7 +143,6 @@ static bool runTest(sycl::range<NDims> dims, sycl::range<NDims> localSize,
   }
 
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   sycl::backend backend = dev.get_backend();
 

--- a/sycl/test-e2e/bindless_images/read_write_1D_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_1D_subregion.cpp
@@ -24,7 +24,6 @@ int main() {
 
   sycl::device dev;
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // declare image data
   constexpr size_t width = 512;

--- a/sycl/test-e2e/bindless_images/read_write_2D_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_2D_subregion.cpp
@@ -17,7 +17,6 @@ int main() {
 
   sycl::device dev;
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // declare image data
   size_t width = 32;

--- a/sycl/test-e2e/bindless_images/read_write_3D_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_3D_subregion.cpp
@@ -20,7 +20,6 @@ int main() {
 
   sycl::device dev;
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // declare image data
   size_t width = 16;

--- a/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
@@ -181,7 +181,6 @@ bool run_test(sycl::range<NDims> dims, sycl::range<NDims> localSize,
   using VecType = sycl::vec<DType, NChannels>;
 
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // skip half tests if not supported
   if constexpr (std::is_same_v<DType, sycl::half>) {

--- a/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
+++ b/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
@@ -21,7 +21,6 @@ bool run_test() {
 
   sycl::device dev;
   sycl::queue q(dev);
-  auto ctxt = q.get_context();
 
   // skip sycl::half tests if fp16 not supported
   if constexpr (std::is_same_v<typename OutType::element_type, sycl::half>) {


### PR DESCRIPTION
`sycl::context ctxt` var is instantiated but then never used in several bindless tests. This PR removes all such cases.