### PR TITLE
[UR][Offload] Small test fixes for CTS

### DIFF
--- a/unified-runtime/source/adapters/offload/adapter.cpp
+++ b/unified-runtime/source/adapters/offload/adapter.cpp
@@ -101,9 +101,19 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
     return ReturnValue(UR_BACKEND_OFFLOAD);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
     return ReturnValue(Adapter.RefCount.load());
+  case UR_ADAPTER_INFO_VERSION:
+    return ReturnValue(1);
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
 
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(ur_adapter_handle_t,
+                                                          const char **,
+                                                          int32_t *) {
+  // This only needs to write out the error if another entry point has returned
+  // "ADAPTER_SPECIFIC", which we never do
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/offload/context.cpp
+++ b/unified-runtime/source/adapters/offload/context.cpp
@@ -24,6 +24,28 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
+urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
+                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+  UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
+
+  switch (propName) {
+  case UR_CONTEXT_INFO_NUM_DEVICES:
+    return ReturnValue(uint32_t{1});
+  case UR_CONTEXT_INFO_DEVICES:
+    return ReturnValue(&hContext->Device, 1);
+  case UR_CONTEXT_INFO_REFERENCE_COUNT:
+    return ReturnValue(hContext->RefCount.load());
+  case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
+  case UR_CONTEXT_INFO_USM_FILL2D_SUPPORT:
+    return ReturnValue(false);
+  default:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
 urContextRetain(ur_context_handle_t hContext) {
   hContext->RefCount++;
   return UR_RESULT_SUCCESS;
@@ -35,4 +57,21 @@ urContextRelease(ur_context_handle_t hContext) {
     delete hContext;
   }
   return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextGetNativeHandle(ur_context_handle_t, ur_native_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+    ur_native_handle_t, ur_adapter_handle_t, uint32_t,
+    const ur_device_handle_t *, const ur_context_native_properties_t *,
+    ur_context_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
+    ur_context_handle_t, ur_context_extended_deleter_t, void *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/offload/device.cpp
+++ b/unified-runtime/source/adapters/offload/device.cpp
@@ -71,6 +71,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS);
   case UR_DEVICE_INFO_BUILD_ON_SUBDEVICE:
     return ReturnValue(false);
+  case UR_DEVICE_INFO_REFERENCE_COUNT:
+    // Devices are never allocated or freed
+    return ReturnValue(uint32_t{1});
+  // Unimplemented features
+  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS:
+  case UR_DEVICE_INFO_GLOBAL_VARIABLE_SUPPORT:
+  case UR_DEVICE_INFO_USM_POOL_SUPPORT:
+  case UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP:
+  case UR_DEVICE_INFO_IMAGE_SUPPORT:
+  case UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT:
+    return ReturnValue(false);
+  case UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT:
+  case UR_DEVICE_INFO_USM_DEVICE_SUPPORT:
+  case UR_DEVICE_INFO_USM_HOST_SUPPORT:
+  case UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT:
+    return ReturnValue(uint32_t{0});
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
@@ -150,4 +166,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceSelectBinary(
 
   // No image can be loaded for the given device
   return UR_RESULT_ERROR_INVALID_BINARY;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceGetNativeHandle(ur_device_handle_t, ur_native_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+    ur_native_handle_t, ur_adapter_handle_t,
+    const ur_device_native_properties_t *, ur_device_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceGetGlobalTimestamps(ur_device_handle_t, uint64_t *, uint64_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/offload/enqueue.cpp
+++ b/unified-runtime/source/adapters/offload/enqueue.cpp
@@ -30,7 +30,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
   (void)pGlobalWorkOffset;
   (void)pLocalWorkSize;
 
-  assert(workDim == 1);
+  if (workDim == 1) {
+    std::cerr
+        << "UR Offload adapter only supports 1d kernel launches at the moment";
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  }
 
   ol_kernel_launch_size_args_t LaunchArgs;
   LaunchArgs.Dimensions = workDim;
@@ -58,4 +62,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
     *phEvent = Event;
   }
   return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill2D(
+    ur_queue_handle_t, void *, size_t, size_t, const void *, size_t, size_t,
+    uint32_t, const ur_event_handle_t *, ur_event_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t, bool, void *, size_t, const void *, size_t, size_t,
+    size_t, uint32_t, const ur_event_handle_t *, ur_event_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/offload/event.cpp
+++ b/unified-runtime/source/adapters/offload/event.cpp
@@ -14,6 +14,31 @@
 #include "event.hpp"
 #include "ur2offload.hpp"
 
+UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hKernel,
+                                                   ur_event_info_t propName,
+                                                   size_t propSize,
+                                                   void *pPropValue,
+                                                   size_t *pPropSizeRet) {
+  UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
+
+  switch (propName) {
+  case UR_EVENT_INFO_REFERENCE_COUNT:
+    return ReturnValue(hKernel->RefCount.load());
+  default:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(ur_event_handle_t,
+                                                            ur_profiling_info_t,
+                                                            size_t, void *,
+                                                            size_t *) {
+  // All variants are optional
+  return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
   for (uint32_t i = 0; i < numEvents; i++) {
@@ -43,4 +68,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
 
   delete hEvent;
   return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventGetNativeHandle(ur_event_handle_t, ur_native_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+    ur_native_handle_t, ur_context_handle_t,
+    const ur_event_native_properties_t *, ur_event_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/offload/kernel.cpp
+++ b/unified-runtime/source/adapters/offload/kernel.cpp
@@ -33,6 +33,23 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
   return UR_RESULT_SUCCESS;
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
+                                                    ur_kernel_info_t propName,
+                                                    size_t propSize,
+                                                    void *pPropValue,
+                                                    size_t *pPropSizeRet) {
+  UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
+
+  switch (propName) {
+  case UR_KERNEL_INFO_REFERENCE_COUNT:
+    return ReturnValue(hKernel->RefCount.load());
+  default:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
   hKernel->RefCount++;
   return UR_RESULT_SUCCESS;
@@ -76,4 +93,35 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetGroupInfo(
     return ReturnValue(GroupSize, 3);
   }
   return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+    ur_kernel_handle_t, ur_device_handle_t, ur_kernel_sub_group_info_t propName,
+    size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+  UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
+  (void)propName;
+
+  return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelGetNativeHandle(ur_kernel_handle_t, ur_native_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+    ur_native_handle_t, ur_context_handle_t, ur_program_handle_t,
+    const ur_kernel_native_properties_t *, ur_kernel_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t, uint32_t, const ur_specialization_constant_info_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
+    ur_kernel_handle_t, ur_queue_handle_t, uint32_t, const size_t *,
+    const size_t *, size_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/offload/platform.cpp
+++ b/unified-runtime/source/adapters/offload/platform.cpp
@@ -60,6 +60,8 @@ urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
     return ReturnValue("FULL_PROFILE");
   case UR_PLATFORM_INFO_BACKEND:
     return ReturnValue(UR_BACKEND_OFFLOAD);
+  case UR_PLATFORM_INFO_ADAPTER:
+    return ReturnValue(&Adapter);
     break;
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
@@ -95,4 +97,21 @@ urPlatformGetBackendOption(ur_platform_handle_t, const char *pFrontendOption,
     return UR_RESULT_SUCCESS;
   }
   return UR_RESULT_ERROR_INVALID_VALUE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetNativeHandle(ur_platform_handle_t, ur_native_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+    ur_native_handle_t, ur_adapter_handle_t,
+    const ur_platform_native_properties_t *, ur_platform_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetApiVersion(ur_platform_handle_t, ur_api_version_t *pVersion) {
+  *pVersion = UR_API_VERSION_CURRENT;
+  return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/offload/program.cpp
+++ b/unified-runtime/source/adapters/offload/program.cpp
@@ -215,6 +215,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramBuildExp(ur_program_handle_t,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
+                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+  UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
+
+  switch (propName) {
+  case UR_PROGRAM_INFO_REFERENCE_COUNT:
+    return ReturnValue(hProgram->RefCount.load());
+  default:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRetain(ur_program_handle_t hProgram) {
   hProgram->RefCount++;
   return UR_RESULT_SUCCESS;
@@ -231,4 +246,20 @@ urProgramRelease(ur_program_handle_t hProgram) {
   }
 
   return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetNativeHandle(ur_program_handle_t, ur_native_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+    ur_native_handle_t, ur_context_handle_t,
+    const ur_program_native_properties_t *, ur_program_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+    ur_program_handle_t, uint32_t, const ur_specialization_constant_info_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/offload/queue.cpp
+++ b/unified-runtime/source/adapters/offload/queue.cpp
@@ -37,6 +37,23 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
   return UR_RESULT_SUCCESS;
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
+                                                   ur_queue_info_t propName,
+                                                   size_t propSize,
+                                                   void *pPropValue,
+                                                   size_t *pPropSizeRet) {
+  UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
+
+  switch (propName) {
+  case UR_QUEUE_INFO_REFERENCE_COUNT:
+    return ReturnValue(hQueue->RefCount.load());
+  default:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
   hQueue->RefCount++;
   return UR_RESULT_SUCCESS;
@@ -56,4 +73,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(ur_queue_handle_t hQueue) {
   return offloadResultToUR(olWaitQueue(hQueue->OffloadQueue));
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urQueueGetNativeHandle(
+    ur_queue_handle_t, ur_queue_native_desc_t *, ur_native_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+    ur_native_handle_t, ur_context_handle_t, ur_device_handle_t,
+    const ur_queue_native_properties_t *, ur_queue_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/offload/ur2offload.hpp
+++ b/unified-runtime/source/adapters/offload/ur2offload.hpp
@@ -23,6 +23,9 @@ inline ur_result_t offloadResultToUR(ol_result_t Result) {
     return UR_RESULT_ERROR_INVALID_NULL_POINTER;
   case OL_ERRC_UNSUPPORTED:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  // Returned whenever a kernel can't be found
+  case OL_ERRC_NOT_FOUND:
+    return UR_RESULT_ERROR_INVALID_KERNEL_NAME;
   default:
     return UR_RESULT_ERROR_UNKNOWN;
   }

--- a/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
@@ -37,11 +37,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urPlatformCreateWithNativeHandle;
   pDdiTable->pfnGet = urPlatformGet;
-  pDdiTable->pfnGetApiVersion = nullptr;
+  pDdiTable->pfnGetApiVersion = urPlatformGetApiVersion;
   pDdiTable->pfnGetInfo = urPlatformGetInfo;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetNativeHandle = urPlatformGetNativeHandle;
   pDdiTable->pfnGetBackendOption = urPlatformGetBackendOption;
   return UR_RESULT_SUCCESS;
 }
@@ -53,12 +53,12 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
     return result;
   }
   pDdiTable->pfnCreate = urContextCreate;
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
-  pDdiTable->pfnGetInfo = nullptr;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urContextCreateWithNativeHandle;
+  pDdiTable->pfnGetInfo = urContextGetInfo;
+  pDdiTable->pfnGetNativeHandle = urContextGetNativeHandle;
   pDdiTable->pfnRelease = urContextRelease;
   pDdiTable->pfnRetain = urContextRetain;
-  pDdiTable->pfnSetExtendedDeleter = nullptr;
+  pDdiTable->pfnSetExtendedDeleter = urContextSetExtendedDeleter;
   return UR_RESULT_SUCCESS;
 }
 
@@ -68,10 +68,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
-  pDdiTable->pfnGetInfo = nullptr;
-  pDdiTable->pfnGetNativeHandle = nullptr;
-  pDdiTable->pfnGetProfilingInfo = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urEventCreateWithNativeHandle;
+  pDdiTable->pfnGetInfo = urEventGetInfo;
+  pDdiTable->pfnGetNativeHandle = urEventGetNativeHandle;
+  pDdiTable->pfnGetProfilingInfo = urEventGetProfilingInfo;
   pDdiTable->pfnRelease = urEventRelease;
   pDdiTable->pfnRetain = urEventRetain;
   pDdiTable->pfnSetCallback = nullptr;
@@ -89,16 +89,17 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
   pDdiTable->pfnCompile = nullptr;
   pDdiTable->pfnCreateWithBinary = urProgramCreateWithBinary;
   pDdiTable->pfnCreateWithIL = nullptr;
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urProgramCreateWithNativeHandle;
   pDdiTable->pfnGetBuildInfo = nullptr;
   pDdiTable->pfnGetFunctionPointer = nullptr;
   pDdiTable->pfnGetGlobalVariablePointer = nullptr;
-  pDdiTable->pfnGetInfo = nullptr;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetInfo = urProgramGetInfo;
+  pDdiTable->pfnGetNativeHandle = urProgramGetNativeHandle;
   pDdiTable->pfnLink = nullptr;
   pDdiTable->pfnRelease = urProgramRelease;
   pDdiTable->pfnRetain = urProgramRetain;
-  pDdiTable->pfnSetSpecializationConstants = nullptr;
+  pDdiTable->pfnSetSpecializationConstants =
+      urProgramSetSpecializationConstants;
   return UR_RESULT_SUCCESS;
 }
 
@@ -109,11 +110,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
     return result;
   }
   pDdiTable->pfnCreate = urKernelCreate;
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urKernelCreateWithNativeHandle;
   pDdiTable->pfnGetGroupInfo = urKernelGetGroupInfo;
-  pDdiTable->pfnGetInfo = nullptr;
-  pDdiTable->pfnGetNativeHandle = nullptr;
-  pDdiTable->pfnGetSubGroupInfo = nullptr;
+  pDdiTable->pfnGetInfo = urKernelGetInfo;
+  pDdiTable->pfnGetNativeHandle = urKernelGetNativeHandle;
+  pDdiTable->pfnGetSubGroupInfo = urKernelGetSubGroupInfo;
   pDdiTable->pfnRelease = urKernelRelease;
   pDdiTable->pfnRetain = urKernelRetain;
   pDdiTable->pfnSetArgLocal = nullptr;
@@ -122,8 +123,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
   pDdiTable->pfnSetArgSampler = nullptr;
   pDdiTable->pfnSetArgValue = urKernelSetArgValue;
   pDdiTable->pfnSetExecInfo = urKernelSetExecInfo;
-  pDdiTable->pfnSetSpecializationConstants = nullptr;
-  pDdiTable->pfnGetSuggestedLocalWorkSize = nullptr;
+  pDdiTable->pfnSetSpecializationConstants = urKernelSetSpecializationConstants;
+  pDdiTable->pfnGetSuggestedLocalWorkSize = urKernelGetSuggestedLocalWorkSize;
   return UR_RESULT_SUCCESS;
 }
 
@@ -184,10 +185,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
   pDdiTable->pfnMemImageRead = nullptr;
   pDdiTable->pfnMemImageWrite = nullptr;
   pDdiTable->pfnMemUnmap = nullptr;
-  pDdiTable->pfnUSMFill2D = nullptr;
+  pDdiTable->pfnUSMFill2D = urEnqueueUSMFill2D;
   pDdiTable->pfnUSMFill = nullptr;
   pDdiTable->pfnUSMAdvise = nullptr;
-  pDdiTable->pfnUSMMemcpy2D = nullptr;
+  pDdiTable->pfnUSMMemcpy2D = urEnqueueUSMMemcpy2D;
   pDdiTable->pfnUSMMemcpy = nullptr;
   pDdiTable->pfnUSMPrefetch = nullptr;
   pDdiTable->pfnReadHostPipe = nullptr;
@@ -205,7 +206,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
   pDdiTable->pfnAdapterRelease = urAdapterRelease;
   pDdiTable->pfnAdapterRetain = urAdapterRetain;
-  pDdiTable->pfnAdapterGetLastError = nullptr;
+  pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
   return UR_RESULT_SUCCESS;
 }
 
@@ -216,11 +217,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
     return result;
   }
   pDdiTable->pfnCreate = urQueueCreate;
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urQueueCreateWithNativeHandle;
   pDdiTable->pfnFinish = urQueueFinish;
   pDdiTable->pfnFlush = nullptr;
-  pDdiTable->pfnGetInfo = nullptr;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetInfo = urQueueGetInfo;
+  pDdiTable->pfnGetNativeHandle = urQueueGetNativeHandle;
   pDdiTable->pfnRelease = urQueueRelease;
   pDdiTable->pfnRetain = urQueueRetain;
   return UR_RESULT_SUCCESS;
@@ -250,11 +251,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urDeviceCreateWithNativeHandle;
   pDdiTable->pfnGet = urDeviceGet;
-  pDdiTable->pfnGetGlobalTimestamps = nullptr;
+  pDdiTable->pfnGetGlobalTimestamps = urDeviceGetGlobalTimestamps;
   pDdiTable->pfnGetInfo = urDeviceGetInfo;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetNativeHandle = urDeviceGetNativeHandle;
   pDdiTable->pfnPartition = urDevicePartition;
   pDdiTable->pfnRelease = urDeviceRelease;
   pDdiTable->pfnRetain = urDeviceRetain;

--- a/unified-runtime/test/conformance/adapter/urAdapterGetInfo.cpp
+++ b/unified-runtime/test/conformance/adapter/urAdapterGetInfo.cpp
@@ -26,7 +26,7 @@ TEST_P(urAdapterGetInfoTest, SuccessBackend) {
                                   &property_value, nullptr));
 
   ASSERT_TRUE(property_value >= UR_BACKEND_LEVEL_ZERO &&
-              property_value <= UR_BACKEND_NATIVE_CPU);
+              property_value <= UR_BACKEND_OFFLOAD);
 }
 
 TEST_P(urAdapterGetInfoTest, SuccessReferenceCount) {


### PR DESCRIPTION
This patch fixes a lot of small issues in order to boost the CTS pass
rate. Specifically:
* A number of optional entry points have been created with a stub entry
  point that just returns UNSUPPORTED.
* Some trivial `getInfo` queries have been implemented.
* Some `getInfo` queries advertise absent features as "not supported".
* Trying to run `urEnqueueKernelLaunch` with dimensions greater than 1
  fails gracefully.
* `urPlatformGetApiVersion` returns the actual API version.
* `OL_ERRC_NOT_FOUND` is mapped to
  `UR_RESULT_ERROR_INVALID_KERNEL_NAME`.
* A conformance test has been updated to accept the Offload enum.

Note that something marked unsupported here does not imply that it
will never be supported; it just isn't supported in the current
version.
