### PR TITLE
[SYCL] Fix shared library build

### DIFF
--- a/llvm/lib/SYCLPostLink/CMakeLists.txt
+++ b/llvm/lib/SYCLPostLink/CMakeLists.txt
@@ -22,8 +22,10 @@ add_llvm_component_library(LLVMSYCLPostLink
   BitWriter
   Core
   Demangle
+  InstCombine
   IRPrinter
   Passes
+  ScalarOpts
   Support
   ipo
   )


### PR DESCRIPTION
Manually verified the fix, error seen [here](https://github.com/intel/llvm/actions/runs/15280153119/job/42976816882), fix [here](https://github.com/intel/llvm/actions/runs/15283845466).

```
/usr/bin/ld: lib/SYCLPostLink/CMakeFiles/LLVMSYCLPostLink.dir/ESIMDPostSplitProcessing.cpp.o: in function `llvm::sycl::lowerESIMDConstructs(llvm::module_split::ModuleDesc&, bool, bool)':
ESIMDPostSplitProcessing.cpp:(.text._ZN4llvm4sycl20lowerESIMDConstructsERNS_12module_split10ModuleDescEbb+0xb67): undefined reference to `llvm::SROAPass::SROAPass(llvm::SROAOptions)'
/usr/bin/ld: ESIMDPostSplitProcessing.cpp:(.text._ZN4llvm4sycl20lowerESIMDConstructsERNS_12module_split10ModuleDescEbb+0xceb): undefined reference to `llvm::SROAPass::SROAPass(llvm::SROAOptions)'
/usr/bin/ld: ESIMDPostSplitProcessing.cpp:(.text._ZN4llvm4sycl20lowerESIMDConstructsERNS_12module_split10ModuleDescEbb+0xd8a): undefined reference to `llvm::InstCombinePass::InstCombinePass(llvm::InstCombineOptions)'
/usr/bin/ld: ESIMDPostSplitProcessing.cpp:(.text._ZN4llvm4sycl20lowerESIMDConstructsERNS_12module_split10ModuleDescEbb+0x10f6): undefined reference to `llvm::SROAPass::SROAPass(llvm::SROAOptions)'
/usr/bin/ld: ESIMDPostSplitProcessing.cpp:(.text._ZN4llvm4sycl20lowerESIMDConstructsERNS_12module_split10ModuleDescEbb+0x1182): undefined reference to `llvm::InstCombinePass::InstCombinePass(llvm::InstCombineOptions)'
```