### PR TITLE
[SYCL] sycl::kernel_id should owns MName

### DIFF
--- a/sycl/source/detail/kernel_id_impl.hpp
+++ b/sycl/source/detail/kernel_id_impl.hpp
@@ -38,7 +38,7 @@ public:
   const char *get_name() { return MName.data(); }
 
 private:
-  KernelNameStrT MName;
+  std::string MName;
 };
 
 } // namespace detail


### PR DESCRIPTION
In 8a5462d for preview the type was changed to string_view, but in some scenario memory for kernel name is released before kernel_id is used. In common case kernel_id_impl is created from ProgramManager::addImages(), i.e. not on hot path.