### PR TITLE
[libclc] Don't run remangler on OpenCL library

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -586,6 +586,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
         ARCH_SUFFIX libspirv-${arch_suffix}
         TRIPLE ${clang_triple}
         TARGET_ENV libspirv-
+        REMANGLE ${LIBCLC_GENERATE_REMANGLED_VARIANTS}
         COMPILE_FLAGS ${spirv_build_flags}
         OPT_FLAGS ${opt_flags}
         LIB_FILES ${libspirv_lib_files}

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -483,7 +483,7 @@ function(add_libclc_builtin_set)
   install( FILES ${builtins_lib} DESTINATION ${CMAKE_INSTALL_DATADIR}/clc )
 
   # Generate remangled variants if requested
-  if( LIBCLC_GENERATE_REMANGLED_VARIANTS )
+  if( LIBCLC_GENERATE_REMANGLED_VARIANTS AND "${ARG_TARGET_ENV} " MATCHES "^libspirv" )
     set( dummy_in ${LIBCLC_LIBRARY_OUTPUT_INTDIR}/libclc_dummy_in.cc )
     add_custom_command( OUTPUT ${dummy_in}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBCLC_LIBRARY_OUTPUT_INTDIR}

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -309,6 +309,8 @@ endfunction()
 #      Optimization options (for opt)
 #  * TARGET_ENV <string>
 #      Prefix to give the final builtin library aliases
+#  * REMANGLE <string>
+#      Bool string indicating whether remangler will be run
 #  * ALIASES <string> ...
 #      List of aliases
 #  * INTERNAL_LINK_DEPENDENCIES <target> ...
@@ -318,7 +320,7 @@ endfunction()
 function(add_libclc_builtin_set)
   cmake_parse_arguments(ARG
     "CLC_INTERNAL"
-    "ARCH;TRIPLE;ARCH_SUFFIX;TARGET_ENV;PARENT_TARGET"
+    "ARCH;TRIPLE;ARCH_SUFFIX;TARGET_ENV;REMANGLE;PARENT_TARGET"
     "LIB_FILES;GEN_FILES;COMPILE_FLAGS;OPT_FLAGS;ALIASES;INTERNAL_LINK_DEPENDENCIES"
     ${ARGN}
   )
@@ -483,7 +485,7 @@ function(add_libclc_builtin_set)
   install( FILES ${builtins_lib} DESTINATION ${CMAKE_INSTALL_DATADIR}/clc )
 
   # Generate remangled variants if requested
-  if( LIBCLC_GENERATE_REMANGLED_VARIANTS AND "${ARG_TARGET_ENV} " MATCHES "^libspirv" )
+  if( ARG_REMANGLE )
     set( dummy_in ${LIBCLC_LIBRARY_OUTPUT_INTDIR}/libclc_dummy_in.cc )
     add_custom_command( OUTPUT ${dummy_in}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBCLC_LIBRARY_OUTPUT_INTDIR}


### PR DESCRIPTION
The remangler is for libspirv. Don't run remangler on OpenCL library until there is a use case. This would avoids confusions on unused remangled OpenCL library in build folder.