### PR TITLE
[CI] Test 'all' cmake target in nightly

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -181,6 +181,7 @@ jobs:
           -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
     - name: Compile
       id: build
+      # Emulate default value for manual dispatch as we've run out of available arguments.
       run: cmake --build $GITHUB_WORKSPACE/build --target ${{ inputs.build_target || 'sycl-toolchain' }}
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -32,6 +32,10 @@ on:
       build_artifact_suffix:
         type: string
         required: true
+      build_target:
+        type: string
+        required: false
+        default: sycl-toolchain
       artifact_archive_name:
         type: string
         default: llvm_sycl.tar.zst
@@ -177,7 +181,7 @@ jobs:
           -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
     - name: Compile
       id: build
-      run: cmake --build $GITHUB_WORKSPACE/build --target sycl-toolchain
+      run: cmake --build $GITHUB_WORKSPACE/build --target ${{ inputs.build_target || 'sycl-toolchain' }}
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
       run: |

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -33,6 +33,7 @@ jobs:
       build_cache_suffix: sprod_shared
       build_artifact_suffix: sprod_shared
       build_configure_extra_args: '--shared-libs --hip --cuda --native_cpu --no-assertions'
+      build_target: all
 
       artifact_archive_name: sycl_linux_shared.tar.zst
 


### PR DESCRIPTION
There was a case where we broke build for the `all` target but `sycl-toolchain` worked, so build `all` to catch this.

Nightly run [here](https://github.com/intel/llvm/actions/runs/15302502386), failures not because of this.

We need the `||` part in ` ${{ inputs.build_target || 'sycl-toolchain' }}` because for the `workflow_dispatch` case, we already have 10 input args which is the max so we can't always have a `inputs.build_target` available without more work.

Closes: https://github.com/intel/llvm/issues/18648