### PR TITLE
[SYCL][E2E][Matrix] Remove XFAIL from cache SLM test on DG2

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_SLM.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_SLM.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: target-spir
-// XFAIL: run-mode && (gpu-intel-dg2 || igc-dev)
+// XFAIL: run-mode && igc-dev
 // XFAIL-TRACKER: CMPLRLLVM-66371
 
 // REQUIRES: aspect-ext_intel_matrix, gpu


### PR DESCRIPTION
It's XPASSing after the latest driver update, see [here](https://github.com/intel/llvm/actions/runs/15296757125/job/43028280618).