### PR TITLE
[UR][Offload] Install libur_adapter_offload.so as part of `install` tgt

### DIFF
--- a/unified-runtime/source/adapters/offload/CMakeLists.txt
+++ b/unified-runtime/source/adapters/offload/CMakeLists.txt
@@ -44,6 +44,7 @@ add_ur_adapter(${TARGET_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/ur_interface_loader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/usm.cpp
 )
+install_ur_library(${TARGET_NAME})
 
 set_target_properties(${TARGET_NAME} PROPERTIES
     VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"


### PR DESCRIPTION
Running `ninja install` in a build of UR with offload enabled didn't
install it into `install/lib`. Now it does.
