### PR TITLE
[UR] Remove global DDI table entries

### DIFF
--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -13006,6 +13006,54 @@ typedef struct ur_loader_config_set_mocking_enabled_params_t {
 } ur_loader_config_set_mocking_enabled_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urAdapterGet
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_adapter_get_params_t {
+  uint32_t *pNumEntries;
+  ur_adapter_handle_t **pphAdapters;
+  uint32_t **ppNumAdapters;
+} ur_adapter_get_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urAdapterRelease
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_adapter_release_params_t {
+  ur_adapter_handle_t *phAdapter;
+} ur_adapter_release_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urAdapterRetain
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_adapter_retain_params_t {
+  ur_adapter_handle_t *phAdapter;
+} ur_adapter_retain_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urAdapterGetLastError
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_adapter_get_last_error_params_t {
+  ur_adapter_handle_t *phAdapter;
+  const char ***pppMessage;
+  int32_t **ppError;
+} ur_adapter_get_last_error_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urAdapterGetInfo
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_adapter_get_info_params_t {
+  ur_adapter_handle_t *phAdapter;
+  ur_adapter_info_t *ppropName;
+  size_t *ppropSize;
+  void **ppPropValue;
+  size_t **ppPropSizeRet;
+} ur_adapter_get_info_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urAdapterSetLoggerCallback
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
@@ -13900,54 +13948,6 @@ typedef struct ur_physical_mem_get_info_params_t {
   void **ppPropValue;
   size_t **ppPropSizeRet;
 } ur_physical_mem_get_info_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urAdapterGet
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_adapter_get_params_t {
-  uint32_t *pNumEntries;
-  ur_adapter_handle_t **pphAdapters;
-  uint32_t **ppNumAdapters;
-} ur_adapter_get_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urAdapterRelease
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_adapter_release_params_t {
-  ur_adapter_handle_t *phAdapter;
-} ur_adapter_release_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urAdapterRetain
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_adapter_retain_params_t {
-  ur_adapter_handle_t *phAdapter;
-} ur_adapter_retain_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urAdapterGetLastError
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_adapter_get_last_error_params_t {
-  ur_adapter_handle_t *phAdapter;
-  const char ***pppMessage;
-  int32_t **ppError;
-} ur_adapter_get_last_error_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urAdapterGetInfo
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_adapter_get_info_params_t {
-  ur_adapter_handle_t *phAdapter;
-  ur_adapter_info_t *ppropName;
-  size_t *ppropSize;
-  void **ppPropValue;
-  size_t **ppPropSizeRet;
-} ur_adapter_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urEnqueueKernelLaunch

--- a/unified-runtime/include/ur_api_funcs.def
+++ b/unified-runtime/include/ur_api_funcs.def
@@ -17,6 +17,11 @@
 
 // Auto-generated file, do not edit.
 
+_UR_API(urAdapterGet)
+_UR_API(urAdapterRelease)
+_UR_API(urAdapterRetain)
+_UR_API(urAdapterGetLastError)
+_UR_API(urAdapterGetInfo)
 _UR_API(urAdapterSetLoggerCallback)
 _UR_API(urAdapterSetLoggerCallbackLevel)
 _UR_API(urPlatformGet)
@@ -102,11 +107,6 @@ _UR_API(urPhysicalMemCreate)
 _UR_API(urPhysicalMemRetain)
 _UR_API(urPhysicalMemRelease)
 _UR_API(urPhysicalMemGetInfo)
-_UR_API(urAdapterGet)
-_UR_API(urAdapterRelease)
-_UR_API(urAdapterRetain)
-_UR_API(urAdapterGetLastError)
-_UR_API(urAdapterGetInfo)
 _UR_API(urEnqueueKernelLaunch)
 _UR_API(urEnqueueEventsWait)
 _UR_API(urEnqueueEventsWaitWithBarrier)

--- a/unified-runtime/include/ur_ddi.h
+++ b/unified-runtime/include/ur_ddi.h
@@ -24,6 +24,32 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterGet
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterGet_t)(uint32_t,
+                                                    ur_adapter_handle_t *,
+                                                    uint32_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterRelease
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterRelease_t)(ur_adapter_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterRetain
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterRetain_t)(ur_adapter_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterGetLastError
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterGetLastError_t)(
+    ur_adapter_handle_t, const char **, int32_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterGetInfo_t)(ur_adapter_handle_t,
+                                                        ur_adapter_info_t,
+                                                        size_t, void *,
+                                                        size_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urAdapterSetLoggerCallback
 typedef ur_result_t(UR_APICALL *ur_pfnAdapterSetLoggerCallback_t)(
     ur_adapter_handle_t, ur_logger_callback_t, void *, ur_logger_level_t);
@@ -36,6 +62,11 @@ typedef ur_result_t(UR_APICALL *ur_pfnAdapterSetLoggerCallbackLevel_t)(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Adapter functions pointers
 typedef struct ur_adapter_dditable_t {
+  ur_pfnAdapterGet_t pfnGet;
+  ur_pfnAdapterRelease_t pfnRelease;
+  ur_pfnAdapterRetain_t pfnRetain;
+  ur_pfnAdapterGetLastError_t pfnGetLastError;
+  ur_pfnAdapterGetInfo_t pfnGetInfo;
   ur_pfnAdapterSetLoggerCallback_t pfnSetLoggerCallback;
   ur_pfnAdapterSetLoggerCallbackLevel_t pfnSetLoggerCallbackLevel;
 } ur_adapter_dditable_t;
@@ -875,62 +906,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPhysicalMemProcAddrTable(
 /// @brief Function-pointer for urGetPhysicalMemProcAddrTable
 typedef ur_result_t(UR_APICALL *ur_pfnGetPhysicalMemProcAddrTable_t)(
     ur_api_version_t, ur_physical_mem_dditable_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urAdapterGet
-typedef ur_result_t(UR_APICALL *ur_pfnAdapterGet_t)(uint32_t,
-                                                    ur_adapter_handle_t *,
-                                                    uint32_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urAdapterRelease
-typedef ur_result_t(UR_APICALL *ur_pfnAdapterRelease_t)(ur_adapter_handle_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urAdapterRetain
-typedef ur_result_t(UR_APICALL *ur_pfnAdapterRetain_t)(ur_adapter_handle_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urAdapterGetLastError
-typedef ur_result_t(UR_APICALL *ur_pfnAdapterGetLastError_t)(
-    ur_adapter_handle_t, const char **, int32_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urAdapterGetInfo
-typedef ur_result_t(UR_APICALL *ur_pfnAdapterGetInfo_t)(ur_adapter_handle_t,
-                                                        ur_adapter_info_t,
-                                                        size_t, void *,
-                                                        size_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Table of Global functions pointers
-typedef struct ur_global_dditable_t {
-  ur_pfnAdapterGet_t pfnAdapterGet;
-  ur_pfnAdapterRelease_t pfnAdapterRelease;
-  ur_pfnAdapterRetain_t pfnAdapterRetain;
-  ur_pfnAdapterGetLastError_t pfnAdapterGetLastError;
-  ur_pfnAdapterGetInfo_t pfnAdapterGetInfo;
-} ur_global_dditable_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's Global table
-///        with current process' addresses
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    /// [in] API version requested
-    ur_api_version_t version,
-    /// [in,out] pointer to table of DDI function pointers
-    ur_global_dditable_t *pDdiTable);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urGetGlobalProcAddrTable
-typedef ur_result_t(UR_APICALL *ur_pfnGetGlobalProcAddrTable_t)(
-    ur_api_version_t, ur_global_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urEnqueueKernelLaunch
@@ -2051,7 +2026,6 @@ typedef struct ur_dditable_t {
   ur_sampler_dditable_t Sampler;
   ur_mem_dditable_t Mem;
   ur_physical_mem_dditable_t PhysicalMem;
-  ur_global_dditable_t Global;
   ur_enqueue_dditable_t Enqueue;
   ur_enqueue_exp_dditable_t EnqueueExp;
   ur_usm_dditable_t USM;

--- a/unified-runtime/include/ur_print.h
+++ b/unified-runtime/include/ur_print.h
@@ -1517,6 +1517,56 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigSetMockingEnabledParams(
     char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_get_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL
+urPrintAdapterGetParams(const struct ur_adapter_get_params_t *params,
+                        char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_release_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterReleaseParams(
+    const struct ur_adapter_release_params_t *params, char *buffer,
+    const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_retain_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterRetainParams(
+    const struct ur_adapter_retain_params_t *params, char *buffer,
+    const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_get_last_error_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterGetLastErrorParams(
+    const struct ur_adapter_get_last_error_params_t *params, char *buffer,
+    const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_get_info_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterGetInfoParams(
+    const struct ur_adapter_get_info_params_t *params, char *buffer,
+    const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_adapter_set_logger_callback_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -2372,56 +2422,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintPhysicalMemReleaseParams(
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPhysicalMemGetInfoParams(
     const struct ur_physical_mem_get_info_params_t *params, char *buffer,
-    const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_get_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL
-urPrintAdapterGetParams(const struct ur_adapter_get_params_t *params,
-                        char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_release_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterReleaseParams(
-    const struct ur_adapter_release_params_t *params, char *buffer,
-    const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_retain_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterRetainParams(
-    const struct ur_adapter_retain_params_t *params, char *buffer,
-    const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_get_last_error_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterGetLastErrorParams(
-    const struct ur_adapter_get_last_error_params_t *params, char *buffer,
-    const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_get_info_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterGetInfoParams(
-    const struct ur_adapter_get_info_params_t *params, char *buffer,
     const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/unified-runtime/include/ur_print.hpp
+++ b/unified-runtime/include/ur_print.hpp
@@ -12410,6 +12410,132 @@ inline std::ostream &operator<<(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_get_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_adapter_get_params_t *params) {
+
+  os << ".NumEntries = ";
+
+  os << *(params->pNumEntries);
+
+  os << ", ";
+  os << ".phAdapters = ";
+  ur::details::printPtr(os,
+                        reinterpret_cast<const void *>(*(params->pphAdapters)));
+  if (*(params->pphAdapters) != NULL) {
+    os << " {";
+    for (size_t i = 0; i < *params->pNumEntries; ++i) {
+      if (i != 0) {
+        os << ", ";
+      }
+
+      ur::details::printPtr(os, (*(params->pphAdapters))[i]);
+    }
+    os << "}";
+  }
+
+  os << ", ";
+  os << ".pNumAdapters = ";
+
+  ur::details::printPtr(os, *(params->ppNumAdapters));
+
+  return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_release_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_adapter_release_params_t *params) {
+
+  os << ".hAdapter = ";
+
+  ur::details::printPtr(os, *(params->phAdapter));
+
+  return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_retain_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_adapter_retain_params_t *params) {
+
+  os << ".hAdapter = ";
+
+  ur::details::printPtr(os, *(params->phAdapter));
+
+  return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_get_last_error_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_adapter_get_last_error_params_t *params) {
+
+  os << ".hAdapter = ";
+
+  ur::details::printPtr(os, *(params->phAdapter));
+
+  os << ", ";
+  os << ".ppMessage = ";
+
+  ur::details::printPtr(os, *(params->pppMessage));
+
+  os << ", ";
+  os << ".pError = ";
+
+  ur::details::printPtr(os, *(params->ppError));
+
+  return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_get_info_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_adapter_get_info_params_t *params) {
+
+  os << ".hAdapter = ";
+
+  ur::details::printPtr(os, *(params->phAdapter));
+
+  os << ", ";
+  os << ".propName = ";
+
+  os << *(params->ppropName);
+
+  os << ", ";
+  os << ".propSize = ";
+
+  os << *(params->ppropSize);
+
+  os << ", ";
+  os << ".pPropValue = ";
+  ur::details::printTagged(os, *(params->ppPropValue), *(params->ppropName),
+                           *(params->ppropSize));
+
+  os << ", ";
+  os << ".pPropSizeRet = ";
+
+  ur::details::printPtr(os, *(params->ppPropSizeRet));
+
+  return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_adapter_set_logger_callback_params_t type
 /// @returns
 ///     std::ostream &
@@ -14924,132 +15050,6 @@ inline std::ostream &operator<<(
   os << ".hPhysicalMem = ";
 
   ur::details::printPtr(os, *(params->phPhysicalMem));
-
-  os << ", ";
-  os << ".propName = ";
-
-  os << *(params->ppropName);
-
-  os << ", ";
-  os << ".propSize = ";
-
-  os << *(params->ppropSize);
-
-  os << ", ";
-  os << ".pPropValue = ";
-  ur::details::printTagged(os, *(params->ppPropValue), *(params->ppropName),
-                           *(params->ppropSize));
-
-  os << ", ";
-  os << ".pPropSizeRet = ";
-
-  ur::details::printPtr(os, *(params->ppPropSizeRet));
-
-  return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_adapter_get_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &
-operator<<(std::ostream &os,
-           [[maybe_unused]] const struct ur_adapter_get_params_t *params) {
-
-  os << ".NumEntries = ";
-
-  os << *(params->pNumEntries);
-
-  os << ", ";
-  os << ".phAdapters = ";
-  ur::details::printPtr(os,
-                        reinterpret_cast<const void *>(*(params->pphAdapters)));
-  if (*(params->pphAdapters) != NULL) {
-    os << " {";
-    for (size_t i = 0; i < *params->pNumEntries; ++i) {
-      if (i != 0) {
-        os << ", ";
-      }
-
-      ur::details::printPtr(os, (*(params->pphAdapters))[i]);
-    }
-    os << "}";
-  }
-
-  os << ", ";
-  os << ".pNumAdapters = ";
-
-  ur::details::printPtr(os, *(params->ppNumAdapters));
-
-  return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_adapter_release_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &
-operator<<(std::ostream &os,
-           [[maybe_unused]] const struct ur_adapter_release_params_t *params) {
-
-  os << ".hAdapter = ";
-
-  ur::details::printPtr(os, *(params->phAdapter));
-
-  return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_adapter_retain_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &
-operator<<(std::ostream &os,
-           [[maybe_unused]] const struct ur_adapter_retain_params_t *params) {
-
-  os << ".hAdapter = ";
-
-  ur::details::printPtr(os, *(params->phAdapter));
-
-  return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_adapter_get_last_error_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(
-    std::ostream &os,
-    [[maybe_unused]] const struct ur_adapter_get_last_error_params_t *params) {
-
-  os << ".hAdapter = ";
-
-  ur::details::printPtr(os, *(params->phAdapter));
-
-  os << ", ";
-  os << ".ppMessage = ";
-
-  ur::details::printPtr(os, *(params->pppMessage));
-
-  os << ", ";
-  os << ".pError = ";
-
-  ur::details::printPtr(os, *(params->ppError));
-
-  return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_adapter_get_info_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &
-operator<<(std::ostream &os,
-           [[maybe_unused]] const struct ur_adapter_get_info_params_t *params) {
-
-  os << ".hAdapter = ";
-
-  ur::details::printPtr(os, *(params->phAdapter));
 
   os << ", ";
   os << ".propName = ";
@@ -20896,6 +20896,21 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os,
   case UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED: {
     os << (const struct ur_loader_config_set_mocking_enabled_params_t *)params;
   } break;
+  case UR_FUNCTION_ADAPTER_GET: {
+    os << (const struct ur_adapter_get_params_t *)params;
+  } break;
+  case UR_FUNCTION_ADAPTER_RELEASE: {
+    os << (const struct ur_adapter_release_params_t *)params;
+  } break;
+  case UR_FUNCTION_ADAPTER_RETAIN: {
+    os << (const struct ur_adapter_retain_params_t *)params;
+  } break;
+  case UR_FUNCTION_ADAPTER_GET_LAST_ERROR: {
+    os << (const struct ur_adapter_get_last_error_params_t *)params;
+  } break;
+  case UR_FUNCTION_ADAPTER_GET_INFO: {
+    os << (const struct ur_adapter_get_info_params_t *)params;
+  } break;
   case UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK: {
     os << (const struct ur_adapter_set_logger_callback_params_t *)params;
   } break;
@@ -21157,21 +21172,6 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os,
   } break;
   case UR_FUNCTION_PHYSICAL_MEM_GET_INFO: {
     os << (const struct ur_physical_mem_get_info_params_t *)params;
-  } break;
-  case UR_FUNCTION_ADAPTER_GET: {
-    os << (const struct ur_adapter_get_params_t *)params;
-  } break;
-  case UR_FUNCTION_ADAPTER_RELEASE: {
-    os << (const struct ur_adapter_release_params_t *)params;
-  } break;
-  case UR_FUNCTION_ADAPTER_RETAIN: {
-    os << (const struct ur_adapter_retain_params_t *)params;
-  } break;
-  case UR_FUNCTION_ADAPTER_GET_LAST_ERROR: {
-    os << (const struct ur_adapter_get_last_error_params_t *)params;
-  } break;
-  case UR_FUNCTION_ADAPTER_GET_INFO: {
-    os << (const struct ur_adapter_get_info_params_t *)params;
   } break;
   case UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH: {
     os << (const struct ur_enqueue_kernel_launch_params_t *)params;

--- a/unified-runtime/scripts/core/adapter.yml
+++ b/unified-runtime/scripts/core/adapter.yml
@@ -14,8 +14,8 @@ ordinal: "1"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves all available adapters"
-class: $x
-name: AdapterGet
+class: $xAdapter
+name: Get
 decl: static
 ordinal: "2"
 details:
@@ -46,8 +46,8 @@ returns:
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Releases the adapter handle reference indicating end of its usage"
-class: $x
-name: AdapterRelease
+class: $xAdapter
+name: Release
 decl: static
 ordinal: "3"
 details:
@@ -64,8 +64,8 @@ params:
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Get a reference to the adapter handle."
-class: $x
-name: AdapterRetain
+class: $xAdapter
+name: Retain
 decl: static
 ordinal: "4"
 details:
@@ -107,8 +107,8 @@ details: |
         $xAdapterGetLastError(hAdapter, &pMessage, &error);
     }
     ```
-class: $x
-name: AdapterGetLastError
+class: $xAdapter
+name: GetLastError
 decl: static
 ordinal: "5"
 params:
@@ -147,8 +147,8 @@ etors:
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves information about the adapter"
-class: $x
-name: AdapterGetInfo
+class: $xAdapter
+name: GetInfo
 decl: static
 ordinal: "6"
 details:

--- a/unified-runtime/source/adapters/adapter.def.in
+++ b/unified-runtime/source/adapters/adapter.def.in
@@ -1,6 +1,5 @@
 LIBRARY @TARGET_LIBNAME@
 EXPORTS
-	urGetGlobalProcAddrTable
 	urGetAdapterProcAddrTable
 	urGetBindlessImagesExpProcAddrTable
 	urGetCommandBufferExpProcAddrTable

--- a/unified-runtime/source/adapters/adapter.map.in
+++ b/unified-runtime/source/adapters/adapter.map.in
@@ -1,6 +1,5 @@
 @TARGET_LIBNAME@ {
 	global:
-		urGetGlobalProcAddrTable;
 		urGetAdapterProcAddrTable;
 		urGetBindlessImagesExpProcAddrTable;
 		urGetCommandBufferExpProcAddrTable;

--- a/unified-runtime/source/adapters/cuda/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/cuda/ur_interface_loader.cpp
@@ -200,17 +200,19 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    ur_api_version_t version, ur_global_dditable_t *pDdiTable) {
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnAdapterGet = urAdapterGet;
-  pDdiTable->pfnAdapterRelease = urAdapterRelease;
-  pDdiTable->pfnAdapterRetain = urAdapterRetain;
-  pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
-  pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
+  pDdiTable->pfnGet = urAdapterGet;
+  pDdiTable->pfnRelease = urAdapterRelease;
+  pDdiTable->pfnRetain = urAdapterRetain;
+  pDdiTable->pfnGetLastError = urAdapterGetLastError;
+  pDdiTable->pfnGetInfo = urAdapterGetInfo;
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
 
   return UR_RESULT_SUCCESS;
 }
@@ -470,21 +472,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
-UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
-    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
-  auto result = validateProcInputs(version, pDdiTable);
-  if (UR_RESULT_SUCCESS != result) {
-    return result;
-  }
-  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
-  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
-
-  return UR_RESULT_SUCCESS;
-}
-
 UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
                                                    ur_dditable_t *pDdiTable) {
-  urGetGlobalProcAddrTable(version, &pDdiTable->Global);
+  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
   urGetBindlessImagesExpProcAddrTable(version, &pDdiTable->BindlessImagesExp);
   urGetCommandBufferExpProcAddrTable(version, &pDdiTable->CommandBufferExp);
   urGetContextProcAddrTable(version, &pDdiTable->Context);
@@ -505,7 +495,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
   urGetUsmP2PExpProcAddrTable(version, &pDdiTable->UsmP2PExp);
   urGetVirtualMemProcAddrTable(version, &pDdiTable->VirtualMem);
   urGetDeviceProcAddrTable(version, &pDdiTable->Device);
-  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/hip/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/hip/ur_interface_loader.cpp
@@ -200,17 +200,19 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    ur_api_version_t version, ur_global_dditable_t *pDdiTable) {
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnAdapterGet = urAdapterGet;
-  pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
-  pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
-  pDdiTable->pfnAdapterRelease = urAdapterRelease;
-  pDdiTable->pfnAdapterRetain = urAdapterRetain;
+  pDdiTable->pfnGet = urAdapterGet;
+  pDdiTable->pfnGetInfo = urAdapterGetInfo;
+  pDdiTable->pfnGetLastError = urAdapterGetLastError;
+  pDdiTable->pfnRelease = urAdapterRelease;
+  pDdiTable->pfnRetain = urAdapterRetain;
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
 
   return UR_RESULT_SUCCESS;
 }
@@ -462,21 +464,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
-UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
-    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
-  auto result = validateProcInputs(version, pDdiTable);
-  if (UR_RESULT_SUCCESS != result) {
-    return result;
-  }
-  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
-  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
-
-  return UR_RESULT_SUCCESS;
-}
-
 UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
                                                    ur_dditable_t *pDdiTable) {
-  urGetGlobalProcAddrTable(version, &pDdiTable->Global);
+  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
   urGetBindlessImagesExpProcAddrTable(version, &pDdiTable->BindlessImagesExp);
   urGetCommandBufferExpProcAddrTable(version, &pDdiTable->CommandBufferExp);
   urGetContextProcAddrTable(version, &pDdiTable->Context);
@@ -497,7 +487,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
   urGetUsmP2PExpProcAddrTable(version, &pDdiTable->UsmP2PExp);
   urGetVirtualMemProcAddrTable(version, &pDdiTable->VirtualMem);
   urGetDeviceProcAddrTable(version, &pDdiTable->Device);
-  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/level_zero/ur_interface_loader.cpp
@@ -33,22 +33,6 @@ namespace ur::level_zero {
 extern "C" {
 #endif
 
-UR_APIEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    ur_api_version_t version, ur_global_dditable_t *pDdiTable) {
-  auto result = validateProcInputs(version, pDdiTable);
-  if (UR_RESULT_SUCCESS != result) {
-    return result;
-  }
-
-  pDdiTable->pfnAdapterGet = ur::level_zero::urAdapterGet;
-  pDdiTable->pfnAdapterRelease = ur::level_zero::urAdapterRelease;
-  pDdiTable->pfnAdapterRetain = ur::level_zero::urAdapterRetain;
-  pDdiTable->pfnAdapterGetLastError = ur::level_zero::urAdapterGetLastError;
-  pDdiTable->pfnAdapterGetInfo = ur::level_zero::urAdapterGetInfo;
-
-  return result;
-}
-
 UR_APIEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
     ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);
@@ -56,6 +40,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
     return result;
   }
 
+  pDdiTable->pfnGet = ur::level_zero::urAdapterGet;
+  pDdiTable->pfnRelease = ur::level_zero::urAdapterRelease;
+  pDdiTable->pfnRetain = ur::level_zero::urAdapterRetain;
+  pDdiTable->pfnGetLastError = ur::level_zero::urAdapterGetLastError;
+  pDdiTable->pfnGetInfo = ur::level_zero::urAdapterGetInfo;
   pDdiTable->pfnSetLoggerCallback = ur::level_zero::urAdapterSetLoggerCallback;
   pDdiTable->pfnSetLoggerCallbackLevel =
       ur::level_zero::urAdapterSetLoggerCallbackLevel;
@@ -573,10 +562,6 @@ ur_result_t populateDdiTable(ur_dditable_t *ddi) {
 #define NAMESPACE_
 #endif
 
-  result = NAMESPACE_::urGetGlobalProcAddrTable(UR_API_VERSION_CURRENT,
-                                                &ddi->Global);
-  if (result != UR_RESULT_SUCCESS)
-    return result;
   result = NAMESPACE_::urGetAdapterProcAddrTable(UR_API_VERSION_CURRENT,
                                                  &ddi->Adapter);
   if (result != UR_RESULT_SUCCESS)

--- a/unified-runtime/source/adapters/mock/ur_mock.cpp
+++ b/unified-runtime/source/adapters/mock/ur_mock.cpp
@@ -98,7 +98,6 @@ ur_result_t mock_urDeviceGetInfo(void *pParams) {
 
 //////////////////////////////////////////////////////////////////////////
 context_t::context_t() {
-  urGetGlobalProcAddrTable(version, &urDdiTable.Global);
   urGetBindlessImagesExpProcAddrTable(version, &urDdiTable.BindlessImagesExp);
   urGetCommandBufferExpProcAddrTable(version, &urDdiTable.CommandBufferExp);
   urGetContextProcAddrTable(version, &urDdiTable.Context);

--- a/unified-runtime/source/adapters/mock/ur_mockddi.cpp
+++ b/unified-runtime/source/adapters/mock/ur_mockddi.cpp
@@ -11973,42 +11973,6 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's Global table
-///        with current process' addresses
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    /// [in] API version requested
-    ur_api_version_t version,
-    /// [in,out] pointer to table of DDI function pointers
-    ur_global_dditable_t *pDdiTable) try {
-  if (nullptr == pDdiTable)
-    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-
-  if (driver::d_context.version < version)
-    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
-
-  ur_result_t result = UR_RESULT_SUCCESS;
-
-  pDdiTable->pfnAdapterGet = driver::urAdapterGet;
-
-  pDdiTable->pfnAdapterRelease = driver::urAdapterRelease;
-
-  pDdiTable->pfnAdapterRetain = driver::urAdapterRetain;
-
-  pDdiTable->pfnAdapterGetLastError = driver::urAdapterGetLastError;
-
-  pDdiTable->pfnAdapterGetInfo = driver::urAdapterGetInfo;
-
-  return result;
-} catch (...) {
-  return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Adapter table
 ///        with current process' addresses
 ///
@@ -12028,6 +11992,16 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
     return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
 
   ur_result_t result = UR_RESULT_SUCCESS;
+
+  pDdiTable->pfnGet = driver::urAdapterGet;
+
+  pDdiTable->pfnRelease = driver::urAdapterRelease;
+
+  pDdiTable->pfnRetain = driver::urAdapterRetain;
+
+  pDdiTable->pfnGetLastError = driver::urAdapterGetLastError;
+
+  pDdiTable->pfnGetInfo = driver::urAdapterGetInfo;
 
   pDdiTable->pfnSetLoggerCallback = driver::urAdapterSetLoggerCallback;
 

--- a/unified-runtime/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -198,17 +198,20 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    ur_api_version_t version, ur_global_dditable_t *pDdiTable) {
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnAdapterGet = urAdapterGet;
-  pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
-  pDdiTable->pfnAdapterRelease = urAdapterRelease;
-  pDdiTable->pfnAdapterRetain = urAdapterRetain;
-  pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
+  pDdiTable->pfnGet = urAdapterGet;
+  pDdiTable->pfnGetInfo = urAdapterGetInfo;
+  pDdiTable->pfnRelease = urAdapterRelease;
+  pDdiTable->pfnRetain = urAdapterRetain;
+  pDdiTable->pfnGetLastError = urAdapterGetLastError;
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
   return UR_RESULT_SUCCESS;
 }
 
@@ -443,21 +446,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
-UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
-    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
-  auto result = validateProcInputs(version, pDdiTable);
-  if (UR_RESULT_SUCCESS != result) {
-    return result;
-  }
-  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
-  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
-
-  return UR_RESULT_SUCCESS;
-}
-
 UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
                                                    ur_dditable_t *pDdiTable) {
-  urGetGlobalProcAddrTable(version, &pDdiTable->Global);
+  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
   urGetBindlessImagesExpProcAddrTable(version, &pDdiTable->BindlessImagesExp);
   urGetCommandBufferExpProcAddrTable(version, &pDdiTable->CommandBufferExp);
   urGetContextProcAddrTable(version, &pDdiTable->Context);
@@ -478,7 +469,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
   urGetUsmP2PExpProcAddrTable(version, &pDdiTable->UsmP2PExp);
   urGetVirtualMemProcAddrTable(version, &pDdiTable->VirtualMem);
   urGetDeviceProcAddrTable(version, &pDdiTable->Device);
-  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
@@ -196,17 +196,19 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    ur_api_version_t version, ur_global_dditable_t *pDdiTable) {
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnAdapterGet = urAdapterGet;
-  pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
-  pDdiTable->pfnAdapterRelease = urAdapterRelease;
-  pDdiTable->pfnAdapterRetain = urAdapterRetain;
-  pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
+  pDdiTable->pfnGet = urAdapterGet;
+  pDdiTable->pfnGetInfo = urAdapterGetInfo;
+  pDdiTable->pfnRelease = urAdapterRelease;
+  pDdiTable->pfnRetain = urAdapterRetain;
+  pDdiTable->pfnGetLastError = urAdapterGetLastError;
+  pDdiTable->pfnSetLoggerCallback = nullptr;
+  pDdiTable->pfnSetLoggerCallbackLevel = nullptr;
   return UR_RESULT_SUCCESS;
 }
 
@@ -414,7 +416,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
 
 UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
                                                    ur_dditable_t *pDdiTable) {
-  urGetGlobalProcAddrTable(version, &pDdiTable->Global);
+  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
   urGetBindlessImagesExpProcAddrTable(version, &pDdiTable->BindlessImagesExp);
   urGetCommandBufferExpProcAddrTable(version, &pDdiTable->CommandBufferExp);
   urGetContextProcAddrTable(version, &pDdiTable->Context);
@@ -435,7 +437,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
   urGetUsmP2PExpProcAddrTable(version, &pDdiTable->UsmP2PExp);
   urGetVirtualMemProcAddrTable(version, &pDdiTable->VirtualMem);
   urGetDeviceProcAddrTable(version, &pDdiTable->Device);
-  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/opencl/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/opencl/ur_interface_loader.cpp
@@ -33,6 +33,23 @@ ur_result_t validateProcInputs(ur_api_version_t Version, void *pDdiTable) {
 extern "C" {
 #endif
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnGet = urAdapterGet;
+  pDdiTable->pfnRelease = urAdapterRelease;
+  pDdiTable->pfnRetain = urAdapterRetain;
+  pDdiTable->pfnGetLastError = urAdapterGetLastError;
+  pDdiTable->pfnGetInfo = urAdapterGetInfo;
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
+  return UR_RESULT_SUCCESS;
+}
+
 UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
     ur_api_version_t Version, ur_platform_dditable_t *pDdiTable) {
   auto Result = validateProcInputs(Version, pDdiTable);
@@ -198,20 +215,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
   pDdiTable->pfnUSMPrefetch = urEnqueueUSMPrefetch;
   pDdiTable->pfnReadHostPipe = urEnqueueReadHostPipe;
   pDdiTable->pfnWriteHostPipe = urEnqueueWriteHostPipe;
-  return UR_RESULT_SUCCESS;
-}
-
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    ur_api_version_t Version, ur_global_dditable_t *pDdiTable) {
-  auto Result = validateProcInputs(Version, pDdiTable);
-  if (UR_RESULT_SUCCESS != Result) {
-    return Result;
-  }
-  pDdiTable->pfnAdapterGet = urAdapterGet;
-  pDdiTable->pfnAdapterRelease = urAdapterRelease;
-  pDdiTable->pfnAdapterRetain = urAdapterRetain;
-  pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
-  pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
   return UR_RESULT_SUCCESS;
 }
 
@@ -450,21 +453,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
-UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
-    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
-  auto result = validateProcInputs(version, pDdiTable);
-  if (UR_RESULT_SUCCESS != result) {
-    return result;
-  }
-  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
-  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
-
-  return UR_RESULT_SUCCESS;
-}
-
 UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
                                                    ur_dditable_t *pDdiTable) {
-  urGetGlobalProcAddrTable(version, &pDdiTable->Global);
+  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
   urGetBindlessImagesExpProcAddrTable(version, &pDdiTable->BindlessImagesExp);
   urGetCommandBufferExpProcAddrTable(version, &pDdiTable->CommandBufferExp);
   urGetContextProcAddrTable(version, &pDdiTable->Context);
@@ -485,7 +476,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urAllAddrTable(ur_api_version_t version,
   urGetUsmP2PExpProcAddrTable(version, &pDdiTable->UsmP2PExp);
   urGetVirtualMemProcAddrTable(version, &pDdiTable->VirtualMem);
   urGetDeviceProcAddrTable(version, &pDdiTable->Device);
-  urGetAdapterProcAddrTable(version, &pDdiTable->Adapter);
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_ddi.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_ddi.cpp
@@ -77,7 +77,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
     uint32_t *pNumAdapters) {
-  auto pfnAdapterGet = getContext()->urDdiTable.Global.pfnAdapterGet;
+  auto pfnAdapterGet = getContext()->urDdiTable.Adapter.pfnGet;
 
   if (nullptr == pfnAdapterGet) {
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1685,18 +1685,19 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's Global table
+/// @brief Exported function for filling application's Adapter table
 ///        with current process' addresses
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
+__urdlllocal ur_result_t UR_APICALL urGetAdapterProcAddrTable(
     /// [in] API version requested
     ur_api_version_t version,
     /// [in,out] pointer to table of DDI function pointers
-    ur_global_dditable_t *pDdiTable) {
+    ur_adapter_dditable_t *pDdiTable) {
   if (nullptr == pDdiTable) {
     return UR_RESULT_ERROR_INVALID_NULL_POINTER;
   }
@@ -1710,7 +1711,7 @@ __urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 
   ur_result_t result = UR_RESULT_SUCCESS;
 
-  pDdiTable->pfnAdapterGet = ur_sanitizer_layer::asan::urAdapterGet;
+  pDdiTable->pfnGet = ur_sanitizer_layer::asan::urAdapterGet;
 
   return result;
 }
@@ -2154,8 +2155,8 @@ ur_result_t initAsanDDITable(ur_dditable_t *dditable) {
   UR_LOG_L(getContext()->logger, QUIET, "==== DeviceSanitizer: ASAN");
 
   if (UR_RESULT_SUCCESS == result) {
-    result = ur_sanitizer_layer::asan::urGetGlobalProcAddrTable(
-        UR_API_VERSION_CURRENT, &dditable->Global);
+    result = ur_sanitizer_layer::asan::urGetAdapterProcAddrTable(
+        UR_API_VERSION_CURRENT, &dditable->Adapter);
   }
 
   if (UR_RESULT_SUCCESS == result) {

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -53,7 +53,7 @@ AsanInterceptor::~AsanInterceptor() {
   m_ShadowMap.clear();
 
   for (auto Adapter : m_Adapters) {
-    getContext()->urDdiTable.Global.pfnAdapterRelease(Adapter);
+    getContext()->urDdiTable.Adapter.pfnRelease(Adapter);
   }
 }
 

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
@@ -310,7 +310,7 @@ public:
     if (m_Adapters.find(Adapter) != m_Adapters.end()) {
       return UR_RESULT_SUCCESS;
     }
-    UR_CALL(getContext()->urDdiTable.Global.pfnAdapterRetain(Adapter));
+    UR_CALL(getContext()->urDdiTable.Adapter.pfnRetain(Adapter));
     m_Adapters.insert(Adapter);
     return UR_RESULT_SUCCESS;
   }

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_ddi.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_ddi.cpp
@@ -65,7 +65,7 @@ ur_result_t urAdapterGet(
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
     uint32_t *pNumAdapters) {
-  auto pfnAdapterGet = getContext()->urDdiTable.Global.pfnAdapterGet;
+  auto pfnAdapterGet = getContext()->urDdiTable.Adapter.pfnGet;
 
   // FIXME: This is a W/A to disable heap extended for MSAN so that we can
   // reserve large VA of GPU.
@@ -1773,18 +1773,22 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's Global table
+/// @brief Exported function for filling application's Adapter table
 ///        with current process' addresses
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-ur_result_t urGetGlobalProcAddrTable(
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+ur_result_t urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t,
     /// [in,out] pointer to table of DDI function pointers
-    ur_global_dditable_t *pDdiTable) {
+    ur_adapter_dditable_t *pDdiTable) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
-  pDdiTable->pfnAdapterGet = ur_sanitizer_layer::msan::urAdapterGet;
+  pDdiTable->pfnGet = ur_sanitizer_layer::msan::urAdapterGet;
 
   return result;
 }
@@ -1988,8 +1992,8 @@ ur_result_t initMsanDDITable(ur_dditable_t *dditable) {
   }
 
   if (UR_RESULT_SUCCESS == result) {
-    result =
-        ur_sanitizer_layer::msan::urGetGlobalProcAddrTable(&dditable->Global);
+    result = ur_sanitizer_layer::msan::urGetAdapterProcAddrTable(
+        UR_API_VERSION_CURRENT, &dditable->Adapter);
   }
 
   if (UR_RESULT_SUCCESS == result) {

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -38,7 +38,7 @@ MsanInterceptor::~MsanInterceptor() {
   m_ContextMap.clear();
 
   for (auto Adapter : m_Adapters) {
-    getContext()->urDdiTable.Global.pfnAdapterRelease(Adapter);
+    getContext()->urDdiTable.Adapter.pfnRelease(Adapter);
   }
 }
 

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
@@ -297,7 +297,7 @@ public:
     if (m_Adapters.find(Adapter) != m_Adapters.end()) {
       return UR_RESULT_SUCCESS;
     }
-    UR_CALL(getContext()->urDdiTable.Global.pfnAdapterRetain(Adapter));
+    UR_CALL(getContext()->urDdiTable.Adapter.pfnRetain(Adapter));
     m_Adapters.insert(Adapter);
     return UR_RESULT_SUCCESS;
   }

--- a/unified-runtime/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/unified-runtime/source/loader/layers/tracing/ur_trcddi.cpp
@@ -32,9 +32,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
     uint32_t *pNumAdapters) {
-  auto pfnAdapterGet = getContext()->urDdiTable.Global.pfnAdapterGet;
+  auto pfnGet = getContext()->urDdiTable.Adapter.pfnGet;
 
-  if (nullptr == pfnAdapterGet)
+  if (nullptr == pfnGet)
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 
   ur_adapter_get_params_t params = {&NumEntries, &phAdapters, &pNumAdapters};
@@ -44,7 +44,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
   auto &logger = getContext()->logger;
   UR_LOG_L(logger, INFO, "   ---> urAdapterGet\n");
 
-  ur_result_t result = pfnAdapterGet(NumEntries, phAdapters, pNumAdapters);
+  ur_result_t result = pfnGet(NumEntries, phAdapters, pNumAdapters);
 
   getContext()->notify_end(UR_FUNCTION_ADAPTER_GET, "urAdapterGet", &params,
                            &result, instance);
@@ -64,9 +64,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
 __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
     /// [in][release] Adapter handle to release
     ur_adapter_handle_t hAdapter) {
-  auto pfnAdapterRelease = getContext()->urDdiTable.Global.pfnAdapterRelease;
+  auto pfnRelease = getContext()->urDdiTable.Adapter.pfnRelease;
 
-  if (nullptr == pfnAdapterRelease)
+  if (nullptr == pfnRelease)
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 
   ur_adapter_release_params_t params = {&hAdapter};
@@ -76,7 +76,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
   auto &logger = getContext()->logger;
   UR_LOG_L(logger, INFO, "   ---> urAdapterRelease\n");
 
-  ur_result_t result = pfnAdapterRelease(hAdapter);
+  ur_result_t result = pfnRelease(hAdapter);
 
   getContext()->notify_end(UR_FUNCTION_ADAPTER_RELEASE, "urAdapterRelease",
                            &params, &result, instance);
@@ -97,9 +97,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
 __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
     /// [in][retain] Adapter handle to retain
     ur_adapter_handle_t hAdapter) {
-  auto pfnAdapterRetain = getContext()->urDdiTable.Global.pfnAdapterRetain;
+  auto pfnRetain = getContext()->urDdiTable.Adapter.pfnRetain;
 
-  if (nullptr == pfnAdapterRetain)
+  if (nullptr == pfnRetain)
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 
   ur_adapter_retain_params_t params = {&hAdapter};
@@ -109,7 +109,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
   auto &logger = getContext()->logger;
   UR_LOG_L(logger, INFO, "   ---> urAdapterRetain\n");
 
-  ur_result_t result = pfnAdapterRetain(hAdapter);
+  ur_result_t result = pfnRetain(hAdapter);
 
   getContext()->notify_end(UR_FUNCTION_ADAPTER_RETAIN, "urAdapterRetain",
                            &params, &result, instance);
@@ -136,10 +136,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
     /// [out] pointer to an integer where the adapter specific error code will
     /// be stored.
     int32_t *pError) {
-  auto pfnAdapterGetLastError =
-      getContext()->urDdiTable.Global.pfnAdapterGetLastError;
+  auto pfnGetLastError = getContext()->urDdiTable.Adapter.pfnGetLastError;
 
-  if (nullptr == pfnAdapterGetLastError)
+  if (nullptr == pfnGetLastError)
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 
   ur_adapter_get_last_error_params_t params = {&hAdapter, &ppMessage, &pError};
@@ -149,7 +148,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
   auto &logger = getContext()->logger;
   UR_LOG_L(logger, INFO, "   ---> urAdapterGetLastError\n");
 
-  ur_result_t result = pfnAdapterGetLastError(hAdapter, ppMessage, pError);
+  ur_result_t result = pfnGetLastError(hAdapter, ppMessage, pError);
 
   getContext()->notify_end(UR_FUNCTION_ADAPTER_GET_LAST_ERROR,
                            "urAdapterGetLastError", &params, &result, instance);
@@ -183,9 +182,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
     /// [out][optional] pointer to the actual number of bytes being queried by
     /// pPropValue.
     size_t *pPropSizeRet) {
-  auto pfnAdapterGetInfo = getContext()->urDdiTable.Global.pfnAdapterGetInfo;
+  auto pfnGetInfo = getContext()->urDdiTable.Adapter.pfnGetInfo;
 
-  if (nullptr == pfnAdapterGetInfo)
+  if (nullptr == pfnGetInfo)
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 
   ur_adapter_get_info_params_t params = {&hAdapter, &propName, &propSize,
@@ -197,7 +196,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
   UR_LOG_L(logger, INFO, "   ---> urAdapterGetInfo\n");
 
   ur_result_t result =
-      pfnAdapterGetInfo(hAdapter, propName, propSize, pPropValue, pPropSizeRet);
+      pfnGetInfo(hAdapter, propName, propSize, pPropValue, pPropSizeRet);
 
   getContext()->notify_end(UR_FUNCTION_ADAPTER_GET_INFO, "urAdapterGetInfo",
                            &params, &result, instance);
@@ -10136,49 +10135,6 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's Global table
-///        with current process' addresses
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    /// [in] API version requested
-    ur_api_version_t version,
-    /// [in,out] pointer to table of DDI function pointers
-    ur_global_dditable_t *pDdiTable) {
-  auto &dditable = ur_tracing_layer::getContext()->urDdiTable.Global;
-
-  if (nullptr == pDdiTable)
-    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-
-  if (UR_MAJOR_VERSION(ur_tracing_layer::getContext()->version) !=
-          UR_MAJOR_VERSION(version) ||
-      UR_MINOR_VERSION(ur_tracing_layer::getContext()->version) >
-          UR_MINOR_VERSION(version))
-    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
-
-  ur_result_t result = UR_RESULT_SUCCESS;
-
-  dditable.pfnAdapterGet = pDdiTable->pfnAdapterGet;
-  pDdiTable->pfnAdapterGet = ur_tracing_layer::urAdapterGet;
-
-  dditable.pfnAdapterRelease = pDdiTable->pfnAdapterRelease;
-  pDdiTable->pfnAdapterRelease = ur_tracing_layer::urAdapterRelease;
-
-  dditable.pfnAdapterRetain = pDdiTable->pfnAdapterRetain;
-  pDdiTable->pfnAdapterRetain = ur_tracing_layer::urAdapterRetain;
-
-  dditable.pfnAdapterGetLastError = pDdiTable->pfnAdapterGetLastError;
-  pDdiTable->pfnAdapterGetLastError = ur_tracing_layer::urAdapterGetLastError;
-
-  dditable.pfnAdapterGetInfo = pDdiTable->pfnAdapterGetInfo;
-  pDdiTable->pfnAdapterGetInfo = ur_tracing_layer::urAdapterGetInfo;
-
-  return result;
-}
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Adapter table
 ///        with current process' addresses
 ///
@@ -10203,6 +10159,21 @@ __urdlllocal ur_result_t UR_APICALL urGetAdapterProcAddrTable(
     return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
 
   ur_result_t result = UR_RESULT_SUCCESS;
+
+  dditable.pfnGet = pDdiTable->pfnGet;
+  pDdiTable->pfnGet = ur_tracing_layer::urAdapterGet;
+
+  dditable.pfnRelease = pDdiTable->pfnRelease;
+  pDdiTable->pfnRelease = ur_tracing_layer::urAdapterRelease;
+
+  dditable.pfnRetain = pDdiTable->pfnRetain;
+  pDdiTable->pfnRetain = ur_tracing_layer::urAdapterRetain;
+
+  dditable.pfnGetLastError = pDdiTable->pfnGetLastError;
+  pDdiTable->pfnGetLastError = ur_tracing_layer::urAdapterGetLastError;
+
+  dditable.pfnGetInfo = pDdiTable->pfnGetInfo;
+  pDdiTable->pfnGetInfo = ur_tracing_layer::urAdapterGetInfo;
 
   dditable.pfnSetLoggerCallback = pDdiTable->pfnSetLoggerCallback;
   pDdiTable->pfnSetLoggerCallback =
@@ -11487,11 +11458,6 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
   logger = logger::create_logger("tracing", true, true);
 
   ur_tracing_layer::getContext()->codelocData = codelocData;
-
-  if (UR_RESULT_SUCCESS == result) {
-    result = ur_tracing_layer::urGetGlobalProcAddrTable(UR_API_VERSION_CURRENT,
-                                                        &dditable->Global);
-  }
 
   if (UR_RESULT_SUCCESS == result) {
     result = ur_tracing_layer::urGetAdapterProcAddrTable(UR_API_VERSION_CURRENT,

--- a/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
+++ b/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
@@ -31,9 +31,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
     uint32_t *pNumAdapters) {
-  auto pfnAdapterGet = getContext()->urDdiTable.Global.pfnAdapterGet;
+  auto pfnGet = getContext()->urDdiTable.Adapter.pfnGet;
 
-  if (nullptr == pfnAdapterGet) {
+  if (nullptr == pfnGet) {
     return UR_RESULT_ERROR_UNINITIALIZED;
   }
 
@@ -42,7 +42,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
       return UR_RESULT_ERROR_INVALID_SIZE;
   }
 
-  ur_result_t result = pfnAdapterGet(NumEntries, phAdapters, pNumAdapters);
+  ur_result_t result = pfnGet(NumEntries, phAdapters, pNumAdapters);
 
   if (getContext()->enableLeakChecking && phAdapters &&
       result == UR_RESULT_SUCCESS) {
@@ -60,9 +60,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
 __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
     /// [in][release] Adapter handle to release
     ur_adapter_handle_t hAdapter) {
-  auto pfnAdapterRelease = getContext()->urDdiTable.Global.pfnAdapterRelease;
+  auto pfnRelease = getContext()->urDdiTable.Adapter.pfnRelease;
 
-  if (nullptr == pfnAdapterRelease) {
+  if (nullptr == pfnRelease) {
     return UR_RESULT_ERROR_UNINITIALIZED;
   }
 
@@ -75,7 +75,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
     getContext()->refCountContext->decrementRefCount(hAdapter, true);
   }
 
-  ur_result_t result = pfnAdapterRelease(hAdapter);
+  ur_result_t result = pfnRelease(hAdapter);
 
   return result;
 }
@@ -85,9 +85,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
 __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
     /// [in][retain] Adapter handle to retain
     ur_adapter_handle_t hAdapter) {
-  auto pfnAdapterRetain = getContext()->urDdiTable.Global.pfnAdapterRetain;
+  auto pfnRetain = getContext()->urDdiTable.Adapter.pfnRetain;
 
-  if (nullptr == pfnAdapterRetain) {
+  if (nullptr == pfnRetain) {
     return UR_RESULT_ERROR_UNINITIALIZED;
   }
 
@@ -96,7 +96,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
       return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
   }
 
-  ur_result_t result = pfnAdapterRetain(hAdapter);
+  ur_result_t result = pfnRetain(hAdapter);
 
   if (getContext()->enableLeakChecking) {
     getContext()->refCountContext->incrementRefCount(hAdapter, true);
@@ -116,10 +116,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
     /// [out] pointer to an integer where the adapter specific error code will
     /// be stored.
     int32_t *pError) {
-  auto pfnAdapterGetLastError =
-      getContext()->urDdiTable.Global.pfnAdapterGetLastError;
+  auto pfnGetLastError = getContext()->urDdiTable.Adapter.pfnGetLastError;
 
-  if (nullptr == pfnAdapterGetLastError) {
+  if (nullptr == pfnGetLastError) {
     return UR_RESULT_ERROR_UNINITIALIZED;
   }
 
@@ -139,7 +138,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
     URLOG_CTX_INVALID_REFERENCE(hAdapter);
   }
 
-  ur_result_t result = pfnAdapterGetLastError(hAdapter, ppMessage, pError);
+  ur_result_t result = pfnGetLastError(hAdapter, ppMessage, pError);
 
   return result;
 }
@@ -162,9 +161,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
     /// [out][optional] pointer to the actual number of bytes being queried by
     /// pPropValue.
     size_t *pPropSizeRet) {
-  auto pfnAdapterGetInfo = getContext()->urDdiTable.Global.pfnAdapterGetInfo;
+  auto pfnGetInfo = getContext()->urDdiTable.Adapter.pfnGetInfo;
 
-  if (nullptr == pfnAdapterGetInfo) {
+  if (nullptr == pfnGetInfo) {
     return UR_RESULT_ERROR_UNINITIALIZED;
   }
 
@@ -191,7 +190,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
   }
 
   ur_result_t result =
-      pfnAdapterGetInfo(hAdapter, propName, propSize, pPropValue, pPropSizeRet);
+      pfnGetInfo(hAdapter, propName, propSize, pPropValue, pPropSizeRet);
 
   return result;
 }
@@ -10933,51 +10932,6 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's Global table
-///        with current process' addresses
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    /// [in] API version requested
-    ur_api_version_t version,
-    /// [in,out] pointer to table of DDI function pointers
-    ur_global_dditable_t *pDdiTable) {
-  auto &dditable = ur_validation_layer::getContext()->urDdiTable.Global;
-
-  if (nullptr == pDdiTable)
-    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-
-  if (UR_MAJOR_VERSION(ur_validation_layer::getContext()->version) !=
-          UR_MAJOR_VERSION(version) ||
-      UR_MINOR_VERSION(ur_validation_layer::getContext()->version) >
-          UR_MINOR_VERSION(version))
-    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
-
-  ur_result_t result = UR_RESULT_SUCCESS;
-
-  dditable.pfnAdapterGet = pDdiTable->pfnAdapterGet;
-  pDdiTable->pfnAdapterGet = ur_validation_layer::urAdapterGet;
-
-  dditable.pfnAdapterRelease = pDdiTable->pfnAdapterRelease;
-  pDdiTable->pfnAdapterRelease = ur_validation_layer::urAdapterRelease;
-
-  dditable.pfnAdapterRetain = pDdiTable->pfnAdapterRetain;
-  pDdiTable->pfnAdapterRetain = ur_validation_layer::urAdapterRetain;
-
-  dditable.pfnAdapterGetLastError = pDdiTable->pfnAdapterGetLastError;
-  pDdiTable->pfnAdapterGetLastError =
-      ur_validation_layer::urAdapterGetLastError;
-
-  dditable.pfnAdapterGetInfo = pDdiTable->pfnAdapterGetInfo;
-  pDdiTable->pfnAdapterGetInfo = ur_validation_layer::urAdapterGetInfo;
-
-  return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Adapter table
 ///        with current process' addresses
 ///
@@ -11002,6 +10956,21 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
     return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
 
   ur_result_t result = UR_RESULT_SUCCESS;
+
+  dditable.pfnGet = pDdiTable->pfnGet;
+  pDdiTable->pfnGet = ur_validation_layer::urAdapterGet;
+
+  dditable.pfnRelease = pDdiTable->pfnRelease;
+  pDdiTable->pfnRelease = ur_validation_layer::urAdapterRelease;
+
+  dditable.pfnRetain = pDdiTable->pfnRetain;
+  pDdiTable->pfnRetain = ur_validation_layer::urAdapterRetain;
+
+  dditable.pfnGetLastError = pDdiTable->pfnGetLastError;
+  pDdiTable->pfnGetLastError = ur_validation_layer::urAdapterGetLastError;
+
+  dditable.pfnGetInfo = pDdiTable->pfnGetInfo;
+  pDdiTable->pfnGetInfo = ur_validation_layer::urAdapterGetInfo;
 
   dditable.pfnSetLoggerCallback = pDdiTable->pfnSetLoggerCallback;
   pDdiTable->pfnSetLoggerCallback =
@@ -12332,11 +12301,6 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
   if (!enableParameterValidation && !enableLeakChecking &&
       !enableLifetimeValidation) {
     return result;
-  }
-
-  if (UR_RESULT_SUCCESS == result) {
-    result = ur_validation_layer::urGetGlobalProcAddrTable(
-        UR_API_VERSION_CURRENT, &dditable->Global);
   }
 
   if (UR_RESULT_SUCCESS == result) {

--- a/unified-runtime/source/loader/loader.def.in
+++ b/unified-runtime/source/loader/loader.def.in
@@ -119,7 +119,6 @@ EXPORTS
 	urGetEnqueueExpProcAddrTable
 	urGetEnqueueProcAddrTable
 	urGetEventProcAddrTable
-	urGetGlobalProcAddrTable
 	urGetKernelExpProcAddrTable
 	urGetKernelProcAddrTable
 	urGetMemProcAddrTable

--- a/unified-runtime/source/loader/loader.map.in
+++ b/unified-runtime/source/loader/loader.map.in
@@ -119,7 +119,6 @@
 		urGetEnqueueExpProcAddrTable;
 		urGetEnqueueProcAddrTable;
 		urGetEventProcAddrTable;
-		urGetGlobalProcAddrTable;
 		urGetKernelExpProcAddrTable;
 		urGetKernelProcAddrTable;
 		urGetMemProcAddrTable;

--- a/unified-runtime/source/loader/ur_ldrddi.cpp
+++ b/unified-runtime/source/loader/ur_ldrddi.cpp
@@ -39,8 +39,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     for (auto &platform : context->platforms) {
       if (platform.initStatus != UR_RESULT_SUCCESS)
         continue;
-      platform.dditable.Global.pfnAdapterGet(1, &phAdapters[adapterIndex],
-                                             nullptr);
+      platform.dditable.Adapter.pfnGet(1, &phAdapters[adapterIndex], nullptr);
       adapterIndex++;
       if (adapterIndex == NumEntries) {
         break;
@@ -63,12 +62,12 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
 
   auto *dditable = *reinterpret_cast<ur_dditable_t **>(hAdapter);
 
-  auto *pfnAdapterRelease = dditable->Global.pfnAdapterRelease;
-  if (nullptr == pfnAdapterRelease)
+  auto *pfnRelease = dditable->Adapter.pfnRelease;
+  if (nullptr == pfnRelease)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
   // forward to device-platform
-  return pfnAdapterRelease(hAdapter);
+  return pfnRelease(hAdapter);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -79,12 +78,12 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
 
   auto *dditable = *reinterpret_cast<ur_dditable_t **>(hAdapter);
 
-  auto *pfnAdapterRetain = dditable->Global.pfnAdapterRetain;
-  if (nullptr == pfnAdapterRetain)
+  auto *pfnRetain = dditable->Adapter.pfnRetain;
+  if (nullptr == pfnRetain)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
   // forward to device-platform
-  return pfnAdapterRetain(hAdapter);
+  return pfnRetain(hAdapter);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -101,12 +100,12 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
 
   auto *dditable = *reinterpret_cast<ur_dditable_t **>(hAdapter);
 
-  auto *pfnAdapterGetLastError = dditable->Global.pfnAdapterGetLastError;
-  if (nullptr == pfnAdapterGetLastError)
+  auto *pfnGetLastError = dditable->Adapter.pfnGetLastError;
+  if (nullptr == pfnGetLastError)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
   // forward to device-platform
-  return pfnAdapterGetLastError(hAdapter, ppMessage, pError);
+  return pfnGetLastError(hAdapter, ppMessage, pError);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -130,13 +129,12 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 
   auto *dditable = *reinterpret_cast<ur_dditable_t **>(hAdapter);
 
-  auto *pfnAdapterGetInfo = dditable->Global.pfnAdapterGetInfo;
-  if (nullptr == pfnAdapterGetInfo)
+  auto *pfnGetInfo = dditable->Adapter.pfnGetInfo;
+  if (nullptr == pfnGetInfo)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
   // forward to device-platform
-  return pfnAdapterGetInfo(hAdapter, propName, propSize, pPropValue,
-                           pPropSizeRet);
+  return pfnGetInfo(hAdapter, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5788,62 +5786,6 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's Global table
-///        with current process' addresses
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    /// [in] API version requested
-    ur_api_version_t version,
-    /// [in,out] pointer to table of DDI function pointers
-    ur_global_dditable_t *pDdiTable) {
-  if (nullptr == pDdiTable)
-    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-
-  if (ur_loader::getContext()->version < version)
-    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
-
-  ur_result_t result = UR_RESULT_SUCCESS;
-
-  // Load the device-platform DDI tables
-  for (auto &platform : ur_loader::getContext()->platforms) {
-    // statically linked adapter inside of the loader
-    if (platform.handle == nullptr)
-      continue;
-
-    if (platform.initStatus != UR_RESULT_SUCCESS)
-      continue;
-    auto getTable = reinterpret_cast<ur_pfnGetGlobalProcAddrTable_t>(
-        ur_loader::LibLoader::getFunctionPtr(platform.handle.get(),
-                                             "urGetGlobalProcAddrTable"));
-    if (!getTable)
-      continue;
-    platform.initStatus = getTable(version, &platform.dditable.Global);
-  }
-
-  if (UR_RESULT_SUCCESS == result) {
-    if (ur_loader::getContext()->platforms.size() != 1 ||
-        ur_loader::getContext()->forceIntercept) {
-      // return pointers to loader's DDIs
-      pDdiTable->pfnAdapterGet = ur_loader::urAdapterGet;
-      pDdiTable->pfnAdapterRelease = ur_loader::urAdapterRelease;
-      pDdiTable->pfnAdapterRetain = ur_loader::urAdapterRetain;
-      pDdiTable->pfnAdapterGetLastError = ur_loader::urAdapterGetLastError;
-      pDdiTable->pfnAdapterGetInfo = ur_loader::urAdapterGetInfo;
-    } else {
-      // return pointers directly to platform's DDIs
-      *pDdiTable = ur_loader::getContext()->platforms.front().dditable.Global;
-    }
-  }
-
-  return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Adapter table
 ///        with current process' addresses
 ///
@@ -5885,6 +5827,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
     if (ur_loader::getContext()->platforms.size() != 1 ||
         ur_loader::getContext()->forceIntercept) {
       // return pointers to loader's DDIs
+      pDdiTable->pfnGet = ur_loader::urAdapterGet;
+      pDdiTable->pfnRelease = ur_loader::urAdapterRelease;
+      pDdiTable->pfnRetain = ur_loader::urAdapterRetain;
+      pDdiTable->pfnGetLastError = ur_loader::urAdapterGetLastError;
+      pDdiTable->pfnGetInfo = ur_loader::urAdapterGetInfo;
       pDdiTable->pfnSetLoggerCallback = ur_loader::urAdapterSetLoggerCallback;
       pDdiTable->pfnSetLoggerCallbackLevel =
           ur_loader::urAdapterSetLoggerCallbackLevel;

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -304,11 +304,11 @@ ur_result_t UR_APICALL urAdapterGet(
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
     uint32_t *pNumAdapters) try {
-  auto pfnAdapterGet = ur_lib::getContext()->urDdiTable.Global.pfnAdapterGet;
-  if (nullptr == pfnAdapterGet)
+  auto pfnGet = ur_lib::getContext()->urDdiTable.Adapter.pfnGet;
+  if (nullptr == pfnGet)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
-  return pfnAdapterGet(NumEntries, phAdapters, pNumAdapters);
+  return pfnGet(NumEntries, phAdapters, pNumAdapters);
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
@@ -333,12 +333,11 @@ ur_result_t UR_APICALL urAdapterGet(
 ur_result_t UR_APICALL urAdapterRelease(
     /// [in][release] Adapter handle to release
     ur_adapter_handle_t hAdapter) try {
-  auto pfnAdapterRelease =
-      ur_lib::getContext()->urDdiTable.Global.pfnAdapterRelease;
-  if (nullptr == pfnAdapterRelease)
+  auto pfnRelease = ur_lib::getContext()->urDdiTable.Adapter.pfnRelease;
+  if (nullptr == pfnRelease)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
-  return pfnAdapterRelease(hAdapter);
+  return pfnRelease(hAdapter);
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
@@ -359,12 +358,11 @@ ur_result_t UR_APICALL urAdapterRelease(
 ur_result_t UR_APICALL urAdapterRetain(
     /// [in][retain] Adapter handle to retain
     ur_adapter_handle_t hAdapter) try {
-  auto pfnAdapterRetain =
-      ur_lib::getContext()->urDdiTable.Global.pfnAdapterRetain;
-  if (nullptr == pfnAdapterRetain)
+  auto pfnRetain = ur_lib::getContext()->urDdiTable.Adapter.pfnRetain;
+  if (nullptr == pfnRetain)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
-  return pfnAdapterRetain(hAdapter);
+  return pfnRetain(hAdapter);
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
@@ -421,12 +419,12 @@ ur_result_t UR_APICALL urAdapterGetLastError(
     /// [out] pointer to an integer where the adapter specific error code will
     /// be stored.
     int32_t *pError) try {
-  auto pfnAdapterGetLastError =
-      ur_lib::getContext()->urDdiTable.Global.pfnAdapterGetLastError;
-  if (nullptr == pfnAdapterGetLastError)
+  auto pfnGetLastError =
+      ur_lib::getContext()->urDdiTable.Adapter.pfnGetLastError;
+  if (nullptr == pfnGetLastError)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
-  return pfnAdapterGetLastError(hAdapter, ppMessage, pError);
+  return pfnGetLastError(hAdapter, ppMessage, pError);
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
@@ -474,13 +472,11 @@ ur_result_t UR_APICALL urAdapterGetInfo(
     /// [out][optional] pointer to the actual number of bytes being queried by
     /// pPropValue.
     size_t *pPropSizeRet) try {
-  auto pfnAdapterGetInfo =
-      ur_lib::getContext()->urDdiTable.Global.pfnAdapterGetInfo;
-  if (nullptr == pfnAdapterGetInfo)
+  auto pfnGetInfo = ur_lib::getContext()->urDdiTable.Adapter.pfnGetInfo;
+  if (nullptr == pfnGetInfo)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
-  return pfnAdapterGetInfo(hAdapter, propName, propSize, pPropValue,
-                           pPropSizeRet);
+  return pfnGetInfo(hAdapter, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }

--- a/unified-runtime/source/loader/ur_libddi.cpp
+++ b/unified-runtime/source/loader/ur_libddi.cpp
@@ -24,11 +24,6 @@ __urdlllocal ur_result_t context_t::ddiInit() {
 
   if (UR_RESULT_SUCCESS == result) {
     result =
-        urGetGlobalProcAddrTable(UR_API_VERSION_CURRENT, &urDdiTable.Global);
-  }
-
-  if (UR_RESULT_SUCCESS == result) {
-    result =
         urGetAdapterProcAddrTable(UR_API_VERSION_CURRENT, &urDdiTable.Adapter);
   }
 


### PR DESCRIPTION
All global DDI table entries were in fact adapter entries. This patch moves these entries into the adapter class thus removing the `urGetGlobalProcAddrTable()` entry.
