### PR TITLE
[NFC][SYCL] Accept `queue_impl` by raw ptr/ref in `MemoryManager`

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -427,7 +427,7 @@ std::vector<ur_event_handle_t> context_impl::initializeDeviceGlobals(
     for (DeviceGlobalMapEntry *DeviceGlobalEntry : DeviceGlobalEntries) {
       // Get or allocate the USM memory associated with the device global.
       DeviceGlobalUSMMem &DeviceGlobalUSM =
-          DeviceGlobalEntry->getOrAllocateDeviceGlobalUSM(QueueImpl);
+          DeviceGlobalEntry->getOrAllocateDeviceGlobalUSM(*QueueImpl);
 
       // If the device global still has a initialization event it should be
       // added to the initialization events list. Since initialization events

--- a/sycl/source/detail/device_global_map_entry.cpp
+++ b/sycl/source/detail/device_global_map_entry.cpp
@@ -41,13 +41,13 @@ OwnedUrEvent DeviceGlobalUSMMem::getInitEvent(const AdapterPtr &Adapter) {
   return OwnedUrEvent(Adapter);
 }
 
-DeviceGlobalUSMMem &DeviceGlobalMapEntry::getOrAllocateDeviceGlobalUSM(
-    const std::shared_ptr<queue_impl> &QueueImpl) {
+DeviceGlobalUSMMem &
+DeviceGlobalMapEntry::getOrAllocateDeviceGlobalUSM(queue_impl &QueueImpl) {
   assert(!MIsDeviceImageScopeDecorated &&
          "USM allocations should not be acquired for device_global with "
          "device_image_scope property.");
-  const std::shared_ptr<context_impl> &CtxImpl = QueueImpl->getContextImplPtr();
-  const device_impl &DevImpl = QueueImpl->getDeviceImpl();
+  const std::shared_ptr<context_impl> &CtxImpl = QueueImpl.getContextImplPtr();
+  const device_impl &DevImpl = QueueImpl.getDeviceImpl();
   std::lock_guard<std::mutex> Lock(MDeviceToUSMPtrMapMutex);
 
   auto DGUSMPtr = MDeviceToUSMPtrMap.find({&DevImpl, CtxImpl.get()});

--- a/sycl/source/detail/device_global_map_entry.hpp
+++ b/sycl/source/detail/device_global_map_entry.hpp
@@ -109,8 +109,7 @@ struct DeviceGlobalMapEntry {
   }
 
   // Gets or allocates USM memory for a device_global.
-  DeviceGlobalUSMMem &
-  getOrAllocateDeviceGlobalUSM(const std::shared_ptr<queue_impl> &QueueImpl);
+  DeviceGlobalUSMMem &getOrAllocateDeviceGlobalUSM(queue_impl &QueueImpl);
 
   // Removes resources for device_globals associated with the context.
   void removeAssociatedResources(const context_impl *CtxImpl);

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -669,7 +669,7 @@ public:
     // of using a throw-away queue.
     queue InitQueue{MContext, Dev};
     auto &USMMem =
-        Entry->getOrAllocateDeviceGlobalUSM(getSyclObjImpl(InitQueue));
+        Entry->getOrAllocateDeviceGlobalUSM(*getSyclObjImpl(InitQueue));
     InitQueue.wait_and_throw();
     return USMMem.getPtr();
   }

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -494,20 +494,19 @@ void prepTermPositions(TermPositions &pos, int Dimensions,
   }
 }
 
-void copyH2D(SYCLMemObjI *SYCLMemObj, char *SrcMem, QueueImplPtr,
+void copyH2D(queue_impl &TgtQueue, SYCLMemObjI *SYCLMemObj, char *SrcMem,
              unsigned int DimSrc, sycl::range<3> SrcSize,
              sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
              unsigned int SrcElemSize, ur_mem_handle_t DstMem,
-             QueueImplPtr TgtQueue, unsigned int DimDst, sycl::range<3> DstSize,
+             unsigned int DimDst, sycl::range<3> DstSize,
              sycl::range<3> DstAccessRange, sycl::id<3> DstOffset,
              unsigned int DstElemSize, std::vector<ur_event_handle_t> DepEvents,
              ur_event_handle_t &OutEvent) {
   (void)SrcAccessRange;
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
-  assert(TgtQueue && "Destination mem object queue must be not nullptr");
 
-  const ur_queue_handle_t Queue = TgtQueue->getHandleRef();
-  const AdapterPtr &Adapter = TgtQueue->getAdapter();
+  const ur_queue_handle_t Queue = TgtQueue.getHandleRef();
+  const AdapterPtr &Adapter = TgtQueue.getAdapter();
 
   detail::SYCLMemObjI::MemObjType MemType = SYCLMemObj->getType();
   TermPositions SrcPos, DstPos;
@@ -564,20 +563,19 @@ void copyH2D(SYCLMemObjI *SYCLMemObj, char *SrcMem, QueueImplPtr,
   }
 }
 
-void copyD2H(SYCLMemObjI *SYCLMemObj, ur_mem_handle_t SrcMem,
-             QueueImplPtr SrcQueue, unsigned int DimSrc, sycl::range<3> SrcSize,
-             sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
-             unsigned int SrcElemSize, char *DstMem, QueueImplPtr,
+void copyD2H(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
+             ur_mem_handle_t SrcMem, unsigned int DimSrc,
+             sycl::range<3> SrcSize, sycl::range<3> SrcAccessRange,
+             sycl::id<3> SrcOffset, unsigned int SrcElemSize, char *DstMem,
              unsigned int DimDst, sycl::range<3> DstSize,
              sycl::range<3> DstAccessRange, sycl::id<3> DstOffset,
              unsigned int DstElemSize, std::vector<ur_event_handle_t> DepEvents,
              ur_event_handle_t &OutEvent) {
   (void)DstAccessRange;
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
-  assert(SrcQueue && "Source mem object queue is expected to be not nullptr");
 
-  const ur_queue_handle_t Queue = SrcQueue->getHandleRef();
-  const AdapterPtr &Adapter = SrcQueue->getAdapter();
+  const ur_queue_handle_t Queue = SrcQueue.getHandleRef();
+  const AdapterPtr &Adapter = SrcQueue.getAdapter();
 
   detail::SYCLMemObjI::MemObjType MemType = SYCLMemObj->getType();
   TermPositions SrcPos, DstPos;
@@ -639,20 +637,20 @@ void copyD2H(SYCLMemObjI *SYCLMemObj, ur_mem_handle_t SrcMem,
   }
 }
 
-void copyD2D(SYCLMemObjI *SYCLMemObj, ur_mem_handle_t SrcMem,
-             QueueImplPtr SrcQueue, unsigned int DimSrc, sycl::range<3> SrcSize,
-             sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
-             unsigned int SrcElemSize, ur_mem_handle_t DstMem, QueueImplPtr,
-             unsigned int DimDst, sycl::range<3> DstSize, sycl::range<3>,
-             sycl::id<3> DstOffset, unsigned int DstElemSize,
-             std::vector<ur_event_handle_t> DepEvents,
+// Only when memory objects are bound to the same context, so one queue_impl is
+// all we need.
+void copyD2D(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
+             ur_mem_handle_t SrcMem, unsigned int DimSrc,
+             sycl::range<3> SrcSize, sycl::range<3> SrcAccessRange,
+             sycl::id<3> SrcOffset, unsigned int SrcElemSize,
+             ur_mem_handle_t DstMem, unsigned int DimDst,
+             sycl::range<3> DstSize, sycl::range<3>, sycl::id<3> DstOffset,
+             unsigned int DstElemSize, std::vector<ur_event_handle_t> DepEvents,
              ur_event_handle_t &OutEvent) {
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
-  assert(SrcQueue && "Source mem object and target mem object queues are "
-                     "expected to be not nullptr");
 
-  const ur_queue_handle_t Queue = SrcQueue->getHandleRef();
-  const AdapterPtr &Adapter = SrcQueue->getAdapter();
+  const ur_queue_handle_t Queue = SrcQueue.getHandleRef();
+  const AdapterPtr &Adapter = SrcQueue.getAdapter();
 
   detail::SYCLMemObjI::MemObjType MemType = SYCLMemObj->getType();
   TermPositions SrcPos, DstPos;
@@ -710,11 +708,10 @@ void copyD2D(SYCLMemObjI *SYCLMemObj, ur_mem_handle_t SrcMem,
   }
 }
 
-static void copyH2H(SYCLMemObjI *, char *SrcMem, QueueImplPtr,
-                    unsigned int DimSrc, sycl::range<3> SrcSize,
-                    sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
-                    unsigned int SrcElemSize, char *DstMem, QueueImplPtr,
-                    unsigned int DimDst, sycl::range<3> DstSize,
+static void copyH2H(SYCLMemObjI *, char *SrcMem, unsigned int DimSrc,
+                    sycl::range<3> SrcSize, sycl::range<3> SrcAccessRange,
+                    sycl::id<3> SrcOffset, unsigned int SrcElemSize,
+                    char *DstMem, unsigned int DimDst, sycl::range<3> DstSize,
                     sycl::range<3> DstAccessRange, sycl::id<3> DstOffset,
                     unsigned int DstElemSize, std::vector<ur_event_handle_t>,
                     ur_event_handle_t &) {
@@ -739,10 +736,10 @@ static void copyH2H(SYCLMemObjI *, char *SrcMem, QueueImplPtr,
 // Copies memory between: host and device, host and host,
 // device and device if memory objects bound to the one context.
 void MemoryManager::copy(SYCLMemObjI *SYCLMemObj, void *SrcMem,
-                         QueueImplPtr SrcQueue, unsigned int DimSrc,
+                         queue_impl *SrcQueue, unsigned int DimSrc,
                          sycl::range<3> SrcSize, sycl::range<3> SrcAccessRange,
                          sycl::id<3> SrcOffset, unsigned int SrcElemSize,
-                         void *DstMem, QueueImplPtr TgtQueue,
+                         void *DstMem, queue_impl *TgtQueue,
                          unsigned int DimDst, sycl::range<3> DstSize,
                          sycl::range<3> DstAccessRange, sycl::id<3> DstOffset,
                          unsigned int DstElemSize,
@@ -751,33 +748,32 @@ void MemoryManager::copy(SYCLMemObjI *SYCLMemObj, void *SrcMem,
 
   if (!SrcQueue) {
     if (!TgtQueue)
-      copyH2H(SYCLMemObj, (char *)SrcMem, nullptr, DimSrc, SrcSize,
-              SrcAccessRange, SrcOffset, SrcElemSize, (char *)DstMem, nullptr,
-              DimDst, DstSize, DstAccessRange, DstOffset, DstElemSize,
-              std::move(DepEvents), OutEvent);
-    else
-      copyH2D(SYCLMemObj, (char *)SrcMem, nullptr, DimSrc, SrcSize,
-              SrcAccessRange, SrcOffset, SrcElemSize,
-              ur::cast<ur_mem_handle_t>(DstMem), std::move(TgtQueue), DimDst,
-              DstSize, DstAccessRange, DstOffset, DstElemSize,
-              std::move(DepEvents), OutEvent);
-  } else {
-    if (!TgtQueue)
-      copyD2H(SYCLMemObj, ur::cast<ur_mem_handle_t>(SrcMem),
-              std::move(SrcQueue), DimSrc, SrcSize, SrcAccessRange, SrcOffset,
-              SrcElemSize, (char *)DstMem, nullptr, DimDst, DstSize,
+      copyH2H(SYCLMemObj, (char *)SrcMem, DimSrc, SrcSize, SrcAccessRange,
+              SrcOffset, SrcElemSize, (char *)DstMem, DimDst, DstSize,
               DstAccessRange, DstOffset, DstElemSize, std::move(DepEvents),
               OutEvent);
     else
-      copyD2D(SYCLMemObj, ur::cast<ur_mem_handle_t>(SrcMem),
-              std::move(SrcQueue), DimSrc, SrcSize, SrcAccessRange, SrcOffset,
-              SrcElemSize, ur::cast<ur_mem_handle_t>(DstMem),
-              std::move(TgtQueue), DimDst, DstSize, DstAccessRange, DstOffset,
-              DstElemSize, std::move(DepEvents), OutEvent);
+      copyH2D(*TgtQueue, SYCLMemObj, (char *)SrcMem, DimSrc, SrcSize,
+              SrcAccessRange, SrcOffset, SrcElemSize,
+              ur::cast<ur_mem_handle_t>(DstMem), DimDst, DstSize,
+              DstAccessRange, DstOffset, DstElemSize, std::move(DepEvents),
+              OutEvent);
+  } else {
+    if (!TgtQueue)
+      copyD2H(*SrcQueue, SYCLMemObj, ur::cast<ur_mem_handle_t>(SrcMem), DimSrc,
+              SrcSize, SrcAccessRange, SrcOffset, SrcElemSize, (char *)DstMem,
+              DimDst, DstSize, DstAccessRange, DstOffset, DstElemSize,
+              std::move(DepEvents), OutEvent);
+    else
+      copyD2D(*SrcQueue, SYCLMemObj, ur::cast<ur_mem_handle_t>(SrcMem), DimSrc,
+              SrcSize, SrcAccessRange, SrcOffset, SrcElemSize,
+              ur::cast<ur_mem_handle_t>(DstMem), DimDst, DstSize,
+              DstAccessRange, DstOffset, DstElemSize, std::move(DepEvents),
+              OutEvent);
   }
 }
 
-void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
+void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, queue_impl &Queue,
                          size_t PatternSize, const unsigned char *Pattern,
                          unsigned int Dim, sycl::range<3> MemRange,
                          sycl::range<3> AccRange, sycl::id<3> Offset,
@@ -785,9 +781,8 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
                          std::vector<ur_event_handle_t> DepEvents,
                          ur_event_handle_t &OutEvent) {
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
-  assert(Queue && "Fill should be called only with a valid device queue");
 
-  const AdapterPtr &Adapter = Queue->getAdapter();
+  const AdapterPtr &Adapter = Queue.getAdapter();
 
   if (SYCLMemObj->getType() == detail::SYCLMemObjI::MemObjType::Buffer) {
 
@@ -801,7 +796,7 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
 
     if (RangesUsable && OffsetUsable) {
       Adapter->call<UrApiKind::urEnqueueMemBufferFill>(
-          Queue->getHandleRef(), ur::cast<ur_mem_handle_t>(Mem), Pattern,
+          Queue.getHandleRef(), ur::cast<ur_mem_handle_t>(Mem), Pattern,
           PatternSize, Offset[0] * ElementSize, RangeMultiplier * ElementSize,
           DepEvents.size(), DepEvents.data(), &OutEvent);
       return;
@@ -819,17 +814,12 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
   }
 }
 
-void *MemoryManager::map(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
+void *MemoryManager::map(SYCLMemObjI *, void *Mem, queue_impl &Queue,
                          access::mode AccessMode, unsigned int, sycl::range<3>,
                          sycl::range<3> AccessRange, sycl::id<3> AccessOffset,
                          unsigned int ElementSize,
                          std::vector<ur_event_handle_t> DepEvents,
                          ur_event_handle_t &OutEvent) {
-  if (!Queue) {
-    throw exception(make_error_code(errc::runtime),
-                    "Not supported configuration of map requested");
-  }
-
   ur_map_flags_t Flags = 0;
 
   switch (AccessMode) {
@@ -857,42 +847,36 @@ void *MemoryManager::map(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
 
   void *MappedPtr = nullptr;
   const size_t BytesToMap = AccessRange[0] * AccessRange[1] * AccessRange[2];
-  const AdapterPtr &Adapter = Queue->getAdapter();
-  memBufferMapHelper(Adapter, Queue->getHandleRef(),
+  const AdapterPtr &Adapter = Queue.getAdapter();
+  memBufferMapHelper(Adapter, Queue.getHandleRef(),
                      ur::cast<ur_mem_handle_t>(Mem), false, Flags,
                      AccessOffset[0], BytesToMap, DepEvents.size(),
                      DepEvents.data(), &OutEvent, &MappedPtr);
   return MappedPtr;
 }
 
-void MemoryManager::unmap(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
+void MemoryManager::unmap(SYCLMemObjI *, void *Mem, queue_impl &Queue,
                           void *MappedPtr,
                           std::vector<ur_event_handle_t> DepEvents,
                           ur_event_handle_t &OutEvent) {
-
-  // Execution on host is not supported here.
-  if (!Queue) {
-    throw exception(make_error_code(errc::runtime),
-                    "Not supported configuration of unmap requested");
-  }
   // All DepEvents are to the same Context.
   // Using the adapter of the Queue.
 
-  const AdapterPtr &Adapter = Queue->getAdapter();
-  memUnmapHelper(Adapter, Queue->getHandleRef(), ur::cast<ur_mem_handle_t>(Mem),
+  const AdapterPtr &Adapter = Queue.getAdapter();
+  memUnmapHelper(Adapter, Queue.getHandleRef(), ur::cast<ur_mem_handle_t>(Mem),
                  MappedPtr, DepEvents.size(), DepEvents.data(), &OutEvent);
 }
 
-void MemoryManager::copy_usm(const void *SrcMem, QueueImplPtr SrcQueue,
+void MemoryManager::copy_usm(const void *SrcMem, queue_impl &SrcQueue,
                              size_t Len, void *DstMem,
                              std::vector<ur_event_handle_t> DepEvents,
                              ur_event_handle_t *OutEvent) {
-  assert(SrcQueue && "USM copy must be called with a valid device queue");
+  const AdapterPtr &Adapter = SrcQueue.getAdapter();
   if (!Len) { // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      SrcQueue->getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
-          SrcQueue->getHandleRef(), DepEvents.size(), DepEvents.data(),
-          OutEvent);
+      Adapter->call<UrApiKind::urEnqueueEventsWait>(SrcQueue.getHandleRef(),
+                                                    DepEvents.size(),
+                                                    DepEvents.data(), OutEvent);
     }
     return;
   }
@@ -901,22 +885,20 @@ void MemoryManager::copy_usm(const void *SrcMem, QueueImplPtr SrcQueue,
     throw exception(make_error_code(errc::invalid),
                     "NULL pointer argument in memory copy operation.");
 
-  const AdapterPtr &Adapter = SrcQueue->getAdapter();
-  Adapter->call<UrApiKind::urEnqueueUSMMemcpy>(SrcQueue->getHandleRef(),
+  Adapter->call<UrApiKind::urEnqueueUSMMemcpy>(SrcQueue.getHandleRef(),
                                                /* blocking */ false, DstMem,
                                                SrcMem, Len, DepEvents.size(),
                                                DepEvents.data(), OutEvent);
 }
 
-void MemoryManager::fill_usm(void *Mem, QueueImplPtr Queue, size_t Length,
+void MemoryManager::fill_usm(void *Mem, queue_impl &Queue, size_t Length,
                              const std::vector<unsigned char> &Pattern,
                              std::vector<ur_event_handle_t> DepEvents,
                              ur_event_handle_t *OutEvent) {
-  assert(Queue && "USM fill must be called with a valid device queue");
   if (!Length) { // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      Queue->getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
-          Queue->getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
+      Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+          Queue.getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
     }
     return;
   }
@@ -924,43 +906,40 @@ void MemoryManager::fill_usm(void *Mem, QueueImplPtr Queue, size_t Length,
   if (!Mem)
     throw exception(make_error_code(errc::invalid),
                     "NULL pointer argument in memory fill operation.");
-  const AdapterPtr &Adapter = Queue->getAdapter();
+  const AdapterPtr &Adapter = Queue.getAdapter();
   Adapter->call<UrApiKind::urEnqueueUSMFill>(
-      Queue->getHandleRef(), Mem, Pattern.size(), Pattern.data(), Length,
+      Queue.getHandleRef(), Mem, Pattern.size(), Pattern.data(), Length,
       DepEvents.size(), DepEvents.data(), OutEvent);
 }
 
-void MemoryManager::prefetch_usm(void *Mem, QueueImplPtr Queue, size_t Length,
+void MemoryManager::prefetch_usm(void *Mem, queue_impl &Queue, size_t Length,
                                  std::vector<ur_event_handle_t> DepEvents,
                                  ur_event_handle_t *OutEvent) {
-  assert(Queue && "USM prefetch must be called with a valid device queue");
-  const AdapterPtr &Adapter = Queue->getAdapter();
-  Adapter->call<UrApiKind::urEnqueueUSMPrefetch>(Queue->getHandleRef(), Mem,
+  const AdapterPtr &Adapter = Queue.getAdapter();
+  Adapter->call<UrApiKind::urEnqueueUSMPrefetch>(Queue.getHandleRef(), Mem,
                                                  Length, 0, DepEvents.size(),
                                                  DepEvents.data(), OutEvent);
 }
 
-void MemoryManager::advise_usm(const void *Mem, QueueImplPtr Queue,
+void MemoryManager::advise_usm(const void *Mem, queue_impl &Queue,
                                size_t Length, ur_usm_advice_flags_t Advice,
                                std::vector<ur_event_handle_t> /*DepEvents*/,
                                ur_event_handle_t *OutEvent) {
-  assert(Queue && "USM advise must be called with a valid device queue");
-  const AdapterPtr &Adapter = Queue->getAdapter();
-  Adapter->call<UrApiKind::urEnqueueUSMAdvise>(Queue->getHandleRef(), Mem,
+  const AdapterPtr &Adapter = Queue.getAdapter();
+  Adapter->call<UrApiKind::urEnqueueUSMAdvise>(Queue.getHandleRef(), Mem,
                                                Length, Advice, OutEvent);
 }
 
 void MemoryManager::copy_2d_usm(const void *SrcMem, size_t SrcPitch,
-                                QueueImplPtr Queue, void *DstMem,
+                                queue_impl &Queue, void *DstMem,
                                 size_t DstPitch, size_t Width, size_t Height,
                                 std::vector<ur_event_handle_t> DepEvents,
                                 ur_event_handle_t *OutEvent) {
-  assert(Queue && "USM copy 2d must be called with a valid device queue");
   if (Width == 0 || Height == 0) {
     // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      Queue->getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
-          Queue->getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
+      Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+          Queue.getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
     }
     return;
   }
@@ -969,18 +948,18 @@ void MemoryManager::copy_2d_usm(const void *SrcMem, size_t SrcPitch,
     throw sycl::exception(sycl::make_error_code(errc::invalid),
                           "NULL pointer argument in 2D memory copy operation.");
 
-  const AdapterPtr &Adapter = Queue->getAdapter();
+  const AdapterPtr &Adapter = Queue.getAdapter();
 
   bool SupportsUSMMemcpy2D = false;
   Adapter->call<UrApiKind::urContextGetInfo>(
-      Queue->getContextImplPtr()->getHandleRef(),
+      Queue.getContextImplPtr()->getHandleRef(),
       UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT, sizeof(bool), &SupportsUSMMemcpy2D,
       nullptr);
 
   if (SupportsUSMMemcpy2D) {
     // Direct memcpy2D is supported so we use this function.
     Adapter->call<UrApiKind::urEnqueueUSMMemcpy2D>(
-        Queue->getHandleRef(),
+        Queue.getHandleRef(),
         /*blocking=*/false, DstMem, DstPitch, SrcMem, SrcPitch, Width, Height,
         DepEvents.size(), DepEvents.data(), OutEvent);
     return;
@@ -988,7 +967,7 @@ void MemoryManager::copy_2d_usm(const void *SrcMem, size_t SrcPitch,
 
   // Otherwise we allow the special case where the copy is to or from host.
 #ifndef NDEBUG
-  context Ctx = createSyclObjFromImpl<context>(Queue->getContextImplPtr());
+  context Ctx = createSyclObjFromImpl<context>(Queue.getContextImplPtr());
   usm::alloc SrcAllocType = get_pointer_type(SrcMem, Ctx);
   usm::alloc DstAllocType = get_pointer_type(DstMem, Ctx);
   bool SrcIsHost =
@@ -1009,28 +988,27 @@ void MemoryManager::copy_2d_usm(const void *SrcMem, size_t SrcPitch,
     char *DstItBegin = static_cast<char *>(DstMem) + I * DstPitch;
     const char *SrcItBegin = static_cast<const char *>(SrcMem) + I * SrcPitch;
     Adapter->call<UrApiKind::urEnqueueUSMMemcpy>(
-        Queue->getHandleRef(),
+        Queue.getHandleRef(),
         /* blocking */ false, DstItBegin, SrcItBegin, Width, DepEvents.size(),
         DepEvents.data(), CopyEvents.data() + I);
     CopyEventsManaged.emplace_back(CopyEvents[I], Adapter,
                                    /*TakeOwnership=*/true);
   }
   // Then insert a wait to coalesce the copy events.
-  Queue->getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
-      Queue->getHandleRef(), CopyEvents.size(), CopyEvents.data(), OutEvent);
+  Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+      Queue.getHandleRef(), CopyEvents.size(), CopyEvents.data(), OutEvent);
 }
 
-void MemoryManager::fill_2d_usm(void *DstMem, QueueImplPtr Queue, size_t Pitch,
+void MemoryManager::fill_2d_usm(void *DstMem, queue_impl &Queue, size_t Pitch,
                                 size_t Width, size_t Height,
                                 const std::vector<unsigned char> &Pattern,
                                 std::vector<ur_event_handle_t> DepEvents,
                                 ur_event_handle_t *OutEvent) {
-  assert(Queue && "USM fill 2d must be called with a valid device queue");
   if (Width == 0 || Height == 0) {
     // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      Queue->getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
-          Queue->getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
+      Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+          Queue.getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
     }
     return;
   }
@@ -1038,23 +1016,21 @@ void MemoryManager::fill_2d_usm(void *DstMem, QueueImplPtr Queue, size_t Pitch,
   if (!DstMem)
     throw sycl::exception(sycl::make_error_code(errc::invalid),
                           "NULL pointer argument in 2D memory fill operation.");
-  const AdapterPtr &Adapter = Queue->getAdapter();
+  const AdapterPtr &Adapter = Queue.getAdapter();
   Adapter->call<UrApiKind::urEnqueueUSMFill2D>(
-      Queue->getHandleRef(), DstMem, Pitch, Pattern.size(), Pattern.data(),
+      Queue.getHandleRef(), DstMem, Pitch, Pattern.size(), Pattern.data(),
       Width, Height, DepEvents.size(), DepEvents.data(), OutEvent);
 }
 
-void MemoryManager::memset_2d_usm(void *DstMem, QueueImplPtr Queue,
-                                  size_t Pitch, size_t Width, size_t Height,
-                                  char Value,
+void MemoryManager::memset_2d_usm(void *DstMem, queue_impl &Queue, size_t Pitch,
+                                  size_t Width, size_t Height, char Value,
                                   std::vector<ur_event_handle_t> DepEvents,
                                   ur_event_handle_t *OutEvent) {
-  assert(Queue && "USM memset 2d must be called with a valid device queue");
   if (Width == 0 || Height == 0) {
     // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      Queue->getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
-          Queue->getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
+      Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+          Queue.getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
     }
     return;
   }
@@ -1069,13 +1045,11 @@ void MemoryManager::memset_2d_usm(void *DstMem, QueueImplPtr Queue,
 }
 
 static void
-memcpyToDeviceGlobalUSM(QueueImplPtr Queue,
+memcpyToDeviceGlobalUSM(queue_impl &Queue,
                         DeviceGlobalMapEntry *DeviceGlobalEntry,
                         size_t NumBytes, size_t Offset, const void *Src,
                         const std::vector<ur_event_handle_t> &DepEvents,
                         ur_event_handle_t *OutEvent) {
-  assert(Queue &&
-         "Copy to device global USM must be called with a valid device queue");
   // Get or allocate USM memory for the device_global.
   DeviceGlobalUSMMem &DeviceGlobalUSM =
       DeviceGlobalEntry->getOrAllocateDeviceGlobalUSM(Queue);
@@ -1083,7 +1057,7 @@ memcpyToDeviceGlobalUSM(QueueImplPtr Queue,
 
   // OwnedPiEvent will keep the initialization event alive for the duration
   // of this function call.
-  OwnedUrEvent ZIEvent = DeviceGlobalUSM.getInitEvent(Queue->getAdapter());
+  OwnedUrEvent ZIEvent = DeviceGlobalUSM.getInitEvent(Queue.getAdapter());
 
   // We may need addtional events, so create a non-const dependency events list
   // to use if we need to modify it.
@@ -1103,14 +1077,10 @@ memcpyToDeviceGlobalUSM(QueueImplPtr Queue,
                           ActualDepEvents, OutEvent);
 }
 
-static void
-memcpyFromDeviceGlobalUSM(QueueImplPtr Queue,
-                          DeviceGlobalMapEntry *DeviceGlobalEntry,
-                          size_t NumBytes, size_t Offset, void *Dest,
-                          const std::vector<ur_event_handle_t> &DepEvents,
-                          ur_event_handle_t *OutEvent) {
-  assert(Queue && "Copying from device global USM must be called with a valid "
-                  "device queue");
+static void memcpyFromDeviceGlobalUSM(
+    queue_impl &Queue, DeviceGlobalMapEntry *DeviceGlobalEntry, size_t NumBytes,
+    size_t Offset, void *Dest, const std::vector<ur_event_handle_t> &DepEvents,
+    ur_event_handle_t *OutEvent) {
   // Get or allocate USM memory for the device_global. Since we are reading from
   // it, we need it initialized if it has not been yet.
   DeviceGlobalUSMMem &DeviceGlobalUSM =
@@ -1119,7 +1089,7 @@ memcpyFromDeviceGlobalUSM(QueueImplPtr Queue,
 
   // OwnedPiEvent will keep the initialization event alive for the duration
   // of this function call.
-  OwnedUrEvent ZIEvent = DeviceGlobalUSM.getInitEvent(Queue->getAdapter());
+  OwnedUrEvent ZIEvent = DeviceGlobalUSM.getInitEvent(Queue.getAdapter());
 
   // We may need addtional events, so create a non-const dependency events list
   // to use if we need to modify it.
@@ -1139,7 +1109,7 @@ memcpyFromDeviceGlobalUSM(QueueImplPtr Queue,
 }
 
 static ur_program_handle_t
-getOrBuildProgramForDeviceGlobal(QueueImplPtr Queue,
+getOrBuildProgramForDeviceGlobal(queue_impl &Queue,
                                  DeviceGlobalMapEntry *DeviceGlobalEntry) {
   assert(DeviceGlobalEntry->MIsDeviceImageScopeDecorated &&
          "device_global is not device image scope decorated.");
@@ -1155,8 +1125,8 @@ getOrBuildProgramForDeviceGlobal(QueueImplPtr Queue,
                           "No image exists with the device_global.");
 
   // Look for cached programs with the device_global.
-  device Device = Queue->get_device();
-  ContextImplPtr ContextImpl = Queue->getContextImplPtr();
+  device Device = Queue.get_device();
+  ContextImplPtr ContextImpl = Queue.getContextImplPtr();
   std::optional<ur_program_handle_t> CachedProgram =
       ContextImpl->getProgramForDeviceGlobal(Device, DeviceGlobalEntry);
   if (CachedProgram)
@@ -1175,42 +1145,35 @@ getOrBuildProgramForDeviceGlobal(QueueImplPtr Queue,
 }
 
 static void
-memcpyToDeviceGlobalDirect(QueueImplPtr Queue,
+memcpyToDeviceGlobalDirect(queue_impl &Queue,
                            DeviceGlobalMapEntry *DeviceGlobalEntry,
                            size_t NumBytes, size_t Offset, const void *Src,
                            const std::vector<ur_event_handle_t> &DepEvents,
                            ur_event_handle_t *OutEvent) {
-  assert(
-      Queue &&
-      "Direct copy to device global must be called with a valid device queue");
   ur_program_handle_t Program =
       getOrBuildProgramForDeviceGlobal(Queue, DeviceGlobalEntry);
-  const AdapterPtr &Adapter = Queue->getAdapter();
+  const AdapterPtr &Adapter = Queue.getAdapter();
   Adapter->call<UrApiKind::urEnqueueDeviceGlobalVariableWrite>(
-      Queue->getHandleRef(), Program, DeviceGlobalEntry->MUniqueId.c_str(),
+      Queue.getHandleRef(), Program, DeviceGlobalEntry->MUniqueId.c_str(),
       false, NumBytes, Offset, Src, DepEvents.size(), DepEvents.data(),
       OutEvent);
 }
 
-static void
-memcpyFromDeviceGlobalDirect(QueueImplPtr Queue,
-                             DeviceGlobalMapEntry *DeviceGlobalEntry,
-                             size_t NumBytes, size_t Offset, void *Dest,
-                             const std::vector<ur_event_handle_t> &DepEvents,
-                             ur_event_handle_t *OutEvent) {
-  assert(Queue && "Direct copy from device global must be called with a valid "
-                  "device queue");
+static void memcpyFromDeviceGlobalDirect(
+    queue_impl &Queue, DeviceGlobalMapEntry *DeviceGlobalEntry, size_t NumBytes,
+    size_t Offset, void *Dest, const std::vector<ur_event_handle_t> &DepEvents,
+    ur_event_handle_t *OutEvent) {
   ur_program_handle_t Program =
       getOrBuildProgramForDeviceGlobal(Queue, DeviceGlobalEntry);
-  const AdapterPtr &Adapter = Queue->getAdapter();
+  const AdapterPtr &Adapter = Queue.getAdapter();
   Adapter->call<UrApiKind::urEnqueueDeviceGlobalVariableRead>(
-      Queue->getHandleRef(), Program, DeviceGlobalEntry->MUniqueId.c_str(),
+      Queue.getHandleRef(), Program, DeviceGlobalEntry->MUniqueId.c_str(),
       false, NumBytes, Offset, Dest, DepEvents.size(), DepEvents.data(),
       OutEvent);
 }
 
 void MemoryManager::copy_to_device_global(
-    const void *DeviceGlobalPtr, bool IsDeviceImageScoped, QueueImplPtr Queue,
+    const void *DeviceGlobalPtr, bool IsDeviceImageScoped, queue_impl &Queue,
     size_t NumBytes, size_t Offset, const void *SrcMem,
     const std::vector<ur_event_handle_t> &DepEvents,
     ur_event_handle_t *OutEvent) {
@@ -1232,7 +1195,7 @@ void MemoryManager::copy_to_device_global(
 }
 
 void MemoryManager::copy_from_device_global(
-    const void *DeviceGlobalPtr, bool IsDeviceImageScoped, QueueImplPtr Queue,
+    const void *DeviceGlobalPtr, bool IsDeviceImageScoped, queue_impl &Queue,
     size_t NumBytes, size_t Offset, void *DstMem,
     const std::vector<ur_event_handle_t> &DepEvents,
     ur_event_handle_t *OutEvent) {
@@ -1583,15 +1546,13 @@ void MemoryManager::ext_oneapi_advise_usm_cmd_buffer(
 }
 
 void MemoryManager::copy_image_bindless(
-    QueueImplPtr Queue, const void *Src, void *Dst,
+    queue_impl &Queue, const void *Src, void *Dst,
     const ur_image_desc_t &SrcDesc, const ur_image_desc_t &DstDesc,
     const ur_image_format_t &SrcFormat, const ur_image_format_t &DstFormat,
     const ur_exp_image_copy_flags_t Flags, ur_rect_offset_t SrcOffset,
     ur_rect_offset_t DstOffset, ur_rect_region_t CopyExtent,
     const std::vector<ur_event_handle_t> &DepEvents,
     ur_event_handle_t *OutEvent) {
-  assert(Queue &&
-         "Copy image bindless must be called with a valid device queue");
   assert((Flags == UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE ||
           Flags == UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST ||
           Flags == UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE ||
@@ -1602,7 +1563,7 @@ void MemoryManager::copy_image_bindless(
         sycl::make_error_code(errc::invalid),
         "NULL pointer argument in bindless image copy operation.");
 
-  const detail::AdapterPtr &Adapter = Queue->getAdapter();
+  const detail::AdapterPtr &Adapter = Queue.getAdapter();
 
   ur_exp_image_copy_region_t CopyRegion{};
   CopyRegion.stype = UR_STRUCTURE_TYPE_EXP_IMAGE_COPY_REGION;
@@ -1611,7 +1572,7 @@ void MemoryManager::copy_image_bindless(
   CopyRegion.dstOffset = DstOffset;
 
   Adapter->call<UrApiKind::urBindlessImagesImageCopyExp>(
-      Queue->getHandleRef(), Src, Dst, &SrcDesc, &DstDesc, &SrcFormat,
+      Queue.getHandleRef(), Src, Dst, &SrcDesc, &DstDesc, &SrcFormat,
       &DstFormat, &CopyRegion, Flags, DepEvents.size(), DepEvents.data(),
       OutEvent);
 }

--- a/sycl/source/detail/memory_manager.hpp
+++ b/sycl/source/detail/memory_manager.hpp
@@ -107,17 +107,17 @@ public:
 
   // Copies memory between: host and device, host and host,
   // device and device if memory objects bound to the one context.
-  static void copy(SYCLMemObjI *SYCLMemObj, void *SrcMem, QueueImplPtr SrcQueue,
+  static void copy(SYCLMemObjI *SYCLMemObj, void *SrcMem, queue_impl *SrcQueue,
                    unsigned int DimSrc, sycl::range<3> SrcSize,
                    sycl::range<3> SrcAccessRange, sycl::id<3> SrcOffset,
-                   unsigned int SrcElemSize, void *DstMem,
-                   QueueImplPtr TgtQueue, unsigned int DimDst,
-                   sycl::range<3> DstSize, sycl::range<3> DstAccessRange,
-                   sycl::id<3> DstOffset, unsigned int DstElemSize,
+                   unsigned int SrcElemSize, void *DstMem, queue_impl *TgtQueue,
+                   unsigned int DimDst, sycl::range<3> DstSize,
+                   sycl::range<3> DstAccessRange, sycl::id<3> DstOffset,
+                   unsigned int DstElemSize,
                    std::vector<ur_event_handle_t> DepEvents,
                    ur_event_handle_t &OutEvent);
 
-  static void fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
+  static void fill(SYCLMemObjI *SYCLMemObj, void *Mem, queue_impl &Queue,
                    size_t PatternSize, const unsigned char *Pattern,
                    unsigned int Dim, sycl::range<3> Size,
                    sycl::range<3> AccessRange, sycl::id<3> AccessOffset,
@@ -125,62 +125,62 @@ public:
                    std::vector<ur_event_handle_t> DepEvents,
                    ur_event_handle_t &OutEvent);
 
-  static void *map(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
+  static void *map(SYCLMemObjI *SYCLMemObj, void *Mem, queue_impl &Queue,
                    access::mode AccessMode, unsigned int Dim,
                    sycl::range<3> Size, sycl::range<3> AccessRange,
                    sycl::id<3> AccessOffset, unsigned int ElementSize,
                    std::vector<ur_event_handle_t> DepEvents,
                    ur_event_handle_t &OutEvent);
 
-  static void unmap(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
+  static void unmap(SYCLMemObjI *SYCLMemObj, void *Mem, queue_impl &Queue,
                     void *MappedPtr, std::vector<ur_event_handle_t> DepEvents,
                     ur_event_handle_t &OutEvent);
 
-  static void copy_usm(const void *SrcMem, QueueImplPtr Queue, size_t Len,
+  static void copy_usm(const void *SrcMem, queue_impl &Queue, size_t Len,
                        void *DstMem, std::vector<ur_event_handle_t> DepEvents,
                        ur_event_handle_t *OutEvent);
 
-  static void fill_usm(void *DstMem, QueueImplPtr Queue, size_t Len,
+  static void fill_usm(void *DstMem, queue_impl &Queue, size_t Len,
                        const std::vector<unsigned char> &Pattern,
                        std::vector<ur_event_handle_t> DepEvents,
                        ur_event_handle_t *OutEvent);
 
-  static void prefetch_usm(void *Ptr, QueueImplPtr Queue, size_t Len,
+  static void prefetch_usm(void *Ptr, queue_impl &Queue, size_t Len,
                            std::vector<ur_event_handle_t> DepEvents,
                            ur_event_handle_t *OutEvent);
 
-  static void advise_usm(const void *Ptr, QueueImplPtr Queue, size_t Len,
+  static void advise_usm(const void *Ptr, queue_impl &Queue, size_t Len,
                          ur_usm_advice_flags_t Advice,
                          std::vector<ur_event_handle_t> DepEvents,
                          ur_event_handle_t *OutEvent);
 
   static void copy_2d_usm(const void *SrcMem, size_t SrcPitch,
-                          QueueImplPtr Queue, void *DstMem, size_t DstPitch,
+                          queue_impl &Queue, void *DstMem, size_t DstPitch,
                           size_t Width, size_t Height,
                           std::vector<ur_event_handle_t> DepEvents,
                           ur_event_handle_t *OutEvent);
 
-  static void fill_2d_usm(void *DstMem, QueueImplPtr Queue, size_t Pitch,
+  static void fill_2d_usm(void *DstMem, queue_impl &Queue, size_t Pitch,
                           size_t Width, size_t Height,
                           const std::vector<unsigned char> &Pattern,
                           std::vector<ur_event_handle_t> DepEvents,
                           ur_event_handle_t *OutEvent);
 
-  static void memset_2d_usm(void *DstMem, QueueImplPtr Queue, size_t Pitch,
+  static void memset_2d_usm(void *DstMem, queue_impl &Queue, size_t Pitch,
                             size_t Width, size_t Height, char Value,
                             std::vector<ur_event_handle_t> DepEvents,
                             ur_event_handle_t *OutEvent);
 
   static void
   copy_to_device_global(const void *DeviceGlobalPtr, bool IsDeviceImageScoped,
-                        QueueImplPtr Queue, size_t NumBytes, size_t Offset,
+                        queue_impl &Queue, size_t NumBytes, size_t Offset,
                         const void *SrcMem,
                         const std::vector<ur_event_handle_t> &DepEvents,
                         ur_event_handle_t *OutEvent);
 
   static void
   copy_from_device_global(const void *DeviceGlobalPtr, bool IsDeviceImageScoped,
-                          QueueImplPtr Queue, size_t NumBytes, size_t Offset,
+                          queue_impl &Queue, size_t NumBytes, size_t Offset,
                           void *DstMem,
                           const std::vector<ur_event_handle_t> &DepEvents,
                           ur_event_handle_t *OutEvent);
@@ -254,7 +254,7 @@ public:
       ur_exp_command_buffer_sync_point_t *OutSyncPoint);
 
   static void copy_image_bindless(
-      QueueImplPtr Queue, const void *Src, void *Dst,
+      queue_impl &Queue, const void *Src, void *Dst,
       const ur_image_desc_t &SrcDesc, const ur_image_desc_t &DstDesc,
       const ur_image_format_t &SrcFormat, const ur_image_format_t &DstFormat,
       const ur_exp_image_copy_flags_t Flags, ur_rect_offset_t SrcOffset,

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -955,7 +955,8 @@ protected:
   event submitMemOpHelper(const std::shared_ptr<queue_impl> &Self,
                           const std::vector<event> &DepEvents,
                           bool CallerNeedsEvent, HandlerFuncT HandlerFunc,
-                          MemMngrFuncT MemMngrFunc, MemMngrArgTs... MemOpArgs);
+                          MemMngrFuncT MemMngrFunc,
+                          MemMngrArgTs &&...MemOpArgs);
 
   // When instrumentation is enabled emits trace event for wait begin and
   // returns the telemetry event generated for the wait

--- a/sycl/source/detail/reduction.cpp
+++ b/sycl/source/detail/reduction.cpp
@@ -184,7 +184,8 @@ addCounterInit(handler &CGH, std::shared_ptr<sycl::detail::queue_impl> &Queue,
   EventImpl->setContextImpl(detail::getSyclObjImpl(Queue->get_context()));
   EventImpl->setStateIncomplete();
   ur_event_handle_t UREvent = nullptr;
-  MemoryManager::fill_usm(Counter.get(), Queue, sizeof(int), {0}, {}, &UREvent);
+  MemoryManager::fill_usm(Counter.get(), *Queue, sizeof(int), {0}, {},
+                          &UREvent);
   EventImpl->setHandle(UREvent);
   CGH.depends_on(createSyclObjFromImpl<event>(EventImpl));
 }


### PR DESCRIPTION
This is intended to be a part of a bigger refactoring around internal RT APIs passing raw references instead of `std::shared_ptr<*_impl>`, similar to what have been implemented for `device_impl` earlier.