### PR TITLE
[NFC][SYCL] More `queue_impl` passing by raw ptr/ref

### DIFF
--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -38,9 +38,9 @@ markBufferAsInternal(const std::shared_ptr<buffer_impl> &BufImpl) {
 }
 
 std::tuple<const RTDeviceBinaryImage *, ur_program_handle_t>
-retrieveKernelBinary(const QueueImplPtr &Queue, const char *KernelName,
+retrieveKernelBinary(queue_impl &Queue, const char *KernelName,
                      CGExecKernel *KernelCG) {
-  device_impl &Dev = Queue->getDeviceImpl();
+  device_impl &Dev = Queue.getDeviceImpl();
   bool isNvidia = Dev.getBackend() == backend::ext_oneapi_cuda;
   bool isHIP = Dev.getBackend() == backend::ext_oneapi_hip;
   if (isNvidia || isHIP) {
@@ -59,7 +59,7 @@ retrieveKernelBinary(const QueueImplPtr &Queue, const char *KernelName,
     if (DeviceImage == DeviceImages.end()) {
       return {nullptr, nullptr};
     }
-    auto ContextImpl = Queue->getContextImplPtr();
+    auto ContextImpl = Queue.getContextImplPtr();
     ur_program_handle_t Program =
         detail::ProgramManager::getInstance().createURProgram(
             **DeviceImage, ContextImpl, {createSyclObjFromImpl<device>(Dev)});
@@ -80,7 +80,7 @@ retrieveKernelBinary(const QueueImplPtr &Queue, const char *KernelName,
     DeviceImage = SyclKernelImpl->getDeviceImage()->get_bin_image_ref();
     Program = SyclKernelImpl->getDeviceImage()->get_ur_program_ref();
   } else {
-    auto ContextImpl = Queue->getContextImplPtr();
+    auto ContextImpl = Queue.getContextImplPtr();
     DeviceImage = &detail::ProgramManager::getInstance().getDeviceImage(
         KernelName, ContextImpl, &Dev);
     Program = detail::ProgramManager::getInstance().createURProgram(

--- a/sycl/source/detail/helpers.hpp
+++ b/sycl/source/detail/helpers.hpp
@@ -27,7 +27,7 @@ void waitEvents(std::vector<sycl::event> DepEvents);
 #endif
 
 std::tuple<const RTDeviceBinaryImage *, ur_program_handle_t>
-retrieveKernelBinary(const QueueImplPtr &, const char *KernelName,
+retrieveKernelBinary(queue_impl &Queue, const char *KernelName,
                      CGExecKernel *CGKernel = nullptr);
 } // namespace detail
 } // namespace _V1

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -124,8 +124,8 @@ translateBinaryImageFormat(ur::DeviceBinaryType Type) {
   }
 }
 
-static ::jit_compiler::BinaryFormat getTargetFormat(const QueueImplPtr &Queue) {
-  auto Backend = Queue->getDeviceImpl().getBackend();
+static ::jit_compiler::BinaryFormat getTargetFormat(queue_impl &Queue) {
+  auto Backend = Queue.getDeviceImpl().getBackend();
   switch (Backend) {
   case backend::ext_oneapi_level_zero:
   case backend::opencl:
@@ -143,7 +143,7 @@ static ::jit_compiler::BinaryFormat getTargetFormat(const QueueImplPtr &Queue) {
 #endif // _WIN32
 
 ur_kernel_handle_t jit_compiler::materializeSpecConstants(
-    const QueueImplPtr &Queue, const RTDeviceBinaryImage *BinImage,
+    queue_impl &Queue, const RTDeviceBinaryImage *BinImage,
     KernelNameStrRefT KernelName,
     const std::vector<unsigned char> &SpecConstBlob) {
 #ifndef _WIN32
@@ -220,8 +220,8 @@ ur_kernel_handle_t jit_compiler::materializeSpecConstants(
   }
 
   RTDeviceBinaryImage MaterializedRTDevBinImage{&MaterializedRawDeviceImage};
-  const auto &Context = Queue->get_context();
-  const auto &Device = Queue->get_device();
+  const auto &Context = Queue.get_context();
+  const auto &Device = Queue.get_device();
   auto NewKernel = PM.getOrCreateMaterializedKernel(
       MaterializedRTDevBinImage, Context, Device, KernelName, SpecConstBlob);
 

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -32,13 +32,12 @@ using JITEnvVar = DynArray<char>;
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
-using QueueImplPtr = std::shared_ptr<queue_impl>;
 
 class jit_compiler {
 
 public:
   ur_kernel_handle_t
-  materializeSpecConstants(const QueueImplPtr &Queue,
+  materializeSpecConstants(queue_impl &Queue,
                            const RTDeviceBinaryImage *BinImage,
                            KernelNameStrRefT KernelName,
                            const std::vector<unsigned char> &SpecConstBlob);

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2383,7 +2383,7 @@ void SetArgBasedOnType(
 }
 
 static ur_result_t SetKernelParamsAndLaunch(
-    const QueueImplPtr &Queue, std::vector<ArgDesc> &Args,
+    queue_impl &Queue, std::vector<ArgDesc> &Args,
     const std::shared_ptr<device_image_impl> &DeviceImageImpl,
     ur_kernel_handle_t Kernel, NDRDescT &NDRDesc,
     std::vector<ur_event_handle_t> &RawEvents, detail::event_impl *OutEventImpl,
@@ -2395,8 +2395,7 @@ static ur_result_t SetKernelParamsAndLaunch(
     int KernelNumArgs = 0,
     detail::kernel_param_desc_t (*KernelParamDescGetter)(int) = nullptr,
     bool KernelHasSpecialCaptures = true) {
-  assert(Queue && "Kernel submissions should have an associated queue");
-  const AdapterPtr &Adapter = Queue->getAdapter();
+  const AdapterPtr &Adapter = Queue.getAdapter();
 
   if (SYCLConfig<SYCL_JIT_AMDGCN_PTX_KERNELS>::get()) {
     std::vector<unsigned char> Empty;
@@ -2434,7 +2433,7 @@ static ur_result_t SetKernelParamsAndLaunch(
     auto setFunc = [&Adapter, Kernel, &DeviceImageImpl, &getMemAllocationFunc,
                     &Queue](detail::ArgDesc &Arg, size_t NextTrueIndex) {
       SetArgBasedOnType(Adapter, Kernel, DeviceImageImpl, getMemAllocationFunc,
-                        Queue->getContextImplPtr(), Arg, NextTrueIndex);
+                        Queue.getContextImplPtr(), Arg, NextTrueIndex);
     };
     applyFuncOnFilteredArgs(EliminatedArgMask, Args, setFunc);
   }
@@ -2450,7 +2449,7 @@ static ur_result_t SetKernelParamsAndLaunch(
         Kernel, ImplicitLocalArg.value(), WorkGroupMemorySize, nullptr);
   }
 
-  adjustNDRangePerKernel(NDRDesc, Kernel, Queue->getDeviceImpl());
+  adjustNDRangePerKernel(NDRDesc, Kernel, Queue.getDeviceImpl());
 
   // Remember this information before the range dimensions are reversed
   const bool HasLocalSize = (NDRDesc.LocalSize[0] != 0);
@@ -2464,7 +2463,7 @@ static ur_result_t SetKernelParamsAndLaunch(
     LocalSize = &NDRDesc.LocalSize[0];
   else {
     Adapter->call<UrApiKind::urKernelGetGroupInfo>(
-        Kernel, Queue->getDeviceImpl().getHandleRef(),
+        Kernel, Queue.getDeviceImpl().getHandleRef(),
         UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, sizeof(RequiredWGSize),
         RequiredWGSize,
         /* pPropSizeRet = */ nullptr);
@@ -2504,7 +2503,7 @@ static ur_result_t SetKernelParamsAndLaunch(
     ur_event_handle_t UREvent = nullptr;
     ur_result_t Error =
         Adapter->call_nocheck<UrApiKind::urEnqueueKernelLaunchCustomExp>(
-            Queue->getHandleRef(), Kernel, NDRDesc.Dims,
+            Queue.getHandleRef(), Kernel, NDRDesc.Dims,
             &NDRDesc.GlobalOffset[0], &NDRDesc.GlobalSize[0], LocalSize,
             property_list.size(), property_list.data(), RawEvents.size(),
             RawEvents.empty() ? nullptr : &RawEvents[0],
@@ -2523,7 +2522,7 @@ static ur_result_t SetKernelParamsAndLaunch(
                   Args...);
         }
         return Adapter->call_nocheck<UrApiKind::urEnqueueKernelLaunch>(Args...);
-      }(Queue->getHandleRef(), Kernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],
+      }(Queue.getHandleRef(), Kernel, NDRDesc.Dims, &NDRDesc.GlobalOffset[0],
         &NDRDesc.GlobalSize[0], LocalSize, RawEvents.size(),
         RawEvents.empty() ? nullptr : &RawEvents[0],
         OutEventImpl ? &UREvent : nullptr);
@@ -2773,7 +2772,7 @@ void enqueueImpKernel(
     }
 
     Error = SetKernelParamsAndLaunch(
-        Queue, Args, DeviceImageImpl, Kernel, NDRDesc, EventsWaitList,
+        *Queue, Args, DeviceImageImpl, Kernel, NDRDesc, EventsWaitList,
         OutEventImpl, EliminatedArgMask, getMemAllocationFunc,
         KernelIsCooperative, KernelUsesClusterLaunch, WorkGroupMemorySize,
         BinImage, KernelName, KernelFuncPtr, KernelNumArgs,
@@ -3279,7 +3278,7 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     const RTDeviceBinaryImage *BinImage = nullptr;
     if (detail::SYCLConfig<detail::SYCL_JIT_AMDGCN_PTX_KERNELS>::get()) {
       std::tie(BinImage, std::ignore) =
-          retrieveKernelBinary(MQueue, KernelName.data());
+          retrieveKernelBinary(*MQueue, KernelName.data());
       assert(BinImage && "Failed to obtain a binary image.");
     }
     enqueueImpKernel(

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -615,7 +615,7 @@ void Scheduler::cleanupAuxiliaryResources(BlockingT Blocking) {
 }
 
 ur_kernel_handle_t Scheduler::completeSpecConstMaterialization(
-    [[maybe_unused]] const QueueImplPtr &Queue,
+    [[maybe_unused]] queue_impl &Queue,
     [[maybe_unused]] const RTDeviceBinaryImage *BinImage,
     [[maybe_unused]] KernelNameStrRefT KernelName,
     [[maybe_unused]] std::vector<unsigned char> &SpecConstBlob) {

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -453,7 +453,7 @@ public:
   void deferMemObjRelease(const std::shared_ptr<detail::SYCLMemObjI> &MemObj);
 
   ur_kernel_handle_t completeSpecConstMaterialization(
-      const QueueImplPtr &Queue, const RTDeviceBinaryImage *BinImage,
+      queue_impl &Queue, const RTDeviceBinaryImage *BinImage,
       KernelNameStrRefT KernelName, std::vector<unsigned char> &SpecConstBlob);
 
   void releaseResources(BlockingT Blocking = BlockingT::BLOCKING);

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -582,7 +582,7 @@ event handler::finalize() {
         const detail::RTDeviceBinaryImage *BinImage = nullptr;
         if (detail::SYCLConfig<detail::SYCL_JIT_AMDGCN_PTX_KERNELS>::get()) {
           std::tie(BinImage, std::ignore) =
-              detail::retrieveKernelBinary(MQueue, MKernelName.data());
+              detail::retrieveKernelBinary(*MQueue, MKernelName.data());
           assert(BinImage && "Failed to obtain a binary image.");
         }
         enqueueImpKernel(


### PR DESCRIPTION
Same as https://github.com/intel/llvm/pull/18712, part of a bigger refactoring around internal RT APIs passing raw references instead of `std::shared_ptr<*_impl>`, similar to what have been implemented for `device_impl` earlier.