### PR TITLE
[L0] Revert copy engine refactor and disable copy-engine for SYCL-Graph on DG2

### DIFF
--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -1097,10 +1097,19 @@ ur_result_t urCommandBufferAppendUSMMemcpyExp(
     ur_event_handle_t * /*Event*/,
     ur_exp_command_buffer_command_handle_t * /*Command*/) {
 
+  bool PreferCopyEngine = !IsDevicePointer(CommandBuffer->Context, Src) ||
+                          !IsDevicePointer(CommandBuffer->Context, Dst);
+  // For better performance, Copy Engines are not preferred given Shared
+  // pointers on DG2.
+  if (CommandBuffer->Device->isDG2() &&
+      (IsSharedPointer(CommandBuffer->Context, Src) ||
+       IsSharedPointer(CommandBuffer->Context, Dst))) {
+    PreferCopyEngine = false;
+  }
+  PreferCopyEngine |= UseCopyEngineForD2DCopy;
+
   return enqueueCommandBufferMemCopyHelper(
-      UR_COMMAND_USM_MEMCPY, CommandBuffer, Dst, Src, Size,
-      PreferCopyEngineUsage(CommandBuffer->Device, CommandBuffer->Context, Src,
-                            Dst),
+      UR_COMMAND_USM_MEMCPY, CommandBuffer, Dst, Src, Size, PreferCopyEngine,
       NumSyncPointsInWaitList, SyncPointWaitList, SyncPoint);
 }
 

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -742,7 +742,9 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   // Create a list for copy commands. Note that to simplify the implementation,
   // the current implementation only uses the main copy engine and does not use
   // the link engine even if available.
-  if (Device->hasMainCopyEngine()) {
+  //
+  // Copy engine usage disabled for DG2, see CMPLRLLVM-68064
+  if (Device->hasMainCopyEngine() && !Device->isDG2()) {
     UR_CALL(createMainCommandList(Context, Device, IsInOrder, false, true,
                                   ZeCopyCommandList));
   }

--- a/unified-runtime/source/adapters/level_zero/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/memory.hpp
@@ -29,9 +29,6 @@ struct ur_device_handle_t_;
 
 bool IsDevicePointer(ur_context_handle_t Context, const void *Ptr);
 bool IsSharedPointer(ur_context_handle_t Context, const void *Ptr);
-bool PreferCopyEngineUsage(ur_device_handle_t Device,
-                           ur_context_handle_t Context, const void *Src,
-                           void *Dst);
 
 // This is an experimental option to test performance of device to device copy
 // operations on copy engines (versus compute engine)


### PR DESCRIPTION
Revert [[L0] Refactor Copy Engine Usage checks for Performance](https://github.com/intel/llvm/commit/781e5761928e82bba6de5f9172ed9fe70d7ea93e) and always disable copy-engine in SYCL-Graph on DG2 as a workaround for CMPLRLLVM-68064.