### PR TITLE
[CI] Remove dependency on devops/scripts/** from IGC dev containers workflow

### DIFF
--- a/.github/workflows/sycl-containers-igc-dev.yaml
+++ b/.github/workflows/sycl-containers-igc-dev.yaml
@@ -6,13 +6,11 @@ on:
       - sycl
     paths:
       - 'devops/actions/build_container/**'
-      - 'devops/scripts/**'
       - 'devops/dependencies-igc-dev.json'
       - '.github/workflows/sycl-containers-igc-dev.yaml'
   pull_request:
     paths:
       - 'devops/actions/build_container/**'
-      - 'devops/scripts/**'
       - 'devops/dependencies-igc-dev.json'
       - '.github/workflows/sycl-containers-igc-dev.yaml'
 


### PR DESCRIPTION
The dependency on devops/scripts/** causes any changes in devops/scripts/** unrelated to IGC dev containers to fail