### PR TITLE
[UR][CI] Skip adapter testing for adapters that haven't been built

### DIFF
--- a/unified-runtime/test/adapters/lit.local.cfg.py
+++ b/unified-runtime/test/adapters/lit.local.cfg.py
@@ -1,0 +1,16 @@
+"""
+Copyright (C) 2025 Intel Corporation
+
+Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+See LICENSE.TXT
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+
+# Skip adapter testing for adapters that have not been built
+if "cuda" not in config.adapters_built:
+    config.excludes.add("cuda")
+if "hip" not in config.adapters_built:
+    config.excludes.add("hip")
+if "level_zero" not in config.adapters_built:
+    config.excludes.add("level_zero")


### PR DESCRIPTION
This doesn't affect the `check-unified-runtime-adapter` target, but does
fix the main `check-unified-runtime` target.
