### PR TITLE
[SYCL][UR] Fix the accuracy of command submission timestamp

### DIFF
--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -1320,17 +1320,20 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuEventCreate(&Event, CU_EVENT_DEFAULT));
     UR_CHECK_ERROR(cuEventRecord(Event, 0));
   }
+
+  if (pDeviceTimestamp) {
+    UR_CHECK_ERROR(cuEventSynchronize(Event));
+    *pDeviceTimestamp = hDevice->getElapsedTime(Event);
+  }
+
+  // Record the host timestamp after the cuEventSynchronize() call for more
+  // precise measurement.
   if (pHostTimestamp) {
 
     using namespace std::chrono;
     *pHostTimestamp =
         duration_cast<nanoseconds>(steady_clock::now().time_since_epoch())
             .count();
-  }
-
-  if (pDeviceTimestamp) {
-    UR_CHECK_ERROR(cuEventSynchronize(Event));
-    *pDeviceTimestamp = hDevice->getElapsedTime(Event);
   }
 
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1604,7 +1604,6 @@ ur_result_t urDeviceGetGlobalTimestamps(
     }
     *HostTimestamp = static_cast<uint64_t>(
         (static_cast<double>(Counter) * 1'000'000'000 / Frequency.QuadPart));
-    std::cout << "L0 adapter host timestamp: " << *HostTimestamp << std::endl;
     return UR_RESULT_SUCCESS;
 #endif
   }


### PR DESCRIPTION
Current "submission time" calculation is inaccurate because we don't use both synchronized timestamps returned by zeDeviceGetGlobalTimestamps but using only device timestamp from that call and use std::chrono "close" to that call to record the host time. This estimation becomes inaccurate pretty quickly. This PR fixes this problem using the known fact that L0 runtime implementation uses CLOCK_MONOTONIC_RAW on Linux and QueryPerformanceCounter on Windows.
So, with this fix, at the first call, we use both device and host timestamps from zeDeviceGetGlobalTimestamps, subsequent calls (when device timestamp is not requested) will return corresponding host timestamp only, without making the `zeDeviceGetGlobalTimestamps`  call which has high latency.

Even though this approach improves accuracy and submit time doesn't become "invalid" (submit time > start_time) fast, it still doesn't guarantee that it will not happen. So, there will be additional fix done in https://github.com/intel/llvm/pull/18717 to fix that. Test is also updated there to check larger number of iterations.

Also apply the same fix as https://github.com/intel/llvm/commit/138bef7c9303e194b99ccb44b4975b79140100fc for cuda adapter (i.e. record host time after cuEventSynchronize for more precise measurement)