### PR TITLE
[SYCL][Graph]Disable DG2 testing on L0 V2

### DIFF
--- a/sycl/test-e2e/Graph/lit.local.cfg
+++ b/sycl/test-e2e/Graph/lit.local.cfg
@@ -1,3 +1,7 @@
 # https://github.com/intel/llvm/issues/17165
 if 'windows' in config.available_features:
    config.unsupported_features += ['arch-intel_gpu_bmg_g21']
+
+# https://github.com/intel/llvm/issues/18668
+# https://github.com/intel/llvm/issues/18579
+config.unsupported_features += ['gpu-intel-dg2 && level_zero_v2_adapter']


### PR DESCRIPTION
Disable SYCL-Graph DG2 E2E testing on the Level-Zero adapter. https://github.com/intel/llvm/issues/18579 and https://github.com/intel/llvm/issues/18668 report large numbers of tests sporadically failing.

Rather than continuing to mark individual tests as unsupported, skip all DG2 graph testing on the V2 adapter until this issue can be investigated and resolved.