### PR TITLE
[UR][OpenCL] Add deleted copy assignment constructor to ur_adapter_handle_t in OpenCL for rule of 3. Specify noexcept to ur_context_handle_t destructor

### DIFF
--- a/unified-runtime/source/adapters/opencl/adapter.hpp
+++ b/unified-runtime/source/adapters/opencl/adapter.hpp
@@ -22,6 +22,7 @@ struct ur_adapter_handle_t_ : ur::opencl::handle_base {
   ~ur_adapter_handle_t_();
 
   ur_adapter_handle_t_(ur_adapter_handle_t_ &) = delete;
+  ur_adapter_handle_t_ &operator=(const ur_adapter_handle_t_ &) = delete;
 
   std::atomic<uint32_t> RefCount = 0;
   logger::Logger &log = logger::get_logger("opencl");

--- a/unified-runtime/source/adapters/opencl/context.hpp
+++ b/unified-runtime/source/adapters/opencl/context.hpp
@@ -45,7 +45,7 @@ struct ur_context_handle_t_ : ur::opencl::handle_base {
   static ur_result_t makeWithNative(native_type Ctx, uint32_t DevCount,
                                     const ur_device_handle_t *phDevices,
                                     ur_context_handle_t &Context);
-  ~ur_context_handle_t_() {
+  ~ur_context_handle_t_() noexcept {
     // If we're reasonably sure this context is about to be destroyed we should
     // clear the ext function pointer cache. This isn't foolproof sadly but it
     // should drastically reduce the chances of the pathological case described


### PR DESCRIPTION
Fixes some coverity issues.

For the `ur_context_handle_t` Coverity was warning an exception is thrown from `[clear](ur::cl::getAdapter()->fnCache.clearCache(CLContext);` however inside here if an error case occurs a call to `std::terminate` so we don't care about the exception.