### PR TITLE
[SYCL] Do not set secondary queue when one is not passed

### DIFF
--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -316,7 +316,7 @@ fill_copy_args(detail::handler_impl *impl,
 
 handler::handler(const std::shared_ptr<detail::queue_impl> &Queue,
                  bool CallerNeedsEvent)
-    : MImplOwner(std::make_shared<detail::handler_impl>(Queue.get(),
+    : MImplOwner(std::make_shared<detail::handler_impl>(nullptr,
                                                         CallerNeedsEvent)),
       impl(MImplOwner.get()), MQueue(Queue) {}
 

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -316,8 +316,8 @@ fill_copy_args(detail::handler_impl *impl,
 
 handler::handler(const std::shared_ptr<detail::queue_impl> &Queue,
                  bool CallerNeedsEvent)
-    : MImplOwner(std::make_shared<detail::handler_impl>(nullptr,
-                                                        CallerNeedsEvent)),
+    : MImplOwner(
+          std::make_shared<detail::handler_impl>(nullptr, CallerNeedsEvent)),
       impl(MImplOwner.get()), MQueue(Queue) {}
 
 handler::handler(detail::handler_impl *HandlerImpl,


### PR DESCRIPTION
In 3a5ee6e secondary queue was set by mistake, it must be not for this constructor.