### PR TITLE
[SYCL][E2E] Fix fallback code path from #18627

### DIFF
--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -15,8 +15,8 @@ config.dpcpp_bin_dir = os.path.join(config.dpcpp_root_dir, 'bin')
 def get_dpcpp_tool_path(name):
     try:
         return subprocess.check_output([config.dpcpp_compiler, "-print-prog-name=" + name], text=True)
-    except CalledProcessError:
-        return os.path.join(config.dpcpp_bin_dir, tool)
+    except subprocess.CalledProcessError:
+        return os.path.join(config.dpcpp_bin_dir, name)
 
 config.llvm_tools_dir = os.path.dirname(get_dpcpp_tool_path("llvm-config"))
 config.lit_tools_dir = os.path.dirname("@TEST_SUITE_LIT@")


### PR DESCRIPTION
Fix the fallback code path taken when `clang --print-prog-name` fails. The fallback code in
871e907bb4a ([SYCL][E2E] Better handle the Intel Compiler in standalone build (NFC) (#18627)) is broken, it uses the wrong variable name (`tool` instead of `name`) and refers to the unqualified `CalledProcessError` without importing it.