### PR TITLE
[SYCL][Graph][L0 v2] Re-enable DG2 E2E tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: linux && run-mode && gpu-intel-dg2 && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18668
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: linux && run-mode && gpu-intel-dg2 && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18668
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: linux && run-mode && gpu-intel-dg2 && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18668
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_interleave_eager.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_interleave_eager.cpp
@@ -4,7 +4,8 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
 
-#define GRAPH_E2E_RECORD_REPLAY
+#define GRAPH_E2E_EXPLICIT
 
-#include "../Inputs/buffer_copy.cpp"
+#include "../Inputs/buffer_interleave_eager.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_ordering.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: run-mode && gpu-intel-dg2 && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18579
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG

--- a/sycl/test-e2e/Graph/Inputs/buffer_interleave_eager.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_interleave_eager.cpp
@@ -1,0 +1,61 @@
+// Tests enqueueing an eager buffer submission followed by two executions
+// of the same graph which also use the buffer.
+
+#include "../graph_common.hpp"
+
+int main() {
+  queue Queue{};
+
+  const size_t N = 10;
+  std::vector<int> Arr(N, 0);
+
+  buffer<int> Buf{N};
+  Buf.set_write_back(false);
+
+  {
+    // Buffer elements set to 8
+    Queue.submit([&](handler &CGH) {
+      auto Acc = Buf.get_access(CGH);
+      CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
+        size_t i = idx;
+        Acc[i] = 8;
+      });
+    });
+
+    // Create graph than adds 2 to buffer elements
+    exp_ext::command_graph Graph{
+        Queue.get_context(),
+        Queue.get_device(),
+        {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+    add_node(Graph, Queue, [&](handler &CGH) {
+      auto Acc = Buf.get_access(CGH);
+      CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
+        size_t i = idx;
+        Acc[i] += 2;
+      });
+    });
+
+    auto ExecGraph = Graph.finalize();
+
+    // Buffer elements set to 10
+    Queue.ext_oneapi_graph(ExecGraph);
+
+    // Buffer elements set to 12
+    Queue.ext_oneapi_graph(ExecGraph);
+
+    // Copy results back
+    Queue.submit([&](handler &CGH) {
+      auto Acc = Buf.get_access(CGH);
+      CGH.copy(Acc, Arr.data());
+    });
+    Queue.wait();
+  }
+
+  const int Expected = 12;
+  for (size_t i = 0; i < N; i++) {
+    assert(check_value(i, Expected, Arr[i], "Arr"));
+  }
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
@@ -73,8 +73,7 @@ int main() {
     });
 
     // Buffer elements set to 10
-    auto Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
 
     // Buffer elements set to 20
     Queue.submit([&](handler &CGH) {

--- a/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: linux && run-mode && gpu-intel-dg2 && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18668
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_interleave_eager.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_interleave_eager.cpp
@@ -4,7 +4,8 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
 
 #define GRAPH_E2E_RECORD_REPLAY
 
-#include "../Inputs/buffer_copy.cpp"
+#include "../Inputs/buffer_interleave_eager.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_ordering.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: run-mode && gpu-intel-dg2 && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18579
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/queue_constructor_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_constructor_buffer.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: linux && run-mode && gpu-intel-dg2 && !igc-dev
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18668
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG

--- a/sycl/test-e2e/Graph/lit.local.cfg
+++ b/sycl/test-e2e/Graph/lit.local.cfg
@@ -1,7 +1,3 @@
 # https://github.com/intel/llvm/issues/17165
 if 'windows' in config.available_features:
    config.unsupported_features += ['arch-intel_gpu_bmg_g21']
-
-# https://github.com/intel/llvm/issues/18668
-# https://github.com/intel/llvm/issues/18579
-config.unsupported_features += ['gpu-intel-dg2 && level_zero_v2_adapter']


### PR DESCRIPTION
PR https://github.com/intel/llvm/pull/18566 fixes the DG2 SYCL-Graph E2E tests fails seen on DG2 for the V2 adapter. Re-enable tests and add a new test with a reduced version of  `buffer_ordering.cpp` that also exposed the bug.

See:
* https://github.com/intel/llvm/issues/18668
* https://github.com/intel/llvm/issues/18579