### PR TITLE
[SYCL][E2E] Fix memory leak introduced in e2e test

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/usm_compatibility.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/usm_compatibility.cpp
@@ -39,7 +39,7 @@ int main() {
   // Check that device type of USM allocation is supported inside free function
   // kernel.
   {
-    int *HostDataPtr = new int[NumOfElements];
+    int HostDataPtr[NumOfElements];
     constexpr int ExpectedResultValue = 111;
     int *DeviceDataPtr = sycl::malloc_device<int>(NumOfElements, Queue);
     sycl::kernel UsedKernel = getKernel<ns::nsNdRangeFreeFunc>(Context);


### PR DESCRIPTION
This PR remove memory leak in e2e test for `sycl_ext_oneapi_free_function_kernels` extension https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/FreeFunctionKernels/test-plan.md 