### PR TITLE
[SYCL][NFC] `sub_group_mask.hpp` cleanup

### DIFF
--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -320,12 +320,12 @@ private:
 
   sub_group_mask(BitsType rhs, size_t bn)
       : Bits(rhs & valuable_bits(bn)), bits_num(bn) {
-#ifdef __SYCL_DEVICE_ONLY__
+#ifndef __SYCL_DEVICE_ONLY__
     assert(bits_num <= max_bits);
 #endif
   }
   inline BitsType valuable_bits(size_t bn) const {
-#ifdef __SYCL_DEVICE_ONLY__
+#ifndef __SYCL_DEVICE_ONLY__
     assert(bn <= max_bits);
 #endif
     BitsType one = 1;

--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
-#include <sycl/builtins.hpp>       // for assert
 #include <sycl/detail/helpers.hpp> // for Builder
 #include <sycl/detail/memcpy.hpp>  // detail::memcpy
 #include <sycl/exception.hpp>      // for errc, exception
@@ -321,10 +320,14 @@ private:
 
   sub_group_mask(BitsType rhs, size_t bn)
       : Bits(rhs & valuable_bits(bn)), bits_num(bn) {
+#ifdef __SYCL_DEVICE_ONLY__
     assert(bits_num <= max_bits);
+#endif
   }
   inline BitsType valuable_bits(size_t bn) const {
+#ifdef __SYCL_DEVICE_ONLY__
     assert(bn <= max_bits);
+#endif
     BitsType one = 1;
     if (bn == max_bits)
       return -one;

--- a/sycl/test-e2e/SubGroupMask/sub_group_mask_ver2.cpp
+++ b/sycl/test-e2e/SubGroupMask/sub_group_mask_ver2.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 
 #include <iostream>
+#include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/sub_group_mask.hpp>
 #include <sycl/sub_group.hpp>

--- a/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
@@ -5,12 +5,14 @@
 // XFAIL: spirv-backend
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/18230
 
-#include <cassert>
-#include <cstring>
+#include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/work_group_memory.hpp>
 #include <sycl/group_barrier.hpp>
 #include <sycl/half_type.hpp>
+
+#include <cassert>
+#include <cstring>
 
 namespace syclexp = sycl::ext::oneapi::experimental;
 


### PR DESCRIPTION
Dropped include of SYCL math built-ins, removed use of non-standard `assert` from device code.