### PR TITLE
[SYCL][NFC] Drop `platform.hpp` includes `core.hpp`

### DIFF
--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -14,7 +14,6 @@
 #include <sycl/detail/export.hpp>             // for __SYCL_EXPORT
 #include <sycl/detail/info_desc_helpers.hpp>  // for is_context_info_desc
 #include <sycl/detail/owner_less_base.hpp>    // for OwnerLessBase
-#include <sycl/platform.hpp>                  // for platform
 #include <sycl/property_list.hpp>             // for property_list
 #include <sycl/usm/usm_enums.hpp>             // for usm::alloc
 #include <ur_api.h>                           // for ur_native_handle_t

--- a/sycl/include/sycl/ext/oneapi/owner_less.hpp
+++ b/sycl/include/sycl/ext/oneapi/owner_less.hpp
@@ -18,7 +18,6 @@
 #include <sycl/ext/oneapi/weak_object.hpp>        // for weak_object
 #include <sycl/kernel.hpp>                        // for kernel
 #include <sycl/kernel_bundle_enums.hpp>           // for bundle_state
-#include <sycl/platform.hpp>                      // for platform
 #include <sycl/properties/image_properties.hpp>   // for sampled_i...
 #include <sycl/queue.hpp>                         // for queue
 #include <sycl/stream.hpp>                        // for stream
@@ -28,6 +27,7 @@ inline namespace _V1 {
 class kernel_id;
 template <bundle_state State> class kernel_bundle;
 template <bundle_state State> class device_image;
+class platform;
 
 namespace ext::oneapi {
 

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -16,6 +16,7 @@
 #include <sycl/ext/oneapi/experimental/device_architecture.hpp>
 #include <sycl/ext/oneapi/experimental/forward_progress.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
 
 #include <memory>
 #include <mutex>
@@ -24,9 +25,6 @@
 
 namespace sycl {
 inline namespace _V1 {
-
-// Forward declaration
-class platform;
 
 namespace detail {
 

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -681,7 +681,7 @@ public:
   bool empty() const noexcept { return MDeviceImages.empty(); }
 
   backend get_backend() const noexcept {
-    return MContext.get_platform().get_backend();
+    return MContext.get_backend();
   }
 
   context get_context() const noexcept { return MContext; }

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -680,9 +680,7 @@ public:
 
   bool empty() const noexcept { return MDeviceImages.empty(); }
 
-  backend get_backend() const noexcept {
-    return MContext.get_backend();
-  }
+  backend get_backend() const noexcept { return MContext.get_backend(); }
 
   context get_context() const noexcept { return MContext; }
 

--- a/sycl/test-e2e/AbiNeutral/catch-exception.cpp
+++ b/sycl/test-e2e/AbiNeutral/catch-exception.cpp
@@ -8,6 +8,7 @@
 // _GLIBCXX_USE_CXX11_ABI=0.
 
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 int main() {
 #ifdef _GLIBCXX_USE_CXX11_ABI

--- a/sycl/test-e2e/AbiNeutral/device-info.cpp
+++ b/sycl/test-e2e/AbiNeutral/device-info.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <mutex>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 #include <vector>
 
 template <typename T> using dpcpp_info_t = typename T::return_type;

--- a/sycl/test-e2e/Adapters/level_zero/imm_cmdlist_per_thread.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/imm_cmdlist_per_thread.cpp
@@ -73,11 +73,6 @@ int main() {
 
   // Create one queue
   auto D = Queue.get_device();
-  const char *devType = D.is_cpu() ? "CPU" : "GPU";
-  std::string adapterName = D.get_platform().get_info<info::platform::name>();
-  std::cout << "Running on device " << devType << " ("
-            << D.get_info<info::device::name>() << ") " << adapterName
-            << " adapter\n";
 
   // Use queue in multiple threads
   std::thread T1(run_sample, Queue, 0);

--- a/sycl/test-e2e/Adapters/retain_events.cpp
+++ b/sycl/test-e2e/Adapters/retain_events.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <numeric>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 #include <sycl/usm.hpp>
 
 namespace {

--- a/sycl/test-e2e/BFloat16/bfloat16_type.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_type.cpp
@@ -13,6 +13,8 @@
 
 #include "bfloat16_type.hpp"
 
+#include <sycl/platform.hpp>
+
 int main() {
 
 #ifdef USE_CUDA_SM80

--- a/sycl/test-e2e/BFloat16/bfloat16_type.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_type.cpp
@@ -13,14 +13,12 @@
 
 #include "bfloat16_type.hpp"
 
-#include <sycl/platform.hpp>
-
 int main() {
 
 #ifdef USE_CUDA_SM80
   // Special build for SM80 CUDA.
   sycl::device Dev{default_selector_v};
-  if (Dev.get_platform().get_backend() != backend::ext_oneapi_cuda) {
+  if (Dev.get_backend() != backend::ext_oneapi_cuda) {
     std::cout << "Test skipped; CUDA run was not run with CUDA device."
               << std::endl;
     return 0;

--- a/sycl/test-e2e/Basic/aspects.cpp
+++ b/sycl/test-e2e/Basic/aspects.cpp
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/Basic/backend_info.cpp
+++ b/sycl/test-e2e/Basic/backend_info.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/Basic/buffer/buffer_migrate.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_migrate.cpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 using namespace sycl;
 
 int main() {

--- a/sycl/test-e2e/Basic/context.cpp
+++ b/sycl/test-e2e/Basic/context.cpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 #include <sycl/properties/all_properties.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Basic/context_platforms.cpp
+++ b/sycl/test-e2e/Basic/context_platforms.cpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/Basic/default_platform.cpp
+++ b/sycl/test-e2e/Basic/default_platform.cpp
@@ -10,6 +10,7 @@
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 int main() {
   sycl::platform Plt;

--- a/sycl/test-e2e/Basic/device-selectors.cpp
+++ b/sycl/test-e2e/Basic/device-selectors.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run-unfiltered-devices} %t.out
 
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 using namespace sycl;
 
 auto exception_handler_lambda = [](exception_list elist) {

--- a/sycl/test-e2e/Basic/device_equality.cpp
+++ b/sycl/test-e2e/Basic/device_equality.cpp
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 #include <utility>
 
 using namespace sycl;

--- a/sycl/test-e2e/Basic/diagnostics/non-uniform-wk-gp-test.cpp
+++ b/sycl/test-e2e/Basic/diagnostics/non-uniform-wk-gp-test.cpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <sycl/backend_types.hpp>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/Basic/info.cpp
+++ b/sycl/test-e2e/Basic/info.cpp
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 #include <cassert>
 #include <cstdint>

--- a/sycl/test-e2e/Basic/intel-ext-device.cpp
+++ b/sycl/test-e2e/Basic/intel-ext-device.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 #include <cassert>
 #include <iostream>

--- a/sycl/test-e2e/Basic/kernel_bundle/kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Basic/kernel_bundle/kernel_bundle_api.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
 
 #include <algorithm>
 #include <vector>

--- a/sycl/test-e2e/Basic/kernel_bundle/kernel_bundle_api_hip.cpp
+++ b/sycl/test-e2e/Basic/kernel_bundle/kernel_bundle_api_hip.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
 
 #include <algorithm>
 #include <vector>

--- a/sycl/test-e2e/Basic/khr_get_default_context.cpp
+++ b/sycl/test-e2e/Basic/khr_get_default_context.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/Basic/query.hpp
+++ b/sycl/test-e2e/Basic/query.hpp
@@ -1,4 +1,5 @@
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 #include <iostream>
 using namespace sycl;

--- a/sycl/test-e2e/Basic/reqd_work_group_size.cpp
+++ b/sycl/test-e2e/Basic/reqd_work_group_size.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 #include <iostream>
 

--- a/sycl/test-e2e/CompositeDevice/composite_device.cpp
+++ b/sycl/test-e2e/CompositeDevice/composite_device.cpp
@@ -6,6 +6,7 @@
 #include "../helpers.hpp"
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/composite_device.hpp>
+#include <sycl/platform.hpp>
 
 #ifdef SYCL_EXT_ONEAPI_COMPOSITE_DEVICE
 

--- a/sycl/test-e2e/CompositeDevice/device_selector_test.cpp
+++ b/sycl/test-e2e/CompositeDevice/device_selector_test.cpp
@@ -4,6 +4,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/composite_device.hpp>
+#include <sycl/platform.hpp>
 
 #ifdef SYCL_EXT_ONEAPI_COMPOSITE_DEVICE
 

--- a/sycl/test-e2e/Config/allowlist.cpp
+++ b/sycl/test-e2e/Config/allowlist.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <string>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 static bool isIdenticalDevices(const std::vector<sycl::device> &Devices) {
   return std::all_of(

--- a/sycl/test-e2e/Config/select_device.cpp
+++ b/sycl/test-e2e/Config/select_device.cpp
@@ -58,6 +58,7 @@
 #include <regex>
 #include <string>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/DeprecatedFeatures/deprecated.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/deprecated.cpp
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/DeprecatedFeatures/deprecated_intel_ext_device.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/deprecated_intel_ext_device.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 #include <cassert>
 #include <iostream>

--- a/sycl/test-e2e/DeprecatedFeatures/opencl_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/opencl_interop.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <exception>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 #include <vector>
 
 #define CL_CHECK_ERRORS(ERR)                                                   \

--- a/sycl/test-e2e/DeprecatedFeatures/platform.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/platform.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 #include <typeinfo>
 
 using namespace sycl;

--- a/sycl/test-e2e/DeprecatedFeatures/queue_old_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/queue_old_interop.cpp
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/FilterSelector/select.cpp
+++ b/sycl/test-e2e/FilterSelector/select.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 #include <sycl/ext/oneapi/filter_selector.hpp>
 

--- a/sycl/test-e2e/FilterSelector/select_device.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device.cpp
@@ -17,6 +17,7 @@
 
 #include "../helpers.hpp"
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace std;

--- a/sycl/test-e2e/FilterSelector/select_device_acc.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_acc.cpp
@@ -12,6 +12,7 @@
 
 #include "../helpers.hpp"
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace std;

--- a/sycl/test-e2e/FilterSelector/select_device_cpu.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_cpu.cpp
@@ -12,6 +12,7 @@
 
 #include "../helpers.hpp"
 #include <sycl/ext/oneapi/filter_selector.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace std;

--- a/sycl/test-e2e/FilterSelector/select_device_cuda.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_cuda.cpp
@@ -12,6 +12,7 @@
 
 #include "../helpers.hpp"
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace std;

--- a/sycl/test-e2e/FilterSelector/select_device_level_zero.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_level_zero.cpp
@@ -11,6 +11,7 @@
 #include "../helpers.hpp"
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace std;

--- a/sycl/test-e2e/FilterSelector/select_device_opencl.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_opencl.cpp
@@ -11,6 +11,7 @@
 #include "../helpers.hpp"
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace std;

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/support.h
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/support.h
@@ -1,5 +1,6 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/group_algorithm.hpp>
+#include <sycl/platform.hpp>
 using namespace sycl;
 
 bool isSupportedDevice(device D) {

--- a/sycl/test-e2e/GroupAlgorithm/support.h
+++ b/sycl/test-e2e/GroupAlgorithm/support.h
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/group_algorithm.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi;

--- a/sycl/test-e2e/KernelCompiler/opencl_multi_device.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_multi_device.cpp
@@ -15,6 +15,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
 
 // Test to check that bundle is buildable from OpenCL source if there are
 // multiple devices in the context.

--- a/sycl/test-e2e/KernelCompiler/sycl_context_error.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_context_error.cpp
@@ -16,6 +16,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
 #include <sycl/usm.hpp>
 
 namespace syclexp = sycl::ext::oneapi::experimental;

--- a/sycl/test-e2e/OneapiDeviceSelector/cuda_top.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/cuda_top.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace std;

--- a/sycl/test-e2e/OneapiDeviceSelector/discard_filters.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/discard_filters.cpp
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 using namespace sycl;
 
 int main() {

--- a/sycl/test-e2e/OneapiDeviceSelector/illegal_input_hang.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/illegal_input_hang.cpp
@@ -1,6 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR=":" %{run-unfiltered-devices} %t.out
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 #include <vector>
 
 // Check that the application does not hang when we attempt

--- a/sycl/test-e2e/OneapiDeviceSelector/level_zero_top.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/level_zero_top.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace std;

--- a/sycl/test-e2e/OptionalKernelFeatures/esimd.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/esimd.cpp
@@ -3,6 +3,7 @@
 
 #include <sycl/aspects.hpp>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 int main() {
   sycl::queue Queue;

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/compile_link.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/compile_link.cpp
@@ -7,6 +7,7 @@
 // devices and run the kernel on each device.
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
 
 class Kernel;
 

--- a/sycl/test-e2e/Regression/cache_test.cpp
+++ b/sycl/test-e2e/Regression/cache_test.cpp
@@ -6,8 +6,8 @@
 #include <iostream>
 #include <level_zero/ze_api.h>
 #include <stdio.h>
-#include <sycl/ext/oneapi/backend/level_zero.hpp>
 #include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/backend/level_zero.hpp>
 #include <sycl/platform.hpp>
 
 using namespace sycl::ext::oneapi;

--- a/sycl/test-e2e/Regression/cache_test.cpp
+++ b/sycl/test-e2e/Regression/cache_test.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <sycl/ext/oneapi/backend/level_zero.hpp>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl::ext::oneapi;
 

--- a/sycl/test-e2e/Regression/device_num.cpp
+++ b/sycl/test-e2e/Regression/device_num.cpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <sstream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using namespace std;

--- a/sycl/test-e2e/Regression/device_pci_address_bdf_format.cpp
+++ b/sycl/test-e2e/Regression/device_pci_address_bdf_format.cpp
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 #include <iostream>
 #include <regex>

--- a/sycl/test-e2e/SubGroup/load_store.cpp
+++ b/sycl/test-e2e/SubGroup/load_store.cpp
@@ -12,6 +12,8 @@
 
 #include "helper.hpp"
 
+#include <sycl/platform.hpp>
+
 #include <algorithm>
 
 template <typename T, int N> class sycl_subgr;

--- a/sycl/test-e2e/USM/P2P/p2p_access.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_access.cpp
@@ -4,6 +4,7 @@
 
 #include <cassert>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 #include <sycl/usm.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/USM/P2P/p2p_atomics.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_atomics.cpp
@@ -9,6 +9,7 @@
 #include <sycl/detail/core.hpp>
 
 #include <sycl/atomic_ref.hpp>
+#include <sycl/platform.hpp>
 #include <sycl/usm.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/USM/P2P/p2p_copy.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_copy.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <numeric>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 #include <sycl/usm.hpp>
 #include <vector>
 

--- a/sycl/test-e2e/USM/usm_pooling.cpp
+++ b/sycl/test-e2e/USM/usm_pooling.cpp
@@ -88,13 +88,6 @@ int main(int argc, char *argv[]) {
   device D = Q.get_device();
   context C = Q.get_context();
 
-  const char *devType = D.is_cpu() ? "CPU" : "GPU";
-  std::string adapterName =
-      D.get_platform().get_info<sycl::info::platform::name>();
-  std::cout << "Running on device " << devType << " ("
-            << D.get_info<sycl::info::device::name>() << ") " << adapterName
-            << " adapter\n";
-
   if (*argv[1] == 'h') {
     std::cerr << "Test zeMemAllocHost\n";
     test_host(C);

--- a/sycl/test-e2e/WeakObject/weak_object_utils.hpp
+++ b/sycl/test-e2e/WeakObject/weak_object_utils.hpp
@@ -5,6 +5,7 @@
 #include <sycl/ext/oneapi/weak_object.hpp>
 #include <sycl/image.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
 #include <sycl/sampler.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/matrix_aspect.cpp
+++ b/sycl/test-e2e/matrix_aspect.cpp
@@ -15,6 +15,7 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 using arch = sycl::ext::oneapi::experimental::architecture;

--- a/sycl/test/include_deps/sycl_accessor.hpp.cpp
+++ b/sycl/test/include_deps/sycl_accessor.hpp.cpp
@@ -82,10 +82,6 @@
 // CHECK-NEXT: info/ext_oneapi_device_traits.def
 // CHECK-NEXT: info/ext_oneapi_kernel_queue_specific_traits.def
 // CHECK-NEXT: info/sycl_backend_traits.def
-// CHECK-NEXT: platform.hpp
-// CHECK-NEXT: detail/string_view.hpp
-// CHECK-NEXT: detail/util.hpp
-// CHECK-NEXT: device_selector.hpp
 // CHECK-NEXT: usm/usm_enums.hpp
 // CHECK-NEXT: properties/buffer_properties.def
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_detail_core.hpp.cpp
+++ b/sycl/test/include_deps/sycl_detail_core.hpp.cpp
@@ -83,10 +83,6 @@
 // CHECK-NEXT: info/ext_oneapi_device_traits.def
 // CHECK-NEXT: info/ext_oneapi_kernel_queue_specific_traits.def
 // CHECK-NEXT: info/sycl_backend_traits.def
-// CHECK-NEXT: platform.hpp
-// CHECK-NEXT: detail/string_view.hpp
-// CHECK-NEXT: detail/util.hpp
-// CHECK-NEXT: device_selector.hpp
 // CHECK-NEXT: usm/usm_enums.hpp
 // CHECK-NEXT: properties/buffer_properties.def
 // CHECK-NEXT: queue.hpp
@@ -104,6 +100,9 @@
 // CHECK-NEXT: nd_range.hpp
 // CHECK-NEXT: detail/optional.hpp
 // CHECK-NEXT: device.hpp
+// CHECK-NEXT: detail/string_view.hpp
+// CHECK-NEXT: detail/util.hpp
+// CHECK-NEXT: device_selector.hpp
 // CHECK-NEXT: kernel_bundle_enums.hpp
 // CHECK-NEXT: event.hpp
 // CHECK-NEXT: exception_list.hpp

--- a/sycl/test/warnings/deprecated_get_backend_info.cpp
+++ b/sycl/test/warnings/deprecated_get_backend_info.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
 
 using namespace sycl;
 


### PR DESCRIPTION
Code that prints platform info was completely dropped from some tests (instead of adding corresponding `#include`), because  that information is anyway unused in our testing infrastructure.