### PR TITLE
[UR][CI] Disable other timeouting test

### DIFF
--- a/.github/workflows/ur-build-hw.yml
+++ b/.github/workflows/ur-build-hw.yml
@@ -164,7 +164,9 @@ jobs:
     - name: Test adapter specific
       env:
         ZE_ENABLE_LOADER_DEBUG_TRACE: 1
-        LIT_OPTS: "--timeout 120 --filter-out '(adapters/level_zero/memcheck.test|adapters/level_zero/v2/deferred_kernel_memcheck.test)'"
+        LIT_OPTS: "--timeout 120"
+        # These tests cause timeouts on CI
+        LIT_FILTER_OUT: "(adapters/level_zero/memcheck.test|adapters/level_zero/v2/deferred_kernel_memcheck.test)"
       run: cmake --build build -j $(nproc) -- check-unified-runtime-adapter
       # Don't run adapter specific tests when building multiple adapters
       if: ${{ matrix.adapter.other_name == '' }}


### PR DESCRIPTION
Change #18397 switches a filter for "memcheck" to an explicit path.
However, that filter would have also hit
deferred_kernel_memcheck.test. Since that test is also timing out
randomly, disable it too.