### PR TITLE
[SYCL] Redistribute USM aspects among CUDA devices

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/DeviceConfigFile.td
+++ b/llvm/include/llvm/SYCLLowerIR/DeviceConfigFile.td
@@ -262,7 +262,10 @@ class CudaTargetInfo<string targetName, list<Aspect> aspectList, int subGroupSiz
   assert !eq(subGroupSize, 32), "sub-group size for Cuda must be equal to 32 and not " # subGroupSize # ".";
 }
 
-defvar CudaMinAspects = !listconcat(AllUSMAspects, [AspectGpu, AspectFp64, AspectOnline_compiler, AspectOnline_linker,
+defvar CudaMinUSMAspects = [AspectUsm_device_allocations, AspectUsm_host_allocations, AspectUsm_shared_allocations];
+defvar CudaSM90USMAspects = [AspectUsm_system_allocations, AspectUsm_atomic_host_allocations, AspectUsm_atomic_shared_allocations];
+
+defvar CudaMinAspects = !listconcat(CudaMinUSMAspects, [AspectGpu, AspectFp64, AspectOnline_compiler, AspectOnline_linker,
     AspectQueue_profiling, AspectExt_intel_pci_address, AspectExt_intel_max_mem_bandwidth, AspectExt_intel_memory_bus_width,
     AspectExt_intel_device_info_uuid, AspectExt_oneapi_native_assert, AspectExt_intel_free_memory, AspectExt_intel_device_id,
     AspectExt_intel_memory_clock_rate, AspectExt_oneapi_ballot_group, AspectExt_oneapi_fixed_size_group,
@@ -292,9 +295,9 @@ def : CudaTargetInfo<"nvidia_gpu_sm_87", !listconcat(CudaMinAspects, CudaBindles
     [AspectFp16, AspectAtomic64, AspectExt_oneapi_cuda_async_barrier])>;
 def : CudaTargetInfo<"nvidia_gpu_sm_89", !listconcat(CudaMinAspects, CudaBindlessImagesAspects,
     [AspectFp16, AspectAtomic64, AspectExt_oneapi_cuda_async_barrier])>;
-def : CudaTargetInfo<"nvidia_gpu_sm_90", !listconcat(CudaMinAspects, CudaBindlessImagesAspects,
+def : CudaTargetInfo<"nvidia_gpu_sm_90", !listconcat(CudaMinAspects, CudaSM90USMAspects, CudaBindlessImagesAspects,
     [AspectFp16, AspectAtomic64, AspectExt_oneapi_cuda_async_barrier, AspectExt_oneapi_cuda_cluster_group])>;
-def : CudaTargetInfo<"nvidia_gpu_sm_90a", !listconcat(CudaMinAspects, CudaBindlessImagesAspects,
+def : CudaTargetInfo<"nvidia_gpu_sm_90a", !listconcat(CudaMinAspects, CudaSM90USMAspects, CudaBindlessImagesAspects,
     [AspectFp16, AspectAtomic64, AspectExt_oneapi_cuda_async_barrier, AspectExt_oneapi_cuda_cluster_group])>;
 
 //


### PR DESCRIPTION
We were previously reporting all USM aspects as supported on all CUDA devices. This is incorrect behaviour as many devices do not support USM system allocations, nor atomic host/shared USM allocations.

Unfortunately it is very difficult to get a conclusive list of which devices support which features.

Links such as [1] suggest that pageable memory access (which the UR adapater uses to determine the runtime equivalents of these aspects) is limited to a Grace Hopper device or newer, or  with Linux systems with HMM enabled. HMM is not something we can currently determine at compile time for these aspects. This change is therefore conservative for older devices (SM6.X) with HMM enabled, where we will now report "false".

For atomic host/shared allocations, the documentation on the 'hostNativeAtomicSupported' property at [1] and [2] suggests that we need both a hardware coherent system, for which [3] suggests we again need at least a Grace Hopper device. However, note again that only "some" hardware-coherent systems support the host native atomics, "including" NVLink-connected devices. This is therefore not an exhaustive list and we can't derive anything conclusive from it. This change might again be conservative for architectures older than Grace Hopper.

In short, this PR essentially just punts the problem slightly further down the road and prevents these three USM aspects from being reported as supported for SM89 devices and earlier.

[1]: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#system-requirements-for-unified-memory.
[2]: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#host-native-atomics
[3]: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#cpu-and-gpu-page-tables-hardware-coherency-vs-software-coherency