### PR TITLE
[SYCL] Fix intel-fpga-ivdep-array regression.

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -4631,7 +4631,7 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
     Addr = emitArraySubscriptGEP(*this, BaseAddr, Idx, E->getType(),
                                  !getLangOpts().PointerOverflowDefined,
                                  SignedIndices, E->getExprLoc(), &ptrType,
-                                 E->getBase());
+                                 E->getBase(), "arrayidx", PtrDecl);
 
     if (SanOpts.has(SanitizerKind::ArrayBounds)) {
       StructFieldAccess Visitor;


### PR DESCRIPTION
Re-add routine parameters lost during conflict resolution.
* 0dcd674f - Merge from 'main' to 'sycl-web' (30 commits)

Fixes test:
* CLANG :: CodeGenSYCL/intel-fpga-ivdep-array.cpp