### PR TITLE
[NFC][SYCL] Ensure `context_impl` is always created via `std::make_shared`

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -112,7 +112,7 @@ __SYCL_EXPORT context make_context(ur_native_handle_t NativeHandle,
       NativeHandle, Adapter->getUrAdapter(), DeviceHandles.size(),
       DeviceHandles.data(), &Properties, &UrContext);
   // Construct the SYCL context from UR context.
-  return detail::createSyclObjFromImpl<context>(std::make_shared<context_impl>(
+  return detail::createSyclObjFromImpl<context>(context_impl::create(
       UrContext, Handler, Adapter, DeviceList, !KeepOwnership));
 }
 

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -69,8 +69,7 @@ context::context(const std::vector<device> &DeviceList,
     throw exception(make_error_code(errc::invalid),
                     "Can't add devices across platforms to a single context.");
   else
-    impl = std::make_shared<detail::context_impl>(DeviceList, AsyncHandler,
-                                                  PropList);
+    impl = detail::context_impl::create(DeviceList, AsyncHandler, PropList);
 }
 context::context(cl_context ClContext, async_handler AsyncHandler) {
   const auto &Adapter = sycl::detail::ur::getAdapter<backend::opencl>();
@@ -81,8 +80,7 @@ context::context(cl_context ClContext, async_handler AsyncHandler) {
   Adapter->call<detail::UrApiKind::urContextCreateWithNativeHandle>(
       nativeHandle, Adapter->getUrAdapter(), 0, nullptr, nullptr, &hContext);
 
-  impl =
-      std::make_shared<detail::context_impl>(hContext, AsyncHandler, Adapter);
+  impl = detail::context_impl::create(hContext, AsyncHandler, Adapter);
 }
 
 template <typename Param>

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -27,19 +27,9 @@ namespace sycl {
 inline namespace _V1 {
 namespace detail {
 
-context_impl::context_impl(const device &Device, async_handler AsyncHandler,
-                           const property_list &PropList)
-    : MOwnedByRuntime(true), MAsyncHandler(AsyncHandler), MDevices(1, Device),
-      MContext(nullptr),
-      MPlatform(detail::getSyclObjImpl(Device.get_platform())),
-      MPropList(PropList), MSupportBufferLocationByDevices(NotChecked) {
-  verifyProps(PropList);
-  MKernelProgramCache.setContextPtr(this);
-}
-
 context_impl::context_impl(const std::vector<sycl::device> Devices,
                            async_handler AsyncHandler,
-                           const property_list &PropList)
+                           const property_list &PropList, private_tag)
     : MOwnedByRuntime(true), MAsyncHandler(AsyncHandler), MDevices(Devices),
       MContext(nullptr),
       MPlatform(detail::getSyclObjImpl(MDevices[0].get_platform())),
@@ -72,7 +62,7 @@ context_impl::context_impl(ur_context_handle_t UrContext,
                            async_handler AsyncHandler,
                            const AdapterPtr &Adapter,
                            const std::vector<sycl::device> &DeviceList,
-                           bool OwnedByRuntime)
+                           bool OwnedByRuntime, private_tag)
     : MOwnedByRuntime(OwnedByRuntime), MAsyncHandler(AsyncHandler),
       MDevices(DeviceList), MContext(UrContext), MPlatform(),
       MSupportBufferLocationByDevices(NotChecked) {

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -29,20 +29,12 @@ inline namespace _V1 {
 // Forward declaration
 class device;
 namespace detail {
-class context_impl {
-public:
-  /// Constructs a context_impl using a single SYCL devices.
-  ///
-  /// The constructed context_impl will use the AsyncHandler parameter to
-  /// handle exceptions.
-  /// PropList carries the properties of the constructed context_impl.
-  ///
-  /// \param Device is an instance of SYCL device.
-  /// \param AsyncHandler is an instance of async_handler.
-  /// \param PropList is an instance of property_list.
-  context_impl(const device &Device, async_handler AsyncHandler,
-               const property_list &PropList);
+class context_impl : std::enable_shared_from_this<context_impl> {
+  struct private_tag {
+    explicit private_tag() = default;
+  };
 
+public:
   /// Constructs a context_impl using a list of SYCL devices.
   ///
   /// Newly created instance will save each SYCL device in the list. This
@@ -56,7 +48,8 @@ public:
   /// \param AsyncHandler is an instance of async_handler.
   /// \param PropList is an instance of property_list.
   context_impl(const std::vector<sycl::device> DeviceList,
-               async_handler AsyncHandler, const property_list &PropList);
+               async_handler AsyncHandler, const property_list &PropList,
+               private_tag);
 
   /// Construct a context_impl using plug-in interoperability handle.
   ///
@@ -70,8 +63,23 @@ public:
   /// transferred to runtime
   context_impl(ur_context_handle_t UrContext, async_handler AsyncHandler,
                const AdapterPtr &Adapter,
-               const std::vector<sycl::device> &DeviceList = {},
-               bool OwnedByRuntime = true);
+               const std::vector<sycl::device> &DeviceList, bool OwnedByRuntime,
+               private_tag);
+
+  context_impl(ur_context_handle_t UrContext, async_handler AsyncHandler,
+               const AdapterPtr &Adapter, private_tag tag)
+      : context_impl(UrContext, AsyncHandler, Adapter,
+                     std::vector<sycl::device>{},
+                     /*OwnedByRuntime*/ true, tag) {}
+
+  // Single variadic method works because all the ctors are expected to be
+  // "public" except the `private_tag` part restricting the creation to
+  // `std::shared_ptr` allocations.
+  template <typename... Ts>
+  static std::shared_ptr<context_impl> create(Ts &&...args) {
+    return std::make_shared<context_impl>(std::forward<Ts>(args)...,
+                                          private_tag{});
+  }
 
   ~context_impl();
 


### PR DESCRIPTION
And once that is guaranteed, inherit it from
`std::enable_shared_from_this`. Further simplifications based on `[shared|weak]_from_this` are left to subsequent PRs.

Earlier related PRs:
https://github.com/intel/llvm/pull/18715 same for `queue_impl`
https://github.com/intel/llvm/pull/18227 same for `device_impl`
https://github.com/intel/llvm/pull/18141 similar for `platform_impl`