### PR TITLE
[SYCL] Fix use-after-free for MockHandler::getKernelName()

### DIFF
--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -253,7 +253,9 @@ public:
     return impl->CGData.MEvents;
   }
   std::vector<sycl::detail::ArgDesc> &getArgs() { return impl->MArgs; }
-  std::string getKernelName() { return MKernelName.data(); }
+  sycl::detail::KernelNameStrT getKernelName() {
+    return toKernelNameStrT(MKernelName);
+  }
   std::shared_ptr<sycl::detail::kernel_impl> &getKernel() { return MKernel; }
   std::shared_ptr<sycl::detail::HostTask> &getHostTask() {
     return impl->MHostTask;


### PR DESCRIPTION
In current implementation, std::string is returned. For preview, caller of getKernelName() creates std::string_view from the temporary string. This sting_view is used after the temporary string is destroyed. In the fix for preview std::string_view is returned, that points to same kernel name as handler::MKernel.