### PR TITLE
[UR][L0 v2] Add USM pool tracking in context and fix async pool cleanup

### DIFF
--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -507,7 +507,7 @@ ur_result_t urUSMPoolCreate(
     *Pool = reinterpret_cast<ur_usm_pool_handle_t>(
         new ur_usm_pool_handle_t_(Context, PoolDesc));
 
-    std::shared_lock<ur_shared_mutex> ContextLock(Context->Mutex);
+    std::scoped_lock<ur_shared_mutex> ContextLock(Context->Mutex);
     Context->UsmPoolHandles.insert(Context->UsmPoolHandles.cend(), *Pool);
 
   } catch (const UsmAllocationException &Ex) {
@@ -531,7 +531,7 @@ ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t Pool) {
   if (Pool->RefCount.decrementAndTest()) {
-    std::shared_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
+    std::scoped_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
     Pool->Context->UsmPoolHandles.remove(Pool);
     delete Pool;
   }
@@ -610,7 +610,7 @@ ur_result_t UR_APICALL urUSMPoolCreateExp(
     *Pool = reinterpret_cast<ur_usm_pool_handle_t>(
         new ur_usm_pool_handle_t_(Context, Device, PoolDesc));
 
-    std::shared_lock<ur_shared_mutex> ContextLock(Context->Mutex);
+    std::scoped_lock<ur_shared_mutex> ContextLock(Context->Mutex);
     Context->UsmPoolHandles.insert(Context->UsmPoolHandles.cend(), *Pool);
 
   } catch (const UsmAllocationException &Ex) {
@@ -627,7 +627,7 @@ ur_result_t UR_APICALL urUSMPoolCreateExp(
 ur_result_t UR_APICALL urUSMPoolDestroyExp(ur_context_handle_t /*Context*/,
                                            ur_device_handle_t /*Device*/,
                                            ur_usm_pool_handle_t Pool) {
-  std::shared_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
+  std::scoped_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
   Pool->Context->UsmPoolHandles.remove(Pool);
   delete Pool;
 

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -116,6 +116,16 @@ ur_usm_pool_handle_t ur_context_handle_t_::getDefaultUSMPool() {
 
 ur_usm_pool_handle_t ur_context_handle_t_::getAsyncPool() { return &asyncPool; }
 
+void ur_context_handle_t_::addUsmPool(ur_usm_pool_handle_t hPool) {
+  std::scoped_lock<ur_shared_mutex> lock(Mutex);
+  usmPoolHandles.push_back(hPool);
+}
+
+void ur_context_handle_t_::removeUsmPool(ur_usm_pool_handle_t hPool) {
+  std::scoped_lock<ur_shared_mutex> lock(Mutex);
+  usmPoolHandles.remove(hPool);
+}
+
 const std::vector<ur_device_handle_t> &
 ur_context_handle_t_::getP2PDevices(ur_device_handle_t hDevice) const {
   return p2pAccessDevices[hDevice->Id.value()];

--- a/unified-runtime/source/adapters/level_zero/v2/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.hpp
@@ -33,6 +33,17 @@ struct ur_context_handle_t_ : ur_object {
   ur_usm_pool_handle_t getDefaultUSMPool();
   ur_usm_pool_handle_t getAsyncPool();
 
+  void addUsmPool(ur_usm_pool_handle_t hPool);
+  void removeUsmPool(ur_usm_pool_handle_t hPool);
+
+  template <typename Func> void forEachUsmPool(Func func) {
+    std::shared_lock<ur_shared_mutex> lock(Mutex);
+    for (const auto &hPool : usmPoolHandles) {
+      if (!func(hPool))
+        break;
+    }
+  }
+
   const std::vector<ur_device_handle_t> &
   getP2PDevices(ur_device_handle_t hDevice) const;
 
@@ -69,4 +80,5 @@ private:
 
   ur_usm_pool_handle_t_ defaultUSMPool;
   ur_usm_pool_handle_t_ asyncPool;
+  std::list<ur_usm_pool_handle_t> usmPoolHandles;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -160,6 +160,10 @@ ur_result_t ur_queue_immediate_in_order_t::queueFinish() {
              (commandListLocked->getZeCommandList(), UINT64_MAX));
 
   hContext->getAsyncPool()->cleanupPoolsForQueue(this);
+  hContext->forEachUsmPool([this](ur_usm_pool_handle_t hPool) {
+    hPool->cleanupPoolsForQueue(this);
+    return true;
+  });
 
   // Free deferred kernels
   for (auto &hKernel : submittedKernels) {

--- a/unified-runtime/source/adapters/level_zero/v2/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.hpp
@@ -38,6 +38,8 @@ struct ur_usm_pool_handle_t_ : ur_object {
                        size_t size, void **ppRetMem);
   ur_result_t free(void *ptr);
 
+  bool hasPool(const umf_memory_pool_handle_t hPool);
+
   std::optional<std::pair<void *, ur_event_handle_t>>
   allocateEnqueued(ur_context_handle_t hContext, void *hQueue,
                    bool isInOrderQueue, ur_device_handle_t hDevice,

--- a/unified-runtime/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -25,8 +25,6 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     uur::deviceTestWithParamPrinter<ur_usm_alloc_info_t>);
 
 TEST_P(urUSMGetMemAllocInfoPoolTest, SuccessPool) {
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
-
   size_t property_size = 0;
   const ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_POOL;
 


### PR DESCRIPTION
This PR mirrors fixes implemented in https://github.com/intel/llvm/pull/18406 to adapter L0 v1.
To cleanup async pools properly, USM pool handles must be tracked. This feature enables `UR_USM_ALLOC_INFO_POOL`  prop to be implemented in `urUSMGetMemAllocInfo`.