### PR TITLE
[NFC] Rename `queue_impl`'s `MNoEventMode`->`MNoLastEventMode`

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -351,15 +351,15 @@ queue_impl::submit_impl(const detail::type_erased_cgfo_ty &CGF,
 
   auto requiresPostProcess = SubmitInfo.PostProcessorFunc() || Streams.size();
   auto noLastEventPath = !isHostTask && !isGraphSubmission &&
-                         MNoEventMode.load(std::memory_order_relaxed) &&
+                         MNoLastEventMode.load(std::memory_order_relaxed) &&
                          !requiresPostProcess;
 
   if (noLastEventPath) {
     std::unique_lock<std::mutex> Lock(MMutex);
 
-    // Check if we are still in no event mode. There could
+    // Check if we are still in no last event mode. There could
     // have been a concurrent submit.
-    if (MNoEventMode.load(std::memory_order_relaxed)) {
+    if (MNoLastEventMode.load(std::memory_order_relaxed)) {
       return finalizeHandlerInOrderNoEventsUnlocked(Handler);
     }
   }

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -604,7 +604,7 @@ public:
     MExtGraphDeps.reset();
 
     if (Graph) {
-      MNoEventMode = false;
+      MNoLastEventMode = false;
     } else {
       trySwitchingToNoEventsMode();
     }
@@ -715,7 +715,7 @@ protected:
 #endif
 
   bool trySwitchingToNoEventsMode() {
-    if (MNoEventMode.load(std::memory_order_relaxed))
+    if (MNoLastEventMode.load(std::memory_order_relaxed))
       return true;
 
     if (!MGraph.expired() || !isInOrder())
@@ -726,7 +726,7 @@ protected:
                                         MDefaultGraphDeps.LastEventPtr))
       return false;
 
-    MNoEventMode.store(true, std::memory_order_relaxed);
+    MNoLastEventMode.store(true, std::memory_order_relaxed);
     MDefaultGraphDeps.LastEventPtr = nullptr;
     return true;
   }
@@ -737,7 +737,7 @@ protected:
     assert(isInOrder());
     assert(MGraph.expired());
     assert(MDefaultGraphDeps.LastEventPtr == nullptr);
-    assert(MNoEventMode);
+    assert(MNoLastEventMode);
 
     MEmpty = false;
 
@@ -762,7 +762,7 @@ protected:
       // Note: This could be improved by moving the handling of dependencies
       // to before calling the CGF.
       Handler.depends_on(EventToBuildDeps);
-    } else if (MNoEventMode) {
+    } else if (MNoLastEventMode) {
       // There might be some operations submitted to the queue
       // but the LastEventPtr is not set. If we are to run a host_task,
       // we need to insert a barrier to ensure proper synchronization.
@@ -770,7 +770,7 @@ protected:
     }
 
     MEmpty = false;
-    MNoEventMode = false;
+    MNoLastEventMode = false;
 
     synchronizeWithExternalEvent(Handler);
 
@@ -785,7 +785,7 @@ protected:
     // this is handled by finalizeHandlerInOrderHostTask
     assert(Handler.getType() != CGType::CodeplayHostTask);
 
-    if (Handler.getType() == CGType::ExecCommandBuffer && MNoEventMode) {
+    if (Handler.getType() == CGType::ExecCommandBuffer && MNoLastEventMode) {
       // TODO: this shouldn't be needed but without this
       // the legacy adapter doesn't synchronize the operations properly
       // when non-immediate command lists are used.
@@ -801,7 +801,7 @@ protected:
     // to before calling the CGF.
     if (EventToBuildDeps && Handler.getType() != CGType::AsyncAlloc) {
       // If we have last event, this means we are no longer in no-event mode.
-      assert(!MNoEventMode);
+      assert(!MNoLastEventMode);
       Handler.depends_on(EventToBuildDeps);
     }
 
@@ -811,7 +811,7 @@ protected:
 
     EventToBuildDeps = parseEvent(Handler.finalize());
     if (EventToBuildDeps)
-      MNoEventMode = false;
+      MNoLastEventMode = false;
 
     // TODO: if the event is NOP we should be able to discard it.
     // However, NOP events are used to describe ordering for graph operations
@@ -1045,7 +1045,7 @@ protected:
   // be true if the queue is in-order, the command graph is not
   // associated with the queue and there has never been any host
   // tasks submitted to the queue.
-  std::atomic<bool> MNoEventMode = false;
+  std::atomic<bool> MNoLastEventMode = false;
 
   // Used exclusively in getLastEvent and queue_empty() implementations
   bool MEmpty = true;


### PR DESCRIPTION
As that's what it is and not a generic/universal no-event mode.