### PR TITLE
[CI][Devops] Remove unstable driver containers

### DIFF
--- a/.github/workflows/sycl-containers-igc-dev.yaml
+++ b/.github/workflows/sycl-containers-igc-dev.yaml
@@ -35,7 +35,6 @@ jobs:
             imagefile: ubuntu2404_intel_drivers
             tag: devigc
             build_args: |
-                  "use_unstable_driver=false"
                   "use_igc_dev=true"
     steps:
       - name: Checkout

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -54,29 +54,23 @@ jobs:
           - name: Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
             tag: latest
-            build_args: "use_unstable_driver=false"
+            build_args: ""
           - name: Intel Drivers Ubuntu 24.04 Docker image
             file: ubuntu2404_intel_drivers
             tag: latest
-            build_args: "use_unstable_driver=false"
-          - name: Intel Drivers (unstable) Ubuntu 24.04 Docker image
-            file: ubuntu2404_intel_drivers
-            tag: unstable
-            build_args: "use_unstable_driver=true"
+            build_args: ""
           - name: Build + Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
             tag: alldeps
             build_args: |
               base_image=ghcr.io/intel/llvm/ubuntu2204_build
               base_tag=latest
-              use_unstable_driver=false
           - name: Build + Intel Drivers Ubuntu 24.04 Docker image
             file: ubuntu2404_intel_drivers
             tag: alldeps
             build_args: |
               base_image=ghcr.io/intel/llvm/ubuntu2404_build
               base_tag=latest
-              use_unstable_driver=false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -5,8 +5,6 @@ FROM $base_image:$base_tag
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG use_unstable_driver=true
-
 USER root
 
 RUN apt update && apt install -yqq wget
@@ -18,12 +16,7 @@ COPY dependencies.json /
 RUN mkdir /runtimes
 ENV INSTALL_LOCATION=/runtimes
 RUN --mount=type=secret,id=github_token \
-    if [ "$use_unstable_driver" = "true" ]; then \
-      install_driver_opt=" --use-latest"; \
-    else \
-      install_driver_opt=" dependencies.json"; \
-    fi && \
-    GITHUB_TOKEN=$(cat /run/secrets/github_token) /install_drivers.sh $install_driver_opt --all
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) /install_drivers.sh dependencies.json --all
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -5,8 +5,6 @@ FROM $base_image:$base_tag
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG use_unstable_driver=true
-
 USER root
 
 RUN apt update && apt install -yqq wget
@@ -18,12 +16,7 @@ COPY dependencies.json /
 RUN mkdir /runtimes
 ENV INSTALL_LOCATION=/runtimes
 RUN --mount=type=secret,id=github_token \
-    if [ "$use_unstable_driver" = "true" ]; then \
-      install_driver_opt=" --use-latest"; \
-    else \
-      install_driver_opt=" dependencies.json"; \
-    fi && \
-    GITHUB_TOKEN=$(cat /run/secrets/github_token) /install_drivers.sh $install_driver_opt --all
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) /install_drivers.sh dependencies.json --all
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 

--- a/devops/scripts/install_drivers.sh
+++ b/devops/scripts/install_drivers.sh
@@ -19,14 +19,6 @@ if [ -f "$1" ]; then
        IGC_DEV_VER=$(jq -r '.linux.igc_dev.version' $CONFIG_FILE_IGC_DEV)
        IGC_DEV_URL=$(jq -r '.linux.igc_dev.url' $CONFIG_FILE_IGC_DEV)
     fi
-elif [[ "$*" == *"--use-latest"* ]]; then
-    CR_TAG=latest
-    IGC_TAG=latest
-    CM_TAG=latest
-    L0_TAG=latest
-    TBB_TAG=latest
-    FPGA_TAG=latest
-    CPU_TAG=latest
 else
     CR_TAG=$compute_runtime_tag
     IGC_TAG=$igc_tag
@@ -43,11 +35,7 @@ fi
 function get_release() {
     REPO=$1
     TAG=$2
-    if [ "$TAG" == "latest" ]; then
-        URL="https://api.github.com/repos/${REPO}/releases/latest"
-    else
-        URL="https://api.github.com/repos/${REPO}/releases/tags/${TAG}"
-    fi
+    URL="https://api.github.com/repos/${REPO}/releases/tags/${TAG}"
     HEADER=""
     if [ "$GITHUB_TOKEN" != "" ]; then
         HEADER="Authorization: Bearer $GITHUB_TOKEN"
@@ -215,7 +203,6 @@ if [[ $# -eq 0 ]] ; then
   echo "--use-dev-igc     - Install development version of Intel Graphics drivers instead"
   echo "--cpu      - Install Intel CPU OpenCL runtime"
   echo "--fpga-emu - Install Intel FPGA Fast emulator"
-  echo "--use-latest      - Use latest for all tags"
   echo "Set INSTALL_LOCATION env variable to specify install location"
   exit 0
 fi


### PR DESCRIPTION
None of CI is using the unstable driver containers, the container driver build is private, and the script building it was failing for a long time and nobody noticed.

Just remove it.