### PR TITLE
[NFC][E2E] Use `UNSUPPORTED-INTENDED` for L0-interop + ze_debug

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
@@ -1,8 +1,6 @@
 // REQUIRES: level_zero, level_zero_dev_kit
-// L0 adapter incorrectly reports memory leaks because it doesn't take into
-// account direct calls to L0 API.
 // UNSUPPORTED: ze_debug
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18299
+// UNSUPPORTED-INTENDED: Leaks detection is done at UR level and doesn't account for native L0 API calls.
 // UNSUPPORTED: linux && gpu-intel-dg2 && run-mode && !igc-dev
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
 // RUN: %{build} %level_zero_options -o %t.out

--- a/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
@@ -1,8 +1,6 @@
 // REQUIRES: level_zero, level_zero_dev_kit
-// L0 adapter incorrectly reports memory leaks because it doesn't take into
-// account direct calls to L0 API.
 // UNSUPPORTED: ze_debug
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18299
+// UNSUPPORTED-INTENDED: Leaks detection is done at UR level and doesn't account for native L0 API calls.
 // UNSUPPORTED: linux && gpu-intel-dg2 && run-mode && !igc-dev
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
 // RUN: %{build} %level_zero_options -o %t.out

--- a/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
@@ -1,8 +1,6 @@
 // REQUIRES: level_zero, level_zero_dev_kit
-// L0 adapter incorrectly reports memory leaks because it doesn't take into
-// account direct calls to L0 API.
 // UNSUPPORTED: ze_debug
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18299
+// UNSUPPORTED-INTENDED: Leaks detection is done at UR level and doesn't account for native L0 API calls.
 // UNSUPPORTED: linux && gpu-intel-dg2 && run-mode && !igc-dev
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
 // RUN: %{build} %level_zero_options -o %t.out


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/issues/18299.