### PR TITLE
[SYCL] Rework logic for noLastEvent mode for in-order queue 

### DIFF
--- a/sycl/source/detail/handler_impl.hpp
+++ b/sycl/source/detail/handler_impl.hpp
@@ -208,6 +208,7 @@ public:
   detail::kernel_param_desc_t (*MKernelParamDescGetter)(int) = nullptr;
   bool MKernelIsESIMD = false;
   bool MKernelHasSpecialCaptures = true;
+  bool MKernelFastPath = false; // if true, bypasses the scheduler
 
   // A pointer to a kernel name based cache retrieved on the application side.
   KernelNameBasedCacheT *MKernelNameBasedCachePtr = nullptr;

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -351,17 +351,11 @@ queue_impl::submit_impl(const detail::type_erased_cgfo_ty &CGF,
 
   auto requiresPostProcess = SubmitInfo.PostProcessorFunc() || Streams.size();
   auto noLastEventPath = !isHostTask && !isGraphSubmission &&
-                         MNoLastEventMode.load(std::memory_order_relaxed) &&
+                         MNoLastEventMode.load(std::memory_order_acquire) &&
                          !requiresPostProcess;
 
   if (noLastEventPath) {
-    std::unique_lock<std::mutex> Lock(MMutex);
-
-    // Check if we are still in no last event mode. There could
-    // have been a concurrent submit.
-    if (MNoLastEventMode.load(std::memory_order_relaxed)) {
-      return finalizeHandlerInOrderNoEventsUnlocked(Handler);
-    }
+    return finalizeHandlerInOrderNoEventsUnlocked(Handler);
   }
 
   detail::EventImplPtr EventImpl;
@@ -751,9 +745,10 @@ ur_native_handle_t queue_impl::getNative(int32_t &NativeHandleDesc) const {
 bool queue_impl::queue_empty() const {
   // If we have in-order queue with non-empty last event, just check its status.
   if (isInOrder()) {
-    std::lock_guard<std::mutex> Lock(MMutex);
-    if (MEmpty)
+    if (MEmpty.load(std::memory_order_acquire))
       return true;
+
+    std::lock_guard<std::mutex> Lock(MMutex);
 
     if (MDefaultGraphDeps.LastEventPtr &&
         !MDefaultGraphDeps.LastEventPtr->isDiscarded())

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -731,6 +731,14 @@ protected:
     return true;
   }
 
+  bool isKernelFastPath(const handler &Handler) {
+    return !Handler.impl->CGData.MRequirements.size() &&
+           !Handler.MStreamStorage.size() &&
+           detail::Scheduler::areEventsSafeForSchedulerBypass(
+               Handler.impl->CGData.MEvents, MContext) &&
+           MNoLastEventMode.load(std::memory_order_acquire);
+  }
+
   template <typename HandlerType = handler>
   detail::EventImplPtr
   finalizeHandlerInOrderNoEventsUnlocked(HandlerType &Handler) {

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -715,7 +715,7 @@ protected:
 #endif
 
   bool trySwitchingToNoEventsMode() {
-    if (MNoLastEventMode.load(std::memory_order_relaxed))
+    if (MNoLastEventMode.load(std::memory_order_acquire))
       return true;
 
     if (!MGraph.expired() || !isInOrder())
@@ -726,7 +726,7 @@ protected:
                                         MDefaultGraphDeps.LastEventPtr))
       return false;
 
-    MNoLastEventMode.store(true, std::memory_order_relaxed);
+    MNoLastEventMode.store(true, std::memory_order_release);
     MDefaultGraphDeps.LastEventPtr = nullptr;
     return true;
   }
@@ -735,11 +735,8 @@ protected:
   detail::EventImplPtr
   finalizeHandlerInOrderNoEventsUnlocked(HandlerType &Handler) {
     assert(isInOrder());
-    assert(MGraph.expired());
-    assert(MDefaultGraphDeps.LastEventPtr == nullptr);
-    assert(MNoLastEventMode);
 
-    MEmpty = false;
+    MEmpty.store(false, std::memory_order_release);
 
     synchronizeWithExternalEvent(Handler);
 
@@ -826,7 +823,7 @@ protected:
     const CGType Type = getSyclObjImpl(Handler)->MCGType;
     std::lock_guard<std::mutex> Lock{MMutex};
 
-    MEmpty = false;
+    MEmpty.store(false, std::memory_order_release);
 
     // The following code supports barrier synchronization if host task is
     // involved in the scenario. Native barriers cannot handle host task
@@ -1048,7 +1045,7 @@ protected:
   std::atomic<bool> MNoLastEventMode = false;
 
   // Used exclusively in getLastEvent and queue_empty() implementations
-  bool MEmpty = true;
+  std::atomic<bool> MEmpty = true;
 
   std::vector<EventImplPtr> MStreamsServiceEvents;
   std::mutex MStreamsServiceEventsMutex;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -416,17 +416,11 @@ event handler::finalize() {
   MIsFinalized = true;
 
   const auto &type = getType();
-  const bool KernelFastPath =
-      (MQueue && !impl->MGraph && !impl->MSubgraphNode &&
-       !MQueue->hasCommandGraph() && !impl->CGData.MRequirements.size() &&
-       !MStreamStorage.size() &&
-       detail::Scheduler::areEventsSafeForSchedulerBypass(
-           impl->CGData.MEvents, MQueue->getContextImplPtr()));
 
   // Extract arguments from the kernel lambda, if required.
   // Skipping this is currently limited to simple kernels on the fast path.
   if (type == detail::CGType::Kernel && impl->MKernelFuncPtr &&
-      (!KernelFastPath || impl->MKernelHasSpecialCaptures)) {
+      (!impl->MKernelFastPath || impl->MKernelHasSpecialCaptures)) {
     clearArgs();
     extractArgsAndReqsFromLambda((char *)impl->MKernelFuncPtr,
                                  impl->MKernelParamDescGetter,
@@ -528,7 +522,7 @@ event handler::finalize() {
       }
     }
 
-    if (KernelFastPath) {
+    if (impl->MKernelFastPath) {
       // if user does not add a new dependency to the dependency graph, i.e.
       // the graph is not changed, then this faster path is used to submit
       // kernel bypassing scheduler and avoiding CommandGroup, Command objects

--- a/sycl/test-e2e/InorderQueue/in_order_multi_queue_host_task.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_multi_queue_host_task.cpp
@@ -1,0 +1,53 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+//==-------- in_order_multi_queue_host_task.cpp ---------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <iostream>
+
+#include <sycl/detail/core.hpp>
+#include <sycl/properties/all_properties.hpp>
+#include <sycl/usm.hpp>
+
+using namespace sycl;
+
+const int dataSize = 1024 * 1024;
+
+int main() {
+  queue Queue1{property::queue::in_order()};
+  queue Queue2{property::queue::in_order()};
+
+  int *dataA = malloc_host<int>(dataSize, Queue1);
+  int *dataB = malloc_host<int>(dataSize, Queue1);
+  int *dataC = malloc_host<int>(dataSize, Queue1);
+
+  auto Event1 = Queue1.submit([&](handler &cgh) {
+    cgh.host_task([&] {
+      for (size_t i = 0; i < dataSize; ++i) {
+        dataA[i] = i;
+      }
+    });
+  });
+
+  Queue2.submit([&](handler &cgh) {
+    cgh.depends_on(Event1);
+    cgh.parallel_for(range<1>(dataSize),
+                     [=](id<1> idx) { dataB[idx[0]] = dataA[idx[0]]; });
+  });
+
+  Queue2.wait();
+
+  for (size_t i = 0; i != dataSize; ++i) {
+    if (dataB[i] != i) {
+      std::cout << "Result mismatches " << dataB[i] << " vs expected " << i
+                << " for index " << i << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This fixes an issue with cross-queue dependencies. The check for noLastEventPath in the queue was not checking whether all dependencies were ready (so it's safe to bypass the scheduler).