### PR TITLE
[DevSAN] Make device sanitizer kernel metadata has a unique id

### DIFF
--- a/llvm/include/llvm/Transforms/Instrumentation/SPIRVSanitizerCommonUtils.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/SPIRVSanitizerCommonUtils.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_TRANSFORMS_INSTRUMENTATION_SPIRVSANITIZERCOMMONUTILS_H
 #define LLVM_TRANSFORMS_INSTRUMENTATION_SPIRVSANITIZERCOMMONUTILS_H
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
@@ -26,6 +27,9 @@ constexpr unsigned kSpirOffloadGenericAS = 4;
 
 TargetExtType *getTargetExtType(Type *Ty);
 bool isJointMatrixAccess(Value *V);
+
+SmallString<128> computeKernelMetadataUniqueId(StringRef Prefix,
+                              SmallVectorImpl<uint8_t> &KernelNamesBytes);
 } // namespace llvm
 
 #endif // LLVM_TRANSFORMS_INSTRUMENTATION_SPIRVSANITIZERCOMMONUTILS_H

--- a/llvm/lib/Transforms/Instrumentation/SPIRVSanitizerCommonUtils.cpp
+++ b/llvm/lib/Transforms/Instrumentation/SPIRVSanitizerCommonUtils.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/Transforms/Instrumentation/SPIRVSanitizerCommonUtils.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/Support/MD5.h"
 
 using namespace llvm;
 
@@ -58,4 +59,17 @@ bool isJointMatrixAccess(Value *V) {
   }
   return false;
 }
+
+SmallString<128>
+computeKernelMetadataUniqueId(StringRef Prefix,
+                              SmallVectorImpl<uint8_t> &KernelNamesBytes) {
+  MD5 Hash;
+  SmallString<32> UniqueIdSuffix;
+  SmallString<128> UniqueId(Prefix);
+  auto R = Hash.hash(KernelNamesBytes);
+  Hash.stringifyResult(R, UniqueIdSuffix);
+  UniqueId.append(UniqueIdSuffix);
+  return UniqueId;
+}
+
 } // namespace llvm

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/extend_launch_info_arg.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/extend_launch_info_arg.ll
@@ -4,6 +4,7 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 ; CHECK: @__AsanKernelMetadata = appending dso_local local_unnamed_addr addrspace(1) global
+; CHECK-SAME: [[ATTR0:#[0-9]+]]
 ; CHECK: @__AsanLaunchInfo = external addrspace(3) global ptr addrspace(1)
 
 define spir_kernel void @sycl_kernel1() #0 {
@@ -25,4 +26,4 @@ entry:
 attributes #0 = { sanitize_address }
 ;; sycl-device-global-size = 16 * 2
 ;; sycl-host-access = 0 read-only
-; CHECK: attributes #{{.*}} = { "sycl-device-global-size"="32" "sycl-device-image-scope" "sycl-host-access"="0" "sycl-unique-id"="_Z20__AsanKernelMetadata" }
+; CHECK: attributes [[ATTR0]] = { "sycl-device-global-size"="32" "sycl-device-image-scope" "sycl-host-access"="0" "sycl-unique-id"="__AsanKernelMetadata833c47834a0b74946e370c23c39607cc" }

--- a/llvm/test/Instrumentation/MemorySanitizer/SPIRV/instrument_global_address_space.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/SPIRV/instrument_global_address_space.ll
@@ -31,4 +31,4 @@ entry:
 }
 
 ; CHECK: attributes [[ATTR0]]
-; CHECK-SAME: "sycl-device-global-size"="32" "sycl-device-image-scope" "sycl-host-access"="0" "sycl-unique-id"="_Z20__MsanKernelMetadata"
+; CHECK-SAME: "sycl-device-global-size"="32" "sycl-device-image-scope" "sycl-host-access"="0" "sycl-unique-id"="__MsanKernelMetadata3ff767e9a7a43f1f3968062dbb4ee3b4"

--- a/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/kernel_metadata.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/kernel_metadata.ll
@@ -4,6 +4,7 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-LABEL: @__TsanKernelMetadata = appending dso_local local_unnamed_addr addrspace(1) global
 ; CHECK-SAME: i64 ptrtoint (ptr addrspace(2) @__tsan_kernel to i64
+; CHECK-SAME: [[ATTR0:#[0-9]+]]
 
 ; Function Attrs: sanitize_thread
 define spir_kernel void @test() #0 {
@@ -11,4 +12,5 @@ entry:
   ret void
 }
 
+; CHECK: attributes [[ATTR0]] = {{.*}} "sycl-unique-id"="__TsanKernelMetadata098f6bcd4621d373cade4e832627b4f6"
 attributes #0 = { sanitize_thread }


### PR DESCRIPTION
We decorated kernel metadata global as a device global, if we don't give a unique id to it, device sanitizer will not work in shared libraries.