### PR TITLE
[UR][OpenCL][CUDA][HIP][L0][L0v2][Offload] Refactor reference counting in UR across all adapters into a new common UR_ReferenceCounter class

### DIFF
--- a/unified-runtime/source/adapters/cuda/adapter.cpp
+++ b/unified-runtime/source/adapters/cuda/adapter.cpp
@@ -66,7 +66,7 @@ urAdapterGet(uint32_t NumEntries, ur_adapter_handle_t *phAdapters,
     std::call_once(InitFlag,
                    [=]() { ur::cuda::adapter = new ur_adapter_handle_t_; });
 
-    ur::cuda::adapter->RefCount++;
+    ur::cuda::adapter->getRefCounter().increment();
     *phAdapters = ur::cuda::adapter;
   }
 
@@ -78,13 +78,13 @@ urAdapterGet(uint32_t NumEntries, ur_adapter_handle_t *phAdapters,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRetain(ur_adapter_handle_t) {
-  ur::cuda::adapter->RefCount++;
+  ur::cuda::adapter->getRefCounter().increment();
 
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
-  if (--ur::cuda::adapter->RefCount == 0) {
+  if (ur::cuda::adapter->getRefCounter().decrement() == 0) {
     delete ur::cuda::adapter;
   }
   return UR_RESULT_SUCCESS;
@@ -108,7 +108,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   case UR_ADAPTER_INFO_BACKEND:
     return ReturnValue(UR_BACKEND_CUDA);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
-    return ReturnValue(ur::cuda::adapter->RefCount.load());
+    return ReturnValue(ur::cuda::adapter->getRefCounter().getCount());
   case UR_ADAPTER_INFO_VERSION:
     return ReturnValue(uint32_t{1});
   default:

--- a/unified-runtime/source/adapters/cuda/adapter.hpp
+++ b/unified-runtime/source/adapters/cuda/adapter.hpp
@@ -11,25 +11,29 @@
 #ifndef UR_CUDA_ADAPTER_HPP_INCLUDED
 #define UR_CUDA_ADAPTER_HPP_INCLUDED
 
+#include "common/ur_ref_counter.hpp"
 #include "logger/ur_logger.hpp"
 #include "platform.hpp"
 #include "tracing.hpp"
 #include <ur_api.h>
 
-#include <atomic>
 #include <memory>
 
 struct ur_adapter_handle_t_ : ur::cuda::handle_base {
-  std::atomic<uint32_t> RefCount = 0;
   struct cuda_tracing_context_t_ *TracingCtx = nullptr;
   logger::Logger &logger;
   std::unique_ptr<ur_platform_handle_t_> Platform;
   ur_adapter_handle_t_();
   ~ur_adapter_handle_t_();
   ur_adapter_handle_t_(const ur_adapter_handle_t_ &) = delete;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
-// Keep the global namespace'd
+// Keep the global namespace
 namespace ur::cuda {
 extern ur_adapter_handle_t adapter;
 } // namespace ur::cuda

--- a/unified-runtime/source/adapters/cuda/command_buffer.cpp
+++ b/unified-runtime/source/adapters/cuda/command_buffer.cpp
@@ -60,7 +60,7 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     bool IsInOrder)
     : handle_base(), Context(Context), Device(Device), IsUpdatable(IsUpdatable),
       IsInOrder(IsInOrder), CudaGraph{nullptr}, CudaGraphExec{nullptr},
-      RefCount{1}, NextSyncPoint{0} {
+      NextSyncPoint{0} {
   urContextRetain(Context);
 }
 
@@ -380,13 +380,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
-  hCommandBuffer->incrementReferenceCount();
+  hCommandBuffer->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
-  if (hCommandBuffer->decrementReferenceCount() == 0) {
+  if (hCommandBuffer->getRefCounter().decrement() == 0) {
     // Ref count has reached zero, release of created commands
     for (auto &Command : hCommandBuffer->CommandHandles) {
       commandHandleDestroy(Command);
@@ -1476,7 +1476,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferGetInfoExp(
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(hCommandBuffer->getReferenceCount());
+    return ReturnValue(hCommandBuffer->getRefCounter().getCount());
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/cuda/context.cpp
+++ b/unified-runtime/source/adapters/cuda/context.cpp
@@ -66,7 +66,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextGetInfo(
     return ReturnValue(hContext->getDevices().data(),
                        hContext->getDevices().size());
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(hContext->getReferenceCount());
+    return ReturnValue(hContext->getRefCounter().getCount());
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // 2D USM memcpy is supported.
     return ReturnValue(true);
@@ -83,7 +83,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextGetInfo(
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
-  if (hContext->decrementReferenceCount() > 0) {
+  if (hContext->getRefCounter().getCount() > 0) {
     return UR_RESULT_SUCCESS;
   }
   hContext->invokeExtendedDeleters();
@@ -94,9 +94,9 @@ urContextRelease(ur_context_handle_t hContext) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRetain(ur_context_handle_t hContext) {
-  assert(hContext->getReferenceCount() > 0);
+  assert(hContext->getRefCounter().getCount() > 0);
 
-  hContext->incrementReferenceCount();
+  hContext->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -593,7 +593,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue("CUDA");
   }
   case UR_DEVICE_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hDevice->getReferenceCount());
+    return ReturnValue(hDevice->getRefCounter().getCount());
   }
   case UR_DEVICE_INFO_VERSION: {
     std::stringstream SS;

--- a/unified-runtime/source/adapters/cuda/device.hpp
+++ b/unified-runtime/source/adapters/cuda/device.hpp
@@ -15,6 +15,7 @@
 #include <umf/memory_provider.h>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
 struct ur_device_handle_t_ : ur::cuda::handle_base {
 private:
@@ -23,7 +24,6 @@ private:
   native_type CuDevice;
   CUcontext CuContext;
   CUevent EvBase; // CUDA event used as base counter
-  std::atomic_uint32_t RefCount;
   ur_platform_handle_t Platform;
   uint32_t DeviceIndex;
 
@@ -42,7 +42,7 @@ public:
   ur_device_handle_t_(native_type cuDevice, CUcontext cuContext, CUevent evBase,
                       ur_platform_handle_t platform, uint32_t DevIndex)
       : handle_base(), CuDevice(cuDevice), CuContext(cuContext), EvBase(evBase),
-        RefCount{1}, Platform(platform), DeviceIndex{DevIndex} {
+        Platform(platform), DeviceIndex{DevIndex} {
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxRegsPerBlock, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
         cuDevice));
@@ -136,7 +136,7 @@ public:
 
   CUcontext getNativeContext() const noexcept { return CuContext; };
 
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   ur_platform_handle_t getPlatform() const noexcept { return Platform; };
 
@@ -178,6 +178,9 @@ public:
   // (UMF_MEMORY_TYPE_SHARED)
   umf_memory_provider_handle_t MemoryProviderShared;
   umf_memory_pool_handle_t MemoryPoolShared;
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 int getAttribute(ur_device_handle_t Device, CUdevice_attribute Attribute);

--- a/unified-runtime/source/adapters/cuda/event.cpp
+++ b/unified-runtime/source/adapters/cuda/event.cpp
@@ -179,7 +179,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
   case UR_EVENT_INFO_COMMAND_TYPE:
     return ReturnValue(hEvent->getCommandType());
   case UR_EVENT_INFO_REFERENCE_COUNT:
-    return ReturnValue(hEvent->getReferenceCount());
+    return ReturnValue(hEvent->getRefCounter().getCount());
   case UR_EVENT_INFO_COMMAND_EXECUTION_STATUS:
     return ReturnValue(hEvent->getExecutionStatus());
   case UR_EVENT_INFO_CONTEXT:
@@ -248,9 +248,7 @@ urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
-  const auto RefCount = hEvent->incrementReferenceCount();
-
-  if (RefCount == 0) {
+  if (hEvent->getRefCounter().increment() == 0) {
     return UR_RESULT_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -260,12 +258,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  if (hEvent->getReferenceCount() == 0) {
+  if (hEvent->getRefCounter().getCount() == 0) {
     return UR_RESULT_ERROR_INVALID_EVENT;
   }
 
   // decrement ref count. If it is 0, delete the event.
-  if (hEvent->decrementReferenceCount() == 0) {
+  if (hEvent->getRefCounter().decrement() == 0) {
     std::unique_ptr<ur_event_handle_t_> event_ptr{hEvent};
     ur_result_t Result = UR_RESULT_ERROR_INVALID_EVENT;
     try {

--- a/unified-runtime/source/adapters/cuda/event.hpp
+++ b/unified-runtime/source/adapters/cuda/event.hpp
@@ -13,6 +13,7 @@
 #include <ur/ur.hpp>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "queue.hpp"
 
 /// UR Event mapping to CUevent
@@ -59,16 +60,12 @@ struct ur_event_handle_t_ : ur::cuda::handle_base {
   ur_command_t getCommandType() const noexcept { return CommandType; }
   ur_context_handle_t getContext() const noexcept { return Context; };
   uint32_t getEventID() const noexcept { return EventID; }
-
-  // Reference counting.
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
-  uint32_t incrementReferenceCount() { return ++RefCount; }
-  uint32_t decrementReferenceCount() { return --RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
 private:
   ur_command_t CommandType; // The type of command associated with event.
 
-  std::atomic_uint32_t RefCount{1}; // Event reference count.
+  UR_ReferenceCounter RefCounter;
 
   bool HasOwnership{true};  // Signifies if event owns the native type.
   bool HasProfiling{false}; // Signifies if event has profiling information.

--- a/unified-runtime/source/adapters/cuda/kernel.cpp
+++ b/unified-runtime/source/adapters/cuda/kernel.cpp
@@ -127,9 +127,10 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
-  UR_ASSERT(hKernel->getReferenceCount() > 0u, UR_RESULT_ERROR_INVALID_KERNEL);
+  UR_ASSERT(hKernel->getRefCounter().getCount() > 0u,
+            UR_RESULT_ERROR_INVALID_KERNEL);
 
-  hKernel->incrementReferenceCount();
+  hKernel->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -137,10 +138,11 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urKernelRelease(ur_kernel_handle_t hKernel) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  UR_ASSERT(hKernel->getReferenceCount() != 0, UR_RESULT_ERROR_INVALID_KERNEL);
+  UR_ASSERT(hKernel->getRefCounter().getCount() != 0,
+            UR_RESULT_ERROR_INVALID_KERNEL);
 
   // decrement ref count. If it is 0, delete the program.
-  if (hKernel->decrementReferenceCount() == 0) {
+  if (hKernel->getRefCounter().decrement() == 0) {
     // no internal cuda resources to clean up. Just delete it.
     delete hKernel;
     return UR_RESULT_SUCCESS;
@@ -248,7 +250,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
   case UR_KERNEL_INFO_NUM_ARGS:
     return ReturnValue(hKernel->getNumArgs());
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(hKernel->getReferenceCount());
+    return ReturnValue(hKernel->getRefCounter().getCount());
   case UR_KERNEL_INFO_CONTEXT:
     return ReturnValue(hKernel->getContext());
   case UR_KERNEL_INFO_PROGRAM:

--- a/unified-runtime/source/adapters/cuda/memory.cpp
+++ b/unified-runtime/source/adapters/cuda/memory.cpp
@@ -78,8 +78,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
-  UR_ASSERT(hMem->getReferenceCount() > 0, UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  hMem->incrementReferenceCount();
+  UR_ASSERT(hMem->getRefCounter().getCount() > 0,
+            UR_RESULT_ERROR_INVALID_MEM_OBJECT);
+  hMem->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -89,7 +90,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
 UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
   try {
     // Do nothing if there are other references
-    if (hMem->decrementReferenceCount() > 0) {
+    if (hMem->getRefCounter().decrement() > 0) {
       return UR_RESULT_SUCCESS;
     }
 
@@ -162,7 +163,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
     return ReturnValue(hMemory->getContext());
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hMemory->getReferenceCount());
+    return ReturnValue(hMemory->getRefCounter().getCount());
   }
 
   default:

--- a/unified-runtime/source/adapters/cuda/physical_mem.cpp
+++ b/unified-runtime/source/adapters/cuda/physical_mem.cpp
@@ -46,13 +46,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urPhysicalMemCreate(
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urPhysicalMemRetain(ur_physical_mem_handle_t hPhysicalMem) {
-  hPhysicalMem->incrementReferenceCount();
+  hPhysicalMem->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urPhysicalMemRelease(ur_physical_mem_handle_t hPhysicalMem) {
-  if (hPhysicalMem->decrementReferenceCount() > 0)
+  if (hPhysicalMem->getRefCounter().decrement() > 0)
     return UR_RESULT_SUCCESS;
 
   try {
@@ -88,7 +88,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPhysicalMemGetInfo(
     return ReturnValue(hPhysicalMem->getProperties());
   }
   case UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPhysicalMem->getReferenceCount());
+    return ReturnValue(hPhysicalMem->getRefCounter().getCount());
   }
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;

--- a/unified-runtime/source/adapters/cuda/program.cpp
+++ b/unified-runtime/source/adapters/cuda/program.cpp
@@ -350,7 +350,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
 
   switch (propName) {
   case UR_PROGRAM_INFO_REFERENCE_COUNT:
-    return ReturnValue(hProgram->getReferenceCount());
+    return ReturnValue(hProgram->getRefCounter().getCount());
   case UR_PROGRAM_INFO_CONTEXT:
     return ReturnValue(hProgram->Context);
   case UR_PROGRAM_INFO_NUM_DEVICES:
@@ -383,8 +383,9 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRetain(ur_program_handle_t hProgram) {
-  UR_ASSERT(hProgram->getReferenceCount() > 0, UR_RESULT_ERROR_INVALID_PROGRAM);
-  hProgram->incrementReferenceCount();
+  UR_ASSERT(hProgram->getRefCounter().getCount() > 0,
+            UR_RESULT_ERROR_INVALID_PROGRAM);
+  hProgram->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -395,11 +396,11 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRelease(ur_program_handle_t hProgram) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  UR_ASSERT(hProgram->getReferenceCount() != 0,
+  UR_ASSERT(hProgram->getRefCounter().getCount() != 0,
             UR_RESULT_ERROR_INVALID_PROGRAM);
 
   // decrement ref count. If it is 0, delete the program.
-  if (hProgram->decrementReferenceCount() == 0) {
+  if (hProgram->getRefCounter().decrement() == 0) {
     std::unique_ptr<ur_program_handle_t_> ProgramPtr{hProgram};
     try {
       ScopedContext Active(hProgram->getDevice());

--- a/unified-runtime/source/adapters/cuda/program.hpp
+++ b/unified-runtime/source/adapters/cuda/program.hpp
@@ -12,9 +12,9 @@
 #include <cuda.h>
 #include <ur_api.h>
 
-#include <atomic>
 #include <unordered_map>
 
+#include "common/ur_ref_counter.hpp"
 #include "context.hpp"
 
 struct ur_program_handle_t_ : ur::cuda::handle_base {
@@ -22,7 +22,6 @@ struct ur_program_handle_t_ : ur::cuda::handle_base {
   native_type Module;
   const char *Binary;
   size_t BinarySizeInBytes;
-  std::atomic_uint32_t RefCount;
   ur_context_handle_t Context;
   ur_device_handle_t Device;
 
@@ -49,9 +48,9 @@ struct ur_program_handle_t_ : ur::cuda::handle_base {
 
   ur_program_handle_t_(ur_context_handle_t Context, ur_device_handle_t Device)
       : handle_base(), Module{nullptr}, Binary{}, BinarySizeInBytes{0},
-        RefCount{1}, Context{Context}, Device{Device},
-        KernelReqdWorkGroupSizeMD{}, KernelMaxWorkGroupSizeMD{},
-        KernelMaxLinearWorkGroupSizeMD{}, KernelReqdSubGroupSizeMD{} {
+        Context{Context}, Device{Device}, KernelReqdWorkGroupSizeMD{},
+        KernelMaxWorkGroupSizeMD{}, KernelMaxLinearWorkGroupSizeMD{},
+        KernelReqdSubGroupSizeMD{} {
     urContextRetain(Context);
 
     // When the log is queried we use strnlen(InfoLog), so it needs to be
@@ -71,13 +70,12 @@ struct ur_program_handle_t_ : ur::cuda::handle_base {
 
   native_type get() const noexcept { return Module; };
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   ur_result_t getGlobalVariablePointer(const char *name,
                                        CUdeviceptr *DeviceGlobal,
                                        size_t *DeviceGlobalSize);
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/cuda/queue.cpp
+++ b/unified-runtime/source/adapters/cuda/queue.cpp
@@ -107,14 +107,14 @@ urQueueCreate(ur_context_handle_t hContext, ur_device_handle_t hDevice,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
-  assert(hQueue->getReferenceCount() > 0);
+  assert(hQueue->getRefCounter().getCount() > 0);
 
-  hQueue->incrementReferenceCount();
+  hQueue->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
-  if (hQueue->decrementReferenceCount() > 0) {
+  if (hQueue->getRefCounter().decrement() > 0) {
     return UR_RESULT_SUCCESS;
   }
 
@@ -229,7 +229,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(hQueue->Device);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(hQueue->getReferenceCount());
+    return ReturnValue(hQueue->getRefCounter().getCount());
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(hQueue->URFlags);
   case UR_QUEUE_INFO_EMPTY: {

--- a/unified-runtime/source/adapters/cuda/sampler.cpp
+++ b/unified-runtime/source/adapters/cuda/sampler.cpp
@@ -73,7 +73,7 @@ urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
 
   switch (propName) {
   case UR_SAMPLER_INFO_REFERENCE_COUNT:
-    return ReturnValue(hSampler->getReferenceCount());
+    return ReturnValue(hSampler->getRefCounter().getCount());
   case UR_SAMPLER_INFO_CONTEXT:
     return ReturnValue(hSampler->Context);
   case UR_SAMPLER_INFO_NORMALIZED_COORDS: {
@@ -95,7 +95,7 @@ urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRetain(ur_sampler_handle_t hSampler) {
-  hSampler->incrementReferenceCount();
+  hSampler->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -103,12 +103,12 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  if (hSampler->getReferenceCount() == 0) {
+  if (hSampler->getRefCounter().getCount() == 0) {
     return UR_RESULT_ERROR_INVALID_SAMPLER;
   }
 
   // decrement ref count. If it is 0, delete the sampler.
-  if (hSampler->decrementReferenceCount() == 0) {
+  if (hSampler->getRefCounter().decrement() == 0) {
     delete hSampler;
   }
 

--- a/unified-runtime/source/adapters/cuda/usm.cpp
+++ b/unified-runtime/source/adapters/cuda/usm.cpp
@@ -290,14 +290,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolCreate(
 UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolRetain(
     /// [in] pointer to USM memory pool
     ur_usm_pool_handle_t Pool) {
-  Pool->incrementReferenceCount();
+  Pool->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolRelease(
     /// [in] pointer to USM memory pool
     ur_usm_pool_handle_t Pool) {
-  if (Pool->decrementReferenceCount() > 0) {
+  if (Pool->getRefCounter().decrement() > 0) {
     return UR_RESULT_SUCCESS;
   }
   Pool->Context->removePool(Pool);
@@ -320,7 +320,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolGetInfo(
 
   switch (propName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPool->getReferenceCount());
+    return ReturnValue(hPool->getRefCounter().getCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(hPool->Context);

--- a/unified-runtime/source/adapters/hip/adapter.cpp
+++ b/unified-runtime/source/adapters/hip/adapter.cpp
@@ -58,7 +58,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
     std::call_once(InitFlag,
                    [=]() { ur::hip::adapter = new ur_adapter_handle_t_; });
 
-    ur::hip::adapter->RefCount++;
+    ur::hip::adapter->getRefCounter().increment();
     *phAdapters = ur::hip::adapter;
   }
   if (pNumAdapters) {
@@ -69,7 +69,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
-  if (--ur::hip::adapter->RefCount == 0) {
+  if (--ur::hip::adapter->getRefCounter().decrement() == 0) {
     delete ur::hip::adapter;
   }
 
@@ -77,7 +77,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRetain(ur_adapter_handle_t) {
-  ur::hip::adapter->RefCount++;
+  ur::hip::adapter->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -99,7 +99,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   case UR_ADAPTER_INFO_BACKEND:
     return ReturnValue(UR_BACKEND_HIP);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
-    return ReturnValue(ur::hip::adapter->RefCount.load());
+    return ReturnValue(ur::hip::adapter->getRefCounter().getCount());
   case UR_ADAPTER_INFO_VERSION:
     return ReturnValue(uint32_t{1});
   default:

--- a/unified-runtime/source/adapters/hip/adapter.cpp
+++ b/unified-runtime/source/adapters/hip/adapter.cpp
@@ -69,7 +69,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
-  if (--ur::hip::adapter->getRefCounter().decrement() == 0) {
+  if (ur::hip::adapter->getRefCounter().decrement() == 0) {
     delete ur::hip::adapter;
   }
 

--- a/unified-runtime/source/adapters/hip/adapter.hpp
+++ b/unified-runtime/source/adapters/hip/adapter.hpp
@@ -11,6 +11,7 @@
 #ifndef UR_HIP_ADAPTER_HPP_INCLUDED
 #define UR_HIP_ADAPTER_HPP_INCLUDED
 
+#include "common/ur_ref_counter.hpp"
 #include "logger/ur_logger.hpp"
 #include "platform.hpp"
 
@@ -18,10 +19,14 @@
 #include <memory>
 
 struct ur_adapter_handle_t_ : ur::hip::handle_base {
-  std::atomic<uint32_t> RefCount = 0;
   logger::Logger &logger;
   std::unique_ptr<ur_platform_handle_t_> Platform;
   ur_adapter_handle_t_();
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 namespace ur::hip {

--- a/unified-runtime/source/adapters/hip/command_buffer.cpp
+++ b/unified-runtime/source/adapters/hip/command_buffer.cpp
@@ -26,7 +26,7 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
     bool IsInOrder)
     : handle_base(), Context(hContext), Device(hDevice),
       IsUpdatable(IsUpdatable), IsInOrder(IsInOrder), HIPGraph{nullptr},
-      HIPGraphExec{nullptr}, RefCount{1}, NextSyncPoint{0} {
+      HIPGraphExec{nullptr}, NextSyncPoint{0} {
   urContextRetain(hContext);
 }
 
@@ -266,13 +266,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
-  hCommandBuffer->incrementReferenceCount();
+  hCommandBuffer->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
-  if (hCommandBuffer->decrementReferenceCount() == 0) {
+  if (hCommandBuffer->getRefCounter().decrement() == 0) {
     delete hCommandBuffer;
   }
   return UR_RESULT_SUCCESS;
@@ -1045,7 +1045,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferGetInfoExp(
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(hCommandBuffer->getReferenceCount());
+    return ReturnValue(hCommandBuffer->getRefCounter().getCount());
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/hip/command_buffer.hpp
+++ b/unified-runtime/source/adapters/hip/command_buffer.hpp
@@ -109,9 +109,8 @@ struct ur_exp_command_buffer_handle_t_ : ur::hip::handle_base {
     registerSyncPoint(SyncPoint, std::move(HIPNode));
     return SyncPoint;
   }
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   // UR context associated with this command-buffer
   ur_context_handle_t Context;
@@ -125,9 +124,6 @@ struct ur_exp_command_buffer_handle_t_ : ur::hip::handle_base {
   hipGraph_t HIPGraph;
   // HIP Graph Exec handle
   hipGraphExec_t HIPGraphExec = nullptr;
-  // Atomic variable counting the number of reference to this command_buffer
-  // using std::atomic prevents data race when incrementing/decrementing.
-  std::atomic_uint32_t RefCount;
 
   // Ordered map of sync_points to ur_events
   std::map<ur_exp_command_buffer_sync_point_t, hipGraphNode_t> SyncPoints;
@@ -138,4 +134,7 @@ struct ur_exp_command_buffer_handle_t_ : ur::hip::handle_base {
   // Handles to individual commands in the command-buffer
   std::vector<std::unique_ptr<ur_exp_command_buffer_command_handle_t_>>
       CommandHandles;
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/hip/context.cpp
+++ b/unified-runtime/source/adapters/hip/context.cpp
@@ -68,7 +68,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
     return ReturnValue(hContext->getDevices().data(),
                        hContext->getDevices().size());
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(hContext->getReferenceCount());
+    return ReturnValue(hContext->getRefCounter().getCount());
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // 2D USM memcpy is supported.
     return ReturnValue(true);
@@ -85,7 +85,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
-  if (hContext->decrementReferenceCount() == 0) {
+  if (hContext->getRefCounter().decrement() == 0) {
     hContext->invokeExtendedDeleters();
     delete hContext;
   }
@@ -94,9 +94,9 @@ urContextRelease(ur_context_handle_t hContext) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRetain(ur_context_handle_t hContext) {
-  assert(hContext->getReferenceCount() > 0);
+  assert(hContext->getRefCounter().getCount() > 0);
 
-  hContext->incrementReferenceCount();
+  hContext->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/hip/device.cpp
+++ b/unified-runtime/source/adapters/hip/device.cpp
@@ -477,7 +477,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue("HIP");
   }
   case UR_DEVICE_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hDevice->getReferenceCount());
+    return ReturnValue(hDevice->getRefCounter().getCount());
   }
   case UR_DEVICE_INFO_VERSION: {
     std::stringstream S;

--- a/unified-runtime/source/adapters/hip/device.hpp
+++ b/unified-runtime/source/adapters/hip/device.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
 #include <ur/ur.hpp>
 
@@ -22,7 +23,7 @@ private:
   using native_type = hipDevice_t;
 
   native_type HIPDevice;
-  std::atomic_uint32_t RefCount;
+  UR_ReferenceCounter RefCounter;
   ur_platform_handle_t Platform;
   hipEvent_t EvBase; // HIP event used as base counter
   uint32_t DeviceIndex;
@@ -38,8 +39,8 @@ private:
 public:
   ur_device_handle_t_(native_type HipDevice, hipEvent_t EvBase,
                       ur_platform_handle_t Platform, uint32_t DeviceIndex)
-      : handle_base(), HIPDevice(HipDevice), RefCount{1}, Platform(Platform),
-        EvBase(EvBase), DeviceIndex(DeviceIndex) {
+      : handle_base(), HIPDevice(HipDevice), Platform(Platform), EvBase(EvBase),
+        DeviceIndex(DeviceIndex) {
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &MaxWorkGroupSize, hipDeviceAttributeMaxThreadsPerBlock, HIPDevice));
@@ -99,7 +100,7 @@ public:
 
   native_type get() const noexcept { return HIPDevice; };
 
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   ur_platform_handle_t getPlatform() const noexcept { return Platform; };
 

--- a/unified-runtime/source/adapters/hip/event.cpp
+++ b/unified-runtime/source/adapters/hip/event.cpp
@@ -189,7 +189,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
   case UR_EVENT_INFO_COMMAND_TYPE:
     return ReturnValue(hEvent->getCommandType());
   case UR_EVENT_INFO_REFERENCE_COUNT:
-    return ReturnValue(hEvent->getReferenceCount());
+    return ReturnValue(hEvent->getRefCounter().getCount());
   case UR_EVENT_INFO_COMMAND_EXECUTION_STATUS: {
     try {
       return ReturnValue(hEvent->getExecutionStatus());
@@ -245,9 +245,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
-  const auto RefCount = hEvent->incrementReferenceCount();
-
-  if (RefCount == 0) {
+  if (hEvent->getRefCounter().increment() == 0) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
 
@@ -257,12 +255,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  if (hEvent->getReferenceCount() == 0) {
+  if (hEvent->getRefCounter().getCount() == 0) {
     return UR_RESULT_ERROR_INVALID_EVENT;
   }
 
   // decrement ref count. If it is 0, delete the event.
-  if (hEvent->decrementReferenceCount() == 0) {
+  if (hEvent->getRefCounter().decrement() == 0) {
     std::unique_ptr<ur_event_handle_t_> event_ptr{hEvent};
     ur_result_t Result = UR_RESULT_ERROR_INVALID_EVENT;
     try {

--- a/unified-runtime/source/adapters/hip/event.hpp
+++ b/unified-runtime/source/adapters/hip/event.hpp
@@ -10,8 +10,8 @@
 #pragma once
 
 #include "common.hpp"
-#include "queue.hpp"
 #include "common/ur_ref_counter.hpp"
+#include "queue.hpp"
 
 /// UR Event mapping to hipEvent_t
 struct ur_event_handle_t_ : ur::hip::handle_base {

--- a/unified-runtime/source/adapters/hip/event.hpp
+++ b/unified-runtime/source/adapters/hip/event.hpp
@@ -11,6 +11,7 @@
 
 #include "common.hpp"
 #include "queue.hpp"
+#include "common/ur_ref_counter.hpp"
 
 /// UR Event mapping to hipEvent_t
 struct ur_event_handle_t_ : ur::hip::handle_base {
@@ -56,16 +57,12 @@ struct ur_event_handle_t_ : ur::hip::handle_base {
   ur_command_t getCommandType() const noexcept { return CommandType; }
   ur_context_handle_t getContext() const noexcept { return Context; };
   uint32_t getEventId() const noexcept { return EventId; }
-
-  // Reference counting.
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
-  uint32_t incrementReferenceCount() { return ++RefCount; }
-  uint32_t decrementReferenceCount() { return --RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
 private:
   ur_command_t CommandType; // The type of command associated with event.
 
-  std::atomic_uint32_t RefCount{1}; // Event reference count.
+  UR_ReferenceCounter RefCounter;
 
   bool HasOwnership{true};  // Signifies if event owns the native type.
   bool HasProfiling{false}; // Signifies if event has profiling information.

--- a/unified-runtime/source/adapters/hip/kernel.cpp
+++ b/unified-runtime/source/adapters/hip/kernel.cpp
@@ -127,9 +127,10 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
-  UR_ASSERT(hKernel->getReferenceCount() > 0u, UR_RESULT_ERROR_INVALID_KERNEL);
+  UR_ASSERT(hKernel->getRefCounter().getCount() > 0u,
+            UR_RESULT_ERROR_INVALID_KERNEL);
 
-  hKernel->incrementReferenceCount();
+  hKernel->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -137,10 +138,11 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urKernelRelease(ur_kernel_handle_t hKernel) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  UR_ASSERT(hKernel->getReferenceCount() != 0, UR_RESULT_ERROR_INVALID_KERNEL);
+  UR_ASSERT(hKernel->getRefCounter().getCount() != 0,
+            UR_RESULT_ERROR_INVALID_KERNEL);
 
   // decrement ref count. If it is 0, delete the program.
-  if (hKernel->decrementReferenceCount() == 0) {
+  if (hKernel->getRefCounter().decrement() == 0) {
     // no internal cuda resources to clean up. Just delete it.
     delete hKernel;
     return UR_RESULT_SUCCESS;
@@ -201,7 +203,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
   case UR_KERNEL_INFO_NUM_ARGS:
     return ReturnValue(hKernel->getNumArgs());
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(hKernel->getReferenceCount());
+    return ReturnValue(hKernel->getRefCounter().getCount());
   case UR_KERNEL_INFO_CONTEXT:
     return ReturnValue(hKernel->getContext());
   case UR_KERNEL_INFO_PROGRAM:

--- a/unified-runtime/source/adapters/hip/kernel.hpp
+++ b/unified-runtime/source/adapters/hip/kernel.hpp
@@ -237,7 +237,7 @@ struct ur_kernel_handle_t_ : ur::hip::handle_base {
                       ur_context_handle_t Ctxt)
       : handle_base(), Function{Func},
         FunctionWithOffsetParam{FuncWithOffsetParam}, Name{Name}, Context{Ctxt},
-        Program{Program}, RefCount{1} {
+        Program{Program} {
     urProgramRetain(Program);
     urContextRetain(Context);
 

--- a/unified-runtime/source/adapters/hip/kernel.hpp
+++ b/unified-runtime/source/adapters/hip/kernel.hpp
@@ -12,10 +12,10 @@
 #include <ur_api.h>
 
 #include <array>
-#include <atomic>
 #include <cassert>
 #include <numeric>
 
+#include "common/ur_ref_counter.hpp"
 #include "program.hpp"
 
 /// Implementation of a UR Kernel for HIP
@@ -41,7 +41,6 @@ struct ur_kernel_handle_t_ : ur::hip::handle_base {
   std::string Name;
   ur_context_handle_t Context;
   ur_program_handle_t Program;
-  std::atomic_uint32_t RefCount;
 
   static constexpr uint32_t ReqdThreadsPerBlockDimensions = 3u;
   size_t ReqdThreadsPerBlock[ReqdThreadsPerBlockDimensions];
@@ -267,11 +266,7 @@ struct ur_kernel_handle_t_ : ur::hip::handle_base {
 
   ur_program_handle_t getProgram() const noexcept { return Program; }
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   native_type get() const noexcept { return Function; };
 
@@ -310,4 +305,7 @@ struct ur_kernel_handle_t_ : ur::hip::handle_base {
   }
 
   uint32_t getLocalSize() const noexcept { return Args.getLocalSize(); }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/hip/memory.cpp
+++ b/unified-runtime/source/adapters/hip/memory.cpp
@@ -63,7 +63,7 @@ checkSupportedImageChannelType(ur_image_channel_type_t ImageChannelType) {
 UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
   try {
     // Do nothing if there are other references
-    if (hMem->decrementReferenceCount() > 0) {
+    if (hMem->getRefCounter().decrement() > 0) {
       return UR_RESULT_SUCCESS;
     }
 
@@ -259,7 +259,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
     return ReturnValue(hMemory->getContext());
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hMemory->getReferenceCount());
+    return ReturnValue(hMemory->getRefCounter().getCount());
   }
 
   default:
@@ -439,8 +439,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
-  UR_ASSERT(hMem->getReferenceCount() > 0, UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  hMem->incrementReferenceCount();
+  UR_ASSERT(hMem->getRefCounter().getCount() > 0,
+            UR_RESULT_ERROR_INVALID_MEM_OBJECT);
+  hMem->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/hip/memory.hpp
+++ b/unified-runtime/source/adapters/hip/memory.hpp
@@ -10,6 +10,8 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
+
 #include "context.hpp"
 #include "event.hpp"
 #include <cassert>
@@ -316,9 +318,6 @@ struct ur_mem_handle_t_ : ur::hip::handle_base {
   // Context where the memory object is accessible
   ur_context Context;
 
-  /// Reference counting of the handler
-  std::atomic_uint32_t RefCount;
-
   // Original mem flags passed
   ur_mem_flags_t MemFlags;
 
@@ -347,7 +346,7 @@ struct ur_mem_handle_t_ : ur::hip::handle_base {
   /// Constructs the UR mem handler for a non-typed allocation ("buffer")
   ur_mem_handle_t_(ur_context_handle_t Ctxt, ur_mem_flags_t MemFlags,
                    BufferMem::AllocMode Mode, void *HostPtr, size_t Size)
-      : Context{Ctxt}, RefCount{1}, MemFlags{MemFlags},
+      : Context{Ctxt}, MemFlags{MemFlags},
         HaveMigratedToDeviceSinceLastWrite(Context->Devices.size(), false),
         Mem{std::in_place_type<BufferMem>, Ctxt, this, Mode, HostPtr, Size} {
     urContextRetain(Context);
@@ -355,9 +354,9 @@ struct ur_mem_handle_t_ : ur::hip::handle_base {
 
   // Subbuffer constructor
   ur_mem_handle_t_(ur_mem Parent, size_t SubBufferOffset)
-      : handle_base(), Context{Parent->Context}, RefCount{1},
-        MemFlags{Parent->MemFlags}, HaveMigratedToDeviceSinceLastWrite(
-                                        Parent->Context->Devices.size(), false),
+      : handle_base(), Context{Parent->Context}, MemFlags{Parent->MemFlags},
+        HaveMigratedToDeviceSinceLastWrite(Parent->Context->Devices.size(),
+                                           false),
         Mem{BufferMem{std::get<BufferMem>(Parent->Mem)}} {
     auto &SubBuffer = std::get<BufferMem>(Mem);
     SubBuffer.Parent = Parent;
@@ -378,7 +377,7 @@ struct ur_mem_handle_t_ : ur::hip::handle_base {
   ur_mem_handle_t_(ur_context Ctxt, ur_mem_flags_t MemFlags,
                    ur_image_format_t ImageFormat, ur_image_desc_t ImageDesc,
                    void *HostPtr)
-      : Context{Ctxt}, RefCount{1}, MemFlags{MemFlags},
+      : Context{Ctxt}, MemFlags{MemFlags},
         HaveMigratedToDeviceSinceLastWrite(Context->Devices.size(), false),
         Mem{std::in_place_type<SurfaceMem>,
             Ctxt,
@@ -419,11 +418,7 @@ struct ur_mem_handle_t_ : ur::hip::handle_base {
 
   ur_context getContext() const noexcept { return Context; }
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   void setLastQueueWritingToMemObj(ur_queue_handle_t WritingQueue) {
     if (LastQueueWritingToMemObj != nullptr) {
@@ -436,4 +431,7 @@ struct ur_mem_handle_t_ : ur::hip::handle_base {
           Device == WritingQueue->getDevice();
     }
   }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/hip/physical_mem.hpp
+++ b/unified-runtime/source/adapters/hip/physical_mem.hpp
@@ -10,6 +10,8 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
+
 #include "device.hpp"
 #include "platform.hpp"
 
@@ -22,9 +24,8 @@ struct ur_physical_mem_handle_t_ : ur::hip::handle_base {
 
   ur_physical_mem_handle_t_() : handle_base(), RefCount(1) {}
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/hip/physical_mem.hpp
+++ b/unified-runtime/source/adapters/hip/physical_mem.hpp
@@ -20,9 +20,7 @@
 /// TODO: Implement.
 ///
 struct ur_physical_mem_handle_t_ : ur::hip::handle_base {
-  std::atomic_uint32_t RefCount;
-
-  ur_physical_mem_handle_t_() : handle_base(), RefCount(1) {}
+  ur_physical_mem_handle_t_() : handle_base() {}
 
   UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 

--- a/unified-runtime/source/adapters/hip/program.cpp
+++ b/unified-runtime/source/adapters/hip/program.cpp
@@ -385,7 +385,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
 
   switch (propName) {
   case UR_PROGRAM_INFO_REFERENCE_COUNT:
-    return ReturnValue(hProgram-- > getRefCounter().getCount());
+    return ReturnValue(hProgram->getRefCounter().getCount());
   case UR_PROGRAM_INFO_CONTEXT:
     return ReturnValue(hProgram->Context);
   case UR_PROGRAM_INFO_NUM_DEVICES:

--- a/unified-runtime/source/adapters/hip/program.cpp
+++ b/unified-runtime/source/adapters/hip/program.cpp
@@ -385,7 +385,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
 
   switch (propName) {
   case UR_PROGRAM_INFO_REFERENCE_COUNT:
-    return ReturnValue(hProgram->getReferenceCount());
+    return ReturnValue(hProgram-- > getRefCounter().getCount());
   case UR_PROGRAM_INFO_CONTEXT:
     return ReturnValue(hProgram->Context);
   case UR_PROGRAM_INFO_NUM_DEVICES:
@@ -418,8 +418,9 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRetain(ur_program_handle_t hProgram) {
-  UR_ASSERT(hProgram->getReferenceCount() > 0, UR_RESULT_ERROR_INVALID_PROGRAM);
-  hProgram->incrementReferenceCount();
+  UR_ASSERT(hProgram->getRefCounter().getCount() > 0,
+            UR_RESULT_ERROR_INVALID_PROGRAM);
+  hProgram->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -430,11 +431,11 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRelease(ur_program_handle_t hProgram) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  UR_ASSERT(hProgram->getReferenceCount() != 0,
+  UR_ASSERT(hProgram->getRefCounter().getCount() != 0,
             UR_RESULT_ERROR_INVALID_PROGRAM);
 
   // decrement ref count. If it is 0, delete the program.
-  if (hProgram->decrementReferenceCount() == 0) {
+  if (hProgram->getRefCounter().decrement() == 0) {
     std::unique_ptr<ur_program_handle_t_> ProgramPtr{hProgram};
     try {
       ScopedDevice Active(hProgram->getDevice());

--- a/unified-runtime/source/adapters/hip/program.hpp
+++ b/unified-runtime/source/adapters/hip/program.hpp
@@ -11,9 +11,9 @@
 
 #include <ur_api.h>
 
-#include <atomic>
 #include <unordered_map>
 
+#include "common/ur_ref_counter.hpp"
 #include "context.hpp"
 
 /// Implementation of UR Program on HIP Module object
@@ -22,7 +22,6 @@ struct ur_program_handle_t_ : ur::hip::handle_base {
   native_type Module;
   const char *Binary;
   size_t BinarySizeInBytes;
-  std::atomic_uint32_t RefCount;
   ur_context_handle_t Context;
   ur_device_handle_t Device;
   std::string ExecutableCache;
@@ -49,7 +48,7 @@ struct ur_program_handle_t_ : ur::hip::handle_base {
 
   ur_program_handle_t_(ur_context_handle_t Ctxt, ur_device_handle_t Device)
       : handle_base(), Module{nullptr}, Binary{}, BinarySizeInBytes{0},
-        RefCount{1}, Context{Ctxt}, Device{Device}, KernelReqdWorkGroupSizeMD{},
+        Context{Ctxt}, Device{Device}, KernelReqdWorkGroupSizeMD{},
         KernelReqdSubGroupSizeMD{} {
     urContextRetain(Context);
 
@@ -71,13 +70,12 @@ struct ur_program_handle_t_ : ur::hip::handle_base {
 
   native_type get() const noexcept { return Module; };
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   ur_result_t getGlobalVariablePointer(const char *name,
                                        hipDeviceptr_t *DeviceGlobal,
                                        size_t *DeviceGlobalSize);
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/hip/queue.cpp
+++ b/unified-runtime/source/adapters/hip/queue.cpp
@@ -107,7 +107,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(hQueue->Device);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(hQueue->getReferenceCount());
+    return ReturnValue(hQueue->getRefCounter().getCount());
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(hQueue->URFlags);
   case UR_QUEUE_INFO_EMPTY: {
@@ -135,14 +135,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
-  UR_ASSERT(hQueue->getReferenceCount() > 0, UR_RESULT_ERROR_INVALID_QUEUE);
+  UR_ASSERT(hQueue->getRefCounter().getCount() > 0,
+            UR_RESULT_ERROR_INVALID_QUEUE);
 
-  hQueue->incrementReferenceCount();
+  hQueue->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
-  if (hQueue->decrementReferenceCount() > 0) {
+  if (hQueue->getRefCounter().decrement() > 0) {
     return UR_RESULT_SUCCESS;
   }
 

--- a/unified-runtime/source/adapters/hip/sampler.cpp
+++ b/unified-runtime/source/adapters/hip/sampler.cpp
@@ -44,7 +44,7 @@ ur_result_t urSamplerGetInfo(ur_sampler_handle_t hSampler,
 
   switch (propName) {
   case UR_SAMPLER_INFO_REFERENCE_COUNT:
-    return ReturnValue(hSampler->getReferenceCount());
+    return ReturnValue(hSampler->getRefCounter().getCount());
   case UR_SAMPLER_INFO_CONTEXT:
     return ReturnValue(hSampler->Context);
   case UR_SAMPLER_INFO_NORMALIZED_COORDS: {
@@ -67,19 +67,19 @@ ur_result_t urSamplerGetInfo(ur_sampler_handle_t hSampler,
 }
 
 ur_result_t urSamplerRetain(ur_sampler_handle_t hSampler) {
-  hSampler->incrementReferenceCount();
+  hSampler->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  if (hSampler->getReferenceCount() == 0) {
+  if (hSampler->getRefCounter().getCount() == 0) {
     return UR_RESULT_ERROR_INVALID_SAMPLER;
   }
 
   // decrement ref count. If it is 0, delete the sampler.
-  if (hSampler->decrementReferenceCount() == 0) {
+  if (hSampler->getRefCounter().decrement() == 0) {
     delete hSampler;
   }
 

--- a/unified-runtime/source/adapters/hip/usm.cpp
+++ b/unified-runtime/source/adapters/hip/usm.cpp
@@ -439,14 +439,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolCreate(
 UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolRetain(
     /// [in] pointer to USM memory pool
     ur_usm_pool_handle_t Pool) {
-  Pool->incrementReferenceCount();
+  Pool->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolRelease(
     /// [in] pointer to USM memory pool
     ur_usm_pool_handle_t Pool) {
-  if (Pool->decrementReferenceCount() > 0) {
+  if (Pool->getRefCounter().decrement() > 0) {
     return UR_RESULT_SUCCESS;
   }
   Pool->Context->removePool(Pool);
@@ -469,7 +469,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolGetInfo(
 
   switch (propName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPool->getReferenceCount());
+    return ReturnValue(hPool->getRefCounter().getCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(hPool->Context);

--- a/unified-runtime/source/adapters/hip/usm.hpp
+++ b/unified-runtime/source/adapters/hip/usm.hpp
@@ -9,6 +9,7 @@
 //===-----------------------------------------------------------------===//
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
 #include <umf_helpers.hpp>
 #include <umf_pools/disjoint_pool_config_parser.hpp>
@@ -16,8 +17,6 @@
 usm::DisjointPoolAllConfigs InitializeDisjointPoolConfig();
 
 struct ur_usm_pool_handle_t_ : ur::hip::handle_base {
-  std::atomic_uint32_t RefCount = 1;
-
   ur_context_handle_t Context = nullptr;
 
   usm::DisjointPoolAllConfigs DisjointPoolConfigs =
@@ -30,13 +29,12 @@ struct ur_usm_pool_handle_t_ : ur::hip::handle_base {
   ur_usm_pool_handle_t_(ur_context_handle_t Context,
                         ur_usm_pool_desc_t *PoolDesc);
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   bool hasUMFPool(umf_memory_pool_t *umf_pool);
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 // Implements memory allocation via driver API for USM allocator interface

--- a/unified-runtime/source/adapters/level_zero/adapter.hpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.hpp
@@ -9,13 +9,14 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
-#include "logger/ur_logger.hpp"
-#include "ur_interface_loader.hpp"
-#include <atomic>
-#include <loader/ur_loader.hpp>
-#include <loader/ze_loader.h>
 #include <mutex>
 #include <optional>
+
+#include "common/ur_ref_counter.hpp"
+#include "logger/ur_logger.hpp"
+#include "ur_interface_loader.hpp"
+#include <loader/ur_loader.hpp>
+#include <loader/ze_loader.h>
 #include <ur/ur.hpp>
 #include <ze_api.h>
 #include <ze_ddi.h>
@@ -27,7 +28,6 @@ class ur_legacy_sink;
 
 struct ur_adapter_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_adapter_handle_t_();
-  std::atomic<uint32_t> RefCount = 0;
   std::mutex Mutex;
 
   zes_pfnDriverGetDeviceByUuidExp_t getDeviceByUUIdFunctionPtr = nullptr;
@@ -47,6 +47,11 @@ struct ur_adapter_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ZeCache<Result<PlatformVec>> PlatformCache;
   logger::Logger &logger;
   HMODULE processHandle = nullptr;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 extern ur_adapter_handle_t_ *GlobalAdapter;

--- a/unified-runtime/source/adapters/level_zero/async_alloc.cpp
+++ b/unified-runtime/source/adapters/level_zero/async_alloc.cpp
@@ -247,7 +247,7 @@ ur_result_t urEnqueueUSMFreeExp(
   }
 
   size_t size = umfPoolMallocUsableSize(hPool, Mem);
-  (*Event)->RefCount.increment();
+  (*Event)->getRefCounter().increment();
   usmPool->AsyncPool.insert(Mem, size, *Event, Queue);
 
   // Signal that USM free event was finished

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -842,13 +842,13 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  CommandBuffer->RefCount.increment();
+  CommandBuffer->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  if (!CommandBuffer->RefCount.decrementAndTest())
+  if (!CommandBuffer->getRefCounter().decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   UR_CALL(waitForOngoingExecution(CommandBuffer));
@@ -1644,7 +1644,7 @@ ur_result_t enqueueImmediateAppendPath(
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->RefCount.increment();
+  (*Event)->getRefCounter().increment();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(CommandListHelper, false, false));
@@ -1727,7 +1727,7 @@ ur_result_t enqueueWaitEventPath(ur_exp_command_buffer_handle_t CommandBuffer,
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->RefCount.increment();
+  (*Event)->getRefCounter().increment();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(SignalCommandList, false /*IsBlocking*/,
@@ -1851,7 +1851,7 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hCommandBuffer->RefCount.load()});
+    return ReturnValue(uint32_t{hCommandBuffer->getRefCounter().getCount()});
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/level_zero/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.hpp
@@ -16,7 +16,7 @@
 #include <zes_api.h>
 
 #include "common.hpp"
-
+#include "common/ur_ref_counter.hpp"
 #include "context.hpp"
 #include "kernel.hpp"
 #include "queue.hpp"
@@ -149,4 +149,9 @@ struct ur_exp_command_buffer_handle_t_ : public ur_object {
   // Track handle objects to free when command-buffer is destroyed.
   std::vector<std::unique_ptr<ur_exp_command_buffer_command_handle_t_>>
       CommandHandles;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -34,6 +34,7 @@
 #include <level_zero/ze_intel_gpu.h>
 #include <umf_pools/disjoint_pool_config_parser.hpp>
 
+#include "common/ur_ref_counter.hpp"
 #include "logger/ur_logger.hpp"
 #include "ur_interface_loader.hpp"
 
@@ -213,55 +214,9 @@ void zeParseError(ze_result_t ZeError, const char *&ErrorString);
 #define ZE_CALL_NOCHECK_NAME(ZeName, ZeArgs, callName)                         \
   ZeCall().doCall(ZeName ZeArgs, callName, #ZeArgs, false)
 
-// This wrapper around std::atomic is created to limit operations with reference
-// counter and to make allowed operations more transparent in terms of
-// thread-safety in the plugin. increment() and load() operations do not need a
-// mutex guard around them since the underlying data is already atomic.
-// decrementAndTest() method is used to guard a code which needs to be
-// executed when object's ref count becomes zero after release. This method also
-// doesn't need a mutex guard because decrement operation is atomic and only one
-// thread can reach ref count equal to zero, i.e. only a single thread can pass
-// through this check.
-struct ReferenceCounter {
-  ReferenceCounter() : RefCount{1} {}
-
-  // Reset the counter to the initial value.
-  void reset() { RefCount = 1; }
-
-  // Used when retaining an object.
-  void increment() { RefCount++; }
-
-  // Supposed to be used in ur*GetInfo* methods where ref count value is
-  // requested.
-  uint32_t load() { return RefCount.load(); }
-
-  // This method allows to guard a code which needs to be executed when object's
-  // ref count becomes zero after release. It is important to notice that only a
-  // single thread can pass through this check. This is true because of several
-  // reasons:
-  //   1. Decrement operation is executed atomically.
-  //   2. It is not allowed to retain an object after its refcount reaches zero.
-  //   3. It is not allowed to release an object more times than the value of
-  //   the ref count.
-  // 2. and 3. basically means that we can't use an object at all as soon as its
-  // refcount reaches zero. Using this check guarantees that code for deleting
-  // an object and releasing its resources is executed once by a single thread
-  // and we don't need to use any mutexes to guard access to this object in the
-  // scope after this check. Of course if we access another objects in this code
-  // (not the one which is being deleted) then access to these objects must be
-  // guarded, for example with a mutex.
-  bool decrementAndTest() { return --RefCount == 0; }
-
-private:
-  std::atomic<uint32_t> RefCount;
-};
-
 // Base class to store common data
 struct ur_object : ur::handle_base<ur::level_zero::ddi_getter> {
-  ur_object() : handle_base(), RefCount{} {}
-
-  // Must be atomic to prevent data race when incrementing/decrementing.
-  ReferenceCounter RefCount;
+  ur_object() : handle_base() {}
 
   // This mutex protects accesses to all the non-const member variables.
   // Exclusive access is required to modify any of these members.
@@ -296,6 +251,11 @@ struct MemAllocRecord : ur_object {
   // TODO: this should go away when memory isolation issue is fixed in the Level
   // Zero runtime.
   ur_context_handle_t Context;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 extern usm::DisjointPoolAllConfigs DisjointPoolConfigInstance;

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -61,7 +61,7 @@ ur_result_t urContextRetain(
 
     /// [in] handle of the context to get a reference of.
     ur_context_handle_t Context) {
-  Context->RefCount.increment();
+  Context->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -113,7 +113,7 @@ ur_result_t urContextGetInfo(
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(uint32_t(Context->Devices.size()));
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Context->RefCount.load()});
+    return ReturnValue(uint32_t{Context->getRefCounter().getCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // 2D USM memcpy is supported.
     return ReturnValue(uint8_t{UseMemcpy2DOperations});
@@ -251,7 +251,7 @@ ur_device_handle_t ur_context_handle_t_::getRootDevice() const {
 // from the list of tracked contexts.
 ur_result_t ContextReleaseHelper(ur_context_handle_t Context) {
 
-  if (!Context->RefCount.decrementAndTest())
+  if (!Context->getRefCounter().decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   if (IndirectAccessTrackingEnabled) {

--- a/unified-runtime/source/adapters/level_zero/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/context.hpp
@@ -23,6 +23,7 @@
 #include <zes_api.h>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "queue.hpp"
 #include "usm.hpp"
 
@@ -358,6 +359,8 @@ struct ur_context_handle_t_ : ur_object {
   // Get handle to the L0 context
   ze_context_handle_t getZeHandle() const;
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   enum EventFlags {
     EVENT_FLAG_HOST_VISIBLE = UR_BIT(0),
@@ -404,6 +407,8 @@ private:
 
     return &EventCaches[index];
   }
+
+  UR_ReferenceCounter RefCounter;
 };
 
 // Helper function to release the context, a caller must lock the platform-level

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -454,7 +454,7 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue((uint32_t)Device->SubDevices.size());
   }
   case UR_DEVICE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Device->RefCount.load()});
+    return ReturnValue(uint32_t{Device->getRefCounter().getCount()});
   case UR_DEVICE_INFO_SUPPORTED_PARTITIONS: {
     // SYCL spec says: if this SYCL device cannot be partitioned into at least
     // two sub devices then the returned vector must be empty.
@@ -1629,7 +1629,7 @@ ur_result_t urDeviceGetGlobalTimestamps(
 ur_result_t urDeviceRetain(ur_device_handle_t Device) {
   // The root-device ref-count remains unchanged (always 1).
   if (Device->isSubDevice()) {
-    Device->RefCount.increment();
+    Device->getRefCounter().increment();
   }
   return UR_RESULT_SUCCESS;
 }
@@ -1637,7 +1637,7 @@ ur_result_t urDeviceRetain(ur_device_handle_t Device) {
 ur_result_t urDeviceRelease(ur_device_handle_t Device) {
   // Root devices are destroyed during the piTearDown process.
   if (Device->isSubDevice()) {
-    if (Device->RefCount.decrementAndTest()) {
+    if (Device->getRefCounter().decrement() == 0) {
       delete Device;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -20,6 +20,7 @@
 
 #include "adapters/level_zero/platform.hpp"
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include <ur/ur.hpp>
 #include <ur_ddi.h>
 #include <ze_api.h>
@@ -212,6 +213,8 @@ struct ur_device_handle_t_ : ur_object {
     return ValidBits == 64 ? ~0ULL : (1ULL << ValidBits) - 1ULL;
   }
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
   // Cache of the immutable device properties.
   ZeCache<ZeStruct<ze_device_properties_t>> ZeDeviceProperties;
   ZeCache<ZeStruct<ze_device_compute_properties_t>> ZeDeviceComputeProperties;
@@ -238,6 +241,9 @@ struct ur_device_handle_t_ : ur_object {
 
   // unique ephemeral identifer of the device in the adapter
   std::optional<DeviceId> Id;
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 inline std::vector<ur_device_handle_t>

--- a/unified-runtime/source/adapters/level_zero/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/event.hpp
@@ -250,7 +250,9 @@ struct ur_event_handle_t_ : ur_object {
   ur_event_handle_t OriginAllocEvent = nullptr;
 
   UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
-  UR_ReferenceCounter &getRefCounterExternal() noexcept { return RefCounterExternal; }
+  UR_ReferenceCounter &getRefCounterExternal() noexcept {
+    return RefCounterExternal;
+  }
 
 private:
   UR_ReferenceCounter RefCounter;

--- a/unified-runtime/source/adapters/level_zero/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/event.hpp
@@ -25,6 +25,8 @@
 #include <zes_api.h>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
+
 #include "queue.hpp"
 #include "ur_api.h"
 
@@ -220,23 +222,7 @@ struct ur_event_handle_t_ : ur_object {
   uint64_t RecordEventStartTimestamp = 0;
   uint64_t RecordEventEndTimestamp = 0;
 
-  // Besides each PI object keeping a total reference count in
-  // ur_object::RefCount we keep special track of the event *external*
-  // references. This way we are able to tell when the event is not referenced
-  // externally anymore, i.e. it can't be passed as a dependency event to
-  // piEnqueue* functions and explicitly waited meaning that we can do some
-  // optimizations:
-  // 1. For in-order queues we can reset and reuse event even if it was not yet
-  // completed by submitting a reset command to the queue (since there are no
-  // external references, we know that nobody can wait this event somewhere in
-  // parallel thread or pass it as a dependency which may lead to hang)
-  // 2. We can avoid creating host proxy event.
-  // This counter doesn't track the lifetime of an event object. Even if it
-  // reaches zero an event object may not be destroyed and can be used
-  // internally in the plugin.
-  std::atomic<uint32_t> RefCountExternal{0};
-
-  bool hasExternalRefs() { return RefCountExternal != 0; }
+  bool hasExternalRefs() { return RefCounterExternal.getCount() != 0; }
 
   // Reset ur_event_handle_t object.
   ur_result_t reset();
@@ -262,6 +248,28 @@ struct ur_event_handle_t_ : ur_object {
   // Used only for asynchronous allocations. This is the event originally used
   // on async free to indicate when the allocation can be used again.
   ur_event_handle_t OriginAllocEvent = nullptr;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+  UR_ReferenceCounter &getRefCounterExternal() noexcept { return RefCounterExternal; }
+
+private:
+  UR_ReferenceCounter RefCounter;
+
+  // Besides each PI object keeping a total reference count in
+  // ur_object::RefCount we keep special track of the event *external*
+  // references. This way we are able to tell when the event is not referenced
+  // externally anymore, i.e. it can't be passed as a dependency event to
+  // piEnqueue* functions and explicitly waited meaning that we can do some
+  // optimizations:
+  // 1. For in-order queues we can reset and reuse event even if it was not yet
+  // completed by submitting a reset command to the queue (since there are no
+  // external references, we know that nobody can wait this event somewhere in
+  // parallel thread or pass it as a dependency which may lead to hang)
+  // 2. We can avoid creating host proxy event.
+  // This counter doesn't track the lifetime of an event object. Even if it
+  // reaches zero an event object may not be destroyed and can be used
+  // internally in the plugin.
+  UR_ReferenceCounter RefCounterExternal;
 };
 
 // Helper function to implement zeHostSynchronize.

--- a/unified-runtime/source/adapters/level_zero/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/event.hpp
@@ -257,11 +257,11 @@ struct ur_event_handle_t_ : ur_object {
 private:
   UR_ReferenceCounter RefCounter;
 
-  // Besides each PI object keeping a total reference count in
-  // ur_object::RefCount we keep special track of the event *external*
+  // Besides each UR object keeping a total reference count in
+  // RefCounter we keep special track of the event *external*
   // references. This way we are able to tell when the event is not referenced
   // externally anymore, i.e. it can't be passed as a dependency event to
-  // piEnqueue* functions and explicitly waited meaning that we can do some
+  // urEnqueue* functions and explicitly waited meaning that we can do some
   // optimizations:
   // 1. For in-order queues we can reset and reuse event even if it was not yet
   // completed by submitting a reset command to the queue (since there are no

--- a/unified-runtime/source/adapters/level_zero/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.cpp
@@ -787,7 +787,7 @@ ur_result_t urKernelGetInfo(
     }
   }
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Kernel->RefCount.load()});
+    return ReturnValue(uint32_t{Kernel->getRefCounter().getCount()});
   case UR_KERNEL_INFO_ATTRIBUTES:
     try {
       uint32_t Size;
@@ -938,7 +938,7 @@ ur_result_t urKernelGetSubGroupInfo(
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t Kernel) {
-  Kernel->RefCount.increment();
+  Kernel->getRefCounter().increment();
 
   return UR_RESULT_SUCCESS;
 }
@@ -946,7 +946,7 @@ ur_result_t urKernelRetain(
 ur_result_t urKernelRelease(
     /// [in] handle for the Kernel to release
     ur_kernel_handle_t Kernel) {
-  if (!Kernel->RefCount.decrementAndTest())
+  if (!Kernel->getRefCounter().decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   auto KernelProgram = Kernel->Program;

--- a/unified-runtime/source/adapters/level_zero/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.hpp
@@ -9,9 +9,11 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
-#include "common.hpp"
-#include "memory.hpp"
 #include <unordered_set>
+
+#include "common.hpp"
+#include "common/ur_ref_counter.hpp"
+#include "memory.hpp"
 
 struct ur_kernel_handle_t_ : ur_object {
   ur_kernel_handle_t_(bool OwnZeHandle, ur_program_handle_t Program)
@@ -106,6 +108,11 @@ struct ur_kernel_handle_t_ : ur_object {
   // Cache of the kernel properties.
   ZeCache<ZeStruct<ze_kernel_properties_t>> ZeKernelProperties;
   ZeCache<std::string> ZeKernelName;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 ur_result_t getZeKernel(ze_device_handle_t hDevice, ur_kernel_handle_t hKernel,

--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -1052,7 +1052,7 @@ ur_result_t urEnqueueMemBufferMap(
 
     // Add the event to the command list.
     CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-    (*Event)->RefCount.increment();
+    (*Event)->getRefCounter().increment();
 
     const auto &ZeCommandList = CommandList->first;
     const auto &WaitList = (*Event)->WaitList;
@@ -1183,7 +1183,7 @@ ur_result_t urEnqueueMemUnmap(
       nullptr /*ForcedCmdQueue*/));
 
   CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-  (*Event)->RefCount.increment();
+  (*Event)->getRefCounter().increment();
 
   const auto &ZeCommandList = CommandList->first;
 
@@ -1635,14 +1635,14 @@ ur_result_t urMemBufferCreate(
 ur_result_t urMemRetain(
     /// [in] handle of the memory object to get access
     ur_mem_handle_t Mem) {
-  Mem->RefCount.increment();
+  Mem->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urMemRelease(
     /// [in] handle of the memory object to release
     ur_mem_handle_t Mem) {
-  if (!Mem->RefCount.decrementAndTest())
+  if (!Mem->getRefCounter().decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   if (Mem->isImage()) {
@@ -1848,7 +1848,7 @@ ur_result_t urMemGetInfo(
     return ReturnValue(size_t{Buffer->Size});
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Buffer->RefCount.load());
+    return ReturnValue(Buffer->getRefCounter().getCount());
   }
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;

--- a/unified-runtime/source/adapters/level_zero/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/memory.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "context.hpp"
 #include "event.hpp"
 #include "program.hpp"
@@ -90,6 +91,8 @@ struct ur_mem_handle_t_ : ur_object {
   // Method to get type of the derived object (image or buffer)
   bool isImage() const { return mem_type == mem_type_t::image; }
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 protected:
   ur_mem_handle_t_(mem_type_t type, ur_context_handle_t Context)
       : UrContext{Context}, UrDevice{nullptr}, mem_type(type) {}
@@ -101,6 +104,9 @@ protected:
   // Since the destructor isn't virtual, callers must destruct it via ur_buffer
   // or ur_image
   ~ur_mem_handle_t_() {};
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 struct ur_buffer final : ur_mem_handle_t_ {
@@ -116,7 +122,7 @@ struct ur_buffer final : ur_mem_handle_t_ {
       : ur_mem_handle_t_(mem_type_t::buffer, Parent->UrContext), Size(Size),
         SubBuffer{{Parent, Origin}} {
     // Retain the Parent Buffer due to the Creation of the SubBuffer.
-    Parent->RefCount.increment();
+    Parent->getRefCounter().increment();
   }
 
   // Interop-buffer constructor

--- a/unified-runtime/source/adapters/level_zero/physical_mem.cpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.cpp
@@ -42,12 +42,12 @@ ur_result_t urPhysicalMemCreate(
 }
 
 ur_result_t urPhysicalMemRetain(ur_physical_mem_handle_t hPhysicalMem) {
-  hPhysicalMem->RefCount.increment();
+  hPhysicalMem->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urPhysicalMemRelease(ur_physical_mem_handle_t hPhysicalMem) {
-  if (!hPhysicalMem->RefCount.decrementAndTest())
+  if (!hPhysicalMem->getRefCounter().decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {
@@ -68,7 +68,7 @@ ur_result_t urPhysicalMemGetInfo(ur_physical_mem_handle_t hPhysicalMem,
 
   switch (propName) {
   case UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPhysicalMem->RefCount.load());
+    return ReturnValue(hPhysicalMem->getRefCounter().getCount());
   }
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;

--- a/unified-runtime/source/adapters/level_zero/physical_mem.hpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
 struct ur_physical_mem_handle_t_ : ur_object {
   ur_physical_mem_handle_t_(ze_physical_mem_handle_t ZePhysicalMem,
@@ -21,4 +22,9 @@ struct ur_physical_mem_handle_t_ : ur_object {
 
   // Keeps the PI context of this memory handle.
   ur_context_handle_t Context;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/level_zero/program.cpp
+++ b/unified-runtime/source/adapters/level_zero/program.cpp
@@ -558,14 +558,14 @@ ur_result_t urProgramLinkExp(
 ur_result_t urProgramRetain(
     /// [in] handle for the Program to retain
     ur_program_handle_t Program) {
-  Program->RefCount.increment();
+  Program->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urProgramRelease(
     /// [in] handle for the Program to release
     ur_program_handle_t Program) {
-  if (!Program->RefCount.decrementAndTest())
+  if (!Program->getRefCounter().decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   delete Program;
@@ -708,7 +708,7 @@ ur_result_t urProgramGetInfo(
 
   switch (PropName) {
   case UR_PROGRAM_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Program->RefCount.load()});
+    return ReturnValue(uint32_t{Program->getRefCounter().getCount()});
   case UR_PROGRAM_INFO_CONTEXT:
     return ReturnValue(Program->Context);
   case UR_PROGRAM_INFO_NUM_DEVICES:
@@ -1115,7 +1115,7 @@ void ur_program_handle_t_::ur_release_program_resources(bool deletion) {
   // must be destroyed before the Module can be destroyed.  So, be sure
   // to destroy build log before destroying the module.
   if (!deletion) {
-    if (!RefCount.decrementAndTest()) {
+    if (!RefCounter.decrement() == 0) {
       return;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/program.hpp
+++ b/unified-runtime/source/adapters/level_zero/program.hpp
@@ -10,6 +10,8 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
+
 #include "device.hpp"
 
 struct ur_program_handle_t_ : ur_object {
@@ -226,6 +228,8 @@ struct ur_program_handle_t_ : ur_object {
   // UR_PROGRAM_INFO_BINARY_SIZES.
   const std::vector<ur_device_handle_t> AssociatedDevices;
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   struct DeviceData {
     // Log from the result of building the program for the device using
@@ -264,4 +268,6 @@ private:
   // handle from the program.
   // TODO: Currently interoparability UR API does not support multiple devices.
   ze_module_handle_t InteropZeModule = nullptr;
+
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/level_zero/queue.hpp
+++ b/unified-runtime/source/adapters/level_zero/queue.hpp
@@ -691,8 +691,8 @@ struct ur_queue_handle_t_ : ur_object {
 private:
   UR_ReferenceCounter RefCounter;
 
-  // Besides each PI object keeping a total reference count in
-  // ur_object::RefCount we keep special track of the queue *external*
+  // Besides each UR object keeping a total reference count in
+  // RefCounter we keep special track of the queue *external*
   // references. This way we are able to tell when the queue is being finished
   // externally, and can wait for internal references to complete, and do proper
   // cleanup of the queue.

--- a/unified-runtime/source/adapters/level_zero/queue.hpp
+++ b/unified-runtime/source/adapters/level_zero/queue.hpp
@@ -684,7 +684,9 @@ struct ur_queue_handle_t_ : ur_object {
   ur_queue_handle_t_ *UnifiedHandle;
 
   UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
-  UR_ReferenceCounter &getRefCounterExternal() noexcept { return RefCounterExternal; }
+  UR_ReferenceCounter &getRefCounterExternal() noexcept {
+    return RefCounterExternal;
+  }
 
 private:
   UR_ReferenceCounter RefCounter;

--- a/unified-runtime/source/adapters/level_zero/sampler.cpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.cpp
@@ -124,14 +124,14 @@ ur_result_t urSamplerCreate(
 ur_result_t urSamplerRetain(
     /// [in] handle of the sampler object to get access
     ur_sampler_handle_t Sampler) {
-  Sampler->RefCount.increment();
+  Sampler->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urSamplerRelease(
     /// [in] handle of the sampler object to release
     ur_sampler_handle_t Sampler) {
-  if (!Sampler->RefCount.decrementAndTest())
+  if (!Sampler->getRefCounter().decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {

--- a/unified-runtime/source/adapters/level_zero/sampler.hpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
 struct ur_sampler_handle_t_ : ur_object {
   ur_sampler_handle_t_(ze_sampler_handle_t Sampler) : ZeSampler{Sampler} {}
@@ -18,6 +19,11 @@ struct ur_sampler_handle_t_ : ur_object {
   ze_sampler_handle_t ZeSampler;
 
   ZeStruct<ze_sampler_desc_t> ZeSamplerDesc;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 // Construct ZE sampler desc from UR sampler desc.

--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -523,14 +523,14 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t Pool) {
-  Pool->RefCount.increment();
+  Pool->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t Pool) {
-  if (Pool->RefCount.decrementAndTest()) {
+  if (Pool->getRefCounter().decrement() == 0) {
     std::scoped_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
     Pool->Context->UsmPoolHandles.remove(Pool);
     delete Pool;
@@ -553,7 +553,7 @@ ur_result_t urUSMPoolGetInfo(
 
   switch (PropName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Pool->RefCount.load());
+    return ReturnValue(Pool->getRefCounter().getCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(Pool->Context);
@@ -1250,7 +1250,7 @@ ur_result_t ZeMemFreeHelper(ur_context_handle_t Context, void *Ptr) {
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.RefCount.decrementAndTest()) {
+    if (!It->second.getRefCounter().decrement() == 0) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }
@@ -1297,7 +1297,7 @@ ur_result_t USMFreeHelper(ur_context_handle_t Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.RefCount.decrementAndTest()) {
+    if (!It->second.getRefCounter().decrement() == 0) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }

--- a/unified-runtime/source/adapters/level_zero/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/usm.hpp
@@ -9,13 +9,14 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
-#include "common.hpp"
+#include <set>
 
+#include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "enqueued_pool.hpp"
 #include "event.hpp"
 #include "ur_api.h"
 #include "ur_pool_manager.hpp"
-#include <set>
 #include <umf_helpers.hpp>
 
 usm::DisjointPoolAllConfigs InitializeDisjointPoolConfig();
@@ -53,9 +54,12 @@ struct ur_usm_pool_handle_t_ : ur_object {
 
   ur_context_handle_t Context;
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   UsmPool *getPool(const usm::pool_descriptor &Desc);
   usm::pool_manager<usm::pool_descriptor, UsmPool> PoolManager;
+  UR_ReferenceCounter RefCounter;
 };
 
 // Exception type to pass allocation errors

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -261,7 +261,7 @@ urCommandBufferCreateExp(ur_context_handle_t context, ur_device_handle_t device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  hCommandBuffer->RefCount.increment();
+  hCommandBuffer->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -269,7 +269,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  if (!hCommandBuffer->RefCount.decrementAndTest())
+  if (!hCommandBuffer->getRefCounter().decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   if (auto executionEvent = hCommandBuffer->getExecutionEventUnlocked()) {
@@ -633,7 +633,7 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hCommandBuffer->RefCount.load()});
+    return ReturnValue(uint32_t{hCommandBuffer->getRefCounter().getCount()});
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -12,6 +12,7 @@
 #include "../helpers/mutable_helpers.hpp"
 #include "command_list_manager.hpp"
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "context.hpp"
 #include "kernel.hpp"
 #include "lockable.hpp"
@@ -53,6 +54,8 @@ struct ur_exp_command_buffer_handle_t_ : public ur_object {
   ur_event_handle_t
   createEventIfRequested(ur_exp_command_buffer_sync_point_t *retSyncPoint);
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   v2::raii::cache_borrowed_event_pool eventPool;
 
@@ -86,4 +89,6 @@ public:
   const bool isProfilingEnabled = false;
 
   lockable<ur_command_list_manager> commandListManager;
+
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -915,7 +915,7 @@ ur_result_t ur_command_list_manager::appendNativeCommandExp(
 void ur_command_list_manager::recordSubmittedKernel(
     ur_kernel_handle_t hKernel) {
   submittedKernels.push_back(hKernel);
-  hKernel->RefCount.increment();
+  hKernel->getRefCounter().increment();
 }
 
 ze_command_list_handle_t ur_command_list_manager::getZeCommandList() {

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -80,12 +80,12 @@ ur_context_handle_t_::ur_context_handle_t_(ze_context_handle_t hContext,
       defaultUSMPool(this, nullptr), asyncPool(this, nullptr) {}
 
 ur_result_t ur_context_handle_t_::retain() {
-  RefCount.increment();
+  RefCounter.increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_context_handle_t_::release() {
-  if (!RefCount.decrementAndTest())
+  if (!RefCounter.decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   delete this;
@@ -201,7 +201,7 @@ ur_result_t urContextGetInfo(ur_context_handle_t hContext,
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(uint32_t(hContext->getDevices().size()));
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hContext->RefCount.load()});
+    return ReturnValue(uint32_t{hContext->getRefCounter().getCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // TODO: this is currently not implemented
     return ReturnValue(uint8_t{false});

--- a/unified-runtime/source/adapters/level_zero/v2/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.hpp
@@ -14,6 +14,8 @@
 
 #include "command_list_cache.hpp"
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
+
 #include "event_pool_cache.hpp"
 #include "usm.hpp"
 
@@ -64,6 +66,8 @@ struct ur_context_handle_t_ : ur_object {
   // For that the Device or its root devices need to be in the context.
   bool isValidDevice(ur_device_handle_t Device) const;
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   const v2::raii::ze_context_handle_t hContext;
   const std::vector<ur_device_handle_t> hDevices;
@@ -81,4 +85,6 @@ private:
   ur_usm_pool_handle_t_ defaultUSMPool;
   ur_usm_pool_handle_t_ asyncPool;
   std::list<ur_usm_pool_handle_t> usmPoolHandles;
+
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -160,12 +160,12 @@ ze_event_handle_t ur_event_handle_t_::getZeEvent() const {
 }
 
 ur_result_t ur_event_handle_t_::retain() {
-  RefCount.increment();
+  RefCounter.increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_event_handle_t_::release() {
-  if (!RefCount.decrementAndTest())
+  if (!RefCounter.decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   if (event_pool) {
@@ -258,7 +258,7 @@ ur_result_t urEventGetInfo(ur_event_handle_t hEvent, ur_event_info_t propName,
     }
   }
   case UR_EVENT_INFO_REFERENCE_COUNT: {
-    return returnValue(hEvent->RefCount.load());
+    return returnValue(hEvent->getRefCounter().increment());
   }
   case UR_EVENT_INFO_COMMAND_QUEUE: {
     auto urQueueHandle = reinterpret_cast<uintptr_t>(hEvent->getQueue()) -

--- a/unified-runtime/source/adapters/level_zero/v2/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.hpp
@@ -17,6 +17,7 @@
 
 #include "adapters/level_zero/v2/queue_api.hpp"
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "event_provider.hpp"
 
 namespace v2 {
@@ -112,9 +113,13 @@ public:
   uint64_t getEventStartTimestmap() const;
   uint64_t getEventEndTimestamp();
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   ur_event_handle_t_(ur_context_handle_t hContext, event_variant hZeEvent,
                      v2::event_flags_t flags, v2::event_pool *pool);
+
+  UR_ReferenceCounter RefCounter;
 
 protected:
   ur_context_handle_t hContext;

--- a/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
@@ -52,8 +52,8 @@ void event_pool::free(ur_event_handle_t event) {
   freelist.push_back(event);
 
   // The event is still in the pool, so we need to increment the refcount
-  assert(event->RefCount.load() == 0);
-  event->RefCount.increment();
+  assert(event->getRefCounter().getCount() == 0);
+  event->getRefCounter().increment();
 }
 
 event_provider *event_pool::getProvider() const { return provider.get(); }

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
@@ -97,7 +97,7 @@ ur_kernel_handle_t_::ur_kernel_handle_t_(
 }
 
 ur_result_t ur_kernel_handle_t_::release() {
-  if (!RefCount.decrementAndTest())
+  if (!RefCounter.decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   // manually release kernels to allow errors to be propagated
@@ -370,7 +370,7 @@ urKernelCreateWithNativeHandle(ur_native_handle_t hNativeKernel,
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t hKernel) try {
-  hKernel->RefCount.increment();
+  hKernel->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -634,7 +634,7 @@ ur_result_t urKernelGetInfo(ur_kernel_handle_t hKernel,
                        spills.size());
   }
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hKernel->RefCount.load()});
+    return ReturnValue(uint32_t{hKernel->getRefCounter().getCount()});
   case UR_KERNEL_INFO_ATTRIBUTES: {
     auto attributes = hKernel->getSourceAttributes();
     return ReturnValue(static_cast<const char *>(attributes.data()));

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
@@ -13,6 +13,7 @@
 #include "../program.hpp"
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "memory.hpp"
 
 struct ur_single_device_kernel_t {
@@ -91,6 +92,8 @@ public:
                                    ze_command_list_handle_t cmdList,
                                    wait_list_view &waitListView);
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   // Keep the program of the kernel.
   const ur_program_handle_t hProgram;
@@ -116,4 +119,6 @@ private:
 
   // pointer to any non-null kernel in deviceKernels
   ur_single_device_kernel_t *nonEmptyKernel;
+
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -671,7 +671,7 @@ ur_result_t urMemGetInfo(ur_mem_handle_t hMem, ur_mem_info_t propName,
     return returnValue(size_t{hMem->getBuffer()->getSize()});
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return returnValue(hMem->getObject()->RefCount.load());
+    return returnValue(hMem->getRefCounter().getCount());
   }
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
@@ -684,14 +684,14 @@ ur_result_t urMemGetInfo(ur_mem_handle_t hMem, ur_mem_info_t propName,
 }
 
 ur_result_t urMemRetain(ur_mem_handle_t hMem) try {
-  hMem->getObject()->RefCount.increment();
+  hMem->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
 
 ur_result_t urMemRelease(ur_mem_handle_t hMem) try {
-  if (!hMem->getObject()->RefCount.decrementAndTest())
+  if (!hMem->getRefCounter().decrement() == 0)
     return UR_RESULT_SUCCESS;
 
   delete hMem;

--- a/unified-runtime/source/adapters/level_zero/v2/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.hpp
@@ -19,6 +19,7 @@
 #include "../image_common.hpp"
 #include "command_list_manager.hpp"
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "lockable.hpp"
 
 using usm_unique_ptr_t = std::unique_ptr<void, std::function<void(void *)>>;
@@ -280,15 +281,9 @@ struct ur_mem_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
         mem);
   }
 
-  ur_object *getObject() {
-    return std::visit(
-        [](auto &&arg) -> ur_object * {
-          return static_cast<ur_object *>(&arg);
-        },
-        mem);
-  }
-
   bool isImage() const { return std::holds_alternative<ur_mem_image_t>(mem); }
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
 private:
   template <typename T, typename... Args>
@@ -300,4 +295,6 @@ private:
                ur_discrete_buffer_handle_t, ur_shared_buffer_handle_t,
                ur_mem_sub_buffer_t, ur_mem_image_t>
       mem;
+
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
@@ -48,7 +48,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRetain() {
     return std::visit(
         [](auto &q) {
-          q.RefCount.increment();
+          q.getRefCounter().increment();
           return UR_RESULT_SUCCESS;
         },
         queue_data);
@@ -57,7 +57,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRelease() {
     return std::visit(
         [queueHandle = this](auto &q) {
-          if (!q.RefCount.decrementAndTest())
+          if (!q.getRefCounter().decrement() == 0)
             return UR_RESULT_SUCCESS;
           delete queueHandle;
           return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -64,7 +64,7 @@ ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(hDevice);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{RefCount.load()});
+    return ReturnValue(uint32_t{RefCounter.getCount()});
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(flags);
   case UR_QUEUE_INFO_SIZE:

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -11,6 +11,7 @@
 
 #include "../common.hpp"
 #include "../device.hpp"
+#include "common/ur_ref_counter.hpp"
 
 #include "context.hpp"
 #include "event.hpp"
@@ -452,6 +453,11 @@ public:
         pfnNativeEnqueue, data, numMemsInMemList, phMemList, pProperties,
         numEventsInWaitList, phEventWaitList, createEventIfRequested(phEvent));
   }
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 } // namespace v2

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -332,7 +332,7 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
-  hPool->RefCount.increment();
+  hPool->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 } catch (umf_result_t e) {
   return umf::umf2urResult(e);
@@ -343,7 +343,7 @@ urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t hPool) try {
-  if (hPool->RefCount.decrementAndTest()) {
+  if (hPool->getRefCounter().decrement() == 0) {
     hPool->getContextHandle()->removeUsmPool(hPool);
     delete hPool;
   }
@@ -369,7 +369,7 @@ ur_result_t urUSMPoolGetInfo(
 
   switch (propName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPool->RefCount.load());
+    return ReturnValue(hPool->getRefCounter().getCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(hPool->getContextHandle());

--- a/unified-runtime/source/adapters/level_zero/v2/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.hpp
@@ -14,6 +14,7 @@
 
 #include "../enqueued_pool.hpp"
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "event.hpp"
 #include "ur_pool_manager.hpp"
 
@@ -49,9 +50,13 @@ struct ur_usm_pool_handle_t_ : ur_object {
   void cleanupPools();
   void cleanupPoolsForQueue(void *hQueue);
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   ur_context_handle_t hContext;
   usm::pool_manager<usm::pool_descriptor, UsmPool> poolManager;
 
   UsmPool *getPool(const usm::pool_descriptor &desc);
+
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/native_cpu/adapter.cpp
+++ b/unified-runtime/source/adapters/native_cpu/adapter.cpp
@@ -13,14 +13,17 @@
 #include "ur_api.h"
 
 struct ur_adapter_handle_t_ : ur::native_cpu::handle_base {
-  std::atomic<uint32_t> RefCount = 0;
   logger::Logger &logger = logger::get_logger("native_cpu");
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 } Adapter;
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
     uint32_t, ur_adapter_handle_t *phAdapters, uint32_t *pNumAdapters) {
   if (phAdapters) {
-    Adapter.RefCount++;
+    Adapter.getRefCounter().increment();
     *phAdapters = &Adapter;
   }
   if (pNumAdapters) {
@@ -30,12 +33,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
-  Adapter.RefCount--;
+  Adapter.getRefCounter().decrement();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRetain(ur_adapter_handle_t) {
-  Adapter.RefCount++;
+  Adapter.getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -57,7 +60,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   case UR_ADAPTER_INFO_BACKEND:
     return ReturnValue(UR_BACKEND_NATIVE_CPU);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
-    return ReturnValue(Adapter.RefCount.load());
+    return ReturnValue(Adapter.getRefCounter().getCount());
   case UR_ADAPTER_INFO_VERSION:
     return ReturnValue(uint32_t{1});
   default:

--- a/unified-runtime/source/adapters/native_cpu/common.hpp
+++ b/unified-runtime/source/adapters/native_cpu/common.hpp
@@ -10,9 +10,11 @@
 
 #pragma once
 
+#include <chrono>
+
+#include "common/ur_ref_counter.hpp"
 #include "logger/ur_logger.hpp"
 #include "ur/ur.hpp"
-#include <chrono>
 
 constexpr size_t MaxMessageSize = 256;
 
@@ -43,25 +45,6 @@ struct ddi_getter {
 };
 using handle_base = ur::handle_base<ddi_getter>;
 } // namespace ur::native_cpu
-
-// Todo: replace this with a common helper once it is available
-struct RefCounted : ur::native_cpu::handle_base {
-  std::atomic_uint32_t _refCount;
-  uint32_t incrementReferenceCount() { return ++_refCount; }
-  uint32_t decrementReferenceCount() { return --_refCount; }
-  RefCounted() : handle_base(), _refCount{1} {}
-  uint32_t getReferenceCount() const { return _refCount; }
-};
-
-// Base class to store common data
-struct ur_object : RefCounted {
-  ur_shared_mutex Mutex;
-};
-
-template <typename T> inline void decrementOrDelete(T *refC) {
-  if (refC->decrementReferenceCount() == 0)
-    delete refC;
-}
 
 inline uint64_t get_timestamp() {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/unified-runtime/source/adapters/native_cpu/context.cpp
+++ b/unified-runtime/source/adapters/native_cpu/context.cpp
@@ -30,13 +30,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRetain(ur_context_handle_t hContext) {
-  hContext->incrementReferenceCount();
+  hContext->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
-  decrementOrDelete(hContext);
+  if (hContext->getRefCounter().decrement() == 0) {
+    delete hContext;
+  }
   return UR_RESULT_SUCCESS;
 }
 
@@ -51,7 +53,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   case UR_CONTEXT_INFO_DEVICES:
     return returnValue(hContext->_device);
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return returnValue(uint32_t{hContext->getReferenceCount()});
+    return returnValue(uint32_t{hContext->getRefCounter().getCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     return returnValue(true);
   case UR_CONTEXT_INFO_USM_FILL2D_SUPPORT:

--- a/unified-runtime/source/adapters/native_cpu/context.hpp
+++ b/unified-runtime/source/adapters/native_cpu/context.hpp
@@ -15,6 +15,7 @@
 #include <ur_api.h>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "device.hpp"
 #include "ur/ur.hpp"
 
@@ -83,7 +84,7 @@ static usm_alloc_info get_alloc_info(void *ptr) {
 
 } // namespace native_cpu
 
-struct ur_context_handle_t_ : RefCounted {
+struct ur_context_handle_t_ {
   ur_context_handle_t_(ur_device_handle_t_ *phDevices) : _device{phDevices} {}
 
   ur_device_handle_t _device;
@@ -135,7 +136,11 @@ struct ur_context_handle_t_ : RefCounted {
     return ptr;
   }
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   std::mutex alloc_mutex;
   std::set<const void *> allocations;
+
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/native_cpu/event.cpp
+++ b/unified-runtime/source/adapters/native_cpu/event.cpp
@@ -28,7 +28,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
   case UR_EVENT_INFO_COMMAND_TYPE:
     return ReturnValue(hEvent->getCommandType());
   case UR_EVENT_INFO_REFERENCE_COUNT:
-    return ReturnValue(hEvent->getReferenceCount());
+    return ReturnValue(hEvent->getRefCounter().getCount());
   case UR_EVENT_INFO_COMMAND_EXECUTION_STATUS:
     return ReturnValue(hEvent->getExecutionStatus());
   case UR_EVENT_INFO_CONTEXT:
@@ -69,12 +69,14 @@ urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
-  hEvent->incrementReferenceCount();
+  hEvent->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
-  decrementOrDelete(hEvent);
+  if (hEvent->getRefCounter().decrement() == 0) {
+    delete hEvent;
+  }
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/native_cpu/event.hpp
+++ b/unified-runtime/source/adapters/native_cpu/event.hpp
@@ -8,14 +8,17 @@
 //
 //===----------------------------------------------------------------------===//
 #pragma once
-#include "common.hpp"
-#include "ur_api.h"
+
 #include <cstdint>
 #include <future>
 #include <mutex>
 #include <vector>
 
-struct ur_event_handle_t_ : RefCounted {
+#include "common.hpp"
+#include "common/ur_ref_counter.hpp"
+#include "ur_api.h"
+
+struct ur_event_handle_t_ {
 
   ur_event_handle_t_(ur_queue_handle_t queue, ur_command_t command_type);
 
@@ -55,6 +58,8 @@ struct ur_event_handle_t_ : RefCounted {
 
   uint64_t get_end_timestamp() const { return timestamp_end; }
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   ur_queue_handle_t queue;
   ur_context_handle_t context;
@@ -65,4 +70,6 @@ private:
   std::packaged_task<void()> callback;
   uint64_t timestamp_start = 0;
   uint64_t timestamp_end = 0;
+
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/native_cpu/kernel.cpp
+++ b/unified-runtime/source/adapters/native_cpu/kernel.cpp
@@ -95,7 +95,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
   case UR_KERNEL_INFO_FUNCTION_NAME:
     return ReturnValue(hKernel->_name);
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hKernel->getReferenceCount()});
+    return ReturnValue(uint32_t{hKernel->getRefCounter().getCount()});
   case UR_KERNEL_INFO_ATTRIBUTES:
     return ReturnValue("");
   case UR_KERNEL_INFO_SPILL_MEM_SIZE:
@@ -194,13 +194,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSubGroupInfo(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
-  hKernel->incrementReferenceCount();
+  hKernel->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelRelease(ur_kernel_handle_t hKernel) {
-  decrementOrDelete(hKernel);
+  if (hKernel->getRefCounter().decrement() == 0) {
+    delete hKernel;
+  }
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/native_cpu/memory.cpp
+++ b/unified-runtime/source/adapters/native_cpu/memory.cpp
@@ -64,7 +64,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t /*hMem*/) {
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
   UR_ASSERT(hMem, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-  decrementOrDelete(hMem);
+  if (hMem->getRefCounter().decrement() == 0) {
+    delete hMem;
+  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -78,7 +80,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
                 !(static_cast<ur_buffer *>(hBuffer))->isSubBuffer(),
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
-  std::shared_lock<ur_shared_mutex> Guard(hBuffer->Mutex);
+  std::shared_lock<ur_shared_mutex> Guard(hBuffer->getMutex());
 
   if (flags != UR_MEM_FLAG_READ_WRITE) {
     die("urMemBufferPartition: NativeCPU implements only read-write buffer,"

--- a/unified-runtime/source/adapters/native_cpu/memory.hpp
+++ b/unified-runtime/source/adapters/native_cpu/memory.hpp
@@ -10,14 +10,13 @@
 
 #pragma once
 
-#include <atomic>
 #include <cstdlib>
 #include <cstring>
 
 #include "common.hpp"
 #include "context.hpp"
 
-struct ur_mem_handle_t_ : ur_object {
+struct ur_mem_handle_t_ {
   ur_mem_handle_t_(size_t Size, bool _IsImage)
       : _mem{static_cast<char *>(malloc(Size))}, _ownsMem{true},
         IsImage{_IsImage} {}
@@ -44,8 +43,13 @@ struct ur_mem_handle_t_ : ur_object {
   char *_mem;
   bool _ownsMem;
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+  ur_shared_mutex &getMutex() noexcept { return Mutex; }
+
 private:
   const bool IsImage;
+  UR_ReferenceCounter RefCounter;
+  ur_shared_mutex Mutex;
 };
 
 struct ur_buffer final : ur_mem_handle_t_ {

--- a/unified-runtime/source/adapters/native_cpu/program.cpp
+++ b/unified-runtime/source/adapters/native_cpu/program.cpp
@@ -171,13 +171,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramLinkExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRetain(ur_program_handle_t hProgram) {
-  hProgram->incrementReferenceCount();
+  hProgram->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRelease(ur_program_handle_t hProgram) {
-  decrementOrDelete(hProgram);
+  if (hProgram->getRefCounter().decrement() == 0) {
+    delete hProgram;
+  }
   return UR_RESULT_SUCCESS;
 }
 
@@ -205,7 +207,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
 
   switch (propName) {
   case UR_PROGRAM_INFO_REFERENCE_COUNT:
-    return returnValue(hProgram->getReferenceCount());
+    return returnValue(hProgram->getRefCounter().getCount());
   case UR_PROGRAM_INFO_CONTEXT:
     return returnValue(nullptr);
   case UR_PROGRAM_INFO_NUM_DEVICES:

--- a/unified-runtime/source/adapters/native_cpu/program.hpp
+++ b/unified-runtime/source/adapters/native_cpu/program.hpp
@@ -12,6 +12,7 @@
 
 #include <ur_api.h>
 
+#include "common/ur_ref_counter.hpp"
 #include "context.hpp"
 
 #include <array>
@@ -21,11 +22,9 @@ namespace native_cpu {
 using WGSize_t = std::array<uint32_t, 3>;
 }
 
-struct ur_program_handle_t_ : RefCounted {
+struct ur_program_handle_t_ {
   ur_program_handle_t_(ur_context_handle_t ctx, const unsigned char *pBinary)
       : _ctx{ctx}, _ptr{pBinary} {}
-
-  uint32_t getReferenceCount() const noexcept { return _refCount; }
 
   ur_context_handle_t _ctx;
   const unsigned char *_ptr;
@@ -41,6 +40,11 @@ struct ur_program_handle_t_ : RefCounted {
   std::unordered_map<std::string, native_cpu::WGSize_t>
       KernelMaxWorkGroupSizeMD;
   std::unordered_map<std::string, uint64_t> KernelMaxLinearWorkGroupSizeMD;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 // The nativecpu_entry struct is also defined as LLVM-IR in the

--- a/unified-runtime/source/adapters/native_cpu/queue.cpp
+++ b/unified-runtime/source/adapters/native_cpu/queue.cpp
@@ -28,7 +28,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(hQueue->getDevice());
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(hQueue->getReferenceCount());
+    return ReturnValue(hQueue->getRefCounter().getCount());
   case UR_QUEUE_INFO_EMPTY:
     return ReturnValue(hQueue->isEmpty());
   default:
@@ -48,13 +48,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
-  hQueue->incrementReferenceCount();
+  hQueue->getRefCounter().increment();
 
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
-  decrementOrDelete(hQueue);
+  if (hQueue->getRefCounter().decrement() == 0) {
+    delete hQueue;
+  }
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/native_cpu/queue.hpp
+++ b/unified-runtime/source/adapters/native_cpu/queue.hpp
@@ -46,12 +46,14 @@ struct ur_queue_handle_t_ {
       auto ev = *events.begin();
       // ur_event_handle_t_::wait removes itself from the events set in the
       // queue.
-      ev->incrementReferenceCount();
+      ev->getRefCounter().increment();
       // Unlocking mutex for removeEvent and for event callbacks that may need
       // to acquire it.
       lock.unlock();
       ev->wait();
-      decrementOrDelete(ev);
+      if (ev->getRefCounter().decrement() == 0) {
+        delete ev;
+      }
       lock.lock();
     }
   }

--- a/unified-runtime/source/adapters/native_cpu/queue.hpp
+++ b/unified-runtime/source/adapters/native_cpu/queue.hpp
@@ -8,12 +8,15 @@
 //
 //===----------------------------------------------------------------------===//
 #pragma once
-#include "common.hpp"
-#include "event.hpp"
-#include "ur_api.h"
+
 #include <set>
 
-struct ur_queue_handle_t_ : RefCounted {
+#include "common.hpp"
+#include "common/ur_ref_counter.hpp"
+#include "event.hpp"
+#include "ur_api.h"
+
+struct ur_queue_handle_t_ {
   ur_queue_handle_t_(ur_device_handle_t device, ur_context_handle_t context,
                      const ur_queue_properties_t *pProps)
       : device(device), context(context),
@@ -64,6 +67,8 @@ struct ur_queue_handle_t_ : RefCounted {
     return events.size() == 0;
   }
 
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
 private:
   ur_device_handle_t device;
   ur_context_handle_t context;
@@ -71,4 +76,6 @@ private:
   const bool inOrder;
   const bool profilingEnabled;
   std::mutex mutex;
+
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/offload/adapter.cpp
+++ b/unified-runtime/source/adapters/offload/adapter.cpp
@@ -67,7 +67,7 @@ ur_result_t ur_adapter_handle_t_::init() {
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
     uint32_t, ur_adapter_handle_t *phAdapters, uint32_t *pNumAdapters) {
   if (phAdapters) {
-    if (++Adapter.RefCount == 1) {
+    if (Adapter.getRefCounter().increment() == 1) {
       Adapter.init();
     }
     *phAdapters = &Adapter;
@@ -79,7 +79,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
-  if (--Adapter.RefCount == 0) {
+  if (Adapter.getRefCounter().decrement() == 0) {
     // This can crash when tracing is enabled.
     // olShutDown();
   };
@@ -87,7 +87,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRetain(ur_adapter_handle_t) {
-  Adapter.RefCount++;
+  Adapter.getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -102,7 +102,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   case UR_ADAPTER_INFO_BACKEND:
     return ReturnValue(UR_BACKEND_OFFLOAD);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
-    return ReturnValue(Adapter.RefCount.load());
+    return ReturnValue(Adapter.getRefCounter().getCount());
   case UR_ADAPTER_INFO_VERSION:
     return ReturnValue(1);
   default:

--- a/unified-runtime/source/adapters/offload/adapter.hpp
+++ b/unified-runtime/source/adapters/offload/adapter.hpp
@@ -10,23 +10,27 @@
 
 #pragma once
 
-#include <atomic>
 #include <cstdint>
 #include <unordered_set>
 
 #include <OffloadAPI.h>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "logger/ur_logger.hpp"
 #include "platform.hpp"
 
 struct ur_adapter_handle_t_ : ur::offload::handle_base {
-  std::atomic_uint32_t RefCount = 0;
   logger::Logger &Logger = logger::get_logger("offload");
   ol_device_handle_t HostDevice = nullptr;
   std::vector<std::unique_ptr<ur_platform_handle_t_>> Platforms;
 
   ur_result_t init();
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 extern ur_adapter_handle_t_ Adapter;

--- a/unified-runtime/source/adapters/offload/common.hpp
+++ b/unified-runtime/source/adapters/offload/common.hpp
@@ -19,7 +19,3 @@ struct ddi_getter {
 };
 using handle_base = ur::handle_base<ur::offload::ddi_getter>;
 } // namespace ur::offload
-
-struct RefCounted : ur::offload::handle_base {
-  std::atomic_uint32_t RefCount = 1;
-};

--- a/unified-runtime/source/adapters/offload/context.cpp
+++ b/unified-runtime/source/adapters/offload/context.cpp
@@ -34,7 +34,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   case UR_CONTEXT_INFO_DEVICES:
     return ReturnValue(&hContext->Device, 1);
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(hContext->RefCount.load());
+    return ReturnValue(hContext->getRefCounter().getCount());
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
   case UR_CONTEXT_INFO_USM_FILL2D_SUPPORT:
     return ReturnValue(false);
@@ -47,13 +47,13 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRetain(ur_context_handle_t hContext) {
-  hContext->RefCount++;
+  hContext->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
-  if (--hContext->RefCount == 0) {
+  if (hContext->getRefCounter().decrement() == 0) {
     delete hContext;
   }
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/offload/context.hpp
+++ b/unified-runtime/source/adapters/offload/context.hpp
@@ -10,14 +10,16 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "adapter.hpp"
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "device.hpp"
 #include <OffloadAPI.h>
-#include <unordered_map>
 #include <ur_api.h>
 
-struct ur_context_handle_t_ : RefCounted {
+struct ur_context_handle_t_ {
   ur_context_handle_t_(ur_device_handle_t hDevice) : Device{hDevice} {
     urDeviceRetain(Device);
   }
@@ -25,4 +27,9 @@ struct ur_context_handle_t_ : RefCounted {
 
   ur_device_handle_t Device;
   std::unordered_map<void *, ol_alloc_type_t> AllocTypeMap;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/offload/event.cpp
+++ b/unified-runtime/source/adapters/offload/event.cpp
@@ -23,7 +23,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hKernel,
 
   switch (propName) {
   case UR_EVENT_INFO_REFERENCE_COUNT:
-    return ReturnValue(hKernel->RefCount.load());
+    return ReturnValue(hKernel->getRefCounter().getCount());
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
@@ -51,13 +51,13 @@ urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
-  hEvent->RefCount++;
+  hEvent->getRefCounter().increment();
 
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
-  if (--hEvent->RefCount == 0) {
+  if (hEvent->getRefCounter().decrement() == 0) {
     // There's a small bug in olDestroyEvent that will crash. Leak the event
     // in the meantime.
     // auto Res = olDestroyEvent(hEvent->OffloadEvent);

--- a/unified-runtime/source/adapters/offload/event.hpp
+++ b/unified-runtime/source/adapters/offload/event.hpp
@@ -14,7 +14,13 @@
 #include <ur_api.h>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
-struct ur_event_handle_t_ : RefCounted {
+struct ur_event_handle_t_ {
   ol_event_handle_t OffloadEvent;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/offload/kernel.cpp
+++ b/unified-runtime/source/adapters/offload/kernel.cpp
@@ -43,7 +43,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
 
   switch (propName) {
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(hKernel->RefCount.load());
+    return ReturnValue(hKernel->getRefCounter().getCount());
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
@@ -52,13 +52,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
-  hKernel->RefCount++;
+  hKernel->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelRelease(ur_kernel_handle_t hKernel) {
-  if (--hKernel->RefCount == 0) {
+  if (hKernel->getRefCounter().decrement() == 0) {
     delete hKernel;
   }
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/offload/kernel.hpp
+++ b/unified-runtime/source/adapters/offload/kernel.hpp
@@ -18,8 +18,9 @@
 #include <vector>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
-struct ur_kernel_handle_t_ : RefCounted {
+struct ur_kernel_handle_t_ {
 
   // Simplified version of the CUDA adapter's argument implementation
   struct OffloadKernelArguments {
@@ -79,4 +80,9 @@ struct ur_kernel_handle_t_ : RefCounted {
 
   ol_kernel_handle_t OffloadKernel;
   OffloadKernelArguments Args{};
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/offload/memory.cpp
+++ b/unified-runtime/source/adapters/offload/memory.cpp
@@ -72,12 +72,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
-  hMem->RefCount++;
+  hMem->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
-  if (--hMem->RefCount > 0) {
+  if (hMem->getRefCounter().getCount() > 0) {
     return UR_RESULT_SUCCESS;
   }
 
@@ -109,7 +109,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
     return ReturnValue(hMemory->getContext());
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hMemory->RefCount.load());
+    return ReturnValue(hMemory->getRefCounter().getCount());
   }
 
   default:

--- a/unified-runtime/source/adapters/offload/memory.hpp
+++ b/unified-runtime/source/adapters/offload/memory.hpp
@@ -13,6 +13,7 @@
 #include "ur_api.h"
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
 struct BufferMem {
   enum class AllocMode {
@@ -40,7 +41,7 @@ struct BufferMem {
   size_t getSize() const noexcept { return Size; }
 };
 
-struct ur_mem_handle_t_ : RefCounted {
+struct ur_mem_handle_t_ {
   ur_context_handle_t Context;
 
   enum class Type { Buffer } MemType;
@@ -61,4 +62,9 @@ struct ur_mem_handle_t_ : RefCounted {
   ~ur_mem_handle_t_() { urContextRelease(Context); }
 
   ur_context_handle_t getContext() const noexcept { return Context; }
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/offload/program.cpp
+++ b/unified-runtime/source/adapters/offload/program.cpp
@@ -221,7 +221,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
 
   switch (propName) {
   case UR_PROGRAM_INFO_REFERENCE_COUNT:
-    return ReturnValue(hProgram->RefCount.load());
+    return ReturnValue(hProgram->getRefCounter().getCount());
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
@@ -231,13 +231,13 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRetain(ur_program_handle_t hProgram) {
-  hProgram->RefCount++;
+  hProgram->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRelease(ur_program_handle_t hProgram) {
-  if (--hProgram->RefCount == 0) {
+  if (hProgram->getRefCounter().decrement() == 0) {
     auto Res = olDestroyProgram(hProgram->OffloadProgram);
     if (Res) {
       return offloadResultToUR(Res);

--- a/unified-runtime/source/adapters/offload/program.hpp
+++ b/unified-runtime/source/adapters/offload/program.hpp
@@ -14,7 +14,13 @@
 #include <ur_api.h>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
-struct ur_program_handle_t_ : RefCounted {
+struct ur_program_handle_t_ {
   ol_program_handle_t OffloadProgram;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/offload/queue.cpp
+++ b/unified-runtime/source/adapters/offload/queue.cpp
@@ -46,7 +46,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
 
   switch (propName) {
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(hQueue->RefCount.load());
+    return ReturnValue(hQueue->getRefCounter().getCount());
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
@@ -55,12 +55,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
-  hQueue->RefCount++;
+  hQueue->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
-  if (--hQueue->RefCount == 0) {
+  if (hQueue->getRefCounter().decrement() == 0) {
     auto Res = olDestroyQueue(hQueue->OffloadQueue);
     if (Res) {
       return offloadResultToUR(Res);

--- a/unified-runtime/source/adapters/offload/queue.hpp
+++ b/unified-runtime/source/adapters/offload/queue.hpp
@@ -16,7 +16,7 @@
 #include "common.hpp"
 #include "common/ur_ref_counter.hpp"
 
-struct ur_queue_handle_t_ : RefCounted {
+struct ur_queue_handle_t_ {
   ol_queue_handle_t OffloadQueue;
   ol_device_handle_t OffloadDevice;
 

--- a/unified-runtime/source/adapters/offload/queue.hpp
+++ b/unified-runtime/source/adapters/offload/queue.hpp
@@ -14,8 +14,14 @@
 #include <ur_api.h>
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
 struct ur_queue_handle_t_ : RefCounted {
   ol_queue_handle_t OffloadQueue;
   ol_device_handle_t OffloadDevice;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/opencl/adapter.cpp
+++ b/unified-runtime/source/adapters/opencl/adapter.cpp
@@ -78,7 +78,7 @@ urAdapterGet(uint32_t NumEntries, ur_adapter_handle_t *phAdapters,
     }
 
     auto &adapter = *phAdapters;
-    adapter->RefCount++;
+    adapter->getRefCounter().increment();
   }
 
   if (pNumAdapters) {
@@ -90,13 +90,13 @@ urAdapterGet(uint32_t NumEntries, ur_adapter_handle_t *phAdapters,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urAdapterRetain(ur_adapter_handle_t hAdapter) {
-  ++hAdapter->RefCount;
+  hAdapter->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urAdapterRelease(ur_adapter_handle_t hAdapter) {
-  if (--hAdapter->RefCount == 0) {
+  if (hAdapter->getRefCounter().decrement() == 0) {
     delete hAdapter;
   }
   return UR_RESULT_SUCCESS;
@@ -119,7 +119,7 @@ urAdapterGetInfo(ur_adapter_handle_t hAdapter, ur_adapter_info_t propName,
   case UR_ADAPTER_INFO_BACKEND:
     return ReturnValue(UR_BACKEND_OPENCL);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
-    return ReturnValue(hAdapter->RefCount.load());
+    return ReturnValue(hAdapter->getRefCounter().getCount());
   case UR_ADAPTER_INFO_VERSION:
     return ReturnValue(uint32_t{1});
   default:

--- a/unified-runtime/source/adapters/opencl/adapter.hpp
+++ b/unified-runtime/source/adapters/opencl/adapter.hpp
@@ -15,7 +15,7 @@
 
 #include "CL/cl.h"
 #include "common.hpp"
-#include "logger/ur_logger.hpp"
+#include "common/ur_ref_counter.hpp"
 
 struct ur_adapter_handle_t_ : ur::opencl::handle_base {
   ur_adapter_handle_t_();
@@ -24,7 +24,6 @@ struct ur_adapter_handle_t_ : ur::opencl::handle_base {
   ur_adapter_handle_t_(ur_adapter_handle_t_ &) = delete;
   ur_adapter_handle_t_ &operator=(const ur_adapter_handle_t_ &) = delete;
 
-  std::atomic<uint32_t> RefCount = 0;
   logger::Logger &log = logger::get_logger("opencl");
   cl_ext::ExtFuncPtrCacheT fnCache{};
 
@@ -37,6 +36,11 @@ struct ur_adapter_handle_t_ : ur::opencl::handle_base {
 #define CL_CORE_FUNCTION(FUNC) decltype(::FUNC) *FUNC = nullptr;
 #include "core_functions.def"
 #undef CL_CORE_FUNCTION
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 namespace ur {

--- a/unified-runtime/source/adapters/opencl/command_buffer.cpp
+++ b/unified-runtime/source/adapters/opencl/command_buffer.cpp
@@ -108,13 +108,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
-  hCommandBuffer->incrementReferenceCount();
+  hCommandBuffer->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
-  if (hCommandBuffer->decrementReferenceCount() == 0) {
+  if (hCommandBuffer->getRefCounter().decrement() == 0) {
     delete hCommandBuffer;
   }
 
@@ -783,7 +783,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferGetInfoExp(
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(hCommandBuffer->getReferenceCount());
+    return ReturnValue(hCommandBuffer->getRefCounter().getCount());
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/opencl/command_buffer.hpp
+++ b/unified-runtime/source/adapters/opencl/command_buffer.hpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include <ur/ur.hpp>
 
 /// Handle to a kernel command.
@@ -53,8 +54,6 @@ struct ur_exp_command_buffer_handle_t_ : ur::opencl::handle_base {
   /// List of commands in the command-buffer.
   std::vector<std::unique_ptr<ur_exp_command_buffer_command_handle_t_>>
       CommandHandles;
-  /// Object reference count
-  std::atomic_uint32_t RefCount;
   /// Track last submission of the command-buffer
   cl_event LastSubmission;
 
@@ -66,11 +65,12 @@ struct ur_exp_command_buffer_handle_t_ : ur::opencl::handle_base {
       : handle_base(), hInternalQueue(hQueue), hContext(hContext),
         hDevice(hDevice), CLCommandBuffer(CLCommandBuffer),
         IsUpdatable(IsUpdatable), IsInOrder(IsInOrder), IsFinalized(false),
-        RefCount(0), LastSubmission(nullptr) {}
+        LastSubmission(nullptr) {}
 
   ~ur_exp_command_buffer_handle_t_();
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/opencl/context.cpp
+++ b/unified-runtime/source/adapters/opencl/context.cpp
@@ -117,9 +117,6 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
-  static std::mutex contextReleaseMutex;
-
-  std::lock_guard<std::mutex> lock(contextReleaseMutex);
   if (hContext->getRefCounter().decrement() == 0) {
     delete hContext;
   }

--- a/unified-runtime/source/adapters/opencl/context.cpp
+++ b/unified-runtime/source/adapters/opencl/context.cpp
@@ -108,7 +108,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
     return ReturnValue(&hContext->Devices[0], hContext->DeviceCount);
   }
   case UR_CONTEXT_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hContext->getReferenceCount());
+    return ReturnValue(hContext->getRefCounter().getCount());
   }
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
@@ -120,7 +120,7 @@ urContextRelease(ur_context_handle_t hContext) {
   static std::mutex contextReleaseMutex;
 
   std::lock_guard<std::mutex> lock(contextReleaseMutex);
-  if (hContext->decrementReferenceCount() == 0) {
+  if (hContext->getRefCounter().decrement() == 0) {
     delete hContext;
   }
 
@@ -129,7 +129,7 @@ urContextRelease(ur_context_handle_t hContext) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRetain(ur_context_handle_t hContext) {
-  hContext->incrementReferenceCount();
+  hContext->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/opencl/device.cpp
+++ b/unified-runtime/source/adapters/opencl/device.cpp
@@ -1019,7 +1019,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return UR_RESULT_SUCCESS;
   }
   case UR_DEVICE_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hDevice->getReferenceCount());
+    return ReturnValue(hDevice->getRefCounter().getCount());
   }
   case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES: {
     CL_RETURN_ON_FAILURE(clGetDeviceInfo(hDevice->CLDevice,
@@ -1568,7 +1568,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
 // Root devices ref count are unchanged through out the program lifetime.
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceRetain(ur_device_handle_t hDevice) {
   if (hDevice->ParentDevice) {
-    hDevice->incrementReferenceCount();
+    hDevice->getRefCounter().increment();
   }
 
   return UR_RESULT_SUCCESS;
@@ -1578,7 +1578,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceRetain(ur_device_handle_t hDevice) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceRelease(ur_device_handle_t hDevice) {
   if (hDevice->ParentDevice) {
-    if (hDevice->decrementReferenceCount() == 0) {
+    if (hDevice->getRefCounter().decrement() == 0) {
       delete hDevice;
     }
   }

--- a/unified-runtime/source/adapters/opencl/device.hpp
+++ b/unified-runtime/source/adapters/opencl/device.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "device.hpp"
 #include "platform.hpp"
 
@@ -51,11 +52,7 @@ struct ur_device_handle_t_ : ur::opencl::handle_base {
     }
   }
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   ur_result_t getDeviceVersion(oclv::OpenCLVersion &Version) {
     size_t DevVerSize = 0;
@@ -114,4 +111,7 @@ struct ur_device_handle_t_ : ur::opencl::handle_base {
 
     return UR_RESULT_SUCCESS;
   }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/opencl/device.hpp
+++ b/unified-runtime/source/adapters/opencl/device.hpp
@@ -20,13 +20,11 @@ struct ur_device_handle_t_ : ur::opencl::handle_base {
   ur_platform_handle_t Platform;
   cl_device_type Type = 0;
   ur_device_handle_t ParentDevice = nullptr;
-  std::atomic<uint32_t> RefCount = 0;
   bool IsNativeHandleOwned = true;
 
   ur_device_handle_t_(native_type Dev, ur_platform_handle_t Plat,
                       ur_device_handle_t Parent)
       : handle_base(), CLDevice(Dev), Platform(Plat), ParentDevice(Parent) {
-    RefCount = 1;
     if (Parent) {
       Type = Parent->Type;
       [[maybe_unused]] auto Res = clRetainDevice(CLDevice);

--- a/unified-runtime/source/adapters/opencl/event.cpp
+++ b/unified-runtime/source/adapters/opencl/event.cpp
@@ -136,14 +136,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
-  if (hEvent->decrementReferenceCount() == 0) {
+  if (hEvent->getRefCounter().decrement() == 0) {
     delete hEvent;
   }
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
-  hEvent->incrementReferenceCount();
+  hEvent->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -188,7 +188,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
     return ReturnValue(hEvent->Queue);
   }
   case UR_EVENT_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hEvent->getReferenceCount());
+    return ReturnValue(hEvent->getRefCounter().getCount());
   }
   default: {
     size_t CheckPropSize = 0;

--- a/unified-runtime/source/adapters/opencl/kernel.cpp
+++ b/unified-runtime/source/adapters/opencl/kernel.cpp
@@ -152,7 +152,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
     return ReturnValue(hKernel->Context);
   }
   case UR_KERNEL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hKernel->getReferenceCount());
+    return ReturnValue(hKernel->getRefCounter().getCount());
   }
   default: {
     size_t CheckPropSize = 0;
@@ -343,13 +343,13 @@ urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
-  hKernel->incrementReferenceCount();
+  hKernel->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelRelease(ur_kernel_handle_t hKernel) {
-  if (hKernel->decrementReferenceCount() == 0) {
+  if (hKernel->getRefCounter().decrement() == 0) {
     delete hKernel;
   }
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/opencl/kernel.hpp
+++ b/unified-runtime/source/adapters/opencl/kernel.hpp
@@ -11,6 +11,7 @@
 
 #include "adapter.hpp"
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "context.hpp"
 #include "program.hpp"
 
@@ -21,14 +22,12 @@ struct ur_kernel_handle_t_ : ur::opencl::handle_base {
   native_type CLKernel;
   ur_program_handle_t Program;
   ur_context_handle_t Context;
-  std::atomic<uint32_t> RefCount = 0;
   bool IsNativeHandleOwned = true;
   clSetKernelArgMemPointerINTEL_fn clSetKernelArgMemPointerINTEL = nullptr;
 
   ur_kernel_handle_t_(native_type Kernel, ur_program_handle_t Program,
                       ur_context_handle_t Context)
       : handle_base(), CLKernel(Kernel), Program(Program), Context(Context) {
-    RefCount = 1;
     urProgramRetain(Program);
     urContextRetain(Context);
 
@@ -46,14 +45,13 @@ struct ur_kernel_handle_t_ : ur::opencl::handle_base {
     }
   }
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   static ur_result_t makeWithNative(native_type NativeKernel,
                                     ur_program_handle_t Program,
                                     ur_context_handle_t Context,
                                     ur_kernel_handle_t &Kernel);
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/opencl/memory.cpp
+++ b/unified-runtime/source/adapters/opencl/memory.cpp
@@ -521,7 +521,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
     return ReturnValue(hMemory->Context);
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hMemory->getReferenceCount());
+    return ReturnValue(hMemory->getRefCounter().getCount());
   }
   default: {
     size_t CheckPropSize = 0;
@@ -569,12 +569,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
-  hMem->incrementReferenceCount();
+  hMem->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
-  if (hMem->decrementReferenceCount() == 0) {
+  if (hMem->getRefCounter().decrement() == 0) {
     delete hMem;
   }
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/opencl/memory.hpp
+++ b/unified-runtime/source/adapters/opencl/memory.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "context.hpp"
 
 #include <vector>
@@ -18,12 +19,10 @@ struct ur_mem_handle_t_ : ur::opencl::handle_base {
   using native_type = cl_mem;
   native_type CLMemory;
   ur_context_handle_t Context;
-  std::atomic<uint32_t> RefCount = 0;
   bool IsNativeHandleOwned = true;
 
   ur_mem_handle_t_(native_type Mem, ur_context_handle_t Ctx)
       : handle_base(), CLMemory(Mem), Context(Ctx) {
-    RefCount = 1;
     urContextRetain(Context);
   }
 
@@ -34,13 +33,12 @@ struct ur_mem_handle_t_ : ur::opencl::handle_base {
     }
   }
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   static ur_result_t makeWithNative(native_type NativeMem,
                                     ur_context_handle_t Ctx,
                                     ur_mem_handle_t &Mem);
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/opencl/program.cpp
+++ b/unified-runtime/source/adapters/opencl/program.cpp
@@ -223,7 +223,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
     return ReturnValue(hProgram->Devices.data(), hProgram->NumDevices);
   }
   case UR_PROGRAM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hProgram->getReferenceCount());
+    return ReturnValue(hProgram->getRefCounter().getCount());
   }
   default: {
     size_t CheckPropSize = 0;
@@ -383,13 +383,13 @@ urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRetain(ur_program_handle_t hProgram) {
-  hProgram->incrementReferenceCount();
+  hProgram->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRelease(ur_program_handle_t hProgram) {
-  if (hProgram->decrementReferenceCount() == 0) {
+  if (hProgram->getRefCounter().decrement() == 0) {
     delete hProgram;
   }
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/opencl/queue.cpp
+++ b/unified-runtime/source/adapters/opencl/queue.cpp
@@ -234,7 +234,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
     return ReturnValue(mapCLQueuePropsToUR(QueueProperties));
   }
   case UR_QUEUE_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hQueue->getReferenceCount());
+    return ReturnValue(hQueue->getRefCounter().getCount());
   }
   default: {
     size_t CheckPropSize = 0;
@@ -289,12 +289,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueFlush(ur_queue_handle_t hQueue) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
-  hQueue->incrementReferenceCount();
+  hQueue->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
-  if (hQueue->decrementReferenceCount() == 0) {
+  if (hQueue->getRefCounter().decrement() == 0) {
     delete hQueue;
   }
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/opencl/queue.hpp
+++ b/unified-runtime/source/adapters/opencl/queue.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "context.hpp"
 #include "device.hpp"
 
@@ -22,7 +23,6 @@ struct ur_queue_handle_t_ : ur::opencl::handle_base {
   ur_device_handle_t Device;
   // Used to keep a handle to the default queue alive if it is different
   std::optional<ur_queue_handle_t> DeviceDefault = std::nullopt;
-  std::atomic<uint32_t> RefCount = 0;
   bool IsNativeHandleOwned = true;
   // Used to implement UR_QUEUE_INFO_EMPTY query
   bool IsInOrder;
@@ -32,7 +32,7 @@ struct ur_queue_handle_t_ : ur::opencl::handle_base {
                      ur_device_handle_t Dev, bool InOrder)
       : handle_base(), CLQueue(Queue), Context(Ctx), Device(Dev),
         IsInOrder(InOrder) {
-    RefCount = 1;
+
     urDeviceRetain(Device);
     urContextRetain(Context);
   }
@@ -53,11 +53,7 @@ struct ur_queue_handle_t_ : ur::opencl::handle_base {
     }
   }
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   // Stores last event for in-order queues. Has no effect if queue is Out Of
   // Order. The last event is used to implement UR_QUEUE_INFO_EMPTY query.
@@ -74,4 +70,7 @@ struct ur_queue_handle_t_ : ur::opencl::handle_base {
     }
     return UR_RESULT_SUCCESS;
   }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/adapters/opencl/sampler.cpp
+++ b/unified-runtime/source/adapters/opencl/sampler.cpp
@@ -175,7 +175,7 @@ urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
     return ReturnValue(hSampler->Context);
   }
   case UR_SAMPLER_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hSampler->getReferenceCount());
+    return ReturnValue(hSampler->getRefCounter().getCount());
   }
   // ur_bool_t have a size of uint8_t, but cl_bool size have the size of
   // uint32_t so this adjust UR_SAMPLER_INFO_NORMALIZED_COORDS info to map
@@ -221,13 +221,13 @@ urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRetain(ur_sampler_handle_t hSampler) {
-  hSampler->incrementReferenceCount();
+  hSampler->getRefCounter().increment();
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRelease(ur_sampler_handle_t hSampler) {
-  if (hSampler->decrementReferenceCount() == 0) {
+  if (hSampler->getRefCounter().decrement() == 0) {
     delete hSampler;
   }
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/opencl/sampler.hpp
+++ b/unified-runtime/source/adapters/opencl/sampler.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_counter.hpp"
 
 #include <vector>
 
@@ -17,12 +18,10 @@ struct ur_sampler_handle_t_ : ur::opencl::handle_base {
   using native_type = cl_sampler;
   native_type CLSampler;
   ur_context_handle_t Context;
-  std::atomic<uint32_t> RefCount = 0;
   bool IsNativeHandleOwned = false;
 
   ur_sampler_handle_t_(native_type Sampler, ur_context_handle_t Ctx)
       : handle_base(), CLSampler(Sampler), Context(Ctx) {
-    RefCount = 1;
     urContextRetain(Context);
   }
 
@@ -33,9 +32,8 @@ struct ur_sampler_handle_t_ : ur::opencl::handle_base {
     }
   }
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/common/cuda-hip/stream_queue.hpp
+++ b/unified-runtime/source/common/cuda-hip/stream_queue.hpp
@@ -15,7 +15,7 @@
 #include <mutex>
 #include <vector>
 
-#include "common/ur_ref_count.hpp"
+#include "common/ur_ref_counter.hpp"
 
 using ur_stream_guard = std::unique_lock<std::mutex>;
 

--- a/unified-runtime/source/common/cuda-hip/stream_queue.hpp
+++ b/unified-runtime/source/common/cuda-hip/stream_queue.hpp
@@ -15,6 +15,8 @@
 #include <mutex>
 #include <vector>
 
+#include "common/ur_ref_count.hpp"
+
 using ur_stream_guard = std::unique_lock<std::mutex>;
 
 /// Generic implementation of an out-of-order UR queue based on in-order
@@ -44,7 +46,6 @@ struct stream_queue_t {
   std::vector<bool> TransferAppliedBarrier;
   ur_context_handle_t_ *Context;
   ur_device_handle_t_ *Device;
-  std::atomic_uint32_t RefCount{1};
   std::atomic_uint32_t EventCount{0};
   std::atomic_uint32_t ComputeStreamIndex{0};
   std::atomic_uint32_t TransferStreamIndex{0};
@@ -344,11 +345,7 @@ struct stream_queue_t {
 
   ur_context_handle_t_ *getContext() const { return Context; };
 
-  uint32_t incrementReferenceCount() noexcept { return ++RefCount; }
-
-  uint32_t decrementReferenceCount() noexcept { return --RefCount; }
-
-  uint32_t getReferenceCount() const noexcept { return RefCount; }
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   uint32_t getNextEventId() noexcept { return ++EventCount; }
 
@@ -383,4 +380,7 @@ struct stream_queue_t {
     native_type getStream() { return q->getThreadLocalStream(); }
     ~interop_guard() { q->getThreadLocalStream() = native_type{0}; }
   };
+
+private:
+  UR_ReferenceCounter RefCounter;
 };

--- a/unified-runtime/source/common/ur_ref_counter.hpp
+++ b/unified-runtime/source/common/ur_ref_counter.hpp
@@ -1,0 +1,28 @@
+/*
+ *
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+ * Exceptions. See LICENSE.TXT
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+#ifndef UR_REF_COUNTER_HPP
+#define UR_REF_COUNTER_HPP 1
+
+#include <cstdint>
+#include <atomic>
+
+class UR_ReferenceCounter {
+public:
+  uint32_t getCount() const noexcept { return Count.load(); }
+  uint32_t increment() { return ++Count; }
+  uint32_t decrement() { return --Count; }
+  void reset() { Count = 1; }
+
+private:
+  std::atomic_uint32_t Count{1};
+};
+
+#endif // UR_REF_COUNTER_HPP

--- a/unified-runtime/source/common/ur_ref_counter.hpp
+++ b/unified-runtime/source/common/ur_ref_counter.hpp
@@ -11,8 +11,8 @@
 #ifndef UR_REF_COUNTER_HPP
 #define UR_REF_COUNTER_HPP 1
 
-#include <cstdint>
 #include <atomic>
+#include <cstdint>
 
 class UR_ReferenceCounter {
 public:

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_buffer.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_buffer.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 
+#include "common/ur_ref_counter.hpp"
 #include "ur/ur.hpp"
 
 namespace ur_sanitizer_layer {
@@ -69,9 +70,12 @@ struct MemBuffer {
 
   std::optional<SubBuffer_t> SubBuffer;
 
-  std::atomic<int32_t> RefCount = 1;
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
 
   ur_shared_mutex Mutex;
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 ur_result_t EnqueueMemCopyRectHelper(

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
@@ -18,10 +18,10 @@
 #include "asan_libdevice.hpp"
 #include "asan_shadow.hpp"
 #include "asan_statistics.hpp"
+#include "common/ur_ref_counter.hpp"
 #include "sanitizer_common/sanitizer_common.hpp"
 #include "sanitizer_common/sanitizer_options.hpp"
 #include "ur_sanitizer_layer.hpp"
-#include "common/ur_ref_counter.hpp"
 
 #include <memory>
 #include <optional>

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
@@ -21,6 +21,7 @@
 #include "sanitizer_common/sanitizer_common.hpp"
 #include "sanitizer_common/sanitizer_options.hpp"
 #include "ur_sanitizer_layer.hpp"
+#include "common/ur_ref_counter.hpp"
 
 #include <memory>
 #include <optional>
@@ -82,7 +83,6 @@ struct QueueInfo {
 
 struct KernelInfo {
   ur_kernel_handle_t Handle;
-  std::atomic<int32_t> RefCount = 1;
 
   // sanitized kernel
   bool IsInstrumented = false;
@@ -107,11 +107,15 @@ struct KernelInfo {
         getContext()->urDdiTable.Kernel.pfnRelease(Handle);
     assert(Result == UR_RESULT_SUCCESS);
   }
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 struct ProgramInfo {
   ur_program_handle_t Handle;
-  std::atomic<int32_t> RefCount = 1;
 
   // Program is built only once, so we don't need to lock it
   std::unordered_set<std::shared_ptr<AllocInfo>> AllocInfoForGlobals;
@@ -130,6 +134,11 @@ struct ProgramInfo {
   }
 
   bool isKernelInstrumented(ur_kernel_handle_t Kernel) const;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 struct ContextInfo {
@@ -137,8 +146,6 @@ struct ContextInfo {
 
   ur_usm_pool_handle_t USMPool{};
   std::once_flag PoolInit;
-
-  std::atomic<int32_t> RefCount = 1;
 
   std::vector<ur_device_handle_t> DeviceList;
   std::unordered_map<ur_device_handle_t, AllocInfoList> AllocInfosMap;
@@ -163,6 +170,11 @@ struct ContextInfo {
   }
 
   ur_usm_pool_handle_t getUSMPool();
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 struct AsanRuntimeDataWrapper {

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_buffer.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_buffer.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 
+#include "common/ur_ref_counter.hpp"
 #include "ur/ur.hpp"
 
 namespace ur_sanitizer_layer {
@@ -69,9 +70,12 @@ struct MemBuffer {
 
   std::optional<SubBuffer_t> SubBuffer;
 
-  std::atomic<int32_t> RefCount = 1;
-
   ur_shared_mutex Mutex;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 ur_result_t EnqueueMemCopyRectHelper(

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
@@ -20,6 +20,7 @@
 #include "sanitizer_common/sanitizer_common.hpp"
 #include "sanitizer_common/sanitizer_options.hpp"
 #include "ur_sanitizer_layer.hpp"
+#include "common/ur_ref_counter.hpp"
 
 #include <memory>
 #include <optional>
@@ -75,7 +76,6 @@ struct QueueInfo {
 
 struct KernelInfo {
   ur_kernel_handle_t Handle;
-  std::atomic<int32_t> RefCount = 1;
 
   // sanitized kernel
   bool IsInstrumented = false;
@@ -102,11 +102,15 @@ struct KernelInfo {
         getContext()->urDdiTable.Kernel.pfnRelease(Handle);
     assert(Result == UR_RESULT_SUCCESS);
   }
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 struct ProgramInfo {
   ur_program_handle_t Handle;
-  std::atomic<int32_t> RefCount = 1;
 
   struct KernelMetada {
     bool CheckLocals;
@@ -130,12 +134,16 @@ struct ProgramInfo {
 
   bool isKernelInstrumented(ur_kernel_handle_t Kernel) const;
   const KernelMetada &getKernelMetadata(ur_kernel_handle_t Kernel) const;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 struct ContextInfo {
   ur_context_handle_t Handle;
   size_t CleanShadowSize = 1024;
-  std::atomic<int32_t> RefCount = 1;
 
   std::vector<ur_device_handle_t> DeviceList;
 
@@ -146,6 +154,11 @@ struct ContextInfo {
   }
 
   ~ContextInfo();
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 struct MsanRuntimeDataWrapper {

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "common/ur_ref_counter.hpp"
 #include "msan_allocator.hpp"
 #include "msan_buffer.hpp"
 #include "msan_libdevice.hpp"
@@ -20,7 +21,6 @@
 #include "sanitizer_common/sanitizer_common.hpp"
 #include "sanitizer_common/sanitizer_options.hpp"
 #include "ur_sanitizer_layer.hpp"
-#include "common/ur_ref_counter.hpp"
 
 #include <memory>
 #include <optional>

--- a/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_buffer.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_buffer.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 
+#include "common/ur_ref_counter.hpp"
 #include "ur/ur.hpp"
 
 namespace ur_sanitizer_layer {
@@ -69,9 +70,12 @@ struct MemBuffer {
 
   std::optional<SubBuffer_t> SubBuffer;
 
-  std::atomic<int32_t> RefCount = 1;
-
   ur_shared_mutex Mutex;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 ur_result_t EnqueueMemCopyRectHelper(

--- a/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_interceptor.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "common/ur_ref_counter.hpp"
 #include "sanitizer_common/sanitizer_allocator.hpp"
 #include "sanitizer_common/sanitizer_common.hpp"
 #include "tsan_buffer.hpp"
@@ -47,8 +48,6 @@ struct DeviceInfo {
 struct ContextInfo {
   ur_context_handle_t Handle;
 
-  std::atomic<uint32_t> RefCount = 1;
-
   std::vector<ur_device_handle_t> DeviceList;
 
   ur_shared_mutex AllocInfosMapMutex;
@@ -72,6 +71,11 @@ struct ContextInfo {
   ContextInfo &operator=(const ContextInfo &) = delete;
 
   void insertAllocInfo(ur_device_handle_t Device, TsanAllocInfo AI);
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 struct DeviceGlobalInfo {
@@ -81,7 +85,6 @@ struct DeviceGlobalInfo {
 
 struct KernelInfo {
   ur_kernel_handle_t Handle = nullptr;
-  std::atomic<int32_t> RefCount = 1;
 
   // lock this mutex if following fields are accessed
   ur_shared_mutex Mutex;
@@ -107,6 +110,11 @@ struct KernelInfo {
   KernelInfo(const KernelInfo &) = delete;
 
   KernelInfo &operator=(const KernelInfo &) = delete;
+
+  UR_ReferenceCounter &getRefCounter() noexcept { return RefCounter; }
+
+private:
+  UR_ReferenceCounter RefCounter;
 };
 
 struct TsanRuntimeDataWrapper {


### PR DESCRIPTION
Closes https://github.com/intel/llvm/issues/18644

Some adapters had a count member in their structs with methods to modify, or a dedicated class which classes inherited from. I opted to create a new class `UR_ReferenceCounter` in `/common/ur_ref_counter.hpp` and added this as a member to any structs which had reference counting to follow preferring composition over inheritance. Happy to hear opinions on other ways of doing it.

Removes `contextReleaseMutex` from OpenCL `urContextRelease` which shouldn't be required.

Also added this across the Sanitizer layers.