### PR TITLE
[SYCL] Re-assign HIP device aspeects

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/DeviceConfigFile.td
+++ b/llvm/include/llvm/SYCLLowerIR/DeviceConfigFile.td
@@ -321,38 +321,49 @@ defvar HipSubgroupSizesGCN5 = [64];     // gfx900-gfx906 GCN5.0 (known as "Vega"
 defvar HipSubgroupSizesRDNA = [32];     // gfxX10-gfx11 (encapsulates RDNA1..3), (wave64 mode available but not used).
 defvar HipSubgroupSizesCDNA = [64];     // gfx908, gfx90a (encapsulates CDNA1..2)
 
-defvar HipMinAspects = [AspectGpu, AspectFp64, AspectOnline_compiler, AspectOnline_linker, AspectQueue_profiling,
-    AspectExt_intel_pci_address, AspectExt_intel_max_mem_bandwidth, AspectExt_intel_device_id,
-    AspectExt_intel_memory_clock_rate, AspectExt_intel_memory_bus_width, AspectExt_intel_free_memory];
+defvar HipMinAspects = [AspectGpu, AspectFp16, AspectFp64,
+    AspectOnline_compiler, AspectOnline_linker, AspectQueue_profiling,
+    AspectExt_intel_pci_address, AspectExt_intel_max_mem_bandwidth,
+    AspectExt_intel_device_id, AspectExt_intel_memory_clock_rate,
+    AspectExt_intel_memory_bus_width, AspectExt_intel_free_memory];
 
+defvar HipUSMAspects = !listremove(AllUSMAspects, [AspectUsm_system_allocations]);
+defvar HipGraphAspects = [AspectExt_oneapi_graph, AspectExt_oneapi_limited_graph];
 // The following AMDGCN targets are ordered based on their ROCm driver support:
 //
 // Officially supported:
-def : HipTargetInfo<"amd_gpu_gfx908", !listconcat(HipMinAspects, AllUSMAspects,
-    [AspectExt_intel_device_info_uuid, AspectExt_oneapi_graph, AspectExt_oneapi_limited_graph]), HipSubgroupSizesCDNA>;
-def : HipTargetInfo<"amd_gpu_gfx90a", !listconcat(HipMinAspects, AllUSMAspects,
-    [AspectExt_intel_device_info_uuid, AspectExt_oneapi_graph, AspectExt_oneapi_limited_graph, AspectExt_oneapi_native_assert]),
+def : HipTargetInfo<"amd_gpu_gfx908", !listconcat(
+    HipMinAspects, HipUSMAspects, HipGraphAspects,
+    [AspectExt_intel_device_info_uuid]), HipSubgroupSizesCDNA>;
+def : HipTargetInfo<"amd_gpu_gfx90a", !listconcat(
+    HipMinAspects, HipUSMAspects, HipGraphAspects,
+    [AspectAtomic64, AspectExt_intel_device_info_uuid, AspectExt_oneapi_native_assert]),
     HipSubgroupSizesCDNA>;
 // TODO: Need to verify whether device-side asserts (oneapi_native_assert) are
 // now working for the new CDNA3 gfx940, gfx941, gfx942 GPUs and fixed for the
 // other supported, gfx1030 and gfx1100, RDNA3 GPUs.
-def : HipTargetInfo<"amd_gpu_gfx940", !listconcat(HipMinAspects, AllUSMAspects,
-    [AspectExt_intel_device_info_uuid, AspectExt_oneapi_graph, AspectExt_oneapi_limited_graph]),
+def : HipTargetInfo<"amd_gpu_gfx940", !listconcat(
+    HipMinAspects, HipUSMAspects, HipGraphAspects,
+    [AspectExt_intel_device_info_uuid]),
     HipSubgroupSizesCDNA>;
-def : HipTargetInfo<"amd_gpu_gfx941", !listconcat(HipMinAspects, AllUSMAspects,
-    [AspectExt_intel_device_info_uuid, AspectExt_oneapi_graph, AspectExt_oneapi_limited_graph]),
+def : HipTargetInfo<"amd_gpu_gfx941", !listconcat(
+    HipMinAspects, HipUSMAspects, HipGraphAspects,
+    [AspectExt_intel_device_info_uuid]),
     HipSubgroupSizesCDNA>;
-def : HipTargetInfo<"amd_gpu_gfx942", !listconcat(HipMinAspects, AllUSMAspects,
-    [AspectExt_intel_device_info_uuid, AspectExt_oneapi_graph, AspectExt_oneapi_limited_graph]),
+def : HipTargetInfo<"amd_gpu_gfx942", !listconcat(
+    HipMinAspects, HipUSMAspects, HipGraphAspects,
+    [AspectExt_intel_device_info_uuid]),
     HipSubgroupSizesCDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1030", !listconcat(HipMinAspects, AllUSMAspects,
-    [AspectExt_intel_device_info_uuid, AspectExt_oneapi_graph, AspectExt_oneapi_limited_graph]),
+def : HipTargetInfo<"amd_gpu_gfx1030", !listconcat(
+    HipMinAspects, HipUSMAspects, HipGraphAspects,
+    [AspectAtomic64, AspectExt_intel_device_info_uuid]),
     HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1100", !listconcat(HipMinAspects, AllUSMAspects,
-    [AspectExt_intel_device_info_uuid, AspectExt_oneapi_graph, AspectExt_oneapi_limited_graph]),
+def : HipTargetInfo<"amd_gpu_gfx1100", !listconcat(
+    HipMinAspects, HipUSMAspects, HipGraphAspects,
+    [AspectExt_intel_device_info_uuid]),
     HipSubgroupSizesRDNA>;
 // Deprecated support:
-def : HipTargetInfo<"amd_gpu_gfx906", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesGCN5>;
+def : HipTargetInfo<"amd_gpu_gfx906", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesGCN5>;
 // Unsupported (or unofficially supported):
 def : HipTargetInfo<"amd_gpu_gfx700", HipMinAspects, HipSubgroupSizesGCN2>;
 def : HipTargetInfo<"amd_gpu_gfx701", HipMinAspects, HipSubgroupSizesGCN2>;
@@ -369,23 +380,23 @@ def : HipTargetInfo<"amd_gpu_gfx900", HipMinAspects, HipSubgroupSizesGCN5>;
 def : HipTargetInfo<"amd_gpu_gfx902", HipMinAspects, HipSubgroupSizesGCN5>;
 def : HipTargetInfo<"amd_gpu_gfx904", HipMinAspects, HipSubgroupSizesGCN5>;
 def : HipTargetInfo<"amd_gpu_gfx909", HipMinAspects, HipSubgroupSizesGCN5>;
-def : HipTargetInfo<"amd_gpu_gfx90c", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesGCN5>;
-def : HipTargetInfo<"amd_gpu_gfx1010", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1011", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1012", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1013", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1031", !listconcat(!listremove(HipMinAspects, [AspectExt_intel_free_memory]), AllUSMAspects),
+def : HipTargetInfo<"amd_gpu_gfx90c", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesGCN5>;
+def : HipTargetInfo<"amd_gpu_gfx1010", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1011", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1012", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1013", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1031", !listconcat(!listremove(HipMinAspects, [AspectExt_intel_free_memory]), HipUSMAspects),
     HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1032", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1033", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1034", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1035", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1036", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1101", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1102", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1103", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1150", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
-def : HipTargetInfo<"amd_gpu_gfx1151", !listconcat(HipMinAspects, AllUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1032", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1033", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1034", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1035", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1036", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1101", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1102", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1103", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1150", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
+def : HipTargetInfo<"amd_gpu_gfx1151", !listconcat(HipMinAspects, HipUSMAspects), HipSubgroupSizesRDNA>;
 // TBA
 def : HipTargetInfo<"amd_gpu_gfx1200", [], []>; // RDNA 4
 def : HipTargetInfo<"amd_gpu_gfx1201", [], []>; // RDNA 4


### PR DESCRIPTION
This commit, in addition to some minor formatting:

* Adds the fp16 aspect to all devices.
* Adds the atomic64 aspect to the two tested devices (gfx90a & gfx1030)
  * The runtime reports this aspect based on querying the device for 'int64' attributes, which doesn't seem right as the aspect covers fp64 atomics too.
* Removes the usm_system_allocations from all devices
  * As best as I can see this will depend on things like PCIe so is not (currently) possible to determine in the compiler.