### PR TITLE
[UR][HIP][Graph] Disable flaky urUpdatableEnqueueCommandBufferExpTest test

### DIFF
--- a/unified-runtime/test/conformance/exp_command_buffer/update/enqueue_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/enqueue_update.cpp
@@ -16,6 +16,9 @@ struct urUpdatableEnqueueCommandBufferExpTest
     : uur::command_buffer::urUpdatableCommandBufferExpExecutionTest {
 
   virtual void SetUp() override {
+    // https://github.com/intel/llvm/issues/18722
+    UUR_KNOWN_FAILURE_ON(uur::HIP{});
+
     program_name = "cpy_and_mult_usm";
     UUR_RETURN_ON_FATAL_FAILURE(
         urUpdatableCommandBufferExpExecutionTest::SetUp());
@@ -184,9 +187,6 @@ TEST_P(urUpdatableEnqueueCommandBufferExpTest, SerializeAcrossQueues) {
 // Tests that submitting a command-buffer twice to an out-of-order queue
 // relying on implicit serialization semantics for dependencies.
 TEST_P(urUpdatableEnqueueCommandBufferExpTest, SerializeOutofOrderQueue) {
-  // See https://github.com/intel/llvm/issues/18722
-  UUR_KNOWN_FAILURE_ON(uur::HIP{});
-
   // First submission to out-of-order queue
   ASSERT_SUCCESS(urEnqueueCommandBufferExp(
       out_of_order_queue, updatable_cmd_buf_handle, 0, nullptr, nullptr));


### PR DESCRIPTION
The `urUpdatableEnqueueCommandBufferExpTest/SerializeAcrossQueues` test failed on HIP in CI recently https://github.com/intel/llvm/actions/runs/15471380123/job/43557243642 Other tests in the same fixture are already documented as as flaky in https://github.com/intel/llvm/issues/18722

Move the skip on HIP devices up to the base fixture to disable all the related tests to keep CI green until it can be investigated and fixed.