### PR TITLE
[UR] Ensure mock target depends on UR_EXTERNAL_DEPENDENCIES

### DIFF
--- a/unified-runtime/scripts/check-hardening.sh
+++ b/unified-runtime/scripts/check-hardening.sh
@@ -28,7 +28,7 @@ for file in $1/lib/*.so; do
         */libOpenCL*)
             # This is not built as part of UR
             true;;
-        */libzeCallMap.so | */libur_mock_headers.so)
+        */libzeCallMap.so | */libur_mock.so)
             # Only used in testing, and are too simple for many of the hardening flags to have an effect.
             true;;
         *)

--- a/unified-runtime/source/mock/CMakeLists.txt
+++ b/unified-runtime/source/mock/CMakeLists.txt
@@ -3,15 +3,15 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_library (ur_mock_headers SHARED
-    "${CMAKE_CURRENT_SOURCE_DIR}/ur_mock_helpers.cpp")
-
-target_include_directories(ur_mock_headers
+add_ur_library(ur_mock SHARED
+    "${CMAKE_CURRENT_SOURCE_DIR}/ur_mock_helpers.cpp"
+)
+target_include_directories(ur_mock
     INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
-target_link_libraries(ur_mock_headers PRIVATE
+target_link_libraries(ur_mock PRIVATE
     ${PROJECT_NAME}::headers
 )
 
-add_library(${PROJECT_NAME}::mock ALIAS ur_mock_headers)
+add_library(${PROJECT_NAME}::mock ALIAS ur_mock)


### PR DESCRIPTION
Firstly, rename `ur_mock_headers` to `ur_mock` as this is a shared library not header only library.

Secondly, when part of a subbuild, ensure that the `ur_mock` target depends on the specified `UR_EXTERNAL_DEPENDENCIES`, this is handled by using `add_ur_library()` in place of `add_library()`.
