### PR TITLE
[SYCL][E2E] Reduce number of `FileCheck` uses

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/track_indirect_access_memory.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/track_indirect_access_memory.cpp
@@ -1,8 +1,6 @@
 // REQUIRES: level_zero, level_zero_dev_kit
 // RUN: %{build} %level_zero_options %threads_lib -o %t.out
-// RUN: env SYCL_PI_LEVEL_ZERO_TRACK_INDIRECT_ACCESS_MEMORY=1 %{run} %t.out 2>&1 | FileCheck %s
-//
-// CHECK: pass
+// RUN: env SYCL_PI_LEVEL_ZERO_TRACK_INDIRECT_ACCESS_MEMORY=1 %{run} %t.out 2>&1
 //
 // Test checks memory tracking and deferred release functionality which is
 // enabled by SYCL_PI_LEVEL_ZERO_TRACK_INDIRECT_ACCESS_MEMORY env variable.
@@ -120,6 +118,5 @@ int main() {
     update_d3_data(q);
   }
 
-  std::cout << "pass" << std::endl;
   return 0;
 }

--- a/sycl/test-e2e/Adapters/level_zero/uuid.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/uuid.cpp
@@ -2,11 +2,10 @@
 // REQUIRES: gpu, level_zero, level_zero_dev_kit
 
 // RUN: %{build} %level_zero_options -o %t.out
-// RUN: %{run} %t.out 2>&1 | FileCheck %s
+// RUN: %{run} %t.out 2>&1
 
 // Test that the UUID is read correctly from Level Zero.
 
-// CHECK: PASSED
 #include <iomanip>
 #include <iostream>
 #include <level_zero/ze_api.h>
@@ -36,6 +35,6 @@ int main() {
     std::cout << "FAILED" << std::endl;
     return -1;
   }
-  std::cout << "PASSED" << std::endl;
+
   return 0;
 }

--- a/sycl/test-e2e/Config/kernel_from_file.cpp
+++ b/sycl/test-e2e/Config/kernel_from_file.cpp
@@ -14,8 +14,7 @@
 // >> ---- translate to SPIR-V
 // RUN: llvm-spirv -o %t.spv %t_app.bc
 // RUN: %clangxx -Wno-error=ignored-attributes %sycl_include -DSYCL_DISABLE_FALLBACK_ASSERT %cxx_std_optionc++17 %include_option %t.h %s -o %t.out %sycl_options -Xclang -verify-ignore-unexpected=note,warning %if preview-mode %{-Wno-unused-command-line-argument%}
-// RUN: env SYCL_USE_KERNEL_SPV=%t.spv %{run} %t.out | FileCheck %s
-// CHECK: Passed
+// RUN: env SYCL_USE_KERNEL_SPV=%t.spv %{run} %t.out
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
@@ -45,11 +44,10 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  if (data == 6) {
-    std::cout << "Passed\n";
-    return 0;
-  } else {
-    std::cout << "Failed: " << data << "!= 6(gold)\n";
+  if (data != 6) {
+    std::cerr << "Failed: " << data << "!= 6(gold)\n";
     return 1;
   }
+
+  return 0;
 }

--- a/sycl/test-e2e/ESIMD/spec_const/spec_const_redefine.cpp
+++ b/sycl/test-e2e/ESIMD/spec_const/spec_const_redefine.cpp
@@ -87,12 +87,11 @@ int main(int argc, char **argv) {
       passed = false;
     }
   }
-  std::cout << (passed ? "passed\n" : "FAILED\n");
+  if (!passed)
+    std::cout << "FAILED\n";
   return passed ? 0 : 1;
 }
 
 // --- Check that only two JIT compilation happened:
 // CHECK-COUNT-2: <--- urProgramBuildExp
 // CHECK-NOT: <--- urProgramBuildExp
-// --- Check that the test completed with expected results:
-// CHECK: passed

--- a/sycl/test-e2e/Regression/implicit_kernel_bundle_image_filtering.cpp
+++ b/sycl/test-e2e/Regression/implicit_kernel_bundle_image_filtering.cpp
@@ -38,12 +38,9 @@ int main() {
         [&](sycl::handler &CGH) { CGH.single_task<class Kernel2>([=]() {}); });
     Q.wait_and_throw();
   }
-  std::cout << "passed" << std::endl;
   return 0;
 }
 
 // --- Check that only a single program is built:
 // CHECK: <--- urProgramBuildExp
 // CHECK-NOT: <--- urProgramBuildExp
-// --- Check that the test completed with expected results:
-// CHECK: passed

--- a/sycl/test-e2e/SeparateCompile/test.cpp
+++ b/sycl/test-e2e/SeparateCompile/test.cpp
@@ -51,8 +51,7 @@
 //
 // >> ---- link the full hetero app
 // RUN: %clangxx wrapper.o a.o b.o -Wno-unused-command-line-argument -o app.exe %sycl_options
-// RUN: %{run} ./app.exe | FileCheck %s
-// CHECK: pass
+// RUN: %{run} ./app.exe
 
 //==----------- test.cpp - Tests SYCL separate compilation -----------------==//
 //
@@ -125,9 +124,6 @@ int main(int argc, char **argv) {
     pass = false;
   }
 
-  if (pass) {
-    std::cout << "pass\n";
-  }
   return pass ? 0 : 1;
 }
 #endif // !B_CPP


### PR DESCRIPTION
LIT is perfectly capable of checking the exit code and there is no need to deal with any extra output parsing and I/O.