### PR TITLE
[CI] Add phony arguments when uploading benchmark results

### DIFF
--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -217,6 +217,8 @@ runs:
           --output-html remote \
           --results-dir "./llvm-ci-perf-results/" \
           --output-dir "./llvm-ci-perf-results/" \
+          --sycl foo \
+          --ur foo \
           --dry-run
         cd -
       done


### PR DESCRIPTION
When reconciling divergent benchmarking results when trying to upload new results to the benchmarking results repo, an invocation of the benchmarking script with `--dry-run` is used to regenerate the results as a part of reconciling.  However, currently, without `--sycl` and `--ur` defined, `--dry-run` will not rewrite the metadata used to display benchmarking results, resulting in the performance dashboard missing information.

This PR fixes the issue by adding phony `--sycl` and `--ur` options to the benchmarking script. The change can be reverted after
https://github.com/intel/llvm/pull/18845 addresses this aforementioned issue.