### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-4063fa2

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-af17e0f",
-      "version": "af17e0f",
-      "updated_at": "2025-04-09T23:37:41Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2915515592/zip",
+      "github_tag": "igc-dev-4063fa2",
+      "version": "4063fa2",
+      "updated_at": "2025-06-07T05:11:17Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/3280535463/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift