### PR TITLE
[SYCL] Allow __glibcxx_assert_fail in SemaSYCL

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -608,8 +608,9 @@ static bool isSYCLUndefinedAllowed(const FunctionDecl *Callee,
   // time and will be ignored when the check succeeds. We allow calls to this
   // function to support some important std functions in SYCL device.
   IsAllowed = (Callee->getName() == LibstdcxxFailedAssertion) &&
-         Callee->getNumParams() == 0 && Callee->getReturnType()->isVoidType() &&
-         SrcMgr.isInSystemHeader(Callee->getLocation());
+              Callee->getNumParams() == 0 &&
+              Callee->getReturnType()->isVoidType() &&
+              SrcMgr.isInSystemHeader(Callee->getLocation());
 
   if (IsAllowed)
     return true;
@@ -622,8 +623,9 @@ static bool isSYCLUndefinedAllowed(const FunctionDecl *Callee,
   // what we did to "__failed_assertion". The prototype is following:
   // void __glibcxx_assert_fail(const char *, int, const char *, const char*);
   IsAllowed = (Callee->getName() == GlibcxxAssertFail) &&
-         Callee->getNumParams() == 4 && Callee->getReturnType()->isVoidType() &&
-         SrcMgr.isInSystemHeader(Callee->getLocation());
+              Callee->getNumParams() == 4 &&
+              Callee->getReturnType()->isVoidType() &&
+              SrcMgr.isInSystemHeader(Callee->getLocation());
 
   return IsAllowed;
 }

--- a/clang/test/SemaSYCL/Inputs/dummy_failed_assert
+++ b/clang/test/SemaSYCL/Inputs/dummy_failed_assert
@@ -1,1 +1,4 @@
 void __failed_assertion();
+namespace std {
+void __glibcxx_assert_fail(const char*, int, const char*, const char*) noexcept;
+}

--- a/clang/test/SemaSYCL/__glibcxx_assert_fail.cpp
+++ b/clang/test/SemaSYCL/__glibcxx_assert_fail.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -verify -DUSR -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -verify -fsyntax-only %s
+// UNSUPPORTED: system-windows
+// This test checks that an undefined "__glibcxx_assert_fail" without SYCL_EXTERNAL will lead to SYCL sema check
+// failure if it is not declared in a system header otherwise no SYCL sema check failure will be triggered.
+
+#include "sycl.hpp"
+#ifdef USR
+namespace std {
+void __glibcxx_assert_fail(const char*, int, const char*, const char*) noexcept;
+// expected-note@-1 {{'__glibcxx_assert_fail' declared here}}
+}
+#else
+#include <dummy_failed_assert>
+#endif
+
+#ifdef USR
+SYCL_EXTERNAL
+void call_glibcxx_assert_fail() {
+  // expected-note@-1 {{called by 'call_glibcxx_assert_fail'}}
+  std::__glibcxx_assert_fail("file1", 10, "func1", "dummy test");
+  // expected-error@-1 {{SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute}}
+}
+#else
+// expected-no-diagnostics
+SYCL_EXTERNAL
+void call_glibcxx_assert_fail() {
+  std::__glibcxx_assert_fail("file1", 10, "func1", "dummy test");
+}
+#endif
+


### PR DESCRIPTION
GCC-15 introduced __glibcxx_assert_fail function used in -O0 for many STL functions' runtime check. Its behavior is similar to normal 'assert', so we have supported it in libdevice in the same way as 'assert'. However, compfail will happen in some scenario reporting "undefined function without SYCL_EXTERNAL" error for "__glibcxx_assert_fail" declared in c++config.h, we have to allow this as exception in SemaSYCL.