### PR TITLE
[SYCL][Graph] Enable Update tests on L0 V2

### DIFF
--- a/sycl/test-e2e/Graph/Update/lit.local.cfg
+++ b/sycl/test-e2e/Graph/Update/lit.local.cfg
@@ -1,3 +1,1 @@
 config.required_features += ['aspect-ext_oneapi_graph']
-# V2 does not have support for MCL yet
-config.unsupported_features += ['level_zero_v2_adapter']


### PR DESCRIPTION
The Level-Zero V2 has had support for graph update since https://github.com/intel/llvm/pull/17925