### PR TITLE
[SYCL][Clang] Add ARM64_SPIRV64 and ARM64SPIR64 target info

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -700,8 +700,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
           return std::make_unique<MicrosoftX86_64_SPIR64TargetInfo>(Triple,
                                                                     Opts);
         else
-          assert(false &&
-                 "Unsupported host architecture (not x86_64 or aarch64)");
+          llvm::report_fatal_error(
+              "Unsupported host architecture (not x86_64 or aarch64)");
       }
     case llvm::Triple::Linux:
       if (IsFPGASubArch)
@@ -754,8 +754,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
           return std::make_unique<MicrosoftX86_64_SPIRV64TargetInfo>(Triple,
                                                                      Opts);
         else
-          assert(false &&
-                 "Unsupported host architecture (not x86_64 or aarch64)");
+          llvm::report_fatal_error(
+              "Unsupported host architecture (not x86_64 or aarch64)");
       }
     default:
       return std::make_unique<SPIRV64TargetInfo>(Triple, Opts);

--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -693,14 +693,17 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       switch (HT.getEnvironment()) {
       default: // Assume MSVC for unknown environments
       case llvm::Triple::MSVC:
-        if (HT.getArch() == llvm::Triple::aarch64)
+        switch (HT.getArch()) {
+        case llvm::Triple::aarch64:
           return std::make_unique<MicrosoftARM64_SPIR64TargetInfo>(Triple,
                                                                    Opts);
-        else if (HT.getArch() == llvm::Triple::x86_64)
+        case llvm::Triple::x86_64:
           return std::make_unique<MicrosoftX86_64_SPIR64TargetInfo>(Triple,
                                                                     Opts);
-        llvm::report_fatal_error(
-            "Unsupported host architecture (not x86_64 or aarch64)");
+        default:
+          llvm::report_fatal_error(
+              "Unsupported host architecture (not x86_64 or aarch64)");
+        }
       }
     case llvm::Triple::Linux:
       if (IsFPGASubArch)
@@ -746,14 +749,17 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       switch (HT.getEnvironment()) {
       default: // Assume MSVC for unknown environments
       case llvm::Triple::MSVC:
-        if (HT.getArch() == llvm::Triple::aarch64)
+        switch (HT.getArch()) {
+        case llvm::Triple::aarch64:
           return std::make_unique<MicrosoftARM64_SPIRV64TargetInfo>(Triple,
                                                                     Opts);
-        else if (HT.getArch() == llvm::Triple::x86_64)
+        case llvm::Triple::x86_64:
           return std::make_unique<MicrosoftX86_64_SPIRV64TargetInfo>(Triple,
                                                                      Opts);
-        llvm::report_fatal_error(
-            "Unsupported host architecture (not x86_64 or aarch64)");
+        default:
+          llvm::report_fatal_error(
+              "Unsupported host architecture (not x86_64 or aarch64)");
+        }
       }
     default:
       return std::make_unique<SPIRV64TargetInfo>(Triple, Opts);

--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -699,9 +699,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
         else if (HT.getArch() == llvm::Triple::x86_64)
           return std::make_unique<MicrosoftX86_64_SPIR64TargetInfo>(Triple,
                                                                     Opts);
-        else
-          llvm::report_fatal_error(
-              "Unsupported host architecture (not x86_64 or aarch64)");
+        llvm::report_fatal_error(
+            "Unsupported host architecture (not x86_64 or aarch64)");
       }
     case llvm::Triple::Linux:
       if (IsFPGASubArch)
@@ -753,9 +752,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
         else if (HT.getArch() == llvm::Triple::x86_64)
           return std::make_unique<MicrosoftX86_64_SPIRV64TargetInfo>(Triple,
                                                                      Opts);
-        else
-          llvm::report_fatal_error(
-              "Unsupported host architecture (not x86_64 or aarch64)");
+        llvm::report_fatal_error(
+            "Unsupported host architecture (not x86_64 or aarch64)");
       }
     default:
       return std::make_unique<SPIRV64TargetInfo>(Triple, Opts);

--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -693,9 +693,15 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       switch (HT.getEnvironment()) {
       default: // Assume MSVC for unknown environments
       case llvm::Triple::MSVC:
-        assert(HT.getArch() == llvm::Triple::x86_64 &&
-               "Unsupported host architecture");
-        return std::make_unique<MicrosoftX86_64_SPIR64TargetInfo>(Triple, Opts);
+        if (HT.getArch() == llvm::Triple::aarch64)
+          return std::make_unique<MicrosoftARM64_SPIR64TargetInfo>(Triple,
+                                                                   Opts);
+        else if (HT.getArch() == llvm::Triple::x86_64)
+          return std::make_unique<MicrosoftX86_64_SPIR64TargetInfo>(Triple,
+                                                                    Opts);
+        else
+          assert(false &&
+                 "Unsupported host architecture (not x86_64 or aarch64)");
       }
     case llvm::Triple::Linux:
       if (IsFPGASubArch)
@@ -741,10 +747,15 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       switch (HT.getEnvironment()) {
       default: // Assume MSVC for unknown environments
       case llvm::Triple::MSVC:
-        assert(HT.getArch() == llvm::Triple::x86_64 &&
-               "Unsupported host architecture");
-        return std::make_unique<MicrosoftX86_64_SPIRV64TargetInfo>(Triple,
-                                                                   Opts);
+        if (HT.getArch() == llvm::Triple::aarch64)
+          return std::make_unique<MicrosoftARM64_SPIRV64TargetInfo>(Triple,
+                                                                    Opts);
+        else if (HT.getArch() == llvm::Triple::x86_64)
+          return std::make_unique<MicrosoftX86_64_SPIRV64TargetInfo>(Triple,
+                                                                     Opts);
+        else
+          assert(false &&
+                 "Unsupported host architecture (not x86_64 or aarch64)");
       }
     default:
       return std::make_unique<SPIRV64TargetInfo>(Triple, Opts);

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -394,6 +394,49 @@ public:
   }
 };
 
+// ARM64 SPIR64 Windows target
+class LLVM_LIBRARY_VISIBILITY WindowsARM64_SPIR64TargetInfo
+    : public WindowsTargetInfo<SPIR64TargetInfo> {
+public:
+  WindowsARM64_SPIR64TargetInfo(const llvm::Triple &Triple,
+                                const TargetOptions &Opts)
+      : WindowsTargetInfo<SPIR64TargetInfo>(Triple, Opts) {
+    LongWidth = LongAlign = 32;
+    DoubleAlign = LongLongAlign = 64;
+    IntMaxType = SignedLongLong;
+    Int64Type = SignedLongLong;
+    SizeType = UnsignedLongLong;
+    PtrDiffType = SignedLongLong;
+    IntPtrType = SignedLongLong;
+    WCharType = UnsignedShort;
+  }
+
+  BuiltinVaListKind getBuiltinVaListKind() const override {
+    return TargetInfo::CharPtrBuiltinVaList;
+  }
+
+  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
+    return (CC == CC_SpirFunction || CC == CC_OpenCLKernel) ? CCCR_OK
+                                                            : CCCR_Warning;
+  }
+};
+
+// ARM64 SPIR64 Windows Visual Studio target
+class LLVM_LIBRARY_VISIBILITY MicrosoftARM64_SPIR64TargetInfo
+    : public WindowsARM64_SPIR64TargetInfo {
+public:
+  MicrosoftARM64_SPIR64TargetInfo(const llvm::Triple &Triple,
+                                  const TargetOptions &Opts)
+      : WindowsARM64_SPIR64TargetInfo(Triple, Opts) {}
+
+  void getTargetDefines(const LangOptions &Opts,
+                        MacroBuilder &Builder) const override {
+    WindowsARM64_SPIR64TargetInfo::getTargetDefines(Opts, Builder);
+    // Device code doesn't need to have ARM64EC defines
+    Builder.defineMacro("_M_ARM64", "1");
+  }
+};
+
 class LLVM_LIBRARY_VISIBILITY BaseSPIRVTargetInfo : public BaseSPIRTargetInfo {
 public:
   BaseSPIRVTargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
@@ -588,6 +631,49 @@ public:
     WindowsX86_64_SPIRV64TargetInfo::getTargetDefines(Opts, Builder);
     Builder.defineMacro("_M_X64", "100");
     Builder.defineMacro("_M_AMD64", "100");
+  }
+};
+
+// ARM64 SPIRV64 Windows target
+class LLVM_LIBRARY_VISIBILITY WindowsARM64_SPIRV64TargetInfo
+    : public WindowsTargetInfo<SPIRV64TargetInfo> {
+public:
+  WindowsARM64_SPIRV64TargetInfo(const llvm::Triple &Triple,
+                                 const TargetOptions &Opts)
+      : WindowsTargetInfo<SPIRV64TargetInfo>(Triple, Opts) {
+    LongWidth = LongAlign = 32;
+    DoubleAlign = LongLongAlign = 64;
+    IntMaxType = SignedLongLong;
+    Int64Type = SignedLongLong;
+    SizeType = UnsignedLongLong;
+    PtrDiffType = SignedLongLong;
+    IntPtrType = SignedLongLong;
+    WCharType = UnsignedShort;
+  }
+
+  BuiltinVaListKind getBuiltinVaListKind() const override {
+    return TargetInfo::CharPtrBuiltinVaList;
+  }
+
+  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
+    return (CC == CC_SpirFunction || CC == CC_OpenCLKernel) ? CCCR_OK
+                                                            : CCCR_Warning;
+  }
+};
+
+// ARM64 SPIRV64 Windows Visual Studio target
+class LLVM_LIBRARY_VISIBILITY MicrosoftARM64_SPIRV64TargetInfo
+    : public WindowsARM64_SPIRV64TargetInfo {
+public:
+  MicrosoftARM64_SPIRV64TargetInfo(const llvm::Triple &Triple,
+                                   const TargetOptions &Opts)
+      : WindowsARM64_SPIRV64TargetInfo(Triple, Opts) {}
+
+  void getTargetDefines(const LangOptions &Opts,
+                        MacroBuilder &Builder) const override {
+    WindowsARM64_SPIRV64TargetInfo::getTargetDefines(Opts, Builder);
+    // Device code doesn't need to have ARM64EC defines
+    Builder.defineMacro("_M_ARM64", "1");
   }
 };
 

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -432,8 +432,6 @@ public:
   void getTargetDefines(const LangOptions &Opts,
                         MacroBuilder &Builder) const override {
     WindowsARM64_SPIR64TargetInfo::getTargetDefines(Opts, Builder);
-    // Device code doesn't need to have ARM64EC defines
-    Builder.defineMacro("_M_ARM64", "1");
   }
 };
 
@@ -672,8 +670,6 @@ public:
   void getTargetDefines(const LangOptions &Opts,
                         MacroBuilder &Builder) const override {
     WindowsARM64_SPIRV64TargetInfo::getTargetDefines(Opts, Builder);
-    // Device code doesn't need to have ARM64EC defines
-    Builder.defineMacro("_M_ARM64", "1");
   }
 };
 

--- a/clang/test/CodeGenSYCL/kernel-arg-accessor-pointer.cpp
+++ b/clang/test/CodeGenSYCL/kernel-arg-accessor-pointer.cpp
@@ -1,4 +1,8 @@
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -aux-triple x86_64-pc-windows-msvc -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -aux-triple x86_64-pc-windows-msvc -fsycl-is-device -internal-isystem %S/Inputs -triple spirv64-unknown-unknown -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -aux-triple aarch64-pc-windows-msvc -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -aux-triple aarch64-pc-windows-msvc -fsycl-is-device -internal-isystem %S/Inputs -triple spirv64-unknown-unknown -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 
 // This test checks if the metadata "kernel-arg-runtime-aligned" and "kernel_arg_exclusive_ptr"
 // are generated if the kernel captures an accessor.

--- a/clang/test/Preprocessor/sycl-macro-target-specific.cpp
+++ b/clang/test/Preprocessor/sycl-macro-target-specific.cpp
@@ -12,6 +12,8 @@
 // RUN: | FileCheck --check-prefix=CHECK-NVPTX-NEG %s
 // RUN: %clang_cc1 %s -fsycl-is-device -triple amdgcn-amdhsa-amdhsa -E -dM \
 // RUN: | FileCheck --check-prefix=CHECK-NVPTX-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64-unknown-unknown -aux-triple aarch64-pc-windows-msvc -E -dM \
+// RUN: | FileCheck --check-prefixes=CHECK-NVPTX-NEG,CHECK-ARM64 %s
 // CHECK-NVPTX: #define __NVPTX__
 // CHECK-NVPTX-NEG-NOT: #define __NVPTX__
 
@@ -27,6 +29,8 @@
 // RUN: | FileCheck --check-prefix=CHECK-AMDGPU-NEG %s
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_fpga-unknown-unknown -E -dM \
 // RUN: | FileCheck --check-prefix=CHECK-AMDGPU-NEG %s
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64-unknown-unknown -aux-triple aarch64-pc-windows-msvc -E -dM \
+// RUN: | FileCheck --check-prefixes=CHECK-AMDGPU-NEG,CHECK-ARM64 %s
 // CHECK-AMDGPU: #define __AMDGPU__
 // CHECK-AMDGPU-NEG-NOT: #define __AMDGPU__
 
@@ -72,3 +76,5 @@
 // RUN: | FileCheck --check-prefix=CHECK-DISABLE-FALLBACK-ASSERT-NEG %s
 // CHECK-DISABLE-FALLBACK-ASSERT: #define SYCL_DISABLE_FALLBACK_ASSERT
 // CHECK-DISABLE-FALLBACK-ASSERT-NEG-NOT: #define SYCL_DISABLE_FALLBACK_ASSERT
+//
+// CHECK-ARM64: #define _M_ARM64


### PR DESCRIPTION
Add TargetInfo for MSVC ARM64 host with SPIR64 or SPIRV64 device target.