### PR TITLE
[SYCL][Graph] Fix data race in the multiple_exec_graphs test

### DIFF
--- a/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
@@ -2,9 +2,10 @@
 // graph.
 
 #include "../graph_common.hpp"
+#include <sycl/properties/queue_properties.hpp>
 
 int main() {
-  queue Queue{};
+  queue Queue{{sycl::property::queue::in_order{}}};
 
   using T = int;
 


### PR DESCRIPTION
The multiple_exec_graphs test enqueues multiple instances of executable graphs without any dependencies. However, there is a data race because the test uses an out-of-order queue and every executable graph modifies the same usm memory pointer. This commit solves the issue by using an in-order queue instead.