### PR TITLE
[SYCL] get kernel info with free functions

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -7123,13 +7123,6 @@ bool SYCLIntegrationHeader::emit(StringRef IntHeaderName) {
   }
   llvm::raw_fd_ostream Out(IntHeaderFD, true /*close in destructor*/);
   emit(Out);
-
-    int IntHeaderFD1 = 0;
-  std::string S{"/tmp/my-files/header.h"};
-  llvm::sys::fs::openFileForWrite(S, IntHeaderFD1);
-  llvm::raw_fd_ostream Out1(IntHeaderFD1, true /*close in destructor*/);
-  emit(Out1);
-
   return true;
 }
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1176,6 +1176,8 @@ bool SemaSYCL::isFreeFunction(const FunctionDecl *FD) {
                    NameValuePair.first == "sycl-single-task-kernel";
           });
       IsFreeFunctionAttr = it != NameValuePairs.end();
+      if (IsFreeFunctionAttr)
+        break;
     }
     if (Redecl->isFirstDecl()) {
       if (IsFreeFunctionAttr)
@@ -7121,6 +7123,13 @@ bool SYCLIntegrationHeader::emit(StringRef IntHeaderName) {
   }
   llvm::raw_fd_ostream Out(IntHeaderFD, true /*close in destructor*/);
   emit(Out);
+
+    int IntHeaderFD1 = 0;
+  std::string S{"/tmp/my-files/header.h"};
+  llvm::sys::fs::openFileForWrite(S, IntHeaderFD1);
+  llvm::raw_fd_ostream Out1(IntHeaderFD1, true /*close in destructor*/);
+  emit(Out1);
+
   return true;
 }
 

--- a/sycl/include/sycl/ext/oneapi/get_kernel_info.hpp
+++ b/sycl/include/sycl/ext/oneapi/get_kernel_info.hpp
@@ -11,8 +11,10 @@
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/info_desc_helpers.hpp>
 #include <sycl/device.hpp>
+#include <sycl/ext/oneapi/experimental/free_function_traits.hpp>
 #include <sycl/kernel_bundle_enums.hpp>
 #include <sycl/queue.hpp>
+#include <sycl/kernel_bundle.hpp>
 
 #include <vector>
 
@@ -56,3 +58,41 @@ get_kernel_info(const queue &Q) {
 } // namespace ext::oneapi
 } // namespace _V1
 } // namespace sycl
+
+// For free functions.
+
+namespace sycl::ext::oneapi::experimental {
+
+template <auto *Func, typename Param>
+std::enable_if_t<ext::oneapi::experimental::is_kernel_v<Func>,
+                 typename sycl::detail::is_kernel_info_desc<Param>::return_type>
+get_kernel_info(const context &ctxt) {
+  auto Bundle = sycl::ext::oneapi::experimental::get_kernel_bundle<
+      Func, sycl::bundle_state::executable>(ctxt);
+  return Bundle.template ext_oneapi_get_kernel<Func>()
+      .template get_info<Param>();
+}
+
+template <auto *Func, typename Param>
+std::enable_if_t<ext::oneapi::experimental::is_kernel_v<Func>,
+                 typename sycl::detail::is_kernel_device_specific_info_desc<
+                     Param>::return_type>
+get_kernel_info(const context &ctxt, const device &dev) {
+  auto Bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+      ctxt, std::vector<sycl::device>{dev});
+  auto kid = sycl::ext::oneapi::experimental::get_kernel_id<Func>();
+  return Bundle.get_kernel(kid).template get_info<Param>(dev);
+}
+
+template <auto *Func, typename Param>
+typename sycl::detail::is_kernel_device_specific_info_desc<Param>::return_type
+get_kernel_info(const queue &q) {
+
+  const sycl::device &dev = q.get_device();
+  const sycl::context &ctxt = q.get_context();
+  auto Bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+      ctxt, std::vector<sycl::device>{dev});
+  auto kid = sycl::ext::oneapi::experimental::get_kernel_id<Func>();
+  return Bundle.get_kernel(kid).template get_info<Param>(dev);
+}
+} // namespace sycl::ext::oneapi::experimental

--- a/sycl/include/sycl/ext/oneapi/get_kernel_info.hpp
+++ b/sycl/include/sycl/ext/oneapi/get_kernel_info.hpp
@@ -85,7 +85,9 @@ get_kernel_info(const context &ctxt, const device &dev) {
 }
 
 template <auto *Func, typename Param>
-typename sycl::detail::is_kernel_device_specific_info_desc<Param>::return_type
+std::enable_if_t<ext::oneapi::experimental::is_kernel_v<Func>,
+                 typename sycl::detail::is_kernel_device_specific_info_desc<
+                     Param>::return_type>
 get_kernel_info(const queue &q) {
 
   const sycl::device &dev = q.get_device();

--- a/sycl/test-e2e/FreeFunctionKernels/get_kernel_info.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/get_kernel_info.cpp
@@ -1,0 +1,117 @@
+// REQUIRES: aspect-usm_shared_allocations
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <sycl/ext/oneapi/free_function_queries.hpp>
+#include <sycl/ext/oneapi/get_kernel_info.hpp>
+#include <sycl/kernel_bundle.hpp>
+#include <sycl/usm.hpp>
+#include <type_traits>
+
+namespace syclext = sycl::ext::oneapi;
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+static constexpr size_t NUM = 1024;
+static constexpr size_t WGSIZE = 16;
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::work_group_size<WGSIZE>))
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
+void func(float start, float *ptr) {
+  size_t id = syclext::this_work_item::get_nd_item<1>().get_global_linear_id();
+  ptr[id] = start + static_cast<float>(id);
+}
+
+bool check_result(int *ptr) {
+  for (size_t i = 0; i < NUM; ++i) {
+    const int expected = 3 + static_cast<int>(i);
+    if (ptr[i] != expected)
+      return true;
+  }
+  return false;
+}
+
+static bool call_kernel_code(sycl::queue &q, sycl::kernel &kernel) {
+  int *ptr = sycl::malloc_shared<int>(NUM, q);
+  q.submit([&](sycl::handler &cgh) {
+     cgh.set_args(3, ptr);
+     sycl::nd_range ndr{{NUM}, {WGSIZE}};
+     cgh.parallel_for(ndr, kernel);
+   }).wait();
+  const bool ret = check_result(ptr);
+  sycl::free(ptr, q);
+  return ret;
+}
+
+bool test_ctxt_dev(sycl::kernel &k, sycl::queue &q) {
+  const auto wg_size_cmp =
+      k.get_info<sycl::info::kernel_device_specific::work_group_size>(
+          q.get_device());
+  const auto wg_size = syclexp::get_kernel_info<
+      func, sycl::info::kernel_device_specific::work_group_size>(
+      q.get_context(), q.get_device());
+  if (wg_size_cmp != wg_size)
+    std::cerr << "Work group size from get_info: " << wg_size_cmp
+              << " is not equal to work group size from get_kernel_info: "
+              << wg_size << std::endl;
+  return wg_size_cmp == wg_size;
+}
+
+bool test_ctxt(sycl::kernel &k, sycl::queue &q) {
+  const auto attributes =
+      syclexp::get_kernel_info<func, sycl::info::kernel::attributes>(
+          q.get_context());
+  const std::string wg_size_str = "work_group_size(";
+  if (attributes.empty() || attributes.find(wg_size_str) == std::string::npos) {
+    std::cerr << "Work group size attribute is not found in kernel attributes"
+              << std::endl;
+    return false;
+  }
+  auto wg_size_pos = attributes.find(wg_size_str);
+  wg_size_pos += wg_size_str.size();
+  const auto comma_pos = attributes.find(',', wg_size_pos);
+  if (comma_pos == std::string::npos) {
+    std::cerr << "Comma not found in work group size attribute string"
+              << std::endl;
+    return false;
+  }
+
+  const auto wg_size_str_value =
+      attributes.substr(wg_size_pos, comma_pos - wg_size_pos);
+  const size_t wg_size = std::stoul(wg_size_str_value);
+  if (wg_size != WGSIZE) {
+    std::cerr << "Work group size from attributes: " << wg_size
+              << " is not equal to expected work group size: " << WGSIZE
+              << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool test_queue(sycl::kernel &k, sycl::queue &q) {
+  const auto wg_size_cmp =
+      k.get_info<sycl::info::kernel_device_specific::work_group_size>(
+          q.get_device());
+  const auto wg_size = syclexp::get_kernel_info<
+      func, sycl::info::kernel_device_specific::work_group_size>(q);
+  if (wg_size_cmp != wg_size)
+    std::cerr << "Work group size from get_info: " << wg_size_cmp
+              << " is not equal to work group size from get_kernel_info: "
+              << wg_size << std::endl;
+  return wg_size_cmp == wg_size;
+}
+
+int main() {
+  sycl::queue q;
+  sycl::context ctxt = q.get_context();
+
+  auto exe_bndl =
+      syclexp::get_kernel_bundle<func, sycl::bundle_state::executable>(ctxt);
+  sycl::kernel k_func = exe_bndl.template ext_oneapi_get_kernel<func>();
+  call_kernel_code(q, k_func);
+
+  bool ret = test_ctxt_dev(k_func, q);
+  ret &= test_ctxt(k_func, q);
+  ret &= test_queue(k_func, q);
+  return ret ? 0 : 1;
+}


### PR DESCRIPTION
This PR 
1. adds **get_kernel_info** functions for kernel free functions, [docs](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc#new-free-functions-to-query-kernel-information-descriptors)
2. fixes bug when more than one property added with **add_ir_attributes_funcion**, free function was not recognized as a kernel function
