### PR TITLE
[UR][L0] SYCL_UR_TRACE makes urEnqueueUSMMemcpy non-blocking with trace flag

### DIFF
--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -1277,8 +1277,11 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
   // So, disable it for modes where we print PI traces. Printing
   // traces incurs much different timings than real execution
   // ansyway, and many regression tests use it.
-  //
-  bool CurrentlyEmpty = !PrintTrace && this->LastCommandEvent == nullptr;
+
+  // For PVC we need to ignore PrintTrace since the logic for regular
+  // commandlist is skipped and we need it to complete to executeCommandList
+  bool CurrentlyEmpty =
+      (!PrintTrace || Device->isPVC()) && this->LastCommandEvent == nullptr;
 
   // The list can be empty if command-list only contains signals of proxy
   // events. It is possible that executeCommandList is called twice for the same


### PR DESCRIPTION
This change makes it so that urEnqueueUSMMemcpy will be blocking and completes data transfer with executeCmdlist logic being ran with SYCL_UR_TRACE=-1 as well. Only changes behavior on PVC