### PR TITLE
[SYCL] Do not count devices for banned platforms

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -116,8 +116,13 @@ std::vector<platform> platform_impl::getAdapterPlatforms(AdapterPtr &Adapter,
     platform Platform = detail::createSyclObjFromImpl<platform>(
         getOrMakePlatformImpl(UrPlatform, Adapter));
     const bool IsBanned = IsBannedPlatform(Platform);
-    const bool HasAnyDevices =
-        !Platform.get_devices(info::device_type::all).empty();
+    bool HasAnyDevices = false;
+
+    // Platform.get_devices() increments the device count for the platform
+    // and if the platform is banned (like OpenCL for AMD), it can cause
+    // incorrect device numbering, when used with ONEAPI_DEVICE_SELECTOR.
+    if (!IsBanned)
+      HasAnyDevices = !Platform.get_devices(info::device_type::all).empty();
 
     if (!Supported) {
       if (IsBanned || !HasAnyDevices) {

--- a/sycl/test-e2e/Regression/device_num.cpp
+++ b/sycl/test-e2e/Regression/device_num.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: any-device-is-hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16805
-
 // RUN: %{build} -o %t.out
 // RUN: env PRINT_FULL_DEVICE_INFO=1 %{run-unfiltered-devices} %t.out > %t1.conf
 // RUN: env ONEAPI_DEVICE_SELECTOR="*:0" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out


### PR DESCRIPTION
Call to `Platform.get_devices()` increments the device count for the adapter (in `Adapter->setLastDeviceId()`) and if a platform is banned (like OpenCL for AMD), it can cause incorrect device numbering, when used with ONEAPI_DEVICE_SELECTOR.

This PR skips call to `Platform.get_devices()` if a platform is banned.