### PR TITLE
[SYCL] Avoid infinite loop when kernel fails to compile with memory error

### DIFF
--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -818,7 +818,9 @@ public:
             BuildResult->Error.Code == UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY) {
           reset();
           BuildResult->updateAndNotify(BuildState::BS_Initial);
-          continue;
+          if (AttemptCounter + 1 < MaxAttempts) {
+            continue;
+          }
         }
 
         BuildResult->updateAndNotify(BuildState::BS_Failed);

--- a/sycl/unittests/kernel-and-program/OutOfResources.cpp
+++ b/sycl/unittests/kernel-and-program/OutOfResources.cpp
@@ -124,7 +124,7 @@ TEST_P(OutOfResourcesTestSuite, urProgramCreateAlwaysFail) {
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
   queue Q(Ctx, default_selector_v);
 
-  bool threwException = false;
+  bool ThrewException = false;
 
   try {
     q.single_task<class OutOfResourcesKernel1>([] {});

--- a/sycl/unittests/kernel-and-program/OutOfResources.cpp
+++ b/sycl/unittests/kernel-and-program/OutOfResources.cpp
@@ -109,9 +109,7 @@ TEST_P(OutOfResourcesTestSuite, urProgramCreate) {
   }
 }
 
-static ur_result_t ProgramCreateWithILAlwaysFail(void *) {
-  return ErrorCode;
-}
+static ur_result_t ProgramCreateWithILAlwaysFail(void *) { return ErrorCode; }
 
 TEST_P(OutOfResourcesTestSuite, urProgramCreateAlwaysFail) {
   sycl::unittest::UrMock<> Mock;
@@ -127,13 +125,13 @@ TEST_P(OutOfResourcesTestSuite, urProgramCreateAlwaysFail) {
   bool ThrewException = false;
 
   try {
-    q.single_task<class OutOfResourcesKernel1>([] {});
+    Q.single_task<class OutOfResourcesKernel1>([] {});
   } catch (exception &Ex) {
     auto Code = detail::get_ur_error(Ex);
     EXPECT_EQ(Code, ErrorCode);
-    threwException = true;
+    ThrewException = true;
   }
-  EXPECT_TRUE(threwException);
+  EXPECT_TRUE(ThrewException);
 }
 
 static int nProgramLink = 0;

--- a/sycl/unittests/kernel-and-program/OutOfResources.cpp
+++ b/sycl/unittests/kernel-and-program/OutOfResources.cpp
@@ -122,7 +122,7 @@ TEST_P(OutOfResourcesTestSuite, urProgramCreateAlwaysFail) {
   sycl::platform Plt{sycl::platform()};
   sycl::context Ctx{Plt};
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  queue q(Ctx, default_selector_v);
+  queue Q(Ctx, default_selector_v);
 
   bool threwException = false;
 


### PR DESCRIPTION
The runtime tries to build a kernel again if compilation fails. But if UR returns a memory error the attempt counter was not compared against the maximum number of attempts, so the compiler was continuously called and eventually the loop counter would have overflowed.