### PR TITLE
[UR][CTS] Update USM tests to prevent crashes in offload adapter

### DIFF
--- a/unified-runtime/test/conformance/testing/include/uur/known_failure.h
+++ b/unified-runtime/test/conformance/testing/include/uur/known_failure.h
@@ -90,6 +90,11 @@ struct NativeCPU : Matcher {
       : Matcher(1, UR_BACKEND_NATIVE_CPU, {il.begin(), il.end()}) {}
 };
 
+struct Offload : Matcher {
+  Offload(std::initializer_list<std::string> il)
+      : Matcher(1, UR_BACKEND_OFFLOAD, {il.begin(), il.end()}) {}
+};
+
 inline bool isKnownFailureOn(ur_adapter_handle_t adapter,
                              const std::vector<Matcher> &matchers) {
   auto adapterInfo = detail::getAdapterInfo(adapter);

--- a/unified-runtime/test/conformance/usm/urUSMDeviceAlloc.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMDeviceAlloc.cpp
@@ -42,11 +42,11 @@ TEST_P(urUSMDeviceAllocTest, Success) {
   uint8_t pattern = 0;
   ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urQueueFlush(queue));
+  ASSERT_SUCCESS(urQueueFlush(queue));
   ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urUSMDeviceAllocTest, SuccessWithDescriptors) {
@@ -70,7 +70,7 @@ TEST_P(urUSMDeviceAllocTest, SuccessWithDescriptors) {
   ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidNullHandleContext) {
@@ -160,5 +160,5 @@ TEST_P(urUSMDeviceAllocAlignmentTest, SuccessAlignedAllocations) {
   ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 }

--- a/unified-runtime/test/conformance/usm/urUSMFree.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMFree.cpp
@@ -28,10 +28,10 @@ TEST_P(urUSMFreeTest, SuccessDeviceAlloc) {
   ur_event_handle_t event = nullptr;
 
   uint8_t pattern = 0;
-  EXPECT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+  ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urQueueFlush(queue));
-  EXPECT_SUCCESS(urEventWait(1, &event));
+  ASSERT_SUCCESS(urQueueFlush(queue));
+  ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
   ASSERT_SUCCESS(urEventRelease(event));
@@ -53,10 +53,10 @@ TEST_P(urUSMFreeTest, SuccessHostAlloc) {
 
   ur_event_handle_t event = nullptr;
   uint8_t pattern = 0;
-  EXPECT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+  ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urQueueFlush(queue));
-  EXPECT_SUCCESS(urEventWait(1, &event));
+  ASSERT_SUCCESS(urQueueFlush(queue));
+  ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
   ASSERT_SUCCESS(urEventRelease(event));
@@ -84,10 +84,10 @@ TEST_P(urUSMFreeTest, SuccessSharedAlloc) {
 
   ur_event_handle_t event = nullptr;
   uint8_t pattern = 0;
-  EXPECT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+  ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urQueueFlush(queue));
-  EXPECT_SUCCESS(urEventWait(1, &event));
+  ASSERT_SUCCESS(urQueueFlush(queue));
+  ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
   ASSERT_SUCCESS(urEventRelease(event));
@@ -121,6 +121,9 @@ struct urUSMFreeDuringExecutionTest : uur::urKernelExecutionTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMFreeDuringExecutionTest);
 
 TEST_P(urUSMFreeDuringExecutionTest, SuccessHost) {
+  // Causes an abort in liboffload
+  UUR_KNOWN_FAILURE_ON(uur::Offload{});
+
   ur_device_usm_access_capability_flags_t host_usm_flags = 0;
   ASSERT_SUCCESS(uur::GetDeviceUSMHostSupport(device, host_usm_flags));
   if (!(host_usm_flags & UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS)) {
@@ -131,9 +134,9 @@ TEST_P(urUSMFreeDuringExecutionTest, SuccessHost) {
       urUSMHostAlloc(context, nullptr, nullptr, allocation_size, &allocation));
   ASSERT_NE(allocation, nullptr);
 
-  EXPECT_SUCCESS(urKernelSetArgPointer(kernel, 0, nullptr, allocation));
-  EXPECT_SUCCESS(urKernelSetArgValue(kernel, 1, sizeof(data), nullptr, &data));
-  EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, kernel, 1, &wg_offset,
+  ASSERT_SUCCESS(urKernelSetArgPointer(kernel, 0, nullptr, allocation));
+  ASSERT_SUCCESS(urKernelSetArgValue(kernel, 1, sizeof(data), nullptr, &data));
+  ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, kernel, 1, &wg_offset,
                                        &array_size, nullptr, 0, nullptr, 0,
                                        nullptr, nullptr));
   ASSERT_SUCCESS(urUSMFree(context, allocation));
@@ -141,6 +144,9 @@ TEST_P(urUSMFreeDuringExecutionTest, SuccessHost) {
 }
 
 TEST_P(urUSMFreeDuringExecutionTest, SuccessDevice) {
+  // Causes an abort in liboffload
+  UUR_KNOWN_FAILURE_ON(uur::Offload{});
+
   ur_device_usm_access_capability_flags_t device_usm_flags = 0;
   ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm_flags));
   if (!(device_usm_flags & UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS)) {
@@ -151,10 +157,10 @@ TEST_P(urUSMFreeDuringExecutionTest, SuccessDevice) {
                                   allocation_size, &allocation));
   ASSERT_NE(allocation, nullptr);
 
-  EXPECT_SUCCESS(urKernelSetArgPointer(kernel, 0, nullptr, allocation));
-  EXPECT_SUCCESS(urKernelSetArgValue(kernel, 1, sizeof(data), nullptr, &data));
+  ASSERT_SUCCESS(urKernelSetArgPointer(kernel, 0, nullptr, allocation));
+  ASSERT_SUCCESS(urKernelSetArgValue(kernel, 1, sizeof(data), nullptr, &data));
 
-  EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, kernel, 1, &wg_offset,
+  ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, kernel, 1, &wg_offset,
                                        &array_size, nullptr, 0, nullptr, 0,
                                        nullptr, nullptr));
   ASSERT_SUCCESS(urUSMFree(context, allocation));
@@ -162,6 +168,9 @@ TEST_P(urUSMFreeDuringExecutionTest, SuccessDevice) {
 }
 
 TEST_P(urUSMFreeDuringExecutionTest, SuccessShared) {
+  // Causes an abort in liboffload
+  UUR_KNOWN_FAILURE_ON(uur::Offload{});
+
   ur_device_usm_access_capability_flags_t shared_usm_flags = 0;
   ASSERT_SUCCESS(
       uur::GetDeviceUSMSingleSharedSupport(device, shared_usm_flags));
@@ -173,9 +182,9 @@ TEST_P(urUSMFreeDuringExecutionTest, SuccessShared) {
                                   allocation_size, &allocation));
   ASSERT_NE(allocation, nullptr);
 
-  EXPECT_SUCCESS(urKernelSetArgPointer(kernel, 0, nullptr, allocation));
-  EXPECT_SUCCESS(urKernelSetArgValue(kernel, 1, sizeof(data), nullptr, &data));
-  EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, kernel, 1, &wg_offset,
+  ASSERT_SUCCESS(urKernelSetArgPointer(kernel, 0, nullptr, allocation));
+  ASSERT_SUCCESS(urKernelSetArgValue(kernel, 1, sizeof(data), nullptr, &data));
+  ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, kernel, 1, &wg_offset,
                                        &array_size, nullptr, 0, nullptr, 0,
                                        nullptr, nullptr));
   ASSERT_SUCCESS(urUSMFree(context, allocation));

--- a/unified-runtime/test/conformance/usm/urUSMHostAlloc.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMHostAlloc.cpp
@@ -45,18 +45,18 @@ TEST_P(urUSMHostAllocTest, Success) {
   uint8_t pattern = 0;
   ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urQueueFlush(queue));
+  ASSERT_SUCCESS(urQueueFlush(queue));
   ASSERT_SUCCESS(urEventWait(1, &event));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
   ASSERT_EQ(*reinterpret_cast<int *>(ptr), 0);
 
   // Set 1, in all bytes of int
   pattern = 1;
   ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urQueueFlush(queue));
+  ASSERT_SUCCESS(urQueueFlush(queue));
   ASSERT_SUCCESS(urEventWait(1, &event));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 
   // replicate it on host
   int set_data = 0;
@@ -87,7 +87,7 @@ TEST_P(urUSMHostAllocTest, SuccessWithDescriptors) {
   ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urUSMHostAllocTest, InvalidNullHandleContext) {
@@ -166,5 +166,5 @@ TEST_P(urUSMHostAllocAlignmentTest, SuccessAlignedAllocations) {
   ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 }

--- a/unified-runtime/test/conformance/usm/urUSMPoolCreate.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMPoolCreate.cpp
@@ -25,7 +25,7 @@ TEST_P(urUSMPoolCreateTest, Success) {
   ur_usm_pool_handle_t pool = nullptr;
   ASSERT_SUCCESS(urUSMPoolCreate(context, &pool_desc, &pool));
   ASSERT_NE(pool, nullptr);
-  EXPECT_SUCCESS(urUSMPoolRelease(pool));
+  ASSERT_SUCCESS(urUSMPoolRelease(pool));
 }
 
 TEST_P(urUSMPoolCreateTest, SuccessWithFlag) {
@@ -36,7 +36,7 @@ TEST_P(urUSMPoolCreateTest, SuccessWithFlag) {
   ur_usm_pool_handle_t pool = nullptr;
   ASSERT_SUCCESS(urUSMPoolCreate(context, &pool_desc, &pool));
   ASSERT_NE(pool, nullptr);
-  EXPECT_SUCCESS(urUSMPoolRelease(pool));
+  ASSERT_SUCCESS(urUSMPoolRelease(pool));
 }
 
 TEST_P(urUSMPoolCreateTest, InvalidNullHandleContext) {

--- a/unified-runtime/test/conformance/usm/urUSMPoolRelease.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMPoolRelease.cpp
@@ -20,7 +20,7 @@ TEST_P(urUSMPoolReleaseTest, Success) {
 
   ASSERT_LT(prevRefCount, refCount);
 
-  EXPECT_SUCCESS(urUSMPoolRelease(pool));
+  ASSERT_SUCCESS(urUSMPoolRelease(pool));
 
   uint32_t afterRefCount = 0;
   ASSERT_SUCCESS(uur::GetObjectReferenceCount(pool, afterRefCount));

--- a/unified-runtime/test/conformance/usm/urUSMPoolRetain.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMPoolRetain.cpp
@@ -21,7 +21,7 @@ TEST_P(urUSMPoolRetainTest, Success) {
 
   ASSERT_LT(prevRefCount, refCount);
 
-  EXPECT_SUCCESS(urUSMPoolRelease(pool));
+  ASSERT_SUCCESS(urUSMPoolRelease(pool));
 
   uint32_t afterRefCount = 0;
   ASSERT_SUCCESS(uur::GetObjectReferenceCount(pool, afterRefCount));

--- a/unified-runtime/test/conformance/usm/urUSMSharedAlloc.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMSharedAlloc.cpp
@@ -46,12 +46,12 @@ TEST_P(urUSMSharedAllocTest, Success) {
 
   ur_event_handle_t event = nullptr;
   uint8_t pattern = 0;
-  EXPECT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+  ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urEventWait(1, &event));
+  ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urUSMSharedAllocTest, SuccessWithDescriptors) {
@@ -74,12 +74,12 @@ TEST_P(urUSMSharedAllocTest, SuccessWithDescriptors) {
 
   ur_event_handle_t event = nullptr;
   uint8_t pattern = 0;
-  EXPECT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+  ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urEventWait(1, &event));
+  ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urUSMSharedAllocTest, SuccessWithMultipleAdvices) {
@@ -97,12 +97,12 @@ TEST_P(urUSMSharedAllocTest, SuccessWithMultipleAdvices) {
 
   ur_event_handle_t event = nullptr;
   uint8_t pattern = 0;
-  EXPECT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+  ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urEventWait(1, &event));
+  ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urUSMSharedAllocTest, InvalidNullHandleContext) {
@@ -192,10 +192,10 @@ TEST_P(urUSMSharedAllocAlignmentTest, SuccessAlignedAllocations) {
 
   ur_event_handle_t event = nullptr;
   uint8_t pattern = 0;
-  EXPECT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+  ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
                                   allocation_size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urEventWait(1, &event));
+  ASSERT_SUCCESS(urEventWait(1, &event));
 
   ASSERT_SUCCESS(urUSMFree(context, ptr));
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 }


### PR DESCRIPTION
The CTS tests for USM uses `EXPECT_SUCCESS` when it should really be
`ASSERT_SUCCESS` (the latter returns, which looks to have been the
intended behaviour).

In addition, some tests have been marked with a new `uur::Offload`
known failure, as they cause liboffload to hit an abort.
