### PR TITLE
[SYCL][Graph] Disable Windows tests on LNL

### DIFF
--- a/sycl/test-e2e/Graph/lit.local.cfg
+++ b/sycl/test-e2e/Graph/lit.local.cfg
@@ -1,3 +1,5 @@
-# https://github.com/intel/llvm/issues/17165
 if 'windows' in config.available_features:
+   # https://github.com/intel/llvm/issues/17165
    config.unsupported_features += ['arch-intel_gpu_bmg_g21']
+   # CMPLRTST-27275
+   config.unsupported_features += ['arch-intel_gpu_lnl_m']


### PR DESCRIPTION
As reported in CMPLRTST-27275 there are windows test fails on Lunar Lake. Disable these tests until issues can be investigated and fixed.