### PR TITLE
[SYCL] Handle non-type template parameters in integration headers

### DIFF
--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -1317,7 +1317,8 @@ void StmtPrinter::VisitDeclRefExpr(DeclRefExpr *Node) {
     OS << "template ";
 
   bool ForceAnonymous =
-      Policy.PrintAsCanonical && VD->getKind() == Decl::NonTypeTemplateParm;
+      Policy.PrintAsCanonical && !Policy.SkipCanonicalizationOfTemplateTypeParms &&
+      VD->getKind() == Decl::NonTypeTemplateParm;
   DeclarationNameInfo NameInfo = Node->getNameInfo();
   if (IdentifierInfo *ID = NameInfo.getName().getAsIdentifierInfo();
       !ForceAnonymous &&

--- a/clang/test/CodeGenSYCL/int_header_nttp.cpp
+++ b/clang/test/CodeGenSYCL/int_header_nttp.cpp
@@ -8,6 +8,7 @@
 // CHECK: Forward declarations of templated kernel function types:
 // CHECK-NEXT: template <typename T, T nttp> struct SelfReferentialNTTP;
 // CHECK-NEXT: template <typename U, int nttp> struct NonSelfRef;
+// CHECK-NEXT: template <int N> struct alignas(N)  OpaqueType;
 
 template<typename T, T nttp>
 struct SelfReferentialNTTP {};
@@ -17,7 +18,15 @@ using Foo = int;
 template<typename U, Foo nttp>
 struct NonSelfRef {};
 
+template <int N> struct alignas(N) OpaqueType {
+  char data[N];
+};
+template <typename T> class Kernel;
+
 void foo() {
-  sycl::kernel_single_task<SelfReferentialNTTP<int, 1>>([](){});
-  sycl::kernel_single_task<NonSelfRef<int, 1>>([](){});
+  auto Lambda = [](){};
+  sycl::kernel_single_task<SelfReferentialNTTP<int, 1>>(Lambda);
+  sycl::kernel_single_task<NonSelfRef<int, 1>>(Lambda);
+  using scalar_t = OpaqueType<sizeof(int)>;
+  sycl::kernel_single_task<class Kernel<scalar_t>>(Lambda);
 }


### PR DESCRIPTION
A recent community change https://github.com/llvm/llvm-project/pull/124858/ affected
how we render some non-type template parameters in the integration header.   We were
generating malformed arguments of the form 'value-parameter-0-1', which obviously
led to compilation errors when including the header in host compilations.