### PR TITLE
[SYCL][NFC] Drop unnecessary `nullptr` check

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -825,7 +825,7 @@ static bool isDeclaredInSYCLNamespace(const Decl *D) {
     ND = cast<NamespaceDecl>(Parent);
   }
 
-  return ND && ND->getName() == "sycl";
+  return ND->getName() == "sycl";
 }
 
 static bool isSYCLPrivateMemoryVar(VarDecl *VD) {


### PR DESCRIPTION
This resolves Coverity issue `440250`
(https://scan.coverity.com/projects/intel-llvm?tab=overview).

We know that `ND` cannot be `nullptr`, but presence of the check makes Coverity think that earlier accesses (within the `while` loop condition) are potentially unsafe.