### PR TITLE
[sycl-rel][NFC] Add --use-zstd to configure.py

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -417,6 +417,9 @@ def main():
         "--native-cpu-libclc-targets",
         help="Target triples for libclc, used by the Native CPU backend",
     )
+    parser.add_argument(
+        "--use-zstd", action="store_true", help="Placeholder, does nothing currently."
+    )
     args, passthrough_args = parser.parse_known_intermixed_args()
 
     print("args:{}".format(args))


### PR DESCRIPTION
https://github.com/intel/llvm/pull/18547 introduced new flag, unsupported by the 6_2 release.