### PR TITLE
[CI] Move setting `--use-zstd` flag from workflow files to configure.py

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -45,7 +45,7 @@ jobs:
         cd $GITHUB_WORKSPACE/build
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
-          --ci-defaults --use-zstd --hip --cuda \
+          --ci-defaults --hip --cuda \
           -DNATIVECPU_USE_OCK=Off \
           -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
 

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -173,7 +173,7 @@ jobs:
         cd $GITHUB_WORKSPACE/build
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
-          --ci-defaults --use-zstd ${{ inputs.build_configure_extra_args }} \
+          --ci-defaults ${{ inputs.build_configure_extra_args }} \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DLLVM_INSTALL_UTILS=ON \

--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
         cd $GITHUB_WORKSPACE/build
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
-          --ci-defaults --use-zstd $ARGS \
+          --ci-defaults $ARGS \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DLLVM_INSTALL_UTILS=ON

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -140,7 +140,7 @@ jobs:
         IF NOT EXIST D:\github\_work\cache MKDIR D:\github\_work\cache
         IF NOT EXIST D:\github\_work\cache\${{inputs.build_cache_suffix}} MKDIR D:\github\_work\cache\${{inputs.build_cache_suffix}}
         python.exe src/buildbot/configure.py -o build ^
-          --ci-defaults --use-zstd %ARGS% ^
+          --ci-defaults %ARGS% ^
           "-DCMAKE_C_COMPILER=${{inputs.cxx}}" ^
           "-DCMAKE_CXX_COMPILER=${{inputs.cxx}}" ^
           "-DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install" ^

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -163,6 +163,9 @@ def do_configure(args, passthrough_args):
             spirv_enable_dis = "ON"
             sycl_install_device_config_file = "ON"
 
+        # Build compiler with zstd in CI.
+        llvm_enable_zstd = "FORCE_ON"
+
     if args.enable_backends:
         sycl_enabled_backends += args.enable_backends
 


### PR DESCRIPTION
Follow up of https://github.com/intel/llvm/pull/18547