### PR TITLE
[NATIVECPU][UR] added mutex to backend queue

### DIFF
--- a/unified-runtime/source/adapters/native_cpu/queue.hpp
+++ b/unified-runtime/source/adapters/native_cpu/queue.hpp
@@ -51,7 +51,6 @@ struct ur_queue_handle_t_ : RefCounted {
       decrementOrDelete(ev);
       lock.lock();
     }
-    events.clear();
   }
 
   ~ur_queue_handle_t_() { finish(); }


### PR DESCRIPTION
Before this PR one thread could add new events to the queue while another removes events, both modifying and potentially corrupting NativeCPU queue::events. This PR adds a mutex to the NativeCPU queue handle to prevent this potential corruption.

Aims to at least fix: `SYCL/HostInteropTask/host-task-two-queues.cpp`