### PR TITLE
[SYCL] emit forward declaration of template specialization into integration header

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -6596,7 +6596,8 @@ public:
       }
       O << TemplateParameters;
       O << FD->getReturnType().getAsString() << " ";
-      O << FD->getNameAsString() << "(" << Args << ");";
+      FD->printName(O, Policy);
+      O << "(" << Args << ");";
       if (NSInserted) {
         O << "\n";
         PrintNSClosingBraces(O, FD);
@@ -7060,6 +7061,10 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     FreeFunctionPrinter FFPrinter(O, Policy);
     if (FTD) {
       FFPrinter.printFreeFunctionDeclaration(FTD, S);
+      if (K.SyclKernel->isFunctionTemplateSpecialization()) {
+        O << "template <> ";
+        FFPrinter.printFreeFunctionDeclaration(K.SyclKernel, ParmListWithNames);
+      }
     } else {
       FFPrinter.printFreeFunctionDeclaration(K.SyclKernel, ParmListWithNames);
     }

--- a/clang/test/CodeGenSYCL/free_function_default_template_arguments.cpp
+++ b/clang/test/CodeGenSYCL/free_function_default_template_arguments.cpp
@@ -268,16 +268,19 @@ namespace Testing::Tests {
 // CHECK-NEXT: }
 
 // CHECK: template <typename T> void templated(ns::Arg<T, float, 3, ns::notatuple> , T end);
+// CHECK-NEXT: template <> void templated(ns::Arg<int, float, 3, ns::notatuple> , int end);
 // CHECK-NEXT: static constexpr auto __sycl_shim3() {
 // CHECK-NEXT:   return (void (*)(struct ns::Arg<int, float, 3, struct ns::notatuple>, int))templated<int>;
 // CHECK-NEXT: }
 
 // CHECK: template <typename T> void templated2(ns::Arg<T, ns::notatuple, 12, ns::notatuple> , T end);
+// CHECK-NEXT: template <> void templated2(ns::Arg<int, ns::notatuple, 12, ns::notatuple> , int end);
 // CHECK-NEXT: static constexpr auto __sycl_shim4() {
 // CHECK-NEXT:   return (void (*)(struct ns::Arg<int, struct ns::notatuple, 12, struct ns::notatuple>, int))templated2<int>;
 // CHECK-NEXT: }
 
 // CHECK: template <typename T, int a> void templated3(ns::Arg<T, ns::notatuple, a, ns::ns1::hasDefaultArg<ns::notatuple>, int, int> , T end);
+// CHECK-NEXT: template <> void templated3(ns::Arg<int, ns::notatuple, 3, ns::ns1::hasDefaultArg<ns::notatuple>, int, int> , int end);
 // CHECK-NEXT: static constexpr auto __sycl_shim5() {
 // CHECK-NEXT:   return (void (*)(struct ns::Arg<int, struct ns::notatuple, 3, class ns::ns1::hasDefaultArg<struct ns::notatuple>, int, int>, int))templated3<int, 3>;
 // CHECK-NEXT: }
@@ -371,6 +374,7 @@ namespace Testing::Tests {
 
 // CHECK: struct TestStruct;
 // CHECK: template <typename T> void templated(ns::Arg<T, float, 3, ns::notatuple> , T end);
+// CHECK-NEXT: template <> void templated(ns::Arg<TestStruct, float, 3, ns::notatuple> , TestStruct end);
 // CHECK-NEXT: static constexpr auto __sycl_shim12() {
 // CHECK-NEXT:  return (void (*)(struct ns::Arg<struct TestStruct, float, 3, struct ns::notatuple>, struct TestStruct))templated<struct TestStruct>;
 // CHECK-NEXT:}
@@ -554,6 +558,7 @@ namespace Testing::Tests {
 // CHECK-NEXT:  }
 
 // CHECK: template <typename ... Args> void variadic_templated(Args... args);
+// CHECK-NEXT: template <> void variadic_templated(int args, float args, char args);
 // CHECK-NEXT: static constexpr auto __sycl_shim22() {
 // CHECK-NEXT:  return (void (*)(int, float, char))variadic_templated<int, float, char>;
 // CHECK-NEXT: }
@@ -569,6 +574,7 @@ namespace Testing::Tests {
 // CHECK-NEXT: }
 
 // CHECK: template <typename ... Args> void variadic_templated(Args... args);
+// CHECK-NEXT: template <> void variadic_templated(int args, float args, char args, int args);
 // CHECK-NEXT: static constexpr auto __sycl_shim23() {
 // CHECK-NEXT:  return (void (*)(int, float, char, int))variadic_templated<int, float, char, int>;
 // CHECK-NEXT: }
@@ -584,6 +590,7 @@ namespace Testing::Tests {
 // CHECK-NEXT: }
 
 // CHECK: template <typename ... Args> void variadic_templated(Args... args);
+// CHECK-NEXT: template <> void variadic_templated(float args, float args);
 // CHECK-NEXT: static constexpr auto __sycl_shim24() {
 // CHECK-NEXT:  return (void (*)(float, float))variadic_templated<float, float>;
 // CHECK-NEXT: }
@@ -599,6 +606,7 @@ namespace Testing::Tests {
 // CHECK-NEXT: }
 
 // CHECK: template <typename T, typename ... Args> void variadic_templated1(T b, Args... args);
+// CHECK-NEXT: template <> void variadic_templated1(float b, char args, char args);
 // CHECK-NEXT: static constexpr auto __sycl_shim25() {
 // CHECK-NEXT:  return (void (*)(float, char, char))variadic_templated1<float, char, char>;
 // CHECK-NEXT: }
@@ -614,6 +622,7 @@ namespace Testing::Tests {
 // CHECK-NEXT: }
 
 // CHECK: template <typename T, typename ... Args> void variadic_templated1(T b, Args... args);
+// CHECK-NEXT: template <> void variadic_templated1(int b, float args, char args);
 // CHECK-NEXT: static constexpr auto __sycl_shim26() {
 // CHECK-NEXT:  return (void (*)(int, float, char))variadic_templated1<int, float, char>;
 // CHECK-NEXT: }

--- a/clang/test/CodeGenSYCL/free_function_int_header.cpp
+++ b/clang/test/CodeGenSYCL/free_function_int_header.cpp
@@ -445,6 +445,7 @@ void ff_20(sycl::accessor<int, 1, sycl::access::mode::read_write> acc) {
 // CHECK: Definition of _Z18__sycl_kernel_ff_3IiEvPT_S0_S0_ as a free function kernel
 // CHECK: Forward declarations of kernel and its argument types:
 // CHECK: template <typename T> void ff_3(T * ptr, T start, T end);
+// CHECK: template <> void ff_3(int * ptr, int start, int end);
 // CHECK-NEXT: static constexpr auto __sycl_shim3() {
 // CHECK-NEXT:   return (void (*)(int *, int, int))ff_3<int>;
 // CHECK-NEXT: }
@@ -462,6 +463,7 @@ void ff_20(sycl::accessor<int, 1, sycl::access::mode::read_write> acc) {
 // CHECK: Definition of _Z18__sycl_kernel_ff_3IfEvPT_S0_S0_ as a free function kernel
 // CHECK: Forward declarations of kernel and its argument types:
 // CHECK: template <typename T> void ff_3(T * ptr, T start, T end);
+// CHECK: template <> void ff_3(float * ptr, float start, float end);
 // CHECK-NEXT: static constexpr auto __sycl_shim4() {
 // CHECK-NEXT:   return (void (*)(float *, float, float))ff_3<float>;
 // CHECK-NEXT: }
@@ -479,6 +481,7 @@ void ff_20(sycl::accessor<int, 1, sycl::access::mode::read_write> acc) {
 // CHECK: Definition of _Z18__sycl_kernel_ff_3IdEvPT_S0_S0_ as a free function kernel
 // CHECK: Forward declarations of kernel and its argument types:
 // CHECK: template <typename T> void ff_3(T * ptr, T start, T end);
+// CHECK: template <> void ff_3(double * ptr, double start, double end);
 // CHECK-NEXT: static constexpr auto __sycl_shim5() {
 // CHECK-NEXT:   return (void (*)(double *, double, double))ff_3<double>;
 // CHECK-NEXT: }
@@ -517,6 +520,7 @@ void ff_20(sycl::accessor<int, 1, sycl::access::mode::read_write> acc) {
 // CHECK: Forward declarations of kernel and its argument types:
 // CHECK: struct Derived;
 // CHECK: template <typename T1, typename T2> void ff_6(T1 S1, T2 S2, int end);
+// CHECK: template <> void ff_6(Agg S1, Derived S2, int end);
 // CHECK-NEXT: static constexpr auto __sycl_shim7() {
 // CHECK-NEXT:   return (void (*)(struct Agg, struct Derived, int))ff_6<struct Agg, struct Derived>;
 // CHECK-NEXT: }
@@ -537,6 +541,7 @@ void ff_20(sycl::accessor<int, 1, sycl::access::mode::read_write> acc) {
 // CHECK: template <int ArrSize> struct KArgWithPtrArray;
 //
 // CHECK: template <int ArrSize> void ff_7(KArgWithPtrArray<ArrSize> KArg);
+// CHECK-NEXT: template <> void ff_7(KArgWithPtrArray<3> KArg);
 // CHECK-NEXT: static constexpr auto __sycl_shim8() {
 // CHECK-NEXT:   return (void (*)(struct KArgWithPtrArray<3>))ff_7<3>;
 // CHECK-NEXT: }
@@ -735,6 +740,7 @@ void ff_20(sycl::accessor<int, 1, sycl::access::mode::read_write> acc) {
 // CHECK: Forward declarations of kernel and its argument types:
 
 // CHECK: template <typename DataT> void ff_11(sycl::local_accessor<DataT, 1> lacc);
+// CHECK-NEXT: template <> void ff_11(sycl::local_accessor<float, 1> lacc);
 // CHECK-NEXT: static constexpr auto __sycl_shim
 // CHECK-NEXT:  return (void (*)(class sycl::local_accessor<float, 1>))ff_11<float>;
 

--- a/sycl/test-e2e/FreeFunctionKernels/template_specialization.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/template_specialization.cpp
@@ -1,0 +1,88 @@
+// REQUIRES: aspect-usm_shared_allocations
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/free_function_queries.hpp>
+#include <sycl/kernel_bundle.hpp>
+#include <sycl/usm.hpp>
+
+using namespace sycl;
+
+struct TestStruct {
+  int x;
+  float y;
+
+  TestStruct(int a, float b) : x(a), y(b) {}
+};
+
+namespace A::B::C {
+class TestClass {
+  int a;
+  float b;
+
+public:
+  TestClass(int x, float y) : a(x), b(y) {}
+
+  void setA(int x) { a = x; }
+  void setB(float y) { b = y; }
+};
+} // namespace A::B::C
+
+template <typename T>
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (ext::oneapi::experimental::nd_range_kernel<1>))
+void sum(T arg) {}
+
+template <>
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (ext::oneapi::experimental::nd_range_kernel<1>))
+void sum<int>(int arg) {
+  arg = 42;
+}
+
+template <> void sum<float>(float arg) { arg = 3.14f; }
+
+template <> void sum<TestStruct>(TestStruct arg) {
+  arg.x = 100;
+  arg.y = 2.0f;
+}
+
+template <> void sum<A::B::C::TestClass>(A::B::C::TestClass arg) {
+  arg.setA(10);
+  arg.setB(5.0f);
+}
+
+template <typename T> void test_func() {
+  queue Q;
+  kernel_bundle bundle =
+      get_kernel_bundle<bundle_state::executable>(Q.get_context());
+  kernel_id id = ext::oneapi::experimental::get_kernel_id<sum<T>>();
+  kernel Kernel = bundle.get_kernel(id);
+  Q.submit([&](handler &h) {
+    h.set_args(static_cast<T>(4));
+    h.parallel_for(nd_range{{1}, {1}}, Kernel);
+  });
+}
+
+template <typename T> void test_func_custom_type() {
+  queue Q;
+  kernel_bundle bundle =
+      get_kernel_bundle<bundle_state::executable>(Q.get_context());
+  kernel_id id = ext::oneapi::experimental::get_kernel_id<sum<T>>();
+  kernel Kernel = bundle.get_kernel(id);
+  Q.submit([&](handler &h) {
+    h.set_args(T(1, 2.0f));
+    h.parallel_for(nd_range{{1}, {1}}, Kernel);
+  });
+}
+
+int main() {
+  test_func<int>();
+  test_func<float>();
+  test_func<uint32_t>();
+  test_func<char>();
+  test_func_custom_type<TestStruct>();
+  test_func_custom_type<A::B::C::TestClass>();
+  return 0;
+}


### PR DESCRIPTION
This PR fixes bug with templated kernel free function and its specialization, i.e. forward declaration of specialization is emitted into integration header too.