### PR TITLE
[SYCL][E2E] Redirect output to `/dev/null` instead of `stdout`

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -316,9 +316,8 @@ with test_env():
 # check if the compiler was built in NDEBUG configuration
 has_ndebug = False
 ps = subprocess.Popen(
-    [config.dpcpp_compiler, "-mllvm", "-debug", "-x", "c", "-", "-S", "-o", "-"],
+    [config.dpcpp_compiler, "-mllvm", "-debug", "-x", "c", "-", "-S", "-o", f"{os.devnull}"],
     stdin=subprocess.PIPE,
-    stdout=subprocess.DEVNULL,
     stderr=subprocess.PIPE,
 )
 _ = ps.communicate(input=b"int main(){}\n")
@@ -426,10 +425,9 @@ ps = subprocess.Popen(
         "c++",
         "-",
         "-o",
-        "-",
+        f"{os.devnull}",
     ],
     stdin=subprocess.PIPE,
-    stdout=subprocess.DEVNULL,
     stderr=subprocess.PIPE,
 )
 op = ps.communicate(input=b"")


### PR DESCRIPTION
Redirecting output to stdout is not working and LIT is instead creating a binary file named `-`
os.devnull equals `/dev/null` on POSIX and 'null' on Windows