### PR TITLE
[SYCL][E2E] Change temporary file names in `DeviceImageDependencies/dynamic_compress` test

### DIFF
--- a/sycl/test-e2e/DeviceImageDependencies/dynamic_compress.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/dynamic_compress.cpp
@@ -9,17 +9,29 @@
 // DEFINE: %{dynamic_lib_options} = -fsycl %fPIC %shared_lib -fsycl-allow-device-image-dependencies -I %S/Inputs %if windows %{-DMAKE_DLL %}
 // DEFINE: %{dynamic_lib_suffix} = %if windows %{dll%} %else %{so%}
 
-// RUN: %clangxx %{dynamic_lib_options} %S/Inputs/d.cpp                                    -o %T/libdevice_d.%{dynamic_lib_suffix}
-// RUN: %clangxx %{dynamic_lib_options} %S/Inputs/c.cpp %if windows %{%T/libdevice_d.lib%} -o %T/libdevice_c.%{dynamic_lib_suffix}
-// RUN: %clangxx %{dynamic_lib_options} %S/Inputs/b.cpp %if windows %{%T/libdevice_c.lib%} -o %T/libdevice_b.%{dynamic_lib_suffix}
-// RUN: %clangxx %{dynamic_lib_options} %S/Inputs/a.cpp %if windows %{%T/libdevice_b.lib%} -o %T/libdevice_a.%{dynamic_lib_suffix}
+// RUN: %clangxx %{dynamic_lib_options} %S/Inputs/d.cpp \
+// RUN:   -o %T/libdevicecompress_d.%{dynamic_lib_suffix}
+
+// RUN: %clangxx %{dynamic_lib_options} %S/Inputs/c.cpp \
+// RUN:   %if windows %{%T/libdevicecompress_d.lib%} \
+// RUN:   -o %T/libdevicecompress_c.%{dynamic_lib_suffix}
+
+// RUN: %clangxx %{dynamic_lib_options} %S/Inputs/b.cpp \
+// RUN:   %if windows %{%T/libdevicecompress_c.lib%} \
+// RUN:   -o %T/libdevicecompress_b.%{dynamic_lib_suffix}
+
+// RUN: %clangxx %{dynamic_lib_options} %S/Inputs/a.cpp \
+// RUN:   %if windows %{%T/libdevicecompress_b.lib%} \
+// RUN:   -o %T/libdevicecompress_a.%{dynamic_lib_suffix}
 
 // Compressed main executable, while dependencies are not compressed.
 
-// RUN: %clangxx -fsycl --offload-compress %{sycl_target_opts} -fsycl-allow-device-image-dependencies -fsycl-device-code-split=per_kernel %S/Inputs/basic.cpp -o %t.out            \
-// RUN: %if windows                                                                       \
-// RUN:   %{%T/libdevice_a.lib%}                                                          \
-// RUN: %else                                                                             \
-// RUN:   %{-L%T -ldevice_a -ldevice_b -ldevice_c -ldevice_d -Wl,-rpath=%T%}
+// RUN: %clangxx -fsycl --offload-compress %{sycl_target_opts} \
+// RUN:   -fsycl-allow-device-image-dependencies -fsycl-device-code-split=per_kernel      \
+// RUN:   %S/Inputs/basic.cpp -o %t.out                                                   \
+// RUN:   %if windows                                                                     \
+// RUN:     %{%T/libdevicecompress_a.lib%}                                                \
+// RUN:   %else                                                                           \
+// RUN:     %{-L%T -ldevicecompress_a -ldevicecompress_b -ldevicecompress_c -ldevicecompress_d -Wl,-rpath=%T%}
 
 // RUN: %{run} %t.out


### PR DESCRIPTION
Temporary files created by dynamic_compress test have the same name as `DeviceImageDependencies/dynamic` test and there can be a race when these two tests are run in parallel. For example: https://github.com/intel/llvm/actions/runs/15594939371/job/43923025923?pr=18828
This PR just changes the name of temporary files