### PR TITLE
[OpenCL] Update OpenCL headers tag to 6eabe90

### DIFF
--- a/opencl/CMakeLists.txt
+++ b/opencl/CMakeLists.txt
@@ -20,7 +20,7 @@ set(OCL_LOADER_REPO
 
 # Repo tags/hashes
 
-set(OCL_HEADERS_TAG 60ba29d8117b5f81d6ab294fa62d9b6688d83f4e)
+set(OCL_HEADERS_TAG 6eabe90aa7b6cff9c67800a2fe25a0cd88d8b749)
 set(OCL_LOADER_TAG ddf6c70230a79cdb8fcccfd3c775b09e6820f42e)
 
 # OpenCL Headers

--- a/unified-runtime/source/adapters/opencl/CMakeLists.txt
+++ b/unified-runtime/source/adapters/opencl/CMakeLists.txt
@@ -57,7 +57,7 @@ if(UR_OPENCL_INCLUDE_DIR)
 else()
     FetchContent_Declare(OpenCL-Headers
         GIT_REPOSITORY  "https://github.com/KhronosGroup/OpenCL-Headers.git"
-        GIT_TAG         60ba29d8117b5f81d6ab294fa62d9b6688d83f4e
+        GIT_TAG         6eabe90aa7b6cff9c67800a2fe25a0cd88d8b749
     )
     FetchContent_MakeAvailable(OpenCL-Headers)
     FetchContent_GetProperties(OpenCL-Headers


### PR DESCRIPTION
Update OpenCL headers tag to
https://github.com/KhronosGroup/OpenCL-Headers/commit/6eabe90aa7b6cff9c67800a2fe25a0cd88d8b749 to include cl_khr_spirv_queries.