### PR TITLE
[SYCL] Fix incorrect return of PropertyValue::data()

### DIFF
--- a/llvm/include/llvm/Support/PropertySetIO.h
+++ b/llvm/include/llvm/Support/PropertySetIO.h
@@ -158,7 +158,17 @@ public:
     }
   }
 
-  const char *data() const { return reinterpret_cast<const char *>(&Val); }
+  const char *data() const {
+    switch (Ty) {
+    case UINT32:
+      return reinterpret_cast<const char *>(&Val.UInt32Val);
+    case BYTE_ARRAY:
+      return reinterpret_cast<const char *>(Val.ByteArrayVal);
+    default:
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "Unsupported property type.");
+    }
+  }
 
 private:
   template <typename T> T &getValueRef();


### PR DESCRIPTION
The data function of PropertyValue was returning a pointer to a pointer when the underlying data was a byte array, rather than returning the byte array pointer itself. This commit fixes the return value for the byte array case.