### PR TITLE
[SYCL][NFC] Remove PropertyValue::copy()

### DIFF
--- a/llvm/include/llvm/Support/PropertySetIO.h
+++ b/llvm/include/llvm/Support/PropertySetIO.h
@@ -162,7 +162,6 @@ public:
 
 private:
   template <typename T> T &getValueRef();
-  void copy(const PropertyValue &P);
 
   Type Ty = NONE;
   // TODO: replace this union with std::variant when uplifting to C++17

--- a/llvm/lib/Support/PropertySetIO.cpp
+++ b/llvm/lib/Support/PropertySetIO.cpp
@@ -176,8 +176,8 @@ PropertyValue::PropertyValue(const PropertyValue &P) { *this = P; }
 PropertyValue::PropertyValue(PropertyValue &&P) { *this = std::move(P); }
 
 PropertyValue &PropertyValue::operator=(PropertyValue &&P) {
-  copy(P);
-
+  Ty = P.Ty;
+  Val = P.Val;
   if (P.getType() == BYTE_ARRAY)
     P.Val.ByteArrayVal = nullptr;
   P.Ty = NONE;
@@ -185,16 +185,13 @@ PropertyValue &PropertyValue::operator=(PropertyValue &&P) {
 }
 
 PropertyValue &PropertyValue::operator=(const PropertyValue &P) {
-  if (P.getType() == BYTE_ARRAY)
+  if (P.getType() == BYTE_ARRAY) {
     *this = PropertyValue(P.asByteArray(), P.getByteArraySizeInBits());
-  else
-    copy(P);
+  } else {
+    Ty = P.Ty;
+    Val = P.Val;
+  }
   return *this;
-}
-
-void PropertyValue::copy(const PropertyValue &P) {
-  Ty = P.Ty;
-  Val = P.Val;
 }
 
 constexpr char PropertySetRegistry::SYCL_SPECIALIZATION_CONSTANTS[];


### PR DESCRIPTION
This commit removes the PropertyValue::copy() foot-gun. This function simply copies the values from one PropertyValue to the other, but for byte arrays, this means the caller of the copy need to ensure that the underlying memory isn't managed by both the original and the copy. Removing the function makes it clearer at the call-sites that this ownership relation has to be maintained explicitly.