### PR TITLE
[DeviceSanitizer] Remove not needed test fix.

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/interop-direct.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-direct.cpp
@@ -1,9 +1,6 @@
 // REQUIRES: level_zero, level_zero_dev_kit
 // UNSUPPORTED: ze_debug, level_zero_v2_adapter
 
-// DeviceSanitizer will report error for cross context USM usage, turn it off
-// RUN: export UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:0"
-
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{run} %t.out
 // RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{run} %t.out


### PR DESCRIPTION
The fix is no longer need and not working at the moment since it does not come with `%{run}`.