### PR TITLE
[CI][Benchmarks] fix LD_LIBRARY_PATH set for compute runtime

### DIFF
--- a/devops/scripts/benchmarks/utils/compute_runtime.py
+++ b/devops/scripts/benchmarks/utils/compute_runtime.py
@@ -30,8 +30,8 @@ class ComputeRuntime:
 
     def ld_libraries(self) -> list[str]:
         paths = [
-            os.path.join(self.gmmlib, "lib64"),
-            os.path.join(self.level_zero, "lib64"),
+            os.path.join(self.gmmlib, "lib"),
+            os.path.join(self.level_zero, "lib"),
             os.path.join(self.compute_runtime, "bin"),
         ]
 

--- a/devops/scripts/benchmarks/utils/utils.py
+++ b/devops/scripts/benchmarks/utils/utils.py
@@ -34,7 +34,12 @@ def run(
         env = os.environ.copy()
 
         for ldlib in ld_library:
-            env["LD_LIBRARY_PATH"] = ldlib + os.pathsep + env.get("LD_LIBRARY_PATH", "")
+            if os.path.isdir(ldlib):
+                env["LD_LIBRARY_PATH"] = (
+                    ldlib + os.pathsep + env.get("LD_LIBRARY_PATH", "")
+                )
+            else:
+                print(f"Warning: LD_LIBRARY_PATH component does not exist: {ldlib}")
 
         # order is important, we want provided sycl rt libraries to be first
         if add_sycl:


### PR DESCRIPTION
The LD_LIBRARY_PATH for the level-zero loader and gmmlib, which are dependencies of compute runtime, were set incorrectly to lib64. This led to issues compatibility issues when running benchmarks.

This patch sets the correct path and adds a warning message so that it's easier to notice such issues in the future.