### PR TITLE
[SYCL] Fix 2D slicepitch info

### DIFF
--- a/sycl/source/detail/image_impl.hpp
+++ b/sycl/source/detail/image_impl.hpp
@@ -70,11 +70,10 @@ private:
 
   void setPitches(const range<2> &Pitch) {
     MRowPitch = Pitch[0];
-    MSlicePitch =
-        (MDimensions == 3) ? Pitch[1] : MRowPitch; // Dimensions will be 2/3.
-    // NumSlices is depth when dim==3, and height when dim==2.
+    MSlicePitch = (MDimensions == 3) ? Pitch[1] : MRowPitch * MRange[1];
+    // NumSlices is depth when dim==3, and 1 when dim==2.
     size_t NumSlices =
-        (MDimensions == 3) ? MRange[2] : MRange[1]; // Dimensions will be 2/3.
+        (MDimensions == 3) ? MRange[2] : 1; // Dimensions will be 2/3.
 
     BaseT::MSizeInBytes = MSlicePitch * NumSlices;
   }


### PR DESCRIPTION
Make slicepitch image size and num slices 1 for a 2D image.

This was incorrect but wasn't failing as many backends ignore `Pitch[1]` for a 2D image.