### PR TITLE
Update dbg-value-range.ll following MCAsmInfo syntax change.

### DIFF
--- a/llvm-spirv/test/DebugInfo/X86/dbg-value-range.ll
+++ b/llvm-spirv/test/DebugInfo/X86/dbg-value-range.ll
@@ -63,9 +63,9 @@ declare void @llvm.dbg.value(metadata, metadata, metadata) nounwind readnone
 ;CHECK-NEXT: [[CLOBBER:Ltmp[0-9]*]]
 
 ;CHECK:Ldebug_loc0:
-;CHECK-NEXT: .set Lset{{.*}},
+;CHECK-NEXT: Lset{{.*}} = 
 ;CHECK-NEXT:	.quad
-;CHECK-NEXT: .set [[CLOBBER_OFF:Lset.*]], [[CLOBBER]]-{{.*}}
+;CHECK-NEXT: [[CLOBBER_OFF:Lset.*]] = [[CLOBBER]]-{{.*}}
 ;CHECK-NEXT:	.quad	[[CLOBBER_OFF]]
 ;CHECK-NEXT:  .short 1 ## Loc expr size
 ;CHECK-NEXT:	.byte	85 ## DW_OP_reg


### PR DESCRIPTION
This update is necessary following the change in 28bda778.