### PR TITLE
[SYCL] Emit kernel names for SYCLBIN

### DIFF
--- a/clang/test/Driver/sycl-post-link-options.cpp
+++ b/clang/test/Driver/sycl-post-link-options.cpp
@@ -21,3 +21,9 @@
 // RUN:   --sycl-post-link-options="-O2 -device-globals -O0" \
 // RUN:   --linker-path=/usr/bin/ld %t.o -o a.out 2>&1 | FileCheck --check-prefix OPTIONS_POSTLINK_JIT_NEW %s
 // OPTIONS_POSTLINK_JIT_NEW: sycl-post-link{{.*}} -spec-const=native -properties -split=auto -emit-only-kernels-as-entry-points -emit-param-info -symbols -emit-exported-symbols -emit-imported-symbols -split-esimd -lower-esimd -O2 -device-globals -O0
+//
+// RUN: clang-linker-wrapper --dry-run --host-triple=x86_64-unknown-linux-gnu \
+// RUN:   -syclbin=executable -sycl-device-libraries=%t.devicelib.o \
+// RUN:   --sycl-post-link-options="-O2 -device-globals -O0" \
+// RUN:   --linker-path=/usr/bin/ld %t.o -o a.out 2>&1 | FileCheck --check-prefix OPTIONS_POSTLINK_JIT_NEW_SYCLBIN %s
+// OPTIONS_POSTLINK_JIT_NEW_SYCLBIN: sycl-post-link{{.*}} -spec-const=native -properties -split=auto -emit-only-kernels-as-entry-points -emit-param-info -symbols -emit-kernel-names -emit-exported-symbols -emit-imported-symbols -split-esimd -lower-esimd -O2 -device-globals -O0

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -694,6 +694,9 @@ getTripleBasedSYCLPostLinkOpts(const ArgList &Args,
                    OPT_no_sycl_device_code_split_esimd, SplitEsimdByDefault);
   if (!Args.hasArg(OPT_sycl_thin_lto))
     PostLinkArgs.push_back("-symbols");
+  // Emit kernel names if we are producing SYCLBIN.
+  if (Args.hasArg(OPT_syclbin_EQ))
+    PostLinkArgs.push_back("-emit-kernel-names");
   // Specialization constant info generation is mandatory -
   // add options unconditionally
   PostLinkArgs.push_back("-emit-exported-symbols");

--- a/llvm/include/llvm/SYCLPostLink/ComputeModuleRuntimeInfo.h
+++ b/llvm/include/llvm/SYCLPostLink/ComputeModuleRuntimeInfo.h
@@ -24,6 +24,7 @@ namespace sycl {
 struct GlobalBinImageProps {
   bool EmitKernelParamInfo;
   bool EmitProgramMetadata;
+  bool EmitKernelNames;
   bool EmitExportedSymbols;
   bool EmitImportedSymbols;
   bool EmitDeviceGlobalPropSet;

--- a/llvm/include/llvm/Support/PropertySetIO.h
+++ b/llvm/include/llvm/Support/PropertySetIO.h
@@ -217,6 +217,7 @@ public:
   static constexpr char SYCL_PROGRAM_METADATA[] = "SYCL/program metadata";
   static constexpr char SYCL_MISC_PROP[] = "SYCL/misc properties";
   static constexpr char SYCL_ASSERT_USED[] = "SYCL/assert used";
+  static constexpr char SYCL_KERNEL_NAMES[] = "SYCL/kernel names";
   static constexpr char SYCL_EXPORTED_SYMBOLS[] = "SYCL/exported symbols";
   static constexpr char SYCL_IMPORTED_SYMBOLS[] = "SYCL/imported symbols";
   static constexpr char SYCL_DEVICE_GLOBALS[] = "SYCL/device globals";

--- a/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
@@ -271,6 +271,14 @@ PropSetRegTy computeModuleProperties(const Module &M,
       }
     }
   }
+  if (GlobProps.EmitKernelNames) {
+    for (const auto *F : EntryPoints) {
+      if (F->getCallingConv() == CallingConv::SPIR_KERNEL) {
+        PropSet.add(PropSetRegTy::SYCL_KERNEL_NAMES, F->getName(),
+                    /*PropVal=*/true);
+      }
+    }
+  }
 
   if (GlobProps.EmitImportedSymbols) {
     // record imported functions in the property set

--- a/llvm/lib/Support/PropertySetIO.cpp
+++ b/llvm/lib/Support/PropertySetIO.cpp
@@ -201,6 +201,7 @@ constexpr char PropertySetRegistry::SYCL_KERNEL_PARAM_OPT_INFO[];
 constexpr char PropertySetRegistry::SYCL_PROGRAM_METADATA[];
 constexpr char PropertySetRegistry::SYCL_MISC_PROP[];
 constexpr char PropertySetRegistry::SYCL_ASSERT_USED[];
+constexpr char PropertySetRegistry::SYCL_KERNEL_NAMES[];
 constexpr char PropertySetRegistry::SYCL_EXPORTED_SYMBOLS[];
 constexpr char PropertySetRegistry::SYCL_IMPORTED_SYMBOLS[];
 constexpr char PropertySetRegistry::SYCL_DEVICE_GLOBALS[];

--- a/llvm/test/tools/sycl-post-link/emit_kernel_names.ll
+++ b/llvm/test/tools/sycl-post-link/emit_kernel_names.ll
@@ -1,0 +1,100 @@
+; This test checks that the post-link tool generates list of kernel names.
+;
+; Global scope
+; RUN: sycl-post-link -properties -symbols -emit-kernel-names -S < %s -o %t.global.files.table
+; RUN: FileCheck %s -input-file=%t.global.files_0.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-GLOBAL-PROP
+;
+; Per-module split
+; RUN: sycl-post-link -properties -symbols -split=source -emit-kernel-names -S < %s -o %t.per_module.files.table
+; RUN: FileCheck %s -input-file=%t.per_module.files_0.prop -implicit-check-not="SpirFunc" --check-prefix=CHECK-PERMODULE-0-PROP
+; RUN: FileCheck %s -input-file=%t.per_module.files_1.prop -implicit-check-not="SpirFunc" --check-prefix=CHECK-PERMODULE-1-PROP
+; RUN: FileCheck %s -input-file=%t.per_module.files_2.prop -implicit-check-not="SpirFunc" --check-prefix=CHECK-KERNELLESS-PROP
+;
+; Per-kernel split
+; RUN: sycl-post-link -properties -symbols -split=kernel -emit-kernel-names -S < %s -o %t.per_kernel.files.table
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_0.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-PERKERNEL-0-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_1.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-PERKERNEL-1-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_2.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-PERKERNEL-2-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_3.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_4.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_5.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-KERNELLESS-PROP
+
+target triple = "spir64-unknown-unknown"
+
+define dso_local spir_kernel void @SpirKernel1(float %arg1) #2 {
+entry:
+  ret void
+}
+
+define dso_local spir_kernel void @SpirKernel2(float %arg1) #1 {
+entry:
+  ret void
+}
+
+define dso_local spir_kernel void @SpirKernel3(float %arg1) #2 {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @SpirFunc1(float %arg1) #0 {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @SpirFunc2(i32 %arg1, i32 %arg2) #1 {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @SpirFunc3(float %arg1) #0 {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @SpirFunc4(float %arg1) {
+entry:
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="a.cpp" }
+attributes #1 = { "sycl-module-id"="b.cpp" }
+attributes #2 = { "sycl-module-id"="c.cpp" }
+
+; Global scope
+; CHECK-GLOBAL-PROP: [SYCL/kernel names]
+; CHECK-GLOBAL-PROP-NEXT: SpirKernel1
+; CHECK-GLOBAL-PROP-NEXT: SpirKernel2
+; CHECK-GLOBAL-PROP-NEXT: SpirKernel3
+
+; Per-module split
+; CHECK-PERMODULE-0-PROP: [SYCL/kernel names]
+; CHECK-PERMODULE-0-PROP-NEXT: SpirKernel1
+; CHECK-PERMODULE-0-PROP-NEXT: SpirKernel3
+; CHECK-PERMODULE-0-PROP-NOT: SpirKernel2
+
+; CHECK-PERMODULE-1-PROP: [SYCL/kernel names]
+; CHECK-PERMODULE-1-PROP-NEXT: SpirKernel2
+; CHECK-PERMODULE-1-PROP-NOT: SpirKernel1
+; CHECK-PERMODULE-1-PROP-NOT: SpirKernel3
+
+; Per-kernel split
+; CHECK-PERKERNEL-0-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-0-PROP-NEXT: SpirKernel3
+; CHECK-PERKERNEL-0-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-0-PROP-NOT: SpirKernel2
+
+; CHECK-PERKERNEL-1-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-1-PROP-NEXT: SpirKernel2
+; CHECK-PERKERNEL-1-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-1-PROP-NOT: SpirKernel3
+
+; CHECK-PERKERNEL-2-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-2-PROP-NEXT: SpirKernel1
+; CHECK-PERKERNEL-2-PROP-NOT: SpirKernel2
+; CHECK-PERKERNEL-2-PROP-NOT: SpirKernel3
+
+; Kernel-less generated modules should have no kernel names
+; CHECK-KERNELLESS-PROP-NOT: [SYCL/kernel names]
+; CHECK-KERNELLESS-PROP-NOT: SpirKernel1
+; CHECK-KERNELLESS-PROP-NOT: SpirKernel2
+; CHECK-KERNELLESS-PROP-NOT: SpirKernel3

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -734,10 +734,12 @@ jit_compiler::performPostLink(ModuleUPtr Module,
                 [](Function *F) { return F->getName(); });
 
       // TODO: Determine what is requested.
-      GlobalBinImageProps PropReq{
-          /*EmitKernelParamInfo=*/true, /*EmitProgramMetadata=*/true,
-          /*EmitExportedSymbols=*/true, /*EmitImportedSymbols=*/true,
-          /*DeviceGlobals=*/true};
+      GlobalBinImageProps PropReq{/*EmitKernelParamInfo=*/true,
+                                  /*EmitProgramMetadata=*/true,
+                                  /*EmitKernelNames=*/true,
+                                  /*EmitExportedSymbols=*/true,
+                                  /*EmitImportedSymbols=*/true,
+                                  /*DeviceGlobals=*/true};
       PropertySetRegistry Properties =
           computeModuleProperties(MDesc.getModule(), MDesc.entries(), PropReq,
                                   AllowDeviceImageDependencies);

--- a/sycl/doc/design/PropertySets.md
+++ b/sycl/doc/design/PropertySets.md
@@ -139,6 +139,16 @@ __Value type:__ 32 bit integer. ("1")
 __Value:__ 1 if the kernel uses assertions and 0 or missing otherwise.
 
 
+### [SYCL/kernel names]
+
+__Key:__ Kernel name.
+
+__Value type:__ 32 bit integer. ("1")
+
+__Value:__ 1 if the name is identifies a kernel inside the binary and 0 or
+missing otherwise.
+
+
 ### [SYCL/exported symbols]
 
 __Key:__ Symbol name.


### PR DESCRIPTION
This commit adds a new property to the property set when producing SYCLBIN files. This new property lists all kernels inside the corresponding binaries.