### PR TITLE
[CI] Bump softprops/action-gh-release action version to 2.3.2

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -333,7 +333,7 @@ jobs:
           echo "TAG=$(date +'%Y-%m-%d')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
         fi
     - name: Upload binaries
-      uses: softprops/action-gh-release@v2.3.0
+      uses: softprops/action-gh-release@v2.3.2
       with:
         files: |
           sycl_linux.tar.gz


### PR DESCRIPTION
to fix a bug causing fail in nightly binaries uploading.

// Failing step in nightly build:
https://github.com/intel/llvm/actions/runs/15625712272/job/44020499377

// Fix described in the release notes of that `action-gh-release` action:
https://github.com/softprops/action-gh-release/releases