### PR TITLE
[SYCL][E2E] Re-enable fp64 cmath tests for cuda/hip

### DIFF
--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -1,7 +1,6 @@
 // UNSUPPORTED: spirv-backend
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17813
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: target-amd || target-nvidia
 
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 255
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 254
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
@@ -98,7 +98,6 @@
 // CHECK-NEXT: DeviceImageDependencies/singleDynamicLibrary.cpp
 // CHECK-NEXT: DeviceLib/built-ins/printf.cpp
 // CHECK-NEXT: DeviceLib/cmath-aot.cpp
-// CHECK-NEXT: DeviceLib/cmath_fp64_test.cpp
 // CHECK-NEXT: DeviceLib/imf_bfloat16_integeral_convesions.cpp
 // CHECK-NEXT: DeviceLib/imf_bfloat16_integeral_convesions.cpp
 // CHECK-NEXT: DeviceLib/imf_double2bfloat16.cpp


### PR DESCRIPTION
Unsure why this test was disabled, but it is passing now.