### PR TITLE
[SYCL][NFC] Cleanup public headers

### DIFF
--- a/sycl/include/sycl/detail/info_desc_helpers.hpp
+++ b/sycl/include/sycl/detail/info_desc_helpers.hpp
@@ -62,24 +62,6 @@ template <typename T> struct is_backend_info_desc : std::false_type {};
 #include <sycl/info/event_profiling_traits.def>
 #undef __SYCL_PARAM_TRAITS_SPEC
 
-template <typename Param> struct IsSubGroupInfo : std::false_type {};
-template <>
-struct IsSubGroupInfo<info::kernel_device_specific::max_num_sub_groups>
-    : std::true_type {};
-template <>
-struct IsSubGroupInfo<info::kernel_device_specific::compile_num_sub_groups>
-    : std::true_type {};
-template <>
-struct IsSubGroupInfo<info::kernel_device_specific::max_sub_group_size>
-    : std::true_type {};
-template <>
-struct IsSubGroupInfo<info::kernel_device_specific::compile_sub_group_size>
-    : std::true_type {};
-template <typename Param> struct IsKernelInfo : std::false_type {};
-template <>
-struct IsKernelInfo<info::kernel_device_specific::ext_codeplay_num_regs>
-    : std::true_type {};
-
 #define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
   template <>                                                                  \
   struct is_##DescType##_info_desc<info::DescType::Desc> : std::true_type {    \

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -208,10 +208,6 @@ public:
   /// Queries this SYCL device for information requested by the template
   /// parameter param
   ///
-  /// Specializations of info::param_traits must be defined in accordance with
-  /// the info parameters in Table 4.20 of SYCL Spec to facilitate returning the
-  /// type associated with the param parameter.
-  ///
   /// \return device info of type described in Table 4.20.
   template <typename Param>
   typename detail::is_device_info_desc<Param>::return_type get_info() const {

--- a/sycl/include/sycl/info/info_desc.hpp
+++ b/sycl/include/sycl/info/info_desc.hpp
@@ -74,24 +74,6 @@ enum class partition_property : intptr_t {
   ext_intel_partition_by_cslice = UR_DEVICE_PARTITION_BY_CSLICE
 };
 
-// FIXME: maybe this should live elsewhere, maybe it should be implemented
-// differently
-inline partition_property
-ConvertPartitionProperty(const ur_device_partition_t &Partition) {
-  switch (Partition) {
-  case UR_DEVICE_PARTITION_EQUALLY:
-    return partition_property::partition_equally;
-  case UR_DEVICE_PARTITION_BY_COUNTS:
-    return partition_property::partition_by_counts;
-  case UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN:
-    return partition_property::partition_by_affinity_domain;
-  case UR_DEVICE_PARTITION_BY_CSLICE:
-    return partition_property::ext_intel_partition_by_cslice;
-  default:
-    return partition_property::no_partition;
-  }
-}
-
 enum class partition_affinity_domain : intptr_t {
   not_applicable = 0,
   numa = UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA,
@@ -101,24 +83,6 @@ enum class partition_affinity_domain : intptr_t {
   L1_cache = UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE,
   next_partitionable = UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE
 };
-
-inline partition_affinity_domain
-ConvertAffinityDomain(const ur_device_affinity_domain_flags_t Domain) {
-  switch (Domain) {
-  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA:
-    return partition_affinity_domain::numa;
-  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE:
-    return partition_affinity_domain::L1_cache;
-  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE:
-    return partition_affinity_domain::L2_cache;
-  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE:
-    return partition_affinity_domain::L3_cache;
-  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE:
-    return partition_affinity_domain::L4_cache;
-  default:
-    return info::partition_affinity_domain::not_applicable;
-  }
-}
 
 enum class local_mem_type : int { none, local, global };
 
@@ -141,12 +105,6 @@ enum class execution_capability : unsigned int {
 };
 
 namespace device {
-// TODO implement the following SYCL 2020 device info descriptors:
-// atomic_fence_order_capabilities, atomic_fence_scope_capabilities, aspects,
-// il_version.
-
-struct atomic_fence_order_capabilities;
-struct atomic_fence_scope_capabilities;
 
 #define __SYCL_PARAM_TRAITS_DEPRECATED(Desc, Message)                          \
   struct __SYCL2020_DEPRECATED(Message) Desc;
@@ -203,17 +161,6 @@ namespace event_profiling {
 } // namespace event_profiling
 #undef __SYCL_PARAM_TRAITS_SPEC
 
-// Provide an alias to the return type for each of the info parameters
-template <typename T, T param> class param_traits {};
-
-template <typename T, T param> struct compatibility_param_traits {};
-
-#define __SYCL_PARAM_TRAITS_SPEC(param_type, param, ret_type)                  \
-  template <> class param_traits<param_type, param_type::param> {              \
-  public:                                                                      \
-    using return_type = ret_type;                                              \
-  };
-#undef __SYCL_PARAM_TRAITS_SPEC
 } // namespace info
 
 #define __SYCL_PARAM_TRAITS_SPEC(Namespace, DescType, Desc, ReturnT, UrCode)   \

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -15,6 +15,7 @@
 #include <sycl/detail/ur.hpp>
 #include <sycl/ext/oneapi/experimental/device_architecture.hpp>
 #include <sycl/ext/oneapi/experimental/forward_progress.hpp>
+#include <sycl/info/info_desc.hpp>
 #include <sycl/kernel_bundle.hpp>
 #include <sycl/platform.hpp>
 
@@ -27,6 +28,40 @@ namespace sycl {
 inline namespace _V1 {
 
 namespace detail {
+
+inline info::partition_property
+ConvertPartitionProperty(const ur_device_partition_t &Partition) {
+  switch (Partition) {
+  case UR_DEVICE_PARTITION_EQUALLY:
+    return info::partition_property::partition_equally;
+  case UR_DEVICE_PARTITION_BY_COUNTS:
+    return info::partition_property::partition_by_counts;
+  case UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN:
+    return info::partition_property::partition_by_affinity_domain;
+  case UR_DEVICE_PARTITION_BY_CSLICE:
+    return info::partition_property::ext_intel_partition_by_cslice;
+  default:
+    return info::partition_property::no_partition;
+  }
+}
+
+inline info::partition_affinity_domain
+ConvertAffinityDomain(const ur_device_affinity_domain_flags_t Domain) {
+  switch (Domain) {
+  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA:
+    return info::partition_affinity_domain::numa;
+  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE:
+    return info::partition_affinity_domain::L1_cache;
+  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE:
+    return info::partition_affinity_domain::L2_cache;
+  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE:
+    return info::partition_affinity_domain::L3_cache;
+  case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE:
+    return info::partition_affinity_domain::L4_cache;
+  default:
+    return info::partition_affinity_domain::not_applicable;
+  }
+}
 
 // Note that UR's enums have weird *_FORCE_UINT32 values, we ignore them in the
 // callers. But we also can't write a fully-covered switch without mentioning it
@@ -503,10 +538,6 @@ public:
   /// Queries this SYCL device for information requested by the template
   /// parameter param
   ///
-  /// Specializations of info::param_traits must be defined in accordance
-  /// with the info parameters in Table 4.20 of SYCL Spec to facilitate
-  /// returning the type associated with the param parameter.
-  ///
   /// \return device info of type described in Table 4.20.
 
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
@@ -728,7 +759,7 @@ public:
       for (auto &entry : ur_dev_partitions) {
         // OpenCL extensions may have partition_properties that
         // are not yet defined for SYCL (eg. CL_DEVICE_PARTITION_BY_NAMES_INTEL)
-        info::partition_property pp(info::ConvertPartitionProperty(entry));
+        info::partition_property pp(detail::ConvertPartitionProperty(entry));
         switch (pp) {
         case info::partition_property::no_partition:
         case info::partition_property::partition_equally:
@@ -767,7 +798,7 @@ public:
         return info::partition_property::no_partition;
       // The old UR implementation also just checked the first element, is that
       // correct?
-      return info::ConvertPartitionProperty(PartitionProperties[0].type);
+      return detail::ConvertPartitionProperty(PartitionProperties[0].type);
     }
     CASE(info::device::partition_type_affinity_domain) {
       std::vector<ur_device_partition_property_t> PartitionProperties =
@@ -776,7 +807,7 @@ public:
         return info::partition_affinity_domain::not_applicable;
       for (const auto &PartitionProp : PartitionProperties) {
         if (PartitionProp.type == UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN)
-          return info::ConvertAffinityDomain(
+          return detail::ConvertAffinityDomain(
               PartitionProp.value.affinity_domain);
       }
 

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -22,6 +22,25 @@ namespace sycl {
 inline namespace _V1 {
 namespace detail {
 
+template <typename Param> struct IsSubGroupInfo : std::false_type {};
+template <>
+struct IsSubGroupInfo<info::kernel_device_specific::max_num_sub_groups>
+    : std::true_type {};
+template <>
+struct IsSubGroupInfo<info::kernel_device_specific::compile_num_sub_groups>
+    : std::true_type {};
+template <>
+struct IsSubGroupInfo<info::kernel_device_specific::max_sub_group_size>
+    : std::true_type {};
+template <>
+struct IsSubGroupInfo<info::kernel_device_specific::compile_sub_group_size>
+    : std::true_type {};
+
+template <typename Param> struct IsKernelInfo : std::false_type {};
+template <>
+struct IsKernelInfo<info::kernel_device_specific::ext_codeplay_num_regs>
+    : std::true_type {};
+
 template <typename Param>
 typename std::enable_if<
     std::is_same<typename Param::return_type, std::string>::value,


### PR DESCRIPTION
There are helper function templates which are only used within `source/` directory, so they were moved in there to reduce the size and complexity of our public headers.

Some legacy dead code have been removed along the way as well.