### PR TITLE
[NFC][SYCL] Pass `context_impl` by raw ptr/ref in `kernel_impl.hpp`

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -360,7 +360,7 @@ kernel make_kernel(const context &TargetContext,
 
   // Construct the SYCL queue from UR queue.
   return detail::createSyclObjFromImpl<kernel>(
-      std::make_shared<kernel_impl>(UrKernel, ContextImpl, KernelBundleImpl));
+      std::make_shared<kernel_impl>(UrKernel, *ContextImpl, KernelBundleImpl));
 }
 
 kernel make_kernel(ur_native_handle_t NativeHandle,

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -638,7 +638,7 @@ public:
         auto [UrKernel, CacheMutex, ArgMask] =
             PM.getOrCreateKernel(Context, AdjustedName,
                                  /*PropList=*/{}, UrProgram);
-        return std::make_shared<kernel_impl>(UrKernel, getSyclObjImpl(Context),
+        return std::make_shared<kernel_impl>(UrKernel, *getSyclObjImpl(Context),
                                              Self, OwnerBundle, ArgMask,
                                              UrProgram, CacheMutex);
       }
@@ -653,7 +653,7 @@ public:
     // Kernel created by urKernelCreate is implicitly retained.
 
     return std::make_shared<kernel_impl>(
-        UrKernel, detail::getSyclObjImpl(Context), Self, OwnerBundle,
+        UrKernel, *detail::getSyclObjImpl(Context), Self, OwnerBundle,
         /*ArgMask=*/nullptr, UrProgram, /*CacheMutex=*/nullptr);
   }
 

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -938,7 +938,7 @@ public:
             SelectedImage->get_ur_program_ref());
 
     return std::make_shared<kernel_impl>(
-        Kernel, detail::getSyclObjImpl(MContext), SelectedImage, Self, ArgMask,
+        Kernel, *detail::getSyclObjImpl(MContext), SelectedImage, Self, ArgMask,
         SelectedImage->get_ur_program_ref(), CacheMutex);
   }
 

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -16,19 +16,19 @@ namespace sycl {
 inline namespace _V1 {
 namespace detail {
 
-kernel_impl::kernel_impl(ur_kernel_handle_t Kernel, ContextImplPtr Context,
+kernel_impl::kernel_impl(ur_kernel_handle_t Kernel, context_impl &Context,
                          KernelBundleImplPtr KernelBundleImpl,
                          const KernelArgMask *ArgMask)
-    : MKernel(Kernel), MContext(Context),
-      MProgram(ProgramManager::getInstance().getUrProgramFromUrKernel(
-          Kernel, *Context)),
+    : MKernel(Kernel), MContext(Context.shared_from_this()),
+      MProgram(ProgramManager::getInstance().getUrProgramFromUrKernel(Kernel,
+                                                                      Context)),
       MCreatedFromSource(true), MKernelBundleImpl(std::move(KernelBundleImpl)),
       MIsInterop(true), MKernelArgMaskPtr{ArgMask} {
   ur_context_handle_t UrContext = nullptr;
   // Using the adapter from the passed ContextImpl
   getAdapter()->call<UrApiKind::urKernelGetInfo>(
       MKernel, UR_KERNEL_INFO_CONTEXT, sizeof(UrContext), &UrContext, nullptr);
-  if (Context->getHandleRef() != UrContext)
+  if (Context.getHandleRef() != UrContext)
     throw sycl::exception(
         make_error_code(errc::invalid),
         "Input context must be the same as the context of cl_kernel");
@@ -37,12 +37,13 @@ kernel_impl::kernel_impl(ur_kernel_handle_t Kernel, ContextImplPtr Context,
   enableUSMIndirectAccess();
 }
 
-kernel_impl::kernel_impl(ur_kernel_handle_t Kernel, ContextImplPtr ContextImpl,
+kernel_impl::kernel_impl(ur_kernel_handle_t Kernel, context_impl &ContextImpl,
                          DeviceImageImplPtr DeviceImageImpl,
                          KernelBundleImplPtr KernelBundleImpl,
                          const KernelArgMask *ArgMask,
                          ur_program_handle_t Program, std::mutex *CacheMutex)
-    : MKernel(Kernel), MContext(std::move(ContextImpl)), MProgram(Program),
+    : MKernel(Kernel), MContext(ContextImpl.shared_from_this()),
+      MProgram(Program),
       MCreatedFromSource(DeviceImageImpl->isNonSYCLSourceBased()),
       MDeviceImageImpl(std::move(DeviceImageImpl)),
       MKernelBundleImpl(std::move(KernelBundleImpl)),

--- a/sycl/source/detail/kernel_impl.hpp
+++ b/sycl/source/detail/kernel_impl.hpp
@@ -28,7 +28,6 @@ namespace detail {
 // Forward declaration
 class kernel_bundle_impl;
 
-using ContextImplPtr = std::shared_ptr<context_impl>;
 using KernelBundleImplPtr = std::shared_ptr<kernel_bundle_impl>;
 class kernel_impl {
 public:
@@ -40,7 +39,7 @@ public:
   /// \param Kernel is a valid UrKernel instance
   /// \param Context is a valid SYCL context
   /// \param KernelBundleImpl is a valid instance of kernel_bundle_impl
-  kernel_impl(ur_kernel_handle_t Kernel, ContextImplPtr Context,
+  kernel_impl(ur_kernel_handle_t Kernel, context_impl &Context,
               KernelBundleImplPtr KernelBundleImpl,
               const KernelArgMask *ArgMask = nullptr);
 
@@ -50,7 +49,7 @@ public:
   /// \param Kernel is a valid UrKernel instance
   /// \param ContextImpl is a valid SYCL context
   /// \param KernelBundleImpl is a valid instance of kernel_bundle_impl
-  kernel_impl(ur_kernel_handle_t Kernel, ContextImplPtr ContextImpl,
+  kernel_impl(ur_kernel_handle_t Kernel, context_impl &ContextImpl,
               DeviceImageImplPtr DeviceImageImpl,
               KernelBundleImplPtr KernelBundleImpl,
               const KernelArgMask *ArgMask, ur_program_handle_t Program,
@@ -245,7 +244,7 @@ public:
 
 private:
   ur_kernel_handle_t MKernel = nullptr;
-  const ContextImplPtr MContext;
+  const std::shared_ptr<context_impl> MContext;
   const ur_program_handle_t MProgram = nullptr;
   bool MCreatedFromSource = true;
   const DeviceImageImplPtr MDeviceImageImpl;

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -27,7 +27,7 @@ kernel::kernel(cl_kernel ClKernel, const context &SyclContext) {
           nativeHandle, detail::getSyclObjImpl(SyclContext)->getHandleRef(),
           nullptr, nullptr, &hKernel);
   impl = std::make_shared<detail::kernel_impl>(
-      hKernel, detail::getSyclObjImpl(SyclContext), nullptr, nullptr);
+      hKernel, *detail::getSyclObjImpl(SyclContext), nullptr, nullptr);
   // This is a special interop constructor for OpenCL, so the kernel must be
   // retained.
   if (get_backend() == backend::opencl) {


### PR DESCRIPTION
Part of the ongoing refactoring to prefer raw ptr/ref for SYCL RT objects by default with explicit `shared_from_this` when lifetimes need to be extended.