### PR TITLE
[SYCL][E2E] Fix -Werror failures in DeviceLib tests

### DIFF
--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -7,7 +7,7 @@
 // RUN: %{build} %{mathflags} -o %t1.out
 // RUN: %{run} %t1.out
 
-// RUN: %{build} -fsycl-device-lib-jit-link %{mathflags} -o %t2.out
+// RUN: %{build} -Wno-error=unused-command-line-argument -fsycl-device-lib-jit-link %{mathflags} -o %t2.out
 // RUN: %{run} %t2.out
 
 #include "math_utils.hpp"

--- a/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
@@ -4,7 +4,7 @@
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
 
-// RUN: %{build} -fsycl-device-lib-jit-link -o %t2.out
+// RUN: %{build} -Wno-error=unused-command-line-argument -fsycl-device-lib-jit-link -o %t2.out
 // RUN: %{run} %t2.out
 
 #include <array>

--- a/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
@@ -2,7 +2,7 @@
 // RUN: %{build} %{mathflags} -o %t1.out
 // RUN: %{run} %t1.out
 
-// RUN: %{build} -fsycl-device-lib-jit-link %{mathflags} -o %t2.out
+// RUN: %{build} -Wno-error=unused-command-line-argument -fsycl-device-lib-jit-link %{mathflags} -o %t2.out
 // RUN: %{run} %t2.out
 
 #include <array>


### PR DESCRIPTION
The `-fsycl-device-lib-jit-link` only has an effect in SPIR compilation so these tests would fail with `-Werror`.

It might be worth re-working these tests a bit to only run this part on spir, but other existing tests already have this change to make it work on `-Werror` so do it as well here to fix the nightly.

Fixes https://github.com/intel/llvm/issues/18744