### PR TITLE
[SYCL][Graph] Disable E2E tests on PTL

### DIFF
--- a/sycl/test-e2e/Graph/lit.local.cfg
+++ b/sycl/test-e2e/Graph/lit.local.cfg
@@ -1,5 +1,7 @@
 if 'windows' in config.available_features:
    # https://github.com/intel/llvm/issues/17165
    config.unsupported_features += ['arch-intel_gpu_bmg_g21']
-   # CMPLRTST-27275
+   # LNL - CMPLRTST-27275
    config.unsupported_features += ['arch-intel_gpu_lnl_m']
+   # PTL - CMPLRTST-27275
+   config.unsupported_features += ['arch-intel_gpu_ptl_u', 'arch-intel_gpu_ptl_h']


### PR DESCRIPTION
`sycl_ext_oneapi_graph` is not yet supported on Windows for PTL devices, see CMPLRTST-27275