### PR TITLE
[SYCL][Doc] Specify usage of `-fsyclbin` and `-fsycl-device-only` together

### DIFF
--- a/sycl/doc/design/SYCLBINDesign.md
+++ b/sycl/doc/design/SYCLBINDesign.md
@@ -225,7 +225,7 @@ clang-offload-packager invocation to clang-linker-wrapper together with the new
 `--syclbin` flag.
 
 Setting this option will override `-fsycl`. Passing`-fsycl-device-only` with
-`-fsyclbin` will cause `-fsycl-device-only` to be considered unused.
+`-fsyclbin` will cause `-fsyclbin` to be considered unused.
 
 The behavior is dependent on using the clang-linker-wrapper. As the current
 default offload compilation behavior is using the old offload model (driver


### PR DESCRIPTION
The correct test is already there: https://github.com/intel/llvm/blob/253228255b8c56bc5d4d8919a2020bcc7847f1ac/clang/test/Driver/fsyclbin.cpp#L8-L14