### PR TITLE
[SYCL][NFC] Remove `sampled_image_accessor` and `unsampled_image_accessor` from required testing items outlined in the test plan for free function kernels extension

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/test-plan.md
+++ b/sycl/test-e2e/FreeFunctionKernels/test-plan.md
@@ -188,15 +188,6 @@ as kernel parameter to free function kernel and use it within kernel.
 A series of checks should be performed that we can pass `vec<T, NumElements>` 
 as kernel parameter to free function kernel and use it within kernel.
 
-#### Test `sampled_image_accessor` as kernel parameter:
-A series of checks should be performed that we can pass `sampled_image_accessor` 
-as kernel parameter to free function kernel and use it within kernel.
-
-#### Test `unsampled_image_accessor` as kernel parameter:
-A series of checks should be performed that we can pass 
-`unsampled_image_accessor` as kernel parameter to free function kernel and 
-use it within kernel.
-
 #### Test `local_accessor` as kernel parameter: 
 A series of checks should be performed that we can pass `local_accessor` 
 as kernel parameter to free function kernel and use it within kernel.


### PR DESCRIPTION
 This PR removes `sampled_image_accessor` and `unsampled_image_accessor` from required testing items outlined in the test plan for free function kernels extension. It's is done because  `sampled_image_accessor` and `unsampled_image_accessor` are not supported by any device and they're only supported by host.