### PR TITLE
[SYCL][E2E] Pass sycl target options to clang in one test

### DIFF
--- a/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
@@ -5,7 +5,7 @@
 
 // RUN: %{build} %{mathflags} -c -DSOURCE1 -o %t1.o
 // RUN: %{build} %{mathflags} -c -DSOURCE2 -o %t2.o
-// RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl  %t1.o %t2.o  -o %t.out
+// RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl %{sycl_target_opts}  %t1.o %t2.o  -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: target-nvidia, target-amd


### PR DESCRIPTION
This is required to ensure that the correct target with the correct options is used when linking with clang in the test. For example without trying to use the `SPIR-V` (not the SPIR) backend for testing with `--param spirv-backend=True` does not take effect. If the test would be run on a non SPIR target it would fail as clang is expecting object files for the SPIR target when `-fsycl-targets` is not set.