### PR TITLE
[SYCL] Enable rand with CUDA and HIP

### DIFF
--- a/libdevice/crt_wrapper.cpp
+++ b/libdevice/crt_wrapper.cpp
@@ -12,10 +12,8 @@
 
 #include <cstdint>
 
-#ifndef __NVPTX__
 #define RAND_NEXT_LEN 1024
 DeviceGlobal<uint64_t[RAND_NEXT_LEN]> RandNext;
-#endif
 
 #if defined(__SPIR__) || defined(__SPIRV__) || defined(__NVPTX__) ||           \
     defined(__AMDGCN__)
@@ -34,7 +32,6 @@ int memcmp(const void *s1, const void *s2, size_t n) {
   return __devicelib_memcmp(s1, s2, n);
 }
 
-#ifndef __NVPTX__
 
 // This simple rand is for ease of use only, the implementation aligns with
 // LLVM libc rand which is based on xorshift64star pseudo random number
@@ -107,7 +104,6 @@ void srand(unsigned int seed) {
   RAND_NEXT_ACC[gid1] = seed;
 }
 
-#endif
 
 #if defined(_WIN32)
 // Truncates a wide (16 or 32 bit) string (wstr) into an ASCII string (str).

--- a/libdevice/crt_wrapper.cpp
+++ b/libdevice/crt_wrapper.cpp
@@ -32,7 +32,6 @@ int memcmp(const void *s1, const void *s2, size_t n) {
   return __devicelib_memcmp(s1, s2, n);
 }
 
-
 // This simple rand is for ease of use only, the implementation aligns with
 // LLVM libc rand which is based on xorshift64star pseudo random number
 // generator. If work item number <= 1024, each work item has its own internal
@@ -103,7 +102,6 @@ void srand(unsigned int seed) {
       (global_size > RAND_NEXT_LEN) ? (gid & (RAND_NEXT_LEN - 1)) : gid;
   RAND_NEXT_ACC[gid1] = seed;
 }
-
 
 #if defined(_WIN32)
 // Truncates a wide (16 or 32 bit) string (wstr) into an ASCII string (str).

--- a/sycl/test-e2e/DeviceLib/rand_test.cpp
+++ b/sycl/test-e2e/DeviceLib/rand_test.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: target-nvidia || target-amd
-
 #include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 254
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 253
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -114,7 +114,6 @@
 // CHECK-NEXT: DeviceLib/imf_half_type_cast.cpp
 // CHECK-NEXT: DeviceLib/imf_half_type_cast.cpp
 // CHECK-NEXT: DeviceLib/imf_simd_emulate_test.cpp
-// CHECK-NEXT: DeviceLib/rand_test.cpp
 // CHECK-NEXT: DeviceLib/separate_compile_test.cpp
 // CHECK-NEXT: ESIMD/PerformanceTests/BitonicSortK.cpp
 // CHECK-NEXT: ESIMD/PerformanceTests/BitonicSortKv2.cpp


### PR DESCRIPTION
This enables building rand for CUDA and HIP and enables the test.