### PR TITLE
[SYCL][LowerWGScope] Fix getSizeTTy to use pointer size in global address space

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerWGScope.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerWGScope.cpp
@@ -144,7 +144,9 @@ template <typename T> static unsigned asUInt(T val) {
 
 static IntegerType *getSizeTTy(Module &M) {
   LLVMContext &Ctx = M.getContext();
-  auto PtrSize = M.getDataLayout().getPointerTypeSize(PointerType::getUnqual(Ctx));
+  const DataLayout &DL = M.getDataLayout();
+  auto PtrSize = DL.getPointerTypeSize(
+      PointerType::get(Ctx, DL.getDefaultGlobalsAddressSpace()));
   return PtrSize == 8 ? Type::getInt64Ty(Ctx) : Type::getInt32Ty(Ctx);
 }
 

--- a/llvm/test/SYCLLowerIR/convergent_ptr_size_in_addrspace.ll
+++ b/llvm/test/SYCLLowerIR/convergent_ptr_size_in_addrspace.ll
@@ -1,26 +1,20 @@
 ; RUN: opt < %s -passes=LowerWGScope -S | FileCheck %s
 
 ; This test checks that pointer size in default global address space is used for
-; size_t type, which is return type of __spirv_LocalInvocationId_* functions.
+; size_t type, which is value type of GV __spirv_BuiltInLocalInvocationIndex.
 ; Note that pointer size in the default address space is 4.
 
 target datalayout = "e-p:32:32-p1:64:64-p2:64:64-p3:32:32-p4:64:64-i64:64-v16:16-v32:32-n16:32:64-G1"
 
 %struct.baz = type { i64 }
 
+; CHECK: @__spirv_BuiltInLocalInvocationIndex = external addrspace(1) constant i64, align 8
+
 define internal void @wibble(ptr byval(%struct.baz) %arg1) !work_group_scope !0 {
-; CHECK-PTX:   call i64 @_Z27__spirv_LocalInvocationId_xv()
-; CHECK-PTX:   call i64 @_Z27__spirv_LocalInvocationId_yv()
-; CHECK-PTX:   call i64 @_Z27__spirv_LocalInvocationId_zv()
+; CHECK:   load i64, ptr addrspace(1) @__spirv_BuiltInLocalInvocationIndex, align 8
 ; CHECK:   call void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 272)
   ret void
 }
-
-; CHECK-PTX: declare i64 @_Z27__spirv_LocalInvocationId_xv()
-
-; CHECK-PTX: declare i64 @_Z27__spirv_LocalInvocationId_yv()
-
-; CHECK-PTX: declare i64 @_Z27__spirv_LocalInvocationId_zv()
 
 ; CHECK: ; Function Attrs: convergent
 ; CHECK: declare void @_Z22__spirv_ControlBarrieriii(i32, i32, i32) #[[ATTR_NUM:[0-9]+]]

--- a/llvm/test/SYCLLowerIR/convergent_ptr_size_in_addrspace.ll
+++ b/llvm/test/SYCLLowerIR/convergent_ptr_size_in_addrspace.ll
@@ -1,0 +1,30 @@
+; RUN: opt < %s -passes=LowerWGScope -S | FileCheck %s
+
+; This test checks that pointer size in default global address space is used for
+; size_t type, which is return type of __spirv_LocalInvocationId_* functions.
+; Note that pointer size in the default address space is 4.
+
+target datalayout = "e-p:32:32-p1:64:64-p2:64:64-p3:32:32-p4:64:64-i64:64-v16:16-v32:32-n16:32:64-G1"
+
+%struct.baz = type { i64 }
+
+define internal void @wibble(ptr byval(%struct.baz) %arg1) !work_group_scope !0 {
+; CHECK-PTX:   call i64 @_Z27__spirv_LocalInvocationId_xv()
+; CHECK-PTX:   call i64 @_Z27__spirv_LocalInvocationId_yv()
+; CHECK-PTX:   call i64 @_Z27__spirv_LocalInvocationId_zv()
+; CHECK:   call void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 272)
+  ret void
+}
+
+; CHECK-PTX: declare i64 @_Z27__spirv_LocalInvocationId_xv()
+
+; CHECK-PTX: declare i64 @_Z27__spirv_LocalInvocationId_yv()
+
+; CHECK-PTX: declare i64 @_Z27__spirv_LocalInvocationId_zv()
+
+; CHECK: ; Function Attrs: convergent
+; CHECK: declare void @_Z22__spirv_ControlBarrieriii(i32, i32, i32) #[[ATTR_NUM:[0-9]+]]
+
+; CHECK: attributes #[[ATTR_NUM]] = { convergent }
+
+!0 = !{}


### PR DESCRIPTION
In LowerWGScope pass, getSizeTTy is used as return type of local id functions. We should use pointer size in global address space, to ensure size_t is sufficient to represent the global range.