### PR TITLE
[SYCL][E2E] Enable regression acos test for cuda/hip

### DIFF
--- a/sycl/test-e2e/Regression/acos.cpp
+++ b/sycl/test-e2e/Regression/acos.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: target-nvidia || target-amd
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 254
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 253
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
@@ -272,7 +272,6 @@
 // CHECK-NEXT: Reduction/reduction_span_pack.cpp
 // CHECK-NEXT: Reduction/reduction_usm.cpp
 // CHECK-NEXT: Reduction/reduction_usm_dw.cpp
-// CHECK-NEXT: Regression/acos.cpp
 // CHECK-NEXT: Regression/barrier_waitlist_with_interop_event.cpp
 // CHECK-NEXT: Regression/complex_global_object.cpp
 // CHECK-NEXT: Regression/event_destruction.cpp


### PR DESCRIPTION
This test is passing now.