### PR TITLE
[SYCL][E2E] Cleanup DeviceImageDependencies unsupported

### DIFF
--- a/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/dynamic.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/dynamic.cpp
@@ -1,8 +1,5 @@
 // Test -fsycl-allow-device-image-dependencies with dynamic libraries.
 
-// UNSUPPORTED: target-nvidia || target-amd
-// UNSUPPORTED-INTENDED: Not implemented yet for Nvidia/AMD backends.
-
 // DEFINE: %{dynamic_lib_options} = -fsycl %fPIC %shared_lib -fsycl-allow-device-image-dependencies -I %S/Inputs %if windows %{-DMAKE_DLL %}
 // DEFINE: %{dynamic_lib_suffix} = %if windows %{dll%} %else %{so%}
 

--- a/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/math_device_lib.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/math_device_lib.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: target-amd || target-nvidia
-// UNSUPPORTED-INTENDED: Not implemented yet for Nvidia/AMD backends.
 
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 

--- a/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/objects.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/objects.cpp
@@ -1,8 +1,5 @@
 // Test -fsycl-allow-device-image-dependencies with objects.
 
-// UNSUPPORTED: target-nvidia || target-amd
-// UNSUPPORTED-INTENDED: Not implemented yet for Nvidia/AMD backends.
-
 // RUN: %clangxx --offload-new-driver -fsycl %S/Inputs/a.cpp -I %S/Inputs -c -o %t_a.o
 // RUN: %clangxx --offload-new-driver -fsycl %S/Inputs/b.cpp -I %S/Inputs -c -o %t_b.o
 // RUN: %clangxx --offload-new-driver -fsycl %S/Inputs/c.cpp -I %S/Inputs -c -o %t_c.o

--- a/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/singleDynamicLibrary.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/singleDynamicLibrary.cpp
@@ -1,9 +1,6 @@
 // Test -fsycl-allow-device-image-dependencies with a single dynamic library on
 // Windows and Linux.
 
-// UNSUPPORTED: target-nvidia || target-amd
-// UNSUPPORTED-INTENDED: Not implemented yet for Nvidia/AMD backends.
-
 // RUN: %clangxx --offload-new-driver -fsycl %fPIC %shared_lib -fsycl-allow-device-image-dependencies -I %S/Inputs \
 // RUN:    %S/Inputs/a.cpp                                                              \
 // RUN:    %S/Inputs/b.cpp                                                              \

--- a/sycl/test-e2e/DeviceImageDependencies/dynamic.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/dynamic.cpp
@@ -1,7 +1,5 @@
 // Test -fsycl-allow-device-image-dependencies with dynamic libraries.
 
-// UNSUPPORTED: target-nvidia || target-amd
-
 // DEFINE: %{dynamic_lib_options} = -fsycl %fPIC %shared_lib -fsycl-allow-device-image-dependencies -I %S/Inputs %if windows %{-DMAKE_DLL %}
 // DEFINE: %{dynamic_lib_suffix} = %if windows %{dll%} %else %{so%}
 

--- a/sycl/test-e2e/DeviceImageDependencies/dynamic_compress.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/dynamic_compress.cpp
@@ -1,9 +1,6 @@
 // Test device image linking when using dynamic libraries when one of
 // the device image is compressed and the other is not.
 
-// UNSUPPORTED: target-nvidia || target-amd
-// UNSUPPORTED-INTENDED: Linking using dynamic libraries is not supported on AMD
-// and Nvidia.
 // REQUIRES: zstd
 
 // DEFINE: %{dynamic_lib_options} = -fsycl %fPIC %shared_lib -fsycl-allow-device-image-dependencies -I %S/Inputs %if windows %{-DMAKE_DLL %}

--- a/sycl/test-e2e/DeviceImageDependencies/lit.local.cfg
+++ b/sycl/test-e2e/DeviceImageDependencies/lit.local.cfg
@@ -1,0 +1,2 @@
+# Device image dependencies aren't supported on Nvidia and AMD
+config.unsupported_features += ['target-nvidia', 'target-amd']

--- a/sycl/test-e2e/DeviceImageDependencies/math_device_lib.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/math_device_lib.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: target-amd || target-nvidia
 
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 

--- a/sycl/test-e2e/DeviceImageDependencies/objects.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/objects.cpp
@@ -1,7 +1,5 @@
 // Test -fsycl-allow-device-image-dependencies with objects.
 
-// UNSUPPORTED: target-nvidia || target-amd
-
 // RUN: %clangxx -fsycl %S/Inputs/a.cpp -I %S/Inputs -c -o %t_a.o
 // RUN: %clangxx -fsycl %S/Inputs/b.cpp -I %S/Inputs -c -o %t_b.o
 // RUN: %clangxx -fsycl %S/Inputs/c.cpp -I %S/Inputs -c -o %t_c.o

--- a/sycl/test-e2e/DeviceImageDependencies/singleDynamicLibrary.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/singleDynamicLibrary.cpp
@@ -1,8 +1,6 @@
 // Test -fsycl-allow-device-image-dependencies with a single dynamic library on Windows
 // and Linux.
 
-// UNSUPPORTED: target-nvidia || target-amd
-
 // RUN: %clangxx -fsycl %fPIC %shared_lib -fsycl-allow-device-image-dependencies -I %S/Inputs \
 // RUN:    %S/Inputs/a.cpp                                                              \
 // RUN:    %S/Inputs/b.cpp                                                              \

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 254
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 250
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
@@ -92,10 +92,6 @@
 // CHECK-NEXT: Basic/kernel_info_attr.cpp
 // CHECK-NEXT: Basic/submit_time.cpp
 // CHECK-NEXT: DeprecatedFeatures/DiscardEvents/discard_events_using_assert.cpp
-// CHECK-NEXT: DeviceImageDependencies/dynamic.cpp
-// CHECK-NEXT: DeviceImageDependencies/math_device_lib.cpp
-// CHECK-NEXT: DeviceImageDependencies/objects.cpp
-// CHECK-NEXT: DeviceImageDependencies/singleDynamicLibrary.cpp
 // CHECK-NEXT: DeviceLib/built-ins/printf.cpp
 // CHECK-NEXT: DeviceLib/cmath-aot.cpp
 // CHECK-NEXT: DeviceLib/imf_bfloat16_integeral_convesions.cpp


### PR DESCRIPTION
This feature is not supported on CUDA and HIP.

There was only one test without the unsupported directive, the `free_function_kernels.cpp` test, but this is also tested in `KernelAndProgram` without the image dependency flag and more thoroughly. So since the feature is unsupported anyway it makes sense to disable it as well.