### PR TITLE
[UR][CUDA] Fix unmap of buffer WRITE_INVALIDATE_REGION mappings

### DIFF
--- a/unified-runtime/source/adapters/cuda/enqueue.cpp
+++ b/unified-runtime/source/adapters/cuda/enqueue.cpp
@@ -1384,7 +1384,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
       BufferImpl.MemAllocMode == BufferMem::AllocMode::AllocHostPtr;
 
   ur_result_t Result = UR_RESULT_SUCCESS;
-  if (!IsPinned && (Map->getMapFlags() & UR_MAP_FLAG_WRITE)) {
+  if (!IsPinned &&
+      (Map->getMapFlags() &
+       (UR_MAP_FLAG_WRITE | UR_MAP_FLAG_WRITE_INVALIDATE_REGION))) {
     // Pinned host memory is only on host so it doesn't need to be written to.
     Result = urEnqueueMemBufferWrite(
         hQueue, hMem, true, Map->getMapOffset(), Map->getMapSize(), pMappedPtr,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -50,10 +50,6 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
 TEST_P(urEnqueueMemBufferMapTestWithWriteFlagParam, SuccessWrite) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-  if (getParam().map_flag == UR_MAP_FLAG_WRITE_INVALIDATE_REGION) {
-    UUR_KNOWN_FAILURE_ON(uur::CUDA{});
-  }
-
   const std::vector<uint32_t> input(count, 0);
   ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
                                          input.data(), 0, nullptr, nullptr));


### PR DESCRIPTION
Buffers mapped with `UR_MAP_FLAG_WRITE_INVALIDATE_REGION` need to copy back to the buffer's device memory when unmapped. The HIP adapter was already doing this, seems like an accidental omission in the CUDA adapter.