### PR TITLE
[UR] fix ur_bool_t printing

### DIFF
--- a/unified-runtime/include/ur_print.hpp
+++ b/unified-runtime/include/ur_print.hpp
@@ -274,6 +274,8 @@ printFlag<ur_exp_enqueue_native_command_flag_t>(std::ostream &os,
 
 } // namespace ur::details
 
+inline std::ostream &operator<<(std::ostream &os,
+                                [[maybe_unused]] const ur_bool_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_structure_type_t value);

--- a/unified-runtime/scripts/templates/print.hpp.mako
+++ b/unified-runtime/scripts/templates/print.hpp.mako
@@ -194,6 +194,7 @@ template <typename T> inline ${x}_result_t printTagged(std::ostream &os, const v
 %endfor
 } // namespace ${x}::details
 
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const ur_bool_t value);
 %for spec in specs:
 %for obj in spec['objects']:
 %if re.match(r"enum", obj['type']):


### PR DESCRIPTION
ur_bool_t was being printed as a c-style string, which led to random characters in traces where boolean values should have been.