### PR TITLE
[SYCL][NFC] Refactor common helpers

### DIFF
--- a/sycl/include/sycl/backend_types.hpp
+++ b/sycl/include/sycl/backend_types.hpp
@@ -66,30 +66,5 @@ inline std::ostream &operator<<(std::ostream &Out, backend be) {
   return Out;
 }
 
-namespace detail {
-inline std::string_view get_backend_name_no_vendor(backend Backend) {
-  switch (Backend) {
-  case backend::host:
-    return "host";
-  case backend::opencl:
-    return "opencl";
-  case backend::ext_oneapi_level_zero:
-    return "level_zero";
-  case backend::ext_oneapi_cuda:
-    return "cuda";
-  case backend::ext_oneapi_hip:
-    return "hip";
-  case backend::ext_oneapi_native_cpu:
-    return "native_cpu";
-  case backend::ext_oneapi_offload:
-    return "offload";
-  case backend::all:
-    return "all";
-  }
-
-  return "";
-}
-} // namespace detail
-
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/sycl/detail/cg_types.hpp
+++ b/sycl/include/sycl/detail/cg_types.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <sycl/detail/array.hpp>               // for array
-#include <sycl/detail/common.hpp>              // for InitializedVal, NDLoop
+#include <sycl/detail/common.hpp>              // for InitializedVal
 #include <sycl/detail/helpers.hpp>             // for Builder
 #include <sycl/detail/host_profiling_info.hpp> // for HostProfilingInfo
 #include <sycl/detail/item_base.hpp>           // for id

--- a/sycl/include/sycl/group.hpp
+++ b/sycl/include/sycl/group.hpp
@@ -114,7 +114,6 @@ template <int NDims> struct NDLoop {
   }
 };
 
-
 // Implements a barrier accross work items within a work group.
 inline void workGroupBarrier() {
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/id.hpp
+++ b/sycl/include/sycl/id.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <sycl/detail/array.hpp>              // for array
-#include <sycl/detail/common.hpp>             // for InitializedVal
 #include <sycl/detail/defines.hpp>            // for __SYCL_ASSUME_INT
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL_DEPRECATED, __SYCL_A...
 #include <sycl/exception.hpp> // for make_error_code, errc, exce...

--- a/sycl/include/sycl/vector.hpp
+++ b/sycl/include/sycl/vector.hpp
@@ -91,6 +91,19 @@ struct elem {
 };
 
 namespace detail {
+// Helper function for creating an arbitrary sized array with the same value
+// repeating.
+template <typename T, size_t... Is>
+static constexpr std::array<T, sizeof...(Is)>
+RepeatValueHelper(const T &Arg, std::index_sequence<Is...>) {
+  auto ReturnArg = [&](size_t) { return Arg; };
+  return {ReturnArg(Is)...};
+}
+template <size_t N, typename T>
+static constexpr std::array<T, N> RepeatValue(const T &Arg) {
+  return RepeatValueHelper(Arg, std::make_index_sequence<N>());
+}
+
 // To be defined in tests, trick to access vec's private methods
 template <typename T1, int T2> class vec_base_test;
 

--- a/sycl/source/detail/adapter.hpp
+++ b/sycl/source/detail/adapter.hpp
@@ -23,6 +23,11 @@
 
 #include <memory>
 #include <mutex>
+#include <string>
+
+#define __SYCL_UR_ERROR_REPORT(backend)                                        \
+  std::string(sycl::detail::get_backend_name_no_vendor(backend)) +             \
+      " backend failed with error: "
 
 #define __SYCL_CHECK_UR_CODE_NO_EXC(expr, backend)                             \
   {                                                                            \
@@ -35,8 +40,31 @@
 
 namespace sycl {
 inline namespace _V1 {
-enum class backend : char;
+
 namespace detail {
+
+inline std::string_view get_backend_name_no_vendor(backend Backend) {
+  switch (Backend) {
+  case backend::host:
+    return "host";
+  case backend::opencl:
+    return "opencl";
+  case backend::ext_oneapi_level_zero:
+    return "level_zero";
+  case backend::ext_oneapi_cuda:
+    return "cuda";
+  case backend::ext_oneapi_hip:
+    return "hip";
+  case backend::ext_oneapi_native_cpu:
+    return "native_cpu";
+  case backend::ext_oneapi_offload:
+    return "offload";
+  case backend::all:
+    return "all";
+  }
+
+  return "";
+}
 
 /// The adapter class provides a unified interface to the underlying low-level
 /// runtimes for the device-agnostic SYCL runtime.

--- a/sycl/source/detail/image_impl.hpp
+++ b/sycl/source/detail/image_impl.hpp
@@ -36,6 +36,17 @@ class handler;
 
 namespace detail {
 
+constexpr size_t getNextPowerOfTwoHelper(size_t Var, size_t Offset) {
+  return Offset != 64
+             ? getNextPowerOfTwoHelper(Var | (Var >> Offset), Offset * 2)
+             : Var;
+}
+
+// Returns the smallest power of two not less than Var
+constexpr size_t getNextPowerOfTwo(size_t Var) {
+  return getNextPowerOfTwoHelper(Var - 1, 1) + 1;
+}
+
 // utility functions and typedefs for image_impl
 using image_allocator = aligned_allocator<byte>;
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -8,6 +8,7 @@
 
 #include <detail/scheduler/scheduler.hpp>
 
+#include <detail/adapter.hpp>
 #include <detail/global_handler.hpp>
 #include <detail/graph_impl.hpp>
 #include <detail/jit_compiler.hpp>

--- a/sycl/tools/sycl-ls/CMakeLists.txt
+++ b/sycl/tools/sycl-ls/CMakeLists.txt
@@ -1,6 +1,11 @@
 add_executable(sycl-ls sycl-ls.cpp)
 add_dependencies(sycl-ls sycl)
-target_include_directories(sycl-ls PRIVATE "${sycl_inc_dir}")
+target_include_directories(sycl-ls
+  PRIVATE
+  ${sycl_inc_dir}
+  # To be able to use internal headers
+  ${SYCL_SOURCE_DIR}/source
+)
 
 set(sycl_lib sycl)
 string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type_lower)

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -59,6 +59,29 @@ public:
   }
 };
 
+inline std::string_view get_backend_name_no_vendor(backend Backend) {
+  switch (Backend) {
+  case backend::host:
+    return "host";
+  case backend::opencl:
+    return "opencl";
+  case backend::ext_oneapi_level_zero:
+    return "level_zero";
+  case backend::ext_oneapi_cuda:
+    return "cuda";
+  case backend::ext_oneapi_hip:
+    return "hip";
+  case backend::ext_oneapi_native_cpu:
+    return "native_cpu";
+  case backend::ext_oneapi_offload:
+    return "offload";
+  case backend::all:
+    return "all";
+  }
+
+  return "";
+}
+
 std::string getDeviceTypeName(const device &Device) {
   auto DeviceType = Device.get_info<info::device::device_type>();
   switch (DeviceType) {
@@ -411,10 +434,10 @@ int main(int argc, char **argv) {
       // adapter.
 
       for (const auto &Device : Devices) {
-        std::cout << "[" << detail::get_backend_name_no_vendor(Backend) << ":"
+        std::cout << "[" << get_backend_name_no_vendor(Backend) << ":"
                   << getDeviceTypeName(Device) << "]";
         if (!SuppressNumberPrinting) {
-          std::cout << "[" << detail::get_backend_name_no_vendor(Backend) << ":"
+          std::cout << "[" << get_backend_name_no_vendor(Backend) << ":"
                     << DeviceNums[Backend] << "]";
           ++DeviceNums[Backend];
         }

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -18,6 +18,10 @@
 //
 #include <sycl/sycl.hpp>
 
+// Comes from sycl/source to share definition of get_backend_name_no_vendor with
+// the SYCL RT
+#include <detail/adapter.hpp>
+
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
@@ -58,29 +62,6 @@ public:
     return Dev.get_info<info::device::device_type>() == MType ? 1 : -1;
   }
 };
-
-inline std::string_view get_backend_name_no_vendor(backend Backend) {
-  switch (Backend) {
-  case backend::host:
-    return "host";
-  case backend::opencl:
-    return "opencl";
-  case backend::ext_oneapi_level_zero:
-    return "level_zero";
-  case backend::ext_oneapi_cuda:
-    return "cuda";
-  case backend::ext_oneapi_hip:
-    return "hip";
-  case backend::ext_oneapi_native_cpu:
-    return "native_cpu";
-  case backend::ext_oneapi_offload:
-    return "offload";
-  case backend::all:
-    return "all";
-  }
-
-  return "";
-}
 
 std::string getDeviceTypeName(const device &Device) {
   auto DeviceType = Device.get_info<info::device::device_type>();
@@ -434,10 +415,10 @@ int main(int argc, char **argv) {
       // adapter.
 
       for (const auto &Device : Devices) {
-        std::cout << "[" << get_backend_name_no_vendor(Backend) << ":"
+        std::cout << "[" << detail::get_backend_name_no_vendor(Backend) << ":"
                   << getDeviceTypeName(Device) << "]";
         if (!SuppressNumberPrinting) {
-          std::cout << "[" << get_backend_name_no_vendor(Backend) << ":"
+          std::cout << "[" << detail::get_backend_name_no_vendor(Backend) << ":"
                     << DeviceNums[Backend] << "]";
           ++DeviceNums[Backend];
         }


### PR DESCRIPTION
- Dropped barely used `__SYCL_ASSERT` macro
- Moved `__SYCL_UR_ERROR_REPORT` macro and corresponding helper function to library
- Moved helpers thare are used in a single header to that header to reduce their impact on other headers
- Moved some helpers into the library