### PR TITLE
[UR][Offload] Dynamically allocate adapter object and check for errors

### DIFF
--- a/unified-runtime/source/adapters/offload/adapter.hpp
+++ b/unified-runtime/source/adapters/offload/adapter.hpp
@@ -29,4 +29,4 @@ struct ur_adapter_handle_t_ : ur::offload::handle_base {
   ur_result_t init();
 };
 
-extern ur_adapter_handle_t_ Adapter;
+extern ur_adapter_handle_t Adapter;

--- a/unified-runtime/source/adapters/offload/enqueue.cpp
+++ b/unified-runtime/source/adapters/offload/enqueue.cpp
@@ -111,7 +111,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
   void *DevPtr = std::get<BufferMem>(hBuffer->Mem).Ptr;
 
-  olMemcpy(hQueue->OffloadQueue, pDst, Adapter.HostDevice, DevPtr + offset,
+  olMemcpy(hQueue->OffloadQueue, pDst, Adapter->HostDevice, DevPtr + offset,
            hQueue->OffloadDevice, size, phEvent ? &EventOut : nullptr);
 
   if (blockingRead) {
@@ -143,7 +143,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
   auto Res =
       olMemcpy(hQueue->OffloadQueue, DevPtr + offset, hQueue->OffloadDevice,
-               pSrc, Adapter.HostDevice, size, phEvent ? &EventOut : nullptr);
+               pSrc, Adapter->HostDevice, size, phEvent ? &EventOut : nullptr);
   if (Res) {
     return offloadResultToUR(Res);
   }

--- a/unified-runtime/source/adapters/offload/memory.cpp
+++ b/unified-runtime/source/adapters/offload/memory.cpp
@@ -60,7 +60,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
 
   if (PerformInitialCopy) {
     auto Res = olMemcpy(nullptr, Ptr, OffloadDevice, HostPtr,
-                        Adapter.HostDevice, size, nullptr);
+                        Adapter->HostDevice, size, nullptr);
     if (Res) {
       return offloadResultToUR(Res);
     }

--- a/unified-runtime/source/adapters/offload/platform.cpp
+++ b/unified-runtime/source/adapters/offload/platform.cpp
@@ -22,12 +22,12 @@ urPlatformGet(ur_adapter_handle_t, uint32_t NumEntries,
               ur_platform_handle_t *phPlatforms, uint32_t *pNumPlatforms) {
 
   if (pNumPlatforms) {
-    *pNumPlatforms = Adapter.Platforms.size();
+    *pNumPlatforms = Adapter->Platforms.size();
   }
 
   if (phPlatforms) {
     size_t PlatformIndex = 0;
-    for (auto &Platform : Adapter.Platforms) {
+    for (auto &Platform : Adapter->Platforms) {
       phPlatforms[PlatformIndex++] = Platform.get();
       if (PlatformIndex == NumEntries) {
         break;


### PR DESCRIPTION
We allow `urAdapterRelease` to be called in a global destructor. To avoid
any issues with destructor ordering, use `urAdapterGet` and
`urAdapterRelease` to manage the offload adapter's lifetime rather than
global init/fini.

In addition, `adapter::init()` now actually checks and returns any error from iterating devices.
