### PR TITLE
[SYCL][Coverity] Fix wrapper escape in graph memory pool

### DIFF
--- a/sycl/source/detail/graph_memory_pool.cpp
+++ b/sycl/source/detail/graph_memory_pool.cpp
@@ -147,7 +147,6 @@ graph_mem_pool::tryReuseExistingAllocation(
 
   while (!NodesToCheck.empty()) {
     auto CurrentNode = NodesToCheck.front().lock();
-    NodesToCheck.pop();
 
     if (CurrentNode->MTotalVisitedEdges > 0) {
       continue;
@@ -179,6 +178,7 @@ graph_mem_pool::tryReuseExistingAllocation(
 
     // Mark node as visited
     CurrentNode->MTotalVisitedEdges = 1;
+    NodesToCheck.pop();
   }
 
   return std::nullopt;


### PR DESCRIPTION
- This is actually a false positive, but this change should prevent future false positives from happening.

Fixes CID: 524576

Note, CID: 516777 is the same false positive but the design of the algorithm in that function makes providing a similar fix impossible.