### PR TITLE
[NATIVECPU][UR] fixed return for UR_KERNEL_INFO_FUNCTION_NAME

### DIFF
--- a/unified-runtime/source/adapters/native_cpu/kernel.cpp
+++ b/unified-runtime/source/adapters/native_cpu/kernel.cpp
@@ -93,7 +93,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
     //  case UR_KERNEL_INFO_PROGRAM:
     //    return ReturnValue(ur_program_handle_t{ Kernel->Program });
   case UR_KERNEL_INFO_FUNCTION_NAME:
-    return ReturnValue(hKernel->_name);
+    return ReturnValue(hKernel->_name.c_str());
   case UR_KERNEL_INFO_REFERENCE_COUNT:
     return ReturnValue(uint32_t{hKernel->getReferenceCount()});
   case UR_KERNEL_INFO_ATTRIBUTES:


### PR DESCRIPTION
Fixing NativeCPU handling of UR_KERNEL_INFO_FUNCTION_NAME.

At least these e2e test will pass on NativeCPU with this patch:
```
  SYCL/FreeFunctionKernels/id_as_kernel_parameter.cpp
  SYCL/FreeFunctionKernels/accessor_as_kernel_parameter.cpp
  SYCL/FreeFunctionKernels/marray_as_kernel_parameter.cpp
  SYCL/FreeFunctionKernels/range_as_kernel_parameter.cpp
  SYCL/FreeFunctionKernels/vec_as_kernel_parameter.cpp
```