### PR TITLE
[SYCL][Clang] Rename `-Wno-libspirv-hip-cuda` to `-Wunsafe-libspirv-not-linked`

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -127,7 +127,7 @@ def err_drv_no_sycl_libspirv : Error<
 def warn_flag_no_sycl_libspirv
     : Warning<"'-fno-sycl-libspirv' should not be used with target '%0'; "
               "libspirv is required for correct behavior">,
-      InGroup<NoLibspirvHipCuda>;
+      InGroup<UnsafeLibspirvNotLinked>;
 def err_drv_mix_cuda_hip : Error<
   "mixed CUDA and HIP compilation is not supported">;
 def err_drv_bad_target_id : Error<

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1600,9 +1600,9 @@ def CudaUnknownVersion: DiagGroup<"unknown-cuda-version">;
 // ignored by CUDA.
 def HIPOnly : DiagGroup<"hip-only">;
 
-// A warning generated when compiling SYCL applications for HIP or CUDA backends
-// without linking LIBSPIRV.
-def NoLibspirvHipCuda : DiagGroup<"no-libspirv-hip-cuda">;
+// A warning generated when compiling SYCL applications without linking LIBSPIRV
+// for targets that require it.
+def UnsafeLibspirvNotLinked : DiagGroup<"unsafe-libspirv-not-linked">;
 
 // Warning about mixed HIP and OpenMP compilation / target offloading.
 def HIPOpenMPOffloading: DiagGroup<"hip-omp-target-directives">;

--- a/clang/test/Driver/sycl-fno-libspirv-warn.cpp
+++ b/clang/test/Driver/sycl-fno-libspirv-warn.cpp
@@ -1,7 +1,7 @@
 /// Test that appropriate warnings are output when -fno-sycl-libspirv is used.
 
 // RUN: not %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda,amdgcn-amd-amdhsa -fno-sycl-libspirv %s -### 2>&1 | FileCheck %s
-// CHECK-DAG: warning: '-fno-sycl-libspirv' should not be used with target 'nvptx64-nvidia-cuda'; libspirv is required for correct behavior [-Wno-libspirv-hip-cuda]
-// CHECK-DAG: warning: '-fno-sycl-libspirv' should not be used with target 'amdgcn-amd-amdhsa'; libspirv is required for correct behavior [-Wno-libspirv-hip-cuda]
+// CHECK-DAG: warning: '-fno-sycl-libspirv' should not be used with target 'nvptx64-nvidia-cuda'; libspirv is required for correct behavior [-Wunsafe-libspirv-not-linked]
+// CHECK-DAG: warning: '-fno-sycl-libspirv' should not be used with target 'amdgcn-amd-amdhsa'; libspirv is required for correct behavior [-Wunsafe-libspirv-not-linked]
 // RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown -fno-sycl-libspirv %s -### 2>&1 | FileCheck --check-prefix=CHECK-SPIR64 %s
 // CHECK-SPIR64: ignoring '-fno-sycl-libspirv' option as it is not currently supported for target 'spir64-unknown-unknown' [-Woption-ignored]


### PR DESCRIPTION
IMO there are a few problems with the current name:
- Its negative option form `-Wno-no-libspirv-hip-cuda` is very awkward.
- It is very specific about the HIP or CUDA backend, which does not allow for future expansion to other backend, that could use libspirv.
- It's not very descriptive in general: in other words, without the context of the error message, what it does.