### PR TITLE
[UR][L0][L0v2] Refactor reference counting in UR L0 and L0v2

### DIFF
--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -675,7 +675,7 @@ ur_result_t urAdapterGet(
     }
     *Adapters = GlobalAdapter;
 
-    if (GlobalAdapter->getRefCount().retain() == 0) {
+    if (GlobalAdapter->RefCount.retain() == 0) {
       adapterStateInit();
     }
   }
@@ -692,7 +692,7 @@ ur_result_t urAdapterRelease([[maybe_unused]] ur_adapter_handle_t Adapter) {
 
   // NOTE: This does not require guarding with a mutex; the instant the ref
   // count hits zero, both Get and Retain are UB.
-  if (GlobalAdapter->getRefCount().release()) {
+  if (GlobalAdapter->RefCount.release()) {
     auto result = adapterStateTeardown();
 #ifdef UR_STATIC_LEVEL_ZERO
     // Given static linking of the L0 Loader, we must delay the loader's
@@ -711,7 +711,7 @@ ur_result_t urAdapterRelease([[maybe_unused]] ur_adapter_handle_t Adapter) {
 
 ur_result_t urAdapterRetain([[maybe_unused]] ur_adapter_handle_t Adapter) {
   assert(GlobalAdapter && GlobalAdapter == Adapter);
-  GlobalAdapter->getRefCount().retain();
+  GlobalAdapter->RefCount.retain();
 
   return UR_RESULT_SUCCESS;
 }
@@ -740,7 +740,7 @@ ur_result_t urAdapterGetInfo(ur_adapter_handle_t, ur_adapter_info_t PropName,
   case UR_ADAPTER_INFO_BACKEND:
     return ReturnValue(UR_BACKEND_LEVEL_ZERO);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
-    return ReturnValue(GlobalAdapter->getRefCount().getCount());
+    return ReturnValue(GlobalAdapter->RefCount.getCount());
   case UR_ADAPTER_INFO_VERSION: {
 #ifdef UR_ADAPTER_LEVEL_ZERO_V2
     uint32_t adapterVersion = 2;

--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -301,7 +301,7 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
   ZeInitResult = ZE_RESULT_ERROR_UNINITIALIZED;
   ZesResult = ZE_RESULT_ERROR_UNINITIALIZED;
 
-  resetRefCount(0);
+  RefCount.reset(0);
 
 #ifdef UR_STATIC_LEVEL_ZERO
   // Given static linking of the L0 Loader, we must delay the loader's
@@ -677,7 +677,7 @@ ur_result_t urAdapterGet(
     }
     *Adapters = GlobalAdapter;
 
-    if (GlobalAdapter->incrementRefCount() == 0) {
+    if (GlobalAdapter->getRefCount().increment() == 0) {
       adapterStateInit();
     }
   }
@@ -694,7 +694,7 @@ ur_result_t urAdapterRelease([[maybe_unused]] ur_adapter_handle_t Adapter) {
 
   // NOTE: This does not require guarding with a mutex; the instant the ref
   // count hits zero, both Get and Retain are UB.
-  if (GlobalAdapter->decrementRefCount() == 0) {
+  if (GlobalAdapter->getRefCount().decrementAndTest()) {
     auto result = adapterStateTeardown();
 #ifdef UR_STATIC_LEVEL_ZERO
     // Given static linking of the L0 Loader, we must delay the loader's
@@ -711,9 +711,9 @@ ur_result_t urAdapterRelease([[maybe_unused]] ur_adapter_handle_t Adapter) {
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t urAdapterRetain(ur_adapter_handle_t) {
+ur_result_t urAdapterRetain([[maybe_unused]] ur_adapter_handle_t Adapter) {
   assert(GlobalAdapter && GlobalAdapter == Adapter);
-  GlobalAdapter->incrementRefCount();
+  GlobalAdapter->getRefCount().increment();
 
   return UR_RESULT_SUCCESS;
 }
@@ -742,12 +742,12 @@ ur_result_t urAdapterGetInfo(ur_adapter_handle_t, ur_adapter_info_t PropName,
   case UR_ADAPTER_INFO_BACKEND:
     return ReturnValue(UR_BACKEND_LEVEL_ZERO);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
-    return ReturnValue(GlobalAdapter->getRefCount());
+    return ReturnValue(GlobalAdapter->getRefCount().getCount());
   case UR_ADAPTER_INFO_VERSION: {
 #ifdef UR_ADAPTER_LEVEL_ZERO_V2
     uint32_t adapterVersion = 2;
 #else
-      uint32_t adapterVersion = 1;
+    uint32_t adapterVersion = 1;
 #endif
     return ReturnValue(adapterVersion);
   }

--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -675,7 +675,7 @@ ur_result_t urAdapterGet(
     }
     *Adapters = GlobalAdapter;
 
-    if (GlobalAdapter->getRefCount().increment() == 0) {
+    if (GlobalAdapter->getRefCount().retain() == 0) {
       adapterStateInit();
     }
   }
@@ -692,7 +692,7 @@ ur_result_t urAdapterRelease([[maybe_unused]] ur_adapter_handle_t Adapter) {
 
   // NOTE: This does not require guarding with a mutex; the instant the ref
   // count hits zero, both Get and Retain are UB.
-  if (GlobalAdapter->getRefCount().decrementAndTest()) {
+  if (GlobalAdapter->getRefCount().release()) {
     auto result = adapterStateTeardown();
 #ifdef UR_STATIC_LEVEL_ZERO
     // Given static linking of the L0 Loader, we must delay the loader's
@@ -711,7 +711,7 @@ ur_result_t urAdapterRelease([[maybe_unused]] ur_adapter_handle_t Adapter) {
 
 ur_result_t urAdapterRetain([[maybe_unused]] ur_adapter_handle_t Adapter) {
   assert(GlobalAdapter && GlobalAdapter == Adapter);
-  GlobalAdapter->getRefCount().increment();
+  GlobalAdapter->getRefCount().retain();
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -675,7 +675,7 @@ ur_result_t urAdapterGet(
     }
     *Adapters = GlobalAdapter;
 
-    if (GlobalAdapter->RefCount++ == 0) {
+    if (GlobalAdapter->incrementRefCount() == 0) {
       adapterStateInit();
     }
   }
@@ -692,7 +692,7 @@ ur_result_t urAdapterRelease([[maybe_unused]] ur_adapter_handle_t Adapter) {
 
   // NOTE: This does not require guarding with a mutex; the instant the ref
   // count hits zero, both Get and Retain are UB.
-  if (--GlobalAdapter->RefCount == 0) {
+  if (GlobalAdapter->decrementRefCount() == 0) {
     auto result = adapterStateTeardown();
 #ifdef UR_STATIC_LEVEL_ZERO
     // Given static linking of the L0 Loader, we must delay the loader's
@@ -709,9 +709,9 @@ ur_result_t urAdapterRelease([[maybe_unused]] ur_adapter_handle_t Adapter) {
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t urAdapterRetain([[maybe_unused]] ur_adapter_handle_t Adapter) {
+ur_result_t urAdapterRetain(ur_adapter_handle_t) {
   assert(GlobalAdapter && GlobalAdapter == Adapter);
-  GlobalAdapter->RefCount++;
+  GlobalAdapter->incrementRefCount();
 
   return UR_RESULT_SUCCESS;
 }
@@ -740,12 +740,12 @@ ur_result_t urAdapterGetInfo(ur_adapter_handle_t, ur_adapter_info_t PropName,
   case UR_ADAPTER_INFO_BACKEND:
     return ReturnValue(UR_BACKEND_LEVEL_ZERO);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
-    return ReturnValue(GlobalAdapter->RefCount.load());
+    return ReturnValue(GlobalAdapter->getRefCount());
   case UR_ADAPTER_INFO_VERSION: {
 #ifdef UR_ADAPTER_LEVEL_ZERO_V2
     uint32_t adapterVersion = 2;
 #else
-    uint32_t adapterVersion = 1;
+      uint32_t adapterVersion = 1;
 #endif
     return ReturnValue(adapterVersion);
   }

--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -296,12 +296,10 @@ Behavior Summary:
   SysMan initialization is skipped.
 */
 ur_adapter_handle_t_::ur_adapter_handle_t_()
-    : handle_base(), logger(logger::get_logger("level_zero")) {
+    : handle_base(), logger(logger::get_logger("level_zero")), RefCount(0) {
   ZeInitDriversResult = ZE_RESULT_ERROR_UNINITIALIZED;
   ZeInitResult = ZE_RESULT_ERROR_UNINITIALIZED;
   ZesResult = ZE_RESULT_ERROR_UNINITIALIZED;
-
-  RefCount.reset(0);
 
 #ifdef UR_STATIC_LEVEL_ZERO
   // Given static linking of the L0 Loader, we must delay the loader's

--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -301,6 +301,8 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
   ZeInitResult = ZE_RESULT_ERROR_UNINITIALIZED;
   ZesResult = ZE_RESULT_ERROR_UNINITIALIZED;
 
+  resetRefCount(0);
+
 #ifdef UR_STATIC_LEVEL_ZERO
   // Given static linking of the L0 Loader, we must delay the loader's
   // destruction of its context until after the UR Adapter is destroyed.

--- a/unified-runtime/source/adapters/level_zero/adapter.hpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.hpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#include "common/ur_ref_count.hpp"
 #include "logger/ur_logger.hpp"
 #include "ur_interface_loader.hpp"
 #include <loader/ur_loader.hpp>
@@ -43,6 +44,11 @@ struct ur_adapter_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ZeCache<Result<PlatformVec>> PlatformCache;
   logger::Logger &logger;
   HMODULE processHandle = nullptr;
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
+private:
+  URRefCount RefCount;
 };
 
 extern ur_adapter_handle_t_ *GlobalAdapter;

--- a/unified-runtime/source/adapters/level_zero/adapter.hpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.hpp
@@ -11,7 +11,6 @@
 
 #include "logger/ur_logger.hpp"
 #include "ur_interface_loader.hpp"
-#include <atomic>
 #include <loader/ur_loader.hpp>
 #include <loader/ze_loader.h>
 #include <optional>
@@ -26,7 +25,6 @@ class ur_legacy_sink;
 
 struct ur_adapter_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_adapter_handle_t_();
-  std::atomic<uint32_t> RefCount = 0;
 
   zes_pfnDriverGetDeviceByUuidExp_t getDeviceByUUIdFunctionPtr = nullptr;
   zes_pfnDriverGet_t getSysManDriversFunctionPtr = nullptr;

--- a/unified-runtime/source/adapters/level_zero/adapter.hpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.hpp
@@ -45,10 +45,10 @@ struct ur_adapter_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   logger::Logger &logger;
   HMODULE processHandle = nullptr;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 extern ur_adapter_handle_t_ *GlobalAdapter;

--- a/unified-runtime/source/adapters/level_zero/adapter.hpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.hpp
@@ -45,9 +45,6 @@ struct ur_adapter_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   logger::Logger &logger;
   HMODULE processHandle = nullptr;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
-
-private:
   ur::RefCount RefCount;
 };
 

--- a/unified-runtime/source/adapters/level_zero/async_alloc.cpp
+++ b/unified-runtime/source/adapters/level_zero/async_alloc.cpp
@@ -247,7 +247,7 @@ ur_result_t urEnqueueUSMFreeExp(
   }
 
   size_t size = umfPoolMallocUsableSize(hPool, Mem);
-  (*Event)->getRefCount().retain();
+  (*Event)->RefCount.retain();
   usmPool->AsyncPool.insert(Mem, size, *Event, Queue);
 
   // Signal that USM free event was finished

--- a/unified-runtime/source/adapters/level_zero/async_alloc.cpp
+++ b/unified-runtime/source/adapters/level_zero/async_alloc.cpp
@@ -247,7 +247,7 @@ ur_result_t urEnqueueUSMFreeExp(
   }
 
   size_t size = umfPoolMallocUsableSize(hPool, Mem);
-  (*Event)->getRefCount().increment();
+  (*Event)->getRefCount().retain();
   usmPool->AsyncPool.insert(Mem, size, *Event, Queue);
 
   // Signal that USM free event was finished

--- a/unified-runtime/source/adapters/level_zero/async_alloc.cpp
+++ b/unified-runtime/source/adapters/level_zero/async_alloc.cpp
@@ -247,7 +247,7 @@ ur_result_t urEnqueueUSMFreeExp(
   }
 
   size_t size = umfPoolMallocUsableSize(hPool, Mem);
-  (*Event)->RefCount.increment();
+  (*Event)->incrementRefCount();
   usmPool->AsyncPool.insert(Mem, size, *Event, Queue);
 
   // Signal that USM free event was finished

--- a/unified-runtime/source/adapters/level_zero/async_alloc.cpp
+++ b/unified-runtime/source/adapters/level_zero/async_alloc.cpp
@@ -247,7 +247,7 @@ ur_result_t urEnqueueUSMFreeExp(
   }
 
   size_t size = umfPoolMallocUsableSize(hPool, Mem);
-  (*Event)->incrementRefCount();
+  (*Event)->getRefCount().increment();
   usmPool->AsyncPool.insert(Mem, size, *Event, Queue);
 
   // Signal that USM free event was finished

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -846,7 +846,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t CommandBuffer) {
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  if (!CommandBuffer->decrementRefCount() == 0)
+  if (!CommandBuffer->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   UR_CALL(waitForOngoingExecution(CommandBuffer));

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -840,13 +840,13 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  CommandBuffer->getRefCount().retain();
+  CommandBuffer->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  if (!CommandBuffer->getRefCount().release())
+  if (!CommandBuffer->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   UR_CALL(waitForOngoingExecution(CommandBuffer));
@@ -1641,7 +1641,7 @@ ur_result_t enqueueImmediateAppendPath(
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->getRefCount().retain();
+  (*Event)->RefCount.retain();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(CommandListHelper, false, false));
@@ -1724,7 +1724,7 @@ ur_result_t enqueueWaitEventPath(ur_exp_command_buffer_handle_t CommandBuffer,
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->getRefCount().retain();
+  (*Event)->RefCount.retain();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(SignalCommandList, false /*IsBlocking*/,
@@ -1848,7 +1848,7 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hCommandBuffer->getRefCount().getCount()});
+    return ReturnValue(uint32_t{hCommandBuffer->RefCount.getCount()});
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -840,13 +840,13 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  CommandBuffer->getRefCount().increment();
+  CommandBuffer->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  if (!CommandBuffer->getRefCount().decrementAndTest())
+  if (!CommandBuffer->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   UR_CALL(waitForOngoingExecution(CommandBuffer));
@@ -1641,7 +1641,7 @@ ur_result_t enqueueImmediateAppendPath(
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->getRefCount().increment();
+  (*Event)->getRefCount().retain();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(CommandListHelper, false, false));
@@ -1724,7 +1724,7 @@ ur_result_t enqueueWaitEventPath(ur_exp_command_buffer_handle_t CommandBuffer,
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->getRefCount().increment();
+  (*Event)->getRefCount().retain();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(SignalCommandList, false /*IsBlocking*/,

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -840,13 +840,13 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  CommandBuffer->RefCount.increment();
+  CommandBuffer->incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  if (!CommandBuffer->RefCount.decrementAndTest())
+  if (!CommandBuffer->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   UR_CALL(waitForOngoingExecution(CommandBuffer));
@@ -1641,7 +1641,7 @@ ur_result_t enqueueImmediateAppendPath(
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->RefCount.increment();
+  (*Event)->incrementRefCount();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(CommandListHelper, false, false));
@@ -1724,7 +1724,7 @@ ur_result_t enqueueWaitEventPath(ur_exp_command_buffer_handle_t CommandBuffer,
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->RefCount.increment();
+  (*Event)->incrementRefCount();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(SignalCommandList, false /*IsBlocking*/,
@@ -1848,7 +1848,7 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hCommandBuffer->RefCount.load()});
+    return ReturnValue(uint32_t{hCommandBuffer->getRefCount()});
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -840,13 +840,13 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  CommandBuffer->incrementRefCount();
+  CommandBuffer->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  if (!CommandBuffer->decrementAndTest())
+  if (!CommandBuffer->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   UR_CALL(waitForOngoingExecution(CommandBuffer));
@@ -1641,7 +1641,7 @@ ur_result_t enqueueImmediateAppendPath(
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->incrementRefCount();
+  (*Event)->getRefCount().increment();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(CommandListHelper, false, false));
@@ -1724,7 +1724,7 @@ ur_result_t enqueueWaitEventPath(ur_exp_command_buffer_handle_t CommandBuffer,
   if (CommandBuffer->CurrentSubmissionEvent) {
     UR_CALL(urEventReleaseInternal(CommandBuffer->CurrentSubmissionEvent));
   }
-  (*Event)->incrementRefCount();
+  (*Event)->getRefCount().increment();
   CommandBuffer->CurrentSubmissionEvent = *Event;
 
   UR_CALL(Queue->executeCommandList(SignalCommandList, false /*IsBlocking*/,
@@ -1848,7 +1848,7 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hCommandBuffer->getRefCount()});
+    return ReturnValue(uint32_t{hCommandBuffer->getRefCount().getCount()});
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/level_zero/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.hpp
@@ -151,8 +151,8 @@ struct ur_exp_command_buffer_handle_t_ : public ur_object {
   std::vector<std::unique_ptr<ur_exp_command_buffer_command_handle_t_>>
       CommandHandles;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.hpp
@@ -151,8 +151,5 @@ struct ur_exp_command_buffer_handle_t_ : public ur_object {
   std::vector<std::unique_ptr<ur_exp_command_buffer_command_handle_t_>>
       CommandHandles;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
-
-private:
   ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.hpp
@@ -17,6 +17,7 @@
 
 #include "common.hpp"
 
+#include "common/ur_ref_count.hpp"
 #include "context.hpp"
 #include "kernel.hpp"
 #include "queue.hpp"
@@ -149,4 +150,9 @@ struct ur_exp_command_buffer_handle_t_ : public ur_object {
   // Track handle objects to free when command-buffer is destroyed.
   std::vector<std::unique_ptr<ur_exp_command_buffer_command_handle_t_>>
       CommandHandles;
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
+private:
+  URRefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -259,10 +259,10 @@ struct MemAllocRecord : ur_object {
   // Zero runtime.
   ur_context_handle_t Context;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 extern usm::DisjointPoolAllConfigs DisjointPoolConfigInstance;

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -34,6 +34,7 @@
 #include <level_zero/ze_intel_gpu.h>
 #include <umf_pools/disjoint_pool_config_parser.hpp>
 
+#include "common/ur_ref_count.hpp"
 #include "logger/ur_logger.hpp"
 #include "ur_interface_loader.hpp"
 
@@ -257,6 +258,11 @@ struct MemAllocRecord : ur_object {
   // TODO: this should go away when memory isolation issue is fixed in the Level
   // Zero runtime.
   ur_context_handle_t Context;
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
+private:
+  URRefCount RefCount;
 };
 
 extern usm::DisjointPoolAllConfigs DisjointPoolConfigInstance;

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -259,9 +259,6 @@ struct MemAllocRecord : ur_object {
   // Zero runtime.
   ur_context_handle_t Context;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
-
-private:
   ur::RefCount RefCount;
 };
 

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -220,55 +220,9 @@ void zeParseError(ze_result_t ZeError, const char *&ErrorString);
 #define ZE_CALL_NOCHECK_NAME(ZeName, ZeArgs, callName)                         \
   ZeCall().doCall(ZeName ZeArgs, callName, #ZeArgs, false)
 
-// This wrapper around std::atomic is created to limit operations with reference
-// counter and to make allowed operations more transparent in terms of
-// thread-safety in the plugin. increment() and load() operations do not need a
-// mutex guard around them since the underlying data is already atomic.
-// decrementAndTest() method is used to guard a code which needs to be
-// executed when object's ref count becomes zero after release. This method also
-// doesn't need a mutex guard because decrement operation is atomic and only one
-// thread can reach ref count equal to zero, i.e. only a single thread can pass
-// through this check.
-struct ReferenceCounter {
-  ReferenceCounter() : RefCount{1} {}
-
-  // Reset the counter to the initial value.
-  void reset() { RefCount = 1; }
-
-  // Used when retaining an object.
-  void increment() { RefCount++; }
-
-  // Supposed to be used in ur*GetInfo* methods where ref count value is
-  // requested.
-  uint32_t load() { return RefCount.load(); }
-
-  // This method allows to guard a code which needs to be executed when object's
-  // ref count becomes zero after release. It is important to notice that only a
-  // single thread can pass through this check. This is true because of several
-  // reasons:
-  //   1. Decrement operation is executed atomically.
-  //   2. It is not allowed to retain an object after its refcount reaches zero.
-  //   3. It is not allowed to release an object more times than the value of
-  //   the ref count.
-  // 2. and 3. basically means that we can't use an object at all as soon as its
-  // refcount reaches zero. Using this check guarantees that code for deleting
-  // an object and releasing its resources is executed once by a single thread
-  // and we don't need to use any mutexes to guard access to this object in the
-  // scope after this check. Of course if we access another objects in this code
-  // (not the one which is being deleted) then access to these objects must be
-  // guarded, for example with a mutex.
-  bool decrementAndTest() { return --RefCount == 0; }
-
-private:
-  std::atomic<uint32_t> RefCount;
-};
-
 // Base class to store common data
 struct ur_object : ur::handle_base<ur::level_zero::ddi_getter> {
-  ur_object() : handle_base(), RefCount{} {}
-
-  // Must be atomic to prevent data race when incrementing/decrementing.
-  ReferenceCounter RefCount;
+  ur_object() : handle_base() {}
 
   // This mutex protects accesses to all the non-const member variables.
   // Exclusive access is required to modify any of these members.

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -251,7 +251,7 @@ ur_device_handle_t ur_context_handle_t_::getRootDevice() const {
 // from the list of tracked contexts.
 ur_result_t ContextReleaseHelper(ur_context_handle_t Context) {
 
-  if (!Context->decrementRefCount() == 0)
+  if (!Context->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (IndirectAccessTrackingEnabled) {

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -61,7 +61,7 @@ ur_result_t urContextRetain(
 
     /// [in] handle of the context to get a reference of.
     ur_context_handle_t Context) {
-  Context->getRefCount().retain();
+  Context->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
@@ -113,7 +113,7 @@ ur_result_t urContextGetInfo(
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(uint32_t(Context->Devices.size()));
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Context->getRefCount().getCount()});
+    return ReturnValue(uint32_t{Context->RefCount.getCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // 2D USM memcpy is supported.
     return ReturnValue(uint8_t{UseMemcpy2DOperations});
@@ -251,7 +251,7 @@ ur_device_handle_t ur_context_handle_t_::getRootDevice() const {
 // from the list of tracked contexts.
 ur_result_t ContextReleaseHelper(ur_context_handle_t Context) {
 
-  if (!Context->getRefCount().release())
+  if (!Context->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   if (IndirectAccessTrackingEnabled) {

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -61,7 +61,7 @@ ur_result_t urContextRetain(
 
     /// [in] handle of the context to get a reference of.
     ur_context_handle_t Context) {
-  Context->incrementRefCount();
+  Context->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -113,7 +113,7 @@ ur_result_t urContextGetInfo(
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(uint32_t(Context->Devices.size()));
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Context->getRefCount()});
+    return ReturnValue(uint32_t{Context->getRefCount().getCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // 2D USM memcpy is supported.
     return ReturnValue(uint8_t{UseMemcpy2DOperations});
@@ -251,7 +251,7 @@ ur_device_handle_t ur_context_handle_t_::getRootDevice() const {
 // from the list of tracked contexts.
 ur_result_t ContextReleaseHelper(ur_context_handle_t Context) {
 
-  if (!Context->decrementAndTest())
+  if (!Context->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (IndirectAccessTrackingEnabled) {

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -61,7 +61,7 @@ ur_result_t urContextRetain(
 
     /// [in] handle of the context to get a reference of.
     ur_context_handle_t Context) {
-  Context->RefCount.increment();
+  Context->incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
@@ -113,7 +113,7 @@ ur_result_t urContextGetInfo(
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(uint32_t(Context->Devices.size()));
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Context->RefCount.load()});
+    return ReturnValue(uint32_t{Context->getRefCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // 2D USM memcpy is supported.
     return ReturnValue(uint8_t{UseMemcpy2DOperations});
@@ -251,7 +251,7 @@ ur_device_handle_t ur_context_handle_t_::getRootDevice() const {
 // from the list of tracked contexts.
 ur_result_t ContextReleaseHelper(ur_context_handle_t Context) {
 
-  if (!Context->RefCount.decrementAndTest())
+  if (!Context->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   if (IndirectAccessTrackingEnabled) {

--- a/unified-runtime/source/adapters/level_zero/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/context.cpp
@@ -61,7 +61,7 @@ ur_result_t urContextRetain(
 
     /// [in] handle of the context to get a reference of.
     ur_context_handle_t Context) {
-  Context->getRefCount().increment();
+  Context->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 }
 
@@ -251,7 +251,7 @@ ur_device_handle_t ur_context_handle_t_::getRootDevice() const {
 // from the list of tracked contexts.
 ur_result_t ContextReleaseHelper(ur_context_handle_t Context) {
 
-  if (!Context->getRefCount().decrementAndTest())
+  if (!Context->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   if (IndirectAccessTrackingEnabled) {

--- a/unified-runtime/source/adapters/level_zero/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/context.hpp
@@ -359,7 +359,7 @@ struct ur_context_handle_t_ : ur_object {
   // Get handle to the L0 context
   ze_context_handle_t getZeHandle() const;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 private:
   enum EventFlags {
@@ -407,8 +407,6 @@ private:
 
     return &EventCaches[index];
   }
-
-  ur::RefCount RefCount;
 };
 
 // Helper function to release the context, a caller must lock the platform-level

--- a/unified-runtime/source/adapters/level_zero/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/context.hpp
@@ -26,6 +26,7 @@
 #include "queue.hpp"
 #include "usm.hpp"
 
+#include "common/ur_ref_count.hpp"
 #include <umf_helpers.hpp>
 
 struct l0_command_list_cache_info {
@@ -358,6 +359,8 @@ struct ur_context_handle_t_ : ur_object {
   // Get handle to the L0 context
   ze_context_handle_t getZeHandle() const;
 
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
 private:
   enum EventFlags {
     EVENT_FLAG_HOST_VISIBLE = UR_BIT(0),
@@ -404,6 +407,8 @@ private:
 
     return &EventCaches[index];
   }
+
+  URRefCount RefCount;
 };
 
 // Helper function to release the context, a caller must lock the platform-level

--- a/unified-runtime/source/adapters/level_zero/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/context.hpp
@@ -359,7 +359,7 @@ struct ur_context_handle_t_ : ur_object {
   // Get handle to the L0 context
   ze_context_handle_t getZeHandle() const;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   enum EventFlags {
@@ -408,7 +408,7 @@ private:
     return &EventCaches[index];
   }
 
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 // Helper function to release the context, a caller must lock the platform-level

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -470,7 +470,7 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue((uint32_t)Device->SubDevices.size());
   }
   case UR_DEVICE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Device->RefCount.load()});
+    return ReturnValue(uint32_t{Device->getRefCount()});
   case UR_DEVICE_INFO_SUPPORTED_PARTITIONS: {
     // SYCL spec says: if this SYCL device cannot be partitioned into at least
     // two sub devices then the returned vector must be empty.
@@ -1666,7 +1666,7 @@ ur_result_t urDeviceGetGlobalTimestamps(
 ur_result_t urDeviceRetain(ur_device_handle_t Device) {
   // The root-device ref-count remains unchanged (always 1).
   if (Device->isSubDevice()) {
-    Device->RefCount.increment();
+    Device->incrementRefCount();
   }
   return UR_RESULT_SUCCESS;
 }
@@ -1674,7 +1674,7 @@ ur_result_t urDeviceRetain(ur_device_handle_t Device) {
 ur_result_t urDeviceRelease(ur_device_handle_t Device) {
   // Root devices are destroyed during the piTearDown process.
   if (Device->isSubDevice()) {
-    if (Device->RefCount.decrementAndTest()) {
+    if (Device->decrementRefCount() == 0) {
       delete Device;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1666,7 +1666,7 @@ ur_result_t urDeviceGetGlobalTimestamps(
 ur_result_t urDeviceRetain(ur_device_handle_t Device) {
   // The root-device ref-count remains unchanged (always 1).
   if (Device->isSubDevice()) {
-    Device->getRefCount().increment();
+    Device->getRefCount().retain();
   }
   return UR_RESULT_SUCCESS;
 }
@@ -1674,7 +1674,7 @@ ur_result_t urDeviceRetain(ur_device_handle_t Device) {
 ur_result_t urDeviceRelease(ur_device_handle_t Device) {
   // Root devices are destroyed during the piTearDown process.
   if (Device->isSubDevice()) {
-    if (Device->getRefCount().decrementAndTest()) {
+    if (Device->getRefCount().release()) {
       delete Device;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -470,7 +470,7 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue((uint32_t)Device->SubDevices.size());
   }
   case UR_DEVICE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Device->getRefCount()});
+    return ReturnValue(uint32_t{Device->getRefCount().getCount()});
   case UR_DEVICE_INFO_SUPPORTED_PARTITIONS: {
     // SYCL spec says: if this SYCL device cannot be partitioned into at least
     // two sub devices then the returned vector must be empty.
@@ -1666,7 +1666,7 @@ ur_result_t urDeviceGetGlobalTimestamps(
 ur_result_t urDeviceRetain(ur_device_handle_t Device) {
   // The root-device ref-count remains unchanged (always 1).
   if (Device->isSubDevice()) {
-    Device->incrementRefCount();
+    Device->getRefCount().increment();
   }
   return UR_RESULT_SUCCESS;
 }
@@ -1674,7 +1674,7 @@ ur_result_t urDeviceRetain(ur_device_handle_t Device) {
 ur_result_t urDeviceRelease(ur_device_handle_t Device) {
   // Root devices are destroyed during the piTearDown process.
   if (Device->isSubDevice()) {
-    if (Device->decrementAndTest()) {
+    if (Device->getRefCount().decrementAndTest()) {
       delete Device;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1674,7 +1674,7 @@ ur_result_t urDeviceRetain(ur_device_handle_t Device) {
 ur_result_t urDeviceRelease(ur_device_handle_t Device) {
   // Root devices are destroyed during the piTearDown process.
   if (Device->isSubDevice()) {
-    if (Device->decrementRefCount() == 0) {
+    if (Device->decrementAndTest()) {
       delete Device;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -470,7 +470,7 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue((uint32_t)Device->SubDevices.size());
   }
   case UR_DEVICE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Device->getRefCount().getCount()});
+    return ReturnValue(uint32_t{Device->RefCount.getCount()});
   case UR_DEVICE_INFO_SUPPORTED_PARTITIONS: {
     // SYCL spec says: if this SYCL device cannot be partitioned into at least
     // two sub devices then the returned vector must be empty.
@@ -1666,7 +1666,7 @@ ur_result_t urDeviceGetGlobalTimestamps(
 ur_result_t urDeviceRetain(ur_device_handle_t Device) {
   // The root-device ref-count remains unchanged (always 1).
   if (Device->isSubDevice()) {
-    Device->getRefCount().retain();
+    Device->RefCount.retain();
   }
   return UR_RESULT_SUCCESS;
 }
@@ -1674,7 +1674,7 @@ ur_result_t urDeviceRetain(ur_device_handle_t Device) {
 ur_result_t urDeviceRelease(ur_device_handle_t Device) {
   // Root devices are destroyed during the piTearDown process.
   if (Device->isSubDevice()) {
-    if (Device->getRefCount().release()) {
+    if (Device->RefCount.release()) {
       delete Device;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -244,9 +244,6 @@ struct ur_device_handle_t_ : ur_object {
   // unique ephemeral identifer of the device in the adapter
   std::optional<DeviceId> Id;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
-
-private:
   ur::RefCount RefCount;
 };
 

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -20,6 +20,7 @@
 
 #include "adapters/level_zero/platform.hpp"
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include <ur/ur.hpp>
 #include <ur_ddi.h>
 #include <ze_api.h>
@@ -242,6 +243,11 @@ struct ur_device_handle_t_ : ur_object {
 
   // unique ephemeral identifer of the device in the adapter
   std::optional<DeviceId> Id;
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
+private:
+  URRefCount RefCount;
 };
 
 inline std::vector<ur_device_handle_t>

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -244,10 +244,10 @@ struct ur_device_handle_t_ : ur_object {
   // unique ephemeral identifer of the device in the adapter
   std::optional<DeviceId> Id;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 inline std::vector<ur_device_handle_t>

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -505,7 +505,7 @@ ur_result_t urEventGetInfo(
     return ReturnValue(Result);
   }
   case UR_EVENT_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Event->getRefCount().getCount());
+    return ReturnValue(Event->RefCount.getCount());
   }
   default:
     UR_LOG(ERR, "Unsupported ParamName in urEventGetInfo: ParamName={}(0x{})",
@@ -874,7 +874,7 @@ ur_result_t
 /// [in] handle of the event object
 urEventRetain(/** [in] handle of the event object */ ur_event_handle_t Event) {
   Event->RefCountExternal++;
-  Event->getRefCount().retain();
+  Event->RefCount.retain();
 
   return UR_RESULT_SUCCESS;
 }
@@ -1088,7 +1088,7 @@ ur_event_handle_t_::~ur_event_handle_t_() {
 
 ur_result_t urEventReleaseInternal(ur_event_handle_t Event,
                                    bool *isEventDeleted) {
-  if (!Event->getRefCount().release())
+  if (!Event->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   if (Event->OriginAllocEvent) {
@@ -1524,7 +1524,7 @@ ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
       std::shared_lock<ur_shared_mutex> Lock(CurQueue->LastCommandEvent->Mutex);
       this->ZeEventList[0] = CurQueue->LastCommandEvent->ZeEvent;
       this->UrEventList[0] = CurQueue->LastCommandEvent;
-      this->UrEventList[0]->getRefCount().retain();
+      this->UrEventList[0]->RefCount.retain();
       TmpListLength = 1;
     } else if (EventListLength > 0) {
       this->ZeEventList = new ze_event_handle_t[EventListLength];
@@ -1660,7 +1660,7 @@ ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
               IsInternal, IsMultiDevice));
           MultiDeviceZeEvent = MultiDeviceEvent->ZeEvent;
           const auto &ZeCommandList = CommandList->first;
-          EventList[I]->getRefCount().retain();
+          EventList[I]->RefCount.retain();
 
           // Append a Barrier to wait on the original event while signalling the
           // new multi device event.
@@ -1676,11 +1676,11 @@ ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
 
           this->ZeEventList[TmpListLength] = MultiDeviceZeEvent;
           this->UrEventList[TmpListLength] = MultiDeviceEvent;
-          this->UrEventList[TmpListLength]->getRefCount().retain();
+          this->UrEventList[TmpListLength]->RefCount.retain();
         } else {
           this->ZeEventList[TmpListLength] = EventList[I]->ZeEvent;
           this->UrEventList[TmpListLength] = EventList[I];
-          this->UrEventList[TmpListLength]->getRefCount().retain();
+          this->UrEventList[TmpListLength]->RefCount.retain();
         }
 
         if (QueueLock.has_value()) {

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -505,7 +505,7 @@ ur_result_t urEventGetInfo(
     return ReturnValue(Result);
   }
   case UR_EVENT_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Event->getRefCount());
+    return ReturnValue(Event->getRefCount().getCount());
   }
   default:
     UR_LOG(ERR, "Unsupported ParamName in urEventGetInfo: ParamName={}(0x{})",
@@ -874,7 +874,7 @@ ur_result_t
 /// [in] handle of the event object
 urEventRetain(/** [in] handle of the event object */ ur_event_handle_t Event) {
   Event->RefCountExternal++;
-  Event->incrementRefCount();
+  Event->getRefCount().increment();
 
   return UR_RESULT_SUCCESS;
 }
@@ -1088,7 +1088,7 @@ ur_event_handle_t_::~ur_event_handle_t_() {
 
 ur_result_t urEventReleaseInternal(ur_event_handle_t Event,
                                    bool *isEventDeleted) {
-  if (!Event->decrementAndTest())
+  if (!Event->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (Event->OriginAllocEvent) {
@@ -1429,7 +1429,7 @@ ur_result_t ur_event_handle_t_::reset() {
   CommandType = UR_EXT_COMMAND_TYPE_USER;
   WaitList = {};
   RefCountExternal = 0;
-  resetRefCount();
+  RefCount.reset();
   CommandList = std::nullopt;
   completionBatch = std::nullopt;
   OriginAllocEvent = nullptr;
@@ -1524,7 +1524,7 @@ ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
       std::shared_lock<ur_shared_mutex> Lock(CurQueue->LastCommandEvent->Mutex);
       this->ZeEventList[0] = CurQueue->LastCommandEvent->ZeEvent;
       this->UrEventList[0] = CurQueue->LastCommandEvent;
-      this->UrEventList[0]->incrementRefCount();
+      this->UrEventList[0]->getRefCount().increment();
       TmpListLength = 1;
     } else if (EventListLength > 0) {
       this->ZeEventList = new ze_event_handle_t[EventListLength];
@@ -1660,7 +1660,7 @@ ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
               IsInternal, IsMultiDevice));
           MultiDeviceZeEvent = MultiDeviceEvent->ZeEvent;
           const auto &ZeCommandList = CommandList->first;
-          EventList[I]->incrementRefCount();
+          EventList[I]->getRefCount().increment();
 
           // Append a Barrier to wait on the original event while signalling the
           // new multi device event.
@@ -1676,11 +1676,11 @@ ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
 
           this->ZeEventList[TmpListLength] = MultiDeviceZeEvent;
           this->UrEventList[TmpListLength] = MultiDeviceEvent;
-          this->UrEventList[TmpListLength]->incrementRefCount();
+          this->UrEventList[TmpListLength]->getRefCount().increment();
         } else {
           this->ZeEventList[TmpListLength] = EventList[I]->ZeEvent;
           this->UrEventList[TmpListLength] = EventList[I];
-          this->UrEventList[TmpListLength]->incrementRefCount();
+          this->UrEventList[TmpListLength]->getRefCount().increment();
         }
 
         if (QueueLock.has_value()) {

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -874,7 +874,7 @@ ur_result_t
 /// [in] handle of the event object
 urEventRetain(/** [in] handle of the event object */ ur_event_handle_t Event) {
   Event->RefCountExternal++;
-  Event->getRefCount().increment();
+  Event->getRefCount().retain();
 
   return UR_RESULT_SUCCESS;
 }
@@ -1088,7 +1088,7 @@ ur_event_handle_t_::~ur_event_handle_t_() {
 
 ur_result_t urEventReleaseInternal(ur_event_handle_t Event,
                                    bool *isEventDeleted) {
-  if (!Event->getRefCount().decrementAndTest())
+  if (!Event->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   if (Event->OriginAllocEvent) {
@@ -1524,7 +1524,7 @@ ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
       std::shared_lock<ur_shared_mutex> Lock(CurQueue->LastCommandEvent->Mutex);
       this->ZeEventList[0] = CurQueue->LastCommandEvent->ZeEvent;
       this->UrEventList[0] = CurQueue->LastCommandEvent;
-      this->UrEventList[0]->getRefCount().increment();
+      this->UrEventList[0]->getRefCount().retain();
       TmpListLength = 1;
     } else if (EventListLength > 0) {
       this->ZeEventList = new ze_event_handle_t[EventListLength];
@@ -1660,7 +1660,7 @@ ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
               IsInternal, IsMultiDevice));
           MultiDeviceZeEvent = MultiDeviceEvent->ZeEvent;
           const auto &ZeCommandList = CommandList->first;
-          EventList[I]->getRefCount().increment();
+          EventList[I]->getRefCount().retain();
 
           // Append a Barrier to wait on the original event while signalling the
           // new multi device event.
@@ -1676,11 +1676,11 @@ ur_result_t ur_ze_event_list_t::createAndRetainUrZeEventList(
 
           this->ZeEventList[TmpListLength] = MultiDeviceZeEvent;
           this->UrEventList[TmpListLength] = MultiDeviceEvent;
-          this->UrEventList[TmpListLength]->getRefCount().increment();
+          this->UrEventList[TmpListLength]->getRefCount().retain();
         } else {
           this->ZeEventList[TmpListLength] = EventList[I]->ZeEvent;
           this->UrEventList[TmpListLength] = EventList[I];
-          this->UrEventList[TmpListLength]->getRefCount().increment();
+          this->UrEventList[TmpListLength]->getRefCount().retain();
         }
 
         if (QueueLock.has_value()) {

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -1088,7 +1088,7 @@ ur_event_handle_t_::~ur_event_handle_t_() {
 
 ur_result_t urEventReleaseInternal(ur_event_handle_t Event,
                                    bool *isEventDeleted) {
-  if (!Event->decrementRefCount() == 0)
+  if (!Event->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (Event->OriginAllocEvent) {

--- a/unified-runtime/source/adapters/level_zero/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/event.hpp
@@ -25,6 +25,7 @@
 #include <zes_api.h>
 
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include "queue.hpp"
 #include "ur_api.h"
 
@@ -262,6 +263,11 @@ struct ur_event_handle_t_ : ur_object {
   // Used only for asynchronous allocations. This is the event originally used
   // on async free to indicate when the allocation can be used again.
   ur_event_handle_t OriginAllocEvent = nullptr;
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
+private:
+  URRefCount RefCount;
 };
 
 // Helper function to implement zeHostSynchronize.

--- a/unified-runtime/source/adapters/level_zero/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/event.hpp
@@ -264,9 +264,6 @@ struct ur_event_handle_t_ : ur_object {
   // on async free to indicate when the allocation can be used again.
   ur_event_handle_t OriginAllocEvent = nullptr;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
-
-private:
   ur::RefCount RefCount;
 };
 

--- a/unified-runtime/source/adapters/level_zero/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/event.hpp
@@ -264,10 +264,10 @@ struct ur_event_handle_t_ : ur_object {
   // on async free to indicate when the allocation can be used again.
   ur_event_handle_t OriginAllocEvent = nullptr;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 // Helper function to implement zeHostSynchronize.

--- a/unified-runtime/source/adapters/level_zero/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.cpp
@@ -946,7 +946,7 @@ ur_result_t urKernelRetain(
 ur_result_t urKernelRelease(
     /// [in] handle for the Kernel to release
     ur_kernel_handle_t Kernel) {
-  if (!Kernel->decrementRefCount() == 0)
+  if (!Kernel->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   auto KernelProgram = Kernel->Program;

--- a/unified-runtime/source/adapters/level_zero/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.cpp
@@ -787,7 +787,7 @@ ur_result_t urKernelGetInfo(
     }
   }
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Kernel->RefCount.load()});
+    return ReturnValue(uint32_t{Kernel->getRefCount()});
   case UR_KERNEL_INFO_ATTRIBUTES:
     try {
       uint32_t Size;
@@ -938,7 +938,7 @@ ur_result_t urKernelGetSubGroupInfo(
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t Kernel) {
-  Kernel->RefCount.increment();
+  Kernel->incrementRefCount();
 
   return UR_RESULT_SUCCESS;
 }
@@ -946,7 +946,7 @@ ur_result_t urKernelRetain(
 ur_result_t urKernelRelease(
     /// [in] handle for the Kernel to release
     ur_kernel_handle_t Kernel) {
-  if (!Kernel->RefCount.decrementAndTest())
+  if (!Kernel->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   auto KernelProgram = Kernel->Program;

--- a/unified-runtime/source/adapters/level_zero/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.cpp
@@ -787,7 +787,7 @@ ur_result_t urKernelGetInfo(
     }
   }
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Kernel->getRefCount().getCount()});
+    return ReturnValue(uint32_t{Kernel->RefCount.getCount()});
   case UR_KERNEL_INFO_ATTRIBUTES:
     try {
       uint32_t Size;
@@ -938,7 +938,7 @@ ur_result_t urKernelGetSubGroupInfo(
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t Kernel) {
-  Kernel->getRefCount().retain();
+  Kernel->RefCount.retain();
 
   return UR_RESULT_SUCCESS;
 }
@@ -946,7 +946,7 @@ ur_result_t urKernelRetain(
 ur_result_t urKernelRelease(
     /// [in] handle for the Kernel to release
     ur_kernel_handle_t Kernel) {
-  if (!Kernel->getRefCount().release())
+  if (!Kernel->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   auto KernelProgram = Kernel->Program;

--- a/unified-runtime/source/adapters/level_zero/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.cpp
@@ -938,7 +938,7 @@ ur_result_t urKernelGetSubGroupInfo(
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t Kernel) {
-  Kernel->getRefCount().increment();
+  Kernel->getRefCount().retain();
 
   return UR_RESULT_SUCCESS;
 }
@@ -946,7 +946,7 @@ ur_result_t urKernelRetain(
 ur_result_t urKernelRelease(
     /// [in] handle for the Kernel to release
     ur_kernel_handle_t Kernel) {
-  if (!Kernel->getRefCount().decrementAndTest())
+  if (!Kernel->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   auto KernelProgram = Kernel->Program;

--- a/unified-runtime/source/adapters/level_zero/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.cpp
@@ -787,7 +787,7 @@ ur_result_t urKernelGetInfo(
     }
   }
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Kernel->getRefCount()});
+    return ReturnValue(uint32_t{Kernel->getRefCount().getCount()});
   case UR_KERNEL_INFO_ATTRIBUTES:
     try {
       uint32_t Size;
@@ -938,7 +938,7 @@ ur_result_t urKernelGetSubGroupInfo(
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t Kernel) {
-  Kernel->incrementRefCount();
+  Kernel->getRefCount().increment();
 
   return UR_RESULT_SUCCESS;
 }
@@ -946,7 +946,7 @@ ur_result_t urKernelRetain(
 ur_result_t urKernelRelease(
     /// [in] handle for the Kernel to release
     ur_kernel_handle_t Kernel) {
-  if (!Kernel->decrementAndTest())
+  if (!Kernel->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   auto KernelProgram = Kernel->Program;

--- a/unified-runtime/source/adapters/level_zero/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.hpp
@@ -109,9 +109,6 @@ struct ur_kernel_handle_t_ : ur_object {
   ZeCache<ZeStruct<ze_kernel_properties_t>> ZeKernelProperties;
   ZeCache<std::string> ZeKernelName;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
-
-private:
   ur::RefCount RefCount;
 };
 

--- a/unified-runtime/source/adapters/level_zero/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.hpp
@@ -109,10 +109,10 @@ struct ur_kernel_handle_t_ : ur_object {
   ZeCache<ZeStruct<ze_kernel_properties_t>> ZeKernelProperties;
   ZeCache<std::string> ZeKernelName;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 ur_result_t getZeKernel(ze_device_handle_t hDevice, ur_kernel_handle_t hKernel,

--- a/unified-runtime/source/adapters/level_zero/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.hpp
@@ -9,9 +9,11 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
-#include "common.hpp"
-#include "memory.hpp"
 #include <unordered_set>
+
+#include "common.hpp"
+#include "common/ur_ref_count.hpp"
+#include "memory.hpp"
 
 struct ur_kernel_handle_t_ : ur_object {
   ur_kernel_handle_t_(bool OwnZeHandle, ur_program_handle_t Program)
@@ -106,6 +108,11 @@ struct ur_kernel_handle_t_ : ur_object {
   // Cache of the kernel properties.
   ZeCache<ZeStruct<ze_kernel_properties_t>> ZeKernelProperties;
   ZeCache<std::string> ZeKernelName;
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
+private:
+  URRefCount RefCount;
 };
 
 ur_result_t getZeKernel(ze_device_handle_t hDevice, ur_kernel_handle_t hKernel,

--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -1052,7 +1052,7 @@ ur_result_t urEnqueueMemBufferMap(
 
     // Add the event to the command list.
     CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-    (*Event)->getRefCount().increment();
+    (*Event)->getRefCount().retain();
 
     const auto &ZeCommandList = CommandList->first;
     const auto &WaitList = (*Event)->WaitList;
@@ -1183,7 +1183,7 @@ ur_result_t urEnqueueMemUnmap(
       nullptr /*ForcedCmdQueue*/));
 
   CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-  (*Event)->getRefCount().increment();
+  (*Event)->getRefCount().retain();
 
   const auto &ZeCommandList = CommandList->first;
 
@@ -1635,14 +1635,14 @@ ur_result_t urMemBufferCreate(
 ur_result_t urMemRetain(
     /// [in] handle of the memory object to get access
     ur_mem_handle_t Mem) {
-  Mem->getRefCount().increment();
+  Mem->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urMemRelease(
     /// [in] handle of the memory object to release
     ur_mem_handle_t Mem) {
-  if (!Mem->getRefCount().decrementAndTest())
+  if (!Mem->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   if (Mem->isImage()) {

--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -1052,7 +1052,7 @@ ur_result_t urEnqueueMemBufferMap(
 
     // Add the event to the command list.
     CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-    (*Event)->incrementRefCount();
+    (*Event)->getRefCount().increment();
 
     const auto &ZeCommandList = CommandList->first;
     const auto &WaitList = (*Event)->WaitList;
@@ -1183,7 +1183,7 @@ ur_result_t urEnqueueMemUnmap(
       nullptr /*ForcedCmdQueue*/));
 
   CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-  (*Event)->incrementRefCount();
+  (*Event)->getRefCount().increment();
 
   const auto &ZeCommandList = CommandList->first;
 
@@ -1635,14 +1635,14 @@ ur_result_t urMemBufferCreate(
 ur_result_t urMemRetain(
     /// [in] handle of the memory object to get access
     ur_mem_handle_t Mem) {
-  Mem->incrementRefCount();
+  Mem->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urMemRelease(
     /// [in] handle of the memory object to release
     ur_mem_handle_t Mem) {
-  if (!Mem->decrementAndTest())
+  if (!Mem->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (Mem->isImage()) {
@@ -1848,7 +1848,7 @@ ur_result_t urMemGetInfo(
     return ReturnValue(size_t{Buffer->Size});
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Buffer->getRefCount());
+    return ReturnValue(Buffer->getRefCount().getCount());
   }
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;

--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -1052,7 +1052,7 @@ ur_result_t urEnqueueMemBufferMap(
 
     // Add the event to the command list.
     CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-    (*Event)->getRefCount().retain();
+    (*Event)->RefCount.retain();
 
     const auto &ZeCommandList = CommandList->first;
     const auto &WaitList = (*Event)->WaitList;
@@ -1183,7 +1183,7 @@ ur_result_t urEnqueueMemUnmap(
       nullptr /*ForcedCmdQueue*/));
 
   CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-  (*Event)->getRefCount().retain();
+  (*Event)->RefCount.retain();
 
   const auto &ZeCommandList = CommandList->first;
 
@@ -1635,14 +1635,14 @@ ur_result_t urMemBufferCreate(
 ur_result_t urMemRetain(
     /// [in] handle of the memory object to get access
     ur_mem_handle_t Mem) {
-  Mem->getRefCount().retain();
+  Mem->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urMemRelease(
     /// [in] handle of the memory object to release
     ur_mem_handle_t Mem) {
-  if (!Mem->getRefCount().release())
+  if (!Mem->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   if (Mem->isImage()) {
@@ -1848,7 +1848,7 @@ ur_result_t urMemGetInfo(
     return ReturnValue(size_t{Buffer->Size});
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Buffer->getRefCount().getCount());
+    return ReturnValue(Buffer->RefCount.getCount());
   }
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;

--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -1642,7 +1642,7 @@ ur_result_t urMemRetain(
 ur_result_t urMemRelease(
     /// [in] handle of the memory object to release
     ur_mem_handle_t Mem) {
-  if (!Mem->decrementRefCount() == 0)
+  if (!Mem->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (Mem->isImage()) {

--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -1052,7 +1052,7 @@ ur_result_t urEnqueueMemBufferMap(
 
     // Add the event to the command list.
     CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-    (*Event)->RefCount.increment();
+    (*Event)->incrementRefCount();
 
     const auto &ZeCommandList = CommandList->first;
     const auto &WaitList = (*Event)->WaitList;
@@ -1183,7 +1183,7 @@ ur_result_t urEnqueueMemUnmap(
       nullptr /*ForcedCmdQueue*/));
 
   CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
-  (*Event)->RefCount.increment();
+  (*Event)->incrementRefCount();
 
   const auto &ZeCommandList = CommandList->first;
 
@@ -1635,14 +1635,14 @@ ur_result_t urMemBufferCreate(
 ur_result_t urMemRetain(
     /// [in] handle of the memory object to get access
     ur_mem_handle_t Mem) {
-  Mem->RefCount.increment();
+  Mem->incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urMemRelease(
     /// [in] handle of the memory object to release
     ur_mem_handle_t Mem) {
-  if (!Mem->RefCount.decrementAndTest())
+  if (!Mem->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   if (Mem->isImage()) {
@@ -1848,7 +1848,7 @@ ur_result_t urMemGetInfo(
     return ReturnValue(size_t{Buffer->Size});
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Buffer->RefCount.load());
+    return ReturnValue(Buffer->getRefCount());
   }
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;

--- a/unified-runtime/source/adapters/level_zero/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/memory.hpp
@@ -116,7 +116,7 @@ struct ur_buffer final : ur_mem_handle_t_ {
       : ur_mem_handle_t_(mem_type_t::buffer, Parent->UrContext), Size(Size),
         SubBuffer{{Parent, Origin}} {
     // Retain the Parent Buffer due to the Creation of the SubBuffer.
-    Parent->RefCount.increment();
+    Parent->incrementRefCount();
   }
 
   // Interop-buffer constructor

--- a/unified-runtime/source/adapters/level_zero/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/memory.hpp
@@ -91,7 +91,7 @@ struct ur_mem_handle_t_ : ur_object {
   // Method to get type of the derived object (image or buffer)
   bool isImage() const { return mem_type == mem_type_t::image; }
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 protected:
   ur_mem_handle_t_(mem_type_t type, ur_context_handle_t Context)
@@ -104,9 +104,6 @@ protected:
   // Since the destructor isn't virtual, callers must destruct it via ur_buffer
   // or ur_image
   ~ur_mem_handle_t_() {};
-
-private:
-  ur::RefCount RefCount;
 };
 
 struct ur_buffer final : ur_mem_handle_t_ {
@@ -122,7 +119,7 @@ struct ur_buffer final : ur_mem_handle_t_ {
       : ur_mem_handle_t_(mem_type_t::buffer, Parent->UrContext), Size(Size),
         SubBuffer{{Parent, Origin}} {
     // Retain the Parent Buffer due to the Creation of the SubBuffer.
-    Parent->getRefCount().retain();
+    Parent->RefCount.retain();
   }
 
   // Interop-buffer constructor

--- a/unified-runtime/source/adapters/level_zero/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/memory.hpp
@@ -122,7 +122,7 @@ struct ur_buffer final : ur_mem_handle_t_ {
       : ur_mem_handle_t_(mem_type_t::buffer, Parent->UrContext), Size(Size),
         SubBuffer{{Parent, Origin}} {
     // Retain the Parent Buffer due to the Creation of the SubBuffer.
-    Parent->getRefCount().increment();
+    Parent->getRefCount().retain();
   }
 
   // Interop-buffer constructor

--- a/unified-runtime/source/adapters/level_zero/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/memory.hpp
@@ -91,7 +91,7 @@ struct ur_mem_handle_t_ : ur_object {
   // Method to get type of the derived object (image or buffer)
   bool isImage() const { return mem_type == mem_type_t::image; }
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 protected:
   ur_mem_handle_t_(mem_type_t type, ur_context_handle_t Context)
@@ -106,7 +106,7 @@ protected:
   ~ur_mem_handle_t_() {};
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 struct ur_buffer final : ur_mem_handle_t_ {

--- a/unified-runtime/source/adapters/level_zero/physical_mem.cpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.cpp
@@ -42,12 +42,12 @@ ur_result_t urPhysicalMemCreate(
 }
 
 ur_result_t urPhysicalMemRetain(ur_physical_mem_handle_t hPhysicalMem) {
-  hPhysicalMem->getRefCount().increment();
+  hPhysicalMem->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urPhysicalMemRelease(ur_physical_mem_handle_t hPhysicalMem) {
-  if (!hPhysicalMem->getRefCount().decrementAndTest())
+  if (!hPhysicalMem->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {

--- a/unified-runtime/source/adapters/level_zero/physical_mem.cpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.cpp
@@ -42,12 +42,12 @@ ur_result_t urPhysicalMemCreate(
 }
 
 ur_result_t urPhysicalMemRetain(ur_physical_mem_handle_t hPhysicalMem) {
-  hPhysicalMem->incrementRefCount();
+  hPhysicalMem->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urPhysicalMemRelease(ur_physical_mem_handle_t hPhysicalMem) {
-  if (!hPhysicalMem->decrementAndTest())
+  if (!hPhysicalMem->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {
@@ -68,7 +68,7 @@ ur_result_t urPhysicalMemGetInfo(ur_physical_mem_handle_t hPhysicalMem,
 
   switch (propName) {
   case UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPhysicalMem->getRefCount());
+    return ReturnValue(hPhysicalMem->getRefCount().getCount());
   }
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;

--- a/unified-runtime/source/adapters/level_zero/physical_mem.cpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.cpp
@@ -42,12 +42,12 @@ ur_result_t urPhysicalMemCreate(
 }
 
 ur_result_t urPhysicalMemRetain(ur_physical_mem_handle_t hPhysicalMem) {
-  hPhysicalMem->getRefCount().retain();
+  hPhysicalMem->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urPhysicalMemRelease(ur_physical_mem_handle_t hPhysicalMem) {
-  if (!hPhysicalMem->getRefCount().release())
+  if (!hPhysicalMem->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {
@@ -68,7 +68,7 @@ ur_result_t urPhysicalMemGetInfo(ur_physical_mem_handle_t hPhysicalMem,
 
   switch (propName) {
   case UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPhysicalMem->getRefCount().getCount());
+    return ReturnValue(hPhysicalMem->RefCount.getCount());
   }
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;

--- a/unified-runtime/source/adapters/level_zero/physical_mem.cpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.cpp
@@ -42,12 +42,12 @@ ur_result_t urPhysicalMemCreate(
 }
 
 ur_result_t urPhysicalMemRetain(ur_physical_mem_handle_t hPhysicalMem) {
-  hPhysicalMem->RefCount.increment();
+  hPhysicalMem->incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urPhysicalMemRelease(ur_physical_mem_handle_t hPhysicalMem) {
-  if (!hPhysicalMem->RefCount.decrementAndTest())
+  if (!hPhysicalMem->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {
@@ -68,7 +68,7 @@ ur_result_t urPhysicalMemGetInfo(ur_physical_mem_handle_t hPhysicalMem,
 
   switch (propName) {
   case UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPhysicalMem->RefCount.load());
+    return ReturnValue(hPhysicalMem->getRefCount());
   }
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;

--- a/unified-runtime/source/adapters/level_zero/physical_mem.cpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.cpp
@@ -47,7 +47,7 @@ ur_result_t urPhysicalMemRetain(ur_physical_mem_handle_t hPhysicalMem) {
 }
 
 ur_result_t urPhysicalMemRelease(ur_physical_mem_handle_t hPhysicalMem) {
-  if (!hPhysicalMem->decrementRefCount() == 0)
+  if (!hPhysicalMem->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {

--- a/unified-runtime/source/adapters/level_zero/physical_mem.hpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.hpp
@@ -23,8 +23,5 @@ struct ur_physical_mem_handle_t_ : ur_object {
   // Keeps the PI context of this memory handle.
   ur_context_handle_t Context;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
-
-private:
   ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/physical_mem.hpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 
 struct ur_physical_mem_handle_t_ : ur_object {
   ur_physical_mem_handle_t_(ze_physical_mem_handle_t ZePhysicalMem,
@@ -21,4 +22,9 @@ struct ur_physical_mem_handle_t_ : ur_object {
 
   // Keeps the PI context of this memory handle.
   ur_context_handle_t Context;
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
+private:
+  URRefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/physical_mem.hpp
+++ b/unified-runtime/source/adapters/level_zero/physical_mem.hpp
@@ -23,8 +23,8 @@ struct ur_physical_mem_handle_t_ : ur_object {
   // Keeps the PI context of this memory handle.
   ur_context_handle_t Context;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/program.cpp
+++ b/unified-runtime/source/adapters/level_zero/program.cpp
@@ -558,14 +558,14 @@ ur_result_t urProgramLinkExp(
 ur_result_t urProgramRetain(
     /// [in] handle for the Program to retain
     ur_program_handle_t Program) {
-  Program->getRefCount().increment();
+  Program->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urProgramRelease(
     /// [in] handle for the Program to release
     ur_program_handle_t Program) {
-  if (!Program->getRefCount().decrementAndTest())
+  if (!Program->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   delete Program;
@@ -1115,7 +1115,7 @@ void ur_program_handle_t_::ur_release_program_resources(bool deletion) {
   // must be destroyed before the Module can be destroyed.  So, be sure
   // to destroy build log before destroying the module.
   if (!deletion) {
-    if (!RefCount.decrementAndTest()) {
+    if (!RefCount.release()) {
       return;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/program.cpp
+++ b/unified-runtime/source/adapters/level_zero/program.cpp
@@ -565,7 +565,7 @@ ur_result_t urProgramRetain(
 ur_result_t urProgramRelease(
     /// [in] handle for the Program to release
     ur_program_handle_t Program) {
-  if (!Program->decrementRefCount() == 0)
+  if (!Program->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   delete Program;
@@ -1115,7 +1115,7 @@ void ur_program_handle_t_::ur_release_program_resources(bool deletion) {
   // must be destroyed before the Module can be destroyed.  So, be sure
   // to destroy build log before destroying the module.
   if (!deletion) {
-    if (!decrementRefCount() == 0) {
+    if (!decrementAndTest()) {
       return;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/program.cpp
+++ b/unified-runtime/source/adapters/level_zero/program.cpp
@@ -558,14 +558,14 @@ ur_result_t urProgramLinkExp(
 ur_result_t urProgramRetain(
     /// [in] handle for the Program to retain
     ur_program_handle_t Program) {
-  Program->getRefCount().retain();
+  Program->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urProgramRelease(
     /// [in] handle for the Program to release
     ur_program_handle_t Program) {
-  if (!Program->getRefCount().release())
+  if (!Program->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   delete Program;
@@ -708,7 +708,7 @@ ur_result_t urProgramGetInfo(
 
   switch (PropName) {
   case UR_PROGRAM_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Program->getRefCount().getCount()});
+    return ReturnValue(uint32_t{Program->RefCount.getCount()});
   case UR_PROGRAM_INFO_CONTEXT:
     return ReturnValue(Program->Context);
   case UR_PROGRAM_INFO_NUM_DEVICES:

--- a/unified-runtime/source/adapters/level_zero/program.cpp
+++ b/unified-runtime/source/adapters/level_zero/program.cpp
@@ -558,14 +558,14 @@ ur_result_t urProgramLinkExp(
 ur_result_t urProgramRetain(
     /// [in] handle for the Program to retain
     ur_program_handle_t Program) {
-  Program->RefCount.increment();
+  Program->incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urProgramRelease(
     /// [in] handle for the Program to release
     ur_program_handle_t Program) {
-  if (!Program->RefCount.decrementAndTest())
+  if (!Program->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   delete Program;
@@ -708,7 +708,7 @@ ur_result_t urProgramGetInfo(
 
   switch (PropName) {
   case UR_PROGRAM_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Program->RefCount.load()});
+    return ReturnValue(uint32_t{Program->getRefCount()});
   case UR_PROGRAM_INFO_CONTEXT:
     return ReturnValue(Program->Context);
   case UR_PROGRAM_INFO_NUM_DEVICES:
@@ -1115,7 +1115,7 @@ void ur_program_handle_t_::ur_release_program_resources(bool deletion) {
   // must be destroyed before the Module can be destroyed.  So, be sure
   // to destroy build log before destroying the module.
   if (!deletion) {
-    if (!RefCount.decrementAndTest()) {
+    if (!decrementRefCount() == 0) {
       return;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/program.cpp
+++ b/unified-runtime/source/adapters/level_zero/program.cpp
@@ -558,14 +558,14 @@ ur_result_t urProgramLinkExp(
 ur_result_t urProgramRetain(
     /// [in] handle for the Program to retain
     ur_program_handle_t Program) {
-  Program->incrementRefCount();
+  Program->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urProgramRelease(
     /// [in] handle for the Program to release
     ur_program_handle_t Program) {
-  if (!Program->decrementAndTest())
+  if (!Program->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   delete Program;
@@ -708,7 +708,7 @@ ur_result_t urProgramGetInfo(
 
   switch (PropName) {
   case UR_PROGRAM_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Program->getRefCount()});
+    return ReturnValue(uint32_t{Program->getRefCount().getCount()});
   case UR_PROGRAM_INFO_CONTEXT:
     return ReturnValue(Program->Context);
   case UR_PROGRAM_INFO_NUM_DEVICES:
@@ -1115,7 +1115,7 @@ void ur_program_handle_t_::ur_release_program_resources(bool deletion) {
   // must be destroyed before the Module can be destroyed.  So, be sure
   // to destroy build log before destroying the module.
   if (!deletion) {
-    if (!decrementAndTest()) {
+    if (!RefCount.decrementAndTest()) {
       return;
     }
   }

--- a/unified-runtime/source/adapters/level_zero/program.hpp
+++ b/unified-runtime/source/adapters/level_zero/program.hpp
@@ -227,7 +227,7 @@ struct ur_program_handle_t_ : ur_object {
   // UR_PROGRAM_INFO_BINARY_SIZES.
   const std::vector<ur_device_handle_t> AssociatedDevices;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   struct DeviceData {
@@ -268,5 +268,5 @@ private:
   // TODO: Currently interoparability UR API does not support multiple devices.
   ze_module_handle_t InteropZeModule = nullptr;
 
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/program.hpp
+++ b/unified-runtime/source/adapters/level_zero/program.hpp
@@ -227,7 +227,7 @@ struct ur_program_handle_t_ : ur_object {
   // UR_PROGRAM_INFO_BINARY_SIZES.
   const std::vector<ur_device_handle_t> AssociatedDevices;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 private:
   struct DeviceData {
@@ -267,6 +267,4 @@ private:
   // handle from the program.
   // TODO: Currently interoparability UR API does not support multiple devices.
   ze_module_handle_t InteropZeModule = nullptr;
-
-  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/program.hpp
+++ b/unified-runtime/source/adapters/level_zero/program.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include "device.hpp"
 
 struct ur_program_handle_t_ : ur_object {
@@ -226,6 +227,8 @@ struct ur_program_handle_t_ : ur_object {
   // UR_PROGRAM_INFO_BINARY_SIZES.
   const std::vector<ur_device_handle_t> AssociatedDevices;
 
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
 private:
   struct DeviceData {
     // Log from the result of building the program for the device using
@@ -264,4 +267,6 @@ private:
   // handle from the program.
   // TODO: Currently interoparability UR API does not support multiple devices.
   ze_module_handle_t InteropZeModule = nullptr;
+
+  URRefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -369,7 +369,7 @@ ur_result_t urQueueGetInfo(
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(Queue->Device);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Queue->getRefCount().getCount()});
+    return ReturnValue(uint32_t{Queue->RefCount.getCount()});
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(Queue->Properties);
   case UR_QUEUE_INFO_SIZE:
@@ -593,7 +593,7 @@ ur_result_t urQueueRetain(
     std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
     Queue->RefCountExternal++;
   }
-  Queue->getRefCount().retain();
+  Queue->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
@@ -612,7 +612,7 @@ ur_result_t urQueueRelease(
       // internal reference count. When the External Reference count == 0, then
       // cleanup of the queue begins and the final decrement of the internal
       // reference count is completed.
-      static_cast<void>(Queue->getRefCount().release());
+      static_cast<void>(Queue->RefCount.release());
       return UR_RESULT_SUCCESS;
     }
 
@@ -1389,7 +1389,7 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
           if (!Event->HostVisibleEvent) {
             Event->HostVisibleEvent =
                 reinterpret_cast<ur_event_handle_t>(HostVisibleEvent);
-            HostVisibleEvent->getRefCount().retain();
+            HostVisibleEvent->RefCount.retain();
           }
         }
 
@@ -1550,7 +1550,7 @@ ur_result_t ur_queue_handle_t_::addEventToQueueCache(ur_event_handle_t Event) {
 }
 
 void ur_queue_handle_t_::active_barriers::add(ur_event_handle_t &Event) {
-  Event->getRefCount().retain();
+  Event->RefCount.retain();
   Events.push_back(Event);
 }
 
@@ -1588,7 +1588,7 @@ void ur_queue_handle_t_::clearEndTimeRecordings() {
 }
 
 ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
-  if (!Queue->getRefCount().release())
+  if (!Queue->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   for (auto &Cache : Queue->EventCaches) {
@@ -1921,7 +1921,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   // Append this Event to the CommandList, if any
   if (CommandList != Queue->CommandListMap.end()) {
     CommandList->second.append(*Event);
-    (*Event)->getRefCount().retain();
+    (*Event)->RefCount.retain();
   }
 
   // We need to increment the reference counter here to avoid ur_queue_handle_t
@@ -1929,7 +1929,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   // urEventRelease requires access to the associated ur_queue_handle_t.
   // In urEventRelease, the reference counter of the Queue is decremented
   // to release it.
-  Queue->getRefCount().retain();
+  Queue->RefCount.retain();
 
   // SYCL RT does not track completion of the events, so it could
   // release a PI event as soon as that's not being waited in the app.
@@ -1961,7 +1961,7 @@ void ur_queue_handle_t_::CaptureIndirectAccesses() {
         // SubmissionsCount turns to 0. We don't want to know how many times
         // allocation was retained by each submission.
         if (Pair.second)
-          Elem.second.getRefCount().retain();
+          Elem.second.RefCount.retain();
       }
     }
     Kernel->SubmissionsCount++;

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -612,7 +612,7 @@ ur_result_t urQueueRelease(
       // internal reference count. When the External Reference count == 0, then
       // cleanup of the queue begins and the final decrement of the internal
       // reference count is completed.
-      static_cast<void>(Queue->decrementRefCount() == 0);
+      static_cast<void>(Queue->decrementAndTest());
       return UR_RESULT_SUCCESS;
     }
 
@@ -1588,7 +1588,7 @@ void ur_queue_handle_t_::clearEndTimeRecordings() {
 }
 
 ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
-  if (!Queue->decrementRefCount() == 0)
+  if (!Queue->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   for (auto &Cache : Queue->EventCaches) {

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -593,7 +593,7 @@ ur_result_t urQueueRetain(
     std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
     Queue->RefCountExternal++;
   }
-  Queue->getRefCount().increment();
+  Queue->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 }
 
@@ -612,7 +612,7 @@ ur_result_t urQueueRelease(
       // internal reference count. When the External Reference count == 0, then
       // cleanup of the queue begins and the final decrement of the internal
       // reference count is completed.
-      static_cast<void>(Queue->getRefCount().decrementAndTest());
+      static_cast<void>(Queue->getRefCount().release());
       return UR_RESULT_SUCCESS;
     }
 
@@ -1389,7 +1389,7 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
           if (!Event->HostVisibleEvent) {
             Event->HostVisibleEvent =
                 reinterpret_cast<ur_event_handle_t>(HostVisibleEvent);
-            HostVisibleEvent->getRefCount().increment();
+            HostVisibleEvent->getRefCount().retain();
           }
         }
 
@@ -1550,7 +1550,7 @@ ur_result_t ur_queue_handle_t_::addEventToQueueCache(ur_event_handle_t Event) {
 }
 
 void ur_queue_handle_t_::active_barriers::add(ur_event_handle_t &Event) {
-  Event->getRefCount().increment();
+  Event->getRefCount().retain();
   Events.push_back(Event);
 }
 
@@ -1588,7 +1588,7 @@ void ur_queue_handle_t_::clearEndTimeRecordings() {
 }
 
 ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
-  if (!Queue->getRefCount().decrementAndTest())
+  if (!Queue->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   for (auto &Cache : Queue->EventCaches) {
@@ -1921,7 +1921,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   // Append this Event to the CommandList, if any
   if (CommandList != Queue->CommandListMap.end()) {
     CommandList->second.append(*Event);
-    (*Event)->getRefCount().increment();
+    (*Event)->getRefCount().retain();
   }
 
   // We need to increment the reference counter here to avoid ur_queue_handle_t
@@ -1929,7 +1929,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   // urEventRelease requires access to the associated ur_queue_handle_t.
   // In urEventRelease, the reference counter of the Queue is decremented
   // to release it.
-  Queue->getRefCount().increment();
+  Queue->getRefCount().retain();
 
   // SYCL RT does not track completion of the events, so it could
   // release a PI event as soon as that's not being waited in the app.
@@ -1961,7 +1961,7 @@ void ur_queue_handle_t_::CaptureIndirectAccesses() {
         // SubmissionsCount turns to 0. We don't want to know how many times
         // allocation was retained by each submission.
         if (Pair.second)
-          Elem.second.getRefCount().increment();
+          Elem.second.getRefCount().retain();
       }
     }
     Kernel->SubmissionsCount++;

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -369,7 +369,7 @@ ur_result_t urQueueGetInfo(
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(Queue->Device);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Queue->RefCount.load()});
+    return ReturnValue(uint32_t{Queue->getRefCount()});
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(Queue->Properties);
   case UR_QUEUE_INFO_SIZE:
@@ -593,7 +593,7 @@ ur_result_t urQueueRetain(
     std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
     Queue->RefCountExternal++;
   }
-  Queue->RefCount.increment();
+  Queue->incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
@@ -612,7 +612,7 @@ ur_result_t urQueueRelease(
       // internal reference count. When the External Reference count == 0, then
       // cleanup of the queue begins and the final decrement of the internal
       // reference count is completed.
-      static_cast<void>(Queue->RefCount.decrementAndTest());
+      static_cast<void>(Queue->decrementRefCount() == 0);
       return UR_RESULT_SUCCESS;
     }
 
@@ -1389,7 +1389,7 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
           if (!Event->HostVisibleEvent) {
             Event->HostVisibleEvent =
                 reinterpret_cast<ur_event_handle_t>(HostVisibleEvent);
-            HostVisibleEvent->RefCount.increment();
+            HostVisibleEvent->incrementRefCount();
           }
         }
 
@@ -1550,7 +1550,7 @@ ur_result_t ur_queue_handle_t_::addEventToQueueCache(ur_event_handle_t Event) {
 }
 
 void ur_queue_handle_t_::active_barriers::add(ur_event_handle_t &Event) {
-  Event->RefCount.increment();
+  Event->incrementRefCount();
   Events.push_back(Event);
 }
 
@@ -1588,7 +1588,7 @@ void ur_queue_handle_t_::clearEndTimeRecordings() {
 }
 
 ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
-  if (!Queue->RefCount.decrementAndTest())
+  if (!Queue->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   for (auto &Cache : Queue->EventCaches) {
@@ -1921,7 +1921,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   // Append this Event to the CommandList, if any
   if (CommandList != Queue->CommandListMap.end()) {
     CommandList->second.append(*Event);
-    (*Event)->RefCount.increment();
+    (*Event)->incrementRefCount();
   }
 
   // We need to increment the reference counter here to avoid ur_queue_handle_t
@@ -1929,7 +1929,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   // urEventRelease requires access to the associated ur_queue_handle_t.
   // In urEventRelease, the reference counter of the Queue is decremented
   // to release it.
-  Queue->RefCount.increment();
+  Queue->incrementRefCount();
 
   // SYCL RT does not track completion of the events, so it could
   // release a PI event as soon as that's not being waited in the app.
@@ -1961,7 +1961,7 @@ void ur_queue_handle_t_::CaptureIndirectAccesses() {
         // SubmissionsCount turns to 0. We don't want to know how many times
         // allocation was retained by each submission.
         if (Pair.second)
-          Elem.second.RefCount.increment();
+          Elem.second.incrementRefCount();
       }
     }
     Kernel->SubmissionsCount++;

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -369,7 +369,7 @@ ur_result_t urQueueGetInfo(
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(Queue->Device);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{Queue->getRefCount()});
+    return ReturnValue(uint32_t{Queue->getRefCount().getCount()});
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(Queue->Properties);
   case UR_QUEUE_INFO_SIZE:
@@ -593,7 +593,7 @@ ur_result_t urQueueRetain(
     std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
     Queue->RefCountExternal++;
   }
-  Queue->incrementRefCount();
+  Queue->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 }
 
@@ -612,7 +612,7 @@ ur_result_t urQueueRelease(
       // internal reference count. When the External Reference count == 0, then
       // cleanup of the queue begins and the final decrement of the internal
       // reference count is completed.
-      static_cast<void>(Queue->decrementAndTest());
+      static_cast<void>(Queue->getRefCount().decrementAndTest());
       return UR_RESULT_SUCCESS;
     }
 
@@ -1389,7 +1389,7 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
           if (!Event->HostVisibleEvent) {
             Event->HostVisibleEvent =
                 reinterpret_cast<ur_event_handle_t>(HostVisibleEvent);
-            HostVisibleEvent->incrementRefCount();
+            HostVisibleEvent->getRefCount().increment();
           }
         }
 
@@ -1550,7 +1550,7 @@ ur_result_t ur_queue_handle_t_::addEventToQueueCache(ur_event_handle_t Event) {
 }
 
 void ur_queue_handle_t_::active_barriers::add(ur_event_handle_t &Event) {
-  Event->incrementRefCount();
+  Event->getRefCount().increment();
   Events.push_back(Event);
 }
 
@@ -1588,7 +1588,7 @@ void ur_queue_handle_t_::clearEndTimeRecordings() {
 }
 
 ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
-  if (!Queue->decrementAndTest())
+  if (!Queue->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   for (auto &Cache : Queue->EventCaches) {
@@ -1921,7 +1921,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   // Append this Event to the CommandList, if any
   if (CommandList != Queue->CommandListMap.end()) {
     CommandList->second.append(*Event);
-    (*Event)->incrementRefCount();
+    (*Event)->getRefCount().increment();
   }
 
   // We need to increment the reference counter here to avoid ur_queue_handle_t
@@ -1929,7 +1929,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   // urEventRelease requires access to the associated ur_queue_handle_t.
   // In urEventRelease, the reference counter of the Queue is decremented
   // to release it.
-  Queue->incrementRefCount();
+  Queue->getRefCount().increment();
 
   // SYCL RT does not track completion of the events, so it could
   // release a PI event as soon as that's not being waited in the app.
@@ -1961,7 +1961,7 @@ void ur_queue_handle_t_::CaptureIndirectAccesses() {
         // SubmissionsCount turns to 0. We don't want to know how many times
         // allocation was retained by each submission.
         if (Pair.second)
-          Elem.second.incrementRefCount();
+          Elem.second.getRefCount().increment();
       }
     }
     Kernel->SubmissionsCount++;

--- a/unified-runtime/source/adapters/level_zero/queue.hpp
+++ b/unified-runtime/source/adapters/level_zero/queue.hpp
@@ -25,6 +25,7 @@
 #include <zes_api.h>
 
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include "device.hpp"
 
 extern "C" {
@@ -692,6 +693,11 @@ struct ur_queue_handle_t_ : ur_object {
 
   // Pointer to the unified handle.
   ur_queue_handle_t_ *UnifiedHandle;
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
+private:
+  URRefCount RefCount;
 };
 
 // This helper function creates a ur_event_handle_t and associate a

--- a/unified-runtime/source/adapters/level_zero/queue.hpp
+++ b/unified-runtime/source/adapters/level_zero/queue.hpp
@@ -694,10 +694,10 @@ struct ur_queue_handle_t_ : ur_object {
   // Pointer to the unified handle.
   ur_queue_handle_t_ *UnifiedHandle;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 // This helper function creates a ur_event_handle_t and associate a

--- a/unified-runtime/source/adapters/level_zero/queue.hpp
+++ b/unified-runtime/source/adapters/level_zero/queue.hpp
@@ -694,9 +694,6 @@ struct ur_queue_handle_t_ : ur_object {
   // Pointer to the unified handle.
   ur_queue_handle_t_ *UnifiedHandle;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
-
-private:
   ur::RefCount RefCount;
 };
 

--- a/unified-runtime/source/adapters/level_zero/sampler.cpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.cpp
@@ -124,14 +124,14 @@ ur_result_t urSamplerCreate(
 ur_result_t urSamplerRetain(
     /// [in] handle of the sampler object to get access
     ur_sampler_handle_t Sampler) {
-  Sampler->RefCount.increment();
+  Sampler->incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urSamplerRelease(
     /// [in] handle of the sampler object to release
     ur_sampler_handle_t Sampler) {
-  if (!Sampler->RefCount.decrementAndTest())
+  if (!Sampler->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {

--- a/unified-runtime/source/adapters/level_zero/sampler.cpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.cpp
@@ -124,14 +124,14 @@ ur_result_t urSamplerCreate(
 ur_result_t urSamplerRetain(
     /// [in] handle of the sampler object to get access
     ur_sampler_handle_t Sampler) {
-  Sampler->incrementRefCount();
+  Sampler->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urSamplerRelease(
     /// [in] handle of the sampler object to release
     ur_sampler_handle_t Sampler) {
-  if (!Sampler->decrementAndTest())
+  if (!Sampler->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {

--- a/unified-runtime/source/adapters/level_zero/sampler.cpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.cpp
@@ -124,14 +124,14 @@ ur_result_t urSamplerCreate(
 ur_result_t urSamplerRetain(
     /// [in] handle of the sampler object to get access
     ur_sampler_handle_t Sampler) {
-  Sampler->getRefCount().increment();
+  Sampler->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urSamplerRelease(
     /// [in] handle of the sampler object to release
     ur_sampler_handle_t Sampler) {
-  if (!Sampler->getRefCount().decrementAndTest())
+  if (!Sampler->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {

--- a/unified-runtime/source/adapters/level_zero/sampler.cpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.cpp
@@ -124,14 +124,14 @@ ur_result_t urSamplerCreate(
 ur_result_t urSamplerRetain(
     /// [in] handle of the sampler object to get access
     ur_sampler_handle_t Sampler) {
-  Sampler->getRefCount().retain();
+  Sampler->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urSamplerRelease(
     /// [in] handle of the sampler object to release
     ur_sampler_handle_t Sampler) {
-  if (!Sampler->getRefCount().release())
+  if (!Sampler->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {

--- a/unified-runtime/source/adapters/level_zero/sampler.cpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.cpp
@@ -131,7 +131,7 @@ ur_result_t urSamplerRetain(
 ur_result_t urSamplerRelease(
     /// [in] handle of the sampler object to release
     ur_sampler_handle_t Sampler) {
-  if (!Sampler->decrementRefCount() == 0)
+  if (!Sampler->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (checkL0LoaderTeardown()) {

--- a/unified-runtime/source/adapters/level_zero/sampler.hpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.hpp
@@ -20,9 +20,6 @@ struct ur_sampler_handle_t_ : ur_object {
 
   ZeStruct<ze_sampler_desc_t> ZeSamplerDesc;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
-
-private:
   ur::RefCount RefCount;
 };
 

--- a/unified-runtime/source/adapters/level_zero/sampler.hpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.hpp
@@ -20,10 +20,10 @@ struct ur_sampler_handle_t_ : ur_object {
 
   ZeStruct<ze_sampler_desc_t> ZeSamplerDesc;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 // Construct ZE sampler desc from UR sampler desc.

--- a/unified-runtime/source/adapters/level_zero/sampler.hpp
+++ b/unified-runtime/source/adapters/level_zero/sampler.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 
 struct ur_sampler_handle_t_ : ur_object {
   ur_sampler_handle_t_(ze_sampler_handle_t Sampler) : ZeSampler{Sampler} {}
@@ -18,6 +19,11 @@ struct ur_sampler_handle_t_ : ur_object {
   ze_sampler_handle_t ZeSampler;
 
   ZeStruct<ze_sampler_desc_t> ZeSamplerDesc;
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
+private:
+  URRefCount RefCount;
 };
 
 // Construct ZE sampler desc from UR sampler desc.

--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -523,14 +523,14 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t Pool) {
-  Pool->getRefCount().increment();
+  Pool->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t Pool) {
-  if (Pool->getRefCount().decrementAndTest()) {
+  if (Pool->getRefCount().release()) {
     std::scoped_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
     Pool->Context->UsmPoolHandles.remove(Pool);
     delete Pool;
@@ -1250,7 +1250,7 @@ ur_result_t ZeMemFreeHelper(ur_context_handle_t Context, void *Ptr) {
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.getRefCount().decrementAndTest()) {
+    if (!It->second.getRefCount().release()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }
@@ -1297,7 +1297,7 @@ ur_result_t USMFreeHelper(ur_context_handle_t Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.getRefCount().decrementAndTest()) {
+    if (!It->second.getRefCount().release()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }

--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -530,7 +530,7 @@ urUSMPoolRetain(ur_usm_pool_handle_t Pool) {
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t Pool) {
-  if (Pool->decrementRefCount() == 0) {
+  if (Pool->decrementAndTest()) {
     std::scoped_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
     Pool->Context->UsmPoolHandles.remove(Pool);
     delete Pool;
@@ -1250,7 +1250,7 @@ ur_result_t ZeMemFreeHelper(ur_context_handle_t Context, void *Ptr) {
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.decrementRefCount() == 0) {
+    if (!It->second.decrementAndTest()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }
@@ -1297,7 +1297,7 @@ ur_result_t USMFreeHelper(ur_context_handle_t Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.decrementRefCount() == 0) {
+    if (!It->second.decrementAndTest()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }

--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -523,14 +523,14 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t Pool) {
-  Pool->RefCount.increment();
+  Pool->incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t Pool) {
-  if (Pool->RefCount.decrementAndTest()) {
+  if (Pool->decrementRefCount() == 0) {
     std::scoped_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
     Pool->Context->UsmPoolHandles.remove(Pool);
     delete Pool;
@@ -553,7 +553,7 @@ ur_result_t urUSMPoolGetInfo(
 
   switch (PropName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Pool->RefCount.load());
+    return ReturnValue(Pool->getRefCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(Pool->Context);
@@ -1250,7 +1250,7 @@ ur_result_t ZeMemFreeHelper(ur_context_handle_t Context, void *Ptr) {
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.RefCount.decrementAndTest()) {
+    if (!It->second.decrementRefCount() == 0) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }
@@ -1297,7 +1297,7 @@ ur_result_t USMFreeHelper(ur_context_handle_t Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.RefCount.decrementAndTest()) {
+    if (!It->second.decrementRefCount() == 0) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }

--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -523,14 +523,14 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t Pool) {
-  Pool->getRefCount().retain();
+  Pool->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t Pool) {
-  if (Pool->getRefCount().release()) {
+  if (Pool->RefCount.release()) {
     std::scoped_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
     Pool->Context->UsmPoolHandles.remove(Pool);
     delete Pool;
@@ -553,7 +553,7 @@ ur_result_t urUSMPoolGetInfo(
 
   switch (PropName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Pool->getRefCount().getCount());
+    return ReturnValue(Pool->RefCount.getCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(Pool->Context);
@@ -1250,7 +1250,7 @@ ur_result_t ZeMemFreeHelper(ur_context_handle_t Context, void *Ptr) {
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.getRefCount().release()) {
+    if (!It->second.RefCount.release()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }
@@ -1297,7 +1297,7 @@ ur_result_t USMFreeHelper(ur_context_handle_t Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.getRefCount().release()) {
+    if (!It->second.RefCount.release()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }

--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -523,14 +523,14 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t Pool) {
-  Pool->incrementRefCount();
+  Pool->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t Pool) {
-  if (Pool->decrementAndTest()) {
+  if (Pool->getRefCount().decrementAndTest()) {
     std::scoped_lock<ur_shared_mutex> ContextLock(Pool->Context->Mutex);
     Pool->Context->UsmPoolHandles.remove(Pool);
     delete Pool;
@@ -553,7 +553,7 @@ ur_result_t urUSMPoolGetInfo(
 
   switch (PropName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(Pool->getRefCount());
+    return ReturnValue(Pool->getRefCount().getCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(Pool->Context);
@@ -1250,7 +1250,7 @@ ur_result_t ZeMemFreeHelper(ur_context_handle_t Context, void *Ptr) {
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.decrementAndTest()) {
+    if (!It->second.getRefCount().decrementAndTest()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }
@@ -1297,7 +1297,7 @@ ur_result_t USMFreeHelper(ur_context_handle_t Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.decrementAndTest()) {
+    if (!It->second.getRefCount().decrementAndTest()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
     }

--- a/unified-runtime/source/adapters/level_zero/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/usm.hpp
@@ -54,13 +54,11 @@ struct ur_usm_pool_handle_t_ : ur_object {
 
   ur_context_handle_t Context;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 private:
   UsmPool *getPool(const usm::pool_descriptor &Desc);
   usm::pool_manager<usm::pool_descriptor, UsmPool> PoolManager;
-
-  ur::RefCount RefCount;
 };
 
 // Exception type to pass allocation errors

--- a/unified-runtime/source/adapters/level_zero/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/usm.hpp
@@ -54,13 +54,13 @@ struct ur_usm_pool_handle_t_ : ur_object {
 
   ur_context_handle_t Context;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   UsmPool *getPool(const usm::pool_descriptor &Desc);
   usm::pool_manager<usm::pool_descriptor, UsmPool> PoolManager;
 
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };
 
 // Exception type to pass allocation errors

--- a/unified-runtime/source/adapters/level_zero/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/usm.hpp
@@ -9,13 +9,14 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
-#include "common.hpp"
+#include <set>
 
+#include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include "enqueued_pool.hpp"
 #include "event.hpp"
 #include "ur_api.h"
 #include "ur_pool_manager.hpp"
-#include <set>
 #include <umf_helpers.hpp>
 
 usm::DisjointPoolAllConfigs InitializeDisjointPoolConfig();
@@ -53,9 +54,13 @@ struct ur_usm_pool_handle_t_ : ur_object {
 
   ur_context_handle_t Context;
 
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
 private:
   UsmPool *getPool(const usm::pool_descriptor &Desc);
   usm::pool_manager<usm::pool_descriptor, UsmPool> PoolManager;
+
+  URRefCount RefCount;
 };
 
 // Exception type to pass allocation errors

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -258,7 +258,7 @@ urCommandBufferCreateExp(ur_context_handle_t context, ur_device_handle_t device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  hCommandBuffer->incrementRefCount();
+  hCommandBuffer->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -266,7 +266,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  if (!hCommandBuffer->decrementAndTest())
+  if (!hCommandBuffer->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (auto executionEvent = hCommandBuffer->getExecutionEventUnlocked()) {
@@ -630,7 +630,7 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hCommandBuffer->getRefCount()});
+    return ReturnValue(uint32_t{hCommandBuffer->getRefCount().getCount()});
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -258,7 +258,7 @@ urCommandBufferCreateExp(ur_context_handle_t context, ur_device_handle_t device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  hCommandBuffer->getRefCount().retain();
+  hCommandBuffer->RefCount.retain();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -266,7 +266,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  if (!hCommandBuffer->getRefCount().release())
+  if (!hCommandBuffer->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   if (auto executionEvent = hCommandBuffer->getExecutionEventUnlocked()) {
@@ -630,7 +630,7 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hCommandBuffer->getRefCount().getCount()});
+    return ReturnValue(uint32_t{hCommandBuffer->RefCount.getCount()});
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -266,7 +266,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  if (!hCommandBuffer->decrementRefCount() == 0)
+  if (!hCommandBuffer->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (auto executionEvent = hCommandBuffer->getExecutionEventUnlocked()) {

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -258,7 +258,7 @@ urCommandBufferCreateExp(ur_context_handle_t context, ur_device_handle_t device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  hCommandBuffer->RefCount.increment();
+  hCommandBuffer->incrementRefCount();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -266,7 +266,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  if (!hCommandBuffer->RefCount.decrementAndTest())
+  if (!hCommandBuffer->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   if (auto executionEvent = hCommandBuffer->getExecutionEventUnlocked()) {
@@ -630,7 +630,7 @@ urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
 
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hCommandBuffer->RefCount.load()});
+    return ReturnValue(uint32_t{hCommandBuffer->getRefCount()});
   case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
     ur_exp_command_buffer_desc_t Descriptor{};
     Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -258,7 +258,7 @@ urCommandBufferCreateExp(ur_context_handle_t context, ur_device_handle_t device,
 
 ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  hCommandBuffer->getRefCount().increment();
+  hCommandBuffer->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -266,7 +266,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
 
 ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) try {
-  if (!hCommandBuffer->getRefCount().decrementAndTest())
+  if (!hCommandBuffer->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   if (auto executionEvent = hCommandBuffer->getExecutionEventUnlocked()) {

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -9,15 +9,18 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#include <unordered_set>
+
 #include "../helpers/mutable_helpers.hpp"
 #include "command_list_manager.hpp"
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include "context.hpp"
 #include "kernel.hpp"
 #include "lockable.hpp"
 #include "queue_api.hpp"
-#include <unordered_set>
 #include <ze_api.h>
+
 struct kernel_command_handle;
 
 struct ur_exp_command_buffer_handle_t_ : public ur_object {
@@ -62,6 +65,8 @@ struct ur_exp_command_buffer_handle_t_ : public ur_object {
   ur_event_handle_t
   createEventIfRequested(ur_exp_command_buffer_sync_point_t *retSyncPoint);
 
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
 private:
   // Stores all sync points that are created by the command buffer.
   std::vector<ur_event_handle_t> syncPoints;
@@ -85,4 +90,6 @@ private:
   ur_event_handle_t currentExecution = nullptr;
 
   v2::raii::cache_borrowed_event_pool eventPool;
+
+  URRefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -65,7 +65,7 @@ struct ur_exp_command_buffer_handle_t_ : public ur_object {
   ur_event_handle_t
   createEventIfRequested(ur_exp_command_buffer_sync_point_t *retSyncPoint);
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 private:
   // Stores all sync points that are created by the command buffer.
@@ -90,6 +90,4 @@ private:
   ur_event_handle_t currentExecution = nullptr;
 
   v2::raii::cache_borrowed_event_pool eventPool;
-
-  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.hpp
@@ -65,7 +65,7 @@ struct ur_exp_command_buffer_handle_t_ : public ur_object {
   ur_event_handle_t
   createEventIfRequested(ur_exp_command_buffer_sync_point_t *retSyncPoint);
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   // Stores all sync points that are created by the command buffer.
@@ -91,5 +91,5 @@ private:
 
   v2::raii::cache_borrowed_event_pool eventPool;
 
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -916,7 +916,7 @@ ur_result_t ur_command_list_manager::appendNativeCommandExp(
 void ur_command_list_manager::recordSubmittedKernel(
     ur_kernel_handle_t hKernel) {
   submittedKernels.push_back(hKernel);
-  hKernel->incrementRefCount();
+  hKernel->getRefCount().increment();
 }
 
 ze_command_list_handle_t ur_command_list_manager::getZeCommandList() {

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -916,7 +916,7 @@ ur_result_t ur_command_list_manager::appendNativeCommandExp(
 void ur_command_list_manager::recordSubmittedKernel(
     ur_kernel_handle_t hKernel) {
   submittedKernels.push_back(hKernel);
-  hKernel->getRefCount().retain();
+  hKernel->RefCount.retain();
 }
 
 ze_command_list_handle_t ur_command_list_manager::getZeCommandList() {

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -916,7 +916,7 @@ ur_result_t ur_command_list_manager::appendNativeCommandExp(
 void ur_command_list_manager::recordSubmittedKernel(
     ur_kernel_handle_t hKernel) {
   submittedKernels.push_back(hKernel);
-  hKernel->getRefCount().increment();
+  hKernel->getRefCount().retain();
 }
 
 ze_command_list_handle_t ur_command_list_manager::getZeCommandList() {

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -916,7 +916,7 @@ ur_result_t ur_command_list_manager::appendNativeCommandExp(
 void ur_command_list_manager::recordSubmittedKernel(
     ur_kernel_handle_t hKernel) {
   submittedKernels.push_back(hKernel);
-  hKernel->RefCount.increment();
+  hKernel->incrementRefCount();
 }
 
 ze_command_list_handle_t ur_command_list_manager::getZeCommandList() {

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -80,12 +80,12 @@ ur_context_handle_t_::ur_context_handle_t_(ze_context_handle_t hContext,
       defaultUSMPool(this, nullptr), asyncPool(this, nullptr) {}
 
 ur_result_t ur_context_handle_t_::retain() {
-  RefCount.increment();
+  RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_context_handle_t_::release() {
-  if (!RefCount.decrementAndTest())
+  if (!RefCount.release())
     return UR_RESULT_SUCCESS;
 
   delete this;

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -85,7 +85,7 @@ ur_result_t ur_context_handle_t_::retain() {
 }
 
 ur_result_t ur_context_handle_t_::release() {
-  if (!decrementRefCount() == 0)
+  if (!decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   delete this;

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -201,7 +201,7 @@ ur_result_t urContextGetInfo(ur_context_handle_t hContext,
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(uint32_t(hContext->getDevices().size()));
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hContext->getRefCount().getCount()});
+    return ReturnValue(uint32_t{hContext->RefCount.getCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // TODO: this is currently not implemented
     return ReturnValue(uint8_t{false});

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -80,12 +80,12 @@ ur_context_handle_t_::ur_context_handle_t_(ze_context_handle_t hContext,
       defaultUSMPool(this, nullptr), asyncPool(this, nullptr) {}
 
 ur_result_t ur_context_handle_t_::retain() {
-  RefCount.increment();
+  incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_context_handle_t_::release() {
-  if (!RefCount.decrementAndTest())
+  if (!decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   delete this;
@@ -201,7 +201,7 @@ ur_result_t urContextGetInfo(ur_context_handle_t hContext,
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(uint32_t(hContext->getDevices().size()));
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hContext->RefCount.load()});
+    return ReturnValue(uint32_t{hContext->getRefCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // TODO: this is currently not implemented
     return ReturnValue(uint8_t{false});

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -80,12 +80,12 @@ ur_context_handle_t_::ur_context_handle_t_(ze_context_handle_t hContext,
       defaultUSMPool(this, nullptr), asyncPool(this, nullptr) {}
 
 ur_result_t ur_context_handle_t_::retain() {
-  incrementRefCount();
+  RefCount.increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_context_handle_t_::release() {
-  if (!decrementAndTest())
+  if (!RefCount.decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   delete this;
@@ -201,7 +201,7 @@ ur_result_t urContextGetInfo(ur_context_handle_t hContext,
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(uint32_t(hContext->getDevices().size()));
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hContext->getRefCount()});
+    return ReturnValue(uint32_t{hContext->getRefCount().getCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // TODO: this is currently not implemented
     return ReturnValue(uint8_t{false});

--- a/unified-runtime/source/adapters/level_zero/v2/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.hpp
@@ -65,7 +65,7 @@ struct ur_context_handle_t_ : ur_object {
   // For that the Device or its root devices need to be in the context.
   bool isValidDevice(ur_device_handle_t Device) const;
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 private:
   const v2::raii::ze_context_handle_t hContext;
@@ -84,6 +84,4 @@ private:
   ur_usm_pool_handle_t_ defaultUSMPool;
   ur_usm_pool_handle_t_ asyncPool;
   std::list<ur_usm_pool_handle_t> usmPoolHandles;
-
-  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.hpp
@@ -14,6 +14,7 @@
 
 #include "command_list_cache.hpp"
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include "event_pool_cache.hpp"
 #include "usm.hpp"
 
@@ -64,6 +65,8 @@ struct ur_context_handle_t_ : ur_object {
   // For that the Device or its root devices need to be in the context.
   bool isValidDevice(ur_device_handle_t Device) const;
 
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
 private:
   const v2::raii::ze_context_handle_t hContext;
   const std::vector<ur_device_handle_t> hDevices;
@@ -81,4 +84,6 @@ private:
   ur_usm_pool_handle_t_ defaultUSMPool;
   ur_usm_pool_handle_t_ asyncPool;
   std::list<ur_usm_pool_handle_t> usmPoolHandles;
+
+  URRefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/context.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.hpp
@@ -65,7 +65,7 @@ struct ur_context_handle_t_ : ur_object {
   // For that the Device or its root devices need to be in the context.
   bool isValidDevice(ur_device_handle_t Device) const;
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   const v2::raii::ze_context_handle_t hContext;
@@ -85,5 +85,5 @@ private:
   ur_usm_pool_handle_t_ asyncPool;
   std::list<ur_usm_pool_handle_t> usmPoolHandles;
 
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -160,12 +160,12 @@ ze_event_handle_t ur_event_handle_t_::getZeEvent() const {
 }
 
 ur_result_t ur_event_handle_t_::retain() {
-  RefCount.increment();
+  RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_event_handle_t_::release() {
-  if (!RefCount.decrementAndTest())
+  if (!RefCount.release())
     return UR_RESULT_SUCCESS;
 
   if (event_pool) {

--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -258,7 +258,7 @@ ur_result_t urEventGetInfo(ur_event_handle_t hEvent, ur_event_info_t propName,
     }
   }
   case UR_EVENT_INFO_REFERENCE_COUNT: {
-    return returnValue(hEvent->getRefCount().getCount());
+    return returnValue(hEvent->RefCount.getCount());
   }
   case UR_EVENT_INFO_COMMAND_QUEUE: {
     auto urQueueHandle = reinterpret_cast<uintptr_t>(hEvent->getQueue()) -

--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -160,12 +160,12 @@ ze_event_handle_t ur_event_handle_t_::getZeEvent() const {
 }
 
 ur_result_t ur_event_handle_t_::retain() {
-  incrementRefCount();
+  RefCount.increment();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_event_handle_t_::release() {
-  if (!decrementAndTest())
+  if (!RefCount.decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (event_pool) {
@@ -258,7 +258,7 @@ ur_result_t urEventGetInfo(ur_event_handle_t hEvent, ur_event_info_t propName,
     }
   }
   case UR_EVENT_INFO_REFERENCE_COUNT: {
-    return returnValue(hEvent->getRefCount());
+    return returnValue(hEvent->getRefCount().getCount());
   }
   case UR_EVENT_INFO_COMMAND_QUEUE: {
     auto urQueueHandle = reinterpret_cast<uintptr_t>(hEvent->getQueue()) -

--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -165,7 +165,7 @@ ur_result_t ur_event_handle_t_::retain() {
 }
 
 ur_result_t ur_event_handle_t_::release() {
-  if (!decrementRefCount() == 0)
+  if (!decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (event_pool) {

--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -160,12 +160,12 @@ ze_event_handle_t ur_event_handle_t_::getZeEvent() const {
 }
 
 ur_result_t ur_event_handle_t_::retain() {
-  RefCount.increment();
+  incrementRefCount();
   return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_event_handle_t_::release() {
-  if (!RefCount.decrementAndTest())
+  if (!decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   if (event_pool) {
@@ -258,7 +258,7 @@ ur_result_t urEventGetInfo(ur_event_handle_t hEvent, ur_event_info_t propName,
     }
   }
   case UR_EVENT_INFO_REFERENCE_COUNT: {
-    return returnValue(hEvent->RefCount.load());
+    return returnValue(hEvent->getRefCount());
   }
   case UR_EVENT_INFO_COMMAND_QUEUE: {
     auto urQueueHandle = reinterpret_cast<uintptr_t>(hEvent->getQueue()) -

--- a/unified-runtime/source/adapters/level_zero/v2/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.hpp
@@ -113,13 +113,11 @@ public:
   uint64_t getEventStartTimestmap() const;
   uint64_t getEventEndTimestamp();
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 private:
   ur_event_handle_t_(ur_context_handle_t hContext, event_variant hZeEvent,
                      v2::event_flags_t flags, v2::event_pool *pool);
-
-  ur::RefCount RefCount;
 
 protected:
   ur_context_handle_t hContext;

--- a/unified-runtime/source/adapters/level_zero/v2/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.hpp
@@ -17,6 +17,7 @@
 
 #include "adapters/level_zero/v2/queue_api.hpp"
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include "event_provider.hpp"
 
 namespace v2 {
@@ -112,9 +113,13 @@ public:
   uint64_t getEventStartTimestmap() const;
   uint64_t getEventEndTimestamp();
 
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
 private:
   ur_event_handle_t_(ur_context_handle_t hContext, event_variant hZeEvent,
                      v2::event_flags_t flags, v2::event_pool *pool);
+
+  URRefCount RefCount;
 
 protected:
   ur_context_handle_t hContext;

--- a/unified-runtime/source/adapters/level_zero/v2/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.hpp
@@ -113,13 +113,13 @@ public:
   uint64_t getEventStartTimestmap() const;
   uint64_t getEventEndTimestamp();
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   ur_event_handle_t_(ur_context_handle_t hContext, event_variant hZeEvent,
                      v2::event_flags_t flags, v2::event_pool *pool);
 
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 
 protected:
   ur_context_handle_t hContext;

--- a/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
@@ -52,8 +52,8 @@ void event_pool::free(ur_event_handle_t event) {
   freelist.push_back(event);
 
   // The event is still in the pool, so we need to increment the refcount
-  assert(event->getRefCount().getCount() == 0);
-  event->getRefCount().retain();
+  assert(event->RefCount.getCount() == 0);
+  event->RefCount.retain();
 }
 
 event_provider *event_pool::getProvider() const { return provider.get(); }

--- a/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
@@ -52,8 +52,8 @@ void event_pool::free(ur_event_handle_t event) {
   freelist.push_back(event);
 
   // The event is still in the pool, so we need to increment the refcount
-  assert(event->RefCount.load() == 0);
-  event->RefCount.increment();
+  assert(event->getRefCount() == 0);
+  event->incrementRefCount();
 }
 
 event_provider *event_pool::getProvider() const { return provider.get(); }

--- a/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
@@ -53,7 +53,7 @@ void event_pool::free(ur_event_handle_t event) {
 
   // The event is still in the pool, so we need to increment the refcount
   assert(event->getRefCount().getCount() == 0);
-  event->getRefCount().increment();
+  event->getRefCount().retain();
 }
 
 event_provider *event_pool::getProvider() const { return provider.get(); }

--- a/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event_pool.cpp
@@ -52,8 +52,8 @@ void event_pool::free(ur_event_handle_t event) {
   freelist.push_back(event);
 
   // The event is still in the pool, so we need to increment the refcount
-  assert(event->getRefCount() == 0);
-  event->incrementRefCount();
+  assert(event->getRefCount().getCount() == 0);
+  event->getRefCount().increment();
 }
 
 event_provider *event_pool::getProvider() const { return provider.get(); }

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
@@ -97,7 +97,7 @@ ur_kernel_handle_t_::ur_kernel_handle_t_(
 }
 
 ur_result_t ur_kernel_handle_t_::release() {
-  if (!decrementRefCount() == 0)
+  if (!decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   // manually release kernels to allow errors to be propagated

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
@@ -370,7 +370,7 @@ urKernelCreateWithNativeHandle(ur_native_handle_t hNativeKernel,
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t hKernel) try {
-  hKernel->getRefCount().retain();
+  hKernel->RefCount.retain();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -634,7 +634,7 @@ ur_result_t urKernelGetInfo(ur_kernel_handle_t hKernel,
                        spills.size());
   }
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hKernel->getRefCount().getCount()});
+    return ReturnValue(uint32_t{hKernel->RefCount.getCount()});
   case UR_KERNEL_INFO_ATTRIBUTES: {
     auto attributes = hKernel->getSourceAttributes();
     return ReturnValue(static_cast<const char *>(attributes.data()));

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
@@ -97,7 +97,7 @@ ur_kernel_handle_t_::ur_kernel_handle_t_(
 }
 
 ur_result_t ur_kernel_handle_t_::release() {
-  if (!RefCount.decrementAndTest())
+  if (!RefCount.release())
     return UR_RESULT_SUCCESS;
 
   // manually release kernels to allow errors to be propagated
@@ -370,7 +370,7 @@ urKernelCreateWithNativeHandle(ur_native_handle_t hNativeKernel,
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t hKernel) try {
-  hKernel->getRefCount().increment();
+  hKernel->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
@@ -97,7 +97,7 @@ ur_kernel_handle_t_::ur_kernel_handle_t_(
 }
 
 ur_result_t ur_kernel_handle_t_::release() {
-  if (!decrementAndTest())
+  if (!RefCount.decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   // manually release kernels to allow errors to be propagated
@@ -370,7 +370,7 @@ urKernelCreateWithNativeHandle(ur_native_handle_t hNativeKernel,
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t hKernel) try {
-  hKernel->incrementRefCount();
+  hKernel->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -634,7 +634,7 @@ ur_result_t urKernelGetInfo(ur_kernel_handle_t hKernel,
                        spills.size());
   }
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hKernel->getRefCount()});
+    return ReturnValue(uint32_t{hKernel->getRefCount().getCount()});
   case UR_KERNEL_INFO_ATTRIBUTES: {
     auto attributes = hKernel->getSourceAttributes();
     return ReturnValue(static_cast<const char *>(attributes.data()));

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.cpp
@@ -97,7 +97,7 @@ ur_kernel_handle_t_::ur_kernel_handle_t_(
 }
 
 ur_result_t ur_kernel_handle_t_::release() {
-  if (!RefCount.decrementAndTest())
+  if (!decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   // manually release kernels to allow errors to be propagated
@@ -370,7 +370,7 @@ urKernelCreateWithNativeHandle(ur_native_handle_t hNativeKernel,
 ur_result_t urKernelRetain(
     /// [in] handle for the Kernel to retain
     ur_kernel_handle_t hKernel) try {
-  hKernel->RefCount.increment();
+  hKernel->incrementRefCount();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -634,7 +634,7 @@ ur_result_t urKernelGetInfo(ur_kernel_handle_t hKernel,
                        spills.size());
   }
   case UR_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{hKernel->RefCount.load()});
+    return ReturnValue(uint32_t{hKernel->getRefCount()});
   case UR_KERNEL_INFO_ATTRIBUTES: {
     auto attributes = hKernel->getSourceAttributes();
     return ReturnValue(static_cast<const char *>(attributes.data()));

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
@@ -92,7 +92,7 @@ public:
                                    ze_command_list_handle_t cmdList,
                                    wait_list_view &waitListView);
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   // Keep the program of the kernel.
@@ -120,5 +120,5 @@ private:
   // pointer to any non-null kernel in deviceKernels
   ur_single_device_kernel_t *nonEmptyKernel;
 
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
@@ -13,6 +13,7 @@
 #include "../program.hpp"
 
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include "memory.hpp"
 
 struct ur_single_device_kernel_t {
@@ -91,6 +92,8 @@ public:
                                    ze_command_list_handle_t cmdList,
                                    wait_list_view &waitListView);
 
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
 private:
   // Keep the program of the kernel.
   const ur_program_handle_t hProgram;
@@ -116,4 +119,6 @@ private:
 
   // pointer to any non-null kernel in deviceKernels
   ur_single_device_kernel_t *nonEmptyKernel;
+
+  URRefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
@@ -92,7 +92,7 @@ public:
                                    ze_command_list_handle_t cmdList,
                                    wait_list_view &waitListView);
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 private:
   // Keep the program of the kernel.
@@ -119,6 +119,4 @@ private:
 
   // pointer to any non-null kernel in deviceKernels
   ur_single_device_kernel_t *nonEmptyKernel;
-
-  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -671,7 +671,7 @@ ur_result_t urMemGetInfo(ur_mem_handle_t hMem, ur_mem_info_t propName,
     return returnValue(size_t{hMem->getBuffer()->getSize()});
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return returnValue(hMem->getObject()->getRefCount());
+    return returnValue(hMem->getRefCount().getCount());
   }
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
@@ -684,14 +684,14 @@ ur_result_t urMemGetInfo(ur_mem_handle_t hMem, ur_mem_info_t propName,
 }
 
 ur_result_t urMemRetain(ur_mem_handle_t hMem) try {
-  hMem->getObject()->incrementRefCount();
+  hMem->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
 
 ur_result_t urMemRelease(ur_mem_handle_t hMem) try {
-  if (!hMem->getObject()->decrementAndTest())
+  if (!hMem->getRefCount().decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   delete hMem;

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -671,7 +671,7 @@ ur_result_t urMemGetInfo(ur_mem_handle_t hMem, ur_mem_info_t propName,
     return returnValue(size_t{hMem->getBuffer()->getSize()});
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return returnValue(hMem->getRefCount().getCount());
+    return returnValue(hMem->RefCount.getCount());
   }
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
@@ -684,14 +684,14 @@ ur_result_t urMemGetInfo(ur_mem_handle_t hMem, ur_mem_info_t propName,
 }
 
 ur_result_t urMemRetain(ur_mem_handle_t hMem) try {
-  hMem->getRefCount().retain();
+  hMem->RefCount.retain();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
 
 ur_result_t urMemRelease(ur_mem_handle_t hMem) try {
-  if (!hMem->getRefCount().release())
+  if (!hMem->RefCount.release())
     return UR_RESULT_SUCCESS;
 
   delete hMem;

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -684,14 +684,14 @@ ur_result_t urMemGetInfo(ur_mem_handle_t hMem, ur_mem_info_t propName,
 }
 
 ur_result_t urMemRetain(ur_mem_handle_t hMem) try {
-  hMem->getRefCount().increment();
+  hMem->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
 
 ur_result_t urMemRelease(ur_mem_handle_t hMem) try {
-  if (!hMem->getRefCount().decrementAndTest())
+  if (!hMem->getRefCount().release())
     return UR_RESULT_SUCCESS;
 
   delete hMem;

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -691,7 +691,7 @@ ur_result_t urMemRetain(ur_mem_handle_t hMem) try {
 }
 
 ur_result_t urMemRelease(ur_mem_handle_t hMem) try {
-  if (!hMem->getObject()->decrementRefCount() == 0)
+  if (!hMem->getObject()->decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   delete hMem;

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -671,7 +671,7 @@ ur_result_t urMemGetInfo(ur_mem_handle_t hMem, ur_mem_info_t propName,
     return returnValue(size_t{hMem->getBuffer()->getSize()});
   }
   case UR_MEM_INFO_REFERENCE_COUNT: {
-    return returnValue(hMem->getObject()->RefCount.load());
+    return returnValue(hMem->getObject()->getRefCount());
   }
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
@@ -684,14 +684,14 @@ ur_result_t urMemGetInfo(ur_mem_handle_t hMem, ur_mem_info_t propName,
 }
 
 ur_result_t urMemRetain(ur_mem_handle_t hMem) try {
-  hMem->getObject()->RefCount.increment();
+  hMem->getObject()->incrementRefCount();
   return UR_RESULT_SUCCESS;
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
 
 ur_result_t urMemRelease(ur_mem_handle_t hMem) try {
-  if (!hMem->getObject()->RefCount.decrementAndTest())
+  if (!hMem->getObject()->decrementRefCount() == 0)
     return UR_RESULT_SUCCESS;
 
   delete hMem;

--- a/unified-runtime/source/adapters/level_zero/v2/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.hpp
@@ -19,6 +19,7 @@
 #include "../image_common.hpp"
 #include "command_list_manager.hpp"
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 
 using usm_unique_ptr_t = std::unique_ptr<void, std::function<void(void *)>>;
 
@@ -279,15 +280,9 @@ struct ur_mem_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
         mem);
   }
 
-  ur_object *getObject() {
-    return std::visit(
-        [](auto &&arg) -> ur_object * {
-          return static_cast<ur_object *>(&arg);
-        },
-        mem);
-  }
-
   bool isImage() const { return std::holds_alternative<ur_mem_image_t>(mem); }
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   template <typename T, typename... Args>
@@ -299,4 +294,7 @@ private:
                ur_discrete_buffer_handle_t, ur_shared_buffer_handle_t,
                ur_mem_sub_buffer_t, ur_mem_image_t>
       mem;
+
+private:
+  URRefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.hpp
@@ -282,7 +282,7 @@ struct ur_mem_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
 
   bool isImage() const { return std::holds_alternative<ur_mem_image_t>(mem); }
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 private:
   template <typename T, typename... Args>
@@ -294,7 +294,4 @@ private:
                ur_discrete_buffer_handle_t, ur_shared_buffer_handle_t,
                ur_mem_sub_buffer_t, ur_mem_image_t>
       mem;
-
-private:
-  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.hpp
@@ -282,7 +282,7 @@ struct ur_mem_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
 
   bool isImage() const { return std::holds_alternative<ur_mem_image_t>(mem); }
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   template <typename T, typename... Args>
@@ -296,5 +296,5 @@ private:
       mem;
 
 private:
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
@@ -51,7 +51,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRetain() {
     return std::visit(
         [](auto &q) {
-          q.getRefCount().increment();
+          q.getRefCount().retain();
           return UR_RESULT_SUCCESS;
         },
         queue_data);
@@ -60,7 +60,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRelease() {
     return std::visit(
         [queueHandle = this](auto &q) {
-          if (!q.getRefCount().decrementAndTest())
+          if (!q.getRefCount().release())
             return UR_RESULT_SUCCESS;
           delete queueHandle;
           return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
@@ -50,7 +50,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRetain() {
     return std::visit(
         [](auto &q) {
-          q.RefCount.increment();
+          q.incrementRefCount();
           return UR_RESULT_SUCCESS;
         },
         queue_data);
@@ -59,7 +59,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRelease() {
     return std::visit(
         [queueHandle = this](auto &q) {
-          if (!q.RefCount.decrementAndTest())
+          if (!q.decrementRefCount() == 0)
             return UR_RESULT_SUCCESS;
           delete queueHandle;
           return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
@@ -13,11 +13,12 @@
 
 #pragma once
 
+#include <variant>
+
 #include "../common.hpp"
 #include "queue_immediate_in_order.hpp"
 #include "queue_immediate_out_of_order.hpp"
 #include <ur_api.h>
-#include <variant>
 
 struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   using data_variant = std::variant<v2::ur_queue_immediate_in_order_t,
@@ -50,7 +51,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRetain() {
     return std::visit(
         [](auto &q) {
-          q.incrementRefCount();
+          q.getRefCount().increment();
           return UR_RESULT_SUCCESS;
         },
         queue_data);
@@ -59,7 +60,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRelease() {
     return std::visit(
         [queueHandle = this](auto &q) {
-          if (!q.decrementAndTest())
+          if (!q.getRefCount().decrementAndTest())
             return UR_RESULT_SUCCESS;
           delete queueHandle;
           return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
@@ -51,7 +51,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRetain() {
     return std::visit(
         [](auto &q) {
-          q.getRefCount().retain();
+          q.RefCount.retain();
           return UR_RESULT_SUCCESS;
         },
         queue_data);
@@ -60,7 +60,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRelease() {
     return std::visit(
         [queueHandle = this](auto &q) {
-          if (!q.getRefCount().release())
+          if (!q.RefCount.release())
             return UR_RESULT_SUCCESS;
           delete queueHandle;
           return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_handle.hpp
@@ -59,7 +59,7 @@ struct ur_queue_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter> {
   ur_result_t queueRelease() {
     return std::visit(
         [queueHandle = this](auto &q) {
-          if (!q.decrementRefCount() == 0)
+          if (!q.decrementAndTest())
             return UR_RESULT_SUCCESS;
           delete queueHandle;
           return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -60,7 +60,7 @@ ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(hDevice);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{RefCount.load()});
+    return ReturnValue(uint32_t{getRefCount()});
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(flags);
   case UR_QUEUE_INFO_SIZE:

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -60,7 +60,7 @@ ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(hDevice);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{getRefCount()});
+    return ReturnValue(uint32_t{getRefCount().getCount()});
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(flags);
   case UR_QUEUE_INFO_SIZE:

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -60,7 +60,7 @@ ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(hDevice);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{getRefCount().getCount()});
+    return ReturnValue(uint32_t{RefCount.getCount()});
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(flags);
   case UR_QUEUE_INFO_SIZE:

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -33,7 +33,6 @@ private:
   lockable<ur_command_list_manager> commandListManager;
   ur_queue_flags_t flags;
   v2::raii::cache_borrowed_event_pool eventPool;
-  ur::RefCount RefCount;
 
 public:
   ur_queue_immediate_in_order_t(ur_context_handle_t, ur_device_handle_t,
@@ -454,7 +453,7 @@ public:
         createEventIfRequested(eventPool.get(), phEvent, this));
   }
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 };
 
 } // namespace v2

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -33,7 +33,7 @@ private:
   lockable<ur_command_list_manager> commandListManager;
   ur_queue_flags_t flags;
   v2::raii::cache_borrowed_event_pool eventPool;
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 
 public:
   ur_queue_immediate_in_order_t(ur_context_handle_t, ur_device_handle_t,
@@ -454,7 +454,7 @@ public:
         createEventIfRequested(eventPool.get(), phEvent, this));
   }
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 };
 
 } // namespace v2

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -12,6 +12,7 @@
 #include "../common.hpp"
 #include "../device.hpp"
 
+#include "common/ur_ref_count.hpp"
 #include "context.hpp"
 #include "event.hpp"
 #include "event_pool_cache.hpp"
@@ -32,6 +33,7 @@ private:
   lockable<ur_command_list_manager> commandListManager;
   ur_queue_flags_t flags;
   v2::raii::cache_borrowed_event_pool eventPool;
+  URRefCount RefCount;
 
 public:
   ur_queue_immediate_in_order_t(ur_context_handle_t, ur_device_handle_t,
@@ -451,6 +453,8 @@ public:
         numEventsInWaitList, phEventWaitList,
         createEventIfRequested(eventPool.get(), phEvent, this));
   }
+
+  URRefCount &getRefCount() noexcept { return RefCount; }
 };
 
 } // namespace v2

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.cpp
@@ -54,7 +54,7 @@ ur_result_t ur_queue_immediate_out_of_order_t::queueGetInfo(
   case UR_QUEUE_INFO_DEVICE:
     return ReturnValue(hDevice);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(uint32_t{RefCount.load()});
+    return ReturnValue(uint32_t{RefCount.getCount()});
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(flags);
   case UR_QUEUE_INFO_SIZE:

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
@@ -50,8 +50,6 @@ private:
            numCommandLists;
   }
 
-  ur::RefCount RefCount;
-
 public:
   ur_queue_immediate_out_of_order_t(ur_context_handle_t, ur_device_handle_t,
                                     uint32_t ordinal,
@@ -507,7 +505,7 @@ public:
         createEventIfRequested(eventPool.get(), phEvent, this));
   }
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 };
 
 } // namespace v2

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
@@ -11,6 +11,7 @@
 
 #include "../common.hpp"
 #include "../device.hpp"
+#include "common/ur_ref_count.hpp"
 
 #include "context.hpp"
 #include "event.hpp"
@@ -48,6 +49,8 @@ private:
     return commandListIndex.fetch_add(1, std::memory_order_relaxed) %
            numCommandLists;
   }
+
+  ur::RefCount RefCount;
 
 public:
   ur_queue_immediate_out_of_order_t(ur_context_handle_t, ur_device_handle_t,
@@ -503,6 +506,8 @@ public:
         numEventsInWaitList, phEventWaitList,
         createEventIfRequested(eventPool.get(), phEvent, this));
   }
+
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 };
 
 } // namespace v2

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -332,7 +332,7 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
-  hPool->incrementRefCount();
+  hPool->getRefCount().increment();
   return UR_RESULT_SUCCESS;
 } catch (umf_result_t e) {
   return umf::umf2urResult(e);
@@ -343,7 +343,7 @@ urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t hPool) try {
-  if (hPool->decrementAndTest()) {
+  if (hPool->getRefCount().decrementAndTest()) {
     hPool->getContextHandle()->removeUsmPool(hPool);
     delete hPool;
   }
@@ -369,7 +369,7 @@ ur_result_t urUSMPoolGetInfo(
 
   switch (propName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPool->getRefCount());
+    return ReturnValue(hPool->getRefCount().getCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(hPool->getContextHandle());

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -332,7 +332,7 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
-  hPool->getRefCount().retain();
+  hPool->RefCount.retain();
   return UR_RESULT_SUCCESS;
 } catch (umf_result_t e) {
   return umf::umf2urResult(e);
@@ -343,7 +343,7 @@ urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t hPool) try {
-  if (hPool->getRefCount().release()) {
+  if (hPool->RefCount.release()) {
     hPool->getContextHandle()->removeUsmPool(hPool);
     delete hPool;
   }
@@ -369,7 +369,7 @@ ur_result_t urUSMPoolGetInfo(
 
   switch (propName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPool->getRefCount().getCount());
+    return ReturnValue(hPool->RefCount.getCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(hPool->getContextHandle());

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -332,7 +332,7 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
-  hPool->getRefCount().increment();
+  hPool->getRefCount().retain();
   return UR_RESULT_SUCCESS;
 } catch (umf_result_t e) {
   return umf::umf2urResult(e);
@@ -343,7 +343,7 @@ urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t hPool) try {
-  if (hPool->getRefCount().decrementAndTest()) {
+  if (hPool->getRefCount().release()) {
     hPool->getContextHandle()->removeUsmPool(hPool);
     delete hPool;
   }

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -343,7 +343,7 @@ urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t hPool) try {
-  if (hPool->decrementRefCount() == 0) {
+  if (hPool->decrementAndTest()) {
     hPool->getContextHandle()->removeUsmPool(hPool);
     delete hPool;
   }

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -332,7 +332,7 @@ ur_result_t urUSMPoolCreate(
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
-  hPool->RefCount.increment();
+  hPool->incrementRefCount();
   return UR_RESULT_SUCCESS;
 } catch (umf_result_t e) {
   return umf::umf2urResult(e);
@@ -343,7 +343,7 @@ urUSMPoolRetain(ur_usm_pool_handle_t hPool) try {
 ur_result_t
 /// [in] pointer to USM memory pool
 urUSMPoolRelease(ur_usm_pool_handle_t hPool) try {
-  if (hPool->RefCount.decrementAndTest()) {
+  if (hPool->decrementRefCount() == 0) {
     hPool->getContextHandle()->removeUsmPool(hPool);
     delete hPool;
   }
@@ -369,7 +369,7 @@ ur_result_t urUSMPoolGetInfo(
 
   switch (propName) {
   case UR_USM_POOL_INFO_REFERENCE_COUNT: {
-    return ReturnValue(hPool->RefCount.load());
+    return ReturnValue(hPool->getRefCount());
   }
   case UR_USM_POOL_INFO_CONTEXT: {
     return ReturnValue(hPool->getContextHandle());

--- a/unified-runtime/source/adapters/level_zero/v2/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.hpp
@@ -14,6 +14,7 @@
 
 #include "../enqueued_pool.hpp"
 #include "common.hpp"
+#include "common/ur_ref_count.hpp"
 #include "event.hpp"
 #include "ur_pool_manager.hpp"
 
@@ -49,9 +50,13 @@ struct ur_usm_pool_handle_t_ : ur_object {
   void cleanupPools();
   void cleanupPoolsForQueue(void *hQueue);
 
+  URRefCount &getRefCount() noexcept { return RefCount; }
+
 private:
   ur_context_handle_t hContext;
   usm::pool_manager<usm::pool_descriptor, UsmPool> poolManager;
 
   UsmPool *getPool(const usm::pool_descriptor &desc);
+
+  URRefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.hpp
@@ -50,13 +50,11 @@ struct ur_usm_pool_handle_t_ : ur_object {
   void cleanupPools();
   void cleanupPoolsForQueue(void *hQueue);
 
-  ur::RefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount RefCount;
 
 private:
   ur_context_handle_t hContext;
   usm::pool_manager<usm::pool_descriptor, UsmPool> poolManager;
 
   UsmPool *getPool(const usm::pool_descriptor &desc);
-
-  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.hpp
@@ -50,7 +50,7 @@ struct ur_usm_pool_handle_t_ : ur_object {
   void cleanupPools();
   void cleanupPoolsForQueue(void *hQueue);
 
-  URRefCount &getRefCount() noexcept { return RefCount; }
+  ur::RefCount &getRefCount() noexcept { return RefCount; }
 
 private:
   ur_context_handle_t hContext;
@@ -58,5 +58,5 @@ private:
 
   UsmPool *getPool(const usm::pool_descriptor &desc);
 
-  URRefCount RefCount;
+  ur::RefCount RefCount;
 };

--- a/unified-runtime/source/common/ur_ref_count.hpp
+++ b/unified-runtime/source/common/ur_ref_count.hpp
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+ * Exceptions. See LICENSE.TXT
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+#ifndef URREFCOUNT_HPP
+#define URREFCOUNT_HPP 1
+
+#include <atomic>
+#include <cstdint>
+
+class URRefCount {
+public:
+  uint32_t getCount() const noexcept { return Count.load(); }
+  uint32_t increment() { return ++Count; }
+  uint32_t decrement() { return --Count; }
+  bool decrementAndTest() { return --Count == 0; }
+  void reset(uint32_t value = 1) { Count = value; }
+
+private:
+  std::atomic_uint32_t Count{1};
+};
+
+#endif // URREFCOUNT_HPP

--- a/unified-runtime/source/common/ur_ref_count.hpp
+++ b/unified-runtime/source/common/ur_ref_count.hpp
@@ -23,9 +23,8 @@ public:
   RefCount &operator=(const RefCount &) = delete;
 
   uint32_t getCount() const noexcept { return Count.load(); }
-  uint32_t increment() { return ++Count; }
-  uint32_t decrement() { return --Count; }
-  bool decrementAndTest() { return --Count == 0; }
+  uint32_t retain() { return ++Count; }
+  bool release() { return --Count == 0; }
   void reset(uint32_t value = 1) { Count = value; }
 
 private:

--- a/unified-runtime/source/common/ur_ref_count.hpp
+++ b/unified-runtime/source/common/ur_ref_count.hpp
@@ -14,8 +14,14 @@
 #include <atomic>
 #include <cstdint>
 
-class URRefCount {
+namespace ur {
+
+class RefCount {
 public:
+  RefCount(uint32_t count = 1) : Count(count) {}
+  RefCount(const RefCount &) = delete;
+  RefCount &operator=(const RefCount &) = delete;
+
   uint32_t getCount() const noexcept { return Count.load(); }
   uint32_t increment() { return ++Count; }
   uint32_t decrement() { return --Count; }
@@ -23,7 +29,9 @@ public:
   void reset(uint32_t value = 1) { Count = value; }
 
 private:
-  std::atomic_uint32_t Count{1};
+  std::atomic_uint32_t Count;
 };
+
+} // namespace ur
 
 #endif // URREFCOUNT_HPP

--- a/unified-runtime/source/ur/ur.hpp
+++ b/unified-runtime/source/ur/ur.hpp
@@ -233,7 +233,7 @@ template <typename getddi> struct handle_base {
   uint32_t incrementRefCount() { return ++Count; }
   uint32_t decrementRefCount() { return --Count; }
   bool decrementAndTest() { return --Count == 0; }
-  void resetRefCount() { Count = 1; }
+  void resetRefCount(uint32_t value = 1) { Count = value; }
 
 private:
   std::atomic_uint32_t Count{1};

--- a/unified-runtime/source/ur/ur.hpp
+++ b/unified-runtime/source/ur/ur.hpp
@@ -228,6 +228,14 @@ template <typename getddi> struct handle_base {
   // Handles are non-copyable.
   handle_base(const handle_base &) = delete;
   handle_base &operator=(const handle_base &) = delete;
+
+  uint32_t getRefCount() const noexcept { return Count.load(); }
+  uint32_t incrementRefCount() { return ++Count; }
+  uint32_t decrementRefCount() { return --Count; }
+  void resetRefCount() { Count = 1; }
+
+private:
+  std::atomic_uint32_t Count{1};
 };
 
 template <typename T, typename Assign>

--- a/unified-runtime/source/ur/ur.hpp
+++ b/unified-runtime/source/ur/ur.hpp
@@ -228,15 +228,6 @@ template <typename getddi> struct handle_base {
   // Handles are non-copyable.
   handle_base(const handle_base &) = delete;
   handle_base &operator=(const handle_base &) = delete;
-
-  uint32_t getRefCount() const noexcept { return Count.load(); }
-  uint32_t incrementRefCount() { return ++Count; }
-  uint32_t decrementRefCount() { return --Count; }
-  bool decrementAndTest() { return --Count == 0; }
-  void resetRefCount(uint32_t value = 1) { Count = value; }
-
-private:
-  std::atomic_uint32_t Count{1};
 };
 
 template <typename T, typename Assign>

--- a/unified-runtime/source/ur/ur.hpp
+++ b/unified-runtime/source/ur/ur.hpp
@@ -232,6 +232,7 @@ template <typename getddi> struct handle_base {
   uint32_t getRefCount() const noexcept { return Count.load(); }
   uint32_t incrementRefCount() { return ++Count; }
   uint32_t decrementRefCount() { return --Count; }
+  bool decrementAndTest() { return --Count == 0; }
   void resetRefCount() { Count = 1; }
 
 private:


### PR DESCRIPTION
For https://github.com/intel/llvm/issues/18644

Most UR adapters had their own reference counting of some sort. This adds a new `RefCount` class and refactors adapter code so all adapters can share the same code for reference counting. This PR handles L0/L0V2 and I will open more PRs for each adapter in turn.