### PR TITLE
[E2E] fix check in Matrix/lit.local.cfg

### DIFF
--- a/sycl/test-e2e/Matrix/lit.local.cfg
+++ b/sycl/test-e2e/Matrix/lit.local.cfg
@@ -8,7 +8,8 @@ if 'windows' in config.available_features:
    config.unsupported_features += ['arch-intel_gpu_bmg_g21']
 
 # https://github.com/intel/llvm/issues/18932
-if 'arch-intel_gpu_pvc' in config.available_features:
+has_arch_gpu_intel_pvc = any('arch-intel_gpu_pvc' in T for T in config.sycl_dev_features.values())
+if has_arch_gpu_intel_pvc:
   config.unsupported_features += ['level_zero_v2_adapter']
 
 config.substitutions.append(("%helper-includes", "-I {}/Inputs".format(os.path.dirname(os.path.abspath(__file__)))))


### PR DESCRIPTION
arch-intel_gpu_pvc is not a part of available_features when the lit.local.cfg file is executed. This led
to Matrix tests not being skiped on PVC for V2 as
expected.

Fix this by parsing config.sycl_dev_features, similarly to MemorySanitizer/lit.local.cfg