### PR TITLE
[UR] Add raii handle for UR context and device

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -47,7 +47,7 @@ struct ur_command_list_manager {
   operator=(const ur_command_list_manager &src) = delete;
   ur_command_list_manager &operator=(ur_command_list_manager &&src) = default;
 
-  ~ur_command_list_manager();
+  ~ur_command_list_manager() = default;
 
   ze_command_list_handle_t getZeCommandList();
 
@@ -273,8 +273,10 @@ private:
       const ur_event_handle_t *phEventWaitList, ur_event_handle_t phEvent,
       ur_command_t commandType);
 
-  ur_context_handle_t hContext;
-  ur_device_handle_t hDevice;
+  // Context needs to be a first member - it needs to be alive
+  // until all other members are destroyed.
+  v2::raii::ur_context_handle_t hContext;
+  v2::raii::ur_device_handle_t hDevice;
 
   std::vector<ur_kernel_handle_t> submittedKernels;
   v2::raii::command_list_unique_handle zeCommandList;


### PR DESCRIPTION
and fix context lifetime management in command_list_manager. There were two issues:
- move ctor and assignment operators were declared as default but that was incorrect - they should set context on the moved-from command_list_manager to nullptr to avoid double free.
- urContextRelease() was called in the desturctor, which means its context could have been released before other members. This was a problem since zeCommandList was trying to return command_list to the context's cache in it's dtor.