### PR TITLE
[SYCL][Unittests] Fix unloading of mock images on Windows

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -134,6 +134,10 @@ GlobalHandler &GlobalHandler::instance() {
   return *RTGlobalObjHandler;
 }
 
+bool GlobalHandler::isInstanceAlive() {
+  return GlobalHandler::getInstancePtr();
+}
+
 template <typename T, typename... Types>
 T &GlobalHandler::getOrCreate(InstWithLock<T> &IWL, Types &&...Args) {
   const LockGuard Lock{IWL.Lock};

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -52,6 +52,9 @@ public:
   /// `__attribute__((destructor))` is called).
   static GlobalHandler &instance();
 
+  /// \return true if the instance has not been deallocated yet.
+  static bool isInstanceAlive();
+
   GlobalHandler(const GlobalHandler &) = delete;
   GlobalHandler(GlobalHandler &&) = delete;
   GlobalHandler &operator=(const GlobalHandler &) = delete;

--- a/sycl/unittests/helpers/MockDeviceImage.hpp
+++ b/sycl/unittests/helpers/MockDeviceImage.hpp
@@ -363,10 +363,15 @@ public:
         nullptr, // not used, put here for compatibility with OpenMP
     };
 
-    __sycl_register_lib(&MAllBinaries);
+    sycl::detail::ProgramManager::getInstance().addImages(&MAllBinaries);
   }
 
-  ~MockDeviceImageArray() { __sycl_unregister_lib(&MAllBinaries); }
+  ~MockDeviceImageArray() {
+    // If there is still a global handler, we are not doing full unloading yet.
+    // As such, we need to clean up the images we registered.
+    if (GlobalHandler::isInstanceAlive())
+      sycl::detail::ProgramManager::getInstance().removeImages(&MAllBinaries);
+  }
 
 private:
   sycl_device_binary_struct MNativeImages[NumberOfImages];


### PR DESCRIPTION
The implementation of mock images try to unload the images using __sycl_unregister_lib. However, this is a no-op on Windows under the assumption that shutdown will handle the images. This causes unittests, like RootGroup, to leave dead binaries in the program manager that subsequent test runs may pick up. This commit fixes this issue by having the mock image arrays forciby remove the images from the program manager instead.