### PR TITLE
[UR] Remove unused UR_EXT_DEVICE_INFO_OPENCL_C_VERSION

### DIFF
--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -607,9 +607,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     SS << "." << Minor;
     return ReturnValue(SS.str().c_str());
   }
-  case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION: {
-    return ReturnValue("");
-  }
   case UR_DEVICE_INFO_EXTENSIONS: {
     std::string SupportedExtensions = "cl_khr_fp64 ";
 

--- a/unified-runtime/source/adapters/hip/device.cpp
+++ b/unified-runtime/source/adapters/hip/device.cpp
@@ -493,9 +493,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 #endif
     return ReturnValue(S.str().c_str());
   }
-  case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION: {
-    return ReturnValue("");
-  }
   case UR_DEVICE_INFO_EXTENSIONS: {
     std::string SupportedExtensions = "";
 

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -514,8 +514,6 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue(*Device->SubDeviceCreationProperty);
   }
   // Everything under here is not supported yet
-  case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION:
-    return ReturnValue("");
   case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC:
     return ReturnValue(static_cast<ur_bool_t>(true));
   case UR_DEVICE_INFO_PRINTF_BUFFER_SIZE:

--- a/unified-runtime/source/adapters/native_cpu/device.cpp
+++ b/unified-runtime/source/adapters/native_cpu/device.cpp
@@ -214,8 +214,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       *pPropSizeRet = 0;
     }
     return UR_RESULT_SUCCESS;
-  case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION:
-    return ReturnValue("");
   case UR_DEVICE_INFO_QUEUE_PROPERTIES:
     return ReturnValue(
         ur_queue_flag_t(UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE |

--- a/unified-runtime/source/adapters/opencl/device.cpp
+++ b/unified-runtime/source/adapters/opencl/device.cpp
@@ -1183,13 +1183,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
     return UR_RESULT_SUCCESS;
   }
-  case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION: {
-    CL_RETURN_ON_FAILURE(clGetDeviceInfo(hDevice->CLDevice,
-                                         CL_DEVICE_OPENCL_C_VERSION, propSize,
-                                         pPropValue, pPropSizeRet));
-
-    return UR_RESULT_SUCCESS;
-  }
   case UR_DEVICE_INFO_BUILT_IN_KERNELS: {
     CL_RETURN_ON_FAILURE(clGetDeviceInfo(hDevice->CLDevice,
                                          CL_DEVICE_BUILT_IN_KERNELS, propSize,

--- a/unified-runtime/source/ur/ur.hpp
+++ b/unified-runtime/source/ur/ur.hpp
@@ -81,11 +81,7 @@ template <> uint32_t inline ur_cast(uint64_t Value) {
   return CastedValue;
 }
 
-// TODO: promote all of the below extensions to the Unified Runtime
-//       and get rid of these ZER_EXT constants.
-const ur_device_info_t UR_EXT_DEVICE_INFO_OPENCL_C_VERSION =
-    (ur_device_info_t)0x103D;
-
+// TODO: Promote the below extensions to the Unified Runtime?
 const ur_command_t UR_EXT_COMMAND_TYPE_USER =
     (ur_command_t)((uint32_t)UR_COMMAND_FORCE_UINT32 - 1);
 


### PR DESCRIPTION
This query isn't accessible publicly, removing it has not caused any test failures.
