### PR TITLE
[SYCL] Fix sycl_unique_stable_id address space

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -1863,9 +1863,11 @@ ScalarExprEmitter::VisitSYCLUniqueStableIdExpr(SYCLUniqueStableIdExpr *E) {
   ASTContext &Context = CGF.getContext();
   std::optional<LangAS> GlobalAS =
       Context.getTargetInfo().getConstantAddressSpace();
+  LangAS AS = GlobalAS.value_or(LangAS::Default);
   llvm::Constant *GlobalConstStr = Builder.CreateGlobalStringPtr(
       E->ComputeName(Context), "__usid_str",
-      static_cast<unsigned>(GlobalAS.value_or(LangAS::Default)));
+      isTargetAddressSpace(AS) ? toTargetAddressSpace(AS)
+                               : static_cast<unsigned>(AS));
 
   unsigned ExprAS = CGF.CGM.getTypes().getTargetAddressSpace(E->getType());
 

--- a/sycl/test/check_device_code/spec_const_usid_str.cpp
+++ b/sycl/test/check_device_code/spec_const_usid_str.cpp
@@ -1,0 +1,16 @@
+// REQUIRES: hip
+// RUN: %clangxx -fsycl -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib %s -S -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK
+
+// This test checks that __usid_str has constant address space.
+
+// CHECK: @__usid_str = private unnamed_addr addrspace(4) constant [38 x i8] c"uid
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+constexpr specialization_id<unsigned int> SPEC_CONST(1024);
+
+SYCL_EXTERNAL unsigned int foo(kernel_handler &kh) {
+  return kh.get_specialization_constant<SPEC_CONST>();
+}


### PR DESCRIPTION
If the language address space represents a target address space, we should convert it to target address space.