### PR TITLE
[SYCL][E2E] Add REQUIRES: opencl-aot to tests

### DIFF
--- a/sycl/test-e2e/NonUniformGroups/ballot_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/ballot_group.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // CPU AOT targets host isa, so we compile on the run system instead.
+// REQUIRES: opencl-aot
 // RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //

--- a/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // CPU AOT targets host isa, so we compile on the run system instead.
+// REQUIRES: opencl-aot
 // RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //

--- a/sycl/test-e2e/NonUniformGroups/fixed_size_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fixed_size_group.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // CPU AOT targets host isa, so we compile on the run system instead.
+// REQUIRES: opencl-aot
 // RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //

--- a/sycl/test-e2e/NonUniformGroups/fixed_size_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fixed_size_group_algorithms.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // CPU AOT targets host isa, so we compile on the run system instead.
+// REQUIRES: opencl-aot
 // RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-device-code-split=per_kernel -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //

--- a/sycl/test-e2e/NonUniformGroups/opportunistic_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/opportunistic_group.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // CPU AOT targets host isa, so we compile on the run system instead.
+// REQUIRES: opencl-aot
 // RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //

--- a/sycl/test-e2e/NonUniformGroups/opportunistic_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/opportunistic_group_algorithms.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // CPU AOT targets host isa, so we compile on the run system instead.
+// REQUIRES: opencl-aot
 // RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //

--- a/sycl/test-e2e/NonUniformGroups/tangle_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/tangle_group.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // CPU AOT targets host isa, so we compile on the run system instead.
+// REQUIRES: opencl-aot
 // RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //

--- a/sycl/test-e2e/NonUniformGroups/tangle_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/tangle_group_algorithms.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // CPU AOT targets host isa, so we compile on the run system instead.
+// REQUIRES: opencl-aot
 // RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s %}
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 //


### PR DESCRIPTION
A number of e2e tests use `opencl-aot` raw in their `RUN:` commands, this causes tests to fail when the tool is not present on the `PATH`. This patch adds `REQUIRES: opencl-aot` to avoid those test failures.
