### PR TITLE
[SYCL] Revert enable_shared_from_this for event_impl

### DIFF
--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -34,7 +34,7 @@ class queue_impl;
 class event_impl;
 using EventImplPtr = std::shared_ptr<sycl::detail::event_impl>;
 
-class event_impl : public std::enable_shared_from_this<event_impl> {
+class event_impl {
   struct private_tag {
     explicit private_tag() = default;
   };


### PR DESCRIPTION
It was introduced in a4c5ace along with other chanes and caused the performance regression.