### PR TITLE
fix native cpu and some tests

### DIFF
--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -118,7 +118,7 @@ unsigned TargetCodeGenInfo::getDeviceKernelCallingConv() const {
     return llvm::CallingConv::SPIR_KERNEL;
   }
   if (getABIInfo().getContext().getLangOpts().SYCLIsNativeCPU) {
-    return getABIInfo().getTarget().getDefaultCallingConv();
+    return llvm::CallingConv::SPIR_KERNEL;
   }
   llvm_unreachable("Unknown kernel calling convention");
 }

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -117,6 +117,9 @@ unsigned TargetCodeGenInfo::getDeviceKernelCallingConv() const {
     // to multiple function arguments etc.
     return llvm::CallingConv::SPIR_KERNEL;
   }
+  if (getABIInfo().getContext().getLangOpts().SYCLIsNativeCPU) {
+    return getABIInfo().getTarget().getDefaultCallingConv();
+  }
   llvm_unreachable("Unknown kernel calling convention");
 }
 

--- a/clang/test/CodeGenSYCL/sycl-device-module-flag.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device-module-flag.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -emit-llvm -internal-isystem %S/Inputs -o - %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64 -emit-llvm -internal-isystem %S/Inputs -o - %s | FileCheck %s
 // RUN: %clang_cc1 -fsycl-is-host -emit-llvm -internal-isystem %S/Inputs -o - %s | FileCheck %s --check-prefixes=HOST
 
 // This test checks if the sycl-device module flag is created for device

--- a/clang/test/CodeGenSYCL/unique_stable_name_windows_diff.cpp
+++ b/clang/test/CodeGenSYCL/unique_stable_name_windows_diff.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -fno-sycl-force-inline-kernel-lambda -triple spir64-unknown-unknown -aux-triple x86_64-pc-windows-msvc -fsycl-is-device -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s '-D$ADDRSPACE=addrspace(1) '
-// RUN: %clang_cc1 -fno-sycl-force-inline-kernel-lambda -triple x86_64-pc-windows-msvc -fsycl-is-device -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s '-D$ADDRSPACE='
+// RUN: %clang_cc1 -fno-sycl-force-inline-kernel-lambda -triple x86_64-pc-windows-msvc -fsycl-is-host -disable-llvm-passes -emit-llvm %s -o - | FileCheck -check-prefixes=CHECK,WIN %s '-D$ADDRSPACE='
 
 
 template<typename KN, typename Func>


### PR DESCRIPTION
We had this previously, but I refactored it upstream again and we lost it.

Also I updated some tests that have `-fsycl-device-only` but no triple, and we want that case to assert.

Also I fixed the stable name test to do the same check using native cpu, and also fix it to actually check the `WIN:` prefix which it wasn't doing before.