### PR TITLE
[SYCL] Fix lifetime bug in root group unit tests

### DIFF
--- a/sycl/unittests/Extensions/RootGroup.cpp
+++ b/sycl/unittests/Extensions/RootGroup.cpp
@@ -42,15 +42,16 @@ struct KernelInfo<QueryKernel> : public unittest::MockKernelInfoBase {
 } // namespace _V1
 } // namespace sycl
 
+static sycl::unittest::MockDeviceImage Img =
+    sycl::unittest::generateDefaultImage({"QueryKernel"});
+static const sycl::unittest::MockDeviceImageArray<1> ImgArray{&Img};
+
 // Test that querying max_num_work_groups with an invalid (zero) work-group size
 // throws the correct exception
 TEST(RootGroupTests, InvalidWorkGroupSize) {
   namespace syclex = sycl::ext::oneapi::experimental;
 
-  // Create a mock device image containing the QueryKernel
-  sycl::unittest::MockDeviceImage Img =
-      sycl::unittest::generateDefaultImage({"QueryKernel"});
-  const sycl::unittest::MockDeviceImageArray<1> ImgArray{&Img};
+  // Create a UR mock for testing
   const sycl::unittest::UrMock<> Mock;
 
   const sycl::queue q;
@@ -75,10 +76,7 @@ TEST(RootGroupTests, InvalidWorkGroupSize) {
 TEST(RootGroupTests, ValidNumWorkGroupsQuery) {
   namespace syclex = sycl::ext::oneapi::experimental;
 
-  // Create a mock device image containing the QueryKernel
-  sycl::unittest::MockDeviceImage Img =
-      sycl::unittest::generateDefaultImage({"QueryKernel"});
-  const sycl::unittest::MockDeviceImageArray<1> ImgArray{&Img};
+  // Create a UR mock for testing
   const sycl::unittest::UrMock<> Mock;
 
   // Set up a mock callback to return a specific group count when queried


### PR DESCRIPTION
Changes the `MockDeviceImage` and `MockDeviceImageArray` to static variables so that they're not created in each test case. Relates to #19068 and #19074. Fixes #18892.