### PR TITLE
[SYCL][NFCI] Move device_global map into separate structure

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -412,7 +412,7 @@ context_impl::initializeDeviceGlobals(ur_program_handle_t NativePrg,
 
     // Device global map entry pointers will not die before the end of the
     // program and the pointers will stay the same, so we do not need
-    // m_DeviceGlobalsMutex here.
+    // to lock the device global map here.
     // The lifetimes of device global map entries representing globals in
     // runtime-compiled code will be tied to the kernel bundle, so the
     // assumption holds in that setting as well.

--- a/sycl/source/detail/device_global_map.hpp
+++ b/sycl/source/detail/device_global_map.hpp
@@ -1,0 +1,157 @@
+//==-------------------- device_global_map.hpp -----------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <mutex>
+#include <unordered_map>
+
+#include <detail/compiler.hpp>
+#include <detail/device_binary_image.hpp>
+#include <detail/device_global_map_entry.hpp>
+#include <sycl/detail/defines_elementary.hpp>
+#include <sycl/detail/kernel_name_str_t.hpp>
+
+namespace sycl {
+inline namespace _V1 {
+namespace detail {
+
+class DeviceGlobalMap {
+public:
+  void initializeEntries(RTDeviceBinaryImage *Img) {
+    const auto &DeviceGlobals = Img->getDeviceGlobals();
+    std::lock_guard<std::mutex> DeviceGlobalsGuard(MDeviceGlobalsMutex);
+    for (const sycl_device_binary_property &DeviceGlobal : DeviceGlobals) {
+      ByteArray DeviceGlobalInfo =
+          DeviceBinaryProperty(DeviceGlobal).asByteArray();
+
+      // The supplied device_global info property is expected to contain:
+      // * 8 bytes - Size of the property.
+      // * 4 bytes - Size of the underlying type in the device_global.
+      // * 4 bytes - 0 if device_global has device_image_scope and any value
+      //             otherwise.
+      DeviceGlobalInfo.dropBytes(8);
+      auto [TypeSize, DeviceImageScopeDecorated] =
+          DeviceGlobalInfo.consume<std::uint32_t, std::uint32_t>();
+      assert(DeviceGlobalInfo.empty() && "Extra data left!");
+
+      // Give the image pointer as an identifier for the image the
+      // device-global is associated with.
+
+      auto ExistingDeviceGlobal = MDeviceGlobals.find(DeviceGlobal->Name);
+      if (ExistingDeviceGlobal != MDeviceGlobals.end()) {
+        // If it has already been registered we update the information.
+        ExistingDeviceGlobal->second->initialize(Img, TypeSize,
+                                                 DeviceImageScopeDecorated);
+      } else {
+        // If it has not already been registered we create a new entry.
+        // Note: Pointer to the device global is not available here, so it
+        //       cannot be set until registration happens.
+        auto EntryUPtr = std::make_unique<DeviceGlobalMapEntry>(
+            DeviceGlobal->Name, Img, TypeSize, DeviceImageScopeDecorated);
+        MDeviceGlobals.emplace(DeviceGlobal->Name, std::move(EntryUPtr));
+      }
+    }
+  }
+
+  void eraseEntries(const RTDeviceBinaryImage *Img) {
+    const auto &DeviceGlobals = Img->getDeviceGlobals();
+    std::lock_guard<std::mutex> DeviceGlobalsGuard(MDeviceGlobalsMutex);
+    for (const sycl_device_binary_property &DeviceGlobal : DeviceGlobals) {
+      if (auto DevGlobalIt = MDeviceGlobals.find(DeviceGlobal->Name);
+          DevGlobalIt != MDeviceGlobals.end()) {
+        auto findDevGlobalByValue = std::find_if(
+            MPtr2DeviceGlobal.begin(), MPtr2DeviceGlobal.end(),
+            [&DevGlobalIt](
+                const std::pair<const void *, DeviceGlobalMapEntry *> &Entry) {
+              return Entry.second == DevGlobalIt->second.get();
+            });
+        if (findDevGlobalByValue != MPtr2DeviceGlobal.end())
+          MPtr2DeviceGlobal.erase(findDevGlobalByValue);
+        MDeviceGlobals.erase(DevGlobalIt);
+      }
+    }
+  }
+
+  void addOrInitialize(const void *DeviceGlobalPtr, const char *UniqueId) {
+    std::lock_guard<std::mutex> DeviceGlobalsGuard(MDeviceGlobalsMutex);
+    auto ExistingDeviceGlobal = MDeviceGlobals.find(UniqueId);
+    if (ExistingDeviceGlobal != MDeviceGlobals.end()) {
+      // Update the existing information and add the entry to the pointer map.
+      ExistingDeviceGlobal->second->initialize(DeviceGlobalPtr);
+      MPtr2DeviceGlobal.insert(
+          {DeviceGlobalPtr, ExistingDeviceGlobal->second.get()});
+      return;
+    }
+
+    auto EntryUPtr =
+        std::make_unique<DeviceGlobalMapEntry>(UniqueId, DeviceGlobalPtr);
+    auto NewEntry = MDeviceGlobals.emplace(UniqueId, std::move(EntryUPtr));
+    MPtr2DeviceGlobal.insert({DeviceGlobalPtr, NewEntry.first->second.get()});
+  }
+
+  DeviceGlobalMapEntry *getEntry(const void *DeviceGlobalPtr) {
+    std::lock_guard<std::mutex> DeviceGlobalsGuard(MDeviceGlobalsMutex);
+    auto Entry = MPtr2DeviceGlobal.find(DeviceGlobalPtr);
+    assert(Entry != MPtr2DeviceGlobal.end() && "Device global entry not found");
+    return Entry->second;
+  }
+
+  DeviceGlobalMapEntry *tryGetEntry(const std::string &UniqueId,
+                                    bool ExcludeDeviceImageScopeDecorated) {
+    std::lock_guard<std::mutex> DeviceGlobalsGuard(MDeviceGlobalsMutex);
+    auto DeviceGlobalEntry = MDeviceGlobals.find(UniqueId);
+    if (DeviceGlobalEntry != MDeviceGlobals.end() &&
+        (!ExcludeDeviceImageScopeDecorated ||
+         !DeviceGlobalEntry->second->MIsDeviceImageScopeDecorated))
+      return DeviceGlobalEntry->second.get();
+    return nullptr;
+  }
+
+  std::vector<DeviceGlobalMapEntry *>
+  getEntries(const std::vector<std::string> &UniqueIds,
+             bool ExcludeDeviceImageScopeDecorated) {
+    std::vector<DeviceGlobalMapEntry *> FoundEntries;
+    FoundEntries.reserve(UniqueIds.size());
+
+    std::lock_guard<std::mutex> DeviceGlobalsGuard(MDeviceGlobalsMutex);
+    for (const std::string &UniqueId : UniqueIds) {
+      auto DeviceGlobalEntry = MDeviceGlobals.find(UniqueId);
+      assert(DeviceGlobalEntry != MDeviceGlobals.end() &&
+             "Device global not found in map.");
+      if (!ExcludeDeviceImageScopeDecorated ||
+          !DeviceGlobalEntry->second->MIsDeviceImageScopeDecorated)
+        FoundEntries.push_back(DeviceGlobalEntry->second.get());
+    }
+    return FoundEntries;
+  }
+
+  const std::unordered_map<const void *, DeviceGlobalMapEntry *>
+  getPointerMap() const {
+    return MPtr2DeviceGlobal;
+  }
+
+  size_t size() const { return MDeviceGlobals.size(); }
+
+  size_t count(const KernelNameStrT &UniqueId) const {
+    return MDeviceGlobals.count(UniqueId);
+  }
+
+private:
+  // Maps between device_global identifiers and associated information.
+  std::unordered_map<KernelNameStrT, std::unique_ptr<DeviceGlobalMapEntry>>
+      MDeviceGlobals;
+  std::unordered_map<const void *, DeviceGlobalMapEntry *> MPtr2DeviceGlobal;
+
+  /// Protects MDeviceGlobals and MPtr2DeviceGlobal.
+  std::mutex MDeviceGlobalsMutex;
+};
+
+} // namespace detail
+} // namespace _V1
+} // namespace sycl

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -9,6 +9,7 @@
 #pragma once
 #include <detail/cg.hpp>
 #include <detail/device_binary_image.hpp>
+#include <detail/device_global_map.hpp>
 #include <detail/device_global_map_entry.hpp>
 #include <detail/host_pipe_map_entry.hpp>
 #include <detail/kernel_arg_mask.hpp>
@@ -530,12 +531,7 @@ protected:
   SanitizerType m_SanitizerFoundInImage;
 
   // Maps between device_global identifiers and associated information.
-  std::unordered_map<KernelNameStrT, std::unique_ptr<DeviceGlobalMapEntry>>
-      m_DeviceGlobals;
-  std::unordered_map<const void *, DeviceGlobalMapEntry *> m_Ptr2DeviceGlobal;
-
-  /// Protects m_DeviceGlobals and m_Ptr2DeviceGlobal.
-  std::mutex m_DeviceGlobalsMutex;
+  DeviceGlobalMap m_DeviceGlobals;
 
   // Maps between host_pipe identifiers and associated information.
   std::unordered_map<std::string, std::unique_ptr<HostPipeMapEntry>>

--- a/sycl/unittests/program_manager/Cleanup.cpp
+++ b/sycl/unittests/program_manager/Cleanup.cpp
@@ -1,6 +1,7 @@
 #include <sycl/sycl.hpp>
 
 #include <detail/device_binary_image.hpp>
+#include <detail/device_global_map.hpp>
 #include <detail/device_image_impl.hpp>
 #include <detail/program_manager/program_manager.hpp>
 #include <helpers/MockDeviceImage.hpp>
@@ -85,16 +86,7 @@ public:
     return m_Ptr2HostPipe;
   }
 
-  std::unordered_map<sycl::detail::KernelNameStrT,
-                     std::unique_ptr<sycl::detail::DeviceGlobalMapEntry>> &
-  getDeviceGlobals() {
-    return m_DeviceGlobals;
-  }
-
-  std::unordered_map<const void *, sycl::detail::DeviceGlobalMapEntry *> &
-  getPtrToDeviceGlobal() {
-    return m_Ptr2DeviceGlobal;
-  }
+  sycl::detail::DeviceGlobalMap &getDeviceGlobals() { return m_DeviceGlobals; }
 };
 
 namespace {
@@ -312,15 +304,14 @@ void checkAllInvolvedContainers(ProgramManagerExposed &PM, size_t ExpectedCount,
   EXPECT_EQ(PM.getKernelImplicitLocalArgPos().size(), ExpectedCount) << Comment;
 
   {
-    EXPECT_EQ(PM.getDeviceGlobals().size(), ExpectedCount) << Comment;
-    EXPECT_TRUE(
-        PM.getDeviceGlobals().count(generateRefName("A", "DeviceGlobal")) > 0)
+    sycl::detail::DeviceGlobalMap &DeviceGlobalMap = PM.getDeviceGlobals();
+    EXPECT_EQ(DeviceGlobalMap.size(), ExpectedCount) << Comment;
+    EXPECT_TRUE(DeviceGlobalMap.count(generateRefName("A", "DeviceGlobal")) > 0)
         << Comment;
-    EXPECT_TRUE(
-        PM.getDeviceGlobals().count(generateRefName("B", "DeviceGlobal")) > 0)
+    EXPECT_TRUE(DeviceGlobalMap.count(generateRefName("B", "DeviceGlobal")) > 0)
         << Comment;
+    EXPECT_EQ(DeviceGlobalMap.getPointerMap().size(), ExpectedCount) << Comment;
   }
-  EXPECT_EQ(PM.getPtrToDeviceGlobal().size(), ExpectedCount) << Comment;
 
   {
     EXPECT_EQ(PM.getHostPipes().size(), ExpectedCount) << Comment;


### PR DESCRIPTION
This commit moves the implementation and protection of the device_global variable registration entries into a separate structure for cleaner separation. This should make it simpler to let kernel_bundle manage lifetime and isolate device_global variables for SYCLBIN in a future patch.