### PR TITLE
[DevASAN][DevMSAN] Use abort instead of exit when in error

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
@@ -345,7 +345,7 @@ public:
 
   void exitWithErrors() {
     m_NormalExit = false;
-    exit(1);
+    std::abort();
   }
 
   bool isNormalExit() { return m_NormalExit; }

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
@@ -332,7 +332,7 @@ public:
 
   void exitWithErrors() {
     m_NormalExit = false;
-    exit(1);
+    std::abort();
   }
 
   bool isNormalExit() { return m_NormalExit; }


### PR DESCRIPTION
When we try to exit the problem when reporting the error, the `exit(1)` could cause hangs in SYCL runtime because it skips some processes before the SYCL shutdown process in atexit stage. The `abort()` is more accurate here because it would stop the whole process right away, and no more SYCL shutdown process with the unstable, early exited program.