### PR TITLE
[SYCL][NFC]  Remove `sampled_image_accessor` and `unsampled_image_accessor` from test plan for free function kernels extension

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/test-plan.md
+++ b/sycl/test-e2e/FreeFunctionKernels/test-plan.md
@@ -192,11 +192,10 @@ as kernel parameter to free function kernel and use it within kernel.
 A series of checks should be performed that we can pass `local_accessor` 
 as kernel parameter to free function kernel and use it within kernel.
 
-#### Test structs that contain one of the following `accessor`, `local_accessor`, `sampled_image_accessor` or `unsampled_image_accessor` types when used as kernel parameter:
+#### Test structs that contain one of the following `accessor`, `local_accessor`, types when used as kernel parameter:
 A series of checks should be performed that we can pass struct that contain 
-one of the following `accessor`, `local_accessor`, `sampled_image_accessor` or 
-`unsampled_image_accessor` types as kernel parameter to free function kernel 
-and use it within kernel.
+one of the following `accessor`, `local_accessor` or types as kernel parameter 
+to free function kernel and use it within kernel.
 
 #### Test `struct` defined at namespace scope as kernel parameter:
 A series of checks should be performed that we can pass `struct` as kernel 

--- a/sycl/test-e2e/FreeFunctionKernels/test-plan.md
+++ b/sycl/test-e2e/FreeFunctionKernels/test-plan.md
@@ -194,7 +194,7 @@ as kernel parameter to free function kernel and use it within kernel.
 
 #### Test structs that contain one of the following `accessor`, `local_accessor`, types when used as kernel parameter:
 A series of checks should be performed that we can pass struct that contain 
-one of the following `accessor`, `local_accessor` or types as kernel parameter 
+either `accessor` or `local_accessor` as kernel parameters 
 to free function kernel and use it within kernel.
 
 #### Test `struct` defined at namespace scope as kernel parameter:

--- a/sycl/test-e2e/FreeFunctionKernels/test-plan.md
+++ b/sycl/test-e2e/FreeFunctionKernels/test-plan.md
@@ -192,7 +192,7 @@ as kernel parameter to free function kernel and use it within kernel.
 A series of checks should be performed that we can pass `local_accessor` 
 as kernel parameter to free function kernel and use it within kernel.
 
-#### Test structs that contain one of the following `accessor`, `local_accessor`, types when used as kernel parameter:
+#### Test structs that contain either `accessor` or `local_accessor` when used as kernel parameter:
 A series of checks should be performed that we can pass struct that contain 
 either `accessor` or `local_accessor` as kernel parameters 
 to free function kernel and use it within kernel.


### PR DESCRIPTION
This PR removes `sampled_image_accessor` and unsampled_image_accessor from planned test regarding structs that containing special types such as  `accessor` and `local_accessor`.
It's fix because it was not removed in previous PR: https://github.com/intel/llvm/pull/18994