### PR TITLE
[SYCL][Graph] Extend BMG Windows E2E skip condition

### DIFF
--- a/sycl/test-e2e/Graph/lit.local.cfg
+++ b/sycl/test-e2e/Graph/lit.local.cfg
@@ -1,6 +1,6 @@
 if 'windows' in config.available_features:
    # https://github.com/intel/llvm/issues/17165
-   config.unsupported_features += ['arch-intel_gpu_bmg_g21']
+   config.unsupported_features += ['arch-intel_gpu_bmg_g21', 'arch-intel_gpu_bmg_g31']
    # LNL - CMPLRTST-27275
    config.unsupported_features += ['arch-intel_gpu_lnl_m']
    # PTL - CMPLRTST-27275


### PR DESCRIPTION
As documented in https://github.com/intel/llvm/issues/17165 SYCL-Graph doesn't yet support BMG on Windows. Extend the current check cover both the BMG arch variants.

See URLZA-612