### PR TITLE
[SYCL][E2E] Remove unused command line option from test

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/address_test.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/address_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out
+// RUN: %{build}  -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/FreeFunctionKernels/address_test.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/address_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build}  -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/FreeFunctionKernels/address_test.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/address_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} --save-temps -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
The `--save-temps` flag seems to have been forgotten in a test when doing local debugging. Its functionality is not used in the test at all. This PR removes it.