### PR TITLE
[SYCL][E2E] Disable syclcompat/kernel/kernel_win.cpp

### DIFF
--- a/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
@@ -1,5 +1,11 @@
 // REQUIRES: windows
 
+// Currently disabled due to flaky failures caused by Windows runtime not
+// unregistering the binaries when runtime-loaded .dll files with SYCL binaries
+// are unloaded.
+// UNSUPPORTED: windows
+// UNSUPPORTED-TRACKER: CMPLRLLVM-68687
+
 // DEFINE: %{sharedflag} = %if cl_options %{/clang:-shared%} %else %{-shared%}
 
 // This test is sensitive to the absolute path of the dll file produced, so we


### PR DESCRIPTION
This commit disables the syclcompat/kernel/kernel_win.cpp E2E test due to a sporadic failure causing binaries not being unregistered when their owner dynamically-loaded libraries are unloaded.