### PR TITLE
[SYCL-JIT][NFCI] Enable few extra warnings

### DIFF
--- a/sycl-jit/CMakeLists.txt
+++ b/sycl-jit/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LLVM_SPIRV_INCLUDE_DIRS "${LLVM_MAIN_SRC_DIR}/../llvm-spirv/include")
 
 if (NOT WIN32 AND NOT CYGWIN)
   # Set library-wide warning options.
-  set(SYCL_JIT_WARNING_FLAGS -Wall -Wextra)
+  set(SYCL_JIT_WARNING_FLAGS -Wall -Wextra -Wconversion -Wimplicit-fallthrough)
 
   option(SYCL_JIT_ENABLE_WERROR "Treat all warnings as errors in SYCL JIT library" ON)
   if(SYCL_JIT_ENABLE_WERROR)

--- a/sycl-jit/jit-compiler/include/DynArray.h
+++ b/sycl-jit/jit-compiler/include/DynArray.h
@@ -22,7 +22,7 @@ public:
   explicit DynArray(size_t Size) { init(Size); }
 
   template <typename InputIt> DynArray(InputIt Begin, InputIt End) {
-    init(End - Begin);
+    init(static_cast<size_t>(End - Begin));
     std::copy(Begin, End, this->begin());
   }
 

--- a/sycl-jit/jit-compiler/lib/rtc/RTC.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/RTC.cpp
@@ -71,7 +71,7 @@ JIT_EXPORT_SYMBOL RTCResult compileSYCL(InMemoryFile SourceFile,
   if (auto *Arg =
           UserArgList.getLastArg(clang::driver::options::OPT_ftime_trace_EQ)) {
     TraceFileName = Arg->getValue();
-    int Granularity =
+    unsigned Granularity =
         500; // microseconds. Same default as in `clang::FrontendOptions`.
     if (auto *Arg = UserArgList.getLastArg(
             clang::driver::options::OPT_ftime_trace_granularity_EQ)) {


### PR DESCRIPTION
Those extra flags are required per our internal guidelines (the full list you can find in `llvm/cmake/modules/AddSecurityFlags.cmake`.

Even though we have this shared cmake module that applies those flags, I don't think that we will be able to use it for every flag, because baseline LLVM that we use isn't warning-free. Therefore, those flags were directly applied to `sycl-jit`.