### PR TITLE
Revert "[SYCL][Graph][L0 V2] Disable failing test in CI (#19036)"

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/interop-level-zero-launch-kernel.cpp
+++ b/sycl/test-e2e/Graph/Explicit/interop-level-zero-launch-kernel.cpp
@@ -9,9 +9,6 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out %S/../Inputs/Kernels/saxpy.spv 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/interop-level-zero-launch-kernel.cpp"

--- a/sycl/test-e2e/Graph/Explicit/memadvise.cpp
+++ b/sycl/test-e2e/Graph/Explicit/memadvise.cpp
@@ -6,9 +6,6 @@
 // Intended - Mem advise command not supported for OpenCL
 // UNSUPPORTED: opencl
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 // Since Mem advise is only a memory hint that doesn't
 // impact results but only performances, we verify
 // that a node is correctly added by checking UR function calls.

--- a/sycl/test-e2e/Graph/Explicit/opencl_local_acc.cpp
+++ b/sycl/test-e2e/Graph/Explicit/opencl_local_acc.cpp
@@ -7,9 +7,6 @@
 
 // REQUIRES: ocloc && (opencl || level_zero)
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/opencl_local_acc.cpp"

--- a/sycl/test-e2e/Graph/Explicit/prefetch.cpp
+++ b/sycl/test-e2e/Graph/Explicit/prefetch.cpp
@@ -6,9 +6,6 @@
 // Intended - prefetch command not supported for OpenCL
 // UNSUPPORTED: opencl
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 // Since Prefetch is only a memory hint that doesn't
 // impact results but only performances, we verify
 // that a node is correctly added by checking UR function calls

--- a/sycl/test-e2e/Graph/Explicit/raw_kernel_arg.cpp
+++ b/sycl/test-e2e/Graph/Explicit/raw_kernel_arg.cpp
@@ -7,9 +7,6 @@
 
 // REQUIRES: ocloc && level_zero
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/raw_kernel_arg.cpp"

--- a/sycl/test-e2e/Graph/Explicit/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/Explicit/spec_constants_handler_api.cpp
@@ -6,9 +6,6 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 // Intended - The following limitation is not restricted to Sycl-Graph
 // but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
 // FIXME: ACC devices use emulation path, which is not yet supported

--- a/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
@@ -4,9 +4,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
+//
 
 // Intended - The following limitation is not restricted to Sycl-Graph
 // but comes from the orignal test : `SpecConstants/2020/kernel-bundle-api.cpp`

--- a/sycl/test-e2e/Graph/RecordReplay/barrier_multi_graph.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_multi_graph.cpp
@@ -5,9 +5,6 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 #include "../graph_common.hpp"
 
 int main() {

--- a/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
@@ -9,9 +9,6 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{run} %t.out %}
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/interop-level-zero-get-native-mem.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-launch-kernel.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-launch-kernel.cpp
@@ -9,9 +9,6 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out %S/../Inputs/Kernels/saxpy.spv 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/interop-level-zero-launch-kernel.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/memadvise.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/memadvise.cpp
@@ -6,9 +6,6 @@
 // Intended - Mem advise command not supported for OpenCL
 // UNSUPPORTED: opencl
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 // Since Mem advise is only a memory hint that doesn't
 // impact results but only performances, we verify
 // that a node is correctly added by checking UR function calls.

--- a/sycl/test-e2e/Graph/RecordReplay/opencl_local_acc.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/opencl_local_acc.cpp
@@ -7,9 +7,6 @@
 
 // REQUIRES: ocloc && (opencl || level_zero)
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/opencl_local_acc.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/prefetch.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/prefetch.cpp
@@ -6,9 +6,6 @@
 // Inteded - prefetch command not supported for OpenCL
 // UNSUPPORTED: opencl
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 // Since Prefetch is only a memory hint that doesn't
 // impact results but only performances, we verify
 // that a node is correctly added by checking UR function calls

--- a/sycl/test-e2e/Graph/RecordReplay/raw_kernel_arg.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/raw_kernel_arg.cpp
@@ -7,9 +7,6 @@
 
 // REQUIRES: ocloc && level_zero
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/raw_kernel_arg.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/spec_constants_handler_api.cpp
@@ -6,9 +6,6 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 // Intended - The following limitation is not restricted to Sycl-Graph
 // but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
 // FIXME: ACC devices use emulation path, which is not yet supported

--- a/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
@@ -6,9 +6,6 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19034
-
 // Intended - The following limitation is not restricted to Sycl-Graph
 // but comes from the orignal test : `SpecConstants/2020/kernel-bundle-api.cpp`
 // FIXME: ACC devices use emulation path, which is not yet supported


### PR DESCRIPTION
This reverts commit 754bb930eb0d65dafa645281aaf8962c2860f88f.

The issue was that https://github.com/intel/llvm/pull/18962 (already reverted) introduced a bug (using uninitialized variable).