### PR TITLE
[DevTSAN] Implement tsan_[read|write] for different address space

### DIFF
--- a/libdevice/sanitizer/tsan_rtl.cpp
+++ b/libdevice/sanitizer/tsan_rtl.cpp
@@ -70,7 +70,7 @@ inline void ConvertGenericPointer(uptr &addr, uint32_t &as) {
     // FIXME: I'm not sure if we need to check ADDRESS_SPACE_CONSTANT,
     // but this can really simplify the generic pointer conversion logic
     as = ADDRESS_SPACE_GLOBAL;
-    addr = old;
+    addr = (uptr)ToGlobal((void *)old);
   }
   TSAN_DEBUG(__spirv_ocl_printf(__tsan_print_generic_to, old, addr, as));
 }
@@ -320,10 +320,10 @@ inline bool ContainsSameAccess(__SYCL_GLOBAL__ RawShadow *s, Shadow cur,
 
 } // namespace
 
-#define TSAN_CHECK(type, is_write, size)                                       \
-  DEVICE_EXTERN_C_NOINLINE void __tsan_##type##size(                           \
-      uptr addr, uint32_t as, const char __SYCL_CONSTANT__ *file,              \
-      uint32_t line, const char __SYCL_CONSTANT__ *func) {                     \
+#define TSAN_CHECK_BASE(type, is_write, size, as)                              \
+  DEVICE_EXTERN_C_NOINLINE void __tsan_##type##size##_p##as(                   \
+      uptr addr, const char __SYCL_CONSTANT__ *file, uint32_t line,            \
+      const char __SYCL_CONSTANT__ *func) {                                    \
     __SYCL_GLOBAL__ RawShadow *shadow_mem = MemToShadow(addr, as);             \
     if (!shadow_mem)                                                           \
       return;                                                                  \
@@ -344,6 +344,11 @@ inline bool ContainsSameAccess(__SYCL_GLOBAL__ RawShadow *s, Shadow cur,
     CheckRace(shadow_mem, cur, type, addr, size, as, file, line, func);        \
   }
 
+#define TSAN_CHECK(type, is_write, size)                                       \
+  TSAN_CHECK_BASE(type, is_write, size, 1)                                     \
+  TSAN_CHECK_BASE(type, is_write, size, 3)                                     \
+  TSAN_CHECK_BASE(type, is_write, size, 4)
+
 TSAN_CHECK(read, false, 1)
 TSAN_CHECK(read, false, 2)
 TSAN_CHECK(read, false, 4)
@@ -353,24 +358,26 @@ TSAN_CHECK(write, true, 2)
 TSAN_CHECK(write, true, 4)
 TSAN_CHECK(write, true, 8)
 
-DEVICE_EXTERN_C_NOINLINE void
-__tsan_write16(uptr addr, uint32_t as, const char __SYCL_CONSTANT__ *file,
-               uint32_t line, const char __SYCL_CONSTANT__ *func) {
-  __tsan_write8(addr, as, file, line, func);
-  __tsan_write8(addr + 8, as, file, line, func);
-}
+#define TSAN_CHECK16_BASE(type, as)                                            \
+  DEVICE_EXTERN_C_NOINLINE void __tsan_##type##16_p##as(                       \
+      uptr addr, const char __SYCL_CONSTANT__ *file, uint32_t line,            \
+      const char __SYCL_CONSTANT__ *func) {                                    \
+    __tsan_##type##8_p##as(addr, file, line, func);                            \
+    __tsan_##type##8_p##as(addr + 8, file, line, func);                        \
+  }
 
-DEVICE_EXTERN_C_NOINLINE void
-__tsan_read16(uptr addr, uint32_t as, const char __SYCL_CONSTANT__ *file,
-              uint32_t line, const char __SYCL_CONSTANT__ *func) {
-  __tsan_read8(addr, as, file, line, func);
-  __tsan_read8(addr + 8, as, file, line, func);
-}
+#define TSAN_CHECK16(type)                                                     \
+  TSAN_CHECK16_BASE(type, 1)                                                   \
+  TSAN_CHECK16_BASE(type, 3)                                                   \
+  TSAN_CHECK16_BASE(type, 4)
 
-#define TSAN_UNALIGNED_CHECK(type, is_write, size)                             \
-  DEVICE_EXTERN_C_NOINLINE void __tsan_unaligned_##type##size(                 \
-      uptr addr, uint32_t as, const char __SYCL_CONSTANT__ *file,              \
-      uint32_t line, const char __SYCL_CONSTANT__ *func) {                     \
+TSAN_CHECK16(read)
+TSAN_CHECK16(write)
+
+#define TSAN_UNALIGNED_CHECK_BASE(type, is_write, size, as)                    \
+  DEVICE_EXTERN_C_NOINLINE void __tsan_unaligned_##type##size##_p##as(         \
+      uptr addr, const char __SYCL_CONSTANT__ *file, uint32_t line,            \
+      const char __SYCL_CONSTANT__ *func) {                                    \
     __SYCL_GLOBAL__ RawShadow *shadow_mem = MemToShadow(addr, as);             \
     if (!shadow_mem)                                                           \
       return;                                                                  \
@@ -413,6 +420,11 @@ __tsan_read16(uptr addr, uint32_t as, const char __SYCL_CONSTANT__ *file,
     }                                                                          \
   }
 
+#define TSAN_UNALIGNED_CHECK(type, is_write, size)                             \
+  TSAN_UNALIGNED_CHECK_BASE(type, is_write, size, 1)                           \
+  TSAN_UNALIGNED_CHECK_BASE(type, is_write, size, 3)                           \
+  TSAN_UNALIGNED_CHECK_BASE(type, is_write, size, 4)
+
 TSAN_UNALIGNED_CHECK(read, false, 1)
 TSAN_UNALIGNED_CHECK(read, false, 2)
 TSAN_UNALIGNED_CHECK(read, false, 4)
@@ -422,21 +434,21 @@ TSAN_UNALIGNED_CHECK(write, true, 2)
 TSAN_UNALIGNED_CHECK(write, true, 4)
 TSAN_UNALIGNED_CHECK(write, true, 8)
 
-DEVICE_EXTERN_C_NOINLINE void
-__tsan_unaligned_write16(uptr addr, uint32_t as,
-                         const char __SYCL_CONSTANT__ *file, uint32_t line,
-                         const char __SYCL_CONSTANT__ *func) {
-  __tsan_unaligned_write8(addr, as, file, line, func);
-  __tsan_unaligned_write8(addr + 8, as, file, line, func);
-}
+#define TSAN_UNALIGNED_CHECK16_BASE(type, as)                                  \
+  DEVICE_EXTERN_C_NOINLINE void __tsan_unaligned_##type##16_p##as(             \
+      uptr addr, const char __SYCL_CONSTANT__ *file, uint32_t line,            \
+      const char __SYCL_CONSTANT__ *func) {                                    \
+    __tsan_unaligned_##type##8_p##as(addr, file, line, func);                  \
+    __tsan_unaligned_##type##8_p##as(addr + 8, file, line, func);              \
+  }
 
-DEVICE_EXTERN_C_NOINLINE void
-__tsan_unaligned_read16(uptr addr, uint32_t as,
-                        const char __SYCL_CONSTANT__ *file, uint32_t line,
-                        const char __SYCL_CONSTANT__ *func) {
-  __tsan_unaligned_read8(addr, as, file, line, func);
-  __tsan_unaligned_read8(addr + 8, as, file, line, func);
-}
+#define TSAN_UNALIGNED_CHECK16(type)                                           \
+  TSAN_UNALIGNED_CHECK16_BASE(type, 1)                                         \
+  TSAN_UNALIGNED_CHECK16_BASE(type, 3)                                         \
+  TSAN_UNALIGNED_CHECK16_BASE(type, 4)
+
+TSAN_UNALIGNED_CHECK16(read)
+TSAN_UNALIGNED_CHECK16(write)
 
 static inline void __tsan_cleanup_private_cpu_impl(uptr addr, uint32_t size) {
   if (size) {

--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -158,15 +158,17 @@ private:
 
   // Accesses sizes are powers of two: 1, 2, 4, 8, 16.
   static const size_t kNumberOfAccessSizes = 5;
+  static const size_t kNumberOfAddressSpace = 5;
   FunctionCallee TsanCleanupPrivate;
   FunctionCallee TsanCleanupStaticLocal;
   FunctionCallee TsanCleanupDynamicLocal;
   FunctionCallee TsanDeviceBarrier;
   FunctionCallee TsanGroupBarrier;
-  FunctionCallee TsanRead[kNumberOfAccessSizes];
-  FunctionCallee TsanWrite[kNumberOfAccessSizes];
-  FunctionCallee TsanUnalignedRead[kNumberOfAccessSizes];
-  FunctionCallee TsanUnalignedWrite[kNumberOfAccessSizes];
+  FunctionCallee TsanRead[kNumberOfAccessSizes][kNumberOfAddressSpace];
+  FunctionCallee TsanWrite[kNumberOfAccessSizes][kNumberOfAddressSpace];
+  FunctionCallee TsanUnalignedRead[kNumberOfAccessSizes][kNumberOfAddressSpace];
+  FunctionCallee TsanUnalignedWrite[kNumberOfAccessSizes]
+                                   [kNumberOfAddressSpace];
 
   friend struct ThreadSanitizer;
 };
@@ -313,34 +315,40 @@ void ThreadSanitizerOnSpirv::initialize() {
       "__tsan_group_barrier", Attr.addFnAttribute(C, Attribute::Convergent),
       IRB.getVoidTy());
 
-  for (size_t i = 0; i < kNumberOfAccessSizes; ++i) {
-    const unsigned ByteSize = 1U << i;
-    std::string ByteSizeStr = utostr(ByteSize);
-    // __tsan_readX/__tsan_writeX(
-    //   ...
-    //   char* file,
-    //   unsigned int line,
-    //   char* func
-    // )
-    SmallString<32> ReadName("__tsan_read" + ByteSizeStr);
-    TsanRead[i] = M.getOrInsertFunction(ReadName, Attr, IRB.getVoidTy(),
-                                        IntptrTy, IRB.getInt32Ty(), Int8PtrTy,
-                                        IRB.getInt32Ty(), Int8PtrTy);
+  for (size_t AddressSpaceIndex = 0; AddressSpaceIndex < kNumberOfAddressSpace;
+       AddressSpaceIndex++) {
+    for (size_t i = 0; i < kNumberOfAccessSizes; ++i) {
+      const unsigned ByteSize = 1U << i;
+      std::string ByteSizeStr = utostr(ByteSize);
+      std::string Suffix = "_p" + itostr(AddressSpaceIndex);
+      // __tsan_readX/__tsan_writeX(
+      //   ...
+      //   char* file,
+      //   unsigned int line,
+      //   char* func
+      // )
+      SmallString<32> ReadName("__tsan_read" + ByteSizeStr + Suffix);
+      TsanRead[i][AddressSpaceIndex] =
+          M.getOrInsertFunction(ReadName, Attr, IRB.getVoidTy(), IntptrTy,
+                                Int8PtrTy, IRB.getInt32Ty(), Int8PtrTy);
 
-    SmallString<32> WriteName("__tsan_write" + ByteSizeStr);
-    TsanWrite[i] = M.getOrInsertFunction(WriteName, Attr, IRB.getVoidTy(),
-                                         IntptrTy, IRB.getInt32Ty(), Int8PtrTy,
-                                         IRB.getInt32Ty(), Int8PtrTy);
+      SmallString<32> WriteName("__tsan_write" + ByteSizeStr + Suffix);
+      TsanWrite[i][AddressSpaceIndex] =
+          M.getOrInsertFunction(WriteName, Attr, IRB.getVoidTy(), IntptrTy,
+                                Int8PtrTy, IRB.getInt32Ty(), Int8PtrTy);
 
-    SmallString<32> UnalignedReadName("__tsan_unaligned_read" + ByteSizeStr);
-    TsanUnalignedRead[i] = M.getOrInsertFunction(
-        UnalignedReadName, Attr, IRB.getVoidTy(), IntptrTy, IRB.getInt32Ty(),
-        Int8PtrTy, IRB.getInt32Ty(), Int8PtrTy);
+      SmallString<32> UnalignedReadName("__tsan_unaligned_read" + ByteSizeStr +
+                                        Suffix);
+      TsanUnalignedRead[i][AddressSpaceIndex] = M.getOrInsertFunction(
+          UnalignedReadName, Attr, IRB.getVoidTy(), IntptrTy, Int8PtrTy,
+          IRB.getInt32Ty(), Int8PtrTy);
 
-    SmallString<32> UnalignedWriteName("__tsan_unaligned_write" + ByteSizeStr);
-    TsanUnalignedWrite[i] = M.getOrInsertFunction(
-        UnalignedWriteName, Attr, IRB.getVoidTy(), IntptrTy, IRB.getInt32Ty(),
-        Int8PtrTy, IRB.getInt32Ty(), Int8PtrTy);
+      SmallString<32> UnalignedWriteName("__tsan_unaligned_write" +
+                                         ByteSizeStr + Suffix);
+      TsanUnalignedWrite[i][AddressSpaceIndex] = M.getOrInsertFunction(
+          UnalignedWriteName, Attr, IRB.getVoidTy(), IntptrTy, Int8PtrTy,
+          IRB.getInt32Ty(), Int8PtrTy);
+    }
   }
 }
 
@@ -1213,6 +1221,8 @@ bool ThreadSanitizer::instrumentLoadOrStore(const InstructionInfo &II,
   assert((!IsVolatile || !IsCompoundRW) && "Compound volatile invalid!");
 
   const uint32_t TypeSize = DL.getTypeStoreSizeInBits(OrigTy);
+  const unsigned int AS = cast<PointerType>(Addr->getType()->getScalarType())
+                        ->getPointerAddressSpace();
   FunctionCallee OnAccessFunc = nullptr;
   if (Alignment >= Align(8) || (Alignment.value() % (TypeSize / 8)) == 0) {
     if (IsCompoundRW)
@@ -1220,7 +1230,8 @@ bool ThreadSanitizer::instrumentLoadOrStore(const InstructionInfo &II,
     else if (IsVolatile)
       OnAccessFunc = IsWrite ? TsanVolatileWrite[Idx] : TsanVolatileRead[Idx];
     else if (Spirv)
-      OnAccessFunc = IsWrite ? Spirv->TsanWrite[Idx] : Spirv->TsanRead[Idx];
+      OnAccessFunc =
+          IsWrite ? Spirv->TsanWrite[Idx][AS] : Spirv->TsanRead[Idx][AS];
     else
       OnAccessFunc = IsWrite ? TsanWrite[Idx] : TsanRead[Idx];
   } else {
@@ -1230,17 +1241,14 @@ bool ThreadSanitizer::instrumentLoadOrStore(const InstructionInfo &II,
       OnAccessFunc = IsWrite ? TsanUnalignedVolatileWrite[Idx]
                              : TsanUnalignedVolatileRead[Idx];
     else if (Spirv)
-      OnAccessFunc = IsWrite ? Spirv->TsanUnalignedWrite[Idx]
-                             : Spirv->TsanUnalignedRead[Idx];
+      OnAccessFunc = IsWrite ? Spirv->TsanUnalignedWrite[Idx][AS]
+                             : Spirv->TsanUnalignedRead[Idx][AS];
     else
       OnAccessFunc = IsWrite ? TsanUnalignedWrite[Idx] : TsanUnalignedRead[Idx];
   }
   if (Spirv) {
     SmallVector<Value *, 5> Args;
     Args.push_back(IRB.CreatePointerCast(Addr, IntptrTy));
-    unsigned int AS = cast<PointerType>(Addr->getType()->getScalarType())
-                          ->getPointerAddressSpace();
-    Args.push_back(ConstantInt::get(IRB.getInt32Ty(), AS));
     Spirv->appendDebugInfoToArgs(II.Inst, Args);
     IRB.CreateCall(OnAccessFunc, Args);
   } else

--- a/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/basic.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/basic.ll
@@ -9,7 +9,7 @@ entry:
   %tmp1 = load i8, ptr addrspace(4) %a, align 1
   %inc = add i8 %tmp1, 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_write1
+  ; CHECK: call void @__tsan_write1_p4
   store i8 %inc, ptr addrspace(4) %a, align 1
   ret void
 }
@@ -21,7 +21,7 @@ entry:
   %tmp1 = load i16, ptr addrspace(4) %a, align 2
   %inc = add i16 %tmp1, 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_write2
+  ; CHECK: call void @__tsan_write2_p4
   store i16 %inc, ptr addrspace(4) %a, align 2
   ret void
 }
@@ -33,30 +33,30 @@ entry:
   %tmp1 = load i32, ptr addrspace(4) %a, align 4
   %inc = add i32 %tmp1, 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_write4
+  ; CHECK: call void @__tsan_write4_p4
   store i32 %inc, ptr addrspace(4) %a, align 4
   ret void
 }
 
 ; Function Attrs: sanitize_thread
-define linkonce_odr dso_local spir_func void @write_8_bytes(ptr addrspace(4) %a) #0 {
+define linkonce_odr dso_local spir_func void @write_8_bytes(ptr addrspace(1) %a) #0 {
 ; CHECK-LABEL: void @write_8_bytes
 entry:
-  %tmp1 = load i64, ptr addrspace(4) %a, align 8
+  %tmp1 = load i64, ptr addrspace(1) %a, align 8
   %inc = add i64 %tmp1, 1
-  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_write8
-  store i64 %inc, ptr addrspace(4) %a, align 8
+  ; CHECK: ptrtoint ptr addrspace(1) %a to i64
+  ; CHECK: call void @__tsan_write8_p1
+  store i64 %inc, ptr addrspace(1) %a, align 8
   ret void
 }
 
 ; Function Attrs: sanitize_thread
-define linkonce_odr dso_local spir_func void @write_16_bytes(ptr addrspace(4) %a) #0 {
+define linkonce_odr dso_local spir_func void @write_16_bytes(ptr addrspace(1) %a) #0 {
 ; CHECK-LABEL: void @write_16_bytes
 entry:
-  store <4 x i32> <i32 0, i32 0, i32 0, i32 0>, ptr addrspace(4) %a, align 16
-  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_write16
+  store <4 x i32> <i32 0, i32 0, i32 0, i32 0>, ptr addrspace(1) %a, align 16
+  ; CHECK: ptrtoint ptr addrspace(1) %a to i64
+  ; CHECK: call void @__tsan_write16_p1
   ret void
 }
 
@@ -65,7 +65,7 @@ define linkonce_odr dso_local spir_func i8 @read_1_byte(ptr addrspace(4) %a) #0 
 entry:
   %tmp1 = load i8, ptr addrspace(4) %a, align 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_read1
+  ; CHECK: call void @__tsan_read1_p4
   ret i8 %tmp1
 }
 
@@ -74,7 +74,7 @@ define linkonce_odr dso_local spir_func i16 @read_2_bytes(ptr addrspace(4) %a) #
 entry:
   %tmp1 = load i16, ptr addrspace(4) %a, align 2
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_read2
+  ; CHECK: call void @__tsan_read2_p4
   ret i16 %tmp1
 }
 
@@ -83,26 +83,26 @@ define linkonce_odr dso_local spir_func i32 @read_4_bytes(ptr addrspace(4) %a) #
 entry:
   %tmp1 = load i32, ptr addrspace(4) %a, align 4
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_read4
+  ; CHECK: call void @__tsan_read4_p4
   ret i32 %tmp1
 }
 
-define linkonce_odr dso_local spir_func i64 @read_8_bytes(ptr addrspace(4) %a) #0 {
+define linkonce_odr dso_local spir_func i64 @read_8_bytes(ptr addrspace(1) %a) #0 {
 ; CHECK-LABEL: i64 @read_8_bytes
 entry:
-  %tmp1 = load i64, ptr addrspace(4) %a, align 8
-  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_read8
+  %tmp1 = load i64, ptr addrspace(1) %a, align 8
+  ; CHECK: ptrtoint ptr addrspace(1) %a to i64
+  ; CHECK: call void @__tsan_read8_p1
   ret i64 %tmp1
 }
 
 ; Function Attrs: sanitize_thread
-define linkonce_odr dso_local spir_func void @read_16_bytes(ptr addrspace(4) %a) #0 {
+define linkonce_odr dso_local spir_func void @read_16_bytes(ptr addrspace(1) %a) #0 {
 ; CHECK-LABEL: void @read_16_bytes
 entry:
-  %temp1 = load <4 x i32>, ptr addrspace(4) %a, align 16
-  ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_read16
+  %temp1 = load <4 x i32>, ptr addrspace(1) %a, align 16
+  ; CHECK: ptrtoint ptr addrspace(1) %a to i64
+  ; CHECK: call void @__tsan_read16_p1
   ret void
 }
 
@@ -113,7 +113,7 @@ entry:
   %tmp1 = load i16, ptr addrspace(4) %a, align 2
   %inc = add i16 %tmp1, 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_unaligned_write2
+  ; CHECK: call void @__tsan_unaligned_write2_p4
   store i16 %inc, ptr addrspace(4) %a, align 1
   ret void
 }
@@ -125,7 +125,7 @@ entry:
   %tmp1 = load i32, ptr addrspace(4) %a, align 4
   %inc = add i32 %tmp1, 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_unaligned_write4
+  ; CHECK: call void @__tsan_unaligned_write4_p4
   store i32 %inc, ptr addrspace(4) %a, align 1
   ret void
 }
@@ -137,7 +137,7 @@ entry:
   %tmp1 = load i64, ptr addrspace(4) %a, align 8
   %inc = add i64 %tmp1, 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_unaligned_write8
+  ; CHECK: call void @__tsan_unaligned_write8_p4
   store i64 %inc, ptr addrspace(4) %a, align 1
   ret void
 }
@@ -148,7 +148,7 @@ define linkonce_odr dso_local spir_func void @unaligned_write_16_bytes(ptr addrs
 entry:
   store <4 x i32> <i32 0, i32 0, i32 0, i32 0>, ptr addrspace(4) %a, align 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_unaligned_write16
+  ; CHECK: call void @__tsan_unaligned_write16_p4
   ret void
 }
 
@@ -157,7 +157,7 @@ define linkonce_odr dso_local spir_func i16 @unaligned_read_2_bytes(ptr addrspac
 entry:
   %tmp1 = load i16, ptr addrspace(4) %a, align 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_unaligned_read2
+  ; CHECK: call void @__tsan_unaligned_read2_p4
   ret i16 %tmp1
 }
 
@@ -166,7 +166,7 @@ define linkonce_odr dso_local spir_func i32 @unaligned_read_4_bytes(ptr addrspac
 entry:
   %tmp1 = load i32, ptr addrspace(4) %a, align 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_unaligned_read4
+  ; CHECK: call void @__tsan_unaligned_read4_p4
   ret i32 %tmp1
 }
 
@@ -175,7 +175,7 @@ define linkonce_odr dso_local spir_func i64 @unaligned_read_8_bytes(ptr addrspac
 entry:
   %tmp1 = load i64, ptr addrspace(4) %a, align 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_unaligned_read8
+  ; CHECK: call void @__tsan_unaligned_read8_p4
   ret i64 %tmp1
 }
 
@@ -185,7 +185,7 @@ define linkonce_odr dso_local spir_func void @unaligned_read_16_bytes(ptr addrsp
 entry:
   %temp1 = load <4 x i32>, ptr addrspace(4) %a, align 1
   ; CHECK: ptrtoint ptr addrspace(4) %a to i64
-  ; CHECK: call void @__tsan_unaligned_read16
+  ; CHECK: call void @__tsan_unaligned_read16_p4
   ret void
 }
 

--- a/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/instrument_local.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/SPIRV/instrument_local.ll
@@ -7,7 +7,7 @@ target triple = "spir64-unknown-unknown"
 define spir_func void @foo() #0 {
 entry:
 ; CHECK-LABEL: define spir_func void @foo()
-; CHECK: call void @__tsan_write4(i64 ptrtoint (ptr addrspace(3) @WGLocalMem.0 to i64), i32 3
+; CHECK: call void @__tsan_write4_p3(i64 ptrtoint (ptr addrspace(3) @WGLocalMem.0 to i64)
   store i32 1, ptr addrspace(3) @WGLocalMem.0, align 4
   br label %exit
 


### PR DESCRIPTION
By doing this, we can reduce redundant conditional branch for better performance.