### PR TITLE
[DeviceMSAN] Allocate MSan clean shadow by readonly memory

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/common/options-redzone.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/options-redzone.cpp
@@ -1,9 +1,8 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DUNSAFE -O0 -g -o %t1.out
 // RUN: env UR_LAYER_ASAN_OPTIONS=redzone:4000 %{run} not %t1.out 2>&1 | FileCheck %s
-// RUN: %{build} %device_asan_flags -DSAFE -O0 -g -o %t2.out
-
 // clang-format off
+// RUN: %{build} %device_asan_flags -DSAFE -O0 -g -o %t2.out
 // RUN: env UR_LOG_SANITIZER=level:debug UR_LAYER_ASAN_OPTIONS=redzone:8 %{run} %t2.out 2>&1 | FileCheck --check-prefixes CHECK-MIN %s
 // clang-format on
 

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -48,7 +48,7 @@ AsanInterceptor::~AsanInterceptor() {
   m_AllocationMap.clear();
 
   for (auto &[_, ShadowMemory] : m_ShadowMap) {
-    ShadowMemory->Destory();
+    ShadowMemory->Destroy();
   }
   m_ShadowMap.clear();
 

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
@@ -155,13 +155,10 @@ ur_result_t ShadowMemoryGPU::Destory() {
     }
     UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
         Context, (const void *)ShadowBegin, GetShadowSize()));
-
-    if (ShadowBegin != 0) {
-      UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
-          Context, (const void *)ShadowBegin, GetShadowSize()));
-      ShadowBegin = ShadowEnd = 0;
-    }
+    ShadowBegin = ShadowEnd = 0;
   }
+
+  UR_CALL(getContext()->urDdiTable.Context.pfnRelease(Context));
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
@@ -153,11 +153,9 @@ ur_result_t ShadowMemoryGPU::Destroy() {
           Context, (void *)MappedPtr, PageSize));
       UR_CALL(getContext()->urDdiTable.PhysicalMem.pfnRelease(PhysicalMem));
     }
-    if (ShadowBegin != 0) {
-      UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
-          Context, (const void *)ShadowBegin, GetShadowSize()));
-      ShadowBegin = ShadowEnd = 0;
-    }
+    UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
+        Context, (const void *)ShadowBegin, GetShadowSize()));
+    ShadowBegin = ShadowEnd = 0;
   }
 
   // NOTE: Context is managed by base class, so it needn't release here

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
@@ -56,7 +56,7 @@ ur_result_t ShadowMemoryCPU::Setup() {
   return URes;
 }
 
-ur_result_t ShadowMemoryCPU::Destory() {
+ur_result_t ShadowMemoryCPU::Destroy() {
   if (ShadowBegin == 0) {
     return UR_RESULT_SUCCESS;
   }
@@ -127,7 +127,7 @@ ur_result_t ShadowMemoryGPU::Setup() {
   return Result;
 }
 
-ur_result_t ShadowMemoryGPU::Destory() {
+ur_result_t ShadowMemoryGPU::Destroy() {
   if (PrivateShadowOffset != 0) {
     UR_CALL(getContext()->urDdiTable.USM.pfnFree(Context,
                                                  (void *)PrivateShadowOffset));
@@ -160,7 +160,7 @@ ur_result_t ShadowMemoryGPU::Destory() {
     }
   }
 
-  UR_CALL(getContext()->urDdiTable.Context.pfnRelease(Context));
+  // NOTE: Context is managed by base class, so it needn't release here
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.cpp
@@ -153,9 +153,11 @@ ur_result_t ShadowMemoryGPU::Destory() {
           Context, (void *)MappedPtr, PageSize));
       UR_CALL(getContext()->urDdiTable.PhysicalMem.pfnRelease(PhysicalMem));
     }
-    UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
-        Context, (const void *)ShadowBegin, GetShadowSize()));
-    ShadowBegin = ShadowEnd = 0;
+    if (ShadowBegin != 0) {
+      UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
+          Context, (const void *)ShadowBegin, GetShadowSize()));
+      ShadowBegin = ShadowEnd = 0;
+    }
   }
 
   UR_CALL(getContext()->urDdiTable.Context.pfnRelease(Context));

--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_shadow.hpp
@@ -36,14 +36,11 @@ struct ShadowMemory {
     [[maybe_unused]] ur_result_t URes =
         getContext()->urDdiTable.Context.pfnRelease(Context);
     assert(URes == UR_RESULT_SUCCESS);
-
-    URes = getContext()->urDdiTable.Device.pfnRelease(Device);
-    assert(URes == UR_RESULT_SUCCESS);
   }
 
   virtual ur_result_t Setup() = 0;
 
-  virtual ur_result_t Destory() = 0;
+  virtual ur_result_t Destroy() = 0;
 
   virtual uptr MemToShadow(uptr Ptr) = 0;
 
@@ -74,7 +71,7 @@ struct ShadowMemoryCPU final : public ShadowMemory {
 
   ur_result_t Setup() override;
 
-  ur_result_t Destory() override;
+  ur_result_t Destroy() override;
 
   uptr MemToShadow(uptr Ptr) override;
 
@@ -103,7 +100,7 @@ struct ShadowMemoryGPU : public ShadowMemory {
 
   ur_result_t Setup() override;
 
-  ur_result_t Destory() override;
+  ur_result_t Destroy() override;
   ur_result_t EnqueuePoisonShadow(ur_queue_handle_t Queue, uptr Ptr, uptr Size,
                                   u8 Value) override final;
 

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -496,8 +496,13 @@ ur_result_t MsanInterceptor::prepareLaunch(
 
   // Clean shadow
   // Its content is always zero, and is used for unsupport memory types
-  UR_CALL(DeviceInfo->Shadow->AllocCleanShadow(
-      Queue, ContextInfo->CleanShadowSize, LaunchInfo.Data.Host.CleanShadow));
+  auto URes = DeviceInfo->Shadow->AllocCleanShadow(
+      Queue, ContextInfo->CleanShadowSize, LaunchInfo.Data.Host.CleanShadow);
+  if (URes != UR_RESULT_SUCCESS) {
+    UR_LOG_L(getContext()->logger, ERR, "Failed to allocate clean shadow: {}",
+             URes);
+    return URes;
+  }
 
   if (LaunchInfo.LocalWorkSize.empty()) {
     LaunchInfo.LocalWorkSize.resize(LaunchInfo.WorkDim);

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -605,11 +605,10 @@ ur_result_t MsanInterceptor::prepareLaunch(
            LaunchInfo.Data.Host.NumLocalArgs,
            ToString(LaunchInfo.Data.Host.DeviceTy), LaunchInfo.Data.Host.Debug);
 
-  ur_result_t URes =
-      getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite(
-          Queue, Program, "__MsanLaunchInfo", false,
-          sizeof(LaunchInfo.Data.DevicePtr), 0, &LaunchInfo.Data.DevicePtr, 0,
-          nullptr, nullptr);
+  URes = getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite(
+      Queue, Program, "__MsanLaunchInfo", false,
+      sizeof(LaunchInfo.Data.DevicePtr), 0, &LaunchInfo.Data.DevicePtr, 0,
+      nullptr, nullptr);
   if (URes != UR_RESULT_SUCCESS) {
     UR_LOG_L(getContext()->logger, INFO,
              "EnqueueWriteGlobal(__MsanLaunchInfo) "

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -30,7 +30,7 @@ MsanInterceptor::~MsanInterceptor() {
   // We must release these objects before releasing adapters, since
   // they may use the adapter in their destructor
   for (const auto &[_, DeviceInfo] : m_DeviceMap) {
-    DeviceInfo->Shadow->Destory();
+    DeviceInfo->Shadow->Destroy();
   }
 
   m_MemBufferMap.clear();

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.hpp
@@ -40,7 +40,7 @@ struct DeviceInfo {
 
   DeviceType Type = DeviceType::UNKNOWN;
   size_t Alignment = 0;
-  std::shared_ptr<MsanShadowMemory> Shadow;
+  std::shared_ptr<ShadowMemory> Shadow;
 
   // Device features
   bool IsSupportSharedSystemUSM = false;

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
@@ -253,11 +253,9 @@ ur_result_t ShadowMemoryGPU::Destroy() {
             Context, (void *)MappedPtr, PageSize));
         UR_CALL(getContext()->urDdiTable.PhysicalMem.pfnRelease(PhysicalMem));
       }
-      if (ShadowBegin != 0) {
-        UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
-            Context, (const void *)ShadowBegin, GetShadowSize()));
-        ShadowBegin = ShadowEnd = 0;
-      }
+      UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
+          Context, (const void *)ShadowBegin, GetShadowSize()));
+      ShadowBegin = ShadowEnd = 0;
     }
 
     UR_CALL(ReleaseCleanShadow());

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
@@ -256,12 +256,7 @@ ur_result_t ShadowMemoryGPU::Destory() {
       }
       UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
           Context, (const void *)ShadowBegin, GetShadowSize()));
-
-      if (ShadowBegin != 0) {
-        UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
-            Context, (const void *)ShadowBegin, GetShadowSize()));
-        ShadowBegin = ShadowEnd = 0;
-      }
+      ShadowBegin = ShadowEnd = 0;
     }
 
     ReleaseCleanShadow();

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
@@ -113,7 +113,7 @@ ur_result_t ShadowMemoryCPU::Setup() {
   return Result;
 }
 
-ur_result_t ShadowMemoryCPU::Destory() {
+ur_result_t ShadowMemoryCPU::Destroy() {
   if (ShadowBegin == 0 && ShadowEnd == 0) {
     return UR_RESULT_SUCCESS;
   }
@@ -221,7 +221,7 @@ ur_result_t ShadowMemoryGPU::Setup() {
   return Result;
 }
 
-ur_result_t ShadowMemoryGPU::Destory() {
+ur_result_t ShadowMemoryGPU::Destroy() {
   if (ShadowBegin == 0) {
     return UR_RESULT_SUCCESS;
   }

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
@@ -497,14 +497,12 @@ ur_result_t ShadowMemoryGPU::AllocCleanShadow(ur_queue_handle_t Queue,
   ur_result_t Result = getContext()->urDdiTable.VirtualMem.pfnReserve(
       Context, Device, CleanShadowSize, (void **)&CleanShadowPtr);
   if (Result != UR_RESULT_SUCCESS) {
-    UR_LOG_L(getContext()->logger, ERR, "VirtualMem.pfnReserve: {}", Result);
     return Result;
   }
 
   Result = getContext()->urDdiTable.PhysicalMem.pfnCreate(
       Context, Device, CleanShadowSize, nullptr, &CleanShadowPhysicalMem);
   if (Result != UR_RESULT_SUCCESS) {
-    UR_LOG_L(getContext()->logger, ERR, "PhysicalMem.pfnCreate: {}", Result);
     return Result;
   }
 
@@ -512,7 +510,6 @@ ur_result_t ShadowMemoryGPU::AllocCleanShadow(ur_queue_handle_t Queue,
       Context, (void *)CleanShadowPtr, CleanShadowSize, CleanShadowPhysicalMem,
       0, UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE);
   if (Result != UR_RESULT_SUCCESS) {
-    UR_LOG_L(getContext()->logger, ERR, "VirtualMem.pfnMap: {}", Result);
     return Result;
   }
 
@@ -520,7 +517,6 @@ ur_result_t ShadowMemoryGPU::AllocCleanShadow(ur_queue_handle_t Queue,
   Result =
       EnqueueUSMSet(Queue, (void *)CleanShadowPtr, (char)0, CleanShadowSize);
   if (Result != UR_RESULT_SUCCESS) {
-    UR_LOG_L(getContext()->logger, ERR, "EnqueueUSMSet: {}", Result);
     return Result;
   }
 
@@ -528,7 +524,6 @@ ur_result_t ShadowMemoryGPU::AllocCleanShadow(ur_queue_handle_t Queue,
       Context, (void *)CleanShadowPtr, CleanShadowSize,
       UR_VIRTUAL_MEM_ACCESS_FLAG_READ_ONLY);
   if (Result != UR_RESULT_SUCCESS) {
-    UR_LOG_L(getContext()->logger, ERR, "VirtualMem.pfnMap2: {}", Result);
     return Result;
   }
 
@@ -540,21 +535,18 @@ ur_result_t ShadowMemoryGPU::ReleaseCleanShadow() {
   ur_result_t Result = getContext()->urDdiTable.VirtualMem.pfnUnmap(
       Context, (void *)CleanShadowPtr, CleanShadowSize);
   if (Result != UR_RESULT_SUCCESS) {
-    UR_LOG_L(getContext()->logger, ERR, "VirtualMem.pfnUnmap: {}", Result);
     return Result;
   }
 
   Result =
       getContext()->urDdiTable.PhysicalMem.pfnRelease(CleanShadowPhysicalMem);
   if (Result != UR_RESULT_SUCCESS) {
-    UR_LOG_L(getContext()->logger, ERR, "PhysicalMem.pfnRelease: {}", Result);
     return Result;
   }
 
   Result = getContext()->urDdiTable.VirtualMem.pfnFree(
       Context, (void *)CleanShadowPtr, CleanShadowSize);
   if (Result != UR_RESULT_SUCCESS) {
-    UR_LOG_L(getContext()->logger, ERR, "VirtualMem.pfnFree: {}", Result);
     return Result;
   }
 

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
@@ -259,9 +259,9 @@ ur_result_t ShadowMemoryGPU::Destory() {
       ShadowBegin = ShadowEnd = 0;
     }
 
-    ReleaseCleanShadow();
+    UR_CALL(ReleaseCleanShadow());
 
-    getContext()->urDdiTable.Context.pfnRelease(Context);
+    UR_CALL(getContext()->urDdiTable.Context.pfnRelease(Context));
 
     return Result;
   }();
@@ -489,7 +489,7 @@ ur_result_t ShadowMemoryGPU::AllocCleanShadow(ur_queue_handle_t Queue,
   }
 
   if (CleanShadowPtr) {
-    ReleaseCleanShadow();
+    UR_CALL(ReleaseCleanShadow());
   }
 
   CleanShadowSize = RoundUpTo(Size, PageSize);

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
@@ -248,15 +248,16 @@ ur_result_t ShadowMemoryGPU::Destroy() {
     }
 
     {
-      const size_t PageSize = GetVirtualMemGranularity(Context, Device);
       for (auto [MappedPtr, PhysicalMem] : VirtualMemMaps) {
         UR_CALL(getContext()->urDdiTable.VirtualMem.pfnUnmap(
             Context, (void *)MappedPtr, PageSize));
         UR_CALL(getContext()->urDdiTable.PhysicalMem.pfnRelease(PhysicalMem));
       }
-      UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
-          Context, (const void *)ShadowBegin, GetShadowSize()));
-      ShadowBegin = ShadowEnd = 0;
+      if (ShadowBegin != 0) {
+        UR_CALL(getContext()->urDdiTable.VirtualMem.pfnFree(
+            Context, (const void *)ShadowBegin, GetShadowSize()));
+        ShadowBegin = ShadowEnd = 0;
+      }
     }
 
     UR_CALL(ReleaseCleanShadow());

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2025 Intel Corporation
+ * Copyright (C) 2024 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
  * Exceptions. See LICENSE.TXT

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.hpp
@@ -28,7 +28,7 @@ struct ShadowMemory {
 
   virtual ur_result_t Setup() = 0;
 
-  virtual ur_result_t Destory() = 0;
+  virtual ur_result_t Destroy() = 0;
 
   virtual uptr MemToShadow(uptr Ptr) = 0;
   virtual uptr MemToOrigin(uptr Ptr) = 0;
@@ -88,7 +88,7 @@ struct ShadowMemoryCPU final : public ShadowMemory {
 
   ur_result_t Setup() override;
 
-  ur_result_t Destory() override;
+  ur_result_t Destroy() override;
 
   uptr MemToShadow(uptr Ptr) override;
   uptr MemToOrigin(uptr Ptr) override;
@@ -132,7 +132,7 @@ struct ShadowMemoryGPU : public ShadowMemory {
 
   ur_result_t Setup() override;
 
-  ur_result_t Destory() override;
+  ur_result_t Destroy() override;
 
   ur_result_t
   EnqueuePoisonShadow(ur_queue_handle_t Queue, uptr Ptr, uptr Size, u8 Value,

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_shadow.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2025 Intel Corporation
+ * Copyright (C) 2024 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
  * Exceptions. See LICENSE.TXT


### PR DESCRIPTION
Clean shadow should always be zeros. 
I tested that gpu doesn't segfault when writing on readonly virtual memories, so it is really ideal to be clean shadow.

Miscs.
- Rename msan shadow memory classes
- Fix one spell error