### PR TITLE
[DevTSAN] Do early return if kernel has no data race reports

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_interceptor.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_interceptor.hpp
@@ -133,6 +133,8 @@ struct TsanRuntimeDataWrapper {
 
   ur_result_t syncToDevice(ur_queue_handle_t Queue);
 
+  bool hasReport(ur_queue_handle_t Queue);
+
   ur_result_t
   importLocalArgsInfo(ur_queue_handle_t Queue,
                       const std::vector<TsanLocalArgsInfo> &LocalArgs);

--- a/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_libdevice.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_libdevice.hpp
@@ -82,6 +82,8 @@ struct TsanLocalArgsInfo {
 constexpr uint64_t TSAN_MAX_NUM_REPORTS = 128;
 
 struct TsanRuntimeData {
+  uint32_t RecordedReportCount = 0;
+
   uintptr_t GlobalShadowOffset = 0;
 
   uintptr_t GlobalShadowOffsetEnd = 0;
@@ -102,8 +104,6 @@ struct TsanRuntimeData {
   uint32_t Debug = 0;
 
   int Lock = 0;
-
-  uint32_t RecordedReportCount = 0;
 
   TsanErrorReport Report[TSAN_MAX_NUM_REPORTS];
 };

--- a/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_shadow.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_shadow.cpp
@@ -169,19 +169,12 @@ ur_result_t ShadowMemoryGPU::CleanShadow(ur_queue_handle_t Queue, uptr Ptr,
         UR_LOG_L(getContext()->logger, DEBUG, "urVirtualMemMap: {} ~ {}",
                  (void *)MappedPtr, (void *)(MappedPtr + PageSize - 1));
 
-        // Initialize to zero
-        URes = EnqueueUSMSet(Queue, (void *)MappedPtr, (char)0, PageSize);
-        if (URes != UR_RESULT_SUCCESS) {
-          UR_LOG_L(getContext()->logger, ERR, "EnqueueUSMBlockingSet(): {}",
-                   URes);
-          return URes;
-        }
-
         VirtualMemMaps[MappedPtr] = PhysicalMem;
       }
     }
   }
 
+  // Initialize to zero
   auto URes = EnqueueUSMSet(Queue, (void *)Begin, (char)0,
                             Size / kShadowCell * kShadowCnt * kShadowSize);
   if (URes != UR_RESULT_SUCCESS) {


### PR DESCRIPTION
Sync runtime data from device to host will cost a lot of time, so we'd better check if kernel has reports first to avoid unnecessary data sync.