### PR TITLE
[SYCL][Driver] Base libspirv path on sycl install candidates

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -182,11 +182,9 @@ const char *SYCLInstallationDetector::findLibspirvPath(
   const SmallString<64> Basename =
       getLibSpirvBasename(DeviceTriple, HostTriple);
   auto searchAt = [&](StringRef Path, const Twine &a = "", const Twine &b = "",
-                      const Twine &c = "", const Twine &d = "",
-                      const Twine &e = "") -> const char * {
+                      const Twine &c = "") -> const char * {
     SmallString<128> LibraryPath(Path);
-    llvm::sys::path::append(LibraryPath, a, b, c, d);
-    llvm::sys::path::append(LibraryPath, e, Basename);
+    llvm::sys::path::append(LibraryPath, a, b, c, Basename);
 
     if (Args.hasArgNoClaim(options::OPT__HASH_HASH_HASH) ||
         llvm::sys::fs::exists(LibraryPath))
@@ -195,14 +193,15 @@ const char *SYCLInstallationDetector::findLibspirvPath(
     return nullptr;
   };
 
-  // Otherwise, assume libclc is installed at the same prefix as clang
-  // Expected path w/out install.
-  if (const char *R = searchAt(D.ResourceDir, "..", "..", "clc"))
-    return R;
+  for (const auto &IC : InstallationCandidates) {
+    // Expected path w/out install.
+    if (const char *R = searchAt(IC, "lib", "clc"))
+      return R;
 
-  // Expected path w/ install.
-  if (const char *R = searchAt(D.ResourceDir, "..", "..", "..", "share", "clc"))
-    return R;
+    // Expected path w/ install.
+    if (const char *R = searchAt(IC, "share", "clc"))
+      return R;
+  }
 
   return nullptr;
 }

--- a/clang/test/Driver/sycl-libspirv-toolchain.cpp
+++ b/clang/test/Driver/sycl-libspirv-toolchain.cpp
@@ -15,7 +15,7 @@
 // RUN: | FileCheck %s --check-prefixes=CHECK-LINUX
 // CHECK-LINUX: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-mlink-builtin-bitcode" "{{.*[\\/]}}remangled-l64-signed_char.libspirv-nvptx64-nvidia-cuda.bc"
 //
-// RUN: %clang -### -resource-dir %{resource_dir} -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib -target x86_64-unknown-windows-msvc %s 2>&1 \
+// RUN: %clang -### -ccc-install-dir %{install_dir} -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib -target x86_64-unknown-windows-msvc %s 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHECK-AMDGCN-WINDOWS
 // CHECK-AMDGCN-WINDOWS: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-mlink-builtin-bitcode" "{{.*[\\/]}}remangled-l32-signed_char.libspirv-amdgcn-amd-amdhsa.bc"
 //
@@ -30,22 +30,22 @@
 // CHECK-CUDA: "-cc1"{{.*}} "-fcuda-is-device"
 // CHECK-CUDA-NOT: "-mlink-builtin-bitcode" "{{.*}}.libspirv-{{.*}}.bc"
 //
-// The path to the remangled libspirv bitcode file is determined by the resource directory.
+// The path to the remangled libspirv bitcode file is determined by the installation directory
 // RUN: %clang -### -ccc-install-dir %{install_dir}  -resource-dir %{resource_dir} -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib %s 2>&1 \
 // RUN: | FileCheck %s -DINSTALL_DIR=%{install_dir} -DRESOURCE_DIR=%{resource_dir} --check-prefixes=CHECK-DIR
-// CHECK-DIR: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-mlink-builtin-bitcode" "[[RESOURCE_DIR]]{{.*[\\/]}}remangled-{{.*}}.libspirv-nvptx64-nvidia-cuda.bc"
+// CHECK-DIR: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-mlink-builtin-bitcode" "[[INSTALL_DIR]]{{.*[\\/]}}remangled-{{.*}}.libspirv-nvptx64-nvidia-cuda.bc"
 //
 // The `-###` option disables file existence checks
 // DEFINE: %{nonexistent_dir} = %/S/Inputs/SYCL/does_not_exist/lib/clang/resource_dir
-// RUN: %clang -### -resource-dir %{nonexistent_dir} -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib %s 2>&1 \
-// RUN: | FileCheck %s     -DDIR=%{nonexistent_dir} --check-prefixes=CHECK-HHH-NONEXISTENT
+// RUN: %clang -### -ccc-install-dir %{nonexistent_dir} -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib %s 2>&1 \
+// RUN: | FileCheck %s         -DDIR=%{nonexistent_dir} --check-prefixes=CHECK-HHH-NONEXISTENT
 // CHECK-HHH-NONEXISTENT: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-mlink-builtin-bitcode" "[[DIR]]{{.*[\\/]}}remangled-{{.*}}.libspirv-nvptx64-nvidia-cuda.bc"
 //
-// RUN: %clang -### -resource-dir %{nonexistent_dir} -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib %s 2>&1 \
-// RUN: | FileCheck %s      -DDIR=%{nonexistent_dir} --check-prefixes=CHECK-AMDGCN-HHH-NONEXISTENT
+// RUN: %clang -### -ccc-install-dir %{nonexistent_dir} -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib %s 2>&1 \
+// RUN: | FileCheck %s         -DDIR=%{nonexistent_dir} --check-prefixes=CHECK-AMDGCN-HHH-NONEXISTENT
 // CHECK-AMDGCN-HHH-NONEXISTENT: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-mlink-builtin-bitcode" "[[DIR]]{{.*[\\/]}}remangled-{{.*}}.libspirv-amdgcn-amd-amdhsa.bc"
 //
 // `-fdriver-only` has no such special handling, so it will not find the file
-// RUN: not %clang -fdriver-only -resource-dir %{nonexistent_dir} -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib %s 2>&1 \
-// RUN: | FileCheck %s --check-prefixes=CHECK-DO-NONEXISTENT
+// RUN: not %clang -fdriver-only -ccc-install-dir %{nonexistent_dir} -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib %s 2>&1 \
+// RUN: | FileCheck %s                      -DDIR=%{nonexistent_dir} --check-prefixes=CHECK-DO-NONEXISTENT
 // CHECK-DO-NONEXISTENT: error: cannot find 'remangled-{{.*}}.libspirv-nvptx64-nvidia-cuda.bc'; provide path to libspirv library via '-fsycl-libspirv-path', or pass '-fno-sycl-libspirv' to build without linking with libspirv


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #19131

## Chain of upstream PRs & tree of downstream PRs as of 2025-06-25

* PR #19130

  * PR #19131

    * **PR #19134 (THIS ONE)**

        * PR #19135

          * PR #19136

<!-- end git-machete generated -->

... instead of the resource directory. This matches the behaviour of
SYCL device libraries. The resource directory has nothing to do with
libspirv, and it might be changed by the `-resource-dir` option, which
would lead us to not find it.