### PR TITLE
[UR][CTS] Skip failing command-buffer OpenCL CTS tests

### DIFF
--- a/unified-runtime/test/conformance/exp_command_buffer/copy.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/copy.cpp
@@ -116,6 +116,10 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     printMemcpyTestString<urCommandBufferMemcpyCommandsTest>);
 
 TEST_P(urCommandBufferMemcpyCommandsTest, Buffer) {
+  // Buffer read & write not supported on OpenCL
+  // See https://github.com/KhronosGroup/OpenCL-Docs/issues/1281
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   std::vector<uint8_t> input(size);
   std::iota(input.begin(), input.end(), 1);
 

--- a/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
@@ -194,6 +194,9 @@ TEST_P(urEnqueueCommandBufferExpTest, SerializeInOrOutOfOrderQueue) {
 // Tests releasing command-buffer while it is still executing relying
 // on synchronization during urCommandBufferReleaseExp call.
 TEST_P(urEnqueueCommandBufferExpTest, EnqueueAndRelease) {
+  // https://github.com/intel/llvm/issues/19139
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
   ASSERT_SUCCESS(urEnqueueCommandBufferExp(
       in_or_out_of_order_queue, cmd_buf_handle, 0, nullptr, nullptr));
 

--- a/unified-runtime/test/conformance/exp_command_buffer/read.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/read.cpp
@@ -15,6 +15,10 @@ struct testParametersRead {
 struct urCommandBufferReadCommandsTest
     : uur::command_buffer::urCommandBufferExpTestWithParam<testParametersRead> {
   void SetUp() override {
+    // Buffer read not supported on OpenCL
+    // see https://github.com/KhronosGroup/OpenCL-Docs/issues/1281
+    UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::command_buffer::urCommandBufferExpTestWithParam<
             testParametersRead>::SetUp());

--- a/unified-runtime/test/conformance/exp_command_buffer/rect_read.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/rect_read.cpp
@@ -75,6 +75,10 @@ struct urCommandBufferAppendMemBufferReadRectTestWithParam
     : public uur::command_buffer::urCommandBufferExpTestWithParam<
           uur::test_parameters_t> {
   void SetUp() override {
+    // Buffer read not supported on OpenCL
+    // see https://github.com/KhronosGroup/OpenCL-Docs/issues/1281
+    UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::command_buffer::urCommandBufferExpTestWithParam<
             uur::test_parameters_t>::SetUp());

--- a/unified-runtime/test/conformance/exp_command_buffer/rect_write.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/rect_write.cpp
@@ -75,6 +75,10 @@ struct urCommandBufferAppendMemBufferWriteRectTestWithParam
           uur::test_parameters_t> {
 
   void SetUp() override {
+    // Buffer write not supported on OpenCL
+    // see https://github.com/KhronosGroup/OpenCL-Docs/issues/1281
+    UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::command_buffer::urCommandBufferExpTestWithParam<
             uur::test_parameters_t>::SetUp());

--- a/unified-runtime/test/conformance/exp_command_buffer/release.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/release.cpp
@@ -12,6 +12,8 @@ using urCommandBufferReleaseExpTest =
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferReleaseExpTest);
 
 TEST_P(urCommandBufferReleaseExpTest, Success) {
+  // https://github.com/intel/llvm/issues/19139
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
   EXPECT_SUCCESS(urCommandBufferRetainExp(cmd_buf_handle));
 
   uint32_t prev_ref_count = 0;

--- a/unified-runtime/test/conformance/exp_command_buffer/retain.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/retain.cpp
@@ -12,6 +12,8 @@ using urCommandBufferRetainExpTest =
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferRetainExpTest);
 
 TEST_P(urCommandBufferRetainExpTest, Success) {
+  // https://github.com/intel/llvm/issues/19139
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
   uint32_t prev_ref_count = 0;
   EXPECT_SUCCESS(uur::GetObjectReferenceCount(cmd_buf_handle, prev_ref_count));
 

--- a/unified-runtime/test/conformance/exp_command_buffer/write.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/write.cpp
@@ -16,6 +16,10 @@ struct urCommandBufferWriteCommandsTest
     : uur::command_buffer::urCommandBufferExpTestWithParam<
           testParametersWrite> {
   void SetUp() override {
+    // Buffer write not supported on OpenCL
+    // see https://github.com/KhronosGroup/OpenCL-Docs/issues/1281
+    UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
+
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::command_buffer::urCommandBufferExpTestWithParam<
             testParametersWrite>::SetUp());


### PR DESCRIPTION
buffer read/write CTS tests aren't supported for the OpenCL adapter, because there is a gap in cl_khr_command_buffer that blocks implementing the required UR entry-points

https://github.com/KhronosGroup/OpenCL-Docs/issues/1281 is the cl_khr_command_buffer issue progressing this.