### PR TITLE
[SYCL][E2E] Remove unused command line arguments from tests

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/address_test.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/address_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} --save-temps -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/FreeFunctionKernels/free_function_kernels_as_device_host_functions.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/free_function_kernels_as_device_host_functions.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} --save-temps -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // This test verifies whether free function kernel can be used as device


### PR DESCRIPTION
In follow up to an earlier PR, this PR removes the `--save-temps` option from 2 E2E tests where it is unused and causing errors in certain QA testing configurations. It is probably a remnant of local debugging.