### PR TITLE
[SYCL] [UR] [Graphs] Added missing UR_CALLs

### DIFF
--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -681,7 +681,7 @@ graph_impl::getLastInorderNode(sycl::detail::queue_impl *Queue) {
 
 void graph_impl::setLastInorderNode(sycl::detail::queue_impl &Queue,
                                     std::shared_ptr<node_impl> Node) {
-  MInorderQueueMap[Queue.weak_from_this()] = Node;
+  MInorderQueueMap[Queue.weak_from_this()] = std::move(Node);
 }
 
 void graph_impl::makeEdge(std::shared_ptr<node_impl> Src,

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -488,23 +488,23 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
       IsUpdatable(Desc->isUpdatable), IsProfilingEnabled(Desc->enableProfiling),
       InOrderRequested(Desc->isInOrder), IsInOrderCmdList(IsInOrderCmdList),
       UseImmediateAppendPath(UseImmediateAppendPath) {
-  ur::level_zero::urContextRetain(Context);
-  ur::level_zero::urDeviceRetain(Device);
+  UR_CALL(ur::level_zero::urContextRetain(Context));
+  UR_CALL(ur::level_zero::urDeviceRetain(Device));
 }
 
 void ur_exp_command_buffer_handle_t_::cleanupCommandBufferResources() {
   // Release the memory allocated to the Context stored in the command_buffer
-  ur::level_zero::urContextRelease(Context);
+  UR_CALL_NOCHECK(ur::level_zero::urContextRelease(Context));
 
   // Release the device
-  ur::level_zero::urDeviceRelease(Device);
+  UR_CALL_NOCHECK(ur::level_zero::urDeviceRelease(Device));
 
   // Release the memory allocated to the CommandList stored in the
   // command_buffer
   if (ZeComputeCommandList && checkL0LoaderTeardown()) {
     ZE_CALL_NOCHECK(zeCommandListDestroy, (ZeComputeCommandList));
-  }
-  if (useCopyEngine() && ZeCopyCommandList && checkL0LoaderTeardown()) {
+    if (useCopyEngine() && ZeCopyCommandList && checkL0LoaderTeardown()) {
+    }
     ZE_CALL_NOCHECK(zeCommandListDestroy, (ZeCopyCommandList));
   }
 
@@ -589,7 +589,7 @@ void ur_exp_command_buffer_handle_t_::cleanupCommandBufferResources() {
 
   for (auto &AssociatedKernel : KernelsList) {
     ReleaseIndirectMem(AssociatedKernel);
-    ur::level_zero::urKernelRelease(AssociatedKernel);
+    UR_CALL_NOCHECK(ur::level_zero::urKernelRelease(AssociatedKernel));
   }
 }
 
@@ -1071,10 +1071,10 @@ ur_result_t urCommandBufferAppendKernelLaunchExp(
     CommandBuffer->KernelsList.push_back(KernelAlternatives[i]);
   }
 
-  ur::level_zero::urKernelRetain(Kernel);
+  UR_CALL(ur::level_zero::urKernelRetain(Kernel));
   // Retain alternative kernels if provided
   for (size_t i = 0; i < NumKernelAlternatives; i++) {
-    ur::level_zero::urKernelRetain(KernelAlternatives[i]);
+    UR_CALL(ur::level_zero::urKernelRetain(KernelAlternatives[i]));
   }
 
   if (Command) {

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -1513,8 +1513,8 @@ ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
                (WaitCommandList->first, CommandBuffer->WaitEvent->ZeEvent,
                 CommandBuffer->WaitEvent->WaitList.Length,
                 CommandBuffer->WaitEvent->WaitList.ZeEventList));
-    Queue->executeCommandList(WaitCommandList, false /*IsBlocking*/,
-                              false /*OKToBatchCommand*/);
+    UR_CALL(Queue->executeCommandList(WaitCommandList, false /*IsBlocking*/,
+                                      false /*OKToBatchCommand*/));
     MustSignalWaitEvent = false;
   }
   // Given WaitEvent was created without specifying Counting Events, then this

--- a/unified-runtime/source/adapters/level_zero/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/command_buffer.cpp
@@ -12,6 +12,7 @@
 #include "helpers/kernel_helpers.hpp"
 #include "helpers/mutable_helpers.hpp"
 #include "logger/ur_logger.hpp"
+#include "ur/ur.hpp"
 #include "ur_api.h"
 #include "ur_interface_loader.hpp"
 #include "ur_level_zero.hpp"
@@ -488,8 +489,8 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
       IsUpdatable(Desc->isUpdatable), IsProfilingEnabled(Desc->enableProfiling),
       InOrderRequested(Desc->isInOrder), IsInOrderCmdList(IsInOrderCmdList),
       UseImmediateAppendPath(UseImmediateAppendPath) {
-  UR_CALL(ur::level_zero::urContextRetain(Context));
-  UR_CALL(ur::level_zero::urDeviceRetain(Device));
+  UR_CALL_NOCHECK(ur::level_zero::urContextRetain(Context));
+  UR_CALL_NOCHECK(ur::level_zero::urDeviceRetain(Device));
 }
 
 void ur_exp_command_buffer_handle_t_::cleanupCommandBufferResources() {
@@ -503,8 +504,8 @@ void ur_exp_command_buffer_handle_t_::cleanupCommandBufferResources() {
   // command_buffer
   if (ZeComputeCommandList && checkL0LoaderTeardown()) {
     ZE_CALL_NOCHECK(zeCommandListDestroy, (ZeComputeCommandList));
-    if (useCopyEngine() && ZeCopyCommandList && checkL0LoaderTeardown()) {
-    }
+  }
+  if (useCopyEngine() && ZeCopyCommandList && checkL0LoaderTeardown()) {
     ZE_CALL_NOCHECK(zeCommandListDestroy, (ZeCopyCommandList));
   }
 


### PR DESCRIPTION
Small fixes flagged by static analyzer:
- Added missing `UR_CALL` and `UR_CALL_NOCHECK` to `ur::level_zero` function calls in Command Buffer,
- Removed one redundant copy of `shared_ptr`