### PR TITLE
Revert "[GHA] Uplift Linux GPU RT version to 25.18.33578.6"

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.22.4",
-      "version": "v1.22.4",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.22.4",
+      "github_tag": "v1.21.9",
+      "version": "v1.21.9",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.21.9",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
Reverts intel/llvm#19107

@igchor found it's randomly crashing, we're working with Neil.