### PR TITLE
[NFC][SYCL] Prefer `context_impl &` as locals/temporaries

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -3545,7 +3545,9 @@ private:
         UserRange, KernelFunc};
   }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   const std::shared_ptr<detail::context_impl> &getContextImplPtr() const;
+#endif
   detail::context_impl &getContextImpl() const;
 
   // Checks if 2D memory operations are supported by the underlying platform.

--- a/sycl/source/detail/async_alloc.cpp
+++ b/sycl/source/detail/async_alloc.cpp
@@ -68,7 +68,7 @@ void *async_malloc(sycl::handler &h, sycl::usm::alloc kind, size_t size) {
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Only device backed asynchronous allocations are supported!");
 
-  auto &Adapter = h.getContextImplPtr()->getAdapter();
+  auto &Adapter = h.getContextImpl().getAdapter();
 
   // Get CG event dependencies for this allocation.
   const auto &DepEvents = h.impl->CGData.MEvents;
@@ -118,7 +118,7 @@ __SYCL_EXPORT void *async_malloc(const sycl::queue &q, sycl::usm::alloc kind,
 __SYCL_EXPORT void *async_malloc_from_pool(sycl::handler &h, size_t size,
                                            const memory_pool &pool) {
 
-  auto &Adapter = h.getContextImplPtr()->getAdapter();
+  auto &Adapter = h.getContextImpl().getAdapter();
   auto &memPoolImpl = sycl::detail::getSyclObjImpl(pool);
 
   // Get CG event dependencies for this allocation.

--- a/sycl/source/detail/backend_impl.hpp
+++ b/sycl/source/detail/backend_impl.hpp
@@ -15,7 +15,7 @@ inline namespace _V1 {
 namespace detail {
 
 template <class T> backend getImplBackend(const T &Impl) {
-  return Impl->getContextImplPtr()->getBackend();
+  return Impl->getContextImpl().getBackend();
 }
 
 } // namespace detail

--- a/sycl/source/detail/bindless_images.cpp
+++ b/sycl/source/detail/bindless_images.cpp
@@ -813,9 +813,9 @@ get_image_memory_support(const image_descriptor &imageDescriptor,
                          const sycl::context &syclContext) {
   std::shared_ptr<sycl::detail::device_impl> DevImpl =
       sycl::detail::getSyclObjImpl(syclDevice);
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  sycl::detail::context_impl &CtxImpl =
+      *sycl::detail::getSyclObjImpl(syclContext);
+  const sycl::detail::AdapterPtr &Adapter = CtxImpl.getAdapter();
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -825,7 +825,7 @@ get_image_memory_support(const image_descriptor &imageDescriptor,
   Adapter->call<sycl::errc::runtime,
                 sycl::detail::UrApiKind::
                     urBindlessImagesGetImageMemoryHandleTypeSupportExp>(
-      CtxImpl->getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
+      CtxImpl.getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
       ur_exp_image_mem_type_t::UR_EXP_IMAGE_MEM_TYPE_USM_POINTER,
       &supportsPointerAllocation);
 
@@ -833,7 +833,7 @@ get_image_memory_support(const image_descriptor &imageDescriptor,
   Adapter->call<sycl::errc::runtime,
                 sycl::detail::UrApiKind::
                     urBindlessImagesGetImageMemoryHandleTypeSupportExp>(
-      CtxImpl->getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
+      CtxImpl.getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
       ur_exp_image_mem_type_t::UR_EXP_IMAGE_MEM_TYPE_OPAQUE_HANDLE,
       &supportsOpaqueAllocation);
 
@@ -864,9 +864,9 @@ __SYCL_EXPORT bool is_image_handle_supported<unsampled_image_handle>(
     const sycl::device &syclDevice, const sycl::context &syclContext) {
   std::shared_ptr<sycl::detail::device_impl> DevImpl =
       sycl::detail::getSyclObjImpl(syclDevice);
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  sycl::detail::context_impl &CtxImpl =
+      *sycl::detail::getSyclObjImpl(syclContext);
+  const sycl::detail::AdapterPtr &Adapter = CtxImpl.getAdapter();
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -881,7 +881,7 @@ __SYCL_EXPORT bool is_image_handle_supported<unsampled_image_handle>(
   Adapter->call<sycl::errc::runtime,
                 sycl::detail::UrApiKind::
                     urBindlessImagesGetImageUnsampledHandleSupportExp>(
-      CtxImpl->getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
+      CtxImpl.getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
       memHandleType, &supportsUnsampledHandle);
 
   return supportsUnsampledHandle;
@@ -904,9 +904,9 @@ __SYCL_EXPORT bool is_image_handle_supported<sampled_image_handle>(
     const sycl::device &syclDevice, const sycl::context &syclContext) {
   std::shared_ptr<sycl::detail::device_impl> DevImpl =
       sycl::detail::getSyclObjImpl(syclDevice);
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl->getAdapter();
+  sycl::detail::context_impl &CtxImpl =
+      *sycl::detail::getSyclObjImpl(syclContext);
+  const sycl::detail::AdapterPtr &Adapter = CtxImpl.getAdapter();
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -921,7 +921,7 @@ __SYCL_EXPORT bool is_image_handle_supported<sampled_image_handle>(
   Adapter->call<
       sycl::errc::runtime,
       sycl::detail::UrApiKind::urBindlessImagesGetImageSampledHandleSupportExp>(
-      CtxImpl->getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
+      CtxImpl.getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
       memHandleType, &supportsSampledHandle);
 
   return supportsSampledHandle;

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -570,13 +570,13 @@ public:
 
   ur_native_handle_t getNative() const {
     assert(MProgram);
-    const auto &ContextImplPtr = detail::getSyclObjImpl(MContext);
-    const AdapterPtr &Adapter = ContextImplPtr->getAdapter();
+    context_impl &ContextImpl = *detail::getSyclObjImpl(MContext);
+    const AdapterPtr &Adapter = ContextImpl.getAdapter();
 
     ur_native_handle_t NativeProgram = 0;
     Adapter->call<UrApiKind::urProgramGetNativeHandle>(MProgram,
                                                        &NativeProgram);
-    if (ContextImplPtr->getBackend() == backend::opencl)
+    if (ContextImpl.getBackend() == backend::opencl)
       __SYCL_OCL_CALL(clRetainProgram, ur::cast<cl_program>(NativeProgram));
 
     return NativeProgram;

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -312,12 +312,6 @@ public:
 
   bool isDefaultConstructed() const noexcept { return MIsDefaultConstructed; }
 
-  ContextImplPtr getContextImplPtr() {
-    if (MIsDefaultConstructed)
-      initContextIfNeeded();
-    return MContext;
-  }
-
   // Sets a sync point which is used when this event represents an enqueue to a
   // Command Buffer.
   void setSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint) {

--- a/sycl/source/detail/graph/graph_impl.hpp
+++ b/sycl/source/detail/graph/graph_impl.hpp
@@ -268,10 +268,15 @@ public:
   /// @return Context associated with graph.
   sycl::context getContext() const { return MContext; }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Query for the context impl tied to this graph.
   /// @return shared_ptr ref for the context impl associated with graph.
   const std::shared_ptr<sycl::detail::context_impl> &getContextImplPtr() const {
     return sycl::detail::getSyclObjImpl(MContext);
+  }
+#endif
+  sycl::detail::context_impl &getContextImpl() const {
+    return *sycl::detail::getSyclObjImpl(MContext);
   }
 
   /// Query for the device_impl tied to this graph.

--- a/sycl/source/detail/handler_impl.hpp
+++ b/sycl/source/detail/handler_impl.hpp
@@ -199,9 +199,9 @@ public:
   template <typename Self = handler_impl> context_impl &get_context() {
     Self *self = this;
     if (auto *Queue = self->get_queue_or_null())
-      return *Queue->getContextImplPtr();
+      return Queue->getContextImpl();
     else
-      return *self->get_graph().getContextImplPtr();
+      return self->get_graph().getContextImpl();
   }
 
   /// If we are submitting a graph using ext_oneapi_graph this will be the graph

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -24,7 +24,6 @@
 
 namespace sycl {
 inline namespace _V1 {
-using ContextImplPtr = std::shared_ptr<sycl::detail::context_impl>;
 namespace detail {
 void waitEvents(std::vector<sycl::event> DepEvents) {
   for (auto SyclEvent : DepEvents) {
@@ -59,10 +58,10 @@ retrieveKernelBinary(queue_impl &Queue, KernelNameStrRefT KernelName,
     if (DeviceImage == DeviceImages.end()) {
       return {nullptr, nullptr};
     }
-    auto ContextImpl = Queue.getContextImplPtr();
+    context_impl &ContextImpl = Queue.getContextImpl();
     ur_program_handle_t Program =
         detail::ProgramManager::getInstance().createURProgram(
-            **DeviceImage, *ContextImpl, {createSyclObjFromImpl<device>(Dev)});
+            **DeviceImage, ContextImpl, {createSyclObjFromImpl<device>(Dev)});
     return {*DeviceImage, Program};
   }
 
@@ -79,11 +78,11 @@ retrieveKernelBinary(queue_impl &Queue, KernelNameStrRefT KernelName,
     DeviceImage = SyclKernelImpl->getDeviceImage()->get_bin_image_ref();
     Program = SyclKernelImpl->getDeviceImage()->get_ur_program_ref();
   } else {
-    auto ContextImpl = Queue.getContextImplPtr();
+    context_impl &ContextImpl = Queue.getContextImpl();
     DeviceImage = &detail::ProgramManager::getInstance().getDeviceImage(
-        KernelName, *ContextImpl, Dev);
+        KernelName, ContextImpl, Dev);
     Program = detail::ProgramManager::getInstance().createURProgram(
-        *DeviceImage, *ContextImpl, {createSyclObjFromImpl<device>(Dev)});
+        *DeviceImage, ContextImpl, {createSyclObjFromImpl<device>(Dev)});
   }
   return {DeviceImage, Program};
 }

--- a/sycl/source/detail/kernel_impl.hpp
+++ b/sycl/source/detail/kernel_impl.hpp
@@ -232,7 +232,7 @@ public:
   bool isInterop() const { return MIsInterop; }
 
   ur_program_handle_t getProgramRef() const { return MProgram; }
-  ContextImplPtr getContextImplPtr() const { return MContext; }
+  context_impl &getContextImpl() const { return *MContext; }
 
   std::mutex &getNoncacheableEnqueueMutex() const {
     return MNoncacheableEnqueueMutex;

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -80,7 +80,7 @@ template <> device queue_impl::get_info<info::queue::device>() const {
 template <>
 typename info::platform::version::return_type
 queue_impl::get_backend_info<info::platform::version>() const {
-  if (getContextImplPtr()->getBackend() != backend::opencl) {
+  if (getContextImpl().getBackend() != backend::opencl) {
     throw sycl::exception(errc::backend_mismatch,
                           "the info::platform::version info descriptor can "
                           "only be queried with an OpenCL backend");
@@ -93,7 +93,7 @@ queue_impl::get_backend_info<info::platform::version>() const {
 template <>
 typename info::device::version::return_type
 queue_impl::get_backend_info<info::device::version>() const {
-  if (getContextImplPtr()->getBackend() != backend::opencl) {
+  if (getContextImpl().getBackend() != backend::opencl) {
     throw sycl::exception(errc::backend_mismatch,
                           "the info::device::version info descriptor can only "
                           "be queried with an OpenCL backend");
@@ -106,7 +106,7 @@ queue_impl::get_backend_info<info::device::version>() const {
 template <>
 typename info::device::backend_version::return_type
 queue_impl::get_backend_info<info::device::backend_version>() const {
-  if (getContextImplPtr()->getBackend() != backend::ext_oneapi_level_zero) {
+  if (getContextImpl().getBackend() != backend::ext_oneapi_level_zero) {
     throw sycl::exception(errc::backend_mismatch,
                           "the info::device::backend_version info descriptor "
                           "can only be queried with a Level Zero backend");
@@ -734,7 +734,7 @@ ur_native_handle_t queue_impl::getNative(int32_t &NativeHandleDesc) const {
 
   Adapter->call<UrApiKind::urQueueGetNativeHandle>(MQueue, &UrNativeDesc,
                                                    &Handle);
-  if (getContextImplPtr()->getBackend() == backend::opencl)
+  if (getContextImpl().getBackend() == backend::opencl)
     __SYCL_OCL_CALL(clRetainCommandQueue, ur::cast<cl_command_queue>(Handle));
 
   return Handle;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2018,7 +2018,7 @@ void instrumentationAddExtraKernelMetadata(
     //       by graph API, when a modifiable graph is finalized.
     FastKernelCacheValPtr FastKernelCacheVal =
         detail::ProgramManager::getInstance().getOrCreateKernel(
-            *Queue->getContextImplPtr(), Queue->getDeviceImpl(), KernelName,
+            Queue->getContextImpl(), Queue->getDeviceImpl(), KernelName,
             KernelNameBasedCachePtr);
     EliminatedArgMask = FastKernelCacheVal->MKernelArgMask;
   }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -1995,7 +1995,7 @@ void handler::depends_on(const detail::EventImplPtr &EventImpl) {
   if (Queue && EventGraph) {
     auto QueueGraph = Queue->getCommandGraph();
 
-    if (EventGraph->getContextImplPtr().get() != &impl->get_context()) {
+    if (&EventGraph->getContextImpl() != &impl->get_context()) {
       throw sycl::exception(
           make_error_code(errc::invalid),
           "Cannot submit to a queue with a dependency from a graph that is "
@@ -2213,6 +2213,7 @@ void handler::memcpyFromHostOnlyDeviceGlobal(void *Dest,
   });
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 const std::shared_ptr<detail::context_impl> &
 handler::getContextImplPtr() const {
   if (auto *Graph = impl->get_graph_or_null()) {
@@ -2220,10 +2221,11 @@ handler::getContextImplPtr() const {
   }
   return impl->get_queue().getContextImplPtr();
 }
+#endif
 
 detail::context_impl &handler::getContextImpl() const {
   if (auto *Graph = impl->get_graph_or_null()) {
-    return *Graph->getContextImplPtr();
+    return Graph->getContextImpl();
   }
   return impl->get_queue().getContextImpl();
 }


### PR DESCRIPTION
Subsequently, use `getContextImpl` instead of `getContextImplPtr` when possible.

Continuation of the refactoring in
https://github.com/intel/llvm/pull/18795
https://github.com/intel/llvm/pull/18877
https://github.com/intel/llvm/pull/18966
https://github.com/intel/llvm/pull/18979
https://github.com/intel/llvm/pull/18980
https://github.com/intel/llvm/pull/18981
https://github.com/intel/llvm/pull/19007
https://github.com/intel/llvm/pull/19030
https://github.com/intel/llvm/pull/19123
https://github.com/intel/llvm/pull/19126