### PR TITLE
[SYCL] [Graph] Remove unnecesary SYCL_EXPORT

### DIFF
--- a/sycl/source/detail/graph/graph_impl.hpp
+++ b/sycl/source/detail/graph/graph_impl.hpp
@@ -953,8 +953,7 @@ private:
 
 namespace std {
 template <sycl::ext::oneapi::experimental::graph_state State>
-struct __SYCL_EXPORT
-    hash<sycl::ext::oneapi::experimental::command_graph<State>> {
+struct hash<sycl::ext::oneapi::experimental::command_graph<State>> {
   size_t operator()(const sycl::ext::oneapi::experimental::command_graph<State>
                         &Graph) const {
     auto ID = sycl::detail::getSyclObjImpl(Graph)->getID();


### PR DESCRIPTION
Fixes post-commit windows CI failure introduced by #19045 