### PR TITLE
[NFC][SYCL] Use `context_impl &` in `sampler_impl` ctor and near it

### DIFF
--- a/sycl/source/detail/sampler_impl.hpp
+++ b/sycl/source/detail/sampler_impl.hpp
@@ -30,7 +30,6 @@ enum class coordinate_normalization_mode : unsigned int;
 namespace detail {
 
 class context_impl;
-using ContextImplPtr = std::shared_ptr<context_impl>;
 
 class sampler_impl {
 public:
@@ -38,7 +37,7 @@ public:
                addressing_mode addressingMode, filtering_mode filteringMode,
                const property_list &propList);
 
-  sampler_impl(cl_sampler clSampler, const ContextImplPtr &syclContext);
+  sampler_impl(cl_sampler clSampler, context_impl &syclContext);
 
   addressing_mode get_addressing_mode() const;
 
@@ -46,7 +45,7 @@ public:
 
   coordinate_normalization_mode get_coordinate_normalization_mode() const;
 
-  ur_sampler_handle_t getOrCreateSampler(const ContextImplPtr &ContextImpl);
+  ur_sampler_handle_t getOrCreateSampler(context_impl &ContextImpl);
 
   ~sampler_impl();
 
@@ -56,7 +55,8 @@ private:
   /// Protects all the fields that can be changed by class' methods.
   std::mutex MMutex;
 
-  std::unordered_map<ContextImplPtr, ur_sampler_handle_t> MContextToSampler;
+  std::unordered_map<std::shared_ptr<context_impl>, ur_sampler_handle_t>
+      MContextToSampler;
 
   coordinate_normalization_mode MCoordNormMode;
   addressing_mode MAddrMode;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2313,8 +2313,7 @@ void SetArgBasedOnType(
     const AdapterPtr &Adapter, ur_kernel_handle_t Kernel,
     const std::shared_ptr<device_image_impl> &DeviceImageImpl,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc,
-    const ContextImplPtr &ContextImpl, detail::ArgDesc &Arg,
-    size_t NextTrueIndex) {
+    context_impl &ContextImpl, detail::ArgDesc &Arg, size_t NextTrueIndex) {
   switch (Arg.MType) {
   case kernel_param_kind_t::kind_dynamic_work_group_memory:
     break;
@@ -2442,7 +2441,7 @@ static ur_result_t SetKernelParamsAndLaunch(
     auto setFunc = [&Adapter, Kernel, &DeviceImageImpl, &getMemAllocationFunc,
                     &Queue](detail::ArgDesc &Arg, size_t NextTrueIndex) {
       SetArgBasedOnType(Adapter, Kernel, DeviceImageImpl, getMemAllocationFunc,
-                        Queue.getContextImplPtr(), Arg, NextTrueIndex);
+                        Queue.getContextImpl(), Arg, NextTrueIndex);
     };
     applyFuncOnFilteredArgs(EliminatedArgMask, Args, setFunc);
   }
@@ -2530,7 +2529,7 @@ static ur_result_t SetKernelParamsAndLaunch(
 
 static std::tuple<ur_kernel_handle_t, std::shared_ptr<device_image_impl>,
                   const KernelArgMask *>
-getCGKernelInfo(const CGExecKernel &CommandGroup, ContextImplPtr ContextImpl,
+getCGKernelInfo(const CGExecKernel &CommandGroup, context_impl &ContextImpl,
                 device_impl &DeviceImpl,
                 std::vector<FastKernelCacheValPtr> &KernelCacheValsToRelease) {
 
@@ -2552,7 +2551,7 @@ getCGKernelInfo(const CGExecKernel &CommandGroup, ContextImplPtr ContextImpl,
   } else {
     FastKernelCacheValPtr FastKernelCacheVal =
         sycl::detail::ProgramManager::getInstance().getOrCreateKernel(
-            *ContextImpl, DeviceImpl, CommandGroup.MKernelName,
+            ContextImpl, DeviceImpl, CommandGroup.MKernelName,
             CommandGroup.MKernelNameBasedCachePtr);
     UrKernel = FastKernelCacheVal->MKernelHandle;
     EliminatedArgMask = FastKernelCacheVal->MKernelArgMask;
@@ -2579,7 +2578,7 @@ ur_result_t enqueueImpCommandBufferKernel(
   std::shared_ptr<device_image_impl> DeviceImageImpl = nullptr;
   const KernelArgMask *EliminatedArgMask = nullptr;
 
-  auto ContextImpl = sycl::detail::getSyclObjImpl(Ctx);
+  context_impl &ContextImpl = *sycl::detail::getSyclObjImpl(Ctx);
   std::tie(UrKernel, DeviceImageImpl, EliminatedArgMask) = getCGKernelInfo(
       CommandGroup, ContextImpl, DeviceImpl, FastKernelCacheValsToRelease);
 
@@ -2599,7 +2598,7 @@ ur_result_t enqueueImpCommandBufferKernel(
     AltUrKernels.push_back(AltUrKernel);
   }
 
-  const sycl::detail::AdapterPtr &Adapter = ContextImpl->getAdapter();
+  const sycl::detail::AdapterPtr &Adapter = ContextImpl.getAdapter();
   auto SetFunc = [&Adapter, &UrKernel, &DeviceImageImpl, &ContextImpl,
                   &getMemAllocationFunc](sycl::detail::ArgDesc &Arg,
                                          size_t NextTrueIndex) {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -44,7 +44,6 @@ class context_impl;
 class DispatchHostTask;
 
 using EventImplPtr = std::shared_ptr<detail::event_impl>;
-using ContextImplPtr = std::shared_ptr<detail::context_impl>;
 using StreamImplPtr = std::shared_ptr<detail::stream_impl>;
 
 class Command;
@@ -749,8 +748,7 @@ void SetArgBasedOnType(
     const detail::AdapterPtr &Adapter, ur_kernel_handle_t Kernel,
     const std::shared_ptr<device_image_impl> &DeviceImageImpl,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc,
-    const ContextImplPtr &ContextImpl, detail::ArgDesc &Arg,
-    size_t NextTrueIndex);
+    context_impl &ContextImpl, detail::ArgDesc &Arg, size_t NextTrueIndex);
 
 template <typename FuncT>
 void applyFuncOnFilteredArgs(const KernelArgMask *EliminatedArgMask,

--- a/sycl/source/sampler.cpp
+++ b/sycl/source/sampler.cpp
@@ -22,7 +22,7 @@ sampler::sampler(coordinate_normalization_mode normalizationMode,
 
 sampler::sampler(cl_sampler clSampler, const context &syclContext)
     : impl(std::make_shared<detail::sampler_impl>(
-          clSampler, detail::getSyclObjImpl(syclContext))) {}
+          clSampler, *detail::getSyclObjImpl(syclContext))) {}
 
 addressing_mode sampler::get_addressing_mode() const {
   return impl->get_addressing_mode();


### PR DESCRIPTION
`SetArgBasedOnType` argument is only used to pass to the `sampler_impl` ctor so update it.

`getCGKernelInfo` is only called in a function that also calls `sampler_impl` ctor so updating its signuature allows to update that caller's local `ContextImpl` variable, so makes sense to do as part of this PR as well.

Continuation of the refactoring in
https://github.com/intel/llvm/pull/18795
https://github.com/intel/llvm/pull/18877
https://github.com/intel/llvm/pull/18966
https://github.com/intel/llvm/pull/18979
https://github.com/intel/llvm/pull/18980
https://github.com/intel/llvm/pull/18981
https://github.com/intel/llvm/pull/19007
https://github.com/intel/llvm/pull/19030
https://github.com/intel/llvm/pull/19123
https://github.com/intel/llvm/pull/19126