### PR TITLE
[UR] Fix urinfo to correctly release Adapters before loader teardown

### DIFF
--- a/unified-runtime/tools/urinfo/urinfo.cpp
+++ b/unified-runtime/tools/urinfo/urinfo.cpp
@@ -208,6 +208,9 @@ options:
 
   ~app() {
     urLoaderConfigRelease(loaderConfig);
+    for (auto adapter : adapters) {
+      urAdapterRelease(adapter);
+    }
     urLoaderTearDown();
   }
 };


### PR DESCRIPTION
- Fix to urinfo to properly call release of adapters otherwise crucial teardown calls for adapters are missing. This was causing issues in UR only builds with adapters like L0 which have cleanup calls in the Adapter Release.