### PR TITLE
[NFC][SYCL] Move `platform::khr_get_default_context` impl to `platform_impl.cpp`

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -71,6 +71,23 @@ platform_impl::getPlatformFromUrDevice(ur_device_handle_t UrDevice,
   return getOrMakePlatformImpl(Plt, Adapter);
 }
 
+context_impl &platform_impl::khr_get_default_context() {
+  GlobalHandler &GH = GlobalHandler::instance();
+  // Keeping the default context for platforms in the global cache to avoid
+  // shared_ptr based circular dependency between platform and context classes
+  std::unordered_map<platform_impl *, std::shared_ptr<context_impl>>
+      &PlatformToDefaultContextCache = GH.getPlatformToDefaultContextCache();
+
+  std::lock_guard<std::mutex> Lock{GH.getPlatformToDefaultContextCacheMutex()};
+
+  auto It = PlatformToDefaultContextCache.find(this);
+  if (PlatformToDefaultContextCache.end() == It)
+    std::tie(It, std::ignore) = PlatformToDefaultContextCache.insert(
+        {this, detail::getSyclObjImpl(context{get_devices()})});
+
+  return *It->second;
+}
+
 static bool IsBannedPlatform(platform Platform) {
   // The NVIDIA OpenCL platform is currently not compatible with DPC++
   // since it is only 1.2 but gets selected by default in many systems

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -203,6 +203,8 @@ public:
   static platform_impl &getPlatformFromUrDevice(ur_device_handle_t UrDevice,
                                                 const AdapterPtr &Adapter);
 
+  context_impl &khr_get_default_context();
+
   // when getting sub-devices for ONEAPI_DEVICE_SELECTOR we may temporarily
   // ensure every device is a root one.
   bool MAlwaysRootDevice = false;

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -8,6 +8,7 @@
 
 #include <detail/backend_impl.hpp>
 #include <detail/config.hpp>
+#include <detail/context_impl.hpp>
 #include <detail/global_handler.hpp>
 #include <detail/platform_impl.hpp>
 #include <detail/ur.hpp>
@@ -89,22 +90,8 @@ platform::get_backend_info() const {
 #undef __SYCL_PARAM_TRAITS_SPEC
 
 context platform::khr_get_default_context() const {
-  // Keeping the default context for platforms in the global cache to avoid
-  // shared_ptr based circular dependency between platform and context classes
-  std::unordered_map<detail::platform_impl *, detail::ContextImplPtr>
-      &PlatformToDefaultContextCache =
-          detail::GlobalHandler::instance().getPlatformToDefaultContextCache();
-
-  std::lock_guard<std::mutex> Lock{
-      detail::GlobalHandler::instance()
-          .getPlatformToDefaultContextCacheMutex()};
-
-  auto It = PlatformToDefaultContextCache.find(impl.get());
-  if (PlatformToDefaultContextCache.end() == It)
-    std::tie(It, std::ignore) = PlatformToDefaultContextCache.insert(
-        {impl.get(), detail::getSyclObjImpl(context{get_devices()})});
-
-  return detail::createSyclObjFromImpl<context>(It->second);
+  return detail::createSyclObjFromImpl<context>(
+      impl->khr_get_default_context());
 }
 
 context platform::ext_oneapi_get_default_context() const {


### PR DESCRIPTION
Noticed this code as part of the ongoing refactoring to prefer raw ptrs/refs for SYCL RT `*_impl` objects. The usage of this API in `queue_impl` doesn't need to go through user-visible SYCL objects, so move the implementation and use the internal interfrace in `queue_impl` and delegate `platform::khr_get_default_context` to `platform_impl`.