### PR TITLE
[SYCL][NFCI] Make device binary image pointers const in more places

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -340,9 +340,9 @@ void context_impl::addDeviceGlobalInitializer(
   }
 }
 
-std::vector<ur_event_handle_t>
-context_impl::initializeDeviceGlobals(ur_program_handle_t NativePrg,
-                                      queue_impl &QueueImpl) {
+std::vector<ur_event_handle_t> context_impl::initializeDeviceGlobals(
+    ur_program_handle_t NativePrg, queue_impl &QueueImpl,
+    detail::kernel_bundle_impl *KernelBundleImplPtr) {
   if (!MDeviceGlobalNotInitializedCnt.load(std::memory_order_acquire))
     return {};
 
@@ -396,6 +396,12 @@ context_impl::initializeDeviceGlobals(ur_program_handle_t NativePrg,
         detail::ProgramManager::getInstance().getDeviceGlobalEntries(
             DeviceGlobalIds,
             /*ExcludeDeviceImageScopeDecorated=*/true);
+    // Kernel bundles may have isolated device globals. They need to be
+    // initialized too.
+    if (KernelBundleImplPtr && KernelBundleImplPtr->getDeviceGlobalMap().size())
+      KernelBundleImplPtr->getDeviceGlobalMap().getEntries(
+          DeviceGlobalIds, /*ExcludeDeviceImageScopeDecorated=*/true,
+          DeviceGlobalEntries);
 
     // If there were no device globals without device_image_scope the device
     // globals are trivially fully initialized and we can end early.

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -223,7 +223,8 @@ public:
 
   /// Initializes device globals for a program on the associated queue.
   std::vector<ur_event_handle_t>
-  initializeDeviceGlobals(ur_program_handle_t NativePrg, queue_impl &QueueImpl);
+  initializeDeviceGlobals(ur_program_handle_t NativePrg, queue_impl &QueueImpl,
+                          detail::kernel_bundle_impl *KernelBundleImplPtr);
 
   void memcpyToHostOnlyDeviceGlobal(device_impl &DeviceImpl,
                                     const void *DeviceGlobalPtr,

--- a/sycl/source/detail/device_binary_image.hpp
+++ b/sycl/source/detail/device_binary_image.hpp
@@ -296,7 +296,7 @@ public:
   }
 
   static DynRTDeviceBinaryImage
-  merge(const std::vector<RTDeviceBinaryImage *> &Imgs);
+  merge(const std::vector<const RTDeviceBinaryImage *> &Imgs);
 
 protected:
   DynRTDeviceBinaryImage();

--- a/sycl/source/detail/device_global_map.hpp
+++ b/sycl/source/detail/device_global_map.hpp
@@ -16,6 +16,7 @@
 #include <detail/device_global_map_entry.hpp>
 #include <sycl/detail/defines_elementary.hpp>
 #include <sycl/detail/kernel_name_str_t.hpp>
+#include <sycl/kernel_bundle.hpp>
 
 namespace sycl {
 inline namespace _V1 {
@@ -23,9 +24,22 @@ namespace detail {
 
 class DeviceGlobalMap {
 public:
-  void initializeEntries(RTDeviceBinaryImage *Img) {
-    const auto &DeviceGlobals = Img->getDeviceGlobals();
+  DeviceGlobalMap(bool OwnerControlledCleanup)
+      : MOwnerControlledCleanup{OwnerControlledCleanup} {}
+
+  ~DeviceGlobalMap() {
+    if (!MOwnerControlledCleanup)
+      for (auto &DeviceGlobalIt : MDeviceGlobals)
+        DeviceGlobalIt.second->cleanup();
+  }
+
+  void initializeEntries(const RTDeviceBinaryImage *Img) {
     std::lock_guard<std::mutex> DeviceGlobalsGuard(MDeviceGlobalsMutex);
+    initializeEntriesLockless(Img);
+  }
+
+  void initializeEntriesLockless(const RTDeviceBinaryImage *Img) {
+    const auto &DeviceGlobals = Img->getDeviceGlobals();
     for (const sycl_device_binary_property &DeviceGlobal : DeviceGlobals) {
       ByteArray DeviceGlobalInfo =
           DeviceBinaryProperty(DeviceGlobal).asByteArray();
@@ -56,6 +70,7 @@ public:
             DeviceGlobal->Name, Img, TypeSize, DeviceImageScopeDecorated);
         MDeviceGlobals.emplace(DeviceGlobal->Name, std::move(EntryUPtr));
       }
+      std::cout << DeviceGlobal->Name << std::endl;
     }
   }
 
@@ -102,9 +117,16 @@ public:
     return Entry->second;
   }
 
-  DeviceGlobalMapEntry *tryGetEntry(const std::string &UniqueId,
-                                    bool ExcludeDeviceImageScopeDecorated) {
+  DeviceGlobalMapEntry *
+  tryGetEntry(const std::string &UniqueId,
+              bool ExcludeDeviceImageScopeDecorated = false) {
     std::lock_guard<std::mutex> DeviceGlobalsGuard(MDeviceGlobalsMutex);
+    return tryGetEntryLockless(UniqueId, ExcludeDeviceImageScopeDecorated);
+  }
+
+  DeviceGlobalMapEntry *
+  tryGetEntryLockless(const std::string &UniqueId,
+                      bool ExcludeDeviceImageScopeDecorated = false) const {
     auto DeviceGlobalEntry = MDeviceGlobals.find(UniqueId);
     if (DeviceGlobalEntry != MDeviceGlobals.end() &&
         (!ExcludeDeviceImageScopeDecorated ||
@@ -113,22 +135,17 @@ public:
     return nullptr;
   }
 
-  std::vector<DeviceGlobalMapEntry *>
-  getEntries(const std::vector<std::string> &UniqueIds,
-             bool ExcludeDeviceImageScopeDecorated) {
-    std::vector<DeviceGlobalMapEntry *> FoundEntries;
-    FoundEntries.reserve(UniqueIds.size());
-
+  void getEntries(const std::vector<std::string> &UniqueIds,
+                  bool ExcludeDeviceImageScopeDecorated,
+                  std::vector<DeviceGlobalMapEntry *> &OutVec) {
     std::lock_guard<std::mutex> DeviceGlobalsGuard(MDeviceGlobalsMutex);
     for (const std::string &UniqueId : UniqueIds) {
       auto DeviceGlobalEntry = MDeviceGlobals.find(UniqueId);
-      assert(DeviceGlobalEntry != MDeviceGlobals.end() &&
-             "Device global not found in map.");
-      if (!ExcludeDeviceImageScopeDecorated ||
-          !DeviceGlobalEntry->second->MIsDeviceImageScopeDecorated)
-        FoundEntries.push_back(DeviceGlobalEntry->second.get());
+      if (DeviceGlobalEntry != MDeviceGlobals.end() &&
+          (!ExcludeDeviceImageScopeDecorated ||
+           !DeviceGlobalEntry->second->MIsDeviceImageScopeDecorated))
+        OutVec.push_back(DeviceGlobalEntry->second.get());
     }
-    return FoundEntries;
   }
 
   const std::unordered_map<const void *, DeviceGlobalMapEntry *>
@@ -143,6 +160,12 @@ public:
   }
 
 private:
+  // Indicates whether the owner will explicitly cleanup the entries. If false
+  // the dtor of DeviceGlobalMap will cleanup the enties.
+  // Note: This lets the global device global map avoid overhead at shutdown and
+  //       instead let the contexts own the associated entries.
+  bool MOwnerControlledCleanup = true;
+
   // Maps between device_global identifiers and associated information.
   std::unordered_map<KernelNameStrT, std::unique_ptr<DeviceGlobalMapEntry>>
       MDeviceGlobals;

--- a/sycl/source/detail/device_global_map_entry.cpp
+++ b/sycl/source/detail/device_global_map_entry.cpp
@@ -68,22 +68,33 @@ DeviceGlobalMapEntry::getOrAllocateDeviceGlobalUSM(queue_impl &QueueImpl) {
   {
     std::lock_guard<std::mutex> Lock(NewAlloc.MInitEventMutex);
     ur_event_handle_t InitEvent;
-    // C++ guarantees members appear in memory in the order they are declared,
-    // so since the member variable that contains the initial contents of the
-    // device_global is right after the usm_ptr member variable we can do
-    // some pointer arithmetic to memcopy over this value to the usm_ptr. This
-    // value inside of the device_global will be zero-initialized if it was not
-    // given a value on construction.
-
-    MemoryManager::copy_usm(reinterpret_cast<const void *>(
-                                reinterpret_cast<uintptr_t>(MDeviceGlobalPtr) +
-                                sizeof(MDeviceGlobalPtr)),
-                            QueueImpl, MDeviceGlobalTSize, NewAlloc.MPtr,
-                            std::vector<ur_event_handle_t>{}, &InitEvent);
+    if (MDeviceGlobalPtr) {
+      // C++ guarantees members appear in memory in the order they are declared,
+      // so since the member variable that contains the initial contents of the
+      // device_global is right after the usm_ptr member variable we can do
+      // some pointer arithmetic to memcopy over this value to the usm_ptr. This
+      // value inside of the device_global will be zero-initialized if it was
+      // not given a value on construction.
+      MemoryManager::copy_usm(
+          reinterpret_cast<const void *>(
+              reinterpret_cast<uintptr_t>(MDeviceGlobalPtr) +
+              sizeof(MDeviceGlobalPtr)),
+          QueueImpl, MDeviceGlobalTSize, NewAlloc.MPtr,
+          std::vector<ur_event_handle_t>{}, &InitEvent);
+    } else {
+      // For SYCLBIN device globals we do not have a host pointer to copy from,
+      // so instead we fill the USM memory with 0's.
+      MemoryManager::fill_usm(NewAlloc.MPtr, QueueImpl, MDeviceGlobalTSize,
+                              {static_cast<unsigned char>(0)}, {}, &InitEvent);
+    }
     NewAlloc.MInitEvent = InitEvent;
   }
 
-  CtxImpl.addAssociatedDeviceGlobal(MDeviceGlobalPtr);
+  // Only device globals with host variables need to be registered with the
+  // context. The rest will be managed by their kernel bundles and cleaned up
+  // accordingly.
+  if (MDeviceGlobalPtr)
+    CtxImpl.addAssociatedDeviceGlobal(MDeviceGlobalPtr);
   return NewAlloc;
 }
 
@@ -111,19 +122,32 @@ DeviceGlobalMapEntry::getOrAllocateDeviceGlobalUSM(const context &Context) {
          "USM allocation for device and context already happened.");
   DeviceGlobalUSMMem &NewAlloc = NewAllocIt.first->second;
 
-  // C++ guarantees members appear in memory in the order they are declared,
-  // so since the member variable that contains the initial contents of the
-  // device_global is right after the usm_ptr member variable we can do
-  // some pointer arithmetic to memcopy over this value to the usm_ptr. This
-  // value inside of the device_global will be zero-initialized if it was not
-  // given a value on construction.
-  MemoryManager::context_copy_usm(
-      reinterpret_cast<const void *>(
-          reinterpret_cast<uintptr_t>(MDeviceGlobalPtr) +
-          sizeof(MDeviceGlobalPtr)),
-      &CtxImpl, MDeviceGlobalTSize, NewAlloc.MPtr);
+  if (MDeviceGlobalPtr) {
+    // C++ guarantees members appear in memory in the order they are declared,
+    // so since the member variable that contains the initial contents of the
+    // device_global is right after the usm_ptr member variable we can do
+    // some pointer arithmetic to memcopy over this value to the usm_ptr. This
+    // value inside of the device_global will be zero-initialized if it was not
+    // given a value on construction.
+    MemoryManager::context_copy_usm(
+        reinterpret_cast<const void *>(
+            reinterpret_cast<uintptr_t>(MDeviceGlobalPtr) +
+            sizeof(MDeviceGlobalPtr)),
+        &CtxImpl, MDeviceGlobalTSize, NewAlloc.MPtr);
+  } else {
+    // For SYCLBIN device globals we do not have a host pointer to copy from,
+    // so instead we fill the USM memory with 0's.
+    std::vector<unsigned char> ImmBuff(MDeviceGlobalTSize,
+                                       static_cast<unsigned char>(0));
+    MemoryManager::context_copy_usm(ImmBuff.data(), &CtxImpl,
+                                    MDeviceGlobalTSize, NewAlloc.MPtr);
+  }
 
-  CtxImpl.addAssociatedDeviceGlobal(MDeviceGlobalPtr);
+  // Only device globals with host variables need to be registered with the
+  // context. The rest will be managed by their kernel bundles and cleaned up
+  // accordingly.
+  if (MDeviceGlobalPtr)
+    CtxImpl.addAssociatedDeviceGlobal(MDeviceGlobalPtr);
   return NewAlloc;
 }
 
@@ -148,6 +172,30 @@ void DeviceGlobalMapEntry::removeAssociatedResources(
       MDeviceToUSMPtrMap.erase(USMPtrIt);
     }
   }
+}
+
+void DeviceGlobalMapEntry::cleanup() {
+  std::lock_guard<std::mutex> Lock{MDeviceToUSMPtrMapMutex};
+  assert(MDeviceGlobalPtr == nullptr &&
+         "Entry has host variable, so it should be associated with a context "
+         "and should be cleaned up by its dtor.");
+  for (auto &USMPtrIt : MDeviceToUSMPtrMap) {
+    // The context should be alive through the kernel_bundle owning these
+    // device_global entries.
+    const context_impl *CtxImpl = USMPtrIt.first.second;
+    DeviceGlobalUSMMem &USMMem = USMPtrIt.second;
+    detail::usm::freeInternal(USMMem.MPtr, CtxImpl);
+    if (USMMem.MInitEvent.has_value())
+      CtxImpl->getAdapter()->call<UrApiKind::urEventRelease>(
+          *USMMem.MInitEvent);
+#ifndef NDEBUG
+    // For debugging we set the event and memory to some recognizable values
+    // to allow us to check that this cleanup happens before erasure.
+    USMMem.MPtr = nullptr;
+    USMMem.MInitEvent = {};
+#endif
+  }
+  MDeviceToUSMPtrMap.clear();
 }
 
 } // namespace detail

--- a/sycl/source/detail/device_global_map_entry.hpp
+++ b/sycl/source/detail/device_global_map_entry.hpp
@@ -55,7 +55,7 @@ struct DeviceGlobalMapEntry {
   // Pointer to the device_global on host.
   const void *MDeviceGlobalPtr = nullptr;
   // Images device_global are used by.
-  std::unordered_set<RTDeviceBinaryImage *> MImages;
+  std::unordered_set<const RTDeviceBinaryImage *> MImages;
   // The image identifiers for the images using the device_global used by in the
   // cache.
   std::set<std::uintptr_t> MImageIdentifiers;
@@ -71,7 +71,7 @@ struct DeviceGlobalMapEntry {
 
   // Constructor for only initializing ID, type size, and device image scope
   // flag. The pointer to the device global will be initialized later.
-  DeviceGlobalMapEntry(std::string UniqueId, RTDeviceBinaryImage *Img,
+  DeviceGlobalMapEntry(std::string UniqueId, const RTDeviceBinaryImage *Img,
                        std::uint32_t DeviceGlobalTSize,
                        bool IsDeviceImageScopeDecorated)
       : MUniqueId(UniqueId), MImages{Img},
@@ -89,7 +89,8 @@ struct DeviceGlobalMapEntry {
 
   // Initialize the device_global's element type size and the flag signalling
   // if the device_global has the device_image_scope property.
-  void initialize(RTDeviceBinaryImage *Img, std::uint32_t DeviceGlobalTSize,
+  void initialize(const RTDeviceBinaryImage *Img,
+                  std::uint32_t DeviceGlobalTSize,
                   bool IsDeviceImageScopeDecorated) {
     if (MDeviceGlobalTSize != 0) {
       // The device global entry has already been initialized. This can happen
@@ -118,6 +119,13 @@ struct DeviceGlobalMapEntry {
 
   // Removes resources for device_globals associated with the context.
   void removeAssociatedResources(const context_impl *CtxImpl);
+
+  // Cleans up the USM memory and intialization events associated with this
+  // entry. This should only be called when the device global entry is not
+  // owned by the program manager, as otherwise it will be bound to the lifetime
+  // of the owner context and will be cleaned up through
+  // removeAssociatedResources.
+  void cleanup();
 
 private:
   // Map from a device and a context to the associated USM allocation for the

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -84,20 +84,15 @@ public:
   bool hasDeviceGlobalName(const std::string &Name) const noexcept {
     return !MDeviceGlobalNames.empty() &&
            std::find(MDeviceGlobalNames.begin(), MDeviceGlobalNames.end(),
-                     mangleDeviceGlobalName(Name)) != MDeviceGlobalNames.end();
+                     Name) != MDeviceGlobalNames.end();
   }
 
   DeviceGlobalMapEntry *tryGetDeviceGlobalEntry(const std::string &Name) const {
     auto &PM = detail::ProgramManager::getInstance();
-    return PM.tryGetDeviceGlobalEntry(MPrefix + mangleDeviceGlobalName(Name));
+    return PM.tryGetDeviceGlobalEntry(MPrefix + Name);
   }
 
 private:
-  static std::string mangleDeviceGlobalName(const std::string &Name) {
-    // TODO: Support device globals declared in namespaces.
-    return "_Z" + std::to_string(Name.length()) + Name;
-  }
-
   void unregisterDeviceGlobalsFromContext() {
     if (MDeviceGlobalNames.empty())
       return;
@@ -1125,11 +1120,12 @@ private:
       // imports.
       // TODO: Consider making a collectDeviceImageDeps variant that takes a
       //       set reference and inserts into that instead.
-      std::set<RTDeviceBinaryImage *> ImgDeps;
+      std::set<const RTDeviceBinaryImage *> ImgDeps;
       for (const device &Device : DevImgImpl->get_devices()) {
-        std::set<RTDeviceBinaryImage *> DevImgDeps = PM.collectDeviceImageDeps(
-            *NewImage, *getSyclObjImpl(Device),
-            /*ErrorOnUnresolvableImport=*/State == bundle_state::executable);
+        std::set<const RTDeviceBinaryImage *> DevImgDeps =
+            PM.collectDeviceImageDeps(*NewImage, *getSyclObjImpl(Device),
+                                      /*ErrorOnUnresolvableImport=*/State ==
+                                          bundle_state::executable);
         ImgDeps.insert(DevImgDeps.begin(), DevImgDeps.end());
       }
 
@@ -1144,13 +1140,13 @@ private:
       if (State == bundle_state::executable) {
         // If target is executable we bundle the image and dependencies together
         // and bring it into state.
-        for (RTDeviceBinaryImage *ImgDep : ImgDeps)
+        for (const RTDeviceBinaryImage *ImgDep : ImgDeps)
           NewImageAndDeps.push_back(PM.createDependencyImage(
               MContext, SupportingDevsRef, ImgDep, bundle_state::input));
       } else if (State == bundle_state::object) {
         // If the target is object, we bring the dependencies into object state
         // individually and put them in the bundle.
-        for (RTDeviceBinaryImage *ImgDep : ImgDeps) {
+        for (const RTDeviceBinaryImage *ImgDep : ImgDeps) {
           DevImgPlainWithDeps ImgDepWithDeps{PM.createDependencyImage(
               MContext, SupportingDevsRef, ImgDep, bundle_state::input)};
           PM.bringSYCLDeviceImageToState(ImgDepWithDeps, State);

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -50,7 +50,7 @@ retrieveKernelBinary(queue_impl &Queue, KernelNameStrRefT KernelName,
         ProgramManager::getInstance().getRawDeviceImages(KernelIds);
     auto DeviceImage = std::find_if(
         DeviceImages.begin(), DeviceImages.end(),
-        [isNvidia](RTDeviceBinaryImage *DI) {
+        [isNvidia](const RTDeviceBinaryImage *DI) {
           const std::string &TargetSpec = isNvidia ? std::string("llvm_nvptx64")
                                                    : std::string("llvm_amdgcn");
           return DI->getFormat() == SYCL_DEVICE_BINARY_TYPE_LLVMIR_BITCODE &&

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -1145,7 +1145,7 @@ getOrBuildProgramForDeviceGlobal(queue_impl &Queue,
   // If there was no cached program, build one.
   auto Context = createSyclObjFromImpl<context>(ContextImpl);
   ProgramManager &PM = ProgramManager::getInstance();
-  RTDeviceBinaryImage &Img = PM.getDeviceImage(
+  const RTDeviceBinaryImage &Img = PM.getDeviceImage(
       DeviceGlobalEntry->MImages, ContextImpl, *getSyclObjImpl(Device));
 
   device_image_plain DeviceImage =

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -135,12 +135,12 @@ public:
   // process. Can only be called after staticInit is done.
   static ProgramManager &getInstance();
 
-  RTDeviceBinaryImage &getDeviceImage(KernelNameStrRefT KernelName,
-                                      context_impl &ContextImpl,
-                                      const device_impl &DeviceImpl);
+  const RTDeviceBinaryImage &getDeviceImage(KernelNameStrRefT KernelName,
+                                            context_impl &ContextImpl,
+                                            const device_impl &DeviceImpl);
 
-  RTDeviceBinaryImage &getDeviceImage(
-      const std::unordered_set<RTDeviceBinaryImage *> &ImagesToVerify,
+  const RTDeviceBinaryImage &getDeviceImage(
+      const std::unordered_set<const RTDeviceBinaryImage *> &ImagesToVerify,
       context_impl &ContextImpl, const device_impl &DeviceImpl);
 
   ur_program_handle_t createURProgram(const RTDeviceBinaryImage &Img,
@@ -287,7 +287,7 @@ public:
   HostPipeMapEntry *getHostPipeEntry(const void *HostPipePtr);
 
   device_image_plain
-  getDeviceImageFromBinaryImage(RTDeviceBinaryImage *BinImage,
+  getDeviceImageFromBinaryImage(const RTDeviceBinaryImage *BinImage,
                                 const context &Ctx, const device &Dev);
 
   // The function returns a vector of SYCL device images that are compiled with
@@ -299,7 +299,7 @@ public:
   // Creates a new dependency image for a given dependency binary image.
   device_image_plain createDependencyImage(const context &Ctx,
                                            const std::vector<device> &Devs,
-                                           RTDeviceBinaryImage *DepImage,
+                                           const RTDeviceBinaryImage *DepImage,
                                            bundle_state DepState);
 
   // Bring image to the required state. Does it inplace
@@ -377,13 +377,13 @@ public:
       KernelNameStrRefT KernelName,
       KernelNameBasedCacheT *KernelNameBasedCachePtr) const;
 
-  std::set<RTDeviceBinaryImage *>
+  std::set<const RTDeviceBinaryImage *>
   getRawDeviceImages(const std::vector<kernel_id> &KernelIDs);
 
-  std::set<RTDeviceBinaryImage *>
+  std::set<const RTDeviceBinaryImage *>
   collectDeviceImageDeps(const RTDeviceBinaryImage &Img, const device_impl &Dev,
                          bool ErrorOnUnresolvableImport = true);
-  std::set<RTDeviceBinaryImage *>
+  std::set<const RTDeviceBinaryImage *>
   collectDeviceImageDepsForImportedSymbols(const RTDeviceBinaryImage &Img,
                                            const device_impl &Dev,
                                            bool ErrorOnUnresolvableImport);
@@ -408,17 +408,17 @@ private:
   void dumpImage(const RTDeviceBinaryImage &Img, uint32_t SequenceID = 0) const;
 
   /// Add info on kernels using assert into cache
-  void cacheKernelUsesAssertInfo(RTDeviceBinaryImage &Img);
+  void cacheKernelUsesAssertInfo(const RTDeviceBinaryImage &Img);
 
   /// Add info on kernels using local arg into cache
-  void cacheKernelImplicitLocalArg(RTDeviceBinaryImage &Img);
+  void cacheKernelImplicitLocalArg(const RTDeviceBinaryImage &Img);
 
-  std::set<RTDeviceBinaryImage *>
+  std::set<const RTDeviceBinaryImage *>
   collectDependentDeviceImagesForVirtualFunctions(
       const RTDeviceBinaryImage &Img, const device_impl &Dev);
 
-  bool isBfloat16DeviceImage(RTDeviceBinaryImage *BinImage);
-  bool shouldBF16DeviceImageBeUsed(RTDeviceBinaryImage *BinImage,
+  bool isBfloat16DeviceImage(const RTDeviceBinaryImage *BinImage);
+  bool shouldBF16DeviceImageBeUsed(const RTDeviceBinaryImage *BinImage,
                                    const device_impl &DeviceImpl);
 
 protected:
@@ -437,7 +437,7 @@ protected:
   // in case of SPIRV + AOT.
   // Using shared_ptr to avoid expensive copy of the vector.
   /// Access must be guarded by the m_KernelIDsMutex mutex.
-  std::unordered_multimap<kernel_id, RTDeviceBinaryImage *>
+  std::unordered_multimap<kernel_id, const RTDeviceBinaryImage *>
       m_KernelIDs2BinImage;
 
   // Maps device binary image to a vector of kernel ids in this image.
@@ -445,7 +445,7 @@ protected:
   // The vector is initialized in addImages function and is supposed to be
   // immutable afterwards.
   /// Access must be guarded by the m_KernelIDsMutex mutex.
-  std::unordered_map<RTDeviceBinaryImage *,
+  std::unordered_map<const RTDeviceBinaryImage *,
                      std::shared_ptr<std::vector<kernel_id>>>
       m_BinImg2KernelIDs;
 
@@ -461,13 +461,13 @@ protected:
   /// in the sycl::detail::__sycl_service_kernel__ namespace which is
   /// exclusively used for this purpose.
   /// Access must be guarded by the m_KernelIDsMutex mutex.
-  std::unordered_multimap<KernelNameStrT, RTDeviceBinaryImage *>
+  std::unordered_multimap<KernelNameStrT, const RTDeviceBinaryImage *>
       m_ServiceKernels;
 
   /// Caches all exported symbols to allow faster lookup when excluding these
   // from kernel bundles.
   /// Access must be guarded by the m_KernelIDsMutex mutex.
-  std::unordered_multimap<KernelNameStrT, RTDeviceBinaryImage *>
+  std::unordered_multimap<KernelNameStrT, const RTDeviceBinaryImage *>
       m_ExportedSymbolImages;
 
   /// Keeps all device images we are refering to during program lifetime. Used
@@ -483,7 +483,7 @@ protected:
   /// Caches list of device images that use or provide virtual functions from
   /// the same set. Used to simplify access.
   /// Access must be guarded by the m_KernelIDsMutex mutex.
-  std::unordered_map<std::string, std::set<RTDeviceBinaryImage *>>
+  std::unordered_map<std::string, std::set<const RTDeviceBinaryImage *>>
       m_VFSet2BinImage;
 
   /// Protects built-in kernel ID cache.
@@ -533,7 +533,9 @@ protected:
   SanitizerType m_SanitizerFoundInImage;
 
   // Maps between device_global identifiers and associated information.
-  DeviceGlobalMap m_DeviceGlobals;
+  // The ownership of entry resources is taken to allow contexts to cleanup
+  // their associated entry resources when they die.
+  DeviceGlobalMap m_DeviceGlobals{/*OwnerControlledCleanup=*/true};
 
   // Maps between host_pipe identifiers and associated information.
   std::unordered_map<std::string, std::unique_ptr<HostPipeMapEntry>>

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2726,7 +2726,7 @@ void enqueueImpKernel(
 
   // Initialize device globals associated with this.
   std::vector<ur_event_handle_t> DeviceGlobalInitEvents =
-      ContextImpl->initializeDeviceGlobals(Program, Queue);
+      ContextImpl->initializeDeviceGlobals(Program, Queue, KernelBundleImplPtr);
   if (!DeviceGlobalInitEvents.empty()) {
     std::vector<ur_event_handle_t> EventsWithDeviceGlobalInits;
     EventsWithDeviceGlobalInits.reserve(RawEvents.size() +

--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -374,7 +374,7 @@ bool is_compatible(const std::vector<kernel_id> &KernelIDs, const device &Dev) {
   // the device and whose target matches the device.
   detail::device_impl &DevImpl = *getSyclObjImpl(Dev);
   for (const auto &KernelID : KernelIDs) {
-    std::set<detail::RTDeviceBinaryImage *> BinImages =
+    std::set<const detail::RTDeviceBinaryImage *> BinImages =
         detail::ProgramManager::getInstance().getRawDeviceImages({KernelID});
 
     if (std::none_of(BinImages.begin(), BinImages.end(),

--- a/sycl/test-e2e/SYCLBIN/Inputs/dg.hpp
+++ b/sycl/test-e2e/SYCLBIN/Inputs/dg.hpp
@@ -1,0 +1,104 @@
+#include "common.hpp"
+
+#include <sycl/usm.hpp>
+
+static constexpr size_t NUM = 1024;
+static constexpr size_t WGSIZE = 16;
+static constexpr float EPS = 0.001;
+
+int main(int argc, char *argv[]) {
+  assert(argc == 2);
+
+  sycl::queue Q;
+  sycl::device Dev = Q.get_device();
+
+  int Failed = CommonLoadCheck(Q.get_context(), argv[1]);
+
+#if defined(SYCLBIN_INPUT_STATE)
+  auto KBInput = syclexp::get_kernel_bundle<sycl::bundle_state::input>(
+      Q.get_context(), std::string{argv[1]});
+  auto KBExe1 = sycl::build(KBInput);
+  auto KBExe2 = sycl::build(KBInput);
+#elif defined(SYCLBIN_OBJECT_STATE)
+  auto KBObj = syclexp::get_kernel_bundle<sycl::bundle_state::object>(
+      Q.get_context(), std::string{argv[1]});
+  auto KBExe1 = sycl::link(KBObj);
+  auto KBExe2 = sycl::link(KBObj);
+#else // defined(SYCLBIN_EXECUTABLE_STATE)
+  auto KBExe1 = syclexp::get_kernel_bundle<sycl::bundle_state::executable>(
+      Q.get_context(), std::string{argv[1]});
+  auto KBExe2 = syclexp::get_kernel_bundle<sycl::bundle_state::executable>(
+      Q.get_context(), std::string{argv[1]});
+#endif
+
+  sycl::kernel AddK = KBExe1.ext_oneapi_get_kernel("ff_dg_adder");
+
+  // Check presence of device globals.
+  assert(KBExe1.ext_oneapi_has_device_global("DG"));
+  // Querying a non-existing device global shall not crash.
+  assert(!KBExe1.ext_oneapi_has_device_global("bogus_DG"));
+
+  void *DGAddr = KBExe1.ext_oneapi_get_device_global_address("DG", Dev);
+  size_t DGSize = KBExe1.ext_oneapi_get_device_global_size("DG");
+  assert(DGSize == 4);
+
+  int32_t Val = -1;
+  auto CheckVal = [&](int32_t Expected) {
+    Val = -1;
+    Q.memcpy(&Val, DGAddr, DGSize).wait();
+    if (Val != Expected) {
+      std::cout << "Val: " << Val << " != " << Expected << '\n';
+      ++Failed;
+    }
+  };
+
+  // Device globals are zero-initialized.
+  CheckVal(0);
+
+  // Set the DG.
+  Val = 123;
+  Q.memcpy(DGAddr, &Val, DGSize).wait();
+  CheckVal(123);
+
+  // Run a kernel using it.
+  Val = -17;
+  Q.submit([&](sycl::handler &CGH) {
+     CGH.set_args(Val);
+     CGH.single_task(AddK);
+   }).wait();
+  CheckVal(123 - 17);
+
+  // Test that each bundle has its distinct set of globals.
+  DGAddr = KBExe2.ext_oneapi_get_device_global_address("DG", Dev);
+  CheckVal(0);
+
+  DGAddr = KBExe1.ext_oneapi_get_device_global_address("DG", Dev);
+  CheckVal(123 - 17);
+
+  // Test global with `device_image_scope`. We currently cannot read/write these
+  // from the host, but they should work device-only.
+  auto SwapK = KBExe2.ext_oneapi_get_kernel("ff_swap");
+  int64_t *ValBuf = sycl::malloc_shared<int64_t>(1, Q);
+  *ValBuf = -1;
+  auto DoSwap = [&]() {
+    Q.submit([&](sycl::handler &CGH) {
+       CGH.set_args(ValBuf);
+       CGH.single_task(SwapK);
+     }).wait();
+  };
+
+  DoSwap();
+  if (*ValBuf != 0) {
+    std::cout << "ValBuf: " << *ValBuf << " != 0";
+    ++Failed;
+  }
+  DoSwap();
+  if (*ValBuf != -1) {
+    std::cout << "ValBuf: " << *ValBuf << " != -1";
+    ++Failed;
+  }
+
+  sycl::free(ValBuf, Q);
+
+  return Failed;
+}

--- a/sycl/test-e2e/SYCLBIN/Inputs/dg_kernel.cpp
+++ b/sycl/test-e2e/SYCLBIN/Inputs/dg_kernel.cpp
@@ -1,0 +1,21 @@
+#include <sycl/sycl.hpp>
+
+namespace syclex = sycl::ext::oneapi::experimental;
+
+syclex::device_global<int32_t> DG;
+
+extern "C" SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (syclex::single_task_kernel)) void ff_dg_adder(int val) {
+  DG += val;
+}
+
+syclex::device_global<int64_t,
+                      decltype(syclex::properties(syclex::device_image_scope))>
+    DG_DIS;
+
+extern "C" SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (syclex::single_task_kernel)) void ff_swap(int64_t *val) {
+  int64_t tmp = DG_DIS;
+  DG_DIS = *val;
+  *val = tmp;
+}

--- a/sycl/test-e2e/SYCLBIN/dg_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_executable.cpp
@@ -1,0 +1,25 @@
+//==----------- dg_executable.cpp --- SYCLBIN extension tests
+//-------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: aspect-usm_device_allocations
+
+// -- Test for using device globals in SYCLBIN.
+
+// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
+// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
+// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
+// REQUIRES: target-spir
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=executable %S/Inputs/dg_kernel.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{l0_leak_check} %{run} %t.out %t.syclbin
+
+#define SYCLBIN_EXECUTABLE_STATE
+
+#include "Inputs/dg.hpp"

--- a/sycl/test-e2e/SYCLBIN/dg_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_input.cpp
@@ -1,0 +1,24 @@
+//==----------- dg_input.cpp --- SYCLBIN extension tests -------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: aspect-usm_device_allocations
+
+// -- Test for using device globals in SYCLBIN.
+
+// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
+// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
+// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
+// REQUIRES: target-spir
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=input %S/Inputs/dg_kernel.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{l0_leak_check} %{run} %t.out %t.syclbin
+
+#define SYCLBIN_INPUT_STATE
+
+#include "Inputs/dg.hpp"

--- a/sycl/test-e2e/SYCLBIN/dg_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_object.cpp
@@ -1,0 +1,24 @@
+//==----------- dg_object.cpp --- SYCLBIN extension tests ------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: aspect-usm_device_allocations
+
+// -- Test for using device globals in SYCLBIN.
+
+// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
+// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
+// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
+// REQUIRES: target-spir
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=object %S/Inputs/dg_kernel.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{l0_leak_check} %{run} %t.out %t.syclbin
+
+#define SYCLBIN_OBJECT_STATE
+
+#include "Inputs/dg.hpp"

--- a/sycl/test/e2e_test_requirements/no_sycl_hpp_in_e2e_tests.cpp
+++ b/sycl/test/e2e_test_requirements/no_sycl_hpp_in_e2e_tests.cpp
@@ -6,7 +6,7 @@
 // CHECK-DAG: README.md
 // CHECK-DAG: lit.cfg.py
 //
-// CHECK-NUM-MATCHES: 25
+// CHECK-NUM-MATCHES: 26
 //
 // This test verifies that `<sycl/sycl.hpp>` isn't used in E2E tests. Instead,
 // fine-grained includes should used, see

--- a/sycl/unittests/program_manager/Cleanup.cpp
+++ b/sycl/unittests/program_manager/Cleanup.cpp
@@ -13,7 +13,7 @@
 class ProgramManagerExposed : public sycl::detail::ProgramManager {
 public:
   std::unordered_multimap<sycl::kernel_id,
-                          sycl::detail::RTDeviceBinaryImage *> &
+                          const sycl::detail::RTDeviceBinaryImage *> &
   getKernelID2BinImage() {
     return m_KernelIDs2BinImage;
   }
@@ -23,20 +23,20 @@ public:
     return m_KernelName2KernelIDs;
   }
 
-  std::unordered_map<sycl::detail::RTDeviceBinaryImage *,
+  std::unordered_map<const sycl::detail::RTDeviceBinaryImage *,
                      std::shared_ptr<std::vector<sycl::kernel_id>>> &
   getBinImage2KernelId() {
     return m_BinImg2KernelIDs;
   }
 
   std::unordered_multimap<sycl::detail::KernelNameStrT,
-                          sycl::detail::RTDeviceBinaryImage *> &
+                          const sycl::detail::RTDeviceBinaryImage *> &
   getServiceKernels() {
     return m_ServiceKernels;
   }
 
   std::unordered_multimap<sycl::detail::KernelNameStrT,
-                          sycl::detail::RTDeviceBinaryImage *> &
+                          const sycl::detail::RTDeviceBinaryImage *> &
   getExportedSymbolImages() {
     return m_ExportedSymbolImages;
   }
@@ -48,7 +48,7 @@ public:
   }
 
   std::unordered_map<std::string,
-                     std::set<sycl::detail::RTDeviceBinaryImage *>> &
+                     std::set<const sycl::detail::RTDeviceBinaryImage *>> &
   getVFSet2BinImage() {
     return m_VFSet2BinImage;
   }


### PR DESCRIPTION
This commit changes the use of RTDeviceBinaryImage pointers to be const in more places. Primary cases where we break this is for compressed images, where decompression happens semi-lazily, so const-casts are occassionally necessary.