### PR TITLE
[CI][Benchmarks] update compute runtime

### DIFF
--- a/devops/scripts/benchmarks/options.py
+++ b/devops/scripts/benchmarks/options.py
@@ -65,7 +65,7 @@ class Options:
     build_compute_runtime: bool = False
     extra_ld_libraries: list[str] = field(default_factory=list)
     extra_env_vars: dict = field(default_factory=dict)
-    compute_runtime_tag: str = "25.22.33944.4"
+    compute_runtime_tag: str = "25.22.33944.8"
     build_igc: bool = False
     current_run_name: str = "This PR"
     preset: str = "Full"


### PR DESCRIPTION
Results look OK:
https://oneapi-src.github.io/unified-runtime/performance/?tags=L0&runs=Baseline_BMG_L0v2%2C25_22_8_BMG_L0v2
https://oneapi-src.github.io/unified-runtime/performance/?tags=L0&runs=Baseline_PVC_L0v2%2C25_22_8_PVC_L0v2

There is a very slight regression in SubmitKernel In Order with completion:
![api_overhead_benchmark_l0 SubmitKernel in order with measure completion not using events (1)](https://github.com/user-attachments/assets/3269c2cf-9341-44a0-b6c7-60b24d83973a)

But it looks like it's simply a case of an optimization being reverted.