### PR TITLE
[NFC][SYCL] Remove `ContextImplPtr` type alias

### DIFF
--- a/sycl/include/sycl/interop_handle.hpp
+++ b/sycl/include/sycl/interop_handle.hpp
@@ -205,6 +205,12 @@ private:
   friend class detail::DispatchHostTask;
   using ReqToMem = std::pair<detail::AccessorImplHost *, ur_mem_handle_t>;
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  // Clean this up (no shared pointers). Not doing it right now because I expect
+  // there will be several iterations of simplifications possible and it would
+  // be hard to track which of them made their way into a minor public release
+  // and which didn't. Let's just clean it up once during ABI breaking window.
+#endif
   interop_handle(std::vector<ReqToMem> MemObjs,
                  const std::shared_ptr<detail::queue_impl> &Queue,
                  const std::shared_ptr<detail::device_impl> &Device,

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -29,7 +29,6 @@ class context;
 namespace detail {
 class Adapter;
 class context_impl;
-using ContextImplPtr = std::shared_ptr<sycl::detail::context_impl>;
 class queue_impl;
 class event_impl;
 using EventImplPtr = std::shared_ptr<sycl::detail::event_impl>;
@@ -388,7 +387,7 @@ protected:
   std::atomic<ur_event_handle_t> MEvent = nullptr;
   // Stores submission time of command associated with event
   uint64_t MSubmitTime = 0;
-  ContextImplPtr MContext;
+  std::shared_ptr<context_impl> MContext;
   std::unique_ptr<HostProfilingInfo> MHostProfilingInfo;
   void *MCommand = nullptr;
   std::weak_ptr<queue_impl> MQueue;

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -185,7 +185,7 @@ ProgramManager &GlobalHandler::getProgramManager() {
   return PM;
 }
 
-std::unordered_map<platform_impl *, ContextImplPtr> &
+std::unordered_map<platform_impl *, std::shared_ptr<context_impl>> &
 GlobalHandler::getPlatformToDefaultContextCache() {
   // The optimization with static reference is not done because
   // there are public methods of the GlobalHandler

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -29,8 +29,6 @@ class XPTIRegistry;
 class ThreadPool;
 struct KernelNameBasedCacheT;
 
-using ContextImplPtr = std::shared_ptr<context_impl>;
-
 /// Wrapper class for global data structures with non-trivial destructors.
 ///
 /// As user code can call SYCL Runtime functions from destructor of global
@@ -64,7 +62,7 @@ public:
 
   void clearPlatforms();
 
-  std::unordered_map<platform_impl *, ContextImplPtr> &
+  std::unordered_map<platform_impl *, std::shared_ptr<context_impl>> &
   getPlatformToDefaultContextCache();
 
   std::mutex &getPlatformToDefaultContextCacheMutex();
@@ -120,7 +118,8 @@ private:
   InstWithLock<ProgramManager> MProgramManager;
   InstWithLock<Sync> MSync;
   InstWithLock<std::vector<std::shared_ptr<platform_impl>>> MPlatformCache;
-  InstWithLock<std::unordered_map<platform_impl *, ContextImplPtr>>
+  InstWithLock<
+      std::unordered_map<platform_impl *, std::shared_ptr<context_impl>>>
       MPlatformToDefaultContextCache;
   InstWithLock<std::mutex> MPlatformToDefaultContextCacheMutex;
   InstWithLock<std::mutex> MPlatformMapMutex;

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -49,8 +49,6 @@ namespace sycl {
 inline namespace _V1 {
 namespace detail {
 
-using ContextImplPtr = std::shared_ptr<sycl::detail::context_impl>;
-
 static constexpr int DbgProgMgr = 0;
 
 static constexpr char UseSpvEnv[]("SYCL_USE_KERNEL_SPV");

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -72,7 +72,6 @@ bool doesImageTargetMatchDevice(const RTDeviceBinaryImage &Img,
 static constexpr uint32_t inline ITTSpecConstId = 0xFF747469;
 
 class context_impl;
-using ContextImplPtr = std::shared_ptr<context_impl>;
 class device_impl;
 class queue_impl;
 class event_impl;

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -51,8 +51,6 @@ class node_impl;
 
 namespace detail {
 
-using ContextImplPtr = std::shared_ptr<detail::context_impl>;
-
 /// Sets max number of queues supported by FPGA RT.
 static constexpr size_t MaxNumQueues = 256;
 
@@ -289,7 +287,11 @@ public:
 
   const AdapterPtr &getAdapter() const { return MContext->getAdapter(); }
 
-  const ContextImplPtr &getContextImplPtr() const { return MContext; }
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+  const std::shared_ptr<context_impl> &getContextImplPtr() const {
+    return MContext;
+  }
+#endif
 
   context_impl &getContextImpl() const { return *MContext; }
 


### PR DESCRIPTION
With most of the `context_impl` passed by raw ptr/ref it's not increasing readability anymore.