### PR TITLE
[NFC][SYCL] Drop `RepeatValue` helper

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -364,19 +364,6 @@ struct ArrayCreator<DataT, FlattenF> {
   static constexpr auto Create() { return std::array<DataT, 0>{}; }
 };
 
-// Helper function for creating an arbitrary sized array with the same value
-// repeating.
-template <typename T, size_t... Is>
-static constexpr std::array<T, sizeof...(Is)>
-RepeatValueHelper(const T &Arg, std::index_sequence<Is...>) {
-  auto ReturnArg = [&](size_t) { return Arg; };
-  return {ReturnArg(Is)...};
-}
-template <size_t N, typename T>
-static constexpr std::array<T, N> RepeatValue(const T &Arg) {
-  return RepeatValueHelper(Arg, std::make_index_sequence<N>());
-}
-
 // to output exceptions caught in ~destructors
 #ifndef NDEBUG
 #define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, e)                              \

--- a/sycl/include/sycl/vector.hpp
+++ b/sycl/include/sycl/vector.hpp
@@ -33,7 +33,7 @@
 
 #include <sycl/access/access.hpp>              // for decorated, address_space
 #include <sycl/aliases.hpp>                    // for half, cl_char, cl_int
-#include <sycl/detail/common.hpp>              // for ArrayCreator, RepeatV...
+#include <sycl/detail/common.hpp>              // for ArrayCreator
 #include <sycl/detail/defines_elementary.hpp>  // for __SYCL2020_DEPRECATED
 #include <sycl/detail/generic_type_traits.hpp> // for is_sigeninteger, is_s...
 #include <sycl/detail/memcpy.hpp>              // for memcpy
@@ -195,6 +195,10 @@ protected:
   alignas(alignment) DataType m_Data;
 
   template <size_t... Is>
+  constexpr vec_base(const DataT &Val, std::index_sequence<Is...>)
+      : m_Data{((void)Is, Val)...} {}
+
+  template <size_t... Is>
   constexpr vec_base(const std::array<DataT, NumElements> &Arr,
                      std::index_sequence<Is...>)
       : m_Data{Arr[Is]...} {}
@@ -262,8 +266,7 @@ public:
   constexpr vec_base &operator=(vec_base &&) = default;
 
   explicit constexpr vec_base(const DataT &arg)
-      : vec_base(RepeatValue<NumElements>(arg),
-                 std::make_index_sequence<NumElements>()) {}
+      : vec_base(arg, std::make_index_sequence<NumElements>()) {}
 
   template <typename... argTN,
             typename = std::enable_if_t<


### PR DESCRIPTION
`vec_base` ctor already uses a private helper to pass `std::index_sequence`, no reason to go through another such helper.