### PR TITLE
[NFC][SYCL] More cleanup after `enable_shared_from_this` for `kernel_bundle_impl`

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -323,7 +323,7 @@ kernel make_kernel(const context &TargetContext,
                    backend Backend) {
   const auto &Adapter = getAdapter(Backend);
   const auto &ContextImpl = getSyclObjImpl(TargetContext);
-  const auto &KernelBundleImpl = getSyclObjImpl(KernelBundle);
+  kernel_bundle_impl &KernelBundleImpl = *getSyclObjImpl(KernelBundle);
 
   // For Level-Zero expect exactly one device image in the bundle. This is
   // natural for interop kernel to get created out of a single native
@@ -334,7 +334,7 @@ kernel make_kernel(const context &TargetContext,
   //
   ur_program_handle_t UrProgram = nullptr;
   if (Backend == backend::ext_oneapi_level_zero) {
-    if (KernelBundleImpl->size() != 1)
+    if (KernelBundleImpl.size() != 1)
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::runtime),
           "make_kernel: kernel_bundle must have single program image " +
@@ -360,7 +360,7 @@ kernel make_kernel(const context &TargetContext,
 
   // Construct the SYCL queue from UR queue.
   return detail::createSyclObjFromImpl<kernel>(
-      std::make_shared<kernel_impl>(UrKernel, *ContextImpl, KernelBundleImpl));
+      std::make_shared<kernel_impl>(UrKernel, *ContextImpl, &KernelBundleImpl));
 }
 
 kernel make_kernel(ur_native_handle_t NativeHandle,

--- a/sycl/source/detail/device_image_impl.cpp
+++ b/sycl/source/detail/device_image_impl.cpp
@@ -35,8 +35,8 @@ std::shared_ptr<kernel_impl> device_image_impl::tryGetExtensionKernel(
           PM.getOrCreateKernel(Context, AdjustedName,
                                /*PropList=*/{}, UrProgram);
       return std::make_shared<kernel_impl>(UrKernel, *getSyclObjImpl(Context),
-                                           Self, OwnerBundle.shared_from_this(),
-                                           ArgMask, UrProgram, CacheMutex);
+                                           Self, OwnerBundle, ArgMask,
+                                           UrProgram, CacheMutex);
     }
     return nullptr;
   }
@@ -49,8 +49,7 @@ std::shared_ptr<kernel_impl> device_image_impl::tryGetExtensionKernel(
   // Kernel created by urKernelCreate is implicitly retained.
 
   return std::make_shared<kernel_impl>(
-      UrKernel, *detail::getSyclObjImpl(Context), Self,
-      OwnerBundle.shared_from_this(),
+      UrKernel, *detail::getSyclObjImpl(Context), Self, OwnerBundle,
       /*ArgMask=*/nullptr, UrProgram, /*CacheMutex=*/nullptr);
 }
 

--- a/sycl/source/detail/handler_impl.hpp
+++ b/sycl/source/detail/handler_impl.hpp
@@ -22,8 +22,6 @@ class dynamic_parameter_impl;
 } // namespace ext::oneapi::experimental::detail
 namespace detail {
 
-using KernelBundleImplPtr = std::shared_ptr<detail::kernel_bundle_impl>;
-
 enum class HandlerSubmissionState : std::uint8_t {
   NO_STATE = 0,
   EXPLICIT_KERNEL_BUNDLE_STATE,

--- a/sycl/source/detail/kernel_impl.hpp
+++ b/sycl/source/detail/kernel_impl.hpp
@@ -40,7 +40,7 @@ public:
   /// \param Context is a valid SYCL context
   /// \param KernelBundleImpl is a valid instance of kernel_bundle_impl
   kernel_impl(ur_kernel_handle_t Kernel, context_impl &Context,
-              KernelBundleImplPtr KernelBundleImpl,
+              kernel_bundle_impl *KernelBundleImpl,
               const KernelArgMask *ArgMask = nullptr);
 
   /// Constructs a SYCL kernel_impl instance from a SYCL device_image,
@@ -51,7 +51,7 @@ public:
   /// \param KernelBundleImpl is a valid instance of kernel_bundle_impl
   kernel_impl(ur_kernel_handle_t Kernel, context_impl &ContextImpl,
               DeviceImageImplPtr DeviceImageImpl,
-              KernelBundleImplPtr &&KernelBundleImpl,
+              const kernel_bundle_impl &KernelBundleImpl,
               const KernelArgMask *ArgMask, ur_program_handle_t Program,
               std::mutex *CacheMutex);
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2536,7 +2536,7 @@ getCGKernelInfo(const CGExecKernel &CommandGroup, context_impl &ContextImpl,
   ur_kernel_handle_t UrKernel = nullptr;
   std::shared_ptr<device_image_impl> DeviceImageImpl = nullptr;
   const KernelArgMask *EliminatedArgMask = nullptr;
-  auto &KernelBundleImplPtr = CommandGroup.MKernelBundle;
+  kernel_bundle_impl *KernelBundleImplPtr = CommandGroup.MKernelBundle.get();
 
   if (auto Kernel = CommandGroup.MSyclKernel; Kernel != nullptr) {
     UrKernel = Kernel->getHandleRef();

--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -213,7 +213,7 @@ get_kernel_bundle_impl(const context &Ctx, const std::vector<device> &Devs,
 detail::KernelBundleImplPtr
 get_kernel_bundle_impl(const context &Ctx, const std::vector<device> &Devs,
                        const sycl::span<char> &Bytes, bundle_state State) {
-  return std::make_shared<detail::kernel_bundle_impl>(Ctx, Devs, Bytes, State);
+  return detail::kernel_bundle_impl::create(Ctx, Devs, Bytes, State);
 }
 
 detail::KernelBundleImplPtr
@@ -524,8 +524,8 @@ obj_kb compile_from_source(
     LogPtr = &Log;
   std::vector<device> UniqueDevices =
       sycl::detail::removeDuplicateDevices(Devices);
-  std::shared_ptr<kernel_bundle_impl> sourceImpl = getSyclObjImpl(SourceKB);
-  std::shared_ptr<kernel_bundle_impl> KBImpl = sourceImpl->compile_from_source(
+  kernel_bundle_impl &sourceImpl = *getSyclObjImpl(SourceKB);
+  std::shared_ptr<kernel_bundle_impl> KBImpl = sourceImpl.compile_from_source(
       UniqueDevices, BuildOptions, LogPtr, RegisteredKernelNames);
   auto result = sycl::detail::createSyclObjFromImpl<obj_kb>(KBImpl);
   if (LogView)
@@ -548,9 +548,8 @@ exe_kb build_from_source(
     LogPtr = &Log;
   std::vector<device> UniqueDevices =
       sycl::detail::removeDuplicateDevices(Devices);
-  const std::shared_ptr<kernel_bundle_impl> &sourceImpl =
-      getSyclObjImpl(SourceKB);
-  std::shared_ptr<kernel_bundle_impl> KBImpl = sourceImpl->build_from_source(
+  kernel_bundle_impl &sourceImpl = *getSyclObjImpl(SourceKB);
+  std::shared_ptr<kernel_bundle_impl> KBImpl = sourceImpl.build_from_source(
       UniqueDevices, BuildOptions, LogPtr, RegisteredKernelNames);
   auto result = sycl::detail::createSyclObjFromImpl<exe_kb>(std::move(KBImpl));
   if (LogView)


### PR DESCRIPTION
Follow-up for https://github.com/intel/llvm/pull/18899.

Also adds proper `private_tag` argument for the ctor added in https://github.com/intel/llvm/pull/18949 that missed that. Also pass `span` by value while on it.