### PR TITLE
[SYCL] Add workaround for undeterminable constexpr lambda return

### DIFF
--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -48,7 +48,7 @@ using properties_t =
     properties<detail::properties_type_list<PropertyValueTs...>>;
 
 template <typename... property_tys>
-inline constexpr bool properties_are_unique = []() constexpr {
+inline constexpr bool properties_are_unique = []() constexpr -> bool {
   if constexpr (sizeof...(property_tys) == 0) {
     return true;
   } else {
@@ -64,7 +64,7 @@ inline constexpr bool properties_are_unique = []() constexpr {
 }();
 
 template <typename... property_tys>
-inline constexpr bool properties_are_sorted = []() constexpr {
+inline constexpr bool properties_are_sorted = []() constexpr -> bool {
   if constexpr (sizeof...(property_tys) == 0) {
     return true;
   } else {

--- a/sycl/include/sycl/ext/oneapi/properties/property.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property.hpp
@@ -258,7 +258,7 @@ protected:
   // Temporary, to ensure new code matches previous behavior and to catch any
   // silly copy-paste mistakes. MSVC can't compile it, but linux-only is
   // enough for this temporary check.
-  static_assert([]() constexpr {
+  static_assert([]() constexpr -> bool {
     if constexpr (std::is_same_v<property_t, key_t>)
       // key_t is incomplete at this point for runtime properties.
       return true;

--- a/sycl/test/regression/grf_properties_wa.cpp
+++ b/sycl/test/regression/grf_properties_wa.cpp
@@ -1,0 +1,15 @@
+// RUN: %clangxx -fsycl -fsyntax-only %s
+
+// Test for a workaround to a bug in clang causing some constexpr lambda
+// expressions to not be identified as returning a bool.
+
+#include <sycl/detail/kernel_properties.hpp>
+#include <sycl/ext/intel/experimental/grf_size_properties.hpp>
+#include <sycl/sycl.hpp>
+
+int main() {
+  if constexpr (false) {
+    sycl::ext::oneapi::experimental::properties prop{
+        sycl::ext::intel::experimental::grf_size<256>};
+  }
+}


### PR DESCRIPTION
Due to a bug in the compiler, certain conditions give false compiler errors for return types of constexpr lambdas. This commit implements workarounds for cases that affect the SYCL headers when using properties.