### PR TITLE
[CI][NFC] Remove Windows driver listing in dependencies.json

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -37,12 +37,6 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclcpu"
     }
   },
-  "windows": {
-    "compute_runtime": {
-      "version": "101.1191",
-      "url": "https://downloadmirror.intel.com/691496/igfx_win_101.1191.zip",
-      "root": ""
-    },
     "tbb": {
       "github_tag": "v2022.1.0",
       "version": "2022.1.0",


### PR DESCRIPTION
We don't use this and it's all done manually, and JSON doesn't support comments, so just remove it to prevent confusion.

The `tbb` and `oclcpu` ones aren't used either, but it's updated by the team to have the download link we use to manually install, so keep those.

Issue: https://github.com/intel/llvm/issues/19192