### PR TITLE
[SYCL][Bindless] Add DX11 memory interop

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
@@ -2074,6 +2074,7 @@ enum class external_mem_handle_type {
   opaque_fd = 0,
   win32_nt_handle = 1,
   win32_nt_dx12_resource = 2,
+  win32_nt_dx11_resource = 3,
 };
 
 // Descriptor templated on specific resource type
@@ -2728,3 +2729,5 @@ This query should be added in a later revision of the proposal.
 |6.10|2025-05-09| - Add `unmap_external_image_memory` and 
                     `unmap_external_linear_memory` APIs.
                   - Clarify how and when external memory should be unmapped.
+|6.11|2025-05-29| - Add `win32_nt_dx11_resource` enum entry to
+                    `external_mem_handle_type` for Direct3D 11 memory interop.

--- a/sycl/include/sycl/ext/oneapi/bindless_images_interop.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images_interop.hpp
@@ -21,6 +21,7 @@ enum class external_mem_handle_type {
   opaque_fd = 0,
   win32_nt_handle = 1,
   win32_nt_dx12_resource = 2,
+  win32_nt_dx11_resource = 3,
 };
 
 // Types of external semaphore handles

--- a/sycl/source/detail/bindless_images.cpp
+++ b/sycl/source/detail/bindless_images.cpp
@@ -447,6 +447,9 @@ __SYCL_EXPORT external_mem import_external_memory<resource_win32_handle>(
   case external_mem_handle_type::win32_nt_dx12_resource:
     urHandleType = UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE;
     break;
+  case external_mem_handle_type::win32_nt_dx11_resource:
+    urHandleType = UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE;
+    break;
   default:
     throw sycl::exception(sycl::make_error_code(sycl::errc::invalid),
                           "Invalid memory handle type");

--- a/sycl/test-e2e/bindless_images/dx11_interop/dx11_interop.h
+++ b/sycl/test-e2e/bindless_images/dx11_interop/dx11_interop.h
@@ -8,6 +8,8 @@
 
 #include <sycl/detail/core.hpp>
 
+#include <atomic>
+
 using namespace dx_helpers;
 
 namespace dx11_interop {
@@ -22,7 +24,7 @@ struct D3D11ProgramState {
   // Can also store a DXGI_ADAPTER_DESC if more state is needed.
   std::string deviceName;
 
-  // Keyed mutex ID for synchronizing access to the shared resource per device.
+  // Keyed mutex ID for synchronizing access to the shared resource.
   std::atomic<UINT64> key;
 
   D3D11ProgramState() = default;

--- a/sycl/test-e2e/bindless_images/dx11_interop/dx11_interop.h
+++ b/sycl/test-e2e/bindless_images/dx11_interop/dx11_interop.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#pragma clang diagnostic ignored "-Waddress-of-temporary"
+
+#include "../helpers/common.hpp"
+#include "../helpers/dx_interop_common.hpp"
+using namespace dx_helpers;
+
+#include <sycl/detail/core.hpp>
+#include <sycl/properties/queue_properties.hpp>
+
+namespace dx11_interop {
+
+/// @brief
+struct g_d3d11ProgramState {
+  // device management
+  ID3D11Device *device{nullptr};
+  ID3D11DeviceContext *deviceContext{nullptr};
+
+  // Temporary, this is to be replaced by LUID.
+  // Can also store a DXGI_ADAPTER_DESC if more state is needed.
+  std::string deviceName;
+
+  g_d3d11ProgramState() = default;
+  ~g_d3d11ProgramState();
+};
+
+g_d3d11ProgramState::~g_d3d11ProgramState() {
+  if (device)
+    device->Release();
+  if (deviceContext)
+    deviceContext->Release();
+}
+
+void initializeD3D11(g_d3d11ProgramState *d3d11ProgramState) {
+  assert(d3d11ProgramState);
+
+  UINT dxgiFactoryFlags = 0;
+#if WITH_DX_DEBUG
+  dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+#endif
+  ComPtr<IDXGIFactory3> factory;
+  ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+
+  ComPtr<IDXGIAdapter1> hardwareAdapter;
+#if defined(PREFER_INTEGRATED_GPU)
+  constexpr auto devicePreference = device_preference::Integrated;
+#else
+  constexpr auto devicePreference = device_preference::Dedicated;
+#endif
+  getDXGIHardwareAdapter<dx_version::DX11>(factory.Get(), &hardwareAdapter,
+                                           devicePreference);
+  if (!hardwareAdapter && devicePreference != device_preference::Unspecified) {
+    // Request again but this time falling back to any available GPU.
+    getDXGIHardwareAdapter<dx_version::DX11>(factory.Get(), &hardwareAdapter);
+  }
+  // At this point we must have a valid DirectX hardware adapter.
+  // This will be resolved once LUID device queries are introduced in SYCL, so
+  // we can first create a sycl device and match it exactly to the DirectX HW
+  // adapter, so we won't need any of the generic heuristics that the above
+  // GetHardwareAdapter function implements in order to find a "suitable" GPU.
+  // That way we will also be able to control it via ONEAPI_DEVICE_SELECTOR
+  // env.
+  assert(hardwareAdapter && "Could not find a valid DirectX hardware adapter.");
+
+  // Creating the D3D11 device.
+  ComPtr<ID3D11Device> device = nullptr;
+  ComPtr<ID3D11DeviceContext> deviceContext = nullptr;
+  UINT deviceFlags = 0;
+#if defined(D3D_DEVICE_DEBUG)
+  deviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+#endif
+  constexpr D3D_FEATURE_LEVEL requestedFeatureLevel = D3D_FEATURE_LEVEL_11_0;
+  D3D_FEATURE_LEVEL featureLevel;
+  ThrowIfFailed(D3D11CreateDevice(hardwareAdapter.Get(),
+                                  D3D_DRIVER_TYPE_UNKNOWN, nullptr, deviceFlags,
+                                  &requestedFeatureLevel, 1, D3D11_SDK_VERSION,
+                                  &device, &featureLevel, &deviceContext));
+
+  // Get the description of the adapter which contains the LUID, etc.
+  DXGI_ADAPTER_DESC1 adapterDesc;
+  ThrowIfFailed(hardwareAdapter->GetDesc1(&adapterDesc));
+
+  d3d11ProgramState->device = device.Detach();
+  d3d11ProgramState->deviceContext = deviceContext.Detach();
+
+  // Convert the description string to a narrow string.
+  // This conversion is a little imperfect due to consideration for locale etc.
+  std::string description{};
+  std::wstring wstrDescription = adapterDesc.Description;
+  std::transform(std::begin(wstrDescription), std::end(wstrDescription),
+                 std::back_inserter(description),
+                 [](wchar_t c) { return static_cast<char>(c); });
+  d3d11ProgramState->deviceName = std::move(description);
+}
+
+inline sycl::device
+getSyclDeviceFromDX11(const g_d3d11ProgramState *d3d11ProgramState) {
+  assert(d3d11ProgramState);
+  return sycl::device(
+      [deviceName = d3d11ProgramState->deviceName](const sycl::device &dev) {
+        int score{-1};
+        // We want a GPU device.
+        if (dev.is_gpu()) {
+          score = 1000;
+        }
+
+        // This heuristic, comparing names, is a little silly, ideally we want
+        // device LUID matching. If we create the SYCL device first we will not
+        // need the selector and instead compare LUIDs on D3D11 device creation.
+        if (const std::string name = dev.get_info<sycl::info::device::name>();
+            deviceName.find(name) != std::string::npos ||
+            name.find(deviceName) != std::string::npos) {
+          score += 500;
+        }
+        return score;
+      });
+}
+
+} // namespace dx11_interop

--- a/sycl/test-e2e/bindless_images/dx11_interop/dx11_interop.h
+++ b/sycl/test-e2e/bindless_images/dx11_interop/dx11_interop.h
@@ -12,7 +12,7 @@ using namespace dx_helpers;
 namespace dx11_interop {
 
 /// @brief
-struct g_d3d11ProgramState {
+struct D3D11ProgramState {
   // device management
   ID3D11Device *device{nullptr};
   ID3D11DeviceContext *deviceContext{nullptr};
@@ -21,18 +21,18 @@ struct g_d3d11ProgramState {
   // Can also store a DXGI_ADAPTER_DESC if more state is needed.
   std::string deviceName;
 
-  g_d3d11ProgramState() = default;
-  ~g_d3d11ProgramState();
+  D3D11ProgramState() = default;
+  ~D3D11ProgramState();
 };
 
-g_d3d11ProgramState::~g_d3d11ProgramState() {
+D3D11ProgramState::~D3D11ProgramState() {
   if (device)
     device->Release();
   if (deviceContext)
     deviceContext->Release();
 }
 
-void initializeD3D11(g_d3d11ProgramState *d3d11ProgramState) {
+void initializeD3D11(D3D11ProgramState *d3d11ProgramState) {
   assert(d3d11ProgramState);
 
   UINT dxgiFactoryFlags = 0;
@@ -61,7 +61,7 @@ void initializeD3D11(g_d3d11ProgramState *d3d11ProgramState) {
   // GetHardwareAdapter function implements in order to find a "suitable" GPU.
   // That way we will also be able to control it via ONEAPI_DEVICE_SELECTOR
   // env.
-  assert(hardwareAdapter && "Could not find a valid DirectX hardware adapter.");
+  assert(hardwareAdapter && "Invalid DirectX hardware adapter.");
 
   // Creating the D3D11 device.
   ComPtr<ID3D11Device> device = nullptr;
@@ -95,7 +95,7 @@ void initializeD3D11(g_d3d11ProgramState *d3d11ProgramState) {
 }
 
 inline sycl::device
-getSyclDeviceFromDX11(const g_d3d11ProgramState *d3d11ProgramState) {
+getSyclDeviceFromDX11(const D3D11ProgramState *d3d11ProgramState) {
   assert(d3d11ProgramState);
   return sycl::device(
       [deviceName = d3d11ProgramState->deviceName](const sycl::device &dev) {

--- a/sycl/test-e2e/bindless_images/dx11_interop/dx11_interop.h
+++ b/sycl/test-e2e/bindless_images/dx11_interop/dx11_interop.h
@@ -1,13 +1,14 @@
-#pragma once
+#ifndef DX11_INTEROP_H
+#define DX11_INTEROP_H
 
 #pragma clang diagnostic ignored "-Waddress-of-temporary"
 
 #include "../helpers/common.hpp"
 #include "../helpers/dx_interop_common.hpp"
-using namespace dx_helpers;
 
 #include <sycl/detail/core.hpp>
-#include <sycl/properties/queue_properties.hpp>
+
+using namespace dx_helpers;
 
 namespace dx11_interop {
 
@@ -20,6 +21,9 @@ struct D3D11ProgramState {
   // Temporary, this is to be replaced by LUID.
   // Can also store a DXGI_ADAPTER_DESC if more state is needed.
   std::string deviceName;
+
+  // Keyed mutex ID for synchronizing access to the shared resource per device.
+  std::atomic<UINT64> key;
 
   D3D11ProgramState() = default;
   ~D3D11ProgramState();
@@ -118,3 +122,5 @@ getSyclDeviceFromDX11(const D3D11ProgramState *d3d11ProgramState) {
 }
 
 } // namespace dx11_interop
+
+#endif // DX11_INTEROP_H

--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
@@ -1,8 +1,8 @@
-// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import
 // REQUIRES: windows
 
 // RUN: %{build} %link-directx -o %t.out
-// RUN: %{run-unfiltered-devices} %t.out
+// RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out
 
 #include "dx11_interop.h"
 
@@ -233,7 +233,7 @@ int runTest(D3D11ProgramState *d3d11ProgramState, sycl::queue syclQueue,
   D3D11_TEXTURE2D_DESC texDesc{};
   texDesc.Width = texWidth;
   texDesc.Height = texHeight;   // if height is 1, we can mimic sharing 1D mem
-  texDesc.MipLevels = 1;        // 1 for a multisampled texture, so no mips
+  texDesc.MipLevels = 1;        // one mip level, so no sub-textures
   texDesc.ArraySize = texDepth; // array slices used for sharing 3D memory
   texDesc.Format = texFormat;
   texDesc.SampleDesc = {.Count = 1, .Quality = 0};
@@ -254,7 +254,7 @@ int runTest(D3D11ProgramState *d3d11ProgramState, sycl::queue syclQueue,
   d3d11ProgramState->key = 0;
 
   // Create an NT handle to a shared resource referring to our texture.
-  // Opening the that shared resource gives access to it on the device.
+  // Opening the shared resource gives access to it for use on the SYCL device.
   ComPtr<IDXGIResource1> sharedResource;
   ThrowIfFailed(texture.As(&sharedResource));
   HANDLE sharedHandle = nullptr;

--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
@@ -1,0 +1,265 @@
+// ...
+
+#include <d3d11.h>
+
+#include "../helpers/common.hpp"
+#include "../helpers/dx_interop_common.hpp"
+
+#include <sycl/ext/oneapi/bindless_images.hpp>
+#include <sycl/properties/queue_properties.hpp>
+
+#include <functional>
+#include <limits>
+#include <string_view>
+
+#pragma clang diagnostic ignored "-Waddress-of-temporary"
+
+using dx_helpers::dx_version;
+
+struct g_d3d11DeviceState {
+  ID3D11Device *device;
+  ID3D11DeviceContext *deviceContext;
+};
+
+template <int NDims, typename DType, int NChannels>
+void runTest(const g_d3d11DeviceState &d3d11DeviceState, sycl::queue syclQueue,
+             sycl::image_channel_type channelType,
+             const sycl::range<NDims> &globalSize,
+             const sycl::range<NDims> &localSize) {
+  // ... (Assume device, context, etc. are initialized) ...
+  auto *pDevice = d3d11DeviceState.device;
+  auto *pDeviceContext = d3d11DeviceState.deviceContext;
+  assert(pDevice && pDeviceContext);
+
+  syclexp::image_descriptor syclImageDesc{globalSize, NChannels, channelType};
+
+  // Verify ability to allocate the above image descriptor.
+  // E.g. LevelZero does not support `unorm` channel types.
+  if (!bindless_helpers::memoryAllocationSupported(
+          syclImageDesc, syclexp::image_memory_handle_type::opaque_handle,
+          syclQueue)) {
+    // We cannot allocate the image memory, skip the test.
+    std::cout << "Memory allocation unsupported. Skipping test.\n";
+    return;
+  }
+
+  // setup the texture dimensions and resource size.
+  const UINT texWidth = globalSize[0];
+  UINT texHeight = 1;
+  UINT texDepth = 1;
+  if constexpr (NDims > 1) {
+    texHeight = globalSize[1];
+    if constexpr (NDims > 2) {
+      texDepth = globalSize[2];
+    }
+  }
+  UINT texMipLevels = 0;
+  const unsigned int numElems = texWidth * texHeight * texDepth * NChannels;
+  // Unfortunately, DX11 does not expose the texture allocatoin information
+  // like DX12, so we have to calculate it manually the best we can (no mips).
+  const size_t allocationSize = numElems * sizeof(DType);
+
+  // Create a shared texture
+  ComPtr<ID3D11Texture2D> pTexture;
+  // Initialize the texture description.
+  // Default use means we'll use ID3D11DeviceContext::UpdateSubresource to fill
+  // the texture data.
+  D3D11_TEXTURE2D_DESC texDesc = {
+      .Width = texWidth,
+      .Height = texHeight,
+      .MipLevels = texMipLevels,
+      .ArraySize = texDepth,
+      .Format = dx_helpers::toDXGIFormat(NChannels, channelType),
+      .SampleDesc = {.Count = 1, .Quality = 0},
+      .Usage = D3D11_USAGE_DEFAULT,
+      .BindFlags = D3D11_BIND_SHADER_RESOURCE,
+      .CPUAccessFlags = 0,
+      // The below flags are required for DX11 resource handle sharing.
+      .MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+                   D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX};
+  HRESULT hr = pDevice->CreateTexture2D(&texDesc, nullptr, &pTexture);
+  assert(SUCCEEDED(hr));
+
+  // Create a shared resource.
+  ComPtr<ID3D11Resource> pResource;
+  hr = pTexture.As(&pResource);
+  assert(SUCCEEDED(hr));
+
+  ComPtr<IDXGIResource1> pDXGIResource;
+  pResource.As(&pDXGIResource);
+  assert(SUCCEEDED(hr));
+
+  HANDLE sharedHandle = nullptr;
+  hr = pDXGIResource->CreateSharedHandle(nullptr, 0, 0, &sharedHandle);
+  assert(SUCCEEDED(hr));
+
+  // Import the memory from the shared handle into SYCL
+#if 1
+  syclexp::external_mem_descriptor<syclexp::resource_win32_handle> extMemDesc{
+      sharedHandle, syclexp::external_mem_handle_type::win32_nt_dx11_resource,
+      allocationSize};
+
+  auto syclExternalMemHandle =
+      syclexp::import_external_memory(extMemDesc, syclQueue);
+
+  auto syclImageMemHandle = syclexp::map_external_image_memory(
+      syclExternalMemHandle, syclImageDesc, syclQueue);
+
+  auto syclImageHandle =
+      syclexp::create_image(syclImageMemHandle, syclImageDesc, syclQueue);
+#endif
+
+  // Populate the texture on the CPU
+  std::vector<DType> inputData;
+  // Initialise the texture data to upload.
+  {
+    inputData.resize(numElems);
+    auto getInputValue = [&](int i) -> DType {
+      if constexpr (std::is_integral_v<DType> ||
+                    std::is_same_v<DType, sycl::half>)
+        i = i % (static_cast<uint64_t>(std::numeric_limits<DType>::max()) / 2);
+      return i;
+    };
+    for (int i = 0; i < inputData.size(); ++i) {
+      inputData[i] = getInputValue(i);
+    }
+  }
+
+  const auto rowPitch = texWidth * sizeof(DType) * NChannels;
+  D3D11_BOX dstRegion;
+  dstRegion.left = 0;
+  dstRegion.right = texWidth;
+  dstRegion.top = 0;
+  dstRegion.bottom = texHeight;
+  dstRegion.front = 0;
+  dstRegion.back = 1;
+  pDeviceContext->UpdateSubresource(pResource.Get(), 0, &dstRegion,
+                                    inputData.data(), rowPitch, 0);
+
+  // Submit the SYCL kernel.
+#if 0
+  try {
+    auto imgHandle = syclImageHandle;
+    using VecType = sycl::vec<DType, NChannels>;
+
+    // All we are doing is doubling the value of each pixel in the texture.
+    syclQueue.submit([&](sycl::handler &cgh) {
+      cgh.parallel_for(
+          sycl::nd_range<NDims>{globalSize, localSize},
+          [=](sycl::nd_item<NDims> it) {
+            if constexpr (NDims == 3) {
+              size_t dim0 = it.get_global_id(0);
+              size_t dim1 = it.get_global_id(1);
+              size_t dim2 = it.get_global_id(2);
+              auto px = syclexp::fetch_image<
+                  std::conditional_t<NChannels == 1, DType, VecType>>(
+                  imgHandle, sycl::int3(dim0, dim1, dim2));
+              px *= static_cast<DType>(2);
+              syclexp::write_image(imgHandle, sycl::int3(dim0, dim1, dim2), px);
+            } else if constexpr (NDims == 2) {
+              size_t dim0 = it.get_global_id(0);
+              size_t dim1 = it.get_global_id(1);
+              auto px = syclexp::fetch_image<
+                  std::conditional_t<NChannels == 1, DType, VecType>>(
+                  imgHandle, sycl::int2(dim0, dim1));
+              px *= static_cast<DType>(2);
+              syclexp::write_image(imgHandle, sycl::int2(dim0, dim1), px);
+            } else {
+              size_t dim0 = it.get_global_id(0);
+              auto px = syclexp::fetch_image<
+                  std::conditional_t<NChannels == 1, DType, VecType>>(
+                  imgHandle, int(dim0));
+              px *= static_cast<DType>(2);
+              syclexp::write_image(imgHandle, int(dim0), px);
+            }
+          });
+    });
+  } catch (sycl::exception e) {
+    std::cerr << "\tKernel submission failed! " << e.what() << std::endl;
+    exit(-1);
+  } catch (...) {
+    std::cerr << "\tKernel submission failed!" << std::endl;
+    exit(-1);
+  }
+#endif
+
+  // Read-back and Verify
+}
+
+int main() {
+  UINT dxgiFactoryFlags = 0;
+  ComPtr<IDXGIFactory4> factory;
+  ThrowIfFailed(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&factory)));
+
+  ComPtr<IDXGIAdapter1> hardwareAdapter;
+  bool skipIntegrated = true;
+  dx_helpers::getDXGIHardwareAdapter<dx_version::DX11>(
+      factory.Get(), &hardwareAdapter, skipIntegrated);
+  if (!hardwareAdapter) {
+    // Request again but this time falling back to any available GPU.
+    skipIntegrated = false;
+    dx_helpers::getDXGIHardwareAdapter<dx_version::DX11>(
+        factory.Get(), &hardwareAdapter, skipIntegrated);
+  }
+  // At this point we must have a valid DirectX hardware adapter.
+  // This will be resolved once LUID device queries are introduced in SYCL, so
+  // we can first create a sycl device and match it exactly to the DirectX HW
+  // adapter, so we won't need any of the generic heuristics that the above
+  // GetHardwareAdapter function implements in order to find a "suitable" GPU.
+  // That way we will also be able to control it via ONEAPI_DEVICE_SELECTOR env.
+  assert(hardwareAdapter && "Could not find a valid DirectX hardware adapter.");
+
+  // Creating the D3D11 device.
+  ComPtr<ID3D11Device> device = nullptr;
+  ComPtr<ID3D11DeviceContext> deviceContext = nullptr;
+  UINT deviceFlags = 0;
+#if defined(D3D_DEVICE_DEBUG)
+  deviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+#endif
+  constexpr D3D_FEATURE_LEVEL requestedFeatureLevel = D3D_FEATURE_LEVEL_11_0;
+  D3D_FEATURE_LEVEL featureLevel;
+  ThrowIfFailed(D3D11CreateDevice(hardwareAdapter.Get(),
+                                  D3D_DRIVER_TYPE_UNKNOWN, nullptr, deviceFlags,
+                                  &requestedFeatureLevel, 1, D3D11_SDK_VERSION,
+                                  &device, &featureLevel, &deviceContext));
+  DXGI_ADAPTER_DESC1 adapterDesc;
+  assert(SUCCEEDED(hardwareAdapter->GetDesc1(&adapterDesc)));
+
+  // Creating the SYCL device.
+  // Convert the description string to a narrow string
+  std::wstring wstrDescription = adapterDesc.Description;
+  std::string description{}; // could preallocate with wstrDescription.size()
+  std::transform(std::begin(wstrDescription), std::end(wstrDescription),
+                 std::back_inserter(description),
+                 [](wchar_t c) { return static_cast<char>(c); });
+  std::cout << "D3D11 Adapter Name: " << description << std::endl;
+  sycl::queue syclQueue([description](const sycl::device &dev) -> int {
+    int score{-1};
+    // We want a GPU device.
+    if (dev.is_gpu()) {
+      score = 1000;
+    }
+    // This heuristic is also very silly, we want LUID as already noted.
+    // Also we won't need a custom device selector at that point since we
+    // will be creating the sycl device first before the DX one anyways.
+    if (std::string name = dev.get_info<sycl::info::device::name>();
+        description.find(name) != std::string::npos ||
+        name.find(description) != std::string::npos) {
+      score += 500;
+    }
+    return score;
+  });
+  std::cout << "SYCL Device Name: "
+            << syclQueue.get_device().get_info<sycl::info::device::name>()
+            << std::endl;
+
+  g_d3d11DeviceState d3d11DeviceState{.device = device.Get(),
+                                      .deviceContext = deviceContext.Get()};
+
+  // test 2D textures
+  runTest<2, uint32_t, 1>(
+      d3d11DeviceState, syclQueue, sycl::image_channel_type::unsigned_int32,
+      sycl::range<2>{256, 256}, sycl::range<2>{16, 16});
+
+  return 0;
+}

--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import
 // REQUIRES: windows
 
 // RUN: %{build} %link-directx -o %t.out
@@ -519,8 +519,8 @@ void DX12InteropTest<NDims, DType, NChannels>::cleanupDX12() {
 
   // Clean up opened handles
   if (m_sharedSemaphoreHandle != INVALID_HANDLE_VALUE)
-    CloseHandle(m_sharedSemaphoreHandle);
-  CloseHandle(m_sharedMemoryHandle);
+    CloseNTHandle(m_sharedSemaphoreHandle);
+  CloseNTHandle(m_sharedMemoryHandle);
   CloseHandle(m_dx12FenceEvent);
 
   // ComPtr handles will be destroyed automatically.

--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.h
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.h
@@ -1,22 +1,12 @@
 
 #pragma once
 
-// Reduce the size of Win32 header files
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-
-// Define NOMINMAX to enable compilation on Windows
-#define NOMINMAX
-
-#include <windows.h>
-
-#include <d3d12.h>
-#include <dxgi1_4.h>
-
 #include <iostream>
 #include <string>
-#include <wrl.h>
+
+#include "../helpers/common.hpp"
+#include "../helpers/dx_interop_common.hpp"
+using namespace dx_helpers;
 
 #include <sycl/ext/oneapi/bindless_images.hpp>
 
@@ -24,18 +14,6 @@
 
 using Microsoft::WRL::ComPtr;
 namespace syclexp = sycl::ext::oneapi::experimental;
-
-inline std::string ResultToString(HRESULT result) {
-  char s_str[64] = {};
-  sprintf_s(s_str, "Error result == 0x%08X", static_cast<uint32_t>(result));
-  return std::string(s_str);
-}
-
-inline void ThrowIfFailed(HRESULT result) {
-  if (result != S_OK) {
-    throw std::runtime_error(ResultToString(result));
-  }
-}
 
 class DX12SYCLDevice {
 public:

--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.h
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.h
@@ -6,13 +6,12 @@
 
 #include "../helpers/common.hpp"
 #include "../helpers/dx_interop_common.hpp"
-using namespace dx_helpers;
 
 #include <sycl/ext/oneapi/bindless_images.hpp>
 
 #include <sycl/properties/queue_properties.hpp>
 
-using Microsoft::WRL::ComPtr;
+using namespace dx_helpers;
 namespace syclexp = sycl::ext::oneapi::experimental;
 
 class DX12SYCLDevice {

--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled_semaphore.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import
+// REQUIRES: aspect-ext_oneapi_external_semaphore_import
 // REQUIRES: windows
 
 // XFAIL: run-mode

--- a/sycl/test-e2e/bindless_images/helpers/dx_interop_common.hpp
+++ b/sycl/test-e2e/bindless_images/helpers/dx_interop_common.hpp
@@ -4,20 +4,17 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-
 // Define NOMINMAX to enable compilation on Windows
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-
 #include <windows.h>
 
 // Windows Runtime C++ Template Library (ComPtr and friends)
 #include <wrl.h>
 
-// For D3D11CreateDevice, ID3D11Device and ID3D11DeviceContext
+// Direct3D 11 and 12 API headers.
 #include <d3d11.h>
-// For D3D12CreateDevice and ID3D12Device
 #include <d3d12.h>
 
 // As we are to share common DXGI interface functionality between our DX 11 and

--- a/sycl/test-e2e/bindless_images/helpers/dx_interop_common.hpp
+++ b/sycl/test-e2e/bindless_images/helpers/dx_interop_common.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DX_INTEROP_COMMON_HPP
+#define DX_INTEROP_COMMON_HPP
 
 // Reduce the size of Win32 header files
 #ifndef WIN32_LEAN_AND_MEAN
@@ -226,7 +227,7 @@ bool isDXGIDebugLayerEnabled(IDXGIFactory1 *pFactory) {
 /// @brief  This helper function does not output a device. It just tests if the
 ///         creating a logical device from the chosen adapter parameters works.
 template <dx_version dxVer>
-bool d3dCreateTestDevice(IDXGIAdapter1 *pAdapter, bool withDebugDevice) {
+bool canCreateDxDevice(IDXGIAdapter1 *pAdapter, bool withDebugDevice) {
   // We don't need any device features of the Direct3D API beyond that version.
   static constexpr D3D_FEATURE_LEVEL minFeatureLevel = D3D_FEATURE_LEVEL_11_0;
   if constexpr (dxVer == dx_version::DX12) {
@@ -320,7 +321,7 @@ void getDXGIHardwareAdapter(
       }
 
       // Test if we can successfully create a device with this adapter.
-      if (detail::d3dCreateTestDevice<dxVer>(adapter.Get(), withDebugDevice)) {
+      if (detail::canCreateDxDevice<dxVer>(adapter.Get(), withDebugDevice)) {
         foundAdapter = true;
         break;
       }
@@ -373,7 +374,7 @@ void getDXGIHardwareAdapter(
       }
 
       // Test if we can successfully create a device with this adapter.
-      if (detail::d3dCreateTestDevice<dxVer>(adapter.Get(), withDebugDevice)) {
+      if (detail::canCreateDxDevice<dxVer>(adapter.Get(), withDebugDevice)) {
         foundAdapter = true;
         break;
       }
@@ -439,7 +440,7 @@ template <dx_version dxVer>
     if ((desc.AdapterLuid.LowPart == luidLowPart) &&
         (desc.AdapterLuid.HighPart == luidHightPart)) {
       // Test if we can successfully create a device with this adapter.
-      if (detail::d3dCreateTestDevice<dxVer>(adapter.Get(), withDebugDevice)) {
+      if (detail::canCreateDxDevice<dxVer>(adapter.Get(), withDebugDevice)) {
         foundAdapter = true;
         break;
       }
@@ -457,3 +458,5 @@ template <dx_version dxVer>
 }
 
 } // namespace dx_helpers
+
+#endif // DX_INTEROP_COMMON_HPP

--- a/sycl/test-e2e/bindless_images/helpers/dx_interop_common.hpp
+++ b/sycl/test-e2e/bindless_images/helpers/dx_interop_common.hpp
@@ -1,0 +1,378 @@
+#pragma once
+
+// Reduce the size of Win32 header files
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+// Define NOMINMAX to enable compilation on Windows
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <windows.h>
+
+// Windows Runtime C++ Template Library (ComPtr and friends)
+#include <wrl.h>
+
+#include <d3d11.h>
+#include <d3d12.h>
+
+// As we are to share common DXGI interface functionality between our DX 11 and
+// DX 12 tests, we include at least dxgi1_4 (introduced with Direct3D 12) as a
+// minimum requirement for both. If OS version supports it, try to use dxgi1_6.
+// DXGI 1.6 is included in Windows 10 as part of the Creators Update (0x0A00).
+#define HAS_DXGI_1_6 (_WIN32_WINNT >= WINVER_WIN10)
+#if HAS_DXGI_1_6
+#include <dxgi1_6.h>
+#else
+#include <dxgi1_4.h>
+#endif
+
+#include <dxgidebug.h>
+
+#include <sycl/detail/core.hpp>
+
+using Microsoft::WRL::ComPtr;
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+inline std::string ResultToString(HRESULT result) {
+  char s_str[64] = {};
+  sprintf_s(s_str, "Error result == 0x%08X", static_cast<uint32_t>(result));
+  return std::string(s_str);
+}
+
+inline void ThrowIfFailed(HRESULT result) {
+  if (result != S_OK) {
+    throw std::runtime_error(ResultToString(result));
+  }
+}
+
+namespace dx_helpers {
+
+enum class dx_version { DX11, DX12 };
+
+DXGI_FORMAT toDXGIFormat(int NChannels, sycl::image_channel_type channelType) {
+  switch (channelType) {
+  case sycl::image_channel_type::snorm_int8:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R8_SNORM;
+    case 2:
+      return DXGI_FORMAT_R8G8_SNORM;
+    case 4:
+      return DXGI_FORMAT_R8G8B8A8_SNORM;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::snorm_int16:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R16_SNORM;
+    case 2:
+      return DXGI_FORMAT_R16G16_SNORM;
+    case 4:
+      return DXGI_FORMAT_R16G16B16A16_SNORM;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::unorm_int8:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R8_UNORM;
+    case 2:
+      return DXGI_FORMAT_R8G8_UNORM;
+    case 4:
+      return DXGI_FORMAT_R8G8B8A8_UNORM;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::unorm_int16:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R16_UNORM;
+    case 2:
+      return DXGI_FORMAT_R16G16_UNORM;
+    case 4:
+      return DXGI_FORMAT_R16G16B16A16_UNORM;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::unorm_short_565:
+    return DXGI_FORMAT_B5G6R5_UNORM;
+  case sycl::image_channel_type::unorm_short_555:
+    return DXGI_FORMAT_B5G5R5A1_UNORM;
+  case sycl::image_channel_type::unorm_int_101010:
+    return DXGI_FORMAT_R10G10B10A2_UNORM;
+  case sycl::image_channel_type::signed_int8:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R8_SINT;
+    case 2:
+      return DXGI_FORMAT_R8G8_SINT;
+    case 4:
+      return DXGI_FORMAT_R8G8B8A8_SINT;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::signed_int16:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R16_SINT;
+    case 2:
+      return DXGI_FORMAT_R16G16_SINT;
+    case 4:
+      return DXGI_FORMAT_R16G16B16A16_SINT;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::signed_int32:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R32_SINT;
+    case 2:
+      return DXGI_FORMAT_R32G32_SINT;
+    case 4:
+      return DXGI_FORMAT_R32G32B32A32_SINT;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::unsigned_int8:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R8_UINT;
+    case 2:
+      return DXGI_FORMAT_R8G8_UINT;
+    case 4:
+      return DXGI_FORMAT_R8G8B8A8_UINT;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::unsigned_int16:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R16_UINT;
+    case 2:
+      return DXGI_FORMAT_R16G16_UINT;
+    case 4:
+      return DXGI_FORMAT_R16G16B16A16_UINT;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::unsigned_int32:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R32_UINT;
+    case 2:
+      return DXGI_FORMAT_R32G32_UINT;
+    case 4:
+      return DXGI_FORMAT_R32G32B32A32_UINT;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::fp16:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R16_FLOAT;
+    case 2:
+      return DXGI_FORMAT_R16G16_FLOAT;
+    case 4:
+      return DXGI_FORMAT_R16G16B16A16_FLOAT;
+    default:
+      break;
+    }
+  case sycl::image_channel_type::fp32:
+    switch (NChannels) {
+    case 1:
+      return DXGI_FORMAT_R32_FLOAT;
+    case 2:
+      return DXGI_FORMAT_R32G32_FLOAT;
+    case 4:
+      return DXGI_FORMAT_R32G32B32A32_FLOAT;
+    default:
+      break;
+    }
+  default:
+    break;
+  }
+  std::cerr << "Unsupported image_channel_type in toDXGIFormat\n";
+  exit(-1);
+}
+
+/// @brief  This is a helper function to find an appropriate hardware adapter.
+/// It does not create the final D3D device but rather tests creating it with
+/// the chosen hardware adapter, so it can be used safely for SYCL interop.
+/// This function has no thread-safety guarantees in its current state.
+/// Ideally we will not be searching for the highest performing adapter but for
+/// the one that specifically matches the SYCL device for interopability. For
+/// that reason we will need to introduce an LUID device query extension first.
+/// @tparam dxVer
+/// @param pFactory
+/// @param ppAdapter
+template <dx_version dxVer>
+void getDXGIHardwareAdapter(IDXGIFactory1 *pFactory, IDXGIAdapter1 **ppAdapter,
+                        bool skipIntegrated = false) {
+  *ppAdapter = nullptr;
+
+  ComPtr<IDXGIAdapter1> adapter;
+
+  constexpr D3D_FEATURE_LEVEL minFeatureLevel = D3D_FEATURE_LEVEL_11_0;
+
+  bool foundAdapter{false};
+  // Find a suitable hardware adapter.
+#if HAS_DXGI_1_6
+  ComPtr<IDXGIFactory6> factory6;
+  if (SUCCEEDED(pFactory->QueryInterface(IID_PPV_ARGS(&factory6)))) {
+    for (UINT adapterIndex = 0; SUCCEEDED(factory6->EnumAdapterByGpuPreference(
+             adapterIndex,
+             skipIntegrated ? DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE
+                            : DXGI_GPU_PREFERENCE_UNSPECIFIED,
+             IID_PPV_ARGS(&adapter)));
+         ++adapterIndex) {
+      if (!adapter) {
+        continue;
+      }
+
+      DXGI_ADAPTER_DESC1 desc;
+      if (FAILED(adapter->GetDesc1(&desc))) {
+        continue;
+      }
+
+      // We don't want the Microsoft Basic Render Driver (software) adapter.
+      if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) {
+        continue;
+      }
+
+      if constexpr (dxVer == dx_version::DX12) {
+        // Check to see whether the adapter supports Direct3D 12, but don't
+        // create the actual device yet.
+        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0,
+                                        _uuidof(ID3D12Device), nullptr))) {
+          foundAdapter = true;
+          break;
+        }
+      } else {
+        // Check to see if the adapter supports Direct3D 11, but don't create
+        // the actual device yet.
+        ComPtr<ID3D11Device> device = nullptr;
+        ComPtr<ID3D11DeviceContext> deviceContext = nullptr;
+        UINT deviceFlags = 0;
+#if defined(D3D_DEVICE_DEBUG)
+        deviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+#endif
+        D3D_FEATURE_LEVEL outFeatureLevel;
+        // We don't want SW renderer. Ideally we specify
+        // D3D_DRIVER_TYPE_HARDWARE on creation but when we specify an Adapter
+        // we need to specify the D3D_DRIVER_TYPE_UNKNOWN enum, otherwise the
+        // call fails. This is okay as we made sure to select the best possible
+        // HW adapter. We can create Device without a DXGIAdapter but we want
+        // one to exist, so we can use it for LUID matching with the SYCL device
+        // for interop.
+        HRESULT Result = D3D11CreateDevice(
+            adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, deviceFlags,
+            &minFeatureLevel, 1u, D3D11_SDK_VERSION, &device, &outFeatureLevel,
+            &deviceContext);
+        if (SUCCEEDED(Result)) {
+          assert(outFeatureLevel == minFeatureLevel); // sanity check
+          std::cout << "Created D3D11 Device successfully.\n";
+          foundAdapter = true;
+          break;
+        }
+      }
+    }
+    // If not found fallback to EnumAdapters1 to search all available HW
+    // adapters.
+  }
+#endif
+
+  // Find a suitable hardware adapter.
+  if (!foundAdapter) {
+    for (UINT adapterIndex = 0;
+         pFactory->EnumAdapters1(adapterIndex, adapter.GetAddressOf()) !=
+         DXGI_ERROR_NOT_FOUND;
+         ++adapterIndex) {
+      if (!adapter) {
+        continue;
+      }
+
+      DXGI_ADAPTER_DESC1 desc;
+      if (FAILED(adapter->GetDesc1(&desc))) {
+        continue;
+      }
+
+      // We don't want the Microsoft Basic Render Driver (software) adapter.
+      if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) {
+        continue;
+      }
+
+      if (skipIntegrated) {
+        // Simple heuristic, but it's hard to do better without external deps.
+        ComPtr<IDXGIAdapter3> tmpAdapter3;
+        DXGI_QUERY_VIDEO_MEMORY_INFO videoMemoryInfo;
+        bool isNonLocalMemoryPresent{false};
+        if (SUCCEEDED(adapter.As(&tmpAdapter3)) && tmpAdapter3 &&
+            SUCCEEDED(tmpAdapter3->QueryVideoMemoryInfo(
+                0, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL, &videoMemoryInfo))) {
+          isNonLocalMemoryPresent = videoMemoryInfo.Budget != 0;
+        }
+        // Integrated GPUs will dedicated the non-local (i.e. system RAM)
+        // memory as local (i.e. VRAM-like), so from this we can potentially
+        // derive that  if  if the non-local memory segment is 0 then it's an
+        // intergrated graphics card that is using/allocating it as local.
+        // In the case of dedicated GPUs both segments will be independent.
+        if (bool isIntegrated = !isNonLocalMemoryPresent; isIntegrated) {
+          continue;
+        }
+      }
+
+      if constexpr (dxVer == dx_version::DX12) {
+        // Check to see if the adapter supports Direct3D 12, but don't create
+        // the actual device yet. All Direct3D 12 drivers support at least
+        // feature level 11_0, making it a safe and reliable choice for device
+        // creation. It is also perfectly sufficient for our interopability
+        // feature testing purposes.
+        if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), minFeatureLevel,
+                                        _uuidof(ID3D12Device), nullptr))) {
+          foundAdapter = true;
+          break;
+        }
+      } else {
+        // Check to see if the adapter supports Direct3D 11, but don't create
+        // the actual device yet.
+        ComPtr<ID3D11Device> device = nullptr;
+        ComPtr<ID3D11DeviceContext> deviceContext = nullptr;
+        UINT deviceFlags = 0;
+#if defined(D3D_DEVICE_DEBUG)
+        deviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+#endif
+        D3D_FEATURE_LEVEL outFeatureLevel;
+        // We don't want SW renderer. Ideally we specify
+        // D3D_DRIVER_TYPE_HARDWARE on creation but when we specify an Adapter
+        // we need to specify the D3D_DRIVER_TYPE_UNKNOWN enum, otherwise the
+        // call fails. This is okay as we made sure to select the best possible
+        // HW adapter. We can create Device without a DXGIAdapter but we want
+        // one to exist, so we can use it for LUID matching with the SYCL device
+        // for interop.
+        HRESULT Result = D3D11CreateDevice(
+            adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, deviceFlags,
+            &minFeatureLevel, 1u, D3D11_SDK_VERSION, &device, &outFeatureLevel,
+            &deviceContext);
+        if (SUCCEEDED(Result)) {
+          assert(outFeatureLevel == minFeatureLevel); // sanity check
+          std::cout << "Created D3D11 Device successfully.\n";
+          foundAdapter = true;
+          break;
+        }
+      }
+    }
+  }
+
+  if (foundAdapter) {
+    // Set the returned adapter.
+    *ppAdapter = adapter.Detach();
+  } else {
+    std::cerr << "Could not find the requested DirectX hardware adapter.";
+  }
+}
+
+} // namespace dx_heleprs

--- a/sycl/test-e2e/bindless_images/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/lit.local.cfg
@@ -18,7 +18,7 @@ else:
 config.substitutions.append(("%link-vulkan", link_vulkan))
 
 if platform.system() == "Windows":
-    dx12libs = ['-ld3d12', '-ldxgi', '-ldxguid']
+    directx_libs = ['-ld3d11', '-ld3d12', '-ldxgi', '-ldxguid']
     if cl_options:
-        dx12libs = ['/clang:' + l for l in dx12libs]
-    config.substitutions.append(("%link-directx", ' '.join(dx12libs)))
+        directx_libs = ['/clang:' + l for l in directx_libs]
+    config.substitutions.append(("%link-directx", ' '.join(directx_libs)))

--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -9796,6 +9796,8 @@ typedef enum ur_exp_external_mem_type_t {
   UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT = 1,
   /// Win32 NT DirectX 12 resource handle
   UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE = 2,
+  /// Win32 NT DirectX 11 resource handle
+  UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE = 3,
   /// @cond
   UR_EXP_EXTERNAL_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
   /// @endcond
@@ -10514,7 +10516,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE <
+///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE <
 ///         memHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pExternalMemDesc`

--- a/unified-runtime/include/ur_print.hpp
+++ b/unified-runtime/include/ur_print.hpp
@@ -11313,6 +11313,9 @@ inline std::ostream &operator<<(std::ostream &os,
   case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE:
     os << "UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE";
     break;
+  case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE:
+    os << "UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE";
+    break;
   default:
     os << "unknown enumerator";
     break;

--- a/unified-runtime/scripts/core/exp-bindless-images.yml
+++ b/unified-runtime/scripts/core/exp-bindless-images.yml
@@ -212,6 +212,8 @@ etors:
     desc: "Win32 NT handle"
   - name: WIN32_NT_DX12_RESOURCE
     desc: "Win32 NT DirectX 12 resource handle"
+  - name: WIN32_NT_DX11_RESOURCE
+    desc: "Win32 NT DirectX 11 resource handle"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Dictates the type of external semaphore handle."

--- a/unified-runtime/scripts/generate_docs.py
+++ b/unified-runtime/scripts/generate_docs.py
@@ -304,7 +304,8 @@ def generate_html(dstpath):
         print("sphinx-build returned non-zero error code.")
         print("--- output ---")
         print(result.stderr.decode())
-        raise Exception("Failed to generate html documentation.")
+        # temporary skip the exception for dev purposes.
+        # raise Exception("Failed to generate html documentation.")
 
 
 def generate_pdf(dstpath):

--- a/unified-runtime/scripts/generate_docs.py
+++ b/unified-runtime/scripts/generate_docs.py
@@ -304,8 +304,7 @@ def generate_html(dstpath):
         print("sphinx-build returned non-zero error code.")
         print("--- output ---")
         print(result.stderr.decode())
-        # temporary skip the exception for dev purposes.
-        # raise Exception("Failed to generate html documentation.")
+        raise Exception("Failed to generate html documentation.")
 
 
 def generate_pdf(dstpath):

--- a/unified-runtime/source/adapters/cuda/image.cpp
+++ b/unified-runtime/source/adapters/cuda/image.cpp
@@ -1516,6 +1516,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
           extMemDesc.type = CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE;
           extMemDesc.flags = CUDA_EXTERNAL_MEMORY_DEDICATED;
           break;
+        case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE:
+          extMemDesc.type = CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE;
+          extMemDesc.flags = CUDA_EXTERNAL_MEMORY_DEDICATED;
+          break;
         case UR_EXP_EXTERNAL_MEM_TYPE_OPAQUE_FD:
         default:
           return UR_RESULT_ERROR_INVALID_VALUE;

--- a/unified-runtime/source/adapters/hip/image.cpp
+++ b/unified-runtime/source/adapters/hip/image.cpp
@@ -1383,15 +1383,19 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
           extMemDesc.type = hipExternalMemoryHandleTypeOpaqueWin32;
           break;
         case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE:
-        case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE:
           // Memory descriptor flag values such as hipExternalMemoryDedicated
           // are not available before HIP 5.6, so we safely fallback to marking
           // this as an unsupported.
 #if HIP_VERSION >= 50600000
-          extMemDesc.type =
-              (memHandleType == UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE)
-                  ? hipExternalMemoryHandleTypeD3D12Resource
-                  : hipExternalMemoryHandleTypeD3D11Resource;
+          extMemDesc.type = hipExternalMemoryHandleTypeD3D12Resource;
+          extMemDesc.flags = hipExternalMemoryDedicated;
+#else
+          return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+#endif
+          break;
+        case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE:
+#if HIP_VERSION >= 50600000
+          extMemDesc.type = hipExternalMemoryHandleTypeD3D11Resource;
           extMemDesc.flags = hipExternalMemoryDedicated;
 #else
           return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/hip/image.cpp
+++ b/unified-runtime/source/adapters/hip/image.cpp
@@ -1383,11 +1383,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
           extMemDesc.type = hipExternalMemoryHandleTypeOpaqueWin32;
           break;
         case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE:
+        case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE:
           // Memory descriptor flag values such as hipExternalMemoryDedicated
           // are not available before HIP 5.6, so we safely fallback to marking
           // this as an unsupported.
 #if HIP_VERSION >= 50600000
-          extMemDesc.type = hipExternalMemoryHandleTypeD3D12Resource;
+          extMemDesc.type =
+              (memHandleType == UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE)
+                  ? hipExternalMemoryHandleTypeD3D12Resource
+                  : hipExternalMemoryHandleTypeD3D11Resource;
           extMemDesc.flags = hipExternalMemoryDedicated;
 #else
           return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/level_zero/image_common.cpp
+++ b/unified-runtime/source/adapters/level_zero/image_common.cpp
@@ -1256,6 +1256,9 @@ ur_result_t urBindlessImagesImportExternalMemoryExp(
       case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE:
         importWin32->flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_D3D12_RESOURCE;
         break;
+      case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE:
+        importWin32->flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_D3D11_TEXTURE;
+        break;
       case UR_EXP_EXTERNAL_MEM_TYPE_OPAQUE_FD:
       default:
         delete importWin32;

--- a/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
+++ b/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
@@ -8314,7 +8314,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     if (NULL == hDevice)
       return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
 
-    if (UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE < memHandleType)
+    if (UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE < memHandleType)
       return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
 

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -8041,7 +8041,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE <
+///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE <
 ///         memHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pExternalMemDesc`

--- a/unified-runtime/source/ur_api.cpp
+++ b/unified-runtime/source/ur_api.cpp
@@ -7027,7 +7027,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE <
+///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX11_RESOURCE <
 ///         memHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pExternalMemDesc`


### PR DESCRIPTION
This PR adds DX11 memory interop.
In DX11 Texture1D and Texture3D cannot be shared between process or devices, so only Texture2D is used but it's layout is adapted (height = 1 for 1D and ArraySlices = depth for 3D) for the interop purposes and testing 1D and 3D image operations on it in the SYCL kernel.
The new DXGI adapter selection fixes issues with non-matching devices between DX and SYCL which also failed the DX12 tests when more than 1 potential adapter is visible to DirectX. Ideally the introduction of LUIDs to SYCL will resolve that completely when they are properly matched. For now, I've added a `[[maybe_unused]] void getDXGIHardwareAdapterFromLUID` function in the common helpers that should be used in the future when LUID querying is available to SYCL device info. The flow should then change to - 1) create SYCL device (so the device selection itself can be manipulated via `ONEAPI_DEVICE_SELECTOR`) , 2) get DXGI adapter for creating a DX logical device (D3D11 or D3D12) by matching adapter LUIDs. Currently we choose the highest perf adapter by default or the integrated if specified via the `enum class device_preference`.

Some notes on synchronisation:

- IKeyedMutex is required for synchronising the access to the shared resource (texture) between devices.
- Currently the SYCL queue calls wait after submission to execute immediately and block until completion, but we can use ID3D11Fence imported in SYCL to signal the completion of the work to D3D11 via SYCL in the future when this kind of interop is considered.