### PR TITLE
[NFC][SYCL] Prepare `unittests/scheduler` for `getSyclObjImpl` to return raw ref

### DIFF
--- a/sycl/unittests/scheduler/BarrierDependencies.cpp
+++ b/sycl/unittests/scheduler/BarrierDependencies.cpp
@@ -69,10 +69,9 @@ TEST_F(SchedulerTest, BarrierWithDependsOn) {
 
   auto EventA =
       QueueA.submit([&](sycl::handler &h) { h.ext_oneapi_barrier(); });
-  std::shared_ptr<detail::event_impl> EventAImpl =
-      detail::getSyclObjImpl(EventA);
+  detail::event_impl &EventAImpl = *detail::getSyclObjImpl(EventA);
   // it means that command is enqueued
-  ASSERT_NE(EventAImpl->getHandle(), nullptr);
+  ASSERT_NE(EventAImpl.getHandle(), nullptr);
 
   ASSERT_FALSE(EventsWaitVisited);
   ASSERT_TRUE(BarrierEventsWaitVisited);
@@ -83,14 +82,13 @@ TEST_F(SchedulerTest, BarrierWithDependsOn) {
     h.depends_on(EventA);
     h.ext_oneapi_barrier();
   });
-  std::shared_ptr<detail::event_impl> EventBImpl =
-      detail::getSyclObjImpl(EventB);
+  detail::event_impl &EventBImpl = *detail::getSyclObjImpl(EventB);
   // it means that command is enqueued
-  ASSERT_NE(EventBImpl->getHandle(), nullptr);
+  ASSERT_NE(EventBImpl.getHandle(), nullptr);
 
   ASSERT_TRUE(EventsWaitVisited);
   ASSERT_EQ(EventsInWaitList.size(), 1u);
-  EXPECT_EQ(EventsInWaitList[0], EventAImpl->getHandle());
+  EXPECT_EQ(EventsInWaitList[0], EventAImpl.getHandle());
 
   ASSERT_TRUE(BarrierEventsWaitVisited);
   ASSERT_EQ(BarrierEventsInWaitList.size(), 0u);
@@ -118,13 +116,11 @@ TEST_F(SchedulerTest, BarrierWaitListWithDependsOn) {
       QueueA.submit([&](sycl::handler &h) { h.ext_oneapi_barrier(); });
   auto EventA2 =
       QueueA.submit([&](sycl::handler &h) { h.ext_oneapi_barrier(); });
-  std::shared_ptr<detail::event_impl> EventAImpl =
-      detail::getSyclObjImpl(EventA);
-  std::shared_ptr<detail::event_impl> EventA2Impl =
-      detail::getSyclObjImpl(EventA2);
+  detail::event_impl &EventAImpl = *detail::getSyclObjImpl(EventA);
+  detail::event_impl &EventA2Impl = *detail::getSyclObjImpl(EventA2);
   // it means that command is enqueued
-  ASSERT_NE(EventAImpl->getHandle(), nullptr);
-  ASSERT_NE(EventA2Impl->getHandle(), nullptr);
+  ASSERT_NE(EventAImpl.getHandle(), nullptr);
+  ASSERT_NE(EventA2Impl.getHandle(), nullptr);
 
   ASSERT_FALSE(EventsWaitVisited);
   ASSERT_TRUE(BarrierEventsWaitVisited);
@@ -135,16 +131,15 @@ TEST_F(SchedulerTest, BarrierWaitListWithDependsOn) {
     h.depends_on(EventA);
     h.ext_oneapi_barrier({EventA2});
   });
-  std::shared_ptr<detail::event_impl> EventBImpl =
-      detail::getSyclObjImpl(EventB);
+  detail::event_impl &EventBImpl = *detail::getSyclObjImpl(EventB);
   // it means that command is enqueued
-  ASSERT_NE(EventBImpl->getHandle(), nullptr);
+  ASSERT_NE(EventBImpl.getHandle(), nullptr);
 
   ASSERT_FALSE(EventsWaitVisited);
   ASSERT_TRUE(BarrierEventsWaitVisited);
   ASSERT_EQ(BarrierEventsInWaitList.size(), 2u);
-  EXPECT_EQ(BarrierEventsInWaitList[0], EventA2Impl->getHandle());
-  EXPECT_EQ(BarrierEventsInWaitList[1], EventAImpl->getHandle());
+  EXPECT_EQ(BarrierEventsInWaitList[0], EventA2Impl.getHandle());
+  EXPECT_EQ(BarrierEventsInWaitList[1], EventAImpl.getHandle());
 
   QueueA.wait();
   QueueB.wait();

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -34,9 +34,8 @@ struct TestCtx {
   bool EventCtx2WasWaited = false;
 
   TestCtx(queue &Queue1, queue &Queue2)
-      : Q1(Queue1), Q2(Queue2),
-        Ctx1(*detail::getSyclObjImpl(Q1.get_context()).get()),
-        Ctx2(*detail::getSyclObjImpl(Q2.get_context()).get()) {
+      : Q1(Queue1), Q2(Queue2), Ctx1(*detail::getSyclObjImpl(Q1.get_context())),
+        Ctx2(*detail::getSyclObjImpl(Q2.get_context())) {
 
     EventCtx1 = mock::createDummyHandle<ur_event_handle_t>();
     EventCtx2 = mock::createDummyHandle<ur_event_handle_t>();
@@ -152,12 +151,10 @@ TEST_F(SchedulerTest, StreamAUXCmdsWait) {
     ASSERT_TRUE(QueueImpl.MStreamsServiceEvents.size() == 1)
         << "Expected 1 service stream event";
 
-    std::shared_ptr<sycl::detail::event_impl> EventImpl =
-        detail::getSyclObjImpl(Event);
+    auto &EventImplProxy =
+        static_cast<EventImplProxyT &>(*detail::getSyclObjImpl(Event));
 
-    auto EventImplProxy = std::static_pointer_cast<EventImplProxyT>(EventImpl);
-
-    ASSERT_EQ(EventImplProxy->MWeakPostCompleteEvents.size(), 1u)
+    ASSERT_EQ(EventImplProxy.MWeakPostCompleteEvents.size(), 1u)
         << "Expected 1 post complete event";
 
     Q.wait();

--- a/sycl/unittests/scheduler/EnqueueWithDependsOnDeps.cpp
+++ b/sycl/unittests/scheduler/EnqueueWithDependsOnDeps.cpp
@@ -20,6 +20,7 @@
 namespace {
 using namespace sycl;
 using EventImplPtr = std::shared_ptr<detail::event_impl>;
+using sycl::detail::getSyclObjImpl;
 
 constexpr auto DisableCleanupName = "SYCL_DISABLE_EXECUTION_GRAPH_CLEANUP";
 
@@ -45,7 +46,7 @@ protected:
       GTEST_SKIP();
 
     queue QueueDev(context(Plt), default_selector_v);
-    QueueDevImpl = detail::getSyclObjImpl(QueueDev);
+    QueueDevImpl = getSyclObjImpl(QueueDev);
   }
 
   void TearDown() {}
@@ -326,25 +327,23 @@ TEST_F(DependsOnTests, ShortcutFunctionWithWaitList) {
   // Mock up an incomplete host task
   auto HostTaskEvent =
       Queue.submit([&](sycl::handler &cgh) { cgh.host_task([=]() {}); });
-  std::shared_ptr<detail::event_impl> HostTaskEventImpl =
-      detail::getSyclObjImpl(HostTaskEvent);
+  detail::event_impl &HostTaskEventImpl = *getSyclObjImpl(HostTaskEvent);
   HostTaskEvent.wait();
-  auto *Cmd = static_cast<detail::Command *>(HostTaskEventImpl->getCommand());
+  auto *Cmd = static_cast<detail::Command *>(HostTaskEventImpl.getCommand());
   ASSERT_NE(Cmd, nullptr);
   Cmd->MIsBlockable = true;
   Cmd->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueBlocked;
-  HostTaskEventImpl->setStateIncomplete();
+  HostTaskEventImpl.setStateIncomplete();
 
   auto SingleTaskEvent = Queue.submit([&](sycl::handler &cgh) {
     cgh.depends_on(HostTaskEvent);
     cgh.single_task<TestKernel<>>([] {});
   });
-  std::shared_ptr<detail::event_impl> SingleTaskEventImpl =
-      detail::getSyclObjImpl(SingleTaskEvent);
-  EXPECT_EQ(SingleTaskEventImpl->getHandle(), nullptr);
+  detail::event_impl &SingleTaskEventImpl = *getSyclObjImpl(SingleTaskEvent);
+  EXPECT_EQ(SingleTaskEventImpl.getHandle(), nullptr);
 
   // make HostTaskEvent completed, so SingleTaskEvent can be enqueued
-  HostTaskEventImpl->setComplete();
+  HostTaskEventImpl.setComplete();
   Cmd->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueSuccess;
   EventsInWaitList.clear();
 
@@ -356,9 +355,9 @@ TEST_F(DependsOnTests, ShortcutFunctionWithWaitList) {
                                             QueueDevImpl->get_context());
   auto ShortcutFuncEvent = Queue.memcpy(
       SecondBuf, FirstBuf, sizeof(int) * ArraySize, {SingleTaskEvent});
-  EXPECT_NE(SingleTaskEventImpl->getHandle(), nullptr);
+  EXPECT_NE(SingleTaskEventImpl.getHandle(), nullptr);
   ASSERT_EQ(EventsInWaitList.size(), 1u);
-  EXPECT_EQ(EventsInWaitList[0], SingleTaskEventImpl->getHandle());
+  EXPECT_EQ(EventsInWaitList[0], SingleTaskEventImpl.getHandle());
   Queue.wait();
   sycl::free(FirstBuf, Queue);
   sycl::free(SecondBuf, Queue);
@@ -372,31 +371,29 @@ TEST_F(DependsOnTests, BarrierWithWaitList) {
 
   auto HostTaskEvent =
       Queue.submit([&](sycl::handler &cgh) { cgh.host_task([=]() {}); });
-  std::shared_ptr<detail::event_impl> HostTaskEventImpl =
-      detail::getSyclObjImpl(HostTaskEvent);
+  detail::event_impl &HostTaskEventImpl = *getSyclObjImpl(HostTaskEvent);
   HostTaskEvent.wait();
-  auto *Cmd = static_cast<detail::Command *>(HostTaskEventImpl->getCommand());
+  auto *Cmd = static_cast<detail::Command *>(HostTaskEventImpl.getCommand());
   ASSERT_NE(Cmd, nullptr);
   Cmd->MIsBlockable = true;
   Cmd->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueBlocked;
-  HostTaskEventImpl->setStateIncomplete();
+  HostTaskEventImpl.setStateIncomplete();
 
   auto SingleTaskEvent = Queue.submit([&](sycl::handler &cgh) {
     cgh.depends_on(HostTaskEvent);
     cgh.single_task<TestKernel<>>([] {});
   });
-  std::shared_ptr<detail::event_impl> SingleTaskEventImpl =
-      detail::getSyclObjImpl(SingleTaskEvent);
-  EXPECT_EQ(SingleTaskEventImpl->getHandle(), nullptr);
+  detail::event_impl &SingleTaskEventImpl = *getSyclObjImpl(SingleTaskEvent);
+  EXPECT_EQ(SingleTaskEventImpl.getHandle(), nullptr);
 
-  HostTaskEventImpl->setComplete();
+  HostTaskEventImpl.setComplete();
   Cmd->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueSuccess;
   EventsInWaitList.clear();
 
   Queue.ext_oneapi_submit_barrier(std::vector<sycl::event>{SingleTaskEvent});
-  EXPECT_NE(SingleTaskEventImpl->getHandle(), nullptr);
+  EXPECT_NE(SingleTaskEventImpl.getHandle(), nullptr);
   ASSERT_EQ(EventsInWaitList.size(), 1u);
-  EXPECT_EQ(EventsInWaitList[0], SingleTaskEventImpl->getHandle());
+  EXPECT_EQ(EventsInWaitList[0], SingleTaskEventImpl.getHandle());
   Queue.wait();
 }
 } // anonymous namespace

--- a/sycl/unittests/scheduler/GraphCleanup.cpp
+++ b/sycl/unittests/scheduler/GraphCleanup.cpp
@@ -159,7 +159,7 @@ static void checkCleanupOnEnqueue(MockScheduler &MS,
   MS.addCopyBack(&MockReq);
   verifyCleanup(Record, AllocaCmd, MockCmd, CommandDeleted);
 
-  MS.removeRecordForMemObj(detail::getSyclObjImpl(Buf).get());
+  MS.removeRecordForMemObj(&*detail::getSyclObjImpl(Buf));
 }
 
 static void checkCleanupOnLeafUpdate(
@@ -191,7 +191,7 @@ static void checkCleanupOnLeafUpdate(
   EXPECT_FALSE(CommandDeleted);
   SchedulerCall(Record);
   EXPECT_TRUE(CommandDeleted);
-  MS.removeRecordForMemObj(detail::getSyclObjImpl(Buf).get());
+  MS.removeRecordForMemObj(&*detail::getSyclObjImpl(Buf));
 }
 
 TEST_F(SchedulerTest, PostEnqueueCleanup) {
@@ -214,10 +214,9 @@ TEST_F(SchedulerTest, PostEnqueueCleanup) {
   MockScheduler MS;
 
   buffer<int, 1> Buf{range<1>(1)};
-  std::shared_ptr<detail::buffer_impl> BufImpl = detail::getSyclObjImpl(Buf);
   detail::Requirement MockReq = getMockRequirement(Buf);
   MockReq.MDims = 1;
-  MockReq.MSYCLMemObj = BufImpl.get();
+  MockReq.MSYCLMemObj = &*detail::getSyclObjImpl(Buf);
 
   checkCleanupOnEnqueue(MS, QueueImpl, Buf, MockReq);
   std::vector<detail::Command *> ToEnqueue;
@@ -279,11 +278,11 @@ TEST_F(SchedulerTest, HostTaskCleanup) {
   event Event = Queue.submit([&](sycl::handler &cgh) {
     cgh.host_task([&]() { std::unique_lock<std::mutex> Lock{Mutex}; });
   });
-  detail::EventImplPtr EventImpl = detail::getSyclObjImpl(Event);
+  detail::event_impl &EventImpl = *detail::getSyclObjImpl(Event);
 
   // Unlike other commands, host task should be kept alive until its
   // completion.
-  auto *Cmd = static_cast<detail::Command *>(EventImpl->getCommand());
+  auto *Cmd = static_cast<detail::Command *>(EventImpl.getCommand());
   ASSERT_NE(Cmd, nullptr);
   EXPECT_TRUE(Cmd->isSuccessfullyEnqueued());
 
@@ -293,7 +292,7 @@ TEST_F(SchedulerTest, HostTaskCleanup) {
   // submitted to the thread pool, shortly after the event is marked
   // as complete.
   detail::GlobalHandler::instance().drainThreadPool();
-  ASSERT_EQ(EventImpl->getCommand(), nullptr);
+  ASSERT_EQ(EventImpl.getCommand(), nullptr);
 }
 
 struct AttachSchedulerWrapper {

--- a/sycl/unittests/scheduler/HostTaskAndBarrier.cpp
+++ b/sycl/unittests/scheduler/HostTaskAndBarrier.cpp
@@ -83,44 +83,50 @@ protected:
                                 {}, true);
   }
 
-  void BuildAndCheckInnerQueueState(std::vector<EventImplPtr> &Events) {
+  std::vector<event> BuildAndCheckInnerQueueState() {
+    std::vector<event> Events;
     {
       std::lock_guard<std::mutex> Guard(QueueDevImpl->MMutex);
       EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier, nullptr);
       EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents.size(), 0u);
     }
 
+    using sycl::detail::event_impl;
+    using sycl::detail::getSyclObjImpl;
+
     sycl::event BlockedHostTask = AddTask(TestCGType::HOST_TASK);
-    EventImplPtr BlockedHostTaskImpl =
-        sycl::detail::getSyclObjImpl(BlockedHostTask);
-    Events.push_back(BlockedHostTaskImpl);
+    event_impl &BlockedHostTaskImpl = *getSyclObjImpl(BlockedHostTask);
+    Events.push_back(BlockedHostTask);
     {
       std::lock_guard<std::mutex> Guard(QueueDevImpl->MMutex);
       EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier, nullptr);
-      ASSERT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents.size(), 1u);
-      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents[0],
-                BlockedHostTaskImpl);
+      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents.size(), 1u);
+      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents[0].get(),
+                &BlockedHostTaskImpl);
     }
 
     sycl::event BarrierEvent = AddTask(TestCGType::BARRIER);
-    EventImplPtr BarrierEventImpl = sycl::detail::getSyclObjImpl(BarrierEvent);
+    event_impl &BarrierEventImpl = *getSyclObjImpl(BarrierEvent);
     {
       std::lock_guard<std::mutex> Guard(QueueDevImpl->MMutex);
-      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier, BarrierEventImpl);
+      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier.get(),
+                &BarrierEventImpl);
       EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents.size(), 0u);
     }
-    Events.push_back(BarrierEventImpl);
+    Events.push_back(BarrierEvent);
 
     sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);
-    EventImplPtr KernelEventImpl = sycl::detail::getSyclObjImpl(KernelEvent);
+    event_impl &KernelEventImpl = *getSyclObjImpl(KernelEvent);
     {
       std::lock_guard<std::mutex> Guard(QueueDevImpl->MMutex);
-      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier, BarrierEventImpl);
-      ASSERT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents.size(), 1u);
-      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents[0],
-                KernelEventImpl);
+      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier.get(),
+                &BarrierEventImpl);
+      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents.size(), 1u);
+      EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents[0].get(),
+                &KernelEventImpl);
     }
-    Events.push_back(KernelEventImpl);
+    Events.push_back(KernelEvent);
+    return Events;
   }
 
   sycl::unittest::UrMock<> Mock;
@@ -138,182 +144,188 @@ protected:
 };
 
 TEST_F(BarrierHandlingWithHostTask, HostTaskBarrierKernel) {
+  using namespace sycl::detail;
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK);
-  EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
-  auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
+  event_impl &HostTaskEventImpl = *getSyclObjImpl(HTEvent);
+  auto HostTaskWaitList = HostTaskEventImpl.getWaitList();
   EXPECT_EQ(HostTaskWaitList.size(), 0u);
-  EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
+  EXPECT_EQ(HostTaskEventImpl.isEnqueued(), true);
 
   sycl::event BarrierEvent = AddTask(TestCGType::BARRIER);
-  EventImplPtr BarrierEventImpl = sycl::detail::getSyclObjImpl(BarrierEvent);
-  auto BarrierWaitList = BarrierEventImpl->getWaitList();
+  event_impl &BarrierEventImpl = *getSyclObjImpl(BarrierEvent);
+  auto BarrierWaitList = BarrierEventImpl.getWaitList();
   ASSERT_EQ(BarrierWaitList.size(), 1u);
-  EXPECT_EQ(BarrierWaitList[0], HostTaskEventImpl);
-  EXPECT_EQ(BarrierEventImpl->isEnqueued(), false);
+  EXPECT_EQ(BarrierWaitList[0].get(), &HostTaskEventImpl);
+  EXPECT_EQ(BarrierEventImpl.isEnqueued(), false);
 
   sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);
-  EventImplPtr KernelEventImpl = sycl::detail::getSyclObjImpl(KernelEvent);
-  auto KernelWaitList = KernelEventImpl->getWaitList();
+  event_impl &KernelEventImpl = *getSyclObjImpl(KernelEvent);
+  auto KernelWaitList = KernelEventImpl.getWaitList();
   ASSERT_EQ(KernelWaitList.size(), 1u);
-  EXPECT_EQ(KernelWaitList[0], BarrierEventImpl);
-  EXPECT_EQ(KernelEventImpl->isEnqueued(), false);
+  EXPECT_EQ(KernelWaitList[0].get(), &BarrierEventImpl);
+  EXPECT_EQ(KernelEventImpl.isEnqueued(), false);
 
   MainLock.unlock();
   QueueDevImpl->wait();
 }
 
 TEST_F(BarrierHandlingWithHostTask, HostTaskKernelBarrier) {
+  using namespace sycl::detail;
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK);
-  EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
-  auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
+  event_impl &HostTaskEventImpl = *getSyclObjImpl(HTEvent);
+  auto HostTaskWaitList = HostTaskEventImpl.getWaitList();
   EXPECT_EQ(HostTaskWaitList.size(), 0u);
-  EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
+  EXPECT_EQ(HostTaskEventImpl.isEnqueued(), true);
 
   sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);
-  EventImplPtr KernelEventImpl = sycl::detail::getSyclObjImpl(KernelEvent);
-  auto KernelWaitList = KernelEventImpl->getWaitList();
+  event_impl &KernelEventImpl = *getSyclObjImpl(KernelEvent);
+  auto KernelWaitList = KernelEventImpl.getWaitList();
   ASSERT_EQ(KernelWaitList.size(), 0u);
-  EXPECT_EQ(KernelEventImpl->isEnqueued(), true);
+  EXPECT_EQ(KernelEventImpl.isEnqueued(), true);
 
   sycl::event BarrierEvent = AddTask(TestCGType::BARRIER);
-  EventImplPtr BarrierEventImpl = sycl::detail::getSyclObjImpl(BarrierEvent);
-  auto BarrierWaitList = BarrierEventImpl->getWaitList();
+  event_impl &BarrierEventImpl = *getSyclObjImpl(BarrierEvent);
+  auto BarrierWaitList = BarrierEventImpl.getWaitList();
   ASSERT_EQ(BarrierWaitList.size(), 1u);
-  EXPECT_EQ(BarrierWaitList[0], HostTaskEventImpl);
-  EXPECT_EQ(BarrierEventImpl->isEnqueued(), false);
+  EXPECT_EQ(BarrierWaitList[0].get(), &HostTaskEventImpl);
+  EXPECT_EQ(BarrierEventImpl.isEnqueued(), false);
 
   MainLock.unlock();
   QueueDevImpl->wait();
 }
 
 TEST_F(BarrierHandlingWithHostTask, BarrierHostTaskKernel) {
+  using namespace sycl::detail;
   sycl::event BarrierEvent = AddTask(TestCGType::BARRIER);
-  EventImplPtr BarrierEventImpl = sycl::detail::getSyclObjImpl(BarrierEvent);
-  auto BarrierWaitList = BarrierEventImpl->getWaitList();
+  event_impl &BarrierEventImpl = *getSyclObjImpl(BarrierEvent);
+  auto BarrierWaitList = BarrierEventImpl.getWaitList();
   ASSERT_EQ(BarrierWaitList.size(), 0u);
-  EXPECT_EQ(BarrierEventImpl->isEnqueued(), true);
+  EXPECT_EQ(BarrierEventImpl.isEnqueued(), true);
 
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK);
-  EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
-  auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
+  event_impl &HostTaskEventImpl = *getSyclObjImpl(HTEvent);
+  auto HostTaskWaitList = HostTaskEventImpl.getWaitList();
   ASSERT_EQ(HostTaskWaitList.size(), 1u);
-  EXPECT_EQ(HostTaskWaitList[0], BarrierEventImpl);
-  EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
+  EXPECT_EQ(HostTaskWaitList[0].get(), &BarrierEventImpl);
+  EXPECT_EQ(HostTaskEventImpl.isEnqueued(), true);
 
   sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);
-  EventImplPtr KernelEventImpl = sycl::detail::getSyclObjImpl(KernelEvent);
-  auto KernelWaitList = KernelEventImpl->getWaitList();
+  event_impl &KernelEventImpl = *getSyclObjImpl(KernelEvent);
+  auto KernelWaitList = KernelEventImpl.getWaitList();
   ASSERT_EQ(KernelWaitList.size(), 0u);
-  EXPECT_EQ(KernelEventImpl->isEnqueued(), true);
+  EXPECT_EQ(KernelEventImpl.isEnqueued(), true);
 
   MainLock.unlock();
   QueueDevImpl->wait();
 }
 
 TEST_F(BarrierHandlingWithHostTask, BarrierKernelHostTask) {
+  using namespace sycl::detail;
   sycl::event BarrierEvent = AddTask(TestCGType::BARRIER);
-  EventImplPtr BarrierEventImpl = sycl::detail::getSyclObjImpl(BarrierEvent);
-  auto BarrierWaitList = BarrierEventImpl->getWaitList();
+  event_impl &BarrierEventImpl = *getSyclObjImpl(BarrierEvent);
+  auto BarrierWaitList = BarrierEventImpl.getWaitList();
   ASSERT_EQ(BarrierWaitList.size(), 0u);
-  EXPECT_EQ(BarrierEventImpl->isEnqueued(), true);
+  EXPECT_EQ(BarrierEventImpl.isEnqueued(), true);
 
   sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);
-  EventImplPtr KernelEventImpl = sycl::detail::getSyclObjImpl(KernelEvent);
-  auto KernelWaitList = KernelEventImpl->getWaitList();
+  event_impl &KernelEventImpl = *getSyclObjImpl(KernelEvent);
+  auto KernelWaitList = KernelEventImpl.getWaitList();
   ASSERT_EQ(KernelWaitList.size(), 0u);
-  EXPECT_EQ(KernelEventImpl->isEnqueued(), true);
+  EXPECT_EQ(KernelEventImpl.isEnqueued(), true);
 
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK);
-  EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
-  auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
+  event_impl &HostTaskEventImpl = *getSyclObjImpl(HTEvent);
+  auto HostTaskWaitList = HostTaskEventImpl.getWaitList();
   ASSERT_EQ(HostTaskWaitList.size(), 1u);
-  EXPECT_EQ(HostTaskWaitList[0], BarrierEventImpl);
-  EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
+  EXPECT_EQ(HostTaskWaitList[0].get(), &BarrierEventImpl);
+  EXPECT_EQ(HostTaskEventImpl.isEnqueued(), true);
 
   MainLock.unlock();
   QueueDevImpl->wait();
 }
 
 TEST_F(BarrierHandlingWithHostTask, KernelHostTaskBarrier) {
+  using namespace sycl::detail;
   sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);
-  EventImplPtr KernelEventImpl = sycl::detail::getSyclObjImpl(KernelEvent);
-  auto KernelWaitList = KernelEventImpl->getWaitList();
+  event_impl &KernelEventImpl = *getSyclObjImpl(KernelEvent);
+  auto KernelWaitList = KernelEventImpl.getWaitList();
   ASSERT_EQ(KernelWaitList.size(), 0u);
-  EXPECT_EQ(KernelEventImpl->isEnqueued(), true);
+  EXPECT_EQ(KernelEventImpl.isEnqueued(), true);
 
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK);
-  EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
-  auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
+  event_impl &HostTaskEventImpl = *getSyclObjImpl(HTEvent);
+  auto HostTaskWaitList = HostTaskEventImpl.getWaitList();
   ASSERT_EQ(HostTaskWaitList.size(), 0u);
-  EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
+  EXPECT_EQ(HostTaskEventImpl.isEnqueued(), true);
 
   sycl::event BarrierEvent = AddTask(TestCGType::BARRIER);
-  EventImplPtr BarrierEventImpl = sycl::detail::getSyclObjImpl(BarrierEvent);
-  auto BarrierWaitList = BarrierEventImpl->getWaitList();
+  event_impl &BarrierEventImpl = *getSyclObjImpl(BarrierEvent);
+  auto BarrierWaitList = BarrierEventImpl.getWaitList();
   ASSERT_EQ(BarrierWaitList.size(), 1u);
-  EXPECT_EQ(BarrierWaitList[0], HostTaskEventImpl);
-  EXPECT_EQ(BarrierEventImpl->isEnqueued(), false);
+  EXPECT_EQ(BarrierWaitList[0].get(), &HostTaskEventImpl);
+  EXPECT_EQ(BarrierEventImpl.isEnqueued(), false);
 
   MainLock.unlock();
   QueueDevImpl->wait();
 }
 
 TEST_F(BarrierHandlingWithHostTask, KernelBarrierHostTask) {
+  using namespace sycl::detail;
   sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);
-  EventImplPtr KernelEventImpl = sycl::detail::getSyclObjImpl(KernelEvent);
-  auto KernelWaitList = KernelEventImpl->getWaitList();
+  event_impl &KernelEventImpl = *getSyclObjImpl(KernelEvent);
+  auto KernelWaitList = KernelEventImpl.getWaitList();
   ASSERT_EQ(KernelWaitList.size(), 0u);
-  EXPECT_EQ(KernelEventImpl->isEnqueued(), true);
+  EXPECT_EQ(KernelEventImpl.isEnqueued(), true);
 
   sycl::event BarrierEvent = AddTask(TestCGType::BARRIER);
-  EventImplPtr BarrierEventImpl = sycl::detail::getSyclObjImpl(BarrierEvent);
-  auto BarrierWaitList = BarrierEventImpl->getWaitList();
+  event_impl &BarrierEventImpl = *getSyclObjImpl(BarrierEvent);
+  auto BarrierWaitList = BarrierEventImpl.getWaitList();
   ASSERT_EQ(BarrierWaitList.size(), 0u);
-  EXPECT_EQ(BarrierEventImpl->isEnqueued(), true);
+  EXPECT_EQ(BarrierEventImpl.isEnqueued(), true);
 
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK);
-  EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
-  auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
+  event_impl &HostTaskEventImpl = *getSyclObjImpl(HTEvent);
+  auto HostTaskWaitList = HostTaskEventImpl.getWaitList();
   ASSERT_EQ(HostTaskWaitList.size(), 1u);
-  EXPECT_EQ(HostTaskWaitList[0], BarrierEventImpl);
-  EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
+  EXPECT_EQ(HostTaskWaitList[0].get(), &BarrierEventImpl);
+  EXPECT_EQ(HostTaskEventImpl.isEnqueued(), true);
 
   MainLock.unlock();
   QueueDevImpl->wait();
 }
 
 TEST_F(BarrierHandlingWithHostTask, HostTaskUnblockedWaitListBarrierKernel) {
+  using namespace sycl::detail;
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK, false);
-  EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
-  auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
+  event_impl &HostTaskEventImpl = *getSyclObjImpl(HTEvent);
+  auto HostTaskWaitList = HostTaskEventImpl.getWaitList();
   EXPECT_EQ(HostTaskWaitList.size(), 0u);
-  EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
+  EXPECT_EQ(HostTaskEventImpl.isEnqueued(), true);
 
   sycl::event BlockedHostTask = AddTask(TestCGType::HOST_TASK);
-  EventImplPtr BlockedHostTaskImpl =
-      sycl::detail::getSyclObjImpl(BlockedHostTask);
-  auto BlockedHostTaskWaitList = BlockedHostTaskImpl->getWaitList();
+  event_impl &BlockedHostTaskImpl = *getSyclObjImpl(BlockedHostTask);
+  auto BlockedHostTaskWaitList = BlockedHostTaskImpl.getWaitList();
   EXPECT_EQ(BlockedHostTaskWaitList.size(), 0u);
-  EXPECT_EQ(BlockedHostTaskImpl->isEnqueued(), true);
+  EXPECT_EQ(BlockedHostTaskImpl.isEnqueued(), true);
 
-  HostTaskEventImpl->wait(HostTaskEventImpl);
+  HostTaskEventImpl.wait(getSyclObjImpl(HTEvent));
 
   std::vector<sycl::event> WaitList{HTEvent};
   sycl::event BarrierEvent = InsertBarrierWithWaitList(WaitList);
-  EventImplPtr BarrierEventImpl = sycl::detail::getSyclObjImpl(BarrierEvent);
-  auto BarrierWaitList = BarrierEventImpl->getWaitList();
+  event_impl &BarrierEventImpl = *getSyclObjImpl(BarrierEvent);
+  auto BarrierWaitList = BarrierEventImpl.getWaitList();
   // Events to wait by barrier are stored in a separated vector. Here we are
   // interested in implicit deps only.
   // Host task in barrier wait list could not be handled by backend so it is
   // added by RT to dependency list to initiate deps tracking by scheduler.
   ASSERT_EQ(BarrierWaitList.size(), 1u);
-  EXPECT_EQ(BarrierEventImpl->isEnqueued(), true);
+  EXPECT_EQ(BarrierEventImpl.isEnqueued(), true);
 
   sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);
-  EventImplPtr KernelEventImpl = sycl::detail::getSyclObjImpl(KernelEvent);
-  auto KernelWaitList = KernelEventImpl->getWaitList();
+  event_impl &KernelEventImpl = *getSyclObjImpl(KernelEvent);
+  auto KernelWaitList = KernelEventImpl.getWaitList();
   ASSERT_EQ(KernelWaitList.size(), 0u);
-  EXPECT_EQ(KernelEventImpl->isEnqueued(), true);
+  EXPECT_EQ(KernelEventImpl.isEnqueued(), true);
 
   MainLock.unlock();
   QueueDevImpl->wait();
@@ -323,8 +335,7 @@ TEST_F(BarrierHandlingWithHostTask,
        QueueInnerCleanupOnHostTaskCompletionNotBlocked) {
   // Checks that host task immediately cleans queue fields up if queue mutex is
   // not locked.
-  std::vector<EventImplPtr> SubmittedCmdEvents;
-  BuildAndCheckInnerQueueState(SubmittedCmdEvents);
+  (void)BuildAndCheckInnerQueueState();
 
   MainLock.unlock();
   QueueDevImpl->wait();
@@ -343,8 +354,7 @@ TEST_F(BarrierHandlingWithHostTask,
   // locked. Applicable for graph execution (waits for host task in submit call,
   // if thread is busy with other host task trying to cleanup resources - we
   // could get dead lock) and also better utilizes host task thread.
-  std::vector<EventImplPtr> SubmittedCmdEvents;
-  BuildAndCheckInnerQueueState(SubmittedCmdEvents);
+  std::vector<event> SubmittedCmdEvents = BuildAndCheckInnerQueueState();
 
   {
     // Block queue fields update.
@@ -355,11 +365,11 @@ TEST_F(BarrierHandlingWithHostTask,
   // Queue mutex was locked and host task was not able to do cleanup.
   {
     std::lock_guard<std::mutex> Guard(QueueDevImpl->MMutex);
-    EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier,
-              SubmittedCmdEvents[1]);
+    EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier.get(),
+              &*detail::getSyclObjImpl(SubmittedCmdEvents[1]));
     ASSERT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents.size(), 1u);
-    EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents[0],
-              SubmittedCmdEvents[2]);
+    EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents[0].get(),
+              &*detail::getSyclObjImpl(SubmittedCmdEvents[2]));
   }
   // Wait or new submission will do cleanup. Checks wait.
   QueueDevImpl->wait();
@@ -376,8 +386,7 @@ TEST_F(BarrierHandlingWithHostTask,
   // locked. Applicable for graph execution (waits for host task in submit call,
   // if thread is busy with other host task trying to cleanup resources - we
   // could get dead lock) and also better utilizes host task thread.
-  std::vector<EventImplPtr> SubmittedCmdEvents;
-  BuildAndCheckInnerQueueState(SubmittedCmdEvents);
+  std::vector<event> SubmittedCmdEvents = BuildAndCheckInnerQueueState();
 
   {
     // Block queue fields update.
@@ -388,11 +397,11 @@ TEST_F(BarrierHandlingWithHostTask,
   // Queue mutex was locked and host task was not able to do cleanup.
   {
     std::lock_guard<std::mutex> Guard(QueueDevImpl->MMutex);
-    EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier,
-              SubmittedCmdEvents[1]);
+    EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.LastBarrier.get(),
+              &*detail::getSyclObjImpl(SubmittedCmdEvents[1]));
     ASSERT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents.size(), 1u);
-    EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents[0],
-              SubmittedCmdEvents[2]);
+    EXPECT_EQ(QueueDevImpl->MDefaultGraphDeps.UnenqueuedCmdEvents[0].get(),
+              &*detail::getSyclObjImpl(SubmittedCmdEvents[2]));
   }
   // Wait or new submission will do cleanup. Checks new submission.
   std::ignore = AddTask(TestCGType::KERNEL_TASK);

--- a/sycl/unittests/scheduler/LeafLimit.cpp
+++ b/sycl/unittests/scheduler/LeafLimit.cpp
@@ -84,7 +84,7 @@ TEST_F(SchedulerTest, LeafLimit) {
       NewestLeaf->MDeps.begin(), NewestLeaf->MDeps.end(),
       [&](const detail::DepDesc &DD) { return DD.MDepCommand == OldestLeaf; }));
   MS.cleanupCommandsForRecord(Rec);
-  auto MemObj = static_cast<sycl::detail::SYCLMemObjI *>(
-      detail::getSyclObjImpl(Buf).get());
+  auto MemObj =
+      static_cast<sycl::detail::SYCLMemObjI *>(&*detail::getSyclObjImpl(Buf));
   MS.removeRecordForMemObj(MemObj);
 }

--- a/sycl/unittests/scheduler/LeafLimitDiffContexts.cpp
+++ b/sycl/unittests/scheduler/LeafLimitDiffContexts.cpp
@@ -53,18 +53,18 @@ TEST_F(SchedulerTest, LeafLimitDiffContexts) {
 
     void InitializeUtils(detail::Requirement &MockReq, MockScheduler &MS) {
 
-      Rec = MS.getOrInsertMemObjRecord(detail::getSyclObjImpl(Queue).get(),
-                                       &MockReq);
+      Rec =
+          MS.getOrInsertMemObjRecord(&*detail::getSyclObjImpl(Queue), &MockReq);
       // Creating Alloca on both - device and host contexts (will be created in
       // real case in insertMemMove for example) It is done to avoid extra
       // AllocCmd insertion during ConnectCmd insertion
       std::vector<detail::Command *> ToEnqueue;
       AllocaCmd = MS.getOrCreateAllocaForReq(
-          Rec, &MockReq, detail::getSyclObjImpl(Queue).get(), ToEnqueue);
+          Rec, &MockReq, &*detail::getSyclObjImpl(Queue), ToEnqueue);
       std::ignore =
           MS.getOrCreateAllocaForReq(Rec, &MockReq, nullptr, ToEnqueue);
-      DepCmd = std::make_unique<MockCommand>(
-          detail::getSyclObjImpl(Queue).get(), MockReq);
+      DepCmd = std::make_unique<MockCommand>(&*detail::getSyclObjImpl(Queue),
+                                             MockReq);
     }
   };
 
@@ -86,7 +86,7 @@ TEST_F(SchedulerTest, LeafLimitDiffContexts) {
   auto AddLeafWithDeps = [&AddedLeaves, &MockReq,
                           &MS](const QueueRelatedObjects &QueueStuff) {
     auto NewLeaf = std::make_unique<MockCommand>(
-        detail::getSyclObjImpl(QueueStuff.Queue).get(), MockReq);
+        &*detail::getSyclObjImpl(QueueStuff.Queue), MockReq);
     // Create edges: all soon-to-be leaves are direct users of MockDep
     std::vector<detail::Command *> ToCleanUp;
     (void)NewLeaf->addDep(detail::DepDesc{QueueStuff.DepCmd.get(), &MockReq,

--- a/sycl/unittests/scheduler/MemObjCommandCleanup.cpp
+++ b/sycl/unittests/scheduler/MemObjCommandCleanup.cpp
@@ -49,7 +49,7 @@ TEST_F(SchedulerTest, MemObjCommandCleanupAllocaUsers) {
   addEdge(MockIndirectUser, MockDirectUser.get(), MockAllocaA);
 
   MS.cleanupCommandsForRecord(RecA);
-  MS.removeRecordForMemObj(detail::getSyclObjImpl(BufA).get());
+  MS.removeRecordForMemObj(&*detail::getSyclObjImpl(BufA));
 
   // Check that the direct user has been left with the second alloca
   // as the only dependency, while the indirect user has been cleaned up.
@@ -84,7 +84,7 @@ TEST_F(SchedulerTest, MemObjCommandCleanupAllocaDeps) {
   ASSERT_EQ(DepCmd.MUsers.count(MockAllocaCmd), 1U);
 
   MS.cleanupCommandsForRecord(MemObjRec);
-  MS.removeRecordForMemObj(detail::getSyclObjImpl(Buf).get());
+  MS.removeRecordForMemObj(&*detail::getSyclObjImpl(Buf));
 
   // Check that DepCmd has its MUsers field cleared.
   ASSERT_EQ(DepCmd.MUsers.size(), 0U);

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -212,7 +212,7 @@ sycl::detail::Requirement getMockRequirement(const MemObjT &MemObj) {
           /*AccessRange*/ {0, 0, 0},
           /*MemoryRange*/ {0, 0, 0},
           /*AccessMode*/ sycl::access::mode::read_write,
-          /*SYCLMemObj*/ sycl::detail::getSyclObjImpl(MemObj).get(),
+          /*SYCLMemObj*/ &*sycl::detail::getSyclObjImpl(MemObj),
           /*Dims*/ 0,
           /*ElementSize*/ 0,
           /*Offset*/ size_t(0)};


### PR DESCRIPTION
I'm planning to change `getSyclObjImpl` to return a raw reference in a later patch, uploading a bunch of PRs in preparation to that to make the subsequent review easier.