### PR TITLE
[NFC][SYCL] Prepare `unittests/program_manager` for `getSyclObjImpl` to return raw ref

### DIFF
--- a/sycl/unittests/program_manager/BuildLog.cpp
+++ b/sycl/unittests/program_manager/BuildLog.cpp
@@ -63,9 +63,9 @@ TEST(BuildLog, OutputNothingOnLevel1) {
   sycl::context Ctx{Dev};
   sycl::queue Queue{Ctx, Dev};
 
-  auto ContextImpl = getSyclObjImpl(Ctx);
+  context_impl &ContextImpl = *getSyclObjImpl(Ctx);
   // Make sure no kernels are cached
-  ContextImpl->getKernelProgramCache().reset();
+  ContextImpl.getKernelProgramCache().reset();
 
   LogRequested = false;
   sycl::kernel_bundle KernelBundle =
@@ -90,9 +90,9 @@ TEST(BuildLog, OutputLogOnLevel2) {
   sycl::context Ctx{Dev};
   sycl::queue Queue{Ctx, Dev};
 
-  auto ContextImpl = getSyclObjImpl(Ctx);
+  context_impl &ContextImpl = *getSyclObjImpl(Ctx);
   // Make sure no kernels are cached
-  ContextImpl->getKernelProgramCache().reset();
+  ContextImpl.getKernelProgramCache().reset();
 
   LogRequested = false;
   sycl::kernel_bundle KernelBundle =

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -165,13 +165,13 @@ public:
 
 const sycl::detail::KernelArgMask *getKernelArgMaskFromBundle(
     const sycl::kernel_bundle<sycl::bundle_state::input> &KernelBundle,
-    std::shared_ptr<sycl::detail::queue_impl> QueueImpl) {
+    sycl::detail::queue_impl &QueueImpl) {
 
   auto ExecBundle = sycl::link(sycl::compile(KernelBundle));
   EXPECT_FALSE(ExecBundle.empty()) << "Expect non-empty exec kernel bundle";
 
   // Emulating processing of command group function
-  MockHandler MockCGH(*QueueImpl);
+  MockHandler MockCGH(QueueImpl);
   MockCGH.use_kernel_bundle(ExecBundle);
   MockCGH.single_task<EAMTestKernel>([] {}); // Actual kernel does not matter
 
@@ -218,7 +218,7 @@ TEST(EliminatedArgMask, KernelBundleWith2Kernels) {
 
   const sycl::detail::KernelArgMask *EliminatedArgMask =
       getKernelArgMaskFromBundle(KernelBundle,
-                                 sycl::detail::getSyclObjImpl(Queue));
+                                 *sycl::detail::getSyclObjImpl(Queue));
   assert(EliminatedArgMask && "EliminatedArgMask must be not null");
 
   sycl::detail::KernelArgMask ExpElimArgMask(EAMTestKernelNumArgs);


### PR DESCRIPTION
I'm planning to change `getSyclObjImpl` to return a raw reference in a later patch, uploading a bunch of PRs in preparation to that to make the subsequent review easier.