### PR TITLE
[NFC][SYCL] Prepare `unittests/kernel-and-program` for `getSyclObjImpl` to return raw ref

### DIFF
--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -105,9 +105,9 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramSourceNegativeBuild) {
   //   program Prg{Ctx};
 
   //   Prg.build_with_source("");
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
 
@@ -117,9 +117,9 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramSourceNegativeBuildWithOpts) {
   //   program Prg{Ctx};
 
   //   Prg.build_with_source("", "-g");
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
 
@@ -131,9 +131,9 @@ TEST_F(KernelAndProgramCacheTest,
 
   //   Prg.compile_with_source("");
   //   Prg.link();
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
 
@@ -146,9 +146,9 @@ TEST_F(KernelAndProgramCacheTest,
 
   //   Prg.compile_with_source("");
   //   Prg.link();
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
 
@@ -161,9 +161,9 @@ TEST_F(KernelAndProgramCacheTest, KernelBundleInputState) {
   sycl::kernel_bundle KernelBundle1 =
       sycl::get_kernel_bundle<sycl::bundle_state::input>(Ctx, {KernelID1});
 
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
 
   EXPECT_EQ(Cache.size(), 0U)
     << "Expect empty cache for kernel_bundles build with input_state.";
@@ -178,9 +178,9 @@ TEST_F(KernelAndProgramCacheTest, KernelBundleObjectState) {
   sycl::kernel_bundle KernelBundle1 =
       sycl::get_kernel_bundle<sycl::bundle_state::object>(Ctx, {KernelID1});
 
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
 
   EXPECT_EQ(Cache.size(), 0U)
     << "Expect empty cache for kernel_bundles build with object_state.";
@@ -198,9 +198,9 @@ TEST_F(KernelAndProgramCacheTest, KernelBundleExecutableState) {
   sycl::kernel_bundle KernelBundle2 =
       sycl::get_kernel_bundle<sycl::bundle_state::executable>(Ctx, {KernelID2});
 
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
 
   EXPECT_EQ(Cache.size(), 1U)
     << "Expect non-empty cache for kernel_bundles with executable_state.";
@@ -228,9 +228,9 @@ TEST_F(KernelAndProgramCacheTest, SpecConstantCacheNegative) {
   EXPECT_EQ(KernelBundle2.get_specialization_constant<SpecConst1>(), 70)
       << "Wrong specialization constant";
 
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
 
   EXPECT_EQ(Cache.size(), 2U) << "Expect an entry for each build in the cache.";
 }
@@ -251,9 +251,9 @@ TEST_F(KernelAndProgramCacheTest, KernelBundleJoin) {
       KernelBundles {KernelBundle1, KernelBundle2};
   sycl::kernel_bundle KernelBundle3 = sycl::join(KernelBundles);
 
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
 
   EXPECT_EQ(Cache.size(), 1U)
       << "Expect no caching for kennel_bundle created via join.";
@@ -278,9 +278,9 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildPositiveBuildOpts) {
   //   Prg4.build_with_kernel_type<CacheTestKernel>();
   //   Prg5.build_with_kernel_type<CacheTestKernel2>("-a");
 
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 3U) << "Expect non-empty cache for programs";
 }
 
@@ -291,9 +291,9 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildNegativeCompileOpts) {
 
   //   Prg.compile_with_kernel_type<CacheTestKernel>("-g");
   //   Prg.link();
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for programs";
 }
 
@@ -304,34 +304,34 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildNegativeLinkOpts) {
 
   //   Prg.compile_with_kernel_type<CacheTestKernel>();
   //   Prg.link("-g");
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   detail::KernelProgramCache::ProgramCache &Cache =
-      CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+      CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for programs";
 }
 
 // Check that kernels built without options are cached.
 TEST_F(KernelAndProgramCacheTest, DISABLED_KernelPositive) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
   //   Prg.build_with_kernel_type<CacheTestKernel>();
   //   kernel Ker = Prg.get_kernel<CacheTestKernel>();
   detail::KernelProgramCache::KernelCacheT &Cache =
-      CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+      CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
   EXPECT_EQ(Cache.size(), 1U) << "Expect non-empty cache for kernels";
 }
 
 // Check that kernels built with options are cached.
 TEST_F(KernelAndProgramCacheTest, DISABLED_KernelPositiveBuildOpts) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
@@ -339,16 +339,16 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_KernelPositiveBuildOpts) {
 
   //   kernel Ker = Prg.get_kernel<CacheTestKernel>();
   detail::KernelProgramCache::KernelCacheT &Cache =
-      CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+      CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
   EXPECT_EQ(Cache.size(), 1U) << "Expect non-empty cache for kernels";
 }
 
 // Check that kernels built with compile options are not cached.
 TEST_F(KernelAndProgramCacheTest, DISABLED_KernelNegativeCompileOpts) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
@@ -356,16 +356,16 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_KernelNegativeCompileOpts) {
   //   Prg.link();
   //   kernel Ker = Prg.get_kernel<CacheTestKernel>();
   detail::KernelProgramCache::KernelCacheT &Cache =
-      CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+      CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for kernels";
 }
 
 // Check that kernels built with link options are not cached.
 TEST_F(KernelAndProgramCacheTest, DISABLED_KernelNegativeLinkOpts) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
@@ -373,16 +373,16 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_KernelNegativeLinkOpts) {
   //   Prg.link("-g");
   //   kernel Ker = Prg.get_kernel<CacheTestKernel>();
   detail::KernelProgramCache::KernelCacheT &Cache =
-      CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+      CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for kernels";
 }
 
 // Check that kernels created from source are not cached.
 TEST_F(KernelAndProgramCacheTest, DISABLED_KernelNegativeSource) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
@@ -390,7 +390,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_KernelNegativeSource) {
   //   kernel Ker = Prg.get_kernel("test");
 
   detail::KernelProgramCache::KernelCacheT &Cache =
-      CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+      CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for kernels";
 }
 
@@ -411,25 +411,25 @@ public:
 // Check that kernels built without options are cached.
 TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelPositive) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
   //   Prg.build_with_kernel_type<CacheTestKernel>();
   //   kernel Ker = Prg.get_kernel<CacheTestKernel>();
   detail::KernelProgramCache::FastKernelCacheT &Cache =
-      MockKernelProgramCache::getFastCache(CtxImpl->getKernelProgramCache());
+      MockKernelProgramCache::getFastCache(CtxImpl.getKernelProgramCache());
   EXPECT_EQ(Cache.size(), 1U) << "Expect non-empty cache for kernels";
 }
 
 // Check that kernels built with options are cached.
 TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelPositiveBuildOpts) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
@@ -437,16 +437,16 @@ TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelPositiveBuildOpts) {
 
   //   kernel Ker = Prg.get_kernel<CacheTestKernel>();
   detail::KernelProgramCache::FastKernelCacheT &Cache =
-      MockKernelProgramCache::getFastCache(CtxImpl->getKernelProgramCache());
+      MockKernelProgramCache::getFastCache(CtxImpl.getKernelProgramCache());
   EXPECT_EQ(Cache.size(), 1U) << "Expect non-empty cache for kernels";
 }
 
 // Check that kernels built with compile options are not cached.
 TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelNegativeCompileOpts) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
@@ -454,16 +454,16 @@ TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelNegativeCompileOpts) {
   //   Prg.link();
   //   kernel Ker = Prg.get_kernel<CacheTestKernel>();
   detail::KernelProgramCache::FastKernelCacheT &Cache =
-      MockKernelProgramCache::getFastCache(CtxImpl->getKernelProgramCache());
+      MockKernelProgramCache::getFastCache(CtxImpl.getKernelProgramCache());
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for kernels";
 }
 
 // Check that kernels built with link options are not cached.
 TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelNegativeLinkOpts) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
@@ -471,7 +471,7 @@ TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelNegativeLinkOpts) {
   //   Prg.link("-g");
   //   kernel Ker = Prg.get_kernel<CacheTestKernel>();
   detail::KernelProgramCache::FastKernelCacheT &Cache =
-      MockKernelProgramCache::getFastCache(CtxImpl->getKernelProgramCache());
+      MockKernelProgramCache::getFastCache(CtxImpl.getKernelProgramCache());
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for kernels";
 }
 
@@ -479,9 +479,9 @@ TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelNegativeLinkOpts) {
 // programs.
 TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelNegativeLinkedProgs) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg1{Ctx};
   //   program Prg2{Ctx};
@@ -492,16 +492,16 @@ TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelNegativeLinkedProgs) {
   //   kernel Ker = Prg.get_kernel<CacheTestKernel>();
 
   detail::KernelProgramCache::FastKernelCacheT &Cache =
-      MockKernelProgramCache::getFastCache(CtxImpl->getKernelProgramCache());
+      MockKernelProgramCache::getFastCache(CtxImpl.getKernelProgramCache());
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for kernels";
 }
 
 // Check that kernels created from source are not cached.
 TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelNegativeSource) {
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
 
-  globalCtx.reset(new TestCtx{CtxImpl->getHandleRef()});
+  globalCtx.reset(new TestCtx{CtxImpl.getHandleRef()});
 
   //   program Prg{Ctx};
 
@@ -509,6 +509,6 @@ TEST_F(KernelAndProgramFastCacheTest, DISABLED_KernelNegativeSource) {
   //   kernel Ker = Prg.get_kernel("test");
 
   detail::KernelProgramCache::FastKernelCacheT &Cache =
-      MockKernelProgramCache::getFastCache(CtxImpl->getKernelProgramCache());
+      MockKernelProgramCache::getFastCache(CtxImpl.getKernelProgramCache());
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for kernels";
 }

--- a/sycl/unittests/kernel-and-program/InMemCacheEviction.cpp
+++ b/sycl/unittests/kernel-and-program/InMemCacheEviction.cpp
@@ -109,7 +109,7 @@ TEST(InMemCacheEvictionTests, TestBasicEvictionAndLRU) {
 
   sycl::platform Plt{sycl::platform()};
   sycl::context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   queue q(Ctx, default_selector_v);
 
   // One program is of 10000 bytes, so 20005 eviction threshold can
@@ -119,11 +119,11 @@ TEST(InMemCacheEvictionTests, TestBasicEvictionAndLRU) {
   // Cache is empty, so one urProgramCreateWithIL call.
   q.single_task<class Kernel1>([] {});
   EXPECT_EQ(NumProgramBuild, 1);
-  CheckNumberOfEntriesInCacheAndEvictionList(*CtxImpl, 1);
+  CheckNumberOfEntriesInCacheAndEvictionList(CtxImpl, 1);
 
   q.single_task<class Kernel2>([] {});
   EXPECT_EQ(NumProgramBuild, 2);
-  CheckNumberOfEntriesInCacheAndEvictionList(*CtxImpl, 2);
+  CheckNumberOfEntriesInCacheAndEvictionList(CtxImpl, 2);
 
   // Move first program to end of eviction list.
   q.single_task<class Kernel1>([] {});
@@ -135,19 +135,19 @@ TEST(InMemCacheEvictionTests, TestBasicEvictionAndLRU) {
   // Kernel2's program should have been evicted.
   q.single_task<class Kernel3>([] {});
   EXPECT_EQ(NumProgramBuild, 3);
-  CheckNumberOfEntriesInCacheAndEvictionList(*CtxImpl, 2);
+  CheckNumberOfEntriesInCacheAndEvictionList(CtxImpl, 2);
 
   // Calling Kernel2 again should trigger urProgramCreateWithIL and
   // should evict Kernel1's program.
   q.single_task<class Kernel2>([] {});
   EXPECT_EQ(NumProgramBuild, 3);
-  CheckNumberOfEntriesInCacheAndEvictionList(*CtxImpl, 2);
+  CheckNumberOfEntriesInCacheAndEvictionList(CtxImpl, 2);
 
   // Calling Kernel1 again should trigger urProgramCreateWithIL and
   // should evict Kernel3's program.
   q.single_task<class Kernel1>([] {});
   EXPECT_EQ(NumProgramBuild, 4);
-  CheckNumberOfEntriesInCacheAndEvictionList(*CtxImpl, 2);
+  CheckNumberOfEntriesInCacheAndEvictionList(CtxImpl, 2);
 }
 
 // Test to verify eviction using concurrent kernel invocation.
@@ -161,7 +161,7 @@ TEST(InMemCacheEvictionTests, TestConcurrentEvictionSameQueue) {
 
   sycl::platform Plt{sycl::platform()};
   context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   queue q(Ctx, default_selector_v);
 
   // One program is of 10000 bytes, so 20005 eviction threshold can
@@ -182,7 +182,7 @@ TEST(InMemCacheEvictionTests, TestConcurrentEvictionSameQueue) {
   }
   q.wait_and_throw();
 
-  CheckNumberOfEntriesInCacheAndEvictionList(*CtxImpl, 2);
+  CheckNumberOfEntriesInCacheAndEvictionList(CtxImpl, 2);
 }
 
 // Test to verify eviction using concurrent kernel invocation when
@@ -196,7 +196,7 @@ TEST(InMemCacheEvictionTests, TestConcurrentEvictionSmallCache) {
                                           &redefinedProgramGetInfoAfter);
 
   context Ctx{platform()};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   queue q(Ctx, default_selector_v);
 
   // One program is of 10000 bytes, so 100 eviction threshold will
@@ -218,5 +218,5 @@ TEST(InMemCacheEvictionTests, TestConcurrentEvictionSmallCache) {
   }
   q.wait_and_throw();
 
-  CheckNumberOfEntriesInCacheAndEvictionList(*CtxImpl, 0);
+  CheckNumberOfEntriesInCacheAndEvictionList(CtxImpl, 0);
 }

--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -152,19 +152,19 @@ TEST_P(MultipleDeviceCacheTest, ProgramRetain) {
     // on number of device images. This test has one image, but other tests can
     // create other images. Additional variable is added to control count of
     // urProgramRetain calls.
-    auto BundleImpl = getSyclObjImpl(Bundle);
+    detail::kernel_bundle_impl &BundleImpl = *getSyclObjImpl(Bundle);
 
     // Bundle should only contain a single image, specifically the one with
     // MultipleDevsCacheTestKernel.
-    EXPECT_EQ(BundleImpl->size(), size_t{1});
+    EXPECT_EQ(BundleImpl.size(), size_t{1});
 
-    int NumRetains = BundleImpl->size() * std::pow(2, NumDevices) - 1;
+    int NumRetains = BundleImpl.size() * std::pow(2, NumDevices) - 1;
     EXPECT_EQ(RetainCounter, NumRetains)
         << "Expect " << NumRetains << " piProgramRetain calls";
 
-    auto CtxImpl = detail::getSyclObjImpl(Context);
+    detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Context);
     detail::KernelProgramCache::KernelCacheT &KernelCache =
-        CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+        CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
 
     EXPECT_EQ(KernelCache.size(), (size_t)2)
         << "Expect 2 programs in kernel cache";

--- a/sycl/unittests/kernel-and-program/OutOfResources.cpp
+++ b/sycl/unittests/kernel-and-program/OutOfResources.cpp
@@ -55,7 +55,7 @@ TEST_P(OutOfResourcesTestSuite, urProgramCreate) {
 
   sycl::platform Plt{sycl::platform()};
   sycl::context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   queue q(Ctx, default_selector_v);
 
   int runningTotal = 0;
@@ -72,7 +72,7 @@ TEST_P(OutOfResourcesTestSuite, urProgramCreate) {
   EXPECT_EQ(nProgramCreate, runningTotal += 2);
   {
     detail::KernelProgramCache::ProgramCache &Cache =
-        CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+        CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
     EXPECT_EQ(Cache.size(), 1U) << "Expected 1 program in the cache";
   }
 
@@ -92,7 +92,7 @@ TEST_P(OutOfResourcesTestSuite, urProgramCreate) {
   EXPECT_EQ(nProgramCreate, runningTotal += 2);
   {
     detail::KernelProgramCache::ProgramCache &Cache =
-        CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+        CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
     EXPECT_EQ(Cache.size(), 1U) << "Expected 1 program in the cache";
   }
 
@@ -104,7 +104,7 @@ TEST_P(OutOfResourcesTestSuite, urProgramCreate) {
   EXPECT_EQ(nProgramCreate, runningTotal += 1);
   {
     detail::KernelProgramCache::ProgramCache &Cache =
-        CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+        CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
     EXPECT_EQ(Cache.size(), 2U) << "Expected 2 program in the cache";
   }
 }
@@ -119,7 +119,6 @@ TEST_P(OutOfResourcesTestSuite, urProgramCreateAlwaysFail) {
 
   sycl::platform Plt{sycl::platform()};
   sycl::context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
   queue Q(Ctx, default_selector_v);
 
   bool ThrewException = false;
@@ -154,14 +153,14 @@ TEST_P(OutOfResourcesTestSuite, urProgramLink) {
 
   sycl::platform Plt{sycl::platform()};
   sycl::context Ctx{Plt};
-  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Ctx);
   queue q(Ctx, default_selector_v);
   // Put some programs in the cache
   q.single_task<class OutOfResourcesKernel1>([] {});
   q.single_task<class OutOfResourcesKernel2>([] {});
   {
     detail::KernelProgramCache::ProgramCache &Cache =
-        CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+        CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
     EXPECT_EQ(Cache.size(), 2U) << "Expect 2 programs in the cache";
   }
 
@@ -178,7 +177,7 @@ TEST_P(OutOfResourcesTestSuite, urProgramLink) {
   // no programs should be in the cache due to out of resources.
   {
     detail::KernelProgramCache::ProgramCache &Cache =
-        CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+        CtxImpl.getKernelProgramCache().acquireCachedPrograms().get();
     EXPECT_EQ(Cache.size(), 0u) << "Expect no programs in the cache";
   }
 }


### PR DESCRIPTION
I'm planning to change `getSyclObjImpl` to return a raw reference in a later patch, uploading a bunch of PRs in preparation to that to make the subsequent review easier.