### PR TITLE
[NFC][SYCL] Prepare misc unittests for `getSyclObjImpl` to return raw ref

### DIFF
--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -620,9 +620,10 @@ TEST_F(DeviceGlobalTest, DeviceGlobalImgScopeUseBeforeCopyTo) {
   Q.single_task<DeviceGlobalImgScopeTestKernel>([]() {}).wait();
 
   // Register the cached program as expected for device global memory operation.
-  auto CtxImpl = sycl::detail::getSyclObjImpl(Q.get_context());
-  sycl::detail::KernelProgramCache::KernelCacheT &KernelCache =
-      CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+  using namespace sycl::detail;
+  context_impl &CtxImpl = *getSyclObjImpl(Q.get_context());
+  KernelProgramCache::KernelCacheT &KernelCache =
+      CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
   ASSERT_EQ(KernelCache.size(), (size_t)1)
       << "Expect 1 program in kernel cache";
   ExpectedReadWriteURProgram = KernelCache.begin()->first;
@@ -649,9 +650,10 @@ TEST_F(DeviceGlobalTest, DeviceGlobalImgScopeUseBeforeMemcpyTo) {
   Q.single_task<DeviceGlobalImgScopeTestKernel>([]() {}).wait();
 
   // Register the cached program as expected for device global memory operation.
-  auto CtxImpl = sycl::detail::getSyclObjImpl(Q.get_context());
-  sycl::detail::KernelProgramCache::KernelCacheT &KernelCache =
-      CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+  using namespace sycl::detail;
+  context_impl &CtxImpl = *getSyclObjImpl(Q.get_context());
+  KernelProgramCache::KernelCacheT &KernelCache =
+      CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
   ASSERT_EQ(KernelCache.size(), (size_t)1)
       << "Expect 1 program in kernel cache";
   ExpectedReadWriteURProgram = KernelCache.begin()->first;
@@ -678,9 +680,10 @@ TEST_F(DeviceGlobalTest, DeviceGlobalImgScopeUseBeforeCopyFrom) {
   Q.single_task<DeviceGlobalImgScopeTestKernel>([]() {}).wait();
 
   // Register the cached program as expected for device global memory operation.
-  auto CtxImpl = sycl::detail::getSyclObjImpl(Q.get_context());
-  sycl::detail::KernelProgramCache::KernelCacheT &KernelCache =
-      CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+  using namespace sycl::detail;
+  context_impl &CtxImpl = *getSyclObjImpl(Q.get_context());
+  KernelProgramCache::KernelCacheT &KernelCache =
+      CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
   ASSERT_EQ(KernelCache.size(), (size_t)1)
       << "Expect 1 program in kernel cache";
   ExpectedReadWriteURProgram = KernelCache.begin()->first;
@@ -707,9 +710,10 @@ TEST_F(DeviceGlobalTest, DeviceGlobalImgScopeUseBeforeMemcpyFrom) {
   Q.single_task<DeviceGlobalImgScopeTestKernel>([]() {}).wait();
 
   // Register the cached program as expected for device global memory operation.
-  auto CtxImpl = sycl::detail::getSyclObjImpl(Q.get_context());
-  sycl::detail::KernelProgramCache::KernelCacheT &KernelCache =
-      CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
+  using namespace sycl::detail;
+  context_impl &CtxImpl = *getSyclObjImpl(Q.get_context());
+  KernelProgramCache::KernelCacheT &KernelCache =
+      CtxImpl.getKernelProgramCache().acquireKernelsPerProgramCache().get();
   ASSERT_EQ(KernelCache.size(), (size_t)1)
       << "Expect 1 program in kernel cache";
   ExpectedReadWriteURProgram = KernelCache.begin()->first;

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -107,15 +107,17 @@ TEST(KernelBundle, KernelBundleAndItsDevImageStateConsistency) {
   auto ObjBundle = sycl::compile(KernelBundle, KernelBundle.get_devices());
   EXPECT_FALSE(ObjBundle.empty()) << "Expect non-empty obj kernel bundle";
 
-  auto ObjBundleImpl = sycl::detail::getSyclObjImpl(ObjBundle);
-  EXPECT_EQ(ObjBundleImpl->get_bundle_state(), sycl::bundle_state::object)
+  sycl::detail::kernel_bundle_impl &ObjBundleImpl =
+      *sycl::detail::getSyclObjImpl(ObjBundle);
+  EXPECT_EQ(ObjBundleImpl.get_bundle_state(), sycl::bundle_state::object)
       << "Expect object device image in bundle";
 
   auto LinkBundle = sycl::link(ObjBundle, ObjBundle.get_devices());
   EXPECT_FALSE(LinkBundle.empty()) << "Expect non-empty exec kernel bundle";
 
-  auto LinkBundleImpl = sycl::detail::getSyclObjImpl(LinkBundle);
-  EXPECT_EQ(LinkBundleImpl->get_bundle_state(), sycl::bundle_state::executable)
+  sycl::detail::kernel_bundle_impl &LinkBundleImpl =
+      *sycl::detail::getSyclObjImpl(LinkBundle);
+  EXPECT_EQ(LinkBundleImpl.get_bundle_state(), sycl::bundle_state::executable)
       << "Expect executable device image in bundle";
 }
 

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -74,8 +74,9 @@ TEST(SpecializationConstant, DefaultValuesAreSet) {
                    [&](auto Image) { return Image.has_kernel(TestKernelID); });
   EXPECT_NE(DevImage, KernelBundle.end());
 
-  auto DevImageImpl = sycl::detail::getSyclObjImpl(*DevImage);
-  const auto &Blob = DevImageImpl->get_spec_const_blob_ref();
+  sycl::detail::device_image_impl &DevImageImpl =
+      *sycl::detail::getSyclObjImpl(*DevImage);
+  const auto &Blob = DevImageImpl.get_spec_const_blob_ref();
 
   int SpecConstVal1 = *reinterpret_cast<const int *>(Blob.data());
   int SpecConstVal2 = *(reinterpret_cast<const int *>(Blob.data()) + 1);
@@ -103,8 +104,9 @@ TEST(SpecializationConstant, DefaultValuesAreOverriden) {
                    [&](auto Image) { return Image.has_kernel(TestKernelID); });
   EXPECT_NE(DevImage, KernelBundle.end());
 
-  auto DevImageImpl = sycl::detail::getSyclObjImpl(*DevImage);
-  auto &Blob = DevImageImpl->get_spec_const_blob_ref();
+  sycl::detail::device_image_impl &DevImageImpl =
+      *sycl::detail::getSyclObjImpl(*DevImage);
+  auto &Blob = DevImageImpl.get_spec_const_blob_ref();
   int SpecConstVal1 = *reinterpret_cast<int *>(Blob.data());
   int SpecConstVal2 = *(reinterpret_cast<int *>(Blob.data()) + 1);
 

--- a/sycl/unittests/buffer/BufferLocation.cpp
+++ b/sycl/unittests/buffer/BufferLocation.cpp
@@ -181,10 +181,9 @@ TEST_F(BufferTest, BufferLocationWithAnotherProp) {
             Acc{Buf, cgh, sycl::write_only, PL};
       })
       .wait();
-  std::shared_ptr<sycl::detail::buffer_impl> BufImpl =
-      sycl::detail::getSyclObjImpl(Buf);
+  sycl::detail::buffer_impl &BufImpl = *sycl::detail::getSyclObjImpl(Buf);
   EXPECT_EQ(
-      BufImpl->get_property<sycl::property::buffer::detail::buffer_location>()
+      BufImpl.get_property<sycl::property::buffer::detail::buffer_location>()
           .get_buffer_location(),
       (uint64_t)3);
 
@@ -200,7 +199,7 @@ TEST_F(BufferTest, BufferLocationWithAnotherProp) {
       .wait();
 
   EXPECT_EQ(
-      BufImpl->has_property<sycl::property::buffer::detail::buffer_location>(),
+      BufImpl.has_property<sycl::property::buffer::detail::buffer_location>(),
       0);
 }
 

--- a/sycl/unittests/buffer/BufferReleaseBase.cpp
+++ b/sycl/unittests/buffer/BufferReleaseBase.cpp
@@ -20,9 +20,7 @@ TEST_F(BufferDestructionCheck, BufferWithSizeOnlyDefault) {
   sycl::detail::buffer_impl *RawBufferImplPtr = NULL;
   {
     sycl::buffer<int, 1> Buf(1);
-    std::shared_ptr<sycl::detail::buffer_impl> BufImpl =
-        sycl::detail::getSyclObjImpl(Buf);
-    RawBufferImplPtr = BufImpl.get();
+    RawBufferImplPtr = &*sycl::detail::getSyclObjImpl(Buf);
     MockCmd = addCommandToBuffer(Buf, Q);
   }
   ASSERT_EQ(MockSchedulerPtr->MDeferredMemObjRelease.size(), 1u);
@@ -57,9 +55,7 @@ TEST_F(BufferDestructionCheck, BufferWithSizeOnlyNonDefaultAllocator) {
         sycl::usm_allocator<int, sycl::usm::alloc::shared>;
     AllocatorTypeTest allocator(Q);
     sycl::buffer<int, 1, AllocatorTypeTest> Buf(1, allocator);
-    std::shared_ptr<sycl::detail::buffer_impl> BufImpl =
-        sycl::detail::getSyclObjImpl(Buf);
-    RawBufferImplPtr = BufImpl.get();
+    RawBufferImplPtr = &*sycl::detail::getSyclObjImpl(Buf);
     MockCmd = addCommandToBuffer(Buf, Q);
     EXPECT_CALL(*MockCmd, Release).Times(1);
   }
@@ -78,9 +74,7 @@ TEST_F(BufferDestructionCheck, BufferWithSizeOnlyDefaultAllocator) {
     using AllocatorTypeTest = sycl::buffer_allocator<int>;
     AllocatorTypeTest allocator;
     sycl::buffer<int, 1, AllocatorTypeTest> Buf(1, allocator);
-    std::shared_ptr<sycl::detail::buffer_impl> BufImpl =
-        sycl::detail::getSyclObjImpl(Buf);
-    RawBufferImplPtr = BufImpl.get();
+    RawBufferImplPtr = &*sycl::detail::getSyclObjImpl(Buf);
     MockCmd = addCommandToBuffer(Buf, Q);
     EXPECT_CALL(*MockCmd, Release).Times(1);
   }
@@ -185,9 +179,7 @@ TEST_F(BufferDestructionCheck, BufferWithIterators) {
   {
     std::vector<int> data{3, 4};
     sycl::buffer<int, 1> Buf(data.begin(), data.end());
-    std::shared_ptr<sycl::detail::buffer_impl> BufImpl =
-        sycl::detail::getSyclObjImpl(Buf);
-    RawBufferImplPtr = BufImpl.get();
+    RawBufferImplPtr = &*sycl::detail::getSyclObjImpl(Buf);
     MockCmd = addCommandToBuffer(Buf, Q);
     EXPECT_CALL(*MockCmd, Release).Times(1);
   }
@@ -218,10 +210,8 @@ TEST_F(BufferDestructionCheck, ReadyToReleaseLogic) {
   sycl::buffer<int, 1> Buf(1);
   sycl::detail::Requirement MockReq = getMockRequirement(Buf);
   sycl::detail::MemObjRecord *Rec = MockSchedulerPtr->getOrInsertMemObjRecord(
-      sycl::detail::getSyclObjImpl(Q).get(), &MockReq);
+      &*sycl::detail::getSyclObjImpl(Q), &MockReq);
 
-  std::shared_ptr<sycl::detail::context_impl> CtxImpl =
-      sycl::detail::getSyclObjImpl(Context);
   MockCmdWithReleaseTracking *ReadCmd = nullptr;
   MockCmdWithReleaseTracking *WriteCmd = nullptr;
   ReadCmd =

--- a/sycl/unittests/buffer/BufferReleaseBase.hpp
+++ b/sycl/unittests/buffer/BufferReleaseBase.hpp
@@ -54,7 +54,7 @@ protected:
   MockCmdWithReleaseTracking *addCommandToBuffer(Buffer &Buf, sycl::queue &Q) {
     sycl::detail::Requirement MockReq = getMockRequirement(Buf);
     sycl::detail::MemObjRecord *Rec = MockSchedulerPtr->getOrInsertMemObjRecord(
-        sycl::detail::getSyclObjImpl(Q).get(), &MockReq);
+        &*sycl::detail::getSyclObjImpl(Q), &MockReq);
     MockCmdWithReleaseTracking *MockCmd = new MockCmdWithReleaseTracking(
         *sycl::detail::getSyclObjImpl(Q), MockReq);
     std::vector<sycl::detail::Command *> ToEnqueue;

--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -123,9 +123,8 @@ TEST(QueueWait, QueueWaitTest) {
     event DepEvent = submitTask(Q, Buf);
 
     // Manually block the next commands.
-    std::shared_ptr<detail::event_impl> DepEventImpl =
-        detail::getSyclObjImpl(DepEvent);
-    auto *Cmd = static_cast<detail::Command *>(DepEventImpl->getCommand());
+    detail::event_impl &DepEventImpl = *detail::getSyclObjImpl(DepEvent);
+    auto *Cmd = static_cast<detail::Command *>(DepEventImpl.getCommand());
     Cmd->MIsBlockable = true;
     Cmd->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueBlocked;
 


### PR DESCRIPTION
I'm planning to change `getSyclObjImpl` to return a raw reference in a later patch, uploading a bunch of PRs in preparation to that to make the subsequent review easier.