### PR TITLE
[NFC][SYCL][Graph] Prepare for getSyclObjImpl to return raw ref

### DIFF
--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -905,12 +905,12 @@ void exec_graph_impl::createCommandBuffers(
   ur_exp_command_buffer_desc_t Desc{
       UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC, nullptr, MIsUpdatable,
       Partition->MIsInOrderGraph && !MEnableProfiling, MEnableProfiling};
-  auto ContextImpl = sycl::detail::getSyclObjImpl(MContext);
-  const sycl::detail::AdapterPtr &Adapter = ContextImpl->getAdapter();
+  context_impl &ContextImpl = *sycl::detail::getSyclObjImpl(MContext);
+  const sycl::detail::AdapterPtr &Adapter = ContextImpl.getAdapter();
   sycl::detail::device_impl &DeviceImpl = *sycl::detail::getSyclObjImpl(Device);
   ur_result_t Res =
       Adapter->call_nocheck<sycl::detail::UrApiKind::urCommandBufferCreateExp>(
-          ContextImpl->getHandleRef(), DeviceImpl.getHandleRef(), &Desc,
+          ContextImpl.getHandleRef(), DeviceImpl.getHandleRef(), &Desc,
           &OutCommandBuffer);
   if (Res != UR_RESULT_SUCCESS) {
     throw sycl::exception(errc::invalid, "Failed to create UR command-buffer");
@@ -1636,8 +1636,9 @@ void exec_graph_impl::populateURKernelUpdateStructs(
     std::vector<ur_exp_command_buffer_update_value_arg_desc_t> &ValueDescs,
     sycl::detail::NDRDescT &NDRDesc,
     ur_exp_command_buffer_update_kernel_launch_desc_t &UpdateDesc) const {
-  auto ContextImpl = sycl::detail::getSyclObjImpl(MContext);
-  const sycl::detail::AdapterPtr &Adapter = ContextImpl->getAdapter();
+  sycl::detail::context_impl &ContextImpl =
+      *sycl::detail::getSyclObjImpl(MContext);
+  const sycl::detail::AdapterPtr &Adapter = ContextImpl.getAdapter();
   sycl::detail::device_impl &DeviceImpl =
       *sycl::detail::getSyclObjImpl(MGraphImpl->getDevice());
 
@@ -1665,7 +1666,7 @@ void exec_graph_impl::populateURKernelUpdateStructs(
     EliminatedArgMask = SyclKernelImpl->getKernelArgMask();
   } else {
     BundleObjs = sycl::detail::ProgramManager::getInstance().getOrCreateKernel(
-        *ContextImpl, DeviceImpl, ExecCG.MKernelName,
+        ContextImpl, DeviceImpl, ExecCG.MKernelName,
         ExecCG.MKernelNameBasedCachePtr);
     UrKernel = BundleObjs->MKernelHandle;
     EliminatedArgMask = BundleObjs->MKernelArgMask;
@@ -1884,8 +1885,8 @@ void exec_graph_impl::updateURImpl(
     StructListIndex++;
   }
 
-  auto ContextImpl = sycl::detail::getSyclObjImpl(MContext);
-  const sycl::detail::AdapterPtr &Adapter = ContextImpl->getAdapter();
+  context_impl &ContextImpl = *sycl::detail::getSyclObjImpl(MContext);
+  const sycl::detail::AdapterPtr &Adapter = ContextImpl.getAdapter();
   Adapter->call<sycl::detail::UrApiKind::urCommandBufferUpdateKernelLaunchExp>(
       CommandBuffer, UpdateDescList.size(), UpdateDescList.data());
 }

--- a/sycl/source/detail/graph/graph_impl.hpp
+++ b/sycl/source/detail/graph/graph_impl.hpp
@@ -358,7 +358,7 @@ public:
     size_t FoundCnt = 0;
     for (std::weak_ptr<node_impl> &SuccA : NodeA->MSuccessors) {
       for (std::weak_ptr<node_impl> &SuccB : NodeB->MSuccessors) {
-        if (NodeA->isSimilar(NodeB) &&
+        if (NodeA->isSimilar(*NodeB) &&
             checkNodeRecursive(SuccA.lock(), SuccB.lock())) {
           FoundCnt++;
           break;
@@ -383,12 +383,12 @@ public:
   /// @param DebugPrint if set to true throw exception with additional debug
   /// information about the spotted graph differences.
   /// @return true if the two graphs are similar, false otherwise
-  bool hasSimilarStructure(std::shared_ptr<detail::graph_impl> Graph,
+  bool hasSimilarStructure(detail::graph_impl &Graph,
                            bool DebugPrint = false) const {
-    if (this == Graph.get())
+    if (this == &Graph)
       return true;
 
-    if (MContext != Graph->MContext) {
+    if (MContext != Graph.MContext) {
       if (DebugPrint) {
         throw sycl::exception(sycl::make_error_code(errc::invalid),
                               "MContext are not the same.");
@@ -396,7 +396,7 @@ public:
       return false;
     }
 
-    if (MDevice != Graph->MDevice) {
+    if (MDevice != Graph.MDevice) {
       if (DebugPrint) {
         throw sycl::exception(sycl::make_error_code(errc::invalid),
                               "MDevice are not the same.");
@@ -404,7 +404,7 @@ public:
       return false;
     }
 
-    if (MEventsMap.size() != Graph->MEventsMap.size()) {
+    if (MEventsMap.size() != Graph.MEventsMap.size()) {
       if (DebugPrint) {
         throw sycl::exception(sycl::make_error_code(errc::invalid),
                               "MEventsMap sizes are not the same.");
@@ -412,7 +412,7 @@ public:
       return false;
     }
 
-    if (MInorderQueueMap.size() != Graph->MInorderQueueMap.size()) {
+    if (MInorderQueueMap.size() != Graph.MInorderQueueMap.size()) {
       if (DebugPrint) {
         throw sycl::exception(sycl::make_error_code(errc::invalid),
                               "MInorderQueueMap sizes are not the same.");
@@ -420,7 +420,7 @@ public:
       return false;
     }
 
-    if (MRoots.size() != Graph->MRoots.size()) {
+    if (MRoots.size() != Graph.MRoots.size()) {
       if (DebugPrint) {
         throw sycl::exception(sycl::make_error_code(errc::invalid),
                               "MRoots sizes are not the same.");
@@ -430,11 +430,11 @@ public:
 
     size_t RootsFound = 0;
     for (std::weak_ptr<node_impl> NodeA : MRoots) {
-      for (std::weak_ptr<node_impl> NodeB : Graph->MRoots) {
+      for (std::weak_ptr<node_impl> NodeB : Graph.MRoots) {
         auto NodeALocked = NodeA.lock();
         auto NodeBLocked = NodeB.lock();
 
-        if (NodeALocked->isSimilar(NodeBLocked)) {
+        if (NodeALocked->isSimilar(*NodeBLocked)) {
           if (checkNodeRecursive(NodeALocked, NodeBLocked)) {
             RootsFound++;
             break;

--- a/sycl/source/detail/graph/node_impl.hpp
+++ b/sycl/source/detail/graph/node_impl.hpp
@@ -326,16 +326,15 @@ public:
   /// @param CompareContentOnly Skip comparisons related to graph structure,
   /// compare only the type and command groups of the nodes
   /// @return True if the two nodes are similar
-  bool isSimilar(const std::shared_ptr<node_impl> &Node,
-                 bool CompareContentOnly = false) const {
+  bool isSimilar(node_impl &Node, bool CompareContentOnly = false) const {
     if (!CompareContentOnly) {
-      if (MSuccessors.size() != Node->MSuccessors.size())
+      if (MSuccessors.size() != Node.MSuccessors.size())
         return false;
 
-      if (MPredecessors.size() != Node->MPredecessors.size())
+      if (MPredecessors.size() != Node.MPredecessors.size())
         return false;
     }
-    if (MCGType != Node->MCGType)
+    if (MCGType != Node.MCGType)
       return false;
 
     switch (MCGType) {
@@ -343,14 +342,14 @@ public:
       sycl::detail::CGExecKernel *ExecKernelA =
           static_cast<sycl::detail::CGExecKernel *>(MCommandGroup.get());
       sycl::detail::CGExecKernel *ExecKernelB =
-          static_cast<sycl::detail::CGExecKernel *>(Node->MCommandGroup.get());
+          static_cast<sycl::detail::CGExecKernel *>(Node.MCommandGroup.get());
       return ExecKernelA->MKernelName.compare(ExecKernelB->MKernelName) == 0;
     }
     case sycl::detail::CGType::CopyUSM: {
       sycl::detail::CGCopyUSM *CopyA =
           static_cast<sycl::detail::CGCopyUSM *>(MCommandGroup.get());
       sycl::detail::CGCopyUSM *CopyB =
-          static_cast<sycl::detail::CGCopyUSM *>(Node->MCommandGroup.get());
+          static_cast<sycl::detail::CGCopyUSM *>(Node.MCommandGroup.get());
       return (CopyA->getSrc() == CopyB->getSrc()) &&
              (CopyA->getDst() == CopyB->getDst()) &&
              (CopyA->getLength() == CopyB->getLength());
@@ -361,7 +360,7 @@ public:
       sycl::detail::CGCopy *CopyA =
           static_cast<sycl::detail::CGCopy *>(MCommandGroup.get());
       sycl::detail::CGCopy *CopyB =
-          static_cast<sycl::detail::CGCopy *>(Node->MCommandGroup.get());
+          static_cast<sycl::detail::CGCopy *>(Node.MCommandGroup.get());
       return (CopyA->getSrc() == CopyB->getSrc()) &&
              (CopyA->getDst() == CopyB->getDst());
     }

--- a/sycl/unittests/Extensions/CommandGraph/Barrier.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Barrier.cpp
@@ -882,7 +882,7 @@ TEST_F(CommandGraphTest, BarrierWithInOrderCommands) {
     ASSERT_EQ(RootNode->MSuccessors.size(), 1lu);
     if (GraphImpl.getEventForNode(RootNode).get() == &*getSyclObjImpl(Node2)) {
       EvenPath = true;
-    } else if (GraphImpl.getEventForNode(RootNode).get(),
+    } else if (GraphImpl.getEventForNode(RootNode).get() ==
                &*getSyclObjImpl(Node1)) {
       EvenPath = false;
     } else {

--- a/sycl/unittests/Extensions/CommandGraph/Barrier.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Barrier.cpp
@@ -29,7 +29,7 @@ TEST_F(CommandGraphTest, EnqueueBarrier) {
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   Graph.end_recording(Queue);
 
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Check the graph structure
   // (1) (2) (3)
@@ -38,14 +38,14 @@ TEST_F(CommandGraphTest, EnqueueBarrier) {
   //     (B)
   //     / \
   //   (4) (5)
-  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
-  for (auto Root : GraphImpl->MRoots) {
+  ASSERT_EQ(GraphImpl.MRoots.size(), 3lu);
+  for (auto Root : GraphImpl.MRoots) {
     auto Node = Root.lock();
     ASSERT_EQ(Node->MSuccessors.size(), 1lu);
     auto BarrierNode = Node->MSuccessors.front().lock();
     ASSERT_EQ(BarrierNode->MCGType, sycl::detail::CGType::Barrier);
-    ASSERT_EQ(GraphImpl->getEventForNode(BarrierNode),
-              sycl::detail::getSyclObjImpl(Barrier));
+    ASSERT_EQ(GraphImpl.getEventForNode(BarrierNode).get(),
+              &*getSyclObjImpl(Barrier));
     ASSERT_EQ(BarrierNode->MPredecessors.size(), 3lu);
     ASSERT_EQ(BarrierNode->MSuccessors.size(), 2lu);
   }
@@ -70,7 +70,7 @@ TEST_F(CommandGraphTest, EnqueueBarrierMultipleQueues) {
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   Graph.end_recording();
 
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Check the graph structure
   // (1) (2) (3)
@@ -78,18 +78,18 @@ TEST_F(CommandGraphTest, EnqueueBarrierMultipleQueues) {
   //     (B)
   //     / \
   //   (4) (5)
-  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
-  for (auto Root : GraphImpl->MRoots) {
+  ASSERT_EQ(GraphImpl.MRoots.size(), 3lu);
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
 
-    if (GraphImpl->getEventForNode(RootNode) ==
-        sycl::detail::getSyclObjImpl(Node2Graph)) {
+    if (GraphImpl.getEventForNode(RootNode).get() ==
+        &*getSyclObjImpl(Node2Graph)) {
 
       ASSERT_EQ(RootNode->MSuccessors.size(), 1lu);
       auto SuccNode = RootNode->MSuccessors.front().lock();
 
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Barrier));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Barrier));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 2lu);
@@ -97,12 +97,12 @@ TEST_F(CommandGraphTest, EnqueueBarrierMultipleQueues) {
       for (auto SuccSucc : SuccNode->MSuccessors) {
         auto SuccSuccNode = SuccSucc.lock();
 
-        if (GraphImpl->getEventForNode(SuccSuccNode) ==
-            sycl::detail::getSyclObjImpl(Node4Graph)) {
+        if (GraphImpl.getEventForNode(SuccSuccNode).get() ==
+            &*getSyclObjImpl(Node4Graph)) {
           ASSERT_EQ(SuccSuccNode->MPredecessors.size(), 1lu);
           ASSERT_EQ(SuccSuccNode->MSuccessors.size(), 0lu);
-        } else if (GraphImpl->getEventForNode(SuccSuccNode) ==
-                   sycl::detail::getSyclObjImpl(Node5Graph)) {
+        } else if (GraphImpl.getEventForNode(SuccSuccNode).get() ==
+                   &*getSyclObjImpl(Node5Graph)) {
           ASSERT_EQ(SuccSuccNode->MPredecessors.size(), 1lu);
           ASSERT_EQ(SuccSuccNode->MSuccessors.size(), 0lu);
         } else {
@@ -137,7 +137,7 @@ TEST_F(CommandGraphTest, EnqueueBarrierWaitList) {
 
   Graph.end_recording(Queue);
 
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Check the graph structure
   // (1) (2) (3)
@@ -146,14 +146,14 @@ TEST_F(CommandGraphTest, EnqueueBarrierWaitList) {
   //     (B)  |
   //     / \ /
   //   (4) (5)
-  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
-  for (auto Root : GraphImpl->MRoots) {
+  ASSERT_EQ(GraphImpl.MRoots.size(), 3lu);
+  for (auto Root : GraphImpl.MRoots) {
     auto Node = Root.lock();
     ASSERT_EQ(Node->MSuccessors.size(), 1lu);
     auto SuccNode = Node->MSuccessors.front().lock();
     if (SuccNode->MCGType == sycl::detail::CGType::Barrier) {
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Barrier));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Barrier));
       ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 2lu);
     } else {
@@ -191,7 +191,7 @@ TEST_F(CommandGraphTest, EnqueueBarrierWaitListMultipleQueues) {
 
   Graph.end_recording();
 
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Check the graph structure
   // (1) (2) (3)
@@ -203,14 +203,14 @@ TEST_F(CommandGraphTest, EnqueueBarrierWaitListMultipleQueues) {
   //    \ | /
   //     \|/
   //     (B2)
-  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
-  for (auto Root : GraphImpl->MRoots) {
+  ASSERT_EQ(GraphImpl.MRoots.size(), 3lu);
+  for (auto Root : GraphImpl.MRoots) {
     auto Node = Root.lock();
     ASSERT_EQ(Node->MSuccessors.size(), 1lu);
     auto SuccNode = Node->MSuccessors.front().lock();
     if (SuccNode->MCGType == sycl::detail::CGType::Barrier) {
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Barrier));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Barrier));
       ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 3lu);
     } else {
@@ -252,7 +252,7 @@ TEST_F(CommandGraphTest, EnqueueMultipleBarrier) {
 
   Graph.end_recording(Queue);
 
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Check the graph structure
   // (1) (2) (3)
@@ -266,21 +266,21 @@ TEST_F(CommandGraphTest, EnqueueMultipleBarrier) {
   //     /|\
   //    / | \
   // (6) (7) (8)
-  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
-  for (auto Root : GraphImpl->MRoots) {
+  ASSERT_EQ(GraphImpl.MRoots.size(), 3lu);
+  for (auto Root : GraphImpl.MRoots) {
     auto Node = Root.lock();
     ASSERT_EQ(Node->MSuccessors.size(), 1lu);
     auto SuccNode = Node->MSuccessors.front().lock();
     if (SuccNode->MCGType == sycl::detail::CGType::Barrier) {
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Barrier1));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Barrier1));
       ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 3lu);
       for (auto Succ1 : SuccNode->MSuccessors) {
         auto SuccBarrier1 = Succ1.lock();
         if (SuccBarrier1->MCGType == sycl::detail::CGType::Barrier) {
-          ASSERT_EQ(GraphImpl->getEventForNode(SuccBarrier1),
-                    sycl::detail::getSyclObjImpl(Barrier2));
+          ASSERT_EQ(GraphImpl.getEventForNode(SuccBarrier1).get(),
+                    &*getSyclObjImpl(Barrier2));
           ASSERT_EQ(SuccBarrier1->MPredecessors.size(), 3lu);
           ASSERT_EQ(SuccBarrier1->MSuccessors.size(), 3lu);
           for (auto Succ2 : SuccBarrier1->MSuccessors) {
@@ -291,8 +291,8 @@ TEST_F(CommandGraphTest, EnqueueMultipleBarrier) {
           }
         } else {
           // Node 4 or Node 5
-          if (GraphImpl->getEventForNode(SuccBarrier1) ==
-              sycl::detail::getSyclObjImpl(Node4Graph)) {
+          if (GraphImpl.getEventForNode(SuccBarrier1).get() ==
+              &*getSyclObjImpl(Node4Graph)) {
             // Node 4
             ASSERT_EQ(SuccBarrier1->MPredecessors.size(), 1lu);
             ASSERT_EQ(SuccBarrier1->MSuccessors.size(), 1lu);
@@ -332,10 +332,10 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousCommand) {
 
   // Check the graph structure
   // (B)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 1lu);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 1lu);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
     ASSERT_EQ(RootNode->MSuccessors.size(), 0lu);
     ASSERT_TRUE(RootNode->MCGType == sycl::detail::CGType::Barrier);
@@ -367,14 +367,13 @@ TEST_F(CommandGraphTest, InOrderQueuesWithBarrier) {
   // (1) (2)
   //  |
   // (B)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2lu);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2lu);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
 
-    if (GraphImpl->getEventForNode(RootNode) ==
-        sycl::detail::getSyclObjImpl(Node1)) {
+    if (GraphImpl.getEventForNode(RootNode).get() == &*getSyclObjImpl(Node1)) {
       ASSERT_EQ(RootNode->MSuccessors.size(), 1lu);
 
       auto SuccNode = RootNode->MSuccessors.front().lock();
@@ -382,8 +381,8 @@ TEST_F(CommandGraphTest, InOrderQueuesWithBarrier) {
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
-    } else if (GraphImpl->getEventForNode(RootNode) ==
-               sycl::detail::getSyclObjImpl(Node2)) {
+    } else if (GraphImpl.getEventForNode(RootNode).get() ==
+               &*getSyclObjImpl(Node2)) {
       ASSERT_EQ(RootNode->MSuccessors.size(), 0lu);
     } else {
       ASSERT_TRUE(false && "Unexpected root node");
@@ -415,17 +414,17 @@ TEST_F(CommandGraphTest, InOrderQueuesWithBarrierWaitList) {
   // (1) (2)
   //  |  /
   // (B)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2lu);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2lu);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
 
     ASSERT_EQ(RootNode->MSuccessors.size(), 1lu);
 
     auto SuccNode = RootNode->MSuccessors.front().lock();
-    ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-              sycl::detail::getSyclObjImpl(BarrierNode));
+    ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+              &*getSyclObjImpl(BarrierNode));
 
     ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
     ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
@@ -459,31 +458,30 @@ TEST_F(CommandGraphTest, InOrderQueuesWithEmptyBarrierWaitList) {
   // (1)  (2)
   //  |    |
   // (B)  (3)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2lu);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2lu);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
 
-    if (GraphImpl->getEventForNode(RootNode) ==
-        sycl::detail::getSyclObjImpl(Node1)) {
+    if (GraphImpl.getEventForNode(RootNode).get() == &*getSyclObjImpl(Node1)) {
       ASSERT_EQ(RootNode->MSuccessors.size(), 1lu);
 
       auto SuccNode = RootNode->MSuccessors.front().lock();
 
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(BarrierNode));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(BarrierNode));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
-    } else if (GraphImpl->getEventForNode(RootNode) ==
-               sycl::detail::getSyclObjImpl(Node2)) {
+    } else if (GraphImpl.getEventForNode(RootNode).get() ==
+               &*getSyclObjImpl(Node2)) {
       ASSERT_EQ(RootNode->MSuccessors.size(), 1lu);
 
       auto SuccNode = RootNode->MSuccessors.front().lock();
 
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Node3));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Node3));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
@@ -524,17 +522,16 @@ TEST_F(CommandGraphTest, BarrierMixedQueueTypes) {
   //   (B) |
   //       |
   //      (3)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2lu);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2lu);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
 
-    if (GraphImpl->getEventForNode(RootNode) ==
-        sycl::detail::getSyclObjImpl(Node1)) {
+    if (GraphImpl.getEventForNode(RootNode).get() == &*getSyclObjImpl(Node1)) {
       ASSERT_EQ(RootNode->MSuccessors.size(), 1lu);
-    } else if (GraphImpl->getEventForNode(RootNode) ==
-               sycl::detail::getSyclObjImpl(Node2)) {
+    } else if (GraphImpl.getEventForNode(RootNode).get() ==
+               &*getSyclObjImpl(Node2)) {
       ASSERT_EQ(RootNode->MSuccessors.size(), 2lu);
     } else {
       ASSERT_TRUE(false && "Unexpected root node");
@@ -543,12 +540,12 @@ TEST_F(CommandGraphTest, BarrierMixedQueueTypes) {
     for (auto Succ : RootNode->MSuccessors) {
       auto SuccNode = Succ.lock();
 
-      if (GraphImpl->getEventForNode(SuccNode) ==
-          sycl::detail::getSyclObjImpl(BarrierNode)) {
+      if (GraphImpl.getEventForNode(SuccNode).get() ==
+          &*getSyclObjImpl(BarrierNode)) {
         ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
         ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
-      } else if (GraphImpl->getEventForNode(SuccNode) ==
-                 sycl::detail::getSyclObjImpl(Node3)) {
+      } else if (GraphImpl.getEventForNode(SuccNode).get() ==
+                 &*getSyclObjImpl(Node3)) {
         ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
         ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
       } else {
@@ -580,19 +577,19 @@ TEST_F(CommandGraphTest, BarrierBetweenExplicitNodes) {
   // (B) (1)
   //      |
   //     (2)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2lu);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2lu);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
 
-    if (GraphImpl->getEventForNode(RootNode) ==
-        sycl::detail::getSyclObjImpl(BarrierNode)) {
+    if (GraphImpl.getEventForNode(RootNode).get() ==
+        &*getSyclObjImpl(BarrierNode)) {
       ASSERT_EQ(RootNode->MSuccessors.size(), 0lu);
-    } else if (RootNode == sycl::detail::getSyclObjImpl(Node1)) {
+    } else if (RootNode.get() == &*getSyclObjImpl(Node1)) {
       ASSERT_EQ(RootNode->MSuccessors.size(), 1lu);
       auto SuccNode = RootNode->MSuccessors.front().lock();
-      ASSERT_EQ(SuccNode, sycl::detail::getSyclObjImpl(Node2));
+      ASSERT_EQ(SuccNode.get(), &*getSyclObjImpl(Node2));
     } else {
       ASSERT_TRUE(false);
     }
@@ -636,19 +633,19 @@ TEST_F(CommandGraphTest, BarrierMultipleOOOQueue) {
   //  (B)      (5)
   //   |
   //  (6)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 4u);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 4u);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
-    auto RootNodeEvent = GraphImpl->getEventForNode(RootNode);
-    if ((RootNodeEvent == sycl::detail::getSyclObjImpl(Node1)) ||
-        (RootNodeEvent == sycl::detail::getSyclObjImpl(Node2))) {
+    auto RootNodeEvent = GraphImpl.getEventForNode(RootNode);
+    if ((RootNodeEvent.get() == &*getSyclObjImpl(Node1)) ||
+        (RootNodeEvent.get() == &*getSyclObjImpl(Node2))) {
 
       auto SuccNode = RootNode->MSuccessors.front().lock();
 
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(BarrierNode));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(BarrierNode));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 1lu);
@@ -658,14 +655,14 @@ TEST_F(CommandGraphTest, BarrierMultipleOOOQueue) {
       ASSERT_EQ(SuccSuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccSuccNode->MSuccessors.size(), 0lu);
 
-      auto Node6Impl = sycl::detail::getSyclObjImpl(Node6);
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccSuccNode), Node6Impl);
-    } else if ((RootNodeEvent == sycl::detail::getSyclObjImpl(Node3)) ||
-               (RootNodeEvent == sycl::detail::getSyclObjImpl(Node4))) {
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccSuccNode).get(),
+                &*getSyclObjImpl(Node6));
+    } else if ((RootNodeEvent.get() == &*getSyclObjImpl(Node3)) ||
+               (RootNodeEvent.get() == &*getSyclObjImpl(Node4))) {
       auto SuccNode = RootNode->MSuccessors.front().lock();
 
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Node5));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Node5));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
@@ -701,23 +698,23 @@ TEST_F(CommandGraphTest, BarrierMultipleInOrderQueue) {
   // (1) (2)
   //  |   |
   // (B) (3)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2u);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2u);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
-    auto RootNodeEvent = GraphImpl->getEventForNode(RootNode);
-    if (RootNodeEvent == sycl::detail::getSyclObjImpl(Node1)) {
+    auto RootNodeEvent = GraphImpl.getEventForNode(RootNode);
+    if (RootNodeEvent.get() == &*getSyclObjImpl(Node1)) {
       auto SuccNode = RootNode->MSuccessors.front().lock();
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(BarrierNode));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(BarrierNode));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
-    } else if (RootNodeEvent == sycl::detail::getSyclObjImpl(Node2)) {
+    } else if (RootNodeEvent.get() == &*getSyclObjImpl(Node2)) {
       auto SuccNode = RootNode->MSuccessors.front().lock();
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Node3));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Node3));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
@@ -752,23 +749,23 @@ TEST_F(CommandGraphTest, BarrierMultipleMixedOrderQueues) {
   // (1) (2)
   //  |   |
   // (B) (3)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2u);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2u);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
-    auto RootNodeEvent = GraphImpl->getEventForNode(RootNode);
-    if (RootNodeEvent == sycl::detail::getSyclObjImpl(Node1)) {
+    auto RootNodeEvent = GraphImpl.getEventForNode(RootNode);
+    if (RootNodeEvent.get() == &*getSyclObjImpl(Node1)) {
       auto SuccNode = RootNode->MSuccessors.front().lock();
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(BarrierNode));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(BarrierNode));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
-    } else if (RootNodeEvent == sycl::detail::getSyclObjImpl(Node2)) {
+    } else if (RootNodeEvent.get() == &*getSyclObjImpl(Node2)) {
       auto SuccNode = RootNode->MSuccessors.front().lock();
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Node3));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Node3));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
@@ -797,23 +794,23 @@ TEST_F(CommandGraphTest, BarrierMultipleQueuesMultipleBarriers) {
   // (1)       (2)
   //  |         |
   // (4)       (3)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2u);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2u);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
-    auto RootNodeEvent = GraphImpl->getEventForNode(RootNode);
-    if (RootNodeEvent == sycl::detail::getSyclObjImpl(Barrier1)) {
+    auto RootNodeEvent = GraphImpl.getEventForNode(RootNode);
+    if (RootNodeEvent.get() == &*getSyclObjImpl(Barrier1)) {
       auto SuccNode = RootNode->MSuccessors.front().lock();
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Barrier4));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Barrier4));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
-    } else if (RootNodeEvent == sycl::detail::getSyclObjImpl(Barrier2)) {
+    } else if (RootNodeEvent.get() == &*getSyclObjImpl(Barrier2)) {
       auto SuccNode = RootNode->MSuccessors.front().lock();
-      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
-                sycl::detail::getSyclObjImpl(Barrier3));
+      ASSERT_EQ(GraphImpl.getEventForNode(SuccNode).get(),
+                &*getSyclObjImpl(Barrier3));
 
       ASSERT_EQ(SuccNode->MPredecessors.size(), 1lu);
       ASSERT_EQ(SuccNode->MSuccessors.size(), 0lu);
@@ -875,19 +872,18 @@ TEST_F(CommandGraphTest, BarrierWithInOrderCommands) {
   // (5)    (6)
   //    \   /
   //    (B5)
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2lu);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2lu);
 
-  for (auto Root : GraphImpl->MRoots) {
+  for (auto Root : GraphImpl.MRoots) {
     auto RootNode = Root.lock();
     bool EvenPath;
 
     ASSERT_EQ(RootNode->MSuccessors.size(), 1lu);
-    if (GraphImpl->getEventForNode(RootNode) ==
-        sycl::detail::getSyclObjImpl(Node2)) {
+    if (GraphImpl.getEventForNode(RootNode).get() == &*getSyclObjImpl(Node2)) {
       EvenPath = true;
-    } else if (GraphImpl->getEventForNode(RootNode),
-               sycl::detail::getSyclObjImpl(Node1)) {
+    } else if (GraphImpl.getEventForNode(RootNode).get(),
+               &*getSyclObjImpl(Node1)) {
       EvenPath = false;
     } else {
       ASSERT_TRUE(false);
@@ -896,47 +892,47 @@ TEST_F(CommandGraphTest, BarrierWithInOrderCommands) {
     auto Succ1Node = RootNode->MSuccessors.front().lock();
     ASSERT_EQ(Succ1Node->MSuccessors.size(), 1lu);
     if (EvenPath) {
-      ASSERT_EQ(GraphImpl->getEventForNode(Succ1Node),
-                sycl::detail::getSyclObjImpl(Barrier2));
+      ASSERT_EQ(GraphImpl.getEventForNode(Succ1Node).get(),
+                &*getSyclObjImpl(Barrier2));
     } else {
-      ASSERT_EQ(GraphImpl->getEventForNode(Succ1Node),
-                sycl::detail::getSyclObjImpl(Barrier1));
+      ASSERT_EQ(GraphImpl.getEventForNode(Succ1Node).get(),
+                &*getSyclObjImpl(Barrier1));
     }
 
     auto Succ2Node = Succ1Node->MSuccessors.front().lock();
     ASSERT_EQ(Succ2Node->MSuccessors.size(), 1lu);
     if (EvenPath) {
-      ASSERT_EQ(GraphImpl->getEventForNode(Succ2Node),
-                sycl::detail::getSyclObjImpl(Node4));
+      ASSERT_EQ(GraphImpl.getEventForNode(Succ2Node).get(),
+                &*getSyclObjImpl(Node4));
     } else {
-      ASSERT_EQ(GraphImpl->getEventForNode(Succ2Node),
-                sycl::detail::getSyclObjImpl(Node3));
+      ASSERT_EQ(GraphImpl.getEventForNode(Succ2Node).get(),
+                &*getSyclObjImpl(Node3));
     }
 
     auto Succ3Node = Succ2Node->MSuccessors.front().lock();
     ASSERT_EQ(Succ3Node->MSuccessors.size(), 1lu);
     if (EvenPath) {
-      ASSERT_EQ(GraphImpl->getEventForNode(Succ3Node),
-                sycl::detail::getSyclObjImpl(Barrier4));
+      ASSERT_EQ(GraphImpl.getEventForNode(Succ3Node).get(),
+                &*getSyclObjImpl(Barrier4));
     } else {
-      ASSERT_EQ(GraphImpl->getEventForNode(Succ3Node),
-                sycl::detail::getSyclObjImpl(Barrier3));
+      ASSERT_EQ(GraphImpl.getEventForNode(Succ3Node).get(),
+                &*getSyclObjImpl(Barrier3));
     }
 
     auto Succ4Node = Succ3Node->MSuccessors.front().lock();
     ASSERT_EQ(Succ4Node->MSuccessors.size(), 1lu);
     if (EvenPath) {
-      ASSERT_EQ(GraphImpl->getEventForNode(Succ4Node),
-                sycl::detail::getSyclObjImpl(Node6));
+      ASSERT_EQ(GraphImpl.getEventForNode(Succ4Node).get(),
+                &*getSyclObjImpl(Node6));
     } else {
-      ASSERT_EQ(GraphImpl->getEventForNode(Succ4Node),
-                sycl::detail::getSyclObjImpl(Node5));
+      ASSERT_EQ(GraphImpl.getEventForNode(Succ4Node).get(),
+                &*getSyclObjImpl(Node5));
     }
 
     auto Succ5Node = Succ4Node->MSuccessors.front().lock();
     ASSERT_EQ(Succ5Node->MSuccessors.size(), 0lu);
     ASSERT_EQ(Succ5Node->MPredecessors.size(), 2lu);
-    ASSERT_EQ(GraphImpl->getEventForNode(Succ5Node),
-              sycl::detail::getSyclObjImpl(Barrier5));
+    ASSERT_EQ(GraphImpl.getEventForNode(Succ5Node).get(),
+              &*getSyclObjImpl(Barrier5));
   }
 }

--- a/sycl/unittests/Extensions/CommandGraph/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/CommandGraph.cpp
@@ -51,64 +51,57 @@ TEST_F(CommandGraphTest, OwnerLessGraph) {
 }
 
 TEST_F(CommandGraphTest, AddNode) {
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
-  ASSERT_TRUE(GraphImpl->MRoots.empty());
+  ASSERT_TRUE(GraphImpl.MRoots.empty());
 
   auto Node1 = Graph.add(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
-  ASSERT_NE(sycl::detail::getSyclObjImpl(Node1), nullptr);
-  ASSERT_FALSE(sycl::detail::getSyclObjImpl(Node1)->isEmpty());
-  ASSERT_EQ(GraphImpl->MRoots.size(), 1lu);
-  ASSERT_EQ((*GraphImpl->MRoots.begin()).lock(),
-            sycl::detail::getSyclObjImpl(Node1));
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1)->MSuccessors.empty());
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1)->MPredecessors.empty());
+  ASSERT_FALSE(getSyclObjImpl(Node1)->isEmpty());
+  ASSERT_EQ(GraphImpl.MRoots.size(), 1lu);
+  ASSERT_EQ(GraphImpl.MRoots.begin()->lock().get(), &*getSyclObjImpl(Node1));
+  ASSERT_TRUE(getSyclObjImpl(Node1)->MSuccessors.empty());
+  ASSERT_TRUE(getSyclObjImpl(Node1)->MPredecessors.empty());
 
   // Add a node which depends on the first
   auto Node2Deps = experimental::property::node::depends_on(Node1);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2Deps.get_dependencies().front()),
-            sycl::detail::getSyclObjImpl(Node1));
+  ASSERT_EQ(&*getSyclObjImpl(Node2Deps.get_dependencies().front()),
+            &*getSyclObjImpl(Node1));
   auto Node2 = Graph.add([&](sycl::handler &cgh) {}, {Node2Deps});
-  ASSERT_NE(sycl::detail::getSyclObjImpl(Node2), nullptr);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node2)->isEmpty());
-  ASSERT_EQ(GraphImpl->MRoots.size(), 1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1)->MSuccessors.size(), 1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1)->MSuccessors.front().lock(),
-            sycl::detail::getSyclObjImpl(Node2));
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1)->MPredecessors.empty());
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2)->MPredecessors.size(), 1lu);
+  ASSERT_TRUE(getSyclObjImpl(Node2)->isEmpty());
+  ASSERT_EQ(GraphImpl.MRoots.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1)->MSuccessors.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1)->MSuccessors.front().lock().get(),
+            &*getSyclObjImpl(Node2));
+  ASSERT_TRUE(getSyclObjImpl(Node1)->MPredecessors.empty());
+  ASSERT_EQ(getSyclObjImpl(Node2)->MPredecessors.size(), 1lu);
 
   // Add a third node which depends on both
   auto Node3 =
       Graph.add([&](sycl::handler &cgh) {},
                 {experimental::property::node::depends_on(Node1, Node2)});
-  ASSERT_NE(sycl::detail::getSyclObjImpl(Node3), nullptr);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node3)->isEmpty());
-  ASSERT_EQ(GraphImpl->MRoots.size(), 1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1)->MSuccessors.size(), 2lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2)->MSuccessors.size(), 1lu);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1)->MPredecessors.empty());
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2)->MPredecessors.size(), 1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node3)->MPredecessors.size(), 2lu);
+  ASSERT_TRUE(getSyclObjImpl(Node3)->isEmpty());
+  ASSERT_EQ(GraphImpl.MRoots.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1)->MSuccessors.size(), 2lu);
+  ASSERT_EQ(getSyclObjImpl(Node2)->MSuccessors.size(), 1lu);
+  ASSERT_TRUE(getSyclObjImpl(Node1)->MPredecessors.empty());
+  ASSERT_EQ(getSyclObjImpl(Node2)->MPredecessors.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node3)->MPredecessors.size(), 2lu);
 
   // Add a fourth node without any dependencies on the others
   auto Node4 = Graph.add([&](sycl::handler &cgh) {});
-  ASSERT_NE(sycl::detail::getSyclObjImpl(Node4), nullptr);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node4)->isEmpty());
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1)->MSuccessors.size(), 2lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2)->MSuccessors.size(), 1lu);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node3)->MSuccessors.empty());
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1)->MPredecessors.empty());
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2)->MPredecessors.size(), 1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node3)->MPredecessors.size(), 2lu);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node4)->MPredecessors.empty());
+  ASSERT_TRUE(getSyclObjImpl(Node4)->isEmpty());
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2lu);
+  ASSERT_EQ(getSyclObjImpl(Node1)->MSuccessors.size(), 2lu);
+  ASSERT_EQ(getSyclObjImpl(Node2)->MSuccessors.size(), 1lu);
+  ASSERT_TRUE(getSyclObjImpl(Node3)->MSuccessors.empty());
+  ASSERT_TRUE(getSyclObjImpl(Node1)->MPredecessors.empty());
+  ASSERT_EQ(getSyclObjImpl(Node2)->MPredecessors.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node3)->MPredecessors.size(), 2lu);
+  ASSERT_TRUE(getSyclObjImpl(Node4)->MPredecessors.empty());
 }
 
 TEST_F(CommandGraphTest, Finalize) {
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-
   sycl::buffer<int> Buf(1);
   auto Node1 = Graph.add([&](sycl::handler &cgh) {
     sycl::accessor A(Buf, cgh, sycl::write_only, sycl::no_init);
@@ -129,42 +122,43 @@ TEST_F(CommandGraphTest, Finalize) {
   Graph.make_edge(Node2, Node1);
 
   auto GraphExec = Graph.finalize();
-  auto GraphExecImpl = sycl::detail::getSyclObjImpl(GraphExec);
+  experimental::detail::exec_graph_impl &GraphExecImpl =
+      *getSyclObjImpl(GraphExec);
 
   // The final schedule should contain three nodes in order: 2->1->3
-  auto Schedule = GraphExecImpl->getSchedule();
+  auto Schedule = GraphExecImpl.getSchedule();
   ASSERT_EQ(Schedule.size(), 3ul);
   auto ScheduleIt = Schedule.begin();
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(sycl::detail::getSyclObjImpl(Node2)));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*getSyclObjImpl(Node2)));
   ScheduleIt++;
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(sycl::detail::getSyclObjImpl(Node1)));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*getSyclObjImpl(Node1)));
   ScheduleIt++;
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(sycl::detail::getSyclObjImpl(Node3)));
-  ASSERT_EQ(Queue.get_context(), GraphExecImpl->getContext());
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*getSyclObjImpl(Node3)));
+  ASSERT_EQ(Queue.get_context(), GraphExecImpl.getContext());
 }
 
 TEST_F(CommandGraphTest, MakeEdge) {
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Add two independent nodes
   auto Node1 = Graph.add(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto Node2 = Graph.add([&](sycl::handler &cgh) {});
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2ul);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1)->MSuccessors.empty());
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1)->MPredecessors.empty());
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node2)->MSuccessors.empty());
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node2)->MPredecessors.empty());
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2ul);
+  ASSERT_TRUE(getSyclObjImpl(Node1)->MSuccessors.empty());
+  ASSERT_TRUE(getSyclObjImpl(Node1)->MPredecessors.empty());
+  ASSERT_TRUE(getSyclObjImpl(Node2)->MSuccessors.empty());
+  ASSERT_TRUE(getSyclObjImpl(Node2)->MPredecessors.empty());
 
   // Connect nodes and verify order
   Graph.make_edge(Node1, Node2);
-  ASSERT_EQ(GraphImpl->MRoots.size(), 1ul);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1)->MSuccessors.size(), 1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1)->MSuccessors.front().lock(),
-            sycl::detail::getSyclObjImpl(Node2));
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1)->MPredecessors.empty());
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node2)->MSuccessors.empty());
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2)->MPredecessors.size(), 1lu);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 1ul);
+  ASSERT_EQ(getSyclObjImpl(Node1)->MSuccessors.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1)->MSuccessors.front().lock().get(),
+            &*getSyclObjImpl(Node2));
+  ASSERT_TRUE(getSyclObjImpl(Node1)->MPredecessors.empty());
+  ASSERT_TRUE(getSyclObjImpl(Node2)->MSuccessors.empty());
+  ASSERT_EQ(getSyclObjImpl(Node2)->MPredecessors.size(), 1lu);
 }
 
 TEST_F(CommandGraphTest, BeginEndRecording) {
@@ -205,20 +199,20 @@ TEST_F(CommandGraphTest, GetCGCopy) {
       {experimental::property::node::depends_on(Node1)});
 
   // Get copy of CG of Node2 and check equality
-  auto Node2Imp = sycl::detail::getSyclObjImpl(Node2);
-  auto Node2CGCopy = Node2Imp->getCGCopy();
-  ASSERT_EQ(Node2CGCopy->getType(), Node2Imp->MCGType);
+  experimental::detail::node_impl &Node2Imp = *getSyclObjImpl(Node2);
+  auto Node2CGCopy = Node2Imp.getCGCopy();
+  ASSERT_EQ(Node2CGCopy->getType(), Node2Imp.MCGType);
   ASSERT_EQ(Node2CGCopy->getType(), sycl::detail::CGType::Kernel);
-  ASSERT_EQ(Node2CGCopy->getType(), Node2Imp->MCommandGroup->getType());
+  ASSERT_EQ(Node2CGCopy->getType(), Node2Imp.MCommandGroup->getType());
   ASSERT_EQ(Node2CGCopy->getAccStorage(),
-            Node2Imp->MCommandGroup->getAccStorage());
+            Node2Imp.MCommandGroup->getAccStorage());
   ASSERT_EQ(Node2CGCopy->getArgsStorage(),
-            Node2Imp->MCommandGroup->getArgsStorage());
-  ASSERT_EQ(Node2CGCopy->getEvents(), Node2Imp->MCommandGroup->getEvents());
+            Node2Imp.MCommandGroup->getArgsStorage());
+  ASSERT_EQ(Node2CGCopy->getEvents(), Node2Imp.MCommandGroup->getEvents());
   ASSERT_EQ(Node2CGCopy->getRequirements(),
-            Node2Imp->MCommandGroup->getRequirements());
+            Node2Imp.MCommandGroup->getRequirements());
   ASSERT_EQ(Node2CGCopy->getSharedPtrStorage(),
-            Node2Imp->MCommandGroup->getSharedPtrStorage());
+            Node2Imp.MCommandGroup->getSharedPtrStorage());
 }
 
 TEST_F(CommandGraphTest, DependencyLeavesKeyword1) {
@@ -233,27 +227,27 @@ TEST_F(CommandGraphTest, DependencyLeavesKeyword1) {
       Graph.add([&](sycl::handler &cgh) { /*empty node */ },
                 {experimental::property::node::depends_on_all_leaves()});
 
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Check the graph structure
   // (1) (2) (3)
   //   \  |  /
   //    \ | /
   //     (E)
-  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
-  auto EmptyImpl = sycl::detail::getSyclObjImpl(EmptyNode);
-  ASSERT_EQ(EmptyImpl->MPredecessors.size(), 3lu);
-  ASSERT_EQ(EmptyImpl->MSuccessors.size(), 0lu);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 3lu);
+  experimental::detail::node_impl &EmptyImpl = *getSyclObjImpl(EmptyNode);
+  ASSERT_EQ(EmptyImpl.MPredecessors.size(), 3lu);
+  ASSERT_EQ(EmptyImpl.MSuccessors.size(), 0lu);
 
-  auto Node1Impl = sycl::detail::getSyclObjImpl(Node1Graph);
-  ASSERT_EQ(Node1Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node1Impl->MSuccessors[0].lock(), EmptyImpl);
-  auto Node2Impl = sycl::detail::getSyclObjImpl(Node2Graph);
-  ASSERT_EQ(Node2Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node2Impl->MSuccessors[0].lock(), EmptyImpl);
-  auto Node3Impl = sycl::detail::getSyclObjImpl(Node3Graph);
-  ASSERT_EQ(Node3Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node3Impl->MSuccessors[0].lock(), EmptyImpl);
+  experimental::detail::node_impl &Node1Impl = *getSyclObjImpl(Node1Graph);
+  ASSERT_EQ(Node1Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node1Impl.MSuccessors[0].lock().get(), &EmptyImpl);
+  experimental::detail::node_impl &Node2Impl = *getSyclObjImpl(Node2Graph);
+  ASSERT_EQ(Node2Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node2Impl.MSuccessors[0].lock().get(), &EmptyImpl);
+  experimental::detail::node_impl &Node3Impl = *getSyclObjImpl(Node3Graph);
+  ASSERT_EQ(Node3Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node3Impl.MSuccessors[0].lock().get(), &EmptyImpl);
 }
 
 TEST_F(CommandGraphTest, DependencyLeavesKeyword2) {
@@ -271,7 +265,7 @@ TEST_F(CommandGraphTest, DependencyLeavesKeyword2) {
       Graph.add([&](sycl::handler &cgh) { /*empty node */ },
                 {experimental::property::node::depends_on_all_leaves()});
 
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Check the graph structure
   // (1) (2) (3)
@@ -279,24 +273,24 @@ TEST_F(CommandGraphTest, DependencyLeavesKeyword2) {
   //    \ | (4)
   //     \| /
   //     (E)
-  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
-  auto EmptyImpl = sycl::detail::getSyclObjImpl(EmptyNode);
-  ASSERT_EQ(EmptyImpl->MPredecessors.size(), 3lu);
-  ASSERT_EQ(EmptyImpl->MSuccessors.size(), 0lu);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 3lu);
+  experimental::detail::node_impl &EmptyImpl = *getSyclObjImpl(EmptyNode);
+  ASSERT_EQ(EmptyImpl.MPredecessors.size(), 3lu);
+  ASSERT_EQ(EmptyImpl.MSuccessors.size(), 0lu);
 
-  auto Node1Impl = sycl::detail::getSyclObjImpl(Node1Graph);
-  ASSERT_EQ(Node1Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node1Impl->MSuccessors[0].lock(), EmptyImpl);
-  auto Node2Impl = sycl::detail::getSyclObjImpl(Node2Graph);
-  ASSERT_EQ(Node2Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node2Impl->MSuccessors[0].lock(), EmptyImpl);
-  auto Node3Impl = sycl::detail::getSyclObjImpl(Node3Graph);
-  ASSERT_EQ(Node3Impl->MSuccessors.size(), 1lu);
+  experimental::detail::node_impl &Node1Impl = *getSyclObjImpl(Node1Graph);
+  ASSERT_EQ(Node1Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node1Impl.MSuccessors[0].lock().get(), &EmptyImpl);
+  experimental::detail::node_impl &Node2Impl = *getSyclObjImpl(Node2Graph);
+  ASSERT_EQ(Node2Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node2Impl.MSuccessors[0].lock().get(), &EmptyImpl);
+  experimental::detail::node_impl &Node3Impl = *getSyclObjImpl(Node3Graph);
+  ASSERT_EQ(Node3Impl.MSuccessors.size(), 1lu);
 
-  auto Node4Impl = sycl::detail::getSyclObjImpl(Node4Graph);
-  ASSERT_EQ(Node4Impl->MPredecessors.size(), 1lu);
-  ASSERT_EQ(Node4Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node4Impl->MSuccessors[0].lock(), EmptyImpl);
+  experimental::detail::node_impl &Node4Impl = *getSyclObjImpl(Node4Graph);
+  ASSERT_EQ(Node4Impl.MPredecessors.size(), 1lu);
+  ASSERT_EQ(Node4Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node4Impl.MSuccessors[0].lock().get(), &EmptyImpl);
 }
 
 TEST_F(CommandGraphTest, DependencyLeavesKeyword3) {
@@ -314,7 +308,7 @@ TEST_F(CommandGraphTest, DependencyLeavesKeyword3) {
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); },
       {experimental::property::node::depends_on(EmptyNode)});
 
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Check the graph structure
   // (1)(2)
@@ -322,24 +316,24 @@ TEST_F(CommandGraphTest, DependencyLeavesKeyword3) {
   //  | (E)
   // (3) |
   //    (4)
-  ASSERT_EQ(GraphImpl->MRoots.size(), 2lu);
-  auto EmptyImpl = sycl::detail::getSyclObjImpl(EmptyNode);
-  ASSERT_EQ(EmptyImpl->MPredecessors.size(), 2lu);
-  ASSERT_EQ(EmptyImpl->MSuccessors.size(), 1lu);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 2lu);
+  experimental::detail::node_impl &EmptyImpl = *getSyclObjImpl(EmptyNode);
+  ASSERT_EQ(EmptyImpl.MPredecessors.size(), 2lu);
+  ASSERT_EQ(EmptyImpl.MSuccessors.size(), 1lu);
 
-  auto Node1Impl = sycl::detail::getSyclObjImpl(Node1Graph);
-  auto Node2Impl = sycl::detail::getSyclObjImpl(Node2Graph);
-  ASSERT_EQ(Node1Impl->MSuccessors.size(), 2lu);
-  ASSERT_EQ(Node2Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node2Impl->MSuccessors[0].lock(), EmptyImpl);
+  experimental::detail::node_impl &Node1Impl = *getSyclObjImpl(Node1Graph);
+  experimental::detail::node_impl &Node2Impl = *getSyclObjImpl(Node2Graph);
+  ASSERT_EQ(Node1Impl.MSuccessors.size(), 2lu);
+  ASSERT_EQ(Node2Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node2Impl.MSuccessors[0].lock().get(), &EmptyImpl);
 
-  auto Node3Impl = sycl::detail::getSyclObjImpl(Node3Graph);
-  ASSERT_EQ(Node3Impl->MPredecessors.size(), 1lu);
-  ASSERT_EQ(Node3Impl->MPredecessors[0].lock(), Node1Impl);
+  experimental::detail::node_impl &Node3Impl = *getSyclObjImpl(Node3Graph);
+  ASSERT_EQ(Node3Impl.MPredecessors.size(), 1lu);
+  ASSERT_EQ(Node3Impl.MPredecessors[0].lock().get(), &Node1Impl);
 
-  auto Node4Impl = sycl::detail::getSyclObjImpl(Node4Graph);
-  ASSERT_EQ(Node4Impl->MPredecessors.size(), 1lu);
-  ASSERT_EQ(Node4Impl->MPredecessors[0].lock(), EmptyImpl);
+  experimental::detail::node_impl &Node4Impl = *getSyclObjImpl(Node4Graph);
+  ASSERT_EQ(Node4Impl.MPredecessors.size(), 1lu);
+  ASSERT_EQ(Node4Impl.MPredecessors[0].lock().get(), &EmptyImpl);
 }
 
 TEST_F(CommandGraphTest, DependencyLeavesKeyword4) {
@@ -356,7 +350,7 @@ TEST_F(CommandGraphTest, DependencyLeavesKeyword4) {
       Graph.add([&](sycl::handler &cgh) { /*empty node */ },
                 {experimental::property::node::depends_on_all_leaves()});
 
-  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
 
   // Check the graph structure
   // (1)(2)
@@ -364,25 +358,25 @@ TEST_F(CommandGraphTest, DependencyLeavesKeyword4) {
   //  (E1) (3)
   //    \  /
   //    (E2)
-  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
-  auto EmptyImpl = sycl::detail::getSyclObjImpl(EmptyNode);
-  ASSERT_EQ(EmptyImpl->MPredecessors.size(), 2lu);
-  ASSERT_EQ(EmptyImpl->MSuccessors.size(), 1lu);
+  ASSERT_EQ(GraphImpl.MRoots.size(), 3lu);
+  experimental::detail::node_impl &EmptyImpl = *getSyclObjImpl(EmptyNode);
+  ASSERT_EQ(EmptyImpl.MPredecessors.size(), 2lu);
+  ASSERT_EQ(EmptyImpl.MSuccessors.size(), 1lu);
 
-  auto Node1Impl = sycl::detail::getSyclObjImpl(Node1Graph);
-  ASSERT_EQ(Node1Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node1Impl->MSuccessors[0].lock(), EmptyImpl);
-  auto Node2Impl = sycl::detail::getSyclObjImpl(Node2Graph);
-  ASSERT_EQ(Node2Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node2Impl->MSuccessors[0].lock(), EmptyImpl);
+  experimental::detail::node_impl &Node1Impl = *getSyclObjImpl(Node1Graph);
+  ASSERT_EQ(Node1Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node1Impl.MSuccessors[0].lock().get(), &EmptyImpl);
+  experimental::detail::node_impl &Node2Impl = *getSyclObjImpl(Node2Graph);
+  ASSERT_EQ(Node2Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node2Impl.MSuccessors[0].lock().get(), &EmptyImpl);
 
-  auto EmptyImpl2 = sycl::detail::getSyclObjImpl(EmptyNode2);
-  auto Node3Impl = sycl::detail::getSyclObjImpl(Node3Graph);
-  ASSERT_EQ(Node3Impl->MPredecessors.size(), 0lu);
-  ASSERT_EQ(Node3Impl->MSuccessors.size(), 1lu);
-  ASSERT_EQ(Node3Impl->MSuccessors[0].lock(), EmptyImpl2);
+  experimental::detail::node_impl &EmptyImpl2 = *getSyclObjImpl(EmptyNode2);
+  experimental::detail::node_impl &Node3Impl = *getSyclObjImpl(Node3Graph);
+  ASSERT_EQ(Node3Impl.MPredecessors.size(), 0lu);
+  ASSERT_EQ(Node3Impl.MSuccessors.size(), 1lu);
+  ASSERT_EQ(Node3Impl.MSuccessors[0].lock().get(), &EmptyImpl2);
 
-  ASSERT_EQ(EmptyImpl2->MPredecessors.size(), 2lu);
+  ASSERT_EQ(EmptyImpl2.MPredecessors.size(), 2lu);
 }
 
 TEST_F(CommandGraphTest, GraphPartitionsMerging) {
@@ -414,8 +408,9 @@ TEST_F(CommandGraphTest, GraphPartitionsMerging) {
   Graph.make_edge(NodeE, NodeHT1);
 
   auto GraphExec = Graph.finalize();
-  auto GraphExecImpl = sycl::detail::getSyclObjImpl(GraphExec);
-  auto PartitionsList = GraphExecImpl->getPartitions();
+  experimental::detail::exec_graph_impl &GraphExecImpl =
+      *getSyclObjImpl(GraphExec);
+  auto PartitionsList = GraphExecImpl.getPartitions();
   ASSERT_EQ(PartitionsList.size(), 5ul);
   ASSERT_FALSE(PartitionsList[0]->MIsHostTask);
   ASSERT_TRUE(PartitionsList[1]->MIsHostTask);
@@ -470,12 +465,10 @@ TEST_F(CommandGraphTest, FillMemsetNodes) {
       CGH.fill(Acc, Value);
     });
 
-    auto NodeAImpl = sycl::detail::getSyclObjImpl(NodeA);
-    auto NodeBImpl = sycl::detail::getSyclObjImpl(NodeB);
+    experimental::detail::node_impl &NodeAImpl = *getSyclObjImpl(NodeA);
+    experimental::detail::node_impl &NodeBImpl = *getSyclObjImpl(NodeB);
 
-    // Check Operator==
-    EXPECT_EQ(NodeAImpl, NodeAImpl);
-    EXPECT_NE(NodeAImpl, NodeBImpl);
+    EXPECT_NE(&NodeAImpl, &NodeBImpl);
   }
 
   // USM
@@ -493,19 +486,15 @@ TEST_F(CommandGraphTest, FillMemsetNodes) {
     auto MemsetNodeB =
         Graph.add([&](handler &CGH) { CGH.memset(USMPtr, Value, 2); });
 
-    auto FillNodeAImpl = sycl::detail::getSyclObjImpl(FillNodeA);
-    auto FillNodeBImpl = sycl::detail::getSyclObjImpl(FillNodeB);
-    auto MemsetNodeAImpl = sycl::detail::getSyclObjImpl(MemsetNodeA);
-    auto MemsetNodeBImpl = sycl::detail::getSyclObjImpl(MemsetNodeB);
+    experimental::detail::node_impl &FillNodeAImpl = *getSyclObjImpl(FillNodeA);
+    experimental::detail::node_impl &FillNodeBImpl = *getSyclObjImpl(FillNodeB);
+    experimental::detail::node_impl &MemsetNodeAImpl =
+        *getSyclObjImpl(MemsetNodeA);
+    experimental::detail::node_impl &MemsetNodeBImpl =
+        *getSyclObjImpl(MemsetNodeB);
 
-    // Check Operator==
-    EXPECT_EQ(FillNodeAImpl, FillNodeAImpl);
-    EXPECT_EQ(FillNodeBImpl, FillNodeBImpl);
-    EXPECT_NE(FillNodeAImpl, FillNodeBImpl);
-
-    EXPECT_EQ(MemsetNodeAImpl, MemsetNodeAImpl);
-    EXPECT_EQ(MemsetNodeBImpl, MemsetNodeBImpl);
-    EXPECT_NE(MemsetNodeAImpl, MemsetNodeBImpl);
+    EXPECT_NE(&FillNodeAImpl, &FillNodeBImpl);
+    EXPECT_NE(&MemsetNodeAImpl, &MemsetNodeBImpl);
     sycl::free(USMPtr, Queue);
   }
 }

--- a/sycl/unittests/Extensions/CommandGraph/Common.hpp
+++ b/sycl/unittests/Extensions/CommandGraph/Common.hpp
@@ -25,6 +25,8 @@
 using namespace sycl;
 using namespace sycl::ext::oneapi;
 
+using sycl::detail::getSyclObjImpl;
+
 // Common Test fixture
 class CommandGraphTest : public ::testing::Test {
 public:

--- a/sycl/unittests/Extensions/CommandGraph/Exceptions.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Exceptions.cpp
@@ -502,20 +502,20 @@ TEST_F(CommandGraphTest, MakeEdgeErrors) {
   // state.
 
   auto CheckGraphStructure = [&]() {
-    auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
-    auto NodeAImpl = sycl::detail::getSyclObjImpl(NodeA);
-    auto NodeBImpl = sycl::detail::getSyclObjImpl(NodeB);
+    experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(Graph);
+    experimental::detail::node_impl &NodeAImpl = *getSyclObjImpl(NodeA);
+    experimental::detail::node_impl &NodeBImpl = *getSyclObjImpl(NodeB);
 
-    ASSERT_EQ(GraphImpl->MRoots.size(), 1lu);
-    ASSERT_EQ((*GraphImpl->MRoots.begin()).lock(), NodeAImpl);
+    ASSERT_EQ(GraphImpl.MRoots.size(), 1lu);
+    ASSERT_EQ(GraphImpl.MRoots.begin()->lock().get(), &NodeAImpl);
 
-    ASSERT_EQ(NodeAImpl->MSuccessors.size(), 1lu);
-    ASSERT_EQ(NodeAImpl->MPredecessors.size(), 0lu);
-    ASSERT_EQ(NodeAImpl->MSuccessors.front().lock(), NodeBImpl);
+    ASSERT_EQ(NodeAImpl.MSuccessors.size(), 1lu);
+    ASSERT_EQ(NodeAImpl.MPredecessors.size(), 0lu);
+    ASSERT_EQ(NodeAImpl.MSuccessors.front().lock().get(), &NodeBImpl);
 
-    ASSERT_EQ(NodeBImpl->MSuccessors.size(), 0lu);
-    ASSERT_EQ(NodeBImpl->MPredecessors.size(), 1lu);
-    ASSERT_EQ(NodeBImpl->MPredecessors.front().lock(), NodeAImpl);
+    ASSERT_EQ(NodeBImpl.MSuccessors.size(), 0lu);
+    ASSERT_EQ(NodeBImpl.MPredecessors.size(), 1lu);
+    ASSERT_EQ(NodeBImpl.MPredecessors.front().lock().get(), &NodeAImpl);
   };
   // Make a normal edge
   ASSERT_NO_THROW(Graph.make_edge(NodeA, NodeB));

--- a/sycl/unittests/Extensions/CommandGraph/InOrderQueue.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/InOrderQueue.cpp
@@ -22,18 +22,16 @@ TEST_F(CommandGraphTest, InOrderQueue) {
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode1 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode1 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode1, nullptr);
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode2 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode2 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
@@ -44,9 +42,8 @@ TEST_F(CommandGraphTest, InOrderQueue) {
   auto Node3Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode3 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode3 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
@@ -58,16 +55,17 @@ TEST_F(CommandGraphTest, InOrderQueue) {
 
   // Finalize main graph and check schedule
   auto GraphExec = InOrderGraph.finalize();
-  auto GraphExecImpl = sycl::detail::getSyclObjImpl(GraphExec);
-  auto Schedule = GraphExecImpl->getSchedule();
+  experimental::detail::exec_graph_impl &GraphExecImpl =
+      *getSyclObjImpl(GraphExec);
+  auto Schedule = GraphExecImpl.getSchedule();
   auto ScheduleIt = Schedule.begin();
   ASSERT_EQ(Schedule.size(), 3ul);
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(PtrNode1));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*PtrNode1));
   ScheduleIt++;
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(PtrNode2));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*PtrNode2));
   ScheduleIt++;
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(PtrNode3));
-  ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl->getContext());
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*PtrNode3));
+  ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl.getContext());
 }
 
 TEST_F(CommandGraphTest, InOrderQueueWithEmpty) {
@@ -82,17 +80,15 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmpty) {
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode1 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode1 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode1, nullptr);
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit([&](sycl::handler &cgh) {});
 
-  auto PtrNode2 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode2 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
@@ -103,9 +99,8 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmpty) {
   auto Node3Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode3 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode3 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
@@ -118,17 +113,18 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmpty) {
   // Finalize main graph and check schedule
   // Note that empty nodes are not scheduled
   auto GraphExec = InOrderGraph.finalize();
-  auto GraphExecImpl = sycl::detail::getSyclObjImpl(GraphExec);
-  auto Schedule = GraphExecImpl->getSchedule();
+  experimental::detail::exec_graph_impl &GraphExecImpl =
+      *getSyclObjImpl(GraphExec);
+  auto Schedule = GraphExecImpl.getSchedule();
   auto ScheduleIt = Schedule.begin();
   // the schedule list contains all types of nodes (even empty nodes)
   ASSERT_EQ(Schedule.size(), 3ul);
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(PtrNode1));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*PtrNode1));
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)->isEmpty());
   ScheduleIt++;
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(PtrNode3));
-  ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl->getContext());
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*PtrNode3));
+  ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl.getContext());
 }
 
 TEST_F(CommandGraphTest, InOrderQueueWithEmptyFirst) {
@@ -141,18 +137,16 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyFirst) {
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit([&](sycl::handler &cgh) {});
 
-  auto PtrNode1 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode1 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode1, nullptr);
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode2 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode2 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
@@ -163,9 +157,8 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyFirst) {
   auto Node3Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode3 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode3 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
@@ -178,17 +171,18 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyFirst) {
   // Finalize main graph and check schedule
   // Note that empty nodes are not scheduled
   auto GraphExec = InOrderGraph.finalize();
-  auto GraphExecImpl = sycl::detail::getSyclObjImpl(GraphExec);
-  auto Schedule = GraphExecImpl->getSchedule();
+  experimental::detail::exec_graph_impl &GraphExecImpl =
+      *getSyclObjImpl(GraphExec);
+  auto Schedule = GraphExecImpl.getSchedule();
   auto ScheduleIt = Schedule.begin();
   // the schedule list contains all types of nodes (even empty nodes)
   ASSERT_EQ(Schedule.size(), 3ul);
   ASSERT_TRUE((*ScheduleIt)->isEmpty());
   ScheduleIt++;
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(PtrNode2));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*PtrNode2));
   ScheduleIt++;
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(PtrNode3));
-  ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl->getContext());
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*PtrNode3));
+  ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl.getContext());
 }
 
 TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
@@ -202,18 +196,16 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode1 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode1 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode1, nullptr);
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode2 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode2 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
@@ -223,9 +215,8 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
 
   auto Node3Graph = InOrderQueue.submit([&](sycl::handler &cgh) {});
 
-  auto PtrNode3 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode3 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
@@ -238,17 +229,18 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
   // Finalize main graph and check schedule
   // Note that empty nodes are not scheduled
   auto GraphExec = InOrderGraph.finalize();
-  auto GraphExecImpl = sycl::detail::getSyclObjImpl(GraphExec);
-  auto Schedule = GraphExecImpl->getSchedule();
+  experimental::detail::exec_graph_impl &GraphExecImpl =
+      *getSyclObjImpl(GraphExec);
+  auto Schedule = GraphExecImpl.getSchedule();
   auto ScheduleIt = Schedule.begin();
   // the schedule list contains all types of nodes (even empty nodes)
   ASSERT_EQ(Schedule.size(), 3ul);
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(PtrNode1));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*PtrNode1));
   ScheduleIt++;
-  ASSERT_TRUE((*ScheduleIt)->isSimilar(PtrNode2));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*PtrNode2));
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)->isEmpty());
-  ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl->getContext());
+  ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl.getContext());
 }
 
 TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
@@ -267,25 +259,23 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
       std::lock_guard<std::mutex> HostTaskLock(HostTaskMutex);
     });
   });
-  auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
+  sycl::detail::event_impl &EventInitialImpl = *getSyclObjImpl(EventInitial);
 
   // Record in-order queue with three nodes.
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode1 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode1 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode1, nullptr);
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode2 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode2 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
@@ -296,9 +286,8 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
   auto Node3Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode3 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode3 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
@@ -311,13 +300,13 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
   auto EventLast = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
-  auto WaitList = EventLastImpl->getWaitList();
+  sycl::detail::event_impl &EventLastImpl = *getSyclObjImpl(EventLast);
+  auto WaitList = EventLastImpl.getWaitList();
   Lock.unlock();
   // Previous task is a host task. Explicit dependency is needed to enforce the
   // execution order.
   ASSERT_EQ(WaitList.size(), 1lu);
-  ASSERT_EQ(WaitList[0], EventInitialImpl);
+  ASSERT_EQ(WaitList[0].get(), &EventInitialImpl);
   InOrderQueue.wait();
 }
 
@@ -338,25 +327,22 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
         std::lock_guard<std::mutex> HostTaskLock(HostTaskMutex);
       });
     });
-    auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
 
     // Record in-order queue with three nodes.
     InOrderGraph.begin_recording(InOrderQueue);
     auto Node1Graph = InOrderQueue.submit(
         [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-    auto PtrNode1 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                        ->getLastInorderNode(
-                            sycl::detail::getSyclObjImpl(InOrderQueue).get());
+    auto PtrNode1 = getSyclObjImpl(InOrderGraph)
+                        ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
     ASSERT_NE(PtrNode1, nullptr);
     ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
     auto Node2Graph = InOrderQueue.submit(
         [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-    auto PtrNode2 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                        ->getLastInorderNode(
-                            sycl::detail::getSyclObjImpl(InOrderQueue).get());
+    auto PtrNode2 = getSyclObjImpl(InOrderGraph)
+                        ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
     ASSERT_NE(PtrNode2, nullptr);
     ASSERT_NE(PtrNode2, PtrNode1);
     ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
@@ -367,9 +353,8 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
     auto Node3Graph = InOrderQueue.submit(
         [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-    auto PtrNode3 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                        ->getLastInorderNode(
-                            sycl::detail::getSyclObjImpl(InOrderQueue).get());
+    auto PtrNode3 = getSyclObjImpl(InOrderGraph)
+                        ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
     ASSERT_NE(PtrNode3, nullptr);
     ASSERT_NE(PtrNode3, PtrNode2);
     ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
@@ -386,11 +371,10 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
     auto EventGraph = InOrderQueue.submit(
         [&](sycl::handler &CGH) { CGH.ext_oneapi_graph(InOrderGraphExec); });
 
-    auto EventGraphImpl = sycl::detail::getSyclObjImpl(EventGraph);
     auto EventLast = InOrderQueue.submit(
         [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
-    auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
-    auto EventLastWaitList = EventLastImpl->getWaitList();
+    sycl::detail::event_impl &EventLastImpl = *getSyclObjImpl(EventLast);
+    auto EventLastWaitList = EventLastImpl.getWaitList();
     // Previous task is not a host task. Explicit dependency is still needed
     // to properly handle blocked tasks (the event will be filtered out before
     // submission to the backend).
@@ -420,25 +404,22 @@ TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
   int *TestData = sycl::malloc_shared<int>(Size, InOrderQueue);
 
   auto EventInitial = InOrderQueue.memset(TestData, 1, Size * sizeof(int));
-  auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
 
   // Record in-order queue with three nodes.
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode1 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode1 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode1, nullptr);
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode2 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode2 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
@@ -449,9 +430,8 @@ TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
   auto Node3Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode3 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode3 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
@@ -484,25 +464,22 @@ TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
 
   auto EventInitial =
       InOrderQueue.memcpy(TestData, TestDataHost.data(), Size * sizeof(int));
-  auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
 
   // Record in-order queue with three nodes.
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode1 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode1 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode1, nullptr);
   ASSERT_TRUE(PtrNode1->MPredecessors.empty());
 
   auto Node2Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode2 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode2 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
@@ -513,9 +490,8 @@ TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
   auto Node3Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
-  auto PtrNode3 = sycl::detail::getSyclObjImpl(InOrderGraph)
-                      ->getLastInorderNode(
-                          sycl::detail::getSyclObjImpl(InOrderQueue).get());
+  auto PtrNode3 = getSyclObjImpl(InOrderGraph)
+                      ->getLastInorderNode(&*getSyclObjImpl(InOrderQueue));
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);

--- a/sycl/unittests/Extensions/CommandGraph/Queries.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Queries.cpp
@@ -89,8 +89,7 @@ TEST_F(CommandGraphTest, GetNodeQueries) {
 
   // Check ordering of all nodes is correct
   for (size_t i = 0; i < GraphNodes.size(); i++) {
-    ASSERT_EQ(sycl::detail::getSyclObjImpl(GraphNodes[i]),
-              sycl::detail::getSyclObjImpl(NodeList[i]));
+    ASSERT_EQ(&*getSyclObjImpl(GraphNodes[i]), &*getSyclObjImpl(NodeList[i]));
   }
 }
 

--- a/sycl/unittests/Extensions/CommandGraph/Subgraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Subgraph.cpp
@@ -32,48 +32,39 @@ TEST_F(CommandGraphTest, SubGraph) {
       {experimental::property::node::depends_on(Node2MainGraph)});
 
   // Assert order of the added sub-graph
-  ASSERT_NE(sycl::detail::getSyclObjImpl(Node2MainGraph), nullptr);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node2MainGraph)->MNodeType ==
+  ASSERT_TRUE(getSyclObjImpl(Node2MainGraph)->MNodeType ==
               experimental::node_type::subgraph);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(MainGraph)->MRoots.size(), 1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1MainGraph)->MSuccessors.size(),
-            1lu);
+  ASSERT_EQ(getSyclObjImpl(MainGraph)->MRoots.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1MainGraph)->MSuccessors.size(), 1lu);
   // Subgraph nodes are duplicated when inserted to parent graph on
   // finalization. we thus check the node content only.
   const bool CompareContentOnly = true;
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1MainGraph)
-                  ->MSuccessors.front()
-                  .lock()
-                  ->MNodeType == experimental::node_type::subgraph);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2MainGraph)->MSuccessors.size(),
-            1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1MainGraph)->MPredecessors.size(),
-            0lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2MainGraph)->MPredecessors.size(),
-            1lu);
+  ASSERT_TRUE(
+      getSyclObjImpl(Node1MainGraph)->MSuccessors.front().lock()->MNodeType ==
+      experimental::node_type::subgraph);
+  ASSERT_EQ(getSyclObjImpl(Node2MainGraph)->MSuccessors.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1MainGraph)->MPredecessors.size(), 0lu);
+  ASSERT_EQ(getSyclObjImpl(Node2MainGraph)->MPredecessors.size(), 1lu);
 
   // Finalize main graph and check schedule
   auto MainGraphExec = MainGraph.finalize();
-  auto MainGraphExecImpl = sycl::detail::getSyclObjImpl(MainGraphExec);
-  auto Schedule = MainGraphExecImpl->getSchedule();
+  experimental::detail::exec_graph_impl &MainGraphExecImpl =
+      *getSyclObjImpl(MainGraphExec);
+  auto Schedule = MainGraphExecImpl.getSchedule();
   auto ScheduleIt = Schedule.begin();
   // The schedule list must contain 4 nodes: the two nodes from the subgraph are
   // merged into the main graph in place of the subgraph node.
   ASSERT_EQ(Schedule.size(), 4ul);
-  ASSERT_TRUE(
-      (*ScheduleIt)->isSimilar(sycl::detail::getSyclObjImpl(Node1MainGraph)));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*getSyclObjImpl(Node1MainGraph)));
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)
-                  ->isSimilar(sycl::detail::getSyclObjImpl(Node1Graph),
-                              CompareContentOnly));
+                  ->isSimilar(*getSyclObjImpl(Node1Graph), CompareContentOnly));
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)
-                  ->isSimilar(sycl::detail::getSyclObjImpl(Node2Graph),
-                              CompareContentOnly));
+                  ->isSimilar(*getSyclObjImpl(Node2Graph), CompareContentOnly));
   ScheduleIt++;
-  ASSERT_TRUE(
-      (*ScheduleIt)->isSimilar(sycl::detail::getSyclObjImpl(Node3MainGraph)));
-  ASSERT_EQ(Queue.get_context(), MainGraphExecImpl->getContext());
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*getSyclObjImpl(Node3MainGraph)));
+  ASSERT_EQ(Queue.get_context(), MainGraphExecImpl.getContext());
 }
 
 TEST_F(CommandGraphTest, SubGraphWithEmptyNode) {
@@ -101,54 +92,44 @@ TEST_F(CommandGraphTest, SubGraphWithEmptyNode) {
       {experimental::property::node::depends_on(Node2MainGraph)});
 
   // Assert order of the added sub-graph
-  ASSERT_NE(sycl::detail::getSyclObjImpl(Node2MainGraph), nullptr);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node2MainGraph)->MNodeType ==
+  ASSERT_TRUE(getSyclObjImpl(Node2MainGraph)->MNodeType ==
               experimental::node_type::subgraph);
   // Check the structure of the main graph.
   // 1 root connected to 1 successor (the single root of the subgraph)
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(MainGraph)->MRoots.size(), 1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1MainGraph)->MSuccessors.size(),
-            1lu);
+  ASSERT_EQ(getSyclObjImpl(MainGraph)->MRoots.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1MainGraph)->MSuccessors.size(), 1lu);
   // Subgraph nodes are duplicated when inserted to parent graph.
   // we thus check the node content only.
   const bool CompareContentOnly = true;
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1MainGraph)
-                  ->MSuccessors.front()
-                  .lock()
-                  ->MNodeType == experimental::node_type::subgraph);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1MainGraph)->MSuccessors.size(),
-            1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2MainGraph)->MSuccessors.size(),
-            1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1MainGraph)->MPredecessors.size(),
-            0lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2MainGraph)->MPredecessors.size(),
-            1lu);
+  ASSERT_TRUE(
+      getSyclObjImpl(Node1MainGraph)->MSuccessors.front().lock()->MNodeType ==
+      experimental::node_type::subgraph);
+  ASSERT_EQ(getSyclObjImpl(Node1MainGraph)->MSuccessors.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node2MainGraph)->MSuccessors.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1MainGraph)->MPredecessors.size(), 0lu);
+  ASSERT_EQ(getSyclObjImpl(Node2MainGraph)->MPredecessors.size(), 1lu);
 
   // Finalize main graph and check schedule
   auto MainGraphExec = MainGraph.finalize();
-  auto MainGraphExecImpl = sycl::detail::getSyclObjImpl(MainGraphExec);
-  auto Schedule = MainGraphExecImpl->getSchedule();
+  experimental::detail::exec_graph_impl &MainGraphExecImpl =
+      *getSyclObjImpl(MainGraphExec);
+  auto Schedule = MainGraphExecImpl.getSchedule();
   auto ScheduleIt = Schedule.begin();
   // The schedule list must contain 5 nodes: 2 main graph nodes and 3 subgraph
   // nodes which have been merged.
   ASSERT_EQ(Schedule.size(), 5ul);
-  ASSERT_TRUE(
-      (*ScheduleIt)->isSimilar(sycl::detail::getSyclObjImpl(Node1MainGraph)));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*getSyclObjImpl(Node1MainGraph)));
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)
-                  ->isSimilar(sycl::detail::getSyclObjImpl(Node1Graph),
-                              CompareContentOnly));
+                  ->isSimilar(*getSyclObjImpl(Node1Graph), CompareContentOnly));
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)->isEmpty()); // empty node inside the subgraph
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)
-                  ->isSimilar(sycl::detail::getSyclObjImpl(Node2Graph),
-                              CompareContentOnly));
+                  ->isSimilar(*getSyclObjImpl(Node2Graph), CompareContentOnly));
   ScheduleIt++;
-  ASSERT_TRUE(
-      (*ScheduleIt)->isSimilar(sycl::detail::getSyclObjImpl(Node3MainGraph)));
-  ASSERT_EQ(Queue.get_context(), MainGraphExecImpl->getContext());
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*getSyclObjImpl(Node3MainGraph)));
+  ASSERT_EQ(Queue.get_context(), MainGraphExecImpl.getContext());
 }
 
 TEST_F(CommandGraphTest, SubGraphWithEmptyNodeLast) {
@@ -176,54 +157,44 @@ TEST_F(CommandGraphTest, SubGraphWithEmptyNodeLast) {
       {experimental::property::node::depends_on(Node2MainGraph)});
 
   // Assert order of the added sub-graph
-  ASSERT_NE(sycl::detail::getSyclObjImpl(Node2MainGraph), nullptr);
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node2MainGraph)->MNodeType ==
+  ASSERT_TRUE(getSyclObjImpl(Node2MainGraph)->MNodeType ==
               experimental::node_type::subgraph);
   // Check the structure of the main graph.
   // 1 root connected to 1 successor (the single root of the subgraph)
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(MainGraph)->MRoots.size(), 1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1MainGraph)->MSuccessors.size(),
-            1lu);
+  ASSERT_EQ(getSyclObjImpl(MainGraph)->MRoots.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1MainGraph)->MSuccessors.size(), 1lu);
   // Subgraph nodes are duplicated when inserted to parent graph.
   // we thus check the node content only.
   const bool CompareContentOnly = true;
-  ASSERT_TRUE(sycl::detail::getSyclObjImpl(Node1MainGraph)
-                  ->MSuccessors.front()
-                  .lock()
-                  ->MNodeType == experimental::node_type::subgraph);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1MainGraph)->MSuccessors.size(),
-            1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2MainGraph)->MSuccessors.size(),
-            1lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node1MainGraph)->MPredecessors.size(),
-            0lu);
-  ASSERT_EQ(sycl::detail::getSyclObjImpl(Node2MainGraph)->MPredecessors.size(),
-            1lu);
+  ASSERT_TRUE(
+      getSyclObjImpl(Node1MainGraph)->MSuccessors.front().lock()->MNodeType ==
+      experimental::node_type::subgraph);
+  ASSERT_EQ(getSyclObjImpl(Node1MainGraph)->MSuccessors.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node2MainGraph)->MSuccessors.size(), 1lu);
+  ASSERT_EQ(getSyclObjImpl(Node1MainGraph)->MPredecessors.size(), 0lu);
+  ASSERT_EQ(getSyclObjImpl(Node2MainGraph)->MPredecessors.size(), 1lu);
 
   // Finalize main graph and check schedule
   auto MainGraphExec = MainGraph.finalize();
-  auto MainGraphExecImpl = sycl::detail::getSyclObjImpl(MainGraphExec);
-  auto Schedule = MainGraphExecImpl->getSchedule();
+  experimental::detail::exec_graph_impl &MainGraphExecImpl =
+      *getSyclObjImpl(MainGraphExec);
+  auto Schedule = MainGraphExecImpl.getSchedule();
   auto ScheduleIt = Schedule.begin();
   // The schedule list must contain 5 nodes: 2 main graph nodes and 3 subgraph
   // nodes which have been merged.
   ASSERT_EQ(Schedule.size(), 5ul);
-  ASSERT_TRUE(
-      (*ScheduleIt)->isSimilar(sycl::detail::getSyclObjImpl(Node1MainGraph)));
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*getSyclObjImpl(Node1MainGraph)));
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)
-                  ->isSimilar(sycl::detail::getSyclObjImpl(Node1Graph),
-                              CompareContentOnly));
+                  ->isSimilar(*getSyclObjImpl(Node1Graph), CompareContentOnly));
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)
-                  ->isSimilar(sycl::detail::getSyclObjImpl(Node2Graph),
-                              CompareContentOnly));
+                  ->isSimilar(*getSyclObjImpl(Node2Graph), CompareContentOnly));
   ScheduleIt++;
   ASSERT_TRUE((*ScheduleIt)->isEmpty()); // empty node inside the subgraph
   ScheduleIt++;
-  ASSERT_TRUE(
-      (*ScheduleIt)->isSimilar(sycl::detail::getSyclObjImpl(Node3MainGraph)));
-  ASSERT_EQ(Queue.get_context(), MainGraphExecImpl->getContext());
+  ASSERT_TRUE((*ScheduleIt)->isSimilar(*getSyclObjImpl(Node3MainGraph)));
+  ASSERT_EQ(Queue.get_context(), MainGraphExecImpl.getContext());
 }
 
 TEST_F(CommandGraphTest, RecordSubGraph) {
@@ -255,12 +226,13 @@ TEST_F(CommandGraphTest, RecordSubGraph) {
 
   // Finalize main graph and check schedule
   auto MainGraphExec = MainGraph.finalize();
-  auto MainGraphExecImpl = sycl::detail::getSyclObjImpl(MainGraphExec);
-  auto Schedule = MainGraphExecImpl->getSchedule();
+  experimental::detail::exec_graph_impl &MainGraphExecImpl =
+      *getSyclObjImpl(MainGraphExec);
+  auto Schedule = MainGraphExecImpl.getSchedule();
 
   // The schedule list must contain 4 nodes: 2 main graph nodes and 2 subgraph
   // nodes which have been merged in to the main graph.
   ASSERT_EQ(Schedule.size(), 4ul);
 
-  ASSERT_EQ(Queue.get_context(), MainGraphExecImpl->getContext());
+  ASSERT_EQ(Queue.get_context(), MainGraphExecImpl.getContext());
 }

--- a/sycl/unittests/Extensions/CommandGraph/TopologicalSort.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/TopologicalSort.cpp
@@ -80,18 +80,19 @@ TEST_F(CommandGraphTest, CheckTopologicalSort) {
 
   auto ExecGraph = Graph.finalize();
 
-  auto ExecGraphImpl = sycl::detail::getSyclObjImpl(ExecGraph);
+  experimental::detail::exec_graph_impl &ExecGraphImpl =
+      *getSyclObjImpl(ExecGraph);
 
   // Creating an executable graph with finalize copies all the nodes to new
   // objects. The new nodes will have an ID equal to OldNodeID + NumNodes. This
   // is implementation dependent but is the only way to test this functionality
-  size_t Node6ID = sycl::detail::getSyclObjImpl(Node6)->getID() + NumNodes;
-  size_t Node3ID = sycl::detail::getSyclObjImpl(Node3)->getID() + NumNodes;
-  size_t Node0ID = sycl::detail::getSyclObjImpl(Node0)->getID() + NumNodes;
-  size_t Node1ID = sycl::detail::getSyclObjImpl(Node1)->getID() + NumNodes;
-  size_t Node2ID = sycl::detail::getSyclObjImpl(Node2)->getID() + NumNodes;
-  size_t Node5ID = sycl::detail::getSyclObjImpl(Node5)->getID() + NumNodes;
-  size_t Node4ID = sycl::detail::getSyclObjImpl(Node4)->getID() + NumNodes;
+  size_t Node6ID = getSyclObjImpl(Node6)->getID() + NumNodes;
+  size_t Node3ID = getSyclObjImpl(Node3)->getID() + NumNodes;
+  size_t Node0ID = getSyclObjImpl(Node0)->getID() + NumNodes;
+  size_t Node1ID = getSyclObjImpl(Node1)->getID() + NumNodes;
+  size_t Node2ID = getSyclObjImpl(Node2)->getID() + NumNodes;
+  size_t Node5ID = getSyclObjImpl(Node5)->getID() + NumNodes;
+  size_t Node4ID = getSyclObjImpl(Node4)->getID() + NumNodes;
 
   std::unordered_map<size_t, size_t> mapExecutionIDToTestID = {
       {Node6ID, 6}, {Node3ID, 3}, {Node0ID, 0}, {Node1ID, 1},
@@ -105,7 +106,7 @@ TEST_F(CommandGraphTest, CheckTopologicalSort) {
       {6, 3, 0, 5, 1, 2, 4}, {6, 3, 0, 5, 2, 1, 4}, {6, 3, 0, 5, 2, 4, 1}};
 
   std::vector<size_t> Schedule;
-  for (auto &NodeImpl : ExecGraphImpl->getSchedule()) {
+  for (auto &NodeImpl : ExecGraphImpl.getSchedule()) {
     Schedule.push_back(mapExecutionIDToTestID[NodeImpl->getID()]);
   }
   ASSERT_EQ(Schedule.size(), 7ul);


### PR DESCRIPTION
I'm planning to change `getSyclObjImpl` to return a raw reference in a later patch, uploading a bunch of PRs in preparation to that to make the subsequent review easier.

I also did `s/sycl::detail::getSyclObjImpl/getSyclObjImpl/g` here to increase readability and to make it simpler to perform the future patch by simple `sed` (and avoid multiline changes).

This PR originated in `unittests/Extensions/CommandGraph`, but I had to modify `isSimilar` and `hasSimilarStructure` in the implementation itself too.