### PR TITLE
[SYCL][E2E] Remove SPIR-V target requirement from SYCLBIN tests

### DIFF
--- a/sycl/test-e2e/SYCLBIN/basic_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_executable.cpp
@@ -11,11 +11,6 @@
 // -- Basic test for compiling and loading a SYCLBIN kernel_bundle in executable
 // -- state.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=executable %S/Inputs/basic_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/basic_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_input.cpp
@@ -11,11 +11,6 @@
 // -- Basic test for compiling and loading a SYCLBIN kernel_bundle in input
 // -- state.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=input %S/Inputs/basic_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/basic_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_object.cpp
@@ -11,11 +11,6 @@
 // -- Basic test for compiling and loading a SYCLBIN kernel_bundle in object
 // -- state.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %S/Inputs/basic_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/link_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_input.cpp
@@ -10,11 +10,6 @@
 
 // -- Test for linking two SYCLBIN kernel_bundle.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=input -fsycl-allow-device-image-dependencies %S/Inputs/exporting_function.cpp -o %t.export.syclbin
 // RUN: %clangxx --offload-new-driver -fsyclbin=input -fsycl-allow-device-image-dependencies %S/Inputs/importing_kernel.cpp -o %t.import.syclbin
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/SYCLBIN/link_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_object.cpp
@@ -10,11 +10,6 @@
 
 // -- Test for linking two SYCLBIN kernel_bundle.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=object -fsycl-allow-device-image-dependencies %S/Inputs/exporting_function.cpp -o %t.export.syclbin
 // RUN: %clangxx --offload-new-driver -fsyclbin=object -fsycl-allow-device-image-dependencies %S/Inputs/importing_kernel.cpp -o %t.import.syclbin
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/SYCLBIN/link_rtc_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_rtc_input.cpp
@@ -15,11 +15,6 @@
 // -- Test for linking where one kernel is runtime-compiled and one is compiled
 // -- to SYCLBIN.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=input -fsycl-allow-device-image-dependencies %S/Inputs/exporting_function.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run}  %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/link_rtc_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_rtc_object.cpp
@@ -15,11 +15,6 @@
 // -- Test for linking where one kernel is runtime-compiled and one is compiled
 // -- to SYCLBIN.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=object -fsycl-allow-device-image-dependencies %S/Inputs/exporting_function.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run}  %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_executable.cpp
@@ -11,11 +11,6 @@
 // -- Test for compiling and loading a kernel bundle with a SYCLBIN containing
 //    the use of optional kernel features.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=executable %S/Inputs/optional_kernel_features.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_input.cpp
@@ -11,11 +11,6 @@
 // -- Test for compiling and loading a kernel bundle with a SYCLBIN containing
 //    the use of optional kernel features.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=input %S/Inputs/optional_kernel_features.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
@@ -12,11 +12,6 @@
 // -- Test for compiling and loading a kernel bundle with a SYCLBIN containing
 //    the use of optional kernel features.
 
-// Due to the regression in https://github.com/intel/llvm/issues/18432 it will
-// fail to build the SYCLBIN with nvptx targets. Once this is fixed,
-// %{sycl_target_opts} should be added to the SYCLBIN generation run-line.
-// REQUIRES: target-spir
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %S/Inputs/optional_kernel_features.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin


### PR DESCRIPTION
The SYCLBIN tests were only enabled for SPIR-V targets due to a bug in PTX builds with the new offload driver
(https://github.com/intel/llvm/issues/18432). Since this is believed to have been fixed, these should be reenabled.