### PR TITLE
[DeviceSanitizer] Add check for PrintUrBuildLogIfError()

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
@@ -286,8 +286,10 @@ void PrintUrBuildLogIfError(ur_result_t Result, ur_program_handle_t Program,
       Result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE)
     return;
 
-  if (!Program || !Devices || NumDevices == 0)
+  if (!Program || !Devices || NumDevices == 0) {
+    UR_LOG_L(getContext()->logger, ERR, "Failed to get build log.");
     return;
+  }
 
   UR_LOG_L(getContext()->logger, ERR, "Printing build log for program {}",
            (void *)Program);

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
@@ -286,6 +286,9 @@ void PrintUrBuildLogIfError(ur_result_t Result, ur_program_handle_t Program,
       Result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE)
     return;
 
+  if (!Program || !Devices || NumDevices == 0)
+    return;
+
   UR_LOG_L(getContext()->logger, ERR, "Printing build log for program {}",
            (void *)Program);
   for (size_t I = 0; I < NumDevices; I++) {


### PR DESCRIPTION
Add some parameter checks for `PrintUrBuildLogIfError()` to avoid calling underlying API with invalid parameters.