### PR TITLE
[SYCL][CMAKE] Refactor `-fPIE` handling

### DIFF
--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -131,14 +131,13 @@ macro(append_common_extra_security_flags)
   endif()
 
   # Position Independent Execution
-  if(is_gcc
-     OR is_clang
-     OR (is_icpx AND MSVC))
-    # The project should be configured with -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    add_compile_option_ext("-fPIE" FPIE)
-    add_link_option_ext("-pie" PIE CMAKE_EXE_LINKER_FLAGS
-                        CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
-  elseif(is_msvc)
+  # We rely on CMake to set the right -fPIE flags for us, but it must be
+  # explicitly requested
+  if (NOT CMAKE_POSITION_INDEPENDENT_CODE)
+    message(FATAL_ERROR "To enable all necessary security flags, CMAKE_POSITION_INDEPENDENT_CODE must be set to ON")
+  endif()
+
+  if(is_msvc)
     add_link_option_ext("/DYNAMICBASE" DYNAMICBASE CMAKE_EXE_LINKER_FLAGS
                         CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
   endif()


### PR DESCRIPTION
CMake is capable of setting `-fPIE` correctly and we don't need to intervene with that.

Without the patch, I see the following errors:

```
FAILED: lib/libze_trace_collector.so
: && /usr/bin/clang++ -fPIC -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite
-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor
 -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -Wall -Wextra 
-fcf-protection=full -Wformat -Wformat-security -fPIC -fPIE -Wno-covered-switch-default -Wall -Wextra -Werror -O2 -g -DNDEBUG  -Wl,-z,defs -Wl,-z,nodelete -pie -shared -Wl,-soname,libze_
trace_collector.so -o lib/libze_trace_collector.so tools/sycl/tools/sycl-trace/CMakeFiles/ze_trace_collector.dir/ze_trace_collector.cpp.o  -Wl,-rpath,build/lib:  lib/libxptifw.so  -ldl && :
clang++: error: argument unused during compilation: '-pie' [-Werror,-Wunused-command-line-argument]
```