### PR TITLE
[UR][CMAKE] Use `-D_FORTIFY_SOURCE=3`

### DIFF
--- a/unified-runtime/cmake/helpers.cmake
+++ b/unified-runtime/cmake/helpers.cmake
@@ -88,7 +88,7 @@ endif()
 
 function(add_ur_target_compile_options name)
     if(NOT MSVC)
-        target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=2)
+        target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=3)
         target_compile_options(${name} PRIVATE
             # Warning options
             -Wall


### PR DESCRIPTION
This aligns UR settings with the global settings we have in `llvm/cmake/modules/AddSecurityFlags.cmake` which are in turn influenced by our guidelines.