### PR TITLE
[NFC] Fix SYCLInstallationDetector InstallationCandidates.

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -147,7 +147,7 @@ SYCLInstallationDetector::SYCLInstallationDetector(const Driver &D)
 SYCLInstallationDetector::SYCLInstallationDetector(
     const Driver &D, const llvm::Triple &HostTriple,
     const llvm::opt::ArgList &Args)
-    : D(D) {}
+    : SYCLInstallationDetector(D) {}
 
 static llvm::SmallString<64>
 getLibSpirvBasename(const llvm::Triple &DeviceTriple,


### PR DESCRIPTION
Originally, SYCLInstallationDetector just had a single constructor parameter D, and filled InstallationCandidates. In the process of upstreaming this, unused arguments HostTriple and Args were added, and InstallationCandidates was removed. Then, when the upstreamed version was pulled into DPC++, we ended up with two constructors, one which did fill InstallationCandidates and one which did not, for no reason.

Ideally, we would align with upstream and use that new constructor everywhere. However, we use SYCLInstallationDetector in places where do not have that information, we need to be able to construct a SYCLInstallationDetector from only a Driver, so using only the upstream constructor is not an option.

Using only the single-argument constructor is also not a good idea, as it makes future pulldowns more difficult. This is the situation we had, and a pulldown brought us to the current situation where the three-parameter constructor was added to resolve the conflict.

Therefore, this commit takes the approach of using the single-parameter constructor to implement the three-parameter constructor, thus ensuring that InstallationCandidates is always filled.

This is NFC at the moment because the only places that rely on InstallationCandidates being filled use the single-parameter constructor.