### PR TITLE
[NFC][SYCL] Prepare `memory_pool`/`async_alloc` for `getSyclObjImpl` to return raw ref

### DIFF
--- a/sycl/source/detail/graph/memory_pool.hpp
+++ b/sycl/source/detail/graph/memory_pool.hpp
@@ -84,7 +84,7 @@ public:
   /// @return A pointer to the start of the allocation
   void *malloc(size_t Size, usm::alloc AllocType,
                const std::vector<std::shared_ptr<node_impl>> &DepNodes,
-               const std::shared_ptr<memory_pool_impl> &MemPool = nullptr);
+               memory_pool_impl *MemPool = nullptr);
 
   /// Return the total amount of memory being used by this pool
   size_t getMemUseCurrent() const {


### PR DESCRIPTION
I'm planning to change `getSyclObjImpl` to return a raw reference in a later patch, uploading a bunch of PRs in preparation to that to make the subsequent review easier.