### PR TITLE
[NFC][SYCL] Use `get_ur_handles` in `bindless_images.cpp`

### DIFF
--- a/sycl/source/detail/bindless_images.cpp
+++ b/sycl/source/detail/bindless_images.cpp
@@ -811,11 +811,7 @@ __SYCL_EXPORT std::vector<image_memory_handle_type>
 get_image_memory_support(const image_descriptor &imageDescriptor,
                          const sycl::device &syclDevice,
                          const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  sycl::detail::context_impl &CtxImpl =
-      *sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl.getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -825,7 +821,7 @@ get_image_memory_support(const image_descriptor &imageDescriptor,
   Adapter->call<sycl::errc::runtime,
                 sycl::detail::UrApiKind::
                     urBindlessImagesGetImageMemoryHandleTypeSupportExp>(
-      CtxImpl.getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
+      urCtx, urDevice, &urDesc, &urFormat,
       ur_exp_image_mem_type_t::UR_EXP_IMAGE_MEM_TYPE_USM_POINTER,
       &supportsPointerAllocation);
 
@@ -833,7 +829,7 @@ get_image_memory_support(const image_descriptor &imageDescriptor,
   Adapter->call<sycl::errc::runtime,
                 sycl::detail::UrApiKind::
                     urBindlessImagesGetImageMemoryHandleTypeSupportExp>(
-      CtxImpl.getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
+      urCtx, urDevice, &urDesc, &urFormat,
       ur_exp_image_mem_type_t::UR_EXP_IMAGE_MEM_TYPE_OPAQUE_HANDLE,
       &supportsOpaqueAllocation);
 
@@ -862,11 +858,7 @@ __SYCL_EXPORT bool is_image_handle_supported<unsampled_image_handle>(
     const image_descriptor &imageDescriptor,
     image_memory_handle_type imageMemoryHandleType,
     const sycl::device &syclDevice, const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  sycl::detail::context_impl &CtxImpl =
-      *sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl.getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -881,8 +873,8 @@ __SYCL_EXPORT bool is_image_handle_supported<unsampled_image_handle>(
   Adapter->call<sycl::errc::runtime,
                 sycl::detail::UrApiKind::
                     urBindlessImagesGetImageUnsampledHandleSupportExp>(
-      CtxImpl.getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
-      memHandleType, &supportsUnsampledHandle);
+      urCtx, urDevice, &urDesc, &urFormat, memHandleType,
+      &supportsUnsampledHandle);
 
   return supportsUnsampledHandle;
 }
@@ -902,11 +894,7 @@ __SYCL_EXPORT bool is_image_handle_supported<sampled_image_handle>(
     const image_descriptor &imageDescriptor,
     image_memory_handle_type imageMemoryHandleType,
     const sycl::device &syclDevice, const sycl::context &syclContext) {
-  std::shared_ptr<sycl::detail::device_impl> DevImpl =
-      sycl::detail::getSyclObjImpl(syclDevice);
-  sycl::detail::context_impl &CtxImpl =
-      *sycl::detail::getSyclObjImpl(syclContext);
-  const sycl::detail::AdapterPtr &Adapter = CtxImpl.getAdapter();
+  auto [urDevice, urCtx, Adapter] = get_ur_handles(syclDevice, syclContext);
 
   ur_image_desc_t urDesc;
   ur_image_format_t urFormat;
@@ -921,8 +909,8 @@ __SYCL_EXPORT bool is_image_handle_supported<sampled_image_handle>(
   Adapter->call<
       sycl::errc::runtime,
       sycl::detail::UrApiKind::urBindlessImagesGetImageSampledHandleSupportExp>(
-      CtxImpl.getHandleRef(), DevImpl->getHandleRef(), &urDesc, &urFormat,
-      memHandleType, &supportsSampledHandle);
+      urCtx, urDevice, &urDesc, &urFormat, memHandleType,
+      &supportsSampledHandle);
 
   return supportsSampledHandle;
 }


### PR DESCRIPTION
I've updated all the known uses when it was introduced in https://github.com/intel/llvm/pull/18168 but then
https://github.com/intel/llvm/pull/17865 added code that didn't use the helper.