### PR TITLE
[NFC] Sync the two copies of ItaniumDemangle.h.

### DIFF
--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -611,6 +611,14 @@ public:
   }
 };
 
+#ifdef _MSC_VER
+// Workaround for MSVC++ bug (Version 2017, 15.8.9) - w/o this forward
+// declaration, the friend declaration in ObjCProtoName below has no effect
+// and leads to compilation error when ObjCProtoName::Protocol private field
+// is accessed in PointerType::printLeft.
+class PointerType;
+#endif // _MSC_VER
+
 class ObjCProtoName : public Node {
   const Node *Ty;
   std::string_view Protocol;
@@ -1234,6 +1242,8 @@ public:
 
   template<typename Fn> void match(Fn F) const { F(Dimension); }
 
+  const Node *getDimension() const { return Dimension; }
+
   void printLeft(OutputBuffer &OB) const override {
     OB += "_Float";
     Dimension->print(OB);
@@ -1547,7 +1557,7 @@ public:
 
   template<typename Fn> void match(Fn F) const { F(Params, Requires); }
 
-  NodeArray getParams() { return Params; }
+  const NodeArray &getParams() const { return Params; }
 
   void printLeft(OutputBuffer &OB) const override {
     ScopedOverride<unsigned> LT(OB.GtIsGt, 0);
@@ -2453,6 +2463,9 @@ public:
     else
       OB << Integer;
   }
+
+  // Retrieves the string view of the integer value this node represents.
+  const std::string_view &getIntegerValue() const { return Integer; }
 };
 
 class IntegerLiteral : public Node {
@@ -2482,6 +2495,10 @@ public:
   }
 
   std::string_view value() const { return Value; }
+
+  // Retrieves the string view of the type string of the integer value this node
+  // represents.
+  const std::string_view &getType() const { return Type; }
 };
 
 class RequiresExpr : public Node {

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -1242,7 +1242,7 @@ public:
 
   template<typename Fn> void match(Fn F) const { F(Dimension); }
 
-  const Node *getDimension() const { return Dimension; } // INTEL
+  const Node *getDimension() const { return Dimension; }
 
   void printLeft(OutputBuffer &OB) const override {
     OB += "_Float";
@@ -2493,10 +2493,8 @@ public:
     if (Type.size() <= 3)
       OB += Type;
   }
-  std::string_view value() const { return Value; }
 
-  // Retrieves the string view of the integer value represented by this node.
-  const std::string_view &getValue() const { return Value; }
+  std::string_view value() const { return Value; }
 
   // Retrieves the string view of the type string of the integer value this node
   // represents.

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -808,7 +808,7 @@ static APInt parseTemplateArg(id::FunctionEncoding *FE, unsigned int N,
       // Overwrite Ty with IntegerLiteral's size
       Ty = parsePrimitiveTypeString(StringRef(&*TyStr.begin(), TyStr.size()),
                                     Ctx);
-    Val = ValL->getValue();
+    Val = ValL->value();
     break;
   }
   case id::Node::KBoolExpr: {


### PR DESCRIPTION
Given that one of the methods is duplicated with upstream LLVM, it was removed and the one user of that method switched to the version that's already upstream.