### PR TITLE
[libclc] Add missing clc_lgamma_r with generic address space pointer arg (#146495)

### DIFF
--- a/libclc/clc/lib/generic/math/clc_lgamma_r.cl
+++ b/libclc/clc/lib/generic/math/clc_lgamma_r.cl
@@ -611,3 +611,10 @@ _CLC_V_V_VP_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, half, __clc_lgamma_r, half,
 #define __CLC_BODY <clc_lgamma_r.inc>
 #include <clc/math/gentype.inc>
 #undef __CLC_ADDRSPACE
+
+#if _CLC_DISTINCT_GENERIC_AS_SUPPORTED
+#define __CLC_ADDRSPACE generic
+#define __CLC_BODY <clc_lgamma_r.inc>
+#include <clc/math/gentype.inc>
+#undef __CLC_ADDRSPACE
+#endif


### PR DESCRIPTION
There is no change to amdgcn--amdhsa.bc and nvptx64--nvidiacl.bc because __opencl_c_generic_address_space is not defined for them.

(cherry picked from commit b0e6faae0842f5e7ad900dd448fb782737bb3612)
This PR fixes pre-commit CI error in #19231: undefined hidden symbol: __clc_lgamma_r(float, int*)