### PR TITLE
[SYCL][NFC] Enable more warnings for SemaSYCL

### DIFF
--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -12,6 +12,40 @@ if (MSVC)
   set_source_files_properties(SemaSYCL.cpp PROPERTIES COMPILE_FLAGS /bigobj)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(is_clang TRUE)
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  set(is_gcc TRUE)
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
+  set(is_icpx TRUE)
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  set(is_msvc TRUE)
+endif()
+
+set(linux_opts "-Wall;-Wextra")
+if (CMAKE_BUILD_TYPE MATCHES "Release")
+  list(APPEND linux_opts "-Wconversion;-Wimplicit-fallthrough")
+endif()
+
+if (is_gcc OR is_clang OR (is_icpx AND NOT WIN32))
+  set(opts_to_apply ${linux_opts})
+elseif (is_msvc)
+  set(opts_to_apply "/W4")
+elseif (is_icpx and WIN32)
+  set(opts_to_apply "/Wall")
+endif()
+
+set_source_files_properties(
+  SemaSYCL.cpp
+  SemaSYCLDeclAttr.cpp
+  PROPERTIES
+    COMPILE_OPTIONS
+      ${opts_to_apply}
+)
+
 clang_tablegen(OpenCLBuiltins.inc -gen-clang-opencl-builtins
   SOURCE OpenCLBuiltins.td
   TARGET ClangOpenCLBuiltinsImpl


### PR DESCRIPTION
There are few compiler flags which are required in accordance with our internal guidelines, but we can't apply them globally, because the upstream code is not warning-free.

However, we do have two isolated downstream files: `SemaSYCL.cpp` and `SemaSYCLDeclAttr.cpp` where we can apply those extra flags without concerns that some code will come to us from the upstream.

Absolute most of the changes is fixing `-Wunused-parameter` warnings