### PR TITLE
[SYCL] Support UR_DEVICE_INFO_USM_CONTEXT_MEMCPY_SUPPORT_EXP on Cuda

### DIFF
--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -1164,7 +1164,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_LOW_POWER_EVENTS_SUPPORT_EXP:
     return ReturnValue(false);
   case UR_DEVICE_INFO_USM_CONTEXT_MEMCPY_SUPPORT_EXP:
-    return ReturnValue(false);
+    return ReturnValue(true);
   case UR_DEVICE_INFO_USE_NATIVE_ASSERT:
     return ReturnValue(true);
   case UR_DEVICE_INFO_USM_P2P_SUPPORT_EXP:

--- a/unified-runtime/source/adapters/cuda/usm.cpp
+++ b/unified-runtime/source/adapters/cuda/usm.cpp
@@ -578,6 +578,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMContextMemcpyExp(ur_context_handle_t,
                                                           void *pDst,
                                                           const void *pSrc,
                                                           size_t Size) {
-  UR_CHECK_ERROR(cuMemcpyHtoD((CUdeviceptr)pDst, pSrc, Size));
+  UR_CHECK_ERROR(cuMemcpy((CUdeviceptr)pDst, (CUdeviceptr)pSrc, Size));
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/cuda/usm.cpp
+++ b/unified-runtime/source/adapters/cuda/usm.cpp
@@ -575,7 +575,9 @@ urUSMPoolTrimToExp(ur_context_handle_t hContext, ur_device_handle_t hDevice,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMContextMemcpyExp(ur_context_handle_t,
-                                                          void *, const void *,
-                                                          size_t) {
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+                                                          void *pDst,
+                                                          const void *pSrc,
+                                                          size_t Size) {
+  UR_CHECK_ERROR(cuMemcpyHtoD((CUdeviceptr)pDst, pSrc, Size));
+  return UR_RESULT_SUCCESS;
 }


### PR DESCRIPTION
This is an optimisation that uses a direct memcopy from host to device.