### PR TITLE
[SYCL][CMAKE] Fix _FORTIFY_SOURCE=3

### DIFF
--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -167,18 +167,18 @@ macro(append_common_extra_security_flags)
   if(LLVM_ON_UNIX)
     # Fortify Source (strongly recommended):
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-      message(WARNING "-D_FORTIFY_SOURCE=3 can only be used with optimization.")
-      message(WARNING "-D_FORTIFY_SOURCE=3 is not supported.")
+      message(WARNING "-D_FORTIFY_SOURCE=2 can only be used with optimization.")
+      message(WARNING "-D_FORTIFY_SOURCE=2 is not supported.")
     else()
       # Sanitizers do not work with checked memory functions, such as
       # __memset_chk. We do not build release packages with sanitizers, so just
-      # avoid -D_FORTIFY_SOURCE=3 under LLVM_USE_SANITIZER.
+      # avoid -D_FORTIFY_SOURCE=2 under LLVM_USE_SANITIZER.
       if(NOT LLVM_USE_SANITIZER)
-        message(STATUS "Building with -D_FORTIFY_SOURCE=3")
-        add_definitions(-D_FORTIFY_SOURCE=3)
+        message(STATUS "Building with -D_FORTIFY_SOURCE=2")
+        add_definitions(-D_FORTIFY_SOURCE=2)
       else()
         message(
-          WARNING "-D_FORTIFY_SOURCE=3 dropped due to LLVM_USE_SANITIZER.")
+          WARNING "-D_FORTIFY_SOURCE=2 dropped due to LLVM_USE_SANITIZER.")
       endif()
     endif()
 

--- a/unified-runtime/cmake/helpers.cmake
+++ b/unified-runtime/cmake/helpers.cmake
@@ -88,7 +88,7 @@ endif()
 
 function(add_ur_target_compile_options name)
     if(NOT MSVC)
-        target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=2)
+        target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=3)
         target_compile_options(${name} PRIVATE
             # Warning options
             -Wall

--- a/unified-runtime/cmake/helpers.cmake
+++ b/unified-runtime/cmake/helpers.cmake
@@ -88,7 +88,13 @@ endif()
 
 function(add_ur_target_compile_options name)
     if(NOT MSVC)
-        target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=3)
+        if (NOT LLVM_ENABLE_PROJECTS)
+            # If UR is built as part of LLVM (i.e. as part of SYCL), then
+            # _FORTIFY_SOURCE will be set globally in advance to a potentially
+            # different value. To avoid redefinition errors, only set the
+            # macro for a "standalone" build.
+            target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=2)
+        endif()
         target_compile_options(${name} PRIVATE
             # Warning options
             -Wall


### PR DESCRIPTION
The problem here is that the macro is actually handled by glibc and value `3` isn't supported with older compiler/glibc combinations, causing warnings about the macro redefinition.

We still have to support older compilers/glibc and therefore two changes were made:
- UR skips setting their own `_FORTIFY_SOURCE` in favor of a global one if it is built as part of LLVM (i.e. not standalone)
- Before setting `_FORTIFY_SOURCE` globally we check the compiler and  fallback to value `2` for older gcc