### PR TITLE
[SYCL] Fix SYCLBIN for CUDA and HIP targets

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -2143,6 +2143,8 @@ Expected<SmallVector<StringRef>> linkAndWrapDeviceFiles(
       if (OutputSYCLBIN) {
         SYCLBIN::SYCLBINModuleDesc MD;
         MD.ArchString = LinkerArgs.getLastArgValue(OPT_arch_EQ);
+        MD.TargetTriple =
+            llvm::Triple{LinkerArgs.getLastArgValue(OPT_triple_EQ)};
         MD.SplitModules = std::move(SplitModules);
         std::scoped_lock<std::mutex> Guard(SYCLBINModulesMtx);
         SYCLBINModules.emplace_back(std::move(MD));

--- a/llvm/include/llvm/Object/SYCLBIN.h
+++ b/llvm/include/llvm/Object/SYCLBIN.h
@@ -36,6 +36,7 @@ public:
 
   struct SYCLBINModuleDesc {
     std::string ArchString;
+    llvm::Triple TargetTriple;
     std::vector<module_split::SplitModule> SplitModules;
   };
 

--- a/llvm/lib/Object/SYCLBIN.cpp
+++ b/llvm/lib/Object/SYCLBIN.cpp
@@ -118,6 +118,9 @@ SYCLBIN::SYCLBINDesc::SYCLBINDesc(BundleState State,
         IRMMetadata.add(
             llvm::util::PropertySetRegistry::SYCLBIN_IR_MODULE_METADATA, "type",
             /*SPIR-V*/ 0);
+        IRMMetadata.add(
+            llvm::util::PropertySetRegistry::SYCLBIN_IR_MODULE_METADATA,
+            "target", MD.TargetTriple.str());
         IRMMetadata.write(IDMetadataOS);
         AMD.IRModuleDescs.emplace_back(std::move(ID));
       } else {
@@ -126,6 +129,9 @@ SYCLBIN::SYCLBINDesc::SYCLBINDesc(BundleState State,
         NDCIMetadata.add(llvm::util::PropertySetRegistry::
                              SYCLBIN_NATIVE_DEVICE_CODE_IMAGE_METADATA,
                          "arch", MD.ArchString);
+        NDCIMetadata.add(llvm::util::PropertySetRegistry::
+                             SYCLBIN_NATIVE_DEVICE_CODE_IMAGE_METADATA,
+                         "target", MD.TargetTriple.str());
         NDCIMetadata.write(IDMetadataOS);
         AMD.NativeDeviceCodeImageDescs.emplace_back(std::move(ID));
       }

--- a/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
@@ -273,7 +273,9 @@ PropSetRegTy computeModuleProperties(const Module &M,
   }
   if (GlobProps.EmitKernelNames) {
     for (const auto *F : EntryPoints) {
-      if (F->getCallingConv() == CallingConv::SPIR_KERNEL) {
+      if (F->getCallingConv() == CallingConv::SPIR_KERNEL ||
+          F->getCallingConv() == CallingConv::PTX_Kernel ||
+          F->getCallingConv() == CallingConv::AMDGPU_KERNEL) {
         PropSet.add(PropSetRegTy::SYCL_KERNEL_NAMES, F->getName(),
                     /*PropVal=*/true);
       }

--- a/llvm/test/tools/sycl-post-link/emit_kernel_names.ll
+++ b/llvm/test/tools/sycl-post-link/emit_kernel_names.ll
@@ -2,7 +2,7 @@
 ;
 ; Global scope
 ; RUN: sycl-post-link -properties -symbols -emit-kernel-names -S < %s -o %t.global.files.table
-; RUN: FileCheck %s -input-file=%t.global.files_0.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-GLOBAL-PROP
+; RUN: FileCheck %s -input-file=%t.global.files_0.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-GLOBAL-PROP
 ;
 ; Per-module split
 ; RUN: sycl-post-link -properties -symbols -split=source -emit-kernel-names -S < %s -o %t.per_module.files.table
@@ -12,16 +12,38 @@
 ;
 ; Per-kernel split
 ; RUN: sycl-post-link -properties -symbols -split=kernel -emit-kernel-names -S < %s -o %t.per_kernel.files.table
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_0.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-PERKERNEL-0-PROP
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_1.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-PERKERNEL-1-PROP
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_2.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-PERKERNEL-2-PROP
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_3.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-KERNELLESS-PROP
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_4.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-KERNELLESS-PROP
-; RUN: FileCheck %s -input-file=%t.per_kernel.files_5.prop --implicit-check-not="SpirFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_0.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-PERKERNEL-0-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_1.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-PERKERNEL-1-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_2.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-PERKERNEL-2-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_3.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_4.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_5.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_6.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-PERKERNEL-6-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_7.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-PERKERNEL-7-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_8.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-PERKERNEL-8-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_9.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_10.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_11.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_12.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-PERKERNEL-12-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_13.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-PERKERNEL-13-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_14.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-PERKERNEL-14-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_15.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_16.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-KERNELLESS-PROP
+; RUN: FileCheck %s -input-file=%t.per_kernel.files_17.prop --implicit-check-not="SpirFunc" --implicit-check-not="PtxFunc" --implicit-check-not="AmdgpuFunc" --check-prefix=CHECK-KERNELLESS-PROP
 
 target triple = "spir64-unknown-unknown"
 
 define dso_local spir_kernel void @SpirKernel1(float %arg1) #2 {
+entry:
+  ret void
+}
+
+define dso_local ptx_kernel void @PtxKernel1(float %arg1) #2 {
+entry:
+  ret void
+}
+
+define dso_local amdgpu_kernel void @AmdgpuKernel1(float %arg1) #2 {
 entry:
   ret void
 }
@@ -31,7 +53,27 @@ entry:
   ret void
 }
 
+define dso_local ptx_kernel void @PtxKernel2(float %arg1) #1 {
+entry:
+  ret void
+}
+
+define dso_local amdgpu_kernel void @AmdgpuKernel2(float %arg1) #1 {
+entry:
+  ret void
+}
+
 define dso_local spir_kernel void @SpirKernel3(float %arg1) #2 {
+entry:
+  ret void
+}
+
+define dso_local ptx_kernel void @PtxKernel3(float %arg1) #2 {
+entry:
+  ret void
+}
+
+define dso_local amdgpu_kernel void @AmdgpuKernel3(float %arg1) #2 {
 entry:
   ret void
 }
@@ -41,7 +83,27 @@ entry:
   ret void
 }
 
+define dso_local ptx_device void @PtxFunc1(float %arg1) #0 {
+entry:
+  ret void
+}
+
+define dso_local amdgpu_cs void @AmdgpuFunc1(float %arg1) #0 {
+entry:
+  ret void
+}
+
 define dso_local spir_func void @SpirFunc2(i32 %arg1, i32 %arg2) #1 {
+entry:
+  ret void
+}
+
+define dso_local ptx_device void @PtxFunc2(i32 %arg1, i32 %arg2) #1 {
+entry:
+  ret void
+}
+
+define dso_local amdgpu_cs void @AmdgpuFunc2(i32 %arg1, i32 %arg2) #1 {
 entry:
   ret void
 }
@@ -51,7 +113,27 @@ entry:
   ret void
 }
 
+define dso_local ptx_device void @PtxFunc3(float %arg1) #0 {
+entry:
+  ret void
+}
+
+define dso_local amdgpu_cs void @AmdgpuFunc3(float %arg1) #0 {
+entry:
+  ret void
+}
+
 define dso_local spir_func void @SpirFunc4(float %arg1) {
+entry:
+  ret void
+}
+
+define dso_local ptx_device void @PtxFunc4(float %arg1) {
+entry:
+  ret void
+}
+
+define dso_local amdgpu_cs void @AmdgpuFunc4(float %arg1) {
 entry:
   ret void
 }
@@ -63,38 +145,146 @@ attributes #2 = { "sycl-module-id"="c.cpp" }
 ; Global scope
 ; CHECK-GLOBAL-PROP: [SYCL/kernel names]
 ; CHECK-GLOBAL-PROP-NEXT: SpirKernel1
+; CHECK-GLOBAL-PROP-NEXT: PtxKernel1
+; CHECK-GLOBAL-PROP-NEXT: AmdgpuKernel1
 ; CHECK-GLOBAL-PROP-NEXT: SpirKernel2
+; CHECK-GLOBAL-PROP-NEXT: PtxKernel2
+; CHECK-GLOBAL-PROP-NEXT: AmdgpuKernel2
 ; CHECK-GLOBAL-PROP-NEXT: SpirKernel3
+; CHECK-GLOBAL-PROP-NEXT: PtxKernel3
+; CHECK-GLOBAL-PROP-NEXT: AmdgpuKernel3
 
 ; Per-module split
 ; CHECK-PERMODULE-0-PROP: [SYCL/kernel names]
 ; CHECK-PERMODULE-0-PROP-NEXT: SpirKernel1
+; CHECK-PERMODULE-0-PROP-NEXT: PtxKernel1
+; CHECK-PERMODULE-0-PROP-NEXT: AmdgpuKernel1
 ; CHECK-PERMODULE-0-PROP-NEXT: SpirKernel3
+; CHECK-PERMODULE-0-PROP-NEXT: PtxKernel3
+; CHECK-PERMODULE-0-PROP-NEXT: AmdgpuKernel3
 ; CHECK-PERMODULE-0-PROP-NOT: SpirKernel2
+; CHECK-PERMODULE-0-PROP-NOT: PtxKernel2
+; CHECK-PERMODULE-0-PROP-NOT: AmdgpuKernel2
 
 ; CHECK-PERMODULE-1-PROP: [SYCL/kernel names]
 ; CHECK-PERMODULE-1-PROP-NEXT: SpirKernel2
+; CHECK-PERMODULE-1-PROP-NEXT: PtxKernel2
+; CHECK-PERMODULE-1-PROP-NEXT: AmdgpuKernel2
 ; CHECK-PERMODULE-1-PROP-NOT: SpirKernel1
+; CHECK-PERMODULE-1-PROP-NOT: PtxKernel1
+; CHECK-PERMODULE-1-PROP-NOT: AmdgpuKernel1
 ; CHECK-PERMODULE-1-PROP-NOT: SpirKernel3
+; CHECK-PERMODULE-1-PROP-NOT: PtxKernel3
+; CHECK-PERMODULE-1-PROP-NOT: AmdgpuKernel3
 
 ; Per-kernel split
 ; CHECK-PERKERNEL-0-PROP: [SYCL/kernel names]
 ; CHECK-PERKERNEL-0-PROP-NEXT: SpirKernel3
-; CHECK-PERKERNEL-0-PROP-NOT: SpirKernel1
 ; CHECK-PERKERNEL-0-PROP-NOT: SpirKernel2
+; CHECK-PERKERNEL-0-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-0-PROP-NOT: PtxKernel3
+; CHECK-PERKERNEL-0-PROP-NOT: PtxKernel2
+; CHECK-PERKERNEL-0-PROP-NOT: PtxKernel1
+; CHECK-PERKERNEL-0-PROP-NOT: AmdgpuKernel3
+; CHECK-PERKERNEL-0-PROP-NOT: AmdgpuKernel2
+; CHECK-PERKERNEL-0-PROP-NOT: AmdgpuKernel1
 
 ; CHECK-PERKERNEL-1-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-1-PROP-NOT: SpirKernel3
 ; CHECK-PERKERNEL-1-PROP-NEXT: SpirKernel2
 ; CHECK-PERKERNEL-1-PROP-NOT: SpirKernel1
-; CHECK-PERKERNEL-1-PROP-NOT: SpirKernel3
+; CHECK-PERKERNEL-1-PROP-NOT: PtxKernel3
+; CHECK-PERKERNEL-1-PROP-NOT: PtxKernel2
+; CHECK-PERKERNEL-1-PROP-NOT: PtxKernel1
+; CHECK-PERKERNEL-1-PROP-NOT: AmdgpuKernel3
+; CHECK-PERKERNEL-1-PROP-NOT: AmdgpuKernel2
+; CHECK-PERKERNEL-1-PROP-NOT: AmdgpuKernel1
 
 ; CHECK-PERKERNEL-2-PROP: [SYCL/kernel names]
-; CHECK-PERKERNEL-2-PROP-NEXT: SpirKernel1
-; CHECK-PERKERNEL-2-PROP-NOT: SpirKernel2
 ; CHECK-PERKERNEL-2-PROP-NOT: SpirKernel3
+; CHECK-PERKERNEL-2-PROP-NOT: SpirKernel2
+; CHECK-PERKERNEL-2-PROP-NEXT: SpirKernel1
+; CHECK-PERKERNEL-2-PROP-NOT: PtxKernel3
+; CHECK-PERKERNEL-2-PROP-NOT: PtxKernel2
+; CHECK-PERKERNEL-2-PROP-NOT: PtxKernel1
+; CHECK-PERKERNEL-2-PROP-NOT: AmdgpuKernel3
+; CHECK-PERKERNEL-2-PROP-NOT: AmdgpuKernel2
+; CHECK-PERKERNEL-2-PROP-NOT: AmdgpuKernel1
+
+; CHECK-PERKERNEL-6-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-6-PROP-NOT: SpirKernel3
+; CHECK-PERKERNEL-6-PROP-NOT: SpirKernel2
+; CHECK-PERKERNEL-6-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-6-PROP-NEXT: PtxKernel3
+; CHECK-PERKERNEL-6-PROP-NOT: PtxKernel2
+; CHECK-PERKERNEL-6-PROP-NOT: PtxKernel1
+; CHECK-PERKERNEL-6-PROP-NOT: AmdgpuKernel3
+; CHECK-PERKERNEL-6-PROP-NOT: AmdgpuKernel2
+; CHECK-PERKERNEL-6-PROP-NOT: AmdgpuKernel1
+
+; CHECK-PERKERNEL-7-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-7-PROP-NOT: SpirKernel3
+; CHECK-PERKERNEL-7-PROP-NOT: SpirKernel2
+; CHECK-PERKERNEL-7-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-7-PROP-NOT: PtxKernel3
+; CHECK-PERKERNEL-7-PROP-NEXT: PtxKernel2
+; CHECK-PERKERNEL-7-PROP-NOT: PtxKernel1
+; CHECK-PERKERNEL-7-PROP-NOT: AmdgpuKernel3
+; CHECK-PERKERNEL-7-PROP-NOT: AmdgpuKernel2
+; CHECK-PERKERNEL-7-PROP-NOT: AmdgpuKernel1
+
+; CHECK-PERKERNEL-8-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-8-PROP-NOT: SpirKernel3
+; CHECK-PERKERNEL-8-PROP-NOT: SpirKernel2
+; CHECK-PERKERNEL-8-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-8-PROP-NOT: PtxKernel3
+; CHECK-PERKERNEL-8-PROP-NOT: PtxKernel2
+; CHECK-PERKERNEL-8-PROP-NEXT: PtxKernel1
+; CHECK-PERKERNEL-8-PROP-NOT: AmdgpuKernel3
+; CHECK-PERKERNEL-8-PROP-NOT: AmdgpuKernel2
+; CHECK-PERKERNEL-8-PROP-NOT: AmdgpuKernel1
+
+; CHECK-PERKERNEL-12-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-12-PROP-NOT: SpirKernel3
+; CHECK-PERKERNEL-12-PROP-NOT: SpirKernel2
+; CHECK-PERKERNEL-12-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-12-PROP-NOT: PtxKernel3
+; CHECK-PERKERNEL-12-PROP-NOT: PtxKernel2
+; CHECK-PERKERNEL-12-PROP-NOT: PtxKernel1
+; CHECK-PERKERNEL-12-PROP-NEXT: AmdgpuKernel3
+; CHECK-PERKERNEL-12-PROP-NOT: AmdgpuKernel2
+; CHECK-PERKERNEL-12-PROP-NOT: AmdgpuKernel1
+
+; CHECK-PERKERNEL-13-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-13-PROP-NOT: SpirKernel3
+; CHECK-PERKERNEL-13-PROP-NOT: SpirKernel2
+; CHECK-PERKERNEL-13-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-13-PROP-NOT: PtxKernel3
+; CHECK-PERKERNEL-13-PROP-NOT: PtxKernel2
+; CHECK-PERKERNEL-13-PROP-NOT: PtxKernel1
+; CHECK-PERKERNEL-13-PROP-NOT: AmdgpuKernel3
+; CHECK-PERKERNEL-13-PROP-NEXT: AmdgpuKernel2
+; CHECK-PERKERNEL-13-PROP-NOT: AmdgpuKernel1
+
+; CHECK-PERKERNEL-14-PROP: [SYCL/kernel names]
+; CHECK-PERKERNEL-14-PROP-NOT: SpirKernel3
+; CHECK-PERKERNEL-14-PROP-NOT: SpirKernel2
+; CHECK-PERKERNEL-14-PROP-NOT: SpirKernel1
+; CHECK-PERKERNEL-14-PROP-NOT: PtxKernel3
+; CHECK-PERKERNEL-14-PROP-NOT: PtxKernel2
+; CHECK-PERKERNEL-14-PROP-NOT: PtxKernel1
+; CHECK-PERKERNEL-14-PROP-NOT: AmdgpuKernel3
+; CHECK-PERKERNEL-14-PROP-NOT: AmdgpuKernel2
+; CHECK-PERKERNEL-14-PROP-NEXT: AmdgpuKernel1
 
 ; Kernel-less generated modules should have no kernel names
 ; CHECK-KERNELLESS-PROP-NOT: [SYCL/kernel names]
 ; CHECK-KERNELLESS-PROP-NOT: SpirKernel1
+; CHECK-KERNELLESS-PROP-NOT: PtxKernel1
+; CHECK-KERNELLESS-PROP-NOT: AmdgpuKernel1
 ; CHECK-KERNELLESS-PROP-NOT: SpirKernel2
+; CHECK-KERNELLESS-PROP-NOT: PtxKernel2
+; CHECK-KERNELLESS-PROP-NOT: AmdgpuKernel2
 ; CHECK-KERNELLESS-PROP-NOT: SpirKernel3
+; CHECK-KERNELLESS-PROP-NOT: PtxKernel3
+; CHECK-KERNELLESS-PROP-NOT: AmdgpuKernel3

--- a/sycl/doc/design/PropertySets.md
+++ b/sycl/doc/design/PropertySets.md
@@ -293,14 +293,15 @@ Set of information about an IR module in a SYCLBIN file.
 | Key      | Value type            | Value |
 | -------- | --------------------- | ----- |
 | "type"   | 32 bit integer. ("1") | Integer representation of one of the pre-defined IR types. It must be one of the following:<ol start="0"><li>SPIR-V</li><li>PTX</li><li>AMDGCN</li></ol> |
-| "target" | Byte array. ("2")     | A string representing the architecture of the binary, corresponding to the value of `-fsycl-targets` option used when compiling this binary. This may be missing if no part of `-fsycl-targets` was used during the compilation of this binary or if `-fsycl-targets` was not used at all. |
+| "target" | Byte array. ("2")     | A string representing the target of the binary, corresponding to the value of `-fsycl-targets` option used when compiling this binary. This may be missing if no part of `-fsycl-targets` was used during the compilation of this binary or if `-fsycl-targets` was not used at all. |
 
 
 ### [SYCLBIN/native device code image metadata]
 
 Set of information about an native device code image in a SYCLBIN file.
 
-| Key    | Value type        | Value |
-| ------ | ----------------- | ----- |
-| "arch" | Byte array. ("2") | A string representing the architecture of the binary, corresponding to the value of `-fsycl-targets` option used when compiling this binary. |
+| Key      | Value type        | Value |
+| -------- | ----------------- | ----- |
+| "arch"   | Byte array. ("2") | A string representing the architecture of the binary, corresponding to the value of `-fsycl-targets` option used when compiling this binary. |
+| "target" | Byte array. ("2") | A string representing the target of the binary, corresponding to the value of `-fsycl-targets` option used when compiling this binary. This may be missing if no part of `-fsycl-targets` was used during the compilation of this binary or if `-fsycl-targets` was not used at all. |
 

--- a/sycl/source/detail/syclbin.cpp
+++ b/sycl/source/detail/syclbin.cpp
@@ -311,6 +311,7 @@ SYCLBINBinaries::SYCLBINBinaries(const char *SYCLBINContent, size_t SYCLBINSize)
 
     for (const SYCLBIN::NativeDeviceCodeImage &NDCI :
          AM.NativeDeviceCodeImages) {
+      assert(NDCI.Metadata != nullptr);
       PropertySet &NDCIMetadataProps = (*NDCI.Metadata)
           [PropertySetRegistry::SYCLBIN_NATIVE_DEVICE_CODE_IMAGE_METADATA];
 

--- a/sycl/source/detail/syclbin.cpp
+++ b/sycl/source/detail/syclbin.cpp
@@ -9,6 +9,7 @@
 // TODO: Remove once we can consistently link the SYCL runtime library with
 // LLVMObject.
 
+#include <detail/compiler.hpp>
 #include <detail/program_manager/program_manager.hpp>
 #include <detail/syclbin.hpp>
 
@@ -122,6 +123,34 @@ std::pair<const char *, size_t> getImageInOffloadBinary(const char *Data,
                           "Invalid image offset and size.");
 
   return std::make_pair(Data + Entry->ImageOffset, Entry->ImageSize);
+}
+
+const char *getDeviceTargetSpecFromTriple(std::string_view Triple) {
+  size_t TargetSize = Triple.find('-');
+  if (TargetSize == Triple.npos)
+    return __SYCL_DEVICE_BINARY_TARGET_UNKNOWN;
+  std::string_view Target = Triple.substr(0, TargetSize);
+
+  // Return the known targets to ensure null-terminated c-style strings.
+  if (Target == __SYCL_DEVICE_BINARY_TARGET_UNKNOWN)
+    return __SYCL_DEVICE_BINARY_TARGET_UNKNOWN;
+  if (Target == __SYCL_DEVICE_BINARY_TARGET_SPIRV32)
+    return __SYCL_DEVICE_BINARY_TARGET_SPIRV32;
+  if (Target == __SYCL_DEVICE_BINARY_TARGET_SPIRV64)
+    return __SYCL_DEVICE_BINARY_TARGET_SPIRV64;
+  if (Target == __SYCL_DEVICE_BINARY_TARGET_SPIRV64_X86_64)
+    return __SYCL_DEVICE_BINARY_TARGET_SPIRV64_X86_64;
+  if (Target == __SYCL_DEVICE_BINARY_TARGET_SPIRV64_GEN)
+    return __SYCL_DEVICE_BINARY_TARGET_SPIRV64_GEN;
+  if (Target == __SYCL_DEVICE_BINARY_TARGET_SPIRV64_FPGA)
+    return __SYCL_DEVICE_BINARY_TARGET_SPIRV64_FPGA;
+  if (Target == __SYCL_DEVICE_BINARY_TARGET_NVPTX64)
+    return __SYCL_DEVICE_BINARY_TARGET_NVPTX64;
+  if (Target == __SYCL_DEVICE_BINARY_TARGET_AMDGCN)
+    return __SYCL_DEVICE_BINARY_TARGET_AMDGCN;
+  if (Target == __SYCL_DEVICE_BINARY_TARGET_NATIVE_CPU)
+    return __SYCL_DEVICE_BINARY_TARGET_NATIVE_CPU;
+  return UR_DEVICE_BINARY_TARGET_UNKNOWN;
 }
 
 } // namespace
@@ -282,12 +311,20 @@ SYCLBINBinaries::SYCLBINBinaries(const char *SYCLBINContent, size_t SYCLBINSize)
 
     for (const SYCLBIN::NativeDeviceCodeImage &NDCI :
          AM.NativeDeviceCodeImages) {
+      PropertySet &NDCIMetadataProps = (*NDCI.Metadata)
+          [PropertySetRegistry::SYCLBIN_NATIVE_DEVICE_CODE_IMAGE_METADATA];
+
+      auto &TargetTripleProp = NDCIMetadataProps["target"];
+      std::string_view TargetTriple = std::string_view{
+          reinterpret_cast<const char *>(TargetTripleProp.asByteArray()),
+          TargetTripleProp.getByteArraySize()};
+
       sycl_device_binary_struct &DeviceBinary = DeviceBinaries.emplace_back();
       DeviceBinary.Version = SYCL_DEVICE_BINARY_VERSION;
       DeviceBinary.Kind = 4;
       DeviceBinary.Format = SYCL_DEVICE_BINARY_TYPE_NATIVE;
       DeviceBinary.DeviceTargetSpec =
-          __SYCL_DEVICE_BINARY_TARGET_UNKNOWN; // TODO: Determine.
+          getDeviceTargetSpecFromTriple(TargetTriple);
       DeviceBinary.CompileOptions = nullptr;
       DeviceBinary.LinkOptions = nullptr;
       DeviceBinary.ManifestStart = nullptr;

--- a/sycl/test-e2e/SYCLBIN/basic_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_executable.cpp
@@ -11,10 +11,6 @@
 // -- Basic test for compiling and loading a SYCLBIN kernel_bundle in executable
 // -- state.
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=executable %{sycl_target_opts} %S/Inputs/basic_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/basic_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_input.cpp
@@ -11,10 +11,6 @@
 // -- Basic test for compiling and loading a SYCLBIN kernel_bundle in input
 // -- state.
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=input %{sycl_target_opts} %S/Inputs/basic_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/basic_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_object.cpp
@@ -11,10 +11,6 @@
 // -- Basic test for compiling and loading a SYCLBIN kernel_bundle in object
 // -- state.
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/basic_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/basic_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_object.cpp
@@ -11,8 +11,8 @@
 // -- Basic test for compiling and loading a SYCLBIN kernel_bundle in object
 // -- state.
 
-// XFAIL: hip
-// XFAIL-INTENDED: HIP backend does not implement linking.
+// UNSUPPORTED: hip
+// UNSUPPORTED-INTENDED: HIP backend does not implement linking.
 
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/basic_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/SYCLBIN/basic_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_object.cpp
@@ -11,6 +11,9 @@
 // -- Basic test for compiling and loading a SYCLBIN kernel_bundle in object
 // -- state.
 
+// XFAIL: hip
+// XFAIL-INTENDED: HIP backend does not implement linking.
+
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/basic_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/dae_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/dae_executable.cpp
@@ -10,10 +10,6 @@
 
 // -- Test for using a kernel from a SYCLBIN with a dead argument.
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=executable %{sycl_target_opts} %S/Inputs/dae_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/dae_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/dae_input.cpp
@@ -10,10 +10,6 @@
 
 // -- Test for using a kernel from a SYCLBIN with a dead argument.
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=input %{sycl_target_opts} %S/Inputs/dae_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/dae_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/dae_object.cpp
@@ -10,10 +10,6 @@
 
 // -- Test for using a kernel from a SYCLBIN with a dead argument.
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/dae_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/dae_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/dae_object.cpp
@@ -10,6 +10,9 @@
 
 // -- Test for using a kernel from a SYCLBIN with a dead argument.
 
+// XFAIL: hip
+// XFAIL-INTENDED: HIP backend does not implement linking.
+
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/dae_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/dae_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/dae_object.cpp
@@ -10,8 +10,8 @@
 
 // -- Test for using a kernel from a SYCLBIN with a dead argument.
 
-// XFAIL: hip
-// XFAIL-INTENDED: HIP backend does not implement linking.
+// UNSUPPORTED: hip
+// UNSUPPORTED-INTENDED: HIP backend does not implement linking.
 
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/dae_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/SYCLBIN/dg_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_executable.cpp
@@ -13,10 +13,6 @@
 // UNSUPPORTED: opencl && gpu
 // UNSUPPORTED-TRACKER: GSD-4287
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=executable %{sycl_target_opts} %S/Inputs/dg_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/dg_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_input.cpp
@@ -13,10 +13,6 @@
 // UNSUPPORTED: opencl && gpu
 // UNSUPPORTED-TRACKER: GSD-4287
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=input %{sycl_target_opts} %S/Inputs/dg_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/dg_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_object.cpp
@@ -13,8 +13,8 @@
 // UNSUPPORTED: opencl && gpu
 // UNSUPPORTED-TRACKER: GSD-4287
 
-// XFAIL: hip
-// XFAIL-INTENDED: HIP backend does not implement linking.
+// UNSUPPORTED: hip
+// UNSUPPORTED-INTENDED: HIP backend does not implement linking.
 
 // XFAIL: cuda
 // XFAIL-TRACKER: CMPLRLLVM-68859

--- a/sycl/test-e2e/SYCLBIN/dg_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_object.cpp
@@ -13,6 +13,12 @@
 // UNSUPPORTED: opencl && gpu
 // UNSUPPORTED-TRACKER: GSD-4287
 
+// XFAIL: hip
+// XFAIL-INTENDED: HIP backend does not implement linking.
+
+// XFAIL: cuda
+// XFAIL-TRACKER: CMPLRLLVM-68859
+
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/dg_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/dg_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_object.cpp
@@ -13,10 +13,6 @@
 // UNSUPPORTED: opencl && gpu
 // UNSUPPORTED-TRACKER: GSD-4287
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/dg_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_executable.cpp
@@ -11,10 +11,6 @@
 // -- Test for compiling and loading a kernel bundle with a SYCLBIN containing
 //    the use of optional kernel features.
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=executable %{sycl_target_opts} %S/Inputs/optional_kernel_features.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_input.cpp
@@ -11,10 +11,6 @@
 // -- Test for compiling and loading a kernel bundle with a SYCLBIN containing
 //    the use of optional kernel features.
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=input %{sycl_target_opts} %S/Inputs/optional_kernel_features.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
@@ -12,6 +12,9 @@
 // -- Test for compiling and loading a kernel bundle with a SYCLBIN containing
 //    the use of optional kernel features.
 
+// XFAIL: hip
+// XFAIL-INTENDED: HIP backend does not implement linking.
+
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/optional_kernel_features.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
@@ -12,10 +12,6 @@
 // -- Test for compiling and loading a kernel bundle with a SYCLBIN containing
 //    the use of optional kernel features.
 
-// SYCLBIN currently only properly detects SPIR-V binaries.
-// XFAIL: !target-spir
-// XFAIL-TRACKER: CMPLRLLVM-68811
-
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/optional_kernel_features.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out %t.syclbin

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
@@ -12,8 +12,8 @@
 // -- Test for compiling and loading a kernel bundle with a SYCLBIN containing
 //    the use of optional kernel features.
 
-// XFAIL: hip
-// XFAIL-INTENDED: HIP backend does not implement linking.
+// UNSUPPORTED: hip
+// UNSUPPORTED-INTENDED: HIP backend does not implement linking.
 
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{sycl_target_opts} %S/Inputs/optional_kernel_features.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out

--- a/sycl/test/syclbin/simple_kernel.cpp
+++ b/sycl/test/syclbin/simple_kernel.cpp
@@ -32,6 +32,7 @@ void TestKernel(int *Ptr, int Size) {
 // CHECK-INPUT-NEXT:       Metadata:
 // CHECK-INPUT-NEXT:         SYCLBIN/ir module metadata:
 // CHECK-INPUT-NEXT:           type: 0
+// CHECK-INPUT-NEXT:           target:
 // CHECK-INPUT-NEXT:     Raw IR bytes: <Binary blob of {{.*}} bytes>
 // CHECK-INPUT-NEXT:   Number of Native Device Code Images: 0
 
@@ -47,6 +48,7 @@ void TestKernel(int *Ptr, int Size) {
 // CHECK-OBJECT-NEXT:       Metadata:
 // CHECK-OBJECT-NEXT:         SYCLBIN/ir module metadata:
 // CHECK-OBJECT-NEXT:           type: 0
+// CHECK-OBJECT-NEXT:           target:
 // CHECK-OBJECT-NEXT:     Raw IR bytes: <Binary blob of {{.*}} bytes>
 // CHECK-OBJECT-NEXT:   Number of Native Device Code Images: 0
 
@@ -62,5 +64,6 @@ void TestKernel(int *Ptr, int Size) {
 // CHECK-EXECUTABLE-NEXT:       Metadata:
 // CHECK-EXECUTABLE-NEXT:         SYCLBIN/ir module metadata:
 // CHECK-EXECUTABLE-NEXT:           type: 0
+// CHECK-EXECUTABLE-NEXT:           target:
 // CHECK-EXECUTABLE-NEXT:     Raw IR bytes: <Binary blob of {{.*}} bytes>
 // CHECK-EXECUTABLE-NEXT:   Number of Native Device Code Images: 0


### PR DESCRIPTION
This commit makes the following changes to make SYCLBINs work for CUDA and HIP:

* Fixes kernel detection when generating kernel name property sets for PTX and AMDGPU IR binaries.
* Adds target triple to the metadata for native device code images.
* Generates target triple for IR modules, as required by the property set metadata design.
* Adds detection of target spec in native device code images based on the new target information.

This allows us to enable most SYCLBIN tests on HIP and CUDA.