### PR TITLE
[Benchmarks] Fix umf library path

### DIFF
--- a/devops/scripts/benchmarks/benches/umf.py
+++ b/devops/scripts/benchmarks/benches/umf.py
@@ -97,7 +97,7 @@ class GBench(Benchmark):
             return
 
         self.oneapi = get_oneapi()
-        self.umf_lib = options.umf + "lib"
+        self.umf_lib = os.path.join(options.umf, "lib")
         self.benchmark_bin = os.path.join(options.umf, "benchmark", self.bench_name)
 
     def is_memory_statistics_included(self, data_row):


### PR DESCRIPTION
Fix wrong path to umf library when passing a path without a trailing slash:
`Warning: LD_LIBRARY_PATH component does not exist: /home/patrykka/unified-memory-framework/buildlib`

Example of a failing run: https://github.com/oneapi-src/unified-memory-framework/actions/runs/16023907732/job/45207108065