### PR TITLE
[NFC] Fix no_sycl_hpp_in_e2e_tests.cpp after 4b96a991eba1

### DIFF
--- a/sycl/test/e2e_test_requirements/no_sycl_hpp_in_e2e_tests.cpp
+++ b/sycl/test/e2e_test_requirements/no_sycl_hpp_in_e2e_tests.cpp
@@ -6,7 +6,7 @@
 // CHECK-DAG: README.md
 // CHECK-DAG: lit.cfg.py
 //
-// CHECK-NUM-MATCHES: 26
+// CHECK-NUM-MATCHES: 27
 //
 // This test verifies that `<sycl/sycl.hpp>` isn't used in E2E tests. Instead,
 // fine-grained includes should used, see


### PR DESCRIPTION
As in title. Patch by brock.wyma@intel.com