### PR TITLE
[libclc] Remove downstream include guards. NFCI.

### DIFF
--- a/libclc/opencl/include/clc/opencl/as_type.h
+++ b/libclc/opencl/include/clc/opencl/as_type.h
@@ -1,5 +1,3 @@
-#ifndef CLC_AS_TYPE
-#define CLC_AS_TYPE
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -85,5 +83,3 @@
 #define as_half8(x) __builtin_astype(x, half8)
 #define as_half16(x) __builtin_astype(x, half16)
 #endif
-
-#endif // CLC_AS_TYPE

--- a/libclc/opencl/include/clc/opencl/convert.h
+++ b/libclc/opencl/include/clc/opencl/convert.h
@@ -1,5 +1,3 @@
-#ifndef CLC_CONVERSIONS
-#define CLC_CONVERSIONS
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -101,5 +99,3 @@ _CLC_VECTOR_CONVERT_TO_SUFFIX()
 #undef _CLC_VECTOR_CONVERT_FROM1
 #undef _CLC_VECTOR_CONVERT_DECL
 #undef _CLC_CONVERT_DECL
-
-#endif // CLC_CONVERSIONS


### PR DESCRIPTION
These don't appear to be necessary, are incorrectly named, and incorrectly placed as they appear before the copyright.

If they are in fact necessary it would be best done upstream instead.