### PR TITLE
[SYCL][NFC] Throw warning when sycl.hpp is included without `-fsycl` flag.

### DIFF
--- a/sycl/doc/PreprocessorMacros.md
+++ b/sycl/doc/PreprocessorMacros.md
@@ -34,6 +34,11 @@ This file describes macros that have effect on SYCL compiler and run-time.
   Disables warning diagnostic issued when calling `device::has(aspect::image)`
   and `platform::has(aspect::image)`.
 
+- **SYCL_DISABLE_FSYCL_SYCLHPP_WARNING**
+
+  Disable warning diagnostic issued when including `<sycl/sycl.hpp>` without
+  `-fsycl` compiler flag.
+
 - **SYCL_FALLBACK_ASSERT**
 
   Defining as non-zero enables the fallback assert feature even on devices

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -8,6 +8,28 @@
 
 #pragma once
 
+// Throw warning when including sycl.hpp without using -fsycl flag.
+// Warning can be disabled by defining SYCL_DISABLE_FSYCL_SYCLHPP_WARNING macro.
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#ifdef _MSC_VER
+#define WARNING(msg) __pragma(message(__FILE__ "(" TOSTRING(__LINE__) "): warning: " msg))
+#elif defined(__GNUC__) || defined(__clang__)
+#define WARNING(msg) _Pragma(TOSTRING(GCC warning msg))
+#else
+#define WARNING(msg) // Unsupported compiler
+#endif
+
+#if !defined(SYCL_LANGUAGE_VERSION) && !defined(SYCL_DISABLE_FSYCL_SYCLHPP_WARNING)
+WARNING("You are including <sycl/sycl.hpp> without -fsycl flag, \
+which is errorenous for device code compilation. This warning \
+can be disabled by setting SYCL_DISABLE_FSYCL_SYCLHPP_WARNING macro.")
+#endif
+#undef WARNING
+#undef TOSTRING
+#undef STRINGIFY
+
 #include <sycl/detail/core.hpp>
 
 #include <sycl/accessor_image.hpp>

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -14,14 +14,16 @@
 #define TOSTRING(x) STRINGIFY(x)
 
 #ifdef _MSC_VER
-#define WARNING(msg) __pragma(message(__FILE__ "(" TOSTRING(__LINE__) "): warning: " msg))
+#define WARNING(msg)                                                           \
+  __pragma(message(__FILE__ "(" TOSTRING(__LINE__) "): warning: " msg))
 #elif defined(__GNUC__) || defined(__clang__)
 #define WARNING(msg) _Pragma(TOSTRING(GCC warning msg))
 #else
 #define WARNING(msg) // Unsupported compiler
 #endif
 
-#if !defined(SYCL_LANGUAGE_VERSION) && !defined(SYCL_DISABLE_FSYCL_SYCLHPP_WARNING)
+#if !defined(SYCL_LANGUAGE_VERSION) &&                                         \
+    !defined(SYCL_DISABLE_FSYCL_SYCLHPP_WARNING)
 WARNING("You are including <sycl/sycl.hpp> without -fsycl flag, \
 which is errorenous for device code compilation. This warning \
 can be disabled by setting SYCL_DISABLE_FSYCL_SYCLHPP_WARNING macro.")

--- a/sycl/test/warnings/no_fsycl_flag.cpp
+++ b/sycl/test/warnings/no_fsycl_flag.cpp
@@ -1,0 +1,7 @@
+// Test to verify that a warning is thrown when the -fsycl flag is not used and
+// <sycl/sycl.hpp> file is included.
+// RUN: %clangxx -I %sycl_include -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK-WARNING
+// RUN: %clangxx -I %sycl_include -fsyntax-only -DSYCL_DISABLE_FSYCL_SYCLHPP_WARNING %s 2>&1 | FileCheck %s --implicit-check-not=CHECK-WARNING
+
+// CHECK-WARNING: You are including <sycl/sycl.hpp> without -fsycl flag, which is errorenous for device code compilation.
+#include <sycl/sycl.hpp>

--- a/sycl/test/warnings/no_fsycl_flag.cpp
+++ b/sycl/test/warnings/no_fsycl_flag.cpp
@@ -1,7 +1,6 @@
 // Test to verify that a warning is thrown when the -fsycl flag is not used and
 // <sycl/sycl.hpp> file is included.
-// RUN: %clangxx -I %sycl_include -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=CHECK-WARNING
-// RUN: %clangxx -I %sycl_include -fsyntax-only -DSYCL_DISABLE_FSYCL_SYCLHPP_WARNING %s 2>&1 | FileCheck %s --implicit-check-not=CHECK-WARNING
+// RUN: %clangxx -std=c++17 -I %sycl_include -fsyntax-only %s -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning
 
-// CHECK-WARNING: You are including <sycl/sycl.hpp> without -fsycl flag, which is errorenous for device code compilation.
+// expected-warning@sycl/sycl.hpp:27 {{You are including <sycl/sycl.hpp> without -fsycl flag, which is errorenous for device code compilation. This warning can be disabled by setting SYCL_DISABLE_FSYCL_SYCLHPP_WARNING macro.}}
 #include <sycl/sycl.hpp>

--- a/sycl/tools/sycl-ls/CMakeLists.txt
+++ b/sycl/tools/sycl-ls/CMakeLists.txt
@@ -9,7 +9,7 @@ if (WIN32 AND "${build_type_lower}" MATCHES "debug")
 endif()
 
 # Disable aspect::image & deprecation warnings.
-target_compile_definitions(sycl-ls PRIVATE SYCL_DISABLE_IMAGE_ASPECT_WARNING SYCL2020_DISABLE_DEPRECATION_WARNINGS)
+target_compile_definitions(sycl-ls PRIVATE SYCL_DISABLE_IMAGE_ASPECT_WARNING SYCL2020_DISABLE_DEPRECATION_WARNINGS SYCL_DISABLE_FSYCL_SYCLHPP_WARNING)
 
 target_link_libraries(sycl-ls
   PRIVATE


### PR DESCRIPTION
To improve user experience.

Fixes https://github.com/intel/llvm/issues/12052