### PR TITLE
[Benchmarks] Remove stdout field from results

### DIFF
--- a/devops/scripts/benchmarks/benches/benchdnn.py
+++ b/devops/scripts/benchmarks/benches/benchdnn.py
@@ -161,7 +161,6 @@ class OneDnnBenchmark(Benchmark):
                 unit="ms",
                 command=command,
                 env=env_vars,
-                stdout=output,
                 git_url=self.suite.git_url(),
                 git_hash=self.suite.git_tag(),
             )

--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -303,7 +303,6 @@ class ComputeBenchmark(Benchmark):
                     stddev=stddev,
                     command=command,
                     env=env_vars,
-                    stdout=result,
                     unit=parse_unit_type(unit),
                     git_url=self.bench.git_url(),
                     git_hash=self.bench.git_hash(),

--- a/devops/scripts/benchmarks/benches/gromacs.py
+++ b/devops/scripts/benchmarks/benches/gromacs.py
@@ -15,7 +15,6 @@ import re
 
 
 class GromacsBench(Suite):
-
     def git_url(self):
         return "https://gitlab.com/gromacs/gromacs.git"
 
@@ -221,7 +220,6 @@ class GromacsBenchmark(Benchmark):
                 unit="s",
                 command=command,
                 env=env_vars,
-                stdout=mdrun_output,
                 git_url=self.suite.git_url(),
                 git_hash=self.suite.git_tag(),
             )

--- a/devops/scripts/benchmarks/benches/llamacpp.py
+++ b/devops/scripts/benchmarks/benches/llamacpp.py
@@ -154,7 +154,6 @@ class LlamaBench(Benchmark):
                     value=mean,
                     command=command,
                     env=env_vars,
-                    stdout=result,
                     unit="token/s",
                     git_url=self.bench.git_url(),
                     git_hash=self.bench.git_hash(),

--- a/devops/scripts/benchmarks/benches/syclbench.py
+++ b/devops/scripts/benchmarks/benches/syclbench.py
@@ -165,7 +165,6 @@ class SyclBenchmark(Benchmark):
                             passed=(row[1] == "PASS"),
                             command=command,
                             env=env_vars,
-                            stdout=row,
                             unit="ms",
                             git_url=self.bench.git_url(),
                             git_hash=self.bench.git_hash(),

--- a/devops/scripts/benchmarks/benches/test.py
+++ b/devops/scripts/benchmarks/benches/test.py
@@ -96,7 +96,6 @@ class TestBench(Benchmark):
                 value=random_value,
                 command=["test", "--arg1", "foo"],
                 env={"A": "B"},
-                stdout="no output",
                 unit="ms",
             )
         ]

--- a/devops/scripts/benchmarks/benches/umf.py
+++ b/devops/scripts/benchmarks/benches/umf.py
@@ -165,7 +165,6 @@ class GBench(Benchmark):
                         value=value,
                         command=command,
                         env=env_vars,
-                        stdout=result,
                         unit=self.get_unit_time_or_overhead(explicit_group),
                     )
                 )

--- a/devops/scripts/benchmarks/benches/velocity.py
+++ b/devops/scripts/benchmarks/benches/velocity.py
@@ -146,7 +146,6 @@ class VelocityBase(Benchmark):
                 value=self.parse_output(result),
                 command=command,
                 env=env_vars,
-                stdout=result,
                 unit=self.unit,
                 git_url=self.vb.git_url(),
                 git_hash=self.vb.git_hash(),

--- a/devops/scripts/benchmarks/utils/result.py
+++ b/devops/scripts/benchmarks/utils/result.py
@@ -15,7 +15,6 @@ class Result:
     value: float
     command: list[str]
     env: dict[str, str]
-    stdout: str
     passed: bool = True
     unit: str = ""
     # stddev can be optionally set by the benchmark,
@@ -36,8 +35,8 @@ class BenchmarkRun:
     name: str = "This PR"
     hostname: str = "Unknown"
     git_hash: str = ""
-    github_repo: str = None
-    date: datetime = field(
+    github_repo: str = ""
+    date: datetime | None = field(
         default=None,
         metadata=config(encoder=datetime.isoformat, decoder=datetime.fromisoformat),
     )


### PR DESCRIPTION
This field is not used anywhere in scripts nor in the dashboard. It was merely saved in the results objects in run json files and copied into data.json making the file significantly bigger.