### PR TITLE
[SYCL][NFC] Make queue::getAdapter() return adapter ref instead of ptr

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -431,7 +431,7 @@ std::vector<ur_event_handle_t> context_impl::initializeDeviceGlobals(
       // are cleaned up separately from cleaning up the device global USM memory
       // this must retain the event.
       {
-        if (OwnedUrEvent ZIEvent = DeviceGlobalUSM.getInitEvent(Adapter))
+        if (OwnedUrEvent ZIEvent = DeviceGlobalUSM.getInitEvent(*Adapter))
           InitEventsRef.push_back(ZIEvent.TransferOwnership());
       }
       // Write the pointer to the device global and store the event in the

--- a/sycl/source/detail/device_global_map_entry.cpp
+++ b/sycl/source/detail/device_global_map_entry.cpp
@@ -25,13 +25,13 @@ DeviceGlobalUSMMem::~DeviceGlobalUSMMem() {
   assert(!MInitEvent.has_value() && "MInitEvent has not been cleaned up.");
 }
 
-OwnedUrEvent DeviceGlobalUSMMem::getInitEvent(const AdapterPtr &Adapter) {
+OwnedUrEvent DeviceGlobalUSMMem::getInitEvent(adapter_impl &Adapter) {
   std::lock_guard<std::mutex> Lock(MInitEventMutex);
   // If there is a init event we can remove it if it is done.
   if (MInitEvent.has_value()) {
     if (get_event_info<info::event::command_execution_status>(
-            *MInitEvent, *Adapter) == info::event_command_status::complete) {
-      Adapter->call<UrApiKind::urEventRelease>(*MInitEvent);
+            *MInitEvent, Adapter) == info::event_command_status::complete) {
+      Adapter.call<UrApiKind::urEventRelease>(*MInitEvent);
       MInitEvent = {};
       return OwnedUrEvent(Adapter);
     } else {

--- a/sycl/source/detail/device_global_map_entry.hpp
+++ b/sycl/source/detail/device_global_map_entry.hpp
@@ -39,7 +39,7 @@ struct DeviceGlobalUSMMem {
 
   // Gets the initialization event if it exists. If not the OwnedUrEvent
   // will contain no event.
-  OwnedUrEvent getInitEvent(const AdapterPtr &Adapter);
+  OwnedUrEvent getInitEvent(adapter_impl &Adapter);
 
 private:
   void *MPtr;

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -1108,7 +1108,7 @@ EventImplPtr exec_graph_impl::enqueuePartitionDirectly(
 
   if (!EventNeeded) {
     Queue.getAdapter()
-        ->call<sycl::detail::UrApiKind::urEnqueueCommandBufferExp>(
+        .call<sycl::detail::UrApiKind::urEnqueueCommandBufferExp>(
             Queue.getHandleRef(), CommandBuffer, UrEnqueueWaitListSize,
             UrEnqueueWaitList, nullptr);
     return nullptr;
@@ -1119,7 +1119,7 @@ EventImplPtr exec_graph_impl::enqueuePartitionDirectly(
     NewEvent->setSubmissionTime();
     ur_event_handle_t UrEvent = nullptr;
     Queue.getAdapter()
-        ->call<sycl::detail::UrApiKind::urEnqueueCommandBufferExp>(
+        .call<sycl::detail::UrApiKind::urEnqueueCommandBufferExp>(
             Queue.getHandleRef(), CommandBuffer, UrEventHandles.size(),
             UrEnqueueWaitList, &UrEvent);
     NewEvent->setHandle(UrEvent);

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -1107,10 +1107,9 @@ EventImplPtr exec_graph_impl::enqueuePartitionDirectly(
       UrEnqueueWaitListSize == 0 ? nullptr : UrEventHandles.data();
 
   if (!EventNeeded) {
-    Queue.getAdapter()
-        .call<sycl::detail::UrApiKind::urEnqueueCommandBufferExp>(
-            Queue.getHandleRef(), CommandBuffer, UrEnqueueWaitListSize,
-            UrEnqueueWaitList, nullptr);
+    Queue.getAdapter().call<sycl::detail::UrApiKind::urEnqueueCommandBufferExp>(
+        Queue.getHandleRef(), CommandBuffer, UrEnqueueWaitListSize,
+        UrEnqueueWaitList, nullptr);
     return nullptr;
   } else {
     auto NewEvent = sycl::detail::event_impl::create_device_event(Queue);
@@ -1118,10 +1117,9 @@ EventImplPtr exec_graph_impl::enqueuePartitionDirectly(
     NewEvent->setStateIncomplete();
     NewEvent->setSubmissionTime();
     ur_event_handle_t UrEvent = nullptr;
-    Queue.getAdapter()
-        .call<sycl::detail::UrApiKind::urEnqueueCommandBufferExp>(
-            Queue.getHandleRef(), CommandBuffer, UrEventHandles.size(),
-            UrEnqueueWaitList, &UrEvent);
+    Queue.getAdapter().call<sycl::detail::UrApiKind::urEnqueueCommandBufferExp>(
+        Queue.getHandleRef(), CommandBuffer, UrEventHandles.size(),
+        UrEnqueueWaitList, &UrEvent);
     NewEvent->setHandle(UrEvent);
     NewEvent->setEventFromSubmittedExecCommandBuffer(true);
     return NewEvent;

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -198,7 +198,7 @@ void memReleaseHelper(const AdapterPtr &Adapter, ur_mem_handle_t Mem) {
   }
 }
 
-void memBufferMapHelper(const AdapterPtr &Adapter, ur_queue_handle_t Queue,
+void memBufferMapHelper(adapter_impl &Adapter, ur_queue_handle_t Queue,
                         ur_mem_handle_t Buffer, bool Blocking,
                         ur_map_flags_t Flags, size_t Offset, size_t Size,
                         uint32_t NumEvents, const ur_event_handle_t *WaitList,
@@ -216,12 +216,12 @@ void memBufferMapHelper(const AdapterPtr &Adapter, ur_queue_handle_t Queue,
                          0 /* guard zone */, CorrID);
   }};
 #endif
-  Adapter->call<UrApiKind::urEnqueueMemBufferMap>(
+  Adapter.call<UrApiKind::urEnqueueMemBufferMap>(
       Queue, Buffer, Blocking, Flags, Offset, Size, NumEvents, WaitList, Event,
       RetMap);
 }
 
-void memUnmapHelper(const AdapterPtr &Adapter, ur_queue_handle_t Queue,
+void memUnmapHelper(adapter_impl &Adapter, ur_queue_handle_t Queue,
                     ur_mem_handle_t Mem, void *MappedPtr, uint32_t NumEvents,
                     const ur_event_handle_t *WaitList,
                     ur_event_handle_t *Event) {
@@ -241,11 +241,11 @@ void memUnmapHelper(const AdapterPtr &Adapter, ur_queue_handle_t Queue,
       // Always use call_nocheck here, because call may throw an exception,
       // and this lambda will be called from destructor, which in combination
       // rewards us with UB.
-      Adapter->call_nocheck<UrApiKind::urEventWait>(1, Event);
+      Adapter.call_nocheck<UrApiKind::urEventWait>(1, Event);
       emitMemReleaseEndTrace(MemObjID, Ptr, CorrID);
     }};
 #endif
-    Adapter->call<UrApiKind::urEnqueueMemUnmap>(Queue, Mem, MappedPtr,
+    Adapter.call<UrApiKind::urEnqueueMemUnmap>(Queue, Mem, MappedPtr,
                                                 NumEvents, WaitList, Event);
   }
 }
@@ -506,7 +506,7 @@ void copyH2D(queue_impl &TgtQueue, SYCLMemObjI *SYCLMemObj, char *SrcMem,
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
 
   const ur_queue_handle_t Queue = TgtQueue.getHandleRef();
-  const AdapterPtr &Adapter = TgtQueue.getAdapter();
+  adapter_impl &Adapter = TgtQueue.getAdapter();
 
   detail::SYCLMemObjI::MemObjType MemType = SYCLMemObj->getType();
   TermPositions SrcPos, DstPos;
@@ -521,7 +521,7 @@ void copyH2D(queue_impl &TgtQueue, SYCLMemObjI *SYCLMemObj, char *SrcMem,
 
   if (MemType == detail::SYCLMemObjI::MemObjType::Buffer) {
     if (1 == DimDst && 1 == DimSrc) {
-      Adapter->call<UrApiKind::urEnqueueMemBufferWrite>(
+      Adapter.call<UrApiKind::urEnqueueMemBufferWrite>(
           Queue, DstMem,
           /*blocking_write=*/false, DstXOffBytes, DstAccessRangeWidthBytes,
           SrcMem + SrcXOffBytes, DepEvents.size(), DepEvents.data(), &OutEvent);
@@ -540,7 +540,7 @@ void copyH2D(queue_impl &TgtQueue, SYCLMemObjI *SYCLMemObj, char *SrcMem,
       ur_rect_region_t RectRegion{DstAccessRangeWidthBytes,
                                   DstAccessRange[DstPos.YTerm],
                                   DstAccessRange[DstPos.ZTerm]};
-      Adapter->call<UrApiKind::urEnqueueMemBufferWriteRect>(
+      Adapter.call<UrApiKind::urEnqueueMemBufferWriteRect>(
           Queue, DstMem,
           /*blocking_write=*/false, BufferOffset, HostOffset, RectRegion,
           BufferRowPitch, BufferSlicePitch, HostRowPitch, HostSlicePitch,
@@ -556,7 +556,7 @@ void copyH2D(queue_impl &TgtQueue, SYCLMemObjI *SYCLMemObj, char *SrcMem,
     ur_rect_region_t Region{DstAccessRange[DstPos.XTerm],
                             DstAccessRange[DstPos.YTerm],
                             DstAccessRange[DstPos.ZTerm]};
-    Adapter->call<UrApiKind::urEnqueueMemImageWrite>(
+    Adapter.call<UrApiKind::urEnqueueMemImageWrite>(
         Queue, DstMem,
         /*blocking_write=*/false, Origin, Region, InputRowPitch,
         InputSlicePitch, SrcMem, DepEvents.size(), DepEvents.data(), &OutEvent);
@@ -575,7 +575,7 @@ void copyD2H(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
 
   const ur_queue_handle_t Queue = SrcQueue.getHandleRef();
-  const AdapterPtr &Adapter = SrcQueue.getAdapter();
+  adapter_impl &Adapter = SrcQueue.getAdapter();
 
   detail::SYCLMemObjI::MemObjType MemType = SYCLMemObj->getType();
   TermPositions SrcPos, DstPos;
@@ -596,7 +596,7 @@ void copyD2H(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
 
   if (MemType == detail::SYCLMemObjI::MemObjType::Buffer) {
     if (1 == DimDst && 1 == DimSrc) {
-      Adapter->call<UrApiKind::urEnqueueMemBufferRead>(
+      Adapter.call<UrApiKind::urEnqueueMemBufferRead>(
           Queue, SrcMem,
           /*blocking_read=*/false, SrcXOffBytes, SrcAccessRangeWidthBytes,
           DstMem + DstXOffBytes, DepEvents.size(), DepEvents.data(), &OutEvent);
@@ -615,7 +615,7 @@ void copyD2H(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
       ur_rect_region_t RectRegion{SrcAccessRangeWidthBytes,
                                   SrcAccessRange[SrcPos.YTerm],
                                   SrcAccessRange[SrcPos.ZTerm]};
-      Adapter->call<UrApiKind::urEnqueueMemBufferReadRect>(
+      Adapter.call<UrApiKind::urEnqueueMemBufferReadRect>(
           Queue, SrcMem,
           /*blocking_read=*/false, BufferOffset, HostOffset, RectRegion,
           BufferRowPitch, BufferSlicePitch, HostRowPitch, HostSlicePitch,
@@ -631,7 +631,7 @@ void copyD2H(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
     ur_rect_region_t Region{SrcAccessRange[SrcPos.XTerm],
                             SrcAccessRange[SrcPos.YTerm],
                             SrcAccessRange[SrcPos.ZTerm]};
-    Adapter->call<UrApiKind::urEnqueueMemImageRead>(
+    Adapter.call<UrApiKind::urEnqueueMemImageRead>(
         Queue, SrcMem, false, Offset, Region, RowPitch, SlicePitch, DstMem,
         DepEvents.size(), DepEvents.data(), &OutEvent);
   }
@@ -650,7 +650,7 @@ void copyD2D(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
 
   const ur_queue_handle_t Queue = SrcQueue.getHandleRef();
-  const AdapterPtr &Adapter = SrcQueue.getAdapter();
+  adapter_impl &Adapter = SrcQueue.getAdapter();
 
   detail::SYCLMemObjI::MemObjType MemType = SYCLMemObj->getType();
   TermPositions SrcPos, DstPos;
@@ -665,7 +665,7 @@ void copyD2D(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
 
   if (MemType == detail::SYCLMemObjI::MemObjType::Buffer) {
     if (1 == DimDst && 1 == DimSrc) {
-      Adapter->call<UrApiKind::urEnqueueMemBufferCopy>(
+      Adapter.call<UrApiKind::urEnqueueMemBufferCopy>(
           Queue, SrcMem, DstMem, SrcXOffBytes, DstXOffBytes,
           SrcAccessRangeWidthBytes, DepEvents.size(), DepEvents.data(),
           &OutEvent);
@@ -689,7 +689,7 @@ void copyD2D(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
       ur_rect_region_t Region{SrcAccessRangeWidthBytes,
                               SrcAccessRange[SrcPos.YTerm],
                               SrcAccessRange[SrcPos.ZTerm]};
-      Adapter->call<UrApiKind::urEnqueueMemBufferCopyRect>(
+      Adapter.call<UrApiKind::urEnqueueMemBufferCopyRect>(
           Queue, SrcMem, DstMem, SrcOrigin, DstOrigin, Region, SrcRowPitch,
           SrcSlicePitch, DstRowPitch, DstSlicePitch, DepEvents.size(),
           DepEvents.data(), &OutEvent);
@@ -702,7 +702,7 @@ void copyD2D(queue_impl &SrcQueue, SYCLMemObjI *SYCLMemObj,
     ur_rect_region_t Region{SrcAccessRange[SrcPos.XTerm],
                             SrcAccessRange[SrcPos.YTerm],
                             SrcAccessRange[SrcPos.ZTerm]};
-    Adapter->call<UrApiKind::urEnqueueMemImageCopy>(
+    Adapter.call<UrApiKind::urEnqueueMemImageCopy>(
         Queue, SrcMem, DstMem, SrcOrigin, DstOrigin, Region, DepEvents.size(),
         DepEvents.data(), &OutEvent);
   }
@@ -782,7 +782,7 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, queue_impl &Queue,
                          ur_event_handle_t &OutEvent) {
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
 
-  const AdapterPtr &Adapter = Queue.getAdapter();
+  adapter_impl &Adapter = Queue.getAdapter();
 
   if (SYCLMemObj->getType() == detail::SYCLMemObjI::MemObjType::Buffer) {
 
@@ -795,7 +795,7 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, queue_impl &Queue,
     size_t RangeMultiplier = AccRange[0] * AccRange[1] * AccRange[2];
 
     if (RangesUsable && OffsetUsable) {
-      Adapter->call<UrApiKind::urEnqueueMemBufferFill>(
+      Adapter.call<UrApiKind::urEnqueueMemBufferFill>(
           Queue.getHandleRef(), ur::cast<ur_mem_handle_t>(Mem), Pattern,
           PatternSize, Offset[0] * ElementSize, RangeMultiplier * ElementSize,
           DepEvents.size(), DepEvents.data(), &OutEvent);
@@ -847,7 +847,7 @@ void *MemoryManager::map(SYCLMemObjI *, void *Mem, queue_impl &Queue,
 
   void *MappedPtr = nullptr;
   const size_t BytesToMap = AccessRange[0] * AccessRange[1] * AccessRange[2];
-  const AdapterPtr &Adapter = Queue.getAdapter();
+  adapter_impl &Adapter = Queue.getAdapter();
   memBufferMapHelper(Adapter, Queue.getHandleRef(),
                      ur::cast<ur_mem_handle_t>(Mem), false, Flags,
                      AccessOffset[0], BytesToMap, DepEvents.size(),
@@ -862,7 +862,7 @@ void MemoryManager::unmap(SYCLMemObjI *, void *Mem, queue_impl &Queue,
   // All DepEvents are to the same Context.
   // Using the adapter of the Queue.
 
-  const AdapterPtr &Adapter = Queue.getAdapter();
+  adapter_impl &Adapter = Queue.getAdapter();
   memUnmapHelper(Adapter, Queue.getHandleRef(), ur::cast<ur_mem_handle_t>(Mem),
                  MappedPtr, DepEvents.size(), DepEvents.data(), &OutEvent);
 }
@@ -871,10 +871,10 @@ void MemoryManager::copy_usm(const void *SrcMem, queue_impl &SrcQueue,
                              size_t Len, void *DstMem,
                              std::vector<ur_event_handle_t> DepEvents,
                              ur_event_handle_t *OutEvent) {
-  const AdapterPtr &Adapter = SrcQueue.getAdapter();
+  adapter_impl &Adapter = SrcQueue.getAdapter();
   if (!Len) { // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      Adapter->call<UrApiKind::urEnqueueEventsWait>(SrcQueue.getHandleRef(),
+      Adapter.call<UrApiKind::urEnqueueEventsWait>(SrcQueue.getHandleRef(),
                                                     DepEvents.size(),
                                                     DepEvents.data(), OutEvent);
     }
@@ -885,7 +885,7 @@ void MemoryManager::copy_usm(const void *SrcMem, queue_impl &SrcQueue,
     throw exception(make_error_code(errc::invalid),
                     "NULL pointer argument in memory copy operation.");
 
-  Adapter->call<UrApiKind::urEnqueueUSMMemcpy>(SrcQueue.getHandleRef(),
+  Adapter.call<UrApiKind::urEnqueueUSMMemcpy>(SrcQueue.getHandleRef(),
                                                /* blocking */ false, DstMem,
                                                SrcMem, Len, DepEvents.size(),
                                                DepEvents.data(), OutEvent);
@@ -907,7 +907,7 @@ void MemoryManager::fill_usm(void *Mem, queue_impl &Queue, size_t Length,
                              ur_event_handle_t *OutEvent) {
   if (!Length) { // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+      Queue.getAdapter().call<UrApiKind::urEnqueueEventsWait>(
           Queue.getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
     }
     return;
@@ -916,8 +916,8 @@ void MemoryManager::fill_usm(void *Mem, queue_impl &Queue, size_t Length,
   if (!Mem)
     throw exception(make_error_code(errc::invalid),
                     "NULL pointer argument in memory fill operation.");
-  const AdapterPtr &Adapter = Queue.getAdapter();
-  Adapter->call<UrApiKind::urEnqueueUSMFill>(
+  adapter_impl &Adapter = Queue.getAdapter();
+  Adapter.call<UrApiKind::urEnqueueUSMFill>(
       Queue.getHandleRef(), Mem, Pattern.size(), Pattern.data(), Length,
       DepEvents.size(), DepEvents.data(), OutEvent);
 }
@@ -925,8 +925,8 @@ void MemoryManager::fill_usm(void *Mem, queue_impl &Queue, size_t Length,
 void MemoryManager::prefetch_usm(void *Mem, queue_impl &Queue, size_t Length,
                                  std::vector<ur_event_handle_t> DepEvents,
                                  ur_event_handle_t *OutEvent) {
-  const AdapterPtr &Adapter = Queue.getAdapter();
-  Adapter->call<UrApiKind::urEnqueueUSMPrefetch>(Queue.getHandleRef(), Mem,
+  adapter_impl &Adapter = Queue.getAdapter();
+  Adapter.call<UrApiKind::urEnqueueUSMPrefetch>(Queue.getHandleRef(), Mem,
                                                  Length, 0, DepEvents.size(),
                                                  DepEvents.data(), OutEvent);
 }
@@ -935,8 +935,8 @@ void MemoryManager::advise_usm(const void *Mem, queue_impl &Queue,
                                size_t Length, ur_usm_advice_flags_t Advice,
                                std::vector<ur_event_handle_t> /*DepEvents*/,
                                ur_event_handle_t *OutEvent) {
-  const AdapterPtr &Adapter = Queue.getAdapter();
-  Adapter->call<UrApiKind::urEnqueueUSMAdvise>(Queue.getHandleRef(), Mem,
+  adapter_impl &Adapter = Queue.getAdapter();
+  Adapter.call<UrApiKind::urEnqueueUSMAdvise>(Queue.getHandleRef(), Mem,
                                                Length, Advice, OutEvent);
 }
 
@@ -948,7 +948,7 @@ void MemoryManager::copy_2d_usm(const void *SrcMem, size_t SrcPitch,
   if (Width == 0 || Height == 0) {
     // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+      Queue.getAdapter().call<UrApiKind::urEnqueueEventsWait>(
           Queue.getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
     }
     return;
@@ -958,17 +958,17 @@ void MemoryManager::copy_2d_usm(const void *SrcMem, size_t SrcPitch,
     throw sycl::exception(sycl::make_error_code(errc::invalid),
                           "NULL pointer argument in 2D memory copy operation.");
 
-  const AdapterPtr &Adapter = Queue.getAdapter();
+  adapter_impl &Adapter = Queue.getAdapter();
 
   bool SupportsUSMMemcpy2D = false;
-  Adapter->call<UrApiKind::urContextGetInfo>(
+  Adapter.call<UrApiKind::urContextGetInfo>(
       Queue.getContextImpl().getHandleRef(),
       UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT, sizeof(bool), &SupportsUSMMemcpy2D,
       nullptr);
 
   if (SupportsUSMMemcpy2D) {
     // Direct memcpy2D is supported so we use this function.
-    Adapter->call<UrApiKind::urEnqueueUSMMemcpy2D>(
+    Adapter.call<UrApiKind::urEnqueueUSMMemcpy2D>(
         Queue.getHandleRef(),
         /*blocking=*/false, DstMem, DstPitch, SrcMem, SrcPitch, Width, Height,
         DepEvents.size(), DepEvents.data(), OutEvent);
@@ -997,7 +997,7 @@ void MemoryManager::copy_2d_usm(const void *SrcMem, size_t SrcPitch,
   for (size_t I = 0; I < Height; ++I) {
     char *DstItBegin = static_cast<char *>(DstMem) + I * DstPitch;
     const char *SrcItBegin = static_cast<const char *>(SrcMem) + I * SrcPitch;
-    Adapter->call<UrApiKind::urEnqueueUSMMemcpy>(
+    Adapter.call<UrApiKind::urEnqueueUSMMemcpy>(
         Queue.getHandleRef(),
         /* blocking */ false, DstItBegin, SrcItBegin, Width, DepEvents.size(),
         DepEvents.data(), CopyEvents.data() + I);
@@ -1005,7 +1005,7 @@ void MemoryManager::copy_2d_usm(const void *SrcMem, size_t SrcPitch,
                                    /*TakeOwnership=*/true);
   }
   // Then insert a wait to coalesce the copy events.
-  Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+  Queue.getAdapter().call<UrApiKind::urEnqueueEventsWait>(
       Queue.getHandleRef(), CopyEvents.size(), CopyEvents.data(), OutEvent);
 }
 
@@ -1017,7 +1017,7 @@ void MemoryManager::fill_2d_usm(void *DstMem, queue_impl &Queue, size_t Pitch,
   if (Width == 0 || Height == 0) {
     // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+      Queue.getAdapter().call<UrApiKind::urEnqueueEventsWait>(
           Queue.getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
     }
     return;
@@ -1026,8 +1026,8 @@ void MemoryManager::fill_2d_usm(void *DstMem, queue_impl &Queue, size_t Pitch,
   if (!DstMem)
     throw sycl::exception(sycl::make_error_code(errc::invalid),
                           "NULL pointer argument in 2D memory fill operation.");
-  const AdapterPtr &Adapter = Queue.getAdapter();
-  Adapter->call<UrApiKind::urEnqueueUSMFill2D>(
+  adapter_impl &Adapter = Queue.getAdapter();
+  Adapter.call<UrApiKind::urEnqueueUSMFill2D>(
       Queue.getHandleRef(), DstMem, Pitch, Pattern.size(), Pattern.data(),
       Width, Height, DepEvents.size(), DepEvents.data(), OutEvent);
 }
@@ -1039,7 +1039,7 @@ void MemoryManager::memset_2d_usm(void *DstMem, queue_impl &Queue, size_t Pitch,
   if (Width == 0 || Height == 0) {
     // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
-      Queue.getAdapter()->call<UrApiKind::urEnqueueEventsWait>(
+      Queue.getAdapter().call<UrApiKind::urEnqueueEventsWait>(
           Queue.getHandleRef(), DepEvents.size(), DepEvents.data(), OutEvent);
     }
     return;
@@ -1163,8 +1163,8 @@ memcpyToDeviceGlobalDirect(queue_impl &Queue,
                            ur_event_handle_t *OutEvent) {
   ur_program_handle_t Program =
       getOrBuildProgramForDeviceGlobal(Queue, DeviceGlobalEntry);
-  const AdapterPtr &Adapter = Queue.getAdapter();
-  Adapter->call<UrApiKind::urEnqueueDeviceGlobalVariableWrite>(
+  adapter_impl &Adapter = Queue.getAdapter();
+  Adapter.call<UrApiKind::urEnqueueDeviceGlobalVariableWrite>(
       Queue.getHandleRef(), Program, DeviceGlobalEntry->MUniqueId.c_str(),
       false, NumBytes, Offset, Src, DepEvents.size(), DepEvents.data(),
       OutEvent);
@@ -1176,8 +1176,8 @@ static void memcpyFromDeviceGlobalDirect(
     ur_event_handle_t *OutEvent) {
   ur_program_handle_t Program =
       getOrBuildProgramForDeviceGlobal(Queue, DeviceGlobalEntry);
-  const AdapterPtr &Adapter = Queue.getAdapter();
-  Adapter->call<UrApiKind::urEnqueueDeviceGlobalVariableRead>(
+  adapter_impl &Adapter = Queue.getAdapter();
+  Adapter.call<UrApiKind::urEnqueueDeviceGlobalVariableRead>(
       Queue.getHandleRef(), Program, DeviceGlobalEntry->MUniqueId.c_str(),
       false, NumBytes, Offset, Dest, DepEvents.size(), DepEvents.data(),
       OutEvent);
@@ -1574,7 +1574,7 @@ void MemoryManager::copy_image_bindless(
         sycl::make_error_code(errc::invalid),
         "NULL pointer argument in bindless image copy operation.");
 
-  const detail::AdapterPtr &Adapter = Queue.getAdapter();
+  detail::adapter_impl &Adapter = Queue.getAdapter();
 
   ur_exp_image_copy_region_t CopyRegion{};
   CopyRegion.stype = UR_STRUCTURE_TYPE_EXP_IMAGE_COPY_REGION;
@@ -1582,7 +1582,7 @@ void MemoryManager::copy_image_bindless(
   CopyRegion.srcOffset = SrcOffset;
   CopyRegion.dstOffset = DstOffset;
 
-  Adapter->call<UrApiKind::urBindlessImagesImageCopyExp>(
+  Adapter.call<UrApiKind::urBindlessImagesImageCopyExp>(
       Queue.getHandleRef(), Src, Dst, &SrcDesc, &DstDesc, &SrcFormat,
       &DstFormat, &CopyRegion, Flags, DepEvents.size(), DepEvents.data(),
       OutEvent);

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -216,9 +216,9 @@ void memBufferMapHelper(adapter_impl &Adapter, ur_queue_handle_t Queue,
                          0 /* guard zone */, CorrID);
   }};
 #endif
-  Adapter.call<UrApiKind::urEnqueueMemBufferMap>(
-      Queue, Buffer, Blocking, Flags, Offset, Size, NumEvents, WaitList, Event,
-      RetMap);
+  Adapter.call<UrApiKind::urEnqueueMemBufferMap>(Queue, Buffer, Blocking, Flags,
+                                                 Offset, Size, NumEvents,
+                                                 WaitList, Event, RetMap);
 }
 
 void memUnmapHelper(adapter_impl &Adapter, ur_queue_handle_t Queue,
@@ -245,8 +245,8 @@ void memUnmapHelper(adapter_impl &Adapter, ur_queue_handle_t Queue,
       emitMemReleaseEndTrace(MemObjID, Ptr, CorrID);
     }};
 #endif
-    Adapter.call<UrApiKind::urEnqueueMemUnmap>(Queue, Mem, MappedPtr,
-                                                NumEvents, WaitList, Event);
+    Adapter.call<UrApiKind::urEnqueueMemUnmap>(Queue, Mem, MappedPtr, NumEvents,
+                                               WaitList, Event);
   }
 }
 
@@ -875,8 +875,8 @@ void MemoryManager::copy_usm(const void *SrcMem, queue_impl &SrcQueue,
   if (!Len) { // no-op, but ensure DepEvents will still be waited on
     if (!DepEvents.empty()) {
       Adapter.call<UrApiKind::urEnqueueEventsWait>(SrcQueue.getHandleRef(),
-                                                    DepEvents.size(),
-                                                    DepEvents.data(), OutEvent);
+                                                   DepEvents.size(),
+                                                   DepEvents.data(), OutEvent);
     }
     return;
   }
@@ -886,9 +886,9 @@ void MemoryManager::copy_usm(const void *SrcMem, queue_impl &SrcQueue,
                     "NULL pointer argument in memory copy operation.");
 
   Adapter.call<UrApiKind::urEnqueueUSMMemcpy>(SrcQueue.getHandleRef(),
-                                               /* blocking */ false, DstMem,
-                                               SrcMem, Len, DepEvents.size(),
-                                               DepEvents.data(), OutEvent);
+                                              /* blocking */ false, DstMem,
+                                              SrcMem, Len, DepEvents.size(),
+                                              DepEvents.data(), OutEvent);
 }
 
 void MemoryManager::context_copy_usm(const void *SrcMem, context_impl *Context,
@@ -927,8 +927,8 @@ void MemoryManager::prefetch_usm(void *Mem, queue_impl &Queue, size_t Length,
                                  ur_event_handle_t *OutEvent) {
   adapter_impl &Adapter = Queue.getAdapter();
   Adapter.call<UrApiKind::urEnqueueUSMPrefetch>(Queue.getHandleRef(), Mem,
-                                                 Length, 0, DepEvents.size(),
-                                                 DepEvents.data(), OutEvent);
+                                                Length, 0, DepEvents.size(),
+                                                DepEvents.data(), OutEvent);
 }
 
 void MemoryManager::advise_usm(const void *Mem, queue_impl &Queue,
@@ -936,8 +936,8 @@ void MemoryManager::advise_usm(const void *Mem, queue_impl &Queue,
                                std::vector<ur_event_handle_t> /*DepEvents*/,
                                ur_event_handle_t *OutEvent) {
   adapter_impl &Adapter = Queue.getAdapter();
-  Adapter.call<UrApiKind::urEnqueueUSMAdvise>(Queue.getHandleRef(), Mem,
-                                               Length, Advice, OutEvent);
+  Adapter.call<UrApiKind::urEnqueueUSMAdvise>(Queue.getHandleRef(), Mem, Length,
+                                              Advice, OutEvent);
 }
 
 void MemoryManager::copy_2d_usm(const void *SrcMem, size_t SrcPitch,

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -63,7 +63,7 @@ getUrEvents(const std::vector<sycl::event> &DepEvents) {
 template <>
 uint32_t queue_impl::get_info<info::queue::reference_count>() const {
   ur_result_t result = UR_RESULT_SUCCESS;
-  getAdapter()->call<UrApiKind::urQueueGetInfo>(
+  getAdapter().call<UrApiKind::urQueueGetInfo>(
       MQueue, UR_QUEUE_INFO_REFERENCE_COUNT, sizeof(result), &result, nullptr);
   return result;
 }
@@ -657,8 +657,7 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
     }
   }
 
-  const AdapterPtr &Adapter = getAdapter();
-  Adapter->call<UrApiKind::urQueueFinish>(getHandleRef());
+  getAdapter().call<UrApiKind::urQueueFinish>(getHandleRef());
 
   if (!isInOrder()) {
     std::vector<EventImplPtr> StreamsServiceEvents;
@@ -735,13 +734,12 @@ void queue_impl::destructorNotification() {
 }
 
 ur_native_handle_t queue_impl::getNative(int32_t &NativeHandleDesc) const {
-  const AdapterPtr &Adapter = getAdapter();
   ur_native_handle_t Handle{};
   ur_queue_native_desc_t UrNativeDesc{UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC,
                                       nullptr, nullptr};
   UrNativeDesc.pNativeData = &NativeHandleDesc;
 
-  Adapter->call<UrApiKind::urQueueGetNativeHandle>(MQueue, &UrNativeDesc,
+  getAdapter().call<UrApiKind::urQueueGetNativeHandle>(MQueue, &UrNativeDesc,
                                                    &Handle);
   if (getContextImpl().getBackend() == backend::opencl)
     __SYCL_OCL_CALL(clRetainCommandQueue, ur::cast<cl_command_queue>(Handle));
@@ -766,7 +764,7 @@ bool queue_impl::queue_empty() const {
 
   // Check the status of the backend queue if this is not a host queue.
   ur_bool_t IsReady = false;
-  getAdapter()->call<UrApiKind::urQueueGetInfo>(
+  getAdapter().call<UrApiKind::urQueueGetInfo>(
       MQueue, UR_QUEUE_INFO_EMPTY, sizeof(IsReady), &IsReady, nullptr);
   if (!IsReady)
     return false;

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -740,7 +740,7 @@ ur_native_handle_t queue_impl::getNative(int32_t &NativeHandleDesc) const {
   UrNativeDesc.pNativeData = &NativeHandleDesc;
 
   getAdapter().call<UrApiKind::urQueueGetNativeHandle>(MQueue, &UrNativeDesc,
-                                                   &Handle);
+                                                       &Handle);
   if (getContextImpl().getBackend() == backend::opencl)
     __SYCL_OCL_CALL(clRetainCommandQueue, ur::cast<cl_command_queue>(Handle));
 

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -275,7 +275,7 @@ public:
   cl_command_queue get() {
     ur_native_handle_t nativeHandle = 0;
     getAdapter().call<UrApiKind::urQueueGetNativeHandle>(MQueue, nullptr,
-                                                          &nativeHandle);
+                                                         &nativeHandle);
     __SYCL_OCL_CALL(clRetainCommandQueue, ur::cast<cl_command_queue>(nativeHandle));
     return ur::cast<cl_command_queue>(nativeHandle);
   }
@@ -503,7 +503,7 @@ public:
       Properties.pNext = &IndexProperties;
     }
     getAdapter().call<UrApiKind::urQueueCreate>(Context, Device, &Properties,
-                                            &Queue);
+                                                &Queue);
 
     return Queue;
   }
@@ -665,7 +665,7 @@ public:
     auto ResEvent = detail::event_impl::create_device_event(*this);
     ur_event_handle_t UREvent = nullptr;
     getAdapter().call<UrApiKind::urEnqueueEventsWait>(getHandleRef(), 0,
-                                                       nullptr, &UREvent);
+                                                      nullptr, &UREvent);
     ResEvent->setHandle(UREvent);
     return ResEvent;
   }

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2343,7 +2343,7 @@ static void SetArgBasedOnType(
     MemObjData.stype = UR_STRUCTURE_TYPE_KERNEL_ARG_MEM_OBJ_PROPERTIES;
     MemObjData.memoryAccess = AccessModeToUr(Req->MAccessMode);
     Adapter.call<UrApiKind::urKernelSetArgMemObj>(Kernel, NextTrueIndex,
-                                                   &MemObjData, MemArg);
+                                                  &MemObjData, MemArg);
     break;
   }
   case kernel_param_kind_t::kind_std_layout: {
@@ -2352,7 +2352,7 @@ static void SetArgBasedOnType(
           Kernel, NextTrueIndex, Arg.MSize, nullptr, Arg.MPtr);
     } else {
       Adapter.call<UrApiKind::urKernelSetArgLocal>(Kernel, NextTrueIndex,
-                                                    Arg.MSize, nullptr);
+                                                   Arg.MSize, nullptr);
     }
 
     break;
@@ -2363,7 +2363,7 @@ static void SetArgBasedOnType(
         (ur_sampler_handle_t)detail::getSyclObjImpl(*SamplerPtr)
             ->getOrCreateSampler(ContextImpl);
     Adapter.call<UrApiKind::urKernelSetArgSampler>(Kernel, NextTrueIndex,
-                                                    nullptr, Sampler);
+                                                   nullptr, Sampler);
     break;
   }
   case kernel_param_kind_t::kind_pointer: {
@@ -2371,7 +2371,7 @@ static void SetArgBasedOnType(
     // pointer UR is expecting.
     const void *Ptr = *static_cast<const void *const *>(Arg.MPtr);
     Adapter.call<UrApiKind::urKernelSetArgPointer>(Kernel, NextTrueIndex,
-                                                    nullptr, Ptr);
+                                                   nullptr, Ptr);
     break;
   }
   case kernel_param_kind_t::kind_specialization_constants_buffer: {
@@ -2409,7 +2409,7 @@ static ur_result_t SetKernelParamsAndLaunch(
     void *KernelFuncPtr = nullptr, int KernelNumArgs = 0,
     detail::kernel_param_desc_t (*KernelParamDescGetter)(int) = nullptr,
     bool KernelHasSpecialCaptures = true) {
-    adapter_impl &Adapter = Queue.getAdapter();
+  adapter_impl &Adapter = Queue.getAdapter();
 
   if (SYCLConfig<SYCL_JIT_AMDGCN_PTX_KERNELS>::get()) {
     std::vector<unsigned char> Empty;
@@ -2428,13 +2428,13 @@ static ur_result_t SetKernelParamsAndLaunch(
       case kernel_param_kind_t::kind_std_layout: {
         int Size = ParamDesc.info;
         Adapter.call<UrApiKind::urKernelSetArgValue>(Kernel, NextTrueIndex,
-                                                      Size, nullptr, ArgPtr);
+                                                     Size, nullptr, ArgPtr);
         break;
       }
       case kernel_param_kind_t::kind_pointer: {
         const void *Ptr = *static_cast<const void *const *>(ArgPtr);
         Adapter.call<UrApiKind::urKernelSetArgPointer>(Kernel, NextTrueIndex,
-                                                        nullptr, Ptr);
+                                                       nullptr, Ptr);
         break;
       }
       default:
@@ -2853,7 +2853,7 @@ ur_result_t ExecCGCommand::enqueueImpCommandBuffer() {
   std::vector<ur_event_handle_t> RawEvents = getUrEvents(EventImpls);
   if (!RawEvents.empty()) {
     MQueue->getAdapter().call<UrApiKind::urEventWait>(RawEvents.size(),
-                                                       &RawEvents[0]);
+                                                      &RawEvents[0]);
   }
 
   ur_exp_command_buffer_sync_point_t OutSyncPoint{};
@@ -3009,7 +3009,7 @@ ur_result_t ExecCGCommand::enqueueImpCommandBuffer() {
   case CGType::EnqueueNativeCommand: {
     // Queue is created by graph_impl before creating command to submit to
     // scheduler.
-    adapter_impl& Adapter = MQueue->getAdapter();
+    adapter_impl &Adapter = MQueue->getAdapter();
     context_impl &ContextImpl = MQueue->getContextImpl();
     device_impl &DeviceImpl = MQueue->getDeviceImpl();
 
@@ -3099,9 +3099,10 @@ ur_result_t ExecCGCommand::enqueueImpCommandBuffer() {
 #endif
 
     if (ChildCommandBuffer) {
-      ur_result_t Res = Adapter.call_nocheck<
-          sycl::detail::UrApiKind::urCommandBufferReleaseExp>(
-          ChildCommandBuffer);
+      ur_result_t Res =
+          Adapter
+              .call_nocheck<sycl::detail::UrApiKind::urCommandBufferReleaseExp>(
+                  ChildCommandBuffer);
       (void)Res;
       assert(Res == UR_RESULT_SUCCESS);
     }

--- a/sycl/source/detail/ur_utils.hpp
+++ b/sycl/source/detail/ur_utils.hpp
@@ -21,11 +21,11 @@ namespace detail {
 
 // RAII object for keeping ownership of a UR event.
 struct OwnedUrEvent {
-  OwnedUrEvent(const AdapterPtr &Adapter)
-      : MEvent{std::nullopt}, MAdapter{Adapter} {}
-  OwnedUrEvent(ur_event_handle_t Event, const AdapterPtr &Adapter,
+  OwnedUrEvent(adapter_impl &Adapter)
+      : MEvent{std::nullopt}, MAdapter{&Adapter} {}
+  OwnedUrEvent(ur_event_handle_t Event, adapter_impl &Adapter,
                bool TakeOwnership = false)
-      : MEvent(Event), MAdapter(Adapter) {
+      : MEvent(Event), MAdapter(&Adapter) {
     // If it is not instructed to take ownership, retain the event to share
     // ownership of it.
     if (!TakeOwnership)
@@ -65,7 +65,7 @@ struct OwnedUrEvent {
 
 private:
   std::optional<ur_event_handle_t> MEvent;
-  const AdapterPtr &MAdapter;
+  adapter_impl *MAdapter;
 };
 
 namespace ur {

--- a/sycl/source/interop_handle.cpp
+++ b/sycl/source/interop_handle.cpp
@@ -43,9 +43,9 @@ interop_handle::getNativeMem(detail::Requirement *Req) const {
                     "Invalid memory object used inside interop");
   }
 
-  auto Adapter = MQueue->getAdapter();
+  detail::adapter_impl &Adapter = MQueue->getAdapter();
   ur_native_handle_t Handle;
-  Adapter->call<detail::UrApiKind::urMemGetNativeHandle>(
+  Adapter.call<detail::UrApiKind::urMemGetNativeHandle>(
       Iter->second, MDevice->getHandleRef(), &Handle);
   return Handle;
 }
@@ -78,9 +78,9 @@ ur_native_handle_t interop_handle::getNativeGraph() const {
         "No backend graph object is available for the command-group");
   }
 
-  auto Adapter = MQueue->getAdapter();
+  detail::adapter_impl& Adapter = MQueue->getAdapter();
   ur_native_handle_t Handle = 0;
-  Adapter->call<detail::UrApiKind::urCommandBufferGetNativeHandleExp>(Graph,
+  Adapter.call<detail::UrApiKind::urCommandBufferGetNativeHandleExp>(Graph,
                                                                       &Handle);
   return Handle;
 }

--- a/sycl/source/interop_handle.cpp
+++ b/sycl/source/interop_handle.cpp
@@ -78,10 +78,10 @@ ur_native_handle_t interop_handle::getNativeGraph() const {
         "No backend graph object is available for the command-group");
   }
 
-  detail::adapter_impl& Adapter = MQueue->getAdapter();
+  detail::adapter_impl &Adapter = MQueue->getAdapter();
   ur_native_handle_t Handle = 0;
   Adapter.call<detail::UrApiKind::urCommandBufferGetNativeHandleExp>(Graph,
-                                                                      &Handle);
+                                                                     &Handle);
   return Handle;
 }
 } // namespace _V1


### PR DESCRIPTION
It's a part of larger refactoring effort to pass adapter via reference instead of pointer everywhere in the codebase.

Follow-up of:
https://github.com/intel/llvm/pull/19186
https://github.com/intel/llvm/pull/19184
https://github.com/intel/llvm/pull/19187
https://github.com/intel/llvm/pull/19202