### PR TITLE
[SYCL] Specify application name for `CreateProcess`

### DIFF
--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -308,7 +308,7 @@ static int unsetFilterEnvVarsAndFork() {
   si.dwFlags |= STARTF_USESTDHANDLES;
 
   PROCESS_INFORMATION pi;
-  if (!CreateProcess(NULL,             /* Applicatioon name. */
+  if (!CreateProcess(L"sycl-ls.exe",   /* Application name. */
                      GetCommandLine(), /* Current process's CLI input. */
                      NULL,             /* Inherit security attributes. */
                      NULL,             /* Thread security attributes. */


### PR DESCRIPTION
`CreateProcess` has a really weird method [1] of inferring an executable name using space as a separator which poses a potential security risk of someone injecting a 3rd-party executable to be launched instead of the original one.

[1]: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw#security-remarks