### PR TITLE
[SYCL] Fix compilation when JIT is disabled

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -170,8 +170,8 @@ struct KernelCompilerBinaryInfo {
       std::string &&Prefix,
       std::shared_ptr<ManagedDeviceGlobalsRegistry> &&DeviceGlobalRegistry)
       : MLanguage{Lang}, MMangledKernelNames{std::move(MangledKernelNames)},
-        MPrefixes{std::move(Prefix)}, MDeviceGlobalRegistries{
-                                          std::move(DeviceGlobalRegistry)} {}
+        MPrefixes{std::move(Prefix)},
+        MDeviceGlobalRegistries{std::move(DeviceGlobalRegistry)} {}
 
   static std::optional<KernelCompilerBinaryInfo>
   Merge(const std::vector<const std::optional<KernelCompilerBinaryInfo> *>

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <JITBinaryInfo.h>
 #include <detail/jit_device_binaries.hpp>
 #include <detail/queue_impl.hpp>
 #include <sycl/detail/kernel_name_str_t.hpp>
@@ -16,6 +15,7 @@
 #if SYCL_EXT_JIT_ENABLE
 #include <Materializer.h>
 #include <RTC.h>
+#include <JITBinaryInfo.h>
 #endif // SYCL_EXT_JIT_ENABLE
 
 #include <functional>
@@ -28,6 +28,7 @@ struct RTCDevImgInfo;
 struct RTCBundleInfo;
 template <typename T> class DynArray;
 using JITEnvVar = DynArray<char>;
+enum class BinaryFormat : uint32_t;
 } // namespace jit_compiler
 
 namespace sycl {

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -13,9 +13,9 @@
 #include <sycl/detail/kernel_name_str_t.hpp>
 #include <sycl/feature_test.hpp>
 #if SYCL_EXT_JIT_ENABLE
+#include <JITBinaryInfo.h>
 #include <Materializer.h>
 #include <RTC.h>
-#include <JITBinaryInfo.h>
 #endif // SYCL_EXT_JIT_ENABLE
 
 #include <functional>

--- a/sycl/source/detail/kernel_compiler/kernel_compiler_sycl.hpp
+++ b/sycl/source/detail/kernel_compiler/kernel_compiler_sycl.hpp
@@ -8,7 +8,9 @@
 
 #pragma once
 
-#include <JITBinaryInfo.h>
+#if SYCL_EXT_JIT_ENABLE
+#include "JITBinaryInfo.h"
+#endif // SYCL_EXT_JIT_ENABLE
 #include <sycl/detail/defines_elementary.hpp>
 #include <sycl/detail/export.hpp> // __SYCL_EXPORT
 #include <sycl/detail/string_view.hpp>
@@ -17,6 +19,10 @@
 
 #include <string>
 #include <vector>
+
+namespace jit_compiler {
+enum class BinaryFormat : uint32_t;
+}
 
 namespace sycl {
 inline namespace _V1 {


### PR DESCRIPTION
This fixes the compilation error if the JIT is disabled in the build as reported in #19291.