### PR TITLE
[SYCL][Unittest] Disable SYCL header warning in unittests

### DIFF
--- a/sycl/cmake/modules/AddSYCLUnitTest.cmake
+++ b/sycl/cmake/modules/AddSYCLUnitTest.cmake
@@ -115,4 +115,6 @@ macro(add_sycl_unittest test_dirname link_variant)
         -Wno-inconsistent-missing-override
     )
   endif()
+  
+  target_compile_definitions(${test_dirname} PRIVATE SYCL_DISABLE_FSYCL_SYCLHPP_WARNING)
 endmacro()


### PR DESCRIPTION
The SYCL unittests include the SYCL headers without using -fsycl. To avoid the new warning for cases that uses this include pattern, we override the warning by defining the
SYCL_DISABLE_FSYCL_SYCLHPP_WARNING preprocessor macro for all unittests.