### PR TITLE
[SYCL][ESIMD][E2E] Disable fast math for mandelbrot_spec.cpp

### DIFF
--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -9,7 +9,8 @@
 // TODO enable on Windows
 // REQUIRES: linux && gpu
 // REQUIRES: aspect-ext_intel_legacy_image
-// RUN: %{build} -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out %T/output_spec.ppm %S/golden_hw.ppm 512 -2.09798 -1.19798 0.004 4.0
 
 #include "../esimd_test_utils.hpp"


### PR DESCRIPTION
The GPU driver team recommended this change, the loss of accuracy causes it to fail, there is no real issue.