### PR TITLE
[Benchmark] detect device in benchmarks

### DIFF
--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -121,12 +121,22 @@ class ComputeBench(Suite):
     def benchmarks(self) -> list[Benchmark]:
         benches = []
 
+        # hand-picked value so that total execution time of the benchmark is
+        # similar on all architectures
+        long_lernel_exec_time_ioq = 20
+        long_kernel_exec_time_ooo = 200 if "bmg" in options.device_architecture else 20
+
         for runtime in list(RUNTIMES):
             # Add SubmitKernel benchmarks using loops
             for in_order_queue in [0, 1]:
                 for measure_completion in [0, 1]:
                     for use_events in [0, 1]:
-                        for kernel_exec_time in [1, 20]:
+                        long_kernel_exec_time = (
+                            long_lernel_exec_time_ioq
+                            if in_order_queue
+                            else long_kernel_exec_time_ooo
+                        )
+                        for kernel_exec_time in [1, long_kernel_exec_time]:
                             benches.append(
                                 SubmitKernel(
                                     self,

--- a/devops/scripts/benchmarks/main.py
+++ b/devops/scripts/benchmarks/main.py
@@ -691,6 +691,15 @@ if __name__ == "__main__":
 
     benchmark_filter = re.compile(args.filter) if args.filter else None
 
+    try:
+        options.device_architecture = get_device_architecture(additional_env_vars)
+    except Exception as e:
+        options.device_architecture = ""
+        log.warning(f"Failed to fetch device architecture: {e}")
+        log.warning("Defaulting to generic benchmark parameters.")
+
+    log.info(f"Selected device architecture: {options.device_architecture}")
+
     main(
         args.benchmark_directory,
         additional_env_vars,

--- a/devops/scripts/benchmarks/utils/validate.py
+++ b/devops/scripts/benchmarks/utils/validate.py
@@ -1,5 +1,6 @@
 import re
 
+
 class Validate:
     """Static class containing methods for validating various fields"""
 


### PR DESCRIPTION
and adjust kernel execution time for SubmitKernel
to ensure similar total execution time for BMG
and PVC.

If there is more than one device on the platform,
a warning is printed and the architecture is not set
(which means be will default to some generic benchmark arguments).

This can be extended in future - e.g. we could allow passing a specific
architecture to scripts, similarly as llvm-lit supports `sycl_devices`.