### PR TITLE
[SYCL][ESIMD][E2E] Disable fast math for second mandelbrot test

### DIFF
--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: aspect-ext_intel_legacy_image
-// RUN: %{build} -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out %T/output.ppm %S/golden_hw.ppm
 
 #include "../esimd_test_utils.hpp"


### PR DESCRIPTION
Did this for the other mandeltest test, do it for this too.