### PR TITLE
Start to reduce libdevice dependencies on libclc

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -96,15 +96,12 @@ endfunction()
 #     Custom target to create
 # * INPUT <string> ...
 #     List of bytecode files to link together
-# * RSP_DIR <string>
-#     Directory where a response file should be placed
-#     (Only needed for WIN32 or CYGWIN)
 # * DEPENDENCIES <string> ...
 #     List of extra dependencies to inject
 function(link_bc)
   cmake_parse_arguments(ARG
     "INTERNALIZE"
-    "TARGET;RSP_DIR"
+    "TARGET"
     "INPUTS;DEPENDENCIES"
     ${ARGN}
   )
@@ -113,7 +110,7 @@ function(link_bc)
   if( WIN32 OR CYGWIN )
     # Create a response file in case the number of inputs exceeds command-line
     # character limits on certain platforms.
-    file( TO_CMAKE_PATH ${ARG_RSP_DIR}/${ARG_TARGET}.rsp RSP_FILE )
+    file( TO_CMAKE_PATH ${LIBCLC_ARCH_OBJFILE_DIR}/${ARG_TARGET}.rsp RSP_FILE )
     # Turn it into a space-separate list of input files
     list( JOIN ARG_INPUTS " " RSP_INPUT )
     file( GENERATE OUTPUT ${RSP_FILE} CONTENT ${RSP_INPUT} )
@@ -414,7 +411,6 @@ function(add_libclc_builtin_set)
     link_bc(
       TARGET ${builtins_link_lib_tgt}
       INPUTS ${bytecode_files}
-      RSP_DIR ${LIBCLC_ARCH_OBJFILE_DIR}
       DEPENDENCIES ${builtins_comp_lib_tgt}
     )
   else()
@@ -425,7 +421,6 @@ function(add_libclc_builtin_set)
     link_bc(
       TARGET ${builtins_link_lib_tmp_tgt}
       INPUTS ${bytecode_files}
-      RSP_DIR ${LIBCLC_ARCH_OBJFILE_DIR}
       DEPENDENCIES ${builtins_comp_lib_tgt}
     )
     set( internal_link_depend_files )
@@ -437,7 +432,6 @@ function(add_libclc_builtin_set)
       TARGET ${builtins_link_lib_tgt}
       INPUTS $<TARGET_PROPERTY:${builtins_link_lib_tmp_tgt},TARGET_FILE>
         ${internal_link_depend_files}
-      RSP_DIR ${LIBCLC_ARCH_OBJFILE_DIR}
       DEPENDENCIES ${builtins_link_lib_tmp_tgt} ${ARG_INTERNAL_LINK_DEPENDENCIES}
     )
   endif()

--- a/libdevice/CMakeLists.txt
+++ b/libdevice/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Utility project providing various functionalities for SPIR-V devices
 # without native support of these functionalities.
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../libclc/cmake/modules/AddLibclc.cmake)
-
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"


### PR DESCRIPTION
The libdevice project included a CMake file from libclc to complete some work. This is an undesirable link for several reasons.

For one, libclc is upstream and libdevice isn't. This means that it's easy to accidentally pull in changes from upstream that alter how libdevice is built. We can see this in the FOLDER property of the link_bc target, which was set to 'libclc/Device IR/Linking'. This would be confusing for any user building DPC++ in an IDE.

For two, this sharing of code also necessitated making downstream changes to libclc, which make maintenance more difficult. This can be seen in the RSP_DIR argument to link_bc, which was never set in libclc to anything other than the upstream value.

This commit therefore starts to sever this dependency by just copying over the two utility functions to libdevice's CMake. They aren't very big and it should make any existing dependencies clearer. For example, we implicitly are relying on libclc being built so that the prepare-bultins target and executable are set up. This isn't an ideal situation but is left for future work.