### PR TITLE
[SYCL][CMAKE] Drop `nodlopen` from hardening flags

### DIFF
--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -196,8 +196,6 @@ macro(append_common_extra_security_flags)
     if(CMAKE_BUILD_TYPE MATCHES "Release")
       add_link_option_ext("-Wl,-z,now" ZNOW CMAKE_EXE_LINKER_FLAGS
                           CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
-      add_link_option_ext("-Wl,-z,nodlopen" ZDLOPEN CMAKE_EXE_LINKER_FLAGS
-                          CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
     endif()
   endif()
 endmacro()


### PR DESCRIPTION
We can't have this flag being applied globally, because it then affects SYCL RT which has plenty of libraries that are supposed to be `dlopen`ed by design.

It probably makes sense to apply `nodlopen` for some of our executables, but that should be done on a case-by-case basis.

For now, let's just fix the toolchain with hardening flags applied, any improvements can be done as a follow-up later.