### PR TITLE
[SYCL][NFC] generate_sycl_abi_symbols CMake target

### DIFF
--- a/sycl/tools/CMakeLists.txt
+++ b/sycl/tools/CMakeLists.txt
@@ -16,3 +16,22 @@ if (SYCL_ENABLE_XPTI_TRACING)
   endif()
 endif()
 
+if(WIN32)
+  set(abi_symbols_dump "${PROJECT_SOURCE_DIR}/test/abi/sycl_symbols_windows.dump")
+else()
+  set(abi_symbols_dump "${PROJECT_SOURCE_DIR}/test/abi/sycl_symbols_linux.dump")
+endif()
+add_custom_command(
+  OUTPUT "${abi_symbols_dump}"
+  COMMAND "${Python3_EXECUTABLE}"
+          "${CMAKE_CURRENT_SOURCE_DIR}/abi_check.py"
+          --mode dump_symbols
+          --llvm-bin-path "$<TARGET_FILE_DIR:llvm-readobj>"
+          --output "${abi_symbols_dump}"
+          # Note that TARGET_LINKER_FILE is required to avoid the SONAME,
+          # but on Windows it gives us the .lib file, so we use TARGET_FILE instead
+          "$<IF:$<PLATFORM_ID:Windows>,$<TARGET_FILE:sycl>,$<TARGET_LINKER_FILE:sycl>>"
+  DEPENDS sycl llvm-readobj
+  COMMENT "Generating ABI symbols dump for SYCL"
+)
+add_custom_target(generate_sycl_abi_symbols DEPENDS "${abi_symbols_dump}")


### PR DESCRIPTION
Currently developers have to manually run `abi_check.py`, but this is error prone for multiple reasons.
This patch adds a custom CMake target `generate_sycl_abi_symbols` that runs the script with the correct arguments and dependencies.

`abi_check.py` has also been updated to take `--llvm-bin-path` as an argument to replace having to specify `LLVM_BIN_PATH`. The old functionality is still supported.