### PR TITLE
[UR][Offload] Initial support for multi-device contexts

### DIFF
--- a/unified-runtime/source/adapters/offload/kernel.cpp
+++ b/unified-runtime/source/adapters/offload/kernel.cpp
@@ -29,6 +29,8 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
     return offloadResultToUR(Res);
   }
 
+  Kernel->Program = hProgram;
+
   *phKernel = Kernel;
 
   return UR_RESULT_SUCCESS;
@@ -99,7 +101,8 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
                  : static_cast<ur_mem_flags_t>(UR_MEM_FLAG_READ_WRITE);
   hKernel->Args.addMemObjArg(argIndex, hArgValue, MemAccess);
 
-  auto Ptr = std::get<BufferMem>(hArgValue->Mem).Ptr;
+  auto Ptr =
+      std::get<BufferMem>(hArgValue->Mem).getPtr(hKernel->Program->Device);
   hKernel->Args.addArg(argIndex, sizeof(void *), &Ptr);
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/offload/kernel.hpp
+++ b/unified-runtime/source/adapters/offload/kernel.hpp
@@ -79,4 +79,6 @@ struct ur_kernel_handle_t_ : RefCounted {
 
   ol_kernel_handle_t OffloadKernel;
   OffloadKernelArguments Args{};
+
+  ur_program_handle_t Program;
 };

--- a/unified-runtime/source/adapters/offload/memory.hpp
+++ b/unified-runtime/source/adapters/offload/memory.hpp
@@ -13,8 +13,27 @@
 #include "ur_api.h"
 
 #include "common.hpp"
+#include "context.hpp"
+#include "queue.hpp"
+#include "ur2offload.hpp"
 
 struct BufferMem {
+
+  enum class BufferStrategy {
+    // When pinned host memory isn't used, make a separate allocation on each
+    // device, and migrate data from the last used device to the current device
+    // when a buffer is used in an enqueue command.
+    DiscreteDeviceAllocs,
+    // When pinned host memory isn't used, make a single shared USM allocation
+    // that is visible on all devices. When a buffer is used in an enqueue
+    // command, prefetch the data to the active device.
+    // TODO: Implement this.
+    SingleSharedAlloc
+  };
+
+  // This is the most conventional implementation of buffers.
+  static constexpr auto Strategy = BufferStrategy::DiscreteDeviceAllocs;
+
   enum class AllocMode {
     Default,
     UseHostPtr,
@@ -40,8 +59,12 @@ struct BufferMem {
   };
 
   ur_mem_handle_t Parent;
-  // Underlying device pointer
-  void *Ptr;
+  // Outer UR mem holding this BufferMem in variant
+  ur_mem_handle_t OuterMemStruct;
+
+  // Underlying device pointers
+  std::vector<void *> Ptrs;
+
   // Pointer associated with this device on the host
   void *HostPtr;
   size_t Size;
@@ -49,12 +72,15 @@ struct BufferMem {
   AllocMode MemAllocMode;
   std::unordered_map<void *, BufferMap> PtrToBufferMap;
 
-  BufferMem(ur_mem_handle_t Parent, BufferMem::AllocMode Mode, void *Ptr,
+  BufferMem(ur_mem_handle_t Parent, ur_mem_handle_t OuterMemStruct,
+            ur_context_handle_t Context, BufferMem::AllocMode Mode,
             void *HostPtr, size_t Size)
-      : Parent{Parent}, Ptr{Ptr}, HostPtr{HostPtr}, Size{Size},
+      : Parent{Parent}, OuterMemStruct{OuterMemStruct},
+        Ptrs(Context->Devices.size(), nullptr), HostPtr{HostPtr}, Size{Size},
         MemAllocMode{Mode} {};
 
-  void *get() const noexcept { return Ptr; }
+  void *getPtr(ur_device_handle_t Device) const noexcept;
+
   size_t getSize() const noexcept { return Size; }
 
   BufferMap *getMapDetails(void *Map) {
@@ -95,19 +121,93 @@ struct ur_mem_handle_t_ : RefCounted {
   enum class Type { Buffer } MemType;
   ur_mem_flags_t MemFlags;
 
+  ur_mutex MemoryAllocationMutex;
+
   // For now we only support BufferMem. Eventually we'll support images, so use
   // a variant to store the underlying object.
   std::variant<BufferMem> Mem;
 
+  // For every device in the context, is it known to have the latest copy of the
+  // data. Operations modifying the buffer should invalidate it on all devices
+  // but the the one the operation occurred on.
+  std::vector<bool> DeviceIsUpToDate;
+
+  ur_queue_handle_t LastQueueWritingToMemObj{nullptr};
+
   ur_mem_handle_t_(ur_context_handle_t Context, ur_mem_handle_t Parent,
                    ur_mem_flags_t MemFlags, BufferMem::AllocMode Mode,
-                   void *Ptr, void *HostPtr, size_t Size)
+                   void *HostPtr, size_t Size)
       : Context{Context}, MemType{Type::Buffer}, MemFlags{MemFlags},
-        Mem{BufferMem{Parent, Mode, Ptr, HostPtr, Size}} {
+        Mem{BufferMem{Parent, this, Context, Mode, HostPtr, Size}},
+        DeviceIsUpToDate(Context->Devices.size(), false) {
     urContextRetain(Context);
   };
 
   ~ur_mem_handle_t_() { urContextRelease(Context); }
 
   ur_context_handle_t getContext() const noexcept { return Context; }
+
+  void *getDevicePointer(const ur_device_handle_t Device) {
+    auto DeviceIdx = Context->getDeviceIndex(Device);
+    auto &Buffer = std::get<BufferMem>(Mem);
+
+    if (auto *Ptr = Buffer.Ptrs[DeviceIdx]) {
+      return Ptr;
+    } else {
+      olMemAlloc(Device->OffloadDevice, OL_ALLOC_TYPE_DEVICE, Buffer.Size,
+                 &Buffer.Ptrs[DeviceIdx]);
+      return Buffer.Ptrs[DeviceIdx];
+    }
+  }
+
+  ur_result_t prepareDeviceAllocation(ur_device_handle_t Device) {
+    // Lock to prevent duplicate allocations in race conditions
+    ur_lock LockGuard(MemoryAllocationMutex);
+
+    auto DeviceIdx = Context->getDeviceIndex(Device);
+    auto &Buffer = std::get<BufferMem>(Mem);
+    auto DevPtr = Buffer.Ptrs[DeviceIdx];
+
+    // Allocation has already been made
+    if (DevPtr != nullptr) {
+      return UR_RESULT_SUCCESS;
+    }
+
+    if (Buffer.MemAllocMode == BufferMem::AllocMode::AllocHostPtr) {
+      // Host allocation has already been made by this point.
+      // TODO: We (probably) need something like cuMemHostGetDevicePointer
+      // for this to work everywhere. For now assume the managed host pointer is
+      // always device-accessible.
+      DevPtr = Buffer.HostPtr;
+
+    } else if (Buffer.MemAllocMode == BufferMem::AllocMode::UseHostPtr) {
+      // TODO: This code path is never used (same as the cuda adapter)
+      DevPtr = Buffer.HostPtr;
+    } else {
+      auto Res = olMemAlloc(Device->OffloadDevice, OL_ALLOC_TYPE_DEVICE,
+                            Buffer.Size, &DevPtr);
+      if (Res) {
+        return offloadResultToUR(Res);
+      }
+    }
+
+    Buffer.Ptrs[DeviceIdx] = DevPtr;
+    return UR_RESULT_SUCCESS;
+  }
+
+  void setLastQueueWritingToMemObj(ur_queue_handle_t WritingQueue) {
+    urQueueRetain(WritingQueue);
+    if (LastQueueWritingToMemObj != nullptr) {
+      urQueueRelease(LastQueueWritingToMemObj);
+    }
+    LastQueueWritingToMemObj = WritingQueue;
+    for (const auto &Device : Context->Devices) {
+      DeviceIsUpToDate[Context->getDeviceIndex(Device)] =
+          Device == WritingQueue->Device;
+    }
+  }
+
+  ur_result_t
+  enqueueMigrateMemoryToDeviceIfNeeded(const ur_device_handle_t Device,
+                                       ol_queue_handle_t Queue);
 };

--- a/unified-runtime/source/adapters/offload/program.hpp
+++ b/unified-runtime/source/adapters/offload/program.hpp
@@ -17,4 +17,5 @@
 
 struct ur_program_handle_t_ : RefCounted {
   ol_program_handle_t OffloadProgram;
+  ur_device_handle_t Device;
 };

--- a/unified-runtime/source/adapters/offload/queue.cpp
+++ b/unified-runtime/source/adapters/offload/queue.cpp
@@ -21,7 +21,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
     [[maybe_unused]] ur_context_handle_t hContext, ur_device_handle_t hDevice,
     const ur_queue_properties_t *, ur_queue_handle_t *phQueue) {
 
-  assert(hContext->Device == hDevice);
+  if (!hContext->containsDevice(hDevice)) {
+    return UR_RESULT_ERROR_INVALID_DEVICE;
+  }
 
   ur_queue_handle_t Queue = new ur_queue_handle_t_();
   auto Res = olCreateQueue(hDevice->OffloadDevice, &Queue->OffloadQueue);
@@ -31,6 +33,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
   }
 
   Queue->OffloadDevice = hDevice->OffloadDevice;
+  Queue->Device = hDevice;
 
   *phQueue = Queue;
 

--- a/unified-runtime/source/adapters/offload/queue.hpp
+++ b/unified-runtime/source/adapters/offload/queue.hpp
@@ -18,4 +18,5 @@
 struct ur_queue_handle_t_ : RefCounted {
   ol_queue_handle_t OffloadQueue;
   ol_device_handle_t OffloadDevice;
+  ur_device_handle_t Device;
 };

--- a/unified-runtime/source/adapters/offload/usm.cpp
+++ b/unified-runtime/source/adapters/offload/usm.cpp
@@ -20,30 +20,29 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMHostAlloc(ur_context_handle_t hContext,
                                                    const ur_usm_desc_t *,
                                                    ur_usm_pool_handle_t,
                                                    size_t size, void **ppMem) {
-  OL_RETURN_ON_ERR(olMemAlloc(hContext->Device->OffloadDevice,
+  // Pick any device to do the host alloc, the allocation will be accessible on
+  // any device in the platform.
+  OL_RETURN_ON_ERR(olMemAlloc(hContext->Devices[0]->OffloadDevice,
                               OL_ALLOC_TYPE_HOST, size, ppMem));
 
-  hContext->AllocTypeMap.insert_or_assign(*ppMem, OL_ALLOC_TYPE_HOST);
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMDeviceAlloc(
-    ur_context_handle_t hContext, ur_device_handle_t, const ur_usm_desc_t *,
+    ur_context_handle_t, ur_device_handle_t Device, const ur_usm_desc_t *,
     ur_usm_pool_handle_t, size_t size, void **ppMem) {
-  OL_RETURN_ON_ERR(olMemAlloc(hContext->Device->OffloadDevice,
-                              OL_ALLOC_TYPE_DEVICE, size, ppMem));
+  OL_RETURN_ON_ERR(
+      olMemAlloc(Device->OffloadDevice, OL_ALLOC_TYPE_DEVICE, size, ppMem));
 
-  hContext->AllocTypeMap.insert_or_assign(*ppMem, OL_ALLOC_TYPE_DEVICE);
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMSharedAlloc(
-    ur_context_handle_t hContext, ur_device_handle_t, const ur_usm_desc_t *,
+    ur_context_handle_t, ur_device_handle_t Device, const ur_usm_desc_t *,
     ur_usm_pool_handle_t, size_t size, void **ppMem) {
-  OL_RETURN_ON_ERR(olMemAlloc(hContext->Device->OffloadDevice,
-                              OL_ALLOC_TYPE_MANAGED, size, ppMem));
+  OL_RETURN_ON_ERR(
+      olMemAlloc(Device->OffloadDevice, OL_ALLOC_TYPE_MANAGED, size, ppMem));
 
-  hContext->AllocTypeMap.insert_or_assign(*ppMem, OL_ALLOC_TYPE_MANAGED);
   return UR_RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
This is largely based on the equivalent functionality in the CUDA and HIP adapters.

This is adequate for liboffload's current upstream AMDGPU and CUDA plugins. Future work is expected to enable Level Zero.

Also removes tracking of USM allocation types as this isn't actually used.