### PR TITLE
[NFCI][SYCL] Drop `detail::waitEvents` under preview

### DIFF
--- a/sycl/include/sycl/detail/helpers.hpp
+++ b/sycl/include/sycl/detail/helpers.hpp
@@ -40,10 +40,6 @@ enum class memory_order;
 namespace detail {
 class buffer_impl;
 
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-__SYCL_EXPORT void waitEvents(std::vector<sycl::event> DepEvents);
-#endif
-
 __SYCL_EXPORT void
 markBufferAsInternal(const std::shared_ptr<buffer_impl> &BufImpl);
 

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -25,11 +25,14 @@
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
-void waitEvents(std::vector<sycl::event> DepEvents) {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// Unused, only keeping for ABI compatibility reasons.
+__SYCL_EXPORT void waitEvents(std::vector<sycl::event> DepEvents) {
   for (auto SyclEvent : DepEvents) {
     detail::getSyclObjImpl(SyclEvent)->waitInternal();
   }
 }
+#endif
 
 __SYCL_EXPORT void
 markBufferAsInternal(const std::shared_ptr<buffer_impl> &BufImpl) {

--- a/sycl/source/detail/helpers.hpp
+++ b/sycl/source/detail/helpers.hpp
@@ -23,10 +23,6 @@ class CGExecKernel;
 class queue_impl;
 class RTDeviceBinaryImage;
 
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-void waitEvents(std::vector<sycl::event> DepEvents);
-#endif
-
 std::tuple<const RTDeviceBinaryImage *, ur_program_handle_t>
 retrieveKernelBinary(queue_impl &Queue, KernelNameStrRefT KernelName,
                      CGExecKernel *CGKernel = nullptr);


### PR DESCRIPTION
Previous `#if`s, especially declarations, made no sense to me.