### PR TITLE
[SYCL] Add validation + exception handling to SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS

### DIFF
--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -218,7 +218,7 @@ public:
         } catch (const std::invalid_argument&) {
         } catch (const std::out_of_range&) {
         }
-	    return false;
+        return false;
       };
 
       // Parse optional parameters of this form (all values required):

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -213,7 +213,8 @@ public:
       auto GuardedStoi = [](size_t &val, const std::string &str) {
         try {
           int ParsedResult = std::stoi(str);
-          if (ParsedResult < 0) return false;
+          if (ParsedResult < 0)
+            return false;
           val = ParsedResult;
           return true;
           // Ignore parsing exceptions, but throw on unexpected exceptions:
@@ -245,7 +246,8 @@ public:
         std::cerr
             << "WARNING: Invalid value passed for "
             << "SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS (Expected format "
-            << "MinRound:PreferredRound:MinRange, where MinRound, PreferredRound"
+            << "MinRound:PreferredRound:MinRange, where MinRound, "
+               "PreferredRound"
             << " > 0, MinRange >= 0). Provided parameters will be ignored."
             << std::endl;
       }

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -214,9 +214,9 @@ public:
         try {
           val = std::stoi(str);
           return true;
-        // Ignore parsing exceptions, but throw on unexpected exceptions:
-        } catch (const std::invalid_argument&) {
-        } catch (const std::out_of_range&) {
+          // Ignore parsing exceptions, but throw on unexpected exceptions:
+        } catch (const std::invalid_argument &) {
+        } catch (const std::out_of_range &) {
         }
         return false;
       };
@@ -225,8 +225,8 @@ public:
       // MinRound:PreferredRound:MinRange
       std::string Params(RoundParams);
       size_t Pos = Params.find(':');
-      if (Pos != std::string::npos &&
-          GuardedStoi(MF, Params.substr(0, Pos)) && MF > 0) {
+      if (Pos != std::string::npos && GuardedStoi(MF, Params.substr(0, Pos)) &&
+          MF > 0) {
         Params.erase(0, Pos + 1);
         Pos = Params.find(':');
         if (Pos != std::string::npos &&
@@ -248,7 +248,8 @@ public:
           << "WARNING: Invalid value passed for "
           << "SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS (Expected format "
           << "MinRound:PreferredRound:MinRange, where MinRound, PreferredRound"
-          << " > 0). Provided parameters will be ignored." << std::endl;
+          << " > 0, MinRange >= 0). Provided parameters will be ignored."
+          << std::endl;
     }
   }
 };

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -205,29 +205,51 @@ public:
       return;
 
     static bool ProcessedFactors = false;
+    static bool FactorsAreValid = false;
     static size_t MF;
     static size_t GF;
     static size_t MR;
     if (!ProcessedFactors) {
+      auto GuardedStoi = [](size_t &val, const std::string &str) {
+        try {
+          val = std::stoi(str);
+          return true;
+        // Ignore parsing exceptions, but throw on unexpected exceptions:
+        } catch (const std::invalid_argument&) {
+        } catch (const std::out_of_range&) {
+        }
+	    return false;
+      };
+
       // Parse optional parameters of this form (all values required):
       // MinRound:PreferredRound:MinRange
       std::string Params(RoundParams);
       size_t Pos = Params.find(':');
-      if (Pos != std::string::npos) {
-        MF = std::stoi(Params.substr(0, Pos));
+      if (Pos != std::string::npos &&
+          GuardedStoi(MF, Params.substr(0, Pos)) && MF > 0) {
         Params.erase(0, Pos + 1);
         Pos = Params.find(':');
-        if (Pos != std::string::npos) {
-          GF = std::stoi(Params.substr(0, Pos));
+        if (Pos != std::string::npos &&
+            GuardedStoi(GF, Params.substr(0, Pos)) && GF > 0) {
           Params.erase(0, Pos + 1);
-          MR = std::stoi(Params);
+          // Factors are valid only if all parsed successfully:
+          FactorsAreValid = GuardedStoi(MR, Params);
+          // Note that MinRange = 0 is considered valid.
         }
       }
       ProcessedFactors = true;
     }
-    MinFactor = MF;
-    GoodFactor = GF;
-    MinRange = MR;
+    if (FactorsAreValid) {
+      MinFactor = MF;
+      GoodFactor = GF;
+      MinRange = MR;
+    } else {
+      std::cerr
+          << "WARNING: Invalid value passed for "
+          << "SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS (Expected format "
+          << "MinRound:PreferredRound:MinRange, where MinRound, PreferredRound"
+          << " > 0). Provided parameters will be ignored." << std::endl;
+    }
   }
 };
 

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -238,18 +238,19 @@ public:
         }
       }
       ProcessedFactors = true;
+      if (!FactorsAreValid) {
+        std::cerr
+            << "WARNING: Invalid value passed for "
+            << "SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS (Expected format "
+            << "MinRound:PreferredRound:MinRange, where MinRound, PreferredRound"
+            << " > 0, MinRange >= 0). Provided parameters will be ignored."
+            << std::endl;
+      }
     }
     if (FactorsAreValid) {
       MinFactor = MF;
       GoodFactor = GF;
       MinRange = MR;
-    } else {
-      std::cerr
-          << "WARNING: Invalid value passed for "
-          << "SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS (Expected format "
-          << "MinRound:PreferredRound:MinRange, where MinRound, PreferredRound"
-          << " > 0, MinRange >= 0). Provided parameters will be ignored."
-          << std::endl;
     }
   }
 };

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -476,13 +476,16 @@ TEST(ConfigTests, CheckParallelForRangeRoundingParams) {
 
   // Lambda to test invalid input -- factors should remain unchanged.
   auto TestBadInput = [&](const char *value, const char *errMsg) {
-    size_t MF = 1, GF = 2, MR = 3;
+    // Original factor values are stored as its own variable as size of size_t
+    // varies depending on system and architecture:
+    constexpr size_t MF = 1, GF = 2, MR = 3;
+    size_t TestMF = MF, TestGF = GF, TestMR = MR;
     SetRoundingParams(value);
-    SYCLConfig<SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS>::GetSettings(MF, GF, MR,
-                                                                     true);
-    EXPECT_EQ(MF, 1) << errMsg;
-    EXPECT_EQ(GF, 2) << errMsg;
-    EXPECT_EQ(MR, 3) << errMsg;
+    SYCLConfig<SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS>::GetSettings(
+      TestMF, TestGF, TestMR, true);
+    EXPECT_EQ(TestMF, MF) << errMsg;
+    EXPECT_EQ(TestGF, GF) << errMsg;
+    EXPECT_EQ(TestMR, MR) << errMsg;
   };
 
   // Test malformed input:

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -449,3 +449,61 @@ TEST(ConfigTests, CheckPersistentCacheEvictionThresholdTest) {
   OnDiskEvicType::reset();
   TestConfig(0);
 }
+
+// SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS accepts ...
+TEST(ConfigTests, CheckParallelForRangeRoundingParams) {
+
+  // Lambda to set SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS.
+  auto SetRoundingParams = [](const char *value) {
+#ifdef _WIN32
+    _putenv_s("SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS", value);
+#else
+    setenv("SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS", value, 1);
+#endif
+    sycl::detail::readConfig(true);
+  };
+
+  // Lambda to assert test parameters are as expected.
+  auto AssertRoundingParams = [](size_t MF, size_t GF, size_t MR, const char* errMsg, bool ForceUpdate = false) {
+    size_t ResultMF = 0, ResultGF = 0, ResultMR = 0;
+    SYCLConfig<SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS>::GetSettings(
+      ResultMF, ResultGF, ResultMR, ForceUpdate);
+    EXPECT_EQ(MF, ResultMF) << errMsg;
+    EXPECT_EQ(GF, ResultGF) << errMsg;
+    EXPECT_EQ(MR, ResultMR) << errMsg;
+  };
+
+  // Lambda to test invalid input -- factors should remain unchanged.
+  auto TestBadInput = [&](const char *value, const char* errMsg) {
+    size_t MF = 1, GF = 2, MR = 3;
+    SetRoundingParams(value);
+    SYCLConfig<SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS>::GetSettings(
+      MF, GF, MR, true);
+    EXPECT_EQ(MF, 1) << errMsg;
+    EXPECT_EQ(GF, 2) << errMsg;
+    EXPECT_EQ(MR, 3) << errMsg;
+  };
+
+  // Test malformed input:
+  constexpr char MalformedErr[] = "Rounding parameters should be ignored on malformed input";
+  TestBadInput("abc", MalformedErr);
+  TestBadInput("42", MalformedErr);
+  TestBadInput(":7", MalformedErr);
+  TestBadInput("7:", MalformedErr);
+  TestBadInput("1:2", MalformedErr);
+  TestBadInput("1:2:", MalformedErr);
+  TestBadInput("1:abc:3", MalformedErr);
+
+  // Test well-formed input, but bad parameters:
+  constexpr char BadParamsErr[] = "Rounding parameters should be ignored if parameters provided are invalid";
+  TestBadInput("0:1:2", BadParamsErr);
+  TestBadInput("1:0:2", BadParamsErr);
+  TestBadInput("-1:2:3", BadParamsErr);
+  TestBadInput("1:2:31415926535897932384626433832795028841971", BadParamsErr);
+
+  // Test valid values.
+  SetRoundingParams("8:16:32");
+  AssertRoundingParams(8, 16, 32, "Failed to read rounding parameters properly");
+  SetRoundingParams("8:16:0");
+  AssertRoundingParams(8, 16, 0, "0 is a valid value for MinRange", /*ForceUpdate =*/ true);
+}

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -482,7 +482,7 @@ TEST(ConfigTests, CheckParallelForRangeRoundingParams) {
     size_t TestMF = MF, TestGF = GF, TestMR = MR;
     SetRoundingParams(value);
     SYCLConfig<SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS>::GetSettings(
-      TestMF, TestGF, TestMR, true);
+        TestMF, TestGF, TestMR, true);
     EXPECT_EQ(TestMF, MF) << errMsg;
     EXPECT_EQ(TestGF, GF) << errMsg;
     EXPECT_EQ(TestMR, MR) << errMsg;

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -464,28 +464,30 @@ TEST(ConfigTests, CheckParallelForRangeRoundingParams) {
   };
 
   // Lambda to assert test parameters are as expected.
-  auto AssertRoundingParams = [](size_t MF, size_t GF, size_t MR, const char* errMsg, bool ForceUpdate = false) {
+  auto AssertRoundingParams = [](size_t MF, size_t GF, size_t MR,
+                                 const char *errMsg, bool ForceUpdate = false) {
     size_t ResultMF = 0, ResultGF = 0, ResultMR = 0;
     SYCLConfig<SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS>::GetSettings(
-      ResultMF, ResultGF, ResultMR, ForceUpdate);
+        ResultMF, ResultGF, ResultMR, ForceUpdate);
     EXPECT_EQ(MF, ResultMF) << errMsg;
     EXPECT_EQ(GF, ResultGF) << errMsg;
     EXPECT_EQ(MR, ResultMR) << errMsg;
   };
 
   // Lambda to test invalid input -- factors should remain unchanged.
-  auto TestBadInput = [&](const char *value, const char* errMsg) {
+  auto TestBadInput = [&](const char *value, const char *errMsg) {
     size_t MF = 1, GF = 2, MR = 3;
     SetRoundingParams(value);
-    SYCLConfig<SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS>::GetSettings(
-      MF, GF, MR, true);
+    SYCLConfig<SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS>::GetSettings(MF, GF, MR,
+                                                                     true);
     EXPECT_EQ(MF, 1) << errMsg;
     EXPECT_EQ(GF, 2) << errMsg;
     EXPECT_EQ(MR, 3) << errMsg;
   };
 
   // Test malformed input:
-  constexpr char MalformedErr[] = "Rounding parameters should be ignored on malformed input";
+  constexpr char MalformedErr[] =
+      "Rounding parameters should be ignored on malformed input";
   TestBadInput("abc", MalformedErr);
   TestBadInput("42", MalformedErr);
   TestBadInput(":7", MalformedErr);
@@ -495,7 +497,8 @@ TEST(ConfigTests, CheckParallelForRangeRoundingParams) {
   TestBadInput("1:abc:3", MalformedErr);
 
   // Test well-formed input, but bad parameters:
-  constexpr char BadParamsErr[] = "Rounding parameters should be ignored if parameters provided are invalid";
+  constexpr char BadParamsErr[] = "Rounding parameters should be ignored if "
+                                  "parameters provided are invalid";
   TestBadInput("0:1:2", BadParamsErr);
   TestBadInput("1:0:2", BadParamsErr);
   TestBadInput("-1:2:3", BadParamsErr);
@@ -503,7 +506,9 @@ TEST(ConfigTests, CheckParallelForRangeRoundingParams) {
 
   // Test valid values.
   SetRoundingParams("8:16:32");
-  AssertRoundingParams(8, 16, 32, "Failed to read rounding parameters properly");
+  AssertRoundingParams(8, 16, 32,
+                       "Failed to read rounding parameters properly");
   SetRoundingParams("8:16:0");
-  AssertRoundingParams(8, 16, 0, "0 is a valid value for MinRange", /*ForceUpdate =*/ true);
+  AssertRoundingParams(8, 16, 0, "0 is a valid value for MinRange",
+                       /*ForceUpdate =*/true);
 }


### PR DESCRIPTION
Bad / nonsensical values in `SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS` result in division by 0 crashes. This PR:
- Adds guards to check that range rounding factors are set to sensical values
- Adds test to ensure only valid range rounding factors can be set