### PR TITLE
[SYCL] Use `std::move` instead of copy

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -64,7 +64,7 @@ context_impl::context_impl(ur_context_handle_t UrContext,
                            async_handler AsyncHandler, adapter_impl &Adapter,
                            const std::vector<sycl::device> &DeviceList,
                            bool OwnedByRuntime, private_tag)
-    : MOwnedByRuntime(OwnedByRuntime), MAsyncHandler(AsyncHandler),
+    : MOwnedByRuntime(OwnedByRuntime), MAsyncHandler(std::move(AsyncHandler)),
       MDevices(DeviceList), MContext(UrContext), MPlatform(),
       MSupportBufferLocationByDevices(NotChecked) {
   if (!MDevices.empty()) {

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -68,7 +68,7 @@ public:
 
   context_impl(ur_context_handle_t UrContext, async_handler AsyncHandler,
                adapter_impl &Adapter, private_tag tag)
-      : context_impl(UrContext, AsyncHandler, Adapter,
+      : context_impl(UrContext, std::move(AsyncHandler), Adapter,
                      std::vector<sycl::device>{},
                      /*OwnedByRuntime*/ true, tag) {}
 

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -124,7 +124,7 @@ public:
   // Interop constructor
   kernel_bundle_impl(context Ctx, std::vector<device> Devs,
                      device_image_plain &DevImage, private_tag Tag)
-      : kernel_bundle_impl(Ctx, Devs, Tag) {
+      : kernel_bundle_impl(std::move(Ctx), std::move(Devs), Tag) {
     MDeviceImages.emplace_back(DevImage);
     MUniqueDeviceImages.emplace_back(DevImage);
   }

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -143,7 +143,7 @@ std::vector<platform> platform_impl::getAdapterPlatforms(AdapterPtr &Adapter,
 
     if (!Supported) {
       if (IsBanned || !HasAnyDevices) {
-        Platforms.push_back(Platform);
+        Platforms.push_back(std::move(Platform));
       }
     } else {
       if (IsBanned) {
@@ -155,7 +155,7 @@ std::vector<platform> platform_impl::getAdapterPlatforms(AdapterPtr &Adapter,
       // 2020 4.6.2 ) If we have an empty platform, we don't report it back
       // from platform::get_platforms().
       if (HasAnyDevices) {
-        Platforms.push_back(Platform);
+        Platforms.push_back(std::move(Platform));
       }
     }
   }

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -442,7 +442,7 @@ static void appendCompileOptionsFromImage(std::string &CompileOpts,
       // Extract everything after this option and add it to the above.
       if (EndOfOpt != std::string::npos)
         NewCompileOpts += CompileOpts.substr(EndOfOpt);
-      CompileOpts = NewCompileOpts;
+      CompileOpts = std::move(NewCompileOpts);
       OptPos = CompileOpts.find(TargetRegisterAllocMode);
     }
     constexpr std::string_view ReplaceOpts[] = {"-foffload-fp32-prec-div",

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3803,7 +3803,7 @@ UpdateCommandBufferCommand::UpdateCommandBufferCommand(
     std::vector<std::shared_ptr<ext::oneapi::experimental::detail::node_impl>>
         Nodes)
     : Command(CommandType::UPDATE_CMD_BUFFER, Queue), MGraph(Graph),
-      MNodes(Nodes) {}
+      MNodes(std::move(Nodes)) {}
 
 ur_result_t UpdateCommandBufferCommand::enqueueImp() {
   waitForPreparedHostEvents();

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -224,8 +224,8 @@ Scheduler::GraphBuilder::getOrInsertMemObjRecord(queue_impl *Queue,
     std::shared_ptr<queue_impl> InteropQueuePtr = queue_impl::create(
         Dev, *InteropCtxPtr, async_handler{}, property_list{});
 
-    MemObject->MRecord.reset(
-        new MemObjRecord{InteropCtxPtr, LeafLimit, AllocateDependency});
+    MemObject->MRecord.reset(new MemObjRecord{InteropCtxPtr, LeafLimit,
+                                              std::move(AllocateDependency)});
     std::vector<Command *> ToEnqueue;
     getOrCreateAllocaForReq(MemObject->MRecord.get(), Req,
                             InteropQueuePtr.get(), ToEnqueue);
@@ -234,7 +234,8 @@ Scheduler::GraphBuilder::getOrInsertMemObjRecord(queue_impl *Queue,
                                 "alloca or exceeding the leaf limit).");
   } else
     MemObject->MRecord.reset(new MemObjRecord{queue_impl::getContext(Queue),
-                                              LeafLimit, AllocateDependency});
+                                              LeafLimit,
+                                              std::move(AllocateDependency)});
 
   MMemObjs.push_back(MemObject);
   return MemObject->MRecord.get();
@@ -1347,7 +1348,7 @@ Command *Scheduler::GraphBuilder::addCommandGraphUpdate(
         e->getCommand() == static_cast<Command *>(NewCmd.get())) {
       continue;
     }
-    if (Command *ConnCmd = NewCmd->addDep(e, ToCleanUp))
+    if (Command *ConnCmd = NewCmd->addDep(std::move(e), ToCleanUp))
       ToEnqueue.push_back(ConnCmd);
   }
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -655,7 +655,8 @@ EventImplPtr Scheduler::addCommandGraphUpdate(
     WriteLockT Lock = acquireWriteLock();
 
     Command *NewCmd = MGraphBuilder.addCommandGraphUpdate(
-        Graph, Nodes, Queue, Requirements, Events, AuxiliaryCmds);
+        Graph, std::move(Nodes), Queue, std::move(Requirements), Events,
+        AuxiliaryCmds);
     if (!NewCmd)
       return nullptr;
     NewCmdEvent = NewCmd->getEvent();

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -200,7 +200,7 @@ struct MemObjRecord {
   MemObjRecord(context_impl *Ctx, std::size_t LeafLimit,
                LeavesCollection::AllocateDependencyF AllocateDependency)
       : MReadLeaves{this, LeafLimit, AllocateDependency},
-        MWriteLeaves{this, LeafLimit, AllocateDependency},
+        MWriteLeaves{this, LeafLimit, std::move(AllocateDependency)},
         MCurContext{Ctx ? Ctx->shared_from_this() : nullptr} {}
   // Contains all allocation commands for the memory object.
   std::vector<AllocaCommandBase *> MAllocaCommands;


### PR DESCRIPTION
Coverity suggested these fixes.