### PR TITLE
[SYCL][NFC] Add user-defined destructor and assignment operator

### DIFF
--- a/sycl/source/detail/graph/memory_pool.hpp
+++ b/sycl/source/detail/graph/memory_pool.hpp
@@ -73,6 +73,9 @@ public:
   /// Memory pool cannot be copied
   graph_mem_pool(graph_mem_pool &) = delete;
 
+  /// Memory pool cannot be assigned
+  graph_mem_pool &operator=(const graph_mem_pool &) = delete;
+
   /// Get a pointer to a new allocation. For device allocations these are
   /// virtual reservations which must be later mapped to allocated physical
   /// memory before use by calling allocateAndMapAll()

--- a/sycl/source/detail/graph/node_impl.hpp
+++ b/sycl/source/detail/graph/node_impl.hpp
@@ -183,6 +183,9 @@ public:
     }
     return *this;
   }
+
+  ~node_impl() {}
+
   /// Checks if this node should be a dependency of another node based on
   /// accessor requirements. This is calculated using access modes if a
   /// requirement to the same buffer is found inside this node.


### PR DESCRIPTION
Coverity suggested to add these to follow the rule-of-three (https://en.cppreference.com/w/cpp/language/rule_of_three.html)