### PR TITLE
[NFC] Remove extra line from the test

### DIFF
--- a/llvm/test/Bitcode/invalid.test
+++ b/llvm/test/Bitcode/invalid.test
@@ -1,6 +1,5 @@
 RUN: export LSAN_OPTIONS=detect_leaks=0
 RUN: not llvm-dis -disable-output %p/Inputs/invalid-empty.bc 2>&1 | \
-RUN: not llvm-dis -disable-output %p/Inputs/invalid-empty.bc 2>&1 | \
 RUN:   FileCheck --check-prefix=INVALID-EMPTY %s
 RUN: not llvm-dis -disable-output %p/Inputs/invalid-pr20485.bc 2>&1 | \
 RUN:   FileCheck --check-prefix=INVALID-ENCODING %s


### PR DESCRIPTION
The duplicate line accidentally appeared during conflict resolution in https://github.com/intel/llvm/commit/a03339b2c144e8b8c95a7a677da24f438c2e3056#diff-ace782300c94221dade4e5f02a303d4b47440f4d43b8f3915d15ce37a59f3cf9R2