### PR TITLE
[SYCL][ESIMD] Make get_hw_thread_id to return 0

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -2481,19 +2481,11 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
 
 /// Get HW Thread ID
 __ESIMD_API int32_t get_hw_thread_id() {
-#ifdef __SYCL_DEVICE_ONLY__
-  return __spirv_BuiltInGlobalHWThreadIDINTEL();
-#else
-  return std::rand();
-#endif // __SYCL_DEVICE_ONLY__
+  return 0;
 }
 /// Get subdevice ID
 __ESIMD_API int32_t get_subdevice_id() {
-#ifdef __SYCL_DEVICE_ONLY__
-  return __spirv_BuiltInSubDeviceIDINTEL();
-#else
   return 0;
-#endif
 }
 
 /// @} sycl_esimd_hw_thread_queries

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -2480,13 +2480,9 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
 /// @{
 
 /// Get HW Thread ID
-__ESIMD_API int32_t get_hw_thread_id() {
-  return 0;
-}
+__ESIMD_API int32_t get_hw_thread_id() { return 0; }
 /// Get subdevice ID
-__ESIMD_API int32_t get_subdevice_id() {
-  return 0;
-}
+__ESIMD_API int32_t get_subdevice_id() { return 0; }
 
 /// @} sycl_esimd_hw_thread_queries
 

--- a/sycl/test-e2e/ESIMD/thread_id_test.cpp
+++ b/sycl/test-e2e/ESIMD/thread_id_test.cpp
@@ -62,19 +62,13 @@ int test_thread_id() {
 
   int Result = 0;
 
-  // Check if all returned elements are non negative
+  // Check if all returned elements are zero
   Result |=
       !std::all_of(VectorOutputSubdeviceId.begin(),
-                   VectorOutputSubdeviceId.end(), [](int i) { return i >= 0; });
+                   VectorOutputSubdeviceId.end(), [](int i) { return i == 0; });
   Result |=
       !std::all_of(VectorOutputThreadId.begin(), VectorOutputThreadId.end(),
-                   [](int i) { return i >= 0; });
-
-  // Check if returned values are not the same
-  std::sort(VectorOutputThreadId.begin(), VectorOutputThreadId.end());
-  Result |=
-      std::equal(VectorOutputThreadId.begin() + 1, VectorOutputThreadId.end(),
-                 VectorOutputThreadId.begin());
+                   [](int i) { return i == 0; });
 
   return Result;
 }


### PR DESCRIPTION
Same for sub device id API. The appropriate SPIR-V extension used for them previously is deprecated.