### PR TITLE
[CI] Fix detecting usage of private emails

### DIFF
--- a/.github/workflows/email-check.yaml
+++ b/.github/workflows/email-check.yaml
@@ -21,14 +21,30 @@ jobs:
 
       - name: Extract author email
         id: author
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git log -1
-          echo "EMAIL=$(git show -s --format='%ae' HEAD~0)" >> $GITHUB_OUTPUT
+          # Use Github GraphQL APIs to get the email associated with the PR author because this takes into account the GitHub settings for email privacy.
+          query='
+          query($login: String!) {
+            user(login: $login) {
+              email
+            }
+          }'
+
+          PR_AUTHOR=${{ github.event.pull_request.user.login }}
+
+          email=$(gh api graphql -f login="$PR_AUTHOR" -f query="$query" --jq '.data.user.email')
+          echo "EMAIL_AUTHOR_GH_UI=$email" >> "$GITHUB_OUTPUT"
+
           # Create empty comment file
           echo "[]" > comments
 
+      # When EMAIL_AUTHOR_GH_UI is NULL, author's email is hidden in GitHub UI.
+      # In this case, we warn the user to turn off "Keep my email addresses private"
+      # setting in their account.
       - name: Validate author email
-        if: ${{ endsWith(steps.author.outputs.EMAIL, 'noreply.github.com')  }}
+        if: ${{ steps.author.outputs.EMAIL_AUTHOR_GH_UI == '' }}
         env:
           COMMENT: >-
             ⚠️ We detected that you are using a GitHub private e-mail address to contribute to the repo.<br/>

--- a/.github/workflows/email-check.yaml
+++ b/.github/workflows/email-check.yaml
@@ -55,6 +55,9 @@ jobs:
           [{"body" : "$COMMENT"}]
           EOF
 
+          # Fail this job.
+          false
+
       - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
         if: always()
         with:


### PR DESCRIPTION
fixes https://github.com/intel/llvm/issues/17675

Currently, in the workflow, we only check the email that was used for the latest commit in the PR. This email can differ from the email settings on the GH UI, from which PR will be authored, once we merge it.