### PR TITLE
[SYCL][NFC] Prepare for `-Wconversion` [1/N]

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -231,7 +231,7 @@ make_kernel_bundle(ur_native_handle_t NativeHandle,
     case (UR_PROGRAM_BINARY_TYPE_NONE):
       if (State == bundle_state::object) {
         auto Res = Adapter.call_nocheck<UrApiKind::urProgramCompileExp>(
-            UrProgram, 1, &Dev, nullptr);
+            UrProgram, 1u, &Dev, nullptr);
         if (Res == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
           Res = Adapter.call_nocheck<UrApiKind::urProgramCompile>(
               ContextImpl.getHandleRef(), UrProgram, nullptr);
@@ -241,7 +241,7 @@ make_kernel_bundle(ur_native_handle_t NativeHandle,
 
       else if (State == bundle_state::executable) {
         auto Res = Adapter.call_nocheck<UrApiKind::urProgramBuildExp>(
-            UrProgram, 1, &Dev, nullptr);
+            UrProgram, 1u, &Dev, nullptr);
         if (Res == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
           Res = Adapter.call_nocheck<UrApiKind::urProgramBuild>(
               ContextImpl.getHandleRef(), UrProgram, nullptr);
@@ -260,11 +260,11 @@ make_kernel_bundle(ur_native_handle_t NativeHandle,
       if (State == bundle_state::executable) {
         ur_program_handle_t UrLinkedProgram = nullptr;
         auto Res = Adapter.call_nocheck<UrApiKind::urProgramLinkExp>(
-            ContextImpl.getHandleRef(), 1, &Dev, 1, &UrProgram, nullptr,
+            ContextImpl.getHandleRef(), 1u, &Dev, 1u, &UrProgram, nullptr,
             &UrLinkedProgram);
         if (Res == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
           Res = Adapter.call_nocheck<UrApiKind::urProgramLink>(
-              ContextImpl.getHandleRef(), 1, &UrProgram, nullptr,
+              ContextImpl.getHandleRef(), 1u, &UrProgram, nullptr,
               &UrLinkedProgram);
         }
         Adapter.checkUrResult<errc::build>(Res);

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -79,7 +79,7 @@ context::context(cl_context ClContext, async_handler AsyncHandler) {
   ur_native_handle_t nativeHandle =
       reinterpret_cast<ur_native_handle_t>(ClContext);
   Adapter.call<detail::UrApiKind::urContextCreateWithNativeHandle>(
-      nativeHandle, Adapter.getUrAdapter(), 0, nullptr, nullptr, &hContext);
+      nativeHandle, Adapter.getUrAdapter(), 0u, nullptr, nullptr, &hContext);
 
   impl = detail::context_impl::create(hContext, AsyncHandler, Adapter);
 }

--- a/sycl/source/detail/adapter_impl.hpp
+++ b/sycl/source/detail/adapter_impl.hpp
@@ -95,7 +95,7 @@ public:
   std::vector<ur_platform_handle_t> &getUrPlatforms() {
     std::call_once(PlatformsPopulated, [&]() {
       uint32_t platformCount = 0;
-      call<UrApiKind::urPlatformGet>(MAdapter, 0, nullptr, &platformCount);
+      call<UrApiKind::urPlatformGet>(MAdapter, 0u, nullptr, &platformCount);
       UrPlatforms.resize(platformCount);
       if (platformCount) {
         call<UrApiKind::urPlatformGet>(MAdapter, platformCount,

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -440,8 +440,8 @@ std::vector<ur_event_handle_t> context_impl::initializeDeviceGlobals(
       void *const &USMPtr = DeviceGlobalUSM.getPtr();
       Adapter.call<UrApiKind::urEnqueueDeviceGlobalVariableWrite>(
           QueueImpl.getHandleRef(), NativePrg,
-          DeviceGlobalEntry->MUniqueId.c_str(), false, sizeof(void *), 0,
-          &USMPtr, 0, nullptr, &InitEvent);
+          DeviceGlobalEntry->MUniqueId.c_str(), false, sizeof(void *), 0u,
+          &USMPtr, 0u, nullptr, &InitEvent);
 
       InitEventsRef.push_back(InitEvent);
     }

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -1259,7 +1259,7 @@ private:
     // Get the kernel names.
     size_t KernelNamesSize;
     Adapter.call<UrApiKind::urProgramGetInfo>(
-        UrProgram, UR_PROGRAM_INFO_KERNEL_NAMES, 0, nullptr, &KernelNamesSize);
+        UrProgram, UR_PROGRAM_INFO_KERNEL_NAMES, 0u, nullptr, &KernelNamesSize);
 
     // semi-colon delimited list of kernel names.
     std::string KernelNamesStr(KernelNamesSize, ' ');

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -271,7 +271,7 @@ std::vector<device> device_impl::create_sub_devices(
   uint32_t SubDevicesCount = 0;
   adapter_impl &Adapter = getAdapter();
   Adapter.call<sycl::errc::invalid, UrApiKind::urDevicePartition>(
-      MDevice, &Properties, 0, nullptr, &SubDevicesCount);
+      MDevice, &Properties, 0u, nullptr, &SubDevicesCount);
 
   return create_sub_devices(&Properties, SubDevicesCount);
 }
@@ -295,7 +295,7 @@ std::vector<device> device_impl::create_sub_devices() const {
 
   uint32_t SubDevicesCount = 0;
   adapter_impl &Adapter = getAdapter();
-  Adapter.call<UrApiKind::urDevicePartition>(MDevice, &Properties, 0, nullptr,
+  Adapter.call<UrApiKind::urDevicePartition>(MDevice, &Properties, 0u, nullptr,
                                              &SubDevicesCount);
 
   return create_sub_devices(&Properties, SubDevicesCount);

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -114,7 +114,7 @@ class device_impl : public std::enable_shared_from_this<device_impl> {
   bool has_info_desc(ur_device_info_t Desc) const {
     size_t return_size = 0;
     return getAdapter().call_nocheck<UrApiKind::urDeviceGetInfo>(
-               MDevice, Desc, 0, nullptr, &return_size) == UR_RESULT_SUCCESS;
+               MDevice, Desc, 0u, nullptr, &return_size) == UR_RESULT_SUCCESS;
   }
 
   // This should really be
@@ -153,7 +153,7 @@ class device_impl : public std::enable_shared_from_this<device_impl> {
           !check_type_in_v<typename ur_ret_t::value_type, bool, std::string>);
       size_t ResultSize = 0;
       ur_result_t Error = getAdapter().call_nocheck<UrApiKind::urDeviceGetInfo>(
-          getHandleRef(), Desc, 0, nullptr, &ResultSize);
+          getHandleRef(), Desc, 0u, nullptr, &ResultSize);
       if (Error != UR_RESULT_SUCCESS)
         return {Error};
       if (ResultSize == 0)
@@ -186,7 +186,7 @@ class device_impl : public std::enable_shared_from_this<device_impl> {
         return urGetInfoString<UrApiKind::urDeviceGetInfo>(*this, Desc);
       } else if constexpr (is_std_vector_v<ur_ret_t>) {
         size_t ResultSize = 0;
-        getAdapter().call<UrApiKind::urDeviceGetInfo>(getHandleRef(), Desc, 0,
+        getAdapter().call<UrApiKind::urDeviceGetInfo>(getHandleRef(), Desc, 0u,
                                                       nullptr, &ResultSize);
         if (ResultSize == 0)
           return ur_ret_t{};

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -524,7 +524,7 @@ ur_native_handle_t event_impl::getNative() {
     ur_event_native_properties_t NativeProperties{};
     ur_event_handle_t UREvent = nullptr;
     Adapter.call<UrApiKind::urEventCreateWithNativeHandle>(
-        0, TempContext, &NativeProperties, &UREvent);
+        0u, TempContext, &NativeProperties, &UREvent);
     this->setHandle(UREvent);
     Handle = UREvent;
   }

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -51,7 +51,7 @@ get_kernel_info(ur_kernel_handle_t Kernel, adapter_impl &Adapter) {
   size_t ResultSize = 0;
 
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Adapter.call<UrApiKind::urKernelGetInfo>(Kernel, UrInfoCode<Param>::value, 0,
+  Adapter.call<UrApiKind::urKernelGetInfo>(Kernel, UrInfoCode<Param>::value, 0u,
                                            nullptr, &ResultSize);
   if (ResultSize == 0) {
     return "";
@@ -176,7 +176,7 @@ get_kernel_device_specific_info<
 
   // First call to get the number of device images
   Adapter.call<UrApiKind::urKernelGetInfo>(
-      Kernel, UR_KERNEL_INFO_SPILL_MEM_SIZE, 0, nullptr, &ResultSize);
+      Kernel, UR_KERNEL_INFO_SPILL_MEM_SIZE, 0u, nullptr, &ResultSize);
 
   size_t DeviceCount = ResultSize / sizeof(uint32_t);
 
@@ -192,8 +192,8 @@ get_kernel_device_specific_info<
                                            &Program, nullptr);
   // Retrieve the associated device list
   size_t URDevicesSize = 0;
-  Adapter.call<UrApiKind::urProgramGetInfo>(Program, UR_PROGRAM_INFO_DEVICES, 0,
-                                            nullptr, &URDevicesSize);
+  Adapter.call<UrApiKind::urProgramGetInfo>(Program, UR_PROGRAM_INFO_DEVICES,
+                                            0u, nullptr, &URDevicesSize);
 
   std::vector<ur_device_handle_t> URDevices(URDevicesSize /
                                             sizeof(ur_device_handle_t));

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -927,7 +927,7 @@ void MemoryManager::prefetch_usm(void *Mem, queue_impl &Queue, size_t Length,
                                  ur_event_handle_t *OutEvent) {
   adapter_impl &Adapter = Queue.getAdapter();
   Adapter.call<UrApiKind::urEnqueueUSMPrefetch>(Queue.getHandleRef(), Mem,
-                                                Length, 0, DepEvents.size(),
+                                                Length, 0u, DepEvents.size(),
                                                 DepEvents.data(), OutEvent);
 }
 
@@ -1263,7 +1263,7 @@ void MemoryManager::ext_oneapi_copyD2D_cmd_buffer(
     Adapter.call<UrApiKind::urCommandBufferAppendMemBufferCopyExp>(
         CommandBuffer, sycl::detail::ur::cast<ur_mem_handle_t>(SrcMem),
         sycl::detail::ur::cast<ur_mem_handle_t>(DstMem), SrcXOffBytes,
-        DstXOffBytes, SrcAccessRangeWidthBytes, Deps.size(), Deps.data(), 0,
+        DstXOffBytes, SrcAccessRangeWidthBytes, Deps.size(), Deps.data(), 0u,
         nullptr, OutSyncPoint, nullptr, nullptr);
   } else {
     // passing 0 for pitches not allowed. Because clEnqueueCopyBufferRect will
@@ -1290,7 +1290,7 @@ void MemoryManager::ext_oneapi_copyD2D_cmd_buffer(
         CommandBuffer, sycl::detail::ur::cast<ur_mem_handle_t>(SrcMem),
         sycl::detail::ur::cast<ur_mem_handle_t>(DstMem), SrcOrigin, DstOrigin,
         Region, SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-        Deps.size(), Deps.data(), 0, nullptr, OutSyncPoint, nullptr, nullptr);
+        Deps.size(), Deps.data(), 0u, nullptr, OutSyncPoint, nullptr, nullptr);
   }
 }
 
@@ -1328,7 +1328,7 @@ void MemoryManager::ext_oneapi_copyD2H_cmd_buffer(
         Adapter.call_nocheck<UrApiKind::urCommandBufferAppendMemBufferReadExp>(
             CommandBuffer, sycl::detail::ur::cast<ur_mem_handle_t>(SrcMem),
             SrcXOffBytes, SrcAccessRangeWidthBytes, DstMem + DstXOffBytes,
-            Deps.size(), Deps.data(), 0, nullptr, OutSyncPoint, nullptr,
+            Deps.size(), Deps.data(), 0u, nullptr, OutSyncPoint, nullptr,
             nullptr);
 
     if (Result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
@@ -1360,7 +1360,7 @@ void MemoryManager::ext_oneapi_copyD2H_cmd_buffer(
                 CommandBuffer, sycl::detail::ur::cast<ur_mem_handle_t>(SrcMem),
                 BufferOffset, HostOffset, RectRegion, BufferRowPitch,
                 BufferSlicePitch, HostRowPitch, HostSlicePitch, DstMem,
-                Deps.size(), Deps.data(), 0, nullptr, OutSyncPoint, nullptr,
+                Deps.size(), Deps.data(), 0u, nullptr, OutSyncPoint, nullptr,
                 nullptr);
     if (Result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
       throw sycl::exception(
@@ -1406,7 +1406,7 @@ void MemoryManager::ext_oneapi_copyH2D_cmd_buffer(
         Adapter.call_nocheck<UrApiKind::urCommandBufferAppendMemBufferWriteExp>(
             CommandBuffer, sycl::detail::ur::cast<ur_mem_handle_t>(DstMem),
             DstXOffBytes, DstAccessRangeWidthBytes, SrcMem + SrcXOffBytes,
-            Deps.size(), Deps.data(), 0, nullptr, OutSyncPoint, nullptr,
+            Deps.size(), Deps.data(), 0u, nullptr, OutSyncPoint, nullptr,
             nullptr);
 
     if (Result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
@@ -1436,7 +1436,7 @@ void MemoryManager::ext_oneapi_copyH2D_cmd_buffer(
         UrApiKind::urCommandBufferAppendMemBufferWriteRectExp>(
         CommandBuffer, sycl::detail::ur::cast<ur_mem_handle_t>(DstMem),
         BufferOffset, HostOffset, RectRegion, BufferRowPitch, BufferSlicePitch,
-        HostRowPitch, HostSlicePitch, SrcMem, Deps.size(), Deps.data(), 0,
+        HostRowPitch, HostSlicePitch, SrcMem, Deps.size(), Deps.data(), 0u,
         nullptr, OutSyncPoint, nullptr, nullptr);
 
     if (Result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
@@ -1461,7 +1461,7 @@ void MemoryManager::ext_oneapi_copy_usm_cmd_buffer(
   adapter_impl &Adapter = Context->getAdapter();
   ur_result_t Result =
       Adapter.call_nocheck<UrApiKind::urCommandBufferAppendUSMMemcpyExp>(
-          CommandBuffer, DstMem, SrcMem, Len, Deps.size(), Deps.data(), 0,
+          CommandBuffer, DstMem, SrcMem, Len, Deps.size(), Deps.data(), 0u,
           nullptr, OutSyncPoint, nullptr, nullptr);
   if (Result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
     throw sycl::exception(
@@ -1487,7 +1487,7 @@ void MemoryManager::ext_oneapi_fill_usm_cmd_buffer(
   ur_result_t Result =
       Adapter.call_nocheck<UrApiKind::urCommandBufferAppendUSMFillExp>(
           CommandBuffer, DstMem, Pattern.data(), Pattern.size(), Len,
-          Deps.size(), Deps.data(), 0, nullptr, OutSyncPoint, nullptr, nullptr);
+          Deps.size(), Deps.data(), 0u, nullptr, OutSyncPoint, nullptr, nullptr);
   if (Result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
@@ -1525,7 +1525,7 @@ void MemoryManager::ext_oneapi_fill_cmd_buffer(
     Adapter.call<UrApiKind::urCommandBufferAppendMemBufferFillExp>(
         CommandBuffer, ur::cast<ur_mem_handle_t>(Mem), Pattern, PatternSize,
         AccessOffset[0] * ElementSize, RangeMultiplier * ElementSize,
-        Deps.size(), Deps.data(), 0, nullptr, OutSyncPoint, nullptr, nullptr);
+        Deps.size(), Deps.data(), 0u, nullptr, OutSyncPoint, nullptr, nullptr);
     return;
   }
   // The sycl::handler uses a parallel_for kernel in the case of unusable
@@ -1542,7 +1542,7 @@ void MemoryManager::ext_oneapi_prefetch_usm_cmd_buffer(
   adapter_impl &Adapter = Context->getAdapter();
   Adapter.call<UrApiKind::urCommandBufferAppendUSMPrefetchExp>(
       CommandBuffer, Mem, Length, ur_usm_migration_flags_t(0), Deps.size(),
-      Deps.data(), 0, nullptr, OutSyncPoint, nullptr, nullptr);
+      Deps.data(), 0u, nullptr, OutSyncPoint, nullptr, nullptr);
 }
 
 void MemoryManager::ext_oneapi_advise_usm_cmd_buffer(
@@ -1553,7 +1553,7 @@ void MemoryManager::ext_oneapi_advise_usm_cmd_buffer(
     ur_exp_command_buffer_sync_point_t *OutSyncPoint) {
   adapter_impl &Adapter = Context->getAdapter();
   Adapter.call<UrApiKind::urCommandBufferAppendUSMAdviseExp>(
-      CommandBuffer, Mem, Length, Advice, Deps.size(), Deps.data(), 0, nullptr,
+      CommandBuffer, Mem, Length, Advice, Deps.size(), Deps.data(), 0u, nullptr,
       OutSyncPoint, nullptr, nullptr);
 }
 

--- a/sycl/source/detail/memory_pool_impl.cpp
+++ b/sycl/source/detail/memory_pool_impl.cpp
@@ -164,7 +164,7 @@ void memory_pool_impl::set_new_threshold(size_t newThreshold) {
   Adapter
       .call<sycl::errc::runtime, sycl::detail::UrApiKind::urUSMPoolSetInfoExp>(
           MPoolHandle, UR_USM_POOL_INFO_RELEASE_THRESHOLD_EXP, &newThreshold,
-          8 /*uint64_t*/);
+          8u /*uint64_t*/);
 }
 
 void memory_pool_impl::reset_reserved_size_high() {
@@ -174,7 +174,7 @@ void memory_pool_impl::reset_reserved_size_high() {
   Adapter
       .call<sycl::errc::runtime, sycl::detail::UrApiKind::urUSMPoolSetInfoExp>(
           MPoolHandle, UR_USM_POOL_INFO_RESERVED_HIGH_EXP,
-          static_cast<void *>(&resetVal), 8 /*uint64_t*/);
+          static_cast<void *>(&resetVal), 8u /*uint64_t*/);
 }
 
 void memory_pool_impl::reset_used_size_high() {
@@ -184,7 +184,7 @@ void memory_pool_impl::reset_used_size_high() {
   Adapter
       .call<sycl::errc::runtime, sycl::detail::UrApiKind::urUSMPoolSetInfoExp>(
           MPoolHandle, UR_USM_POOL_INFO_USED_HIGH_EXP,
-          static_cast<void *>(&resetVal), 8 /*uint64_t*/);
+          static_cast<void *>(&resetVal), 8u /*uint64_t*/);
 }
 
 } // namespace detail

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -494,7 +494,7 @@ platform_impl::get_devices(info::device_type DeviceType) const {
 
   uint32_t NumDevices = 0;
   MAdapter->call<UrApiKind::urDeviceGet>(MPlatform, UrDeviceType,
-                                         0, // CP info::device_type::all
+                                         0u, // CP info::device_type::all
                                          nullptr, &NumDevices);
   const backend Backend = getBackend();
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -62,7 +62,7 @@ static void enableITTAnnotationsIfNeeded(const ur_program_handle_t &Prog,
     ur_specialization_constant_info_t SpecConstInfo = {
         ITTSpecConstId, sizeof(char), &SpecValue};
     Adapter.call<UrApiKind::urProgramSetSpecializationConstants>(
-        Prog, 1, &SpecConstInfo);
+        Prog, 1u, &SpecConstInfo);
   }
 }
 
@@ -598,7 +598,7 @@ static bool compatibleWithDevice(const RTDeviceBinaryImage *BinImage,
 
   ur_result_t Error = Adapter.call_nocheck<UrApiKind::urDeviceSelectBinary>(
       URDeviceHandle, &UrBinary,
-      /*num bin images = */ (uint32_t)1, &SuitableImageID);
+      /*num bin images = */ 1u, &SuitableImageID);
   if (Error != UR_RESULT_SUCCESS && Error != UR_RESULT_ERROR_INVALID_BINARY)
     throw detail::set_ur_error(exception(make_error_code(errc::runtime),
                                          "Invalid binary image or device"),
@@ -852,7 +852,7 @@ static void setSpecializationConstants(device_image_impl &InputImpl,
             SpecIDDesc.ID, SpecIDDesc.Size,
             SpecConsts.data() + SpecIDDesc.BlobOffset};
         Adapter.call<UrApiKind::urProgramSetSpecializationConstants>(
-            Prog, 1, &SpecConstInfo);
+            Prog, 1u, &SpecConstInfo);
       }
     }
   }
@@ -1216,8 +1216,8 @@ ProgramManager::getProgramBuildLog(const ur_program_handle_t &Program,
                                    context_impl &Context) {
   size_t URDevicesSize = 0;
   adapter_impl &Adapter = Context.getAdapter();
-  Adapter.call<UrApiKind::urProgramGetInfo>(Program, UR_PROGRAM_INFO_DEVICES, 0,
-                                            nullptr, &URDevicesSize);
+  Adapter.call<UrApiKind::urProgramGetInfo>(Program, UR_PROGRAM_INFO_DEVICES,
+                                            0u, nullptr, &URDevicesSize);
   std::vector<ur_device_handle_t> URDevices(URDevicesSize /
                                             sizeof(ur_device_handle_t));
   Adapter.call<UrApiKind::urProgramGetInfo>(Program, UR_PROGRAM_INFO_DEVICES,
@@ -1229,7 +1229,7 @@ ProgramManager::getProgramBuildLog(const ur_program_handle_t &Program,
     std::string DeviceBuildInfoString;
     size_t DeviceBuildInfoStrSize = 0;
     Adapter.call<UrApiKind::urProgramGetBuildInfo>(
-        Program, Device, UR_PROGRAM_BUILD_INFO_LOG, 0, nullptr,
+        Program, Device, UR_PROGRAM_BUILD_INFO_LOG, 0u, nullptr,
         &DeviceBuildInfoStrSize);
     if (DeviceBuildInfoStrSize > 0) {
       std::vector<char> DeviceBuildInfo(DeviceBuildInfoStrSize);
@@ -1241,7 +1241,7 @@ ProgramManager::getProgramBuildLog(const ur_program_handle_t &Program,
 
     std::string DeviceNameString;
     size_t DeviceNameStrSize = 0;
-    Adapter.call<UrApiKind::urDeviceGetInfo>(Device, UR_DEVICE_INFO_NAME, 0,
+    Adapter.call<UrApiKind::urDeviceGetInfo>(Device, UR_DEVICE_INFO_NAME, 0u,
                                              nullptr, &DeviceNameStrSize);
     if (DeviceNameStrSize > 0) {
       std::vector<char> DeviceName(DeviceNameStrSize);

--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -208,7 +208,7 @@ static void initializeAdapters(std::vector<adapter_impl *> &Adapters,
   }
 
   uint32_t adapterCount = 0;
-  CHECK_UR_SUCCESS(adapterGet(0, nullptr, &adapterCount));
+  CHECK_UR_SUCCESS(adapterGet(0u, nullptr, &adapterCount));
   std::vector<ur_adapter_handle_t> adapters(adapterCount);
   CHECK_UR_SUCCESS(adapterGet(adapterCount, adapters.data(), nullptr));
 

--- a/sycl/source/virtual_mem.cpp
+++ b/sycl/source/virtual_mem.cpp
@@ -45,7 +45,7 @@ __SYCL_EXPORT size_t get_mem_granularity(const device &SyclDevice,
 #ifndef NDEBUG
   size_t InfoOutputSize = 0;
   Adapter->call<sycl::detail::UrApiKind::urVirtualMemGranularityGetInfo>(
-      urCtx, urDevice, GranularityQuery, 0, nullptr, &InfoOutputSize);
+      urCtx, urDevice, GranularityQuery, 0u, nullptr, &InfoOutputSize);
   assert(InfoOutputSize == sizeof(size_t) &&
          "Unexpected output size of granularity info query.");
 #endif // NDEBUG
@@ -139,7 +139,7 @@ __SYCL_EXPORT address_access_mode get_access_mode(const void *Ptr,
 #ifndef NDEBUG
   size_t InfoOutputSize = 0;
   Adapter->call<sycl::detail::UrApiKind::urVirtualMemGetInfo>(
-      urCtx, Ptr, NumBytes, UR_VIRTUAL_MEM_INFO_ACCESS_MODE, 0, nullptr,
+      urCtx, Ptr, NumBytes, UR_VIRTUAL_MEM_INFO_ACCESS_MODE, 0u, nullptr,
       &InfoOutputSize);
   assert(InfoOutputSize == sizeof(ur_virtual_mem_access_flags_t) &&
          "Unexpected output size of access mode info query.");


### PR DESCRIPTION
`-Wconversion` is required per our SDL processes and it will be enabled in intel/llvm#19306.

Updated all literal arguments passed to UR APIs, because corresponding functions expect an unsigned integer.