### PR TITLE
[SYCL][Doc] Fix links in free function kernel spec

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
@@ -43,7 +43,7 @@ the SYCL specification refer to that revision.
 
 This extension also depends on the following other SYCL extensions:
 
-* link:../proposed/sycl_ext_oneapi_free_function_queries.asciidoc[
+* link:../supported/sycl_ext_oneapi_free_function_queries.asciidoc[
   sycl_ext_oneapi_free_function_queries]
 * link:../experimental/sycl_ext_oneapi_properties.asciidoc[
   sycl_ext_oneapi_properties]
@@ -667,7 +667,7 @@ parameters are used to pass the kernel arguments instead.
 Therefore, a free function kernel must obtain the iteration ID in some other
 way.
 Typically, a free function kernel uses the functions specified in
-link:../proposed/sycl_ext_oneapi_free_function_queries.asciidoc[
+link:../supported/sycl_ext_oneapi_free_function_queries.asciidoc[
 sycl_ext_oneapi_free_function_queries] for this purpose.
 
 === Address space of kernel arguments
@@ -893,7 +893,7 @@ when the kernel adheres to the following restrictions:
 * The kernel function is declared as `extern "C"`;
 * Each formal argument to the kernel is either a {cpp} trivially copyable type
   or the `work_group_memory` type (see
-  link:../proposed/sycl_ext_oneapi_work_group_memory.asciidoc[
+  link:../experimental/sycl_ext_oneapi_work_group_memory.asciidoc[
   sycl_ext_oneapi_work_group_memory]); and
 * The translation unit containing the kernel is compiled with the
   `-fno-sycl-dead-args-optimization` option.
@@ -902,7 +902,7 @@ In order to invoke a kernel using Level Zero or OpenCL, the application must
 first obtain the raw backend content of the device image that contains the
 kernel.
 One way to do this is by using
-link:../proposed/sycl_ext_oneapi_device_image_backend_content.asciidoc[
+link:../experimental/sycl_ext_oneapi_device_image_backend_content.asciidoc[
 sycl_ext_oneapi_device_image_backend_content].
 It is also possible to compile the application in AOT mode via the
 `-fsycl-targets` compiler option and then extract the device image's backend
@@ -1046,7 +1046,7 @@ argument, effectively turning the call into a no-op.
 
 * We're pretty sure that we want to define some syntax that allows a free
   function kernel to be enqueued using the APIs defined in
-  link:../proposed/sycl_ext_oneapi_enqueue_functions.asciidoc[
+  link:../experimental/sycl_ext_oneapi_enqueue_functions.asciidoc[
   sycl_ext_oneapi_enqueue_functions], but we haven't settled on the exact API
   yet.
   One option is like this:
@@ -1094,7 +1094,7 @@ void iota(sycl::nd_item<1> nditem, float start, float *ptr) { /*...*/  }
 ```
 
 The advantage is that the user wouldn't need to use the functions in
-link:../proposed/sycl_ext_oneapi_free_function_queries.asciidoc[
+link:../supported/sycl_ext_oneapi_free_function_queries.asciidoc[
 sycl_ext_oneapi_free_function_queries] to get the iteration index.
 Doing this raises some new questions, though:
 


### PR DESCRIPTION
Update links as the dependent extensions have been promoted to either "experimental" or "supported".