### PR TITLE
[NFC][SYCL] Add `devices_range` helper to cleanup `persistent_device_code_cache`

### DIFF
--- a/sycl/source/detail/graph/node_impl.hpp
+++ b/sycl/source/detail/graph/node_impl.hpp
@@ -10,8 +10,9 @@
 
 #include <detail/accessor_impl.hpp> // for AccessorImplHost
 #include <detail/cg.hpp>            // for CGExecKernel, CGHostTask, ArgDesc...
-#include <detail/host_task.hpp>     // for HostTask
-#include <sycl/detail/cg_types.hpp> // for CGType
+#include <detail/helpers.hpp>
+#include <detail/host_task.hpp>        // for HostTask
+#include <sycl/detail/cg_types.hpp>    // for CGType
 #include <sycl/detail/kernel_desc.hpp> // for kernel_param_kind_t
 
 #include <cstring>
@@ -761,82 +762,43 @@ private:
   }
 };
 
-// Non-owning!
-class nodes_range {
-  template <typename... Containers>
-  using storage_iter_impl =
-      std::variant<typename Containers::const_iterator...>;
+struct nodes_deref_impl {
+  template <typename T> static node_impl &dereference(T &Elem) {
+    if constexpr (std::is_same_v<std::decay_t<decltype(Elem)>,
+                                 std::weak_ptr<node_impl>>) {
+      // This assumes that weak_ptr doesn't actually manage lifetime and
+      // the object is guaranteed to be alive (which seems to be the
+      // assumption across all graph code).
+      return *Elem.lock();
+    } else {
+      return *Elem;
+    }
+  }
+};
 
-  using storage_iter = storage_iter_impl<
-      std::vector<std::shared_ptr<node_impl>>, std::vector<node_impl *>,
-      // Next one is temporary. It looks like `weak_ptr`s aren't
-      // used for the actual lifetime management and the objects are
-      // always guaranteed to be alive. Once the code is cleaned
-      // from `weak_ptr`s this alternative should be removed too.
-      std::vector<std::weak_ptr<node_impl>>,
-      //
-      std::set<std::shared_ptr<node_impl>>, std::set<node_impl *>,
-      //
-      std::list<node_impl *>>;
+template <typename... ContainerTy>
+using nodes_iterator_impl =
+    variadic_iterator<nodes_deref_impl,
+                      typename ContainerTy::const_iterator...>;
 
-  storage_iter Begin;
-  storage_iter End;
-  const size_t Size;
+using nodes_iterator = nodes_iterator_impl<
+    std::vector<std::shared_ptr<node_impl>>, std::vector<node_impl *>,
+    // Next one is temporary. It looks like `weak_ptr`s aren't
+    // used for the actual lifetime management and the objects are
+    // always guaranteed to be alive. Once the code is cleaned
+    // from `weak_ptr`s this alternative should be removed too.
+    std::vector<std::weak_ptr<node_impl>>,
+    //
+    std::set<std::shared_ptr<node_impl>>, std::set<node_impl *>,
+    //
+    std::list<node_impl *>>;
+
+class nodes_range : public iterator_range<nodes_iterator> {
+private:
+  using Base = iterator_range<nodes_iterator>;
 
 public:
-  nodes_range(const nodes_range &Other) = default;
-
-  template <
-      typename ContainerTy,
-      typename = std::enable_if_t<!std::is_same_v<nodes_range, ContainerTy>>>
-  nodes_range(ContainerTy &Container)
-      : Begin{Container.begin()}, End{Container.end()}, Size{Container.size()} {
-  }
-
-  class iterator {
-    storage_iter It;
-
-    iterator(storage_iter It) : It(It) {}
-    friend class nodes_range;
-
-  public:
-    iterator &operator++() {
-      It = std::visit(
-          [](auto &&It) {
-            ++It;
-            return storage_iter{It};
-          },
-          It);
-      return *this;
-    }
-    bool operator!=(const iterator &Other) const { return It != Other.It; }
-
-    node_impl &operator*() {
-      return std::visit(
-          [](auto &&It) -> node_impl & {
-            auto &Elem = *It;
-            if constexpr (std::is_same_v<std::decay_t<decltype(Elem)>,
-                                         std::weak_ptr<node_impl>>) {
-              // This assumes that weak_ptr doesn't actually manage lifetime and
-              // the object is guaranteed to be alive (which seems to be the
-              // assumption across all graph code).
-              return *Elem.lock();
-            } else {
-              return *Elem;
-            }
-          },
-          It);
-    }
-  };
-
-  iterator begin() const {
-    return {std::visit([](auto &&It) { return storage_iter{It}; }, Begin)};
-  }
-  iterator end() const {
-    return {std::visit([](auto &&It) { return storage_iter{It}; }, End)};
-  }
-  size_t size() const { return Size; }
-  bool empty() const { return Size == 0; }
+  using Base::Base;
 };
 
 inline nodes_range node_impl::successors() const { return MSuccessors; }

--- a/sycl/source/detail/helpers.hpp
+++ b/sycl/source/detail/helpers.hpp
@@ -6,12 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#pragma once
+
 #include <sycl/detail/kernel_name_str_t.hpp>
 
 #include <ur_api.h>
 
 #include <memory>
 #include <tuple>
+#include <variant>
 #include <vector>
 
 namespace sycl {
@@ -26,6 +29,63 @@ class RTDeviceBinaryImage;
 std::tuple<const RTDeviceBinaryImage *, ur_program_handle_t>
 retrieveKernelBinary(queue_impl &Queue, KernelNameStrRefT KernelName,
                      CGExecKernel *CGKernel = nullptr);
+
+template <typename DereferenceImpl, typename... Iterators>
+class variadic_iterator {
+  using storage_iter = std::variant<Iterators...>;
+
+  storage_iter It;
+
+public:
+  template <typename IterTy>
+  variadic_iterator(IterTy &&It) : It(std::forward<IterTy>(It)) {}
+
+  variadic_iterator &operator++() {
+    It = std::visit(
+        [](auto &&It) {
+          ++It;
+          return storage_iter{It};
+        },
+        It);
+    return *this;
+  }
+  bool operator!=(const variadic_iterator &Other) const {
+    return It != Other.It;
+  }
+
+  decltype(auto) operator*() {
+    return std::visit(
+        [](auto &&It) -> decltype(auto) {
+          return DereferenceImpl::dereference(*It);
+        },
+        It);
+  }
+};
+
+// Non-owning!
+template <typename iterator> class iterator_range {
+public:
+  iterator_range(const iterator_range &Other) = default;
+
+  template <typename IterTy>
+  iterator_range(IterTy Begin, IterTy End, size_t Size)
+      : Begin(Begin), End(End), Size(Size) {}
+
+  template <typename ContainerTy>
+  iterator_range(const ContainerTy &Container)
+      : iterator_range(Container.begin(), Container.end(), Container.size()) {}
+
+  iterator begin() const { return Begin; }
+  iterator end() const { return End; }
+  size_t size() const { return Size; }
+  bool empty() const { return Size == 0; }
+  decltype(auto) front() const { return *begin(); }
+
+private:
+  iterator Begin;
+  iterator End;
+  const size_t Size;
+};
 } // namespace detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/detail/persistent_device_code_cache.cpp
+++ b/sycl/source/detail/persistent_device_code_cache.cpp
@@ -126,10 +126,10 @@ std::string getUniqueFilename(const std::string &base_name) {
  */
 std::vector<std::vector<char>>
 getProgramBinaryData(const ur_program_handle_t &NativePrg,
-                     const std::vector<device> &Devices) {
+                     devices_range Devices) {
   assert(!Devices.empty() && "At least one device is expected");
   // We expect all devices to be from the same platform/adpater.
-  adapter_impl &Adapter = detail::getSyclObjImpl(Devices[0])->getAdapter();
+  adapter_impl &Adapter = Devices.front().getAdapter();
   unsigned int DeviceNum = 0;
   Adapter.call<UrApiKind::urProgramGetInfo>(
       NativePrg, UR_PROGRAM_INFO_NUM_DEVICES, sizeof(DeviceNum), &DeviceNum,
@@ -159,17 +159,17 @@ getProgramBinaryData(const ur_program_handle_t &NativePrg,
   // Select only binaries for the input devices preserving one to one
   // correpsondence.
   std::vector<std::vector<char>> Result(Devices.size());
-  for (size_t DeviceIndex = 0; DeviceIndex < Devices.size(); DeviceIndex++) {
-    auto DeviceIt = std::find_if(
-        URDevices.begin(), URDevices.end(),
-        [&Devices, &DeviceIndex](const ur_device_handle_t &URDevice) {
-          return URDevice ==
-                 detail::getSyclObjImpl(Devices[DeviceIndex])->getHandleRef();
-        });
+  auto ResultIt = Result.begin();
+  for (device_impl &Device : Devices) {
+    auto DeviceIt = std::find_if(URDevices.begin(), URDevices.end(),
+                                 [&Device](const ur_device_handle_t &URDevice) {
+                                   return URDevice == Device.getHandleRef();
+                                 });
     assert(DeviceIt != URDevices.end() &&
            "Device is not associated with the program");
     auto URDeviceIndex = std::distance(URDevices.begin(), DeviceIt);
-    Result[DeviceIndex] = std::move(Binaries[URDeviceIndex]);
+    *ResultIt = std::move(Binaries[URDeviceIndex]);
+    ++ResultIt;
   }
 
   // Return binaries correpsonding to the input devices.
@@ -433,8 +433,7 @@ void PersistentDeviceCodeCache::updateCacheFileSizeAndTriggerEviction(
  * device in the list to a separate file.
  */
 void PersistentDeviceCodeCache::putItemToDisc(
-    const std::vector<device> &Devices,
-    const std::vector<const RTDeviceBinaryImage *> &Imgs,
+    devices_range Devices, const std::vector<const RTDeviceBinaryImage *> &Imgs,
     const SerializedObj &SpecConsts, const std::string &BuildOptionsString,
     const ur_program_handle_t &NativePrg) {
 
@@ -456,12 +455,13 @@ void PersistentDeviceCodeCache::putItemToDisc(
 
   // Total size of the item that we just wrote to the cache.
   size_t TotalSize = 0;
-  for (size_t DeviceIndex = 0; DeviceIndex < Devices.size(); DeviceIndex++) {
+  auto BinaryDataIt = BinaryData.begin();
+  for (device_impl &Device : Devices) {
     // If we don't have binary for the device, skip it.
-    if (BinaryData[DeviceIndex].empty())
+    if (BinaryDataIt->empty())
       continue;
-    std::string DirName = getCacheItemPath(Devices[DeviceIndex], SortedImgs,
-                                           SpecConsts, BuildOptionsString);
+    std::string DirName =
+        getCacheItemPath(Device, SortedImgs, SpecConsts, BuildOptionsString);
 
     if (DirName.empty())
       return;
@@ -473,10 +473,10 @@ void PersistentDeviceCodeCache::putItemToDisc(
       LockCacheItem Lock{FileName};
       if (Lock.isOwned()) {
         std::string FullFileName = FileName + ".bin";
-        writeBinaryDataToFile(FullFileName, BinaryData[DeviceIndex]);
+        writeBinaryDataToFile(FullFileName, *BinaryDataIt);
         trace("device binary has been cached: ", FullFileName);
-        writeSourceItem(FileName + ".src", Devices[DeviceIndex], SortedImgs,
-                        SpecConsts, BuildOptionsString);
+        writeSourceItem(FileName + ".src", Device, SortedImgs, SpecConsts,
+                        BuildOptionsString);
 
         // Update Total cache size after adding the new items.
         TotalSize += getFileSize(FileName + ".src");
@@ -495,6 +495,7 @@ void PersistentDeviceCodeCache::putItemToDisc(
           std::string("error outputting persistent cache: ") +
           std::strerror(errno));
     }
+    ++BinaryDataIt;
   }
 
   // Update the cache size file and trigger cache eviction if needed.
@@ -503,7 +504,7 @@ void PersistentDeviceCodeCache::putItemToDisc(
 }
 
 void PersistentDeviceCodeCache::putCompiledKernelToDisc(
-    const std::vector<device> &Devices, const std::string &BuildOptionsString,
+    devices_range Devices, const std::string &BuildOptionsString,
     const std::string &SourceStr, const ur_program_handle_t &NativePrg) {
 
   repopulateCacheSizeFile(getRootDir());
@@ -520,12 +521,13 @@ void PersistentDeviceCodeCache::putCompiledKernelToDisc(
   // Total size of the item that we are writing to the cache.
   size_t TotalSize = 0;
 
-  for (size_t DeviceIndex = 0; DeviceIndex < Devices.size(); DeviceIndex++) {
+  auto BinaryDataIt = BinaryData.begin();
+  for (device_impl &Device : Devices) {
     // If we don't have binary for the device, skip it.
-    if (BinaryData[DeviceIndex].empty())
+    if (BinaryDataIt->empty())
       continue;
-    std::string DirName = getCompiledKernelItemPath(
-        Devices[DeviceIndex], BuildOptionsString, SourceStr);
+    std::string DirName =
+        getCompiledKernelItemPath(Device, BuildOptionsString, SourceStr);
 
     try {
       OSUtil::makeDir(DirName.c_str());
@@ -533,7 +535,7 @@ void PersistentDeviceCodeCache::putCompiledKernelToDisc(
       LockCacheItem Lock{FileName};
       if (Lock.isOwned()) {
         std::string FullFileName = FileName + ".bin";
-        writeBinaryDataToFile(FullFileName, BinaryData[DeviceIndex]);
+        writeBinaryDataToFile(FullFileName, *BinaryDataIt);
         PersistentDeviceCodeCache::trace_KernelCompiler(
             "binary has been cached: ", FullFileName);
 
@@ -550,6 +552,7 @@ void PersistentDeviceCodeCache::putCompiledKernelToDisc(
       PersistentDeviceCodeCache::trace_KernelCompiler(
           std::string("error outputting cache: ") + std::strerror(errno));
     }
+    ++BinaryDataIt;
   }
 
   // Update the cache size file and trigger cache eviction if needed.
@@ -611,8 +614,7 @@ void PersistentDeviceCodeCache::putDeviceCodeIRToDisc(
  * devices.
  */
 std::vector<std::vector<char>> PersistentDeviceCodeCache::getItemFromDisc(
-    const std::vector<device> &Devices,
-    const std::vector<const RTDeviceBinaryImage *> &Imgs,
+    devices_range Devices, const std::vector<const RTDeviceBinaryImage *> &Imgs,
     const SerializedObj &SpecConsts, const std::string &BuildOptionsString) {
   assert(!Devices.empty());
   if (!areImagesCacheable(Imgs))
@@ -621,9 +623,10 @@ std::vector<std::vector<char>> PersistentDeviceCodeCache::getItemFromDisc(
   std::vector<const RTDeviceBinaryImage *> SortedImgs = getSortedImages(Imgs);
   std::vector<std::vector<char>> Binaries(Devices.size());
   std::string FileNames;
-  for (size_t DeviceIndex = 0; DeviceIndex < Devices.size(); DeviceIndex++) {
-    std::string Path = getCacheItemPath(Devices[DeviceIndex], SortedImgs,
-                                        SpecConsts, BuildOptionsString);
+  auto BinariesIt = Binaries.begin();
+  for (device_impl &Device : Devices) {
+    std::string Path =
+        getCacheItemPath(Device, SortedImgs, SpecConsts, BuildOptionsString);
 
     if (Path.empty() || !OSUtil::isPathPresent(Path))
       return {};
@@ -635,11 +638,11 @@ std::vector<std::vector<char>> PersistentDeviceCodeCache::getItemFromDisc(
            OSUtil::isPathPresent(FileName + ".src")) {
 
       if (!LockCacheItem::isLocked(FileName) &&
-          isCacheItemSrcEqual(FileName + ".src", Devices[DeviceIndex],
-                              SortedImgs, SpecConsts, BuildOptionsString)) {
+          isCacheItemSrcEqual(FileName + ".src", Device, SortedImgs, SpecConsts,
+                              BuildOptionsString)) {
         try {
           std::string FullFileName = FileName + ".bin";
-          Binaries[DeviceIndex] = readBinaryDataFromFile(FullFileName);
+          *BinariesIt = readBinaryDataFromFile(FullFileName);
 
           // Explicitly update the access time of the file. This is required for
           // eviction.
@@ -655,8 +658,9 @@ std::vector<std::vector<char>> PersistentDeviceCodeCache::getItemFromDisc(
       FileName = Path + "/" + std::to_string(++i);
     }
     // If there is no binary for any device, return empty vector.
-    if (Binaries[DeviceIndex].empty())
+    if (BinariesIt->empty())
       return {};
+    ++BinariesIt;
   }
   PersistentDeviceCodeCache::trace("using cached device binary: ", FileNames);
   return Binaries;
@@ -667,14 +671,15 @@ std::vector<std::vector<char>> PersistentDeviceCodeCache::getItemFromDisc(
  */
 std::vector<std::vector<char>>
 PersistentDeviceCodeCache::getCompiledKernelFromDisc(
-    const std::vector<device> &Devices, const std::string &BuildOptionsString,
+    devices_range Devices, const std::string &BuildOptionsString,
     const std::string &SourceStr) {
   assert(!Devices.empty());
   std::vector<std::vector<char>> Binaries(Devices.size());
   std::string FileNames;
-  for (size_t DeviceIndex = 0; DeviceIndex < Devices.size(); DeviceIndex++) {
-    std::string DirName = getCompiledKernelItemPath(
-        Devices[DeviceIndex], BuildOptionsString, SourceStr);
+  auto BinariesIt = Binaries.begin();
+  for (device_impl &Device : Devices) {
+    std::string DirName =
+        getCompiledKernelItemPath(Device, BuildOptionsString, SourceStr);
 
     if (DirName.empty() || !OSUtil::isPathPresent(DirName))
       return {};
@@ -687,7 +692,7 @@ PersistentDeviceCodeCache::getCompiledKernelFromDisc(
       if (!LockCacheItem::isLocked(FileName)) {
         try {
           std::string FullFileName = FileName + ".bin";
-          Binaries[DeviceIndex] = readBinaryDataFromFile(FullFileName);
+          *BinariesIt = readBinaryDataFromFile(FullFileName);
 
           // Explicitly update the access time of the file. This is required for
           // eviction.
@@ -703,8 +708,9 @@ PersistentDeviceCodeCache::getCompiledKernelFromDisc(
       FileName = DirName + "/" + std::to_string(++i);
     }
     // If there is no binary for any device, return empty vector.
-    if (Binaries[DeviceIndex].empty())
+    if (BinariesIt->empty())
       return {};
+    ++BinariesIt;
   }
   PersistentDeviceCodeCache::trace_KernelCompiler("using cached binary: ",
                                                   FileNames);
@@ -746,7 +752,7 @@ PersistentDeviceCodeCache::getDeviceCodeIRFromDisc(const std::string &Key) {
 
 /* Returns string value which can be used to identify different device
  */
-std::string PersistentDeviceCodeCache::getDeviceIDString(const device &Device) {
+std::string PersistentDeviceCodeCache::getDeviceIDString(device_impl &Device) {
   return Device.get_platform().get_info<sycl::info::platform::name>() + "/" +
          Device.get_info<sycl::info::device::name>() + "/" +
          Device.get_info<sycl::info::device::version>() + "/" +
@@ -814,7 +820,7 @@ PersistentDeviceCodeCache::readBinaryDataFromFile(const std::string &FileName) {
  * specialization constant values, device code SPIR-V images.
  */
 void PersistentDeviceCodeCache::writeSourceItem(
-    const std::string &FileName, const device &Device,
+    const std::string &FileName, device_impl &Device,
     const std::vector<const RTDeviceBinaryImage *> &SortedImgs,
     const SerializedObj &SpecConsts, const std::string &BuildOptionsString) {
   std::ofstream FileStream{FileName, std::ios::binary};
@@ -850,7 +856,7 @@ void PersistentDeviceCodeCache::writeSourceItem(
  * If file read operations fail cache item is treated as not equal.
  */
 bool PersistentDeviceCodeCache::isCacheItemSrcEqual(
-    const std::string &FileName, const device &Device,
+    const std::string &FileName, device_impl &Device,
     const std::vector<const RTDeviceBinaryImage *> &SortedImgs,
     const SerializedObj &SpecConsts, const std::string &BuildOptionsString) {
   std::ifstream FileStream{FileName, std::ios::binary};
@@ -900,7 +906,7 @@ bool PersistentDeviceCodeCache::isCacheItemSrcEqual(
  * device, build options and specialization constants values.
  */
 std::string PersistentDeviceCodeCache::getCacheItemPath(
-    const device &Device, const std::vector<const RTDeviceBinaryImage *> &Imgs,
+    device_impl &Device, const std::vector<const RTDeviceBinaryImage *> &Imgs,
     const SerializedObj &SpecConsts, const std::string &BuildOptionsString) {
   std::string cache_root{getRootDir()};
   if (cache_root.empty()) {
@@ -926,7 +932,7 @@ std::string PersistentDeviceCodeCache::getCacheItemPath(
 }
 
 std::string PersistentDeviceCodeCache::getCompiledKernelItemPath(
-    const device &Device, const std::string &BuildOptionsString,
+    device_impl &Device, const std::string &BuildOptionsString,
     const std::string &SourceString) {
 
   std::string cache_root{getRootDir()};

--- a/sycl/source/detail/persistent_device_code_cache.hpp
+++ b/sycl/source/detail/persistent_device_code_cache.hpp
@@ -112,7 +112,7 @@ private:
    * specialization constant values, device code SPIR-V images.
    */
   static void
-  writeSourceItem(const std::string &FileName, const device &Device,
+  writeSourceItem(const std::string &FileName, device_impl &Device,
                   const std::vector<const RTDeviceBinaryImage *> &SortedImgs,
                   const SerializedObj &SpecConsts,
                   const std::string &BuildOptionsString);
@@ -120,12 +120,12 @@ private:
   /* Check that cache item key sources are equal to the current program
    */
   static bool isCacheItemSrcEqual(
-      const std::string &FileName, const device &Device,
+      const std::string &FileName, device_impl &Device,
       const std::vector<const RTDeviceBinaryImage *> &SortedImgs,
       const SerializedObj &SpecConsts, const std::string &BuildOptionsString);
 
   /* Form string representing device version */
-  static std::string getDeviceIDString(const device &Device);
+  static std::string getDeviceIDString(device_impl &Device);
 
   /* Returns true if specified images should be cached on disk. It checks if
    * cache is enabled, images have SPIRV type and match thresholds. */
@@ -165,7 +165,7 @@ public:
   /* Get directory name for storing current cache item
    */
   static std::string
-  getCacheItemPath(const device &Device,
+  getCacheItemPath(device_impl &Device,
                    const std::vector<const RTDeviceBinaryImage *> &SortedImgs,
                    const SerializedObj &SpecConsts,
                    const std::string &BuildOptionsString);
@@ -174,7 +174,7 @@ public:
    * kernel_compiler ).
    */
   static std::string
-  getCompiledKernelItemPath(const device &Device,
+  getCompiledKernelItemPath(device_impl &Device,
                             const std::string &BuildOptionsString,
                             const std::string &SourceString);
 
@@ -191,13 +191,13 @@ public:
    * stored in vector of chars.
    */
   static std::vector<std::vector<char>>
-  getItemFromDisc(const std::vector<device> &Devices,
+  getItemFromDisc(devices_range Devices,
                   const std::vector<const RTDeviceBinaryImage *> &Imgs,
                   const SerializedObj &SpecConsts,
                   const std::string &BuildOptionsString);
 
   static std::vector<std::vector<char>>
-  getCompiledKernelFromDisc(const std::vector<device> &Devices,
+  getCompiledKernelFromDisc(devices_range Devices,
                             const std::string &BuildOptionsString,
                             const std::string &SourceStr);
 
@@ -206,13 +206,13 @@ public:
   /* Stores build program in persistent cache
    */
   static void
-  putItemToDisc(const std::vector<device> &Devices,
+  putItemToDisc(devices_range Devices,
                 const std::vector<const RTDeviceBinaryImage *> &Imgs,
                 const SerializedObj &SpecConsts,
                 const std::string &BuildOptionsString,
                 const ur_program_handle_t &NativePrg);
 
-  static void putCompiledKernelToDisc(const std::vector<device> &Devices,
+  static void putCompiledKernelToDisc(devices_range Devices,
                                       const std::string &BuildOptionsString,
                                       const std::string &SourceStr,
                                       const ur_program_handle_t &NativePrg);

--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -224,8 +224,8 @@ public:
                              std::to_string(ThreadCount)};
     DeviceCodeID = ProgramID;
     std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
-        {Dev}, {&Img}, {'S', 'p', 'e', 'c', 'C', 'o', 'n', 's', 't', ProgramID},
-        BuildOptions);
+        *getSyclObjImpl(Dev), {&Img},
+        {'S', 'p', 'e', 'c', 'C', 'o', 'n', 's', 't', ProgramID}, BuildOptions);
     ASSERT_NO_ERROR(llvm::sys::fs::remove_directories(ItemDir));
 
     Barrier b(ThreadCount);
@@ -288,7 +288,7 @@ TEST_P(PersistentDeviceCodeCache, KeysWithNullTermSymbol) {
   std::string Key{'1', '\0', '3', '4', '\0'};
   std::vector<unsigned char> SpecConst(Key.begin(), Key.end());
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
-      Dev, {&Img}, SpecConst, Key);
+      *getSyclObjImpl(Dev), {&Img}, SpecConst, Key);
   ASSERT_NO_ERROR(llvm::sys::fs::remove_directories(ItemDir));
 
   detail::PersistentDeviceCodeCache::putItemToDisc({Dev}, {&Img}, SpecConst,
@@ -340,7 +340,7 @@ TEST_P(PersistentDeviceCodeCache, MultipleImages) {
                                  B->getRawData().EntriesBegin->GetName()) < 0;
             });
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
-      Dev, Imgs, {}, BuildOptions);
+      *getSyclObjImpl(Dev), Imgs, {}, BuildOptions);
   ASSERT_NO_ERROR(llvm::sys::fs::remove_directories(ItemDir));
 
   detail::PersistentDeviceCodeCache::putItemToDisc({Dev}, Imgs, {},
@@ -393,7 +393,7 @@ TEST_P(PersistentDeviceCodeCache, ConcurentReadWriteCacheBigItem) {
 TEST_P(PersistentDeviceCodeCache, CorruptedCacheFiles) {
   std::string BuildOptions{"--corrupted-file"};
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
-      Dev, {&Img}, {}, BuildOptions);
+      *getSyclObjImpl(Dev), {&Img}, {}, BuildOptions);
   ASSERT_NO_ERROR(llvm::sys::fs::remove_directories(ItemDir));
 
   // Only source file is present
@@ -478,7 +478,7 @@ TEST_P(PersistentDeviceCodeCache, CorruptedCacheFiles) {
 TEST_P(PersistentDeviceCodeCache, LockFile) {
   std::string BuildOptions{"--obsolete-lock"};
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
-      Dev, {&Img}, {}, BuildOptions);
+      *getSyclObjImpl(Dev), {&Img}, {}, BuildOptions);
   ASSERT_NO_ERROR(llvm::sys::fs::remove_directories(ItemDir));
 
   // Create 1st cahe item
@@ -528,7 +528,7 @@ TEST_P(PersistentDeviceCodeCache, LockFile) {
 TEST_P(PersistentDeviceCodeCache, AccessDeniedForCacheDir) {
   std::string BuildOptions{"--build-options"};
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
-      Dev, {&Img}, {}, BuildOptions);
+      *getSyclObjImpl(Dev), {&Img}, {}, BuildOptions);
   ASSERT_NO_ERROR(llvm::sys::fs::remove_directories(ItemDir));
   detail::PersistentDeviceCodeCache::putItemToDisc({Dev}, {&Img}, {},
                                                    BuildOptions, NativeProg);
@@ -584,7 +584,7 @@ TEST_P(PersistentDeviceCodeCache, BasicEviction) {
                                                    BuildOptions, NativeProg);
 
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
-      Dev, {&Img}, {}, BuildOptions);
+      *getSyclObjImpl(Dev), {&Img}, {}, BuildOptions);
   size_t SizeOfOneEntry = (size_t)(detail::getDirectorySize(ItemDir));
 
   detail::PersistentDeviceCodeCache::putItemToDisc({Dev}, {&Img}, {},

--- a/sycl/unittests/program_manager/MultipleDevsKernelBundle.cpp
+++ b/sycl/unittests/program_manager/MultipleDevsKernelBundle.cpp
@@ -574,7 +574,7 @@ TEST_P(MultipleDevsKernelBundleTest, DISABLED_PersistentCache) {
   sycl_device_binary Bin = &BinStruct;
   detail::RTDeviceBinaryImage RTBinImg{Bin};
   auto Res = detail::PersistentDeviceCodeCache::getItemFromDisc(
-      {Devices[0], Devices[2]}, {&RTBinImg}, {}, {});
+      std::vector<sycl::device>{Devices[0], Devices[2]}, {&RTBinImg}, {}, {});
   EXPECT_EQ(Res.size(), static_cast<size_t>(2))
       << "Expected cache items to be loaded";
 


### PR DESCRIPTION
Same idea as with `nodes_range` from
https://github.com/intel/llvm/pull/19295, this PR generalizes the approach and makes both `nodes_|devices_range` use the same common utility.

`persistent_device_code_cache` was chosen randomly to apply simplifications by using the new helper. Subsequent PRs will likely make wider usage of it.