### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-398538e

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-af17e0f",
-      "version": "af17e0f",
-      "updated_at": "2025-04-09T23:37:41Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2915515592/zip",
+      "github_tag": "igc-dev-398538e",
+      "version": "398538e",
+      "updated_at": "2025-07-12T05:16:57Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/3517968454/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift