### PR TITLE
[SYCL][Offload] Enable Offload backend in E2E tests

### DIFF
--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -210,6 +210,10 @@ or via the ***LIT_OPTS*** environment variable.
 compilation command line for GPU device. If not specified "-device *" value is
 used.
 
+***OFFLOAD_BUILD_TARGET*** - when testing the Offload backend, this must be set
+to specify the correct build target type for the available Offload device.
+Valid values are `target-nvidia` and `target-amd`.
+
 ## Special test categories
 
 There are two special directories for extended testing. See documentation at:

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -22,6 +22,7 @@ config.backend_to_target = {
     "cuda": "target-nvidia",
     "hip": "target-amd",
     "native_cpu": "target-native_cpu",
+    "offload": config.offload_build_target,
 }
 config.target_to_triple = {
     "target-spir": "spir64",
@@ -683,6 +684,7 @@ available_devices = {
     "level_zero": "gpu",
     "hip": "gpu",
     "native_cpu": "cpu",
+    "offload": "gpu",
 }
 for d in remove_level_zero_suffix(config.sycl_devices):
     be, dev = d.split(":")

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -34,6 +34,7 @@ config.cuda_libs_dir = "@CUDA_LIBS_DIR@"
 config.cuda_include = "@CUDA_INCLUDE@"
 config.hip_libs_dir = "@HIP_LIBS_DIR@"
 config.hip_include = "@HIP_INCLUDE@"
+config.offload_build_target = "@OFFLOAD_BUILD_TARGET@"
 
 config.opencl_include_dir = os.path.join(config.sycl_include, 'sycl')
 

--- a/unified-runtime/source/adapters/offload/device.cpp
+++ b/unified-runtime/source/adapters/offload/device.cpp
@@ -67,6 +67,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_PLATFORM:
     return ReturnValue(hDevice->Platform);
     break;
+  case UR_DEVICE_INFO_USM_DEVICE_SUPPORT:
+  case UR_DEVICE_INFO_USM_HOST_SUPPORT:
   case UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT:
     return ReturnValue(UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS);
   case UR_DEVICE_INFO_BUILD_ON_SUBDEVICE:
@@ -78,6 +80,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(uint32_t{3});
   case UR_DEVICE_INFO_COMPILER_AVAILABLE:
     return ReturnValue(true);
+  case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL:
+    // TODO: Implement subgroups in Offload
+    return ReturnValue(1);
   // Unimplemented features
   case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS:
   case UR_DEVICE_INFO_GLOBAL_VARIABLE_SUPPORT:
@@ -85,12 +90,25 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP:
   case UR_DEVICE_INFO_IMAGE_SUPPORT:
   case UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT:
+  case UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT:
+  // TODO: Atomic queries in Offload
+  case UR_DEVICE_INFO_ATOMIC_64:
+  case UR_DEVICE_INFO_IMAGE_SRGB:
+  case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY:
+  case UR_DEVICE_INFO_LINKER_AVAILABLE:
     return ReturnValue(false);
   case UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT:
-  case UR_DEVICE_INFO_USM_DEVICE_SUPPORT:
-  case UR_DEVICE_INFO_USM_HOST_SUPPORT:
   case UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT:
     return ReturnValue(uint32_t{0});
+  case UR_DEVICE_INFO_QUEUE_PROPERTIES:
+  case UR_DEVICE_INFO_KERNEL_LAUNCH_CAPABILITIES:
+    return ReturnValue(0);
+  case UR_DEVICE_INFO_SUPPORTED_PARTITIONS: {
+    if (pPropSizeRet) {
+      *pPropSizeRet = 0;
+    }
+    return UR_RESULT_SUCCESS;
+  }
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }


### PR DESCRIPTION
Enable the Offload backend in the E2E tests. The Offload UR adapter is still experimental and a WIP, the purpose of E2E testing now is purely to help develop the adapter and liboffload itself. The Offload adapter is not built by default.
