### PR TITLE
[SYCL][NativeCPU] Update clang-linker-wrapper.

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -674,9 +674,8 @@ getTripleBasedSYCLPostLinkOpts(const ArgList &Args,
   // because it only increases amount of code for device compiler to handle,
   // without any actual benefits.
   // TODO: Try to extend this feature for non-Intel GPUs.
-  if ((!Args.hasFlag(OPT_no_sycl_remove_unused_external_funcs,
-                     OPT_sycl_remove_unused_external_funcs, false) &&
-       !Triple.isNativeCPU()) &&
+  if (!Args.hasFlag(OPT_no_sycl_remove_unused_external_funcs,
+                    OPT_sycl_remove_unused_external_funcs, false) &&
       !Args.hasArg(OPT_sycl_allow_device_image_dependencies) &&
       !Triple.isNVPTX() && !Triple.isAMDGPU())
     PostLinkArgs.push_back("-emit-only-kernels-as-entry-points");
@@ -1567,8 +1566,7 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
     return ClangPath.takeError();
 
   llvm::Triple Triple(Args.getLastArgValue(OPT_triple_EQ));
-  if (Triple.isNativeCPU())
-    Triple = llvm::Triple(Args.getLastArgValue(OPT_host_triple_EQ));
+  llvm::Triple HostTriple(Args.getLastArgValue(OPT_host_triple_EQ));
 
   StringRef Arch = Args.getLastArgValue(OPT_arch_EQ);
   // Create a new file to write the linked device image to. Assume that the
@@ -1585,7 +1583,7 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
       "--no-default-config",
       "-o",
       *TempFileOrErr,
-      Args.MakeArgString("--target=" + Triple.getTriple()),
+      Args.MakeArgString("--target=" + (Triple.isNativeCPU() ? HostTriple : Triple).getTriple()),
   };
 
   if (!Arch.empty())
@@ -1602,16 +1600,24 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
         {"-Xlinker",
          Args.MakeArgString("--plugin-opt=" + StringRef(Arg->getValue()))});
 
-  if (!Triple.isNVPTX() && !Triple.isSPIRV())
+  if (!Triple.isNVPTX() && !Triple.isSPIRV() && !Triple.isNativeCPU())
     CmdArgs.push_back("-Wl,--no-undefined");
 
   if (IsSYCLKind && Triple.isNVPTX())
     CmdArgs.push_back("-S");
+
+  if (IsSYCLKind && Triple.isNativeCPU()) {
+    CmdArgs.push_back("-Wno-override-module");
+    CmdArgs.push_back("-mllvm");
+    CmdArgs.push_back("-sycl-native-cpu-backend");
+    CmdArgs.push_back("-c");
+  }
+
   for (StringRef InputFile : InputFiles)
     CmdArgs.push_back(InputFile);
 
   // If this is CPU offloading we copy the input libraries.
-  if (!Triple.isGPU()) {
+  if (!Triple.isGPU() && !Triple.isNativeCPU()) {
     CmdArgs.push_back("-Wl,-Bsymbolic");
     CmdArgs.push_back("-shared");
     ArgStringList LinkerArgs;
@@ -1662,6 +1668,38 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
     if (llvm::Triple(Arg.split('=').first) == Triple)
       CmdArgs.append({"-Xclang", "-mlink-builtin-bitcode", "-Xclang",
                       Args.MakeArgString(Arg.split('=').second)});
+  }
+
+  // link NativeCPU utils lib if needed
+  if (Triple.isNativeCPU()) {
+    if (auto *A = Args.getLastArg(OPT_sycl_device_library_location_EQ)) {
+      std::string NativeCPUUtilsLib = "";
+
+      SmallVector<std::string, 8> LibraryPaths;
+      for (const auto &Path : A->getValues()) {
+        SmallString<128> LPath(Path);
+        if (llvm::sys::fs::exists(LPath)) {
+          LibraryPaths.emplace_back(LPath);
+        }
+      }
+
+      for (auto &LPath : LibraryPaths) {
+        // Call llvm-link without --only-needed to link to the nativecpu_utils
+        // lib
+        const char LibNativeCPUUtilsName[] = "libsycl-nativecpu_utils.bc";
+        SmallString<128> LibNativeCPUUtilsPath(LPath);
+        llvm::sys::path::append(LibNativeCPUUtilsPath, LibNativeCPUUtilsName);
+        if (llvm::sys::fs::exists(LibNativeCPUUtilsPath)) {
+          NativeCPUUtilsLib = LibNativeCPUUtilsPath.str();
+          break;
+        }
+      }
+
+      if (NativeCPUUtilsLib != "") {
+        CmdArgs.append({"-Xclang", "-mlink-bitcode-file", "-Xclang",
+                        Args.MakeArgString(NativeCPUUtilsLib)});
+      }
+    }
   }
 
   // The OpenMPOpt pass can introduce new calls and is expensive, we do
@@ -2137,6 +2175,13 @@ Expected<SmallVector<StringRef>> linkAndWrapDeviceFiles(
           SplitModules[I].ModuleFilePath = *BundledFileOrErr;
         } else {
           SplitModules[I].ModuleFilePath = *ClangOutputOrErr;
+          if (Triple.isNativeCPU()) {
+            // Add to WrappedOutput directly rather than combining this with the
+            // below because WrappedOutput holds references and
+            // SplitModules[I].ModuleFilePath will go out of scope too soon.
+            std::scoped_lock Guard(ImageMtx);
+            WrappedOutput.push_back(*ClangOutputOrErr);
+          }
         }
       }
 

--- a/sycl/test/native_cpu/atomic-base.cpp
+++ b/sycl/test/native_cpu/atomic-base.cpp
@@ -4,6 +4,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 
+// RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t-new --offload-new-driver
+// RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t-new
+
 #include <sycl/sycl.hpp>
 #include <vector>
 

--- a/sycl/test/native_cpu/multiple_tu.cpp
+++ b/sycl/test/native_cpu/multiple_tu.cpp
@@ -12,6 +12,13 @@
 //RUN: %clangxx -fsycl -fsycl-targets=native_cpu -g %t_plusone-debug.o %t_main-debug.o %t_init-debug.o -o %t-debug
 //RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t-debug
 
+// New offload driver
+//RUN: %clangxx -fsycl -fsycl-targets=native_cpu --offload-new-driver %s -c -o %t_main-new_offload.o
+//RUN: %clangxx -fsycl -fsycl-targets=native_cpu --offload-new-driver %S/Inputs/init.cpp -c -o %t_init-new_offload.o
+//RUN: %clangxx -fsycl -fsycl-targets=native_cpu --offload-new-driver %S/Inputs/plusone.cpp -c -o %t_plusone-new_offload.o
+//RUN: %clangxx -fsycl -fsycl-targets=native_cpu --offload-new-driver %t_plusone-new_offload.o %t_main-new_offload.o %t_init-new_offload.o -o %t-new_offload
+//RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t-new_offload
+
 #include "Inputs/common.h"
 #include <iostream>
 

--- a/sycl/test/native_cpu/vector-add.cpp
+++ b/sycl/test/native_cpu/vector-add.cpp
@@ -22,6 +22,10 @@
 // verify the (profiling) outputs.
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -fprofile-instr-generate -fcoverage-mapping -mllvm -system-headers-coverage -c -o %t
 
+// Use new offload driver
+// RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t-new --offload-new-driver
+// RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t-new
+
 #include <sycl/sycl.hpp>
 
 #include <array>


### PR DESCRIPTION
The current support for NativeCPU in clang-linker-wrapper had not been maintained; this commit updates it to work again and adds some minimal testing.