### PR TITLE
[SYCL] Fix error handling and add more failure info to syclbin-dump

### DIFF
--- a/sycl/test/syclbin/input_files.cpp
+++ b/sycl/test/syclbin/input_files.cpp
@@ -1,6 +1,4 @@
 // RUN: not syclbin-dump nonexistent.syclbin 2>&1 | FileCheck %s --check-prefix CHECK-NONEXISTENT-FILE
 // RUN: not syclbin-dump %S/Inputs/malformed.syclbin 2>&1 | FileCheck %s --check-prefix CHECK-MALFORMED-FILE
-// UNSUPPORTED: linux
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19404
-// CHECK-NONEXISTENT-FILE: Failed to open or read file nonexistent.syclbin
-// CHECK-MALFORMED-FILE: Invalid data was encountered while parsing the file
+// CHECK-NONEXISTENT-FILE: Failed to open or read file nonexistent.syclbin: No such file or directory
+// CHECK-MALFORMED-FILE: Failed to parse SYCLBIN file: Incorrect SYCLBIN magic number.

--- a/sycl/test/syclbin/input_files.cpp
+++ b/sycl/test/syclbin/input_files.cpp
@@ -1,4 +1,4 @@
 // RUN: not syclbin-dump nonexistent.syclbin 2>&1 | FileCheck %s --check-prefix CHECK-NONEXISTENT-FILE
 // RUN: not syclbin-dump %S/Inputs/malformed.syclbin 2>&1 | FileCheck %s --check-prefix CHECK-MALFORMED-FILE
-// CHECK-NONEXISTENT-FILE: Failed to open or read file nonexistent.syclbin: No such file or directory
+// CHECK-NONEXISTENT-FILE: Failed to open or read file nonexistent.syclbin:
 // CHECK-MALFORMED-FILE: Failed to parse SYCLBIN file: Incorrect SYCLBIN magic number.

--- a/sycl/tools/syclbin-dump/syclbin-dump.cpp
+++ b/sycl/tools/syclbin-dump/syclbin-dump.cpp
@@ -100,8 +100,9 @@ int main(int argc, char **argv) {
 
   auto FileMemBufferOrError = llvm::MemoryBuffer::getFileOrSTDIN(
       TargetFilename, /*IsText=*/false, /*RequiresNullTerminator=*/false);
-  if (!FileMemBufferOrError) {
-    errs() << "Failed to open or read file " << TargetFilename << "\n";
+  if (std::error_code EC = FileMemBufferOrError.getError()) {
+    errs() << "Failed to open or read file " << TargetFilename << ": "
+           << EC.message() << "\n";
     return 1;
   }
 
@@ -116,19 +117,25 @@ int main(int argc, char **argv) {
 
   std::unique_ptr<llvm::object::OffloadBinary> ParsedOffloadBinary;
   MemoryBufferRef SYCLBINImageBuffer = [&]() {
-    // If we failed to load as an offload binary, it may still be a SYCLBIN at
-    // an outer level.
-    if (llvm::object::OffloadBinary::create(**FileMemBufferOrError)
-            .moveInto(ParsedOffloadBinary))
+    if (llvm::Error E =
+            llvm::object::OffloadBinary::create(**FileMemBufferOrError)
+                .moveInto(ParsedOffloadBinary)) {
+      // If we failed to load as an offload binary, it may still be a SYCLBIN at
+      // an outer level.
+      (bool)llvm::handleErrors(
+          std::move(E),
+          [](std::unique_ptr<ECError>) -> Error { return Error::success(); });
       return MemoryBufferRef(**FileMemBufferOrError);
-    else
+    } else {
       return MemoryBufferRef(ParsedOffloadBinary->getImage(), "");
+    }
   }();
 
   std::unique_ptr<llvm::object::SYCLBIN> ParsedSYCLBIN;
-  if (llvm::object::SYCLBIN::read(SYCLBINImageBuffer).moveInto(ParsedSYCLBIN)) {
-    errs() << "Failed to parse SYCLBIN file.\n";
-    return 1;
+  if (llvm::Error E = llvm::object::SYCLBIN::read(SYCLBINImageBuffer)
+                          .moveInto(ParsedSYCLBIN)) {
+    errs() << "Failed to parse SYCLBIN file: " << E << "\n";
+    std::abort();
   }
 
   OS << "Version: " << ParsedSYCLBIN->Version << "\n";

--- a/sycl/tools/syclbin-dump/syclbin-dump.cpp
+++ b/sycl/tools/syclbin-dump/syclbin-dump.cpp
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
                 .moveInto(ParsedOffloadBinary)) {
       // If we failed to load as an offload binary, it may still be a SYCLBIN at
       // an outer level.
-      (bool)llvm::handleErrors(
+      std::ignore = (bool)llvm::handleErrors(
           std::move(E),
           [](std::unique_ptr<ECError>) -> Error { return Error::success(); });
       return MemoryBufferRef(**FileMemBufferOrError);


### PR DESCRIPTION
This commit fixes an issue with unhandled LLVM errors and prints additional information for some error-conditions in syclbin-dump.

Fixes https://github.com/intel/llvm/issues/19404