### PR TITLE
[SYCL][clang] Fix after conflict with 6a99326

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -18936,6 +18936,17 @@ void Sema::ActOnCXXExitDeclInitializer(Scope *S, Decl *D) {
   if (S && D->isOutOfLine())
     ExitDeclaratorContext(S);
 
+  if (auto *VD = dyn_cast<VarDecl>(D)) {
+    if (!VD->isUsableInConstantExpressions(Context) &&
+        !VD->hasConstantInitialization()) {
+      for (auto &DDEntry : MaybeDeviceDeferredDiags)
+        for (auto &DD : DDEntry.second)
+          DeviceDeferredDiags[DDEntry.first].push_back(DD);
+    }
+    MaybeDeviceDeferredDiags.clear();
+  }
+  InConstexprVarInit = false;
+
   PopExpressionEvaluationContext();
 }
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -18029,14 +18029,8 @@ HandleImmediateInvocations(Sema &SemaRef,
       // - it is a subexpression of a manifestly constant-evaluated expression
       //   or conversion.
       return;
-    } else {
-      for (auto &DDEntry : SemaRef.MaybeDeviceDeferredDiags)
-        for (auto &DD : DDEntry.second)
-          SemaRef.DeviceDeferredDiags[DDEntry.first].push_back(DD);
     }
   }
-  SemaRef.MaybeDeviceDeferredDiags.clear();
-  SemaRef.InConstexprVarInit = false;
 
   /// When we have more than 1 ImmediateInvocationCandidates or previously
   /// failed immediate invocations, we need to check for nested


### PR DESCRIPTION
To allow all C++ features in constexpr contexts we need to track constexpr initializers of variables. The mentioned commit moved some code to handle consteval better but we need the code where it used to be since it is not only consteval that we care about.