### PR TITLE
[SYCL][UR][L0 v2] Update pDesc in urQueueGetNativeHandle

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -90,9 +90,13 @@ ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
 }
 
 ur_result_t ur_queue_immediate_in_order_t::queueGetNativeHandle(
-    ur_queue_native_desc_t * /*pDesc*/, ur_native_handle_t *phNativeQueue) {
+    ur_queue_native_desc_t *pDesc, ur_native_handle_t *phNativeQueue) {
   *phNativeQueue = reinterpret_cast<ur_native_handle_t>(
       commandListManager.get_no_lock()->getZeCommandList());
+  if (pDesc && pDesc->pNativeData) {
+    // pNativeData == isImmediateQueue
+    *(reinterpret_cast<int32_t *>(pDesc->pNativeData)) = 1;
+  }
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.cpp
@@ -94,10 +94,14 @@ ur_result_t ur_queue_immediate_out_of_order_t::queueGetInfo(
 }
 
 ur_result_t ur_queue_immediate_out_of_order_t::queueGetNativeHandle(
-    ur_queue_native_desc_t * /*pDesc*/, ur_native_handle_t *phNativeQueue) {
+    ur_queue_native_desc_t *pDesc, ur_native_handle_t *phNativeQueue) {
   *phNativeQueue = reinterpret_cast<ur_native_handle_t>(
       (*commandListManagers.get_no_lock())[getNextCommandListId()]
           .getZeCommandList());
+  if (pDesc && pDesc->pNativeData) {
+    // pNativeData == isImmediateQueue
+    *(reinterpret_cast<int32_t *>(pDesc->pNativeData)) = 1;
+  }
   return UR_RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
SYCL expects urQueueGetNativeHandle to set pNativeData to 1 or 0 depending on whether the queue is using immediate command list. V2 adapter was not setting this at all, which resulted in SYCL reading uninitialized data.