### PR TITLE
[SYCL][LIT] Fix `warnings/no_fsycl_flag.cpp`

### DIFF
--- a/sycl/test/warnings/no_fsycl_flag.cpp
+++ b/sycl/test/warnings/no_fsycl_flag.cpp
@@ -2,5 +2,5 @@
 // <sycl/sycl.hpp> file is included.
 // RUN: %clangxx -std=c++17 -I %sycl_include -fsyntax-only %s -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning
 
-// expected-warning@sycl/sycl.hpp:27 {{You are including <sycl/sycl.hpp> without -fsycl flag, which is errorenous for device code compilation. This warning can be disabled by setting SYCL_DISABLE_FSYCL_SYCLHPP_WARNING macro.}}
+// expected-warning@sycl/sycl.hpp:* {{You are including <sycl/sycl.hpp> without -fsycl flag, which is errorenous for device code compilation. This warning can be disabled by setting SYCL_DISABLE_FSYCL_SYCLHPP_WARNING macro.}}
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
This test is failing internally because the line number doesn't match as <sycl/sycl.hpp> internally have a different copyright header than open-source.

The line number doesn't matter, so this PR replaces it with a wild card instead.