### PR TITLE
[SYCL][CMake] Fix and apply hardening flags to `sycl-rel-6_2`

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -174,6 +174,7 @@ def do_configure(args, passthrough_args):
         # Our codebase isn't ready for those new warnings just yet
         if platform.system() == "Windows":
             sycl_werror = "OFF"
+            xpti_enable_werror = "OFF"
 
     cmake_cmd = [
         "cmake",

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -236,6 +236,8 @@ def do_configure(args, passthrough_args):
         cmake_cmd += args.cmake_opt
 
     if args.add_security_flags:
+        if args.add_security_flags != 'none':
+            cmake_cmd.extend(["-DCMAKE_POSITION_INDEPENDENT_CODE=ON"])
         cmake_cmd.extend(["-DEXTRA_SECURITY_FLAGS={}".format(args.add_security_flags)])
 
     # Add path to root CMakeLists.txt

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -170,6 +170,11 @@ def do_configure(args, passthrough_args):
 
     install_dir = os.path.join(abs_obj_dir, "install")
 
+    if args.add_security_flags and args.add_security_flags != 'none':
+        # Our codebase isn't ready for those new warnings just yet
+        if platform.system() == "Windows":
+            sycl_werror = "OFF"
+
     cmake_cmd = [
         "cmake",
         "-G",

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -170,12 +170,6 @@ def do_configure(args, passthrough_args):
 
     install_dir = os.path.join(abs_obj_dir, "install")
 
-    if args.add_security_flags and args.add_security_flags != 'none':
-        # Our codebase isn't ready for those new warnings just yet
-        if platform.system() == "Windows":
-            sycl_werror = "OFF"
-            xpti_enable_werror = "OFF"
-
     cmake_cmd = [
         "cmake",
         "-G",

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -1,7 +1,7 @@
 macro(add_compile_option_ext flag name)
-  cmake_parse_arguments(ARG "" "" "" ${ARGN}) 
+  cmake_parse_arguments(ARG "" "" "" ${ARGN})
   set(CHECK_STRING "${flag}")
-  if (MSVC)
+  if(MSVC)
     set(CHECK_STRING "/WX ${CHECK_STRING}")
   else()
     set(CHECK_STRING "-Werror ${CHECK_STRING}")
@@ -9,7 +9,7 @@ macro(add_compile_option_ext flag name)
 
   check_c_compiler_flag("${CHECK_STRING}" "C_SUPPORTS_${name}")
   check_cxx_compiler_flag("${CHECK_STRING}" "CXX_SUPPORTS_${name}")
-  if (C_SUPPORTS_${name} AND CXX_SUPPORTS_${name})
+  if(C_SUPPORTS_${name} AND CXX_SUPPORTS_${name})
     message(STATUS "Building with ${flag}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flag}")
@@ -31,73 +31,207 @@ macro(add_link_option_ext flag name)
   endif()
 endmacro()
 
+set(is_gcc FALSE)
+set(is_clang FALSE)
+set(is_msvc FALSE)
+set(is_icpx FALSE)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(is_clang TRUE)
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  set(is_gcc TRUE)
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
+  set(is_icpx TRUE)
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  set(is_msvc TRUE)
+endif()
+
 macro(append_common_extra_security_flags)
-  if( LLVM_ON_UNIX )
+  # Compiler Warnings and Error Detection
+  # Note: in intel/llvm we build both linux and win with --ci-defaults.
+  # This flag also enables -Werror or /WX.
+  if(is_gcc
+     OR is_clang
+     OR (is_icpx AND MSVC))
+    add_compile_option_ext("-Wall" WALL)
+    add_compile_option_ext("-Wextra" WEXTRA)
+  elseif(is_icpx)
+    add_compile_option_ext("/Wall" WALL)
+  elseif(is_msvc)
+    add_compile_option_ext("/W4" WALL)
+  endif()
+
+  if(CMAKE_BUILD_TYPE MATCHES "Release")
+    if(is_gcc
+       OR is_clang
+       OR (is_icpx AND MSVC))
+      add_compile_option_ext("-Wconversion" WCONVERSION)
+      add_compile_option_ext("-Wimplicit-fallthrough" WIMPLICITFALLTHROUGH)
+    endif()
+  endif()
+
+  # Control Flow Integrity
+  if(is_gcc
+     OR is_clang
+     OR (is_icpx AND MSVC))
+    add_compile_option_ext("-fcf-protection=full" FCFPROTECTION)
+  elseif(is_icpx)
+    add_compile_option_ext("/Qcf-protection:full" FCFPROTECTION)
+  elseif(is_msvc)
+    add_link_option_ext("/LTCG" LTCG CMAKE_EXE_LINKER_FLAGS
+                        CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+    add_compile_option_ext("/sdl" SDL)
+    add_compile_option_ext("/guard:cf" GUARDCF)
+    add_link_option_ext("/CETCOMPAT" CETCOMPAT CMAKE_EXE_LINKER_FLAGS
+                        CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+  endif()
+
+  # Format String Defense
+  if(is_gcc
+     OR is_clang
+     OR (is_icpx AND MSVC))
+    add_compile_option_ext("-Wformat" WFORMAT)
+    add_compile_option_ext("-Wformat-security" WFORMATSECURITY)
+  elseif(is_icpx)
+    add_compile_option_ext("/Wformat" WFORMAT)
+    add_compile_option_ext("/Wformat-security" WFORMATSECURITY)
+  elseif(is_msvc)
+    add_compile_option_ext("/analyze" ANALYZE)
+  endif()
+
+  if(CMAKE_BUILD_TYPE MATCHES "Release")
+    if(is_gcc
+       OR is_clang
+       OR (is_icpx AND MSVC))
+      add_compile_option_ext("-Werror=format-security" WERRORFORMATSECURITY)
+    endif()
+  endif()
+
+  # Inexecutable Stack
+  if(CMAKE_BUILD_TYPE MATCHES "Release")
+    if(is_gcc
+       OR is_clang
+       OR (is_icpx AND MSVC))
+      add_link_option_ext(
+        "-Wl,-z,noexecstack" NOEXECSTACK CMAKE_EXE_LINKER_FLAGS
+        CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+    endif()
+  endif()
+
+  # Position Independent Code
+  if(is_gcc
+     OR is_clang
+     OR (is_icpx AND MSVC))
+    add_compile_option_ext("-fPIC" FPIC)
+  elseif(is_msvc)
+    add_compile_option_ext("/Gy" GY)
+  endif()
+
+  # Position Independent Execution
+  if(is_gcc
+     OR is_clang
+     OR (is_icpx AND MSVC))
+    # The project should be configured with -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    add_compile_option_ext("-fPIE" FPIE)
+    add_link_option_ext("-pie" PIE CMAKE_EXE_LINKER_FLAGS
+                        CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+  elseif(is_msvc)
+    add_link_option_ext("/DYNAMICBASE" DYNAMICBASE CMAKE_EXE_LINKER_FLAGS
+                        CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+  endif()
+
+  if(CMAKE_BUILD_TYPE MATCHES "Release")
+    if(is_msvc)
+      add_link_option_ext("/NXCOMPAT" NXCOMPAT CMAKE_EXE_LINKER_FLAGS
+                          CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+    endif()
+  endif()
+
+  # Stack Protection
+  if(is_msvc)
+    add_compile_option_ext("/GS" GS)
+  elseif(
+    is_gcc
+    OR is_clang
+    OR (is_icpx AND MSVC))
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+      add_compile_option_ext("-fstack-protector" FSTACKPROTECTOR)
+    elseif(CMAKE_BUILD_TYPE MATCHES "Release")
+      add_compile_option_ext("-fstack-protector-strong" FSTACKPROTECTORSTRONG)
+      add_compile_option_ext("-fstack-clash-protection" FSTACKCLASHPROTECTION)
+    endif()
+  endif()
+
+  if(LLVM_ON_UNIX)
     # Fortify Source (strongly recommended):
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-      message(WARNING
-        "-D_FORTIFY_SOURCE=2 can only be used with optimization.")
-      message(WARNING "-D_FORTIFY_SOURCE=2 is not supported.")
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+      message(WARNING "-D_FORTIFY_SOURCE=3 can only be used with optimization.")
+      message(WARNING "-D_FORTIFY_SOURCE=3 is not supported.")
     else()
-      # Sanitizers do not work with checked memory functions,
-      # such as __memset_chk. We do not build release packages
-      # with sanitizers, so just avoid -D_FORTIFY_SOURCE=2
-      # under LLVM_USE_SANITIZER.
-      if (NOT LLVM_USE_SANITIZER)
-        message(STATUS "Building with -D_FORTIFY_SOURCE=2")
-        add_definitions(-D_FORTIFY_SOURCE=2)
+      # Sanitizers do not work with checked memory functions, such as
+      # __memset_chk. We do not build release packages with sanitizers, so just
+      # avoid -D_FORTIFY_SOURCE=3 under LLVM_USE_SANITIZER.
+      if(NOT LLVM_USE_SANITIZER)
+        message(STATUS "Building with -D_FORTIFY_SOURCE=3")
+        add_definitions(-D_FORTIFY_SOURCE=3)
       else()
-        message(WARNING
-          "-D_FORTIFY_SOURCE=2 dropped due to LLVM_USE_SANITIZER.")
+        message(
+          WARNING "-D_FORTIFY_SOURCE=3 dropped due to LLVM_USE_SANITIZER.")
       endif()
     endif()
 
-    # Format String Defense
-    add_compile_option_ext("-Wformat" WFORMAT)
-    add_compile_option_ext("-Wformat-security" WFORMATSECURITY)
-    add_compile_option_ext("-Werror=format-security" WERRORFORMATSECURITY)
-
-    # Stack Protection
-    add_compile_option_ext("-fstack-protector-strong" FSTACKPROTECTORSTRONG)
+    if(LLVM_ENABLE_ASSERTIONS)
+      add_definitions(-D_GLIBCXX_ASSERTIONS)
+    endif()
 
     # Full Relocation Read Only
-    add_link_option_ext("-Wl,-z,relro" ZRELRO
-      CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS
-      CMAKE_SHARED_LINKER_FLAGS)
+    if(CMAKE_BUILD_TYPE MATCHES "Release")
+      add_link_option_ext("-Wl,-z,relro" ZRELRO CMAKE_EXE_LINKER_FLAGS
+                          CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+    endif()
 
     # Immediate Binding (Bindnow)
-    add_link_option_ext("-Wl,-z,now" ZNOW
-      CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS
-      CMAKE_SHARED_LINKER_FLAGS)
+    if(CMAKE_BUILD_TYPE MATCHES "Release")
+      add_link_option_ext("-Wl,-z,now" ZNOW CMAKE_EXE_LINKER_FLAGS
+                          CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+      add_link_option_ext("-Wl,-z,nodlopen" ZDLOPEN CMAKE_EXE_LINKER_FLAGS
+                          CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+    endif()
   endif()
 endmacro()
 
-if ( EXTRA_SECURITY_FLAGS )
-    if (EXTRA_SECURITY_FLAGS STREQUAL "none")
+if(EXTRA_SECURITY_FLAGS)
+  if(EXTRA_SECURITY_FLAGS STREQUAL "none")
     # No actions.
-    elseif (EXTRA_SECURITY_FLAGS STREQUAL "default")
-      append_common_extra_security_flags()
-    elseif (EXTRA_SECURITY_FLAGS STREQUAL "sanitize")
-      append_common_extra_security_flags()
-      if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        add_compile_option_ext("-fsanitize=cfi" FSANITIZE_CFI)
-        add_link_option_ext("-fsanitize=cfi" FSANITIZE_CFI_LINK
-          CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS
-          CMAKE_SHARED_LINKER_FLAGS)
-        # Recommended option although linking a DSO with SafeStack is not currently supported by compiler.
-        #add_compile_option_ext("-fsanitize=safe-stack" FSANITIZE_SAFESTACK)
-        #add_link_option_ext("-fsanitize=safe-stack" FSANITIZE_SAFESTACK_LINK
-        #  CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS
-        #  CMAKE_SHARED_LINKER_FLAGS)
-      else()
-        add_compile_option_ext("-fcf-protection=full -mcet" FCF_PROTECTION)
-        # need to align compile and link option set, link now is set unconditionally
-        add_link_option_ext("-fcf-protection=full -mcet" FCF_PROTECTION_LINK
-          CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS
-          CMAKE_SHARED_LINKER_FLAGS)
-      endif()
+  elseif(EXTRA_SECURITY_FLAGS STREQUAL "default")
+    append_common_extra_security_flags()
+  elseif(EXTRA_SECURITY_FLAGS STREQUAL "sanitize")
+    append_common_extra_security_flags()
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      add_compile_option_ext("-fsanitize=cfi" FSANITIZE_CFI)
+      add_link_option_ext(
+        "-fsanitize=cfi" FSANITIZE_CFI_LINK CMAKE_EXE_LINKER_FLAGS
+        CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+      # Recommended option although linking a DSO with SafeStack is not
+      # currently supported by compiler.
+      # add_compile_option_ext("-fsanitize=safe-stack" FSANITIZE_SAFESTACK)
+      # add_link_option_ext("-fsanitize=safe-stack" FSANITIZE_SAFESTACK_LINK
+      # CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS
+      # CMAKE_SHARED_LINKER_FLAGS)
     else()
-      message(FATAL_ERROR "Unsupported value of EXTRA_SECURITY_FLAGS: ${EXTRA_SECURITY_FLAGS}")
+      add_compile_option_ext("-fcf-protection=full -mcet" FCF_PROTECTION)
+      # need to align compile and link option set, link now is set
+      # unconditionally
+      add_link_option_ext(
+        "-fcf-protection=full -mcet" FCF_PROTECTION_LINK CMAKE_EXE_LINKER_FLAGS
+        CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
     endif()
+  else()
+    message(
+      FATAL_ERROR
+        "Unsupported value of EXTRA_SECURITY_FLAGS: ${EXTRA_SECURITY_FLAGS}")
+  endif()
 endif()
-

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -131,14 +131,13 @@ macro(append_common_extra_security_flags)
   endif()
 
   # Position Independent Execution
-  if(is_gcc
-     OR is_clang
-     OR (is_icpx AND MSVC))
-    # The project should be configured with -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    add_compile_option_ext("-fPIE" FPIE)
-    add_link_option_ext("-pie" PIE CMAKE_EXE_LINKER_FLAGS
-                        CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
-  elseif(is_msvc)
+  # We rely on CMake to set the right -fPIE flags for us, but it must be
+  # explicitly requested
+  if (NOT CMAKE_POSITION_INDEPENDENT_CODE)
+    message(FATAL_ERROR "To enable all necessary security flags, CMAKE_POSITION_INDEPENDENT_CODE must be set to ON")
+  endif()
+
+  if(is_msvc)
     add_link_option_ext("/DYNAMICBASE" DYNAMICBASE CMAKE_EXE_LINKER_FLAGS
                         CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
   endif()

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -74,8 +74,6 @@ macro(append_common_extra_security_flags)
   elseif(is_icpx)
     add_compile_option_ext("/Wformat" WFORMAT)
     add_compile_option_ext("/Wformat-security" WFORMATSECURITY)
-  elseif(is_msvc)
-    add_compile_option_ext("/analyze" ANALYZE)
   endif()
 
   if(CMAKE_BUILD_TYPE MATCHES "Release")

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -50,29 +50,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 endif()
 
 macro(append_common_extra_security_flags)
-  # Compiler Warnings and Error Detection
-  # Note: in intel/llvm we build both linux and win with --ci-defaults.
-  # This flag also enables -Werror or /WX.
-  if(is_gcc
-     OR is_clang
-     OR (is_icpx AND MSVC))
-    add_compile_option_ext("-Wall" WALL)
-    add_compile_option_ext("-Wextra" WEXTRA)
-  elseif(is_icpx)
-    add_compile_option_ext("/Wall" WALL)
-  elseif(is_msvc)
-    add_compile_option_ext("/W4" WALL)
-  endif()
-
-  if(CMAKE_BUILD_TYPE MATCHES "Release")
-    if(is_gcc
-       OR is_clang
-       OR (is_icpx AND MSVC))
-      add_compile_option_ext("-Wconversion" WCONVERSION)
-      add_compile_option_ext("-Wimplicit-fallthrough" WIMPLICITFALLTHROUGH)
-    endif()
-  endif()
-
   # Control Flow Integrity
   if(is_gcc
      OR is_clang

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -60,7 +60,6 @@ macro(append_common_extra_security_flags)
   elseif(is_msvc)
     add_link_option_ext("/LTCG" LTCG CMAKE_EXE_LINKER_FLAGS
                         CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
-    add_compile_option_ext("/sdl" SDL)
     add_compile_option_ext("/guard:cf" GUARDCF)
     add_link_option_ext("/CETCOMPAT" CETCOMPAT CMAKE_EXE_LINKER_FLAGS
                         CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -31,7 +31,7 @@ macro(add_link_option_ext flag name)
   endif()
 endmacro()
 
-function(append_common_extra_security_flags)
+macro(append_common_extra_security_flags)
   if( LLVM_ON_UNIX )
     # Fortify Source (strongly recommended):
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -70,7 +70,7 @@ function(append_common_extra_security_flags)
       CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS
       CMAKE_SHARED_LINKER_FLAGS)
   endif()
-endfunction()
+endmacro()
 
 if ( EXTRA_SECURITY_FLAGS )
     if (EXTRA_SECURITY_FLAGS STREQUAL "none")

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -107,7 +107,10 @@ macro(append_common_extra_security_flags)
   # Position Independent Execution
   # We rely on CMake to set the right -fPIE flags for us, but it must be
   # explicitly requested
-  if (NOT CMAKE_POSITION_INDEPENDENT_CODE)
+  if (CMAKE_POSITION_INDEPENDENT_CODE)
+    include(CheckPIESupported)
+    check_pie_supported()
+  else()
     message(FATAL_ERROR "To enable all necessary security flags, CMAKE_POSITION_INDEPENDENT_CODE must be set to ON")
   endif()
 

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -164,24 +164,39 @@ macro(append_common_extra_security_flags)
     endif()
   endif()
 
-  if(LLVM_ON_UNIX)
-    # Fortify Source (strongly recommended):
+  # Fortify Source (strongly recommended):
+  if (NOT WIN32)
+    # Strictly speaking, _FORTIFY_SOURCE is a glibc feature and not a compiler
+    # feature. However, we experienced some issues (warnings about redefined macro
+    # which are problematic under -Werror) when setting it to value '3' with older
+    # gcc versions. Hence the check.
+    # Value '3' became supported in glibc somewhere around gcc 12, so that is
+    # what we are looking for.
+    if (is_gcc AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+      set(FORTIFY_SOURCE "-D_FORTIFY_SOURCE=2")
+    else()
+      # Assuming that the problem is not reproducible with other compilers
+      set(FORTIFY_SOURCE "-D_FORTIFY_SOURCE=3")
+    endif()
+
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-      message(WARNING "-D_FORTIFY_SOURCE=3 can only be used with optimization.")
-      message(WARNING "-D_FORTIFY_SOURCE=3 is not supported.")
+      message(WARNING "${FORTIFY_SOURCE} can only be used with optimization.")
+      message(WARNING "${FORTIFY_SOURCE} is not supported.")
     else()
       # Sanitizers do not work with checked memory functions, such as
       # __memset_chk. We do not build release packages with sanitizers, so just
-      # avoid -D_FORTIFY_SOURCE=3 under LLVM_USE_SANITIZER.
+      # avoid -D_FORTIFY_SOURCE=N under LLVM_USE_SANITIZER.
       if(NOT LLVM_USE_SANITIZER)
-        message(STATUS "Building with -D_FORTIFY_SOURCE=3")
-        add_definitions(-D_FORTIFY_SOURCE=3)
+        message(STATUS "Building with ${FORTIFY_SOURCE}")
+        add_definitions(${FORTIFY_SOURCE})
       else()
         message(
-          WARNING "-D_FORTIFY_SOURCE=3 dropped due to LLVM_USE_SANITIZER.")
+          WARNING "${FORTIFY_SOURCE} dropped due to LLVM_USE_SANITIZER.")
       endif()
     endif()
+  endif()
 
+  if(LLVM_ON_UNIX)
     if(LLVM_ENABLE_ASSERTIONS)
       add_definitions(-D_GLIBCXX_ASSERTIONS)
     endif()

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -196,8 +196,6 @@ macro(append_common_extra_security_flags)
     if(CMAKE_BUILD_TYPE MATCHES "Release")
       add_link_option_ext("-Wl,-z,now" ZNOW CMAKE_EXE_LINKER_FLAGS
                           CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
-      add_link_option_ext("-Wl,-z,nodlopen" ZDLOPEN CMAKE_EXE_LINKER_FLAGS
-                          CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
     endif()
   endif()
 endmacro()

--- a/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
@@ -355,12 +355,6 @@ static constexpr ext::oneapi::experimental::architecture
 // target name is specified via "-fsycl-targets", the associated invocation of
 // the device compiler will set this variable to false, and that will trigger
 // an error for code that uses "if_architecture_is".
-#pragma warning(push)
-// By some reason the following diagnostic is emitted which breaks -Werror (/WX)
-// build. Preprocessed code looks like (0 == 1) || (0 == 1) || ..., so it looks
-// like a bug in the MSVC compiler, hence disabling it.
-// (<non-zero constant> || <non-zero constant>) is always a non-zero constant.  Did you intend to use the bitwise-and operator?
-#pragma warning(disable: 6285)
 static constexpr bool is_allowable_aot_mode =
     (__SYCL_TARGET_INTEL_X86_64__ == 1) ||
     (__SYCL_TARGET_INTEL_GPU_BDW__ == 1) ||
@@ -449,7 +443,6 @@ static constexpr bool is_allowable_aot_mode =
     (__SYCL_TARGET_AMD_GPU_GFX1151__ == 1) ||
     (__SYCL_TARGET_AMD_GPU_GFX1200__ == 1) ||
     (__SYCL_TARGET_AMD_GPU_GFX1201__ == 1);
-#pragma warning(pop)
 
 constexpr static std::optional<ext::oneapi::experimental::architecture>
 get_current_architecture_aot() {

--- a/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
@@ -355,6 +355,12 @@ static constexpr ext::oneapi::experimental::architecture
 // target name is specified via "-fsycl-targets", the associated invocation of
 // the device compiler will set this variable to false, and that will trigger
 // an error for code that uses "if_architecture_is".
+#pragma warning(push)
+// By some reason the following diagnostic is emitted which breaks -Werror (/WX)
+// build. Preprocessed code looks like (0 == 1) || (0 == 1) || ..., so it looks
+// like a bug in the MSVC compiler, hence disabling it.
+// (<non-zero constant> || <non-zero constant>) is always a non-zero constant.  Did you intend to use the bitwise-and operator?
+#pragma warning(disable: 6285)
 static constexpr bool is_allowable_aot_mode =
     (__SYCL_TARGET_INTEL_X86_64__ == 1) ||
     (__SYCL_TARGET_INTEL_GPU_BDW__ == 1) ||
@@ -443,6 +449,7 @@ static constexpr bool is_allowable_aot_mode =
     (__SYCL_TARGET_AMD_GPU_GFX1151__ == 1) ||
     (__SYCL_TARGET_AMD_GPU_GFX1200__ == 1) ||
     (__SYCL_TARGET_AMD_GPU_GFX1201__ == 1);
+#pragma warning(pop)
 
 constexpr static std::optional<ext::oneapi::experimental::architecture>
 get_current_architecture_aot() {

--- a/unified-runtime/cmake/helpers.cmake
+++ b/unified-runtime/cmake/helpers.cmake
@@ -88,7 +88,13 @@ endif()
 
 function(add_ur_target_compile_options name)
     if(NOT MSVC)
-        target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=2)
+        if (NOT LLVM_ENABLE_PROJECTS)
+            # If UR is built as part of LLVM (i.e. as part of SYCL), then
+            # _FORTIFY_SOURCE will be set globally in advance to a potentially
+            # different value. To avoid redefinition errors, only set the
+            # macro for a "standalone" build.
+            target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=2)
+        endif()
         target_compile_options(${name} PRIVATE
             # Warning options
             -Wall


### PR DESCRIPTION
This PR contains several cherry-picks and some unique changes which have not been applied to the `sycl` branch yet.

The intent of this PR is to enable as much (quickly) possible hardening flags to be in better compliance with our SDL requirements.
The main thing this PR is after are things like immediate bindings, fortify source, stack protection and `relro`.
The thing that this PR is **not** after are extra warning flags - some of them we can't apply globally because LLVM itself isn't warning free, some of them we can't apply even locally to SYCL RT because we haven't fixed corresponding warnings yet.

Patches which were cherry-picked from the `sycl` branch:

- [SYCL] Fix AddSecurityFlags having no side effects (https://github.com/intel/llvm/pull/17690)
  - Patch-By: Alexey Sachkov <alexey.sachkov@intel.com>
- [SYCL] Refresh hardening flags applied to the project (https://github.com/intel/llvm/pull/18398)
  - Patch-By: Nikita Kornev <nikita.kornev@intel.com>
- [SYCL][CMAKE] Refactor -fPIE handling (https://github.com/intel/llvm/pull/19235)
  - Patch-By: Alexey Sachkov <alexey.sachkov@intel.com>
- [SYCL][CMAKE] Drop nodlopen from hardening flags (https://github.com/intel/llvm/pull/19357) 
  - Patch-By: Alexey Sachkov <alexey.sachkov@intel.com>
- [SYCL][CMAKE] Fix _FORTIFY_SOURCE=3 (https://github.com/intel/llvm/pull/19268)
  - Patch-By: Alexey Sachkov <alexey.sachkov@intel.com>
- [SYCL][CMake] Properly enable -pie hardening flag (https://github.com/intel/llvm/pull/19447)
  - Patch-By: Alexey Sachkov <alexey.sachkov@intel.com>

Additional changes which have **not** been applied to the `sycl` branch:
- Adjusted `configure.py` to the new way of `-fPIE` handling
- Dropped `/sdl` flag because LLVM isn't warning-free
  - it will be applied locally to SYCL RT in a separate PR against the `sycl` branch for future releases
- Dropped `/analyze` flag because SYCL RT isn't warning-free 
  - it will be applied locally to SYCL RT in a separate PR against the `sycl` branch for future releases
  
