### PR TITLE
[CI] Disable liboffload job

### DIFF
--- a/.github/workflows/ur-precommit.yml
+++ b/.github/workflows/ur-precommit.yml
@@ -99,11 +99,12 @@ jobs:
       docker_image: ${{ matrix.docker_image || 'ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps'}}
       image_options: ${{ matrix.image_options || '' }}
 
-  offload_build:
-    name: Adapters (Offload)
-    needs: [detect_changes, source_checks]
-    if: ${{ always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur_offload_adapter') }}
-    uses: ./.github/workflows/ur-build-offload.yml
+# TODO: Enable once the apt package at https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-snapshot/ is updated
+#  offload_build:
+#    name: Adapters (Offload)
+#    needs: [detect_changes, source_checks]
+#    if: ${{ always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur_offload_adapter') }}
+#    uses: ./.github/workflows/ur-build-offload.yml
 
   macos:
     name: MacOS build only


### PR DESCRIPTION
The packages it requires haven't been updated since the 3rd of July (as
of this commit), so disable for now.
