### PR TITLE
[SYCL][CMake] Properly enable `-pie` hardening flag

### DIFF
--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -133,11 +133,11 @@ macro(append_common_extra_security_flags)
   # Position Independent Execution
   # We rely on CMake to set the right -fPIE flags for us, but it must be
   # explicitly requested
-  if (NOT CMAKE_POSITION_INDEPENDENT_CODE)
-    message(FATAL_ERROR "To enable all necessary security flags, CMAKE_POSITION_INDEPENDENT_CODE must be set to ON")
-  else()
+  if (CMAKE_POSITION_INDEPENDENT_CODE)
     include(CheckPIESupported)
     check_pie_supported()
+  else()
+    message(FATAL_ERROR "To enable all necessary security flags, CMAKE_POSITION_INDEPENDENT_CODE must be set to ON")
   endif()
 
   if(is_msvc)

--- a/llvm/cmake/modules/AddSecurityFlags.cmake
+++ b/llvm/cmake/modules/AddSecurityFlags.cmake
@@ -135,6 +135,9 @@ macro(append_common_extra_security_flags)
   # explicitly requested
   if (NOT CMAKE_POSITION_INDEPENDENT_CODE)
     message(FATAL_ERROR "To enable all necessary security flags, CMAKE_POSITION_INDEPENDENT_CODE must be set to ON")
+  else()
+    include(CheckPIESupported)
+    check_pie_supported()
   endif()
 
   if(is_msvc)


### PR DESCRIPTION
We rely on CMake to set the right set of compliation and link flags to enable positition independent code and position independent execution.

Before this commit, necessary compliation flags were applied just fine, but link flags were missing. To get link flags, some extra CMake functions should be called.