### PR TITLE
[CI] Install missing igc-dev deps

### DIFF
--- a/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers_igc_dev.Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 USER root
 
-RUN apt update && apt install -yqq libllvm14
+RUN apt update && apt install -yqq libllvm14 libllvm15 libz3-4
 
 COPY scripts/get_release.py /
 COPY scripts/install_drivers.sh /


### PR DESCRIPTION
Causing `dlopen` failure at runtime