### PR TITLE
[SYCL][ESIMD] Fix ESIMD post-commit test failures

### DIFF
--- a/sycl/test/check_device_code/esimd/intrins_trans.cpp
+++ b/sycl/test/check_device_code/esimd/intrins_trans.cpp
@@ -107,7 +107,7 @@ test_mem_intrins(int *addr, const vec<float, 8> &xf,
   {
     uint32_t offset = 256;
     __esimd_slm_block_st<int, 8, 4>(offset, get8i());
-    // CHECK: store <8 x i32> %call16, ptr addrspace(3) inttoptr (i32 256 to ptr addrspace(3)), align 4
+    // CHECK: store <8 x i32> %{{[a-zA-Z0-9.]+}}, ptr addrspace(3) inttoptr (i32 256 to ptr addrspace(3)), align 4
   }
   {
     auto x = __esimd_svm_gather<unsigned char, 8>(get8ui64(), get8ui16());

--- a/sycl/test/check_device_code/esimd/spirv_intrins_trans.cpp
+++ b/sycl/test/check_device_code/esimd/spirv_intrins_trans.cpp
@@ -15,8 +15,8 @@ kernel_SubgroupLocalInvocationId(size_t *DoNotOptimize,
   DoNotOptimize[0] = __spirv_SubgroupLocalInvocationId();
   DoNotOptimize32[0] = __spirv_SubgroupLocalInvocationId() + 3;
   // CHECK-LABEL: @{{.*}}kernel_SubgroupLocalInvocationId
-  // CHECK: store i64 0, ptr addrspace(4) %DoNotOptimize, align 8
-  // CHECK: store i32 3, ptr addrspace(4) %DoNotOptimize32, align 4
+  // CHECK: store i64 0, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 8
+  // CHECK: store i32 3, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 4
 }
 
 SYCL_ESIMD_KERNEL SYCL_EXTERNAL void
@@ -24,8 +24,8 @@ kernel_SubgroupSize(size_t *DoNotOptimize, uint32_t *DoNotOptimize32) {
   DoNotOptimize[0] = __spirv_SubgroupSize();
   DoNotOptimize32[0] = __spirv_SubgroupSize() + 7;
   // CHECK-LABEL: @{{.*}}kernel_SubgroupSize
-  // CHECK: store i64 1, ptr addrspace(4) %DoNotOptimize, align 8
-  // CHECK: store i32 8, ptr addrspace(4) %DoNotOptimize32, align 4
+  // CHECK: store i64 1, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 8
+  // CHECK: store i32 8, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 4
 }
 
 SYCL_ESIMD_KERNEL SYCL_EXTERNAL void
@@ -33,6 +33,6 @@ kernel_SubgroupMaxSize(size_t *DoNotOptimize, uint32_t *DoNotOptimize32) {
   DoNotOptimize[0] = __spirv_SubgroupMaxSize();
   DoNotOptimize32[0] = __spirv_SubgroupMaxSize() + 9;
   // CHECK-LABEL: @{{.*}}kernel_SubgroupMaxSize
-  // CHECK: store i64 1, ptr addrspace(4) %DoNotOptimize, align 8
-  // CHECK: store i32 10, ptr addrspace(4) %DoNotOptimize32, align 4
+  // CHECK: store i64 1, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 8
+  // CHECK: store i32 10, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 4
 }


### PR DESCRIPTION
Fix test failures introduced by https://github.com/intel/llvm/pull/19411, namely:
```
Failed Tests (2):
  SYCL :: check_device_code/esimd/intrins_trans.cpp
  SYCL :: check_device_code/esimd/spirv_intrins_trans.cpp
```
