### PR TITLE
[UR][Offload] Implement urProgramCreateWithIL

### DIFF
--- a/unified-runtime/source/adapters/offload/device.cpp
+++ b/unified-runtime/source/adapters/offload/device.cpp
@@ -76,6 +76,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(uint32_t{1});
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS:
     return ReturnValue(uint32_t{3});
+  case UR_DEVICE_INFO_COMPILER_AVAILABLE:
+    return ReturnValue(true);
   // Unimplemented features
   case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS:
   case UR_DEVICE_INFO_GLOBAL_VARIABLE_SUPPORT:

--- a/unified-runtime/source/adapters/offload/program.cpp
+++ b/unified-runtime/source/adapters/offload/program.cpp
@@ -125,6 +125,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
   return UR_RESULT_SUCCESS;
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramCreateWithIL(ur_context_handle_t hContext, const void *pIL,
+                      size_t length, const ur_program_properties_t *pProperties,
+                      ur_program_handle_t *phProgram) {
+  // Liboffload consumes both IR and binaries through the same entrypoint
+  return urProgramCreateWithBinary(hContext, 1, &hContext->Device, &length,
+                                   reinterpret_cast<const uint8_t **>(&pIL),
+                                   pProperties, phProgram);
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urProgramBuild(ur_context_handle_t,
                                                    ur_program_handle_t,
                                                    const char *) {
@@ -145,12 +155,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCompile(ur_context_handle_t,
                                                      const char *) {
   // Do nothing, program is built upon creation
   return UR_RESULT_SUCCESS;
-}
-
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramCreateWithIL(ur_context_handle_t, const void *, size_t,
-                      const ur_program_properties_t *, ur_program_handle_t *) {
-  return UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL


### PR DESCRIPTION
Offload consumes both IL and binaries through the same entrypoint, so
there's no point in drawing a distinction.
