### PR TITLE
[UR][L0][L0v2] Remove redundant cleanup from async alloc

### DIFF
--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -1230,17 +1230,10 @@ ur_result_t ur_usm_pool_handle_t_::allocate(ur_context_handle_t Context,
 
   *RetMem = umfPoolAlignedMalloc(UmfPool, Size, Alignment);
   if (*RetMem == nullptr) {
-    if (Pool->AsyncPool.cleanup()) { // true means that objects were deallocated
-      // let's try again
-      *RetMem = umfPoolAlignedMalloc(UmfPool, Size, Alignment);
-    }
-    if (*RetMem == nullptr) {
-      auto UmfRet = umfPoolGetLastAllocationError(UmfPool);
-      UR_LOG(ERR,
-             "enqueueUSMAllocHelper: allocation from the UMF pool {} failed",
-             UmfPool);
-      return umf::umf2urResult(UmfRet);
-    }
+    auto UmfRet = umfPoolGetLastAllocationError(UmfPool);
+    UR_LOG(ERR, "enqueueUSMAllocHelper: allocation from the UMF pool {} failed",
+           UmfPool);
+    return umf::umf2urResult(UmfRet);
   }
 
   if (IndirectAccessTrackingEnabled) {

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -229,14 +229,8 @@ ur_result_t ur_usm_pool_handle_t_::allocate(
 
   *ppRetMem = umfPoolAlignedMalloc(umfPool, size, alignment);
   if (*ppRetMem == nullptr) {
-    if (pool->asyncPool.cleanup()) { // true means that objects were deallocated
-      // let's try again
-      *ppRetMem = umfPoolAlignedMalloc(umfPool, size, alignment);
-    }
-    if (*ppRetMem == nullptr) {
-      auto umfRet = umfPoolGetLastAllocationError(umfPool);
-      return umf::umf2urResult(umfRet);
-    }
+    auto umfRet = umfPoolGetLastAllocationError(umfPool);
+    return umf::umf2urResult(umfRet);
   }
 
   return UR_RESULT_SUCCESS;


### PR DESCRIPTION
The current implementation unnecessarily cleans up the freelist when enqueueing new USM allocations. This creates a potential scenario where active allocations present in the freelist could be incorrectly freed.