### PR TITLE
[SYCL][UR][L0] Fix handling of UR_ADAPTERS_FORCE_LOAD

### DIFF
--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -503,19 +503,22 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
 
       PlatformVec platforms;
 
+      bool forceLoadedAdapter = ur_getenv("UR_ADAPTERS_FORCE_LOAD").has_value();
+      if (!forceLoadedAdapter) {
 #ifdef UR_ADAPTER_LEVEL_ZERO_V2
-      auto [useV2, reason] = shouldUseV2Adapter();
-      if (!useV2) {
-        UR_LOG(INFO, "Skipping L0 V2 adapter: {}", reason);
-        return;
-      }
+        auto [useV2, reason] = shouldUseV2Adapter();
+        if (!useV2) {
+          UR_LOG(INFO, "Skipping L0 V2 adapter: {}", reason);
+          return;
+        }
 #else
-      auto [useV1, reason] = shouldUseV1Adapter();
-      if (!useV1) {
-        UR_LOG(INFO, "Skipping L0 V1 adapter: {}", reason);
-        return;
-      }
+        auto [useV1, reason] = shouldUseV1Adapter();
+        if (!useV1) {
+          UR_LOG(INFO, "Skipping L0 V1 adapter: {}", reason);
+          return;
+        }
 #endif
+      }
 
       // Check if the user has enabled the default L0 SysMan initialization.
       const int UrSysmanZesinitEnable = [&UserForcedSysManInit] {


### PR DESCRIPTION
The change making L0 v2 adapter default for BMG broke handling of UR_ADAPTERS_FORCE_LOAD. Depending on the platform, urAdapterGet could return 0 available adapter even if force loadded.