### PR TITLE
[SYCL] Revert m_ExportedSymbolImages key type back to a string

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -464,9 +464,11 @@ protected:
       m_ServiceKernels;
 
   /// Caches all exported symbols to allow faster lookup when excluding these
-  // from kernel bundles.
+  /// from kernel bundles.
   /// Access must be guarded by the m_KernelIDsMutex mutex.
-  std::unordered_multimap<KernelNameStrT, const RTDeviceBinaryImage *>
+  /// Owns its keys to support the bfloat16 use case with dynamic images,
+  /// where the symbol is taken from another image (that might be unloaded).
+  std::unordered_multimap<std::string, const RTDeviceBinaryImage *>
       m_ExportedSymbolImages;
 
   /// Keeps all device images we are refering to during program lifetime. Used

--- a/sycl/unittests/program_manager/Cleanup.cpp
+++ b/sycl/unittests/program_manager/Cleanup.cpp
@@ -35,7 +35,7 @@ public:
     return m_ServiceKernels;
   }
 
-  std::unordered_multimap<sycl::detail::KernelNameStrT,
+  std::unordered_multimap<std::string,
                           const sycl::detail::RTDeviceBinaryImage *> &
   getExportedSymbolImages() {
     return m_ExportedSymbolImages;


### PR DESCRIPTION
It was changed to a string view in preview builds of the library under the assumption that such strings are always owned by one of the loaded images.

Bfloat16 device library images are an exception to that rule, where the dynamic device binary image ends up using a reference to the string from another binary. If that binary is unloaded, the string view keys will be invalidated.

Since this particular map lies outside of the kernel submission hotpath (and it's the only one with a string view key type that gets filled out for bfloat16 device binary images), this patch just reverts the key type back to a string.