### PR TITLE
Revert "[CI] Fix detecting usage of private emails"

### DIFF
--- a/.github/workflows/email-check.yaml
+++ b/.github/workflows/email-check.yaml
@@ -21,30 +21,14 @@ jobs:
 
       - name: Extract author email
         id: author
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          # Use Github GraphQL APIs to get the email associated with the PR author because this takes into account the GitHub settings for email privacy.
-          query='
-          query($login: String!) {
-            user(login: $login) {
-              email
-            }
-          }'
-
-          PR_AUTHOR=${{ github.event.pull_request.user.login }}
-
-          email=$(gh api graphql -f login="$PR_AUTHOR" -f query="$query" --jq '.data.user.email')
-          echo "EMAIL_AUTHOR_GH_UI=$email" >> "$GITHUB_OUTPUT"
-
+          git log -1
+          echo "EMAIL=$(git show -s --format='%ae' HEAD~0)" >> $GITHUB_OUTPUT
           # Create empty comment file
           echo "[]" > comments
 
-      # When EMAIL_AUTHOR_GH_UI is NULL, author's email is hidden in GitHub UI.
-      # In this case, we warn the user to turn off "Keep my email addresses private"
-      # setting in their account.
       - name: Validate author email
-        if: ${{ steps.author.outputs.EMAIL_AUTHOR_GH_UI == '' }}
+        if: ${{ endsWith(steps.author.outputs.EMAIL, 'noreply.github.com')  }}
         env:
           COMMENT: >-
             ⚠️ We detected that you are using a GitHub private e-mail address to contribute to the repo.<br/>
@@ -54,9 +38,6 @@ jobs:
           cat << EOF > comments
           [{"body" : "$COMMENT"}]
           EOF
-
-          # Fail this job.
-          false
 
       - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
         if: always()


### PR DESCRIPTION
Reverts intel/llvm#19394 sadly.

The workflow is failing if user's email is not listed publicly on your GH profile. This is different from not having your email public on Github (in Github email settings page vs. email field in Github profile/email settings).

Reverting this PR till I figure out a fix.