### PR TITLE
[SYCL][UR][L0 v2] Coverity fixes

### DIFF
--- a/unified-runtime/source/adapters/level_zero/adapter.cpp
+++ b/unified-runtime/source/adapters/level_zero/adapter.cpp
@@ -21,6 +21,8 @@
 #include <umf.h>
 #endif
 
+ZeUSMImportExtension ZeUSMImport;
+
 // Due to multiple DLLMain definitions with SYCL, Global Adapter is init at
 // variable creation.
 #if defined(_WIN32)

--- a/unified-runtime/source/adapters/level_zero/common.cpp
+++ b/unified-runtime/source/adapters/level_zero/common.cpp
@@ -84,8 +84,6 @@ bool setEnvVar(const char *name, const char *value) {
   return true;
 }
 
-ZeUSMImportExtension ZeUSMImport;
-
 void zeParseError(ze_result_t ZeError, const char *&ErrorString) {
   switch (ZeError) {
 #define ZE_ERRCASE(ERR)                                                        \

--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -166,7 +166,7 @@ ur_result_t ur_exp_command_buffer_handle_t_::registerExecutionEventUnlocked(
   return UR_RESULT_SUCCESS;
 }
 
-ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
+ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() try {
   UR_CALL_NOCHECK(commandListManager.lock()->releaseSubmittedKernels());
 
   if (currentExecution) {
@@ -175,6 +175,9 @@ ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
   for (auto &event : syncPoints) {
     event->release();
   }
+} catch (...) {
+  UR_LOG(DEBUG, "ur_exp_command_buffer_handle_t_ destructor failed with: {}",
+         exceptionToResult(std::current_exception()));
 }
 
 ur_result_t ur_exp_command_buffer_handle_t_::applyUpdateCommands(


### PR DESCRIPTION
- catch potential exception in ~ur_exp_command_buffer_handle_t_
- move ZeUSMImport definition to adapter.cpp:
  ZeUSMImport is used by global adapter constructor (on Windows).
  It needs to be initialized before the global adapter.
  
  According to Coverity:
  The constructor of global object "GlobalAdapter" itself makes use
  of global object "ZeUSMImport" defined in another compilation unit.
  The order of construction is unspecified, so "GlobalAdapter" might
  be created before "ZeUSMImport" is available.