### PR TITLE
[UR][L0v2][SYCL] Enable e2e tests

### DIFF
--- a/sycl/test-e2e/AsyncAlloc/device/async_alloc_from_default_pool.cpp
+++ b/sycl/test-e2e/AsyncAlloc/device/async_alloc_from_default_pool.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18488
-
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/properties/queue_properties.hpp>

--- a/sycl/test-e2e/AsyncAlloc/device/async_alloc_from_pool.cpp
+++ b/sycl/test-e2e/AsyncAlloc/device/async_alloc_from_pool.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18488
-
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/properties/queue_properties.hpp>

--- a/sycl/test-e2e/AsyncAlloc/device/async_alloc_zero_init.cpp
+++ b/sycl/test-e2e/AsyncAlloc/device/async_alloc_zero_init.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18488
-
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/properties/queue_properties.hpp>

--- a/sycl/test-e2e/AsyncAlloc/device/memory_pool.cpp
+++ b/sycl/test-e2e/AsyncAlloc/device/memory_pool.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-INTENDED: v2 adapter does not support pool statistics.
-
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/properties/queue_properties.hpp>

--- a/sycl/test-e2e/AsyncAlloc/device/ooo_queue_async_alloc_from_pool.cpp
+++ b/sycl/test-e2e/AsyncAlloc/device/ooo_queue_async_alloc_from_pool.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18488
-
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/properties/queue_properties.hpp>

--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -607,8 +607,26 @@ ur_result_t UR_APICALL urUSMPoolDestroyExp(ur_context_handle_t /*Context*/,
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t UR_APICALL urUSMPoolSetInfoExp(ur_usm_pool_handle_t,
-                                           ur_usm_pool_info_t, void *, size_t) {
+ur_result_t UR_APICALL urUSMPoolSetInfoExp(ur_usm_pool_handle_t /*Pool*/,
+                                           ur_usm_pool_info_t PropName,
+                                           void * /*PropValue*/,
+                                           size_t PropSize) {
+  if (PropSize < sizeof(size_t)) {
+    return UR_RESULT_ERROR_INVALID_SIZE;
+  }
+
+  switch (PropName) {
+  // TODO: Support for pool release threshold and maximum size hints.
+  case UR_USM_POOL_INFO_RELEASE_THRESHOLD_EXP:
+  case UR_USM_POOL_INFO_MAXIMUM_SIZE_EXP:
+  // TODO: Allow user to overwrite pool peak statistics.
+  case UR_USM_POOL_INFO_RESERVED_HIGH_EXP:
+  case UR_USM_POOL_INFO_USED_HIGH_EXP:
+    break;
+  default:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  }
+
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/level_zero/v2/api.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/api.cpp
@@ -41,28 +41,6 @@ ur_result_t urEventSetCallback(ur_event_handle_t hEvent,
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-ur_result_t UR_APICALL urUSMPoolCreateExp(ur_context_handle_t hContext,
-                                          ur_device_handle_t hDevice,
-                                          ur_usm_pool_desc_t *PoolDesc,
-                                          ur_usm_pool_handle_t *pPool) {
-  UR_LOG(ERR, "{} function not implemented!", __FUNCTION__);
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-}
-
-ur_result_t UR_APICALL urUSMPoolDestroyExp(ur_context_handle_t hContext,
-                                           ur_device_handle_t hDevice,
-                                           ur_usm_pool_handle_t hPool) {
-  UR_LOG(ERR, "{} function not implemented!", __FUNCTION__);
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-}
-
-ur_result_t UR_APICALL urUSMPoolSetInfoExp(ur_usm_pool_handle_t hPool,
-                                           ur_usm_pool_info_t propName,
-                                           void *pPropValue, size_t propSize) {
-  UR_LOG(ERR, "{} function not implemented!", __FUNCTION__);
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-}
-
 ur_result_t UR_APICALL urUSMPoolGetDevicePoolExp(ur_context_handle_t hContext,
                                                  ur_device_handle_t hDevice,
                                                  ur_usm_pool_handle_t *pPool) {

--- a/unified-runtime/source/adapters/level_zero/v2/usm.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.hpp
@@ -55,6 +55,9 @@ private:
 struct ur_usm_pool_handle_t_ : ur_object {
   ur_usm_pool_handle_t_(ur_context_handle_t hContext,
                         ur_usm_pool_desc_t *pPoolDes);
+  ur_usm_pool_handle_t_(ur_context_handle_t hContext,
+                        ur_device_handle_t hDevice,
+                        ur_usm_pool_desc_t *pPoolDes);
 
   ur_context_handle_t getContextHandle() const;
 


### PR DESCRIPTION
L0v2 adapter was marked as unsupported in some async alloc tests due to missing features.

Those tests were failing because of the missing functions: `urUSMPoolGetInfoExp`, `urUSMPoolSetInfoExp`, `urUSMPoolCreateExp`, `urUSMPoolDestroyExp`, `urUSMPoolGetDefaultDevicePoolExp`.
Closes #18488