### PR TITLE
[UR][CTS] Use `ASSERT` instead of `EXPECT` in test bodies

### DIFF
--- a/unified-runtime/test/conformance/adapter/urAdapterRelease.cpp
+++ b/unified-runtime/test/conformance/adapter/urAdapterRelease.cpp
@@ -18,7 +18,7 @@ TEST_P(urAdapterReleaseTest, Success) {
                                   &referenceCountBefore, nullptr));
 
   uint32_t referenceCountAfter = 0;
-  EXPECT_SUCCESS(urAdapterRelease(adapter));
+  ASSERT_SUCCESS(urAdapterRelease(adapter));
   ASSERT_SUCCESS(urAdapterGetInfo(adapter, UR_ADAPTER_INFO_REFERENCE_COUNT,
                                   sizeof(referenceCountAfter),
                                   &referenceCountAfter, nullptr));

--- a/unified-runtime/test/conformance/adapter/urAdapterRetain.cpp
+++ b/unified-runtime/test/conformance/adapter/urAdapterRetain.cpp
@@ -17,7 +17,7 @@ TEST_P(urAdapterRetainTest, Success) {
                                   &referenceCountBefore, nullptr));
 
   uint32_t referenceCountAfter = 0;
-  EXPECT_SUCCESS(urAdapterRetain(adapter));
+  ASSERT_SUCCESS(urAdapterRetain(adapter));
   ASSERT_SUCCESS(urAdapterGetInfo(adapter, UR_ADAPTER_INFO_REFERENCE_COUNT,
                                   sizeof(referenceCountAfter),
                                   &referenceCountAfter, nullptr));

--- a/unified-runtime/test/conformance/context/urContextRetain.cpp
+++ b/unified-runtime/test/conformance/context/urContextRetain.cpp
@@ -20,7 +20,7 @@ TEST_P(urContextRetainTest, Success) {
 
   ASSERT_LT(prevRefCount, refCount);
 
-  EXPECT_SUCCESS(urContextRelease(context));
+  ASSERT_SUCCESS(urContextRelease(context));
 }
 
 TEST_P(urContextRetainTest, InvalidNullHandleContext) {

--- a/unified-runtime/test/conformance/device/urDeviceRelease.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceRelease.cpp
@@ -12,7 +12,7 @@ TEST_P(urDeviceReleaseTest, Success) {
   uint32_t prevRefCount = 0;
   ASSERT_SUCCESS(uur::GetObjectReferenceCount(device, prevRefCount));
 
-  EXPECT_SUCCESS(urDeviceRelease(device));
+  ASSERT_SUCCESS(urDeviceRelease(device));
 
   uint32_t refCount = 0;
   ASSERT_SUCCESS(uur::GetObjectReferenceCount(device, refCount));
@@ -46,14 +46,14 @@ TEST_P(urDeviceReleaseTest, SuccessSubdevices) {
   uint32_t prevRefCount = 0;
   ASSERT_SUCCESS(uur::GetObjectReferenceCount(sub_device, prevRefCount));
 
-  EXPECT_SUCCESS(urDeviceRelease(sub_device));
+  ASSERT_SUCCESS(urDeviceRelease(sub_device));
 
   uint32_t refCount = 0;
   ASSERT_SUCCESS(uur::GetObjectReferenceCount(sub_device, refCount));
 
   ASSERT_GT(prevRefCount, refCount);
 
-  EXPECT_SUCCESS(urDeviceRelease(sub_device));
+  ASSERT_SUCCESS(urDeviceRelease(sub_device));
 }
 
 TEST_P(urDeviceReleaseTest, InvalidNullHandle) {

--- a/unified-runtime/test/conformance/device/urDeviceRetain.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceRetain.cpp
@@ -51,8 +51,8 @@ TEST_P(urDeviceRetainTest, SuccessSubdevices) {
 
   ASSERT_LT(prevRefCount, refCount);
 
-  EXPECT_SUCCESS(urDeviceRelease(sub_device));
-  EXPECT_SUCCESS(urDeviceRelease(sub_device));
+  ASSERT_SUCCESS(urDeviceRelease(sub_device));
+  ASSERT_SUCCESS(urDeviceRelease(sub_device));
 }
 
 TEST_P(urDeviceRetainTest, InvalidNullHandle) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueEventsWait.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueEventsWait.cpp
@@ -92,9 +92,9 @@ TEST_P(urEnqueueEventsWaitTest, Success) {
   ASSERT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size,
                                         output.data(), 0, nullptr, nullptr));
   ASSERT_EQ(input, output);
-  EXPECT_SUCCESS(urEventRelease(event1));
-  EXPECT_SUCCESS(urEventRelease(waitEvent));
-  EXPECT_SUCCESS(urEventRelease(event2));
+  ASSERT_SUCCESS(urEventRelease(event1));
+  ASSERT_SUCCESS(urEventRelease(waitEvent));
+  ASSERT_SUCCESS(urEventRelease(event2));
 }
 
 TEST_P(urEnqueueEventsWaitTest, InvalidNullHandleQueue) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
@@ -41,10 +41,10 @@ struct urEnqueueEventsWaitWithBarrierTest
 
   void TearDown() override {
     if (src_buffer) {
-      EXPECT_SUCCESS(urMemRelease(src_buffer));
+      ASSERT_SUCCESS(urMemRelease(src_buffer));
     }
     if (dst_buffer) {
-      EXPECT_SUCCESS(urMemRelease(dst_buffer));
+      ASSERT_SUCCESS(urMemRelease(dst_buffer));
     }
     urMultiQueueTestWithParam::TearDown();
   }
@@ -110,32 +110,32 @@ TEST_P(urEnqueueEventsWaitWithBarrierTest, Success) {
   ur_event_handle_t waitEvent = nullptr;
   ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue1, src_buffer, dst_buffer, 0, 0,
                                         size, 0, nullptr, &event1));
-  EXPECT_SUCCESS(EnqueueBarrier(queue2, 1, &event1, &waitEvent));
-  EXPECT_SUCCESS(urQueueFlush(queue2));
-  EXPECT_SUCCESS(urQueueFlush(queue1));
-  EXPECT_SUCCESS(urEventWait(1, &waitEvent));
+  ASSERT_SUCCESS(EnqueueBarrier(queue2, 1, &event1, &waitEvent));
+  ASSERT_SUCCESS(urQueueFlush(queue2));
+  ASSERT_SUCCESS(urQueueFlush(queue1));
+  ASSERT_SUCCESS(urEventWait(1, &waitEvent));
 
   std::vector<uint32_t> output(count, 1);
-  EXPECT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size,
+  ASSERT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size,
                                         output.data(), 0, nullptr, nullptr));
   EXPECT_EQ(input, output);
-  EXPECT_SUCCESS(urEventRelease(waitEvent));
-  EXPECT_SUCCESS(urEventRelease(event1));
+  ASSERT_SUCCESS(urEventRelease(waitEvent));
+  ASSERT_SUCCESS(urEventRelease(event1));
 
   ur_event_handle_t event2 = nullptr;
   input.assign(count, 420);
-  EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size,
+  ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size,
                                          input.data(), 0, nullptr, nullptr));
-  EXPECT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0,
+  ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0,
                                         size, 0, nullptr, &event2));
-  EXPECT_SUCCESS(EnqueueBarrier(queue1, 1, &event2, &waitEvent));
-  EXPECT_SUCCESS(urQueueFlush(queue2));
-  EXPECT_SUCCESS(urQueueFlush(queue1));
-  EXPECT_SUCCESS(urEventWait(1, &waitEvent));
-  EXPECT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size,
+  ASSERT_SUCCESS(EnqueueBarrier(queue1, 1, &event2, &waitEvent));
+  ASSERT_SUCCESS(urQueueFlush(queue2));
+  ASSERT_SUCCESS(urQueueFlush(queue1));
+  ASSERT_SUCCESS(urEventWait(1, &waitEvent));
+  ASSERT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size,
                                         output.data(), 0, nullptr, nullptr));
-  EXPECT_SUCCESS(urEventRelease(waitEvent));
-  EXPECT_SUCCESS(urEventRelease(event2));
+  ASSERT_SUCCESS(urEventRelease(waitEvent));
+  ASSERT_SUCCESS(urEventRelease(event2));
   EXPECT_EQ(input, output);
 }
 
@@ -181,15 +181,15 @@ TEST_P(urEnqueueEventsWaitWithBarrierOrderingTest,
     constexpr uint32_t ONE = 1;
     urEnqueueMemBufferWrite(queue, buffer, true, 0, sizeof(uint32_t), &ONE, 0,
                             nullptr, &event);
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 1, &event, nullptr));
-    EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, add_kernel, 1, &offset, &count,
+    ASSERT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 1, &event, nullptr));
+    ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, add_kernel, 1, &offset, &count,
                                          nullptr, 0, nullptr, 0, nullptr,
                                          &event));
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 1, &event, nullptr));
-    EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, mul_kernel, 1, &offset, &count,
+    ASSERT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 1, &event, nullptr));
+    ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, mul_kernel, 1, &offset, &count,
                                          nullptr, 0, nullptr, 0, nullptr,
                                          &event));
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 1, &event, nullptr));
+    ASSERT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 1, &event, nullptr));
     addHelper.ValidateBuffer(buffer, sizeof(uint32_t), 4004);
   }
 }
@@ -212,15 +212,15 @@ TEST_P(urEnqueueEventsWaitWithBarrierOrderingTest,
     constexpr uint32_t ONE = 1;
     urEnqueueMemBufferWrite(queue, buffer, true, 0, sizeof(uint32_t), &ONE, 0,
                             nullptr, nullptr);
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, &event));
-    EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, add_kernel, 1, &offset, &count,
+    ASSERT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, add_kernel, 1, &offset, &count,
                                          nullptr, 0, nullptr, 1, &event,
                                          nullptr));
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, &event));
-    EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, mul_kernel, 1, &offset, &count,
+    ASSERT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, mul_kernel, 1, &offset, &count,
                                          nullptr, 0, nullptr, 1, &event,
                                          nullptr));
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, &event));
     addHelper.ValidateBuffer(buffer, sizeof(uint32_t), 4004);
   }
 }
@@ -242,17 +242,17 @@ TEST_P(urEnqueueEventsWaitWithBarrierOrderingTest, SuccessEventDependencies) {
     constexpr uint32_t ONE = 1;
     urEnqueueMemBufferWrite(queue, buffer, true, 0, sizeof(uint32_t), &ONE, 0,
                             nullptr, &event[0]);
-    EXPECT_SUCCESS(
+    ASSERT_SUCCESS(
         urEnqueueEventsWaitWithBarrier(queue, 1, &event[0], &event[1]));
-    EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, add_kernel, 1, &offset, &count,
+    ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, add_kernel, 1, &offset, &count,
                                          nullptr, 0, nullptr, 1, &event[1],
                                          &event[2]));
-    EXPECT_SUCCESS(
+    ASSERT_SUCCESS(
         urEnqueueEventsWaitWithBarrier(queue, 1, &event[2], &event[3]));
-    EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, mul_kernel, 1, &offset, &count,
+    ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, mul_kernel, 1, &offset, &count,
                                          nullptr, 0, nullptr, 1, &event[3],
                                          &event[4]));
-    EXPECT_SUCCESS(
+    ASSERT_SUCCESS(
         urEnqueueEventsWaitWithBarrier(queue, 1, &event[4], &event[5]));
     addHelper.ValidateBuffer(buffer, sizeof(uint32_t), 4004);
   }
@@ -275,15 +275,15 @@ TEST_P(urEnqueueEventsWaitWithBarrierOrderingTest,
     constexpr uint32_t ONE = 1;
     urEnqueueMemBufferWrite(queue, buffer, true, 0, sizeof(uint32_t), &ONE, 0,
                             nullptr, nullptr);
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, nullptr));
-    EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, add_kernel, 1, &offset, &count,
+    ASSERT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, add_kernel, 1, &offset, &count,
                                          nullptr, 0, nullptr, 0, nullptr,
                                          nullptr));
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, nullptr));
-    EXPECT_SUCCESS(urEnqueueKernelLaunch(queue, mul_kernel, 1, &offset, &count,
+    ASSERT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, mul_kernel, 1, &offset, &count,
                                          nullptr, 0, nullptr, 0, nullptr,
                                          nullptr));
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue, 0, nullptr, nullptr));
     addHelper.ValidateBuffer(buffer, sizeof(uint32_t), 4004);
   }
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -631,7 +631,7 @@ TEST_P(urEnqueueKernelLaunchMultiDeviceTest, KernelLaunchReadDifferentQueues) {
                                        nullptr, 0, nullptr, nullptr));
 
   // Wait for the queue to finish executing.
-  EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
+  ASSERT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
 
   // Then the remaining queues do blocking reads from the buffer. Since the
   // queues target different devices this checks that any devices memory has

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -121,11 +121,11 @@ TEST_P(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
   ur_mem_handle_t dst_buffer = nullptr;
   ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
                                    nullptr, &dst_buffer));
-  EXPECT_SUCCESS(urEnqueueMemBufferCopy(queues[0], buffer, dst_buffer, 0, 0,
+  ASSERT_SUCCESS(urEnqueueMemBufferCopy(queues[0], buffer, dst_buffer, 0, 0,
                                         size, 0, nullptr, nullptr));
 
   // Wait for the queue to finish executing.
-  EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
+  ASSERT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
 
   // Then the remaining queues do blocking reads from the buffer. Since the
   // queues target different devices this checks that any devices memory has
@@ -133,7 +133,7 @@ TEST_P(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
   for (unsigned i = 1; i < queues.size(); ++i) {
     const auto queue = queues[i];
     std::vector<uint32_t> output(count, 0);
-    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
                                           output.data(), 0, nullptr, nullptr));
     for (unsigned j = 0; j < count; ++j) {
       EXPECT_EQ(input, output[j])
@@ -141,5 +141,5 @@ TEST_P(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
     }
   }
 
-  EXPECT_SUCCESS(urMemRelease(dst_buffer));
+  ASSERT_SUCCESS(urMemRelease(dst_buffer));
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -101,30 +101,30 @@ TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
   // Fill src buffer with sequentially increasing values.
   std::vector<uint8_t> input(src_buffer_size, 0x0);
   std::iota(std::begin(input), std::end(input), 0x0);
-  EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer,
+  ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer,
                                          /* is_blocking */ true, 0,
                                          src_buffer_size, input.data(), 0,
                                          nullptr, nullptr));
 
   ur_mem_handle_t dst_buffer = nullptr;
-  EXPECT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+  ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
                                    dst_buffer_size, nullptr, &dst_buffer));
 
   // Zero destination buffer to begin with since the write may not cover the
   // whole buffer.
   const uint8_t zero = 0x0;
-  EXPECT_SUCCESS(urEnqueueMemBufferFill(queue, dst_buffer, &zero, sizeof(zero),
+  ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, dst_buffer, &zero, sizeof(zero),
                                         0, dst_buffer_size, 0, nullptr,
                                         nullptr));
 
   // Enqueue the rectangular copy between the buffers.
-  EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(
+  ASSERT_SUCCESS(urEnqueueMemBufferCopyRect(
       queue, src_buffer, dst_buffer, src_buffer_origin, dst_buffer_origin,
       region, src_buffer_row_pitch, src_buffer_slice_pitch,
       dst_buffer_row_pitch, dst_buffer_slice_pitch, 0, nullptr, nullptr));
 
   std::vector<uint8_t> output(dst_buffer_size, 0x0);
-  EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer,
+  ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer,
                                         /* is_blocking */ true, 0,
                                         dst_buffer_size, output.data(), 0,
                                         nullptr, nullptr));
@@ -139,8 +139,8 @@ TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
   EXPECT_EQ(expected, output);
 
   // Cleanup.
-  EXPECT_SUCCESS(urMemRelease(src_buffer));
-  EXPECT_SUCCESS(urMemRelease(dst_buffer));
+  ASSERT_SUCCESS(urMemRelease(src_buffer));
+  ASSERT_SUCCESS(urMemRelease(dst_buffer));
 }
 
 struct urEnqueueMemBufferCopyRectTest : uur::urQueueTest {
@@ -321,12 +321,12 @@ TEST_P(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
   ur_mem_handle_t dst_buffer = nullptr;
   ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
                                    nullptr, &dst_buffer));
-  EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(
+  ASSERT_SUCCESS(urEnqueueMemBufferCopyRect(
       queues[0], buffer, dst_buffer, {0, 0, 0}, {0, 0, 0}, {size, 1, 1}, size,
       size, size, size, 0, nullptr, nullptr));
 
   // Wait for the queue to finish executing.
-  EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
+  ASSERT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
 
   // Then the remaining queues do blocking reads from the buffer. Since the
   // queues target different devices this checks that any devices memory has
@@ -334,7 +334,7 @@ TEST_P(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
   for (unsigned i = 1; i < queues.size(); ++i) {
     const auto queue = queues[i];
     std::vector<uint32_t> output(count, 0);
-    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
                                           output.data(), 0, nullptr, nullptr));
     for (unsigned j = 0; j < count; ++j) {
       EXPECT_EQ(input, output[j])
@@ -342,5 +342,5 @@ TEST_P(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
     }
   }
 
-  EXPECT_SUCCESS(urMemRelease(dst_buffer));
+  ASSERT_SUCCESS(urMemRelease(dst_buffer));
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -99,13 +99,13 @@ TEST_P(urEnqueueMemBufferReadRectTestWithParam, Success) {
   // The input will just be sequentially increasing values.
   std::vector<uint8_t> input(buffer_size, 0x0);
   std::iota(std::begin(input), std::end(input), 0x0);
-  EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* isBlocking */ true,
+  ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* isBlocking */ true,
                                          0, input.size(), input.data(), 0,
                                          nullptr, nullptr));
 
   // Enqueue the rectangular read.
   std::vector<uint8_t> output(host_size, 0x0);
-  EXPECT_SUCCESS(urEnqueueMemBufferReadRect(
+  ASSERT_SUCCESS(urEnqueueMemBufferReadRect(
       queue, buffer, /* isBlocking */ true, buffer_offset, host_offset, region,
       buffer_row_pitch, buffer_slice_pitch, host_row_pitch, host_slice_pitch,
       output.data(), 0, nullptr, nullptr));
@@ -119,7 +119,7 @@ TEST_P(urEnqueueMemBufferReadRectTestWithParam, Success) {
   EXPECT_EQ(expected, output);
 
   // Cleanup.
-  EXPECT_SUCCESS(urMemRelease(buffer));
+  ASSERT_SUCCESS(urMemRelease(buffer));
 }
 
 struct urEnqueueMemBufferReadRectTest : public uur::urMemBufferQueueTest {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -106,13 +106,13 @@ TEST_P(urEnqueueMemBufferWriteRectTestWithParam, Success) {
   std::iota(std::begin(input), std::end(input), 0x0);
 
   // Enqueue the rectangular write from that host buffer.
-  EXPECT_SUCCESS(urEnqueueMemBufferWriteRect(
+  ASSERT_SUCCESS(urEnqueueMemBufferWriteRect(
       queue, buffer, /* isBlocking */ true, buffer_origin, host_origin, region,
       buffer_row_pitch, buffer_slice_pitch, host_row_pitch, host_slice_pitch,
       input.data(), 0, nullptr, nullptr));
 
   std::vector<uint8_t> output(buffer_size, 0x0);
-  EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, /* is_blocking */ true,
+  ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, /* is_blocking */ true,
                                         0, buffer_size, output.data(), 0,
                                         nullptr, nullptr));
 
@@ -126,7 +126,7 @@ TEST_P(urEnqueueMemBufferWriteRectTestWithParam, Success) {
   EXPECT_EQ(expected, output);
 
   // Cleanup.
-  EXPECT_SUCCESS(urMemRelease(buffer));
+  ASSERT_SUCCESS(urMemRelease(buffer));
 }
 
 struct urEnqueueMemBufferWriteRectTest : public uur::urMemBufferQueueTest {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
@@ -290,7 +290,7 @@ TEST_P(urEnqueueMemImageCopyMultiDeviceTest, CopyReadDifferentQueues) {
                                        origin, region3D, 0, nullptr, nullptr));
 
   // Wait for the queue to finish executing.
-  EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
+  ASSERT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
 
   // The remaining queues do blocking reads from the image1D/2D/3D. Since the
   // queues target different devices this checks that any devices memory has

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -105,14 +105,14 @@ TEST_P(urEnqueueUSMFillTestWithParam, Success) {
 
   ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
                                   size, 0, nullptr, &event));
-  EXPECT_SUCCESS(urQueueFlush(queue));
+  ASSERT_SUCCESS(urQueueFlush(queue));
 
   ASSERT_SUCCESS(urEventWait(1, &event));
   ur_event_status_t event_status;
   ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(
       event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
   ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 
   ASSERT_NO_FATAL_FAILURE(verifyData());
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -139,14 +139,14 @@ TEST_P(urEnqueueUSMFill2DTestWithParam, Success) {
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
       urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size, pattern.data(), width,
                          height, 0, nullptr, &event));
-  EXPECT_SUCCESS(urQueueFlush(queue));
+  ASSERT_SUCCESS(urQueueFlush(queue));
 
   ASSERT_SUCCESS(urEventWait(1, &event));
   ur_event_status_t event_status;
   ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(
       event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
   ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
-  EXPECT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urEventRelease(event));
 
   ASSERT_NO_FATAL_FAILURE(verifyData());
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
@@ -105,7 +105,7 @@ TEST_P(urEnqueueUSMMemcpyTest, BlockingWithEvent) {
       urEventGetInfo(memcpy_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
                      sizeof(ur_event_status_t), &event_status, nullptr));
   ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
-  EXPECT_SUCCESS(urEventRelease(memcpy_event));
+  ASSERT_SUCCESS(urEventRelease(memcpy_event));
   ASSERT_NO_FATAL_FAILURE(verifyData());
 }
 

--- a/unified-runtime/test/conformance/event/urEventWait.cpp
+++ b/unified-runtime/test/conformance/event/urEventWait.cpp
@@ -75,13 +75,13 @@ TEST_P(urEventWaitTest, Success) {
                                         size, output.data(), 0, nullptr,
                                         &event2));
   std::vector<ur_event_handle_t> events{event1, event2};
-  EXPECT_SUCCESS(urQueueFlush(queues[0]));
+  ASSERT_SUCCESS(urQueueFlush(queues[0]));
   ASSERT_SUCCESS(
       urEventWait(static_cast<uint32_t>(events.size()), events.data()));
   ASSERT_EQ(input[0], output);
 
-  EXPECT_SUCCESS(urEventRelease(event1));
-  EXPECT_SUCCESS(urEventRelease(event2));
+  ASSERT_SUCCESS(urEventRelease(event1));
+  ASSERT_SUCCESS(urEventRelease(event2));
 }
 
 using urEventWaitNegativeTest = uur::urQueueTest;
@@ -125,7 +125,7 @@ TEST_P(urEventWaitTest, WaitWithMultipleContexts) {
   }
 
   for (auto &event : events) {
-    EXPECT_SUCCESS(urEventRelease(event));
+    ASSERT_SUCCESS(urEventRelease(event));
   }
 }
 
@@ -162,6 +162,6 @@ TEST_P(urEventWaitTest, WithCrossContextDependencies) {
       urEventWait(static_cast<uint32_t>(events.size()), events.data()));
   ASSERT_EQ(input.front(), output);
 
-  EXPECT_SUCCESS(urEventRelease(event1));
-  EXPECT_SUCCESS(urEventRelease(event2));
+  ASSERT_SUCCESS(urEventRelease(event1));
+  ASSERT_SUCCESS(urEventRelease(event2));
 }

--- a/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
@@ -201,6 +201,6 @@ TEST_P(urEnqueueCommandBufferExpTest, EnqueueAndRelease) {
       in_or_out_of_order_queue, cmd_buf_handle, 0, nullptr, nullptr));
 
   // Release the command buffer without explicitly waiting beforehand
-  EXPECT_SUCCESS(urCommandBufferReleaseExp(cmd_buf_handle));
+  ASSERT_SUCCESS(urCommandBufferReleaseExp(cmd_buf_handle));
   cmd_buf_handle = nullptr;
 }

--- a/unified-runtime/test/conformance/exp_command_buffer/rect_read.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/rect_read.cpp
@@ -132,7 +132,7 @@ TEST_P(urCommandBufferAppendMemBufferReadRectTestWithParam, Success) {
 
   // Enqueue the rectangular read.
   std::vector<uint8_t> output(host_size, 0x0);
-  EXPECT_SUCCESS(urCommandBufferAppendMemBufferReadRectExp(
+  ASSERT_SUCCESS(urCommandBufferAppendMemBufferReadRectExp(
       cmd_buf_handle, buffer, buffer_origin, host_origin, region,
       buffer_row_pitch, buffer_slice_pitch, host_row_pitch, host_slice_pitch,
       output.data(), 0, nullptr, 0, nullptr, nullptr, nullptr, nullptr));

--- a/unified-runtime/test/conformance/exp_command_buffer/release.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/release.cpp
@@ -14,15 +14,15 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferReleaseExpTest);
 TEST_P(urCommandBufferReleaseExpTest, Success) {
   // https://github.com/intel/llvm/issues/19139
   UUR_KNOWN_FAILURE_ON(uur::OpenCL{});
-  EXPECT_SUCCESS(urCommandBufferRetainExp(cmd_buf_handle));
+  ASSERT_SUCCESS(urCommandBufferRetainExp(cmd_buf_handle));
 
   uint32_t prev_ref_count = 0;
-  EXPECT_SUCCESS(uur::GetObjectReferenceCount(cmd_buf_handle, prev_ref_count));
+  ASSERT_SUCCESS(uur::GetObjectReferenceCount(cmd_buf_handle, prev_ref_count));
 
-  EXPECT_SUCCESS(urCommandBufferReleaseExp(cmd_buf_handle));
+  ASSERT_SUCCESS(urCommandBufferReleaseExp(cmd_buf_handle));
 
   uint32_t ref_count = 0;
-  EXPECT_SUCCESS(uur::GetObjectReferenceCount(cmd_buf_handle, ref_count));
+  ASSERT_SUCCESS(uur::GetObjectReferenceCount(cmd_buf_handle, ref_count));
 
   EXPECT_GT(prev_ref_count, ref_count);
 }

--- a/unified-runtime/test/conformance/exp_command_buffer/update/invalid_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/invalid_update.cpp
@@ -130,7 +130,7 @@ TEST_P(InvalidUpdateTest, NotUpdatableCommandBuffer) {
                    UR_RESULT_ERROR_INVALID_OPERATION);
   ASSERT_EQ(test_command_handle, nullptr);
 
-  EXPECT_SUCCESS(urCommandBufferFinalizeExp(test_cmd_buf_handle));
+  ASSERT_SUCCESS(urCommandBufferFinalizeExp(test_cmd_buf_handle));
   finalized = true;
 
   // Set new value to use for fill at kernel index 1
@@ -168,7 +168,7 @@ TEST_P(InvalidUpdateTest, NotUpdatableCommandBuffer) {
   EXPECT_EQ(UR_RESULT_ERROR_INVALID_NULL_HANDLE, result);
 
   if (test_cmd_buf_handle) {
-    EXPECT_SUCCESS(urCommandBufferReleaseExp(test_cmd_buf_handle));
+    ASSERT_SUCCESS(urCommandBufferReleaseExp(test_cmd_buf_handle));
   }
 }
 
@@ -263,8 +263,8 @@ TEST_P(InvalidUpdateTest, CommandBufferMismatch) {
       urCommandBufferCreateExp(context, device, &desc, &test_cmd_buf_handle));
   EXPECT_NE(test_cmd_buf_handle, nullptr);
 
-  EXPECT_SUCCESS(urCommandBufferFinalizeExp(test_cmd_buf_handle));
-  EXPECT_SUCCESS(urCommandBufferFinalizeExp(updatable_cmd_buf_handle));
+  ASSERT_SUCCESS(urCommandBufferFinalizeExp(test_cmd_buf_handle));
+  ASSERT_SUCCESS(urCommandBufferFinalizeExp(updatable_cmd_buf_handle));
   finalized = true;
 
   // Set new value to use for fill at kernel index 1
@@ -302,7 +302,7 @@ TEST_P(InvalidUpdateTest, CommandBufferMismatch) {
   EXPECT_EQ(UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_COMMAND_HANDLE_EXP, result);
 
   if (test_cmd_buf_handle) {
-    EXPECT_SUCCESS(urCommandBufferReleaseExp(test_cmd_buf_handle));
+    ASSERT_SUCCESS(urCommandBufferReleaseExp(test_cmd_buf_handle));
   }
 }
 

--- a/unified-runtime/test/conformance/kernel/urKernelRetain.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelRetain.cpp
@@ -12,7 +12,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelRetainTest);
 
 TEST_P(urKernelRetainTest, Success) {
   ASSERT_SUCCESS(urKernelRetain(kernel));
-  EXPECT_SUCCESS(urKernelRelease(kernel));
+  ASSERT_SUCCESS(urKernelRelease(kernel));
 }
 
 TEST_P(urKernelRetainTest, InvalidNullHandleKernel) {

--- a/unified-runtime/test/conformance/program/urProgramRetain.cpp
+++ b/unified-runtime/test/conformance/program/urProgramRetain.cpp
@@ -20,7 +20,7 @@ TEST_P(urProgramRetainTest, Success) {
 
   ASSERT_LT(prevRefCount, refCount);
 
-  EXPECT_SUCCESS(urProgramRetain(program));
+  ASSERT_SUCCESS(urProgramRetain(program));
 }
 
 TEST_P(urProgramRetainTest, InvalidNullHandleProgram) {

--- a/unified-runtime/test/conformance/queue/urQueueRetain.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueRetain.cpp
@@ -22,7 +22,7 @@ TEST_P(urQueueRetainTest, Success) {
 
   ASSERT_LT(prevRefCount, refCount);
 
-  EXPECT_SUCCESS(urQueueRelease(queue));
+  ASSERT_SUCCESS(urQueueRelease(queue));
 }
 
 TEST_P(urQueueRetainTest, InvalidNullHandleQueue) {

--- a/unified-runtime/test/conformance/virtual_memory/urVirtualMemMap.cpp
+++ b/unified-runtime/test/conformance/virtual_memory/urVirtualMemMap.cpp
@@ -17,7 +17,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
 TEST_P(urVirtualMemMapWithFlagsTest, Success) {
   ASSERT_SUCCESS(
       urVirtualMemMap(context, virtual_ptr, size, physical_mem, 0, getParam()));
-  EXPECT_SUCCESS(urVirtualMemUnmap(context, virtual_ptr, size));
+  ASSERT_SUCCESS(urVirtualMemUnmap(context, virtual_ptr, size));
 }
 
 using urVirtualMemMapTest = uur::urVirtualMemTest;

--- a/unified-runtime/test/conformance/virtual_memory/urVirtualMemReserve.cpp
+++ b/unified-runtime/test/conformance/virtual_memory/urVirtualMemReserve.cpp
@@ -22,7 +22,7 @@ TEST_P(urVirtualMemReserveTestWithParam, SuccessNoStartPointer) {
                                      &virtual_mem_start));
   ASSERT_NE(virtual_mem_start, nullptr);
 
-  EXPECT_SUCCESS(
+  ASSERT_SUCCESS(
       urVirtualMemFree(context, virtual_mem_start, virtual_mem_size));
 }
 
@@ -41,8 +41,8 @@ TEST_P(urVirtualMemReserveTestWithParam, SuccessWithStartPointer) {
   ASSERT_NE(virtual_mem_ptr, nullptr);
 
   // both pointers have to be freed
-  EXPECT_SUCCESS(urVirtualMemFree(context, origin_ptr, page_size));
-  EXPECT_SUCCESS(urVirtualMemFree(context, virtual_mem_ptr, page_size));
+  ASSERT_SUCCESS(urVirtualMemFree(context, origin_ptr, page_size));
+  ASSERT_SUCCESS(urVirtualMemFree(context, virtual_mem_ptr, page_size));
 }
 
 using urVirtualMemReserveTest = uur::urVirtualMemGranularityTest;


### PR DESCRIPTION
`EXPECT` doesn't return from the current function, so a number of tests
would keep going if they failed, in one case segfaulting due to writing
to memory that was not allocated correctly.

Standardise the test suite so that it always returns on the first
failure using `ASSERT` where possible.
