### PR TITLE
[SYCL][Graph] Disable E2E tests on MTL

### DIFF
--- a/sycl/test-e2e/Graph/lit.local.cfg
+++ b/sycl/test-e2e/Graph/lit.local.cfg
@@ -1,3 +1,5 @@
+# MTL - CMPLRLLVM-68693, CMPLRTST-25611, CMPLRLLVM-68457
+config.unsupported_features += ['arch-intel_gpu_mtl_h', 'arch-intel_gpu_mtl_u']
 if 'windows' in config.available_features:
    # https://github.com/intel/llvm/issues/17165
    config.unsupported_features += ['arch-intel_gpu_bmg_g21', 'arch-intel_gpu_bmg_g31']


### PR DESCRIPTION
Mark SYCL-Graph E2E tests as unsupported on MTL. We have built up several bug reports on this architecture that need investigated and fixed, see the code comment. Rather than tracking lots of individual bugs, disable MTL until we can give the architecture a thorough investigation and re-enable once we have fixed the bugs and are confident in its support.

Note that unlike the other architectures in the lit file, these also manifest on Ubuntu as well as Windows.