### PR TITLE
[UR][CUDA][Coverity] Don't check nvmlShutdown return in destructor

### DIFF
--- a/unified-runtime/source/adapters/cuda/device.hpp
+++ b/unified-runtime/source/adapters/cuda/device.hpp
@@ -113,7 +113,7 @@ public:
       umfMemoryProviderDestroy(MemoryProviderShared);
     }
     if (NVMLDevice.has_value()) {
-      UR_CHECK_ERROR(nvmlShutdown());
+      nvmlShutdown();
     }
     cuDevicePrimaryCtxRelease(CuDevice);
   }


### PR DESCRIPTION
`UR_CHECK_ERROR` throws an exception so we can't use it from a destructor.

Since devices only get released at application shutdown, there's not much we can do if `nvmlShutdown` reports an error, and the OS will promptly cleanup anything left as it tears down the process anyway.

So just skip checking the error code from `nvmlShutdown`, this is already what we do for other cleanup/shutdown in this destructor.

Fixes: https://github.com/intel/llvm/issues/19500