### PR TITLE
[SYCL][E2E] Avoid illegal failure order in compare_exchange_strong test

### DIFF
--- a/sycl/test-e2e/AtomicRef/compare_exchange.h
+++ b/sycl/test-e2e/AtomicRef/compare_exchange.h
@@ -49,7 +49,14 @@ void compare_exchange_local_test(queue q, size_t N) {
                   : order,
               scope, space > (loc[0]);
          T result = T(N); // Avoid copying pointer
-         bool success = atm.compare_exchange_strong(result, (T)gid, order);
+         // From SYCL AtomicRef spec: The failure memory order of this atomic
+         // operation must be relaxed, acquire or seq_cst.
+         auto failure_order =
+             (order == memory_order::acq_rel || order == memory_order::release)
+                 ? memory_order::relaxed
+                 : order;
+         bool success =
+             atm.compare_exchange_strong(result, (T)gid, order, failure_order);
          if (success) {
            out[gid] = result;
          } else {
@@ -99,7 +106,14 @@ void compare_exchange_global_test(queue q, size_t N) {
                   : order,
               scope, space > (exc[0]);
          T result = T(N); // Avoid copying pointer
-         bool success = atm.compare_exchange_strong(result, (T)gid, order);
+         // From SYCL AtomicRef spec: The failure memory order of this atomic
+         // operation must be relaxed, acquire or seq_cst.
+         auto failure_order =
+             (order == memory_order::acq_rel || order == memory_order::release)
+                 ? memory_order::relaxed
+                 : order;
+         bool success =
+             atm.compare_exchange_strong(result, (T)gid, order, failure_order);
          if (success) {
            out[gid] = result;
          } else {
@@ -140,7 +154,14 @@ void compare_exchange_global_test_usm_shared(queue q, size_t N) {
                   : order,
               scope, space > (exc[0]);
          T result = initial; // Avoid copying pointer
-         bool success = atm.compare_exchange_strong(result, (T)gid, order);
+         // From SYCL AtomicRef spec: The failure memory order of this atomic
+         // operation must be relaxed, acquire or seq_cst.
+         auto failure_order =
+             (order == memory_order::acq_rel || order == memory_order::release)
+                 ? memory_order::relaxed
+                 : order;
+         bool success =
+             atm.compare_exchange_strong(result, (T)gid, order, failure_order);
          if (success) {
            output[gid] = result;
          } else {


### PR DESCRIPTION
The AtomicRef/compare_exchange_strong E2E test allowed `acq_rel` and `release` being passed as the failure memory order. This is not allowed by the SYCL AtomicRef spec (see Table 132), and might cause failures on some backends.

This change explicitly sets the failure memory order argument in compare_exchange_strong to avoid `acq_rel` and `release` being passed. Previously, an overloaded compare_exchange_strong function was used, which set the same memory order for failure and success.