### PR TITLE
[SYCL][ESIMD] Fix warning in header

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
@@ -112,7 +112,7 @@ static inline constexpr bool is_clang_vector_type_v =
 
 template <class T> struct vector_element_type;
 
-template <class T, int N> struct vector_element_type<vector_type_t<T, N>> {
+template <class T, int N> struct vector_element_type<raw_vector_type<T, N>> {
   using type = T;
 };
 

--- a/sycl/test/self-contained-headers/lit.local.cfg
+++ b/sycl/test/self-contained-headers/lit.local.cfg
@@ -7,9 +7,6 @@ config.test_format = SYCLHeadersTest()
 # standalone. `os.path.join` is required here so the filtering works
 # cross-platform
 config.sycl_headers_xfail = [
-    os.path.join(
-        "sycl", "ext", "intel", "esimd", "detail", "types_elementary.hpp"
-    ),
     # FIXME: remove this rule when the header is moved to the clang project
     os.path.join(
         "sycl", "stl_wrappers", "__sycl_cmath_wrapper_impl.hpp"


### PR DESCRIPTION
We can't use the alias here, we need to use the original type.

Also it fixed some self contained header test for some reason so remove the XFAIL for that.