### PR TITLE
[SYCL] Check access to /dev/dri/renderD* in sycl-ls

### DIFF
--- a/sycl/test/tools/Inputs/mock_renderd_access.c
+++ b/sycl/test/tools/Inputs/mock_renderd_access.c
@@ -1,0 +1,41 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+int stat(const char *pathname, struct stat *statbuf) {
+  const char *mock_mode = getenv("MOCK_STAT_MODE");
+  if (strstr(pathname, "renderD128")) {
+    if (mock_mode && strcmp(mock_mode, "notfound") == 0) {
+      errno = ENOENT;
+      return -1;
+    }
+    if (mock_mode && strcmp(mock_mode, "exists") == 0) {
+      memset(statbuf, 0, sizeof(*statbuf));
+      statbuf->st_mode = S_IFCHR | 0666;
+      return 0;
+    }
+  }
+  // Default: file does not exist
+  errno = ENOENT;
+  return -1;
+}
+
+int open(const char *pathname, int flags, ...) {
+  const char *mock_mode = getenv("MOCK_OPEN_MODE");
+  if (strstr(pathname, "renderD128")) {
+    if (mock_mode && strcmp(mock_mode, "deny") == 0) {
+      errno = EACCES;
+      return -1;
+    }
+    if (mock_mode && strcmp(mock_mode, "allow") == 0) {
+      return 3; // Dummy fd
+    }
+  }
+  // Default: permission denied
+  errno = EACCES;
+  return -1;
+}

--- a/sycl/test/tools/render-group.cpp
+++ b/sycl/test/tools/render-group.cpp
@@ -1,0 +1,21 @@
+// REQUIRES: linux
+
+// Compile Inputs/mock_renderd_access.c to a shared library and then use
+// LD_PRELOAD to mock the stat and open functions.
+// RUN: %clang -shared -fPIC -o %t-mock_stat.so %S/Inputs/mock_renderd_access.c
+
+// Check the case when /dev/dri/renderD128 does not exist.
+// RUN: env MOCK_STAT_MODE=notfound LD_PRELOAD=%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s -check-prefix=CHECK-NOTFOUND
+// We don't expect any warning about permissions in this case.
+// CHECK-NOTFOUND-NOT: WARNING: Unable to access /dev/dri/renderD128 due to permissions (EACCES).
+
+// Check the case when /dev/dri/renderD128 exists but is not accessible.
+// RUN: env MOCK_STAT_MODE=exists MOCK_OPEN_MODE=deny LD_PRELOAD=%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s --check-prefix=CHECK-DENY
+// CHECK-DENY: WARNING: Unable to access /dev/dri/renderD128 due to permissions (EACCES).
+// CHECK-DENY-NEXT: You might be missing the 'render' group locally.
+// CHECK-DENY-NEXT: Try: sudo usermod -a -G render $USER
+// CHECK-DENY-NEXT: Then log out and log back in.
+
+// Check the case when /dev/dri/renderD128 exists and is accessible.
+// RUN: env MOCK_STAT_MODE=exists MOCK_OPEN_MODE=allow LD_PRELOAD=%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s --check-prefix=CHECK-GRANT
+// CHECK-GRANT-NOT: WARNING: Unable to access /dev/dri/renderD128 due to permissions (EACCES).

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -26,6 +26,13 @@
 #include <string>
 #include <vector>
 
+#ifdef __linux__
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
 #ifdef _WIN32
 #include <system_error>
 #include <windows.h>
@@ -344,8 +351,30 @@ static int unsetFilterEnvVarsAndFork() {
 }
 #endif
 
-int main(int argc, char **argv) {
+static void checkRenderGroupPermission() {
+#ifdef __linux__
+  // Check for /dev/dri/render* devices
+  for (int i = 128; i < 256; ++i) {
+    std::string path = std::string("/dev/dri/renderD") + std::to_string(i);
+    struct stat st;
+    if (stat(path.c_str(), &st) == 0) {
+      int fd = open(path.c_str(), O_RDWR);
+      if (fd < 0 && errno == EACCES) {
+        std::cerr << "WARNING: Unable to access " << path
+                  << " due to permissions (EACCES).\n"
+                  << "You might be missing the 'render' group locally.\n"
+                  << "Try: sudo usermod -a -G render $USER\n"
+                  << "Then log out and log back in.\n";
+        break;
+      }
+      if (fd >= 0)
+        close(fd);
+    }
+  }
+#endif
+}
 
+int main(int argc, char **argv) {
   if (argc == 1) {
     verbose = false;
     DiscardFilters = false;
@@ -360,6 +389,9 @@ int main(int argc, char **argv) {
         return printUsageAndExit();
     }
   }
+
+  if (verbose)
+    checkRenderGroupPermission();
 
   bool SuppressNumberPrinting = false;
   // Print warning and suppress printing device ids if any of


### PR DESCRIPTION
This patch adds a check in sycl-ls to verify that the user has permission to access /dev/dri/renderD* device nodes, if they are present. If a device node exists but cannot be opened due to insufficient permissions (typically because the user is not in the render group), a clear warning is printed.

This helps users quickly identify missing group membership as the cause of device enumeration failures, instead of silently failing and requiring time-consuming troubleshooting.