### PR TITLE
[SYCL][E2E] Set a proper requirement for subdevice test

### DIFF
--- a/sycl/test-e2e/Adapters/sycl-ls-uuid-subdevs.cpp
+++ b/sycl/test-e2e/Adapters/sycl-ls-uuid-subdevs.cpp
@@ -1,14 +1,10 @@
 /* Test to check that sycl-ls is outputting UUID and number of sub and sub-sub
  * devices. */
-// REQUIRES:  gpu, level_zero
+// REQUIRES:  gpu, level_zero, gpu-intel-pvc
 
-// XFAIL: linux && run-mode && (arch-intel_gpu_bmg_g21 || gpu-intel-dg2) && !igc-dev
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
-
-// XFAIL: windows && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
 // As of now, ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
 // which is the new default on PVC.
+// PVC is the only HW now that supports 4 CCS.
 
 // RUN: %{run-unfiltered-devices} env ONEAPI_DEVICE_SELECTOR="level_zero:*" env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE env ZEX_NUMBER_OF_CCS=0:4 sycl-ls --verbose | \
 // RUN: FileCheck %s


### PR DESCRIPTION
This test was XFAILed on bmg and dg2 for Linux and Win (partially but must be completely). 
https://github.com/intel/llvm/issues/18576#issuecomment-2949810180
Currently only PVC has support of 4 CCS that is publicly documented here:
https://github.com/intel/compute-runtime/blob/master/level_zero/doc/experimental_extensions/MULTI_CCS_MODES.md#interaction-with-affinity-mask
Those HW with more than 1 CCS only support 1,2.
This test was added for verification of sycl-ls output (82ebc2309f84556390af330fa8be012d91535404).
I believe it is enough to test it on PVC only then instead of extending it to other platforms with complex logic of querying and passing capabilities.
