### PR TITLE
[NativeCPU] Add aux triple to native_cpu_as

### DIFF
--- a/clang/test/CodeGenSYCL/native_cpu_as.cpp
+++ b/clang/test/CodeGenSYCL/native_cpu_as.cpp
@@ -1,10 +1,10 @@
 // This test is temporarily disabled for SYCL Native CPU on Windows
 // UNSUPPORTED: system-windows
 // Checks that name mangling matches between SYCL Native CPU and OpenCL
-// RUN: %clang_cc1 -triple=native_cpu -DCPP -fsycl-is-device -emit-llvm -internal-isystem %S/Inputs -o %t_sycl.ll %s
+// RUN: %clang_cc1 -triple=native_cpu -aux-triple x86_64-unknown-unknown -DCPP -fsycl-is-device -emit-llvm -internal-isystem %S/Inputs -o %t_sycl.ll %s
 // RUN: FileCheck -input-file=%t_sycl.ll %s
 
-// RUN: %clang_cc1 -triple=native_cpu -x cl -DOCL -emit-llvm -internal-isystem %S/Inputs -o %t_ocl.ll %s
+// RUN: %clang_cc1 -triple=native_cpu -aux-triple x86_64-unknown-unknown -x cl -DOCL -emit-llvm -internal-isystem %S/Inputs -o %t_ocl.ll %s
 // RUN: FileCheck -input-file=%t_ocl.ll %s
 
 #ifdef CPP


### PR DESCRIPTION
This commit adds the -aux-triple to the clang/test/CodeGenSYCL/native_cpu_as.cpp test. This ensures proper data layout information to propagate.