### PR TITLE
[NFC][SYCL] Better "managed" `ur_program_handle_t`

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -343,7 +343,7 @@ kernel make_kernel(const context &TargetContext,
     const device_image<bundle_state::executable> &DeviceImage =
         *KernelBundle.begin();
     device_image_impl &DeviceImageImpl = *getSyclObjImpl(DeviceImage);
-    UrProgram = DeviceImageImpl.get_ur_program_ref();
+    UrProgram = DeviceImageImpl.get_ur_program();
   }
 
   // Create UR kernel first.

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -128,10 +128,7 @@ context_impl::~context_impl() {
               DeviceGlobal);
       DGEntry->removeAssociatedResources(this);
     }
-    for (auto LibProg : MCachedLibPrograms) {
-      assert(LibProg.second && "Null program must not be kept in the cache");
-      getAdapter().call<UrApiKind::urProgramRelease>(LibProg.second);
-    }
+    MCachedLibPrograms.clear();
     // TODO catch an exception and put it to list of asynchronous exceptions
     getAdapter().call_nocheck<UrApiKind::urContextRelease>(MContext);
   } catch (std::exception &e) {

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -134,7 +134,7 @@ public:
 
   using CachedLibProgramsT =
       std::map<std::pair<DeviceLibExt, ur_device_handle_t>,
-               ur_program_handle_t>;
+               Managed<ur_program_handle_t>>;
 
   /// In contrast to user programs, which are compiled from user code, library
   /// programs come from the SYCL runtime. They are identified by the

--- a/sycl/source/detail/device_image_impl.cpp
+++ b/sycl/source/detail/device_image_impl.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<kernel_impl> device_image_impl::tryGetExtensionKernel(
       if (!KID || !has_kernel(*KID))
         continue;
 
-      auto UrProgram = get_ur_program_ref();
+      auto UrProgram = get_ur_program();
       auto [UrKernel, CacheMutex, ArgMask] =
           PM.getOrCreateKernel(Context, AdjustedName,
                                /*PropList=*/{}, UrProgram);
@@ -41,7 +41,7 @@ std::shared_ptr<kernel_impl> device_image_impl::tryGetExtensionKernel(
     return nullptr;
   }
 
-  ur_program_handle_t UrProgram = get_ur_program_ref();
+  ur_program_handle_t UrProgram = get_ur_program();
   detail::adapter_impl &Adapter = getSyclObjImpl(Context)->getAdapter();
   ur_kernel_handle_t UrKernel = nullptr;
   Adapter.call<UrApiKind::urKernelCreate>(UrProgram, AdjustedName.c_str(),

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -260,7 +260,8 @@ public:
                     ur_program_handle_t Program, uint8_t Origins, private_tag)
       : MBinImage(BinImage), MContext(std::move(Context)),
         MDevices(Devices.to<std::vector<device_impl *>>()), MState(State),
-        MProgram(Program), MKernelIDs(std::move(KernelIDs)),
+        MProgram(Program, getSyclObjImpl(MContext)->getAdapter()),
+        MKernelIDs(std::move(KernelIDs)),
         MSpecConstsDefValBlob(getSpecConstsDefValBlob()), MOrigins(Origins) {
     updateSpecConstSymMap();
     if (BinImage && (MOrigins & ImageOriginSYCLBIN)) {
@@ -294,8 +295,8 @@ public:
       std::unique_ptr<DynRTDeviceBinaryImage> &&MergedImageStorage, private_tag)
       : MBinImage(BinImage), MContext(std::move(Context)),
         MDevices(Devices.to<std::vector<device_impl *>>()), MState(State),
-        MProgram(Program), MKernelIDs(std::move(KernelIDs)),
-        MKernelNames{std::move(KernelNames)},
+        MProgram(Program, getSyclObjImpl(MContext)->getAdapter()),
+        MKernelIDs(std::move(KernelIDs)), MKernelNames{std::move(KernelNames)},
         MEliminatedKernelArgMasks{std::move(EliminatedKernelArgMasks)},
         MSpecConstsBlob(SpecConstsBlob),
         MSpecConstsDefValBlob(getSpecConstsDefValBlob()),
@@ -311,7 +312,8 @@ public:
                     private_tag)
       : MBinImage(BinImage), MContext(std::move(Context)),
         MDevices(Devices.to<std::vector<device_impl *>>()), MState(State),
-        MProgram(Program), MKernelNames{std::move(KernelNames)},
+        MProgram(Program, getSyclObjImpl(MContext)->getAdapter()),
+        MKernelNames{std::move(KernelNames)},
         MEliminatedKernelArgMasks{std::move(EliminatedKernelArgMasks)},
         MSpecConstsDefValBlob(getSpecConstsDefValBlob()),
         MOrigins(ImageOriginKernelCompiler),
@@ -329,8 +331,7 @@ public:
       private_tag)
       : MBinImage(BinImage), MContext(std::move(Context)),
         MDevices(Devices.to<std::vector<device_impl *>>()), MState(State),
-        MProgram(nullptr), MKernelIDs(std::move(KernelIDs)),
-        MKernelNames{std::move(KernelNames)},
+        MKernelIDs(std::move(KernelIDs)), MKernelNames{std::move(KernelNames)},
         MSpecConstsDefValBlob(getSpecConstsDefValBlob()),
         MOrigins(ImageOriginKernelCompiler),
         MRTCBinInfo(KernelCompilerBinaryInfo{
@@ -344,7 +345,7 @@ public:
                     include_pairs_t &&IncludePairsVec, private_tag)
       : MBinImage(Src), MContext(std::move(Context)),
         MDevices(Devices.to<std::vector<device_impl *>>()),
-        MState(bundle_state::ext_oneapi_source), MProgram(nullptr),
+        MState(bundle_state::ext_oneapi_source),
         MSpecConstsDefValBlob(getSpecConstsDefValBlob()),
         MOrigins(ImageOriginKernelCompiler),
         MRTCBinInfo(
@@ -357,7 +358,7 @@ public:
                     private_tag)
       : MBinImage(Bytes), MContext(std::move(Context)),
         MDevices(Devices.to<std::vector<device_impl *>>()),
-        MState(bundle_state::ext_oneapi_source), MProgram(nullptr),
+        MState(bundle_state::ext_oneapi_source),
         MSpecConstsDefValBlob(getSpecConstsDefValBlob()),
         MOrigins(ImageOriginKernelCompiler),
         MRTCBinInfo(KernelCompilerBinaryInfo{Lang}) {
@@ -371,7 +372,8 @@ public:
       : MBinImage(static_cast<const RTDeviceBinaryImage *>(nullptr)),
         MContext(std::move(Context)),
         MDevices(Devices.to<std::vector<device_impl *>>()), MState(State),
-        MProgram(Program), MKernelNames{std::move(KernelNames)},
+        MProgram(Program, getSyclObjImpl(MContext)->getAdapter()),
+        MKernelNames{std::move(KernelNames)},
         MSpecConstsDefValBlob(getSpecConstsDefValBlob()),
         MOrigins(ImageOriginKernelCompiler),
         MRTCBinInfo(KernelCompilerBinaryInfo{Lang}) {}
@@ -558,9 +560,7 @@ public:
     return get_devices().contains(Dev);
   }
 
-  const ur_program_handle_t &get_ur_program_ref() const noexcept {
-    return MProgram;
-  }
+  ur_program_handle_t get_ur_program() const noexcept { return MProgram; }
 
   const RTDeviceBinaryImage *const &get_bin_image_ref() const {
     return std::get<const RTDeviceBinaryImage *>(MBinImage);
@@ -617,20 +617,14 @@ public:
     return NativeProgram;
   }
 
-  ~device_image_impl() {
-    try {
-      if (MProgram) {
-        adapter_impl &Adapter = getSyclObjImpl(MContext)->getAdapter();
-        Adapter.call<UrApiKind::urProgramRelease>(MProgram);
-      }
-      if (MSpecConstsBuffer) {
-        std::lock_guard<std::mutex> Lock{MSpecConstAccessMtx};
-        adapter_impl &Adapter = getSyclObjImpl(MContext)->getAdapter();
-        memReleaseHelper(Adapter, MSpecConstsBuffer);
-      }
-    } catch (std::exception &e) {
-      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~device_image_impl", e);
+  ~device_image_impl() try {
+    if (MSpecConstsBuffer) {
+      std::lock_guard<std::mutex> Lock{MSpecConstAccessMtx};
+      adapter_impl &Adapter = getSyclObjImpl(MContext)->getAdapter();
+      memReleaseHelper(Adapter, MSpecConstsBuffer);
     }
+  } catch (std::exception &e) {
+    __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~device_image_impl", e);
   }
 
   std::string adjustKernelName(std::string_view Name) const {
@@ -1298,7 +1292,7 @@ private:
   std::vector<device_impl *> MDevices;
   bundle_state MState;
   // Native program handler which this device image represents
-  ur_program_handle_t MProgram = nullptr;
+  Managed<ur_program_handle_t> MProgram;
 
   // List of kernel ids available in this image, elements should be sorted
   // according to LessByNameComp. Shared between images for performance reasons

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -617,6 +617,12 @@ public:
     return NativeProgram;
   }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+// https://developercommunity.visualstudio.com/t/False-C4297-warning-while-using-function/1130300
+// https://godbolt.org/z/xsMvKf84f
+#pragma warning(disable : 4297)
+#endif
   ~device_image_impl() try {
     if (MSpecConstsBuffer) {
       std::lock_guard<std::mutex> Lock{MSpecConstAccessMtx};
@@ -625,7 +631,11 @@ public:
     }
   } catch (std::exception &e) {
     __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~device_image_impl", e);
+    return; // Don't re-throw.
   }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
   std::string adjustKernelName(std::string_view Name) const {
     if (MOrigins & ImageOriginSYCLBIN) {

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -1014,11 +1014,11 @@ public:
     auto [Kernel, CacheMutex, ArgMask] =
         detail::ProgramManager::getInstance().getOrCreateKernel(
             MContext, KernelID.get_name(), /*PropList=*/{},
-            SelectedImage->get_ur_program_ref());
+            SelectedImage->get_ur_program());
 
     return std::make_shared<kernel_impl>(
         Kernel, *detail::getSyclObjImpl(MContext), SelectedImage, *this,
-        ArgMask, SelectedImage->get_ur_program_ref(), CacheMutex);
+        ArgMask, SelectedImage->get_ur_program(), CacheMutex);
   }
 
   std::shared_ptr<kernel_impl>

--- a/sycl/source/detail/kernel_name_based_cache_t.hpp
+++ b/sycl/source/detail/kernel_name_based_cache_t.hpp
@@ -27,31 +27,26 @@ struct FastKernelCacheVal {
                                      caching is disabled, the pointer is
                                      nullptr. */
   const KernelArgMask *MKernelArgMask; /* Eliminated kernel argument mask. */
-  ur_program_handle_t MProgramHandle;  /* UR program handle corresponding to
-                                     this kernel. */
-  const adapter_impl &MAdapterPtr;     /* We can keep reference to the adapter
-                                because during 2-stage shutdown the kernel
-                                cache is destroyed deliberately before the
-                                adapter. */
+  Managed<ur_program_handle_t> MProgramHandle; /* UR program handle
+                                    corresponding to this kernel. */
+  adapter_impl &MAdapter; /* We can keep reference to the adapter
+                            because during 2-stage shutdown the kernel
+                            cache is destroyed deliberately before the
+                            adapter. */
 
   FastKernelCacheVal(ur_kernel_handle_t KernelHandle, std::mutex *Mutex,
                      const KernelArgMask *KernelArgMask,
-                     ur_program_handle_t ProgramHandle,
-                     const adapter_impl &AdapterPtr)
+                     ur_program_handle_t ProgramHandle, adapter_impl &Adapter)
       : MKernelHandle(KernelHandle), MMutex(Mutex),
-        MKernelArgMask(KernelArgMask), MProgramHandle(ProgramHandle),
-        MAdapterPtr(AdapterPtr) {}
+        MKernelArgMask(KernelArgMask), MProgramHandle(ProgramHandle, Adapter),
+        MAdapter(Adapter) {}
 
   ~FastKernelCacheVal() {
     if (MKernelHandle)
-      MAdapterPtr.call<sycl::detail::UrApiKind::urKernelRelease>(MKernelHandle);
-    if (MProgramHandle)
-      MAdapterPtr.call<sycl::detail::UrApiKind::urProgramRelease>(
-          MProgramHandle);
+      MAdapter.call<sycl::detail::UrApiKind::urKernelRelease>(MKernelHandle);
     MKernelHandle = nullptr;
     MMutex = nullptr;
     MKernelArgMask = nullptr;
-    MProgramHandle = nullptr;
   }
 
   FastKernelCacheVal(const FastKernelCacheVal &) = delete;

--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -12,7 +12,7 @@
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
-const adapter_impl &KernelProgramCache::getAdapter() {
+adapter_impl &KernelProgramCache::getAdapter() {
   return MParentContext->getAdapter();
 }
 

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -119,10 +119,20 @@ public:
       Val = Managed<ur_program_handle_t>{Adapter};
       this->State.store(InitialState);
     }
+#ifdef _MSC_VER
+#pragma warning(push)
+// https://developercommunity.visualstudio.com/t/False-C4297-warning-while-using-function/1130300
+// https://godbolt.org/z/xsMvKf84f
+#pragma warning(disable : 4297)
+#endif
     ~ProgramBuildResult() try {
     } catch (std::exception &e) {
       __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~ProgramBuildResult", e);
+      return; // Don't re-throw.
     }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
   };
   using ProgramBuildResultPtr = std::shared_ptr<ProgramBuildResult>;
 

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -1152,7 +1152,7 @@ getOrBuildProgramForDeviceGlobal(queue_impl &Queue,
       PM.getDeviceImageFromBinaryImage(&Img, Context, Device);
   device_image_plain BuiltImage =
       PM.build(std::move(DeviceImage), {std::move(Device)}, {});
-  return getSyclObjImpl(BuiltImage)->get_ur_program_ref();
+  return getSyclObjImpl(BuiltImage)->get_ur_program();
 }
 
 static void

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -920,10 +920,7 @@ ProgramManager::getBuiltURProgram(const BinImgWithDeps &ImgWithDeps,
                                    NativePrg, Adapter);
     }
 
-    UrFuncInfo<UrApiKind::urProgramRelease> programReleaseInfo;
-    auto programRelease =
-        programReleaseInfo.getFuncPtrFromModule(ur::getURLoaderLibrary());
-    ProgramPtr ProgramManaged(NativePrg, programRelease);
+    Managed<ur_program_handle_t> ProgramManaged(NativePrg, Adapter);
 
     // Link a fallback implementation of device libraries if they are not
     // supported by a device compiler.
@@ -938,7 +935,7 @@ ProgramManager::getBuiltURProgram(const BinImgWithDeps &ImgWithDeps,
     if (UseDeviceLibs)
       DeviceLibReqMask = getDeviceLibReqMask(MainImg);
 
-    std::vector<ur_program_handle_t> ProgramsToLink;
+    std::vector<Managed<ur_program_handle_t>> ProgramsToLink;
     // If we had a program in cache, then it should have been the fully linked
     // program already.
     if (!DeviceCodeWasInCache) {
@@ -950,8 +947,8 @@ ProgramManager::getBuiltURProgram(const BinImgWithDeps &ImgWithDeps,
         if (UseDeviceLibs)
           DeviceLibReqMask |= getDeviceLibReqMask(*BinImg);
 
-        ur_program_handle_t NativePrg =
-            createURProgram(*BinImg, ContextImpl, Devs);
+        Managed<ur_program_handle_t> NativePrg{
+            createURProgram(*BinImg, ContextImpl, Devs), Adapter};
 
         if (BinImg->supportsSpecConstants()) {
           enableITTAnnotationsIfNeeded(NativePrg, Adapter);
@@ -960,22 +957,22 @@ ProgramManager::getBuiltURProgram(const BinImgWithDeps &ImgWithDeps,
                 *getSyclObjImpl(DevImgWithDeps->getAll()[I]), NativePrg,
                 Adapter);
         }
-        ProgramsToLink.push_back(NativePrg);
+        ProgramsToLink.push_back(std::move(NativePrg));
       }
     }
 
     auto URDevices = Devs.to<std::vector<ur_device_handle_t>>();
 
-    ProgramPtr BuiltProgram =
+    Managed<ur_program_handle_t> BuiltProgram =
         build(std::move(ProgramManaged), ContextImpl, CompileOpts, LinkOpts,
               URDevices, DeviceLibReqMask, ProgramsToLink,
               /*CreatedFromBinary*/ MainImg.getFormat() !=
                   SYCL_DEVICE_BINARY_TYPE_SPIRV);
 
-    // Those extra programs won't be used anymore, just the final linked result
-    for (ur_program_handle_t Prg : ProgramsToLink)
-      Adapter.call<UrApiKind::urProgramRelease>(Prg);
-    emitBuiltProgramInfo(BuiltProgram.get(), ContextImpl);
+    // Those extra programs won't be used anymore, just the final
+    // linked result:
+    ProgramsToLink.clear();
+    emitBuiltProgramInfo(BuiltProgram, ContextImpl);
 
     {
       std::lock_guard<std::mutex> Lock(MNativeProgramsMutex);
@@ -983,20 +980,20 @@ ProgramManager::getBuiltURProgram(const BinImgWithDeps &ImgWithDeps,
       // so keys in the map can be invalid (reference count went to zero and the
       // underlying program disposed of). Protecting from incorrect values by
       // removal of map entries with same handle (obviously invalid entries).
-      std::ignore = NativePrograms.erase(BuiltProgram.get());
+      std::ignore = NativePrograms.erase(BuiltProgram);
       for (const RTDeviceBinaryImage *Img : ImgWithDeps) {
         NativePrograms.insert(
-            {BuiltProgram.get(), {ContextImpl.shared_from_this(), Img}});
+            {BuiltProgram, {ContextImpl.shared_from_this(), Img}});
       }
     }
 
-    ContextImpl.addDeviceGlobalInitializer(BuiltProgram.get(), Devs, &MainImg);
+    ContextImpl.addDeviceGlobalInitializer(BuiltProgram, Devs, &MainImg);
 
     // Save program to persistent cache if it is not there
     if (!DeviceCodeWasInCache) {
       PersistentDeviceCodeCache::putItemToDisc(
           Devs, ImgWithDeps.getAll(), SpecConsts, CompileOpts + LinkOpts,
-          BuiltProgram.get());
+          BuiltProgram);
     }
 
     return BuiltProgram.release();
@@ -1350,13 +1347,13 @@ loadDeviceLibFallback(context_impl &Context, DeviceLibExt Extension,
          "At least one device is expected in the input vector");
   // Vector of devices that don't have the library cached.
   for (auto Dev : Devices) {
-    auto CacheResult = CachedLibPrograms.emplace(
-        std::make_pair(std::make_pair(Extension, Dev), nullptr));
-    auto Cached = !CacheResult.second;
+    auto CacheResult = CachedLibPrograms.emplace(std::make_pair(
+        std::make_pair(Extension, Dev), Managed<ur_program_handle_t>{}));
+    bool Cached = !CacheResult.second;
     if (!Cached) {
       DevicesToCompile.push_back(Dev);
     } else {
-      auto CachedURProgram = CacheResult.first->second;
+      ur_program_handle_t CachedURProgram = CacheResult.first->second;
       assert(CachedURProgram && "If device lib UR program was cached then is "
                                 "expected to be not a nullptr");
       assert(((URProgram && URProgram == CachedURProgram) || (!URProgram)) &&
@@ -1395,7 +1392,8 @@ loadDeviceLibFallback(context_impl &Context, DeviceLibExt Extension,
     Adapter.call<UrApiKind::urProgramRetain>(URProgram);
 
   for (auto Dev : DevicesToCompile)
-    CachedLibPrograms[std::make_pair(Extension, Dev)] = URProgram;
+    CachedLibPrograms[std::make_pair(Extension, Dev)] =
+        Managed<ur_program_handle_t>{URProgram, Adapter};
 
   // TODO no spec constants are used in the std libraries, support in the future
   // Do not use compile options for library programs: it is not clear if user
@@ -1710,15 +1708,16 @@ static inline bool isDeviceImageCompressed(sycl_device_binary Bin) {
   return currFormat == SYCL_DEVICE_BINARY_TYPE_COMPRESSED_NONE;
 }
 
-ProgramManager::ProgramPtr ProgramManager::build(
-    ProgramPtr Program, context_impl &Context,
+Managed<ur_program_handle_t> ProgramManager::build(
+    Managed<ur_program_handle_t> Program, context_impl &Context,
     const std::string &CompileOptions, const std::string &LinkOptions,
     std::vector<ur_device_handle_t> &Devices, uint32_t DeviceLibReqMask,
-    const std::vector<ur_program_handle_t> &ExtraProgramsToLink,
+    const std::vector<Managed<ur_program_handle_t>> &ExtraProgramsToLink,
     bool CreatedFromBinary) {
 
   if constexpr (DbgProgMgr > 0) {
-    std::cerr << ">>> ProgramManager::build(" << Program.get() << ", "
+    std::cerr << ">>> ProgramManager::build("
+              << static_cast<ur_program_handle_t>(Program) << ", "
               << CompileOptions << ", " << LinkOptions << ", "
               << VecToString(Devices) << ", " << std::hex << DeviceLibReqMask
               << std::dec << ", " << VecToString(ExtraProgramsToLink) << ", "
@@ -1748,16 +1747,16 @@ ProgramManager::ProgramPtr ProgramManager::build(
                                      ? CompileOptions
                                      : (CompileOptions + " " + LinkOptions);
     ur_result_t Error = Adapter.call_nocheck<UrApiKind::urProgramBuildExp>(
-        Program.get(), Devices.size(), Devices.data(), Options.c_str());
+        Program, Devices.size(), Devices.data(), Options.c_str());
     if (Error == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
       Error = Adapter.call_nocheck<UrApiKind::urProgramBuild>(
-          Context.getHandleRef(), Program.get(), Options.c_str());
+          Context.getHandleRef(), Program, Options.c_str());
     }
 
     if (Error != UR_RESULT_SUCCESS)
       throw detail::set_ur_error(
           exception(make_error_code(errc::build),
-                    getProgramBuildLog(Program.get(), Context)),
+                    getProgramBuildLog(Program, Context)),
           Error);
 
     return Program;
@@ -1765,11 +1764,13 @@ ProgramManager::ProgramPtr ProgramManager::build(
 
   // Include the main program and compile/link everything together
   if (!CreatedFromBinary) {
-    auto Res = doCompile(Adapter, Program.get(), Devices.size(), Devices.data(),
+    auto Res = doCompile(Adapter, Program, Devices.size(), Devices.data(),
                          Context.getHandleRef(), CompileOptions.c_str());
     Adapter.checkUrResult<errc::build>(Res);
   }
-  LinkPrograms.push_back(Program.get());
+  // Should be `std::move(Program)` once `LinkPrograms` is switched to
+  // `Managed<ur_program_handle_t`:
+  LinkPrograms.push_back(Program);
 
   for (ur_program_handle_t Prg : ExtraProgramsToLink) {
     if (!CreatedFromBinary) {
@@ -1780,7 +1781,7 @@ ProgramManager::ProgramPtr ProgramManager::build(
     LinkPrograms.push_back(Prg);
   }
 
-  ur_program_handle_t LinkedProg = nullptr;
+  Managed<ur_program_handle_t> LinkedProg{Adapter};
   auto doLink = [&] {
     auto Res = Adapter.call_nocheck<UrApiKind::urProgramLinkExp>(
         Context.getHandleRef(), Devices.size(), Devices.data(),
@@ -1802,12 +1803,12 @@ ProgramManager::ProgramPtr ProgramManager::build(
   }
 
   // Link program call returns a new program object if all parameters are valid,
-  // or NULL otherwise. Release the original (user) program.
-  Program.reset(LinkedProg);
+  // or NULL otherwise.
   if (Error != UR_RESULT_SUCCESS) {
     if (LinkedProg) {
       // A non-trivial error occurred during linkage: get a build log, release
-      // an incomplete (but valid) LinkedProg, and throw.
+      // an incomplete (but valid) LinkedProg (via implicit dtor call), and
+      // throw.
       throw detail::set_ur_error(
           exception(make_error_code(errc::build),
                     getProgramBuildLog(LinkedProg, Context)),
@@ -1815,7 +1816,7 @@ ProgramManager::ProgramPtr ProgramManager::build(
     }
     Adapter.checkUrResult(Error);
   }
-  return Program;
+  return LinkedProg;
 }
 
 void ProgramManager::cacheKernelUsesAssertInfo(const RTDeviceBinaryImage &Img) {
@@ -2864,15 +2865,14 @@ ProgramManager::compile(const DevImgPlainWithDeps &ImgWithDeps,
         CompileOptions, *(InputImpl.get_bin_image_ref()), Devs, Adapter);
     // Should always come last!
     appendCompileEnvironmentVariablesThatAppend(CompileOptions);
-    ur_result_t Error =
-        doCompile(Adapter, ObjectImpl->get_ur_program_ref(), Devs.size(),
-                  URDevices.data(),
-                  getSyclObjImpl(InputImpl.get_context()).get()->getHandleRef(),
-                  CompileOptions.c_str());
+    ur_result_t Error = doCompile(
+        Adapter, ObjectImpl->get_ur_program(), Devs.size(), URDevices.data(),
+        getSyclObjImpl(InputImpl.get_context()).get()->getHandleRef(),
+        CompileOptions.c_str());
     if (Error != UR_RESULT_SUCCESS)
       throw sycl::exception(
           make_error_code(errc::build),
-          getProgramBuildLog(ObjectImpl->get_ur_program_ref(),
+          getProgramBuildLog(ObjectImpl->get_ur_program(),
                              *getSyclObjImpl(ObjectImpl->get_context())));
 
     CompiledImages.push_back(
@@ -2956,7 +2956,7 @@ ProgramManager::link(const std::vector<device_image_plain> &Imgs,
   std::vector<ur_program_handle_t> URPrograms;
   URPrograms.reserve(Imgs.size());
   for (const device_image_plain &Img : Imgs)
-    URPrograms.push_back(getSyclObjImpl(Img)->get_ur_program_ref());
+    URPrograms.push_back(getSyclObjImpl(Img)->get_ur_program());
 
   auto URDevices = Devs.to<std::vector<ur_device_handle_t>>();
 
@@ -3255,16 +3255,13 @@ ur_kernel_handle_t ProgramManager::getOrCreateMaterializedKernel(
   auto Program = createURProgram(Img, ContextImpl, {Device});
   detail::device_impl &DeviceImpl = *detail::getSyclObjImpl(Device);
   adapter_impl &Adapter = DeviceImpl.getAdapter();
-  UrFuncInfo<UrApiKind::urProgramRelease> programReleaseInfo;
-  auto programRelease =
-      programReleaseInfo.getFuncPtrFromModule(ur::getURLoaderLibrary());
-  ProgramPtr ProgramManaged(Program, programRelease);
+  Managed<ur_program_handle_t> ProgramManaged(Program, Adapter);
 
   std::string CompileOpts;
   std::string LinkOpts;
   applyOptionsFromEnvironment(CompileOpts, LinkOpts);
   // No linking of extra programs reqruired.
-  std::vector<ur_program_handle_t> ExtraProgramsToLink;
+  std::vector<Managed<ur_program_handle_t>> ExtraProgramsToLink;
   std::vector<ur_device_handle_t> Devs = {DeviceImpl.getHandleRef()};
   auto BuildProgram =
       build(std::move(ProgramManaged), ContextImpl, CompileOpts, LinkOpts, Devs,
@@ -3272,7 +3269,7 @@ ur_kernel_handle_t ProgramManager::getOrCreateMaterializedKernel(
             ExtraProgramsToLink);
   ur_kernel_handle_t UrKernel{nullptr};
   Adapter.call<errc::kernel_not_supported, UrApiKind::urKernelCreate>(
-      BuildProgram.get(), KernelName.data(), &UrKernel);
+      BuildProgram, KernelName.data(), &UrKernel);
   {
     std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
     m_MaterializedKernels[KernelName][SpecializationConsts] = UrKernel;

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -393,15 +393,12 @@ private:
   ProgramManager(ProgramManager const &) = delete;
   ProgramManager &operator=(ProgramManager const &) = delete;
 
-  using ProgramPtr = std::unique_ptr<std::remove_pointer_t<ur_program_handle_t>,
-                                     decltype(&::urProgramRelease)>;
-  ProgramPtr build(ProgramPtr Program, context_impl &Context,
-                   const std::string &CompileOptions,
-                   const std::string &LinkOptions,
-                   std::vector<ur_device_handle_t> &Devices,
-                   uint32_t DeviceLibReqMask,
-                   const std::vector<ur_program_handle_t> &ProgramsToLink,
-                   bool CreatedFromBinary = false);
+  Managed<ur_program_handle_t>
+  build(Managed<ur_program_handle_t> Program, context_impl &Context,
+        const std::string &CompileOptions, const std::string &LinkOptions,
+        std::vector<ur_device_handle_t> &Devices, uint32_t DeviceLibReqMask,
+        const std::vector<Managed<ur_program_handle_t>> &ProgramsToLink,
+        bool CreatedFromBinary = false);
 
   /// Dumps image to current directory
   void dumpImage(const RTDeviceBinaryImage &Img, uint32_t SequenceID = 0) const;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2719,7 +2719,7 @@ void enqueueImpKernel(
     Kernel = SyclKernelImpl->getHandleRef();
     DeviceImageImpl = SyclKernelImpl->getDeviceImage();
 
-    Program = DeviceImageImpl->get_ur_program_ref();
+    Program = DeviceImageImpl->get_ur_program();
 
     EliminatedArgMask = SyclKernelImpl->getKernelArgMask();
     KernelMutex = SyclKernelImpl->getCacheMutex();
@@ -2806,7 +2806,7 @@ ur_result_t enqueueReadWriteHostPipe(queue_impl &Queue,
             hostPipeEntry->getDevBinImage(), Queue.get_context(), Device);
     device_image_plain BuiltImage = ProgramManager::getInstance().build(
         std::move(devImgPlain), {std::move(Device)}, {});
-    Program = getSyclObjImpl(BuiltImage)->get_ur_program_ref();
+    Program = getSyclObjImpl(BuiltImage)->get_ur_program();
   }
   assert(Program && "Program for this hostpipe is not compiled.");
 

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -187,7 +187,7 @@ const sycl::detail::KernelArgMask *getKernelArgMaskFromBundle(
   EXPECT_TRUE(SyclKernelImpl != nullptr);
   std::shared_ptr<sycl::detail::device_image_impl> DeviceImageImpl =
       SyclKernelImpl->getDeviceImage();
-  ur_program_handle_t Program = DeviceImageImpl->get_ur_program_ref();
+  ur_program_handle_t Program = DeviceImageImpl->get_ur_program();
 
   EXPECT_TRUE(nullptr == ExecKernel->MSyclKernel ||
               !ExecKernel->MSyclKernel->isCreatedFromSource());


### PR DESCRIPTION
There was `ProgramManager::ProgramPtr` alias over `std::unique_ptr` with a custom deleter to RAII-manage `ur_program_handle_t` lifetime but it was applied in just a few places with the rest of the usage left with C-style explicit management.

This PR introduce a dedicated helper class to manage all UR handle types that I think is more convenient than `ProgramManager::ProgramPtr`. I'm also switching all the objects that stored `ur_program_handle_t` and then `urProgramRelease`d them to use that new helper, while leaving the full refactoring (i.e., create those `Managed` objects at `urProgramCreate*`/`urProgramRetain` point) to a subsequent PRs to ease review process.

Other `ur*_handle_t`s are left to subsequent changes as well.