### PR TITLE
[SYCL][Unit] Fix unit-tests after intel/llvm#19399

### DIFF
--- a/sycl/cmake/modules/AddSYCLUnitTest.cmake
+++ b/sycl/cmake/modules/AddSYCLUnitTest.cmake
@@ -39,6 +39,11 @@ macro(add_sycl_unittest test_dirname link_variant)
     )
   endif()
 
+  if (SYCL_ENABLE_XPTI_TRACING)
+    target_compile_definitions(${test_dirname}
+      PRIVATE XPTI_ENABLE_INSTRUMENTATION XPTI_STATIC_LIBRARY)
+  endif()
+
   # check-sycl-unittests was using an old sycl library. So, to get
   # around this problem, we add the new sycl library to the PATH and
   # LD_LIBRARY_PATH on Windows and Linux respectively.

--- a/sycl/unittests/scheduler/CMakeLists.txt
+++ b/sycl/unittests/scheduler/CMakeLists.txt
@@ -23,8 +23,3 @@ add_sycl_unittest(SchedulerTests OBJECT
     HostTaskAndBarrier.cpp
     BarrierDependencies.cpp
 )
-
-if (SYCL_ENABLE_XPTI_TRACING)
-  target_compile_definitions(SchedulerTests
-    PRIVATE XPTI_ENABLE_INSTRUMENTATION XPTI_STATIC_LIBRARY)
-endif()


### PR DESCRIPTION
intel/llvm#19399 made layout of `scheduler` class dependent on whether or not XPTI instrumentation is enabled. This caused issues with layout mismatch when `scheduler.hpp` is included directly from unit-tests, because macro enabling XPTI were not aligned between the RT and unit-tests.

The issue was caught for scheduler unit-tests and fixed in intel/llvm#19399, but apparently we have more unit-tests which need scheduler. Internal testing discovered issues with buffer unit-tests.

Therefore, re-applied the fix from intel/llvm#19399 globally to all unit-tests to prevent issues like this appearing in new and other existing unit-tests.