### PR TITLE
[NativeCPU] Use host data layout.

### DIFF
--- a/clang/lib/Basic/Targets/NativeCPU.cpp
+++ b/clang/lib/Basic/Targets/NativeCPU.cpp
@@ -48,7 +48,6 @@ NativeCPUTargetInfo::NativeCPUTargetInfo(const llvm::Triple &Triple,
   UseAddrSpaceMapMangling = true;
   HasLegalHalfType = true;
   HasFloat16 = true;
-  resetDataLayout("e");
 
   llvm::Triple HostTriple([&] {
     // Take the default target triple if no other host triple is specified so
@@ -58,9 +57,13 @@ NativeCPUTargetInfo::NativeCPUTargetInfo(const llvm::Triple &Triple,
 
     return llvm::Triple(Opts.HostTriple);
   }());
-  if (!HostTriple.isNativeCPU()) {
+  if (HostTriple.isNativeCPU()) {
+    // This should never happen, just make sure we do not crash.
+    resetDataLayout("e");
+  } else {
     HostTarget = AllocateTarget(HostTriple, Opts);
     copyAuxTarget(&*HostTarget);
+    resetDataLayout(HostTarget->getDataLayoutString());
   }
 }
 
@@ -68,4 +71,5 @@ void NativeCPUTargetInfo::setAuxTarget(const TargetInfo *Aux) {
   assert(Aux && "Cannot invoke setAuxTarget without a valid auxiliary target!");
   copyAuxTarget(Aux);
   getTargetOpts() = Aux->getTargetOpts();
+  resetDataLayout(Aux->getDataLayoutString());
 }

--- a/clang/test/CodeGenSYCL/native_cpu_target_features.cpp
+++ b/clang/test/CodeGenSYCL/native_cpu_target_features.cpp
@@ -1,9 +1,9 @@
-// RUN: %clang_cc1 -triple native_cpu -aux-triple x86_64-unknown-linux-gnu -fsycl-is-device -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,NOAVX
-// RUN: %clang_cc1 -triple native_cpu -aux-triple x86_64-unknown-linux-gnu -aux-target-cpu skylake -fsycl-is-device -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AVX
-// RUN: %clang_cc1 -triple native_cpu -aux-triple x86_64-unknown-linux-gnu -aux-target-feature +avx -fsycl-is-device -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,AVX
+// RUN: %clang_cc1 -triple native_cpu -aux-triple x86_64-unknown-linux-gnu -fsycl-is-device -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,X86,NOAVX
+// RUN: %clang_cc1 -triple native_cpu -aux-triple x86_64-unknown-linux-gnu -aux-target-cpu skylake -fsycl-is-device -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,X86,AVX
+// RUN: %clang_cc1 -triple native_cpu -aux-triple x86_64-unknown-linux-gnu -aux-target-feature +avx -fsycl-is-device -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,X86,AVX
 //
 // This is not sensible but check that we do not crash.
-// RUN: %clang_cc1 -triple native_cpu -aux-triple native_cpu -fsycl-is-device -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,NOAVX
+// RUN: %clang_cc1 -triple native_cpu -aux-triple native_cpu -fsycl-is-device -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,NOX86,NOAVX
 
 #include "Inputs/sycl.hpp"
 using namespace sycl;
@@ -13,6 +13,9 @@ int main() {
   sycl::queue deviceQueue;
   deviceQueue.submit([&](handler &h) { h.single_task<Test>([=] {}); });
 }
+
+// X86: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// NOX86: target datalayout = "e"
 
 // CHECK: void @_ZTS4Test() [[ATTRS:#[0-9]+]]
 // CHECK: [[ATTRS]] = {


### PR DESCRIPTION
For compilations without an aux target, the data layout string is not used by us because it only appears in device libs where it will be overwritten when the device lib gets merged in.

For compilations with an aux target, the data layout string should be set to that of the aux target, the aux target may be relying on that.