### PR TITLE
[SYCL][ESIMD] Run all passes with O0 opt level

### DIFF
--- a/llvm/lib/SYCLPostLink/ESIMDPostSplitProcessing.cpp
+++ b/llvm/lib/SYCLPostLink/ESIMDPostSplitProcessing.cpp
@@ -30,11 +30,12 @@ using namespace llvm::module_split;
 
 namespace {
 
-ModulePassManager buildESIMDLoweringPipeline(bool OptLevelO0, bool SplitESIMD) {
+ModulePassManager buildESIMDLoweringPipeline(bool ForceDisableOpt,
+                                             bool SplitESIMD) {
   ModulePassManager MPM;
   MPM.addPass(SYCLLowerESIMDPass(!SplitESIMD));
 
-  if (!OptLevelO0) {
+  if (!ForceDisableOpt) {
     FunctionPassManager FPM;
     FPM.addPass(SROAPass(SROAOptions::ModifyCFG));
     MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
@@ -43,7 +44,7 @@ ModulePassManager buildESIMDLoweringPipeline(bool OptLevelO0, bool SplitESIMD) {
   FunctionPassManager MainFPM;
   MainFPM.addPass(ESIMDLowerLoadStorePass{});
 
-  if (!OptLevelO0) {
+  if (!ForceDisableOpt) {
     MainFPM.addPass(SROAPass(SROAOptions::ModifyCFG));
     MainFPM.addPass(EarlyCSEPass(true));
     MainFPM.addPass(InstCombinePass{});
@@ -64,7 +65,7 @@ ModulePassManager buildESIMDLoweringPipeline(bool OptLevelO0, bool SplitESIMD) {
 
 // When ESIMD code was separated from the regular SYCL code,
 // we can safely process ESIMD part.
-bool sycl::lowerESIMDConstructs(ModuleDesc &MD, bool OptLevelO0,
+bool sycl::lowerESIMDConstructs(ModuleDesc &MD, bool ForceDisableOpt,
                                 bool SplitESIMD) {
   // TODO: support options like -debug-pass, -print-[before|after], and others
   LoopAnalysisManager LAM;
@@ -81,7 +82,8 @@ bool sycl::lowerESIMDConstructs(ModuleDesc &MD, bool OptLevelO0,
 
   std::vector<std::string> Names;
   MD.saveEntryPointNames(Names);
-  ModulePassManager MPM = buildESIMDLoweringPipeline(OptLevelO0, SplitESIMD);
+  ModulePassManager MPM =
+      buildESIMDLoweringPipeline(ForceDisableOpt, SplitESIMD);
   PreservedAnalyses Res = MPM.run(MD.getModule(), MAM);
 
   // GenXSPIRVWriterAdaptor pass replaced some functions with "rewritten"

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
@@ -14,6 +14,10 @@
 ; RUN: sycl-post-link -properties -split-esimd -lower-esimd -O2 -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O2
 
+; -O0 lowering
+; RUN: sycl-post-link -properties -split-esimd -lower-esimd -O0 -S < %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O0
+
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"
 
@@ -49,6 +53,15 @@ attributes #0 = { "sycl-module-id"="a.cpp" }
 ; CHECK-NO-LOWERING:   call spir_func void @_Z15__esimd_barrierv()
 ; CHECK-NO-LOWERING:   ret void
 ; CHECK-NO-LOWERING: }
+
+; With -O0, we only lower ESIMD code, but no other optimizations
+; CHECK-O0: define dso_local spir_kernel void @ESIMD_kernel() #{{[0-9]}} !sycl_explicit_simd !{{[0-9]}} !intel_reqd_sub_group_size !{{[0-9]}} {
+; CHECK-O0: entry:
+; CHECK-O0:   %0 = load <3 x i64>, {{.*}} addrspacecast {{.*}} @__spirv_BuiltInGlobalInvocationId
+; CHECK-O0:   %1 = extractelement <3 x i64> %0, i64 0
+; CHECK-O0:   call void @llvm.genx.barrier()
+; CHECK-O0:   ret void
+; CHECK-O0: }
 
 ; With -O2, unused call was optimized away
 ; CHECK-O2: define dso_local spir_kernel void @ESIMD_kernel()

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
@@ -14,8 +14,8 @@
 ; RUN: sycl-post-link -properties -split-esimd -lower-esimd -O2 -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O2
 
-; -O0 lowering
-; RUN: sycl-post-link -properties -split-esimd -lower-esimd -O0 -S < %s -o %t.table
+; -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+; RUN: sycl-post-link -properties -split-esimd -lower-esimd -O0 -force-disable-opt -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O0
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-post-link-test.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-post-link-test.ll
@@ -1,4 +1,5 @@
-; RUN: sycl-post-link -properties -split-esimd -lower-esimd -O0 -S < %s -o %t.table
+; -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+; RUN: sycl-post-link -properties -split-esimd -lower-esimd -O0 -force-disable-opt -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll
 ; This test checks that IR code below can be successfully processed by
 ; sycl-post-link. In this IR no extractelement instruction and no casting are used

--- a/llvm/test/tools/sycl-post-link/sycl-post-link-test.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-post-link-test.ll
@@ -20,8 +20,10 @@ entry:
   store i32 %add.i, ptr addrspace(1) %_arg_DoNotOptimize32, align 4
   ret void
 }
-; CHECK: store i64 0, ptr addrspace(1) %_arg_DoNotOptimize, align 8
-; CHECK: store i32 3, ptr addrspace(1) %_arg_DoNotOptimize32, align 4
+; CHECK: %conv.i = zext i32 0 to i64
+; CHECK: store i64 %conv.i, ptr addrspace(1) %_arg_DoNotOptimize, align 8
+; CHECK: %add.i = add i32 0, 3
+; CHECK: store i32 %add.i, ptr addrspace(1) %_arg_DoNotOptimize32, align 4
 
 ; Function Attrs: convergent norecurse
 define dso_local spir_kernel void @kernel_SubgroupSize(ptr addrspace(1) noundef align 8 %_arg_DoNotOptimize, ptr addrspace(1) noundef align 4 %_arg_DoNotOptimize32)#0 !sycl_explicit_simd !3{
@@ -33,8 +35,10 @@ entry:
   store i32 %add.i, ptr addrspace(1) %_arg_DoNotOptimize32, align 4
   ret void
 }
-; CHECK: store i64 1, ptr addrspace(1) %_arg_DoNotOptimize, align 8
-; CHECK: store i32 8, ptr addrspace(1) %_arg_DoNotOptimize32, align 4
+; CHECK: %conv.i = zext i32 1 to i64
+; CHECK: store i64 %conv.i, ptr addrspace(1) %_arg_DoNotOptimize, align 8
+; CHECK: %add.i = add i32 1, 7
+; CHECK: store i32 %add.i, ptr addrspace(1) %_arg_DoNotOptimize32, align 4
 
 ; Function Attrs: convergent norecurse
 define dso_local spir_kernel void @kernel_SubgroupMaxSize(ptr addrspace(1) noundef align 8 %_arg_DoNotOptimize, ptr addrspace(1) noundef align 4 %_arg_DoNotOptimize32) #0 !sycl_explicit_simd !3 {
@@ -46,8 +50,10 @@ entry:
   store i32 %add.i, ptr addrspace(1) %_arg_DoNotOptimize32, align 4
   ret void
 }
-; CHECK: store i64 1, ptr addrspace(1) %_arg_DoNotOptimize, align 8
-; CHECK: store i32 10, ptr addrspace(1) %_arg_DoNotOptimize32, align 4
+; CHECK: %conv.i = zext i32 1 to i64
+; CHECK: store i64 %conv.i, ptr addrspace(1) %_arg_DoNotOptimize, align 8
+; CHECK: %add.i = add i32 1, 9
+; CHECK: store i32 %add.i, ptr addrspace(1) %_arg_DoNotOptimize32, align 4
 
 attributes #0 = { "sycl-module-id"="a.cpp" }
 

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -177,6 +177,10 @@ cl::opt<bool> OptLevelO3("O3",
                          cl::desc("Optimization level 3. Similar to clang -O3"),
                          cl::cat(PostLinkCat));
 
+cl::opt<bool> ForceDisableOpt("force-disable-opt",
+                              cl::desc("Force no optimizations."),
+                              cl::cat(PostLinkCat));
+
 cl::opt<module_split::IRSplitMode> SplitMode(
     "split", cl::desc("split input module"), cl::Optional,
     cl::init(module_split::SPLIT_NONE),
@@ -523,7 +527,7 @@ handleESIMD(module_split::ModuleDesc &&MDesc, bool &Modified,
   for (auto &MD : Result) {
     DUMP_ENTRY_POINTS(MD.entries(), MD.Name.c_str(), 3);
     if (LowerEsimd && MD.isESIMD())
-      Modified |= sycl::lowerESIMDConstructs(MD, OptLevelO0, SplitEsimd);
+      Modified |= sycl::lowerESIMDConstructs(MD, ForceDisableOpt, SplitEsimd);
   }
 
   if (!SplitEsimd && Result.size() > 1) {

--- a/sycl/test/check_device_code/esimd/fp16_converts.cpp
+++ b/sycl/test/check_device_code/esimd/fp16_converts.cpp
@@ -5,7 +5,8 @@
 
 // Checks that lowerESIMD pass builds proper vc-intrinsics
 // RUN: %clangxx -O2 -fsycl -c -fsycl-device-only -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll
 
 #include <sycl/ext/intel/esimd.hpp>

--- a/sycl/test/check_device_code/esimd/fp16_converts.cpp
+++ b/sycl/test/check_device_code/esimd/fp16_converts.cpp
@@ -34,7 +34,9 @@ __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
 SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void bf16_vector() {
   simd<float, 8> F32 = 0;
   simd<bfloat16, 8> BF16 = F32;
+  // CHECK: call <8 x half> @llvm.genx.bf.cvt.v8f16.v8f32(<8 x float> {{[^)]+}})
   simd<float, 8> F32_conv = BF16;
+  // CHECK: call <8 x float> @llvm.genx.bf.cvt.v8f32.v8f16(<8 x half> {{[^)]+}})
 }
 
 SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void bf16_scalar() {

--- a/sycl/test/check_device_code/esimd/intrins_trans.cpp
+++ b/sycl/test/check_device_code/esimd/intrins_trans.cpp
@@ -101,13 +101,15 @@ test_mem_intrins(int *addr, const vec<float, 8> &xf,
   {
     uint32_t offset = 128;
     vec<int, 8> x = __esimd_slm_block_ld<int, 8, 32>(offset);
-    // CHECK: load <8 x i32>, ptr addrspace(3) inttoptr (i32 128 to ptr addrspace(3)), align 32
+    // CHECK: %[[VAR_OFF1:[0-9a-zA-Z_.]+]] = inttoptr i32 %{{[a-zA-Z0-9.]+}} to ptr addrspace(3)
+    // CHECK-NEXT: load <8 x i32>, ptr addrspace(3) %[[VAR_OFF1]], align 32
     use(x);
   }
   {
     uint32_t offset = 256;
     __esimd_slm_block_st<int, 8, 4>(offset, get8i());
-    // CHECK: store <8 x i32> %call16, ptr addrspace(3) inttoptr (i32 256 to ptr addrspace(3)), align 4
+    // CHECK: %[[VAR_OFF2:[0-9a-zA-Z_.]+]] = inttoptr i32 %{{[a-zA-Z0-9.]+}} to ptr addrspace(3)
+    // CHECK-NEXT: store <8 x i32> %{{[a-zA-Z0-9.]+}}, ptr addrspace(3) %[[VAR_OFF2]], align 4
   }
   {
     auto x = __esimd_svm_gather<unsigned char, 8>(get8ui64(), get8ui16());
@@ -208,36 +210,40 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
   v_addr += offsets;
 
   __esimd_svm_atomic0<atomic_op::inc, uint32_t, VL>(v_addr.data(), pred.data());
-  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.inc.v32i32.v32i1.v32i64(<32 x i1> undef, <32 x i64> zeroinitializer, <32 x i32> undef)
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.inc.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
 
   __esimd_svm_atomic1<atomic_op::add, uint32_t, VL>(v_addr.data(), v1.data(),
                                                     pred.data());
-  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.add.v32i32.v32i1.v32i64(<32 x i1> undef, <32 x i64> zeroinitializer, <32 x i32> zeroinitializer, <32 x i32> undef)
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.add.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
   __esimd_svm_atomic2<atomic_op::cmpxchg, uint32_t, VL>(
       v_addr.data(), v1.data(), v1.data(), pred.data());
-  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.cmpxchg.v32i32.v32i1.v32i64(<32 x i1> undef, <32 x i64> zeroinitializer, <32 x i32> zeroinitializer, <32 x i32> zeroinitializer, <32 x i32> undef)
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.cmpxchg.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
 
   simd<uint32_t, VL> v00 = __esimd_svm_block_ld<uint32_t, VL, 4>(vec_ptr);
+  // CHECK: %[[VAR1:[0-9a-zA-Z_.]+]] = load <32 x i32>, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 4
   __esimd_svm_block_st<uint32_t, VL, 128>(vec_ptr, v00.data());
+  // CHECK-NEXT: store <32 x i32> %[[VAR1]], ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 128
 
   simd<uint32_t, VL> v01 =
       __esimd_svm_gather<uint32_t, VL>(v_addr.data(), pred.data());
-  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.gather.v32i32.v32i1.v32i64(<32 x i1> undef, i32 0, <32 x i64> zeroinitializer, <32 x i32> undef)
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.gather.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
 
   __esimd_svm_scatter<uint32_t, VL>(v_addr.data(), v01.data(), pred.data());
-  // CHECK: call void @llvm.genx.svm.scatter.v32i1.v32i64.v32i32(<32 x i1> undef, i32 0, <32 x i64> zeroinitializer, <32 x i32> %{{[0-9a-zA-Z_.]+}})
+  // CHECK: call void @llvm.genx.svm.scatter.v32i1.v32i64.v32i32(<32 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}})
 
   simd<short, 16> mina(0, 1);
   simd<short, 16> minc(5);
   minc = __esimd_smin<short, 16>(mina.data(), minc.data());
+  // CHECK:  %{{[0-9a-zA-Z_.]+}} = call <16 x i16> @llvm.genx.smin.v16i16.v16i16(<16 x i16> %{{[0-9a-zA-Z_.]+}}, <16 x i16> %{{[0-9a-zA-Z_.]+}})
 
   simd<float, 1> diva(2.f);
   simd<float, 1> divb(1.f);
   diva = __esimd_ieee_div<float, 1>(diva.data(), divb.data());
+  // CHECK:  %{{[0-9a-zA-Z_.]+}} = call <1 x float> @llvm.genx.ieee.div.v1f32(<1 x float>  %{{[0-9a-zA-Z_.]+}}, <1 x float>  %{{[0-9a-zA-Z_.]+}})
 
   simd<float, 16> a(0.1f);
   simd<float, 8> b = __esimd_rdregion<float, 16, 8, 0, 8, 1>(a.data(), 0);
-  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <8 x float> @llvm.genx.rdregionf.v8f32.v16f32.i16(<16 x float> splat (float 0x3FB99999A0000000), i32 0, i32 8, i32 1, i16 0, i32 0)
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <8 x float> @llvm.genx.rdregionf.v8f32.v16f32.i16(<16 x float> %{{[0-9a-zA-Z_.]+}}, i32 0, i32 8, i32 1, i16 0, i32 0)
 
   simd<float, 16> c(0.0f);
 
@@ -255,17 +261,21 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
   auto d = __esimd_wrregion<float, 16 /*ret size*/, 8 /*write size*/,
                             0 /*vstride*/, 8 /*row width*/, 1 /*hstride*/>(
       c.data() /*dst*/, b.data() /*src*/, 0 /*offset*/);
-  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x float> @llvm.genx.wrregionf.v16f32.v8f32.i16.v8i1(<16 x float> zeroinitializer, <8 x float> %{{[0-9a-zA-Z_.]+}}, i32 0, i32 8, i32 1, i16 0, i32 0, <8 x i1> splat (i1 true))
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x float> @llvm.genx.wrregionf.v16f32.v8f32.i16.v8i1(<16 x float> %{{[0-9a-zA-Z_.]+}}, <8 x float> %{{[0-9a-zA-Z_.]+}}, i32 0, i32 8, i32 1, i16 0, i32 0, <8 x i1> splat (i1 true))
 
   simd<int, 32> va;
   va = media_block_load<int, 4, 8>(pA, x, y);
-  // CHECK: %[[SI0_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef)
-  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.media.ld.v32i32(i32 0, i32 %{{[0-9a-zA-Z_.]+}}, i32 0, i32 32, i32 0, i32 0)
+  // CHECK: %[[SI0_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %{{[0-9a-zA-Z_.]+}})
+  // CHECK: store i32 %[[SI0_VAL]], ptr addrspace(4) %[[SI0_ADDR:[0-9a-zA-Z_.]+]]
+  // CHECK: %[[SI0:[0-9a-zA-Z_.]+]] = load i32, ptr addrspace(4) %[[SI0_ADDR]]
+  // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.media.ld.v32i32(i32 0, i32 %[[SI0]], i32 0, i32 32, i32 %{{[0-9a-zA-Z_.]+}}, i32 %{{[0-9a-zA-Z_.]+}})
 
   simd<int, 32> vb = va + 1;
   media_block_store<int, 4, 8>(pB, x, y, vb);
-  // CHECK: %[[SI2_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef)
-  // CHECK: call void @llvm.genx.media.st.v32i32(i32 0, i32 %{{[0-9a-zA-Z_.]+}}, i32 0, i32 32, i32 0, i32 0, <32 x i32> %{{[0-9a-zA-Z_.]+}})
+  // CHECK: %[[SI2_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %{{[0-9a-zA-Z_.]+}})
+  // CHECK: store i32 %[[SI2_VAL]], ptr addrspace(4) %[[SI2_ADDR:[0-9a-zA-Z_.]+]]
+  // CHECK: %[[SI2:[0-9a-zA-Z_.]+]] = load i32, ptr addrspace(4) %[[SI2_ADDR]]
+  // CHECK: call void @llvm.genx.media.st.v32i32(i32 0, i32 %[[SI2]], i32 0, i32 32, i32 %{{[0-9a-zA-Z_.]+}}, i32 %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}})
 
   auto ee = __esimd_vload<int, 16>((detail::vector_type_t<int, 16> *)(&vg));
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <16 x i32> @llvm.genx.vload.v16i32.p0(ptr {{.*}})
@@ -281,35 +291,47 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
 
     // 4-byte element gather
     simd<int, 8> v = gather<int, 8>(acc, offsets, 100);
-    // CHECK-STATEFUL: %[[SI3_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(ptr addrspace(1) noundef undef)
-    // CHECK-STATEFUL: call <8 x i32> @llvm.genx.gather.masked.scaled2.v8i32.v8i32.v8i1(i32 2, i16 0, i32 %{{[0-9a-zA-Z_.]+}}, i32 100, <8 x i32> splat (i32 1), <8 x i1> splat (i1 true))
-    // CHECK-STATELESS: call <8 x i32> @llvm.genx.svm.gather.v8i32.v8i1.v8i64(<8 x i1> splat (i1 true), i32 0, <8 x i64> undef, <8 x i32> undef)
+    // CHECK-STATEFUL: %[[SI3_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(ptr addrspace(1) noundef %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATEFUL: store i32 %[[SI3_VAL]], ptr addrspace(4) %[[SI3_ADDR:[0-9a-zA-Z_.]+]]
+    // CHECK-STATEFUL: %[[SI3:[0-9a-zA-Z_.]+]] = load i32, ptr addrspace(4) %[[SI3_ADDR]]
+    // CHECK-STATEFUL: call <8 x i32> @llvm.genx.gather.masked.scaled2.v8i32.v8i32.v8i1(i32 2, i16 0, i32 %[[SI3]], i32 %{{[0-9a-zA-Z_.]+}}, <8 x i32> %{{[0-9a-zA-Z_.]+}}, <8 x i1> %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATELESS: call <8 x i32> @llvm.genx.svm.gather.v8i32.v8i1.v8i64(<8 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, <8 x i64> %{{[0-9a-zA-Z_.]+}}, <8 x i32> undef)
 
     // 4-byte element scatter
     scatter<int, 8>(acc, offsets, v, 100, pred);
-    // CHECK-STATEFUL: %[[SI4_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(ptr addrspace(1) noundef undef)
-    // CHECK STATEFUL: call void @llvm.genx.scatter.scaled.v8i1.v8i32.v8i32(<8 x i1> <i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false>, i32 2, i16 0, i32 %{{[0-9a-zA-Z_.]+}}, i32 0, <8 x i32> splat (i32 101), <8 x i32> %{{[0-9a-zA-Z_.]+}})
-    // CHECK-STATELESS: call void @llvm.genx.svm.scatter.v8i1.v8i64.v8i32(<8 x i1> <i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false>, i32 0, <8 x i64> undef, <8 x i32> %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATEFUL: %[[SI4_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(ptr addrspace(1) noundef %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATEFUL: store i32 %[[SI4_VAL]], ptr addrspace(4) %[[SI4_ADDR:[0-9a-zA-Z_.]+]]
+    // CHECK-STATEFUL: %[[SI4:[0-9a-zA-Z_.]+]] = load i32, ptr addrspace(4) %[[SI4_ADDR]]
+    // CHECK-STATEFUL: call void @llvm.genx.scatter.scaled.v8i1.v8i32.v8i32(<8 x i1> %{{[0-9a-zA-Z_.]+}}, i32 2, i16 0, i32 %[[SI4]], i32 %{{[0-9a-zA-Z_.]+}}, <8 x i32> %{{[0-9a-zA-Z_.]+}}, <8 x i32> %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATELESS: call void @llvm.genx.svm.scatter.v8i1.v8i64.v8i32(<8 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, <8 x i64> %{{[0-9a-zA-Z_.]+}}, <8 x i32> %{{[0-9a-zA-Z_.]+}})
 
     // 1-byte element gather: same code with and without mask
     simd<unsigned char, 8> v1 = gather<unsigned char, 8>(acc, offsets, 100);
-    // CHECK-STATEFUL: %[[SI5_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(ptr addrspace(1) noundef undef)
-    // CHECK-STATEFUL: call <8 x i32> @llvm.genx.gather.masked.scaled2.v8i32.v8i32.v8i1(i32 0, i16 0, i32 %{{[0-9a-zA-Z_.]+}}, i32 0, <8 x i32> splat (i32 1), <8 x i1> <i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false>)
-    // CHECK-STATELESS: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> <i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false>, i32 0, <8 x i64> undef, <32 x i8> undef)
+    // CHECK-STATEFUL: %[[SI5_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(ptr addrspace(1) noundef %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATEFUL: store i32 %[[SI5_VAL]], ptr addrspace(4) %[[SI5_ADDR:[0-9a-zA-Z_.]+]]
+    // CHECK-STATEFUL: %[[SI5:[0-9a-zA-Z_.]+]] = load i32, ptr addrspace(4) %[[SI5_ADDR]]
+    // CHECK-STATEFUL: call <8 x i32> @llvm.genx.gather.masked.scaled2.v8i32.v8i32.v8i1(i32 0, i16 0, i32 %[[SI5]], i32 %{{[0-9a-zA-Z_.]+}}, <8 x i32> %{{[0-9a-zA-Z_.]+}}, <8 x i1> %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATELESS: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, <8 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i8> undef)
 
     // 1-byte element gather using the mask
     v1 = gather<unsigned char, 8>(acc, offsets, 100, pred);
+    // CHECK-STATEFUL: call <8 x i32> @llvm.genx.gather.masked.scaled2.v8i32.v8i32.v8i1(i32 0, i16 0, i32 {{[^)]+}}, i32 {{[^)]+}}, <8 x i32> {{[^)]+}}, <8 x i1> {{[^)]+}})
+    // CHECK-STATELESS: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> {{[^)]+}}, i32 0, <8 x i64> {{[^)]+}}, <32 x i8> undef)
 
     // 1-byte element gather using the mask - the mask is signed, which may
     // expose different issues/conflicts in gather API.
     simd<int32_t, 8> ioffsets = 1;
     v1 = gather<unsigned char, 8>(acc, ioffsets, 0, pred);
+    // CHECK-STATEFUL: call <8 x i32> @llvm.genx.gather.masked.scaled2.v8i32.v8i32.v8i1(i32 0, i16 0, i32 {{[^)]+}}, i32 {{[^)]+}}, <8 x i32> {{[^)]+}}, <8 x i1> {{[^)]+}})
+    // CHECK-STATELESS: call <32 x i8> @llvm.genx.svm.gather.v32i8.v8i1.v8i64(<8 x i1> {{[^)]+}}, i32 0, <8 x i64> {{[^)]+}}, <32 x i8> undef)
 
     // 1-byte element scatter
     scatter<unsigned char, 8>(acc, offsets, v1, 100, pred);
-    // CHECK-STATEFUL: %[[SI6_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(ptr addrspace(1) noundef undef)
-    // CHECK-STATEFUL: call void @llvm.genx.scatter.scaled.v8i1.v8i32.v8i32(<8 x i1> <i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false>, i32 0, i16 0, i32 %{{[0-9a-zA-Z_.]+}}, i32 0, <8 x i32> splat (i32 101), <8 x i32> %{{[0-9a-zA-Z_.]+}})
-    // CHECK-STATELESS: call void @llvm.genx.svm.scatter.v8i1.v8i64.v32i8(<8 x i1> <i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false>, i32 0, <8 x i64> undef, <32 x i8> %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATEFUL: %[[SI6_VAL:[0-9a-zA-Z_.]+]] = call spir_func noundef i32 @_Z21__spirv_ConvertPtrToU{{.*}}(ptr addrspace(1) noundef %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATEFUL: store i32 %[[SI6_VAL]], ptr addrspace(4) %[[SI6_ADDR:[0-9a-zA-Z_.]+]]
+    // CHECK-STATEFUL: %[[SI6:[0-9a-zA-Z_.]+]] = load i32, ptr addrspace(4) %[[SI6_ADDR]]
+    // CHECK-STATEFUL: call void @llvm.genx.scatter.scaled.v8i1.v8i32.v8i32(<8 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, i16 0, i32 %[[SI6]], i32 %{{[0-9a-zA-Z_.]+}}, <8 x i32> %{{[0-9a-zA-Z_.]+}}, <8 x i32> %{{[0-9a-zA-Z_.]+}})
+    // CHECK-STATELESS: call void @llvm.genx.svm.scatter.v8i1.v8i64.v32i8(<8 x i1> %{{[0-9a-zA-Z_.]+}}, i32 0, <8 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i8> %{{[0-9a-zA-Z_.]+}})
   }
   __esimd_fence(fence_mask::global_coherent_fence);
   // CHECK: call void @llvm.genx.fence(i8 1)

--- a/sycl/test/check_device_code/esimd/intrins_trans.cpp
+++ b/sycl/test/check_device_code/esimd/intrins_trans.cpp
@@ -1,9 +1,11 @@
 // RUN: %clangxx %clang_O0 -fsycl -fsycl-device-only -fno-sycl-esimd-force-stateless-mem -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATEFUL
 
 // RUN: %clangxx %clang_O0 -fsycl -fsycl-device-only -fsycl-esimd-force-stateless-mem -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=true -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=true -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATELESS
 
 // Checks ESIMD intrinsic translation with opaque pointers.

--- a/sycl/test/check_device_code/esimd/intrins_trans.cpp
+++ b/sycl/test/check_device_code/esimd/intrins_trans.cpp
@@ -107,7 +107,7 @@ test_mem_intrins(int *addr, const vec<float, 8> &xf,
   {
     uint32_t offset = 256;
     __esimd_slm_block_st<int, 8, 4>(offset, get8i());
-    // CHECK: store <8 x i32> %{{[a-zA-Z0-9.]+}}, ptr addrspace(3) inttoptr (i32 256 to ptr addrspace(3)), align 4
+    // CHECK: store <8 x i32> %call16, ptr addrspace(3) inttoptr (i32 256 to ptr addrspace(3)), align 4
   }
   {
     auto x = __esimd_svm_gather<unsigned char, 8>(get8ui64(), get8ui16());

--- a/sycl/test/check_device_code/esimd/lsc.cpp
+++ b/sycl/test/check_device_code/esimd/lsc.cpp
@@ -1,9 +1,11 @@
 // RUN: %clangxx -O0 -fsycl -fno-sycl-esimd-force-stateless-mem -fsycl-device-only -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATEFUL
 
 // RUN: %clangxx -O0 -fsycl -fsycl-esimd-force-stateless-mem -fsycl-device-only -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATELESS
 
 // Checks ESIMD intrinsic translation.

--- a/sycl/test/check_device_code/esimd/lsc.cpp
+++ b/sycl/test/check_device_code/esimd/lsc.cpp
@@ -40,59 +40,70 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void foo(AccType &acc) {
   int *ptr = 0;
   uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
 
-  // CHECK: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> zeroinitializer, <4 x i32> splat (i32 1), i32 0)
+  // CHECK: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   simd<int, VL> data1 = 1;
   lsc_block_store<int, VL>(ptr, data1);
 
+  // CHECK: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   simd<int, VL> data2 = lsc_block_load<int, VL>(ptr);
 
-  //CHECK: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> splat (i1 true), i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> zeroinitializer, i32 0)
+  //CHECK: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0)
   lsc_prefetch<int, VL, lsc_data_size::default_size, cache_hint::uncached,
                cache_hint::cached>(ptr);
 
   simd<uint32_t, VL> offsets = simd<uint32_t, VL>(1) * sizeof(int);
   simd_mask<VL> mask;
 
-  // CHECK: call void @llvm.genx.lsc.store.stateless.v4i1.v4i64.v4i32(<4 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> splat (i32 1), i32 0)
+  // CHECK: call void @llvm.genx.lsc.store.stateless.v4i1.v4i64.v4i32(<4 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   lsc_scatter<int>(ptr, offsets, data1);
 
+  // CHECK: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   simd<int, VL> data3 = lsc_gather<int>(ptr, offsets);
 
-  // CHECK: call void @llvm.genx.lsc.prefetch.stateless.v4i1.v4i64(<4 x i1> splat (i1 true), i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), i32 0)
+  // CHECK: call void @llvm.genx.lsc.prefetch.stateless.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, i32 0)
   lsc_prefetch<int, 1, lsc_data_size::default_size, cache_hint::uncached,
                cache_hint::cached>(ptr, offsets);
 
   uint32_t surf_offset = 1 * VL * sizeof(int);
 
-  // CHECK-STATEFUL:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4i32(<1 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> splat (i32 16), <4 x i32> splat (i32 1), i32 {{[^)]+}})
-  // CHECK-STATELESS: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x i32> splat (i32 1), i32 0)
+  // CHECK-STATEFUL:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   lsc_block_store<int, VL>(acc, surf_offset, data1);
 
+  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.load.bti.v4i32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   simd<int, VL> data4 = lsc_block_load<int, VL>(acc, surf_offset);
 
-  // CHECK-STATEFUL:  call void @llvm.genx.lsc.prefetch.bti.v1i1.v1i32(<1 x i1> splat (i1 true), i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> splat (i32 16), i32 {{[^)]+}})
-  // CHECK-STATELESS: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> splat (i1 true), i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0)
+  // CHECK-STATEFUL:  call void @llvm.genx.lsc.prefetch.bti.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0)
   lsc_prefetch<int, 4, lsc_data_size::default_size, cache_hint::uncached,
                cache_hint::cached>(acc, surf_offset);
 
-  // CHECK-STATEFUL:  call void @llvm.genx.lsc.store.bti.v4i1.v4i32.v4i32(<4 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> splat (i32 1), i32 {{[^)]+}})
-  // CHECK-STATELESS: call void @llvm.genx.lsc.store.stateless.v4i1.v4i64.v4i32(<4 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> splat (i32 1), i32 0)
+  // CHECK-STATEFUL:  call void @llvm.genx.lsc.store.bti.v4i1.v4i32.v4i32(<4 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call void @llvm.genx.lsc.store.stateless.v4i1.v4i64.v4i32(<4 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   lsc_scatter<int>(acc, offsets, data1);
 
+  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.load.merge.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}})
+  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   simd<int, VL> data5 = lsc_gather<int>(acc, offsets);
 
+  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.load.merge.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}})
+  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   data5 = lsc_gather<int>(acc, offsets, mask);
 
+  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.load.merge.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}})
+  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   data5 = lsc_gather<int>(acc, offsets, mask, data5);
 
-  // CHECK-STATEFUL:  call void @llvm.genx.lsc.prefetch.bti.v4i1.v4i32(<4 x i1> splat (i1 true), i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), i32 {{[^)]+}})
-  // CHECK-STATELESS: call void @llvm.genx.lsc.prefetch.stateless.v4i1.v4i64(<4 x i1> splat (i1 true), i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, i32 0)
+  // CHECK-STATEFUL:  call void @llvm.genx.lsc.prefetch.bti.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call void @llvm.genx.lsc.prefetch.stateless.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 0, i8 1, i8 2, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, i32 0)
   lsc_prefetch<int, 1, lsc_data_size::default_size, cache_hint::uncached,
                cache_hint::cached>(acc, offsets);
 
-  // CHECK: call void @llvm.genx.lsc.store.slm.v1i1.v1i32.v4i32(<1 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> splat (i32 16), <4 x i32> splat (i32 1), i32 0)
+  // CHECK: call void @llvm.genx.lsc.store.slm.v1i1.v1i32.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   lsc_slm_block_store<int, VL>(surf_offset, data1);
 
+  // CHECK: call <4 x i32> @llvm.genx.lsc.load.merge.slm.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   simd<int, VL> data6 = lsc_slm_gather<int>(offsets);
 
   auto add = simd<int, VL>(5);
@@ -100,42 +111,42 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void foo(AccType &acc) {
   auto swap = compare * 2;
   auto pred = simd_mask<VL>(1);
 
-  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}} i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
   auto res_flat_atomic_0 =
       lsc_atomic_update<atomic_op::inc, int>(ptr, offsets, pred);
 
-  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 12, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> splat (i32 5), <4 x i32> undef, i32 0, <4 x i32> undef)
+  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
   auto res_flat_atomic_1 =
       lsc_atomic_update<atomic_op::add, int>(ptr, offsets, add, pred);
 
-  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 18, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> <i32 4, i32 5, i32 6, i32 7>, <4 x i32> <i32 8, i32 10, i32 12, i32 14>, i32 0, <4 x i32> undef)
+  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
   auto res_flat_atomic_2 = lsc_atomic_update<atomic_op::cmpxchg, int>(
       ptr, offsets, compare, swap, pred);
 
-  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
   auto res_slm_atomic_0 =
       lsc_slm_atomic_update<atomic_op::inc, int>(offsets, pred);
 
-  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 12, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> splat (i32 5), <4 x i32> undef, i32 0, <4 x i32> undef)
+  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
   auto res_slm_atomic_1 =
       lsc_slm_atomic_update<atomic_op::add, int>(offsets, add, pred);
 
-  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 18, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> <i32 4, i32 5, i32 6, i32 7>, <4 x i32> <i32 8, i32 10, i32 12, i32 14>, i32 0, <4 x i32> undef)
+  // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
   auto res_slm_atomic_2 = lsc_slm_atomic_update<atomic_op::cmpxchg, int>(
       offsets, compare, swap, pred);
 
-  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> undef, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
-  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> %{{[a-zA-Z0-9.]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
   auto res_surf_atomic_0 =
       lsc_atomic_update<atomic_op::inc, int>(acc, offsets, pred);
 
-  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 12, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> splat (i32 5), <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
-  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 12, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> splat (i32 5), <4 x i32> undef, i32 0, <4 x i32> undef)
+  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
   auto res_surf_atomic_1 =
       lsc_atomic_update<atomic_op::add, int>(acc, offsets, add, pred);
 
-  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 18, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> <i32 4, i32 5, i32 6, i32 7>, <4 x i32> <i32 8, i32 10, i32 12, i32 14>, i32 {{[^)]+}}, <4 x i32> undef)
-  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 18, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> <i32 4, i32 5, i32 6, i32 7>, <4 x i32> <i32 8, i32 10, i32 12, i32 14>, i32 0, <4 x i32> undef)
+  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> undef)
+  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
   auto res_surf_atomic_2 = lsc_atomic_update<atomic_op::cmpxchg, int>(
       acc, offsets, compare, swap, pred);
 
@@ -144,21 +155,22 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void foo(AccType &acc) {
   constexpr unsigned NumBlocks = 2;
   unsigned data_height, data_width, data_pitch, x, y;
 
+  // CHECK: call <32 x i32> @llvm.genx.lsc.load2d.stateless.v32i32.v1i1.i64(<1 x i1> {{[^)]+}}, i8 1, i8 1, i8 3, i8 1, i8 2, i16 4, i16 4, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   simd<int, Width * Height * NumBlocks> data7 =
       lsc_load_2d<int, Width, Height, NumBlocks, false, false,
                   cache_hint::uncached, cache_hint::uncached>(
           ptr, data_width, data_height, data_pitch, x, y);
 
   simd<int, Width * Height * 1> data8 = 7;
-  // CHECK: call void @llvm.genx.lsc.store2d.stateless.v1i1.i64.v16i32(<1 x i1> splat (i1 true), i8 1, i8 1, i8 3, i8 1, i8 1, i16 4, i16 4, i8 0, i64 0, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, <16 x i32> splat (i32 7))
+  // CHECK: call void @llvm.genx.lsc.store2d.stateless.v1i1.i64.v16i32(<1 x i1> {{[^)]+}}, i8 1, i8 1, i8 3, i8 1, i8 1, i16 4, i16 4, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x i32> {{[^)]+}})
   lsc_store_2d<int, Width, Height, cache_hint::uncached, cache_hint::uncached>(
       ptr, data_width, data_height, data_pitch, x, y, data8);
 
-  // CHECK: call void @llvm.genx.lsc.prefetch2d.stateless.v1i1.i64(<1 x i1> splat (i1 true), i8 1, i8 2, i8 3, i8 1, i8 2, i16 4, i16 4, i8 0, i64 0, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef)
+  // CHECK: call void @llvm.genx.lsc.prefetch2d.stateless.v1i1.i64(<1 x i1> {{[^)]+}}, i8 1, i8 2, i8 3, i8 1, i8 2, i16 4, i16 4, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   lsc_prefetch_2d<int, Width, Height, NumBlocks, cache_hint::uncached,
                   cache_hint::cached>(ptr, data_width, data_height, data_pitch,
                                       x, y);
 
   fence<memory_kind::local, fence_flush_op::none, fence_scope::group>();
-  // CHECK: call void @llvm.genx.lsc.fence.v16i1(<16 x i1> splat (i1 true), i8 3, i8 0, i8 0)
+  // CHECK: call void @llvm.genx.lsc.fence.v16i1(<16 x i1> {{[^)]+}}, i8 3, i8 0, i8 0)
 }

--- a/sycl/test/check_device_code/esimd/memory_properties_atomic_update.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_atomic_update.cpp
@@ -1,9 +1,11 @@
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fno-sycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATEFUL
 
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fsycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATELESS
 
 // Checks ESIMD memory functions accepting compile time properties for

--- a/sycl/test/check_device_code/esimd/memory_properties_atomic_update.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_atomic_update.cpp
@@ -75,47 +75,47 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
   // Test atomic update with no operands.
   {
     // USM
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}} i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_0 =
         atomic_update<atomic_op::inc, int>(ptr, offsets, pred, props_a);
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}} i8 8, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_1 =
         atomic_update<atomic_op::inc, int>(ptr, offsets, pred, props_b);
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}} i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_2 =
         atomic_update<atomic_op::inc, int>(ptr, offsets, props_a);
 
-    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}} i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_3 =
         atomic_update<atomic_op::inc, int>(ptr, offsets_view, pred, props_a);
     res_atomic_3 =
         atomic_update<atomic_op::inc>(ptr, offsets_view, pred, props_a);
 
-    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}} i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_4 =
         atomic_update<atomic_op::inc, int, VL>(ptr, offsets_view, props_a);
     res_atomic_4 = atomic_update<atomic_op::inc>(ptr, offsets_view, props_a);
 
-    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}} i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_5 = atomic_update<atomic_op::inc, int, VL>(
         ptr, offsets_view.select<VL, 1>(), props_a);
     res_atomic_5 = atomic_update<atomic_op::inc>(
         ptr, offsets_view.select<VL, 1>(), props_a);
 
     // atomic_upate without cache hints:
-    // CHECK: call <4 x i32> @llvm.genx.svm.atomic.inc.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), <4 x i64> splat (i64 4), <4 x i32> undef)
+    // CHECK: call <4 x i32> @llvm.genx.svm.atomic.inc.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, <4 x i64> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_6 =
         atomic_update<atomic_op::inc, int, VL>(ptr, offsets, pred);
 
     // atomic_upate without cache hints and mask:
-    // CHECK: call <4 x i32> @llvm.genx.svm.atomic.inc.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), <4 x i64> splat (i64 4), <4 x i32> undef)
+    // CHECK: call <4 x i32> @llvm.genx.svm.atomic.inc.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, <4 x i64> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_7 = atomic_update<atomic_op::inc, int, VL>(ptr, offsets);
 
     // Try the atomic_update without cache hints, but with non-standard
     // vector length to check that LSC atomic is generated.
-    // CHECK: call <5 x i32> @llvm.genx.lsc.xatomic.stateless.v5i32.v5i1.v5i64(<5 x i1> splat (i1 true), i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <5 x i64> splat (i64 4), <5 x i32> undef, <5 x i32> undef, i32 0, <5 x i32> undef)
+    // CHECK: call <5 x i32> @llvm.genx.lsc.xatomic.stateless.v5i32.v5i1.v5i64(<5 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <5 x i64> {{[^)]+}}, <5 x i32> undef, <5 x i32> undef, i32 0, <5 x i32> undef)
     {
       constexpr int VL = 5;
       simd<uint32_t, VL> offsets = simd<uint32_t, VL>(1) * sizeof(int);
@@ -126,7 +126,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
 
     // Try with int16_t to check that LSC atomic is generated
     // The result is later casted to int16, not captured here.
-    // CHECK: call <8 x i32> @llvm.genx.lsc.xatomic.stateless.v8i32.v8i1.v8i64(<8 x i1> splat (i1 true), i8 8, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <8 x i64> splat (i64 2), <8 x i32> undef, <8 x i32> undef, i32 0, <8 x i32> undef)
+    // CHECK: call <8 x i32> @llvm.genx.lsc.xatomic.stateless.v8i32.v8i1.v8i64(<8 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <8 x i64> {{[^)]+}}, <8 x i32> undef, <8 x i32> undef, i32 0, <8 x i32> undef)
     {
       int16_t *ptr = 0;
       constexpr int VL = 8;
@@ -137,51 +137,52 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
 
     // Accessor
 
-    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> undef, <4 x i32> undef, i32 %{{[a-zA-Z0-9.]+}}, <4 x i32> undef)
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_acc_0 =
         atomic_update<atomic_op::inc, int>(acc, offsets, pred, props_a);
 
-    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 8, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> undef, <4 x i32> undef, i32 %{{[a-zA-Z0-9.]+}}, <4 x i32> undef)
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_acc_1 =
         atomic_update<atomic_op::inc, int>(acc, offsets, pred, props_b);
 
-    // CHECK-STATEFUL:  call <4 x i64> @llvm.genx.lsc.xatomic.bti.v4i64.v4i1.v4i32(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 4, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i64> undef, <4 x i64> undef, i32 %{{[a-zA-Z0-9.]+}}, <4 x i64> undef)
-    // CHECK-STATELESS: call <4 x i64> @llvm.genx.lsc.xatomic.stateless.v4i64.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 4, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i64> undef, <4 x i64> undef, i32 0, <4 x i64> undef)
+    // CHECK-STATEFUL:  call <4 x i64> @llvm.genx.lsc.xatomic.bti.v4i64.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 4, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i64> undef, <4 x i64> undef, i32 {{[^)]+}}, <4 x i64> undef)
+    // CHECK-STATELESS: call <4 x i64> @llvm.genx.lsc.xatomic.stateless.v4i64.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 4, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i64> undef, <4 x i64> undef, i32 0, <4 x i64> undef)
     auto res_atomic_acc_2 =
         atomic_update<atomic_op::inc, int64_t>(acc, offsets, props_a);
 
-    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> undef, <4 x i32> undef, i32 %{{[a-zA-Z0-9.]+}}, <4 x i32> undef)
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_acc_3 =
         atomic_update<atomic_op::inc, int>(acc, offsets_view, pred, props_a);
 
-    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> undef, <4 x i32> undef, i32 %{{[a-zA-Z0-9.]+}}, <4 x i32> undef)
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_acc_4 =
         atomic_update<atomic_op::inc, int, VL>(acc, offsets_view, props_a);
 
-    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> splat (i32 4), <4 x i32> undef, <4 x i32> undef, i32 %{{[a-zA-Z0-9.]+}}, <4 x i32> undef)
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 8, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_acc_5 = atomic_update<atomic_op::inc, int, VL>(
         acc, offsets_view.select<VL, 1>(), props_a);
 
     // atomic_upate without cache hints:
-    // CHECK-STATEFUL: call <4 x i32> @llvm.genx.dword.atomic.inc.v4i32.v4i1(<4 x i1> splat (i1 true), i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.svm.atomic.inc.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), <4 x i64> {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATEFUL: call <4 x i32> @llvm.genx.dword.atomic.inc.v4i32.v4i1(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.svm.atomic.inc.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, <4 x i64> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_acc_6 =
         atomic_update<atomic_op::inc, int, VL>(acc, offsets, pred);
 
     // atomic_upate without cache hints and mask:
-    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.dword.atomic.inc.v4i32.v4i1(<4 x i1> splat (i1 true), i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.svm.atomic.inc.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), <4 x i64> {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.dword.atomic.inc.v4i32.v4i1(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.svm.atomic.inc.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, <4 x i64> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_acc_7 =
         atomic_update<atomic_op::inc, int, VL>(acc, offsets);
 
     // Try the atomic_update without cache hints, but with non-standard
     // vector length to check that LSC atomic is generated.
-    // CHECK-STATELESS: call <5 x i32> @llvm.genx.lsc.xatomic.stateless.v5i32.v5i1.v5i64(<5 x i1> splat (i1 true), i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <5 x i64> {{[^)]+}}, <5 x i32> undef, <5 x i32> undef, i32 0, <5 x i32> undef)
+    // CHECK-STATEFUL:  call <5 x i32> @llvm.genx.lsc.xatomic.bti.v5i32.v5i1.v5i32(<5 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <5 x i32> {{[^)]+}}, <5 x i32> undef, <5 x i32> undef, i32 {{[^)]+}}, <5 x i32> undef)
+    // CHECK-STATELESS: call <5 x i32> @llvm.genx.lsc.xatomic.stateless.v5i32.v5i1.v5i64(<5 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <5 x i64> {{[^)]+}}, <5 x i32> undef, <5 x i32> undef, i32 0, <5 x i32> undef)
     {
       constexpr int VL = 5;
       simd<uint32_t, VL> offsets = simd<uint32_t, VL>(1) * sizeof(int);
@@ -191,7 +192,8 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
     }
     // Try with int16_t to check that LSC atomic is generated
     // The result is later casted to int16, not captured here.
-    // CHECK-STATELESS: call <8 x i32> @llvm.genx.lsc.xatomic.stateless.v8i32.v8i1.v8i64(<8 x i1> splat (i1 true), i8 8, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <8 x i64> {{[^)]+}}, <8 x i32> undef, <8 x i32> undef, i32 0, <8 x i32> undef)
+    // CHECK-STATEFUL:  call <8 x i32> @llvm.genx.lsc.xatomic.bti.v8i32.v8i1.v8i32(<8 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <8 x i32> {{[^)]+}}, <8 x i32> undef, <8 x i32> undef, i32 {{[^)]+}}, <8 x i32> undef)
+    // CHECK-STATELESS: call <8 x i32> @llvm.genx.lsc.xatomic.stateless.v8i32.v8i1.v8i64(<8 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <8 x i64> {{[^)]+}}, <8 x i32> undef, <8 x i32> undef, i32 0, <8 x i32> undef)
     {
       using AccType =
           sycl::accessor<int16_t, 1, sycl::access::mode::read_write>;
@@ -207,63 +209,76 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
   {
     // USM
 
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_0 =
         atomic_update<atomic_op::add, int>(ptr, offsets, add, pred, props_a);
 
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_1 =
         atomic_update<atomic_op::add, int>(ptr, offsets, add, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_2 = atomic_update<atomic_op::add, int, VL>(
         ptr, offsets, add_view, pred, props_a);
     res_atomic_2 =
         atomic_update<atomic_op::add>(ptr, offsets, add_view, pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_3 =
         atomic_update<atomic_op::add, int, VL>(ptr, offsets, add_view, props_a);
     res_atomic_3 =
         atomic_update<atomic_op::add>(ptr, offsets, add_view, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     res_atomic_3 = atomic_update<atomic_op::add, int, VL>(
         ptr, offsets, add_view.select<VL, 1>(), props_a);
     res_atomic_3 = atomic_update<atomic_op::add>(
         ptr, offsets, add_view.select<VL, 1>(), props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_4 = atomic_update<atomic_op::add, int, VL>(
         ptr, offsets_view, add, pred, props_a);
     res_atomic_4 =
         atomic_update<atomic_op::add>(ptr, offsets_view, add, pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_5 =
         atomic_update<atomic_op::add, int, VL>(ptr, offsets_view, add, props_a);
     res_atomic_5 =
         atomic_update<atomic_op::add>(ptr, offsets_view, add, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     res_atomic_5 = atomic_update<atomic_op::add, int, VL>(
         ptr, offsets_view.select<VL, 1>(), add, props_a);
     res_atomic_5 = atomic_update<atomic_op::add>(
         ptr, offsets_view.select<VL, 1>(), add, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_6 = atomic_update<atomic_op::add, int, VL>(
         ptr, offsets_view, add_view, pred, props_a);
     res_atomic_6 = atomic_update<atomic_op::add>(ptr, offsets_view, add_view,
                                                  pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_7 = atomic_update<atomic_op::add, int, VL>(
         ptr, offsets_view, add_view, props_a);
     res_atomic_7 =
         atomic_update<atomic_op::add>(ptr, offsets_view, add_view, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     res_atomic_7 = atomic_update<atomic_op::add, int, VL>(
         ptr, offsets_view.select<VL, 1>(), add_view.select<VL, 1>(), props_a);
     res_atomic_7 = atomic_update<atomic_op::add>(
         ptr, offsets_view.select<VL, 1>(), add_view.select<VL, 1>(), props_a);
 
     // atomic_update without cache hints:
+    // CHECK: call <4 x i32> @llvm.genx.svm.atomic.add.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, <4 x i64> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_8 =
         atomic_update<atomic_op::add, int>(ptr, offsets, add, pred);
 
     // Try with int16_t to check that LSC atomic is generated
     // The result is later casted to int16, not captured here.
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32>{{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     {
       int16_t *ptr = 0;
       constexpr int VL = 4;
@@ -275,7 +290,8 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
 
     // Accessors
 
-    // CHECK-STATELESS-COUNT-20: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> splat (i64 4), <4 x i32> splat (i32 5), <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-STATEFUL-COUNT-26:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS-COUNT-26: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_9 =
         atomic_update<atomic_op::add, int>(acc, offsets, add, pred, props_a);
 
@@ -355,13 +371,15 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
         acc, offsets_view.select<VL, 1>(), add_view.select<VL, 1>(), props_a);
 
     // atomic_update without cache hints:
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.svm.atomic.sub.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), <4 x i64> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 5), <4 x i32> undef)
+    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.dword.atomic.sub.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.svm.atomic.sub.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_17 =
         atomic_update<atomic_op::sub, int>(acc, offsets, add, pred);
 
     // Try with int16_t to check that LSC atomic is generated
     // The result is later casted to int16, not captured here.
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 12, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i64> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 5), <4 x i32> undef, i32 0, <4 x i32> undef)
+    // CHECK-STATEFUL: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     {
       using AccType =
           sycl::accessor<int16_t, 1, sycl::access::mode::read_write>;
@@ -378,87 +396,105 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
   {
     // USM
 
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_1 = atomic_update<atomic_op::cmpxchg, int>(
         ptr, offsets, swap, compare, pred, props_a);
 
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_2 = atomic_update<atomic_op::cmpxchg, int>(
         ptr, offsets, swap, compare, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_3 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets, swap, compare_view, pred, props_a);
     res_atomic_3 = atomic_update<atomic_op::cmpxchg>(
         ptr, offsets, swap, compare_view, pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     res_atomic_3 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets, swap, compare_view.select<VL, 1>(), pred, props_a);
     res_atomic_3 = atomic_update<atomic_op::cmpxchg>(
         ptr, offsets, swap, compare_view.select<VL, 1>(), pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_4 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets, swap, compare_view, props_a);
     res_atomic_4 = atomic_update<atomic_op::cmpxchg>(ptr, offsets, swap,
                                                      compare_view, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_5 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets, swap_view, compare, pred, props_a);
     res_atomic_5 = atomic_update<atomic_op::cmpxchg>(ptr, offsets, swap_view,
                                                      compare, pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_6 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets, swap_view, compare, props_a);
     res_atomic_6 = atomic_update<atomic_op::cmpxchg>(ptr, offsets, swap_view,
                                                      compare, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_7 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets, swap_view, compare_view, pred, props_a);
     res_atomic_7 = atomic_update<atomic_op::cmpxchg>(
         ptr, offsets, swap_view, compare_view, pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_8 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets, swap_view, compare_view, props_a);
     res_atomic_8 = atomic_update<atomic_op::cmpxchg>(ptr, offsets, swap_view,
                                                      compare_view, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_9 = atomic_update<atomic_op::cmpxchg, int>(
         ptr, offsets_view, swap, compare, pred, props_a);
     res_atomic_9 = atomic_update<atomic_op::cmpxchg>(ptr, offsets_view, swap,
                                                      compare, pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_10 = atomic_update<atomic_op::cmpxchg, int>(
         ptr, offsets_view, swap, compare, props_a);
     res_atomic_10 = atomic_update<atomic_op::cmpxchg>(ptr, offsets_view, swap,
                                                       compare, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_11 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets_view, swap, compare_view, pred, props_a);
     res_atomic_11 = atomic_update<atomic_op::cmpxchg>(
         ptr, offsets_view, swap, compare_view, pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_12 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets_view, swap, compare_view, props_a);
     res_atomic_12 = atomic_update<atomic_op::cmpxchg>(ptr, offsets_view, swap,
                                                       compare_view, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_13 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets_view, swap_view, compare, pred, props_a);
     res_atomic_13 = atomic_update<atomic_op::cmpxchg>(
         ptr, offsets_view, swap_view, compare, pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_14 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets_view, swap_view, compare, props_a);
     res_atomic_14 = atomic_update<atomic_op::cmpxchg>(
         ptr, offsets_view, swap_view, compare, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_15 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets_view, swap_view, compare_view, pred, props_a);
     res_atomic_15 = atomic_update<atomic_op::cmpxchg>(
         ptr, offsets_view, swap_view, compare_view, pred, props_a);
 
+    // CHECK-COUNT-2: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_16 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets_view, swap_view, compare_view, props_a);
     res_atomic_16 = atomic_update<atomic_op::cmpxchg>(
         ptr, offsets_view, swap_view, compare_view, props_a);
 
+    // CHECK-COUNT-26: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     res_atomic_4 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets, swap, compare_view.select<VL, 1>(), props_a);
 
@@ -560,19 +596,23 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       auto compare = swap * 2;
       auto pred = simd_mask<VL>(1);
       // Do not pass the properties.
+      // CHECK: call <8 x float> @llvm.genx.lsc.xatomic.stateless.v8f32.v8i1.v8i64(<8 x i1> {{[^)]+}}, i8 23, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <8 x i64> {{[^)]+}}, <8 x float> {{[^)]+}}, <8 x float> {{[^)]+}}, i32 0, <8 x float> undef)
       auto atomic_res0 = atomic_update<atomic_op::fcmpxchg, float, VL>(
           ptrf, offsets, swap, compare, pred);
       // Now with cache hints.
+      // CHECK: call <8 x float> @llvm.genx.lsc.xatomic.stateless.v8f32.v8i1.v8i64(<8 x i1> {{[^)]+}}, i8 23, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <8 x i64> {{[^)]+}}, <8 x float> {{[^)]+}}, <8 x float> {{[^)]+}}, i32 0, <8 x float> undef)
       auto atomic_res1 = atomic_update<atomic_op::fcmpxchg, float, VL>(
           ptrf, offsets, swap, compare, pred, props_a);
     }
 
     // atomic_update without cache hints
+    // CHECK: call <4 x i32> @llvm.genx.svm.atomic.cmpxchg.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, <4 x i64> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_100 = atomic_update<atomic_op::cmpxchg, int, VL>(
         ptr, offsets, swap, compare, pred);
 
     // Try with int16_t to check that LSC atomic is generated
     // The result is later casted to int16, not captured here.
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     {
       int16_t *ptr = 0;
       constexpr int VL = 4;
@@ -585,7 +625,8 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
 
     // Accessors
 
-    // CHECK-STATELESS-COUNT-58: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
+    // CHECK-STATEFUL-COUNT-58:  call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS-COUNT-58: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_17 = atomic_update<atomic_op::cmpxchg>(
         acc, offsets, swap, compare, pred, props_a);
 
@@ -783,24 +824,27 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       auto compare = swap * 2;
       auto pred = simd_mask<VL>(1);
       // Do not pass the properties.
-      // CHECK-STATELESS: call <8 x float> @llvm.genx.lsc.xatomic.stateless.v8f32.v8i1.v8i64(<8 x i1> splat (i1 true), i8 23, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <8 x i64> %{{[a-zA-Z0-9.]+}}, <8 x float> splat (float 8.000000e+00), <8 x float> splat (float 4.000000e+00), i32 0, <8 x float> undef)
+      // CHECK-STATEFUL:  call <8 x float> @llvm.genx.lsc.xatomic.bti.v8f32.v8i1.v8i32(<8 x i1> {{[^)]+}}, i8 23, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <8 x i32> {{[^)]+}}, <8 x float> {{[^)]+}} <8 x float> {{[^)]+}}, i32 {{[^)]+}}, <8 x float> undef)
+      // CHECK-STATELESS: call <8 x float> @llvm.genx.lsc.xatomic.stateless.v8f32.v8i1.v8i64(<8 x i1> {{[^)]+}}, i8 23, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <8 x i64> {{[^)]+}}, <8 x float> {{[^)]+}}, <8 x float> {{[^)]+}}, i32 0, <8 x float> undef)
       auto atomic_res0 = atomic_update<atomic_op::fcmpxchg, float, VL>(
           acc, offsets, swap, compare, pred);
       // Now with cache hints.
-      // CHECK-STATELESS: call <8 x float> @llvm.genx.lsc.xatomic.stateless.v8f32.v8i1.v8i64(<8 x i1> splat (i1 true), i8 23, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <8 x i64> %{{[a-zA-Z0-9.]+}}, <8 x float> splat (float 8.000000e+00), <8 x float> splat (float 4.000000e+00), i32 0, <8 x float> undef)
+      // CHECK-STATEFUL:  call <8 x float> @llvm.genx.lsc.xatomic.bti.v8f32.v8i1.v8i32(<8 x i1> {{[^)]+}}, i8 23, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <8 x i32> {{[^)]+}}, <8 x float> {{[^)]+}} <8 x float> {{[^)]+}}, i32 {{[^)]+}}, <8 x float> undef)
+      // CHECK-STATELESS: call <8 x float> @llvm.genx.lsc.xatomic.stateless.v8f32.v8i1.v8i64(<8 x i1> {{[^)]+}}, i8 23, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <8 x i64> {{[^)]+}}, <8 x float> {{[^)]+}}, <8 x float> {{[^)]+}}, i32 0, <8 x float> undef)
       auto atomic_res1 = atomic_update<atomic_op::fcmpxchg, float, VL>(
           acc, offsets, swap, compare, pred, props_a);
     }
 
     // atomic_update without cache hints
-    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.dword.atomic.cmpxchg.v4i32.v4i1(<4 x i1> splat (i1 true), i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.svm.atomic.cmpxchg.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.dword.atomic.cmpxchg.v4i32.v4i1(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.svm.atomic.cmpxchg.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_33 = atomic_update<atomic_op::cmpxchg, int, VL>(
         acc, offsets, swap, compare, pred);
 
     // Try with int16_t to check that LSC atomic is generated
     // The result is later casted to int16, not captured here.
-    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> splat (i1 true), i8 18, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i64> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 4), <4 x i32> splat (i32 8), i32 0, <4 x i32> undef)
+    // CHECK-STATEFUL: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     {
       using AccType =
           sycl::accessor<int16_t, 1, sycl::access::mode::read_write>;
@@ -816,6 +860,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
 
   // Test slm_atomic_update without operands.
   {
+    // CHECK-COUNT-6: call <4 x i32> @llvm.genx.dword.atomic.dec.v4i32.v4i1(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
     {
       auto res_slm_atomic_0 =
           slm_atomic_update<atomic_op::dec, int>(offsets, pred);
@@ -831,6 +876,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
     }
 
     // Expect DWORD for load.
+    // CHECK: call <4 x i32> @llvm.genx.dword.atomic.or.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
     auto res_slm_atomic_4 =
         slm_atomic_update<atomic_op::load, int>(offsets, pred);
 
@@ -840,6 +886,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       simd<uint32_t, VL> offsets = simd<uint32_t, VL>(1) * sizeof(int16_t);
       auto pred = simd_mask<VL>(1);
 
+      // CHECK: call <8 x i32> @llvm.genx.lsc.xatomic.slm.v8i32.v8i1.v8i32(<8 x i1> {{[^)]+}}, i8 10, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <8 x i32> {{[^)]+}}, <8 x i32> {{[^)]+}}, <8 x i32> undef, i32 0, <8 x i32> undef)
       auto res_slm_atomic_0 =
           slm_atomic_update<atomic_op::load, int16_t>(offsets, pred);
     }
@@ -847,6 +894,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
 
   // Test slm_atomic_update with one operand.
   {
+    // CHECK-COUNT-26: call <4 x i32> @llvm.genx.dword.atomic.add.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
     {
       auto res_slm_atomic_1 =
           slm_atomic_update<atomic_op::add>(offsets, add, pred);
@@ -905,6 +953,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       simd<uint32_t, VL> offsets = simd<uint32_t, VL>(1) * sizeof(int16_t);
       simd<int16_t, VL> add = simd<int16_t, VL>(1) * sizeof(int);
 
+      // CHECK: call <16 x i32> @llvm.genx.lsc.xatomic.slm.v16i32.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 12, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <16 x i32> {{[^)]+}}, <16 x i32> {{[^)]+}}, <16 x i32> undef, i32 0, <16 x i32> undef)
       auto res_slm_atomic_0 =
           slm_atomic_update<atomic_op::add, int16_t>(offsets, add);
     }
@@ -915,6 +964,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       auto pred = simd_mask<VL>(1);
       simd<float, VL> min = simd<float, VL>(1) * sizeof(int);
 
+      // CHECK: call <16 x float> @llvm.genx.lsc.xatomic.slm.v16f32.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 21, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <16 x i32> {{[^)]+}}, <16 x float> {{[^)]+}}, <16 x float> undef, i32 0, <16 x float> undef)
       auto res_slm_atomic_0 =
           slm_atomic_update<atomic_op::fmin, float>(offsets, min, pred);
     }
@@ -925,6 +975,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       auto pred = simd_mask<VL>(1);
       simd<sycl::half, VL> min = simd<sycl::half, VL>(1) * sizeof(int);
 
+      // CHECK: call <16 x i32> @llvm.genx.lsc.xatomic.slm.v16i32.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 21, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <16 x i32> {{[^)]+}}, <16 x i32> {{[^)]+}}, <16 x i32> undef, i32 0, <16 x i32> undef)
       auto res_slm_atomic_0 =
           slm_atomic_update<atomic_op::fmin, sycl::half>(offsets, min, pred);
     }
@@ -932,7 +983,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
 
   // Test slm_atomic_update with two operands.
   {
-    // CHECK-COUNT-57: call <4 x i32> @llvm.genx.dword.atomic.cmpxchg.v4i32.v4i1(<4 x i1> splat (i1 true), i32 {{[^)]+}}, <4 x i32> %{{[a-zA-Z0-9.]+}}, <4 x i32> <i32 8, i32 10, i32 12, i32 14>, <4 x i32> <i32 4, i32 5, i32 6, i32 7>, <4 x i32> undef)
+    // CHECK-COUNT-58: call <4 x i32> @llvm.genx.dword.atomic.cmpxchg.v4i32.v4i1(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_1 =
         slm_atomic_update<atomic_op::cmpxchg>(offsets, swap, compare, pred);
     auto res_atomic_2 =
@@ -1087,6 +1138,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       auto compare = simd<int16_t, VL>(VL, 1);
       auto swap = compare * 2;
 
+      // CHECK: call <16 x i32> @llvm.genx.lsc.xatomic.slm.v16i32.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <16 x i32> {{[^)]+}}, <16 x i32> {{[^)]+}}, <16 x i32> {{[^)]+}}, i32 0, <16 x i32> undef)
       auto res_slm_atomic_0 =
           slm_atomic_update<atomic_op::cmpxchg, int16_t, VL>(offsets, swap,
                                                              compare);
@@ -1100,6 +1152,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       auto swap = compare * 2;
       auto pred = simd_mask<VL>(1);
 
+      // CHECK: call <16 x i64> @llvm.genx.lsc.xatomic.slm.v16i64.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 4, i8 1, i8 1, i8 0, <16 x i32> {{[^)]+}}, <16 x i64> {{[^)]+}}, <16 x i64> {{[^)]+}}, i32 0, <16 x i64> undef)
       auto res_slm_atomic_0 = slm_atomic_update<atomic_op::cmpxchg, int64_t>(
           offsets, swap, compare, pred);
     }
@@ -1112,6 +1165,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       auto swap = compare * 2;
       auto pred = simd_mask<VL>(1);
 
+      // CHECK: call <16 x float> @llvm.genx.lsc.xatomic.slm.v16f32.v16i1.v16i32(<16 x i1> {{[^)]+}} i8 23, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <16 x i32> {{[^)]+}}, <16 x float> {{[^)]+}}, <16 x float> {{[^)]+}}, i32 0, <16 x float> undef)
       auto res_slm_atomic_0 = slm_atomic_update<atomic_op::fcmpxchg, float>(
           offsets, swap, compare, pred);
     }
@@ -1119,6 +1173,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
 
   // Test with local accessor.
   // Zero operand atomic.
+  // CHECK-COUNT-6: call <4 x i32> @llvm.genx.dword.atomic.inc.v4i32.v4i1(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
   {
     auto res_slm_atomic_1 =
         atomic_update<atomic_op::inc, int>(local_acc, offsets, pred);
@@ -1137,13 +1192,14 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
     {
       using LocalAccType = sycl::local_accessor<int16_t, 1>;
       LocalAccType *local_acc = nullptr;
-      // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> splat (i1 true), i8 18, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i32> %{{[a-zA-Z0-9.]+}}, <4 x i32> <i32 4, i32 5, i32 6, i32 7>, <4 x i32> <i32 8, i32 10, i32 12, i32 14>, i32 0, <4 x i32> undef)
+      // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 8, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> undef, <4 x i32> undef, i32 0, <4 x i32> undef)
       auto res_slm_atomic_1 =
           atomic_update<atomic_op::inc, int16_t>(*local_acc, offsets);
     }
   }
   // One operand atomic.
   {
+    // CHECK-COUNT-26: call <4 x i32> @llvm.genx.dword.atomic.add.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
     auto res_slm_atomic_1 =
         atomic_update<atomic_op::add>(local_acc, offsets, add, pred);
     auto res_slm_atomic_2 =
@@ -1205,12 +1261,14 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       using LocalAccType = sycl::local_accessor<int16_t, 1>;
       LocalAccType *local_acc = nullptr;
       simd<int16_t, VL> add = simd<int16_t, VL>(1) * sizeof(int);
+      // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
       auto res_slm_atomic_1 =
           atomic_update<atomic_op::add, int16_t>(*local_acc, offsets, add);
     }
   }
   // Two operand atomic.
   {
+    // CHECK-COUNT-58: call <4 x i32> @llvm.genx.dword.atomic.cmpxchg.v4i32.v4i1(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
     auto res_slm_atomic_1 = atomic_update<atomic_op::cmpxchg>(
         local_acc, offsets, swap, compare, pred);
     auto res_slm_atomic_2 =
@@ -1351,6 +1409,7 @@ test_atomic_update(AccType &acc, LocalAccTypeInt local_acc, float *ptrf,
       LocalAccType *local_acc = nullptr;
       auto compare = simd<int16_t, VL>(VL, 1);
       auto swap = compare * 2;
+      // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.slm.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 18, i8 0, i8 0, i16 1, i32 0, i8 6, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
       auto res_slm_atomic_1 = atomic_update<atomic_op::cmpxchg, int16_t, VL>(
           *local_acc, offsets, swap, compare);
     }

--- a/sycl/test/check_device_code/esimd/memory_properties_copytocopyfrom.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_copytocopyfrom.cpp
@@ -1,9 +1,11 @@
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fno-sycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATEFUL
 
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fsycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATELESS
 
 // Checks ESIMD copy_to and copy_from functions accepting compile time

--- a/sycl/test/check_device_code/esimd/memory_properties_copytocopyfrom.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_copytocopyfrom.cpp
@@ -63,17 +63,20 @@ test_copy_to(AccType &acc, LocalAccType &local_acc, float *ptrf,
                      cache_hint_L2<cache_hint::write_back>, alignment<32>};
   properties props_b{alignment<32>};
   simd<float, 16> vals;
-  // CHECK: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v16f32(<1 x i1> splat (i1 true), i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 6, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <16 x float> undef, i32 0)
+  // CHECK: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v16f32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 6, i8 2, i8 0, <1 x i64> {{[^)]+}}, <16 x float> {{[^)]+}}, i32 0)
   vals.copy_to(ptrf, props_a);
+  // CHECK: store <16 x float> {{[^)]+}}, ptr addrspace(4) {{[^)]+}}, align 32
   vals.copy_to(ptrf, props_b);
 
-  // CHECK-STATEFUL: call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v16f32(<1 x i1> splat (i1 true), i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 6, i8 2, i8 0, <1 x i32> %{{[a-zA-Z0-9.]+}}, <16 x float> undef, i32 %{{[a-zA-Z0-9.]+}})
-  // CHECK-STATELESS: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v16f32(<1 x i1> splat (i1 true), i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 6, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <16 x float> undef, i32 0)
+  // CHECK-STATEFUL: call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v16f32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 6, i8 2, i8 0, <1 x i32> {{[^)]+}}, <16 x float> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v16f32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 6, i8 2, i8 0, <1 x i64> {{[^)]+}}, <16 x float> {{[^)]+}}, i32 0)
   vals.copy_to(acc, byte_offset64, props_a);
 
-  // CHECK-STATEFUL: call void @llvm.genx.oword.st.v16f32(i32 %{{[a-zA-Z0-9.]+}}, i32 %{{[a-zA-Z0-9.]+}}, <16 x float> undef)
+  // CHECK-STATEFUL: call void @llvm.genx.oword.st.v16f32(i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x float> {{[^)]+}})
+  // CHECK-STATELESS: store <16 x float> {{[^)]+}}, ptr addrspace(4) {{[^)]+}}, align 32
   vals.copy_to(acc, byte_offset64, props_b);
 
+  // CHECK-COUNT-2: store <16 x float> {{[^)]+}}, ptr addrspace(3) {{[^)]+}}, align 32
   vals.copy_to(local_acc, byte_offset64, props_a);
   vals.copy_to(local_acc, byte_offset64, props_b);
 }
@@ -86,14 +89,21 @@ test_copy_from(AccType &acc, LocalAccType &local_acc, float *ptrf,
                      cache_hint_L2<cache_hint::cached>, alignment<32>};
   properties props_b{alignment<32>};
   simd<float, 16> vals;
+  // CHECK: call <16 x float> @llvm.genx.lsc.load.merge.stateless.v16f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 2, i16 1, i32 0, i8 3, i8 6, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <16 x float> {{[^)]+}})
   vals.copy_from(ptrf, props_a);
 
+  // CHECK: load <16 x float>, ptr addrspace(4) {{[^)]+}}, align 32
   vals.copy_from(ptrf, props_b);
 
+  // CHECK-STATEFUL: call <16 x float> @llvm.genx.lsc.load.bti.v16f32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 2, i16 1, i32 0, i8 3, i8 6, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call <16 x float> @llvm.genx.lsc.load.merge.stateless.v16f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 2, i16 1, i32 0, i8 3, i8 6, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <16 x float> {{[^)]+}})
   vals.copy_from(acc, byte_offset64, props_a);
 
+  // CHECK-STATEFUL: call <16 x float> @llvm.genx.oword.ld.v16f32(i32 0, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: load <16 x float>, ptr addrspace(4) {{[^)]+}}, align 32
   vals.copy_from(acc, byte_offset64, props_b);
 
+  // CHECK-COUNT-2: load <16 x float>, ptr addrspace(3) {{[^)]+}}, align 32
   vals.copy_from(local_acc, byte_offset64, props_a);
   vals.copy_from(local_acc, byte_offset64, props_b);
 }
@@ -106,13 +116,20 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_ctor(AccType &acc,
   properties props_a{cache_hint_L1<cache_hint::cached>,
                      cache_hint_L2<cache_hint::cached>, alignment<32>};
   properties props_b{alignment<32>};
+  // CHECK: call <8 x float> @llvm.genx.lsc.load.merge.stateless.v8f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 2, i16 1, i32 0, i8 3, i8 5, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <8 x float> {{[^)]+}})
   simd<float, 8> foo(ptrf, props_a);
+  // CHECK: load <8 x float>, ptr addrspace(4) {{[^)]+}}, align 32
   simd<float, 8> bar(ptrf, props_b);
 
+  // CHECK-STATEFUL: call <8 x float> @llvm.genx.lsc.load.bti.v8f32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 2, i16 1, i32 0, i8 3, i8 5, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call <8 x float> @llvm.genx.lsc.load.merge.stateless.v8f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 2, i16 1, i32 0, i8 3, i8 5, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <8 x float> {{[^)]+}})
   simd<float, 8> acc_foo(acc, byte_offset64, props_a);
 
+  // CHECK-STATEFUL: call <8 x float> @llvm.genx.oword.ld.v8f32(i32 0, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: load <8 x float>, ptr addrspace(4) {{[^)]+}}, align 32
   simd<float, 8> acc_bar(acc, byte_offset64, props_b);
 
+  // CHECK-COUNT-2: load <8 x float>, ptr addrspace(3) {{[^)]+}}, align 32
   simd<float, 8> lacc_foo(local_acc, byte_offset64, props_a);
   simd<float, 8> lacc_bar(local_acc, byte_offset64, props_b);
 }

--- a/sycl/test/check_device_code/esimd/memory_properties_gather.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_gather.cpp
@@ -1,9 +1,11 @@
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fno-sycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATEFUL
 
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fsycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATELESS
 
 // Checks ESIMD memory functions accepting compile time properties for gather

--- a/sycl/test/check_device_code/esimd/memory_properties_gather.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_gather.cpp
@@ -1,10 +1,10 @@
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fno-sycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
 // RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -S %t -o %t.table
-// RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK
+// RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATEFUL
 
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fsycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
 // RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -S %t -o %t.table
-// RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK
+// RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATELESS
 
 // Checks ESIMD memory functions accepting compile time properties for gather
 // APIs. NOTE: must be run in -O0, as optimizer optimizes away some of the code.
@@ -97,6 +97,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
   // 12) gather(lacc, ...): same as (9), (10), (11) above, but with VS > 1.
 
   // 1) gather(usm, offsets): offsets is simd or simd_view
+  // CHECK-COUNT-10: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   usm = gather(ptrf, ioffset_n32);
   usm = gather<float, 32>(ptrf, ioffset_n32_view);
   usm = gather<float, 32>(ptrf, ioffset_n32_view.select<32, 1>());
@@ -110,6 +111,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
   usm = gather(ptrf, loffset_n32_view);
   usm = gather(ptrf, loffset_n32_view.select<32, 1>());
 
+  // CHECK-COUNT-10: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   usm = gather(ptrf, ioffset_n32, props_align8);
   usm = gather<float, 32>(ptrf, ioffset_n32_view, props_align8);
   usm = gather<float, 32>(ptrf, ioffset_n32_view.select<32, 1>(), props_align8);
@@ -124,6 +126,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
   usm = gather(ptrf, loffset_n32_view.select<32, 1>(), props_align8);
 
   // 2) gather(usm, offsets, mask): offsets is simd or simd_view
+  // CHECK-COUNT-10: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   usm = gather(ptrf, ioffset_n32, mask_n32);
   usm = gather<float, 32>(ptrf, ioffset_n32_view, mask_n32);
   usm = gather<float, 32>(ptrf, ioffset_n32_view.select<32, 1>(), mask_n32);
@@ -137,6 +140,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
   usm = gather(ptrf, loffset_n32_view, mask_n32);
   usm = gather(ptrf, loffset_n32_view.select<32, 1>(), mask_n32);
 
+  // CHECK-COUNT-10: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   usm = gather(ptrf, ioffset_n32, mask_n32, props_align8);
   usm = gather<float, 32>(ptrf, ioffset_n32_view, mask_n32, props_align8);
   usm = gather<float, 32>(ptrf, ioffset_n32_view.select<32, 1>(), mask_n32,
@@ -153,6 +157,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
   usm = gather(ptrf, loffset_n32_view.select<32, 1>(), mask_n32, props_align8);
 
   // 3) gather(usm, offsets, mask, pass_thru)
+  // CHECK-COUNT-26: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   usm = gather(ptrf, ioffset_n32, mask_n32, pass_thru);
   usm = gather<float, 32>(ptrf, ioffset_n32_view, mask_n32, pass_thru);
   usm = gather<float, 32>(ptrf, ioffset_n32, mask_n32, pass_thru_view);
@@ -191,6 +196,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
   usm = gather(ptrf, loffset_n32_view.select<32, 1>(), mask_n32,
                pass_thru_view.select<32, 1>());
 
+  // CHECK-COUNT-26: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   usm = gather(ptrf, ioffset_n32, mask_n32, pass_thru, props_align8);
   usm = gather<float, 32>(ptrf, ioffset_n32_view, mask_n32, pass_thru,
                           props_align8);
@@ -240,6 +246,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
                pass_thru_view.select<32, 1>(), props_align8);
 
   // 4) gather(usm, ...): same as (1), (2), (3) above, but with VS > 1.
+  // CHECK-COUNT-92: call <32 x i32> @llvm.genx.lsc.load.merge.stateless.v32i32.v16i1.v16i64(<16 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, i32 0, <32 x i32> {{[^)]+}})
   // 4a) check VS > 1. no 'mask' operand first.
   usm = gather<float, 32, 2>(ptrf, ioffset_n16);
   usm = gather<float, 32, 2>(ptrf, ioffset_n16_view);
@@ -396,6 +403,9 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
                   pass_thru_view.select<32, 1>(), props_align4);
 
   // 5) gather(acc, offsets): offsets is simd or simd_view
+  // CHECK-STATEFUL-COUNT-12: call <32 x float> @llvm.genx.gather.masked.scaled2.v32f32.v32i32.v32i1(i32 2, i16 0, i32 {{[^)]+}}, i32 {{[^)]+}}, <32 x i32> {{[^)]+}}, <32 x i1> {{[^)]+}})
+  // CHECK-STATEFUL-COUNT-28: call <32 x i32> @llvm.genx.lsc.load.merge.bti.v32i32.v32i1.v32i32(<32 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i32> {{[^)]+}}, i32 {{[^)]+}}, <32 x i32> {{[^)]+}})
+  // CHECK-STATELESS-COUNT-40: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   acc_res = gather<float>(acc, ioffset_n32);
   acc_res = gather<float, 32>(acc, ioffset_n32_view);
   acc_res = gather<float, 32>(acc, ioffset_n32_view.select<32, 1>());
@@ -464,6 +474,8 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
                    pass_thru_view.select<32, 1>(), props_align4);
 
   // 8) gather(ac, ...): same as (5), (6), (7) above, but with VS > 1.
+  // CHECK-STATEFUL-COUNT-38: call <32 x i32> @llvm.genx.lsc.load.merge.bti.v32i32.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, i32 {{[^)]+}}, <32 x i32> {{[^)]+}})
+  // CHECK-STATELESS-COUNT-38: call <32 x i32> @llvm.genx.lsc.load.merge.stateless.v32i32.v16i1.v16i64(<16 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, i32 0, <32 x i32> {{[^)]+}})
   acc_res = gather<float, 32, 2>(acc, ioffset_n16);
   acc_res = gather<float, 32, 2>(acc, ioffset_n16_view);
   acc_res = gather<float, 32, 2>(acc, ioffset_n16, props_align4);
@@ -530,6 +542,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
                       pass_thru_view.select<32, 1>(), props_align4);
 
   // 9) gather(lacc, offsets): offsets is simd or simd_view
+  // CHECK-COUNT-38: call <32 x float> @llvm.masked.gather.v32f32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   acc_res = gather<float>(local_acc, ioffset_n32);
   acc_res = gather<float, 32>(local_acc, ioffset_n32_view);
   acc_res = gather<float, 32>(local_acc, ioffset_n32_view.select<32, 1>());
@@ -609,6 +622,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
                    pass_thru_view.select<32, 1>(), props_align4);
 
   // 12) gather(lacc, ...): same as (9), (10), (11) above, but with VS > 1.
+  // CHECK-COUNT-39: call <32 x i32> @llvm.genx.lsc.load.merge.slm.v32i32.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, i32 0, <32 x i32> {{[^)]+}})
   acc_res = gather<float, 32, 2>(local_acc, ioffset_n16);
   acc_res = gather<float, 32, 2>(local_acc, ioffset_n16_view);
   acc_res = gather<float, 32, 2>(local_acc, ioffset_n16, props_align4);
@@ -682,6 +696,7 @@ test_gather(AccType &acc, LocalAccType &local_acc, float *ptrf,
                       pass_thru_view.select<32, 1>(), props_align4);
 
   // Validate that a new API doesn't conflict with the old API.
+  // CHECK-COUNT-2: call <32 x float> @llvm.masked.gather.v32f32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   acc_res = gather<float, 32>(local_acc, ioffset_n32, 0);
   acc_res = gather<float, 32>(local_acc, ioffset_n32, 0, mask_n32);
 }
@@ -713,25 +728,30 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_slm_gather(int byte_offset32) {
   // 4) slm_gather(...): same as (1), (2), (3) above, but with VS > 1.
 
   // 1) slm_gather(offsets): offsets is simd or simd_view
+  // CHECK-COUNT-3: call <32 x float> @llvm.masked.gather.v32f32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   slm = slm_gather<float>(ioffset_n32);
   slm = slm_gather<float, 32>(ioffset_n32_view);
   slm = slm_gather<float, 32>(ioffset_n32_view.select<32, 1>());
 
+  // CHECK-COUNT-3: call <32 x float> @llvm.masked.gather.v32f32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   slm = slm_gather<float>(ioffset_n32, props_align8);
   slm = slm_gather<float, 32>(ioffset_n32_view, props_align8);
   slm = slm_gather<float, 32>(ioffset_n32_view.select<32, 1>(), props_align8);
 
   // 2) slm_gather(offsets, mask): offsets is simd or simd_view
+  // CHECK-COUNT-3: call <32 x float> @llvm.masked.gather.v32f32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   slm = slm_gather<float>(ioffset_n32, mask_n32);
   slm = slm_gather<float, 32>(ioffset_n32_view, mask_n32);
   slm = slm_gather<float, 32>(ioffset_n32_view.select<32, 1>(), mask_n32);
 
+  // CHECK-COUNT-3: call <32 x float> @llvm.masked.gather.v32f32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   slm = slm_gather<float>(ioffset_n32, mask_n32, props_align8);
   slm = slm_gather<float, 32>(ioffset_n32_view, mask_n32, props_align8);
   slm = slm_gather<float, 32>(ioffset_n32_view.select<32, 1>(), mask_n32,
                               props_align8);
 
   // 3) slm_gather(offsets, mask, pass_thru)
+  // CHECK-COUNT-13: call <32 x float> @llvm.masked.gather.v32f32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   slm = slm_gather<float>(ioffset_n32, mask_n32, pass_thru);
   slm = slm_gather<float, 32>(ioffset_n32_view, mask_n32, pass_thru);
   slm = slm_gather<float, 32>(ioffset_n32, mask_n32, pass_thru_view);
@@ -751,6 +771,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_slm_gather(int byte_offset32) {
   slm = slm_gather(ioffset_n32_view.select<32, 1>(), mask_n32,
                    pass_thru_view.select<32, 1>());
 
+  // CHECK-COUNT-13: call <32 x float> @llvm.masked.gather.v32f32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   slm = slm_gather<float>(ioffset_n32, mask_n32, pass_thru, props_align8);
   slm = slm_gather<float, 32>(ioffset_n32_view, mask_n32, pass_thru,
                               props_align8);
@@ -776,6 +797,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_slm_gather(int byte_offset32) {
                    pass_thru_view.select<32, 1>(), props_align8);
 
   // 4) slm_gather(...): same as (1), (2), (3) above, but with VS > 1.
+  // CHECK-COUNT-38: call <32 x i32> @llvm.genx.lsc.load.merge.slm.v32i32.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, i32 0, <32 x i32> {{[^)]+}})
   // 4a) check VS > 1. no 'mask' operand first.
   slm = slm_gather<float, 32, 2>(ioffset_n16);
   slm = slm_gather<float, 32, 2>(ioffset_n16_view);

--- a/sycl/test/check_device_code/esimd/memory_properties_load_store.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_load_store.cpp
@@ -1,9 +1,11 @@
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fno-sycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATEFUL
 
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fsycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATELESS
 
 // Checks ESIMD memory functions accepting compile time properties for

--- a/sycl/test/check_device_code/esimd/memory_properties_load_store.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_load_store.cpp
@@ -93,27 +93,36 @@ test_block_load(AccType &acc, LocalAccType &local_acc, float *ptrf,
   const int *ptri = reinterpret_cast<const int *>(ptrf);
   const int8_t *ptrb = reinterpret_cast<const int8_t *>(ptrf);
 
+  // CHECK: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   auto d1 = block_load<float, N>(ptrf, props_a);
 
+  // CHECK: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   auto d2 = block_load<int, N>(ptri, byte_offset32, props_a);
 
+  // CHECK: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   auto d3 = block_load<float, N>(ptrf, byte_offset64, props_b);
 
+  // CHECK: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   simd_mask<1> mask = 1;
   auto d4 = block_load<float, N>(ptrf, mask, props_a);
 
+  // CHECK-COUNT-3: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   auto d5 = block_load<float, N>(ptrf, mask, pass_thru, props_b);
   d5 = block_load(ptrf, mask, pass_thru, props_b);
   d5 = block_load(ptrf, mask, pass_thru_view, props_b);
 
+  // CHECK: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   auto d6 = block_load<float, N>(ptrf, byte_offset32, mask, props_a);
 
+  // CHECK: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   auto d7 = block_load<int, N>(ptri, byte_offset64, mask, props_b);
 
+  // CHECK-COUNT-3: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   auto d8 = block_load<int, N>(ptri, byte_offset32, mask, pass_thrui, props_a);
   d8 = block_load(ptri, byte_offset32, mask, pass_thrui, props_a);
   d8 = block_load(ptri, byte_offset32, mask, pass_thrui_view, props_a);
 
+  // CHECK: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   auto d9 = block_load<int, N>(ptri, byte_offset64, mask, pass_thru, props_b);
 
   // Now try block_load without cache hints and using the mask to verify
@@ -121,32 +130,53 @@ test_block_load(AccType &acc, LocalAccType &local_acc, float *ptrf,
   // not power-of-two because only svm/legacy block_load supports
   // non-power-of-two vector lengths now.
 
+  // CHECK: load <5 x float>, ptr addrspace(4) {{[^)]+}}, align 4
   auto x1 = block_load<float, 5>(ptrf, props_c);
 
+  // CHECK: load <6 x i32>, ptr addrspace(4) {{[^)]+}}, align 4
   auto x2 = block_load<int, 6>(ptri, byte_offset32, props_c);
 
+  // CHECK: load <7 x float>, ptr addrspace(4) {{[^)]+}}, align 4
   auto x3 = block_load<float, 7>(ptrf, byte_offset64, props_c);
 
   // Verify ACCESSOR-based block_load.
 
+  // CHECK-STATEFUL:  call <4 x float> @llvm.genx.lsc.load.bti.v4f32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   auto a1 = block_load<float, N>(acc, props_a);
 
+  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.load.bti.v4i32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   auto a2 = block_load<int, N>(acc, byte_offset32, props_a);
 
+  // CHECK-STATEFUL:  call <4 x float> @llvm.genx.lsc.load.bti.v4f32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   auto a3 = block_load<float, N>(acc, byte_offset64, props_b);
 
+  // CHECK-STATEFUL:  call <4 x float> @llvm.genx.lsc.load.merge.bti.v4f32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x float> {{[^)]+}})
+  // CHECK-STATELESS: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   auto a4 = block_load<float, N>(acc, mask, props_a);
 
+  // CHECK-STATEFUL-COUNT-2:  call <4 x float> @llvm.genx.lsc.load.merge.bti.v4f32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x float> {{[^)]+}})
+  // CHECK-STATELESS-COUNT-2: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   auto a5 = block_load<float, N>(acc, mask, pass_thru, props_b);
   a5 = block_load<float, N>(acc, mask, pass_thru_view, props_b);
 
+  // CHECK-STATEFUL:  call <4 x float> @llvm.genx.lsc.load.merge.bti.v4f32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x float> {{[^)]+}})
+  // CHECK-STATELESS: call <4 x float> @llvm.genx.lsc.load.merge.stateless.v4f32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x float> {{[^)]+}})
   auto a6 = block_load<float, N>(acc, byte_offset32, mask, props_a);
 
+  // CHECK-STATEFUL:  call <4 x i32> @llvm.genx.lsc.load.merge.bti.v4i32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}})
+  // CHECK-STATELESS: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   auto a7 = block_load<int, N>(acc, byte_offset64, mask, props_b);
 
+  // CHECK-STATEFUL-COUNT-2:  call <4 x i32> @llvm.genx.lsc.load.merge.bti.v4i32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}})
+  // CHECK-STATELESS-COUNT-2: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 5, i8 2, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   auto a8 = block_load<int, N>(acc, byte_offset32, mask, pass_thru, props_a);
   a8 = block_load<int, N>(acc, byte_offset32, mask, pass_thru_view, props_a);
 
+  // CHECK-STATEFUL-COUNT-2:  call <4 x i32> @llvm.genx.lsc.load.merge.bti.v4i32.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}})
+  // CHECK-STATELESS-COUNT-2: call <4 x i32> @llvm.genx.lsc.load.merge.stateless.v4i32.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0, <4 x i32> {{[^)]+}})
   auto a9 = block_load<int, N>(acc, byte_offset64, mask, pass_thrui, props_b);
   a9 = block_load<int, N>(acc, byte_offset64, mask, pass_thrui_view, props_b);
 
@@ -155,41 +185,56 @@ test_block_load(AccType &acc, LocalAccType &local_acc, float *ptrf,
   // not power-of-two because only svm/legacy block_load supports
   // non-power-of-two vector lengths now.
 
+  // CHECK-STATEFUL:  call <4 x float> @llvm.genx.oword.ld.v4f32(i32 0, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: load <4 x float>, ptr addrspace(4) {{[^)]+}}, align 16
   auto z1 = block_load<float, 4>(acc, props_c);
 
+  // CHECK-STATEFUL:  call <8 x i32> @llvm.genx.oword.ld.unaligned.v8i32(i32 0, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: load <8 x i32>, ptr addrspace(4) {{[^)]+}}, align 4
   auto z2 = block_load<int, 8>(acc, byte_offset32, props_c);
 
+  // CHECK-STATEFUL:  call <16 x float> @llvm.genx.oword.ld.v16f32(i32 0, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS: load <16 x float>, ptr addrspace(4) {{[^)]+}}, align 16
   auto z3 = block_load<float, 16>(acc, byte_offset64, props_c16);
 
   // Now try SLM block_load() with and without cache hints that are ignored.
 
+  // CHECK: load <11 x double>, ptr addrspace(3) {{[^)]+}}, align 16
   auto slm_bl1 = slm_block_load<double, 11>(byte_offset32, props_a);
 
+  // CHECK: call <8 x double> @llvm.genx.lsc.load.slm.v8f64.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 4, i8 5, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 0)
   auto slm_bl2 = slm_block_load<double, 8>(byte_offset32, mask, props_c16);
 
   simd<double, 8> pass_thrud = 2.0;
   auto pass_thrud_view = pass_thrud.select<8, 1>();
+  // CHECK-COUNT-2: call <8 x double> @llvm.genx.lsc.load.merge.slm.v8f64.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 4, i8 5, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 0, <8 x double> {{[^)]+}})
   auto slm_bl3 =
       slm_block_load<double, 8>(byte_offset32, mask, pass_thrud, props_c16);
   slm_bl3 = slm_block_load(byte_offset32, mask, pass_thrud_view, props_c16);
 
   // Now try block_load() accepting local accessor.
 
+  // CHECK: load <2 x double>, ptr addrspace(3) {{[^)]+}}, align 16
   auto lacc_bl1 = block_load<double, 2>(local_acc, props_a);
 
+  // CHECK: load <5 x double>, ptr addrspace(3) {{[^)]+}}, align 8
   auto lacc_bl2 = block_load<double, 5>(local_acc, byte_offset32, props_b);
 
+  // CHECK: call <8 x double> @llvm.genx.lsc.load.slm.v8f64.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 4, i8 5, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 0)
   auto lacc_bl3 = block_load<double, 8>(local_acc, mask, props_a);
 
+  // CHECK-COUNT-2: call <16 x double> @llvm.genx.lsc.load.merge.slm.v16f64.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 4, i8 6, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 0, <16 x double> {{[^)]+}})
   simd<double, 16> pass_thrud16 = 2.0;
   auto pass_thrud16_view = pass_thrud16.select<16, 1>();
   auto lacc_bl4 =
       block_load<double, 16>(local_acc, mask, pass_thrud16, props_b);
   lacc_bl4 = block_load(local_acc, mask, pass_thrud16_view, props_b);
 
+  // CHECK: call <32 x double> @llvm.genx.lsc.load.slm.v32f64.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 4, i8 7, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 0)
   auto lacc_bl5 =
       block_load<double, 32>(local_acc, byte_offset32, mask, props_a);
 
+  // CHECK-COUNT-2: call <4 x double> @llvm.genx.lsc.load.merge.slm.v4f64.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 4, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 0, <4 x double> {{[^)]+}})
   simd<double, 4> pass_thrud4 = 2.0;
   auto pass_thrud4_view = pass_thrud4.select<4, 1>();
   auto lacc_bl6 = block_load<double, 4>(local_acc, byte_offset32, mask,
@@ -202,6 +247,7 @@ test_block_load(AccType &acc, LocalAccType &local_acc, float *ptrf,
   // TODO: Extend this kind of tests:
   //   {usm, acc, local_acc, slm} x {byte, word, dword, qword}.
 
+  // CHECK: load <16 x i8>, ptr addrspace(4) {{[^)]+}}, align 4
   auto align_check1 = block_load<int8_t, 16>(ptrb);
 }
 
@@ -227,87 +273,89 @@ test_block_store(AccType &acc, LocalAccType &local_acc, float *ptrf,
   simd_mask<1> mask = 1;
   auto view = vals.select<N, 1>();
   auto viewi = valsi.select<N, 1>();
-  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x float> splat (float 1.000000e+00), i32 0)
+  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 0)
   block_store(ptrf, vals, store_props_a);
   block_store(ptrf, view, store_props_a);
 
-  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 1), i32 0)
+  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   block_store(ptri, byte_offset32, valsi, store_props_a);
   block_store(ptri, byte_offset32, viewi, store_props_a);
 
-  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> splat (i1 true), i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x float> splat (float 1.000000e+00), i32 0)
+  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 0)
   block_store(ptrf, byte_offset64, vals, store_props_c);
   block_store(ptrf, byte_offset64, view, store_props_c);
 
-  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x float> splat (float 1.000000e+00), i32 0)
+  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 0)
   block_store(ptrf, vals, mask, store_props_a);
   block_store(ptrf, view, mask, store_props_a);
 
-  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> splat (i1 true), i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 1), i32 0)
+  // CHECK-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   block_store(ptri, byte_offset64, valsi, mask, store_props_c);
   block_store(ptri, byte_offset64, viewi, mask, store_props_c);
 
   // Test SVM/legacy USM block store
 
-  // CHECK: store <4 x float> splat (float 1.000000e+00), ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 8
-  // CHECK: store <4 x float> splat (float 1.000000e+00), ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 16
+  // CHECK-COUNT-2: store <4 x float> {{[^)]+}}, ptr addrspace(4) {{[^)]+}}, align 16
   block_store(ptrf, vals, store_props_b);
   block_store(ptrf, view, store_props_b);
 
+  // CHECK-COUNT-2: store <4 x float> {{[^)]+}}, ptr addrspace(4) {{[^)]+}}, align 8
   block_store(ptrf, vals, store_props_d);
   block_store(ptrf, view, store_props_d);
 
+  // CHECK-COUNT-2: store <4 x float> {{[^)]+}}, ptr addrspace(4) {{[^)]+}}, align 16
   block_store(ptrf, byte_offset32, vals, store_props_b);
   block_store(ptrf, byte_offset32, view, store_props_b);
 
   // Test accessor block store
 
-  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4f32(<1 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> zeroinitializer, <4 x float> splat (float 1.000000e+00), i32 {{[^)]+}})
-  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x float> splat (float 1.000000e+00), i32 0)
+  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 0)
   block_store(acc, vals, store_props_a);
   block_store(acc, view, store_props_a);
 
-  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4i32(<1 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x i32> splat (i32 1), i32 %{{[a-zA-Z0-9.]+}})
-  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 1), i32 0)
+  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   block_store(acc, byte_offset32, valsi, store_props_a);
   block_store(acc, byte_offset32, viewi, store_props_a);
 
-  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4f32(<1 x i1> splat (i1 true), i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> %{{[a-zA-Z0-9.]+}}, <4 x float> splat (float 1.000000e+00), i32 %{{[a-zA-Z0-9.]+}})
-  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> splat (i1 true), i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x float> splat (float 1.000000e+00), i32 0)
+  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 0)
   block_store(acc, byte_offset64, vals, store_props_c);
   block_store(acc, byte_offset64, view, store_props_c);
 
-  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4f32(<1 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> zeroinitializer, <4 x float> splat (float 1.000000e+00), i32 %{{[a-zA-Z0-9.]+}})
-  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x float> splat (float 1.000000e+00), i32 0)
+  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 0)
   block_store(acc, vals, mask, store_props_a);
   block_store(acc, view, mask, store_props_a);
 
-  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4i32(<1 x i1> splat (i1 true), i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 1), i32 {{[^)]+}})
-  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> splat (i1 true), i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 1), i32 0)
+  // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   block_store(acc, byte_offset64, valsi, mask, store_props_c);
   block_store(acc, byte_offset64, viewi, mask, store_props_c);
 
   // Test accessor SVM/legacy block store
 
   // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.oword.st.v4f32(i32 {{[^)]+}}, i32 {{[^)]+}}, <4 x float> {{[^)]+}})
-  // CHECK-STATELESS-COUNT-2: store <4 x float> splat (float 1.000000e+00), ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 16
+  // CHECK-STATELESS-COUNT-2: store <4 x float> {{[^)]+}}, ptr addrspace(4) {{[^)]+}}, align 16
   block_store(acc, vals, store_props_b);
   block_store(acc, view, store_props_b);
 
   // CHECK-STATEFUL-COUNT-2:  call void @llvm.genx.oword.st.v4i32(i32 {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}})
-  // CHECK-STATELESS-COUNT-2: store <4 x i32> splat (i32 1), ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 16
+  // CHECK-STATELESS-COUNT-2: store <4 x i32> {{[^)]+}}, ptr addrspace(4) {{[^)]+}}, align 16
   block_store(acc, byte_offset32, valsi, store_props_b);
   block_store(acc, byte_offset32, viewi, store_props_b);
 
   // Now try SLM block_store() with and without cache hints that are ignored.
 
-  // CHECK: store <4 x float> splat (float 1.000000e+00), ptr addrspace(3) %{{[a-zA-Z0-9.]+}}, align 16
+  // CHECK-COUNT-5: store <4 x float> {{[^)]+}}, ptr addrspace(3) {{[^)]+}}, align 16
   slm_block_store<float, N>(byte_offset32, vals, store_props_b);
   slm_block_store<float, N>(byte_offset32, view, store_props_b);
   slm_block_store<float, N>(byte_offset32, view.select<N, 1>(), store_props_b);
   slm_block_store(byte_offset32, view, store_props_b);
   slm_block_store(byte_offset32, view.select<N, 1>(), store_props_b);
 
+  // CHECK-COUNT-5: store <4 x float> {{[^)]+}}, ptr addrspace(3) {{[^)]+}}, align 16
   slm_block_store<float, N>(byte_offset32, vals, store_props_a);
   slm_block_store<float, N>(byte_offset32, view, store_props_a);
   slm_block_store<float, N>(byte_offset32, view.select<N, 1>(), store_props_a);
@@ -316,7 +364,7 @@ test_block_store(AccType &acc, LocalAccType &local_acc, float *ptrf,
 
   // Now try SLM block_store() with a predicate.
 
-  // CHECK-COUNT-5: call void @llvm.genx.lsc.store.slm.v1i1.v1i32.v4i32(<1 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 1), i32 0)
+  // CHECK-COUNT-5: call void @llvm.genx.lsc.store.slm.v1i1.v1i32.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   slm_block_store<int, N>(byte_offset32, valsi, mask, store_props_b);
   slm_block_store<int, N>(byte_offset32, viewi, mask, store_props_b);
   slm_block_store<int, N>(byte_offset32, viewi.select<N, 1>(), mask,
@@ -326,14 +374,14 @@ test_block_store(AccType &acc, LocalAccType &local_acc, float *ptrf,
 
   // Now try block_store() accepting local accessor.
 
-  // CHECK-COUNT-5: store <4 x float> splat (float 1.000000e+00), ptr addrspace(3) %{{[a-zA-Z0-9.]+}}, align 8
+  // CHECK-COUNT-5: store <4 x float> {{[^)]+}}, ptr addrspace(3) {{[^)]+}}, align 8
   block_store<float, N>(local_acc, vals, store_props_d);
   block_store<float, N>(local_acc, view, store_props_d);
   block_store<float, N>(local_acc, view.select<N, 1>(), store_props_d);
   block_store(local_acc, view, store_props_d);
   block_store(local_acc, view.select<N, 1>(), store_props_d);
 
-  // CHECK-COUNT-5: store <4 x i32> splat (i32 1), ptr addrspace(3) %{{[a-zA-Z0-9.]+}}, align 8
+  // CHECK-COUNT-5: store <4 x i32> {{[^)]+}}, ptr addrspace(3) {{[^)]+}}, align 8
   block_store<int, N>(local_acc, byte_offset32, valsi, store_props_d);
   block_store<int, N>(local_acc, byte_offset32, viewi, store_props_d);
   block_store<int, N>(local_acc, byte_offset32, viewi.select<N, 1>(),
@@ -341,14 +389,14 @@ test_block_store(AccType &acc, LocalAccType &local_acc, float *ptrf,
   block_store(local_acc, byte_offset32, viewi, store_props_d);
   block_store(local_acc, byte_offset32, viewi.select<N, 1>(), store_props_d);
 
-  // CHECK-COUNT-5: call void @llvm.genx.lsc.store.slm.v1i1.v1i32.v4f32(<1 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> %{{[a-zA-Z0-9.]+}}, <4 x float> splat (float 1.000000e+00), i32 0)
+  // CHECK-COUNT-5: call void @llvm.genx.lsc.store.slm.v1i1.v1i32.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 0)
   block_store<float, N>(local_acc, vals, mask, store_props_a);
   block_store<float, N>(local_acc, view, mask, store_props_a);
   block_store<float, N>(local_acc, view.select<N, 1>(), mask, store_props_a);
   block_store(local_acc, view, mask, store_props_a);
   block_store(local_acc, view.select<N, 1>(), mask, store_props_a);
 
-  // CHECK-COUNT-5: call void @llvm.genx.lsc.store.slm.v1i1.v1i32.v4i32(<1 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> %{{[a-zA-Z0-9.]+}}, <4 x i32> splat (i32 1), i32 0)
+  // CHECK-COUNT-5: call void @llvm.genx.lsc.store.slm.v1i1.v1i32.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   block_store<int, N>(local_acc, byte_offset32, valsi, mask, store_props_c);
   block_store<int, N>(local_acc, byte_offset32, viewi, mask, store_props_c);
   block_store<int, N>(local_acc, byte_offset32, viewi.select<N, 1>(), mask,

--- a/sycl/test/check_device_code/esimd/memory_properties_prefetch_2d.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_prefetch_2d.cpp
@@ -1,9 +1,11 @@
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fno-sycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATEFUL
 
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fsycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATELESS
 
 // Checks ESIMD memory functions accepting compile time properties for prefetch

--- a/sycl/test/check_device_code/esimd/memory_properties_prefetch_2d.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_prefetch_2d.cpp
@@ -82,7 +82,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_prefetch(AccType &acc, float *ptrf,
 
   // 1) prefetch(usm, offsets): offsets is simd or simd_view
 
-  // CHECK-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v32i1.v32i64(<32 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v32i1.v32i64(<32 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> {{[^)]+}}, i32 0)
   prefetch(ptrf, ioffset_n32, props_cache_load);
   prefetch<float, 32>(ptrf, ioffset_n32_view, props_cache_load);
   prefetch<float, 32>(ptrf, ioffset_n32_view.select<32, 1>(), props_cache_load);
@@ -96,7 +96,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_prefetch(AccType &acc, float *ptrf,
   prefetch(ptrf, loffset_n32_view.select<32, 1>(), props_cache_load);
 
   // 2) prefetch(usm, offsets, mask): offsets is simd or simd_view
-  // CHECK-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v32i1.v32i64(<32 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v32i1.v32i64(<32 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> {{[^)]+}}, i32 0)
   prefetch(ptrf, ioffset_n32, mask_n32, props_cache_load);
   prefetch<float, 32>(ptrf, ioffset_n32_view, mask_n32, props_cache_load);
   prefetch<float, 32>(ptrf, ioffset_n32_view.select<32, 1>(), mask_n32,
@@ -112,7 +112,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_prefetch(AccType &acc, float *ptrf,
   prefetch(ptrf, loffset_n32_view.select<32, 1>(), mask_n32, props_cache_load);
 
   // 3) prefetch(usm, offset): offset is scalar
-  // CHECK-COUNT-16: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-COUNT-16: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0)
   __ESIMD_NS::prefetch(ptrf, byte_offset32, props_cache_load);
   __ESIMD_NS::prefetch(ptrf, byte_offset64, props_cache_load);
   __ESIMD_NS::prefetch(ptrf, props_cache_load);
@@ -136,7 +136,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_prefetch(AccType &acc, float *ptrf,
                                    props_cache_load_align);
 
   // 4) prefetch(usm, ...): same as (1), (2) above, but with VS > 1.
-  // CHECK-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64(<16 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64(<16 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, i32 0)
   prefetch<float, 32, 2>(ptrf, ioffset_n16, props_cache_load);
   prefetch<float, 32, 2>(ptrf, ioffset_n16_view, props_cache_load);
   prefetch<float, 32, 2>(ptrf, ioffset_n16_view.select<16, 1>(),
@@ -151,7 +151,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_prefetch(AccType &acc, float *ptrf,
   prefetch<2>(ptrf, loffset_n16_view, props_cache_load);
   prefetch<2>(ptrf, loffset_n16_view.select<16, 1>(), props_cache_load);
 
-  // CHECK-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64(<16 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64(<16 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, i32 0)
   prefetch<float, 32, 2>(ptrf, ioffset_n16, mask_n16, props_cache_load);
   prefetch<float, 32, 2>(ptrf, ioffset_n16_view, mask_n16, props_cache_load);
   prefetch<float, 32, 2>(ptrf, ioffset_n16_view.select<16, 1>(), mask_n16,
@@ -168,7 +168,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_prefetch(AccType &acc, float *ptrf,
   prefetch<2>(ptrf, loffset_n16_view.select<16, 1>(), mask_n16,
               props_cache_load);
 
-  // CHECK-COUNT-2: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 7, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-COUNT-2: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 7, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0)
   __ESIMD_NS::prefetch<float, 32>(ptrf, 0, props_cache_load);
   __ESIMD_NS::prefetch<float, 32>(ptrf, 0, 1, props_cache_load);
 
@@ -179,23 +179,23 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_prefetch(AccType &acc, float *ptrf,
   // 4) prefetch(acc, offset): same as (1) and (2) above, but with VS > 1.
 
   // 1) prefetch(acc, offsets): offsets is simd or simd_view
-  // CHECK-STATEFUL-COUNT-3: call void @llvm.genx.lsc.prefetch.bti.v32i1.v32i32(<32 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
-  // CHECK-STATELESS-COUNT-3: call void @llvm.genx.lsc.prefetch.stateless.v32i1.v32i64(<32 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-3: call void @llvm.genx.lsc.prefetch.bti.v32i1.v32i32(<32 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-3: call void @llvm.genx.lsc.prefetch.stateless.v32i1.v32i64(<32 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> {{[^)]+}}, i32 0)
   prefetch<float>(acc, ioffset_n32, props_cache_load);
   prefetch<float, 32>(acc, ioffset_n32_view, props_cache_load);
   prefetch<float, 32>(acc, ioffset_n32_view.select<32, 1>(), props_cache_load);
 
   // 2) prefetch(acc, offsets, mask): offsets is simd or simd_view
-  // CHECK-STATEFUL-COUNT-3: call void @llvm.genx.lsc.prefetch.bti.v32i1.v32i32(<32 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
-  // CHECK-STATELESS-COUNT-3: call void @llvm.genx.lsc.prefetch.stateless.v32i1.v32i64(<32 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-3: call void @llvm.genx.lsc.prefetch.bti.v32i1.v32i32(<32 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-3: call void @llvm.genx.lsc.prefetch.stateless.v32i1.v32i64(<32 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> {{[^)]+}}, i32 0)
   prefetch<float>(acc, ioffset_n32, mask_n32, props_cache_load);
   prefetch<float, 32>(acc, ioffset_n32_view, mask_n32, props_cache_load);
   prefetch<float, 32>(acc, ioffset_n32_view.select<32, 1>(), mask_n32,
                       props_cache_load);
 
   // 3) prefetch(acc, offset): offset is scalar
-  // CHECK-STATEFUL-COUNT-10: call void @llvm.genx.lsc.prefetch.bti.v1i1.v1i32(<1 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
-  // CHECK-STATELESS-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-10: call void @llvm.genx.lsc.prefetch.bti.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-10: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 1, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0)
   prefetch<float>(acc, byte_offset32, props_cache_load);
   prefetch<float>(acc, props_cache_load);
   prefetch<float>(acc, mask_n1, props_cache_load);
@@ -209,22 +209,22 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_prefetch(AccType &acc, float *ptrf,
   prefetch<uint8_t, 4>(acc, byte_offset32, mask_n1, props_cache_load_align);
 
   // 4) prefetch(usm, ...): same as (1), (2) above, but with VS > 1.
-  // CHECK-STATEFUL-COUNT-3: call void @llvm.genx.lsc.prefetch.bti.v16i1.v16i32(<16 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, i32 {{[^)]+}})
-  // CHECK-STATELESS-COUNT-3: call void @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64(<16 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-3: call void @llvm.genx.lsc.prefetch.bti.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-3: call void @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64(<16 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, i32 0)
   prefetch<float, 32, 2>(acc, ioffset_n16, props_cache_load);
   prefetch<float, 32, 2>(acc, ioffset_n16_view, props_cache_load);
   prefetch<float, 32, 2>(acc, ioffset_n16_view.select<16, 1>(),
                          props_cache_load);
 
-  // CHECK-STATEFUL-COUNT-3: call void @llvm.genx.lsc.prefetch.bti.v16i1.v16i32(<16 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, i32 {{[^)]+}})
-  // CHECK-STATELESS-COUNT-3: call void @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64(<16 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-3: call void @llvm.genx.lsc.prefetch.bti.v16i1.v16i32(<16 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-3: call void @llvm.genx.lsc.prefetch.stateless.v16i1.v16i64(<16 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, i32 0)
   prefetch<float, 32, 2>(acc, ioffset_n16, mask_n16, props_cache_load);
   prefetch<float, 32, 2>(acc, ioffset_n16_view, mask_n16, props_cache_load);
   prefetch<float, 32, 2>(acc, ioffset_n16_view.select<16, 1>(), mask_n16,
                          props_cache_load);
 
-  // CHECK-STATEFUL-COUNT-2: call void @llvm.genx.lsc.prefetch.bti.v1i1.v1i32(<1 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 7, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
-  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> splat (i1 true), i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 7, i8 2, i8 0, <1 x i64> %{{[a-zA-Z0-9.]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-2: call void @llvm.genx.lsc.prefetch.bti.v1i1.v1i32(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 7, i8 2, i8 0, <1 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-2: call void @llvm.genx.lsc.prefetch.stateless.v1i1.v1i64(<1 x i1> {{[^)]+}}, i8 0, i8 2, i8 1, i16 1, i32 0, i8 3, i8 7, i8 2, i8 0, <1 x i64> {{[^)]+}}, i32 0)
   prefetch<float, 32>(acc, 0, props_cache_load);
   prefetch<float, 32>(acc, 0, 1, props_cache_load);
 }
@@ -254,7 +254,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
   // 4) store_2d(): combinations of explicit and default template parameters
   // 5) same as (4) but without compile time properties
 
-  // CHECK-COUNT-3: call void @llvm.genx.lsc.prefetch2d.stateless.v1i1.i64(<1 x i1> splat (i1 true), i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-COUNT-3: call void @llvm.genx.lsc.prefetch2d.stateless.v1i1.i64(<1 x i1> {{[^)]+}}, i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   prefetch_2d<float, BlockWidth, BlockHeight, NBlocks>(
       ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X, Y, props_cache_load);
   prefetch_2d<float, BlockWidth, BlockHeight>(
@@ -262,7 +262,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
   prefetch_2d<float, BlockWidth>(ptr, SurfaceWidth, SurfaceHeight, SurfacePitch,
                                  X, Y, props_cache_load);
 
-  // CHECK: call <16 x float> @llvm.genx.lsc.load2d.stateless.v16f32.v1i1.i64(<1 x i1> splat (i1 true), i8 0, i8 0, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 %{{[a-zA-Z0-9.]+}}, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef)
+  // CHECK-COUNT-5: call <16 x float> @llvm.genx.lsc.load2d.stateless.v16f32.v1i1.i64(<1 x i1> {{[^)]+}}, i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   Vals =
       load_2d<float, BlockWidth, BlockHeight, NBlocks, Transposed, Transformed>(
           ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X, Y,
@@ -276,6 +276,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
   Vals = load_2d<float, BlockWidth>(ptr, SurfaceWidth, SurfaceHeight,
                                     SurfacePitch, X, Y, props_cache_load);
 
+  // CHECK-COUNT-5: call <16 x float> @llvm.genx.lsc.load2d.stateless.v16f32.v1i1.i64(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   Vals =
       load_2d<float, BlockWidth, BlockHeight, NBlocks, Transposed, Transformed>(
           ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X, Y);
@@ -288,7 +289,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
   Vals = load_2d<float, BlockWidth>(ptr, SurfaceWidth, SurfaceHeight,
                                     SurfacePitch, X, Y);
 
-  // CHECK-COUNT-4: call void @llvm.genx.lsc.store2d.stateless.v1i1.i64.v16f32(<1 x i1> splat (i1 true), i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x float> {{[^)]+}})
+  // CHECK-COUNT-4: call void @llvm.genx.lsc.store2d.stateless.v1i1.i64.v16f32(<1 x i1> {{[^)]+}}, i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x float> {{[^)]+}})
   store_2d<float, BlockWidth, BlockHeight>(ptr, SurfaceWidth, SurfaceHeight,
                                            SurfacePitch, X, Y, Vals,
                                            props_cache_load);
@@ -301,7 +302,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
       ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X, Y,
       Vals_view.select<16, 1>(), props_cache_load);
 
-  // CHECK-COUNT-4: call void @llvm.genx.lsc.store2d.stateless.v1i1.i64.v16f32(<1 x i1> splat (i1 true), i8 0, i8 0, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x float> {{[^)]+}})
+  // CHECK-COUNT-4: call void @llvm.genx.lsc.store2d.stateless.v1i1.i64.v16f32(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x float> {{[^)]+}})
   store_2d<float, BlockWidth, BlockHeight>(ptr, SurfaceWidth, SurfaceHeight,
                                            SurfacePitch, X, Y, Vals);
   store_2d<float, BlockWidth>(ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X,

--- a/sycl/test/check_device_code/esimd/memory_properties_scatter.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_scatter.cpp
@@ -1,9 +1,11 @@
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fno-sycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem=false -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATEFUL
 
 // RUN: %clangxx -O0 -fsycl -fsycl-device-only -fsycl-esimd-force-stateless-mem -D__ESIMD_GATHER_SCATTER_LLVM_IR -Xclang -emit-llvm %s -o %t
-// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -properties -split-esimd -lower-esimd -lower-esimd-force-stateless-mem -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes=CHECK,CHECK-STATELESS
 
 // Checks ESIMD memory functions accepting compile time properties for scatter

--- a/sycl/test/check_device_code/esimd/memory_properties_scatter.cpp
+++ b/sycl/test/check_device_code/esimd/memory_properties_scatter.cpp
@@ -83,10 +83,11 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
   auto usm_view = usm.select<32, 1>();
 
   // Validate that a new API doesn't conflict with the old API.
+  // CHECK-COUNT-2: call <32 x float> @llvm.masked.gather.v32f32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
   acc_res = gather<float, 32>(local_acc, ioffset_n32, 0);
   acc_res = gather<float, 32>(local_acc, ioffset_n32, 0, mask_n32);
 
-  // CHECK-COUNT-4: call void @llvm.masked.scatter.v32f32.v32p4(<32 x float> undef, <32 x ptr addrspace(4)> %{{[a-zA-Z0-9.]+}}, i32 4, <32 x i1> splat (i1 true))
+  // CHECK-COUNT-4: call void @llvm.masked.scatter.v32f32.v32p4(<32 x float> {{[^)]+}}, <32 x ptr addrspace(4)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}})
   scatter(ptrf, ioffset_n32, usm, mask_n32);
 
   scatter(ptrf, ioffset_n32, usm);
@@ -95,7 +96,7 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
 
   scatter(ptrf, ioffset_n32, usm, props_align4);
 
-  // CHECK-COUNT-22: call void @llvm.genx.lsc.store.stateless.v32i1.v32i64.v32i32(<32 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 0)
+  // CHECK-COUNT-22: call void @llvm.genx.lsc.store.stateless.v32i1.v32i64.v32i32(<32 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 0)
   scatter(ptrf, ioffset_n32, usm, mask_n32, props_cache_load);
   scatter(ptrf, ioffset_n32, usm, props_cache_load);
 
@@ -138,7 +139,7 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
           props_cache_load);
 
   // VS > 1
-  // CHECK-COUNT-24: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 0)
+  // CHECK-COUNT-24: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 0)
   scatter<float, 32, 2>(ptrf, ioffset_n16, usm, mask_n16, props_cache_load);
 
   scatter<float, 32, 2>(ptrf, ioffset_n16, usm, props_cache_load);
@@ -189,7 +190,7 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
   scatter<2>(ptrf, ioffset_n16_view.select<16, 1>(), usm_view.select<32, 1>(),
              props_cache_load);
 
-  // CHECK-COUNT-14: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 0)
+  // CHECK-COUNT-14: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 0)
   scatter<float, 32, 2>(ptrf, ioffset_n16, usm, mask_n16);
 
   scatter<float, 32, 2>(ptrf, ioffset_n16, usm);
@@ -273,7 +274,7 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
           props_align4);
 
   // VS > 1
-  // CHECK-COUNT-26: call void @llvm.genx.lsc.store.slm.v16i1.v16i32.v32i32(<16 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 0)
+  // CHECK-COUNT-26: call void @llvm.genx.lsc.store.slm.v16i1.v16i32.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, <32 x i32>{{[^)]+}}, i32 0)
   scatter<float, 32, 2>(local_acc, ioffset_n16, usm, mask_n16, props_align4);
 
   scatter<float, 32, 2>(local_acc, ioffset_n16, usm, props_align4);
@@ -327,7 +328,7 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
   scatter<2>(local_acc, ioffset_n16_view.select<16, 1>(),
              usm_view.select<32, 1>(), props_align4);
 
-  // CHECK-COUNT-26: call void @llvm.genx.lsc.store.slm.v16i1.v16i32.v32i32(<16 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 0)
+  // CHECK-COUNT-26: call void @llvm.genx.lsc.store.slm.v16i1.v16i32.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, <32 x i32>{{[^)]+}}, i32 0)
   scatter<float, 32, 2>(local_acc, ioffset_n16, usm, mask_n16);
 
   scatter<float, 32, 2>(local_acc, ioffset_n16, usm);
@@ -400,7 +401,7 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
   scatter(ptrf, ioffset_n10, usm_n10);
 
   // Test accessor
-  // CHECK-STATEFUL-COUNT-4: call void @llvm.genx.scatter.scaled.v32i1.v32i32.v32f32(<32 x i1> splat (i1 true), i32 2, i16 0, i32 %{{[a-zA-Z0-9.]+}}, i32 0, <32 x i32> %{{[a-zA-Z0-9.]+}}, <32 x float> undef)
+  // CHECK-STATEFUL-COUNT-4: call void @llvm.genx.scatter.scaled.v32i1.v32i32.v32f32(<32 x i1> {{[^)]+}}, i16 0, i32 {{[^)]+}}, i32 {{[^)]+}}, <32 x i32> {{[^)]+}}, <32 x float> {{[^)]+}})
   // CHECK-STATELESS-COUNT-4: call void @llvm.masked.scatter.v32f32.v32p4(<32 x float> {{[^)]+}}, <32 x ptr addrspace(4)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}})
   scatter(acc, ioffset_n32, usm, mask_n32);
 
@@ -410,8 +411,8 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
 
   scatter(acc, ioffset_n32, usm, props_align4);
 
-  // CHECK-STATEFUL-COUNT-20: call void @llvm.genx.lsc.store.bti.v32i1.v32i32.v32i32(<32 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i32> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 %{{[a-zA-Z0-9.]+}})
-  // CHECK-STATELESS-COUNT-20: call void @llvm.genx.lsc.store.stateless.v32i1.v32i64.v32i32(<32 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 0)
+  // CHECK-STATEFUL-COUNT-20: call void @llvm.genx.lsc.store.bti.v32i1.v32i32.v32i32(<32 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i32> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-20: call void @llvm.genx.lsc.store.stateless.v32i1.v32i64.v32i32(<32 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 0)
   scatter(acc, ioffset_n32, usm, mask_n32, props_cache_load);
   scatter(acc, ioffset_n32, usm, props_cache_load);
 
@@ -451,8 +452,8 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
           props_cache_load);
 
   // VS > 1
-  // CHECK-STATELESS-COUNT-26: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 0)
-  // CHECK-STATEFUL-COUNT-26: call void @llvm.genx.lsc.store.bti.v16i1.v16i32.v32i32(<16 x i1> splat (i1 true), i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 %{{[a-zA-Z0-9.]+}})
+  // CHECK-STATELESS-COUNT-26: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-26: call void @llvm.genx.lsc.store.bti.v16i1.v16i32.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
   scatter<float, 32, 2>(acc, ioffset_n16, usm, mask_n16, props_cache_load);
 
   scatter<float, 32, 2>(acc, ioffset_n16, usm, props_cache_load);
@@ -504,8 +505,8 @@ test_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
   scatter<2>(acc, ioffset_n16_view.select<16, 1>(), usm_view.select<32, 1>(),
              props_cache_load);
 
-  // CHECK-STATELESS-COUNT-26: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 0)
-  // CHECK-STATEFUL-COUNT-26:  call void @llvm.genx.lsc.store.bti.v16i1.v16i32.v32i32(<16 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 %{{[a-zA-Z0-9.]+}})
+  // CHECK-STATELESS-COUNT-26: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-26:  call void @llvm.genx.lsc.store.bti.v16i1.v16i32.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
   scatter<float, 32, 2>(acc, ioffset_n16, usm, mask_n16);
 
   scatter<float, 32, 2>(acc, ioffset_n16, usm);
@@ -658,7 +659,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_slm_scatter(int byte_offset32) {
               mask_n32, props_align8);
 
   // 4) slm_gather(...): same as (1), (2), above, but with VS > 1.
-  // CHECK-COUNT-52: call void @llvm.genx.lsc.store.slm.v16i1.v16i32.v32i32(<16 x i1> splat (i1 true), i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> %{{[a-zA-Z0-9.]+}}, <32 x i32> undef, i32 0)
+  // CHECK-COUNT-52: call void @llvm.genx.lsc.store.slm.v16i1.v16i32.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, <32 x i32>{{[^)]+}}, i32 0)
   // 4a) check VS > 1. no 'mask' operand first.
   slm_scatter<float, 32, 2>(ioffset_n16, slm);
   slm_scatter<float, 32, 2>(ioffset_n16_view, slm);
@@ -738,8 +739,8 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_slm_scatter(int byte_offset32) {
   slm_scatter(ioffset_n10, slm_n10);
 
   // Check a case to verify emulation for 64 bit data types
-  // CHECK-COUNT-1: call <32 x i32> @llvm.masked.gather.v32i32.v32p3(<32 x ptr addrspace(3)> %{{[a-zA-Z0-9.]+}}, i32 8, <32 x i1> splat (i1 true), <32 x i32> poison)
-  // CHECK-COUNT-1: call <32 x i32> @llvm.masked.gather.v32i32.v32p3(<32 x ptr addrspace(3)> %{{[a-zA-Z0-9.]+}}, i32 4, <32 x i1> splat (i1 true), <32 x i32> poison)
+  // CHECK-COUNT-1: call <32 x i32> @llvm.masked.gather.v32i32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}}, <32 x i32> {{[^)]+}})
+  // CHECK-COUNT-1: call <32 x i32> @llvm.masked.gather.v32i32.v32p3(<32 x ptr addrspace(3)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x i32> {{[^)]+}})
   auto slm_64 = slm_gather<int64_t>(ioffset_n32);
   // CHECK-COUNT-1: call void @llvm.masked.scatter.v32i32.v32p3(<32 x i32> {{[^)]+}}, <32 x ptr addrspace(3)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}})
   // CHECK-COUNT-1: call void @llvm.masked.scatter.v32i32.v32p3(<32 x i32> {{[^)]+}}, <32 x ptr addrspace(3)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}})

--- a/sycl/test/check_device_code/esimd/slm_init_no_inline.cpp
+++ b/sycl/test/check_device_code/esimd/slm_init_no_inline.cpp
@@ -1,0 +1,27 @@
+// RUN: %clangxx -fsycl -O0 -fsycl-device-only -Xclang -emit-llvm -o %t.comp.ll %s
+// RUN: sycl-post-link -ir-output-only -lower-esimd -S %t.comp.ll -O0 -o %t.out.ll
+// RUN: FileCheck --input-file=%t.out.ll %s
+
+// This test verifies that calls the call of slm_init<N>() that is originally
+// placed inside the kernel stays in the kernel and not outlined into
+// a separate spir_func functions.
+
+#include <iostream>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+
+int main() {
+  queue Q;
+  nd_range<1> NDR{range<1>{2}, range<1>{2}};
+  Q.parallel_for(NDR, [=](nd_item<1> NDI) SYCL_ESIMD_KERNEL {
+     slm_init(1024);
+   }).wait();
+  // CHECK:     spir_kernel void @_ZTSZ4mainEUlN4sycl3_V17nd_itemILi1EEEE_()
+  // CHECK-NOT: ret void
+  // CHECK:     call void @llvm.genx.slm.init
+
+  return 0;
+}

--- a/sycl/test/check_device_code/esimd/slm_init_no_inline.cpp
+++ b/sycl/test/check_device_code/esimd/slm_init_no_inline.cpp
@@ -1,5 +1,6 @@
 // RUN: %clangxx -fsycl -O0 -fsycl-device-only -Xclang -emit-llvm -o %t.comp.ll %s
-// RUN: sycl-post-link -ir-output-only -lower-esimd -S %t.comp.ll -O0 -o %t.out.ll
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -ir-output-only -lower-esimd -S %t.comp.ll -O0 -force-disable-opt -o %t.out.ll
 // RUN: FileCheck --input-file=%t.out.ll %s
 
 // This test verifies that calls the call of slm_init<N>() that is originally

--- a/sycl/test/check_device_code/esimd/spirv_intrins_trans.cpp
+++ b/sycl/test/check_device_code/esimd/spirv_intrins_trans.cpp
@@ -15,8 +15,9 @@ kernel_SubgroupLocalInvocationId(size_t *DoNotOptimize,
   DoNotOptimize[0] = __spirv_SubgroupLocalInvocationId();
   DoNotOptimize32[0] = __spirv_SubgroupLocalInvocationId() + 3;
   // CHECK-LABEL: @{{.*}}kernel_SubgroupLocalInvocationId
-  // CHECK: store i64 0, ptr addrspace(4) %DoNotOptimize, align 8
-  // CHECK: store i32 3, ptr addrspace(4) %DoNotOptimize32, align 4
+  // CHECK: [[ZEXT0:%.*]] = zext i32 0 to i64
+  // CHECK: store i64 [[ZEXT0]]
+  // CHECK: add i32 0, 3
 }
 
 SYCL_ESIMD_KERNEL SYCL_EXTERNAL void
@@ -24,8 +25,9 @@ kernel_SubgroupSize(size_t *DoNotOptimize, uint32_t *DoNotOptimize32) {
   DoNotOptimize[0] = __spirv_SubgroupSize();
   DoNotOptimize32[0] = __spirv_SubgroupSize() + 7;
   // CHECK-LABEL: @{{.*}}kernel_SubgroupSize
-  // CHECK: store i64 1, ptr addrspace(4) %DoNotOptimize, align 8
-  // CHECK: store i32 8, ptr addrspace(4) %DoNotOptimize32, align 4
+  // CHECK: [[ZEXT0:%.*]] = zext i32 1 to i64
+  // CHECK: store i64 [[ZEXT0]]
+  // CHECK: add i32 1, 7
 }
 
 SYCL_ESIMD_KERNEL SYCL_EXTERNAL void
@@ -33,6 +35,7 @@ kernel_SubgroupMaxSize(size_t *DoNotOptimize, uint32_t *DoNotOptimize32) {
   DoNotOptimize[0] = __spirv_SubgroupMaxSize();
   DoNotOptimize32[0] = __spirv_SubgroupMaxSize() + 9;
   // CHECK-LABEL: @{{.*}}kernel_SubgroupMaxSize
-  // CHECK: store i64 1, ptr addrspace(4) %DoNotOptimize, align 8
-  // CHECK: store i32 10, ptr addrspace(4) %DoNotOptimize32, align 4
+  // CHECK: [[ZEXT0:%.*]] = zext i32 1 to i64
+  // CHECK: store i64 [[ZEXT0]]
+  // CHECK: add i32 1, 9
 }

--- a/sycl/test/check_device_code/esimd/spirv_intrins_trans.cpp
+++ b/sycl/test/check_device_code/esimd/spirv_intrins_trans.cpp
@@ -1,5 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -S -emit-llvm -x c++ %s -o %t
-// RUN: sycl-post-link -split-esimd -lower-esimd -O0 -S %t -o %t.table
+// -O0 lowering, requires `-force-disable-opt` to disable all optimizations.
+// RUN: sycl-post-link -split-esimd -lower-esimd -O0 -force-disable-opt -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll
 
 // This test checks that all LLVM-IR instructions that work with SPIR-V builtins

--- a/sycl/test/check_device_code/esimd/spirv_intrins_trans.cpp
+++ b/sycl/test/check_device_code/esimd/spirv_intrins_trans.cpp
@@ -15,8 +15,8 @@ kernel_SubgroupLocalInvocationId(size_t *DoNotOptimize,
   DoNotOptimize[0] = __spirv_SubgroupLocalInvocationId();
   DoNotOptimize32[0] = __spirv_SubgroupLocalInvocationId() + 3;
   // CHECK-LABEL: @{{.*}}kernel_SubgroupLocalInvocationId
-  // CHECK: store i64 0, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 8
-  // CHECK: store i32 3, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 4
+  // CHECK: store i64 0, ptr addrspace(4) %DoNotOptimize, align 8
+  // CHECK: store i32 3, ptr addrspace(4) %DoNotOptimize32, align 4
 }
 
 SYCL_ESIMD_KERNEL SYCL_EXTERNAL void
@@ -24,8 +24,8 @@ kernel_SubgroupSize(size_t *DoNotOptimize, uint32_t *DoNotOptimize32) {
   DoNotOptimize[0] = __spirv_SubgroupSize();
   DoNotOptimize32[0] = __spirv_SubgroupSize() + 7;
   // CHECK-LABEL: @{{.*}}kernel_SubgroupSize
-  // CHECK: store i64 1, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 8
-  // CHECK: store i32 8, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 4
+  // CHECK: store i64 1, ptr addrspace(4) %DoNotOptimize, align 8
+  // CHECK: store i32 8, ptr addrspace(4) %DoNotOptimize32, align 4
 }
 
 SYCL_ESIMD_KERNEL SYCL_EXTERNAL void
@@ -33,6 +33,6 @@ kernel_SubgroupMaxSize(size_t *DoNotOptimize, uint32_t *DoNotOptimize32) {
   DoNotOptimize[0] = __spirv_SubgroupMaxSize();
   DoNotOptimize32[0] = __spirv_SubgroupMaxSize() + 9;
   // CHECK-LABEL: @{{.*}}kernel_SubgroupMaxSize
-  // CHECK: store i64 1, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 8
-  // CHECK: store i32 10, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 4
+  // CHECK: store i64 1, ptr addrspace(4) %DoNotOptimize, align 8
+  // CHECK: store i32 10, ptr addrspace(4) %DoNotOptimize32, align 4
 }


### PR DESCRIPTION
In https://github.com/intel/llvm/pull/19411, we simply went for running all passes regardless of the optimization level. However, the change made it quite difficult to test a lot of the ESIMD functionalities, and some tests were even useless after the change. https://github.com/intel/llvm/pull/19411 --and it's follow up https://github.com/intel/llvm/pull/19453--, is now reverted, and we're taking a new approach: we still run all passes with `-O0`, but we add a new `-force-disable-opt` option to `sycl-post-link` so we can still test for ESIMD functionalities and keep the tests valid.