### PR TITLE
[SYCL][NVPTX][AMDGCN] Fix compilation for cmath long double

### DIFF
--- a/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
+++ b/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
@@ -71,7 +71,7 @@ using __sycl_promote_t =
 // TODO: Enable long double support where possible.
 // TODO: float16_t and bfloat16_t support if the standard library
 //       supports C++23.
-// TODO: constexpr support for these functions (C++23, C++)
+// TODO: constexpr support for these functions (C++23, C++26)
 //
 // The following two macros provide an easy way to define these overloads for
 // basic built-ins with one or two floating-point parameters.

--- a/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
+++ b/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
@@ -19,8 +19,7 @@
 #define __SYCL_DEVICE_C                                                        \
   extern "C" __attribute__((sycl_device_only, always_inline))
 
-// For std::enable_if, std::is_integral, std::is_floating_point, std::is_same,
-// and std::conjunction
+// For std::enable_if, std::is_integral, std::is_same and std::conjunction
 #include <type_traits>
 
 // Promotion templates: the C++ standard library provides overloads that allow
@@ -29,26 +28,28 @@
 // When multiple floating point arguments are available passing arguments with
 // different precision should promote to the larger type. The template helpers
 // below provide the machinery to define these promoting overloads.
-template <typename T,
-          bool = (std::is_integral_v<T> || std::is_floating_point_v<T>)>
-struct __sycl_promote {
-private:
-  // Integer types are promoted to double.
-  template <typename U>
-  static std::enable_if_t<std::is_integral_v<U>, double> test();
-
-  // Floating point types are used as-is.
-  template <typename U>
-  static std::enable_if_t<std::is_floating_point_v<U>, U> test();
-
-public:
-  // We rely on dummy templated methods and decltype to select the right type
-  // based on the input T.
-  typedef decltype(test<T>()) type;
+template <typename T, bool = std::is_integral_v<T>> struct __sycl_promote {
+  using type = double;
 };
 
 // Variant without ::type to allow SFINAE for non-promotable types.
 template <typename T> struct __sycl_promote<T, false> {};
+
+// float and double are left as is
+template <> struct __sycl_promote<float> {
+  using type = float;
+};
+template <> struct __sycl_promote<double> {
+  using type = double;
+};
+// long double is not supported yet, SFNIAE it away explicitly.
+// We don't provide these overloads to makes sure that
+// mixed precision calls that include long double are
+// resolved to the "host" overload (defined by the real <cmath>),
+// matching the behaviour without promotion.
+// our long double overloads would fail to compile because
+// we'd be trying to call non SPIR-V built-ins that don't support long double.
+template <> struct __sycl_promote<long double> {};
 
 // With two or three parameters we need to promote integers and possibly
 // floating point types. We rely on operator+ with decltype to deduce the
@@ -68,6 +69,9 @@ using __sycl_promote_t =
 //
 // TODO: Consider targets that don't have double support.
 // TODO: Enable long double support where possible.
+// TODO: float16_t and bfloat16_t support if the standard library
+//       supports C++23.
+// TODO: constexpr support for these functions (C++23, C++)
 //
 // The following two macros provide an easy way to define these overloads for
 // basic built-ins with one or two floating-point parameters.

--- a/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
+++ b/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
@@ -19,7 +19,6 @@
 #define __SYCL_DEVICE_C                                                        \
   extern "C" __attribute__((sycl_device_only, always_inline))
 
-// For std::enable_if, std::is_integral, std::is_same and std::conjunction
 #include <type_traits>
 
 // Promotion templates: the C++ standard library provides overloads that allow

--- a/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
+++ b/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
@@ -41,7 +41,7 @@ template <> struct __sycl_promote<float> {
 template <> struct __sycl_promote<double> {
   using type = double;
 };
-// long double is not supported yet, SFNIAE it away explicitly.
+// long double is not supported yet, SFINAE it away explicitly.
 // We don't provide these overloads to makes sure that
 // mixed precision calls that include long double are
 // resolved to the "host" overload (defined by the real <cmath>),

--- a/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
+++ b/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
@@ -41,14 +41,14 @@ template <> struct __sycl_promote<float> {
 template <> struct __sycl_promote<double> {
   using type = double;
 };
-// long double is not supported yet, SFINAE it away explicitly.
+// long double is not supported yet, so we don't define it,
+// letting it SFINAE away too.
 // We don't provide these overloads to makes sure that
 // mixed precision calls that include long double are
 // resolved to the "host" overload (defined by the real <cmath>),
-// matching the behaviour without promotion.
-// our long double overloads would fail to compile because
-// we'd be trying to call non SPIR-V built-ins that don't support long double.
-template <> struct __sycl_promote<long double> {};
+// matching the behavior without promotion.
+// Our long double overloads would fail to compile because
+// we'd be trying to call SPIR-V built-ins that don't support long double.
 
 // With two or three parameters we need to promote integers and possibly
 // floating point types. We rely on operator+ with decltype to deduce the

--- a/sycl/test/check_device_code/math-builtins/cmath-fallback-ld.cpp
+++ b/sycl/test/check_device_code/math-builtins/cmath-fallback-ld.cpp
@@ -1,0 +1,19 @@
+// Note: This isn't really target specific and should be switched to spir when
+// it's enabled for it.
+
+// RUN: %clang -fsycl -fsyntax-only -fsycl-targets=nvptx64-nvidia-cuda -nocudalib %s
+
+// Check that mixed calls with long double don't cause compile errors on the device.
+// Long double is not supported on the device for cmath built-ins. We can't
+// make this an error during overload resolution, because in SYCL all functions
+// are semantically checked for both host and device.
+
+#include <cmath>
+
+long double f(double f, double d, long double ld, int *pi) {
+    long double r = 0.l;
+    r = std::fmod(d, ld);
+    r = std::remquo(d, ld, pi);
+    r = std::fma(f, d, ld);
+    return r;
+}

--- a/sycl/test/check_device_code/math-builtins/cmath-fallback-ld.cpp
+++ b/sycl/test/check_device_code/math-builtins/cmath-fallback-ld.cpp
@@ -3,17 +3,17 @@
 
 // RUN: %clang -fsycl -fsyntax-only -fsycl-targets=nvptx64-nvidia-cuda -nocudalib %s
 
-// Check that mixed calls with long double don't cause compile errors on the device.
-// Long double is not supported on the device for cmath built-ins. We can't
-// make this an error during overload resolution, because in SYCL all functions
-// are semantically checked for both host and device.
+// Check that mixed calls with long double don't cause compile errors on the
+// device. Long double is not supported on the device for cmath built-ins. We
+// can't make this an error during overload resolution, because in SYCL all
+// functions are semantically checked for both host and device.
 
 #include <cmath>
 
 long double f(double f, double d, long double ld, int *pi) {
-    long double r = 0.l;
-    r = std::fmod(d, ld);
-    r = std::remquo(d, ld, pi);
-    r = std::fma(f, d, ld);
-    return r;
+  long double r = 0.l;
+  r = std::fmod(d, ld);
+  r = std::remquo(d, ld, pi);
+  r = std::fma(f, d, ld);
+  return r;
 }


### PR DESCRIPTION
Make sure to not define `long double` wrappers in the cmath wrapper. We unintentionally defined these for two or three argument functions with mixed types. These definitions fail to compile if we try to use them, because there are no SPIR-V builtins for long double. By not defining them, overload resolution will pick the "host" versions. We can't make overload resolution fail, because function bodies that are not called on the device still need to be semantically valid for the device.

This was discovered by the SYCL CTS, in its reference implementation for the builtins. That code is never called on the device, but it needs to compile without errors.