### PR TITLE
[Benchmarks] fix IGC compilation

### DIFF
--- a/devops/scripts/benchmarks/git_project.py
+++ b/devops/scripts/benchmarks/git_project.py
@@ -19,17 +19,20 @@ class GitProject:
         directory: Path,
         name: str,
         force_rebuild: bool = False,
+        no_suffix_src: bool = False,
     ) -> None:
         self._url = url
         self._ref = ref
         self._directory = directory
         self._name = name
         self._force_rebuild = force_rebuild
+        self._no_suffix_src = no_suffix_src
         self._rebuild_needed = self._git_clone()
 
     @property
     def src_dir(self) -> Path:
-        return self._directory / f"{self._name}-src"
+        suffix = "" if self._no_suffix_src else "-src"
+        return self._directory / f"{self._name}{suffix}"
 
     @property
     def build_dir(self) -> Path:

--- a/devops/scripts/benchmarks/utils/compute_runtime.py
+++ b/devops/scripts/benchmarks/utils/compute_runtime.py
@@ -95,12 +95,14 @@ class ComputeRuntime:
                 "9d255266e1df8f1dc5d11e1fbb03213acfaa4fc7",
                 Path(options.workdir),
                 "vc-intrinsics",
+                no_suffix_src=True,
             )
             llvm_project = GitProject(
                 "https://github.com/llvm/llvm-project",
                 "llvmorg-15.0.7",
                 Path(options.workdir),
                 "llvm-project",
+                no_suffix_src=True,
             )
             llvm_projects = llvm_project.src_dir / "llvm" / "projects"
             GitProject(
@@ -108,24 +110,28 @@ class ComputeRuntime:
                 "ocl-open-150",
                 llvm_projects,
                 "opencl-clang",
+                no_suffix_src=True,
             )
             GitProject(
                 "https://github.com/KhronosGroup/SPIRV-LLVM-Translator",
                 "llvm_release_150",
                 llvm_projects,
                 "llvm-spirv",
+                no_suffix_src=True,
             )
             GitProject(
                 "https://github.com/KhronosGroup/SPIRV-Tools.git",
                 "f289d047f49fb60488301ec62bafab85573668cc",
                 Path(options.workdir),
                 "SPIRV-Tools",
+                no_suffix_src=True,
             )
             GitProject(
                 "https://github.com/KhronosGroup/SPIRV-Headers.git",
                 "0e710677989b4326ac974fd80c5308191ed80965",
                 Path(options.workdir),
                 "SPIRV-Headers",
+                no_suffix_src=True,
             )
 
             configure_args = [


### PR DESCRIPTION
Recent refactor of compute-runtime utils, #19303, introduced a regression that caused IGC dependencies to be fetched into incorrect directories, causing build failures.

This patch fixes the directory path for IGC directories, allowing the recent compute-runtime drivers to be built.