### PR TITLE
[sycl-rel][CI] Add a token to bypass request limit

### DIFF
--- a/.github/workflows/sycl-rel-nightly-launch.yml
+++ b/.github/workflows/sycl-rel-nightly-launch.yml
@@ -26,7 +26,7 @@ jobs:
         # older >24h. That means the previous run already tested this commit.
         run: |
           if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-            latest_commit_time=$(curl -s https://api.github.com/repos/intel/llvm/commits/sycl-rel-6_2 | jq -r '.commit.committer.date')
+            latest_commit_time=$(curl -s -H "Authorization: token $GH_TOKEN" https://api.github.com/repos/intel/llvm/commits/sycl-rel-6_2 | jq -r '.commit.committer.date')
             echo $latest_commit_time
             latest_commit_epoch=$(date -d "$latest_commit_time" +%s)
             now_epoch=$(date +%s)


### PR DESCRIPTION
In general it works without token, but sometimes the default limit is not enough.