### PR TITLE
[SYCL][NativeCPU] Limit generic ABI to builtins.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -494,6 +494,7 @@ def TargetAnyX86 : TargetArch<["x86", "x86_64"]>;
 def TargetSPIRV : TargetArch<["spirv", "spirv32", "spirv64"]>;
 def TargetWebAssembly : TargetArch<["wasm32", "wasm64"]>;
 def TargetNVPTX : TargetArch<["nvptx", "nvptx64"]>;
+def TargetNativeCPU : TargetArch<["native_cpu"]>;
 def TargetWindows : TargetSpec {
   let OSes = ["Win32"];
 }
@@ -4488,6 +4489,11 @@ def RISCVVLSCC: DeclOrTypeAttr, TargetSpecificAttr<TargetRISCV> {
                   Clang<"riscv_vls_cc">];
  let Args = [UnsignedArgument<"VectorWidth", /*opt*/1>];
  let Documentation = [RISCVVLSCCDocs];
+}
+
+def NativeCPULibclcCall : DeclOrTypeAttr, TargetSpecificAttr<TargetNativeCPU> {
+  let Spellings = [Clang<"libclc_call", 0>];
+  let Documentation = [Undocumented];
 }
 
 def Target : InheritableAttr {

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1702,6 +1702,11 @@ public:
     return CC_C;
   }
 
+  /// Gets the calling convention for libclc built-ins for the given target.
+  virtual CallingConv getLibclcCallingConv() const {
+    return getDefaultCallingConv();
+  }
+
   /// Get the default atomic options.
   AtomicOptions getAtomicOpts() const { return AtomicOpts; }
 

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -4342,6 +4342,7 @@ bool AttributedType::isCallingConv() const {
   case attr::PreserveNone:
   case attr::RISCVVectorCC:
   case attr::RISCVVLSCC:
+  case attr::NativeCPULibclcCall:
     return true;
   }
   llvm_unreachable("invalid attr kind");

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2112,6 +2112,9 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
   case attr::RISCVVLSCC:
     OS << "riscv_vls_cc";
     break;
+  case attr::NativeCPULibclcCall:
+    OS << "libclc_call";
+    break;
   case attr::NoDeref:
     OS << "noderef";
     break;

--- a/clang/lib/Basic/Targets/NativeCPU.cpp
+++ b/clang/lib/Basic/Targets/NativeCPU.cpp
@@ -68,4 +68,5 @@ void NativeCPUTargetInfo::setAuxTarget(const TargetInfo *Aux) {
   assert(Aux && "Cannot invoke setAuxTarget without a valid auxiliary target!");
   copyAuxTarget(Aux);
   getTargetOpts() = Aux->getTargetOpts();
+  resetDataLayout(Aux->getDataLayoutString());
 }

--- a/clang/lib/Basic/Targets/NativeCPU.h
+++ b/clang/lib/Basic/Targets/NativeCPU.h
@@ -49,7 +49,12 @@ public:
 
   void setSupportedOpenCLOpts() override { supportAllOpenCLOpts(); }
 
+  CallingConv getLibclcCallingConv() const override { return CC_SpirFunction; }
+
   CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
+    if (CC == CC_SpirFunction)
+      return CCCR_OK;
+
     if (HostTarget)
       return HostTarget->checkCallingConvention(CC);
 

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -334,6 +334,9 @@ static CallingConv getCallingConventionForDecl(const ObjCMethodDecl *D,
     }
   }
 
+  if (D->hasAttr<NativeCPULibclcCallAttr>())
+    return CC_SpirFunction;
+
   return CC_C;
 }
 

--- a/clang/lib/CodeGen/Targets/NativeCPU.cpp
+++ b/clang/lib/CodeGen/Targets/NativeCPU.cpp
@@ -20,6 +20,8 @@ private:
 public:
   NativeCPUABIInfo(CodeGen::CodeGenTypes &CGT, const ABIInfo *HostABIInfo)
       : DefaultABIInfo(CGT), HostABIInfo(HostABIInfo) {}
+
+  void computeInfo(CGFunctionInfo &FI) const override;
 };
 
 class NativeCPUTargetCodeGenInfo : public TargetCodeGenInfo {
@@ -36,6 +38,17 @@ public:
         HostTargetCodeGenInfo(std::move(HostTargetCodeGenInfo)) {}
 };
 } // namespace
+
+void NativeCPUABIInfo::computeInfo(CGFunctionInfo &FI) const {
+  if (HostABIInfo &&
+      FI.getCallingConvention() != llvm::CallingConv::SPIR_FUNC) {
+    HostABIInfo->computeInfo(FI);
+    return;
+  }
+
+  DefaultABIInfo::computeInfo(FI);
+  FI.setEffectiveCallingConvention(llvm::CallingConv::C);
+}
 
 std::unique_ptr<TargetCodeGenInfo> CodeGen::createNativeCPUTargetCodeGenInfo(
     CodeGenModule &CGM,

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5374,6 +5374,9 @@ static void handleCallConvAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     D->addAttr(::new (S.Context) RISCVVLSCCAttr(S.Context, AL, VectorLength));
     return;
   }
+  case ParsedAttr::AT_NativeCPULibclcCall:
+    D->addAttr(::new (S.Context) NativeCPULibclcCallAttr(S.Context, AL));
+    return;
   default:
     llvm_unreachable("unexpected attribute kind");
   }
@@ -5645,6 +5648,9 @@ bool Sema::CheckCallingConvAttr(const ParsedAttr &Attrs, CallingConv &CC,
     CC = CC_DeviceKernel;
     break;
   }
+  case ParsedAttr::AT_NativeCPULibclcCall:
+    CC = CC_SpirFunction;
+    break;
   default: llvm_unreachable("unexpected attribute kind");
   }
 
@@ -7646,6 +7652,7 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
   case ParsedAttr::AT_PreserveNone:
   case ParsedAttr::AT_RISCVVectorCC:
   case ParsedAttr::AT_RISCVVLSCC:
+  case ParsedAttr::AT_NativeCPULibclcCall:
     handleCallConvAttr(S, D, AL);
     break;
   case ParsedAttr::AT_DeviceKernel:

--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -22,6 +22,7 @@
 #include "clang/AST/ExprCXX.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/LangOptions.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/ModuleLoader.h"
 #include "clang/Lex/Preprocessor.h"
@@ -788,7 +789,7 @@ static void GetProgModelBuiltinFctOverloads(
     std::vector<QualType> &FunctionList, SmallVector<QualType, 1> &RetTypes,
     SmallVector<SmallVector<QualType, 1>, 5> &ArgTypes, bool IsVariadic) {
   FunctionProtoType::ExtProtoInfo PI(
-      Context.getDefaultCallingConvention(false, false, true));
+      Context.getTargetInfo().getLibclcCallingConv());
   PI.Variadic = IsVariadic;
   PI.ExceptionSpec = FunctionProtoType::ExceptionSpecInfo{EST_BasicNoexcept};
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -144,7 +144,8 @@ static void diagnoseBadTypeAttribute(Sema &S, const ParsedAttr &attr,
   case ParsedAttr::AT_M68kRTD:                                                 \
   case ParsedAttr::AT_PreserveNone:                                            \
   case ParsedAttr::AT_RISCVVectorCC:                                           \
-  case ParsedAttr::AT_RISCVVLSCC
+  case ParsedAttr::AT_RISCVVLSCC:                                              \
+  case ParsedAttr::AT_NativeCPULibclcCall
 
 // Function type attributes.
 #define FUNCTION_TYPE_ATTRS_CASELIST                                           \
@@ -7659,6 +7660,8 @@ static Attr *getCCTypeAttr(ASTContext &Ctx, ParsedAttr &Attr) {
 
     return ::new (Ctx) RISCVVLSCCAttr(Ctx, Attr, ABIVLen);
   }
+  case ParsedAttr::AT_NativeCPULibclcCall:
+    return createSimpleAttr<NativeCPULibclcCallAttr>(Ctx, Attr);
   }
   llvm_unreachable("unexpected attribute kind!");
 }

--- a/libclc/clc/include/clc/clcfunc.h
+++ b/libclc/clc/include/clc/clcfunc.h
@@ -22,6 +22,10 @@
 #define _CLC_DEF
 #elif defined(CLC_CLSPV)
 #define _CLC_DEF __attribute__((noinline)) __attribute__((clspv_libclc_builtin))
+#elif defined(CLC_NATIVE_CPU)
+#define _CLC_DEF __attribute__((always_inline)) __attribute__((libclc_call))
+#undef _CLC_DECL
+#define _CLC_DECL __attribute__((libclc_call))
 #else
 #define _CLC_DEF __attribute__((always_inline))
 #endif

--- a/libdevice/nativecpu_utils.cpp
+++ b/libdevice/nativecpu_utils.cpp
@@ -25,9 +25,10 @@ using __nativecpu_state = native_cpu::state;
 
 #undef DEVICE_EXTERNAL
 #undef DEVICE_EXTERN_C
-#define DEVICE_EXTERN_C extern "C" SYCL_EXTERNAL
+#define DEVICE_EXTERN_C extern "C" SYCL_EXTERNAL __attribute__((libclc_call))
 #define DEVICE_EXTERNAL_C DEVICE_EXTERN_C __attribute__((always_inline))
-#define DEVICE_EXTERNAL SYCL_EXTERNAL __attribute__((always_inline))
+#define DEVICE_EXTERNAL                                                        \
+  SYCL_EXTERNAL __attribute__((always_inline, libclc_call))
 
 // Several functions are used implicitly by WorkItemLoopsPass and
 // PrepareSYCLNativeCPUPass and need to be marked as used to prevent them being

--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -1472,6 +1472,13 @@ Error IRLinker::run() {
     EnableTripleWarning = !SrcHasLibDeviceTriple;
     EnableDLWarning = !(SrcHasLibDeviceTriple && SrcHasLibDeviceDL);
   }
+  // Likewise, during SYCL Native CPU compilation we link with bitcode with a
+  // generic data layout, which is compatible with the concrete host data layout
+  // and the concrete host target that we use later on.
+  if (SrcTriple.isNativeCPU()) {
+    EnableDLWarning = false;
+    EnableTripleWarning = false;
+  }
 
   if (EnableDLWarning && (SrcM->getDataLayout() != DstM.getDataLayout())) {
     emitWarning("Linking two modules of different data layouts: '" +

--- a/sycl/include/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/detail/defines_elementary.hpp
@@ -25,7 +25,12 @@
 #endif // __SYCL_ALWAYS_INLINE
 
 #ifdef SYCL_EXTERNAL
+#ifdef __NativeCPU__
+#define __DPCPP_SYCL_EXTERNAL SYCL_EXTERNAL __attribute__((__libclc_call__))
+#define __DPCPP_SYCL_EXTERNAL_LIBC SYCL_EXTERNAL
+#else
 #define __DPCPP_SYCL_EXTERNAL SYCL_EXTERNAL
+#endif
 #else
 #ifdef __SYCL_DEVICE_ONLY__
 #define __DPCPP_SYCL_EXTERNAL __attribute__((sycl_device))


### PR DESCRIPTION
In #17408, NativeCPU became a target in order to be able to pick the ABI for its own libclc functions consistently, without having targets affect this. This was, and is, required to be able to use libclc independent of target and target options. However, it breaks some calls into libc. Therefore, this PR allows the calling convention to be explicitly specified, ensures it is specified for any libclc functions, and ensures it is not specified for any libc functions.

Fixes the SYCL-E2E acos, cmath, and exp-std-complex tests.