### PR TITLE
[SYCL][NFC] Decouple property parsing from `KernelWrapper`

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1294,7 +1294,10 @@ private:
 
       detail::KernelWrapper<detail::WrapAs::parallel_for, KName,
                             decltype(Wrapper), TransformedArgType,
-                            decltype(this), PropertiesT>::wrap(this, Wrapper);
+                            PropertiesT>::wrap(Wrapper);
+
+      detail::KernelLaunchPropertyWrapper::parseProperties<KName>(this,
+                                                                  Wrapper);
 #ifndef __SYCL_DEVICE_ONLY__
       constexpr detail::string_view Name{detail::getKernelName<NameT>()};
       verifyUsedKernelBundleInternal(Name);
@@ -1319,8 +1322,9 @@ private:
       // If parallel_for range rounding is forced then only range rounded
       // kernel is generated
       detail::KernelWrapper<detail::WrapAs::parallel_for, NameT, KernelType,
-                            TransformedArgType, decltype(this),
-                            PropertiesT>::wrap(this, KernelFunc);
+                            TransformedArgType, PropertiesT>::wrap(KernelFunc);
+      detail::KernelLaunchPropertyWrapper::parseProperties<NameT>(this,
+                                                                  KernelFunc);
 #ifndef __SYCL_DEVICE_ONLY__
       constexpr detail::string_view Name{detail::getKernelName<NameT>()};
 
@@ -1400,7 +1404,9 @@ private:
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
     (void)Props;
     detail::KernelWrapper<WrapAsVal, NameT, KernelType, ElementType,
-                          decltype(this), PropertiesT>::wrap(this, KernelFunc);
+                          PropertiesT>::wrap(KernelFunc);
+    detail::KernelLaunchPropertyWrapper::parseProperties<NameT>(this,
+                                                                KernelFunc);
 #ifndef __SYCL_DEVICE_ONLY__
     if constexpr (WrapAsVal == detail::WrapAs::single_task) {
       throwOnKernelParameterMisuse<KernelName, KernelType>();
@@ -1441,7 +1447,9 @@ private:
     (void)Props;
     (void)Kernel;
     detail::KernelWrapper<WrapAsVal, NameT, KernelType, ElementType,
-                          decltype(this), PropertiesT>::wrap(this, KernelFunc);
+                          PropertiesT>::wrap(KernelFunc);
+    detail::KernelLaunchPropertyWrapper::parseProperties<NameT>(this,
+                                                                KernelFunc);
 #ifndef __SYCL_DEVICE_ONLY__
     if constexpr (WrapAsVal == detail::WrapAs::single_task) {
       throwOnKernelParameterMisuse<KernelName, KernelType>();
@@ -3643,9 +3651,7 @@ private:
   void instantiateKernelOnHost(void *InstantiateKernelOnHostPtr);
 
   friend class detail::HandlerAccess;
-  template <detail::WrapAs, typename, typename, typename, typename, typename,
-            typename>
-  friend struct detail::KernelWrapper;
+  friend struct detail::KernelLaunchPropertyWrapper;
 
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
   __SYCL_DLL_LOCAL detail::handler_impl *get_impl() { return impl; }


### PR DESCRIPTION
Motivation behind this PR is to club together all data members and functions required for parsing kernel launch properties, so that this code can be reused for the no-handler submission path.