### PR TITLE
[CI] Install clang and libc++ in build containers

### DIFF
--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -26,7 +26,7 @@ apt update && apt install -yqq \
       curl \
       libhwloc-dev \
       libzstd-dev \
-      time
+      time 
 
 # To obtain latest release of spriv-tool.
 # Same as what's done in SPRIV-LLVM-TRANSLATOR:
@@ -36,3 +36,9 @@ apt update && apt install -yqq \
 curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | apt-key add -
 echo "deb https://packages.lunarg.com/vulkan $VERSION_CODENAME main" | tee -a /etc/apt/sources.list
 apt update && apt install -yqq spirv-tools pkg-config
+
+if [[ "$VERSION_CODENAME" == "jammy" ]]; then
+    apt-get install -yqq clang-14 libc++-14-dev
+else
+    apt-get install -yqq clang-18 libc++-18-dev
+fi


### PR DESCRIPTION
I'm planning to add a build using libc++ to the nightly, so we need clang and libc++ installed.

Installing clang shouldn't cause a problem with the wrong clang being used for LIT testing as we pass the absolute path to the built clang, ex here.

build-e2e:
```
Run cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e \ 
-DCMAKE_CXX_COMPILER="$GITHUB_WORKSPACE/toolchain/bin/clang++" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" 
```

run-e2e:
```
  echo PATH=$PWD/toolchain/bin/:$PATH >> $GITHUB_ENV
```

We need to specify the clang version to install because of some Ubuntu nonsense.