### PR TITLE
Fix build when linking against SPIRVLib with SPIR-V backend

### DIFF
--- a/llvm-spirv/lib/SPIRV/CMakeLists.txt
+++ b/llvm-spirv/lib/SPIRV/CMakeLists.txt
@@ -40,9 +40,8 @@ set(SRC_LIST
   libSPIRV/SPIRVValue.cpp
   libSPIRV/SPIRVError.cpp
 )
-add_llvm_library(LLVMSPIRVLib
-  ${SRC_LIST}
-  LINK_COMPONENTS
+
+set(SPIRVLIB_LINK_COMPONENTS
     Analysis
     BitWriter
     CodeGen
@@ -54,6 +53,16 @@ add_llvm_library(LLVMSPIRVLib
     Support
     TargetParser
     TransformUtils
+    )
+
+if(SPIRV_BACKEND_FOUND)
+  list(APPEND SPIRVLIB_LINK_COMPONENTS "SPIRVCodeGen")
+endif()
+
+  add_llvm_library(LLVMSPIRVLib
+  ${SRC_LIST}
+  LINK_COMPONENTS
+    ${SPIRVLIB_LINK_COMPONENTS}
   DEPENDS
     intrinsics_gen
   )

--- a/llvm-spirv/tools/llvm-spirv/CMakeLists.txt
+++ b/llvm-spirv/tools/llvm-spirv/CMakeLists.txt
@@ -10,10 +10,6 @@ set(LLVM_LINK_COMPONENTS
   TransformUtils
 )
 
-if(SPIRV_BACKEND_FOUND)
-  list(APPEND LLVM_LINK_COMPONENTS "SPIRVCodeGen")
-endif()
-
 # llvm_setup_rpath messes with the rpath making llvm-spirv not
 # executable from the build directory in out-of-tree builds
 set(add_llvm_tool_options)


### PR DESCRIPTION
Cherry pick of https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3274

Needed to fix shared library build.