### PR TITLE
[CI] Detect changes to libdevice

### DIFF
--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -54,6 +54,8 @@ jobs:
               - *libclc
               - 'sycl/*'
               - 'sycl/!(test-e2e|doc)/**'
+            libdevice: &libdevice
+              - 'libdevice/**'
             ci:
               - .github/workflows/**
               # devops/* contains config files, including drivers versions.
@@ -100,7 +102,7 @@ jobs:
               return '${{ steps.changes.outputs.changes }}';
             }
             // Treat everything as changed for huge PRs.
-            return ["llvm", "llvm_spirv", "clang", "sycl_jit", "xptifw", "libclc", "sycl", "ci", "esimd", "ur", "ur_cuda_adapter", "ur_offload_adapter"];
+            return ["llvm", "llvm_spirv", "clang", "sycl_jit", "xptifw", "libclc", "sycl", "libdevice", "ci", "esimd", "ur", "ur_cuda_adapter", "ur_offload_adapter"];
 
       - run: echo '${{ steps.result.outputs.result }}'
      

--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -54,7 +54,6 @@ jobs:
               - *libclc
               - 'sycl/*'
               - 'sycl/!(test-e2e|doc)/**'
-            libdevice: &libdevice
               - 'libdevice/**'
             ci:
               - .github/workflows/**
@@ -102,7 +101,7 @@ jobs:
               return '${{ steps.changes.outputs.changes }}';
             }
             // Treat everything as changed for huge PRs.
-            return ["llvm", "llvm_spirv", "clang", "sycl_jit", "xptifw", "libclc", "sycl", "libdevice", "ci", "esimd", "ur", "ur_cuda_adapter", "ur_offload_adapter"];
+            return ["llvm", "llvm_spirv", "clang", "sycl_jit", "xptifw", "libclc", "sycl", "ci", "esimd", "ur", "ur_cuda_adapter", "ur_offload_adapter"];
 
       - run: echo '${{ steps.result.outputs.result }}'
      

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -42,7 +42,7 @@ on:
       changes:
         type: string
         description: 'Filter matches for the changed files in the PR'
-        default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc, libdevice]'
+        default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc]'
         required: false
       retention-days:
         description: 'Artifacts retention period'
@@ -70,7 +70,7 @@ on:
         type: choice
         options:
           - "[]"
-          - '[llvm, clang, sycl, llvm_spirv, xptifw, libclc, libdevice]'
+          - '[llvm, clang, sycl, llvm_spirv, xptifw, libclc]'
       build_image:
         type: choice
         options:
@@ -218,7 +218,7 @@ jobs:
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-libclc
     - name: check-libdevice
-      if: always() && !cancelled() && contains(inputs.changes, 'libdevice')
+      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-libdevice
     - name: Check E2E test requirements

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -17,7 +17,7 @@ on:
       changes:
         type: string
         description: 'Filter matches for the changed files in the PR'
-        default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc, libdevice]'
+        default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc]'
         required: false
       ref:
         type: string
@@ -54,7 +54,7 @@ on:
         options:
           - "[]"
           - '[sycl]'
-          - '[llvm, clang, sycl, llvm_spirv, xptifw, libclc, libdevice]'
+          - '[llvm, clang, sycl, llvm_spirv, xptifw, libclc]'
       build_cache_suffix:
         type: choice
         options:
@@ -180,7 +180,7 @@ jobs:
       run: |
         cmake --build build --target check-xptifw
     - name: check-libdevice
-      if: always() && !cancelled() && contains(inputs.changes, 'libdevice')
+      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
       run: |
         cmake --build build --target check-libdevice
     - name: Generate/diff new ABI symbols

--- a/libdevice/cmake/modules/ImfSrcConcate.cmake
+++ b/libdevice/cmake/modules/ImfSrcConcate.cmake
@@ -1,4 +1,4 @@
-set(imf_fp32_fallback_src_list imf_utils/integer_misc.cpp 
+set(imf_fp32_fallback_src_list imf_utils/integer_misc.cpp
                                imf_utils/half_convert.cpp
                                imf_utils/float_convert.cpp
                                imf_utils/simd_emulate.cpp

--- a/libdevice/cmake/modules/ImfSrcConcate.cmake
+++ b/libdevice/cmake/modules/ImfSrcConcate.cmake
@@ -1,4 +1,4 @@
-set(imf_fp32_fallback_src_list imf_utils/integer_misc.cpp
+set(imf_fp32_fallback_src_list imf_utils/integer_misc.cpp 
                                imf_utils/half_convert.cpp
                                imf_utils/float_convert.cpp
                                imf_utils/simd_emulate.cpp


### PR DESCRIPTION
We check this in the windows/linux build workflows but we never set it, so use the existing `sycl` specifier.

Closes: https://github.com/intel/llvm/issues/19573