### PR TITLE
[NFC][SYCL] No need for `std::optional<ur_event_handle_t>` in `device_global_map_entry`

### DIFF
--- a/sycl/source/detail/device_global_map_entry.cpp
+++ b/sycl/source/detail/device_global_map_entry.cpp
@@ -22,23 +22,23 @@ DeviceGlobalUSMMem::~DeviceGlobalUSMMem() {
   // and the event. When asserts are enabled the values are set, so we check
   // these here.
   assert(MPtr == nullptr && "MPtr has not been cleaned up.");
-  assert(!MInitEvent.has_value() && "MInitEvent has not been cleaned up.");
+  assert(MInitEvent == nullptr && "MInitEvent has not been cleaned up.");
 }
 
 OwnedUrEvent DeviceGlobalUSMMem::getInitEvent(adapter_impl &Adapter) {
   std::lock_guard<std::mutex> Lock(MInitEventMutex);
+  if (MInitEvent == nullptr)
+    return OwnedUrEvent(Adapter);
+
   // If there is a init event we can remove it if it is done.
-  if (MInitEvent.has_value()) {
-    if (get_event_info<info::event::command_execution_status>(
-            *MInitEvent, Adapter) == info::event_command_status::complete) {
-      Adapter.call<UrApiKind::urEventRelease>(*MInitEvent);
-      MInitEvent = {};
-      return OwnedUrEvent(Adapter);
-    } else {
-      return OwnedUrEvent(*MInitEvent, Adapter);
-    }
+  if (get_event_info<info::event::command_execution_status>(
+          MInitEvent, Adapter) == info::event_command_status::complete) {
+    Adapter.call<UrApiKind::urEventRelease>(MInitEvent);
+    MInitEvent = nullptr;
+    return OwnedUrEvent(Adapter);
+  } else {
+    return OwnedUrEvent(MInitEvent, Adapter);
   }
-  return OwnedUrEvent(Adapter);
 }
 
 DeviceGlobalUSMMem &
@@ -158,14 +158,14 @@ void DeviceGlobalMapEntry::removeAssociatedResources(
     if (USMPtrIt != MDeviceToUSMPtrMap.end()) {
       DeviceGlobalUSMMem &USMMem = USMPtrIt->second;
       detail::usm::freeInternal(USMMem.MPtr, CtxImpl);
-      if (USMMem.MInitEvent.has_value())
+      if (USMMem.MInitEvent != nullptr)
         CtxImpl->getAdapter().call<UrApiKind::urEventRelease>(
-            *USMMem.MInitEvent);
+            USMMem.MInitEvent);
 #ifndef NDEBUG
       // For debugging we set the event and memory to some recognizable values
       // to allow us to check that this cleanup happens before erasure.
       USMMem.MPtr = nullptr;
-      USMMem.MInitEvent = {};
+      USMMem.MInitEvent = nullptr;
 #endif
       MDeviceToUSMPtrMap.erase(USMPtrIt);
     }
@@ -183,13 +183,13 @@ void DeviceGlobalMapEntry::cleanup() {
     const context_impl *CtxImpl = USMPtrIt.first.second;
     DeviceGlobalUSMMem &USMMem = USMPtrIt.second;
     detail::usm::freeInternal(USMMem.MPtr, CtxImpl);
-    if (USMMem.MInitEvent.has_value())
-      CtxImpl->getAdapter().call<UrApiKind::urEventRelease>(*USMMem.MInitEvent);
+    if (USMMem.MInitEvent != nullptr)
+      CtxImpl->getAdapter().call<UrApiKind::urEventRelease>(USMMem.MInitEvent);
 #ifndef NDEBUG
     // For debugging we set the event and memory to some recognizable values
     // to allow us to check that this cleanup happens before erasure.
     USMMem.MPtr = nullptr;
-    USMMem.MInitEvent = {};
+    USMMem.MInitEvent = nullptr;
 #endif
   }
   MDeviceToUSMPtrMap.clear();

--- a/sycl/source/detail/device_global_map_entry.hpp
+++ b/sycl/source/detail/device_global_map_entry.hpp
@@ -44,7 +44,7 @@ struct DeviceGlobalUSMMem {
 private:
   void *MPtr;
   std::mutex MInitEventMutex;
-  std::optional<ur_event_handle_t> MInitEvent;
+  ur_event_handle_t MInitEvent = nullptr;
 
   friend struct DeviceGlobalMapEntry;
 };


### PR DESCRIPTION
Using `nullptr` for not having an event is just fine.