### PR TITLE
[NFCI][SYCL] Change `scheduler::enqueueCommandForCG` to accept `event_impl &`

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -285,7 +285,7 @@ Command::getUrEventsBlocking(const std::vector<EventImplPtr> &EventImpls,
           !EventImpl->getCommand()->producesPiEvent())
         continue;
       std::vector<Command *> AuxCmds;
-      Scheduler::getInstance().enqueueCommandForCG(EventImpl, AuxCmds,
+      Scheduler::getInstance().enqueueCommandForCG(*EventImpl, AuxCmds,
                                                    BLOCKING);
     }
     // Do not add redundant event dependencies for in-order queues.

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -144,7 +144,7 @@ EventImplPtr Scheduler::addCG(
     }
   }
 
-  enqueueCommandForCG(NewEvent, AuxiliaryCmds);
+  enqueueCommandForCG(*NewEvent, AuxiliaryCmds);
 
   if (!AuxiliaryResources.empty())
     registerAuxiliaryResources(NewEvent, std::move(AuxiliaryResources));
@@ -152,23 +152,21 @@ EventImplPtr Scheduler::addCG(
   return NewEvent;
 }
 
-void Scheduler::enqueueCommandForCG(EventImplPtr NewEvent,
+void Scheduler::enqueueCommandForCG(event_impl &Event,
                                     std::vector<Command *> &AuxiliaryCmds,
                                     BlockingT Blocking) {
   std::vector<Command *> ToCleanUp;
   {
     ReadLockT Lock = acquireReadLock();
 
-    Command *NewCmd = (NewEvent) ? NewEvent->getCommand() : nullptr;
+    Command *NewCmd = Event.getCommand();
 
     EnqueueResultT Res;
     bool Enqueued;
 
     auto CleanUp = [&]() {
       if (NewCmd && (NewCmd->MDeps.size() == 0 && NewCmd->MUsers.size() == 0)) {
-        if (NewEvent) {
-          NewEvent->setCommand(nullptr);
-        }
+        Event.setCommand(nullptr);
         delete NewCmd;
       }
       cleanupCommands(ToCleanUp);

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -465,7 +465,7 @@ public:
   void releaseResources(BlockingT Blocking = BlockingT::BLOCKING);
   bool isDeferredMemObjectsEmpty();
 
-  void enqueueCommandForCG(EventImplPtr NewEvent,
+  void enqueueCommandForCG(event_impl &Event,
                            std::vector<Command *> &AuxilaryCmds,
                            BlockingT Blocking = NON_BLOCKING);
 


### PR DESCRIPTION
Before this PR, its implementation had code paths for `nullptr` argument, but it's never `nullptr` at any of the call sites. Originally, this method was added in https://github.com/intel/llvm/pull/7531 and was called with `nullptr` argument from some fusion code (at least), but it doesn't seem to be the case anymore (and fusion support has been removed from the project).

Also, for some reason it was accepting `std::shared_ptr<event_impl>` by value and not by reference (no idea why), and the name was `NewEvent` without any comments/documentation. The former is irrelevant after this change, and for the latter I'm changing the name to a neutral "Event". If someone has a better understanding, please let me know.