### PR TITLE
[SYCL][CMake] Apply SYCL_LIBDEVICE_CXX_FLAGS to IMF host compile

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -56,13 +56,18 @@ set(compile_opts
 set(SYCL_LIBDEVICE_GCC_TOOLCHAIN "" CACHE PATH "Path to GCC installation")
 
 set(SYCL_LIBDEVICE_CXX_FLAGS "" CACHE STRING "C++ compiler flags for SYCL libdevice")
+if(NOT SYCL_LIBDEVICE_CXX_FLAGS STREQUAL "")
+  separate_arguments(SYCL_LIBDEVICE_CXX_FLAGS NATIVE_COMMAND ${SYCL_LIBDEVICE_CXX_FLAGS})
+endif()
+
 if (NOT SYCL_LIBDEVICE_GCC_TOOLCHAIN STREQUAL "")
   list(APPEND SYCL_LIBDEVICE_CXX_FLAGS "--gcc-install-dir=${SYCL_LIBDEVICE_GCC_TOOLCHAIN}")
 endif()
+
 if(NOT SYCL_LIBDEVICE_CXX_FLAGS STREQUAL "")
-  separate_arguments(SYCL_LIBDEVICE_CXX_FLAGS NATIVE_COMMAND ${SYCL_LIBDEVICE_CXX_FLAGS})
   list(APPEND compile_opts ${SYCL_LIBDEVICE_CXX_FLAGS})
 endif()
+
 if(LLVM_LIBCXX_USED)
   list(APPEND compile_opts "-stdlib=libc++")
 endif()

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -646,6 +646,7 @@ set(imf_bf16_fallback_src ${imf_fallback_src_dir}/imf_bf16_fallback.cpp)
 set(imf_host_cxx_flags -c
   --target=${LLVM_HOST_TRIPLE}
   -D__LIBDEVICE_HOST_IMPL__
+  ${SYCL_LIBDEVICE_CXX_FLAGS}
 )
 
 if (NOT SYCL_LIBDEVICE_GCC_TOOLCHAIN STREQUAL "")

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -57,7 +57,7 @@ set(SYCL_LIBDEVICE_GCC_TOOLCHAIN "" CACHE PATH "Path to GCC installation")
 
 set(SYCL_LIBDEVICE_CXX_FLAGS "" CACHE STRING "C++ compiler flags for SYCL libdevice")
 if (NOT SYCL_LIBDEVICE_GCC_TOOLCHAIN STREQUAL "")
-  list(APPEND compile_opts "--gcc-install-dir=${SYCL_LIBDEVICE_GCC_TOOLCHAIN}")
+  list(APPEND SYCL_LIBDEVICE_CXX_FLAGS "--gcc-install-dir=${SYCL_LIBDEVICE_GCC_TOOLCHAIN}")
 endif()
 if(NOT SYCL_LIBDEVICE_CXX_FLAGS STREQUAL "")
   separate_arguments(SYCL_LIBDEVICE_CXX_FLAGS NATIVE_COMMAND ${SYCL_LIBDEVICE_CXX_FLAGS})
@@ -648,10 +648,6 @@ set(imf_host_cxx_flags -c
   -D__LIBDEVICE_HOST_IMPL__
   ${SYCL_LIBDEVICE_CXX_FLAGS}
 )
-
-if (NOT SYCL_LIBDEVICE_GCC_TOOLCHAIN STREQUAL "")
-  list(APPEND imf_host_cxx_flags "--gcc-install-dir=${SYCL_LIBDEVICE_GCC_TOOLCHAIN}")
-endif()
 
 if(LLVM_LIBCXX_USED)
   list(APPEND  imf_host_cxx_flags "-stdlib=libc++")


### PR DESCRIPTION
We need to apply the custom flags both to the libdevice BC file generation and the imf host compile, as these flags could contain paths to stdlibc++ or glibc which are used in both.

I forgot to do this in my [change](https://github.com/intel/llvm/pull/19521) adding this flag.