### PR TITLE
[NFCI][SYCL] Don't get `&Self` in `device_impl` from `MPlatform`

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -375,11 +375,9 @@ uint64_t device_impl::getCurrentDeviceTime() {
 bool device_impl::extOneapiCanBuild(
     ext::oneapi::experimental::source_language Language) {
   try {
-    // Get the shared_ptr to this object from the platform that owns it.
-    device_impl &Self = MPlatform->getOrMakeDeviceImpl(MDevice);
     return sycl::ext::oneapi::experimental::detail::
         is_source_kernel_bundle_supported(Language,
-                                          std::vector<device_impl *>{&Self});
+                                          std::vector<device_impl *>{this});
 
   } catch (sycl::exception &) {
     return false;
@@ -390,11 +388,10 @@ bool device_impl::extOneapiCanCompile(
     ext::oneapi::experimental::source_language Language) {
   try {
     // Currently only SYCL language is supported for compiling.
-    device_impl &Self = MPlatform->getOrMakeDeviceImpl(MDevice);
     return Language == ext::oneapi::experimental::source_language::sycl &&
            sycl::ext::oneapi::experimental::detail::
                is_source_kernel_bundle_supported(
-                   Language, std::vector<device_impl *>{&Self});
+                   Language, std::vector<device_impl *>{this});
   } catch (sycl::exception &) {
     return false;
   }


### PR DESCRIPTION
Looks like it was necessary when we used `std::shared_ptr<device_impl>` a lot more. No need for it now.