### PR TITLE
[SYCL][UR][L0 v2] use UR ioq by default (even for ooo sycl queue)

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -160,6 +160,7 @@ For a description of parallel for range rounding in DPC++ see
 | `SYCL_PI_LEVEL_ZERO_DISABLE_USM_ALLOCATOR` | Any(\*) | Disable USM allocator in Level Zero adapter (each memory request will go directly to Level Zero runtime) |
 | `SYCL_PI_LEVEL_ZERO_TRACK_INDIRECT_ACCESS_MEMORY` | Any(\*) | Enable support of the kernels with indirect access and corresponding deferred release of memory allocations in the Level Zero adapter. |
 | `SYCL_UR_USE_LEVEL_ZERO_V2` | Integer | Enable ('1') or disable ('0') the use of a preview version of the Level Zero adapter, which features a redesigned architecture aimed at optimizing performance for different queue modes (immediate/batched, in-order/out-of-order). This version is expected to reduce runtime overhead and currently only support immediate, in-order mode. If you experience any performance or functional issues with this adapter enabled, please report them on GitHub, specifying the adapter used. |
+| `SYCL_UR_LEVEL_ZERO_USE_OOO_CMD_LIST` | Integer | By default L0 adapter will use a single in-order command list to back a SYCL queue, even if Out-of-order queue is requested. This offers the best performance in most cases. If actual Out-of-order behavior is needed, this env variable should be set to '1'.
 
 `(*) Note: Any means this environment variable is effective when set to any non-null value.`
 


### PR DESCRIPTION
SYCL queue is created as Out-of-order by default. The performance of OOO queue in L0 v2 adapter is significantly worse than the performance of the in-order queue and also worse than OOO queue in the legacy adapter.

Make IOQ the default choice, even if OOO is requested, unless user explicitly asks for OOO, by setting an env variable.