### PR TITLE
[SYCL][LIT] Disable tests that fail with libc++

### DIFF
--- a/sycl/test/basic_tests/accessor/host-acc-assign-op.cpp
+++ b/sycl/test/basic_tests/accessor/host-acc-assign-op.cpp
@@ -1,6 +1,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %t.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 #include <sycl/sycl.hpp>
 
 int main() {

--- a/sycl/test/basic_tests/accessor/target_device.cpp
+++ b/sycl/test/basic_tests/accessor/target_device.cpp
@@ -1,5 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 // This short test simply confirms that target::device
 // is supported correctly.
 // TODO: delete this test and test the functionality

--- a/sycl/test/basic_tests/builtins/relational_builtins.cpp
+++ b/sycl/test/basic_tests/builtins/relational_builtins.cpp
@@ -1,6 +1,9 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t.out %}
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 // NOTE: Compile the test fully to ensure the library exports the right host
 // symbols.
 

--- a/sycl/test/basic_tests/device-selectors-exception.cpp
+++ b/sycl/test/basic_tests/device-selectors-exception.cpp
@@ -5,6 +5,9 @@
 // all.
 // RUN: %if preview-breaking-changes-supported %{ env ONEAPI_DEVICE_SELECTOR="*:-1" %t.out %}
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 #include <sycl/sycl.hpp>
 using namespace sycl;
 

--- a/sycl/test/basic_tests/group.cpp
+++ b/sycl/test/basic_tests/group.cpp
@@ -1,6 +1,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %t.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 //==--------------- group.cpp - SYCL group test ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/host_image_accessor_read.cpp
+++ b/sycl/test/basic_tests/host_image_accessor_read.cpp
@@ -1,6 +1,9 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %t.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 //==---- host_image_accessor_read.cpp - SYCL host image accessor check ----==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/id.cpp
+++ b/sycl/test/basic_tests/id.cpp
@@ -3,6 +3,9 @@
 // RUN: %clangxx -D__SYCL_DISABLE_ID_TO_INT_CONV__ -fsycl %s -o %t_dis.out
 // RUN: %t_dis.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 //==--------------- id.cpp - SYCL id test ----------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/item.cpp
+++ b/sycl/test/basic_tests/item.cpp
@@ -1,5 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %t.out
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 //==--------------- item.cpp - SYCL item test ------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/range.cpp
+++ b/sycl/test/basic_tests/range.cpp
@@ -1,5 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %t.out
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 //==--------------- range.cpp - SYCL range test ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/vectors/vectors.cpp
+++ b/sycl/test/basic_tests/vectors/vectors.cpp
@@ -2,6 +2,8 @@
 // RUN: %t_default.out
 // RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t_vec.out %}
 // RUN: %if preview-breaking-changes-supported %{ %t_vec.out %}
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 
 //==--------------- vectors.cpp - SYCL vectors test ------------------------==//
 //

--- a/sycl/test/esimd/odr.cpp
+++ b/sycl/test/esimd/odr.cpp
@@ -10,6 +10,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown -DSOURCE2 -c %s -o %t2.o
 // RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown %t1.o %t2.o -o %t.exe
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 #include <iostream>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>

--- a/sycl/test/extensions/device_architecture/device_architecture.cpp
+++ b/sycl/test/extensions/device_architecture/device_architecture.cpp
@@ -5,6 +5,9 @@
 
 // RUN: %clangxx -fsycl -DSYCL_EXT_ONEAPI_DEVICE_ARCHITECTURE_NEW_DESIGN_IMPL %s -o %t.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 #include <sycl/ext/oneapi/experimental/device_architecture.hpp>
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/invoke_simd/return-type-uniform.cpp
+++ b/sycl/test/invoke_simd/return-type-uniform.cpp
@@ -1,4 +1,7 @@
 // RUN: %clangxx -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %s -o /dev/null
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 #include <sycl/sycl.hpp>

--- a/sycl/test/matrix/matrix-bfloat16-test-coord-basicB.cpp
+++ b/sycl/test/matrix/matrix-bfloat16-test-coord-basicB.cpp
@@ -1,5 +1,8 @@
 // RUN: %clangxx -fsycl -O2 %s -o %t.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 // Kernel B sum by col
 #include <cmath>
 #include <iostream>

--- a/sycl/test/matrix/matrix-bfloat16-test.cpp
+++ b/sycl/test/matrix/matrix-bfloat16-test.cpp
@@ -1,4 +1,7 @@
 // RUN: %clangxx -fsycl -O2 %s -o %t.out
+
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 #include <iostream>
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/matrix/matrix-elemwise-ops.cpp
+++ b/sycl/test/matrix/matrix-elemwise-ops.cpp
@@ -1,5 +1,8 @@
 // RUN: %clangxx -fsycl -O2 %s -o %t.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 #include <iostream>
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/matrix/matrix-tf32-test.cpp
+++ b/sycl/test/matrix/matrix-tf32-test.cpp
@@ -1,5 +1,8 @@
 // RUN: %clangxx -fsycl -O2 %s -o %t.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 #include <iostream>
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/regression/bit_cast_lin.cpp
+++ b/sycl/test/regression/bit_cast_lin.cpp
@@ -1,4 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -fsycl-host-compiler-options='-std=c++17' %s -o %t.out
 // UNSUPPORTED: windows
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 
 #include "bit_cast.hpp"

--- a/sycl/test/regression/check_config_processing.cpp
+++ b/sycl/test/regression/check_config_processing.cpp
@@ -5,6 +5,9 @@
 // RUN: ls *.dot
 // RUN: rm *.dot
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 #include <iostream>
 #include <regex>
 #include <sycl/sycl.hpp>

--- a/sycl/test/regression/fsycl-save-temps.cpp
+++ b/sycl/test/regression/fsycl-save-temps.cpp
@@ -9,6 +9,9 @@
 // Verify that a sample compilation succeeds with -save-temps
 // RUN: %clangxx -fsycl -save-temps %s -o %t.out
 
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
+
 #include <sycl/sycl.hpp>
 
 void foo() {}

--- a/sycl/test/regression/host_builtins_gcc.cpp
+++ b/sycl/test/regression/host_builtins_gcc.cpp
@@ -3,6 +3,8 @@
 // expected-no-diagnostics
 //
 // REQUIRES: linux
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 //
 // Tests that using gcc as the host compiler correctly compiles SYCL builtins on
 // host.

--- a/sycl/test/regression/memcpy-in-vec-as.cpp
+++ b/sycl/test/regression/memcpy-in-vec-as.cpp
@@ -1,4 +1,6 @@
 // RUN: %clangxx -fsycl -D_FORTIFY_SOURCE=2 %s -o %t.out
+// XFAIL: libcxx
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 #include <iostream>
 #include <sycl/sycl.hpp>
 

--- a/sycl/unittests/program_manager/CMakeLists.txt
+++ b/sycl/unittests/program_manager/CMakeLists.txt
@@ -1,4 +1,7 @@
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# https://github.com/intel/llvm/issues/19597
+if (NOT LLVM_LIBCXX_USED)
 add_sycl_unittest(ProgramManagerTests OBJECT
   CompileTarget.cpp
   BuildLog.cpp
@@ -8,6 +11,7 @@ add_sycl_unittest(ProgramManagerTests OBJECT
   Cleanup.cpp
   MultipleDevsKernelBundle.cpp
 )
+endif()
 
 add_subdirectory(arg_mask)
 add_subdirectory(DynamicLinking)

--- a/sycl/unittests/program_manager/DynamicLinking/CMakeLists.txt
+++ b/sycl/unittests/program_manager/DynamicLinking/CMakeLists.txt
@@ -1,5 +1,8 @@
 # These tests introduce images with unresolved dependencies, which can affect other tests if they use kernel bundle API.
 # TODO this can be merged back into program manager tests once __sycl_unregister_lib is implemented.
+# https://github.com/intel/llvm/issues/19597
+if (NOT LLVM_LIBCXX_USED)
 add_sycl_unittest(DynamicLinkingTests OBJECT
   DynamicLinking.cpp
 )
+endif()

--- a/sycl/unittests/thread_safety/CMakeLists.txt
+++ b/sycl/unittests/thread_safety/CMakeLists.txt
@@ -1,4 +1,7 @@
+# https://github.com/intel/llvm/issues/19591
+if (NOT LLVM_LIBCXX_USED)
 add_sycl_unittest(ThreadSafetyTests OBJECT 
     HostAccessorDeadLock.cpp
     InteropKernelEnqueue.cpp
 )
+endif()


### PR DESCRIPTION
These tests fail when the compiler is built with libc++.