### PR TITLE
[libclc] Let builtins_remangle_path generating command depend on prepare-${obj_suffix} target

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -510,7 +510,7 @@ function(add_libclc_builtin_set)
           --char-signedness=${signedness}
           --input-ir=${builtins_lib}
           ${dummy_in}
-          DEPENDS ${builtins_lib} ${libclc-remangler_target} ${dummy_in})
+          DEPENDS prepare-${obj_suffix} ${builtins_lib} ${libclc-remangler_target} ${dummy_in})
         add_custom_target( "remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}" ALL
           DEPENDS "${builtins_remangle_path}" "${dummy_in}")
         set_target_properties("remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}"


### PR DESCRIPTION
The add_custom_command depends on builtins_lib, but not on prepare-${obj_suffix} target that generates builtins_lib. cmake documentation doesn't mention that the add_custom_command will automatically depends on prepare-${obj_suffix} target.

The dependency was removed in f07c1fa1d88a. However, our downstream repo reintroduced it to fix build error in CMPLRLLVM-57824, where builtins_lib is used while still being generated.
This PR adds the dependency back. Then, cmake will create a target-level dependency to make sure prepare-${obj_suffix} target is built before target "remangled-${long_width}-${signedness}_char.${obj_suffix_mangled}".