### PR TITLE
[DevOps] Build the SPIR-V backend by default

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -46,8 +46,7 @@ jobs:
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults --hip --cuda \
-          -DNATIVECPU_USE_OCK=Off \
-          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
+          -DNATIVECPU_USE_OCK=Off
 
     - name: Build with coverity
       run: $GITHUB_WORKSPACE/cov-analysis-linux64-*/bin/cov-build --dir cov-int cmake --build $GITHUB_WORKSPACE/build --target sycl-toolchain

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -177,8 +177,7 @@ jobs:
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DLLVM_INSTALL_UTILS=ON \
-          -DNATIVECPU_USE_OCK=Off \
-          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
+          -DNATIVECPU_USE_OCK=Off
     - name: Compile
       id: build
       # Emulate default value for manual dispatch as we've run out of available arguments.

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -146,8 +146,7 @@ jobs:
           "-DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install" ^
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
           -DCMAKE_C_COMPILER_LAUNCHER=ccache ^
-          -DLLVM_INSTALL_UTILS=ON ^
-          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
+          -DLLVM_INSTALL_UTILS=ON
     - name: Build
       id: build
       shell: bash

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -46,7 +46,7 @@ def do_configure(args, passthrough_args):
     xptifw_dir = os.path.join(abs_src_dir, "xptifw")
     libdevice_dir = os.path.join(abs_src_dir, "libdevice")
     jit_dir = os.path.join(abs_src_dir, "sycl-jit")
-    llvm_targets_to_build = args.host_target
+    llvm_targets_to_build = args.host_target + ";SPIRV"
     llvm_enable_projects = "clang;" + llvm_external_projects
     libclc_build_native = "OFF"
     libclc_targets_to_build = ""

--- a/clang/test/Driver/sycl-linker-wrapper.cpp
+++ b/clang/test/Driver/sycl-linker-wrapper.cpp
@@ -206,7 +206,7 @@
 // -------
 // Generate .o file as linker wrapper input.
 //
-// RUN: %clang %s -fsycl -fsycl-targets=native_cpu -c --offload-new-driver -o %t6.o
+// RUN: %clang %s -fsycl -fsycl-targets=native_cpu -c --offload-new-driver -fno-sycl-libspirv -o %t6.o
 //
 // RUN: clang-linker-wrapper "--host-triple=x86_64-unknown-linux-gnu" "-sycl-device-library-location=%S/Inputs/native_cpu" "--sycl-post-link-options=SYCL_POST_LINK_OPTIONS" "--linker-path=/usr/bin/ld" "--" HOST_LINKER_FLAGS "-dynamic-linker" HOST_DYN_LIB "-o" "a.out" %t6.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-CMDS-NATIVE-CPU %s
 // CHK-CMDS-NATIVE-CPU: "{{.*}}/spirv-to-ir-wrapper" {{.*}} --llvm-spirv-opts --spirv-preserve-auxdata --spirv-target-env=SPV-IR --spirv-builtin-format=global


### PR DESCRIPTION
It's a non-experimental backend and we test with it in CI here, so build it by default. Note it is still not used by default.

Also fix a failing test with SPV backend enabled and Native CPU disabled.