### PR TITLE
[CI] Add libc++ build job to nightly

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -1,5 +1,9 @@
 name: Reusable SYCL Linux build workflow
 
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_call:
     inputs:
@@ -186,12 +190,21 @@ jobs:
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
       run: |
+        if [[ "${{ inputs.build_configure_extra_args }}" == *"--use-libcxx"* ]]; then
+          # https://github.com/llvm/llvm-project/issues/59429
+          export LIT_FILTER_OUT="ExecutionEngine/MCJIT"
+        fi
+
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm
     - name: check-clang
       if: always() && !cancelled() && contains(inputs.changes, 'clang')
       run: |
         # Can we move this to Dockerfile? Hopefully, noop on Windows.
         export XDG_CACHE_HOME=$GITHUB_WORKSPACE/os_cache
+        if [[ "${{ inputs.build_configure_extra_args }}" == *"--use-libcxx"* ]]; then
+          # https://github.com/llvm/llvm-project/issues/59428
+          export LIT_FILTER_OUT="(E|e)xception"
+        fi
         cmake --build $GITHUB_WORKSPACE/build --target check-clang
     - name: check-sycl
       if: always() && !cancelled() && contains(inputs.changes, 'sycl')
@@ -281,7 +294,6 @@ jobs:
 
     - name: Source OneAPI TBB vars.sh
       if: ${{ inputs.e2e_binaries_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
-      shell: bash
       run: |
         # https://github.com/actions/runner/issues/1964 prevents us from using
         # the ENTRYPOINT in the image.

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -51,6 +51,20 @@ jobs:
 
       artifact_archive_name: sycl_linux_oneapi.tar.zst
 
+  ubuntu2404_libcxx_build:
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl-linux-build.yml
+    secrets: inherit
+    with:
+      build_cache_root: "/__w/"
+      build_cache_suffix: libcxx
+      build_artifact_suffix: libcxx
+      build_configure_extra_args: --use-libcxx -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=OFF
+      cc: clang-18
+      cxx: clang++-18
+
+      artifact_archive_name: sycl_linux_libcxx.tar.zst
+
   ubuntu2204_test:
     needs: [ubuntu2204_build]
     if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}

--- a/sycl/unittests/misc/CMakeLists.txt
+++ b/sycl/unittests/misc/CMakeLists.txt
@@ -1,8 +1,11 @@
 set(sycl_lib_dir $<TARGET_FILE_DIR:sycl>)
 add_definitions(-DSYCL_LIB_DIR="${sycl_lib_dir}")
+# https://github.com/intel/llvm/issues/19626
+if(NOT LLVM_LIBCXX_USED)
 add_sycl_unittest(MiscTests SHARED
   CircularBuffer.cpp
   OsUtils.cpp
   PropertyUtils.cpp
 )
+endif()
 add_subdirectory(LinkGraph)


### PR DESCRIPTION
We are trying to be more packagable by Linux distros so I cleaned up libc++ support, add a build job to lock it down in the nightly.

Run results [here](https://github.com/intel/llvm/actions/runs/16603313011/job/46968573846), `check-clang` fail unrelated, I'm fixing it in another PR.