### PR TITLE
[UR] Update PYTHON_EXECUTABLE to Python3_EXECUTABLE in cmake

### DIFF
--- a/unified-runtime/cmake/helpers.cmake
+++ b/unified-runtime/cmake/helpers.cmake
@@ -279,7 +279,7 @@ function(configure_linker_file input output)
     configure_file(${input} ${tmp} ${ARGN})
     # Strip guarded lines and capture stripped content from stdout
     execute_process(
-        COMMAND ${PYTHON_EXECUTABLE}
+        COMMAND ${Python3_EXECUTABLE}
             ${PROJECT_SOURCE_DIR}/scripts/strip-guarded-lines.py ${tmp}
             # List names of guarded blocks to include in the output file here
         OUTPUT_VARIABLE stripped


### PR DESCRIPTION
`${Python3_EXECUTABLE}` is what is set by FindPython3 and is what is used everywhere else.
`${PYTHON_EXECUTABLE}` may be unset depending, causing the build to fail.

This failure case gets hit when compiling under NixOS for example

There's a few instances of  `PYTHON_EXECUTABLE` left in upstream LLVM, though I haven't verified whether it builds properly with those changed to `Python3_EXECUTABLE`, so they're untouched here.