### PR TITLE
[SPIRV] id and range builtins integration for SYCL

### DIFF
--- a/clang/lib/Headers/__clang_spirv_builtins.h
+++ b/clang/lib/Headers/__clang_spirv_builtins.h
@@ -53,30 +53,30 @@
 
 // Builtin IDs and sizes
 
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_num_workgroups) __size_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_num_workgroups) __size_t
     __spirv_BuiltInNumWorkgroups(int);
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_workgroup_size) __size_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_workgroup_size) __size_t
     __spirv_BuiltInWorkgroupSize(int);
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_workgroup_id) __size_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_workgroup_id) __size_t
     __spirv_BuiltInWorkgroupId(int);
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_local_invocation_id) __size_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_local_invocation_id) __size_t
     __spirv_BuiltInLocalInvocationId(int);
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_global_invocation_id) __size_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_global_invocation_id) __size_t
     __spirv_BuiltInGlobalInvocationId(int);
 
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_global_size) __size_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_global_size) __size_t
     __spirv_BuiltInGlobalSize(int);
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_global_offset) __size_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_global_offset) __size_t
     __spirv_BuiltInGlobalOffset(int);
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_subgroup_size) __uint32_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_subgroup_size) __uint32_t
     __spirv_BuiltInSubgroupSize();
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_subgroup_max_size) __uint32_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_subgroup_max_size) __uint32_t
     __spirv_BuiltInSubgroupMaxSize();
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_num_subgroups) __uint32_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_num_subgroups) __uint32_t
     __spirv_BuiltInNumSubgroups();
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_subgroup_id) __uint32_t
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_subgroup_id) __uint32_t
     __spirv_BuiltInSubgroupId();
-extern __SPIRV_BUILTIN_ALIAS(__builtin_spirv_subgroup_local_invocation_id)
+extern __SPIRV_SYCL_EXTERNAL __SPIRV_BUILTIN_ALIAS(__builtin_spirv_subgroup_local_invocation_id)
     __uint32_t __spirv_BuiltInSubgroupLocalInvocationId();
 
 // OpGenericCastToPtrExplicit

--- a/clang/test/CodeGenSPIRV/Builtins/ids_and_ranges.c
+++ b/clang/test/CodeGenSPIRV/Builtins/ids_and_ranges.c
@@ -2,12 +2,19 @@
 // RUN: %clang_cc1 -O1 -triple spirv64 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK64
 // RUN: %clang_cc1 -O1 -triple spirv32 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK32
 
+#ifdef __SYCL_DEVICE_ONLY__
+#define SYCL_EXTERNAL  __attribute__((sycl_device))
+#else
+#define SYCL_EXTERNAL
+#endif
+
+
 // CHECK: @test_num_workgroups(
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK64-NEXT:    tail call i64 @llvm.spv.num.workgroups.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.num.workgroups.i32(i32 0)
 //
-unsigned int test_num_workgroups() {
+SYCL_EXTERNAL unsigned int test_num_workgroups() {
     return __builtin_spirv_num_workgroups(0);
 }
 
@@ -16,7 +23,7 @@ unsigned int test_num_workgroups() {
 // CHECK64-NEXT:    tail call i64 @llvm.spv.workgroup.size.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.workgroup.size.i32(i32 0)
 //
-unsigned int test_workgroup_size() {
+SYCL_EXTERNAL unsigned int test_workgroup_size() {
     return __builtin_spirv_workgroup_size(0);
 }
 
@@ -25,7 +32,7 @@ unsigned int test_workgroup_size() {
 // CHECK64-NEXT:    tail call i64 @llvm.spv.group.id.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.group.id.i32(i32 0)
 //
-unsigned int test_workgroup_id() {
+SYCL_EXTERNAL unsigned int test_workgroup_id() {
     return __builtin_spirv_workgroup_id(0);
 }
 
@@ -34,7 +41,7 @@ unsigned int test_workgroup_id() {
 // CHECK64-NEXT:    tail call i64 @llvm.spv.thread.id.in.group.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.thread.id.in.group.i32(i32 0)
 //
-unsigned int test_local_invocation_id() {
+SYCL_EXTERNAL unsigned int test_local_invocation_id() {
     return __builtin_spirv_local_invocation_id(0);
 }
 
@@ -43,7 +50,7 @@ unsigned int test_local_invocation_id() {
 // CHECK64-NEXT:    tail call i64 @llvm.spv.thread.id.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.thread.id.i32(i32 0)
 //
-unsigned int test_global_invocation_id() {
+SYCL_EXTERNAL unsigned int test_global_invocation_id() {
     return __builtin_spirv_global_invocation_id(0);
 }
 
@@ -52,7 +59,7 @@ unsigned int test_global_invocation_id() {
 // CHECK64-NEXT:    tail call i64 @llvm.spv.global.size.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.global.size.i32(i32 0)
 //
-unsigned int test_global_size() {
+SYCL_EXTERNAL unsigned int test_global_size() {
     return __builtin_spirv_global_size(0);
 }
 
@@ -61,7 +68,7 @@ unsigned int test_global_size() {
 // CHECK64-NEXT:    tail call i64 @llvm.spv.global.offset.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.global.offset.i32(i32 0)
 //
-unsigned int test_global_offset() {
+SYCL_EXTERNAL unsigned int test_global_offset() {
     return __builtin_spirv_global_offset(0);
 }
 
@@ -69,7 +76,7 @@ unsigned int test_global_offset() {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.size()
 //
-unsigned int test_subgroup_size() {
+SYCL_EXTERNAL unsigned int test_subgroup_size() {
     return __builtin_spirv_subgroup_size();
 }
 
@@ -77,7 +84,7 @@ unsigned int test_subgroup_size() {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.max.size()
 //
-unsigned int test_subgroup_max_size() {
+SYCL_EXTERNAL unsigned int test_subgroup_max_size() {
     return __builtin_spirv_subgroup_max_size();
 }
 
@@ -85,7 +92,7 @@ unsigned int test_subgroup_max_size() {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.num.subgroups()
 //
-unsigned int test_num_subgroups() {
+SYCL_EXTERNAL unsigned int test_num_subgroups() {
     return __builtin_spirv_num_subgroups();
 }
 
@@ -93,7 +100,7 @@ unsigned int test_num_subgroups() {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.id()
 //
-unsigned int test_subgroup_id() {
+SYCL_EXTERNAL unsigned int test_subgroup_id() {
     return __builtin_spirv_subgroup_id();
 }
 
@@ -101,6 +108,6 @@ unsigned int test_subgroup_id() {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.local.invocation.id()
 //
-unsigned int test_subgroup_local_invocation_id() {
+SYCL_EXTERNAL unsigned int test_subgroup_local_invocation_id() {
     return __builtin_spirv_subgroup_local_invocation_id();
 }

--- a/clang/test/Headers/spirv_ids.cpp
+++ b/clang/test/Headers/spirv_ids.cpp
@@ -4,6 +4,11 @@
 // RUN: %clang_cc1 -Wno-unused-value -O0 -internal-isystem %S/../../lib/Headers -include __clang_spirv_builtins.h -triple spirv32 -emit-llvm %s -x cl -o - | FileCheck %s -check-prefixes=CHECK32
 // RUN: %clang_cc1 -Wno-unused-value -O0 -internal-isystem %S/../../lib/Headers -include __clang_spirv_builtins.h -triple nvptx64 -emit-llvm %s -fsycl-is-device -o - | FileCheck %s -check-prefixes=NV
 
+#ifdef __SYCL_DEVICE_ONLY__
+#define SYCL_EXTERNAL  __attribute__((sycl_device))
+#else
+#define SYCL_EXTERNAL
+#endif
 
 // CHECK64: call i64 @llvm.spv.num.workgroups.i64(i32 0)
 // CHECK64: call i64 @llvm.spv.num.workgroups.i64(i32 1)
@@ -80,7 +85,7 @@
 // NV: call noundef i32 @_Z25__spirv_BuiltInSubgroupIdv() #2
 // NV: call noundef i32 @_Z40__spirv_BuiltInSubgroupLocalInvocationIdv() #2
 
-void test_id_and_range() {
+SYCL_EXTERNAL void test_id_and_range() {
   __spirv_BuiltInNumWorkgroups(0);
   __spirv_BuiltInNumWorkgroups(1);
   __spirv_BuiltInNumWorkgroups(2);


### PR DESCRIPTION
https://github.com/intel/llvm/commit/27c9b55659c99fad4583fb6fa29dd079ea8b9582 was added upstream, but because it has limited SYCL support, tests can't run properly.