### PR TITLE
[CI] Fix Linux OneAPI build LIT tests

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -188,8 +188,10 @@ jobs:
       run: cmake --build $GITHUB_WORKSPACE/build --target ${{ inputs.build_target || 'sycl-toolchain' }}
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
+      env:
+        BUILD_CONFIGURE_EXTRA_ARGS: ${{ inputs.build_configure_extra_args }}
       run: |
-        if [[ "${{ inputs.build_configure_extra_args }}" == *"--use-libcxx"* ]]; then
+        if [[ "${BUILD_CONFIGURE_EXTRA_ARGS}" == *"--use-libcxx"* ]]; then
           # https://github.com/llvm/llvm-project/issues/59429
           export LIT_FILTER_OUT="ExecutionEngine/MCJIT"
         fi
@@ -197,10 +199,12 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm
     - name: check-clang
       if: always() && !cancelled() && contains(inputs.changes, 'clang')
+      env:
+        BUILD_CONFIGURE_EXTRA_ARGS: ${{ inputs.build_configure_extra_args }}
       run: |
         # Can we move this to Dockerfile? Hopefully, noop on Windows.
         export XDG_CACHE_HOME=$GITHUB_WORKSPACE/os_cache
-        if [[ "${{ inputs.build_configure_extra_args }}" == *"--use-libcxx"* ]]; then
+        if [[ "${BUILD_CONFIGURE_EXTRA_ARGS}" == *"--use-libcxx"* ]]; then
           # https://github.com/llvm/llvm-project/issues/59428
           export LIT_FILTER_OUT="(E|e)xception"
         fi

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -189,6 +189,7 @@ jobs:
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
       env:
+        # Can't inline to support possible quotes inside:
         BUILD_CONFIGURE_EXTRA_ARGS: ${{ inputs.build_configure_extra_args }}
       run: |
         if [[ "${BUILD_CONFIGURE_EXTRA_ARGS}" == *"--use-libcxx"* ]]; then
@@ -200,6 +201,7 @@ jobs:
     - name: check-clang
       if: always() && !cancelled() && contains(inputs.changes, 'clang')
       env:
+        # Can't inline to support possible quotes inside:
         BUILD_CONFIGURE_EXTRA_ARGS: ${{ inputs.build_configure_extra_args }}
       run: |
         # Can we move this to Dockerfile? Hopefully, noop on Windows.


### PR DESCRIPTION
Dumb interaction between github workflow variable usage in bash scripts, the variable happens to contain quotes only for the oneAPI build so that broke when I added these bash `if` statements. Make it a bash var to fix it.

Bad: https://github.com/intel/llvm/actions/runs/16612784850/job/47040968439 (HEAD)
Good: https://github.com/intel/llvm/actions/runs/16627822780/job/47051427259 (this PR)