### PR TITLE
[CI] Refactor toolchain-artifact related inputs/outputs

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -33,25 +33,30 @@ on:
         type: string
         required: false
         default: "--hip --cuda --native_cpu"
-      build_artifact_suffix:
-        type: string
-        required: true
       build_target:
         type: string
         required: false
         default: sycl-toolchain
-      artifact_archive_name:
-        type: string
-        default: llvm_sycl.tar.zst
+
       changes:
         type: string
         description: 'Filter matches for the changed files in the PR'
         default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc]'
         required: false
+
+      # Artifacts:
+
       retention-days:
         description: 'Artifacts retention period'
         type: string
         default: 3
+
+      toolchain_artifact:
+        type: string
+        required: true
+      toolchain_artifact_filename:
+        type: string
+        default: llvm_sycl.tar.zst
       e2e_binaries_artifact:
         type: string
         required: false
@@ -62,10 +67,12 @@ on:
     outputs:
       build_conclusion:
         value: ${{ jobs.build.outputs.build_conclusion }}
-      artifact_archive_name:
-        value: ${{ jobs.build.outputs.artifact_archive_name }}
-      artifact_decompress_command:
-        value: ${{ jobs.build.outputs.artifact_decompress_command }}
+      toolchain_artifact:
+        value: ${{ inputs.toolchain_artifact }}
+      toolchain_artifact_filename:
+        value: ${{ jobs.build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command:
+        value: ${{ jobs.build.outputs.toolchain_decompress_command }}
 
   workflow_dispatch:
     inputs:
@@ -102,10 +109,10 @@ on:
         options:
           - "default"
 
-      build_artifact_suffix:
+      toolchain_artifact:
         type: choice
         options:
-          - "default"
+          - "sycl_linux_default"
       retention-days:
         type: choice
         options:
@@ -126,8 +133,8 @@ jobs:
       options: -u 1001:1001
     outputs:
       build_conclusion: ${{ steps.build.conclusion }}
-      artifact_archive_name: ${{ steps.artifact_info.outputs.ARCHIVE_NAME }}
-      artifact_decompress_command: ${{ steps.artifact_info.outputs.DECOMPRESS }}
+      toolchain_artifact_filename: ${{ steps.artifact_info.outputs.ARCHIVE_NAME }}
+      toolchain_decompress_command: ${{ steps.artifact_info.outputs.DECOMPRESS }}
     env:
       CCACHE_DIR: ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }}
       CCACHE_MAXSIZE: 8G
@@ -136,7 +143,7 @@ jobs:
       # To reduce number of inputs parameters that is limited for manual triggers.
       id: artifact_info
       run: |
-        NAME="${{inputs.artifact_archive_name}}"
+        NAME="${{inputs.toolchain_artifact_filename}}"
         if [ -z "$NAME" ]; then
           NAME=llvm_sycl.tar.zst
         fi
@@ -281,7 +288,7 @@ jobs:
       if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       uses: actions/upload-artifact@v4
       with:
-        name: sycl_linux_${{ inputs.build_artifact_suffix }}
+        name: ${{ inputs.toolchain_artifact }}
         path: ${{ steps.artifact_info.outputs.ARCHIVE_NAME }}
         retention-days: ${{ inputs.retention-days }}
 

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -73,9 +73,9 @@ jobs:
       # pre-commit workflow.
       repo_ref: ${{ github.event.workflow_run.referenced_workflows[0].sha }}
 
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: llvm_sycl.tar.zst
-      sycl_toolchain_decompress_command: zstd
+      toolchain_artifact: sycl_linux_default
+      toolchain_artifact_filename: llvm_sycl.tar.zst
+      toolchain_decompress_command: zstd
 
   update-check:
     needs: [create-check, e2e-cuda]

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -50,13 +50,14 @@ jobs:
     with:
       build_ref: ${{ github.sha }}
       build_cache_root: "/__w/"
-      build_artifact_suffix: "default"
       build_cache_suffix: "default"
       # Docker image has last nightly pre-installed and added to the PATH
       build_image: "ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest"
       cc: clang
       cxx: clang++
       changes: ${{ needs.detect_changes.outputs.filters }}
+
+      toolchain_artifact: sycl_linux_default
       e2e_binaries_artifact: sycl_e2e_bin_default
 
   # If a PR changes CUDA adapter, run the build on Ubuntu 22.04 as well.
@@ -70,10 +71,11 @@ jobs:
     with:
       build_ref: ${{ github.sha }}
       build_cache_root: "/__w/"
-      build_artifact_suffix: "ubuntu22"
       build_cache_suffix: "ubuntu22"
       build_image: "ghcr.io/intel/llvm/ubuntu2204_build:latest"
       changes: ${{ needs.detect_changes.outputs.filters }}
+
+      toolchain_artifact: sycl_linux_ubuntu22
 
   run_prebuilt_e2e_tests:
     needs: [build, detect_changes]
@@ -146,9 +148,9 @@ jobs:
       target_devices: ${{ matrix.target_devices }}
       extra_lit_opts: ${{ matrix.extra_lit_opts }}
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.build.outputs.toolchain_decompress_command }}
       e2e_binaries_artifact: ${{ matrix.e2e_binaries_artifact || 'sycl_e2e_bin_default' }}
       e2e_testing_mode: 'run-only'
 
@@ -185,9 +187,9 @@ jobs:
       benchmark_preset: 'Minimal'
       benchmark_dry_run: true
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.build.outputs.toolchain_decompress_command }}
 
   test-perf:
     needs: [build, detect_changes]
@@ -224,6 +226,6 @@ jobs:
 
       repo_ref: ${{ github.sha }}
 
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.build.outputs.toolchain_decompress_command }}

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -45,15 +45,15 @@ on:
         required: False
         description: Commit SHA or branch to checkout e2e/cts tests.
 
-      sycl_toolchain_artifact:
+      toolchain_artifact:
         type: string
         default: ''
         required: False
-      sycl_toolchain_archive:
+      toolchain_artifact_filename:
         type: string
         default: ''
         required: False
-      sycl_toolchain_decompress_command:
+      toolchain_decompress_command:
         type: string
         default: ''
         required: False
@@ -252,21 +252,22 @@ jobs:
         comm -13 env_before env_after >> $GITHUB_ENV
         rm env_before env_after
     - name: Download SYCL toolchain
-      if: inputs.sycl_toolchain_artifact != '' && github.event_name != 'workflow_run'
+      if: inputs.toolchain_artifact != '' && github.event_name != 'workflow_run'
       uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.sycl_toolchain_artifact }}
+        name: ${{ inputs.toolchain_artifact }}
     - name: Debug prints [workflow_run]
-      if: inputs.sycl_toolchain_artifact != '' && github.event_name == 'workflow_run'
+      if: inputs.toolchain_artifact != '' && github.event_name == 'workflow_run'
       run: |
         pwd
         ls
     - name: Download SYCL toolchain [workflow_run]
-      if: inputs.sycl_toolchain_artifact != '' && github.event_name == 'workflow_run'
+      # NOTE: This is for `sycl-linux-precommit-aws.yml`.
+      if: inputs.toolchain_artifact != '' && github.event_name == 'workflow_run'
       uses: actions/github-script@v7
       with:
         script: |
-          const name = '${{ inputs.sycl_toolchain_artifact }}'
+          const name = '${{ inputs.toolchain_artifact }}'
           let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
              owner: context.repo.owner,
              repo: context.repo.repo,
@@ -284,18 +285,18 @@ jobs:
           let fs = require('fs');
           fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/` + name + '.zip', Buffer.from(download.data));
     - name: Unzip artifact [workflow_run]
-      if: inputs.sycl_toolchain_artifact != '' && github.event_name == 'workflow_run'
+      if: inputs.toolchain_artifact != '' && github.event_name == 'workflow_run'
       run: |
         pwd
         ls
-        unzip ${{ inputs.sycl_toolchain_artifact }}.zip
-        rm ${{ inputs.sycl_toolchain_artifact }}.zip
+        unzip ${{ inputs.toolchain_artifact }}.zip
+        rm ${{ inputs.toolchain_artifact }}.zip
     - name: Extract/Setup SYCL toolchain
-      if: inputs.sycl_toolchain_artifact != ''
+      if: inputs.toolchain_artifact != ''
       run: |
         mkdir toolchain
-        tar -I '${{ inputs.sycl_toolchain_decompress_command }}' -xf ${{ inputs.sycl_toolchain_archive }} -C toolchain
-        rm -f ${{ inputs.sycl_toolchain_archive }}
+        tar -I '${{ inputs.toolchain_decompress_command }}' -xf ${{ inputs.toolchain_artifact_filename }} -C toolchain
+        rm -f ${{ inputs.toolchain_artifact_filename }}
         echo PATH=$PWD/toolchain/bin/:$PATH >> $GITHUB_ENV
         echo LD_LIBRARY_PATH=$PWD/toolchain/lib/:$LD_LIBRARY_PATH >> $GITHUB_ENV
     - run: which clang++ sycl-ls

--- a/.github/workflows/sycl-nightly-benchmarking.yml
+++ b/.github/workflows/sycl-nightly-benchmarking.yml
@@ -14,10 +14,11 @@ jobs:
     secrets: inherit
     with:
       build_cache_root: "/__w/"
-      build_artifact_suffix: default
       build_configure_extra_args: '--no-assertions'
       build_image: ghcr.io/intel/llvm/ubuntu2404_build:latest
-      artifact_archive_name: sycl_linux.tar.gz
+
+      toolchain_artifact: sycl_linux_default
+      toolchain_artifact_filename: sycl_linux.tar.gz
 
   run-sycl-benchmarks:
     needs: [ubuntu2204_build]
@@ -44,7 +45,7 @@ jobs:
       benchmark_save_name: ${{ matrix.save_name }}
       benchmark_preset: ${{ matrix.preset }}
       repo_ref: ${{ matrix.ref }}
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -14,14 +14,14 @@ jobs:
     secrets: inherit
     with:
       build_cache_root: "/__w/"
-      build_artifact_suffix: default
       build_configure_extra_args: '--hip --cuda'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
-      retention-days: 90
 
+      retention-days: 90
+      toolchain_artifact: sycl_linux_default
       # We upload the build for people to download/use, override its name and
       # prefer widespread gzip compression.
-      artifact_archive_name: sycl_linux.tar.gz
+      toolchain_artifact_filename: sycl_linux.tar.gz
 
   # Build used for performance testing only: not intended for testing
   linux_shared_build:
@@ -31,11 +31,11 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_cache_suffix: sprod_shared
-      build_artifact_suffix: sprod_shared
       build_configure_extra_args: '--shared-libs --hip --cuda --native_cpu --no-assertions'
       build_target: all
 
-      artifact_archive_name: sycl_linux_shared.tar.zst
+      toolchain_artifact: sycl_linux_sprod_shared
+      toolchain_artifact_filename: sycl_linux_shared.tar.zst
 
   ubuntu2404_oneapi_build:
     if: github.repository == 'intel/llvm'
@@ -44,12 +44,12 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_cache_suffix: oneapi
-      build_artifact_suffix: oneapi
       build_configure_extra_args: -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
       cc: icx
       cxx: icpx
 
-      artifact_archive_name: sycl_linux_oneapi.tar.zst
+      toolchain_artifact: sycl_linux_oneapi
+      toolchain_artifact_filename: sycl_linux_oneapi.tar.zst
 
   ubuntu2404_libcxx_build:
     if: github.repository == 'intel/llvm'
@@ -58,12 +58,12 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_cache_suffix: libcxx
-      build_artifact_suffix: libcxx
       build_configure_extra_args: --use-libcxx -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=OFF
       cc: clang-18
       cxx: clang++-18
 
-      artifact_archive_name: sycl_linux_libcxx.tar.zst
+      toolchain_artifact: sycl_linux_libcxx
+      toolchain_artifact_filename: sycl_linux_libcxx.tar.zst
 
   ubuntu2204_test:
     needs: [ubuntu2204_build]
@@ -137,9 +137,9 @@ jobs:
       tests_selector: e2e
       extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' ${{ matrix.extra_lit_opts }}"
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
   ubuntu2404_oneapi_test:
     needs: [ubuntu2404_oneapi_build]
@@ -152,9 +152,9 @@ jobs:
       extra_lit_opts: -j 50
       image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_artifact: sycl_linux_oneapi
-      sycl_toolchain_archive: ${{ needs.ubuntu2404_oneapi_build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.ubuntu2404_oneapi_build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_decompress_command }}
 
   build-win:
     uses: ./.github/workflows/sycl-windows-build.yml
@@ -163,7 +163,7 @@ jobs:
       retention-days: 90
       # We upload both Linux/Windows build via Github's "Releases"
       # functionality, make sure Linux/Windows names follow the same pattern.
-      artifact_archive_name: sycl_windows.tar.gz
+      toolchain_artifact_filename: sycl_windows.tar.gz
       # Disable the spirv-dis requirement as to not require SPIR-V Tools.
       build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off
       build_target: all
@@ -180,7 +180,7 @@ jobs:
       name: Intel GEN12 Graphics with Level Zero
       runner: '["Windows","gen12"]'
       target_devices: level_zero:gpu
-      sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
+      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
 
   cuda-aws-start:
     needs: [ubuntu2204_build]
@@ -202,9 +202,9 @@ jobs:
       target_devices: cuda:gpu
       repo_ref: ${{ github.sha }}
 
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
   cuda-aws-stop:
     needs: [cuda-aws-start, cuda-run-tests]
@@ -225,9 +225,9 @@ jobs:
       image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
       tests_selector: cts
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
       sycl_cts_artifact: sycl_cts_bin_linux
 
   run-sycl-cts-linux:
@@ -255,9 +255,9 @@ jobs:
       target_devices: ${{ matrix.target_devices }}
       tests_selector: cts
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
       sycl_cts_artifact: sycl_cts_bin_linux
 
   build-sycl-cts-win:
@@ -270,7 +270,7 @@ jobs:
       cts_testing_mode: 'build-only'
       tests_selector: cts
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
+      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
       sycl_cts_artifact: sycl_cts_bin_win
 
   run-sycl-cts-win:
@@ -291,7 +291,7 @@ jobs:
       target_devices: ${{ matrix.target_devices }}
       tests_selector: cts
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
+      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
       sycl_cts_artifact: sycl_cts_bin_win
 
   nightly_build_upload:

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -40,8 +40,9 @@ jobs:
     with:
       build_cache_root: "/__w/llvm"
       build_cache_suffix: default
-      build_artifact_suffix: default
       build_configure_extra_args: --no-assertions --hip --cuda --native_cpu -DSYCL_ENABLE_STACK_PRINTING=ON -DSYCL_LIB_WITH_DEBUG_SYMBOL=ON
+
+      toolchain_artifact: sycl_linux_default
 
   e2e-lin:
     needs: [detect_changes, build-lin]
@@ -84,9 +85,9 @@ jobs:
 
       repo_ref: ${{ github.sha }}
 
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.build-lin.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.build-lin.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.build-lin.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.build-lin.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.build-lin.outputs.toolchain_decompress_command }}
 
       # Do not install drivers on AMD and CUDA runners.
       install_igc_driver: >-
@@ -118,7 +119,7 @@ jobs:
       name: Intel GEN12 Graphics with Level Zero
       runner: '["Windows","gen12"]'
       target_devices: "level_zero:gpu"
-      sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
+      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
       cxx: icx
       # https://github.com/intel/llvm/issues/18458
       env: "{'LIT_FILTER_OUT':'std_array.cpp|compile_on_win_with_mdd.cpp'}"

--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -101,13 +101,14 @@ jobs:
           github.ref
         }}
       build_cache_root: "/__w/"
-      build_artifact_suffix: "prod_noassert"
       build_cache_suffix: "prod_noassert"
       build_configure_extra_args: "--no-assertions"
       build_image: "ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest"
       cc: clang
       cxx: clang++
       changes: '[]'
+
+      toolchain_artifact: sycl_linux_prod_noassert
 
   run_benchmarks_build:
     name: Run Benchmarks on Build
@@ -133,6 +134,6 @@ jobs:
       benchmark_save_name: ${{ matrix.save_name }}
       benchmark_preset: ${{ inputs.preset }}
       repo_ref: ${{ matrix.ref }}
-      sycl_toolchain_artifact: sycl_linux_prod_noassert
-      sycl_toolchain_archive: ${{ needs.build_sycl.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.build_sycl.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.build_sycl.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.build_sycl.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.build_sycl.outputs.toolchain_decompress_command }}

--- a/.github/workflows/sycl-weekly.yml
+++ b/.github/workflows/sycl-weekly.yml
@@ -15,8 +15,9 @@ jobs:
     secrets: inherit
     with:
       build_cache_root: "/__w/"
-      build_artifact_suffix: default
       build_configure_extra_args: ''
+
+      toolchain_artifact: sycl_linux_default
 
   # This job builds SYCL-CTS with -fsycl-use-spirv-backend-for-spirv-gen.
   build-sycl-cts:
@@ -30,9 +31,9 @@ jobs:
       image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
       tests_selector: cts
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
       extra_cmake_args: -DDPCPP_FLAGS=-fsycl-use-spirv-backend-for-spirv-gen
       sycl_cts_artifact: sycl_cts_bin
 
@@ -61,7 +62,7 @@ jobs:
       target_devices: ${{ matrix.target_devices }}
       tests_selector: cts
       repo_ref: ${{ github.sha }}
-      sycl_toolchain_artifact: sycl_linux_default
-      sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
       sycl_cts_artifact: sycl_cts_bin

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -3,10 +3,17 @@ name: Reusable SYCL Windows build workflow
 on:
   workflow_call:
     inputs:
+      cxx:
+        type: string
+        required: false
+        default: "cl"
       build_cache_suffix:
         type: string
         required: false
         default: "default"
+      ref:
+        type: string
+        required: False
       build_configure_extra_args:
         type: string
         required: false
@@ -14,28 +21,26 @@ on:
         type: string
         required: false
         default: sycl-toolchain
+
       changes:
         type: string
         description: 'Filter matches for the changed files in the PR'
         default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc]'
         required: false
-      ref:
-        type: string
-        required: False
-      artifact_archive_name:
-        type: string
-        default: llvm_sycl.tar.gz
+
+      # Artifacts:
       retention-days:
         description: 'Artifacts retention period'
         type: string
         default: 3
+
+      toolchain_artifact_filename:
+        type: string
+        default: llvm_sycl.tar.gz
       e2e_binaries_artifact:
         type: string
         required: false
-      cxx:
-        type: string
-        required: false
-        default: "cl"
+
       pack_release:
         type: string
         required: false
@@ -43,8 +48,8 @@ on:
     outputs:
       build_conclusion:
         value: ${{ jobs.build.outputs.build_conclusion }}
-      artifact_archive_name:
-        value: ${{ inputs.artifact_archive_name }}
+      toolchain_artifact_filename:
+        value: ${{ inputs.toolchain_artifact_filename }}
 
   workflow_dispatch:
     inputs:
@@ -67,7 +72,7 @@ on:
         options:
           - "sycl-toolchain"
           - "all"
-      artifact_archive_name:
+      toolchain_artifact_filename:
         type: choice
         options:
           - 'llvm_sycl.tar.gz'
@@ -202,13 +207,13 @@ jobs:
 
     - name: Pack toolchain release
       if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' && inputs.pack_release == 'true' }}
-      run: tar -czf ${{ inputs.artifact_archive_name }} -C install .
+      run: tar -czf ${{ inputs.toolchain_artifact_filename }} -C install .
     - name: Upload toolchain release
       if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' && inputs.pack_release == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: sycl_windows_release
-        path: ${{ inputs.artifact_archive_name }}
+        path: ${{ inputs.toolchain_artifact_filename }}
         retention-days: ${{ inputs.retention-days }}
 
     - name: Install utilities
@@ -229,13 +234,13 @@ jobs:
       if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       shell: bash
       run: |
-        tar -czf ${{ inputs.artifact_archive_name }} -C install .
+        tar -czf ${{ inputs.toolchain_artifact_filename }} -C install .
     - name: Upload toolchain
       if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       uses: actions/upload-artifact@v4
       with:
         name: sycl_windows_default
-        path: ${{ inputs.artifact_archive_name }}
+        path: ${{ inputs.toolchain_artifact_filename }}
         retention-days: ${{ inputs.retention-days }}
 
     - name: Setup SYCL toolchain

--- a/.github/workflows/sycl-windows-precommit.yml
+++ b/.github/workflows/sycl-windows-precommit.yml
@@ -72,6 +72,6 @@ jobs:
       name: ${{ matrix.name }}
       runner: ${{ matrix.runner }}
       target_devices: "level_zero:gpu"
-      sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
+      toolchain_artifact_filename: ${{ needs.build.outputs.toolchain_artifact_filename }}
       e2e_testing_mode: run-only
       e2e_binaries_artifact: sycl_windows_e2ebin

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -39,11 +39,11 @@ on:
         required: False
         description: Commit SHA or branch to checkout e2e/cts tests.
 
-      sycl_toolchain_artifact:
+      toolchain_artifact:
         type: string
         default: 'sycl_windows_default'
         required: False
-      sycl_toolchain_archive:
+      toolchain_artifact_filename:
         type: string
         default: ''
         required: False
@@ -131,13 +131,13 @@ jobs:
     - name: Download compiler toolchain
       uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.sycl_toolchain_artifact }}
+        name: ${{ inputs.toolchain_artifact }}
     - name: Extract SYCL toolchain
       shell: bash
       run: |
         mkdir install
-        tar -xf ${{ inputs.sycl_toolchain_archive }} -C install
-        rm ${{ inputs.sycl_toolchain_archive }}
+        tar -xf ${{ inputs.toolchain_artifact_filename }} -C install
+        rm ${{ inputs.toolchain_artifact_filename }}
     - name: Setup SYCL toolchain
       run: |
         echo "PATH=$env:GITHUB_WORKSPACE\\install\\bin;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
* Group all artifact-related inputs in `sycl-linux-build.yml`. I plan on refactoring artifacts for E2E tests/release toolchain in a subsequent PR.
* Unify inputs/outputs names between `sycl-*-build.yml` and `sycl-*-run-tests.yml`. Windows still has less flexibility, but for the inputs that exist there the names still match Linux and the inputs are ordered similarly to Linux.
* Add `${{ needs.build.outputs.toolchain_artifact }}` instead of duplicating the artifact name. Aligns usage with actual filename/decompress command.