### PR TITLE
[UR][L0] Set kernel arguments only for queue's associated device

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
@@ -24,6 +24,17 @@ struct ur_single_device_kernel_t {
   ur_device_handle_t hDevice;
   v2::raii::ze_kernel_handle_t hKernel;
   mutable ZeCache<ZeStruct<ze_kernel_properties_t>> zeKernelProperties;
+
+  // Implementation of urKernelSetArgValue.
+  ur_result_t setArgValue(uint32_t argIndex, size_t argSize,
+                          const ur_kernel_arg_value_properties_t *pProperties,
+                          const void *pArgValue);
+
+  // Implementation of urKernelSetArgPointer.
+  ur_result_t
+  setArgPointer(uint32_t argIndex,
+                const ur_kernel_arg_pointer_properties_t *pProperties,
+                const void *pArgValue);
 };
 
 struct ur_kernel_handle_t_ : ur_object {
@@ -93,6 +104,9 @@ public:
                                    wait_list_view &waitListView);
 
   ur::RefCount RefCount;
+
+  std::optional<std::reference_wrapper<ur_single_device_kernel_t>>
+  getSingleDeviceKernel(ur_device_handle_t hDevice);
 
 private:
   // Keep the program of the kernel.


### PR DESCRIPTION
Ensure that kernel arguments are set only for the device associated
with the queue being used for kernel launch. Previously, arguments
were set for all devices in the kernel's device map, which was
unnecessary and potentially incorrect when launching on a specific
device.

Logic to set kernel arguments was moved to helper `EnqueueKernelLaunchCommon`
to avoid retrieving L0 kernel handle multiple times.