### PR TITLE
[SYCL][E2E] Remove XFAIL from passing KernelCompiler tests in preview mode

### DIFF
--- a/sycl/test-e2e/KernelCompiler/sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl.cpp
@@ -11,9 +11,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{l0_leak_check} %{run} %t.out
 
-// XFAIL: preview-mode && run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18390
-
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/KernelCompiler/sycl_imf.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_imf.cpp
@@ -15,9 +15,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out
 
-// XFAIL: preview-mode && run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18390
-
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/KernelCompiler/sycl_join.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_join.cpp
@@ -12,9 +12,6 @@
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{run} %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{l0_leak_check} %{run} %t.out
 
-// XFAIL: preview-mode && run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18390
-
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
 #include <sycl/usm.hpp>


### PR DESCRIPTION
Passing in nightly [here](https://github.com/intel/llvm/actions/runs/16639139151/job/47086848029).

Updated https://github.com/intel/llvm/issues/18390