### PR TITLE
[SYCL][test-e2e] Fix leaks in interop-thread.cpp

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/interop-thread.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-thread.cpp
@@ -168,7 +168,7 @@ sycl::event operation(sycl::queue q) {
 
   ze_event_handle_t l0_event = getEvent();
   auto sycl_event = sycl::make_event<sycl::backend::ext_oneapi_level_zero>(
-      {l0_event, sycl::ext::oneapi::level_zero::ownership::keep},
+      {l0_event, sycl::ext::oneapi::level_zero::ownership::transfer},
       q.get_context());
 
   zeEventHostSignal(l0_event);
@@ -282,5 +282,12 @@ int main(int argc, char *argv[]) {
     std::cout << E.what() << std::endl;
     return 1;
   }
+
+  ops.clear();
+  old_ops.clear();
+
+  zeEventPoolDestroy(event_pool);
+  zeContextDestroy(context);
+
   return 0;
 }


### PR DESCRIPTION
Found by running the test with (loader) leak checking enabled.