### PR TITLE
[UR][L0] urBindlessImagesGetImageMemoryHandleTypeSupportExp correction

### DIFF
--- a/unified-runtime/source/adapters/level_zero/image_common.cpp
+++ b/unified-runtime/source/adapters/level_zero/image_common.cpp
@@ -1014,16 +1014,6 @@ bool verifyCommonImagePropertiesSupport(
     }
   }
 
-  // Verify unnormalized channel type support.
-  // LevelZero currently doesn't support unnormalized channel types.
-  switch (pImageFormat->channelType) {
-  default:
-    break;
-  case UR_IMAGE_CHANNEL_TYPE_UNORM_INT8:
-  case UR_IMAGE_CHANNEL_TYPE_UNORM_INT16:
-    return false;
-  }
-
   return supported;
 }
 


### PR DESCRIPTION
VK_FORMAT_R8G8B8A8_UNORM is supported on L0 urt, correction to verifyCommonImagePropertiesSupport.