### PR TITLE
[SYCL][NFCI] Move abs and div to cstdlib header

### DIFF
--- a/libdevice/cmath_wrapper.cpp
+++ b/libdevice/cmath_wrapper.cpp
@@ -11,15 +11,6 @@
 #if defined(__SPIR__) || defined(__SPIRV__)
 
 DEVICE_EXTERN_C_INLINE
-int abs(int x) { return __devicelib_abs(x); }
-
-DEVICE_EXTERN_C_INLINE
-long int labs(long int x) { return __devicelib_labs(x); }
-
-DEVICE_EXTERN_C_INLINE
-long long int llabs(long long int x) { return __devicelib_llabs(x); }
-
-DEVICE_EXTERN_C_INLINE
 float fabsf(float x) { return __devicelib_fabsf(x); }
 
 DEVICE_EXTERN_C_INLINE
@@ -50,15 +41,6 @@ float rsqrtf(float x) { return __devicelib_rsqrtf(x); }
 
 DEVICE_EXTERN_C_INLINE
 float exp10f(float x) { return __devicelib_exp10f(x); }
-
-DEVICE_EXTERN_C_INLINE
-div_t div(int x, int y) { return __devicelib_div(x, y); }
-
-DEVICE_EXTERN_C_INLINE
-ldiv_t ldiv(long x, long y) { return __devicelib_ldiv(x, y); }
-
-DEVICE_EXTERN_C_INLINE
-lldiv_t lldiv(long long x, long long y) { return __devicelib_lldiv(x, y); }
 
 DEVICE_EXTERN_C_INLINE
 float roundf(float x) { return __devicelib_roundf(x); }

--- a/libdevice/device_math.h
+++ b/libdevice/device_math.h
@@ -14,33 +14,6 @@
     defined(__AMDGCN__)
 #include <cstdint>
 
-typedef struct {
-  int32_t quot;
-  int32_t rem;
-} __devicelib_div_t_32;
-
-typedef struct {
-  int64_t quot;
-  int64_t rem;
-} __devicelib_div_t_64;
-
-typedef __devicelib_div_t_32 div_t;
-#ifdef _WIN32
-typedef __devicelib_div_t_32 ldiv_t;
-#else
-typedef __devicelib_div_t_64 ldiv_t;
-#endif
-typedef __devicelib_div_t_64 lldiv_t;
-
-DEVICE_EXTERN_C
-int __devicelib_abs(int x);
-
-DEVICE_EXTERN_C
-long int __devicelib_labs(long int x);
-
-DEVICE_EXTERN_C
-long long int __devicelib_llabs(long long int x);
-
 DEVICE_EXTERN_C
 float __devicelib_fabsf(float x);
 
@@ -106,15 +79,6 @@ double __devicelib_exp10(double x);
 
 DEVICE_EXTERN_C
 float __devicelib_exp10f(float x);
-
-DEVICE_EXTERN_C
-div_t __devicelib_div(int x, int y);
-
-DEVICE_EXTERN_C
-ldiv_t __devicelib_ldiv(long int x, long int y);
-
-DEVICE_EXTERN_C
-lldiv_t __devicelib_lldiv(long long int x, long long int y);
 
 DEVICE_EXTERN_C
 double __devicelib_round(double x);

--- a/libdevice/fallback-cmath.cpp
+++ b/libdevice/fallback-cmath.cpp
@@ -17,15 +17,6 @@
 // during the build based on libdevice to avoid manually sync.
 
 DEVICE_EXTERN_C_INLINE
-int __devicelib_abs(int x) { return x < 0 ? -x : x; }
-
-DEVICE_EXTERN_C_INLINE
-long int __devicelib_labs(long int x) { return x < 0 ? -x : x; }
-
-DEVICE_EXTERN_C_INLINE
-long long int __devicelib_llabs(long long int x) { return x < 0 ? -x : x; }
-
-DEVICE_EXTERN_C_INLINE
 float __devicelib_fabsf(float x) { return x < 0 ? -x : x; }
 
 DEVICE_EXTERN_C_INLINE
@@ -61,15 +52,6 @@ float __devicelib_rsqrtf(float x) { return __spirv_ocl_rsqrt(x); }
 
 DEVICE_EXTERN_C_INLINE
 float __devicelib_exp10f(float x) { return __spirv_ocl_exp10(x); }
-
-DEVICE_EXTERN_C_INLINE
-div_t __devicelib_div(int x, int y) { return {x / y, x % y}; }
-
-DEVICE_EXTERN_C_INLINE
-ldiv_t __devicelib_ldiv(long x, long y) { return {x / y, x % y}; }
-
-DEVICE_EXTERN_C_INLINE
-lldiv_t __devicelib_lldiv(long long x, long long y) { return {x / y, x % y}; }
 
 DEVICE_EXTERN_C_INLINE
 float __devicelib_scalbnf(float x, int n) { return __spirv_ocl_ldexp(x, n); }

--- a/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
+++ b/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
@@ -98,19 +98,6 @@ using __sycl_promote_t =
     return __spirv_ocl_##NAME((type)x, (type)y);                               \
   }
 
-/// <cstdlib>
-// FIXME: Move this to a cstdlib fallback header.
-
-__SYCL_DEVICE div_t div(int x, int y) { return {x / y, x % y}; }
-__SYCL_DEVICE ldiv_t ldiv(long x, long y) { return {x / y, x % y}; }
-__SYCL_DEVICE lldiv_t ldiv(long long x, long long y) { return {x / y, x % y}; }
-
-__SYCL_DEVICE long long abs(long long n) { return n < 0 ? -n : n; }
-__SYCL_DEVICE_C long long llabs(long long n) { return n < 0 ? -n : n; }
-__SYCL_DEVICE long abs(long n) { return n < 0 ? -n : n; }
-__SYCL_DEVICE int abs(int n) { return n < 0 ? -n : n; }
-__SYCL_DEVICE_C long labs(long n) { return n < 0 ? -n : n; }
-
 /// Basic operations
 //
 

--- a/sycl/include/sycl/stl_wrappers/cmath
+++ b/sycl/include/sycl/stl_wrappers/cmath
@@ -32,13 +32,6 @@
 
 #ifdef __SYCL_DEVICE_ONLY__
 extern "C" {
-extern __DPCPP_SYCL_EXTERNAL_LIBC int abs(int x);
-extern __DPCPP_SYCL_EXTERNAL_LIBC long int labs(long int x);
-extern __DPCPP_SYCL_EXTERNAL_LIBC long long int llabs(long long int x);
-
-extern __DPCPP_SYCL_EXTERNAL_LIBC div_t div(int x, int y);
-extern __DPCPP_SYCL_EXTERNAL_LIBC ldiv_t ldiv(long int x, long int y);
-extern __DPCPP_SYCL_EXTERNAL_LIBC lldiv_t lldiv(long long int x, long long int y);
 extern __DPCPP_SYCL_EXTERNAL_LIBC float scalbnf(float x, int n);
 extern __DPCPP_SYCL_EXTERNAL_LIBC double scalbn(double x, int n);
 extern __DPCPP_SYCL_EXTERNAL_LIBC float logf(float x);

--- a/sycl/include/sycl/stl_wrappers/cstdlib
+++ b/sycl/include/sycl/stl_wrappers/cstdlib
@@ -1,0 +1,37 @@
+//==- cstdlib --------------------------------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+// Include real STL <cstdlib> header - the next one from the include search
+// directories.
+#if defined(__has_include_next)
+// GCC/clang support go through this path.
+#include_next <cstdlib>
+#else
+// MSVC doesn't support "#include_next", so we have to be creative.
+// Our header is located in "stl_wrappers/cstdlib" so it won't be picked by the
+// following include. MSVC's installation, on the other hand, has the layout
+// where the following would result in the <cstdlib> we want. This is obviously
+// hacky, but the best we can do...
+#include <../include/cstdlib>
+#endif
+
+#ifdef __SYCL_DEVICE_ONLY__
+extern "C" {
+__attribute__((sycl_device_only, always_inline)) div_t div(int x, int y) { return {x / y, x % y}; }
+__attribute__((sycl_device_only, always_inline)) ldiv_t ldiv(long x, long y) { return {x / y, x % y}; }
+__attribute__((sycl_device_only, always_inline)) lldiv_t ldiv(long long x, long long y) { return {x / y, x % y}; }
+
+__attribute__((sycl_device_only, always_inline)) int abs(int n) { return n < 0 ? -n : n; }
+__attribute__((sycl_device_only, always_inline)) long abs(long n) { return n < 0 ? -n : n; }
+__attribute__((sycl_device_only, always_inline)) long long abs(long long n) { return n < 0 ? -n : n; }
+__attribute__((sycl_device_only, always_inline)) long labs(long n) { return n < 0 ? -n : n; }
+__attribute__((sycl_device_only, always_inline)) long long llabs(long long n) { return n < 0 ? -n : n; }
+}
+#endif // __SYCL_DEVICE_ONLY__

--- a/sycl/test-e2e/DeviceLib/cmath_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_test.cpp
@@ -15,6 +15,7 @@
 #include "math_utils.hpp"
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <std/experimental/simd.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test/include_deps/sycl_accessor.hpp.cpp
+++ b/sycl/test/include_deps/sycl_accessor.hpp.cpp
@@ -9,6 +9,7 @@
 // CHECK-NEXT: detail/defines_elementary.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
+// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: exception.hpp
 // CHECK-NEXT: detail/export.hpp

--- a/sycl/test/include_deps/sycl_buffer.hpp.cpp
+++ b/sycl/test/include_deps/sycl_buffer.hpp.cpp
@@ -8,6 +8,7 @@
 // CHECK-NEXT: access/access.hpp
 // CHECK-NEXT: detail/defines_elementary.hpp
 // CHECK-NEXT: backend_types.hpp
+// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: exception.hpp
 // CHECK-NEXT: detail/export.hpp

--- a/sycl/test/include_deps/sycl_detail_core.hpp.cpp
+++ b/sycl/test/include_deps/sycl_detail_core.hpp.cpp
@@ -10,6 +10,7 @@
 // CHECK-NEXT: detail/defines_elementary.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
+// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: exception.hpp
 // CHECK-NEXT: detail/export.hpp


### PR DESCRIPTION
These functions are declared in cmath and use data type defined in
cstdlib. Some cmath implementations include cstdlib implicitly, but
not all of them. Moving declarations to a standalone header removes
dependency on cmath implementation.