### PR TITLE
[SYCL] Fix noexcept mismatch in HostKernel destructors

### DIFF
--- a/sycl/include/sycl/detail/cg_types.hpp
+++ b/sycl/include/sycl/detail/cg_types.hpp
@@ -169,7 +169,7 @@ public:
 
   char *getPtr() override { return reinterpret_cast<char *>(&MKernel); }
 
-  ~HostKernel() override noexcept = default;
+  ~HostKernel() noexcept override = default;
 
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   // This function is needed for host-side compilation to keep kernels

--- a/sycl/include/sycl/detail/cg_types.hpp
+++ b/sycl/include/sycl/detail/cg_types.hpp
@@ -151,7 +151,7 @@ public:
   // Return pointer to the lambda object.
   // Used to extract captured variables.
   virtual char *getPtr() = 0;
-  virtual ~HostKernelBase() = default;
+  virtual ~HostKernelBase() noexcept = default;
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   // NOTE: InstatiateKernelOnHost() should not be called.
   virtual void InstantiateKernelOnHost() = 0;
@@ -169,7 +169,7 @@ public:
 
   char *getPtr() override { return reinterpret_cast<char *>(&MKernel); }
 
-  ~HostKernel() = default;
+  ~HostKernel() override noexcept = default;
 
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   // This function is needed for host-side compilation to keep kernels


### PR DESCRIPTION
Marked base and derived destructors as noexcept to resolve compiler error: exception specification of overriding function is more lax than base version.