### PR TITLE
[SYCL][E2E] Disable two reduction tests sporadically failing

### DIFF
--- a/sycl/test-e2e/Reduction/reduction_big_data.cpp
+++ b/sycl/test-e2e/Reduction/reduction_big_data.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
+// UNSUPPORTED: windows && run-mode
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19680
+//
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // where the bigger data size and/or non-uniform work-group sizes may cause
 // errors.

--- a/sycl/test-e2e/Reduction/regression_after_pr_6343.cpp
+++ b/sycl/test-e2e/Reduction/regression_after_pr_6343.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// UNSUPPORTED: windows && run-mode
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19680
+
 #include <sycl/detail/core.hpp>
 
 #include <sycl/reduction.hpp>


### PR DESCRIPTION
If we see more Reduction failures I'll disable the whole directory.

Issue: https://github.com/intel/llvm/issues/19680