### PR TITLE
[GDB] Fix pretty-printer crash for sycl::item MOffset

### DIFF
--- a/sycl/gdb/libsycl.so-gdb.py
+++ b/sycl/gdb/libsycl.so-gdb.py
@@ -1074,10 +1074,13 @@ class SYCLItemPrinter(SYCLPrinter):
         string = self.type_name(self.gdb_type())
         extent = SYCLRangePrinter(sycl_item.extent()).value_as_string()
         string += " range " + extent
-        offset_id = SYCLItem(self.gdb_value()).offset()
-        offset = SYCLIdPrinter(offset_id).value_as_string()
-        if offset not in ["0", "{0, 0}", "{0, 0, 0}"]:
-            string += ", offset " + offset
+        try:
+            offset_id = SYCLItem(self.gdb_value()).offset()
+            offset = SYCLIdPrinter(offset_id).value_as_string()
+            if offset not in ["0", "{0, 0}", "{0, 0, 0}"]:
+                string += ", offset " + offset
+        except:
+            pass  # device offset disabled
         string += " = " + self.value_as_string()
         return string
 


### PR DESCRIPTION
The pretty printer looks for an `MOffset` field in `sycl::item` impl without considering whether or not offset has been enabled (Offset was deprecated in SYCL 2020). Add a check to avoid printing `MOffset` if offset has been disabled.