### PR TITLE
[CI] Refactor processing of E2E failures

### DIFF
--- a/devops/actions/run-tests/e2e/action.yml
+++ b/devops/actions/run-tests/e2e/action.yml
@@ -67,18 +67,21 @@ runs:
       LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time 3600 --time-tests --param print_features=True --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} ${{ inputs.extra_lit_opts }}
     run: |
       ninja -C build-e2e check-sycl-e2e > e2e.log 2>&1
+  # Two steps below are duplicated between Lin/Win actions, updates must change both
   - name: E2E logs
     if: ${{ always() }}
     shell: bash
     run: |
-      echo "::group::E2E full log"
+      echo "::group::Show Full E2E Log"
       cat e2e.log
       echo "::endgroup::"
-  - name: Report E2E failures
+  - name: Report E2E Failures
     if: steps.run_e2e.outcome != 'success'
     shell: bash
+    # For some reason Github uses the first line from the `run: |` section for
+    # the folded entry when displaying instead of this step's name.
     run: |
-        # This is duplicated between lin/win, updates must change both.
+        # Report E2E Failures
         awk '/^Failed Tests|Unexpectedly Passed Tests|Unresolved tests|Timed Out Tests|Testing Time/{flag=1}/FAILED: CMakeFiles/{flag=0}flag' e2e.log >> $GITHUB_STEP_SUMMARY
         awk '/^Failed Tests|Unexpectedly Passed Tests|Unresolved tests|Timed Out Tests|Testing Time/{flag=1}/FAILED: CMakeFiles/{flag=0}flag' e2e.log
         exit 1

--- a/devops/actions/run-tests/e2e/action.yml
+++ b/devops/actions/run-tests/e2e/action.yml
@@ -60,18 +60,28 @@ runs:
     run: |
       cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.sycl_compiler || '$(which clang++)'}}" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" ${{ steps.cmake_opts.outputs.opts }}
   - name: SYCL End-to-end tests
-    shell: bash {0}
+    id: run_e2e
+    continue-on-error: true
+    shell: bash
     env:
       LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time 3600 --time-tests --param print_features=True --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} ${{ inputs.extra_lit_opts }}
     run: |
       ninja -C build-e2e check-sycl-e2e > e2e.log 2>&1
-      exit_code=$?
+  - name: E2E logs
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      echo "::group::E2E full log"
       cat e2e.log
-      if [ $exit_code -ne 0 ]; then
+      echo "::endgroup::"
+  - name: Report E2E failures
+    if: steps.run_e2e.outcome != 'success'
+    shell: bash
+    run: |
         # This is duplicated between lin/win, updates must change both.
         awk '/^Failed Tests|Unexpectedly Passed Tests|Unresolved tests|Timed Out Tests|Testing Time/{flag=1}/FAILED: CMakeFiles/{flag=0}flag' e2e.log >> $GITHUB_STEP_SUMMARY
-      fi
-      exit $exit_code
+        awk '/^Failed Tests|Unexpectedly Passed Tests|Unresolved tests|Timed Out Tests|Testing Time/{flag=1}/FAILED: CMakeFiles/{flag=0}flag' e2e.log
+        exit 1
 
   - name: Pack E2E binaries
     if: ${{ always() && !cancelled() && inputs.binaries_artifact != '' && inputs.testing_mode != 'run-only'}}

--- a/devops/actions/run-tests/windows/e2e/action.yml
+++ b/devops/actions/run-tests/windows/e2e/action.yml
@@ -72,20 +72,28 @@ runs:
     run: ls build-e2e > e2econf_files.txt
 
   - name: Run End-to-End tests
-    shell: bash {0}
+    id: run_e2e
+    continue-on-error: true
+    shell: bash
     env:
       LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time ${{ inputs.e2e_testing_mode == 'run-only' && 1200 || 3600 }} --time-tests --param print_features=True --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} ${{ inputs.extra_lit_opts }}
     run: |
-      # Run E2E tests.
       cmake --build build-e2e --target check-sycl-e2e > e2e.log 2>&1
-
-      exit_code=$?
+  - name: E2E logs
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      echo "::group::E2E full log"
       cat e2e.log
-      if [ $exit_code -ne 0 ]; then
+      echo "::endgroup::"
+  - name: Report E2E failures
+    if: steps.run_e2e.outcome != 'success'
+    shell: bash
+    run: |
         # This is duplicated between lin/win, updates must change both.
         awk '/^Failed Tests|Unexpectedly Passed Tests|Unresolved tests|Timed Out Tests|Testing Time/{flag=1}/FAILED: CMakeFiles/{flag=0}flag' e2e.log >> $GITHUB_STEP_SUMMARY
-      fi
-      exit $exit_code
+        awk '/^Failed Tests|Unexpectedly Passed Tests|Unresolved tests|Timed Out Tests|Testing Time/{flag=1}/FAILED: CMakeFiles/{flag=0}flag' e2e.log
+        exit 1
 
   # Github CI doesn't support containers on Windows, so we cannot guarantee
   # that paths are the same between building and running systems. To avoid

--- a/devops/actions/run-tests/windows/e2e/action.yml
+++ b/devops/actions/run-tests/windows/e2e/action.yml
@@ -79,18 +79,21 @@ runs:
       LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time ${{ inputs.e2e_testing_mode == 'run-only' && 1200 || 3600 }} --time-tests --param print_features=True --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} ${{ inputs.extra_lit_opts }}
     run: |
       cmake --build build-e2e --target check-sycl-e2e > e2e.log 2>&1
+  # Two steps below are duplicated between Lin/Win actions, updates must change both
   - name: E2E logs
     if: ${{ always() }}
     shell: bash
     run: |
-      echo "::group::E2E full log"
+      echo "::group::Show Full E2E Log"
       cat e2e.log
       echo "::endgroup::"
-  - name: Report E2E failures
+  - name: Report E2E Failures
     if: steps.run_e2e.outcome != 'success'
     shell: bash
+    # For some reason Github uses the first line from the `run: |` section for
+    # the folded entry when displaying instead of this step's name.
     run: |
-        # This is duplicated between lin/win, updates must change both.
+        # Report E2E Failures
         awk '/^Failed Tests|Unexpectedly Passed Tests|Unresolved tests|Timed Out Tests|Testing Time/{flag=1}/FAILED: CMakeFiles/{flag=0}flag' e2e.log >> $GITHUB_STEP_SUMMARY
         awk '/^Failed Tests|Unexpectedly Passed Tests|Unresolved tests|Timed Out Tests|Testing Time/{flag=1}/FAILED: CMakeFiles/{flag=0}flag' e2e.log
         exit 1

--- a/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
@@ -2,7 +2,6 @@
 // RUN: %{run} %t.out
 // RUN: %if windows %{  %{build} -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus' -o %t2.out %}
 // RUN: %if windows %{  %{run} %t2.out  %}
-// RUN: %{run} false
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 // RUN: %if windows %{  %{build} -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus' -o %t2.out %}
 // RUN: %if windows %{  %{run} %t2.out  %}
+// RUN: %{run} false
 
 #include <sycl/detail/core.hpp>
 


### PR DESCRIPTION
Use a separate step so that the logs would be available if the workflow was cancelled. Also changes the "failing" step to only show the names of the failing tests instead of the whole e2e run log (that is still available in a separate foldable step).