### PR TITLE
[SYCL][Test] Fix mock calls in render-group test

### DIFF
--- a/sycl/test/tools/Inputs/mock_renderd_access.c
+++ b/sycl/test/tools/Inputs/mock_renderd_access.c
@@ -1,5 +1,7 @@
 #define _GNU_SOURCE
 
+#include <assert.h>
+#include <dlfcn.h>
 #include <errno.h>
 #include <glob.h>
 #include <stdarg.h>
@@ -10,7 +12,22 @@ int glob(const char *pattern, int flags, int (*errfunc)(const char *, int),
          glob_t *pglob) {
   const char *mock_mode = getenv("MOCK_GLOB_MODE");
   if (mock_mode && strcmp(mock_mode, "exists") == 0) {
-    // Simulate that /dev/dri/renderD* exists
+    pglob->gl_pathc = 2;
+    pglob->gl_pathv = malloc(2 * sizeof(char *));
+    pglob->gl_pathv[0] = strdup("/dev/dri/renderD128");
+    pglob->gl_pathv[1] = strdup("/dev/dri/renderD129");
+    return 0;
+  }
+  // Default behavior: no matches
+  pglob->gl_pathc = 0;
+  pglob->gl_pathv = NULL;
+  return 0;
+}
+
+int glob64(const char *pattern, int flags, int (*errfunc)(const char *, int),
+           glob64_t *pglob) {
+  const char *mock_mode = getenv("MOCK_GLOB_MODE");
+  if (mock_mode && strcmp(mock_mode, "exists") == 0) {
     pglob->gl_pathc = 2;
     pglob->gl_pathv = malloc(2 * sizeof(char *));
     pglob->gl_pathv[0] = strdup("/dev/dri/renderD128");
@@ -34,31 +51,80 @@ void globfree(glob_t *pglob) {
   }
 }
 
-int open(const char *pathname, int flags, ...) {
+void globfree64(glob64_t *pglob) {
+  if (pglob->gl_pathv) {
+    for (size_t i = 0; i < pglob->gl_pathc; ++i) {
+      free(pglob->gl_pathv[i]);
+    }
+    free(pglob->gl_pathv);
+    pglob->gl_pathv = NULL;
+    pglob->gl_pathc = 0;
+  }
+}
+
+static int (*real_open)(const char *, int, ...) = NULL;
+static int (*real_open64)(const char *, int, ...) = NULL;
+
+#define DUMMY_FD_128 128
+#define DUMMY_FD_129 129
+
+int mock_open_helper(const char *pathname) {
   const char *mock_mode = getenv("MOCK_OPEN_MODE");
-  if (strstr(pathname, "renderD12")) {
-    if (mock_mode && strcmp(mock_mode, "deny") == 0) {
+  assert(mock_mode != NULL && "MOCK_OPEN_MODE environment variable is not set");
+  if (strcmp(mock_mode, "deny") == 0) {
+    errno = EACCES;
+    return -1;
+  }
+
+  if (strstr(pathname, "renderD128"))
+    return DUMMY_FD_128;
+
+  if (strstr(pathname, "renderD129")) {
+    if (mock_mode && strcmp(mock_mode, "deny_second") == 0) {
       errno = EACCES;
       return -1;
     }
-
-    if (mock_mode && strcmp(mock_mode, "deny_second") == 0) {
-      // Simulate that the second file is not accessible
-      if (strstr(pathname, "renderD129")) {
-        errno = EACCES;
-        return -1;
-      } else {
-        return 3;
-      }
-    }
-
-    if (mock_mode && strcmp(mock_mode, "allow") == 0) {
-      return 3; // Dummy fd
-    }
+    return DUMMY_FD_129;
   }
-  // Default: permission denied
-  errno = EACCES;
-  return -1;
+  assert(0 && "Unexpected pathname in mock_open_helper");
 }
 
-int close(int fd) { return 0; }
+int open(const char *pathname, int flags, ...) {
+  if (strstr(pathname, "renderD12"))
+    return mock_open_helper(pathname);
+
+  // Call the real open function if not renderD12*.
+  va_list ap;
+  va_start(ap, flags);
+  mode_t mode = va_arg(ap, mode_t);
+  va_end(ap);
+  if (!real_open)
+    real_open = dlsym(RTLD_NEXT, "open");
+  return real_open(pathname, flags, mode);
+}
+
+int open64(const char *pathname, int flags, ...) {
+  if (strstr(pathname, "renderD12"))
+    return mock_open_helper(pathname);
+
+  // Call the real open function if not renderD12*.
+  va_list ap;
+  va_start(ap, flags);
+  mode_t mode = va_arg(ap, mode_t);
+  va_end(ap);
+  if (!real_open64)
+    real_open64 = dlsym(RTLD_NEXT, "open64");
+  return real_open64(pathname, flags, mode);
+}
+
+static int (*real_close)(int) = NULL;
+
+int close(int fd) {
+  if (fd == DUMMY_FD_128 || fd == DUMMY_FD_129) {
+    // Mock close for our dummy file descriptors.
+    return 0;
+  }
+
+  int (*real_close)(int) = dlsym(RTLD_NEXT, "close");
+  return real_close(fd);
+}


### PR DESCRIPTION
Enhance the mock library used in the render-group SYCL test to support both standard and large file variants (glob, glob64, open, open64, globfree, globfree64).
When large file support is enabled in the build, the mock library now correctly provides the required *64 symbols. Additionally, if files are not /dev/dri/renderD* then fallback to the real library functions, preserving rest of the sycl-ls functionality.
This improves reliability across different build configurations.