### PR TITLE
[Bench] Fix validation standards for compare.py

### DIFF
--- a/devops/scripts/benchmarks/compare.py
+++ b/devops/scripts/benchmarks/compare.py
@@ -112,13 +112,9 @@ class Compare:
         def validate_benchmark_result(result: BenchmarkRun) -> bool:
             """
             Returns True if result file:
-            - Was ran on the target machine/hostname specified
-            - Sanity check: ensure metadata are all expected values:
               - Date is truly before cutoff timestamp
               - Name truly matches up with specified result_name
             """
-            if result.hostname != hostname:
-                return False
             if result.name != result_name:
                 log.warning(
                     f"Result file {result_path} does not match specified result name {result.name}."


### PR DESCRIPTION
Due to the performance BMG machine being taken down for intel/llvm recently, there is a gap in the data stored in intel/llvm-ci-perf-results. In preparation for bringing up the BMG machine next week, I have swapped out the data for the data from unified-runtime CI.

In order for the data in unified-runtime CI to work, we need to relax the validation standards in compare.py.