### PR TITLE
[SYCL][TEST] Skip `free_function_host_compiler.cpp` when using `libcxx`

### DIFF
--- a/sycl/test/extensions/free_function_kernels/free_function_host_compiler.cpp
+++ b/sycl/test/extensions/free_function_kernels/free_function_host_compiler.cpp
@@ -2,6 +2,7 @@
 // RUN: %clangxx -fsycl -fno-sycl-unnamed-lambda %s
 // RUN: %clangxx -fsycl -fsycl-host-compiler=g++ %s
 // REQUIRES: linux
+// UNSUPPORTED: libcxx
 
 // This test serves as a sanity check that compilation succeeds
 // for a simple free function kernel when using the host compiler


### PR DESCRIPTION
GNU `g++` host compiler doesn't work with libcxx without some voodoo magic.