### PR TITLE
[CI][NFC] Fix the step name after 5e0db3edfa

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/sycl-detect-changes.yml
 
   build:
-    name: Self-Build
+    name: Self build
     needs: [detect_changes]
     if: always() && success()
     uses: ./.github/workflows/sycl-linux-build.yml

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -44,6 +44,7 @@ jobs:
     uses: ./.github/workflows/sycl-detect-changes.yml
 
   build:
+    name: Self-Build
     needs: [detect_changes]
     if: always() && success()
     uses: ./.github/workflows/sycl-linux-build.yml

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/sycl-detect-changes.yml
 
   build-lin:
-    name: Linux (Self build + no-assertions)
+    name: Linux (GCC + no-assertions)
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl-linux-build.yml
     with:


### PR DESCRIPTION
We swapped self-build clang and GCC in 5e0db3edfa.
Update the step name to avoid confusion.
