### PR TITLE
Partially revert 9df2111d9f24fdb22d6f898dd2ffd061aa43492c

### DIFF
--- a/llvm/docs/requirements-hashed.txt
+++ b/llvm/docs/requirements-hashed.txt
@@ -118,9 +118,9 @@ commonmark==0.9.1 \
     --hash=sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60 \
     --hash=sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9
     # via recommonmark
-docutils==0.22 \
-    --hash=sha256:4ed966a0e96a0477d852f7af31bdcb3adc049fbb35ccba358c2ea8a03287615e \
-    --hash=sha256:ba9d57750e92331ebe7c08a1bbf7a7f8143b86c476acd51528b042216a6aad0f
+docutils==0.21.2 \
+    --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f \
+    --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2
     # via
     #   -r requirements.txt
     #   myst-parser

--- a/llvm/docs/requirements.txt
+++ b/llvm/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==8.1.3
-docutils==0.22
+docutils==0.21.2
 sphinx-markdown-tables==0.0.17
 recommonmark==0.7.1
 sphinx-automodapi==0.20.0


### PR DESCRIPTION
It bumped the docutiils version to 0.22 but there is no release of `sphinx` that supports 0.22. 

The next `sphinx` release should have it.

Doc CI is broken because of this, see https://github.com/intel/llvm/pull/19701