### PR TITLE
[UR][CMake] Improve handling of UMF and hdr_histogram

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -428,7 +428,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   endif()
 endif()
 
-if(NOT UR_USE_EXTERNAL_UMF)
+if(TARGET umf)
   install(TARGETS umf
     LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT unified-memory-framework
     ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT unified-memory-framework

--- a/unified-runtime/source/common/CMakeLists.txt
+++ b/unified-runtime/source/common/CMakeLists.txt
@@ -36,26 +36,6 @@ target_include_directories(ur_common PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
 
-message(STATUS "Download Unified Memory Framework from github.com")
-if (NOT DEFINED UMF_REPO)
-    set(UMF_REPO "https://github.com/oneapi-src/unified-memory-framework.git")
-endif()
-
-if (NOT DEFINED UMF_TAG)
-    # commit 1de269c00e46b7cbdbafa2247812c8c4bb4ed4a5
-    # Author: Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>
-    # Date:   Mon Jul 21 15:42:59 2025 +0200
-    # 1.0.0 release
-    set(UMF_TAG v1.0.0)
-endif()
-
-message(STATUS "Will fetch Unified Memory Framework from ${UMF_REPO}")
-
-include(FetchContent)
-FetchContent_Declare(unified-memory-framework
-    GIT_REPOSITORY    ${UMF_REPO}
-    GIT_TAG           ${UMF_TAG}
-)
 
 if (UR_STATIC_ADAPTER_L0)
     if (UMF_BUILD_SHARED_LIBRARY)
@@ -63,14 +43,34 @@ if (UR_STATIC_ADAPTER_L0)
         set(UMF_BUILD_SHARED_LIBRARY OFF)
     endif()
 endif()
+  
+set(UR_USE_EXTERNAL_UMF ON CACHE BOOL "Use a pre-built UMF if available")
 
-set(UR_USE_EXTERNAL_UMF OFF CACHE BOOL "Use a pre-built UMF")
-
-if (UR_USE_EXTERNAL_UMF)
-  find_package(umf REQUIRED)
+if(UR_USE_EXTERNAL_UMF)
+  find_package(umf QUIET)
+endif()
+if(umf_FOUND)
+  message(STATUS "Using preinstalled UMF at ${umf_DIR}, ignoring UMF build related options")
   # Add an alias matching the FetchContent case
   add_library(umf::headers ALIAS umf::umf_headers)
 else()
+  set(UMF_REPO "https://github.com/oneapi-src/unified-memory-framework.git")
+
+  # commit 1de269c00e46b7cbdbafa2247812c8c4bb4ed4a5
+  # Author: Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>
+  # Date:   Mon Jul 21 15:42:59 2025 +0200
+  # 1.0.0 release
+  set(UMF_TAG v1.0.0)
+
+  if(NOT FETCHCONTENT_SOURCE_DIR_UNIFIED-MEMORY-FRAMEWORK)
+    message(STATUS "Will fetch Unified Memory Framework from ${UMF_REPO}")
+  endif()
+
+  include(FetchContent)
+  FetchContent_Declare(unified-memory-framework
+    GIT_REPOSITORY    ${UMF_REPO}
+    GIT_TAG           ${UMF_TAG}
+    )
   set(UMF_BUILD_TESTS OFF CACHE INTERNAL "Build UMF tests")
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "Build UMF examples")
   set(UMF_BUILD_SHARED_LIBRARY ${UMF_BUILD_SHARED_LIBRARY} CACHE INTERNAL "Build UMF shared library")
@@ -80,6 +80,10 @@ else()
 endif()
 
 if(UR_ENABLE_LATENCY_HISTOGRAM)
+  find_package(hdr_histogram QUIET)
+  if(hdr_histogram_FOUND)
+    set(hdr_histogram_SOURCE_DIR "${hdr_histogram_DIR}")
+  else()
     set(HDR_HISTOGRAM_BUILD_STATIC CACHE INTERNAL ON "")
     set(HDR_HISTOGRAM_BUILD_SHARED CACHE INTERNAL OFF "")
 
@@ -91,10 +95,10 @@ if(UR_ENABLE_LATENCY_HISTOGRAM)
 
     FetchContent_MakeAvailable(hdr_histogram)
     FetchContent_GetProperties(hdr_histogram)
-
-    target_link_libraries(ur_common PUBLIC hdr_histogram_static)
-    target_include_directories(ur_common PUBLIC $<BUILD_INTERFACE:${hdr_histogram_SOURCE_DIR}/include>)
-    target_compile_options(ur_common PUBLIC -DUR_ENABLE_LATENCY_HISTOGRAM=1)
+  endif()
+  target_link_libraries(ur_common PUBLIC hdr_histogram_static)
+  target_include_directories(ur_common PUBLIC $<BUILD_INTERFACE:${hdr_histogram_SOURCE_DIR}/include>)
+  target_compile_options(ur_common PUBLIC -DUR_ENABLE_LATENCY_HISTOGRAM=1)
 endif()
 
 target_link_libraries(ur_common PUBLIC


### PR DESCRIPTION
First, add support for pre-installed `hdr_histogram`.

Second, make `UR_USE_EXTERNAL_UMF` on by default and have it fallback to `FetchContent` if it is not found. The user can disable it to force `FetchContent`.

We don't need repo or tag variables because the user can just set `FETCHCONTENT_SOURCE_DIR_UNIFIED-MEMORY-FRAMEWORK`, and this matches how we handle other deps.