### PR TITLE
[SYCL] variadic_iterator noexcept

### DIFF
--- a/sycl/source/detail/helpers.hpp
+++ b/sycl/source/detail/helpers.hpp
@@ -59,23 +59,18 @@ public:
   template <typename IterTy>
   variadic_iterator(IterTy &&It) : It(std::forward<IterTy>(It)) {}
 
-  variadic_iterator &operator++() {
-    It = std::visit(
-        [](auto &&It) {
-          ++It;
-          return storage_iter{It};
-        },
-        It);
+  variadic_iterator &operator++() noexcept {
+    std::visit([](auto &&It) noexcept { ++It; }, It);
     return *this;
   }
-  bool operator!=(const variadic_iterator &Other) const {
+  bool operator!=(const variadic_iterator &Other) const noexcept{
     return It != Other.It;
   }
-  bool operator==(const variadic_iterator &Other) const {
+  bool operator==(const variadic_iterator &Other) const noexcept{
     return It == Other.It;
   }
 
-  decltype(auto) operator*() {
+  decltype(auto) operator*() noexcept {
     return std::visit(
         [](auto &&It) -> decltype(auto) {
           decltype(auto) Elem = *It;

--- a/sycl/source/detail/helpers.hpp
+++ b/sycl/source/detail/helpers.hpp
@@ -63,10 +63,10 @@ public:
     std::visit([](auto &&It) noexcept { ++It; }, It);
     return *this;
   }
-  bool operator!=(const variadic_iterator &Other) const noexcept{
+  bool operator!=(const variadic_iterator &Other) const noexcept {
     return It != Other.It;
   }
-  bool operator==(const variadic_iterator &Other) const noexcept{
+  bool operator==(const variadic_iterator &Other) const noexcept {
     return It == Other.It;
   }
 


### PR DESCRIPTION
variadic_iterator was recently introduced and is used by several routines that are marked as noexcept, some being API.  Changing its operator++ to be noexcept to prevent issues and put Coverity's mind at ease