### PR TITLE
[libclc] Fix merge conflict resolve in spirv clc_fmin/fmax

### DIFF
--- a/libclc/clc/lib/spirv/math/clc_fmax.cl
+++ b/libclc/clc/lib/spirv/math/clc_fmax.cl
@@ -6,37 +6,27 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/clcmacro.h>
 #include <clc/internal/clc.h>
-#include <clc/math/clc_fmax.h>
-
-#define __CLC_FUNCTION __clc_fmax
-#define __CLC_BUILTIN __ocml_fmax
-
-float __ocml_fmax_f32(float, float);
-#define __CLC_BUILTIN_F __CLC_XCONCAT(__CLC_BUILTIN, _f32)
-
-#ifdef cl_khr_fp64
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-double __ocml_fmax_f64(double, double);
-#define __CLC_BUILTIN_D __CLC_XCONCAT(__CLC_BUILTIN, _f64)
 
 _CLC_DEF _CLC_OVERLOAD float __clc_fmax(float x, float y) {
   return __builtin_fmaxf(x, y);
 }
 
+#ifdef cl_khr_fp64
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
 _CLC_DEF _CLC_OVERLOAD double __clc_fmax(double x, double y) {
   return __builtin_fmax(x, y);
 }
-#endif // cl_khr_fp64
+#endif
 
 #ifdef cl_khr_fp16
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-half __ocml_fmax_f16(half, half);
-#define __CLC_BUILTIN_H __CLC_XCONCAT(__CLC_BUILTIN, _f16)
-
 _CLC_DEF _CLC_OVERLOAD half __clc_fmax(half x, half y) {
   return __builtin_fmaxf16(x, y);
 }
-#endif // cl_khr_fp16
+#endif
 
-#include <clc/math/binary_builtin.inc>
+#define FUNCTION __clc_fmax
+#define __CLC_BODY <clc/shared/binary_def_scalarize.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/spirv/math/clc_fmin.cl
+++ b/libclc/clc/lib/spirv/math/clc_fmin.cl
@@ -6,37 +6,27 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/clcmacro.h>
 #include <clc/internal/clc.h>
-#include <clc/math/clc_fmin.h>
-
-#define __CLC_FUNCTION __clc_fmin
-#define __CLC_BUILTIN __ocml_fmin
-
-float __ocml_fmin_f32(float, float);
-#define __CLC_BUILTIN_F __CLC_XCONCAT(__CLC_BUILTIN, _f32)
-
-#ifdef cl_khr_fp64
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-double __ocml_fmin_f64(double, double);
-#define __CLC_BUILTIN_D __CLC_XCONCAT(__CLC_BUILTIN, _f64)
-
-_CLC_DEF _CLC_OVERLOAD double __clc_fmin(double x, double y) {
-  return __builtin_fmin(x, y);
-}
-#endif // cl_khr_fp64
-
-#ifdef cl_khr_fp16
-#pragma OPENCL EXTENSION cl_khr_fp16 : enable
-half __ocml_fmin_f16(half, half);
-#define __CLC_BUILTIN_H __CLC_XCONCAT(__CLC_BUILTIN, _f16)
 
 _CLC_DEF _CLC_OVERLOAD float __clc_fmin(float x, float y) {
   return __builtin_fminf(x, y);
 }
 
+#ifdef cl_khr_fp64
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+_CLC_DEF _CLC_OVERLOAD double __clc_fmin(double x, double y) {
+  return __builtin_fmin(x, y);
+}
+#endif
+
+#ifdef cl_khr_fp16
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
 _CLC_DEF _CLC_OVERLOAD half __clc_fmin(half x, half y) {
   return __builtin_fminf16(x, y);
 }
-#endif // cl_khr_fp16
+#endif
 
-#include <clc/math/binary_builtin.inc>
+#define FUNCTION __clc_fmin
+#define __CLC_BODY <clc/shared/binary_def_scalarize.inc>
+#include <clc/math/gentype.inc>


### PR DESCRIPTION
The two files should remain unchanged from llorg. Fixes 30d0184a94d2.