### PR TITLE
[SYCL] Detect ze call leaking in E2E tests

### DIFF
--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -389,6 +389,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
                 elif code is lit.Test.FAIL:
                     code = lit.Test.XFAIL
             return code
+
         def check_leak(output):
             keyword_found = False
             for line in output.splitlines():
@@ -403,7 +404,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
         if len(devices_for_test) == 1:
             device = devices_for_test[0]
             result.code = map_result(test.config.sycl_dev_features[device], result.code)
-        if test.config.ur_l0_leaks_debug and result.code is lit.Test.PASS:
+        if litConfig.params.get("ur_l0_leaks_debug") and result.code is lit.Test.PASS:
             result.code = check_leak(result.output)
 
         # Set this to empty so internal lit code won't change our result if it incorrectly

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -392,8 +392,9 @@ class SYCLEndToEndTest(lit.formats.ShTest):
 
         def check_leak(output):
             keyword_found = False
+            leak_pattern = r"LEAK\s*=\s*\d+"
             for line in output.splitlines():
-                if keyword_found and "LEAK" in line:
+                if keyword_found and re.search(leak_pattern, line):
                     return lit.Test.FAIL
                 if "Check balance of create/destroy calls" in line:
                     keyword_found = True


### PR DESCRIPTION
After https://github.com/intel/llvm/pull/19328, UR_L0_LEAKS_DEBUG stop throwing exceptions when leaks are detected so LIT can't report failures. Add a leak checking in format.py to keep "--param ur_l0_leaks_debug=1" work as before.