### PR TITLE
[SYCL][NATIVECPU] Fix TargetInfo initialization (DataLayoutString)

### DIFF
--- a/clang/lib/Basic/Targets/NativeCPU.cpp
+++ b/clang/lib/Basic/Targets/NativeCPU.cpp
@@ -72,7 +72,7 @@ void NativeCPUTargetInfo::setAuxTarget(const TargetInfo *Aux) {
   resetDataLayout(Aux->getDataLayoutString());
 }
 
-// A target may initialise its DataLayoutString and potentially other features in
+// A target may initialise its DataLayoutString and potentially other features
 // in `handleTargetFeatures` (as opposed to its constructor), so we can only
 // copy the features and query DataLayoutString after that function was called.
 bool NativeCPUTargetInfo::handleTargetFeatures(

--- a/clang/lib/Basic/Targets/NativeCPU.cpp
+++ b/clang/lib/Basic/Targets/NativeCPU.cpp
@@ -62,8 +62,6 @@ NativeCPUTargetInfo::NativeCPUTargetInfo(const llvm::Triple &Triple,
     resetDataLayout("e");
   } else {
     HostTarget = AllocateTarget(HostTriple, Opts);
-    copyAuxTarget(&*HostTarget);
-    resetDataLayout(HostTarget->getDataLayoutString());
   }
 }
 
@@ -72,4 +70,18 @@ void NativeCPUTargetInfo::setAuxTarget(const TargetInfo *Aux) {
   copyAuxTarget(Aux);
   getTargetOpts() = Aux->getTargetOpts();
   resetDataLayout(Aux->getDataLayoutString());
+}
+
+// A target may initialise its DataLayoutString and potentially other features in
+// in `handleTargetFeatures` (as opposed to its constructor), so we can only
+// copy the features and query DataLayoutString after that function was called.
+bool NativeCPUTargetInfo::handleTargetFeatures(
+    std::vector<std::string> &Features, DiagnosticsEngine &Diags) {
+  if (HostTarget) {
+    if (!HostTarget->handleTargetFeatures(Features, Diags))
+      return false;
+    copyAuxTarget(&*HostTarget);
+    resetDataLayout(HostTarget->getDataLayoutString());
+  }
+  return true;
 }

--- a/clang/lib/Basic/Targets/NativeCPU.h
+++ b/clang/lib/Basic/Targets/NativeCPU.h
@@ -56,6 +56,9 @@ public:
     return TargetInfo::checkCallingConvention(CC);
   }
 
+  bool handleTargetFeatures(std::vector<std::string> &Features,
+                            DiagnosticsEngine &Diags) override;
+
 protected:
   void setAuxTarget(const TargetInfo *Aux) override;
 

--- a/clang/test/CodeGenSYCL/native_cpu_target_features.cpp
+++ b/clang/test/CodeGenSYCL/native_cpu_target_features.cpp
@@ -5,6 +5,11 @@
 // This is not sensible but check that we do not crash.
 // RUN: %clang_cc1 -triple native_cpu -aux-triple native_cpu -fsycl-is-device -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,NOX86,NOAVX
 
+// Ensures NativeCPU does not cause a compiler assert when querying the host
+// target's DataLayoutString, which used to happen on ARM which initializes
+// DataLayoutString not in its constructor but afterwards.
+// RUN: %clang_cc1 -cc1 -fsycl-is-device -triple native_cpu -aux-triple aarch64-arm-none-eabi -emit-llvm-bc -o %t %s
+
 #include "Inputs/sycl.hpp"
 using namespace sycl;
 

--- a/clang/test/CodeGenSYCL/native_cpu_target_features.cpp
+++ b/clang/test/CodeGenSYCL/native_cpu_target_features.cpp
@@ -8,7 +8,7 @@
 // Ensures NativeCPU does not cause a compiler assert when querying the host
 // target's DataLayoutString, which used to happen on ARM which initializes
 // DataLayoutString not in its constructor but afterwards.
-// RUN: %clang_cc1 -cc1 -fsycl-is-device -triple native_cpu -aux-triple aarch64-arm-none-eabi -emit-llvm-bc -o %t %s
+// RUN: %clang_cc1 -fsycl-is-device -triple native_cpu -aux-triple aarch64-arm-none-eabi -emit-llvm-bc -o %t %s
 
 #include "Inputs/sycl.hpp"
 using namespace sycl;


### PR DESCRIPTION
Some clang targets (for example for Arm) may not initialize `DataLayoutString` in their TargetInfo constructor, which meant calls `getDataLayoutString`  right after the constructor cause an assert.

This PR defers the initialization of the NativeCPU TargetInfo to after the call of `handleTargetFeatures`  of the host cpu Target info, which on Arm initializes `DataLayoutString`, but may also catch more initializations.