### PR TITLE
[UR] Properly skip L0v2 kernels' tests if UR_DPCXX is missing

### DIFF
--- a/unified-runtime/test/adapters/level_zero/CMakeLists.txt
+++ b/unified-runtime/test/adapters/level_zero/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -39,7 +39,7 @@ if(NOT UR_FOUND_DPCXX)
     # Tests that require kernels can't be used if we aren't generating
     # device binaries
     message(WARNING
-        "UR_DPCXX is not defined, skipping some adapter tests for ${adapter}")
+        "UR_DPCXX is not defined, skipping kernels' tests for L0")
 else()
     add_conformance_kernels_test(link urProgramLink.cpp)
     add_l0_loader_kernels_test(kernel_create urKernelCreateWithNativeHandle.cpp)

--- a/unified-runtime/test/adapters/level_zero/v2/CMakeLists.txt
+++ b/unified-runtime/test/adapters/level_zero/v2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -67,8 +67,15 @@ add_l0_v2_devices_test(memory_residency
     ${PROJECT_SOURCE_DIR}/source/adapters/level_zero/ur_level_zero.cpp
 )
 
-add_l0_v2_kernels_test(deferred_kernel
-    deferred_kernel.cpp
-    ${PROJECT_SOURCE_DIR}/source/adapters/level_zero/common.cpp
-    ${PROJECT_SOURCE_DIR}/source/adapters/level_zero/ur_level_zero.cpp
-)
+if(NOT UR_FOUND_DPCXX)
+    # Tests that require kernels can't be used if we aren't generating
+    # device binaries
+    message(WARNING
+        "UR_DPCXX is not defined, skipping kernels' tests for L0v2")
+else()
+    add_l0_v2_kernels_test(deferred_kernel
+        deferred_kernel.cpp
+        ${PROJECT_SOURCE_DIR}/source/adapters/level_zero/common.cpp
+        ${PROJECT_SOURCE_DIR}/source/adapters/level_zero/ur_level_zero.cpp
+    )
+endif()


### PR DESCRIPTION
Without this change, when configuring UR and `UR_DPCXX` wasn't set I was getting an error about missing `generate_device_binaries` target.