### PR TITLE
[SYCL][E2E] Use `UNSUPPORTED: target-nvidia` instead of `cuda`

### DIFF
--- a/sycl/test-e2e/NewOffloadDriver/multisource.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/multisource.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: cuda
+// UNSUPPORTED: target-nvidia
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18432
 // Separate kernel sources and host code sources
 // Test with `--offload-new-driver`

--- a/sycl/test-e2e/NewOffloadDriver/split-per-source-main.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/split-per-source-main.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: target-nvidia
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18432
 // RUN: %{build} -Wno-error=unused-command-line-argument -fsycl-device-code-split=per_source -I %S/Inputs -o %t.out %S/Inputs/split-per-source-second-file.cpp \
 // RUN: --offload-new-driver -fsycl-dead-args-optimization

--- a/sycl/test-e2e/NewOffloadDriver/sycl-external-with-optional-features.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/sycl-external-with-optional-features.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: target-nvidia
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18432
 // Test with `--offload-new-driver`
 // RUN: %{build} -DSOURCE1 --offload-new-driver -c -o %t1.o


### PR DESCRIPTION
So that I can pre-build E2E binaries for use in trunk backward compatibility CI.