### PR TITLE
[SYCL] Avoid illegal order in compare_exchange_*

### DIFF
--- a/sycl/include/sycl/atomic_ref.hpp
+++ b/sycl/include/sycl/atomic_ref.hpp
@@ -232,7 +232,14 @@ public:
   compare_exchange_strong(T &expected, T desired,
                           memory_order order = default_read_modify_write_order,
                           memory_scope scope = default_scope) const noexcept {
-    return compare_exchange_strong(expected, desired, order, order, scope);
+    memory_order success = order;
+    memory_order failure = order;
+    if (order == memory_order::acq_rel) {
+      failure = memory_order::acquire;
+    } else if (order == memory_order::release) {
+      failure = memory_order::relaxed;
+    }
+    return compare_exchange_strong(expected, desired, success, failure, scope);
   }
 
   bool
@@ -256,7 +263,14 @@ public:
   compare_exchange_weak(T &expected, T desired,
                         memory_order order = default_read_modify_write_order,
                         memory_scope scope = default_scope) const noexcept {
-    return compare_exchange_weak(expected, desired, order, order, scope);
+    memory_order success = order;
+    memory_order failure = order;
+    if (order == memory_order::acq_rel) {
+      failure = memory_order::acquire;
+    } else if (order == memory_order::release) {
+      failure = memory_order::relaxed;
+    }
+    return compare_exchange_weak(expected, desired, success, failure, scope);
   }
 
 protected:


### PR DESCRIPTION
The atomic_ref compare_exchange_* functions, which take only one memory order argument, call the respective compare_exchange_* functions, which take two memory order arguments, and use the same order for both the success and failure memory orders. This might result in UB where the 'acquire' or 'release' failure order is used. This commit ensures that an illegal failure order is never passed.