### PR TITLE
Add sycl-jit e2e feature

### DIFF
--- a/sycl/test-e2e/KernelCompiler/sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{l0_leak_check} %{run} %t.out

--- a/sycl/test-e2e/KernelCompiler/sycl_basic.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_basic.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{l0_leak_check} %{run} %t.out

--- a/sycl/test-e2e/KernelCompiler/sycl_cache.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_cache.cpp
@@ -12,7 +12,7 @@
 // target. Don't run eviction check for CUDA/HIP, so that we don't have to find
 // a magic number that works for all binaries (and by definition is flaky).
 
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 
 // DEFINE: %{cache_vars} = env SYCL_CACHE_PERSISTENT=1 SYCL_CACHE_TRACE=7 SYCL_CACHE_DIR=%t/cache_dir
 // DEFINE: %{max_cache_size} = SYCL_CACHE_MAX_SIZE=30000

--- a/sycl/test-e2e/KernelCompiler/sycl_cache_pm.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_cache_pm.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: (opencl || level_zero)
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 
 // -- Test the kernel_compiler with SYCL source.
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/KernelCompiler/sycl_device_globals.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_device_globals.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 
 // UNSUPPORTED: opencl && gpu
 // UNSUPPORTED-TRACKER: GSD-4287

--- a/sycl/test-e2e/KernelCompiler/sycl_imf.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_imf.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 // REQUIRES: (opencl || level_zero)
 
 // UNSUPPORTED: accelerator

--- a/sycl/test-e2e/KernelCompiler/sycl_include_paths.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_include_paths.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{run} %t.out %S | FileCheck %s --check-prefixes=CHECK,CHECK-NOCWD

--- a/sycl/test-e2e/KernelCompiler/sycl_join.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_join.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aspect-usm_shared_allocations
+// REQUIRES: sycl-jit, aspect-usm_shared_allocations
 
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{run} %t.out

--- a/sycl/test-e2e/KernelCompiler/sycl_lifetimes.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_lifetimes.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} env SYCL_UR_TRACE=-1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s

--- a/sycl/test-e2e/KernelCompiler/sycl_namespaces.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_namespaces.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{l0_leak_check} %{run} %t.out

--- a/sycl/test-e2e/KernelCompiler/sycl_overload.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_overload.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aspect-usm_device_allocations
+// REQUIRES: sycl-jit, aspect-usm_device_allocations
 
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{l0_leak_check} %{run} %t.out

--- a/sycl/test-e2e/KernelCompiler/sycl_time_trace.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_time_trace.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: sycl-jit
+
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{run} %t.out | FileCheck %s
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -970,6 +970,9 @@ elif os.path.exists(f"{config.sycl_include}/llvm/SYCLLowerIR/DeviceConfigFile.hp
     config.available_features.add("device-config-file")
     config.substitutions.append(("%device_config_file_include_flag", ""))
 
+if config.enable_sycl_jit == "ON":
+    config.available_features.add("sycl-jit")
+
 # That has to be executed last so that all device-independent features have been
 # discovered already.
 config.sycl_dev_features = {}

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -62,6 +62,8 @@ config.vulkan_found = "@Vulkan_FOUND@"
 config.run_launcher = lit_config.params.get('run_launcher', "@SYCL_E2E_RUN_LAUNCHER@")
 config.allow_unknown_arch = "@SYCL_E2E_LIT_ALLOW_UNKNOWN_ARCH@"
 
+config.enable_sycl_jit = "@SYCL_ENABLE_EXTENSION_JIT@"
+
 import lit.llvm
 lit.llvm.initialize(lit_config, config)
 


### PR DESCRIPTION
The project may be built with --disable-jit.
Updating the tests that fail without this feature.