### PR TITLE
[SYCL][E2E] Better control of testing `preview-mode`

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -342,9 +342,13 @@ with test_env():
     else:
         config.substitutions.append(("%level_zero_options", ""))
 
-if lit_config.params.get("test-preview-mode", False):
+test_preview = lit_config.params.get("test-preview-mode")
+if test_preview is not None and test_preview not in ["True", "False"]:
+    lit_config.fatal("test-preview-mode must be unset or set to True/False")
+
+if test_preview == "True":
     config.available_features.add("preview-mode")
-else:
+elif test_preview is None:
     # Check for sycl-preview library
     check_preview_breaking_changes_file = "preview_breaking_changes_link.cpp"
     with open_check_file(check_preview_breaking_changes_file) as fp:


### PR DESCRIPTION
Before the PR we had two modes:

* Default, auto-detect preview support in toolchain and have individual tests run dedicated `RUN`-lines
* `--param test-preview-mode=<anything but False>`, run entire suite in preview mode using non-preview `RUN`-lines. Special `RUN`-lines dedicated to preview are ignored.

This PR changes it to this:

* Only allow `test-preview-mode` to be unset or set to True/False, fatal error on any other value.
* If True/unset behave as in two previous scenarios
* If False, only execute `RUN`-lines without preview markup

I need this for compatibility testing because preview mode isn't backward ABI-compatible and I'm going to cherry-pick this to `sycl-rel-6_[23]`

For trunk, I think we should just remove special `RUN`-lines and rely on "full preview" mode job in CI, but that will be a separate PR (because I wouldn't be able to backport such a big change).

Cherry-picks https://github.com/intel/llvm/pull/19727