### PR TITLE
[SYCL][E2E] Remove preview/CXX11_ABI RUN lines from `AbiNeutral/*`

### DIFF
--- a/sycl/test-e2e/AbiNeutral/catch-exception.cpp
+++ b/sycl/test-e2e/AbiNeutral/catch-exception.cpp
@@ -1,11 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -D_GLIBCXX_USE_CXX11_ABI=0 -o %t2.out %}
-// RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 // REQUIRES: level_zero && gpu
 
-// This test case tests if compiling works with or without
-// _GLIBCXX_USE_CXX11_ABI=0.
+// Most interested in result of Nightly run that sets _GLIBCXX_USE_CXX11_ABI=0.
 
 #include <sycl/detail/core.hpp>
 #include <sycl/platform.hpp>

--- a/sycl/test-e2e/AbiNeutral/device-info.cpp
+++ b/sycl/test-e2e/AbiNeutral/device-info.cpp
@@ -1,10 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_ENABLE_DEFAULT_CONTEXTS=1 %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -D_GLIBCXX_USE_CXX11_ABI=0 -o %t2.out %}
-// RUN: %if preview-breaking-changes-supported %{ env SYCL_ENABLE_DEFAULT_CONTEXTS=1 %{run} %t2.out %}
 
-// This test case tests if compiling works with or without
-// _GLIBCXX_USE_CXX11_ABI=0.
+// Most interested in result of Nightly run that sets _GLIBCXX_USE_CXX11_ABI=0.
 
 #include <deque>
 #include <iostream>

--- a/sycl/test-e2e/AbiNeutral/submit-kernel.cpp
+++ b/sycl/test-e2e/AbiNeutral/submit-kernel.cpp
@@ -1,10 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -D_GLIBCXX_USE_CXX11_ABI=0 -o %t2.out %}
-// RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
-// This test case tests if compiling works with or without
-// _GLIBCXX_USE_CXX11_ABI=0.
+// Most interested in result of Nightly run that sets _GLIBCXX_USE_CXX11_ABI=0.
 
 #include <iostream>
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
We test that combination in Nightly unconditionally on SPR/PVC https://github.com/intel/llvm/blob/efe036e5b5f0229824f874d3fc489377877a0115/.github/workflows/sycl-nightly.yml#L120-L132 and that functionality isn't device/backend-dependent, so no need for extra RUN lines.