### PR TITLE
[CI] Use E2E container binaries in `run-only` manual E2E task dispatch

### DIFF
--- a/devops/actions/run-tests/e2e/action.yml
+++ b/devops/actions/run-tests/e2e/action.yml
@@ -4,6 +4,9 @@ inputs:
   ref:
     required: false
   binaries_artifact:
+    # Number of input parameters for manual 'workflow_dispatch' is limited, so
+    # we treat empty value as 'in-container' when in 'run-only' mode via
+    # 'workflow_dispatch'.
     required: false
   testing_mode:
     required: true
@@ -19,12 +22,14 @@ inputs:
   sycl_compiler:
     required: false
 
-
 runs:
   using: "composite"
   steps:
   - name: Checkout E2E tests
-    if: ${{ !(inputs.testing_mode == 'run-only' && inputs.binaries_artifact == 'in-container') }}
+    if: |
+      !(inputs.testing_mode == 'run-only'
+         && (inputs.binaries_artifact == 'in-container'
+             || github.event_name == 'workflow_dispatch'))
     uses: actions/checkout@v4
     with:
       path: llvm
@@ -33,19 +38,28 @@ runs:
         llvm/utils/lit
         sycl/test-e2e
   - name: Download E2E Binaries
-    if: ${{ inputs.testing_mode == 'run-only' && inputs.binaries_artifact != 'in-container' }}
+    if: |
+      inputs.testing_mode == 'run-only'
+      && !(inputs.binaries_artifact == 'in-container'
+           || github.event_name == 'workflow_dispatch')
     uses: actions/download-artifact@v4
     with:
       name: ${{ inputs.binaries_artifact }}
   - name: Extract E2E Binaries
-    if: ${{ inputs.testing_mode == 'run-only' && inputs.binaries_artifact != 'in-container' }}
+    if: |
+      inputs.testing_mode == 'run-only'
+      && !(inputs.binaries_artifact == 'in-container'
+           || github.event_name == 'workflow_dispatch')
     shell: bash
     run: |
       mkdir build-e2e
       tar -I 'zstd' -xf e2e_binaries.tar.zst -C build-e2e
 
   - name: Extract E2E tests from container image
-    if: ${{ inputs.testing_mode == 'run-only' && inputs.binaries_artifact == 'in-container' }}
+    if: |
+      inputs.testing_mode == 'run-only'
+      && (inputs.binaries_artifact == 'in-container'
+          || github.event_name == 'workflow_dispatch')
     shell: bash
     run: |
       mkdir build-e2e llvm


### PR DESCRIPTION
https://github.com/intel/llvm/pull/19719 broke `workflow_dispatch` mode for manual E2E task invocation for compatibility testing as we don't have the required `binaries_artifact` input in that mode. Github limits number of input parameters in `workflow_dispatch` mode, so restore the functionality without introducing extra input.