### PR TITLE
[Inline] Enable constant folding for fpbuiltin sqrt

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -1700,6 +1700,12 @@ bool llvm::canConstantFoldCallTo(const CallBase *Call, const Function *F) {
   case Intrinsic::amdgcn_fma_legacy:
   case Intrinsic::amdgcn_fract:
   case Intrinsic::amdgcn_sin:
+
+  // Floating point builtin intrinsics can be folded if accuracy requirements
+  // are satisfied in addition to the rules defined for regular floating point
+  // operations.
+  case Intrinsic::fpbuiltin_sqrt:
+
   // The intrinsics below depend on rounding mode in MXCSR.
   case Intrinsic::x86_sse_cvtss2si:
   case Intrinsic::x86_sse_cvtss2si64:
@@ -2547,6 +2553,7 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
           return ConstantFP::get(Ty->getContext(), U);
         return ConstantFoldFP(atan, APF, Ty);
       case Intrinsic::sqrt:
+      case Intrinsic::fpbuiltin_sqrt:
         return ConstantFoldFP(sqrt, APF, Ty);
       case Intrinsic::amdgcn_cos:
       case Intrinsic::amdgcn_sin: {

--- a/llvm/test/Transforms/Inline/inline_constprop.ll
+++ b/llvm/test/Transforms/Inline/inline_constprop.ll
@@ -374,3 +374,18 @@ bb.true:
 bb.false:
   ret float %x
 }
+
+define float @caller9() {
+; Check that we can constant-prop through fp intrinsics
+;
+; CHECK-LABEL: @caller9(
+; CHECK-NEXT: ret float 2.000000e+00
+  %x = call float @callee9(float 16.0)
+  ret float %x
+}
+
+define float @callee9(float %x) {
+  %s = call fast float @llvm.sqrt.f32(float %x)
+  %fs = call fast float @llvm.fpbuiltin.sqrt.f32(float %s)
+  ret float %fs
+}

--- a/llvm/test/Transforms/Inline/inline_constprop.ll
+++ b/llvm/test/Transforms/Inline/inline_constprop.ll
@@ -376,7 +376,7 @@ bb.false:
 }
 
 define float @caller9() {
-; Check that we can constant-prop through fp intrinsics
+; Check that we can constant-prop through fp intrinsics.
 ;
 ; CHECK-LABEL: @caller9(
 ; CHECK-NEXT: ret float 2.000000e+00


### PR DESCRIPTION
Constant folding should meet any accuracy requirements enforceby the
fpbuiltin intrinsic as it provides correctly-rounded implementation.