### PR TITLE
[CI] Update legacy key value format

### DIFF
--- a/devops/containers/nightly.Dockerfile
+++ b/devops/containers/nightly.Dockerfile
@@ -9,8 +9,8 @@ COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 RUN mkdir -p /opt/sycl
 ADD sycl_linux.tar.gz /opt/sycl/
 
-ENV PATH /opt/sycl/bin:$PATH
-ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH
+ENV PATH=/opt/sycl/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/sycl/lib:$LD_LIBRARY_PATH
 
 USER sycl
 


### PR DESCRIPTION
Github actions issues warnings.
See: https://github.com/intel/llvm/actions/runs/16870249031
https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/