### PR TITLE
[CI] Backward-compatibility testing against `sycl-rel-6_3`

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -83,7 +83,8 @@ jobs:
     name: Read compatibility testing exclude list
     runs-on: [Linux, build]
     outputs:
-      FILTER: ${{ steps.result.outputs.FILTER }}
+      FILTER_6_2: ${{ steps.result.outputs.FILTER_6_2 }}
+      FILTER_6_3: ${{ steps.result.outputs.FILTER_6_3 }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -96,7 +97,8 @@ jobs:
       run: |
         # Transform to format expected by `llvm-lit --filter-out "pattern1|pattern2|..."`.
         # First, remove comments/empty lines, then join lines with "|" as separator.
-        echo FILTER="$(grep -v '^#\|^\W*$' devops/compat_ci_exclude.sycl-rel-6_2 | paste -sd '|')" >> $GITHUB_OUTPUT
+        echo FILTER_6_2="$(grep -v '^#\|^\W*$' devops/compat_ci_exclude.sycl-rel-6_2 | paste -sd '|')" >> $GITHUB_OUTPUT
+        echo FILTER_6_3="$(grep -v '^#\|^\W*$' devops/compat_ci_exclude.sycl-rel-6_3 | paste -sd '|')" >> $GITHUB_OUTPUT
 
   run_prebuilt_e2e_tests:
     needs: [build, detect_changes, compat_read_exclude]
@@ -147,7 +149,13 @@ jobs:
             runner: '["Linux", "pvc"]'
             image: ghcr.io/intel/llvm/sycl_prebuilt_tests:sycl-rel-6_2
             target_devices: level_zero:gpu
-            extra_lit_opts: '--param test-preview-mode=False --filter-out "${{ needs.compat_read_exclude.outputs.FILTER }}"'
+            extra_lit_opts: '--param test-preview-mode=False --filter-out "${{ needs.compat_read_exclude.outputs.FILTER_6_2 }}"'
+            e2e_binaries_artifact: 'in-container'
+          - name: ABI compatibility against sycl-rel-6_3
+            runner: '["Linux", "pvc"]'
+            image: ghcr.io/intel/llvm/sycl_prebuilt_tests:sycl-rel-6_3
+            target_devices: level_zero:gpu
+            extra_lit_opts: '--param test-preview-mode=False --filter-out "${{ needs.compat_read_exclude.outputs.FILTER_6_3 }}"'
             e2e_binaries_artifact: 'in-container'
 
     uses: ./.github/workflows/sycl-linux-run-tests.yml

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -159,6 +159,7 @@ on:
         options:
           - 'ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest'
           - 'ghcr.io/intel/llvm/sycl_prebuilt_tests:sycl-rel-6_2'
+          - 'ghcr.io/intel/llvm/sycl_prebuilt_tests:sycl-rel-6_3'
           - 'ghcr.io/intel/llvm/ubuntu2404_intel_drivers:alldeps'
       image_options:
         description: |

--- a/devops/compat_ci_exclude.sycl-rel-6_3
+++ b/devops/compat_ci_exclude.sycl-rel-6_3
@@ -1,0 +1,24 @@
+# Failed against sycl-rel-6_3 toolchain when creating the container:
+Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
+Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
+
+# Likely OK, but need author to provide justification, get approval/confirmation
+# from someone:
+
+# https://github.com/intel/llvm/pull/18565
+# This one should have probably be done in multiple PRs, first improving the
+# test's CHECKs and then making an actual functional change.
+#
+# Based on the title, I'd expect to see reduction in number of ur*retain/release
+# calls, but it only moves a few ur*release CHECKs, so I'll let the author
+# update this explanation.
+KernelAndProgram/disable-caching.cpp
+
+# https://github.com/intel/llvm/pull/19238
+NonUniformGroups/opportunistic_group.cpp
+
+# The test is extremely hacky and relies on CI installing some extra files that
+# are used during test execution. Looks like we need that to come from the
+# toolchain used to build the test, not the toolchain we're using SYCL RT from
+# to run against pre-built E2E binaries.
+Basic/device_config_file_consistency.cpp


### PR DESCRIPTION
Looks like we have three runners with `pvc` label and only one of them has `build` on it too (and we have three more non-`pvc` `build` runners), so I wouldn't expect `pvc` tasks to be a bottleneck.