### PR TITLE
[SYCL] fix for flaky ~event failure in Win unit tests

### DIFF
--- a/sycl/unittests/context_device/DeviceRefCounter.cpp
+++ b/sycl/unittests/context_device/DeviceRefCounter.cpp
@@ -28,6 +28,9 @@ static ur_result_t redefinedDeviceReleaseAfter(void *) {
   return UR_RESULT_SUCCESS;
 }
 
+#ifndef WIN32
+// This test passes because the UrMock emulates teardown on Linux, but
+// on Windows there is a difference so this test is skipped.
 TEST(DevRefCounter, DevRefCounter) {
   {
     sycl::unittest::UrMock<> Mock;
@@ -41,6 +44,7 @@ TEST(DevRefCounter, DevRefCounter) {
     sycl::platform Plt = sycl::platform();
 
     Plt.get_devices();
-  }
+  } // <- ~UrMock destructor called here.
   EXPECT_EQ(DevRefCounter, 0);
 }
+#endif // !WIN32

--- a/sycl/unittests/helpers/UrMock.hpp
+++ b/sycl/unittests/helpers/UrMock.hpp
@@ -596,6 +596,16 @@ public:
 
     sycl::detail::ur::initializeUr(UrLoaderConfig);
     urLoaderConfigRelease(UrLoaderConfig);
+
+    // We clear platform cache for each test run, so that tests can have a
+    // different backend. This forces platforms to be reconstructed (and thus
+    // queries about UR backend info to be called again) This also erases each
+    // platform's devices (normally done in the library shutdown) so that
+    // platforms/devices' lifetimes could work in unittests scenario. In SYCL,
+    // this is normally done at shutdown, but between Win/Lin and static/shared
+    // differences, there is no correct parallel in the ~UrMock destructor.
+    // Instead we do it here. Simple and clean.
+    detail::GlobalHandler::instance().getPlatformCache().clear();
   }
 
   UrMock(UrMock<Backend> &&Other) = delete;
@@ -606,18 +616,8 @@ public:
     // these between tests
     detail::GlobalHandler::instance().prepareSchedulerToRelease(true);
     detail::GlobalHandler::instance().releaseDefaultContexts();
-#ifndef WIN32
-    // Clear platform cache in case subsequent tests want a different backend.
-    // This forces platforms to be reconstructed (and thus queries about UR
-    // backend info to be called again) This also erases each platform's devices
-    // (normally done in the library shutdown) so that platforms/devices'
-    // lifetimes could work in unittests scenario. But on Windows, because the
-    // shutdown/teardown timing is slightly different, doing this now can cause
-    // a race which will cause errors. At the moment, skipping this on Windows
-    // is fine. If, in the future, we really need to clear this, do it in the
-    // UrMock constructor.
-    detail::GlobalHandler::instance().getPlatformCache().clear();
-#endif // !WIN32
+    // the platform cache is cleared at the BEGINING of the mock.
+
     mock::getCallbacks().resetCallbacks();
   }
 

--- a/sycl/unittests/helpers/UrMock.hpp
+++ b/sycl/unittests/helpers/UrMock.hpp
@@ -606,14 +606,18 @@ public:
     // these between tests
     detail::GlobalHandler::instance().prepareSchedulerToRelease(true);
     detail::GlobalHandler::instance().releaseDefaultContexts();
-    // clear platform cache in case subsequent tests want a different backend,
-    // this forces platforms to be reconstructed (and thus queries about UR
-    // backend info to be called again)
-    //
-    // This also erases each platform's devices (normally done in the library
-    // shutdown) so that platforms/devices' lifetimes could work in unittests
-    // scenario.
+#ifndef WIN32
+    // Clear platform cache in case subsequent tests want a different backend.
+    // This forces platforms to be reconstructed (and thus queries about UR
+    // backend info to be called again) This also erases each platform's devices
+    // (normally done in the library shutdown) so that platforms/devices'
+    // lifetimes could work in unittests scenario. But on Windows, because the
+    // shutdown/teardown timing is slightly different, doing this now can cause
+    // a race which will cause errors. At the moment, skipping this on Windows
+    // is fine. If, in the future, we really need to clear this, do it in the
+    // UrMock constructor.
     detail::GlobalHandler::instance().getPlatformCache().clear();
+#endif // !WIN32
     mock::getCallbacks().resetCallbacks();
   }
 


### PR DESCRIPTION
Windows shutdown/teardown doesn't have the exact same timing as on Linux, and even more in the the unit tests which are statically compiled ( so no DllMain() call, which means no space between the calls to `shutdown_early()` and `shutdown_late()` ).  Here we remove a race between the platform deletion in the mock and the win shutdown. This fixes a flaky failure we are seeing in a couple of the unit tests. 