### PR TITLE
[CI][NFC] Add clarification for ext_oneapi_can_compile change

### DIFF
--- a/devops/compat_ci_exclude.sycl-rel-6_2
+++ b/devops/compat_ci_exclude.sycl-rel-6_2
@@ -12,6 +12,16 @@ DiscardEvents/invalid_event_exceptions.cpp
 # Throw exception instead of returning garbage
 Basic/info.cpp
 
+# https://github.com/intel/llvm/pull/17442 changed the behavior of
+# ext_oneapi_can_compile to refer to whether a source-based kernel_bundle can
+# be used with compile rather than build. This makes the OpenCL kernel compiler
+# tests from the previous release fail as they expect that it returns true for
+# OpenCL-based kernel_bundles. The APIs are experimental, so this change in
+# behavior is allowed and is not considered an API/ABI break.
+KernelCompiler/opencl.cpp
+KernelCompiler/opencl_cache_eviction.cpp
+KernelCompiler/opencl_queries.cpp
+
 # Likely OK, but need author to provide justification, get approval/confirmation
 # from someone:
 
@@ -47,16 +57,6 @@ Assert/assert_in_one_kernel.cpp
 Assert/assert_in_simultaneous_kernels.cpp
 Assert/assert_in_simultaneously_multiple_tus.cpp
 Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
-
-# https://github.com/intel/llvm/pull/17442 changed the behavior of
-# ext_oneapi_can_compile to refer to whether a source-based kernel_bundle can
-# be used with compile rather than build. This makes the OpenCL kernel compiler
-# tests from the previous release fail as they expect that it returns true for
-# OpenCL-based kernel_bundles. The APIs are experimental, so this change in
-# behavior is allowed and is not considered an API/ABI break.
-KernelCompiler/opencl.cpp
-KernelCompiler/opencl_cache_eviction.cpp
-KernelCompiler/opencl_queries.cpp
 
 # https://github.com/intel/llvm/pull/18403 (pulldown, so probably offload-tools
 # team should be looking into this)


### PR DESCRIPTION
This commit adds a clarification to the change in ext_oneapi_can_compile that causes behavioral differences between releases.