### PR TITLE
[SYCL] Avoid additional allocations in has_extension

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -106,6 +106,9 @@ device_impl::get_backend_info<info::device::backend_version>() const {
 #endif
 
 bool device_impl::has_extension(const std::string &ExtensionName) const {
+  if (ExtensionName.empty())
+    return false;
+
   const std::string AllExtensionNames{
       get_info_impl<UR_DEVICE_INFO_EXTENSIONS>()};
 

--- a/sycl/unittests/context_device/HasExtensionWordBoundary.cpp
+++ b/sycl/unittests/context_device/HasExtensionWordBoundary.cpp
@@ -116,6 +116,13 @@ TEST_F(HasExtensionWordBoundaryTest, MatchAfterPartialMatch) {
   EXPECT_TRUE(Dev.has_extension("cl_khr_fp64"));
 }
 
+TEST_F(HasExtensionWordBoundaryTest, MatchEmptyString) {
+  sycl::platform Plt{sycl::platform()};
+  sycl::device Dev = Plt.get_devices()[0];
+
+  EXPECT_FALSE(Dev.has_extension(""));
+}
+
 TEST_F(HasExtensionWordBoundaryTest, NonUniformGroupExtensions) {
   MockExtensions = "cl_khr_subgroup_non_uniform_vote "
                    "cl_khr_subgroup_ballot "


### PR DESCRIPTION
https://github.com/intel/llvm/pull/19264 fixed an issue where has_extension would allow partial matches to return true. However, the proposed solution makes additional allocations to pad the strings used. To avoid this, this commit changes the implementation to explicitly check for the partial match conditions without padding either strings.