### PR TITLE
[DevMSAN] Correctly apply stride for dest/src pointer when do async copy

### DIFF
--- a/libdevice/sanitizer/msan_rtl.cpp
+++ b/libdevice/sanitizer/msan_rtl.cpp
@@ -303,11 +303,15 @@ inline void ReportError(const uint32_t size, const char __SYCL_CONSTANT__ *file,
 
 // This function is only used for shadow propagation
 template <typename T>
-void GroupAsyncCopy(uptr Dest, uptr Src, size_t NumElements, size_t Stride) {
+void GroupAsyncCopy(uptr Dest, uptr Src, size_t NumElements, size_t Stride,
+                    bool StrideOnSrc) {
   auto DestPtr = (__SYCL_GLOBAL__ T *)Dest;
   auto SrcPtr = (const __SYCL_GLOBAL__ T *)Src;
   for (size_t i = 0; i < NumElements; i++) {
-    DestPtr[i] = SrcPtr[i * Stride];
+    if (StrideOnSrc)
+      DestPtr[i] = SrcPtr[i * Stride];
+    else
+      DestPtr[i * Stride] = SrcPtr[i];
   }
 }
 
@@ -749,16 +753,20 @@ __msan_unpoison_strided_copy(uptr dest, uint32_t dest_as, uptr src,
 
     switch (element_size) {
     case 1:
-      GroupAsyncCopy<int8_t>(shadow_dest, shadow_src, counts, stride);
+      GroupAsyncCopy<int8_t>(shadow_dest, shadow_src, counts, stride,
+                             src_as == ADDRESS_SPACE_GLOBAL);
       break;
     case 2:
-      GroupAsyncCopy<int16_t>(shadow_dest, shadow_src, counts, stride);
+      GroupAsyncCopy<int16_t>(shadow_dest, shadow_src, counts, stride,
+                              src_as == ADDRESS_SPACE_GLOBAL);
       break;
     case 4:
-      GroupAsyncCopy<int32_t>(shadow_dest, shadow_src, counts, stride);
+      GroupAsyncCopy<int32_t>(shadow_dest, shadow_src, counts, stride,
+                              src_as == ADDRESS_SPACE_GLOBAL);
       break;
     case 8:
-      GroupAsyncCopy<int64_t>(shadow_dest, shadow_src, counts, stride);
+      GroupAsyncCopy<int64_t>(shadow_dest, shadow_src, counts, stride,
+                              src_as == ADDRESS_SPACE_GLOBAL);
       break;
     default:
       __spirv_ocl_printf(__msan_print_strided_copy_unsupport_type,


### PR DESCRIPTION
Currently, we always define stride in elements when writing to destination pointer. However, according to spirv spec, the stride can only be applied to global ptr.