### PR TITLE
[libspirv] Use clc function in libspirv generic math half_* functions

### DIFF
--- a/libclc/libspirv/lib/generic/math/half_cos.cl
+++ b/libclc/libspirv/lib/generic/math/half_cos.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_cos.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_cos
-#define __CLC_FUNCTION __spirv_ocl_half_cos
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_cos
+#define __IMPL_FUNCTION(x) __clc_half_cos
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_divide.cl
+++ b/libclc/libspirv/lib/generic/math/half_divide.cl
@@ -6,10 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_divide.h>
 #include <libspirv/spirv.h>
 
-#define divide(x, y) (x / y)
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_divide
+#define __IMPL_FUNCTION(x) __clc_half_divide
+#define __CLC_BODY <clc/shared/binary_def.inc>
 
-#define __CLC_BUILTIN divide
-#define __CLC_FUNCTION __spirv_ocl_half_divide
-#include <clc/math/binary_builtin.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_exp.cl
+++ b/libclc/libspirv/lib/generic/math/half_exp.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_exp.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_exp
-#define __CLC_FUNCTION __spirv_ocl_half_exp
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_exp
+#define __IMPL_FUNCTION(x) __clc_half_exp
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_exp10.cl
+++ b/libclc/libspirv/lib/generic/math/half_exp10.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_exp10.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_exp10
-#define __CLC_FUNCTION __spirv_ocl_half_exp10
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_exp10
+#define __IMPL_FUNCTION(x) __clc_half_exp10
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_exp2.cl
+++ b/libclc/libspirv/lib/generic/math/half_exp2.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_exp2.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_exp2
-#define __CLC_FUNCTION __spirv_ocl_half_exp2
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_exp2
+#define __IMPL_FUNCTION(x) __clc_half_exp2
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_log.cl
+++ b/libclc/libspirv/lib/generic/math/half_log.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_log.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_log
-#define __CLC_FUNCTION __spirv_ocl_half_log
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_log
+#define __IMPL_FUNCTION(x) __clc_half_log
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_log10.cl
+++ b/libclc/libspirv/lib/generic/math/half_log10.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_log10.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_log10
-#define __CLC_FUNCTION __spirv_ocl_half_log10
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_log10
+#define __IMPL_FUNCTION(x) __clc_half_log10
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_log2.cl
+++ b/libclc/libspirv/lib/generic/math/half_log2.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_log2.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_log2
-#define __CLC_FUNCTION __spirv_ocl_half_log2
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_log2
+#define __IMPL_FUNCTION(x) __clc_half_log2
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_powr.cl
+++ b/libclc/libspirv/lib/generic/math/half_powr.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_powr.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_powr
-#define __CLC_FUNCTION __spirv_ocl_half_powr
-#include <clc/math/binary_builtin.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_powr
+#define __IMPL_FUNCTION(x) __clc_half_powr
+#define __CLC_BODY <clc/shared/binary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_recip.cl
+++ b/libclc/libspirv/lib/generic/math/half_recip.cl
@@ -6,10 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_recip.h>
 #include <libspirv/spirv.h>
 
-#define recip(x) (1.0f / x)
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_recip
+#define __IMPL_FUNCTION(x) __clc_half_recip
+#define __CLC_BODY <clc/shared/unary_def.inc>
 
-#define __CLC_BUILTIN recip
-#define __CLC_FUNCTION __spirv_ocl_half_recip
-#include <clc/math/unary_builtin_scalarize.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_rsqrt.cl
+++ b/libclc/libspirv/lib/generic/math/half_rsqrt.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_rsqrt.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_rsqrt
-#define __CLC_FUNCTION __spirv_ocl_half_rsqrt
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_rsqrt
+#define __IMPL_FUNCTION(x) __clc_half_rsqrt
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_sin.cl
+++ b/libclc/libspirv/lib/generic/math/half_sin.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_sin.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_sin
-#define __CLC_FUNCTION __spirv_ocl_half_sin
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_sin
+#define __IMPL_FUNCTION(x) __clc_half_sin
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_sqrt.cl
+++ b/libclc/libspirv/lib/generic/math/half_sqrt.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_sqrt.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_sqrt
-#define __CLC_FUNCTION __spirv_ocl_half_sqrt
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_sqrt
+#define __IMPL_FUNCTION(x) __clc_half_sqrt
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>

--- a/libclc/libspirv/lib/generic/math/half_tan.cl
+++ b/libclc/libspirv/lib/generic/math/half_tan.cl
@@ -6,8 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clc/math/clc_half_tan.h>
 #include <libspirv/spirv.h>
 
-#define __CLC_BUILTIN __spirv_ocl_tan
-#define __CLC_FUNCTION __spirv_ocl_half_tan
-#include <clc/math/unary_builtin_scalarize.inc>
+#define __FLOAT_ONLY
+#define FUNCTION __spirv_ocl_half_tan
+#define __IMPL_FUNCTION(x) __clc_half_tan
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
+#include <clc/math/gentype.inc>


### PR DESCRIPTION
Also delete double/half type implementations, which are not allowed per spec.

llvm-diff shows lots of changes in libspirv-amdgcn--amdhsa.bc and libspirv-nvptx64--nvidiacl.bc, due to use of __ocml_* and __nv_* built-ins in clc and libspirv in intel/llvm repo.
Based on review comment in https://github.com/llvm/llvm-project/pull/153328, libclc shouldn't use __ocml_*. So bitcode change in this PR is expected.