### PR TITLE
[SYCL][Doc] Minor tweaks to SPV_INTEL_function_variants

### DIFF
--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_function_variants.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_function_variants.asciidoc
@@ -253,7 +253,7 @@ If the *{spec_capability_name}* capability is declared:
    *OpName* or *OpMemberName* referencing the instruction are removed.
 ** The decoration itself is removed.
 
-* If all 'Condition' operands of *{conditional_copy_name}* have been specialized to a known value, replace *{conditional_copy_name}* with *OpCopyObject* using the 'Operand' whose 'Condition' is *true*.
+* If all 'Condition' operands of *{conditional_copy_name}* have been specialized to a known value, replace *{conditional_copy_name}* with *OpCopyObject* using the first 'Operand' whose 'Condition' is *true*.
 
 * If the module does not contain any decorations or instructions defined by this extension, any present *OpCapability {spec_capability_name}*, *OpCapability {fnvar_capability_name}* or *OpExtension {extension_name}* instructions are removed.
 
@@ -494,7 +494,7 @@ Add to Section 3.56.9, Function Instructions:
  +
  Make a copy of 'Operand X' if 'Condition X' is *true*.
 
- From all 'Condition X'-'Operand X' pairs, 'exactly' one 'Condition X' must be *true*. Consequently, at least one 'Condition X'-'Operand X' pair must be present.
+ From all 'Condition X'-'Operand X' pairs, at least one 'Condition X' must be *true*. Consequently, at least one 'Condition X'-'Operand X' pair must be present.
 
  Each 'Condition X' must be the result of a specialization constant of scalar 'Boolean' type.
 
@@ -505,7 +505,7 @@ Add to Section 3.56.9, Function Instructions:
 1+|Capability: +
 *{spec_capability_name}*
 
-| 5 + variable | {conditional_copy_token}
+| 3 + variable | {conditional_copy_token}
 | '<id>' +
 'Result Type'
 | 'Result <id>'

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_function_variants.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_function_variants.asciidoc
@@ -476,7 +476,7 @@ See *Specialization*.
 1+|Capability: +
 *{fnvar_capability_name}*
 
-| 4 + variable | {spec_const_capabilities_token}
+| 3 + variable | {spec_const_capabilities_token}
 | '<id>' +
 'Result Type'
 | 'Result <id>'

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_function_variants.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_function_variants.asciidoc
@@ -60,8 +60,8 @@ Copyright (c) 2025 Intel Corporation. All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2025-05-08
-| Revision           | 0.11
+| Last Modified Date | 2025-08-13
+| Revision           | 0.12
 |========================================
 
 
@@ -762,4 +762,5 @@ Given the target `x86_64`, features `avx2,avx512f` and architecture `intel_cpu_s
 |0.9|2025-04-02|Jakub Žádník|Add conditional extension and specialization by capabilities
 |0.10|2025-04-22|Jakub Žádník|Added more precise wording regarding architecture comparisons
 |0.11|2025-05-08|Jakub Žádník|Misc corrections and clarifications
+|0.12|2025-08-13|Jakub Žádník|Fix word counts to match consumer impl; Allow multiple true conditional copy conditions
 |========================================


### PR DESCRIPTION
* Fixes word count to match the consumer implementation
* Allows multiple OpConditionalCopyINTEL condition operands to be true. During specialization, the first operand whose condition is true is selected.