### PR TITLE
[SYCL] Fix libspirv invalid path in -###

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -64,12 +64,11 @@ const char *SYCLInstallationDetector::findLibspirvPath(
   const SmallString<64> Basename =
       getLibSpirvBasename(DeviceTriple, HostTriple);
   auto searchAt = [&](StringRef Path, const Twine &a = "", const Twine &b = "",
-                      const Twine &c = "") -> const char * {
+                      bool HashHashHashEnabled = false) -> const char * {
     SmallString<128> LibraryPath(Path);
-    llvm::sys::path::append(LibraryPath, a, b, c, Basename);
+    llvm::sys::path::append(LibraryPath, a, b, "", Basename);
 
-    if (Args.hasArgNoClaim(options::OPT__HASH_HASH_HASH) ||
-        llvm::sys::fs::exists(LibraryPath))
+    if (HashHashHashEnabled || llvm::sys::fs::exists(LibraryPath))
       return Args.MakeArgString(LibraryPath);
 
     return nullptr;
@@ -81,7 +80,9 @@ const char *SYCLInstallationDetector::findLibspirvPath(
       return R;
 
     // Expected path w/ install.
-    if (const char *R = searchAt(IC, "share", "clc"))
+    bool HashHashHashEnabled = (&IC == &InstallationCandidates.back()) &&
+                               Args.hasArgNoClaim(options::OPT__HASH_HASH_HASH);
+    if (const char *R = searchAt(IC, "share", "clc", HashHashHashEnabled))
       return R;
   }
 

--- a/clang/test/Driver/sycl-libspirv-toolchain.cpp
+++ b/clang/test/Driver/sycl-libspirv-toolchain.cpp
@@ -29,10 +29,10 @@
 // CHECK-CUDA: "-cc1"{{.*}} "-fcuda-is-device"
 // CHECK-CUDA-NOT: "-mlink-builtin-bitcode" "{{.*}}.libspirv-{{.*}}.bc"
 //
-// The path to the remangled libspirv bitcode file is determined by the installation directory
+// The path to the remangled libspirv bitcode file is determined by the installation directory and `/share/clc/` is part of the path.
 // RUN: %clang -### -ccc-install-dir %{install_dir}  -resource-dir %{resource_dir} -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib %s 2>&1 \
-// RUN: | FileCheck %s -DINSTALL_DIR=%{install_dir} -DRESOURCE_DIR=%{resource_dir} --check-prefixes=CHECK-DIR
-// CHECK-DIR: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-mlink-builtin-bitcode" "[[INSTALL_DIR]]{{.*[\\/]}}remangled-{{.*}}.libspirv-nvptx64-nvidia-cuda.bc"
+// RUN: | FileCheck %s -DINSTALL_DIR=%{install_dir} --check-prefixes=CHECK-DIR
+// CHECK-DIR: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-mlink-builtin-bitcode" "[[INSTALL_DIR]]{{.*[\\/]}}share{{.*}}clc{{.*}}remangled-{{.*}}.libspirv-nvptx64-nvidia-cuda.bc"
 //
 // The `-###` option disables file existence checks
 // DEFINE: %{nonexistent_dir} = %/S/Inputs/SYCL/does_not_exist/lib/clang/resource_dir


### PR DESCRIPTION
In our downstream repo, bf21b9de88b3 exposed a regression that libspirv path is invalid in -### output. Before bf21b9de88b3, the path was correctly found by `searchAt(D.ResourceDir, "..", "..", "clc")`, which was deleted by the commit.
Root cause is that in -### mode the process should not early return upon the first candidate, which may do not exist. Instead, it should evaluate all candidates.