### PR TITLE
[SYCL] Fix reported P2P accessibility across platforms

### DIFF
--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -236,6 +236,12 @@ void device::ext_oneapi_disable_peer_access(const device &peer) {
 
 bool device::ext_oneapi_can_access_peer(const device &peer,
                                         ext::oneapi::peer_access attr) {
+  // Peer access cannot be granted across platforms, but the handles could
+  // potentially mimic device handles from other adapters, so we need to avoid
+  // calling the adapters with handles from other platforms.
+  if (peer.get_platform() != get_platform())
+    return false;
+
   ur_device_handle_t Device = impl->getHandleRef();
   ur_device_handle_t Peer = peer.impl->getHandleRef();
 

--- a/sycl/test-e2e/USM/P2P/p2p_access_across_platforms.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_access_across_platforms.cpp
@@ -21,7 +21,7 @@ int main() {
   if (D1 == D2) {
     std::cout << "There are no devices from different platforms. Skipping."
               << std::endl;
-    return 1;
+    return 0;
   }
 
   assert(!D1.ext_oneapi_can_access_peer(D2));

--- a/sycl/test-e2e/USM/P2P/p2p_access_across_platforms.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_access_across_platforms.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || hip || level_zero
 // RUN:  %{build} -o %t.out
 // RUN:  %{run} %t.out
 

--- a/sycl/test-e2e/USM/P2P/p2p_access_across_platforms.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_access_across_platforms.cpp
@@ -1,0 +1,29 @@
+// REQUIRES: cuda || hip || level_zero
+// RUN:  %{build} -o %t.out
+// RUN:  %{run} %t.out
+
+// Tests that P2P access is not reported as possible across platforms.
+
+#include <cassert>
+#include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
+
+int main() {
+  sycl::device D1;
+  sycl::device D2 = D1;
+  for (sycl::platform P : sycl::platform::get_platforms()) {
+    if (P != D1.get_platform() && !P.get_devices().empty()) {
+      D2 = P.get_devices()[0];
+      break;
+    }
+  }
+
+  if (D1 == D2) {
+    std::cout << "There are no devices from different platforms. Skipping."
+              << std::endl;
+    return 1;
+  }
+
+  assert(!D1.ext_oneapi_can_access_peer(D2));
+  return 0;
+}


### PR DESCRIPTION
The current P2P extension implementation assumes that the devices are from the same platform, which may not be the case. In cases where they are not the same, the adapters will try to access the handles as if they were the layout of the corresponding adapter, which may manifest as invalid accesses or unexpected read internal handle values, which can in turn conflict with actual device handles, potentially causing false positives. This commit adds a check that the devices are from the same platform before requesting the information from the backend.