### PR TITLE
Revert "[SYCL] Remove oneapi::sub_group under preview"

### DIFF
--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -32,9 +32,7 @@ inline namespace _V1 {
 struct sub_group;
 namespace ext {
 namespace oneapi {
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 struct sub_group;
-#endif
 namespace experimental {
 template <typename ParentGroup> class fragment;
 
@@ -77,12 +75,9 @@ template <int Dimensions> struct group_scope<group<Dimensions>> {
   static constexpr __spv::Scope::Flag value = __spv::Scope::Flag::Workgroup;
 };
 
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct group_scope<::sycl::ext::oneapi::sub_group> {
   static constexpr __spv::Scope::Flag value = __spv::Scope::Flag::Subgroup;
 };
-#endif
-
 template <> struct group_scope<::sycl::sub_group> {
   static constexpr __spv::Scope::Flag value = __spv::Scope::Flag::Subgroup;
 };
@@ -277,13 +272,9 @@ using WidenOpenCLTypeTo32_t = std::conditional_t<
 template <typename Group> struct GroupId {
   using type = size_t;
 };
-
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct GroupId<::sycl::ext::oneapi::sub_group> {
   using type = uint32_t;
 };
-#endif
-
 template <> struct GroupId<::sycl::sub_group> {
   using type = uint32_t;
 };

--- a/sycl/include/sycl/detail/type_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits.hpp
@@ -22,9 +22,7 @@ inline namespace _V1 {
 template <int Dimensions> class group;
 struct sub_group;
 namespace ext::oneapi {
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 struct sub_group;
-#endif
 
 namespace experimental {
 template <typename Group, std::size_t Extent> class group_with_scratchpad;
@@ -42,12 +40,9 @@ struct is_fixed_topology_group<root_group<Dimensions>> : std::true_type {};
 template <int Dimensions>
 struct is_fixed_topology_group<sycl::group<Dimensions>> : std::true_type {};
 
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 struct is_fixed_topology_group<sycl::ext::oneapi::sub_group> : std::true_type {
 };
-#endif
-
 template <> struct is_fixed_topology_group<sycl::sub_group> : std::true_type {};
 
 template <class T> struct is_user_constructed_group : std::false_type {};
@@ -79,10 +74,7 @@ struct is_group<group<Dimensions>> : std::true_type {};
 
 template <typename T> struct is_sub_group : std::false_type {};
 
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct is_sub_group<ext::oneapi::sub_group> : std::true_type {};
-#endif
-
 template <> struct is_sub_group<sycl::sub_group> : std::true_type {};
 
 template <typename T>

--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -13,7 +13,6 @@
 
 #include <tuple> // for _Swallow_assign, ignore
 
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 namespace sycl {
 inline namespace _V1 {
 namespace ext::oneapi {
@@ -35,4 +34,3 @@ private:
 } // namespace ext::oneapi
 } // namespace _V1
 } // namespace sycl
-#endif

--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -38,10 +38,8 @@ template <typename Group> struct group_scope;
 
 namespace ext::oneapi {
 
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 // forward decalre sycl::ext::oneapi::sub_group
 struct sub_group;
-#endif
 
 // defining `group_ballot` here to make predicate default `true`
 // need to forward declare sub_group_mask first
@@ -362,11 +360,8 @@ ext::oneapi::sub_group_mask commonGroupBallotImpl(Group G, bool Predicate) {
           Val, __spirv_BuiltInSubgroupMaxSize());
   // For sub-groups we do not need to apply the mask, but for others it will
   // split converging groups accordingly.
-  if constexpr (
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-      !std::is_same_v<std::decay_t<Group>, ext::oneapi::sub_group> &&
-#endif
-      !std::is_same_v<std::decay_t<Group>, sycl::sub_group>)
+  if constexpr (!std::is_same_v<std::decay_t<Group>, ext::oneapi::sub_group> &&
+                !std::is_same_v<std::decay_t<Group>, sycl::sub_group>)
     Mask &= sycl::detail::GetMask(G);
   return Mask;
 }


### PR DESCRIPTION
As discussed in https://github.com/intel/llvm/pull/13258, not all of sycl_ext_oneapi_named_sub_group_sizes has replacements ready. As such, we cannot remove the sub_group class yet.