### PR TITLE
[SYCL] Add sycl_ext_named_sub_group_sizes kernel properties

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_named_sub_group_sizes.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_named_sub_group_sizes.asciidoc
@@ -51,11 +51,12 @@ This extension also depends on the following other SYCL extensions:
 
 == Status
 
-This is a proposed extension specification, intended to gather community
-feedback. Interfaces defined in this specification may not be implemented yet
-or may be in a preliminary state. The specification itself may also change in
-incompatible ways before it is finalized. Shipping software products should not
-rely on APIs defined in this specification.
+This is an experimental extension specification, intended to provide early
+access to features and gather community feedback.  Interfaces defined in this
+specification are implemented in {dpcpp}, but they are not finalized and may
+change incompatibly in future versions of {dpcpp} without prior notice.
+*Shipping software products should not rely on APIs defined in this
+specification.*
 
 
 == Overview

--- a/sycl/include/sycl/ext/oneapi/experimental/named_sub_group_sizes.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/named_sub_group_sizes.hpp
@@ -15,8 +15,8 @@ inline namespace _V1 {
 namespace ext::oneapi::experimental {
 
 struct named_sub_group_size {
-  static constexpr uint32_t primary = 0;
-  static constexpr uint32_t automatic = -1;
+  static constexpr uint32_t primary = -1;
+  static constexpr uint32_t automatic = -2;
 };
 
 inline constexpr sub_group_size_key::value_t<named_sub_group_size::primary>

--- a/sycl/include/sycl/ext/oneapi/experimental/named_sub_group_sizes.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/named_sub_group_sizes.hpp
@@ -1,0 +1,45 @@
+//== named_sub_group_sizes.hpp --- SYCL extension for named sub-group sizes ==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/ext/oneapi/kernel_properties/properties.hpp>
+
+namespace sycl {
+inline namespace _V1 {
+namespace ext::oneapi::experimental {
+
+struct named_sub_group_size {
+  static constexpr uint32_t primary = 0;
+  static constexpr uint32_t automatic = -1;
+};
+
+inline constexpr sub_group_size_key::value_t<named_sub_group_size::primary>
+    sub_group_size_primary;
+
+inline constexpr sub_group_size_key::value_t<named_sub_group_size::automatic>
+    sub_group_size_automatic;
+
+namespace detail {
+template <>
+struct PropertyMetaInfo<
+    sub_group_size_key::value_t<named_sub_group_size::automatic>> {
+  // sub_group_size_automatic means that the kernel can be compiled with
+  // any sub-group size. That is, if the kernel has the sub_group_size_automatic
+  // property, then no sycl-sub-group-size IR attribute needs to be attached.
+  // Specializing PropertyMetaInfo for sub_group_size_automatic and setting
+  // name to an empty string will result in no sycl-sub-group-size IR being
+  // attached.
+  static constexpr const char *name = "";
+  static constexpr const char *value = 0;
+};
+} // namespace detail
+
+} // namespace ext::oneapi::experimental
+} // namespace _V1
+} // namespace sycl

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -127,6 +127,7 @@ can be disabled by setting SYCL_DISABLE_FSYCL_SYCLHPP_WARNING macro.")
 #include <sycl/ext/oneapi/experimental/group_helpers_sorters.hpp>
 #include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/group_sort.hpp>
+#include <sycl/ext/oneapi/experimental/named_sub_group_sizes.hpp>
 #include <sycl/ext/oneapi/experimental/prefetch.hpp>
 #include <sycl/ext/oneapi/experimental/profiling_tag.hpp>
 #include <sycl/ext/oneapi/experimental/raw_kernel_arg.hpp>

--- a/sycl/source/feature_test.hpp.in
+++ b/sycl/source/feature_test.hpp.in
@@ -124,6 +124,7 @@ inline namespace _V1 {
 #define SYCL_KHR_DEFAULT_CONTEXT 1
 #define SYCL_EXT_INTEL_EVENT_MODE 1
 #define SYCL_EXT_ONEAPI_TANGLE 1
+#define SYCL_EXT_ONEAPI_NAMED_SUB_GROUP_SIZES 1
 
 // Unfinished KHR extensions. These extensions are only available if the
 // __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS macro is defined.

--- a/sycl/test/extensions/properties/properties_kernel_named_sub_group_size.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_named_sub_group_size.cpp
@@ -21,4 +21,4 @@ int main() {
   q.parallel_for<class Kernel2>(ndr, P2, [=](auto id) {});
 }
 
-// CHECK: ![[SGSizeAttr]] = !{i32 0}
+// CHECK: ![[SGSizeAttr]] = !{i32 -1}

--- a/sycl/test/extensions/properties/properties_kernel_named_sub_group_size.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_named_sub_group_size.cpp
@@ -1,0 +1,24 @@
+// RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q;
+  sycl::nd_range<1> ndr{6, 2};
+
+  // CHECK: spir_kernel void @{{.*}}Kernel1()
+  // CHECK-SAME: !intel_reqd_sub_group_size ![[SGSizeAttr:[0-9]+]]
+  sycl::ext::oneapi::experimental::properties P1{
+      sycl::ext::oneapi::experimental::sub_group_size_primary};
+  q.parallel_for<class Kernel1>(ndr, P1, [=](auto id) {});
+
+  // CHECK: spir_kernel void @{{.*}}Kernel2()
+  // CHECK-NOT: intel_reqd_sub_group_size
+  // CHECK-SAME: {
+  sycl::ext::oneapi::experimental::properties P2{
+      sycl::ext::oneapi::experimental::sub_group_size_automatic};
+  q.parallel_for<class Kernel2>(ndr, P2, [=](auto id) {});
+}
+
+// CHECK: ![[SGSizeAttr]] = !{i32 0}

--- a/sycl/test/extensions/properties/properties_kernel_negative.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_negative.cpp
@@ -301,11 +301,6 @@ void check_sub_group_size() {
   // expected-error@+1 {{too few template arguments for variable template 'sub_group_size'}}
   auto WGSize0 = sycl::ext::oneapi::experimental::sub_group_size<>;
 
-  // expected-error-re@sycl/ext/oneapi/kernel_properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: sub_group_size_key property must contain a non-zero value.}}
-  // expected-error@sycl/ext/oneapi/kernel_properties/properties.hpp:* {{constexpr variable 'sub_group_size<0>' must be initialized by a constant expression}}
-  // expected-note@+1 {{in instantiation of variable template specialization 'sycl::ext::oneapi::experimental::sub_group_size<0>' requested here}}
-  auto WGSize1 = sycl::ext::oneapi::experimental::sub_group_size<0>;
-
   sycl::queue Q;
 
   // expected-error-re@sycl/ext/oneapi/properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}

--- a/sycl/test/extensions/properties/properties_kernel_negative.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_negative.cpp
@@ -301,6 +301,11 @@ void check_sub_group_size() {
   // expected-error@+1 {{too few template arguments for variable template 'sub_group_size'}}
   auto WGSize0 = sycl::ext::oneapi::experimental::sub_group_size<>;
 
+  // expected-error-re@sycl/ext/oneapi/kernel_properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: sub_group_size_key property must contain a non-zero value.}}
+  // expected-error@sycl/ext/oneapi/kernel_properties/properties.hpp:* {{constexpr variable 'sub_group_size<0>' must be initialized by a constant expression}}
+  // expected-note@+1 {{in instantiation of variable template specialization 'sycl::ext::oneapi::experimental::sub_group_size<0>' requested here}}
+  auto WGSize1 = sycl::ext::oneapi::experimental::sub_group_size<0>;
+
   sycl::queue Q;
 
   // expected-error-re@sycl/ext/oneapi/properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}


### PR DESCRIPTION
This PR adds the kernel properties required for [sycl_ext_named_sub_group_sizes](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_named_sub_group_sizes.asciidoc). When `sub_group_size_primary` is attached to a kernel, the kernel has its `!intel_reqd_sub_group_size` contain the value -1. When `sub_group_size_automatic` is attached to a kernel, the kernel does not receive any `!intel_reqd_sub_group_size` metadata. From an optional kernel features/`sycl-post-link` perspective, these behaviors are aligned with the specification, allowing `sub_group_size_automatic` marked kernels to be bundled with kernels with no attached `sub_group_size` property, while kernels marked with `sub_group_size_primary` are bundled separately with respect to other kernels marked with a required sub group size.