### PR TITLE
[SYCL][Docs] Move sycl_ext_oneapi_forward_progress to experimental

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_forward_progress.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_forward_progress.asciidoc
@@ -59,11 +59,12 @@ extension.
 
 == Status
 
-This is a proposed extension specification, intended to gather community
-feedback.  Interfaces defined in this specification may not be implemented yet
-or may be in a preliminary state.  The specification itself may also change in
-incompatible ways before it is finalized.  *Shipping software products should
-not rely on APIs defined in this specification.*
+This is an experimental extension specification, intended to provide early
+access to features and gather community feedback.  Interfaces defined in this
+specification are implemented in {dpcpp}, but they are not finalized and may
+change incompatibly in future versions of {dpcpp} without prior notice.
+*Shipping software products should not rely on APIs defined in this
+specification.*
 
 
 == Overview


### PR DESCRIPTION
This commit moves the sycl_ext_oneapi_forward_progress extension to experimental, following its implementation in
https://github.com/intel/llvm/pull/13389.