### PR TITLE
[SYCL][Docs] Add accessor property list to handler::require

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_accessor_properties.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_accessor_properties.asciidoc
@@ -335,6 +335,20 @@ class accessor {
 ...
 ```
 
+The `handler::require` function is modified to reflect this type change:
+
+```c++
+namespace sycl {
+class handler {
+public:
+  template <typename DataT, int Dimensions, access_mode AccessMode,
+            target AccessTarget, access::placeholder IsPlaceholder,
+            typename property_listT>
+  void require(accessor<DataT, Dimensions, AccessMode, AccessTarget, IsPlaceholder, property_listT> acc);
+};
+} // namespace sycl
+```
+
 Modify the code listing to add variants of all the accessor constructors that take a property_list 
 that instead take an accessor_property_list:
 

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1586,8 +1586,11 @@ public:
   ///
   /// \param Acc is a SYCL accessor describing required memory region.
   template <typename DataT, int Dims, access::mode AccMode,
-            access::target AccTarget, access::placeholder isPlaceholder>
-  void require(accessor<DataT, Dims, AccMode, AccTarget, isPlaceholder> Acc) {
+            access::target AccTarget, access::placeholder isPlaceholder,
+            typename propertyListT>
+  void require(
+      accessor<DataT, Dims, AccMode, AccTarget, isPlaceholder, propertyListT>
+          Acc) {
     if (Acc.is_placeholder())
       associateWithHandler(&Acc, AccTarget);
   }

--- a/sycl/test-e2e/Basic/accessor/accessor_property_list_placeholder.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor_property_list_placeholder.cpp
@@ -1,0 +1,22 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/detail/core.hpp>
+
+constexpr int Val = 42;
+
+int main() {
+  sycl::queue Q;
+  int OutVal = 0;
+  {
+    sycl::buffer<int> Buffer(&OutVal, sycl::range{1});
+    sycl::accessor Acc(Buffer, sycl::ext::oneapi::accessor_property_list{
+                                   sycl::ext::oneapi::no_alias});
+    Q.submit([&](sycl::handler &CGH) {
+      CGH.require(Acc);
+      CGH.single_task([=]() { Acc[0] = Val; });
+    });
+  }
+  assert(OutVal == Val);
+  return 0;
+}


### PR DESCRIPTION
This commit adds the extension accessor property list type to the type of accessor in the handler::require signature. This allows for the extension property lists to be used with placeholder accessors.

Fixes https://github.com/intel/llvm/issues/3536.