### PR TITLE
[NFC][SYCL] Update an outdated comment `initLocalInvocationId`

### DIFF
--- a/sycl/include/sycl/nd_item.hpp
+++ b/sycl/include/sycl/nd_item.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <sycl/__spirv/spirv_types.hpp>       // for Scope
-#include <sycl/__spirv/spirv_vars.hpp>        // for initLocalInvocationId
+#include <sycl/__spirv/spirv_vars.hpp> // for initBuiltInLocalInvocationId
 #include <sycl/access/access.hpp>             // for mode, fence_space
 #include <sycl/detail/defines.hpp>            // for __SYCL_ASSUME_INT
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED, __SY...


### PR DESCRIPTION
It was renamed to initBuiltInLocalInvocationId in 8fe0c4df9758