### PR TITLE
[UR] Allow `urProgramGetFunctionPointer` to return `UNSUPPORTED`

### DIFF
--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -5722,6 +5722,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramRelease(
 ///     - ::UR_RESULT_ERROR_FUNCTION_ADDRESS_NOT_AVAILABLE
 ///         + If `pFunctionName` could be located, but its address couldn't be
 ///         retrieved.
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the backend does not support querying function pointers.
 UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
     /// [in] handle of the device to retrieve pointer for.
     ur_device_handle_t hDevice,

--- a/unified-runtime/scripts/core/program.yml
+++ b/unified-runtime/scripts/core/program.yml
@@ -323,6 +323,8 @@ returns:
         - "If `pFunctionName` couldn't be found in `hProgram`."
     - $X_RESULT_ERROR_FUNCTION_ADDRESS_NOT_AVAILABLE:
         - "If `pFunctionName` could be located, but its address couldn't be retrieved."
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+        - "If the backend does not support querying function pointers."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves a pointer to a device global variable."

--- a/unified-runtime/source/adapters/offload/program.cpp
+++ b/unified-runtime/source/adapters/offload/program.cpp
@@ -293,3 +293,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetFunctionPointer([[maybe_unused]] ur_device_handle_t hDevice,
+                            [[maybe_unused]] ur_program_handle_t hProgram,
+                            [[maybe_unused]] const char *pFunctionName,
+                            [[maybe_unused]] void **ppFunctionPointer) {
+  // liboffload doesn't support a representation of function pointers (yet)
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
@@ -91,7 +91,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
   pDdiTable->pfnCreateWithIL = urProgramCreateWithIL;
   pDdiTable->pfnCreateWithNativeHandle = urProgramCreateWithNativeHandle;
   pDdiTable->pfnGetBuildInfo = nullptr;
-  pDdiTable->pfnGetFunctionPointer = nullptr;
+  pDdiTable->pfnGetFunctionPointer = urProgramGetFunctionPointer;
   pDdiTable->pfnGetGlobalVariablePointer = urProgramGetGlobalVariablePointer;
   pDdiTable->pfnGetInfo = urProgramGetInfo;
   pDdiTable->pfnGetNativeHandle = urProgramGetNativeHandle;

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -3438,6 +3438,8 @@ ur_result_t UR_APICALL urProgramRelease(
 ///     - ::UR_RESULT_ERROR_FUNCTION_ADDRESS_NOT_AVAILABLE
 ///         + If `pFunctionName` could be located, but its address couldn't be
 ///         retrieved.
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the backend does not support querying function pointers.
 ur_result_t UR_APICALL urProgramGetFunctionPointer(
     /// [in] handle of the device to retrieve pointer for.
     ur_device_handle_t hDevice,

--- a/unified-runtime/source/ur_api.cpp
+++ b/unified-runtime/source/ur_api.cpp
@@ -3024,6 +3024,8 @@ ur_result_t UR_APICALL urProgramRelease(
 ///     - ::UR_RESULT_ERROR_FUNCTION_ADDRESS_NOT_AVAILABLE
 ///         + If `pFunctionName` could be located, but its address couldn't be
 ///         retrieved.
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the backend does not support querying function pointers.
 ur_result_t UR_APICALL urProgramGetFunctionPointer(
     /// [in] handle of the device to retrieve pointer for.
     ur_device_handle_t hDevice,

--- a/unified-runtime/test/conformance/program/urProgramGetFunctionPointer.cpp
+++ b/unified-runtime/test/conformance/program/urProgramGetFunctionPointer.cpp
@@ -24,7 +24,8 @@ TEST_P(urProgramGetFunctionPointerTest, Success) {
   void *function_pointer = nullptr;
   ur_result_t res = urProgramGetFunctionPointer(
       device, program, function_name.data(), &function_pointer);
-  if (res == UR_RESULT_ERROR_FUNCTION_ADDRESS_NOT_AVAILABLE) {
+  if (res == UR_RESULT_ERROR_FUNCTION_ADDRESS_NOT_AVAILABLE ||
+      res == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
     return;
   }
   ASSERT_SUCCESS(res);
@@ -36,17 +37,10 @@ TEST_P(urProgramGetFunctionPointerTest, InvalidKernelName) {
   std::string missing_function = "aFakeFunctionName";
   auto result = urProgramGetFunctionPointer(
       device, program, missing_function.data(), &function_pointer);
-  ur_backend_t backend;
-  ASSERT_SUCCESS(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
-                                   sizeof(backend), &backend, nullptr));
-  // TODO: level zero backend incorrectly returns
-  // UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-  if (backend == UR_BACKEND_LEVEL_ZERO) {
-    ASSERT_EQ(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, result);
-  } else {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_KERNEL_NAME, result);
+  if (result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+    return;
   }
-
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_KERNEL_NAME, result);
   ASSERT_EQ(function_pointer, nullptr);
 }
 


### PR DESCRIPTION
This is primarily for liboffload which doesn't support it yet, and
probably never will for AMD devices (which don't seem to have this
functionality). In theory it will also affect level zero, at least
according to a comment, but urProgramGetFunctionPointer seems to be
implemented there.
