### PR TITLE
[UR][Offload] Implement (most) kernel info queries

### DIFF
--- a/unified-runtime/source/adapters/offload/kernel.cpp
+++ b/unified-runtime/source/adapters/offload/kernel.cpp
@@ -29,6 +29,9 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
     return offloadResultToUR(Res);
   }
 
+  Kernel->Name = pKernelName;
+  Kernel->Program = hProgram;
+
   *phKernel = Kernel;
 
   return UR_RESULT_SUCCESS;
@@ -44,6 +47,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
   switch (propName) {
   case UR_KERNEL_INFO_REFERENCE_COUNT:
     return ReturnValue(hKernel->RefCount.load());
+  case UR_KERNEL_INFO_FUNCTION_NAME:
+    return ReturnValue(hKernel->Name.c_str());
+  case UR_KERNEL_INFO_PROGRAM:
+    return ReturnValue(hKernel->Program);
+  case UR_KERNEL_INFO_CONTEXT:
+    return ReturnValue(hKernel->Program->URContext);
+  case UR_KERNEL_INFO_ATTRIBUTES:
+    return ReturnValue("");
+  case UR_KERNEL_INFO_NUM_ARGS:
+    // This is unimplementable on liboffload (and AMD/Nvidia in general)
+    [[fallthrough]];
   default:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }

--- a/unified-runtime/source/adapters/offload/kernel.hpp
+++ b/unified-runtime/source/adapters/offload/kernel.hpp
@@ -78,5 +78,7 @@ struct ur_kernel_handle_t_ : RefCounted {
   };
 
   ol_symbol_handle_t OffloadKernel;
+  ur_program_handle_t Program;
   OffloadKernelArguments Args{};
+  std::string Name;
 };

--- a/unified-runtime/test/conformance/kernel/urKernelGetInfo.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelGetInfo.cpp
@@ -28,6 +28,9 @@ TEST_P(urKernelGetInfoTest, SuccessFunctionName) {
 }
 
 TEST_P(urKernelGetInfoTest, SuccessNumArgs) {
+  // Not implementable on liboffload
+  UUR_KNOWN_FAILURE_ON(uur::Offload{});
+
   const ur_kernel_info_t property_name = UR_KERNEL_INFO_NUM_ARGS;
   size_t property_size = 0;
 
@@ -245,22 +248,22 @@ TEST_P(urKernelGetInfoTest, InvalidEnumeration) {
 
 TEST_P(urKernelGetInfoTest, InvalidSizeZero) {
   size_t property_size = 0;
-  ASSERT_SUCCESS(urKernelGetInfo(kernel, UR_KERNEL_INFO_NUM_ARGS, 0, nullptr,
-                                 &property_size));
+  ASSERT_SUCCESS(urKernelGetInfo(kernel, UR_KERNEL_INFO_FUNCTION_NAME, 0,
+                                 nullptr, &property_size));
 
   std::vector<char> property_value(property_size);
-  ASSERT_EQ_RESULT(urKernelGetInfo(kernel, UR_KERNEL_INFO_NUM_ARGS, 0,
+  ASSERT_EQ_RESULT(urKernelGetInfo(kernel, UR_KERNEL_INFO_FUNCTION_NAME, 0,
                                    property_value.data(), nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urKernelGetInfoTest, InvalidSizeSmall) {
   size_t property_size = 0;
-  ASSERT_SUCCESS(urKernelGetInfo(kernel, UR_KERNEL_INFO_NUM_ARGS, 0, nullptr,
-                                 &property_size));
+  ASSERT_SUCCESS(urKernelGetInfo(kernel, UR_KERNEL_INFO_FUNCTION_NAME, 0,
+                                 nullptr, &property_size));
 
   std::vector<char> property_value(property_size);
-  ASSERT_EQ_RESULT(urKernelGetInfo(kernel, UR_KERNEL_INFO_NUM_ARGS,
+  ASSERT_EQ_RESULT(urKernelGetInfo(kernel, UR_KERNEL_INFO_FUNCTION_NAME,
                                    property_value.size() - 1,
                                    property_value.data(), nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
@@ -268,17 +271,17 @@ TEST_P(urKernelGetInfoTest, InvalidSizeSmall) {
 
 TEST_P(urKernelGetInfoTest, InvalidNullPointerPropValue) {
   size_t property_size = 0;
-  ASSERT_SUCCESS(urKernelGetInfo(kernel, UR_KERNEL_INFO_NUM_ARGS, 0, nullptr,
-                                 &property_size));
-  ASSERT_EQ_RESULT(urKernelGetInfo(kernel, UR_KERNEL_INFO_NUM_ARGS,
+  ASSERT_SUCCESS(urKernelGetInfo(kernel, UR_KERNEL_INFO_FUNCTION_NAME, 0,
+                                 nullptr, &property_size));
+  ASSERT_EQ_RESULT(urKernelGetInfo(kernel, UR_KERNEL_INFO_FUNCTION_NAME,
                                    property_size, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
 TEST_P(urKernelGetInfoTest, InvalidNullPointerPropSizeRet) {
-  ASSERT_EQ_RESULT(
-      urKernelGetInfo(kernel, UR_KERNEL_INFO_NUM_ARGS, 0, nullptr, nullptr),
-      UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  ASSERT_EQ_RESULT(urKernelGetInfo(kernel, UR_KERNEL_INFO_FUNCTION_NAME, 0,
+                                   nullptr, nullptr),
+                   UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
 TEST_P(urKernelGetInfoTest, KernelNameCorrect) {


### PR DESCRIPTION
Almost all of the required kernel info queries have been implemented.
The only exception is `NUM_ARGS`, which isn't reported by liboffload,
CUDA or HSA (the UR plugins return the *current* number of arguments,
not the total). This test has been marked as a known failure and tests
that use it as a placeholder value have been changed to use NAME.
