### PR TITLE
[NFC][SYCL] Add `sycl::detail::sycl_obj_hash` helper

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2945,16 +2945,16 @@ struct std::hash<
     : public sycl::detail::sycl_obj_hash<
           sycl::accessor<DataT, Dimensions, AccessMode, AccessTarget,
                          IsPlaceholder>,
-          true /*UnsupportedOnDevice*/> {};
+          false /*SupportedOnDevice*/> {};
 
 template <typename DataT, int Dimensions, sycl::access_mode AccessMode>
 struct std::hash<sycl::host_accessor<DataT, Dimensions, AccessMode>>
     : public sycl::detail::sycl_obj_hash<
           sycl::host_accessor<DataT, Dimensions, AccessMode>,
-          true /*UnsupportedOnDevice*/> {};
+          false /*SupportedOnDevice*/> {};
 
 template <typename DataT, int Dimensions>
 struct std::hash<sycl::local_accessor<DataT, Dimensions>>
     : public sycl::detail::sycl_obj_hash<
           sycl::local_accessor<DataT, Dimensions>,
-          true /*UnsupportedOnDevice*/> {};
+          false /*SupportedOnDevice*/> {};

--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2937,61 +2937,24 @@ host_accessor(buffer<DataT, Dimensions, AllocatorT>, Type1, Type2, Type3, Type4,
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
 template <typename DataT, int Dimensions, sycl::access::mode AccessMode,
           sycl::access::target AccessTarget,
           sycl::access::placeholder IsPlaceholder>
-struct hash<sycl::accessor<DataT, Dimensions, AccessMode, AccessTarget,
-                           IsPlaceholder>> {
-  using AccType = sycl::accessor<DataT, Dimensions, AccessMode, AccessTarget,
-                                 IsPlaceholder>;
-
-  size_t operator()(const AccType &A) const {
-#ifdef __SYCL_DEVICE_ONLY__
-    // Hash is not supported on DEVICE. Just return 0 here.
-    (void)A;
-    return 0;
-#else
-    // getSyclObjImpl() here returns a pointer to either AccessorImplHost
-    // or LocalAccessorImplHost depending on the AccessTarget.
-    auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
-    return hash<decltype(AccImplPtr)>()(AccImplPtr);
-#endif
-  }
-};
+struct std::hash<
+    sycl::accessor<DataT, Dimensions, AccessMode, AccessTarget, IsPlaceholder>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::accessor<DataT, Dimensions, AccessMode, AccessTarget,
+                         IsPlaceholder>,
+          true /*UnsupportedOnDevice*/> {};
 
 template <typename DataT, int Dimensions, sycl::access_mode AccessMode>
-struct hash<sycl::host_accessor<DataT, Dimensions, AccessMode>> {
-  using AccType = sycl::host_accessor<DataT, Dimensions, AccessMode>;
-
-  size_t operator()(const AccType &A) const {
-#ifdef __SYCL_DEVICE_ONLY__
-    // Hash is not supported on DEVICE. Just return 0 here.
-    (void)A;
-    return 0;
-#else
-    // getSyclObjImpl() here returns a pointer to AccessorImplHost.
-    auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
-    return hash<decltype(AccImplPtr)>()(AccImplPtr);
-#endif
-  }
-};
+struct std::hash<sycl::host_accessor<DataT, Dimensions, AccessMode>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::host_accessor<DataT, Dimensions, AccessMode>,
+          true /*UnsupportedOnDevice*/> {};
 
 template <typename DataT, int Dimensions>
-struct hash<sycl::local_accessor<DataT, Dimensions>> {
-  using AccType = sycl::local_accessor<DataT, Dimensions>;
-
-  size_t operator()(const AccType &A) const {
-#ifdef __SYCL_DEVICE_ONLY__
-    // Hash is not supported on DEVICE. Just return 0 here.
-    (void)A;
-    return 0;
-#else
-    // getSyclObjImpl() here returns a pointer to LocalAccessorImplHost.
-    auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
-    return hash<decltype(AccImplPtr)>()(AccImplPtr);
-#endif
-  }
-};
-
-} // namespace std
+struct std::hash<sycl::local_accessor<DataT, Dimensions>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::local_accessor<DataT, Dimensions>,
+          true /*UnsupportedOnDevice*/> {};

--- a/sycl/include/sycl/accessor_image.hpp
+++ b/sycl/include/sycl/accessor_image.hpp
@@ -1364,7 +1364,7 @@ struct std::hash<
     : public sycl::detail::sycl_obj_hash<
           sycl::unsampled_image_accessor<DataT, Dimensions, AccessMode,
                                          AccessTarget>,
-          true /*UnsupportedOnDevice*/> {};
+          false /*SupportedOnDevice*/> {};
 
 template <typename DataT, int Dimensions, sycl::access_mode AccessMode>
 struct std::hash<
@@ -1377,7 +1377,7 @@ template <typename DataT, int Dimensions, sycl::image_target AccessTarget>
 struct std::hash<sycl::sampled_image_accessor<DataT, Dimensions, AccessTarget>>
     : public sycl::detail::sycl_obj_hash<
           sycl::sampled_image_accessor<DataT, Dimensions, AccessTarget>,
-          true /*UnsupportedOnDevice*/> {};
+          false /*SupportedOnDevice*/> {};
 
 template <typename DataT, int Dimensions>
 struct std::hash<sycl::host_sampled_image_accessor<DataT, Dimensions>>

--- a/sycl/include/sycl/accessor_image.hpp
+++ b/sycl/include/sycl/accessor_image.hpp
@@ -1357,62 +1357,29 @@ private:
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
 template <typename DataT, int Dimensions, sycl::access_mode AccessMode,
           sycl::image_target AccessTarget>
-struct hash<sycl::unsampled_image_accessor<DataT, Dimensions, AccessMode,
-                                           AccessTarget>> {
-  using AccType = sycl::unsampled_image_accessor<DataT, Dimensions, AccessMode,
-                                                 AccessTarget>;
-
-  size_t operator()(const AccType &A) const {
-#ifdef __SYCL_DEVICE_ONLY__
-    // Hash is not supported on DEVICE. Just return 0 here.
-    (void)A;
-    return 0;
-#else
-    auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
-    return hash<decltype(AccImplPtr)>()(AccImplPtr);
-#endif
-  }
-};
+struct std::hash<
+    sycl::unsampled_image_accessor<DataT, Dimensions, AccessMode, AccessTarget>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::unsampled_image_accessor<DataT, Dimensions, AccessMode,
+                                         AccessTarget>,
+          true /*UnsupportedOnDevice*/> {};
 
 template <typename DataT, int Dimensions, sycl::access_mode AccessMode>
-struct hash<
-    sycl::host_unsampled_image_accessor<DataT, Dimensions, AccessMode>> {
-  using AccType =
-      sycl::host_unsampled_image_accessor<DataT, Dimensions, AccessMode>;
-
-  size_t operator()(const AccType &A) const {
-    auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
-    return hash<decltype(AccImplPtr)>()(AccImplPtr);
-  }
+struct std::hash<
+    sycl::host_unsampled_image_accessor<DataT, Dimensions, AccessMode>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::host_unsampled_image_accessor<DataT, Dimensions, AccessMode>> {
 };
 
 template <typename DataT, int Dimensions, sycl::image_target AccessTarget>
-struct hash<sycl::sampled_image_accessor<DataT, Dimensions, AccessTarget>> {
-  using AccType = sycl::sampled_image_accessor<DataT, Dimensions, AccessTarget>;
-
-  size_t operator()(const AccType &A) const {
-#ifdef __SYCL_DEVICE_ONLY__
-    // Hash is not supported on DEVICE. Just return 0 here.
-    (void)A;
-    return 0;
-#else
-    auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
-    return hash<decltype(AccImplPtr)>()(AccImplPtr);
-#endif
-  }
-};
+struct std::hash<sycl::sampled_image_accessor<DataT, Dimensions, AccessTarget>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::sampled_image_accessor<DataT, Dimensions, AccessTarget>,
+          true /*UnsupportedOnDevice*/> {};
 
 template <typename DataT, int Dimensions>
-struct hash<sycl::host_sampled_image_accessor<DataT, Dimensions>> {
-  using AccType = sycl::host_sampled_image_accessor<DataT, Dimensions>;
-
-  size_t operator()(const AccType &A) const {
-    auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
-    return hash<decltype(AccImplPtr)>()(AccImplPtr);
-  }
-};
-
-} // namespace std
+struct std::hash<sycl::host_sampled_image_accessor<DataT, Dimensions>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::host_sampled_image_accessor<DataT, Dimensions>> {};

--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -863,12 +863,7 @@ buffer(const T *, const range<dimensions> &,
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
 template <typename T, int dimensions, typename AllocatorT>
-struct hash<sycl::buffer<T, dimensions, AllocatorT>> {
-  size_t operator()(const sycl::buffer<T, dimensions, AllocatorT> &b) const {
-    return hash<std::shared_ptr<sycl::detail::buffer_impl>>()(
-        sycl::detail::getSyclObjImpl(b));
-  }
-};
-} // namespace std
+struct std::hash<sycl::buffer<T, dimensions, AllocatorT>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::buffer<T, dimensions, AllocatorT>> {};

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -311,11 +311,6 @@ inline exception::exception(context Ctx, int EV,
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::context> {
-  size_t operator()(const sycl::context &Context) const {
-    return hash<std::shared_ptr<sycl::detail::context_impl>>()(
-        sycl::detail::getSyclObjImpl(Context));
-  }
-};
-} // namespace std
+template <>
+struct std::hash<sycl::context>
+    : public sycl::detail::sycl_obj_hash<sycl::context> {};

--- a/sycl/include/sycl/detail/impl_utils.hpp
+++ b/sycl/include/sycl/detail/impl_utils.hpp
@@ -59,9 +59,12 @@ T createSyclObjFromImpl(
   return createSyclObjFromImpl<T>(ImplRef.shared_from_this());
 }
 
-template <typename T, bool UnsupportedOnDevice = false> struct sycl_obj_hash {
+template <typename T, bool SupportedOnDevice = true> struct sycl_obj_hash {
   size_t operator()(const T &Obj) const {
-    if constexpr (UnsupportedOnDevice) {
+    if constexpr (SupportedOnDevice) {
+      auto &Impl = sycl::detail::getSyclObjImpl(Obj);
+      return std::hash<std::decay_t<decltype(Impl)>>{}(Impl);
+    } else {
 #ifdef __SYCL_DEVICE_ONLY__
       (void)Obj;
       return 0;
@@ -69,9 +72,6 @@ template <typename T, bool UnsupportedOnDevice = false> struct sycl_obj_hash {
       auto &Impl = sycl::detail::getSyclObjImpl(Obj);
       return std::hash<std::decay_t<decltype(Impl)>>{}(Impl);
 #endif
-    } else {
-      auto &Impl = sycl::detail::getSyclObjImpl(Obj);
-      return std::hash<std::decay_t<decltype(Impl)>>{}(Impl);
     }
   }
 };

--- a/sycl/include/sycl/detail/impl_utils.hpp
+++ b/sycl/include/sycl/detail/impl_utils.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cassert>     // for assert
+#include <functional>  // for hash
 #include <type_traits> // for add_pointer_t
 #include <utility>     // for forward
 
@@ -57,6 +58,23 @@ T createSyclObjFromImpl(
         ImplRef) {
   return createSyclObjFromImpl<T>(ImplRef.shared_from_this());
 }
+
+template <typename T, bool UnsupportedOnDevice = false> struct sycl_obj_hash {
+  size_t operator()(const T &Obj) const {
+    if constexpr (UnsupportedOnDevice) {
+#ifdef __SYCL_DEVICE_ONLY__
+      (void)Obj;
+      return 0;
+#else
+      auto &Impl = sycl::detail::getSyclObjImpl(Obj);
+      return std::hash<std::decay_t<decltype(Impl)>>{}(Impl);
+#endif
+    } else {
+      auto &Impl = sycl::detail::getSyclObjImpl(Obj);
+      return std::hash<std::decay_t<decltype(Impl)>>{}(Impl);
+    }
+  }
+};
 
 } // namespace detail
 } // namespace _V1

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -407,11 +407,6 @@ private:
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::device> {
-  size_t operator()(const sycl::device &Device) const {
-    return hash<std::shared_ptr<sycl::detail::device_impl>>()(
-        sycl::detail::getSyclObjImpl(Device));
-  }
-};
-} // namespace std
+template <>
+struct std::hash<sycl::device>
+    : public sycl::detail::sycl_obj_hash<sycl::device> {};

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -175,11 +175,6 @@ private:
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::event> {
-  size_t operator()(const sycl::event &e) const {
-    return hash<std::shared_ptr<sycl::detail::event_impl>>()(
-        sycl::detail::getSyclObjImpl(e));
-  }
-};
-} // namespace std
+template <>
+struct std::hash<sycl::event>
+    : public sycl::detail::sycl_obj_hash<sycl::event> {};

--- a/sycl/include/sycl/ext/oneapi/bindless_images_memory.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images_memory.hpp
@@ -117,13 +117,7 @@ enum class image_memory_handle_type : unsigned int {
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::ext::oneapi::experimental::image_mem> {
-  size_t operator()(
-      const sycl::ext::oneapi::experimental::image_mem &image_mem) const {
-    return hash<std::shared_ptr<
-        sycl::ext::oneapi::experimental::detail::image_mem_impl>>()(
-        sycl::detail::getSyclObjImpl(image_mem));
-  }
-};
-} // namespace std
+template <>
+struct std::hash<sycl::ext::oneapi::experimental::image_mem>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::ext::oneapi::experimental::image_mem> {};

--- a/sycl/include/sycl/ext/oneapi/experimental/async_alloc/memory_pool.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/async_alloc/memory_pool.hpp
@@ -110,13 +110,7 @@ protected:
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::ext::oneapi::experimental::memory_pool> {
-  size_t operator()(
-      const sycl::ext::oneapi::experimental::memory_pool &mem_pool) const {
-    return hash<std::shared_ptr<
-        sycl::ext::oneapi::experimental::detail::memory_pool_impl>>()(
-        sycl::detail::getSyclObjImpl(mem_pool));
-  }
-};
-} // namespace std
+template <>
+struct std::hash<sycl::ext::oneapi::experimental::memory_pool>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::ext::oneapi::experimental::memory_pool> {};

--- a/sycl/include/sycl/ext/oneapi/virtual_mem/physical_mem.hpp
+++ b/sycl/include/sycl/ext/oneapi/virtual_mem/physical_mem.hpp
@@ -71,12 +71,7 @@ private:
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::ext::oneapi::experimental::physical_mem> {
-  size_t operator()(
-      const sycl::ext::oneapi::experimental::physical_mem &PhysicalMem) const {
-    return hash<std::shared_ptr<sycl::detail::physical_mem_impl>>()(
-        sycl::detail::getSyclObjImpl(PhysicalMem));
-  }
-};
-} // namespace std
+template <>
+struct std::hash<sycl::ext::oneapi::experimental::physical_mem>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::ext::oneapi::experimental::physical_mem> {};

--- a/sycl/include/sycl/image.hpp
+++ b/sycl/include/sycl/image.hpp
@@ -1160,30 +1160,17 @@ private:
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
 template <int Dimensions, typename AllocatorT>
-struct hash<sycl::image<Dimensions, AllocatorT>> {
-  size_t operator()(const sycl::image<Dimensions, AllocatorT> &I) const {
-    return hash<std::shared_ptr<sycl::detail::image_impl>>()(
-        sycl::detail::getSyclObjImpl(I));
-  }
+struct std::hash<sycl::image<Dimensions, AllocatorT>>
+    : public sycl::detail::sycl_obj_hash<sycl::image<Dimensions, AllocatorT>> {
 };
 
 template <int Dimensions, typename AllocatorT>
-struct hash<sycl::unsampled_image<Dimensions, AllocatorT>> {
-  size_t
-  operator()(const sycl::unsampled_image<Dimensions, AllocatorT> &I) const {
-    return hash<std::shared_ptr<sycl::detail::image_impl>>()(
-        sycl::detail::getSyclObjImpl(I));
-  }
-};
+struct std::hash<sycl::unsampled_image<Dimensions, AllocatorT>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::unsampled_image<Dimensions, AllocatorT>> {};
 
 template <int Dimensions, typename AllocatorT>
-struct hash<sycl::sampled_image<Dimensions, AllocatorT>> {
-  size_t
-  operator()(const sycl::sampled_image<Dimensions, AllocatorT> &I) const {
-    return hash<std::shared_ptr<sycl::detail::image_impl>>()(
-        sycl::detail::getSyclObjImpl(I));
-  }
-};
-} // namespace std
+struct std::hash<sycl::sampled_image<Dimensions, AllocatorT>>
+    : public sycl::detail::sycl_obj_hash<
+          sycl::sampled_image<Dimensions, AllocatorT>> {};

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -280,11 +280,6 @@ private:
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::kernel> {
-  size_t operator()(const sycl::kernel &Kernel) const {
-    return hash<std::shared_ptr<sycl::detail::kernel_impl>>()(
-        sycl::detail::getSyclObjImpl(Kernel));
-  }
-};
-} // namespace std
+template <>
+struct std::hash<sycl::kernel>
+    : public sycl::detail::sycl_obj_hash<sycl::kernel> {};

--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -1362,25 +1362,14 @@ handler::get_specialization_constant() const {
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::kernel_id> {
-  size_t operator()(const sycl::kernel_id &KernelID) const {
-    return hash<std::shared_ptr<sycl::detail::kernel_id_impl>>()(
-        sycl::detail::getSyclObjImpl(KernelID));
-  }
-};
+template <>
+struct std::hash<sycl::kernel_id>
+    : public sycl::detail::sycl_obj_hash<sycl::kernel_id> {};
 
-template <sycl::bundle_state State> struct hash<sycl::device_image<State>> {
-  size_t operator()(const sycl::device_image<State> &DeviceImage) const {
-    return hash<std::shared_ptr<sycl::detail::device_image_impl>>()(
-        sycl::detail::getSyclObjImpl(DeviceImage));
-  }
-};
+template <sycl::bundle_state State>
+struct std::hash<sycl::device_image<State>>
+    : public sycl::detail::sycl_obj_hash<sycl::device_image<State>> {};
 
-template <sycl::bundle_state State> struct hash<sycl::kernel_bundle<State>> {
-  size_t operator()(const sycl::kernel_bundle<State> &KernelBundle) const {
-    return hash<std::shared_ptr<sycl::detail::kernel_bundle_impl>>()(
-        sycl::detail::getSyclObjImpl(KernelBundle));
-  }
-};
-} // namespace std
+template <sycl::bundle_state State>
+struct std::hash<sycl::kernel_bundle<State>>
+    : public sycl::detail::sycl_obj_hash<sycl::kernel_bundle<State>> {};

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -246,11 +246,6 @@ private:
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::platform> {
-  size_t operator()(const sycl::platform &p) const {
-    return hash<std::shared_ptr<sycl::detail::platform_impl>>()(
-        sycl::detail::getSyclObjImpl(p));
-  }
-};
-} // namespace std
+template <>
+struct std::hash<sycl::platform>
+    : public sycl::detail::sycl_obj_hash<sycl::platform> {};

--- a/sycl/include/sycl/sampler.hpp
+++ b/sycl/include/sycl/sampler.hpp
@@ -146,16 +146,7 @@ struct image_sampler {
 } // namespace _V1
 } // namespace sycl
 
-namespace std {
-template <> struct hash<sycl::sampler> {
-  size_t operator()(const sycl::sampler &s) const {
-#ifdef __SYCL_DEVICE_ONLY__
-    (void)s;
-    return 0;
-#else
-    return hash<std::shared_ptr<sycl::detail::sampler_impl>>()(
-        sycl::detail::getSyclObjImpl(s));
-#endif
-  }
-};
-} // namespace std
+template <>
+struct std::hash<sycl::sampler>
+    : public sycl::detail::sycl_obj_hash<sycl::sampler,
+                                         true /*UnsupportedOnDevice*/> {};

--- a/sycl/include/sycl/sampler.hpp
+++ b/sycl/include/sycl/sampler.hpp
@@ -149,4 +149,4 @@ struct image_sampler {
 template <>
 struct std::hash<sycl::sampler>
     : public sycl::detail::sycl_obj_hash<sycl::sampler,
-                                         true /*UnsupportedOnDevice*/> {};
+                                         false /*SupportedOnDevice*/> {};

--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -1308,4 +1308,4 @@ inline const stream &operator<<(const stream &Out, const T &RHS) {
 template <>
 struct std::hash<sycl::stream>
     : public sycl::detail::sycl_obj_hash<sycl::stream,
-                                         true /*UnsupportedOnDevice*/> {};
+                                         false /*SupportedOnDevice*/> {};

--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -1304,16 +1304,8 @@ inline const stream &operator<<(const stream &Out, const T &RHS) {
 
 } // namespace _V1
 } // namespace sycl
-namespace std {
-template <> struct hash<sycl::stream> {
-  size_t operator()(const sycl::stream &S) const {
-#ifdef __SYCL_DEVICE_ONLY__
-    (void)S;
-    return 0;
-#else
-    return hash<std::shared_ptr<sycl::detail::stream_impl>>()(
-        sycl::detail::getSyclObjImpl(S));
-#endif
-  }
-};
-} // namespace std
+
+template <>
+struct std::hash<sycl::stream>
+    : public sycl::detail::sycl_obj_hash<sycl::stream,
+                                         true /*UnsupportedOnDevice*/> {};


### PR DESCRIPTION
Unfortunately, can't simplify further in C++17.

In C++20 that could be changed to

```
template <class T>
    requires(is_sycl_common_reference_semantics_class_v<T>)
struct std::hash<T> {
// sycl_obj_hash impl inlined here.
};
```

But even in C++17 this PR removes copy-paste and places the implementation in a single place.