### PR TITLE
[SYCL][E2E] Require CUDA on max(_linear)_work_group_size property tests

### DIFF
--- a/sycl/test-e2e/Basic/max_linear_work_group_size_props.cpp
+++ b/sycl/test-e2e/Basic/max_linear_work_group_size_props.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// This property is not yet supported by all UR adapters
-// XFAIL: level_zero, opencl, hip
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16403
+// This feature is currently only supported on CUDA.
+// REQUIRES: cuda
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/Basic/max_work_group_size_props.cpp
+++ b/sycl/test-e2e/Basic/max_work_group_size_props.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// This property is not yet supported by all UR adapters
-// XFAIL: level_zero, opencl, hip
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/16403
+// This feature is currently only supported on CUDA.
+// REQUIRES: cuda
 
 #include <sycl/detail/core.hpp>
 


### PR DESCRIPTION
This commit changes the requirements in
sycl/test-e2e/Basic/max_work_group_size_props.cpp and sycl/test-e2e/Basic/max_linear_work_group_size_props.cpp to require CUDA rather than exclude other backends. This is done as the extension feature is explicitly marked as CUDA-specific in the extension document.

Closes https://github.com/intel/llvm/issues/16403