### PR TITLE
[CI] Change codeowners for backward ABI-compatibility exclude lists

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -223,3 +223,6 @@ llvm/test/Instrumentation/ThreadSanitizer/ @intel/dpcpp-sanitizers-review
 sycl/test-e2e/AddressSanitizer/ @intel/dpcpp-sanitizers-review
 sycl/test-e2e/MemorySanitizer/ @intel/dpcpp-sanitizers-review
 sycl/test-e2e/ThreadSanitizer/ @intel/dpcpp-sanitizers-review
+
+# ABI compatibility
+devops/compat_ci_exclude.sycl-rel-** @gmlueck @xtian-github


### PR DESCRIPTION
https://github.com/intel/llvm/pull/19719 and
https://github.com/intel/llvm/pull/19761 added pre-commit jobs to run E2E tests pre-built with latest "open-source" releases against the newly built sycl-toolchain libraries. Those can fail if either an actual break is happenning or if the test was doing some `FileCheck`ing and that output has changed in some way (which might not be an actual ABI break).

However, I think the testing is still good enough to require an explicit approvals by folks in charge of ABI breaking changes. For the case of just output change the author should be able to convince owners that the change isn't ABI-breaking relatively easily.