### PR TITLE
[SYCL] XFAIL ext_intel_queue_index.cpp on DG2

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/ext_intel_queue_index.cpp
@@ -4,7 +4,10 @@
 // XFAIL: gpu-intel-pvc-1T
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15699
 
-// XFAIL: linux && run-mode && (arch-intel_gpu_bmg_g21 || gpu-intel-dg2) && !igc-dev
+// XFAIL: gpu-intel-dg2
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
+
+// XFAIL: linux && run-mode && arch-intel_gpu_bmg_g21 && !igc-dev
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
 
 // XFAIL: windows && arch-intel_gpu_bmg_g21


### PR DESCRIPTION
This test is currently failing on Windows DG2 machines. Same reasoning as https://github.com/intel/llvm/pull/19811: as mentioned in https://github.com/intel/llvm/issues/18576, the root cause here is that DG2 never supported ZEX_NUMBER_OF_CCS. Therefore, XFAIL-ing this test on all DG2 machines (previously it is only XFAIL-ed on Linux DG2 machines).