### PR TITLE
[UR][L0] Remove Driver Exp Implementation of External Semaphore

### DIFF
--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -136,44 +136,15 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
   const auto &ZeCommandList = CommandList->first;
   const auto &WaitList = (*Event)->WaitList;
 
-  if (UrPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
-    ze_external_semaphore_wait_params_ext_t WaitParams = {
-        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXT, nullptr, 0};
-    WaitParams.value = hasValue ? waitValue : 0;
-    ze_external_semaphore_ext_handle_t hExtSemaphore =
-        reinterpret_cast<ze_external_semaphore_ext_handle_t>(hSemaphore);
-    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
-                   .zexCommandListAppendWaitExternalSemaphoresExp,
-               (ZeCommandList, 1, &hExtSemaphore, &WaitParams, ZeEvent,
-                WaitList.Length, WaitList.ZeEventList));
-  } else {
-    ze_command_list_handle_t translatedCommandList;
-    ZE2UR_CALL(zelLoaderTranslateHandle,
-               (ZEL_HANDLE_COMMAND_LIST, ZeCommandList,
-                (void **)&translatedCommandList));
-    ze_event_handle_t translatedEvent = ZeEvent;
-    if (ZeEvent) {
-      ZE2UR_CALL(zelLoaderTranslateHandle,
-                 (ZEL_HANDLE_EVENT, ZeEvent, (void **)&translatedEvent));
-    }
-    std::vector<ze_event_handle_t> EventHandles(WaitList.Length + 1, nullptr);
-    if (WaitList.Length > 0) {
-      for (size_t i = 0; i < WaitList.Length; i++) {
-        ze_event_handle_t ZeEvent = WaitList.ZeEventList[i];
-        ZE2UR_CALL(zelLoaderTranslateHandle,
-                   (ZEL_HANDLE_EVENT, ZeEvent, (void **)&EventHandles[i + 1]));
-      }
-    }
-    ze_intel_external_semaphore_wait_params_exp_t WaitParams = {
-        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXP, nullptr, 0};
-    WaitParams.value = hasValue ? waitValue : 0;
-    const ze_intel_external_semaphore_exp_handle_t hExtSemaphore =
-        reinterpret_cast<ze_intel_external_semaphore_exp_handle_t>(hSemaphore);
-    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
-                   .zexExpCommandListAppendWaitExternalSemaphoresExp,
-               (translatedCommandList, 1, &hExtSemaphore, &WaitParams,
-                translatedEvent, WaitList.Length, EventHandles.data()));
-  }
+  ze_external_semaphore_wait_params_ext_t WaitParams = {
+      ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXT, nullptr, 0};
+  WaitParams.value = hasValue ? waitValue : 0;
+  ze_external_semaphore_ext_handle_t hExtSemaphore =
+      reinterpret_cast<ze_external_semaphore_ext_handle_t>(hSemaphore);
+  ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
+                 .zexCommandListAppendWaitExternalSemaphoresExp,
+             (ZeCommandList, 1, &hExtSemaphore, &WaitParams, ZeEvent,
+              WaitList.Length, WaitList.ZeEventList));
 
   return UR_RESULT_SUCCESS;
 }
@@ -221,47 +192,16 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
   const auto &ZeCommandList = CommandList->first;
   const auto &WaitList = (*Event)->WaitList;
 
-  if (UrPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
-    ze_external_semaphore_signal_params_ext_t SignalParams = {
-        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXT, nullptr, 0};
-    SignalParams.value = hasValue ? signalValue : 0;
-    ze_external_semaphore_ext_handle_t hExtSemaphore =
-        reinterpret_cast<ze_external_semaphore_ext_handle_t>(hSemaphore);
+  ze_external_semaphore_signal_params_ext_t SignalParams = {
+      ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXT, nullptr, 0};
+  SignalParams.value = hasValue ? signalValue : 0;
+  ze_external_semaphore_ext_handle_t hExtSemaphore =
+      reinterpret_cast<ze_external_semaphore_ext_handle_t>(hSemaphore);
 
-    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
-                   .zexCommandListAppendSignalExternalSemaphoresExp,
-               (ZeCommandList, 1, &hExtSemaphore, &SignalParams, ZeEvent,
-                WaitList.Length, WaitList.ZeEventList));
-  } else {
-    ze_intel_external_semaphore_signal_params_exp_t SignalParams = {
-        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXP, nullptr,
-        0};
-    SignalParams.value = hasValue ? signalValue : 0;
-    const ze_intel_external_semaphore_exp_handle_t hExtSemaphore =
-        reinterpret_cast<ze_intel_external_semaphore_exp_handle_t>(hSemaphore);
-
-    ze_command_list_handle_t translatedCommandList;
-    ZE2UR_CALL(zelLoaderTranslateHandle,
-               (ZEL_HANDLE_COMMAND_LIST, ZeCommandList,
-                (void **)&translatedCommandList));
-    ze_event_handle_t translatedEvent = ZeEvent;
-    if (ZeEvent) {
-      ZE2UR_CALL(zelLoaderTranslateHandle,
-                 (ZEL_HANDLE_EVENT, ZeEvent, (void **)&translatedEvent));
-    }
-    std::vector<ze_event_handle_t> EventHandles(WaitList.Length + 1, nullptr);
-    if (WaitList.Length > 0) {
-      for (size_t i = 0; i < WaitList.Length; i++) {
-        ze_event_handle_t ZeEvent = WaitList.ZeEventList[i];
-        ZE2UR_CALL(zelLoaderTranslateHandle,
-                   (ZEL_HANDLE_EVENT, ZeEvent, (void **)&EventHandles[i + 1]));
-      }
-    }
-    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
-                   .zexExpCommandListAppendSignalExternalSemaphoresExp,
-               (translatedCommandList, 1, &hExtSemaphore, &SignalParams,
-                translatedEvent, WaitList.Length, EventHandles.data()));
-  }
+  ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
+                 .zexCommandListAppendSignalExternalSemaphoresExp,
+             (ZeCommandList, 1, &hExtSemaphore, &SignalParams, ZeEvent,
+              WaitList.Length, WaitList.ZeEventList));
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/level_zero/image_common.cpp
+++ b/unified-runtime/source/adapters/level_zero/image_common.cpp
@@ -1356,125 +1356,59 @@ ur_result_t urBindlessImagesImportExternalSemaphoreExp(
                   " {} function not supported!", __FUNCTION__);
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
-  if (UrPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
-    ze_external_semaphore_ext_desc_t SemDesc = {
-        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_EXT_DESC, nullptr,
-        ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_FD};
-    ze_external_semaphore_ext_handle_t ExtSemaphoreHandle;
-    ze_external_semaphore_fd_ext_desc_t FDExpDesc = {
-        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_FD_EXT_DESC, nullptr, 0};
-    ze_external_semaphore_win32_ext_desc_t Win32ExpDesc = {
-        ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WIN32_EXT_DESC, nullptr, nullptr,
-        nullptr};
-    void *pNext = const_cast<void *>(pExternalSemaphoreDesc->pNext);
-    while (pNext != nullptr) {
-      const ur_base_desc_t *BaseDesc =
-          static_cast<const ur_base_desc_t *>(pNext);
-      if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR) {
-        auto FileDescriptor =
-            static_cast<const ur_exp_file_descriptor_t *>(pNext);
-        FDExpDesc.fd = FileDescriptor->fd;
-        SemDesc.pNext = &FDExpDesc;
-        switch (semHandleType) {
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD:
-          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_FD;
-          break;
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_FD:
-          SemDesc.flags =
-              ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_VK_TIMELINE_SEMAPHORE_FD;
-          break;
-        default:
-          return UR_RESULT_ERROR_INVALID_VALUE;
-        }
-      } else if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE) {
-        SemDesc.pNext = &Win32ExpDesc;
-        auto Win32Handle = static_cast<const ur_exp_win32_handle_t *>(pNext);
-        switch (semHandleType) {
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT:
-          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_WIN32;
-          break;
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE:
-          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D12_FENCE;
-          break;
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_WIN32_NT:
-          SemDesc.flags =
-              ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_VK_TIMELINE_SEMAPHORE_WIN32;
-          break;
-        default:
-          return UR_RESULT_ERROR_INVALID_VALUE;
-        }
-        Win32ExpDesc.handle = Win32Handle->handle;
+  ze_external_semaphore_ext_desc_t SemDesc = {
+      ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_EXT_DESC, nullptr,
+      ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_FD};
+  ze_external_semaphore_ext_handle_t ExtSemaphoreHandle;
+  ze_external_semaphore_fd_ext_desc_t FDExpDesc = {
+      ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_FD_EXT_DESC, nullptr, 0};
+  ze_external_semaphore_win32_ext_desc_t Win32ExpDesc = {
+      ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WIN32_EXT_DESC, nullptr, nullptr,
+      nullptr};
+  void *pNext = const_cast<void *>(pExternalSemaphoreDesc->pNext);
+  while (pNext != nullptr) {
+    const ur_base_desc_t *BaseDesc = static_cast<const ur_base_desc_t *>(pNext);
+    if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR) {
+      auto FileDescriptor =
+          static_cast<const ur_exp_file_descriptor_t *>(pNext);
+      FDExpDesc.fd = FileDescriptor->fd;
+      SemDesc.pNext = &FDExpDesc;
+      switch (semHandleType) {
+      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD:
+        SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_FD;
+        break;
+      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_FD:
+        SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_VK_TIMELINE_SEMAPHORE_FD;
+        break;
+      default:
+        return UR_RESULT_ERROR_INVALID_VALUE;
       }
-      pNext = const_cast<void *>(BaseDesc->pNext);
-    }
-    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp,
-               (hDevice->ZeDevice, &SemDesc, &ExtSemaphoreHandle));
-    *phExternalSemaphoreHandle =
-        (ur_exp_external_semaphore_handle_t)ExtSemaphoreHandle;
-
-  } else {
-    ze_intel_external_semaphore_exp_desc_t SemDesc = {
-        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_EXP_DESC, nullptr,
-        ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_FD};
-    ze_intel_external_semaphore_exp_handle_t ExtSemaphoreHandle;
-    ze_intel_external_semaphore_desc_fd_exp_desc_t FDExpDesc = {
-        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_FD_EXP_DESC, nullptr, 0};
-    _ze_intel_external_semaphore_win32_exp_desc_t Win32ExpDesc = {
-        ZE_INTEL_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WIN32_EXP_DESC, nullptr,
-        nullptr, nullptr};
-    void *pNext = const_cast<void *>(pExternalSemaphoreDesc->pNext);
-    while (pNext != nullptr) {
-      const ur_base_desc_t *BaseDesc =
-          static_cast<const ur_base_desc_t *>(pNext);
-      if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR) {
-        auto FileDescriptor =
-            static_cast<const ur_exp_file_descriptor_t *>(pNext);
-        FDExpDesc.fd = FileDescriptor->fd;
-        SemDesc.pNext = &FDExpDesc;
-        switch (semHandleType) {
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD:
-          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_FD;
-          break;
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_FD:
-          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_FD;
-          break;
-        default:
-          return UR_RESULT_ERROR_INVALID_VALUE;
-        }
-      } else if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE) {
-        SemDesc.pNext = &Win32ExpDesc;
-        auto Win32Handle = static_cast<const ur_exp_win32_handle_t *>(pNext);
-        switch (semHandleType) {
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT:
-          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_OPAQUE_WIN32;
-          break;
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE:
-          SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_D3D12_FENCE;
-          break;
-        case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_WIN32_NT:
-          SemDesc.flags =
-              ZE_EXTERNAL_SEMAPHORE_EXP_FLAGS_TIMELINE_SEMAPHORE_WIN32;
-          break;
-        default:
-          return UR_RESULT_ERROR_INVALID_VALUE;
-        }
-        Win32ExpDesc.handle = Win32Handle->handle;
+    } else if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE) {
+      SemDesc.pNext = &Win32ExpDesc;
+      auto Win32Handle = static_cast<const ur_exp_win32_handle_t *>(pNext);
+      switch (semHandleType) {
+      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT:
+        SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_WIN32;
+        break;
+      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE:
+        SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D12_FENCE;
+        break;
+      case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_TIMELINE_WIN32_NT:
+        SemDesc.flags =
+            ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_VK_TIMELINE_SEMAPHORE_WIN32;
+        break;
+      default:
+        return UR_RESULT_ERROR_INVALID_VALUE;
       }
-      pNext = const_cast<void *>(BaseDesc->pNext);
+      Win32ExpDesc.handle = Win32Handle->handle;
     }
-
-    ze_device_handle_t translatedDevice;
-    ZE2UR_CALL(zelLoaderTranslateHandle, (ZEL_HANDLE_DEVICE, hDevice->ZeDevice,
-                                          (void **)&translatedDevice));
-    // If the L0 loader is not aware of the extension, the handles need to be
-    // translated
-    ZE2UR_CALL(
-        UrPlatform->ZeExternalSemaphoreExt.zexExpImportExternalSemaphoreExp,
-        (translatedDevice, &SemDesc, &ExtSemaphoreHandle));
-
-    *phExternalSemaphoreHandle =
-        (ur_exp_external_semaphore_handle_t)ExtSemaphoreHandle;
+    pNext = const_cast<void *>(BaseDesc->pNext);
   }
+
+  ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp,
+             (hDevice->ZeDevice, &SemDesc, &ExtSemaphoreHandle));
+  *phExternalSemaphoreHandle =
+      (ur_exp_external_semaphore_handle_t)ExtSemaphoreHandle;
 
   return UR_RESULT_SUCCESS;
 }
@@ -1488,15 +1422,9 @@ ur_result_t urBindlessImagesReleaseExternalSemaphoreExp(
                   " {} function not supported!", __FUNCTION__);
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
-  if (UrPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
-    ZE2UR_CALL(
-        UrPlatform->ZeExternalSemaphoreExt.zexDeviceReleaseExternalSemaphoreExp,
-        ((ze_external_semaphore_ext_handle_t)hExternalSemaphore));
-  } else {
-    ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
-                   .zexExpDeviceReleaseExternalSemaphoreExp,
-               ((ze_intel_external_semaphore_exp_handle_t)hExternalSemaphore));
-  }
+  ZE2UR_CALL(
+      UrPlatform->ZeExternalSemaphoreExt.zexDeviceReleaseExternalSemaphoreExp,
+      ((ze_external_semaphore_ext_handle_t)hExternalSemaphore));
 
   return UR_RESULT_SUCCESS;
 }

--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -218,7 +218,6 @@ ur_result_t ur_platform_handle_t_::initialize() {
              (ZeDriver, &Count, ZeExtensions.data()));
 
   bool MutableCommandListSpecExtensionSupported = false;
-  bool ZeIntelExternalSemaphoreExtensionSupported = false;
   bool ZeExternalSemaphoreExtensionSupported = false;
   bool ZeImmediateCommandListAppendExtensionFound = false;
   for (auto &extension : ZeExtensions) {
@@ -258,13 +257,6 @@ ur_result_t ur_platform_handle_t_::initialize() {
                 strlen(ZE_MUTABLE_COMMAND_LIST_EXP_NAME) + 1) == 0) {
       if (extension.version == ZE_MUTABLE_COMMAND_LIST_EXP_VERSION_1_1) {
         MutableCommandListSpecExtensionSupported = true;
-      }
-    }
-    // Check if extension is available for Exp External Sempahores
-    if (strncmp(extension.name, ZE_INTEL_EXTERNAL_SEMAPHORE_EXP_NAME,
-                strlen(ZE_INTEL_EXTERNAL_SEMAPHORE_EXP_NAME) + 1) == 0) {
-      if (extension.version == ZE_EXTERNAL_SEMAPHORE_EXP_VERSION_1_0) {
-        ZeIntelExternalSemaphoreExtensionSupported = true;
       }
     }
     // Check if extension is available for Spec External Sempahores
@@ -380,38 +372,6 @@ ur_result_t ur_platform_handle_t_::initialize() {
             .zexCommandListAppendSignalExternalSemaphoresExp != nullptr;
     ZeExternalSemaphoreExt.Supported |=
         ZeExternalSemaphoreExt.zexDeviceReleaseExternalSemaphoreExp != nullptr;
-    ZeExternalSemaphoreExt.LoaderExtension = true;
-  } else if (ZeIntelExternalSemaphoreExtensionSupported) {
-    ZeExternalSemaphoreExt.Supported |=
-        (ZE_CALL_NOCHECK(
-             zeDriverGetExtensionFunctionAddress,
-             (ZeDriver, "zeIntelDeviceImportExternalSemaphoreExp",
-              reinterpret_cast<void **>(
-                  &ZeExternalSemaphoreExt.zexExpImportExternalSemaphoreExp))) ==
-         0);
-    ZeExternalSemaphoreExt.Supported |=
-        (ZE_CALL_NOCHECK(
-             zeDriverGetExtensionFunctionAddress,
-             (ZeDriver, "zeIntelCommandListAppendWaitExternalSemaphoresExp",
-              reinterpret_cast<void **>(
-                  &ZeExternalSemaphoreExt
-                       .zexExpCommandListAppendWaitExternalSemaphoresExp))) ==
-         0);
-    ZeExternalSemaphoreExt.Supported |=
-        (ZE_CALL_NOCHECK(
-             zeDriverGetExtensionFunctionAddress,
-             (ZeDriver, "zeIntelCommandListAppendSignalExternalSemaphoresExp",
-              reinterpret_cast<void **>(
-                  &ZeExternalSemaphoreExt
-                       .zexExpCommandListAppendSignalExternalSemaphoresExp))) ==
-         0);
-    ZeExternalSemaphoreExt.Supported |=
-        (ZE_CALL_NOCHECK(
-             zeDriverGetExtensionFunctionAddress,
-             (ZeDriver, "zeIntelDeviceReleaseExternalSemaphoreExp",
-              reinterpret_cast<void **>(
-                  &ZeExternalSemaphoreExt
-                       .zexExpDeviceReleaseExternalSemaphoreExp))) == 0);
   }
 
   // Check if mutable command list extension is supported and initialize

--- a/unified-runtime/source/adapters/level_zero/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/platform.hpp
@@ -133,12 +133,6 @@ struct ur_platform_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter>,
   // Structure with function pointers for External Semaphore Extension.
   struct ZeExternalSemaphoreExtension {
     bool Supported = false;
-    // If LoaderExtension is true, the L0 loader is aware of the External
-    // Semaphore Extension. If it is false, the extension has to be loaded
-    // directly from the driver using zeDriverGetExtensionFunctionAddress. If it
-    // is loaded directly from the driver, any handles passed to it must be
-    // translated using zelLoaderTranslateHandle.
-    bool LoaderExtension = false;
     // Spec Functions
     ze_pfnDeviceImportExternalSemaphoreExt_t zexImportExternalSemaphoreExp =
         nullptr;
@@ -148,22 +142,6 @@ struct ur_platform_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter>,
         zexCommandListAppendSignalExternalSemaphoresExp = nullptr;
     ze_pfnDeviceReleaseExternalSemaphoreExt_t
         zexDeviceReleaseExternalSemaphoreExp = nullptr;
-    // Driver EXP Functions
-    ze_result_t (*zexExpImportExternalSemaphoreExp)(
-        ze_device_handle_t, const ze_intel_external_semaphore_exp_desc_t *,
-        ze_intel_external_semaphore_exp_handle_t *);
-    ze_result_t (*zexExpCommandListAppendWaitExternalSemaphoresExp)(
-        ze_command_list_handle_t, unsigned int,
-        const ze_intel_external_semaphore_exp_handle_t *,
-        const ze_intel_external_semaphore_wait_params_exp_t *,
-        ze_event_handle_t, uint32_t, ze_event_handle_t *);
-    ze_result_t (*zexExpCommandListAppendSignalExternalSemaphoresExp)(
-        ze_command_list_handle_t, size_t,
-        const ze_intel_external_semaphore_exp_handle_t *,
-        const ze_intel_external_semaphore_signal_params_exp_t *,
-        ze_event_handle_t, uint32_t, ze_event_handle_t *);
-    ze_result_t (*zexExpDeviceReleaseExternalSemaphoreExp)(
-        ze_intel_external_semaphore_exp_handle_t);
   } ZeExternalSemaphoreExt;
 
   struct ZeCommandListImmediateAppendExtension {

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -911,8 +911,7 @@ ur_result_t ur_command_list_manager::bindlessImagesWaitExternalSemaphoreExp(
     uint64_t waitValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t phEvent) {
   auto hPlatform = hContext->getPlatform();
-  if (!hPlatform->ZeExternalSemaphoreExt.Supported == false ||
-      !hPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
+  if (!hPlatform->ZeExternalSemaphoreExt.Supported == false) {
     UR_LOG_LEGACY(ERR,
                   logger::LegacyMessage("[UR][L0] {} function not supported!"),
                   "{} function not supported!", __FUNCTION__);
@@ -942,8 +941,7 @@ ur_result_t ur_command_list_manager::bindlessImagesSignalExternalSemaphoreExp(
     uint64_t signalValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t phEvent) {
   auto hPlatform = hContext->getPlatform();
-  if (!hPlatform->ZeExternalSemaphoreExt.Supported == false ||
-      !hPlatform->ZeExternalSemaphoreExt.LoaderExtension) {
+  if (!hPlatform->ZeExternalSemaphoreExt.Supported == false) {
     UR_LOG_LEGACY(ERR,
                   logger::LegacyMessage("[UR][L0] {} function not supported!"),
                   "{} function not supported!", __FUNCTION__);


### PR DESCRIPTION
- Intel L0 GPU Driver no longer supports the Driver Exp Implementation of External Semaphore and the code has been removed from the codebase, therefore the support needs to be removed from the adapter to allow compiling with newer ze_intel_gpu.h headers. 
- L0 Spec implementation is the only version required for customer support.