### PR TITLE
[SYCL] Fix SYCLBIN-related Coverity issues

### DIFF
--- a/sycl/source/detail/syclbin.hpp
+++ b/sycl/source/detail/syclbin.hpp
@@ -40,6 +40,8 @@ public:
   SYCLBIN(const SYCLBIN &Other) = delete;
   SYCLBIN(SYCLBIN &&Other) = default;
 
+  ~SYCLBIN() = default;
+
   SYCLBIN &operator=(const SYCLBIN &Other) = delete;
   SYCLBIN &operator=(SYCLBIN &&Other) = default;
 
@@ -119,12 +121,14 @@ struct SYCLBINBinaries {
 
   SYCLBINBinaries(const char *SYCLBINContent, size_t SYCLBINSize);
 
+  ~SYCLBINBinaries() = default;
+
   std::vector<const RTDeviceBinaryImage *>
   getBestCompatibleImages(device_impl &Dev);
   std::vector<const RTDeviceBinaryImage *>
   getBestCompatibleImages(devices_range Dev);
 
-  uint8_t getState() const noexcept {
+  uint8_t getState() const {
     PropertySet &GlobalMetadata =
         (*ParsedSYCLBIN
               .GlobalMetadata)[PropertySetRegistry::SYCLBIN_GLOBAL_METADATA];


### PR DESCRIPTION
This commit fixes the following Coverity issues:
* Adds explicit destructor to the SYCLBIN and SYCLBINBinaries classes, adhering to the rule-of-three.
* Removes noexcept from SYCLBINBinaries::getState() as the access to GlobalMetadata may throw an exception.