### PR TITLE
[SYCL] set __SYCL_COMPILER_VERSION from CMake variable or git commit timestamp

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -190,7 +190,33 @@ set(SYCL_EXT_ONEAPI_BACKEND_HIP ${LLVM_HAS_AMDGPU_TARGET})
 # Configure SYCL version macro
 set(sycl_inc_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(sycl_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/source)
-string(TIMESTAMP __SYCL_COMPILER_VERSION "%Y%m%d")
+
+if(NOT DEFINED SYCL_COMPILER_VERSION)
+  find_package(Git QUIET)
+  if(GIT_FOUND)
+    # Get the date of the latest commit
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} log -1 --format=%cd --date=format:%Y%m%d
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      RESULT_VARIABLE GIT_RESULT
+      OUTPUT_VARIABLE GIT_DATE
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(GIT_RESULT EQUAL 0 AND GIT_DATE)
+      set(SYCL_COMPILER_VERSION "${GIT_DATE}")
+    endif()
+  endif()
+
+  if(NOT DEFINED SYCL_COMPILER_VERSION)
+    message(WARNING "No value for SYCL_COMPILER_VERSION passed and couldn't determine timestamp of last commit, falling back to current timestamp.")
+    string(TIMESTAMP SYCL_COMPILER_VERSION "%Y%m%d")
+  endif()
+endif()
+
+set(__SYCL_COMPILER_VERSION "${SYCL_COMPILER_VERSION}")
+message(STATUS "SYCL Compiler Version: ${__SYCL_COMPILER_VERSION}")
+
 configure_file("source/version.hpp.in" "${SYCL_INCLUDE_BUILD_DIR}/sycl/version.hpp")
 configure_file("source/feature_test.hpp.in" "${SYCL_INCLUDE_BUILD_DIR}/sycl/feature_test.hpp")
 


### PR DESCRIPTION
This PR changes the way CMake sets `__SYCL_COMPILER_VERSION` from using the date of compilation to:

- using `-DSYCL_COMPILER_VERSION=...` if set
- otherwise, running git to get the timestamp of the latest commit, and using that
- falling back to the old behavior if the first two fail

See #19692 for the rationale behind this. TL;DR: Make `__SYCL_COMPILER_VERSION` reproducible. Closes #19692.