### PR TITLE
[SYCL] Fix for free_function_host_compiler lit test

### DIFF
--- a/sycl/test/extensions/free_function_kernels/free_function_host_compiler.cpp
+++ b/sycl/test/extensions/free_function_kernels/free_function_host_compiler.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl %s
 // RUN: %clangxx -fsycl -fno-sycl-unnamed-lambda %s
-// RUN: %clangxx -fsycl -fsycl-host-compiler=g++ %s
+// RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -fsycl-host-compiler-options="-std=c++17" %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 


### PR DESCRIPTION
This PR fixes issue when g++ is used as host compiler and its version does not support C++17 by default.
So by adding this flag ` -fsycl-host-compiler-options="-std=c++17"` we ensure that the lit test is compiled with C++17 standard which is required by SYCL.