### PR TITLE
[Docs] Remove OpenMP branch mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,6 @@ for general guidelines around contributing to this project. You can then see
 [ContributeToDPCPP](./sycl/doc/developer/ContributeToDPCPP.md) for DPC++ specific 
 guidelines.
 
-## Late-outline OpenMP\* and OpenMP\* Offload
-
-See [openmp](/openmp) branch.
-
 # License
 
 See [LICENSE](./sycl/LICENSE.TXT) for details.


### PR DESCRIPTION
This removes the mention of the old unused openmp branch from the top-level readme.

Closes https://github.com/intel/llvm/issues/11489.