### PR TITLE
[SYCL] Use numeric_limits instead of NAN And INFINITY macros

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/bfloat16_math.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/bfloat16_math.hpp
@@ -44,7 +44,7 @@ constexpr int num_elements_v = sycl::detail::num_elements<T>::value;
 
 /******************* isnan ********************/
 
-// According to bfloat16 format, NAN value's exponent field is 0xFF and
+// According to bfloat16 format, NaN value's exponent field is 0xFF and
 // significand has non-zero bits.
 template <typename T>
 std::enable_if_t<std::is_same_v<T, bfloat16>, bool> isnan(T x) {

--- a/sycl/include/sycl/ext/oneapi/experimental/complex/detail/complex_math.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/complex/detail/complex_math.hpp
@@ -187,7 +187,8 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
     proj(const complex<_Tp> &__c) {
   complex<_Tp> __r = __c;
   if (sycl::isinf(__c.real()) || sycl::isinf(__c.imag()))
-    __r = complex<_Tp>(INFINITY, sycl::copysign(_Tp(0), __c.imag()));
+    __r = complex<_Tp>(std::numeric_limits<float>::infinity(),
+                       sycl::copysign(_Tp(0), __c.imag()));
   return __r;
 }
 
@@ -214,7 +215,8 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
   if (sycl::isnan(__rho) || sycl::signbit(__rho))
-    return complex<_Tp>(_Tp(NAN), _Tp(NAN));
+    return complex<_Tp>(_Tp(std::numeric_limits<float>::quiet_NaN()),
+                        _Tp(std::numeric_limits<float>::quiet_NaN()));
   if (sycl::isnan(__theta)) {
     if (sycl::isinf(__rho))
       return complex<_Tp>(__rho, __theta);
@@ -222,8 +224,9 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
   }
   if (sycl::isinf(__theta)) {
     if (sycl::isinf(__rho))
-      return complex<_Tp>(__rho, _Tp(NAN));
-    return complex<_Tp>(_Tp(NAN), _Tp(NAN));
+      return complex<_Tp>(__rho, _Tp(std::numeric_limits<float>::quiet_NaN()));
+    return complex<_Tp>(_Tp(std::numeric_limits<float>::quiet_NaN()),
+                        _Tp(std::numeric_limits<float>::quiet_NaN()));
   }
   _Tp __x = __rho * sycl::cos(__theta);
   if (sycl::isnan(__x))
@@ -259,7 +262,8 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     sqrt(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
-    return complex<_Tp>(_Tp(INFINITY), __x.imag());
+    return complex<_Tp>(_Tp(std::numeric_limits<float>::infinity()),
+                        __x.imag());
   if (sycl::isinf(__x.real())) {
     if (__x.real() > _Tp(0))
       return complex<_Tp>(__x.real(), sycl::isnan(__x.imag())
@@ -288,7 +292,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
         __i = _Tp(1);
     } else if (__i == 0 || !sycl::isfinite(__i)) {
       if (sycl::isinf(__i))
-        __i = _Tp(NAN);
+        __i = _Tp(std::numeric_limits<float>::quiet_NaN());
       return complex<_Tp>(__x.real(), __i);
     }
   }
@@ -436,8 +440,9 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
                         sycl::copysign(__pi / _Tp(2), __x.imag()));
   }
   if (sycl::fabs(__x.real()) == _Tp(1) && __x.imag() == _Tp(0)) {
-    return complex<_Tp>(sycl::copysign(_Tp(INFINITY), __x.real()),
-                        sycl::copysign(_Tp(0), __x.imag()));
+    return complex<_Tp>(
+        sycl::copysign(_Tp(std::numeric_limits<float>::infinity()), __x.real()),
+        sycl::copysign(_Tp(0), __x.imag()));
   }
   complex<_Tp> __z = log((_Tp(1) + __x) / (_Tp(1) - __x)) / _Tp(2);
   return complex<_Tp>(sycl::copysign(__z.real(), __x.real()),
@@ -451,9 +456,11 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     sinh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
-    return complex<_Tp>(__x.real(), _Tp(NAN));
+    return complex<_Tp>(__x.real(),
+                        _Tp(std::numeric_limits<float>::quiet_NaN()));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
-    return complex<_Tp>(__x.real(), _Tp(NAN));
+    return complex<_Tp>(__x.real(),
+                        _Tp(std::numeric_limits<float>::quiet_NaN()));
   if (__x.imag() == 0 && !sycl::isfinite(__x.real()))
     return __x;
   return complex<_Tp>(sycl::sinh(__x.real()) * sycl::cos(__x.imag()),
@@ -467,9 +474,11 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     cosh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
-    return complex<_Tp>(sycl::fabs(__x.real()), _Tp(NAN));
+    return complex<_Tp>(sycl::fabs(__x.real()),
+                        _Tp(std::numeric_limits<float>::quiet_NaN()));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
-    return complex<_Tp>(_Tp(NAN), __x.real());
+    return complex<_Tp>(_Tp(std::numeric_limits<float>::quiet_NaN()),
+                        __x.real());
   if (__x.real() == 0 && __x.imag() == 0)
     return complex<_Tp>(_Tp(1), __x.imag());
   if (__x.imag() == 0 && !sycl::isfinite(__x.real()))

--- a/sycl/include/sycl/stl_wrappers/__sycl_complex_impl.hpp
+++ b/sycl/include/sycl/stl_wrappers/__sycl_complex_impl.hpp
@@ -12,7 +12,8 @@
 // This header defines device-side overloads of <complex> functions.
 
 #ifdef __SYCL_DEVICE_ONLY__
-#include <cmath> // For INFINITY.
+
+#include <limits>
 
 // The 'sycl_device_only' attribute enables device-side overloading.
 #define __SYCL_DEVICE __attribute__((sycl_device_only, always_inline))
@@ -82,8 +83,9 @@ float __complex__ __mulsc3(float __a, float __b, float __c, float __d) {
       __recalc = 1.0f;
     }
     if (__recalc) {
-      z = __SYCL_CMPLXF((INFINITY * (__a * __c - __b * __d)),
-                        (INFINITY * (__a * __d + __b * __c)));
+      z = __SYCL_CMPLXF(
+          (std::numeric_limits<float>::infinity() * (__a * __c - __b * __d)),
+          (std::numeric_limits<float>::infinity() * (__a * __d + __b * __c)));
     }
   }
   return z;
@@ -131,8 +133,9 @@ double __complex__ __muldc3(double __a, double __b, double __c, double __d) {
       __recalc = 1.0;
     }
     if (__recalc) {
-      z = __SYCL_CMPLX((INFINITY * (__a * __c - __b * __d)),
-                       (INFINITY * (__a * __d + __b * __c)));
+      z = __SYCL_CMPLX(
+          (std::numeric_limits<float>::infinity() * (__a * __c - __b * __d)),
+          (std::numeric_limits<float>::infinity() * (__a * __d + __b * __c)));
     }
   }
   return z;
@@ -161,15 +164,19 @@ float __complex__ __divsc3(float __a, float __b, float __c, float __d) {
   z = __SYCL_CMPLXF(z_real, z_imag);
   if (__spirv_IsNan(z_real) && __spirv_IsNan(z_imag)) {
     if ((__denom == 0.0f) && (!__spirv_IsNan(__a) || !__spirv_IsNan(__b))) {
-      z_real = __spirv_ocl_copysign(INFINITY, __c) * __a;
-      z_imag = __spirv_ocl_copysign(INFINITY, __c) * __b;
+      z_real =
+          __spirv_ocl_copysign(std::numeric_limits<float>::infinity(), __c) *
+          __a;
+      z_imag =
+          __spirv_ocl_copysign(std::numeric_limits<float>::infinity(), __c) *
+          __b;
       z = __SYCL_CMPLXF(z_real, z_imag);
     } else if ((__spirv_IsInf(__a) || __spirv_IsInf(__b)) &&
                __spirv_IsFinite(__c) && __spirv_IsFinite(__d)) {
       __a = __spirv_ocl_copysign(__spirv_IsInf(__a) ? 1.0f : 0.0f, __a);
       __b = __spirv_ocl_copysign(__spirv_IsInf(__b) ? 1.0f : 0.0f, __b);
-      z_real = INFINITY * (__a * __c + __b * __d);
-      z_imag = INFINITY * (__b * __c - __a * __d);
+      z_real = std::numeric_limits<float>::infinity() * (__a * __c + __b * __d);
+      z_imag = std::numeric_limits<float>::infinity() * (__b * __c - __a * __d);
       z = __SYCL_CMPLXF(z_real, z_imag);
     } else if (__spirv_IsInf(__logbw) && __logbw > 0.0f &&
                __spirv_IsFinite(__a) && __spirv_IsFinite(__b)) {
@@ -203,15 +210,19 @@ double __complex__ __divdc3(double __a, double __b, double __c, double __d) {
   z = __SYCL_CMPLX(z_real, z_imag);
   if (__spirv_IsNan(z_real) && __spirv_IsNan(z_imag)) {
     if ((__denom == 0.0) && (!__spirv_IsNan(__a) || !__spirv_IsNan(__b))) {
-      z_real = __spirv_ocl_copysign((double)INFINITY, __c) * __a;
-      z_imag = __spirv_ocl_copysign((double)INFINITY, __c) * __b;
+      z_real =
+          __spirv_ocl_copysign(std::numeric_limits<double>::infinity(), __c) *
+          __a;
+      z_imag =
+          __spirv_ocl_copysign(std::numeric_limits<double>::infinity(), __c) *
+          __b;
       z = __SYCL_CMPLX(z_real, z_imag);
     } else if ((__spirv_IsInf(__a) || __spirv_IsInf(__b)) &&
                __spirv_IsFinite(__c) && __spirv_IsFinite(__d)) {
       __a = __spirv_ocl_copysign(__spirv_IsInf(__a) ? 1.0 : 0.0, __a);
       __b = __spirv_ocl_copysign(__spirv_IsInf(__b) ? 1.0 : 0.0, __b);
-      z_real = INFINITY * (__a * __c + __b * __d);
-      z_imag = INFINITY * (__b * __c - __a * __d);
+      z_real = std::numeric_limits<float>::infinity() * (__a * __c + __b * __d);
+      z_imag = std::numeric_limits<float>::infinity() * (__b * __c - __a * __d);
       z = __SYCL_CMPLX(z_real, z_imag);
     } else if (__spirv_IsInf(__logbw) && __logbw > 0.0 &&
                __spirv_IsFinite(__a) && __spirv_IsFinite(__b)) {
@@ -247,14 +258,16 @@ __SYCL_DEVICE_C
 float __complex__ cprojf(float __complex__ z) {
   float __complex__ r = z;
   if (__spirv_IsInf(crealf(z)) || __spirv_IsInf(cimagf(z)))
-    r = __SYCL_CMPLXF(INFINITY, __spirv_ocl_copysign(0.0f, cimagf(z)));
+    r = __SYCL_CMPLXF(std::numeric_limits<float>::infinity(),
+                      __spirv_ocl_copysign(0.0f, cimagf(z)));
   return r;
 }
 __SYCL_DEVICE_C
 double __complex__ cproj(double __complex__ z) {
   double __complex__ r = z;
   if (__spirv_IsInf(creal(z)) || __spirv_IsInf(cimag(z)))
-    r = __SYCL_CMPLX(INFINITY, __spirv_ocl_copysign(0.0, cimag(z)));
+    r = __SYCL_CMPLX(std::numeric_limits<float>::infinity(),
+                     __spirv_ocl_copysign(0.0, cimag(z)));
   return r;
 }
 
@@ -275,7 +288,7 @@ float __complex__ cexpf(float __complex__ z) {
       return z;
     } else if (z_imag == 0.f || !__spirv_IsFinite(z_imag)) {
       if (__spirv_IsInf(z_imag))
-        return __SYCL_CMPLXF(z_real, NAN);
+        return __SYCL_CMPLXF(z_real, std::numeric_limits<float>::quiet_NaN());
     }
   }
 
@@ -293,16 +306,18 @@ double __complex__ cexp(double __complex__ z) {
         z_imag = 1.0;
     } else if (z_imag == 0.0 || !__spirv_IsFinite(z_imag)) {
       if (__spirv_IsInf(z_imag))
-        z_imag = NAN;
+        z_imag = std::numeric_limits<float>::quiet_NaN();
       return __SYCL_CMPLX(z_real, z_imag);
     }
   } else if (__spirv_IsNan(z_real)) {
     if (z_imag == 0.0)
       return z;
-    return __SYCL_CMPLX(NAN, NAN);
+    return __SYCL_CMPLX(std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN());
   } else if (__spirv_IsFinite(z_real) &&
              (__spirv_IsNan(z_imag) || __spirv_IsInf(z_imag))) {
-    return __SYCL_CMPLX(NAN, NAN);
+    return __SYCL_CMPLX(std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN());
   }
   double __e = __spirv_ocl_exp(z_real);
   double ret_real = __e * __spirv_ocl_cos(z_imag);
@@ -354,7 +369,8 @@ double __complex__ cpow(double __complex__ x, double __complex__ y) {
 __SYCL_DEVICE_C
 float __complex__ cpolarf(float rho, float theta) {
   if (__spirv_IsNan(rho) || __spirv_SignBitSet(rho))
-    return __SYCL_CMPLXF(NAN, NAN);
+    return __SYCL_CMPLXF(std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN());
   if (__spirv_IsNan(theta)) {
     if (__spirv_IsInf(rho))
       return __SYCL_CMPLXF(rho, theta);
@@ -362,8 +378,9 @@ float __complex__ cpolarf(float rho, float theta) {
   }
   if (__spirv_IsInf(theta)) {
     if (__spirv_IsInf(rho))
-      return __SYCL_CMPLXF(rho, NAN);
-    return __SYCL_CMPLXF(NAN, NAN);
+      return __SYCL_CMPLXF(rho, std::numeric_limits<float>::quiet_NaN());
+    return __SYCL_CMPLXF(std::numeric_limits<float>::quiet_NaN(),
+                         std::numeric_limits<float>::quiet_NaN());
   }
   float x = rho * __spirv_ocl_cos(theta);
   if (__spirv_IsNan(x))
@@ -376,7 +393,8 @@ float __complex__ cpolarf(float rho, float theta) {
 __SYCL_DEVICE_C
 double __complex__ cpolar(double rho, double theta) {
   if (__spirv_IsNan(rho) || __spirv_SignBitSet(rho))
-    return __SYCL_CMPLX(NAN, NAN);
+    return __SYCL_CMPLX(std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN());
   if (__spirv_IsNan(theta)) {
     if (__spirv_IsInf(rho))
       return __SYCL_CMPLX(rho, theta);
@@ -384,8 +402,9 @@ double __complex__ cpolar(double rho, double theta) {
   }
   if (__spirv_IsInf(theta)) {
     if (__spirv_IsInf(rho))
-      return __SYCL_CMPLX(rho, NAN);
-    return __SYCL_CMPLX(NAN, NAN);
+      return __SYCL_CMPLX(rho, std::numeric_limits<float>::quiet_NaN());
+    return __SYCL_CMPLX(std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN());
   }
   double x = rho * __spirv_ocl_cos(theta);
   if (__spirv_IsNan(x))
@@ -401,7 +420,7 @@ float __complex__ csqrtf(float __complex__ z) {
   float z_real = crealf(z);
   float z_imag = cimagf(z);
   if (__spirv_IsInf(z_imag))
-    return __SYCL_CMPLXF(INFINITY, z_imag);
+    return __SYCL_CMPLXF(std::numeric_limits<float>::infinity(), z_imag);
   if (__spirv_IsInf(z_real)) {
     if (z_real > 0.0f)
       return __SYCL_CMPLXF(z_real, __spirv_IsNan(z_imag)
@@ -417,7 +436,7 @@ double __complex__ csqrt(double __complex__ z) {
   double z_real = creal(z);
   double z_imag = cimag(z);
   if (__spirv_IsInf(z_imag))
-    return __SYCL_CMPLX(INFINITY, z_imag);
+    return __SYCL_CMPLX(std::numeric_limits<float>::infinity(), z_imag);
   if (__spirv_IsInf(z_real)) {
     if (z_real > 0.0)
       return __SYCL_CMPLX(z_real, __spirv_IsNan(z_imag)
@@ -434,9 +453,9 @@ float __complex__ csinhf(float __complex__ z) {
   float z_real = crealf(z);
   float z_imag = cimagf(z);
   if (__spirv_IsInf(z_real) && !__spirv_IsFinite(z_imag))
-    return __SYCL_CMPLXF(z_real, NAN);
+    return __SYCL_CMPLXF(z_real, std::numeric_limits<float>::quiet_NaN());
   if (z_real == 0 && !__spirv_IsFinite(z_imag))
-    return __SYCL_CMPLXF(z_real, NAN);
+    return __SYCL_CMPLXF(z_real, std::numeric_limits<float>::quiet_NaN());
   if (z_imag == 0 && !__spirv_IsFinite(z_real))
     return z;
   return __SYCL_CMPLXF(__spirv_ocl_sinh(z_real) * __spirv_ocl_cos(z_imag),
@@ -447,9 +466,9 @@ double __complex__ csinh(double __complex__ z) {
   double z_real = creal(z);
   double z_imag = cimag(z);
   if (__spirv_IsInf(z_real) && !__spirv_IsFinite(z_imag))
-    return __SYCL_CMPLX(z_real, NAN);
+    return __SYCL_CMPLX(z_real, std::numeric_limits<float>::quiet_NaN());
   if (z_real == 0 && !__spirv_IsFinite(z_imag))
-    return __SYCL_CMPLX(z_real, NAN);
+    return __SYCL_CMPLX(z_real, std::numeric_limits<float>::quiet_NaN());
   if (z_imag == 0 && !__spirv_IsFinite(z_real))
     return z;
   return __SYCL_CMPLX(__spirv_ocl_sinh(z_real) * __spirv_ocl_cos(z_imag),
@@ -461,9 +480,10 @@ float __complex__ ccoshf(float __complex__ z) {
   float z_real = crealf(z);
   float z_imag = cimagf(z);
   if (__spirv_IsInf(z_real) && !__spirv_IsFinite(z_imag))
-    return __SYCL_CMPLXF(__spirv_ocl_fabs(z_real), NAN);
+    return __SYCL_CMPLXF(__spirv_ocl_fabs(z_real),
+                         std::numeric_limits<float>::quiet_NaN());
   if (z_real == 0 && !__spirv_IsFinite(z_imag))
-    return __SYCL_CMPLXF(NAN, z_real);
+    return __SYCL_CMPLXF(std::numeric_limits<float>::quiet_NaN(), z_real);
   if (z_real == 0 && z_imag == 0)
     return __SYCL_CMPLXF(1.0f, z_imag);
   if (z_imag == 0 && !__spirv_IsFinite(z_real))
@@ -476,9 +496,10 @@ double __complex__ ccosh(double __complex__ z) {
   double z_real = creal(z);
   double z_imag = cimag(z);
   if (__spirv_IsInf(z_real) && !__spirv_IsFinite(z_imag))
-    return __SYCL_CMPLX(__spirv_ocl_fabs(z_real), NAN);
+    return __SYCL_CMPLX(__spirv_ocl_fabs(z_real),
+                        std::numeric_limits<float>::quiet_NaN());
   if (z_real == 0 && !__spirv_IsFinite(z_imag))
-    return __SYCL_CMPLX(NAN, z_real);
+    return __SYCL_CMPLX(std::numeric_limits<float>::quiet_NaN(), z_real);
   if (z_real == 0 && z_imag == 0)
     return __SYCL_CMPLX(1.0f, z_imag);
   if (z_imag == 0 && !__spirv_IsFinite(z_real))
@@ -790,8 +811,9 @@ float __complex__ catanhf(float __complex__ z) {
     return __SYCL_CMPLXF(__spirv_ocl_copysign(0.0f, z_real),
                          __spirv_ocl_copysign(__pi / 2.0f, z_imag));
   if (__spirv_ocl_fabs(z_real) == 1.0f && z_imag == 0.0f)
-    return __SYCL_CMPLXF(__spirv_ocl_copysign(INFINITY, z_real),
-                         __spirv_ocl_copysign(0.0f, z_imag));
+    return __SYCL_CMPLXF(
+        __spirv_ocl_copysign(std::numeric_limits<float>::infinity(), z_real),
+        __spirv_ocl_copysign(0.0f, z_imag));
   float __complex__ t1 = 1.0f + z;
   float __complex__ t2 = 1.0f - z;
   float __complex__ t3 =
@@ -820,7 +842,7 @@ double __complex__ catanh(double __complex__ z) {
                         __spirv_ocl_copysign(__pi / 2.0, z_imag));
   if (__spirv_ocl_fabs(z_real) == 1.0 && z_imag == 0.0)
     return __SYCL_CMPLX(
-        __spirv_ocl_copysign(static_cast<double>(INFINITY), z_real),
+        __spirv_ocl_copysign(std::numeric_limits<double>::infinity(), z_real),
         __spirv_ocl_copysign(0.0, z_imag));
   double __complex__ t1 = 1.0 + z;
   double __complex__ t2 = 1.0 - z;

--- a/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
+++ b/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
@@ -64,7 +64,7 @@ template <typename T> bool test() {
       /* 31 */ std::complex<T>(-1.e+6, 0),
 
       /* 32 */ std::complex<T>(QNaN, QNaN),
-      /* 33 */ std::complex<T>(-Infinity, NAN),
+      /* 33 */ std::complex<T>(-Infinity, QNaN),
       /* 34 */ std::complex<T>(-2, QNaN),
       /* 35 */ std::complex<T>(-1, QNaN),
       /* 36 */ std::complex<T>(-0.5, QNaN),

--- a/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
+++ b/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
@@ -1,14 +1,14 @@
 // This test checks edge cases handling for std::exp(std::complex<T>) used
 // in SYCL kernels.
 
-// This include should happen before <sycl/detail/core.hpp> or otherwise NAN
-// may not be constexpr on some Windows configurations. See intel/llvm#19114
-#include <cmath>
-
 #include <sycl/detail/core.hpp>
 
 #include <complex>
+#include <limits>
 #include <type_traits>
+
+constexpr float QNaN = std::numeric_limits<float>::quiet_NaN();
+constexpr float Infinity = std::numeric_limits<float>::infinity();
 
 bool check(bool cond, const std::string &cond_str, int line,
            unsigned testcase) {
@@ -63,32 +63,32 @@ template <typename T> bool test() {
       /* 30 */ std::complex<T>(1.e+6, 0),
       /* 31 */ std::complex<T>(-1.e+6, 0),
 
-      /* 32 */ std::complex<T>(NAN, NAN),
-      /* 33 */ std::complex<T>(-INFINITY, NAN),
-      /* 34 */ std::complex<T>(-2, NAN),
-      /* 35 */ std::complex<T>(-1, NAN),
-      /* 36 */ std::complex<T>(-0.5, NAN),
-      /* 37 */ std::complex<T>(-0., NAN),
-      /* 38 */ std::complex<T>(+0., NAN),
-      /* 39 */ std::complex<T>(0.5, NAN),
-      /* 40 */ std::complex<T>(1, NAN),
-      /* 41 */ std::complex<T>(2, NAN),
-      /* 42 */ std::complex<T>(INFINITY, NAN),
+      /* 32 */ std::complex<T>(QNaN, QNaN),
+      /* 33 */ std::complex<T>(-Infinity, NAN),
+      /* 34 */ std::complex<T>(-2, QNaN),
+      /* 35 */ std::complex<T>(-1, QNaN),
+      /* 36 */ std::complex<T>(-0.5, QNaN),
+      /* 37 */ std::complex<T>(-0., QNaN),
+      /* 38 */ std::complex<T>(+0., QNaN),
+      /* 39 */ std::complex<T>(0.5, QNaN),
+      /* 40 */ std::complex<T>(1, QNaN),
+      /* 41 */ std::complex<T>(2, QNaN),
+      /* 42 */ std::complex<T>(Infinity, QNaN),
 
-      /* 43 */ std::complex<T>(NAN, -INFINITY),
-      /* 44 */ std::complex<T>(-INFINITY, -INFINITY),
-      /* 45 */ std::complex<T>(-2, -INFINITY),
-      /* 46 */ std::complex<T>(-1, -INFINITY),
-      /* 47 */ std::complex<T>(-0.5, -INFINITY),
-      /* 48 */ std::complex<T>(-0., -INFINITY),
-      /* 49 */ std::complex<T>(+0., -INFINITY),
-      /* 50 */ std::complex<T>(0.5, -INFINITY),
-      /* 51 */ std::complex<T>(1, -INFINITY),
-      /* 52 */ std::complex<T>(2, -INFINITY),
-      /* 53 */ std::complex<T>(INFINITY, -INFINITY),
+      /* 43 */ std::complex<T>(QNaN, -Infinity),
+      /* 44 */ std::complex<T>(-Infinity, -Infinity),
+      /* 45 */ std::complex<T>(-2, -Infinity),
+      /* 46 */ std::complex<T>(-1, -Infinity),
+      /* 47 */ std::complex<T>(-0.5, -Infinity),
+      /* 48 */ std::complex<T>(-0., -Infinity),
+      /* 49 */ std::complex<T>(+0., -Infinity),
+      /* 50 */ std::complex<T>(0.5, -Infinity),
+      /* 51 */ std::complex<T>(1, -Infinity),
+      /* 52 */ std::complex<T>(2, -Infinity),
+      /* 53 */ std::complex<T>(Infinity, -Infinity),
 
-      /* 54 */ std::complex<T>(NAN, -2),
-      /* 55 */ std::complex<T>(-INFINITY, -2),
+      /* 54 */ std::complex<T>(QNaN, -2),
+      /* 55 */ std::complex<T>(-Infinity, -2),
       /* 56 */ std::complex<T>(-2, -2),
       /* 57 */ std::complex<T>(-1, -2),
       /* 58 */ std::complex<T>(-0.5, -2),
@@ -97,10 +97,10 @@ template <typename T> bool test() {
       /* 61 */ std::complex<T>(0.5, -2),
       /* 62 */ std::complex<T>(1, -2),
       /* 63 */ std::complex<T>(2, -2),
-      /* 64 */ std::complex<T>(INFINITY, -2),
+      /* 64 */ std::complex<T>(Infinity, -2),
 
-      /* 65 */ std::complex<T>(NAN, -1),
-      /* 66 */ std::complex<T>(-INFINITY, -1),
+      /* 65 */ std::complex<T>(QNaN, -1),
+      /* 66 */ std::complex<T>(-Infinity, -1),
       /* 67 */ std::complex<T>(-2, -1),
       /* 68 */ std::complex<T>(-1, -1),
       /* 69 */ std::complex<T>(-0.5, -1),
@@ -109,10 +109,10 @@ template <typename T> bool test() {
       /* 72 */ std::complex<T>(0.5, -1),
       /* 73 */ std::complex<T>(1, -1),
       /* 74 */ std::complex<T>(2, -1),
-      /* 75 */ std::complex<T>(INFINITY, -1),
+      /* 75 */ std::complex<T>(Infinity, -1),
 
-      /* 76 */ std::complex<T>(NAN, -0.5),
-      /* 77 */ std::complex<T>(-INFINITY, -0.5),
+      /* 76 */ std::complex<T>(QNaN, -0.5),
+      /* 77 */ std::complex<T>(-Infinity, -0.5),
       /* 78 */ std::complex<T>(-2, -0.5),
       /* 79 */ std::complex<T>(-1, -0.5),
       /* 80 */ std::complex<T>(-0.5, -0.5),
@@ -121,10 +121,10 @@ template <typename T> bool test() {
       /* 83 */ std::complex<T>(0.5, -0.5),
       /* 84 */ std::complex<T>(1, -0.5),
       /* 85 */ std::complex<T>(2, -0.5),
-      /* 86 */ std::complex<T>(INFINITY, -0.5),
+      /* 86 */ std::complex<T>(Infinity, -0.5),
 
-      /* 87 */ std::complex<T>(NAN, -0.),
-      /* 88 */ std::complex<T>(-INFINITY, -0.),
+      /* 87 */ std::complex<T>(QNaN, -0.),
+      /* 88 */ std::complex<T>(-Infinity, -0.),
       /* 89 */ std::complex<T>(-2, -0.),
       /* 90 */ std::complex<T>(-1, -0.),
       /* 91 */ std::complex<T>(-0.5, -0.),
@@ -133,10 +133,10 @@ template <typename T> bool test() {
       /* 94 */ std::complex<T>(0.5, -0.),
       /* 95 */ std::complex<T>(1, -0.),
       /* 96 */ std::complex<T>(2, -0.),
-      /* 97 */ std::complex<T>(INFINITY, -0.),
+      /* 97 */ std::complex<T>(Infinity, -0.),
 
-      /* 98 */ std::complex<T>(NAN, +0.),
-      /* 99 */ std::complex<T>(-INFINITY, +0.),
+      /* 98 */ std::complex<T>(QNaN, +0.),
+      /* 99 */ std::complex<T>(-Infinity, +0.),
       /* 100 */ std::complex<T>(-2, +0.),
       /* 101 */ std::complex<T>(-1, +0.),
       /* 102 */ std::complex<T>(-0.5, +0.),
@@ -145,10 +145,10 @@ template <typename T> bool test() {
       /* 105 */ std::complex<T>(0.5, +0.),
       /* 106 */ std::complex<T>(1, +0.),
       /* 107 */ std::complex<T>(2, +0.),
-      /* 108 */ std::complex<T>(INFINITY, +0.),
+      /* 108 */ std::complex<T>(Infinity, +0.),
 
-      /* 109 */ std::complex<T>(NAN, 0.5),
-      /* 110 */ std::complex<T>(-INFINITY, 0.5),
+      /* 109 */ std::complex<T>(QNaN, 0.5),
+      /* 110 */ std::complex<T>(-Infinity, 0.5),
       /* 111 */ std::complex<T>(-2, 0.5),
       /* 112 */ std::complex<T>(-1, 0.5),
       /* 113 */ std::complex<T>(-0.5, 0.5),
@@ -157,10 +157,10 @@ template <typename T> bool test() {
       /* 116 */ std::complex<T>(0.5, 0.5),
       /* 117 */ std::complex<T>(1, 0.5),
       /* 118 */ std::complex<T>(2, 0.5),
-      /* 119 */ std::complex<T>(INFINITY, 0.5),
+      /* 119 */ std::complex<T>(Infinity, 0.5),
 
-      /* 120 */ std::complex<T>(NAN, 1),
-      /* 121 */ std::complex<T>(-INFINITY, 1),
+      /* 120 */ std::complex<T>(QNaN, 1),
+      /* 121 */ std::complex<T>(-Infinity, 1),
       /* 122 */ std::complex<T>(-2, 1),
       /* 123 */ std::complex<T>(-1, 1),
       /* 124 */ std::complex<T>(-0.5, 1),
@@ -169,10 +169,10 @@ template <typename T> bool test() {
       /* 127 */ std::complex<T>(0.5, 1),
       /* 128 */ std::complex<T>(1, 1),
       /* 129 */ std::complex<T>(2, 1),
-      /* 130 */ std::complex<T>(INFINITY, 1),
+      /* 130 */ std::complex<T>(Infinity, 1),
 
-      /* 131 */ std::complex<T>(NAN, 2),
-      /* 132 */ std::complex<T>(-INFINITY, 2),
+      /* 131 */ std::complex<T>(QNaN, 2),
+      /* 132 */ std::complex<T>(-Infinity, 2),
       /* 133 */ std::complex<T>(-2, 2),
       /* 134 */ std::complex<T>(-1, 2),
       /* 135 */ std::complex<T>(-0.5, 2),
@@ -181,19 +181,19 @@ template <typename T> bool test() {
       /* 138 */ std::complex<T>(0.5, 2),
       /* 139 */ std::complex<T>(1, 2),
       /* 140 */ std::complex<T>(2, 2),
-      /* 141 */ std::complex<T>(INFINITY, 2),
+      /* 141 */ std::complex<T>(Infinity, 2),
 
-      /* 142 */ std::complex<T>(NAN, INFINITY),
-      /* 143 */ std::complex<T>(-INFINITY, INFINITY),
-      /* 144 */ std::complex<T>(-2, INFINITY),
-      /* 145 */ std::complex<T>(-1, INFINITY),
-      /* 146 */ std::complex<T>(-0.5, INFINITY),
-      /* 147 */ std::complex<T>(-0., INFINITY),
-      /* 148 */ std::complex<T>(+0., INFINITY),
-      /* 149 */ std::complex<T>(0.5, INFINITY),
-      /* 150 */ std::complex<T>(1, INFINITY),
-      /* 151 */ std::complex<T>(2, INFINITY),
-      /* 152 */ std::complex<T>(INFINITY, INFINITY)};
+      /* 142 */ std::complex<T>(QNaN, Infinity),
+      /* 143 */ std::complex<T>(-Infinity, Infinity),
+      /* 144 */ std::complex<T>(-2, Infinity),
+      /* 145 */ std::complex<T>(-1, Infinity),
+      /* 146 */ std::complex<T>(-0.5, Infinity),
+      /* 147 */ std::complex<T>(-0., Infinity),
+      /* 148 */ std::complex<T>(+0., Infinity),
+      /* 149 */ std::complex<T>(0.5, Infinity),
+      /* 150 */ std::complex<T>(1, Infinity),
+      /* 151 */ std::complex<T>(2, Infinity),
+      /* 152 */ std::complex<T>(Infinity, Infinity)};
 
   try {
     sycl::queue q;


### PR DESCRIPTION
This commit replaces the uses of NAN and INFINITY in the SYCL complex headers with std::numeric_limits<float>::quiet_NaN() and std::numeric_limits<float>::infinity() respectively. This avoids issues where the definition of the macros could cause issues with differing constexpr'ness between platforms.

Fixes https://github.com/intel/llvm/issues/19114.