### PR TITLE
[UR][L0] Fix Implict Event sync during external semaphore wait/signal

### DIFF
--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -146,6 +146,8 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
              (ZeCommandList, 1, &hExtSemaphore, &WaitParams, ZeEvent,
               WaitList.Length, WaitList.ZeEventList));
 
+  UR_CALL(hQueue->executeCommandList(CommandList, false, OkToBatch));
+
   return UR_RESULT_SUCCESS;
 }
 
@@ -202,6 +204,8 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
                  .zexCommandListAppendSignalExternalSemaphoresExp,
              (ZeCommandList, 1, &hExtSemaphore, &SignalParams, ZeEvent,
               WaitList.Length, WaitList.ZeEventList));
+
+  UR_CALL(hQueue->executeCommandList(CommandList, false, OkToBatch));
 
   return UR_RESULT_SUCCESS;
 }


### PR DESCRIPTION
- When SYCl Calls the L0 adapter without a signal event, L0 creates an internal event.
- Given in order command queue, the internal event for the wait/signal is implicitly added to the wait list of the next command if executeCommandList is called.
- This ensures that the internal event is properly synchronized with the command queue during that next call given SYCL is failing to create a UR event for tracking the wait/signal.