### PR TITLE
[SYCL] Keep bfloat16 native and fallback spv for compatibility 

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -602,12 +602,10 @@ add_devicelibs(libsycl-fallback-cmath-fp64
   DEPENDENCIES ${cmath_obj_deps})
 add_devicelibs(libsycl-fallback-bfloat16
   SRC fallback-bfloat16.cpp
-  FILETYPES "${filetypes_no_spv}"
   BUILD_ARCHS ${full_build_archs}
   DEPENDENCIES ${bfloat16_obj_deps})
 add_devicelibs(libsycl-native-bfloat16
   SRC bfloat16_wrapper.cpp
-  FILETYPES "${filetypes_no_spv}"
   BUILD_ARCHS ${full_build_archs}
   DEPENDENCIES ${bfloat16_obj_deps})
 


### PR DESCRIPTION
This is a cherry-pick of intel/llvm#19780

Previously, we stopped building and deploying native/fallback bfloat16 spv files since latest compiler will embed required files into user's executable. However, we found some developers hadn't switched to latest compiler, then compatibility issue would happen. This PR continues to build and deploy, we will remove the files util a marjor release.