### PR TITLE
[SYCL] Update `detail::string_view` impl

### DIFF
--- a/sycl/include/sycl/detail/string_view.hpp
+++ b/sycl/include/sycl/detail/string_view.hpp
@@ -68,51 +68,15 @@ public:
 
   constexpr const char *data() const noexcept { return str ? str : ""; }
 
-  constexpr explicit operator std::string_view() const noexcept {
+  constexpr operator std::string_view() const noexcept {
+    if (str == nullptr)
+      return std::string_view{};
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
     return std::string_view(str, len);
 #else
     return std::string_view(str);
 #endif
   }
-
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-  friend constexpr bool operator==(string_view lhs,
-                                   std::string_view rhs) noexcept {
-    return rhs == std::string_view(lhs);
-  }
-  friend constexpr bool operator==(std::string_view lhs,
-                                   string_view rhs) noexcept {
-    return lhs == std::string_view(rhs);
-  }
-
-  friend constexpr bool operator!=(string_view lhs,
-                                   std::string_view rhs) noexcept {
-    return rhs != std::string_view(lhs);
-  }
-  friend constexpr bool operator!=(std::string_view lhs,
-                                   string_view rhs) noexcept {
-    return lhs != std::string_view(rhs);
-  }
-#else
-  friend constexpr bool operator==(string_view lhs,
-                                   std::string_view rhs) noexcept {
-    return rhs == lhs.data();
-  }
-  friend constexpr bool operator==(std::string_view lhs,
-                                   string_view rhs) noexcept {
-    return lhs == rhs.data();
-  }
-
-  friend constexpr bool operator!=(string_view lhs,
-                                   std::string_view rhs) noexcept {
-    return rhs != lhs.data();
-  }
-  friend constexpr bool operator!=(std::string_view lhs,
-                                   string_view rhs) noexcept {
-    return lhs != rhs.data();
-  }
-#endif
 };
 
 } // namespace detail


### PR DESCRIPTION
* Fix potential `nullptr` dereference when casting default-constructed object to `std::string_view`.
* Make that conversion operator implicit (because why shouldn't it be?)
* Not that it's implicit, there is no need in comparison operators with `std::string_view`, because that conversion will be considered implicitly.

I also have no idea why there was `__INTEL_PREVIEW_BREAKING_CHANGES` guard before.