### PR TITLE
[GHA] Uplift Linux GPU RT version to 25.31.34666.3

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -1,15 +1,15 @@
 {
   "linux": {
     "compute_runtime": {
-      "github_tag": "25.27.34303.5",
-      "version": "25.27.34303.5",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/25.27.34303.5",
+      "github_tag": "25.31.34666.3",
+      "version": "25.31.34666.3",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/25.31.34666.3",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "v2.14.1",
-      "version": "v2.14.1",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/v2.14.1",
+      "github_tag": "v2.16.0",
+      "version": "v2.16.0",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/v2.16.0",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {


### PR DESCRIPTION
Scheduled drivers uplift