### PR TITLE
[UR][Offload] Implement `urMemBufferPartition`

### DIFF
--- a/unified-runtime/source/adapters/cuda/memory.cpp
+++ b/unified-runtime/source/adapters/cuda/memory.cpp
@@ -348,18 +348,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
     flags = UR_MEM_FLAG_READ_WRITE;
   }
 
-  UR_ASSERT(!(flags &
-              (UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER |
-               UR_MEM_FLAG_ALLOC_HOST_POINTER | UR_MEM_FLAG_USE_HOST_POINTER)),
+  UR_ASSERT(subBufferFlagsAreLegal(hBuffer->MemFlags, flags),
             UR_RESULT_ERROR_INVALID_VALUE);
-  if (hBuffer->MemFlags & UR_MEM_FLAG_WRITE_ONLY) {
-    UR_ASSERT(!(flags & (UR_MEM_FLAG_READ_WRITE | UR_MEM_FLAG_READ_ONLY)),
-              UR_RESULT_ERROR_INVALID_VALUE);
-  }
-  if (hBuffer->MemFlags & UR_MEM_FLAG_READ_ONLY) {
-    UR_ASSERT(!(flags & (UR_MEM_FLAG_READ_WRITE | UR_MEM_FLAG_WRITE_ONLY)),
-              UR_RESULT_ERROR_INVALID_VALUE);
-  }
 
   auto &BufferImpl = std::get<BufferMem>(hBuffer->Mem);
   UR_ASSERT(((pRegion->origin + pRegion->size) <= BufferImpl.getSize()),

--- a/unified-runtime/source/adapters/hip/memory.cpp
+++ b/unified-runtime/source/adapters/hip/memory.cpp
@@ -162,18 +162,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
     flags = UR_MEM_FLAG_READ_WRITE;
   }
 
-  UR_ASSERT(!(flags &
-              (UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER |
-               UR_MEM_FLAG_ALLOC_HOST_POINTER | UR_MEM_FLAG_USE_HOST_POINTER)),
+  UR_ASSERT(subBufferFlagsAreLegal(hBuffer->MemFlags, flags),
             UR_RESULT_ERROR_INVALID_VALUE);
-  if (hBuffer->MemFlags & UR_MEM_FLAG_WRITE_ONLY) {
-    UR_ASSERT(!(flags & (UR_MEM_FLAG_READ_WRITE | UR_MEM_FLAG_READ_ONLY)),
-              UR_RESULT_ERROR_INVALID_VALUE);
-  }
-  if (hBuffer->MemFlags & UR_MEM_FLAG_READ_ONLY) {
-    UR_ASSERT(!(flags & (UR_MEM_FLAG_READ_WRITE | UR_MEM_FLAG_WRITE_ONLY)),
-              UR_RESULT_ERROR_INVALID_VALUE);
-  }
 
   auto &BufferImpl = std::get<BufferMem>(hBuffer->Mem);
   UR_ASSERT(((pRegion->origin + pRegion->size) <= BufferImpl.getSize()),

--- a/unified-runtime/source/adapters/offload/memory.hpp
+++ b/unified-runtime/source/adapters/offload/memory.hpp
@@ -92,7 +92,6 @@ struct BufferMem {
 struct ur_mem_handle_t_ : RefCounted {
   ur_context_handle_t Context;
 
-  enum class Type { Buffer } MemType;
   ur_mem_flags_t MemFlags;
 
   // For now we only support BufferMem. Eventually we'll support images, so use
@@ -102,7 +101,7 @@ struct ur_mem_handle_t_ : RefCounted {
   ur_mem_handle_t_(ur_context_handle_t Context, ur_mem_handle_t Parent,
                    ur_mem_flags_t MemFlags, BufferMem::AllocMode Mode,
                    void *Ptr, void *HostPtr, size_t Size)
-      : Context{Context}, MemType{Type::Buffer}, MemFlags{MemFlags},
+      : Context{Context}, MemFlags{MemFlags},
         Mem{BufferMem{Parent, Mode, Ptr, HostPtr, Size}} {
     urContextRetain(Context);
   };
@@ -110,4 +109,11 @@ struct ur_mem_handle_t_ : RefCounted {
   ~ur_mem_handle_t_() { urContextRelease(Context); }
 
   ur_context_handle_t getContext() const noexcept { return Context; }
+
+  BufferMem *AsBufferMem() noexcept {
+    if (std::holds_alternative<BufferMem>(Mem)) {
+      return &std::get<BufferMem>(Mem);
+    }
+    return nullptr;
+  }
 };

--- a/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
@@ -150,7 +150,7 @@ urGetMemProcAddrTable(ur_api_version_t version, ur_mem_dditable_t *pDdiTable) {
     return result;
   }
   pDdiTable->pfnBufferCreate = urMemBufferCreate;
-  pDdiTable->pfnBufferPartition = nullptr;
+  pDdiTable->pfnBufferPartition = urMemBufferPartition;
   pDdiTable->pfnBufferCreateWithNativeHandle = nullptr;
   pDdiTable->pfnImageCreateWithNativeHandle = nullptr;
   pDdiTable->pfnGetInfo = urMemGetInfo;

--- a/unified-runtime/source/common/ur_util.hpp
+++ b/unified-runtime/source/common/ur_util.hpp
@@ -568,4 +568,21 @@ std::array<T, N> createArrayOf(F &&ctor) {
                                    std::make_index_sequence<N>{});
 }
 
+// Helper function for `urMemBufferPartition`
+//
+// Returns true if and only if `child`'s flags are compatible with `parent`'s.
+inline bool subBufferFlagsAreLegal(ur_mem_flags_t parent,
+                                   ur_mem_flags_t child) {
+  if (child & (UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER |
+               UR_MEM_FLAG_ALLOC_HOST_POINTER | UR_MEM_FLAG_USE_HOST_POINTER))
+    return false;
+  if (parent & UR_MEM_FLAG_WRITE_ONLY &&
+      (child & (UR_MEM_FLAG_READ_WRITE | UR_MEM_FLAG_READ_ONLY)))
+    return false;
+  if (parent & UR_MEM_FLAG_READ_ONLY &&
+      (child & (UR_MEM_FLAG_READ_WRITE | UR_MEM_FLAG_WRITE_ONLY)))
+    return false;
+  return true;
+}
+
 #endif /* UR_UTIL_H */


### PR DESCRIPTION
This takes a subsection of the buffer, which for liboffload is just a
pointer offset. Some other cleanup was done as well.
