### PR TITLE
[SYCL][E2E] Temporarily disable reduction test execution

### DIFF
--- a/sycl/test-e2e/Reduction/lit.local.cfg
+++ b/sycl/test-e2e/Reduction/lit.local.cfg
@@ -1,0 +1,4 @@
+# https://github.com/intel/llvm/issues/19680
+# https://github.com/intel/llvm/issues/19767
+if 'run-mode' in config.available_features:
+  config.unsupported_features += ['true']


### PR DESCRIPTION
Failing sporadically on basically all platforms and OSs.

https://github.com/intel/llvm/issues/19680
https://github.com/intel/llvm/issues/19767