### PR TITLE
[SYCL][E2E][Graph] xfail interop-level-zero-get-native-mem on PTL

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
@@ -4,6 +4,8 @@
 // for native L0 API calls.
 // UNSUPPORTED: linux && (gpu-intel-dg2 || arch-intel_gpu_bmg_g21) && run-mode && !igc-dev
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
+// XFAIL: arch-intel_gpu_ptl_u || arch-intel_gpu_ptl_h
+// XFAIL-TRACKER: CMPLRTST-27745
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
@@ -4,6 +4,8 @@
 // for native L0 API calls.
 // UNSUPPORTED: linux && (gpu-intel-dg2 || arch-intel_gpu_bmg_g21) && run-mode && !igc-dev
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
+// XFAIL: arch-intel_gpu_ptl_u || arch-intel_gpu_ptl_h
+// XFAIL-TRACKER: CMPLRTST-27745
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Current last remaining failures on PTL for SYCL Graph that we need to investigate further.