### PR TITLE
Resolve sycl-web test failures caused by https://github.com/llvm/llvm-project/pull/140282

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -6901,7 +6901,7 @@ CodeGenModule::getLLVMLinkageForDeclarator(const DeclaratorDecl *D,
   // have this, linkonce_odr suffices. If -fno-sycl-rdc is passed, we know there
   // is only one translation unit and can so mark them internal.
   if (getLangOpts().SYCLIsDevice && !D->hasAttr<DeviceKernelAttr>() &&
-      !(D->hasAttr<SYCLDeviceAttr>() || D->hasAttr<SYCLExternalAttr>()) &&
+      !D->hasAttr<SYCLDeviceAttr>() && !D->hasAttr<SYCLExternalAttr>() &&
       !SemaSYCL::isTypeDecoratedWithDeclAttribute<SYCLDeviceGlobalAttr>(
           D->getType()))
     return getLangOpts().GPURelocatableDeviceCode

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -6901,7 +6901,7 @@ CodeGenModule::getLLVMLinkageForDeclarator(const DeclaratorDecl *D,
   // have this, linkonce_odr suffices. If -fno-sycl-rdc is passed, we know there
   // is only one translation unit and can so mark them internal.
   if (getLangOpts().SYCLIsDevice && !D->hasAttr<DeviceKernelAttr>() &&
-      !D->hasAttr<SYCLDeviceAttr>() &&
+      !(D->hasAttr<SYCLDeviceAttr>() || D->hasAttr<SYCLExternalAttr>()) &&
       !SemaSYCL::isTypeDecoratedWithDeclAttribute<SYCLDeviceGlobalAttr>(
           D->getType()))
     return getLangOpts().GPURelocatableDeviceCode

--- a/clang/test/CodeGenSPIRV/Builtins/generic_cast_to_ptr_explicit.c
+++ b/clang/test/CodeGenSPIRV/Builtins/generic_cast_to_ptr_explicit.c
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -O1 -triple spirv32 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s
 
 #ifdef __SYCL_DEVICE_ONLY__
-#define SYCL_EXTERNAL [[clang::sycl_external]]
+#define SYCL_EXTERNAL [[clang::sycl_external]] __attribute__((sycl_device))
 #else
 #define SYCL_EXTERNAL
 #endif

--- a/clang/test/CodeGenSPIRV/Builtins/generic_cast_to_ptr_explicit.c
+++ b/clang/test/CodeGenSPIRV/Builtins/generic_cast_to_ptr_explicit.c
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -O1 -triple spirv32 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s
 
 #ifdef __SYCL_DEVICE_ONLY__
-#define SYCL_EXTERNAL [[clang::sycl_external]] __attribute__((sycl_device))
+#define SYCL_EXTERNAL [[clang::sycl_external]]
 #else
 #define SYCL_EXTERNAL
 #endif

--- a/clang/test/CodeGenSPIRV/Builtins/ids_and_ranges.c
+++ b/clang/test/CodeGenSPIRV/Builtins/ids_and_ranges.c
@@ -7,7 +7,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.num.workgroups.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.num.workgroups.i32(i32 0)
 //
-[[clang::sycl_external]] unsigned int test_num_workgroups() {
+[[clang::sycl_external]] __attribute__((sycl_device))  unsigned int test_num_workgroups() {
     return __builtin_spirv_num_workgroups(0);
 }
 
@@ -16,7 +16,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.workgroup.size.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.workgroup.size.i32(i32 0)
 //
-[[clang::sycl_external]] unsigned int test_workgroup_size() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_workgroup_size() {
     return __builtin_spirv_workgroup_size(0);
 }
 
@@ -25,7 +25,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.group.id.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.group.id.i32(i32 0)
 //
-[[clang::sycl_external]] unsigned int test_workgroup_id() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_workgroup_id() {
     return __builtin_spirv_workgroup_id(0);
 }
 
@@ -34,7 +34,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.thread.id.in.group.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.thread.id.in.group.i32(i32 0)
 //
-[[clang::sycl_external]] unsigned int test_local_invocation_id() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_local_invocation_id() {
     return __builtin_spirv_local_invocation_id(0);
 }
 
@@ -43,7 +43,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.thread.id.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.thread.id.i32(i32 0)
 //
-[[clang::sycl_external]] unsigned int test_global_invocation_id() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_global_invocation_id() {
     return __builtin_spirv_global_invocation_id(0);
 }
 
@@ -52,7 +52,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.global.size.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.global.size.i32(i32 0)
 //
-[[clang::sycl_external]] unsigned int test_global_size() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_global_size() {
     return __builtin_spirv_global_size(0);
 }
 
@@ -61,7 +61,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.global.offset.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.global.offset.i32(i32 0)
 //
-[[clang::sycl_external]] unsigned int test_global_offset() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_global_offset() {
     return __builtin_spirv_global_offset(0);
 }
 
@@ -69,7 +69,7 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.size()
 //
-[[clang::sycl_external]] unsigned int test_subgroup_size() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_subgroup_size() {
     return __builtin_spirv_subgroup_size();
 }
 
@@ -77,7 +77,7 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.max.size()
 //
-[[clang::sycl_external]] unsigned int test_subgroup_max_size() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_subgroup_max_size() {
     return __builtin_spirv_subgroup_max_size();
 }
 
@@ -85,7 +85,7 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.num.subgroups()
 //
-[[clang::sycl_external]] unsigned int test_num_subgroups() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_num_subgroups() {
     return __builtin_spirv_num_subgroups();
 }
 
@@ -93,7 +93,7 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.id()
 //
-[[clang::sycl_external]] unsigned int test_subgroup_id() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_subgroup_id() {
     return __builtin_spirv_subgroup_id();
 }
 
@@ -101,6 +101,6 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.local.invocation.id()
 //
-[[clang::sycl_external]] unsigned int test_subgroup_local_invocation_id() {
+[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_subgroup_local_invocation_id() {
     return __builtin_spirv_subgroup_local_invocation_id();
 }

--- a/clang/test/CodeGenSPIRV/Builtins/ids_and_ranges.c
+++ b/clang/test/CodeGenSPIRV/Builtins/ids_and_ranges.c
@@ -2,12 +2,18 @@
 // RUN: %clang_cc1 -O1 -triple spirv64 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK64
 // RUN: %clang_cc1 -O1 -triple spirv32 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK32
 
+#ifdef __SYCL_DEVICE_ONLY__
+#define SYCL_EXTERNAL [[clang::sycl_external]] __attribute__((sycl_device))
+#else
+#define SYCL_EXTERNAL
+#endif
+
 // CHECK: @{{.*}}test_num_workgroups{{.*}}(
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK64-NEXT:    tail call i64 @llvm.spv.num.workgroups.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.num.workgroups.i32(i32 0)
 //
-[[clang::sycl_external]] __attribute__((sycl_device))  unsigned int test_num_workgroups() {
+SYCL_EXTERNAL unsigned int test_num_workgroups() {
     return __builtin_spirv_num_workgroups(0);
 }
 
@@ -16,7 +22,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.workgroup.size.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.workgroup.size.i32(i32 0)
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_workgroup_size() {
+SYCL_EXTERNAL unsigned int test_workgroup_size() {
     return __builtin_spirv_workgroup_size(0);
 }
 
@@ -25,7 +31,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.group.id.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.group.id.i32(i32 0)
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_workgroup_id() {
+SYCL_EXTERNAL unsigned int test_workgroup_id() {
     return __builtin_spirv_workgroup_id(0);
 }
 
@@ -34,7 +40,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.thread.id.in.group.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.thread.id.in.group.i32(i32 0)
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_local_invocation_id() {
+SYCL_EXTERNAL unsigned int test_local_invocation_id() {
     return __builtin_spirv_local_invocation_id(0);
 }
 
@@ -43,7 +49,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.thread.id.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.thread.id.i32(i32 0)
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_global_invocation_id() {
+SYCL_EXTERNAL unsigned int test_global_invocation_id() {
     return __builtin_spirv_global_invocation_id(0);
 }
 
@@ -52,7 +58,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.global.size.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.global.size.i32(i32 0)
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_global_size() {
+SYCL_EXTERNAL unsigned int test_global_size() {
     return __builtin_spirv_global_size(0);
 }
 
@@ -61,7 +67,7 @@
 // CHECK64-NEXT:    tail call i64 @llvm.spv.global.offset.i64(i32 0)
 // CHECK32-NEXT:    tail call i32 @llvm.spv.global.offset.i32(i32 0)
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_global_offset() {
+SYCL_EXTERNAL unsigned int test_global_offset() {
     return __builtin_spirv_global_offset(0);
 }
 
@@ -69,7 +75,7 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.size()
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_subgroup_size() {
+SYCL_EXTERNAL unsigned int test_subgroup_size() {
     return __builtin_spirv_subgroup_size();
 }
 
@@ -77,7 +83,7 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.max.size()
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_subgroup_max_size() {
+SYCL_EXTERNAL unsigned int test_subgroup_max_size() {
     return __builtin_spirv_subgroup_max_size();
 }
 
@@ -85,7 +91,7 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.num.subgroups()
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_num_subgroups() {
+SYCL_EXTERNAL unsigned int test_num_subgroups() {
     return __builtin_spirv_num_subgroups();
 }
 
@@ -93,7 +99,7 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.id()
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_subgroup_id() {
+SYCL_EXTERNAL unsigned int test_subgroup_id() {
     return __builtin_spirv_subgroup_id();
 }
 
@@ -101,6 +107,6 @@
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    tail call i32 @llvm.spv.subgroup.local.invocation.id()
 //
-[[clang::sycl_external]] __attribute__((sycl_device)) unsigned int test_subgroup_local_invocation_id() {
+SYCL_EXTERNAL unsigned int test_subgroup_local_invocation_id() {
     return __builtin_spirv_subgroup_local_invocation_id();
 }

--- a/clang/test/CodeGenSPIRV/Builtins/ids_and_ranges.c
+++ b/clang/test/CodeGenSPIRV/Builtins/ids_and_ranges.c
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -O1 -triple spirv32 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK32
 
 #ifdef __SYCL_DEVICE_ONLY__
-#define SYCL_EXTERNAL [[clang::sycl_external]] __attribute__((sycl_device))
+#define SYCL_EXTERNAL [[clang::sycl_external]]
 #else
 #define SYCL_EXTERNAL
 #endif


### PR DESCRIPTION
This patch fixes test failures caused by the upstream patch that adds sycl_external attribute and restricts emitting device code. 