### PR TITLE
[SYCL] Add `_invoke_watson` to corecrt STL wrapper

### DIFF
--- a/sycl/include/sycl/stl_wrappers/corecrt.h
+++ b/sycl/include/sycl/stl_wrappers/corecrt.h
@@ -14,8 +14,8 @@
 
 // As a workaround, this wrapper defines a custom, empty defination of
 // _invalid_parameter and _invoke_watson for device code.
-// MSVC picks up these definitions instead of the ones defined in MSVC's
-// corecrt header.
+// MSVC picks up these definitions instead of the declarations from MSVC's
+// <corecrt> header.
 
 #pragma once
 


### PR DESCRIPTION
**Problem**
`Basic/std_array.cpp` fails to compile with MSVC 19.44.35207.1 with the following error
```
$ ./clang-cl.exe -fsycl -D_DEBUG -fsycl-device-only ./sycl/test-e2e/Basic/std_array.cpp /Od /MDd /Zi /EHsc
In file included from ../../sycl/test-e2e/Basic/std_array.cpp:8:
In file included from D:\iusers\uagarwal\llvm\build\bin\..\include\sycl/queue.hpp:12:
In file included from D:\iusers\uagarwal\llvm\build\bin\..\include\sycl/accessor.hpp:12:
In file included from D:\iusers\uagarwal\llvm\build\bin\..\include\sycl/buffer.hpp:14:
In file included from D:\iusers\uagarwal\llvm\build\bin\..\include\sycl/detail/common.hpp:17:
c:/Program files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.44.35207/include\array(531,9): error: SYCL kernel cannot call an undefined
      function without SYCL_EXTERNAL attribute
  531 |         _STL_VERIFY(_Pos < _Size, "array subscript out of range");
      |         ^
c:/Program files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.44.35207/include\yvals.h(259,9): note: expanded from macro '_STL_VERIFY'
  259 |         _STL_REPORT_ERROR(mesg); \
      |         ^
c:/Program files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.44.35207/include\yvals.h(255,5): note: expanded from macro '_STL_REPORT_ERROR'
  255 |     _MSVC_STL_DOOM_FUNCTION(mesg)
      |     ^
c:/Program files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.44.35207/include\yvals.h(249,41): note: expanded from macro
      '_MSVC_STL_DOOM_FUNCTION'
  249 | #define _MSVC_STL_DOOM_FUNCTION(mesg) ::_invoke_watson(nullptr, nullptr, nullptr, 0, 0)
      |                                         ^
c:/Program files (x86)/Windows Kits/10/include/10.0.26100.0/ucrt\corecrt.h(375,23): note: '_invoke_watson' declared here
  375 | _ACRTIMP void __cdecl _invoke_watson(
      |                       ^
c:/Program files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.44.35207/include\array(529,39): note: called by 'operator[]'
  529 |     _NODISCARD _CONSTEXPR17 reference operator[](_In_range_(<, _Size) size_type _Pos) noexcept /* strengthened */ {
      |                                       ^
1 error generated.
```

**Solution**
Similar to what we did for `_invalid_parameter` (https://github.com/intel/llvm/pull/18400), mock `_invoke_watson` in corecrt STL wrapper.

