### PR TITLE
[UR][Offload] Make all queue UR CTS tests pass

### DIFF
--- a/unified-runtime/source/adapters/offload/device.cpp
+++ b/unified-runtime/source/adapters/offload/device.cpp
@@ -200,9 +200,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(uint32_t{0});
   case UR_DEVICE_INFO_QUEUE_PROPERTIES:
   case UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES:
-  case UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES:
     return ReturnValue(
         ur_queue_flags_t{UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE});
+  case UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES:
+    return ReturnValue(0);
   case UR_DEVICE_INFO_KERNEL_LAUNCH_CAPABILITIES:
     return ReturnValue(0);
   case UR_DEVICE_INFO_SUPPORTED_PARTITIONS: {

--- a/unified-runtime/source/adapters/offload/queue.cpp
+++ b/unified-runtime/source/adapters/offload/queue.cpp
@@ -55,12 +55,26 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
 
   switch (propName) {
+  case UR_QUEUE_INFO_CONTEXT:
+    return ReturnValue(hQueue->UrContext);
+  case UR_QUEUE_INFO_DEVICE:
+    return ReturnValue(hQueue->UrContext->Device);
+  case UR_QUEUE_INFO_EMPTY: {
+    bool Empty;
+    OL_RETURN_ON_ERR(hQueue->isEmpty(Empty));
+    return ReturnValue(Empty);
+  }
   case UR_QUEUE_INFO_FLAGS:
     return ReturnValue(hQueue->Flags);
   case UR_QUEUE_INFO_REFERENCE_COUNT:
     return ReturnValue(hQueue->RefCount.load());
-  default:
+  // These two are not technically optional, but other backends return
+  // UNSUPPORTED
+  case UR_QUEUE_INFO_SIZE:
+  case UR_QUEUE_INFO_DEVICE_DEFAULT:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  default:
+    return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
 
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/offload/queue.hpp
+++ b/unified-runtime/source/adapters/offload/queue.hpp
@@ -46,6 +46,26 @@ struct ur_queue_handle_t_ : RefCounted {
 
   bool isInOrder() const { return OffloadQueues.size() == 1; }
 
+  // This queue is empty if and only if all queues are empty
+  ol_result_t isEmpty(bool &Empty) const {
+    Empty = true;
+
+    for (auto *Q : OffloadQueues) {
+      if (!Q) {
+        continue;
+      }
+      if (auto Err =
+              olGetQueueInfo(Q, OL_QUEUE_INFO_EMPTY, sizeof(Empty), &Empty)) {
+        return Err;
+      }
+      if (!Empty) {
+        return OL_SUCCESS;
+      }
+    }
+
+    return OL_SUCCESS;
+  }
+
   ol_result_t nextQueueNoLock(ol_queue_handle_t &Handle) {
     auto &Slot = OffloadQueues[(QueueOffset++) % OffloadQueues.size()];
 

--- a/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
@@ -237,7 +237,7 @@ urGetUSMProcAddrTable(ur_api_version_t version, ur_usm_dditable_t *pDdiTable) {
   }
   pDdiTable->pfnDeviceAlloc = urUSMDeviceAlloc;
   pDdiTable->pfnFree = urUSMFree;
-  pDdiTable->pfnGetMemAllocInfo = nullptr;
+  pDdiTable->pfnGetMemAllocInfo = urUSMGetMemAllocInfo;
   pDdiTable->pfnHostAlloc = urUSMHostAlloc;
   pDdiTable->pfnPoolCreate = nullptr;
   pDdiTable->pfnPoolRetain = nullptr;

--- a/unified-runtime/source/adapters/offload/usm.cpp
+++ b/unified-runtime/source/adapters/offload/usm.cpp
@@ -55,3 +55,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMFree(ur_context_handle_t hContext,
   hContext->AllocTypeMap.erase(pMem);
   return offloadResultToUR(olMemFree(pMem));
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+    [[maybe_unused]] ur_context_handle_t hContext,
+    [[maybe_unused]] const void *pMem,
+    [[maybe_unused]] ur_usm_alloc_info_t propName,
+    [[maybe_unused]] size_t propSize, [[maybe_unused]] void *pPropValue,
+    [[maybe_unused]] size_t *pPropSizeRet) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}


### PR DESCRIPTION
With this change, the CTS tests for queues are now all passing. This
patch introduces the following changes:
* All `UR_DEVICE_INFO_QUEUE` values are handled.
* `UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES` now is 0 to match the UR
  HIP/Nvidia backends.
* A stub function for `urUSMGetMemAllocInfo` is implemented. This is
  required because now `UR_DEVICE_INFO_QUEUE_CONTEXT` is implemented,
  the validation layer will try to call it.
