### PR TITLE
[UR][Offload] Fix waiting on empty events

### DIFF
--- a/unified-runtime/source/adapters/offload/enqueue.cpp
+++ b/unified-runtime/source/adapters/offload/enqueue.cpp
@@ -25,11 +25,15 @@ ol_result_t waitOnEvents(ol_queue_handle_t Queue,
   if (NumEvents) {
     std::vector<ol_event_handle_t> OlEvents;
     OlEvents.reserve(NumEvents);
+    size_t RealEventCount = 0;
     for (size_t I = 0; I < NumEvents; I++) {
-      OlEvents.push_back(UrEvents[I]->OffloadEvent);
+      if (UrEvents[I]->OffloadEvent) {
+        RealEventCount++;
+        OlEvents.push_back(UrEvents[I]->OffloadEvent);
+      }
     }
 
-    return olWaitEvents(Queue, OlEvents.data(), NumEvents);
+    return olWaitEvents(Queue, OlEvents.data(), RealEventCount);
   }
   return OL_SUCCESS;
 }


### PR DESCRIPTION
The event pointer can be nullptr if the event is a "no-op". This was
previously not handled in the `waitOnEvents helper`, now it is.
