### PR TITLE
[CI] Add a workflow to check ready PRs

### DIFF
--- a/.github/workflows/sycl-check-ready-to-merge-prs.yml
+++ b/.github/workflows/sycl-check-ready-to-merge-prs.yml
@@ -1,0 +1,50 @@
+# This workflow checks for ready-to-merge PRs - if a PR is open, not a draft,
+# passed all checks, and has been approved, it will ping @intel/llvm-gatekeepers
+# if this group has not already been mentioned or if the last mention was more
+# than $days days ago.
+
+name: Check ready-to-merge PRs
+
+on:
+  schedule:
+    - cron: '0 * * * *' # every hour
+  workflow_dispatch:
+
+jobs:
+  notify-ready-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Number of days before repeating the gatekeepers ping
+          days=3
+          days_in_seconds=$((days*24*60*60))
+
+          # Function to ping gatekeepers and print debug info
+          ping_gatekeepers() {
+            pr_number=$1
+            gh pr comment "$pr_number" --repo intel/llvm --body "@intel/llvm-gatekeepers please consider merging"
+            echo "Pinged @intel/llvm-gatekeepers for https://github.com/intel/llvm/pull/$pr_number"
+          }
+
+          # Get the list of suitable PRs
+          prs=$(gh pr list --search "is:open review:approved draft:no status:success" --repo intel/llvm --json number --jq '.[].number')
+          now=$(date -u +%s)
+          for pr in $prs; do
+            # Get the timestamp of the latest comment mentioning @intel/llvm-gatekeepers
+            latest_ts=$(gh pr view $pr --repo intel/llvm --json comments \
+              --jq '[.comments[] | select(.body | test("@intel/llvm-gatekeepers")) | .createdAt] | last')
+            # If there is no previous mention, ping the gatekeepers
+            if [[ -z "$latest_ts" ]]; then
+              ping_gatekeepers "$pr"
+            # If the latest mention is older than $days, ping the gatekeepers again
+            else
+              comment_time=$(date -u -d "$latest_ts" +%s)
+              age=$((now - comment_time))
+              if (( age >= days_in_seconds )); then
+                ping_gatekeepers "$pr"
+              fi
+            fi
+          done

--- a/.github/workflows/sycl-check-ready-to-merge-prs.yml
+++ b/.github/workflows/sycl-check-ready-to-merge-prs.yml
@@ -10,8 +10,12 @@ on:
     - cron: '0 * * * *' # every hour
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   notify-ready-prs:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check


### PR DESCRIPTION
This workflow checks for ready-to-merge PRs - if a PR is open, not a draft, passed all checks, and has been approved, it will ping @intel/llvm-gatekeepers if this group has not already been mentioned or if the last mention was more than $days days ago.