### PR TITLE
[CI] Sign nightly linux build

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -46,6 +46,10 @@ on:
 
       # Artifacts:
 
+      sign_artifacts:
+        type: boolean
+        default: false
+
       retention-days:
         description: 'Artifacts retention period'
         type: string
@@ -131,7 +135,11 @@ on:
         options:
           - "sycl_linux_default"
 
-permissions: read-all
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  packages: read
 
 jobs:
   build:
@@ -308,6 +316,12 @@ jobs:
     - name: Pack toolchain
       if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       run: tar -I '${{ steps.artifact_info.outputs.COMPRESS }}' -cf ${{ steps.artifact_info.outputs.ARCHIVE_NAME }} -C $GITHUB_WORKSPACE/toolchain .
+    - name: Sign the toolchain archive & upload the signature artifact
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' && inputs.sign_artifacts == true }}
+      uses: ./devops/actions/sign_artifacts_and_upload_signature
+      with:
+        archive_path: ${{ steps.artifact_info.outputs.ARCHIVE_NAME }}
+        artifact_name: ${{ inputs.toolchain_artifact }}_signing_artifact
     - name: Upload toolchain
       if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -25,6 +25,11 @@ jobs:
 
   ubuntu2204_build:
     if: github.repository == 'intel/llvm'
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
     uses: ./.github/workflows/sycl-linux-build.yml
     secrets: inherit
     with:
@@ -32,6 +37,7 @@ jobs:
       build_configure_extra_args: '--hip --cuda'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
 
+      sign_artifacts: true
       retention-days: 90
       toolchain_artifact: sycl_linux_default
       # We upload the build for people to download/use, override its name and

--- a/devops/actions/sign_artifacts_and_upload_signature/action.yml
+++ b/devops/actions/sign_artifacts_and_upload_signature/action.yml
@@ -1,0 +1,25 @@
+name: "Sign and upload artifacts"
+
+description: "Signs an archive and uploads the signing artifacts."
+
+inputs:
+  archive_path:
+    description: "Path to the archive to sign"
+    required: true
+  artifact_name:
+    description: "Name for the signing artifact"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Sign the archive
+      uses: sigstore/gh-action-sigstore-python@v3.0.1
+      with:
+        inputs: ${{ inputs.archive_path }}
+
+    - name: Upload signing artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.archive_path }}.sigstore.json


### PR DESCRIPTION
This PR adds an optional step in sycl-linux-build to sign a build using the sigstore/cosign action.

We should sign our release binaries. Currently we're performing it manually outside CI due to security reasons. But in future we'd like to switch to cosign instead. Therefore we're introducing this as part of nightly for now to test it in advance.
Cosign ensures that a blob was signed exactly by the specific workflow.

Test run: https://github.com/intel/llvm/actions/runs/17404358377
To verify:
```
cosign-windows-amd64.exe verify-blob \
--bundle /path_to/sycl_linux.tar.gz.sigstore.json /path_to/sycl_linux.tar.gz \
--certificate-identity https://github.com/intel/llvm/.github/workflows/sycl-linux-build.yml@refs/heads/BRANCH_NAME
```