### PR TITLE
[UR] Make offload program CTS tests pass

### DIFF
--- a/unified-runtime/source/adapters/offload/program.hpp
+++ b/unified-runtime/source/adapters/offload/program.hpp
@@ -22,4 +22,23 @@ struct ur_program_handle_t_ : RefCounted {
   size_t BinarySizeInBytes;
   // A mapping from mangled global names -> names in the binary
   std::unordered_map<std::string, std::string> GlobalIDMD;
+  // The UR offload backend doesn't draw distinctions between these types (we
+  // always have a fully built binary), but we need to track what state we are
+  // pretending to be in
+  ur_program_binary_type_t BinaryType;
+  std::string Error;
+
+  static ur_program_handle_t_ *newErrorProgram(ur_context_handle_t Context,
+                                               const uint8_t *Binary,
+                                               size_t BinarySizeInBytes,
+                                               std::string &&Error) {
+    return new ur_program_handle_t_{{},
+                                    nullptr,
+                                    Context,
+                                    Binary,
+                                    BinarySizeInBytes,
+                                    {},
+                                    UR_PROGRAM_BINARY_TYPE_NONE,
+                                    Error};
+  }
 };

--- a/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
@@ -90,12 +90,12 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
   pDdiTable->pfnCreateWithBinary = urProgramCreateWithBinary;
   pDdiTable->pfnCreateWithIL = urProgramCreateWithIL;
   pDdiTable->pfnCreateWithNativeHandle = urProgramCreateWithNativeHandle;
-  pDdiTable->pfnGetBuildInfo = nullptr;
+  pDdiTable->pfnGetBuildInfo = urProgramGetBuildInfo;
   pDdiTable->pfnGetFunctionPointer = urProgramGetFunctionPointer;
   pDdiTable->pfnGetGlobalVariablePointer = urProgramGetGlobalVariablePointer;
   pDdiTable->pfnGetInfo = urProgramGetInfo;
   pDdiTable->pfnGetNativeHandle = urProgramGetNativeHandle;
-  pDdiTable->pfnLink = nullptr;
+  pDdiTable->pfnLink = urProgramLink;
   pDdiTable->pfnRelease = urProgramRelease;
   pDdiTable->pfnRetain = urProgramRetain;
   pDdiTable->pfnSetSpecializationConstants =

--- a/unified-runtime/test/conformance/program/urProgramLink.cpp
+++ b/unified-runtime/test/conformance/program/urProgramLink.cpp
@@ -94,6 +94,10 @@ struct urProgramLinkErrorTest : uur::urQueueTest {
     if (backend == UR_BACKEND_CUDA) {
       GTEST_SKIP();
     }
+    // Not meaningful for liboffload
+    if (backend == UR_BACKEND_OFFLOAD) {
+      GTEST_SKIP();
+    }
 
     std::shared_ptr<std::vector<char>> il_binary{};
     UUR_RETURN_ON_FATAL_FAILURE(uur::KernelsEnvironment::instance->LoadSource(


### PR DESCRIPTION
The CTS tests for the program part of the API now pass (or are skipped).
This mostly was a matter of implementing olProgramGetBuildInfo and
olProgramLink (but only for one binary - specifying more than one is an
error). The build failure tests have also been tweaked a bit to better
reflect their optional nature.
