### PR TITLE
[SYCL][E2E] Replace REQUIRES with XFAIL

### DIFF
--- a/sycl/test-e2e/bindless_images/copies/host_to_host_pitched.cpp
+++ b/sycl/test-e2e/bindless_images/copies/host_to_host_pitched.cpp
@@ -2,6 +2,8 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images_2d_usm
 // XFAIL: level_zero
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/17663
+// XFAIL: hip
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19957
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/bindless_images/copies/host_to_host_pitched.cpp
+++ b/sycl/test-e2e/bindless_images/copies/host_to_host_pitched.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images
 // REQUIRES: aspect-ext_oneapi_bindless_images_2d_usm
-// REQUIRES: cuda
+// XFAIL: level_zero
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17663
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/bindless_images/sampling_2D_USM_host.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D_USM_host.cpp
@@ -1,5 +1,6 @@
-// REQUIRES: cuda
 // REQUIRES: aspect-ext_oneapi_bindless_images_2d_usm
+// XFAIL: level_zero
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17663
 
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out

--- a/sycl/test-e2e/bindless_images/sampling_2D_USM_host.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D_USM_host.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images_2d_usm
 // XFAIL: level_zero
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/17663
+// XFAIL: hip
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19957
 
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out


### PR DESCRIPTION
Those tests should not be launched only on CUDA, because they already have an aspect requirement.

However, they do not pass on L0 yet because of missing functionality there.
They don't pass on HIP either - still `XFAIL` is a better approach than `REQUIRES`