### PR TITLE
[SYCL] Remove `SYCL_USE_NATIVE_FP_ATOMICS` macro

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1545,10 +1545,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     // with TI set to the device TargetInfo.
     const llvm::Triple &Triple = TI.getTriple();
     const llvm::Triple::SubArchType SubArch = Triple.getSubArch();
-    if (Triple.isNVPTX() || Triple.isAMDGPU() ||
-        (Triple.isSPIR() && SubArch != llvm::Triple::SPIRSubArch_fpga) ||
-        Triple.isNativeCPU())
-      Builder.defineMacro("SYCL_USE_NATIVE_FP_ATOMICS");
+
     // Enable generation of USM address spaces for FPGA.
     if (SubArch == llvm::Triple::SPIRSubArch_fpga) {
       Builder.defineMacro("__ENABLE_USM_ADDR_SPACE__");

--- a/clang/test/Preprocessor/sycl-macro-target-specific.cpp
+++ b/clang/test/Preprocessor/sycl-macro-target-specific.cpp
@@ -34,21 +34,6 @@
 // CHECK-AMDGPU: #define __AMDGPU__
 // CHECK-AMDGPU-NEG-NOT: #define __AMDGPU__
 
-// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64-unknown-unknown -E -dM \
-// RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
-// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_gen-unknown-unknown -E -dM \
-// RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
-// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_x86_64-unknown-unknown -E -dM \
-// RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
-// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_fpga-unknown-unknown -E -dM \
-// RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS-NEG %s
-// RUN: %clang_cc1 %s -fsycl-is-device -triple nvptx64-nvidia-nvcl -E -dM \
-// RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
-// RUN: %clang_cc1 %s -fsycl-is-device -triple amdgcn-amdhsa-amdhsa -E -dM \
-// RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
-// RUN: %clang_cc1 %s -fsycl-is-device -triple native_cpu \
-// RUN: -E -dM | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
-
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_fpga-unknown-unknown -E -dM \
 // RUN: | FileCheck --check-prefix=CHECK-USM-ADDR-SPACE %s
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64-unknown-unknown -E -dM \

--- a/clang/test/Preprocessor/sycl-macro-target-specific.cpp
+++ b/clang/test/Preprocessor/sycl-macro-target-specific.cpp
@@ -48,8 +48,6 @@
 // RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
 // RUN: %clang_cc1 %s -fsycl-is-device -triple native_cpu \
 // RUN: -E -dM | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
-// CHECK-SYCL-FP-ATOMICS: #define SYCL_USE_NATIVE_FP_ATOMICS
-// CHECK-SYCL-FP-ATOMICS-NEG-NOT: #define SYCL_USE_NATIVE_FP_ATOMICS
 
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_fpga-unknown-unknown -E -dM \
 // RUN: | FileCheck --check-prefix=CHECK-USM-ADDR-SPACE %s

--- a/sycl/include/sycl/atomic_ref.hpp
+++ b/sycl/include/sycl/atomic_ref.hpp
@@ -469,9 +469,7 @@ public:
 
   T fetch_add(T operand, memory_order order = default_read_modify_write_order,
               memory_scope scope = default_scope) const noexcept {
-// TODO: Remove the "native atomics" macro check once implemented for all
-// backends
-#if defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_USE_NATIVE_FP_ATOMICS)
+#if defined(__SYCL_DEVICE_ONLY__)
     return detail::spirv::AtomicFAdd(ptr, scope, order, operand);
 #else
     auto load_order = detail::getLoadOrder(order);
@@ -492,9 +490,7 @@ public:
 
   T fetch_sub(T operand, memory_order order = default_read_modify_write_order,
               memory_scope scope = default_scope) const noexcept {
-// TODO: Remove the "native atomics" macro check once implemented for all
-// backends
-#if defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_USE_NATIVE_FP_ATOMICS)
+#if defined(__SYCL_DEVICE_ONLY__)
     return detail::spirv::AtomicFAdd(ptr, scope, order, -operand);
 #else
     auto load_order = detail::getLoadOrder(order);
@@ -513,9 +509,7 @@ public:
 
   T fetch_min(T operand, memory_order order = default_read_modify_write_order,
               memory_scope scope = default_scope) const noexcept {
-// TODO: Remove the "native atomics" macro check once implemented for all
-// backends
-#if defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_USE_NATIVE_FP_ATOMICS)
+#if defined(__SYCL_DEVICE_ONLY__)
     return detail::spirv::AtomicMin(ptr, scope, order, operand);
 #else
     auto load_order = detail::getLoadOrder(order);
@@ -529,9 +523,7 @@ public:
 
   T fetch_max(T operand, memory_order order = default_read_modify_write_order,
               memory_scope scope = default_scope) const noexcept {
-// TODO: Remove the "native atomics" macro check once implemented for all
-// backends
-#if defined(__SYCL_DEVICE_ONLY__) && defined(SYCL_USE_NATIVE_FP_ATOMICS)
+#if defined(__SYCL_DEVICE_ONLY__)
     return detail::spirv::AtomicMax(ptr, scope, order, operand);
 #else
     auto load_order = detail::getLoadOrder(order);


### PR DESCRIPTION
This PR removes `SYCL_USE_NATIVE_FP_ATOMICS` macro.
It's removed because we don't support FPGA anymore and macro was defined for all target except FPGA.
https://github.com/intel/llvm/blob/45cf4436aac62b68c55c7ba8ba994004b88220f7/clang/lib/Frontend/InitPreprocessor.cpp#L1548-L1551