### PR TITLE
[SYCL][E2E][NFC] Mark `nthreadsGPU` as `constexpr`

### DIFF
--- a/sycl/test-e2e/Regression/commandlist/Inputs/main.cpp
+++ b/sycl/test-e2e/Regression/commandlist/Inputs/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
   bool lock{true};
   bool sharedQueue{true};
   // int nthreadsGPU = 1;
-  int nthreadsGPU = 8;
+  constexpr int nthreadsGPU = 8;
   int arr_size = 20;
   int iter_gpu = 200;
   unsigned int nitems = 0;


### PR DESCRIPTION
`nthreadsGPU` is used to declare an array at 
https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/Regression/commandlist/Inputs/main.cpp#L102 which throws an error:
```
error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
```
This PR marks this variable as constexpr.