### PR TITLE
Fix data race in the ProgramManager::getOrCreateDeviceKernelInfo

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1822,6 +1822,7 @@ ProgramManager::kernelImplicitLocalArgPos(KernelNameStrRefT KernelName) const {
 
 DeviceKernelInfo &ProgramManager::getOrCreateDeviceKernelInfo(
     const CompileTimeKernelInfoTy &Info) {
+  std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
   auto Result =
       m_DeviceKernelInfoMap.try_emplace(KernelNameStrT{Info.Name.data()}, Info);
   Result.first->second.setCompileTimeInfoIfNeeded(Info);
@@ -1830,6 +1831,7 @@ DeviceKernelInfo &ProgramManager::getOrCreateDeviceKernelInfo(
 
 DeviceKernelInfo &
 ProgramManager::getOrCreateDeviceKernelInfo(KernelNameStrRefT KernelName) {
+  std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
   auto Result = m_DeviceKernelInfoMap.try_emplace(
       KernelName, CompileTimeKernelInfoTy{std::string_view(KernelName)});
   return Result.first->second;

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2139,6 +2139,9 @@ void ProgramManager::removeImages(sycl_device_binaries DeviceBinary) {
   // Acquire lock to read and modify maps for kernel bundles
   std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
 
+  // Acquire lock to erase DeviceKernelInfoMap
+  std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
+
   for (int I = 0; I < DeviceBinary->NumDeviceBinaries; I++) {
     sycl_device_binary RawImg = &(DeviceBinary->DeviceBinaries[I]);
 

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -540,6 +540,9 @@ protected:
   // by caching the pointers when possible.
   std::unordered_map<KernelNameStrT, DeviceKernelInfo> m_DeviceKernelInfoMap;
 
+  // Protects m_DeviceKernelInfoMap.
+  std::mutex m_DeviceKernelInfoMapMutex;
+
   // Sanitizer type used in device image
   SanitizerType m_SanitizerFoundInImage;
 


### PR DESCRIPTION
The data race was detected by a unit test while working on #19843.