### PR TITLE
[SYCL][CMake] Fix emhash build error

### DIFF
--- a/xptifw/src/CMakeLists.txt
+++ b/xptifw/src/CMakeLists.txt
@@ -67,7 +67,7 @@ function(add_xpti_library LIB_NAME)
     $<BUILD_INTERFACE:${XPTI_DIR}/include>
   )
 
-  target_link_libraries(${LIB_NAME} PUBLIC emhash::emhash)
+  target_link_libraries(${LIB_NAME} PUBLIC $<BUILD_INTERFACE:emhash::emhash>)
 
   find_package(Threads REQUIRED)
   target_link_libraries(${LIB_NAME} PUBLIC ${CMAKE_DL_LIBS} Threads::Threads)


### PR DESCRIPTION
We only need to link against `emhash` in build, it's an interface library representing a header-only project (so all linking does is add includes), and it's only used internally in xptifw and in a single non-installed header, but some other part of the code could use that non-installed header, so we need to link against it, but only for build.


Issue introduced in https://github.com/intel/llvm/pull/19894