### PR TITLE
[SYCL] Disable self-contained-headers test on Windows

### DIFF
--- a/sycl/test/self-contained-headers/lit.local.cfg
+++ b/sycl/test/self-contained-headers/lit.local.cfg
@@ -7,8 +7,4 @@ config.test_format = SYCLHeadersTest()
 # standalone. `os.path.join` is required here so the filtering works
 # cross-platform
 config.sycl_headers_xfail = [
-    # FIXME: remove this rule when the header is moved to the clang project
-    os.path.join(
-        "sycl", "stl_wrappers", "__sycl_cmath_wrapper_impl.hpp"
-    ),
 ]

--- a/sycl/test/self-contained-headers/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp.cpp
+++ b/sycl/test/self-contained-headers/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp.cpp
@@ -7,4 +7,5 @@
 // include cmath or not. It means the test result depends on the system
 // environment.
 
+// TODO: Longer term that header should really be moved to the clang project.
 #include <sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp>

--- a/sycl/test/self-contained-headers/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp.cpp
+++ b/sycl/test/self-contained-headers/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
 // expected-no-diagnostics
 //
+// XFAIL: !system-windows
 // UNSUPPORTED: system-windows
 // Different versions of STL implementations by Microsoft either implicitly
 // include cmath or not. It means the test result depends on the system

--- a/sycl/test/self-contained-headers/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp.cpp
+++ b/sycl/test/self-contained-headers/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp.cpp
@@ -1,0 +1,9 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+//
+// UNSUPPORTED: system-windows
+// Different versions of STL implementations by Microsoft either implicitly
+// include cmath or not. It means the test result depends on the system
+// environment.
+
+#include <sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp>


### PR DESCRIPTION
The test is flaky and has no value in general.