### PR TITLE
[SYCL-RTC] Distribute `libdevice`'s `*.bc` files inside `libsycl-jit.so`

### DIFF
--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -9,12 +9,15 @@ else()
 set(SYCL_JIT_VIRTUAL_TOOLCHAIN_ROOT "/sycl-jit-toolchain/")
 endif()
 
-# TODO: libdevice
-set(SYCL_JIT_RESOURCE_DEPS sycl-headers clang ${CMAKE_CURRENT_SOURCE_DIR}/utils/generate.py)
+set(SYCL_JIT_RESOURCE_DEPS
+  sycl-headers    # include/sycl
+  clang           # lib/clang/N/include
+  libsycldevice   # lib/*.bc
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils/generate.py)
 
 if ("libclc" IN_LIST LLVM_ENABLE_PROJECTS)
   # Somehow just "libclc" doesn't build "remangled-*" (and maybe whatever else).
-  list(APPEND SYCL_JIT_RESOURCE_DEPS libclc libspirv-builtins)
+  list(APPEND SYCL_JIT_RESOURCE_DEPS libclc libspirv-builtins) # lib/clc/*.bc
 endif()
 
 add_custom_command(


### PR DESCRIPTION
Follows https://github.com/intel/llvm/pull/19924 that did the same with headers. With this PR all SYCL Toolchain dependencies are linked as resources into the `libsycl-jit.so` and not accessing DPCPP installation on disk in runtime.