### PR TITLE
[SYCL] Don't use asterisk in filenames.

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -305,8 +305,9 @@ Expected<StringRef> writeOffloadFile(const OffloadFile &File,
       sys::path::stem(Binary.getMemoryBufferRef().getBufferIdentifier());
   StringRef Suffix = getImageKindName(Binary.getImageKind());
 
+  StringRef BinArch = (Binary.getArch() == "*") ? "any" : Binary.getArch();
   auto TempFileOrErr = createOutputFile(
-      Prefix + "-" + Binary.getTriple() + "-" + Binary.getArch(),
+      Prefix + "-" + Binary.getTriple() + "-" + BinArch,
       HasSYCLOffloadKind ? getImageKindName(Binary.getImageKind()) : "o");
   if (!TempFileOrErr)
     return TempFileOrErr.takeError();


### PR DESCRIPTION
The use of asterisk ("\*") for filenames in Windows is problematic (see https://github.com/intel/llvm/issues/19373). Replace the use of "\*" with "any". Even though the original problem only affects Windows, the fix is not problematic for Linux, so I think it's better to keep only one code path.

Fixes https://github.com/intel/llvm/issues/19373.