### PR TITLE
[UR][OpenCL] Delete unused copy constructors and assignments

### DIFF
--- a/unified-runtime/source/adapters/opencl/context.hpp
+++ b/unified-runtime/source/adapters/opencl/context.hpp
@@ -24,9 +24,9 @@ struct ur_context_handle_t_ : ur::opencl::handle_base {
   bool IsNativeHandleOwned = true;
   ur::RefCount RefCount;
 
-  ur_context_handle_t_(const ur_context_handle_t_&) = delete;
-  ur_context_handle_t_& operator=(const ur_context_handle_t_&) = delete;
-  
+  ur_context_handle_t_(const ur_context_handle_t_ &) = delete;
+  ur_context_handle_t_ &operator=(const ur_context_handle_t_ &) = delete;
+
   ur_context_handle_t_(native_type Ctx, uint32_t DevCount,
                        const ur_device_handle_t *phDevices)
       : handle_base(), CLContext(Ctx), DeviceCount(DevCount) {

--- a/unified-runtime/source/adapters/opencl/device.hpp
+++ b/unified-runtime/source/adapters/opencl/device.hpp
@@ -23,8 +23,8 @@ struct ur_device_handle_t_ : ur::opencl::handle_base {
   bool IsNativeHandleOwned = true;
   ur::RefCount RefCount;
 
-  ur_device_handle_t_(const ur_device_handle_t_&) = delete;
-  ur_device_handle_t_& operator=(const ur_device_handle_t_&) = delete;
+  ur_device_handle_t_(const ur_device_handle_t_ &) = delete;
+  ur_device_handle_t_ &operator=(const ur_device_handle_t_ &) = delete;
 
   ur_device_handle_t_(native_type Dev, ur_platform_handle_t Plat,
                       ur_device_handle_t Parent)

--- a/unified-runtime/source/adapters/opencl/kernel.hpp
+++ b/unified-runtime/source/adapters/opencl/kernel.hpp
@@ -26,9 +26,9 @@ struct ur_kernel_handle_t_ : ur::opencl::handle_base {
   clSetKernelArgMemPointerINTEL_fn clSetKernelArgMemPointerINTEL = nullptr;
   ur::RefCount RefCount;
 
-  ur_kernel_handle_t_(const ur_kernel_handle_t_&) = delete;
-  ur_kernel_handle_t_& operator=(const ur_kernel_handle_t_&) = delete;
-  
+  ur_kernel_handle_t_(const ur_kernel_handle_t_ &) = delete;
+  ur_kernel_handle_t_ &operator=(const ur_kernel_handle_t_ &) = delete;
+
   ur_kernel_handle_t_(native_type Kernel, ur_program_handle_t Program,
                       ur_context_handle_t Context)
       : handle_base(), CLKernel(Kernel), Program(Program), Context(Context) {

--- a/unified-runtime/source/adapters/opencl/memory.hpp
+++ b/unified-runtime/source/adapters/opencl/memory.hpp
@@ -22,9 +22,9 @@ struct ur_mem_handle_t_ : ur::opencl::handle_base {
   bool IsNativeHandleOwned = true;
   ur::RefCount RefCount;
 
-  ur_mem_handle_t_(const ur_mem_handle_t_&) = delete;
-  ur_mem_handle_t_& operator=(const ur_mem_handle_t_&) = delete;
-  
+  ur_mem_handle_t_(const ur_mem_handle_t_ &) = delete;
+  ur_mem_handle_t_ &operator=(const ur_mem_handle_t_ &) = delete;
+
   ur_mem_handle_t_(native_type Mem, ur_context_handle_t Ctx)
       : handle_base(), CLMemory(Mem), Context(Ctx) {
     urContextRetain(Context);

--- a/unified-runtime/source/adapters/opencl/platform.hpp
+++ b/unified-runtime/source/adapters/opencl/platform.hpp
@@ -22,8 +22,8 @@ struct ur_platform_handle_t_ : ur::opencl::handle_base {
   std::map<cl_device_id, ur_device_handle_t> SubDevices;
   std::mutex SubDevicesLock;
 
-  ur_platform_handle_t_(const ur_platform_handle_t_&) = delete;
-  ur_platform_handle_t_& operator=(const ur_platform_handle_t_&) = delete;
+  ur_platform_handle_t_(const ur_platform_handle_t_ &) = delete;
+  ur_platform_handle_t_ &operator=(const ur_platform_handle_t_ &) = delete;
 
   ur_platform_handle_t_(native_type Plat) : handle_base(), CLPlatform(Plat) {}
 

--- a/unified-runtime/source/adapters/opencl/queue.hpp
+++ b/unified-runtime/source/adapters/opencl/queue.hpp
@@ -29,8 +29,8 @@ struct ur_queue_handle_t_ : ur::opencl::handle_base {
   ur_event_handle_t LastEvent = nullptr;
   ur::RefCount RefCount;
 
-  ur_queue_handle_t_(const ur_queue_handle_t_&) = delete;
-  ur_queue_handle_t_& operator=(const ur_queue_handle_t_&) = delete;
+  ur_queue_handle_t_(const ur_queue_handle_t_ &) = delete;
+  ur_queue_handle_t_ &operator=(const ur_queue_handle_t_ &) = delete;
 
   ur_queue_handle_t_(native_type Queue, ur_context_handle_t Ctx,
                      ur_device_handle_t Dev, bool InOrder)

--- a/unified-runtime/source/adapters/opencl/sampler.hpp
+++ b/unified-runtime/source/adapters/opencl/sampler.hpp
@@ -21,8 +21,8 @@ struct ur_sampler_handle_t_ : ur::opencl::handle_base {
   bool IsNativeHandleOwned = false;
   ur::RefCount RefCount;
 
-  ur_sampler_handle_t_(const ur_sampler_handle_t_&) = delete;
-  ur_sampler_handle_t_& operator=(const ur_sampler_handle_t_&) = delete;
+  ur_sampler_handle_t_(const ur_sampler_handle_t_ &) = delete;
+  ur_sampler_handle_t_ &operator=(const ur_sampler_handle_t_ &) = delete;
 
   ur_sampler_handle_t_(native_type Sampler, ur_context_handle_t Ctx)
       : handle_base(), CLSampler(Sampler), Context(Ctx) {


### PR DESCRIPTION
Coverity reported an issue regarding Rule-of-3 violation. In some handlers only destructor was user-defined. These handlers are used as unique_ptr which means that copy operation will never be executed. That`s why I decided to remove copy constructors and copy assignments