### PR TITLE
[UR] Update compute-runtime tag

### DIFF
--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -125,7 +125,7 @@ if(L0_COMPUTE_RUNTIME_HEADERS)
     set(COMPUTE_RUNTIME_REPO_PATH "${L0_COMPUTE_RUNTIME_HEADERS}")
 else()
     set(UR_COMPUTE_RUNTIME_REPO "https://github.com/intel/compute-runtime.git")
-    set(UR_COMPUTE_RUNTIME_TAG 25.05.32567.17)
+    set(UR_COMPUTE_RUNTIME_TAG 25.31.34666.3)
 
     include(FetchContent)
     # Sparse fetch only the dir with level zero headers for experimental features to avoid pulling in the entire compute-runtime.

--- a/unified-runtime/source/adapters/level_zero/common.cpp
+++ b/unified-runtime/source/adapters/level_zero/common.cpp
@@ -327,8 +327,8 @@ ze_structure_type_t getZeStructureType<ze_device_cache_line_size_ext_t>() {
 
 #ifdef ZE_INTEL_DEVICE_BLOCK_ARRAY_EXP_NAME
 template <>
-ze_structure_type_t
-getZeStructureType<ze_intel_device_block_array_exp_properties_t>() {
+ze_structure_type_ext_t
+getZexStructureType<ze_intel_device_block_array_exp_properties_t>() {
   return ZE_INTEL_DEVICE_BLOCK_ARRAY_EXP_PROPERTIES;
 }
 #endif // ZE_INTEL_DEVICE_BLOCK_ARRAY_EXP_NAME

--- a/unified-runtime/source/adapters/level_zero/common.hpp
+++ b/unified-runtime/source/adapters/level_zero/common.hpp
@@ -170,6 +170,7 @@ bool setEnvVar(const char *name, const char *value);
 // Returns the ze_structure_type_t to use in .stype of a structured descriptor.
 // Intentionally not defined; will give an error if no proper specialization
 template <class T> ze_structure_type_t getZeStructureType();
+template <class T> ze_structure_type_ext_t getZexStructureType();
 template <class T> zes_structure_type_t getZesStructureType();
 
 // The helpers to properly default initialize Level-Zero descriptor and
@@ -177,6 +178,13 @@ template <class T> zes_structure_type_t getZesStructureType();
 template <class T> struct ZeStruct : public T {
   ZeStruct() : T{} { // zero initializes base struct
     this->stype = getZeStructureType<T>();
+    this->pNext = nullptr;
+  }
+};
+
+template <class T> struct ZexStruct : public T {
+  ZexStruct() : T{} { // zero initializes base struct
+    this->stype = getZexStructureType<T>();
     this->pNext = nullptr;
   }
 };

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1964,7 +1964,7 @@ ur_result_t ur_device_handle_t_::initialize(int SubSubDeviceOrdinal,
 #ifdef ZE_INTEL_DEVICE_BLOCK_ARRAY_EXP_NAME
   ZeDeviceBlockArrayProperties.Compute =
       [ZeDevice](
-          ZeStruct<ze_intel_device_block_array_exp_properties_t> &Properties) {
+          ZexStruct<ze_intel_device_block_array_exp_properties_t> &Properties) {
         ze_device_properties_t P;
         P.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
         P.pNext = &Properties;

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -244,7 +244,7 @@ struct ur_device_handle_t_ : ur_object {
   ZeCache<ZeStruct<ze_mutable_command_list_exp_properties_t>>
       ZeDeviceMutableCmdListsProperties;
 #ifdef ZE_INTEL_DEVICE_BLOCK_ARRAY_EXP_NAME
-  ZeCache<ZeStruct<ze_intel_device_block_array_exp_properties_t>>
+  ZeCache<ZexStruct<ze_intel_device_block_array_exp_properties_t>>
       ZeDeviceBlockArrayProperties;
 #endif // ZE_INTEL_DEVICE_BLOCK_ARRAY_EXP_NAME
   ZeCache<ZeStruct<ze_device_vector_width_properties_ext_t>>

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_cache.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_cache.cpp
@@ -14,8 +14,8 @@
 #include "../device.hpp"
 
 template <>
-ze_structure_type_t
-getZeStructureType<zex_intel_queue_copy_operations_offload_hint_exp_desc_t>() {
+ze_structure_type_ext_t
+getZexStructureType<zex_intel_queue_copy_operations_offload_hint_exp_desc_t>() {
   return ZEX_INTEL_STRUCTURE_TYPE_QUEUE_COPY_OPERATIONS_OFFLOAD_HINT_EXP_PROPERTIES;
 }
 
@@ -61,7 +61,8 @@ static bool ForceDisableCopyOffload = [] {
 
 raii::ze_command_list_handle_t
 command_list_cache_t::createCommandList(const command_list_descriptor_t &desc) {
-  ZeStruct<zex_intel_queue_copy_operations_offload_hint_exp_desc_t> offloadDesc;
+  ZexStruct<zex_intel_queue_copy_operations_offload_hint_exp_desc_t>
+      offloadDesc;
   auto requestedCopyOffload =
       std::visit([](auto &&arg) { return arg.CopyOffloadEnabled; }, desc);
 


### PR DESCRIPTION
This PR updates compute-runtime tag, and introduces ZexStruct to adapt to changes from commit https://github.com/intel/compute-runtime/commit/0dd253567440b093a2630cc5440fadbb50256cf6.