### PR TITLE
[SYCL][Doc] Remove incorrect "KernelName" in spec

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_functions.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_functions.asciidoc
@@ -386,11 +386,11 @@ a!
 ----
 namespace sycl::ext::oneapi::experimental {
 
-template <typename KernelName, int Dimensions, typename... Args>
+template <int Dimensions, typename... Args>
 void parallel_for(sycl::queue q, sycl::range<Dimensions> r,
                   const sycl::kernel& k, Args&&... args);
 
-template <typename KernelName, int Dimensions, typename... Args>
+template <int Dimensions, typename... Args>
 void parallel_for(sycl::handler &h, sycl::range<Dimensions> r,
                   const sycl::kernel& k, Args&&... args);
 
@@ -409,14 +409,12 @@ a!
 ----
 namespace sycl::ext::oneapi::experimental {
 
-template <typename KernelName, int Dimensions,
-          typename Properties, typename... Args>
+template <int Dimensions, typename Properties, typename... Args>
 void parallel_for(sycl::queue q,
                   launch_config<sycl::range<Dimensions>, Properties> c,
                   const sycl::kernel& k, Args&& args...);
 
-template <typename KernelName, int Dimensions,
-          typename Properties, typename... Args>
+template <int Dimensions, typename Properties, typename... Args>
 void parallel_for(sycl::handler &h,
                   launch_config<sycl::range<Dimensions>, Properties> c,
                   const sycl::kernel& k, Args&& args...);
@@ -503,11 +501,11 @@ a!
 ----
 namespace sycl::ext::oneapi::experimental {
 
-template <typename KernelName, int Dimensions, typename... Args>
+template <int Dimensions, typename... Args>
 void nd_launch(sycl::queue q, sycl::nd_range<Dimensions> r,
                const sycl::kernel& k, Args&&... args);
 
-template <typename KernelName, int Dimensions, typename... Args>
+template <int Dimensions, typename... Args>
 void nd_launch(sycl::handler &h, sycl::nd_range<Dimensions> r,
                const sycl::kernel& k, Args&&... args);
 
@@ -527,14 +525,12 @@ a!
 ----
 namespace sycl::ext::oneapi::experimental {
 
-template <typename KernelName, int Dimensions,
-          typename Properties, typename... Args>
+template <int Dimensions, typename Properties, typename... Args>
 void nd_launch(sycl::queue q,
                launch_config<sycl::nd_range<Dimensions>, Properties> c,
                const sycl::kernel& k, Args&& args...);
 
-template <typename KernelName, int Dimensions,
-          typename Properties, typename... Args>
+template <int Dimensions, typename Properties, typename... Args>
 void nd_launch(sycl::handler &h,
                launch_config<sycl::nd_range<Dimensions>, Properties> c,
                const sycl::kernel& k, Args&& args...);


### PR DESCRIPTION
The overloads of `parallel_for` and `nd_launch` that take a `sycl::kernel` object should not allow the application to specify a name for the kernel.  The kernel which is invoked by these overloads is determined at runtime (by the value of the `sycl::kernel` object), so it's not possible to assign a static name.

The implementation was already correct, so this is just fixing a documentation bug.