### PR TITLE
[SYCL] Minor fix in the `ProgramManager::getOrCreateDeviceKernelInfo`

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1823,10 +1823,11 @@ ProgramManager::kernelImplicitLocalArgPos(KernelNameStrRefT KernelName) const {
 DeviceKernelInfo &ProgramManager::getOrCreateDeviceKernelInfo(
     const CompileTimeKernelInfoTy &Info) {
   std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
-  auto Result =
+  auto [Iter, Inserted] =
       m_DeviceKernelInfoMap.try_emplace(KernelNameStrT{Info.Name.data()}, Info);
-  Result.first->second.setCompileTimeInfoIfNeeded(Info);
-  return Result.first->second;
+  if (!Inserted)
+    Iter->second.setCompileTimeInfoIfNeeded(Info);
+  return Iter->second;
 }
 
 DeviceKernelInfo &


### PR DESCRIPTION
We do not need to update the CompileTimeInfo if we just inserted it.