### PR TITLE
[SYCL] Fixes for `usm_allocator` properties 

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/usm_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/usm_properties.hpp
@@ -39,16 +39,10 @@ private:
   uint64_t MLocation;
 };
 
+// If new properties are added here, update `verifyUSMAllocatorProperties` to
+// include them!
+
 } // namespace intel::experimental::property::usm
 } // namespace ext
-
-template <>
-struct is_property<ext::oneapi::property::usm::device_read_only>
-    : std::true_type {};
-
-template <>
-struct is_property<ext::intel::experimental::property::usm::buffer_location>
-    : std::true_type {};
-
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -644,9 +644,22 @@ void release_from_device_copy(const void *Ptr, const queue &Queue) {
 } // namespace ext::oneapi::experimental
 
 __SYCL_EXPORT void verifyUSMAllocatorProperties(const property_list &PropList) {
-  auto NoAllowedPropertiesCheck = [](int) { return false; };
-  detail::PropertyValidator::checkPropsAndThrow(
-      PropList, NoAllowedPropertiesCheck, NoAllowedPropertiesCheck);
+  auto DataLessCheck = [](int Kind) {
+    switch (Kind) {
+    case detail::DeviceReadOnly:
+      return true;
+    }
+    return false;
+  };
+  auto WithDataCheck = [](int Kind) {
+    switch (Kind) {
+    case detail::PropWithDataKind::AccPropBufferLocation:
+      return true;
+    }
+    return false;
+  };
+  detail::PropertyValidator::checkPropsAndThrow(PropList, DataLessCheck,
+                                                WithDataCheck);
 }
 
 } // namespace _V1

--- a/sycl/test-e2e/USM/properties.cpp
+++ b/sycl/test-e2e/USM/properties.cpp
@@ -1,0 +1,15 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/ext/intel/experimental/usm_properties.hpp>
+#include <sycl/usm/usm_allocator.hpp>
+
+int main() {
+  sycl::queue q;
+
+  // Ensure properties are supported when constructing the allocator:
+  sycl::usm_allocator<int, sycl::usm::alloc::shared> allocator{
+      q,
+      {sycl::ext::oneapi::property::usm::device_read_only{},
+       sycl::ext::intel::experimental::property::usm::buffer_location{1}}};
+}


### PR DESCRIPTION
This is a cherry-pick of intel/llvm#19890

* Fix `verifyUSMAllocatorProperties` to allow supported properties
* No need to specialize `is_property<...>` for USM properties - `std::base_of_v<>`-based implementation covers that.