### PR TITLE
[Benchmark] Fix benchmark dashboard failing to load metadata

### DIFF
--- a/devops/scripts/benchmarks/html/scripts.js
+++ b/devops/scripts/benchmarks/html/scripts.js
@@ -1606,6 +1606,12 @@ function fetchAndProcessData(url, isArchived = false) {
                 // Replace existing data for current data
                 loadedBenchmarkRuns = newRuns;
             }
+
+            // The following variables have same values regardless of whether
+            // we load archived or current data
+            benchmarkMetadata = data.metadata || benchmarkMetadata || {};
+            benchmarkTags = data.tags || benchmarkTags || {};
+
             initializeCharts();
         })
         .catch(error => {


### PR DESCRIPTION
A previous PR removed these lines, causing metadata to no longer load in the benchmark dashboard. This PR restores these lines.