### PR TITLE
[NFCI][SYCL] Reduce dependencies of `<sycl/range.hpp>`

### DIFF
--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -62,6 +62,16 @@ template <typename SYCLObjT> class weak_object;
 } // namespace ext::oneapi
 
 namespace detail {
+// XPTI helpers for creating array from a range.
+inline std::array<size_t, 3> rangeToArray(const range<3> &r) {
+  return {r[0], r[1], r[2]};
+}
+inline std::array<size_t, 3> rangeToArray(const range<2> &r) {
+  return {r[0], r[1], 0};
+}
+inline std::array<size_t, 3> rangeToArray(const range<1> &r) {
+  return {r[0], 0, 0};
+}
 
 class buffer_impl;
 

--- a/sycl/include/sycl/ext/oneapi/experimental/graph/node.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph/node.hpp
@@ -20,6 +20,7 @@
 
 namespace sycl {
 inline namespace _V1 {
+class event;
 namespace ext {
 namespace oneapi {
 namespace experimental {

--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -8,16 +8,18 @@
 
 #pragma once
 
-#include <sycl/detail/array.hpp>   // for array
-#include <sycl/detail/helpers.hpp> // for Builder
+#include <sycl/detail/array.hpp> // for array
 
-#include <array>       // for array
 #include <stddef.h>    // for size_t
 #include <type_traits> // for enable_if_t
 
 namespace sycl {
 inline namespace _V1 {
 template <int Dimensions> class id;
+
+namespace detail {
+class Builder;
+}
 
 /// Defines the iteration domain of either a single work-group in a parallel
 /// dispatch, or the overall Dimensions of the dispatch.
@@ -228,19 +230,6 @@ range(size_t)->range<1>;
 range(size_t, size_t)->range<2>;
 range(size_t, size_t, size_t)->range<3>;
 #endif
-
-namespace detail {
-// XPTI helpers for creating array from a range.
-inline std::array<size_t, 3> rangeToArray(const range<3> &r) {
-  return {r[0], r[1], r[2]};
-}
-inline std::array<size_t, 3> rangeToArray(const range<2> &r) {
-  return {r[0], r[1], 0};
-}
-inline std::array<size_t, 3> rangeToArray(const range<1> &r) {
-  return {r[0], 0, 0};
-}
-} // namespace detail
 
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/syclcompat/traits.hpp
+++ b/sycl/include/syclcompat/traits.hpp
@@ -29,8 +29,9 @@
 #include <cstddef>
 #include <sycl/ext/oneapi/properties/properties.hpp>
 #include <sycl/ext/oneapi/properties/property_value.hpp>
-#include <sycl/range.hpp>
+#include <sycl/nd_item.hpp>
 #include <sycl/nd_range.hpp>
+#include <sycl/range.hpp>
 #include <type_traits>
 
 namespace [[deprecated("syclcompat is deprecated")]] syclcompat {

--- a/sycl/test/abi/layout_accessors_device.cpp
+++ b/sycl/test/abi/layout_accessors_device.cpp
@@ -20,7 +20,7 @@ SYCL_EXTERNAL void hostAcc(accessor<int, 1, access::mode::read, access::target::
 // CHECK-NEXT: 0 |   class sycl::detail::accessor_common<int, 1, sycl::access::mode::read, sycl::access::target::device, sycl::access::placeholder::false_t> (base) (empty)
 // CHECK-NEXT: 0 |   class sycl::detail::OwnerLessBase<class sycl::accessor<int, 1, sycl::access::mode::read, sycl::access::target::device> > (base) (empty)
 // CHECK-NEXT: 0 |   class sycl::detail::AccessorImplDevice<1> impl
-// CHECK-NEXT: 0 |     class sycl::id<1> Offset
+// CHECK-NEXT: 0 |     class sycl::id<> Offset
 // CHECK-NEXT: 0 |       class sycl::detail::array<> (base)
 // CHECK-NEXT: 0 |         size_t[1] common_array
 // CHECK-NEXT: 8 |     class sycl::range<> AccessRange
@@ -52,7 +52,7 @@ SYCL_EXTERNAL void hostAcc(accessor<int, 1, access::mode::read_write, access::ta
 // CHECK-NEXT: 8 |       class sycl::range<> MemRange
 // CHECK-NEXT: 8 |         class sycl::detail::array<> (base)
 // CHECK-NEXT: 8 |           size_t[1] common_array
-// CHECK-NEXT: 16 |       class sycl::id<1> Offset
+// CHECK-NEXT: 16 |       class sycl::id<> Offset
 // CHECK-NEXT: 16 |         class sycl::detail::array<> (base)
 // CHECK-NEXT: 16 |           size_t[1] common_array
 // CHECK-NEXT: 24 |     ConcreteASPtrType MData
@@ -74,7 +74,7 @@ SYCL_EXTERNAL void hostAcc(local_accessor<int, 1> Acc) {
 // CHECK-NEXT: 8 |       class sycl::range<> MemRange
 // CHECK-NEXT: 8 |         class sycl::detail::array<> (base)
 // CHECK-NEXT: 8 |           size_t[1] common_array
-// CHECK-NEXT: 16 |       class sycl::id<1> Offset
+// CHECK-NEXT: 16 |       class sycl::id<> Offset
 // CHECK-NEXT: 16 |         class sycl::detail::array<> (base)
 // CHECK-NEXT: 16 |           size_t[1] common_array
 // CHECK-NEXT: 24 |     ConcreteASPtrType MData

--- a/sycl/test/gdb/accessors-device.cpp
+++ b/sycl/test/gdb/accessors-device.cpp
@@ -17,7 +17,7 @@ int main() {
 // AccessorImplDevice must have MemRange and Offset fields
 
 // CHECK:           0 | class sycl::detail::AccessorImplDevice<1>
-// CHECK-NEXT:      0 |   class sycl::id<1> Offset
+// CHECK-NEXT:      0 |   class sycl::id<> Offset
 // CHECK-NEXT:      0 |     class sycl::detail::array<> (base)
 // CHECK-NEXT:      0 |       size_t[1] common_array
 // CHECK-NEXT:      8 |   class sycl::range<> AccessRange
@@ -35,7 +35,7 @@ int main() {
 // CHECK-NEXT:      0 |   class sycl::detail::accessor_common<int, 1, sycl::access::mode::read_write, sycl::access::target::device, sycl::access::placeholder::false_t> (base) (empty)
 // CHECK-NEXT:      0 |   class sycl::detail::OwnerLessBase<class sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::device, sycl::access::placeholder::false_t> > (base) (empty)
 // CHECK-NEXT:      0 |   class sycl::detail::AccessorImplDevice<1> impl
-// CHECK-NEXT:      0 |     class sycl::id<1> Offset
+// CHECK-NEXT:      0 |     class sycl::id<> Offset
 // CHECK-NEXT:      0 |       class sycl::detail::array<> (base)
 // CHECK-NEXT:      0 |         size_t[1] common_array
 // CHECK-NEXT:      8 |     class sycl::range<> AccessRange

--- a/sycl/test/gdb/printers.cpp
+++ b/sycl/test/gdb/printers.cpp
@@ -72,7 +72,7 @@ sycl::item<2, false> item_wo_offset =
 // CHECK:        24 |   platform_impl & MPlatform
 
 // DEVICE:        0 | class sycl::detail::AccessorImplDevice<1>
-// DEVICE:        0 |   class sycl::id<1> Offset
+// DEVICE:        0 |   class sycl::id<> Offset
 // DEVICE:        8 |   class sycl::range<> AccessRange
 // DEVICE:       16 |   class sycl::range<> MemRange
 
@@ -105,10 +105,10 @@ sycl::item<2, false> item_wo_offset =
 // CHECK:         0 |     class sycl::range<> MExtent
 // CHECK:         0 |       class sycl::detail::array<> (base)
 // CHECK:         0 |         size_t[1] common_array
-// CHECK:         8 |     class sycl::id<1> MIndex
+// CHECK:         8 |     class sycl::id<> MIndex
 // CHECK:         8 |       class sycl::detail::array<> (base)
 // CHECK:         8 |         size_t[1] common_array
-// CHECK:        16 |     class sycl::id<1> MOffset
+// CHECK:        16 |     class sycl::id<> MOffset
 // CHECK:        16 |       class sycl::detail::array<> (base)
 // CHECK:        16 |         size_t[1] common_array
 


### PR DESCRIPTION
North star goal: compile

```cpp
#include <something>
namespace syclext = sycl::ext::oneapi;
namespace syclexp = sycl::ext::oneapi::experimental;
SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
void foo(int *p) {
    size_t id = syclext::this_work_item::get_nd_item<1>().get_global_linear_id();
    p[id] = 0;
}

```

as fast as possible by limiting number of necessary includes.

`item`/`nd_item`/`nd_range`/etc. are all dependent on `range`, so the first tiny step would be to speed up its compilation as much as possible.