### PR TITLE
[Driver][SYCL][NFC] Fix tests fails when libclc project is disabled

### DIFF
--- a/clang/test/Driver/lit.local.cfg
+++ b/clang/test/Driver/lit.local.cfg
@@ -49,3 +49,6 @@ if llvm_config.use_lld(required=False):
 
 if config.ppc_linux_default_ieeelongdouble:
     config.available_features.add("ppc_linux_default_ieeelongdouble")
+
+if "libclc" in config.llvm_enabled_projects:
+    config.available_features.add("libclc")

--- a/clang/test/Driver/sycl-add-default-spec-consts-image-old-model.cpp
+++ b/clang/test/Driver/sycl-add-default-spec-consts-image-old-model.cpp
@@ -13,7 +13,7 @@
 // RUN: %clang -### -fsycl --no-offload-new-driver -fsycl-add-default-spec-consts-image -fsycl-targets=spir64_gen 2>&1  %s | FileCheck %s -check-prefix=CHECK-AOT
 // RUN: %clang -### -fsycl --no-offload-new-driver -fsycl-add-default-spec-consts-image -fsycl-targets=spir64_x86_64 2>&1 %s | FileCheck %s -check-prefix=CHECK-AOT
 // RUN: %clang -### -fsycl --no-offload-new-driver -fsycl-add-default-spec-consts-image -fsycl-targets=intel_gpu_pvc 2>&1 %s | FileCheck %s -check-prefix=CHECK-AOT
-// RUN: %clang -### -fsycl --no-offload-new-driver -fsycl-add-default-spec-consts-image -fsycl-targets=nvidia_gpu_sm_90 -nocudalib 2>&1 %s | FileCheck %s -check-prefix=CHECK-AOT
+// RUN: %clang -### -fsycl --no-offload-new-driver -fsycl-add-default-spec-consts-image -fsycl-targets=nvidia_gpu_sm_90 -fno-sycl-libspirv -nocudalib 2>&1 %s | FileCheck %s -check-prefix=CHECK-AOT
 // RUN: %clang -### -fsycl --no-offload-new-driver -fsycl-add-default-spec-consts-image -fsycl-targets=amd_gpu_gfx1034 -fno-sycl-libspirv -nogpulib  2>&1 %s | FileCheck %s -check-prefix=CHECK-AOT
 // CHECK-AOT-NOT: warning: -fsycl-add-default-spec-consts-image flag has an effect only in Ahead of Time Compilation mode (AOT)
 // CHECK-AOT: {{.*}}sycl-post-link{{.*}} "-generate-device-image-default-spec-consts"

--- a/clang/test/Driver/sycl-device-traits-macros-nvptx.cpp
+++ b/clang/test/Driver/sycl-device-traits-macros-nvptx.cpp
@@ -1,6 +1,6 @@
 // Check device traits macros are defined if sycl is enabled:
 // Compiling for the default CUDA target passing the triple to '-fsycl-targets'.
-// RUN: %clangxx -nocudalib -fsycl -fsycl-targets=nvptx64-nvidia-cuda -### %s 2>&1 \
+// RUN: %clangxx -fno-sycl-libspirv -nocudalib -fsycl -fsycl-targets=nvptx64-nvidia-cuda -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEFAULT-TRIPLE %s
 // CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEFAULT-TRIPLE: clang{{.*}} "-triple" "nvptx64-nvidia-cuda"
 // CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEFAULT-TRIPLE-COUNT-2: "-D__SYCL_ANY_DEVICE_HAS_ANY_ASPECT__=1"
@@ -9,68 +9,68 @@
 
 // Compiling for a specific CUDA target passing the device to '-fsycl-targets'.
 //
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_50 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_50 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_52 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_52 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_53 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_53 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_60 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_60 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_61 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_61 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_62 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_62 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_70 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_70 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_72 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_72 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_75 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_75 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_80 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_80 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_86 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_86 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_87 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_87 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_89 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_89 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_90 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_90 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_90a -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_90a -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-DEVICE-TRIPLE
 
 // Compiling for a CUDA target passing the device arch to '--offload-arch' (using the '--cuda-gpu-arch' alias).
 //
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_50 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_50 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_52 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_52 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_53 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_53 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_61 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_61 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_62 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_62 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_72 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_72 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_75 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_75 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_86 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_86 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_87 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_87 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_89 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_89 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_90 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_90 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_90a -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_90a -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH
 
 // Check device traits macros are defined if sycl is enabled:
@@ -86,11 +86,11 @@
 // CHECK-SYCL-NVPTX-NVIDIA-CUDA-OFFLOAD-ARCH: "-D__SYCL_ALL_DEVICES_HAVE_{{[a-z0-9_]+}}__=1"
 
 // Test all Cuda devices support at least the aspects of the least capable one.
-// RUN: %clangxx -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_50 -### %s > %t 2>&1
-// RUN: %clangxx -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_60 -### %s >> %t 2>&1
-// RUN: %clangxx -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_70 -### %s >> %t 2>&1
-// RUN: %clangxx -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_80 -### %s >> %t 2>&1
-// RUN: %clangxx -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_90 -### %s >> %t 2>&1
+// RUN: %clangxx -fno-sycl-libspirv -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_50 -### %s > %t 2>&1
+// RUN: %clangxx -fno-sycl-libspirv -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_60 -### %s >> %t 2>&1
+// RUN: %clangxx -fno-sycl-libspirv -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_70 -### %s >> %t 2>&1
+// RUN: %clangxx -fno-sycl-libspirv -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_80 -### %s >> %t 2>&1
+// RUN: %clangxx -fno-sycl-libspirv -nocudalib -fsycl -fsycl-targets=nvidia_gpu_sm_90 -### %s >> %t 2>&1
 // RUN: FileCheck --input-file=%t --check-prefixes=CHECK-SM50,CHECK-SM60,CHECK-SM70,CHECK-SM80,CHECK-SM90 %s
 // CHECK-SM50: "-D__SYCL_TARGET_NVIDIA_GPU_SM_50__"{{.*}} "-D__SYCL_ALL_DEVICES_HAVE_[[ASPECT:[a-z0-9]+]]__=1"
 // CHECK-SM60: "-D__SYCL_TARGET_NVIDIA_GPU_SM_60__"{{.*}} "-D__SYCL_ALL_DEVICES_HAVE_[[ASPECT]]__=1"

--- a/clang/test/Driver/sycl-instrumentation-old-model.c
+++ b/clang/test/Driver/sycl-instrumentation-old-model.c
@@ -33,14 +33,14 @@
 // Verify that ITT annotations are not pulled in for non-SPIR-V targets as
 // well as when device code instrumentation is explicitly turned off.
 // RUN: %clangxx -fsycl --no-offload-new-driver --sysroot=%S/Inputs/SYCL \
-// RUN:   -fsycl-targets=nvptx64-nvidia-cuda -nocudalib -### %s 2>&1 \
+// RUN:   -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv -nocudalib -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 // RUN: %clangxx -fsycl --no-offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -fno-sycl-instrument-device-code -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 // RUN: %clangxx -fsycl --no-offload-new-driver --sysroot=%s/Inputs/SYCL \
 // RUN:   -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code \
-// RUN:   -nocudalib -### %s 2>&1 \
+// RUN:   -fno-sycl-libspirv -nocudalib -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 
 // CHECK-NONPASSED-NOT: "-fsycl-instrument-device-code"

--- a/clang/test/Driver/sycl-instrumentation.c
+++ b/clang/test/Driver/sycl-instrumentation.c
@@ -23,7 +23,7 @@
 // we still link ITT annotations libraries to ensure ABI compatibility with previous release.
 // RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-ITT-LINK-ONLY %s
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=nvptx64-nvidia-cuda -nocudalib -### %s 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv -nocudalib -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 
 // CHECK-ITT-LINK-ONLY-NOT: "-fsycl-instrument-device-code"
@@ -31,7 +31,7 @@
 
 // RUN: %clangxx -fsycl --offload-new-driver -fno-sycl-instrument-device-code -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -nocudalib -### %s 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -fno-sycl-libspirv -nocudalib -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 
 // CHECK-NONPASSED-NOT: "-fsycl-instrument-device-code"

--- a/clang/test/Driver/sycl-libspirv-toolchain.cpp
+++ b/clang/test/Driver/sycl-libspirv-toolchain.cpp
@@ -1,4 +1,5 @@
 // Test the search logic for the libspirv bitcode library in the offloading toolchains that need it.
+// REQUIRES: libclc
 
 // DEFINE: %{install_dir}  = %/S/Inputs/SYCL/bin
 // DEFINE: %{resource_dir} = %/S/Inputs/SYCL/lib/clang/resource_dir

--- a/clang/test/Driver/sycl-no-bundle-offload-arch.cpp
+++ b/clang/test/Driver/sycl-no-bundle-offload-arch.cpp
@@ -1,10 +1,10 @@
-// RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib\
+// RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv -nocudalib\
 // RUN:   -fno-bundle-offload-arch -c %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-BUNDLE-TAG-OBJ %s
 //
 // CHK-BUNDLE-TAG-OBJ-NOT: clang-offload-bundler{{.*}}-targets=sycl-nvptx64-nvidia-cuda-sm_"
 
-// RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib\
+// RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv -nocudalib\
 // RUN:   -fno-bundle-offload-arch %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-BUNDLE-TAG %s
 //

--- a/clang/test/Driver/sycl-nvptx-fast-math.cpp
+++ b/clang/test/Driver/sycl-nvptx-fast-math.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: nvptx-registered-target
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
 // RUN: | FileCheck --check-prefix=CHECK-DEFAULT %s
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda -ffast-math %s 2>&1 \
 // RUN: | FileCheck --check-prefix=CHECK-FAST %s
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda -funsafe-math-optimizations %s 2>&1 \
 // RUN: | FileCheck --check-prefix=CHECK-FAST %s
 

--- a/clang/test/Driver/sycl-nvptx-id-queries-fit-in-int.cpp
+++ b/clang/test/Driver/sycl-nvptx-id-queries-fit-in-int.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: nvptx-registered-target
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
 // RUN: | FileCheck --check-prefix=CHECK-DEFAULT %s
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-id-queries-fit-in-int %s 2>&1 \
 // RUN: | FileCheck --check-prefix=CHECK-DEFAULT %s
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fsycl-id-queries-fit-in-int %s 2>&1 \
 // RUN: | FileCheck --check-prefix=CHECK-INT %s
 

--- a/clang/test/Driver/sycl-nvptx-link.cpp
+++ b/clang/test/Driver/sycl-nvptx-link.cpp
@@ -9,28 +9,28 @@
 // this old in SYCL, but we still test the driver's ability to pick out the
 // correctly versioned libdevice. We use Inputs/CUDA_80 which has a full set of
 // libdevice files.
-// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
+// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv \
 // RUN:    -Xsycl-target-backend --cuda-gpu-arch=sm_30 \
 // RUN:    --sysroot=%S/Inputs/SYCL --cuda-path=%S/Inputs/CUDA_80/usr/local/cuda %s 2>&1 \
 // RUN:    | FileCheck %s --check-prefixes=CHECK,LIBDEVICE30
-// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
+// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv \
 // RUN:    -Xsycl-target-backend --cuda-gpu-arch=sm_35 \
 // RUN:    --sysroot=%S/Inputs/SYCL --cuda-path=%S/Inputs/CUDA_80/usr/local/cuda %s 2>&1 \
 // RUN:    | FileCheck %s --check-prefixes=CHECK,LIBDEVICE35
-// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
+// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv \
 // RUN:    -Xsycl-target-backend --cuda-gpu-arch=sm_50 \
 // RUN:    --sysroot=%S/Inputs/SYCL --cuda-path=%S/Inputs/CUDA_80/usr/local/cuda %s 2>&1 \
 // RUN:    | FileCheck %s --check-prefixes=CHECK,LIBDEVICE50
 
 // CUDA-9+ uses the same libdevice for all GPU variants
-// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
+// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv \
 // RUN:    -Xsycl-target-backend --cuda-gpu-arch=sm_35 \
 // RUN:    --sysroot=%S/Inputs/SYCL --cuda-path=%S/Inputs/CUDA_90/usr/local/cuda %s 2>&1 \
 // RUN:    | FileCheck %s --check-prefixes=CHECK,LIBDEVICE10
 
 // Check also that -nocudalib is obeyed
 // RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib \
-// RUN:    -Xsycl-target-backend --cuda-gpu-arch=sm_35 \
+// RUN:    -fno-sycl-libspirv -Xsycl-target-backend --cuda-gpu-arch=sm_35 \
 // RUN:    --sysroot=%S/Inputs/SYCL --cuda-path=%S/Inputs/CUDA_90/usr/local/cuda %s 2>&1 \
 // RUN:    | FileCheck %s --check-prefixes=CHECK,NOLIBDEVICE
 
@@ -38,8 +38,6 @@
 // CHECK: llvm-link
 
 // CHECK: llvm-link
-// CHECK-SAME: -only-needed
-// CHECK-SAME: libspirv-nvptx64-nvidia-cuda.bc
 // LIBDEVICE10-SAME: libdevice.10.bc
 // LIBDEVICE30-SAME: libdevice.compute_30.10.bc
 // LIBDEVICE35-SAME: libdevice.compute_35.10.bc

--- a/clang/test/Driver/sycl-nvptx-memcpy-opt.cpp
+++ b/clang/test/Driver/sycl-nvptx-memcpy-opt.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
 // RUN: | FileCheck --check-prefix=CHECK-DEFAULT %s
 

--- a/clang/test/Driver/sycl-nvptx-native-half-ty-opt.cpp
+++ b/clang/test/Driver/sycl-nvptx-native-half-ty-opt.cpp
@@ -1,18 +1,18 @@
 /// Check that -fnative-half-type is added automatically for SM versions
 /// greater or equal to 53.
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_53 %s -### 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_53 %s -### 2>&1 | \
 // RUN: FileCheck --check-prefix=CHECK-53 %s
 // CHECK-53: clang{{.*}} "-triple" "nvptx64-nvidia-cuda"{{.*}}"-fnative-half-type"
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_70 %s -### 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_70 %s -### 2>&1 | \
 // RUN: FileCheck --check-prefix=CHECK-70 %s
 // CHECK-70: clang{{.*}} "-triple" "nvptx64-nvidia-cuda"{{.*}}"-fnative-half-type"
 
 /// As the default is set to SM_50, make sure that the option is not added.
-// RUN: not %clangxx -fsycl -nocudalib -fsycl -fsycl-targets=nvidia64-nvidia-cuda %s -### 2>&1 | \
+// RUN: not %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl -fsycl-targets=nvidia64-nvidia-cuda %s -### 2>&1 | \
 // RUN: FileCheck --check-prefix=CHECK-DEFAULT %s
 // CHECK-DEFAULT-NOT: {{.*}}"-fnative-half-type"
 
 /// SM < 53
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_50 %s -### 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_50 %s -### 2>&1 | \
 // RUN: FileCheck --check-prefix=CHECK-50 %s
 // CHECK-50-NOT: {{.*}}"-fnative-half-type"

--- a/clang/test/Driver/sycl-nvptx-short-ptr.cpp
+++ b/clang/test/Driver/sycl-nvptx-short-ptr.cpp
@@ -1,8 +1,8 @@
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
 // RUN: | FileCheck --check-prefix=CHECK-DEFAULT %s
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fcuda-short-ptr %s 2>&1 \
 // RUN: | FileCheck --check-prefix=CHECK-SHORT %s
 

--- a/clang/test/Driver/sycl-nvptx-sqrt.cpp
+++ b/clang/test/Driver/sycl-nvptx-sqrt.cpp
@@ -1,12 +1,12 @@
 // REQUIRES: nvptx-registered-target
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
 // RUN:   -fsycl-fp32-prec-sqrt \
 // RUN:   %s \
 // RUN: 2>&1 | FileCheck --check-prefix=CHECK-CORRECT %s
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
 // RUN:   -foffload-fp32-prec-sqrt \
 // RUN:   %s \
@@ -14,7 +14,7 @@
 
 // CHECK-CORRECT: "-fcuda-prec-sqrt"
 
-// RUN: %clang -### -nocudalib \
+// RUN: %clang -### -fno-sycl-libspirv -nocudalib \
 // RUN:   -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
 // RUN:   %s \
 // RUN: 2>&1 | FileCheck --check-prefix=CHECK-APPROX %s

--- a/clang/test/Driver/sycl-offload-arch-nvidia-gpu.cpp
+++ b/clang/test/Driver/sycl-offload-arch-nvidia-gpu.cpp
@@ -1,49 +1,49 @@
 /// Tests the behaviors of using --offload-arch for offloading
 // SYCL kernels to NVidia GPUs using --offload-new-driver.
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_50 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_50 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_50 -DMAC_STR=SM_50
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_52 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_52 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_52 -DMAC_STR=SM_52
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_53 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_53 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_53 -DMAC_STR=SM_53
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_60 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_60 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_60 -DMAC_STR=SM_60
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_61 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_61 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_61 -DMAC_STR=SM_61
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_62 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_62 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_62 -DMAC_STR=SM_62
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_70 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_70 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_70 -DMAC_STR=SM_70
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_72 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_72 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_72 -DMAC_STR=SM_72
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_75 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_75 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_75 -DMAC_STR=SM_75
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_80 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_80 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_80 -DMAC_STR=SM_80
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_86 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_86 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_86 -DMAC_STR=SM_86
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_87 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_87 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_87 -DMAC_STR=SM_87
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_89 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_89 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_89 -DMAC_STR=SM_89
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_90 -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_90 -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_90 -DMAC_STR=SM_90
 
-// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_90a -nocudalib -### %s 2>&1 | \
+// RUN: %clangxx --offload-new-driver -fsycl --offload-arch=sm_90a -fno-sycl-libspirv -nocudalib -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=CLANG-OFFLOAD-PACKAGER-GPU,MACRO_NVIDIA -DDEV_STR=sm_90a -DMAC_STR=SM_90A
 
 // MACRO_NVIDIA: clang{{.*}} "-triple" "nvptx64-nvidia-cuda"

--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -212,7 +212,7 @@
 // ARCH_CHECK: clang-offload-packager{{.*}} "--image=file={{.*}}triple=spir64_gen-unknown-unknown,arch=bdw,kind=sycl{{.*}}"
 
 /// Verify that --cuda-path is passed to clang-linker-wrapper for SYCL offload
-// RUN: %clangxx -fsycl -### -fsycl-targets=nvptx64-nvidia-cuda \
+// RUN: %clangxx -fsycl -### -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv \
 // RUN:          --cuda-gpu-arch=sm_20 --cuda-path=%S/Inputs/CUDA_80/usr/local/cuda %s \
 // RUN:          --offload-new-driver 2>&1 \
 // RUN:   | FileCheck -check-prefix NVPTX_CUDA_PATH %s
@@ -236,7 +236,7 @@
 
 // Check if fsycl-targets correctly processes multiple NVidia
 // and AMD GPU targets.
-// RUN:   %clang -### -fsycl -fsycl-targets=nvidia_gpu_sm_60,nvidia_gpu_sm_70 -nocudalib --offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl -fsycl-targets=nvidia_gpu_sm_60,nvidia_gpu_sm_70 -fno-sycl-libspirv -nocudalib --offload-new-driver  %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-MACRO-SM-60,CHK-MACRO-SM-70 %s
 // CHK-MACRO-SM-60: clang{{.*}} "-fsycl-is-device"{{.*}} "-D__SYCL_TARGET_NVIDIA_GPU_SM_60__"{{.*}}
 // CHK-MACRO-SM-70: clang{{.*}} "-fsycl-is-device"{{.*}} "-D__SYCL_TARGET_NVIDIA_GPU_SM_70__"{{.*}}

--- a/clang/test/Driver/sycl-offload-old-model.c
+++ b/clang/test/Driver/sycl-offload-old-model.c
@@ -904,7 +904,7 @@
 
 // Check if fsycl-targets correctly processes multiple NVidia
 // and AMD GPU targets.
-// RUN:   %clang -### -fsycl -fsycl-targets=nvidia_gpu_sm_60,nvidia_gpu_sm_70 -nocudalib --no-offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl -fsycl-targets=nvidia_gpu_sm_60,nvidia_gpu_sm_70 -fno-sycl-libspirv -nocudalib --no-offload-new-driver  %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-MACRO-SM-60,CHK-MACRO-SM-70 %s
 // CHK-MACRO-SM-60: clang{{.*}} "-fsycl-is-device"{{.*}} "-D__SYCL_TARGET_NVIDIA_GPU_SM_60__"{{.*}}
 // CHK-MACRO-SM-70: clang{{.*}} "-fsycl-is-device"{{.*}} "-D__SYCL_TARGET_NVIDIA_GPU_SM_70__"{{.*}}

--- a/clang/test/Driver/sycl-offload-static-lib-2-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib-2-old-model.cpp
@@ -20,9 +20,9 @@
 // RUN:   | FileCheck %s -check-prefixes=STATIC_LIB,STATIC_LIB_DEF -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -L/dummy/dir %t_lib.lo -### %t_obj.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=STATIC_LIB,STATIC_LIB_DEF -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L/dummy/dir %t_lib.a -### %t_obj.o 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L/dummy/dir %t_lib.a -### %t_obj.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=STATIC_LIB_NVPTX -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L/dummy/dir %t_lib.lo -### %t_obj.o 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L/dummy/dir %t_lib.lo -### %t_obj.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=STATIC_LIB_NVPTX -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
 // STATIC_LIB: clang-offload-bundler{{.*}} "-type=o" "-targets={{.*}},[[BUNDLE_TRIPLE]]" "-input=[[INPUTO:.+\.o]]" "-output=[[HOSTOBJ:.+\.o]]" "-output={{.+\.o}}"
 // STATIC_LIB: clang-offload-deps{{.*}} "-targets=[[BUNDLE_TRIPLE]]"
@@ -42,7 +42,7 @@
 // RUN:   | FileCheck %s -check-prefixes=STATIC_L_LIB,STATIC_L_LIB_DEF -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -Xlinker -Bstatic -L%t_dir -L%S/Inputs/SYCL -llin64 -### %t_obj.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=STATIC_L_LIB,STATIC_L_LIB_DEF -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L%S/Inputs/SYCL -llin64 -### %t_obj.o 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L%S/Inputs/SYCL -llin64 -### %t_obj.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=STATIC_L_LIB_NVPTX -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
 // STATIC_L_LIB: clang-offload-bundler{{.*}} "-type=o" "-targets={{.*}},[[BUNDLE_TRIPLE]]" "-input=[[INPUTO:.+\.o]]" "-output=[[HOSTOBJ:.+\.o]]" "-output={{.+\.o}}"
 // STATIC_L_LIB: clang-offload-deps{{.*}} "-targets=[[BUNDLE_TRIPLE]]"
@@ -70,7 +70,7 @@
 // RUN: touch %t-3.o
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver %t_lib.a -### %t-1.o %t-2.o %t-3.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=STATIC_LIB_MULTI_O,STATIC_LIB_MULTI_O_DEF -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda %t_lib.a -### %t-1.o %t-2.o %t-3.o 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda %t_lib.a -### %t-1.o %t-2.o %t-3.o 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=STATIC_LIB_MULTI_O,STATIC_LIB_MULTI_O_NVPTX -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
 // STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=o" "-targets={{.*}},[[BUNDLE_TRIPLE]]" "-input={{.+}}-1.o"
 // STATIC_LIB_MULTI_O: clang-offload-bundler{{.*}} "-type=o" "-targets={{.*}},[[BUNDLE_TRIPLE]]" "-input={{.+}}-2.o"
@@ -154,7 +154,7 @@
 // RUN: touch %t_lib.a
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver %t_lib.a -o output_name -lOpenCL -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_SRC2 -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown -DDEPS_TRIPLE=sycl-spir64-unknown-unknown
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda %t_lib.a -o output_name -lOpenCL -### %s 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda %t_lib.a -o output_name -lOpenCL -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_SRC2 -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50 -DDEPS_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
 // STATIC_LIB_SRC2: clang{{.*}} "-emit-obj" {{.*}} "-o" "[[HOSTOBJ:.+\.o]]"
 // STATIC_LIB_SRC2: ld{{(.exe)?}}" {{.*}} "-o" "[[HOSTEXE:.+\.out]]" {{.*}}"--unresolved-symbols=ignore-all"
@@ -172,7 +172,7 @@
 // RUN: touch %t_lib.a
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver %t_lib.a -o output_name -lstdc++ -z relro -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_SRC3 -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda %t_lib.a -o output_name -lstdc++ -z relro -### %s 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda %t_lib.a -o output_name -lstdc++ -z relro -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_SRC3 -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
 // STATIC_LIB_SRC3: clang-offload-bundler{{.*}} "-type=a{{(oo)*}}" "-targets=[[BUNDLE_TRIPLE]]"
 // STATIC_LIB_SRC3: llvm-link{{.*}} "{{.*}}"
@@ -180,7 +180,7 @@
 
 /// Test device linking behaviors with spir64 and nvptx targets
 // RUN: touch %t_lib.a
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda,spir64 %t_lib.a -### %s 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda,spir64 %t_lib.a -### %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_MIX -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
 // STATIC_LIB_MIX: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-nvptx64-nvidia-cuda-sm_50,sycl-spir64-unknown-unknown" {{.*}} "-output=[[NVPTXLIST:.+\.txt]]" "-output=[[SYCLLIST:.+\.txt]]"
 // STATIC_LIB_MIX: llvm-link{{.*}} "@[[NVPTXLIST]]"
@@ -199,9 +199,9 @@
 // RUN:   | FileCheck %s -check-prefixes=WHOLE_STATIC_LIB,WHOLE_STATIC_LIB_1,WHOLE_STATIC_LIB_DEF -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -L/dummy/dir %t_obj.o -Wl,@%/t_arg.arg -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=WHOLE_STATIC_LIB,WHOLE_STATIC_LIB_DEF -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L/dummy/dir %t_obj.o -Wl,--whole-archive %t_lib.a %t_lib_2.a -Wl,--no-whole-archive -### 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L/dummy/dir %t_obj.o -Wl,--whole-archive %t_lib.a %t_lib_2.a -Wl,--no-whole-archive -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=WHOLE_STATIC_LIB,WHOLE_STATIC_LIB_1,WHOLE_STATIC_LIB_NVPTX -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L/dummy/dir %t_obj.o -Wl,@%/t_arg.arg -### 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -L/dummy/dir %t_obj.o -Wl,@%/t_arg.arg -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=WHOLE_STATIC_LIB,WHOLE_STATIC_LIB_NVPTX -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
 // WHOLE_STATIC_LIB: clang-offload-bundler{{.*}} "-type=o" "-targets={{.*}},[[BUNDLE_TRIPLE]]"
 // WHOLE_STATIC_LIB_DEF: clang-offload-bundler{{.*}} "-type=aoo" "-targets=[[BUNDLE_TRIPLE]]" "-input=[[INPUTA:.+\.a]]" "-output=[[OUTPUTA:.+\.txt]]"
@@ -231,16 +231,16 @@
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_NOSRC -check-prefix=STATIC_LIB_NOSRC-SPIR -DTARGET=spir64 -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -L/dummy/dir %t_lib.lo -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_NOSRC -check-prefix=STATIC_LIB_NOSRC-SPIR -DTARGET=spir64 -DBUNDLE_TRIPLE=sycl-spir64-unknown-unknown
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -L/dummy/dir %t_lib.a -### 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -L/dummy/dir %t_lib.a -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_NOSRC -check-prefix=STATIC_LIB_NOSRC-CUDA -DTARGET=nvptx64 -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -L/dummy/dir %t_lib.lo -### 2>&1 \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -L/dummy/dir %t_lib.lo -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=STATIC_LIB_NOSRC -check-prefix=STATIC_LIB_NOSRC-CUDA -DTARGET=nvptx64 -DBUNDLE_TRIPLE=sycl-nvptx64-nvidia-cuda-sm_50
 // STATIC_LIB_NOSRC-SPIR: clang-offload-bundler{{.*}} "-type=aoo" "-targets=[[BUNDLE_TRIPLE]]" "-input={{.*}}_lib.{{(a|lo)}}" "-output=[[DEVICELIB:.+\.txt]]" "-unbundle"
 // STATIC_LIB_NOSRC-SPIR: llvm-foreach{{.*}}spirv-to-ir-wrapper{{.*}} "[[DEVICELIB]]" "-o" "[[DEVICELIST:.+\.txt]]"
 // STATIC_LIB_NOSRC-SPIR: llvm-link{{.*}} "@[[DEVICELIST]]" "-o" "[[BCFILE:.+\.bc]]"
 // STATIC_LIB_NOSRC-CUDA: clang-offload-bundler{{.*}} "-type=a" "-targets=[[BUNDLE_TRIPLE]]" "-input={{.*}}_lib.{{(a|lo)}}" "-output=[[DEVICELIB:.+\.a]]" "-unbundle"
 // STATIC_LIB_NOSRC-CUDA: llvm-link{{.*}} "[[DEVICELIB]]" "-o" "[[BCFILE1:.+\.bc]]"
-// STATIC_LIB_NOSRC-CUDA: llvm-link{{.*}} "[[BCFILE1]]" "{{.*}}" "-o" "[[BCFILE:.+\.bc]]"
+// STATIC_LIB_NOSRC-CUDA: llvm-link{{.*}} "[[BCFILE1]]"{{.*}} "-o" "[[BCFILE:.+\.bc]]"
 // STATIC_LIB_NOSRC: sycl-post-link{{.*}} "-o" "[[TABLE:.+]]" "[[BCFILE]]"
 // STATIC_LIB_NOSRC: file-table-tform{{.*}} "-o" "[[LIST:.+]]" "[[TABLE]]"
 // STATIC_LIB_NOSRC-SPIR: llvm-foreach{{.*}}llvm-spirv{{.*}} "-o" "[[OBJLIST:.+\.txt]]"{{.*}} "[[LIST]]"

--- a/clang/test/Driver/sycl-offload-with-split-old-model.c
+++ b/clang/test/Driver/sycl-offload-with-split-old-model.c
@@ -311,7 +311,7 @@
 // RUN:    | FileCheck %s -check-prefixes=CHK-ESIMD-SPLIT-OFF
 // RUN:   %clang -### -fsycl --no-offload-new-driver %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefixes=CHK-ESIMD-SPLIT-DEFAULT
-// RUN:   %clang -### -fsycl --no-offload-new-driver -nocudalib -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
+// RUN:   %clang -### -fsycl --no-offload-new-driver -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefixes=CHK-ESIMD-SPLIT-NON-SPIRV
 // CHK-ESIMD-SPLIT-ON: sycl-post-link{{.*}} "-split-esimd"{{.*}} "-o"{{.*}}
 // CHK-ESIMD-SPLIT-OFF-NOT: sycl-post-link{{.*}} "-split-esimd"{{.*}}

--- a/clang/test/Driver/sycl-oneapi-gpu-nvidia.cpp
+++ b/clang/test/Driver/sycl-oneapi-gpu-nvidia.cpp
@@ -1,34 +1,34 @@
 /// Tests the behaviors of using -fsycl-targets=nvidia_gpu*
 
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_50 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_50 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_50 -DMAC_STR=SM_50
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_52 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_52 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_52 -DMAC_STR=SM_52
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_53 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_53 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_53 -DMAC_STR=SM_53
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_60 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_60 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_60 -DMAC_STR=SM_60
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_61 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_61 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_61 -DMAC_STR=SM_61
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_62 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_62 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_62 -DMAC_STR=SM_62
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_70 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_70 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_70 -DMAC_STR=SM_70
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_72 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_72 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_72 -DMAC_STR=SM_72
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_75 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_75 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_75 -DMAC_STR=SM_75
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_80 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_80 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_80 -DMAC_STR=SM_80
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_86 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_86 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_86 -DMAC_STR=SM_86
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_87 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_87 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_87 -DMAC_STR=SM_87
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_89 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_89 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_89 -DMAC_STR=SM_89
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_90 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_90 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_90 -DMAC_STR=SM_90
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_90a -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_90a -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE_NVIDIA,MACRO_NVIDIA -DDEV_STR=sm_90a -DMAC_STR=SM_90A
 // MACRO_NVIDIA: clang{{.*}}  "-fsycl-is-host"
 // MACRO_NVIDIA: "-D__SYCL_TARGET_NVIDIA_GPU_[[MAC_STR]]__"
@@ -44,7 +44,7 @@
 // BAD_NVIDIA_INPUT: error: SYCL target is invalid: 'nvidia_gpu_bad'
 
 // Check if the partial SYCL triple for NVidia GPUs translate to the full string.
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64 -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=NVIDIA-TRIPLE
 // NVIDIA-TRIPLE: clang{{.*}} "-triple" "nvptx64-nvidia-cuda"
 
@@ -63,7 +63,7 @@
 // BAD_TARGET_TRIPLE: error: SYCL target is invalid: 'nvptx-nvidia-cuda'
 
 /// Test for proper creation of fat object
-// RUN: %clangxx -c -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_50 \
+// RUN: %clangxx -c -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_50 \
 // RUN:   -fsycl-libspirv-path=%S/Inputs/SYCL/libspirv.bc \
 // RUN:   -target x86_64-unknown-linux-gnu -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=NVIDIA_FATO
@@ -72,7 +72,7 @@
 
 /// Test for proper consumption of fat object
 // RUN: touch %t.o
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvidia_gpu_sm_50 \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvidia_gpu_sm_50 \
 // RUN:   -fsycl-libspirv-path=%S/Inputs/SYCL/libspirv.bc \
 // RUN:   -target x86_64-unknown-linux-gnu -### %t.o 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=NVIDIA_CONSUME_FAT

--- a/clang/test/Driver/sycl-save-ptx-files.cpp
+++ b/clang/test/Driver/sycl-save-ptx-files.cpp
@@ -4,14 +4,14 @@
 // while targeting CUDA enabled GPUs.
 
 // Linux
-// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -save-offload-code=/user/input/path %s 2>&1 \
+// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -save-offload-code=/user/input/path -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHECK-PTX-FILES,CHECK-SPIRV-FILES
 
 // clang --driver-mode=g++
-// RUN: %clangxx -### -fsycl  -fsycl-targets=nvptx64-nvidia-cuda -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -save-offload-code=/user/input/path %s 2>&1 \
+// RUN: %clangxx -### -fsycl  -fsycl-targets=nvptx64-nvidia-cuda -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -save-offload-code=/user/input/path -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHECK-PTX-FILES
 
-// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -save-offload-code= %s 2>&1 \
+// RUN: %clang -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown -target x86_64-unknown-linux-gnu --cuda-path=%S/Inputs/CUDA/usr/local/cuda -save-offload-code= -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHECK-PTX-FILES-CWD,CHECK-SPIRV-FILES-CWD
 
 // CHECK-PTX-FILES: llvm-foreach{{.*}} "--out-ext=s"{{.*}} "--out-dir=/user/input/path{{(/|\\\\)}}" "--" "{{.*}}clang{{.*}}" {{.*}} "-fsycl-is-device" {{.*}}.s{{.*}}
@@ -22,20 +22,20 @@
 // Windows - Check if PTX files are saved in the user provided path.
 // RUN: %clang_cl -### -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
-// RUN: -Qsave-offload-code=/user/input/path %s 2>&1 \
+// RUN: -Qsave-offload-code=/user/input/path -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHECK-PTX-WIN %s
 
 // Windows - Check if PTX and SPV files are saved in user provided path.
 // RUN: %clang_cl -### -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda,spir64-unknown-unknown --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
-// RUN: -Qsave-offload-code=/user/input/path %s 2>&1 \
+// RUN: -Qsave-offload-code=/user/input/path -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-PTX-WIN,CHECK-SPV-WIN %s
 
 // Windows - Check PTX files saved in current working directory when -save-offload-code
 // is empty. 
 // RUN: %clang_cl -### -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
-// RUN: -Qsave-offload-code= %s 2>&1 \
+// RUN: -Qsave-offload-code= -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHECK-PTX-WIN-CWD %s
 
 // CHECK-PTX-WIN: llvm-foreach{{.*}} "--out-ext=s"{{.*}} "--out-dir=/user/input/path{{(/|\\\\)}}" "--" "{{.*}}clang{{.*}}" {{.*}} "-fsycl-is-device" {{.*}}.asm{{.*}}

--- a/clang/test/Driver/sycl-target-mismatch-nvptx.cpp
+++ b/clang/test/Driver/sycl-target-mismatch-nvptx.cpp
@@ -1,29 +1,29 @@
 // REQUIRES: nvptx-registered-target
 
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60  \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60  \
 // RUN:   %S/Inputs/SYCL/libnvptx64-sm_50.a -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=NVPTX64_DIAG
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60 \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60 \
 // RUN:   -L%S/Inputs/SYCL -lnvptx64-sm_50 -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=NVPTX64_DIAG
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60 \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60 \
 // RUN:   %S/Inputs/SYCL/objnvptx64-sm_50.o -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=NVPTX64_DIAG
 // NVPTX64_DIAG: linked binaries do not contain expected 'nvptx64-nvidia-cuda-sm_60' target; found targets: 'nvptx64-nvidia-cuda-sm_50' [-Wsycl-target]
 
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_50 \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_50 \
 // RUN:   %S/Inputs/SYCL/libnvptx64-sm_50.a -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=NVPTX64_MATCH_DIAG
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_50 \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_50 \
 // RUN:   -L%S/Inputs/SYCL -lnvptx64-sm_50 -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=NVPTX64_MATCH_DIAG
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_50 \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_50 \
 // RUN:   %S/Inputs/SYCL/objnvptx64-sm_50.o -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=NVPTX64_MATCH_DIAG
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda \
 // RUN:   %S/Inputs/SYCL/objnvptx64-sm_50.o -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=NVPTX64_MATCH_DIAG
-// RUN: %clangxx -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60 \
+// RUN: %clangxx -fsycl -fno-sycl-libspirv -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_60 \
 // RUN:   -Wno-sycl-target %S/Inputs/SYCL/objnvptx64-sm_50.o -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=NVPTX64_MATCH_DIAG
 // NVPTX64_MATCH_DIAG-NOT: linked binaries do not contain expected

--- a/clang/test/Driver/sycl-triple-dae-flags.cpp
+++ b/clang/test/Driver/sycl-triple-dae-flags.cpp
@@ -5,7 +5,7 @@
 // CHECK-NOT: -fenable-sycl-dae
 // CHECK-NOT: -emit-param-info
 //
-// RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fsycl-dead-args-optimization -nocudalib %s 2> %t.cuda.out
+// RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fsycl-dead-args-optimization -fno-sycl-libspirv -nocudalib %s 2> %t.cuda.out
 // RUN: FileCheck %s --check-prefixes=CHECK-FENABLE,CHECK-EMIT --input-file %t.cuda.out
 //
 // RUN: %clangxx -### -fsycl -fsycl-targets=spir64-unknown-unknown -fsycl-dead-args-optimization %s 2> %t.out

--- a/clang/test/Driver/sycl-windows-cuda-path.cpp
+++ b/clang/test/Driver/sycl-windows-cuda-path.cpp
@@ -5,7 +5,7 @@
 
 // REQUIRES: system-windows
 // RUN: env CUDA_PATH=%S\Inputs\CUDA_111\usr\local\cuda %clang -fsycl \
-// RUN: -fsycl-targets=nvptx64-nvidia-cuda -### -v %s 2>&1 | \
+// RUN: -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv -### -v %s 2>&1 | \
 // RUN: FileCheck %s
 
 // CHECK: Found CUDA installation: {{.*}}Inputs\CUDA_111\usr\local\cuda, version 11.1

--- a/clang/test/lit.site.cfg.py.in
+++ b/clang/test/lit.site.cfg.py.in
@@ -47,6 +47,7 @@ config.have_llvm_driver = @LLVM_TOOL_LLVM_DRIVER_BUILD@
 config.spirv_tools_tests = @LLVM_INCLUDE_SPIRV_TOOLS_TESTS@
 config.substitutions.append(("%llvm-version-major", "@LLVM_VERSION_MAJOR@"))
 config.has_key_instructions = @LLVM_EXPERIMENTAL_KEY_INSTRUCTIONS@
+config.llvm_enabled_projects = "@LLVM_ENABLE_PROJECTS@".split(";")
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
The tests fail since 388ccf577a3d when libclc project is disabled, since there is no libspirv bitcode file.
Fix them by adding `-fno-sycl-libspirv` flag.
Add `REQUIRES: libclc` to libspirv specific tests.