### PR TITLE
[CI] Use cosign to sign nightly builds

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -332,6 +332,11 @@ jobs:
       toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
       sycl_cts_artifact: sycl_cts_bin_win
 
+  # Verification example:
+  # cosign-windows-amd64.exe verify-blob sycl_linux.tar.gz \
+  # --bundle sycl_linux.tar.gz.sigstore.json \
+  # --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  # --certificate-identity https://github.com/intel/llvm/.github/workflows/sycl-nightly.yml@refs/heads/sycl
   nightly_build_upload:
     name: Nightly Build Upload
     if: ${{ github.ref_name == 'sycl' }}
@@ -339,6 +344,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -346,6 +352,10 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: sycl_windows_default
+    - name: Sign with sigstore/cosign
+      uses: sigstore/gh-action-sigstore-python@v3.0.1
+      with:
+        inputs: sycl_linux.tar.gz sycl_windows.tar.gz
     - name: Compute tag
       id: tag
       run: |
@@ -361,6 +371,8 @@ jobs:
         files: |
           sycl_linux.tar.gz
           sycl_windows.tar.gz
+          sycl_linux.tar.gz.sigstore.json
+          sycl_windows.tar.gz.sigstore.json
         tag_name: nightly-${{ steps.tag.outputs.TAG }}
         name: DPC++ daily ${{ steps.tag.outputs.TAG }}
         prerelease: true


### PR DESCRIPTION
Enable artifact signing with sigstore/cosign in CI. This ensures that the builds were built exactly by the sycl-nightly workflow.