### PR TITLE
[SYCL] Fix build with older gcc

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1840,8 +1840,9 @@ DeviceKernelInfo &ProgramManager::getOrCreateDeviceKernelInfo(
 DeviceKernelInfo &
 ProgramManager::getOrCreateDeviceKernelInfo(KernelNameStrRefT KernelName) {
   std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
-  auto Result = m_DeviceKernelInfoMap.try_emplace(
-      KernelName, CompileTimeKernelInfoTy{std::string_view(KernelName)});
+  CompileTimeKernelInfoTy DefaultCompileTimeInfo{std::string_view(KernelName)};
+  auto Result =
+      m_DeviceKernelInfoMap.try_emplace(KernelName, DefaultCompileTimeInfo);
   return Result.first->second;
 }
 


### PR DESCRIPTION
Works around an internal compiler error that's observed in Jenkins precommit.

```
sycl/source/detail/program_manager/program_manager.cpp:1845:75: internal compiler error: in replace_placeholders_r, at cp/tree.c:2804
KernelName, CompileTimeKernelInfoTy{detail::string_view(KernelName)});
```