### PR TITLE
[CI] Add manual trigger for updating Github pages to sycl-docs.yml

### DIFF
--- a/.github/workflows/sycl-docs.yml
+++ b/.github/workflows/sycl-docs.yml
@@ -10,6 +10,7 @@ on:
     - '.github/workflows/sycl-docs.yml'
     - 'clang/docs/**'
     - 'sycl/doc/**'
+    - 'devops/benchmarks/scripts/html/**'
   push:
     branches:
     - sycl
@@ -17,6 +18,16 @@ on:
     - '.github/workflows/sycl-docs.yml'
     - 'clang/docs/**'
     - 'sycl/doc/**'
+    - 'devops/benchmarks/scripts/html/**'
+  workflow_dispatch:
+    inputs:
+      update_gh_pages:
+        type: choice
+        description: Update Github Pages
+        options:
+          - true
+          - false
+        default: true
 
 permissions:
   contents: read
@@ -62,5 +73,5 @@ jobs:
       with:
         path: ./install_docs
     - name: Deploy to GitHub Pages
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' || inputs.update_gh_pages == 'true' }}
       uses: actions/deploy-pages@v4


### PR DESCRIPTION
I made PR #20026 yesterday to fix a bug in the benchmarking CI dashboard, but looks like my changes were not deployed onto Github pages.

This PR:
- Adds benchmarking dashboard to the list of paths in workflow triggers
- Adds a manual trigger to sycl-docs.yml, allowing people to manually trigger a github pages update if necessary in the future