### PR TITLE
[SYCL][BindlessImages] Fix external semaphore dependencies and return events

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3687,7 +3687,8 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     return Adapter
         .call_nocheck<UrApiKind::urBindlessImagesWaitExternalSemaphoreExp>(
             MQueue->getHandleRef(), SemWait->getExternalSemaphore(),
-            OptWaitValue.has_value(), WaitValue, 0, nullptr, nullptr);
+            OptWaitValue.has_value(), WaitValue, RawEvents.size(),
+            RawEvents.data(), Event);
   }
   case CGType::SemaphoreSignal: {
     assert(MQueue &&
@@ -3700,7 +3701,8 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     return Adapter
         .call_nocheck<UrApiKind::urBindlessImagesSignalExternalSemaphoreExp>(
             MQueue->getHandleRef(), SemSignal->getExternalSemaphore(),
-            OptSignalValue.has_value(), SignalValue, 0, nullptr, nullptr);
+            OptSignalValue.has_value(), SignalValue, RawEvents.size(),
+            RawEvents.data(), Event);
   }
   case CGType::AsyncAlloc: {
     // NO-OP. Async alloc calls adapter immediately in order to return a valid

--- a/sycl/unittests/Extensions/BindlessImages/CMakeLists.txt
+++ b/sycl/unittests/Extensions/BindlessImages/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_sycl_unittest(BindlessImagesExtensionTests OBJECT
+  Semaphores.cpp
+)

--- a/sycl/unittests/Extensions/BindlessImages/Semaphores.cpp
+++ b/sycl/unittests/Extensions/BindlessImages/Semaphores.cpp
@@ -1,0 +1,127 @@
+#include <helpers/UrMock.hpp>
+
+#include <gtest/gtest.h>
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/bindless_images.hpp>
+#include <sycl/ext/oneapi/bindless_images_interop.hpp>
+#include <sycl/queue.hpp>
+
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+constexpr uint64_t WaitValue = 42;
+constexpr uint64_t SignalValue = 24;
+
+thread_local int urBindlessImagesWaitExternalSemaphoreExp_counter = 0;
+thread_local bool urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue =
+    false;
+inline ur_result_t
+urBindlessImagesWaitExternalSemaphoreExp_replace(void *pParams) {
+  ++urBindlessImagesWaitExternalSemaphoreExp_counter;
+  ur_bindless_images_wait_external_semaphore_exp_params_t Params =
+      *reinterpret_cast<
+          ur_bindless_images_wait_external_semaphore_exp_params_t *>(pParams);
+  EXPECT_EQ(*Params.phasWaitValue,
+            urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue);
+  if (urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue) {
+    EXPECT_EQ(*Params.pwaitValue, WaitValue);
+  }
+  EXPECT_EQ(*Params.pphEvent, nullptr);
+  EXPECT_EQ(*Params.pnumEventsInWaitList, uint32_t{0});
+  EXPECT_NE(*Params.pphEventWaitList, nullptr);
+  return UR_RESULT_SUCCESS;
+}
+
+thread_local int urBindlessImagesSignalExternalSemaphoreExp_counter = 0;
+thread_local bool
+    urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = false;
+thread_local uint32_t
+    urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 0;
+inline ur_result_t
+urBindlessImagesSignalExternalSemaphoreExp_replace(void *pParams) {
+  ++urBindlessImagesSignalExternalSemaphoreExp_counter;
+  ur_bindless_images_signal_external_semaphore_exp_params_t Params =
+      *reinterpret_cast<
+          ur_bindless_images_signal_external_semaphore_exp_params_t *>(pParams);
+  EXPECT_EQ(*Params.pphEvent, nullptr);
+  EXPECT_EQ(*Params.phasSignalValue,
+            urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue);
+  if (urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue) {
+    EXPECT_EQ(*Params.psignalValue, SignalValue);
+  }
+  if (urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents) {
+    EXPECT_NE(*Params.pphEvent, nullptr);
+  }
+
+  else {
+    EXPECT_EQ(*Params.pphEvent, nullptr);
+  }
+  EXPECT_EQ(*Params.pnumEventsInWaitList,
+            urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents);
+  EXPECT_NE(*Params.pphEventWaitList, nullptr);
+  return UR_RESULT_SUCCESS;
+}
+
+TEST(BindlessImagesExtensionTests, ExternalSemaphoreWait) {
+  sycl::unittest::UrMock<> Mock;
+  mock::getCallbacks().set_replace_callback(
+      "urBindlessImagesWaitExternalSemaphoreExp",
+      &urBindlessImagesWaitExternalSemaphoreExp_replace);
+  urBindlessImagesWaitExternalSemaphoreExp_counter = 0;
+
+  sycl::queue Q;
+  syclexp::external_semaphore DummySemaphore{};
+
+  urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue = false;
+  Q.ext_oneapi_wait_external_semaphore(DummySemaphore);
+  EXPECT_EQ(urBindlessImagesWaitExternalSemaphoreExp_counter, 1);
+
+  urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue = true;
+  Q.ext_oneapi_wait_external_semaphore(DummySemaphore, WaitValue);
+  EXPECT_EQ(urBindlessImagesWaitExternalSemaphoreExp_counter, 2);
+}
+
+TEST(BindlessImagesExtensionTests, ExternalSemaphoreSignal) {
+  sycl::unittest::UrMock<> Mock;
+  mock::getCallbacks().set_replace_callback(
+      "urBindlessImagesSignalExternalSemaphoreExp",
+      &urBindlessImagesSignalExternalSemaphoreExp_replace);
+  urBindlessImagesSignalExternalSemaphoreExp_counter = 0;
+
+  sycl::queue Q;
+  syclexp::external_semaphore DummySemaphore{};
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = false;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 0;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 1);
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = true;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 0;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, SignalValue);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 2);
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = false;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 1;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, sycl::event{});
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 3);
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = true;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 1;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, SignalValue,
+                                         sycl::event{});
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 4);
+
+  std::vector<sycl::event> DummyEventList(2);
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = false;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 2;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, DummyEventList);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 5);
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = true;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 2;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, SignalValue,
+                                         DummyEventList);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 6);
+}

--- a/sycl/unittests/Extensions/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CMakeLists.txt
@@ -26,6 +26,7 @@ add_sycl_unittest(ExtensionsTests OBJECT
   USMPrefetch.cpp
 )
 
+add_subdirectory(BindlessImages)
 add_subdirectory(CommandGraph)
 add_subdirectory(VirtualFunctions)
 add_subdirectory(VirtualMemory)


### PR DESCRIPTION
This commit fixes an issue where bindless images semaphore operations (signal/wait) would neither use dependency events of the submission nor return the corresponding event from the backend operation. This commit fixes both of these issues.