### PR TITLE
Kernel object and lambda must have the same name

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1467,12 +1467,13 @@ private:
       setNDRangeDescriptor(std::move(params)...);
     }
 
-    setDeviceKernelInfo(std::move(Kernel));
-    if (lambdaAndKernelHaveEqualName<NameT>()) {
-      StoreLambda<NameT, KernelType, Dims, ElementType>(std::move(KernelFunc));
-    } else {
-      extractArgsAndReqs();
+    MKernel = detail::getSyclObjImpl(Kernel);
+    if (!lambdaAndKernelHaveEqualName<NameT>()) {
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "the kernel name must match the name of the lambda");
     }
+    StoreLambda<NameT, KernelType, Dims, ElementType>(std::move(KernelFunc));
     processProperties<Info.IsESIMD, PropertiesT>(Props);
 #endif
   }
@@ -1926,12 +1927,15 @@ public:
     // No need to check if range is out of INT_MAX limits as it's compile-time
     // known constant
     setNDRangeDescriptor(range<1>{1});
-    setDeviceKernelInfo(std::move(Kernel));
-    if (lambdaAndKernelHaveEqualName<NameT>()) {
-      StoreLambda<NameT, KernelType, /*Dims*/ 1, void>(std::move(KernelFunc));
-    } else {
-      extractArgsAndReqs();
+
+    MKernel = detail::getSyclObjImpl(std::move(Kernel));
+    if (!lambdaAndKernelHaveEqualName<NameT>()) {
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "the kernel name must match the name of the lambda");
     }
+    StoreLambda<NameT, KernelType, /*Dims*/ 1, void>(std::move(KernelFunc));
+
 #else
     detail::CheckDeviceCopyable<KernelType>();
 #endif


### PR DESCRIPTION
Today, the API that accepts both a kernel object and a corresponding lambda ignores the case when the name stored in the kernel object differs from the lambda name. This PR modifies this behavior and throws an exception if names do not match.