### PR TITLE
[UR] Fix usm pools creation failure at context initialization 

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -258,7 +258,7 @@ std::vector<device> device_impl::create_sub_devices(
                               affinityDomainToString(AffinityDomain) + ".");
   }
 
-  ur_device_partition_property_t Prop;
+  ur_device_partition_property_t Prop{};
   Prop.type = UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN;
   Prop.value.affinity_domain =
       static_cast<ur_device_affinity_domain_flags_t>(AffinityDomain);
@@ -285,9 +285,8 @@ std::vector<device> device_impl::create_sub_devices() const {
         "sycl::info::partition_property::ext_intel_partition_by_cslice.");
   }
 
-  ur_device_partition_property_t Prop;
+  ur_device_partition_property_t Prop{};
   Prop.type = UR_DEVICE_PARTITION_BY_CSLICE;
-
   ur_device_partition_properties_t Properties{};
   Properties.stype = UR_STRUCTURE_TYPE_DEVICE_PARTITION_PROPERTIES;
   Properties.pProperties = &Prop;

--- a/sycl/test-e2e/Adapters/level_zero/context_create_sub_sub_device.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/context_create_sub_sub_device.cpp
@@ -1,0 +1,42 @@
+// REQUIRES:  arch-intel_gpu_pvc, level_zero
+// UNSUPPORTED: gpu-intel-pvc-1T
+// UNSUPPORTED-TRACKER: GSD-9121
+
+// DEFINE: %{setup_env} = env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE ZE_AFFINITY_MASK=0 ZEX_NUMBER_OF_CCS=0:4
+// RUN: %{build} -o %t.out
+// RUN: %{setup_env} %{run} %t.out
+
+// Check that context can be created successfully when sub-sub-devices are
+// exposed.
+#include <iostream>
+#include <sycl/detail/core.hpp>
+#include <vector>
+
+using namespace sycl;
+
+int main() {
+  std::cout << "[info] start context_create_sub_sub_device test" << std::endl;
+  device d;
+  std::vector<device> subsubdevices;
+
+  auto subdevices = d.create_sub_devices<
+      info::partition_property::partition_by_affinity_domain>(
+      info::partition_affinity_domain::next_partitionable);
+  std::cout << "[info] sub device size = " << subdevices.size() << std::endl;
+
+  for (auto &subdev : subdevices) {
+    subsubdevices = subdev.create_sub_devices<
+        info::partition_property::ext_intel_partition_by_cslice>();
+
+    std::cout << "[info] sub-sub device size = " << subsubdevices.size()
+              << std::endl;
+  }
+
+  // Create contexts
+  context ctx1(d);
+  context ctx2(subdevices);
+  context ctx3(subsubdevices);
+
+  std::cout << "[info] contexts created successfully" << std::endl;
+  return 0;
+}

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -248,16 +248,20 @@ struct ur_device_handle_t_ : ur_object {
   ur::RefCount RefCount;
 };
 
-inline std::vector<ur_device_handle_t>
-CollectDevicesAndSubDevices(const std::vector<ur_device_handle_t> &Devices) {
+// Collects a flat vector of unique devices for USM memory pool creation.
+// Traverses the input devices and their sub-devices, ensuring each Level Zero
+// device handle appears only once in the result.
+inline std::vector<ur_device_handle_t> CollectDevicesForUsmPoolCreation(
+    const std::vector<ur_device_handle_t> &Devices) {
   std::vector<ur_device_handle_t> DevicesAndSubDevices;
-  std::unordered_set<ur_device_handle_t> Seen;
+  std::unordered_set<ze_device_handle_t> Seen;
+
   std::function<void(const std::vector<ur_device_handle_t> &)>
       CollectDevicesAndSubDevicesRec =
           [&](const std::vector<ur_device_handle_t> &Devices) {
             for (auto &Device : Devices) {
-              // Only add device if has not been seen before.
-              if (Seen.insert(Device).second) {
+              // Only add device if ZeDevice has not been seen before.
+              if (Seen.insert(Device->ZeDevice).second) {
                 DevicesAndSubDevices.push_back(Device);
                 CollectDevicesAndSubDevicesRec(Device->SubDevices);
               }

--- a/unified-runtime/source/adapters/level_zero/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/usm.cpp
@@ -1061,7 +1061,8 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
     }
   }
 
-  auto DevicesAndSubDevices = CollectDevicesAndSubDevices(Context->Devices);
+  auto DevicesAndSubDevices =
+      CollectDevicesForUsmPoolCreation(Context->Devices);
   auto Descriptors = usm::pool_descriptor::createFromDevices(
       this, Context, DevicesAndSubDevices);
   for (auto &Desc : Descriptors) {

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -168,7 +168,7 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t hContext,
   }
 
   auto devicesAndSubDevices =
-      CollectDevicesAndSubDevices(hContext->getDevices());
+      CollectDevicesForUsmPoolCreation(hContext->getDevices());
   auto descriptors = usm::pool_descriptor::createFromDevices(
       this, hContext, devicesAndSubDevices);
   for (auto &desc : descriptors) {


### PR DESCRIPTION
This is a cherry-pick of intel/llvm#19921

Context creation was failing when sub-sub-devices were exposed, because the Level Zero adapter attempted to add multiple USM pools with identical descriptors. This occurred since, for the L0 backend, sub-sub-devices and their parent sub-devices share the same Level Zero device handle and should use the same USM pool.

This PR resolves the issue by ensuring only devices with unique Level Zero
handles are collected for USM pool creation, preventing duplicate pools.

Additionally, this PR fixes an issue with an uninitialized `ur_device_partition_property_t` variable passed to UR. Previously, this could result in an unexpected value for `value.affinity_domain` when the property type was `UR_DEVICE_PARTITION_BY_CSLICE` resulting on error from
adapter.