### PR TITLE
[SYCL] Fix `self-contained-headers` tests on Win

### DIFF
--- a/sycl/include/sycl/info/info_desc.hpp
+++ b/sycl/include/sycl/info/info_desc.hpp
@@ -22,6 +22,7 @@
 
 #include <sycl/range.hpp>
 
+#include <string>
 #include <vector>
 
 // This is used in trait .def files when there isn't a corresponding backend


### PR DESCRIPTION
Regressed after
https://github.com/intel/llvm/pull/20029, similarly to the build itself. The build was fixed earlier in https://github.com/intel/llvm/pull/20057, but that wasn't enough to fix `check-sycl` on Win.