### PR TITLE
[libclc] Make LIBCLC_OUTPUT_LIBRARY_DIR directory before build

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -349,6 +349,7 @@ file( TO_CMAKE_PATH ${LIBCLC_LIBRARY_OUTPUT_INTDIR}/clc LIBCLC_LIBRARY_OUTPUT_IN
 # Setup the paths where libclc runtimes should be stored.
 # FIXME: Align with upstream
 set( LIBCLC_OUTPUT_LIBRARY_DIR ${LIBCLC_LIBRARY_OUTPUT_INTDIR} )
+file( MAKE_DIRECTORY ${LIBCLC_OUTPUT_LIBRARY_DIR} )
 
 foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
   message( STATUS "libclc target '${t}' is enabled" )


### PR DESCRIPTION
libclc libraries are put in LIBCLC_OUTPUT_LIBRARY_DIR directory. Ninja generator implicitly creates the output directory when generating library files, but "Unix Makefiles" generator does not. Fixes `No such file or directory` error in #20058.