### PR TITLE
[SYCL][UR] Do not call `urDeviceRetain()` in `device_impl` constructor at all

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -30,9 +30,9 @@ device_impl::device_impl(ur_device_handle_t Device, platform_impl &Platform,
                       : get_info_impl<UR_DEVICE_INFO_PARENT_DEVICE>()),
       // TODO catch an exception and put it to list of asynchronous exceptions:
       MCache{*this} {
-  // Interoperability Constructor already calls DeviceRetain in
-  // urDeviceCreateWithNativeHandle.
-  getAdapter().call<UrApiKind::urDeviceRetain>(MDevice);
+  // urDeviceRetain(MDevice) should not be called here,
+  // because RefCounter is initialized with 1,
+  // when the device is created.
 }
 
 device_impl::~device_impl() {

--- a/sycl/unittests/context_device/DeviceRefCounter.cpp
+++ b/sycl/unittests/context_device/DeviceRefCounter.cpp
@@ -43,12 +43,7 @@ TEST(DevRefCounter, DevRefCounter) {
     sycl::platform Plt = sycl::platform();
 
     Plt.get_devices();
-    EXPECT_NE(DevRefCounter, 0);
-    // This is the behavior that SYCL performs at shutdown, but there
-    // are timing differences Lin/Win and shared/static that make
-    // it not map correctly into our mock.
-    // So for this test, we just do it.
-    sycl::detail::GlobalHandler::instance().getPlatformCache().clear();
+
+    EXPECT_EQ(DevRefCounter, 0);
   }
-  EXPECT_EQ(DevRefCounter, 0);
 }


### PR DESCRIPTION
`urDeviceRetain(MDevice)` should not be called in the `device_impl` constructor at all,
because `RefCounter` is initialized with 1, when the device is created.

It fixes URT-961.
