### PR TITLE
[SYCL][Native CPU] Add missing components.

### DIFF
--- a/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
+++ b/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
@@ -21,15 +21,17 @@ add_llvm_component_library(LLVMSYCLNativeCPUUtils
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/SYCLLowerIR
   
   LINK_COMPONENTS
+  AggressiveInstCombine
   Analysis
   Core
-  Support
+  IPO
   Passes
+  ScalarOpts
+  Support
   SYCLLowerIR
   Target
   TargetParser
   TransformUtils
-  ipo
   ${OCK_LIBS}
 )
 

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/CMakeLists.txt
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/CMakeLists.txt
@@ -21,8 +21,11 @@ add_llvm_component_library(LLVMNativeCPUPipeline
   ${CMAKE_CURRENT_SOURCE_DIR}/source/work_item_loops_pass.cpp
 
   LINK_COMPONENTS
-  Passes
+  Analysis
   Core
+  Passes
+  Support
+  TransformUtils
   )
 
 # TODO: Move to under LLVM include and work out why ADDITIONAL_HEADER_DIRS

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/CMakeLists.txt
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/CMakeLists.txt
@@ -106,16 +106,18 @@ endif()
 add_llvm_component_library(LLVMNativeCPUVecz
   ${COMMON_SRCS}
   LINK_COMPONENTS
+  AggressiveInstCombine
+  Analysis
+  Core
+  InstCombine
+  IPO
   NativeCPUPipeline
-  support
-  core
-  analysis
-  instcombine
-  aggressiveinstcombine
-  transformutils
-  scalaropts
-  ipo
-  passes
+  Passes
+  ScalarOpts
+  Support
+  Target
+  TargetParser
+  TransformUtils
   )
 
 target_include_directories(LLVMNativeCPUVecz


### PR DESCRIPTION
In the default configuration, effectively components would be linked in implicitly, but with --shared-libs, that is not the case and we need to make sure to list all components we use.

Fixes #20061