### PR TITLE
[SYCL][E2E] Check oclcpu version

### DIFF
--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -42,6 +42,12 @@ def parse_min_intel_driver_req(line_number, line, output):
         # Return "win" version as (101, 4502) to ease later comparison.
         output["win"] = tuple(map(int, win.group(1).split(".")))
 
+    cpu = re.search(r"cpu: *([0-9]{4})", line)
+    if cpu:
+        if "cpu" in output:
+            raise ValueError('Multiple entries for "cpu" version')
+        output["cpu"] = int(cpu.group(1))
+
     return output
 
 
@@ -165,7 +171,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
 
             driver_ok = True
             if test.intel_driver_req:
-                for fmt in ["lin", "win"]:
+                for fmt in ["lin", "win", "cpu"]:
                     if (
                         fmt in test.intel_driver_req
                         and fmt in test.config.intel_driver_ver[full_name]

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -1013,14 +1013,17 @@ for full_name, sycl_device in zip(
         if re.match(r" *Driver *:", line):
             _, driver_str = line.split(":", 1)
             driver_str = driver_str.strip()
-            lin = re.match(r"[0-9]{1,2}\.[0-9]{1,2}\.([0-9]{5})", driver_str)
-            if lin:
-                intel_driver_ver["lin"] = int(lin.group(1))
-            win = re.match(
-                r"[0-9]{1,2}\.[0-9]{1,2}\.([0-9]{3})\.([0-9]{4})", driver_str
-            )
-            if win:
-                intel_driver_ver["win"] = (int(win.group(1)), int(win.group(2)))
+            if sycl_device.endswith("gpu"):
+                lin = re.match(r"[0-9]{1,2}\.[0-9]{1,2}\.([0-9]{5})", driver_str)
+                if lin:
+                    intel_driver_ver["lin"] = int(lin.group(1))
+                win = re.match(
+                    r"[0-9]{1,2}\.[0-9]{1,2}\.([0-9]{3})\.([0-9]{4})", driver_str
+                )
+                if win:
+                    intel_driver_ver["win"] = (int(win.group(1)), int(win.group(2)))
+            elif sycl_device.endswith("cpu"):
+                intel_driver_ver["cpu"] = driver_str
         if re.match(r" *Aspects *:", line):
             _, aspects_str = line.split(":", 1)
             dev_aspects.append(aspects_str.strip().split(" "))


### PR DESCRIPTION
This patch allows to check the version of CPU RT in E2E tests. E.g. REQUIRES-INTEL-DRIVER: cpu: 2025.20.6.0.04_224945