### PR TITLE
[NFC][SYCL] Prefer `(void)` over `std::ignore`

### DIFF
--- a/sycl/include/sycl/accessor_image.hpp
+++ b/sycl/include/sycl/accessor_image.hpp
@@ -907,7 +907,7 @@ public:
   DataT read(const CoordT &Coords) const noexcept {
 #ifdef __SYCL_DEVICE_ONLY__
     // Currently not reachable on device.
-    std::ignore = Coords;
+    (void)Coords;
     return {0, 0, 0, 0};
 #else
     return host_base_class::read<DataT>(Coords);
@@ -925,8 +925,8 @@ public:
   void write(const CoordT &Coords, const DataT &Color) const {
 #ifdef __SYCL_DEVICE_ONLY__
     // Currently not reachable on device.
-    std::ignore = Coords;
-    std::ignore = Color;
+    (void)Coords;
+    (void)Color;
 #else
     host_base_class::write<DataT>(Coords, Color);
 #endif // __SYCL_DEVICE_ONLY__
@@ -938,7 +938,7 @@ private:
       : host_base_class{Impl}
 #endif // __SYCL_DEVICE_ONLY__
   {
-    std::ignore = Impl;
+    (void)Impl;
   }
 
   template <class Obj>
@@ -1216,7 +1216,7 @@ public:
   DataT read(const CoordT &Coords) const noexcept {
 #ifdef __SYCL_DEVICE_ONLY__
     // Currently not reachable on device.
-    std::ignore = Coords;
+    (void)Coords;
     return {0, 0, 0, 0};
 #else
     return host_base_class::read<DataT>(Coords);
@@ -1229,7 +1229,7 @@ private:
       : host_base_class{Impl}
 #endif // __SYCL_DEVICE_ONLY__
   {
-    std::ignore = Impl;
+    (void)Impl;
   }
 
   template <class Obj>

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -924,7 +924,7 @@ template <typename GroupT, typename T>
 EnableIfNativeShuffle<T> Shuffle(GroupT g, T x, id<1> local_id) {
   uint32_t LocalId = MapShuffleID(g, local_id);
 #ifndef __NVPTX__
-  std::ignore = g;
+  (void)g;
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
                     GroupT> &&
                 detail::is_vec<T>::value) {
@@ -957,7 +957,7 @@ EnableIfNativeShuffle<T> Shuffle(GroupT g, T x, id<1> local_id) {
 template <typename GroupT, typename T>
 EnableIfNativeShuffle<T> ShuffleXor(GroupT g, T x, id<1> mask) {
 #ifndef __NVPTX__
-  std::ignore = g;
+  (void)g;
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
                     GroupT> &&
                 detail::is_vec<T>::value) {

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -2155,7 +2155,7 @@ __ESIMD_API simd<Tx, N> block_load(AccessorTy acc,
   return block_load<Tx, N>(__ESIMD_DNS::accessorToPointer<Tx>(acc, byte_offset),
                            flags);
 #else
-  std::ignore = flags;
+  (void)flags;
   constexpr unsigned Sz = sizeof(T) * N;
   static_assert(Sz >= detail::OperandSize::OWORD,
                 "block size must be at least 1 oword");

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -110,7 +110,7 @@ public:
   static _dataT read(queue &Q, bool &Success,
                      memory_order Order = memory_order::seq_cst) {
     // Order is currently unused.
-    std::ignore = Order;
+    (void)Order;
 
     const device Dev = Q.get_device();
     bool IsPipeSupported =
@@ -139,7 +139,7 @@ public:
   static void write(queue &Q, const _dataT &Data, bool &Success,
                     memory_order Order = memory_order::seq_cst) {
     // Order is currently unused.
-    std::ignore = Order;
+    (void)Order;
 
     const device Dev = Q.get_device();
     bool IsPipeSupported =
@@ -267,7 +267,7 @@ public:
   // Host API
   static _dataT read(queue &Q, memory_order Order = memory_order::seq_cst) {
     // Order is currently unused.
-    std::ignore = Order;
+    (void)Order;
 
     const device Dev = Q.get_device();
     bool IsPipeSupported =
@@ -290,7 +290,7 @@ public:
   static void write(queue &Q, const _dataT &Data,
                     memory_order Order = memory_order::seq_cst) {
     // Order is currently unused.
-    std::ignore = Order;
+    (void)Order;
 
     const device Dev = Q.get_device();
     bool IsPipeSupported =

--- a/sycl/include/sycl/ext/oneapi/experimental/prefetch.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/prefetch.hpp
@@ -90,9 +90,9 @@ void prefetch_impl(T *ptr, size_t bytes, Properties properties) {
   }
   __spirv_ocl_prefetch(ptrAnnotated, bytes);
 #else
-  std::ignore = ptr;
-  std::ignore = bytes;
-  std::ignore = properties;
+  (void)ptr;
+  (void)bytes;
+  (void)properties;
 #endif
 }
 
@@ -101,7 +101,7 @@ void joint_prefetch_impl(Group g, T *ptr, size_t bytes, Properties properties) {
   // Although calling joint_prefetch is functionally equivalent to calling
   // prefetch from every work-item in a group, native suppurt may be added to to
   // issue cooperative prefetches more efficiently on some hardware.
-  std::ignore = g;
+  (void)g;
   prefetch_impl(ptr, bytes, properties);
 }
 } // namespace detail

--- a/sycl/include/sycl/ext/oneapi/experimental/user_defined_reductions.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/user_defined_reductions.hpp
@@ -33,10 +33,10 @@ T reduce_over_group_impl(GroupHelper group_helper, T x, size_t num_elements,
   group_barrier(g);
   return group_broadcast(g, result);
 #else
-  std::ignore = group_helper;
-  std::ignore = x;
-  std::ignore = num_elements;
-  std::ignore = binary_op;
+  (void)group_helper;
+  (void)x;
+  (void)num_elements;
+  (void)binary_op;
   throw exception(make_error_code(errc::runtime),
                   "Group algorithms are not supported on host.");
 #endif
@@ -73,7 +73,7 @@ reduce_over_group(GroupHelper group_helper, V x, T init,
 #ifdef __SYCL_DEVICE_ONLY__
   return binary_op(init, reduce_over_group(group_helper, x, binary_op));
 #else
-  std::ignore = group_helper;
+  (void)group_helper;
   throw exception(make_error_code(errc::runtime),
                   "Group algorithms are not supported on host.");
 #endif
@@ -107,10 +107,10 @@ joint_reduce(GroupHelper group_helper, Ptr first, Ptr last,
   return detail::reduce_over_group_impl(group_helper, partial, num_elements,
                                         binary_op);
 #else
-  std::ignore = group_helper;
-  std::ignore = first;
-  std::ignore = last;
-  std::ignore = binary_op;
+  (void)group_helper;
+  (void)first;
+  (void)last;
+  (void)binary_op;
   throw exception(make_error_code(errc::runtime),
                   "Group algorithms are not supported on host.");
 #endif
@@ -129,8 +129,8 @@ joint_reduce(GroupHelper group_helper, Ptr first, Ptr last, T init,
 #ifdef __SYCL_DEVICE_ONLY__
   return binary_op(init, joint_reduce(group_helper, first, last, binary_op));
 #else
-  std::ignore = group_helper;
-  std::ignore = last;
+  (void)group_helper;
+  (void)last;
   throw exception(make_error_code(errc::runtime),
                   "Group algorithms are not supported on host.");
 #endif

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-intel.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-intel.hpp
@@ -520,7 +520,7 @@ template <typename Group, typename T,
 inline __SYCL_ALWAYS_INLINE decltype(auto)
 get_wi_data(Group sg, sycl::ext::oneapi::experimental::matrix::joint_matrix<
                           Group, T, Use, Rows, Cols, Layout> &jm) {
-  std::ignore = sg;
+  (void)sg;
   return wi_data(jm);
 }
 
@@ -546,9 +546,9 @@ joint_matrix_store(Group,
   static_assert(Space != access::address_space::private_space,
                 "Joint Matrix doesn't support store to private memory!");
 #if defined(__NVPTX__)
-  std::ignore = src;
-  std::ignore = dst;
-  std::ignore = stride;
+  (void)src;
+  (void)dst;
+  (void)stride;
   throw exception(
       make_error_code(errc::runtime),
       "This version of the matrix extension is only currently supported on "
@@ -569,9 +569,9 @@ joint_matrix_store(Group,
       stride);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = src;
-  std::ignore = dst;
-  std::ignore = stride;
+  (void)src;
+  (void)dst;
+  (void)stride;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -593,9 +593,9 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
     size_t stride) {
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__)
-  std::ignore = src;
-  std::ignore = dst;
-  std::ignore = stride;
+  (void)src;
+  (void)dst;
+  (void)stride;
   throw exception(
       make_error_code(errc::runtime),
       "This version of the matrix extension is only currently supported on "
@@ -615,9 +615,9 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
       stride);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = src;
-  std::ignore = dst;
-  std::ignore = stride;
+  (void)src;
+  (void)dst;
+  (void)stride;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -634,7 +634,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_apply(
     F &&lambda) {
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__)
-  std::ignore = sg;
+  (void)sg;
   for (int i = 0; i < jm.matrix_impl.wi_marray.size(); i++) {
     lambda(jm.matrix_impl.wi_marray[i]);
   }
@@ -651,9 +651,9 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_apply(
   }
 #endif
 #else
-  std::ignore = sg;
-  std::ignore = jm;
-  std::ignore = lambda;
+  (void)sg;
+  (void)jm;
+  (void)lambda;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif
@@ -679,12 +679,12 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_fill_checked(
       spv_matrix_layout_traits<Layout>::value>(
       CoordX, CoordY, Height, Width, static_cast<storage_element_type>(Value));
 #else
-  std::ignore = Res;
-  std::ignore = Value;
-  std::ignore = Height;
-  std::ignore = Width;
-  std::ignore = CoordX;
-  std::ignore = CoordY;
+  (void)Res;
+  (void)Value;
+  (void)Height;
+  (void)Width;
+  (void)CoordX;
+  (void)CoordY;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -704,7 +704,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load_checked(
 #if defined(__SYCL_DEVICE_ONLY__)
   static_assert(Space != access::address_space::private_space,
                 "Joint Matrix doesn't support load from private memory!");
-  std::ignore = sg;
+  (void)sg;
   using DecorT = typename sycl::detail::DecoratedType<T, Space>::type;
   DecorT *Ptr = sycl::detail::getDecorated<DecorT>(Src);
   Res.spvm = __spirv_CooperativeMatrixLoadCheckedINTEL<
@@ -714,15 +714,15 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load_checked(
       Ptr, CoordX, CoordY, sycl::detail::joint_matrix_layout_to_spv(Layout),
       Height, Width, Stride);
 #else
-  std::ignore = sg;
-  std::ignore = Res;
-  std::ignore = Src;
-  std::ignore = Stride;
-  std::ignore = Height;
-  std::ignore = Width;
-  std::ignore = Layout;
-  std::ignore = CoordX;
-  std::ignore = CoordY;
+  (void)sg;
+  (void)Res;
+  (void)Src;
+  (void)Stride;
+  (void)Height;
+  (void)Width;
+  (void)Layout;
+  (void)CoordX;
+  (void)CoordY;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -743,7 +743,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load_checked(
 #if defined(__SYCL_DEVICE_ONLY__)
   static_assert(Space != access::address_space::private_space,
                 "Joint Matrix doesn't support load from private memory!");
-  std::ignore = sg;
+  (void)sg;
   using DecorT = typename sycl::detail::DecoratedType<T, Space>::type;
   DecorT *Ptr = sycl::detail::getDecorated<DecorT>(Src);
   Res.spvm = __spirv_CooperativeMatrixLoadCheckedINTEL<
@@ -752,14 +752,14 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load_checked(
       Ptr, CoordX, CoordY, spv_matrix_layout_traits<Layout>::value, Height,
       Width, Stride);
 #else
-  std::ignore = sg;
-  std::ignore = Res;
-  std::ignore = Src;
-  std::ignore = Stride;
-  std::ignore = Height;
-  std::ignore = Width;
-  std::ignore = CoordX;
-  std::ignore = CoordY;
+  (void)sg;
+  (void)Res;
+  (void)Src;
+  (void)Stride;
+  (void)Height;
+  (void)Width;
+  (void)CoordX;
+  (void)CoordY;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -776,7 +776,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store_checked(
 #if defined(__SYCL_DEVICE_ONLY__)
   static_assert(Space != access::address_space::private_space,
                 "Joint Matrix doesn't support store to private memory!");
-  std::ignore = sg;
+  (void)sg;
   using DecorT = typename sycl::detail::DecoratedType<T, Space>::type;
   DecorT *Ptr = sycl::detail::getDecorated<DecorT>(Dst);
   __spirv_CooperativeMatrixStoreCheckedINTEL<
@@ -786,15 +786,15 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store_checked(
       Ptr, CoordX, CoordY, Src.spvm,
       sycl::detail::joint_matrix_layout_to_spv(Layout), Height, Width, Stride);
 #else
-  std::ignore = sg;
-  std::ignore = Src;
-  std::ignore = Dst;
-  std::ignore = Stride;
-  std::ignore = Height;
-  std::ignore = Width;
-  std::ignore = Layout;
-  std::ignore = CoordX;
-  std::ignore = CoordY;
+  (void)sg;
+  (void)Src;
+  (void)Dst;
+  (void)Stride;
+  (void)Height;
+  (void)Width;
+  (void)Layout;
+  (void)CoordX;
+  (void)CoordY;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -811,7 +811,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store_checked(
 #if defined(__SYCL_DEVICE_ONLY__)
   static_assert(Space != access::address_space::private_space,
                 "Joint Matrix doesn't support store to private memory!");
-  std::ignore = sg;
+  (void)sg;
   using DecorT = typename sycl::detail::DecoratedType<T, Space>::type;
   DecorT *Ptr = sycl::detail::getDecorated<DecorT>(Dst);
   __spirv_CooperativeMatrixStoreCheckedINTEL<
@@ -820,14 +820,14 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store_checked(
       Ptr, CoordX, CoordY, Src.spvm, spv_matrix_layout_traits<Layout>::value,
       Height, Width, Stride);
 #else
-  std::ignore = sg;
-  std::ignore = Src;
-  std::ignore = Dst;
-  std::ignore = Stride;
-  std::ignore = Height;
-  std::ignore = Width;
-  std::ignore = CoordX;
-  std::ignore = CoordY;
+  (void)sg;
+  (void)Src;
+  (void)Dst;
+  (void)Stride;
+  (void)Height;
+  (void)Width;
+  (void)CoordX;
+  (void)CoordY;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -846,7 +846,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load_checked(
     size_t Stride, layout Layout, size_t Height, size_t Width, size_t CoordX,
     size_t CoordY) {
 #if defined(__SYCL_DEVICE_ONLY__)
-  std::ignore = sg;
+  (void)sg;
   T *Ptr = Src.get();
   Res.spvm = __spirv_CooperativeMatrixLoadCheckedINTEL<
       T, S, NumRows, NumCols, spv_matrix_use_traits<use::accumulator>::value,
@@ -854,15 +854,15 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load_checked(
       Ptr, CoordX, CoordY, sycl::detail::joint_matrix_layout_to_spv(Layout),
       Height, Width, Stride);
 #else
-  std::ignore = sg;
-  std::ignore = Res;
-  std::ignore = Src;
-  std::ignore = Stride;
-  std::ignore = Height;
-  std::ignore = Width;
-  std::ignore = Layout;
-  std::ignore = CoordX;
-  std::ignore = CoordY;
+  (void)sg;
+  (void)Res;
+  (void)Src;
+  (void)Stride;
+  (void)Height;
+  (void)Width;
+  (void)Layout;
+  (void)CoordX;
+  (void)CoordY;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -880,7 +880,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load_checked(
     ext::oneapi::experimental::annotated_ptr<T, PropertyListT> Src,
     size_t Stride, size_t Height, size_t Width, size_t CoordX, size_t CoordY) {
 #if defined(__SYCL_DEVICE_ONLY__)
-  std::ignore = sg;
+  (void)sg;
   T *Ptr = Src.get();
   Res.spvm = __spirv_CooperativeMatrixLoadCheckedINTEL<
       T, S, NumRows, NumCols, spv_matrix_use_traits<Use>::value,
@@ -888,14 +888,14 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load_checked(
       Ptr, CoordX, CoordY, spv_matrix_layout_traits<Layout>::value, Height,
       Width, Stride);
 #else
-  std::ignore = sg;
-  std::ignore = Res;
-  std::ignore = Src;
-  std::ignore = Stride;
-  std::ignore = Height;
-  std::ignore = Width;
-  std::ignore = CoordX;
-  std::ignore = CoordY;
+  (void)sg;
+  (void)Res;
+  (void)Src;
+  (void)Stride;
+  (void)Height;
+  (void)Width;
+  (void)CoordX;
+  (void)CoordY;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -911,7 +911,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store_checked(
     size_t Stride, layout Layout, size_t Height, size_t Width, size_t CoordX,
     size_t CoordY) {
 #if defined(__SYCL_DEVICE_ONLY__)
-  std::ignore = sg;
+  (void)sg;
   T *Ptr = Dst.get();
   __spirv_CooperativeMatrixStoreCheckedINTEL<
       T, T, NumRows, NumCols, spv_matrix_use_traits<use::accumulator>::value,
@@ -919,15 +919,15 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store_checked(
       Ptr, CoordX, CoordY, Src.spvm,
       sycl::detail::joint_matrix_layout_to_spv(Layout), Height, Width, Stride);
 #else
-  std::ignore = sg;
-  std::ignore = Src;
-  std::ignore = Dst;
-  std::ignore = Stride;
-  std::ignore = Height;
-  std::ignore = Width;
-  std::ignore = Layout;
-  std::ignore = CoordX;
-  std::ignore = CoordY;
+  (void)sg;
+  (void)Src;
+  (void)Dst;
+  (void)Stride;
+  (void)Height;
+  (void)Width;
+  (void)Layout;
+  (void)CoordX;
+  (void)CoordY;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -941,7 +941,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store_checked(
     ext::oneapi::experimental::annotated_ptr<T, PropertyListT> Dst,
     size_t Stride, size_t Height, size_t Width, size_t CoordX, size_t CoordY) {
 #if defined(__SYCL_DEVICE_ONLY__)
-  std::ignore = sg;
+  (void)sg;
   T *Ptr = Dst.get();
   __spirv_CooperativeMatrixStoreCheckedINTEL<
       T, Tp, NumRows, NumCols, spv_matrix_use_traits<Use>::value,
@@ -949,14 +949,14 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store_checked(
       Ptr, CoordX, CoordY, Src.spvm, spv_matrix_layout_traits<Layout>::value,
       Height, Width, Stride);
 #else
-  std::ignore = sg;
-  std::ignore = Src;
-  std::ignore = Dst;
-  std::ignore = Stride;
-  std::ignore = Height;
-  std::ignore = Width;
-  std::ignore = CoordX;
-  std::ignore = CoordY;
+  (void)sg;
+  (void)Src;
+  (void)Dst;
+  (void)Stride;
+  (void)Height;
+  (void)Width;
+  (void)CoordX;
+  (void)CoordY;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
@@ -86,7 +86,7 @@ joint_matrix_apply(Group sg, joint_matrix<Group, T, Use, M, N, Layout> &jm,
                    F &&lambda) {
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__) || defined(__HIP_PLATFORM_AMD_MFMA__)
-  std::ignore = sg;
+  (void)sg;
   for (int i = 0; i < jm.matrix_impl.wi_marray.size(); i++) {
     lambda(jm.matrix_impl.wi_marray[i]);
   }
@@ -102,9 +102,9 @@ joint_matrix_apply(Group sg, joint_matrix<Group, T, Use, M, N, Layout> &jm,
   }
 #endif
 #else
-  std::ignore = sg;
-  std::ignore = jm;
-  std::ignore = lambda;
+  (void)sg;
+  (void)jm;
+  (void)lambda;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif
@@ -119,7 +119,7 @@ joint_matrix_apply(Group sg, joint_matrix<Group, T0, Use, M, N, Layout> &jm0,
                    F &&lambda) {
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__) || defined(__HIP_PLATFORM_AMD_MFMA__)
-  std::ignore = sg;
+  (void)sg;
   for (int i = 0; i < jm0.matrix_impl.wi_marray.size(); i++) {
     lambda(jm0.matrix_impl.wi_marray[i], jm1.matrix_impl.wi_marray[i]);
   }
@@ -141,10 +141,10 @@ joint_matrix_apply(Group sg, joint_matrix<Group, T0, Use, M, N, Layout> &jm0,
   }
 #endif
 #else
-  std::ignore = sg;
-  std::ignore = jm0;
-  std::ignore = jm1;
-  std::ignore = lambda;
+  (void)sg;
+  (void)jm0;
+  (void)jm1;
+  (void)lambda;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif
@@ -171,8 +171,8 @@ joint_matrix_fill(Group,
           static_cast<storage_element_type>(v));
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = res;
-  std::ignore = v;
+  (void)res;
+  (void)v;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -193,14 +193,14 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
   static_assert(Space != access::address_space::private_space,
                 "Joint Matrix doesn't support load from private memory!");
 #if defined(__NVPTX__)
-  std::ignore = sg;
+  (void)sg;
   sycl::ext::oneapi::detail::load_accumulator_cuda(res.matrix_impl, src, stride,
                                                    Layout);
 #elif defined(__HIP_PLATFORM_AMD_MFMA__)
   sycl::ext::oneapi::detail::load_accumulator_hip(res.matrix_impl, src, stride,
                                                   Layout, sg);
 #else
-  std::ignore = sg;
+  (void)sg;
   using DecorT = typename sycl::detail::DecoratedType<T, Space>::type;
   DecorT *Ptr = sycl::detail::getDecorated<DecorT>(src);
   res.spvm = __spirv_CooperativeMatrixLoadKHR<
@@ -210,11 +210,11 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
       Ptr, sycl::detail::joint_matrix_layout_to_spv(Layout), stride);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = sg;
-  std::ignore = res;
-  std::ignore = src;
-  std::ignore = stride;
-  std::ignore = Layout;
+  (void)sg;
+  (void)res;
+  (void)src;
+  (void)stride;
+  (void)Layout;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -236,7 +236,7 @@ joint_matrix_load(Group sg,
   static_assert(Space != access::address_space::private_space,
                 "Joint Matrix doesn't support load from private memory!");
 #if defined(__NVPTX__)
-  std::ignore = sg;
+  (void)sg;
   sycl::ext::oneapi::detail::load_multiplicand_cuda<S, T, NumRows, NumCols, Use,
                                                     Layout, Space>(
       res.matrix_impl, src, stride);
@@ -245,7 +245,7 @@ joint_matrix_load(Group sg,
                                                    NumCols, Use, Layout, Space>(
       res.matrix_impl, src, stride, sg);
 #else
-  std::ignore = sg;
+  (void)sg;
   using DecorT = typename sycl::detail::DecoratedType<T, Space>::type;
   DecorT *Ptr = sycl::detail::getDecorated<DecorT>(src);
   res.spvm =
@@ -255,10 +255,10 @@ joint_matrix_load(Group sg,
           Ptr, spv_matrix_layout_traits<Layout>::value, stride);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = sg;
-  std::ignore = res;
-  std::ignore = src;
-  std::ignore = stride;
+  (void)sg;
+  (void)res;
+  (void)src;
+  (void)stride;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -276,14 +276,14 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
     size_t stride, sycl::ext::oneapi::experimental::matrix::layout Layout) {
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__)
-  std::ignore = sg;
+  (void)sg;
   throw exception(make_error_code(errc::runtime),
                   "Use joint_matrix_load on multi_ptr on Nvidia device.");
 #elif defined(__HIP_PLATFORM_AMD_MFMA__)
   throw exception(make_error_code(errc::runtime),
                   "Use joint_matrix_load on multi_ptr on AMD device.");
 #else
-  std::ignore = sg;
+  (void)sg;
   T *Ptr = src.get();
   res.spvm = __spirv_CooperativeMatrixLoadKHR<
       T, S, NumRows, NumCols, spv_matrix_use_traits<use::accumulator>::value,
@@ -291,11 +291,11 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
       Ptr, sycl::detail::joint_matrix_layout_to_spv(Layout), stride);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = sg;
-  std::ignore = res;
-  std::ignore = src;
-  std::ignore = stride;
-  std::ignore = Layout;
+  (void)sg;
+  (void)res;
+  (void)src;
+  (void)stride;
+  (void)Layout;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -314,14 +314,14 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
     size_t stride) {
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__)
-  std::ignore = sg;
+  (void)sg;
   throw exception(make_error_code(errc::runtime),
                   "Use joint_matrix_load on multi_ptr on Nvidia device.");
 #elif defined(__HIP_PLATFORM_AMD_MFMA__)
   throw exception(make_error_code(errc::runtime),
                   "Use joint_matrix_load on multi_ptr on AMD device.");
 #else
-  std::ignore = sg;
+  (void)sg;
   T *Ptr = src.get();
   res.spvm =
       __spirv_CooperativeMatrixLoadKHR<T, S, NumRows, NumCols,
@@ -330,10 +330,10 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
           Ptr, spv_matrix_layout_traits<Layout>::value, stride);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = sg;
-  std::ignore = res;
-  std::ignore = src;
-  std::ignore = stride;
+  (void)sg;
+  (void)res;
+  (void)src;
+  (void)stride;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -352,7 +352,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
   static_assert(Space != access::address_space::private_space,
                 "Joint Matrix doesn't support store to private memory!");
 #if defined(__NVPTX__)
-  std::ignore = sg;
+  (void)sg;
   sycl::ext::oneapi::detail::joint_matrix_store_cuda<T, NumRows, NumCols,
                                                      Space>(
       src.matrix_impl, dst, stride, Layout);
@@ -361,7 +361,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
                                                     Space>(src.matrix_impl, dst,
                                                            stride, Layout, sg);
 #else
-  std::ignore = sg;
+  (void)sg;
   using DecorT = typename sycl::detail::DecoratedType<T, Space>::type;
   DecorT *Ptr = sycl::detail::getDecorated<DecorT>(dst);
   __spirv_CooperativeMatrixStoreKHR<
@@ -371,11 +371,11 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
       Ptr, src.spvm, sycl::detail::joint_matrix_layout_to_spv(Layout), stride);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = sg;
-  std::ignore = src;
-  std::ignore = dst;
-  std::ignore = stride;
-  std::ignore = Layout;
+  (void)sg;
+  (void)src;
+  (void)dst;
+  (void)stride;
+  (void)Layout;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -392,14 +392,14 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
     size_t stride, sycl::ext::oneapi::experimental::matrix::layout Layout) {
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__)
-  std::ignore = sg;
+  (void)sg;
   throw exception(make_error_code(errc::runtime),
                   "Use joint_matrix_store on multi_ptr on Nvidia device.");
 #elif defined(__HIP_PLATFORM_AMD_MFMA__)
   throw exception(make_error_code(errc::runtime),
                   "Use joint_matrix_store on multi_ptr on AMD device.");
 #else
-  std::ignore = sg;
+  (void)sg;
   T *Ptr = dst.get();
   __spirv_CooperativeMatrixStoreKHR<
       T, T, NumRows, NumCols, spv_matrix_use_traits<use::accumulator>::value,
@@ -407,11 +407,11 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
       Ptr, src.spvm, sycl::detail::joint_matrix_layout_to_spv(Layout), stride);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = sg;
-  std::ignore = src;
-  std::ignore = dst;
-  std::ignore = stride;
-  std::ignore = Layout;
+  (void)sg;
+  (void)src;
+  (void)dst;
+  (void)stride;
+  (void)Layout;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -466,10 +466,10 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_mad(
       A.spvm, B.spvm, C.spvm, MatrixOperand);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = A;
-  std::ignore = B;
-  std::ignore = C;
-  std::ignore = D;
+  (void)A;
+  (void)B;
+  (void)C;
+  (void)D;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -482,7 +482,7 @@ void joint_matrix_copy(
     joint_matrix<Group, T2, Use2, Rows, Cols, Layout2> &dst) {
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__) || defined(__HIP_PLATFORM_AMD_MFMA__)
-  std::ignore = sg;
+  (void)sg;
   dst.matrix_impl.wi_marray = src.matrix_impl.wi_marray;
 #else
   using storage_element_type =
@@ -508,9 +508,9 @@ void joint_matrix_copy(
   }
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = sg;
-  std::ignore = dst;
-  std::ignore = src;
+  (void)sg;
+  (void)dst;
+  (void)src;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)
@@ -549,28 +549,28 @@ joint_matrix_prefetch(Group sg, T *Ptr, size_t stride,
                       Properties properties = {}) {
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__)
-  std::ignore = sg;
-  std::ignore = properties;
+  (void)sg;
+  (void)properties;
   throw exception(make_error_code(errc::runtime),
                   "joint_matrix_prefetch is not supported on Nvidia device.");
 #elif defined(__HIP_PLATFORM_AMD_MFMA__)
-  std::ignore = sg;
-  std::ignore = properties;
+  (void)sg;
+  (void)properties;
   throw exception(make_error_code(errc::runtime),
                   "joint_matrix_prefetch is not supported on AMD device.");
 #else
-  std::ignore = sg;
+  (void)sg;
   auto prop = properties.template get_property<prefetch_hint_key>();
   __spirv_CooperativeMatrixPrefetchINTEL<T>(
       Ptr, NumRows, NumCols, detail::PropertyMetaInfo<decltype(prop)>::value,
       sycl::detail::joint_matrix_layout_to_spv(Layout), stride);
 #endif // defined(__NVPTX__)
 #else
-  std::ignore = sg;
-  std::ignore = Ptr;
-  std::ignore = stride;
-  std::ignore = Layout;
-  std::ignore = properties;
+  (void)sg;
+  (void)Ptr;
+  (void)stride;
+  (void)Layout;
+  (void)properties;
   throw exception(make_error_code(errc::runtime),
                   "joint matrix is not supported on host.");
 #endif // defined(__SYCL_DEVICE_ONLY__)

--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -26,7 +26,7 @@ struct __SYCL_DEPRECATED("use sycl::sub_group() instead") sub_group
   // sycl::ext::oneapi::sub_group sg = item.get_sub_group();
   // Note: this constructor is used for implicit conversion. Since the
   // sub_group class doesn't have any members, just ignore the arg.
-  sub_group(const sycl::sub_group &sg) : sub_group() { std::ignore = sg; }
+  sub_group(const sycl::sub_group &sg) : sub_group() { (void)sg; }
 
 private:
   sub_group() = default;

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -913,7 +913,7 @@ private:
         setKernelCacheConfig(StableKernelCacheConfig::LargeData);
       }
     } else {
-      std::ignore = Props;
+      (void)Props;
     }
 
     constexpr bool UsesRootSync = PropertiesT::template has_property<

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -1036,7 +1036,7 @@ public:
   template <typename KernelName, typename FuncTy,
             bool HasIdentity = has_identity>
   std::enable_if_t<!HasIdentity> withInitializedMem(handler &CGH, FuncTy Func) {
-    std::ignore = CGH;
+    (void)CGH;
     assert(!initializeToIdentity() &&
            "Initialize to identity not allowed for identity-less reductions.");
     Func(accessor{MRedOut, CGH});
@@ -1079,7 +1079,7 @@ public:
   bool initializeToIdentity() const { return InitializeToIdentity; }
 
   auto getUserRedVarAccess(handler &CGH) {
-    std::ignore = CGH;
+    (void)CGH;
     if constexpr (is_usm)
       return MRedOut;
     else
@@ -1816,7 +1816,7 @@ template <> struct NDRangeReduction<reduction::strategy::basic> {
     size_t NWorkGroups = NDRange.get_group_range().size();
 
     bool IsUpdateOfUserVar = !Redu.initializeToIdentity();
-    std::ignore = IsUpdateOfUserVar;
+    (void)IsUpdateOfUserVar;
 
     // The type of the Out "accessor" differs between scenarios when there is
     // just one WorkGroup and when there are multiple. Use this lambda to write
@@ -2802,7 +2802,7 @@ void reduction_parallel_for(handler &CGH, range<Dims> Range,
 template <typename T, typename AllocatorT, typename BinaryOperation>
 auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH,
                BinaryOperation Combiner, const property_list &PropList = {}) {
-  std::ignore = CGH;
+  (void)CGH;
   detail::verifyReductionProps(PropList);
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
@@ -2831,7 +2831,7 @@ auto reduction(T *Var, BinaryOperation Combiner,
 template <typename T, typename AllocatorT, typename BinaryOperation>
 auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
                BinaryOperation Combiner, const property_list &PropList = {}) {
-  std::ignore = CGH;
+  (void)CGH;
   detail::verifyReductionProps(PropList);
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();

--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -637,8 +637,8 @@ struct sub_group {
 #ifdef __SYCL_DEVICE_ONLY__
     return lhs.get_group_id() == rhs.get_group_id();
 #else
-    std::ignore = lhs;
-    std::ignore = rhs;
+    (void)lhs;
+    (void)rhs;
     throw sycl::exception(make_error_code(errc::feature_not_supported),
                           "Sub-groups are not supported on host.");
 #endif
@@ -648,8 +648,8 @@ struct sub_group {
 #ifdef __SYCL_DEVICE_ONLY__
     return !(lhs == rhs);
 #else
-    std::ignore = lhs;
-    std::ignore = rhs;
+    (void)lhs;
+    (void)rhs;
     throw sycl::exception(make_error_code(errc::feature_not_supported),
                           "Sub-groups are not supported on host.");
 #endif

--- a/sycl/include/sycl/vector.hpp
+++ b/sycl/include/sycl/vector.hpp
@@ -112,7 +112,7 @@ public:
 // conversions are needed as in the case below:
 //
 //   sycl::vec<int, 1> v;
-//   std::ignore = static_cast<bool>(v);
+//   (void)static_cast<bool>(v);
 //
 // Make sure the snippet above compiles. That is important because
 //


### PR DESCRIPTION
One of my recent PRs to reduce header dependencies of `id/item/range/etc.` has caused some compile time errors downstream with `std::ignore` not being declared because we use different version of STL than the one in the upstream CI.

We do want to have our device headers as lightweight as possible (especially in the context of SYCL RTC), so it makes sense to just use `(void)` uniformly instead of `std::ignore`. UR experience also found that the compile-time price of `(void)` is smaller as well.