### PR TITLE
[UR][Offload] Sync queues before destroying them

### DIFF
--- a/unified-runtime/source/adapters/offload/queue.cpp
+++ b/unified-runtime/source/adapters/offload/queue.cpp
@@ -91,6 +91,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
       if (!Q) {
         break;
       }
+      OL_RETURN_ON_ERR(olSyncQueue(Q));
       OL_RETURN_ON_ERR(olDestroyQueue(Q));
     }
     delete hQueue;


### PR DESCRIPTION
urQueueRelease now waits for all work in the queue to complete, which
is consistent with other plugins.
