### PR TITLE
[SYCL][E2E] Follow-up to pull/20084

### DIFF
--- a/sycl/test-e2e/Experimental/clock.cpp
+++ b/sycl/test-e2e/Experimental/clock.cpp
@@ -1,3 +1,4 @@
+// REQUIRES-INTEL-DRIVER: cpu: 2026
 // REQUIRES: aspect-usm_shared_allocations
 // REQUIRES: aspect-ext_oneapi_clock_sub_group || aspect-ext_oneapi_clock_work_group || aspect-ext_oneapi_clock_device
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -42,11 +42,11 @@ def parse_min_intel_driver_req(line_number, line, output):
         # Return "win" version as (101, 4502) to ease later comparison.
         output["win"] = tuple(map(int, win.group(1).split(".")))
 
-    cpu = re.search(r"cpu: *([0-9]{4})", line)
+    cpu = re.search(r"cpu:\s*([^\s]+)", line)
     if cpu:
         if "cpu" in output:
             raise ValueError('Multiple entries for "cpu" version')
-        output["cpu"] = int(cpu.group(1))
+        output["cpu"] = cpu.group(1)
 
     return output
 


### PR DESCRIPTION
Forgot to include this change into the patch.
pull/20084 allows to check the version of CPU RT in E2E tests. E.g. REQUIRES-INTEL-DRIVER: cpu: 2025.20.6.0.04_224945.

This patch fixes reading the required cpu version.
