### PR TITLE
[SYCL] reenable Graph/RecordReplay/host_task2_multiple_roots.cpp test on BMG on v2 L0 adapter

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/host_task2_multiple_roots.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task2_multiple_roots.cpp
@@ -13,9 +13,6 @@
 // UNSUPPORTED: windows
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/11852
 
-// UNSUPPORTED: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18996
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/host_task2_multiple_roots.cpp"


### PR DESCRIPTION
After verification of issue [#18996](https://github.com/intel/llvm/issues/18996) - test passed locally and on CI, re-enabled