### PR TITLE
[SYCL RTC] Make `resource.cpp` independent of any includes

### DIFF
--- a/sycl-jit/jit-compiler/include/Resource.h
+++ b/sycl-jit/jit-compiler/include/Resource.h
@@ -8,13 +8,29 @@
 
 #pragma once
 
-#include <iterator>
-#include <string_view>
-#include <utility>
-
-namespace jit_compiler {
+namespace jit_compiler::resource {
+// `resource.cpp` is compiled using freshly built clang and it's very hard to
+// sync compilation options between that and normal compilation for other files.
+// Note that some of the options might affect ABI (e.g., libstdc++ vs. libc++
+// usage, or custom sysroot/gcc installation directory). A much easier approach
+// is to ensure that `resource.cpp` doesn't have any includes at all, hence
+// these helpers:
+template <class T, unsigned long long N>
+constexpr unsigned long long size(const T (&)[N]) noexcept {
+  return N;
+}
+struct resource_string_view {
+  template <unsigned long long N>
+  resource_string_view(const char (&S)[N]) : S(S), Size(N - 1) {}
+  const char *S;
+  unsigned long long Size;
+};
+struct resource_file {
+  resource_string_view Path;
+  resource_string_view Content;
+};
 // Defined in the auto-generated file:
-extern const std::pair<std::string_view, std::string_view> ToolchainFiles[];
-extern size_t NumToolchainFiles;
-extern std::string_view ToolchainPrefix;
-} // namespace jit_compiler
+extern const resource_file ToolchainFiles[];
+extern unsigned long long NumToolchainFiles;
+extern resource_string_view ToolchainPrefix;
+} // namespace jit_compiler::resource

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -100,8 +100,12 @@ private:
 
 class SYCLToolchain {
   SYCLToolchain() {
+    using namespace jit_compiler::resource;
+
     for (size_t i = 0; i < NumToolchainFiles; ++i) {
-      auto [Path, Content] = ToolchainFiles[i];
+      resource_file RF = ToolchainFiles[i];
+      std::string_view Path{RF.Path.S, RF.Path.Size};
+      std::string_view Content{RF.Content.S, RF.Content.Size};
       ToolchainFS->addFile(Path, 0, llvm::MemoryBuffer::getMemBuffer(Content));
     }
   }
@@ -196,12 +200,14 @@ public:
     return std::move(Lib);
   }
 
+  std::string_view getPrefix() const { return Prefix; }
   std::string_view getClangXXExe() const { return ClangXXExe; }
 
 private:
   clang::IgnoringDiagConsumer IgnoreDiag;
-  std::string ClangXXExe =
-      (jit_compiler::ToolchainPrefix + "/bin/clang++").str();
+  std::string_view Prefix{jit_compiler::resource::ToolchainPrefix.S,
+                          jit_compiler::resource::ToolchainPrefix.Size};
+  std::string ClangXXExe = (Prefix + "/bin/clang++").str();
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> ToolchainFS =
       llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
 };
@@ -500,7 +506,7 @@ Error jit_compiler::linkDeviceLibraries(llvm::Module &Module,
   LLVMContext &Context = Module.getContext();
   for (const std::string &LibName : LibNames) {
     std::string LibPath =
-        (jit_compiler::ToolchainPrefix + "/lib/" + LibName).str();
+        (SYCLToolchain::instance().getPrefix() + "/lib/" + LibName).str();
 
     ModuleUPtr LibModule;
     if (auto Error = SYCLToolchain::instance()
@@ -519,7 +525,7 @@ Error jit_compiler::linkDeviceLibraries(llvm::Module &Module,
   // For GPU targets we need to link against vendor provided libdevice.
   if (IsCudaHIP) {
     Triple T{Module.getTargetTriple()};
-    Driver D{(jit_compiler::ToolchainPrefix + "/bin/clang++").str(),
+    Driver D{(SYCLToolchain::instance().getPrefix() + "/bin/clang++").str(),
              T.getTriple(), Diags};
     auto [CPU, Features] =
         Translator::getTargetCPUAndFeatureAttrs(&Module, "", Format);
@@ -765,7 +771,7 @@ jit_compiler::performPostLink(ModuleUPtr Module,
     auto &Ctx = Modules.front()->getContext();
     auto WrapLibraryInDevImg = [&](const std::string &LibName) -> Error {
       std::string LibPath =
-          (jit_compiler::ToolchainPrefix + "/lib/" + LibName).str();
+          (SYCLToolchain::instance().getPrefix() + "/lib/" + LibName).str();
       ModuleUPtr LibModule;
       if (auto Error = SYCLToolchain::instance()
                            .loadBitcodeLibrary(LibPath, Ctx)

--- a/sycl-jit/jit-compiler/utils/generate.py
+++ b/sycl-jit/jit-compiler/utils/generate.py
@@ -28,8 +28,8 @@ def main():
             """
 #include <Resource.h>
 
-namespace jit_compiler {
-const std::pair<std::string_view, std::string_view> ToolchainFiles[] = {"""
+namespace jit_compiler::resource {
+const resource_file ToolchainFiles[] = {"""
         )
 
         def process_file(file_path):
@@ -41,7 +41,7 @@ const std::pair<std::string_view, std::string_view> ToolchainFiles[] = {"""
     static const char data[] = {{
     #embed "{file_path}" if_empty(0)
         , 0}};
-    return std::string_view(data, std::size(data) - 1);
+    return resource_string_view{{data}};
     }}()
 }},"""
             )
@@ -66,9 +66,9 @@ const std::pair<std::string_view, std::string_view> ToolchainFiles[] = {"""
             f"""
 }};
 
-size_t NumToolchainFiles = std::size(ToolchainFiles);
-std::string_view ToolchainPrefix = "{args.prefix}";
-}} // namespace jit_compiler
+unsigned long long NumToolchainFiles = size(ToolchainFiles);
+resource_string_view ToolchainPrefix{{"{args.prefix}"}};
+}} // namespace jit_compiler::resource
 """
         )
 


### PR DESCRIPTION
The rest of the project can use flags like `-stdlib=<...>` or `--sysroot` that might affect ABI. Rather than trying to propagate those through our fragile CMake hacks to compile that file with freshly built `clang`, make sure that the file is as self-sufficient as possible (i.e, no STL/libc usage) as that seems to be a more stable solution.