### PR TITLE
[SYCL][UR][L0v2] Mark Basic/buffer/buffer_create.cpp test as unsupported

### DIFF
--- a/sycl/test-e2e/Basic/buffer/buffer_create.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_create.cpp
@@ -8,6 +8,11 @@
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
 // UNSUPPORTED: ze_debug
 
+// L0v2 adapter doesn't optimize buffer creation based on device type yet
+// (integrated buffer implementation needs more work).
+// UNSUPPORTED: level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20121
+
 #include <iostream>
 #include <level_zero/ze_api.h>
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
It fails because L0v2 adapter behaves differently from v1 when it comes to buffer creation. This test contains a hardcoded check involving implementation details of the adapter.