### PR TITLE
[SYCL] Fix barrier on barrier dependency between queues 

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -667,6 +667,7 @@ public:
     getAdapter().call<UrApiKind::urEnqueueEventsWait>(getHandleRef(), 0,
                                                       nullptr, &UREvent);
     ResEvent->setHandle(UREvent);
+    ResEvent->setEnqueued();
     return ResEvent;
   }
 


### PR DESCRIPTION
This is a cherry-pick of intel/llvm#19970

Currently for the pattern like this:
```
sycl::event eb1 = q1.ext_oneapi_submit_barrier();
q2.ext_oneapi_submit_barrier({ eb1 });

```
the second barrier ignores `eb1` in the waitlist because it is not marked as enqueued even though it is supposed to. This PR fixes that.

Fixes https://github.com/intel/llvm/issues/19777