### PR TITLE
[UR] Improve handling for devices/platforms that don't support images

### DIFF
--- a/unified-runtime/include/ur_api.h
+++ b/unified-runtime/include/ur_api.h
@@ -3621,6 +3621,8 @@ typedef struct ur_image_desc_t {
 ///         + `pImageDesc && pImageDesc->numSamples != 0`
 ///         + `pImageDesc && pImageDesc->rowPitch != 0 && pHost == nullptr`
 ///         + `pImageDesc && pImageDesc->slicePitch != 0 && pHost == nullptr`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
@@ -4055,6 +4057,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `propSize != 0 && pPropValue == NULL`
 ///         + `pPropValue == NULL && pPropSizeRet == NULL`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
@@ -4184,6 +4188,8 @@ typedef struct ur_sampler_desc_t {
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreate(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
@@ -4210,6 +4216,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 UR_APIEXPORT ur_result_t UR_APICALL urSamplerRetain(
     /// [in][retain] handle of the sampler object to get access
     ur_sampler_handle_t hSampler);
@@ -4232,6 +4240,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 UR_APIEXPORT ur_result_t UR_APICALL urSamplerRelease(
     /// [in][release] handle of the sampler object to release
     ur_sampler_handle_t hSampler);
@@ -4264,6 +4274,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetInfo(
     /// [in] handle of the sampler object
     ur_sampler_handle_t hSampler,
@@ -6594,6 +6606,8 @@ typedef struct ur_kernel_arg_sampler_properties_t {
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgSampler(
     /// [in] handle of the kernel object
     ur_kernel_handle_t hKernel,

--- a/unified-runtime/scripts/core/kernel.yml
+++ b/unified-runtime/scripts/core/kernel.yml
@@ -421,6 +421,8 @@ params:
       desc: "[in] handle of Sampler object."
 returns:
     - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+      - "Device `$X_DEVICE_INFO_IMAGE_SUPPORT` is false"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Properties for for $xKernelSetArgMemObj."

--- a/unified-runtime/scripts/core/memory.yml
+++ b/unified-runtime/scripts/core/memory.yml
@@ -258,6 +258,8 @@ returns:
       - "`pImageDesc && pImageDesc->numSamples != 0`"
       - "`pImageDesc && pImageDesc->rowPitch != 0 && pHost == nullptr`"
       - "`pImageDesc && pImageDesc->slicePitch != 0 && pHost == nullptr`"
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+      - "Device `$X_DEVICE_INFO_IMAGE_SUPPORT` is false"
     - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
     - $X_RESULT_ERROR_INVALID_OPERATION
     - $X_RESULT_ERROR_INVALID_HOST_PTR:
@@ -627,6 +629,8 @@ returns:
     - $X_RESULT_ERROR_INVALID_NULL_POINTER:
         - "`propSize != 0 && pPropValue == NULL`"
         - "`pPropValue == NULL && pPropSizeRet == NULL`"
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+      - "Device `$X_DEVICE_INFO_IMAGE_SUPPORT` is false"
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY

--- a/unified-runtime/scripts/core/sampler.yml
+++ b/unified-runtime/scripts/core/sampler.yml
@@ -105,6 +105,8 @@ returns:
     - $X_RESULT_ERROR_INVALID_OPERATION
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+      - "Device `$X_DEVICE_INFO_IMAGE_SUPPORT` is false"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Get a reference to the sampler object handle. Increment its reference count"
@@ -121,6 +123,8 @@ returns:
     - $X_RESULT_ERROR_INVALID_SAMPLER
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+      - "Device `$X_DEVICE_INFO_IMAGE_SUPPORT` is false"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Decrement the sampler's reference count and delete the sampler if the reference count becomes zero."
@@ -137,6 +141,8 @@ returns:
     - $X_RESULT_ERROR_INVALID_SAMPLER
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+      - "Device `$X_DEVICE_INFO_IMAGE_SUPPORT` is false"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Query information about a sampler object"
@@ -173,6 +179,8 @@ returns:
     - $X_RESULT_ERROR_INVALID_SAMPLER
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+      - "Device `$X_DEVICE_INFO_IMAGE_SUPPORT` is false"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Return sampler native sampler handle."

--- a/unified-runtime/source/adapters/offload/CMakeLists.txt
+++ b/unified-runtime/source/adapters/offload/CMakeLists.txt
@@ -17,6 +17,7 @@ add_ur_adapter(${TARGET_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/platform.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/program.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/queue.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sampler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ur2offload.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ur_interface_loader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/usm.cpp

--- a/unified-runtime/source/adapters/offload/kernel.cpp
+++ b/unified-runtime/source/adapters/offload/kernel.cpp
@@ -160,3 +160,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
     const size_t *, size_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgSampler(
+    ur_kernel_handle_t, uint32_t, const ur_kernel_arg_sampler_properties_t *,
+    ur_sampler_handle_t) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/unified-runtime/source/adapters/offload/memory.cpp
+++ b/unified-runtime/source/adapters/offload/memory.cpp
@@ -142,3 +142,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
 
   return urMemRetain(hBuffer);
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemImageCreate(ur_context_handle_t, ur_mem_flags_t, const ur_image_format_t *,
+                 const ur_image_desc_t *, void *, ur_mem_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
+    ur_native_handle_t, ur_context_handle_t, const ur_image_format_t *,
+    const ur_image_desc_t *, const ur_mem_native_properties_t *,
+    ur_mem_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t,
+                                                      ur_image_info_t, size_t,
+                                                      void *, size_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/unified-runtime/source/adapters/offload/sampler.cpp
+++ b/unified-runtime/source/adapters/offload/sampler.cpp
@@ -1,0 +1,52 @@
+//===--------- sampler.cpp - LLVM Offload Adapter -------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ur_api.h"
+
+UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreate(
+    ur_context_handle_t /*hContext*/, const ur_sampler_desc_t * /*pDesc*/,
+    ur_sampler_handle_t * /*phSampler*/) {
+
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerRetain(ur_sampler_handle_t /*hSampler*/) {
+
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerRelease(ur_sampler_handle_t /*hSampler*/) {
+
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetInfo(
+    ur_sampler_handle_t /*hSampler*/, ur_sampler_info_t /*propName*/,
+    size_t /*propSize*/, void * /*pPropValue*/, size_t * /*pPropSizeRet*/) {
+
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerGetNativeHandle(ur_sampler_handle_t /*hSampler*/,
+                         ur_native_handle_t * /*phNativeSampler*/) {
+
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+    ur_native_handle_t /*hNativeSampler*/, ur_context_handle_t /*hContext*/,
+    const ur_sampler_native_properties_t * /*pProperties*/,
+    ur_sampler_handle_t * /*phSampler*/) {
+
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
@@ -120,7 +120,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
   pDdiTable->pfnSetArgLocal = nullptr;
   pDdiTable->pfnSetArgMemObj = urKernelSetArgMemObj;
   pDdiTable->pfnSetArgPointer = urKernelSetArgPointer;
-  pDdiTable->pfnSetArgSampler = nullptr;
+  pDdiTable->pfnSetArgSampler = urKernelSetArgSampler;
   pDdiTable->pfnSetArgValue = urKernelSetArgValue;
   pDdiTable->pfnSetExecInfo = urKernelSetExecInfo;
   pDdiTable->pfnSetSpecializationConstants = urKernelSetSpecializationConstants;
@@ -134,12 +134,12 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnCreate = nullptr;
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
-  pDdiTable->pfnGetInfo = nullptr;
-  pDdiTable->pfnGetNativeHandle = nullptr;
-  pDdiTable->pfnRelease = nullptr;
-  pDdiTable->pfnRetain = nullptr;
+  pDdiTable->pfnCreate = urSamplerCreate;
+  pDdiTable->pfnCreateWithNativeHandle = urSamplerCreateWithNativeHandle;
+  pDdiTable->pfnGetInfo = urSamplerGetInfo;
+  pDdiTable->pfnGetNativeHandle = urSamplerGetNativeHandle;
+  pDdiTable->pfnRelease = urSamplerRelease;
+  pDdiTable->pfnRetain = urSamplerRetain;
   return UR_RESULT_SUCCESS;
 }
 
@@ -152,11 +152,11 @@ urGetMemProcAddrTable(ur_api_version_t version, ur_mem_dditable_t *pDdiTable) {
   pDdiTable->pfnBufferCreate = urMemBufferCreate;
   pDdiTable->pfnBufferPartition = urMemBufferPartition;
   pDdiTable->pfnBufferCreateWithNativeHandle = nullptr;
-  pDdiTable->pfnImageCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnImageCreateWithNativeHandle = urMemImageCreateWithNativeHandle;
   pDdiTable->pfnGetInfo = urMemGetInfo;
   pDdiTable->pfnGetNativeHandle = nullptr;
-  pDdiTable->pfnImageCreate = nullptr;
-  pDdiTable->pfnImageGetInfo = nullptr;
+  pDdiTable->pfnImageCreate = urMemImageCreate;
+  pDdiTable->pfnImageGetInfo = urMemImageGetInfo;
   pDdiTable->pfnRelease = urMemRelease;
   pDdiTable->pfnRetain = urMemRetain;
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -1605,6 +1605,8 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///         + `pImageDesc && pImageDesc->numSamples != 0`
 ///         + `pImageDesc && pImageDesc->rowPitch != 0 && pHost == nullptr`
 ///         + `pImageDesc && pImageDesc->slicePitch != 0 && pHost == nullptr`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
@@ -2022,6 +2024,8 @@ ur_result_t UR_APICALL urMemGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `propSize != 0 && pPropValue == NULL`
 ///         + `pPropValue == NULL && pPropSizeRet == NULL`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
@@ -2082,6 +2086,8 @@ ur_result_t UR_APICALL urMemImageGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urSamplerCreate(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
@@ -2116,6 +2122,8 @@ ur_result_t UR_APICALL urSamplerCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urSamplerRetain(
     /// [in][retain] handle of the sampler object to get access
     ur_sampler_handle_t hSampler) try {
@@ -2146,6 +2154,8 @@ ur_result_t UR_APICALL urSamplerRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urSamplerRelease(
     /// [in][release] handle of the sampler object to release
     ur_sampler_handle_t hSampler) try {
@@ -2186,6 +2196,8 @@ ur_result_t UR_APICALL urSamplerRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urSamplerGetInfo(
     /// [in] handle of the sampler object
     ur_sampler_handle_t hSampler,
@@ -4159,6 +4171,8 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urKernelSetArgSampler(
     /// [in] handle of the kernel object
     ur_kernel_handle_t hKernel,

--- a/unified-runtime/source/ur_api.cpp
+++ b/unified-runtime/source/ur_api.cpp
@@ -1427,6 +1427,8 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///         + `pImageDesc && pImageDesc->numSamples != 0`
 ///         + `pImageDesc && pImageDesc->rowPitch != 0 && pHost == nullptr`
 ///         + `pImageDesc && pImageDesc->slicePitch != 0 && pHost == nullptr`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
@@ -1792,6 +1794,8 @@ ur_result_t UR_APICALL urMemGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `propSize != 0 && pPropValue == NULL`
 ///         + `pPropValue == NULL && pPropSizeRet == NULL`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
@@ -1847,6 +1851,8 @@ ur_result_t UR_APICALL urMemImageGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urSamplerCreate(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
@@ -1876,6 +1882,8 @@ ur_result_t UR_APICALL urSamplerCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urSamplerRetain(
     /// [in][retain] handle of the sampler object to get access
     ur_sampler_handle_t hSampler) {
@@ -1901,6 +1909,8 @@ ur_result_t UR_APICALL urSamplerRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urSamplerRelease(
     /// [in][release] handle of the sampler object to release
     ur_sampler_handle_t hSampler) {
@@ -1936,6 +1946,8 @@ ur_result_t UR_APICALL urSamplerRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urSamplerGetInfo(
     /// [in] handle of the sampler object
     ur_sampler_handle_t hSampler,
@@ -3644,6 +3656,8 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Device `::UR_DEVICE_INFO_IMAGE_SUPPORT` is false
 ur_result_t UR_APICALL urKernelSetArgSampler(
     /// [in] handle of the kernel object
     ur_kernel_handle_t hKernel,

--- a/unified-runtime/test/conformance/sampler/urSamplerCreate.cpp
+++ b/unified-runtime/test/conformance/sampler/urSamplerCreate.cpp
@@ -95,8 +95,9 @@ TEST_P(urSamplerCreateTest, InvalidNullHandleContext) {
       UR_SAMPLER_FILTER_MODE_LINEAR,    /* filterMode */
   };
   uur::raii::Sampler hSampler = nullptr;
-  ASSERT_EQ_RESULT(urSamplerCreate(nullptr, &sampler_desc, hSampler.ptr()),
-                   UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UUR_ASSERT_RESULT_OR_UNSUPPORTED(
+      urSamplerCreate(nullptr, &sampler_desc, hSampler.ptr()),
+      UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urSamplerCreateTest, InvalidEnumerationAddrMode) {
@@ -108,8 +109,9 @@ TEST_P(urSamplerCreateTest, InvalidEnumerationAddrMode) {
       UR_SAMPLER_FILTER_MODE_LINEAR,           /* filterMode */
   };
   uur::raii::Sampler hSampler = nullptr;
-  ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, hSampler.ptr()),
-                   UR_RESULT_ERROR_INVALID_ENUMERATION);
+  UUR_ASSERT_RESULT_OR_UNSUPPORTED(
+      urSamplerCreate(context, &sampler_desc, hSampler.ptr()),
+      UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
 TEST_P(urSamplerCreateTest, InvalidEnumerationFilterMode) {
@@ -121,8 +123,9 @@ TEST_P(urSamplerCreateTest, InvalidEnumerationFilterMode) {
       UR_SAMPLER_FILTER_MODE_FORCE_UINT32, /* filterMode */
   };
   uur::raii::Sampler hSampler = nullptr;
-  ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, hSampler.ptr()),
-                   UR_RESULT_ERROR_INVALID_ENUMERATION);
+  UUR_ASSERT_RESULT_OR_UNSUPPORTED(
+      urSamplerCreate(context, &sampler_desc, hSampler.ptr()),
+      UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
 TEST_P(urSamplerCreateTest, InvalidNullPointer) {
@@ -134,9 +137,11 @@ TEST_P(urSamplerCreateTest, InvalidNullPointer) {
       UR_SAMPLER_FILTER_MODE_FORCE_UINT32, /* filterMode */
   };
   uur::raii::Sampler hSampler = nullptr;
-  ASSERT_EQ_RESULT(urSamplerCreate(context, nullptr, hSampler.ptr()),
-                   UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UUR_ASSERT_RESULT_OR_UNSUPPORTED(
+      urSamplerCreate(context, nullptr, hSampler.ptr()),
+      UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
-  ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, nullptr),
-                   UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UUR_ASSERT_RESULT_OR_UNSUPPORTED(
+      urSamplerCreate(context, &sampler_desc, nullptr),
+      UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }

--- a/unified-runtime/test/conformance/testing/include/uur/checks.h
+++ b/unified-runtime/test/conformance/testing/include/uur/checks.h
@@ -37,7 +37,7 @@ inline std::ostream &operator<<(std::ostream &out, const Result &result) {
   }                                                                            \
   (void)0
 
-#define UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(ret)                                 \
+#define UUR_ASSERT_RESULT_OR_UNSUPPORTED(result, ret)                          \
   do {                                                                         \
     auto status = ret;                                                         \
     if (status == UR_RESULT_ERROR_UNSUPPORTED_FEATURE ||                       \
@@ -45,9 +45,12 @@ inline std::ostream &operator<<(std::ostream &out, const Result &result) {
         status == UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE) {                    \
       GTEST_SKIP();                                                            \
     } else {                                                                   \
-      ASSERT_EQ(status, UR_RESULT_SUCCESS);                                    \
+      ASSERT_EQ(status, result);                                               \
     }                                                                          \
   } while (0)
+
+#define UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(ret)                                 \
+  UUR_ASSERT_RESULT_OR_UNSUPPORTED(UR_RESULT_SUCCESS, ret)
 
 inline bool stringPropertyIsValid(const char *property,
                                   const size_t property_size) {


### PR DESCRIPTION
Image support is optional and depends on UR_DEVICE_INFO_IMAGE_SUPPORT.
Now, entrypoints that involve images should return UNSUPPORTED_FEATURE
if image support is unavailable.

The offload plugin now defines image functions as stubs that return this
"UNSUPPORTED_FEATURE" value.

CTS testing is more rebust. Support for images is now checked before
trying to load the kernel binary, since that binary will not be
available for platforms that don't support images.
