### PR TITLE
[SYCL][Native CPU] Avoid dangling references.

### DIFF
--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/transform/control_flow_conversion_pass.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/transform/control_flow_conversion_pass.cpp
@@ -115,6 +115,10 @@ private:
     Instruction *persistedCombinedDivergentExitMask = nullptr;
   };
 
+  /// @brief Create loop masks for the specified loop and its subloops.
+  /// @param[in] L Loop which should have its LoopMasksInfo created.
+  void createLoopMasks(Loop *L);
+
   /// @brief Convert the function's CFG to data-flow.
   /// @return true if the function's CFG was converted, false otherwise.
   bool convertToDataFlow();
@@ -538,6 +542,13 @@ bool ControlFlowConversionState::replaceReachableUses(Reachability &RC,
   return true;
 }
 
+void ControlFlowConversionState::Impl::createLoopMasks(Loop *L) {
+  LoopMasks[L];
+  for (auto *L : L->getSubLoops()) {
+    createLoopMasks(L);
+  }
+}
+
 bool ControlFlowConversionState::Impl::convertToDataFlow() {
   DT = &AM.getResult<DominatorTreeAnalysis>(F);
   PDT = &AM.getResult<PostDominatorTreeAnalysis>(F);
@@ -546,7 +557,7 @@ bool ControlFlowConversionState::Impl::convertToDataFlow() {
 
   // Make sure every loop has an entry in the masks table before we start.
   for (auto *L : *LI) {
-    LoopMasks[L];
+    createLoopMasks(L);
   }
 
   if (!VU.choices().linearizeBOSCC()) {


### PR DESCRIPTION
In multiple places, we take a reference to an element in LoopMasks and expect that reference to remain valid. LoopMasks is a DenseMap which does not promise that references to existing elements remain valid as new elements are inserted. We pre-populate LoopMasks to try and avoid this becoming a problem, but we were pre-populating it only with top-level loops, when sub-loops may also cause references to become invalid. Adjust the pre-population to take all loops into account.