### PR TITLE
[libspirv][remangler] Don't remangle internal functions.

### DIFF
--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -883,6 +883,9 @@ private:
   }
 
   bool remangleFunction(Function &Func, llvm::Module *M) {
+    if (Func.hasLocalLinkage())
+      return true;
+
     if (!Func.getName().starts_with("_Z"))
       return true;
 


### PR DESCRIPTION
There is no need to remangle functions with local (internal/private) linkage, they won't be called from outside libclc.
Skipping them avoids issues with compiler added suffixes like ".0". We could fix remangling to handle those suffixes, but skipping them is simpler, and we don't expect suffixes on externally visible functions anyway.

Skipping over internal functions could also improve performance when remangling large modules with many internal functions.

This fixes an issue we see when building libclc for a downstream target, where we build libspirv from smaller bitcode files, the error there was:
```plaintext
[11/22] Generating ../../lib/clc/remangled-l32-signed_char.libspirv-<target-triple>.bc
FAILED: lib/clc/remangled-l32-signed_char.libspirv-<target-triple>.bc llvm/lib/clc/remangled-l32-signed_char.libspirv-<target-triple>.bc
cd llvm/tools/libclc && cmake -E make_directory llvm/./lib/clc && llvm/bin/libclc-remangler -o llvm/./lib/clc/remangled-l32-signed_char.libspirv-<target-triple>.bc --triple=<target-triple> --long-width=l32 --char-signedness=signed --input-ir=llvm/./lib/clc/libspirv-<target-triple>.bc llvm/./lib/clc/libclc_dummy_in.cc
Unhandled type: __clc_copysign(float, float)
Unhandled type.
UNREACHABLE executed at llvm/libclc/utils/libclc-remangler/LibclcRemangler.cpp:590!
```
due to a function named `@_Z14__clc_copysignff.9` with internal linkage. The function was likely created by `llvm-link` when merging multiple copies of `copysign` into the resulting module.