### PR TITLE
[SYCL][UR] Fix conversion OpenCL return code to UR

### DIFF
--- a/unified-runtime/source/adapters/opencl/device.cpp
+++ b/unified-runtime/source/adapters/opencl/device.cpp
@@ -1755,6 +1755,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
   // TODO: Cache OpenCL version for each device and platform
   auto RetErr = hDevice->getDeviceVersion(DevVer);
+
+  if (RetErr == CL_INVALID_OPERATION) {
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  }
   CL_RETURN_ON_FAILURE(RetErr);
 
   RetErr = hDevice->Platform->getPlatformVersion(PlatVer);


### PR DESCRIPTION
Change to limit possible return values of the `urDeviceGetGlobalTimestamps` to the documented ones.

According to: https://oneapi-src.github.io/unified-runtime/core/api.html#urdevicegetglobaltimestamps
Related with: #18863 
