### PR TITLE
[SYCL][NFC] Queue class ABI cleanup [1/N]

### DIFF
--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -401,10 +401,12 @@ public:
   typename detail::is_backend_info_desc<Param>::return_type
       get_backend_info() const;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 private:
   // A shorthand for `get_device().has()' which is expected to be a bit quicker
   // than the long version
   bool device_has(aspect Aspect) const;
+#endif
 
 public:
   /// Submits a command group function object to the queue, in order to be
@@ -3453,6 +3455,7 @@ public:
         CodeLoc);
   }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// @brief Returns true if the queue was created with the
   /// ext::codeplay::experimental::property::queue::enable_fusion property.
   ///
@@ -3460,7 +3463,10 @@ public:
   /// `has_property<ext::codeplay::experimental::property::queue::enable_fusion>()`.
   ///
   // TODO(#15184) Remove this function in the next ABI-breaking window.
+  __SYCL_DEPRECATED(
+      "Support for ext_codeplay_kernel_fusion extesnsion is dropped")
   bool ext_codeplay_supports_fusion() const;
+#endif
 
   /// Shortcut for executing a graph of commands.
   ///

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -453,6 +453,7 @@ event queue::memcpyFromDeviceGlobal(void *Dest, const void *DeviceGlobalPtr,
                                       /*CallerNeedsEvent=*/true);
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 bool queue::device_has(aspect Aspect) const {
   // avoid creating sycl object from impl
   return impl->getDeviceImpl().has(Aspect);
@@ -460,6 +461,7 @@ bool queue::device_has(aspect Aspect) const {
 
 // TODO(#15184) Remove this function in the next ABI-breaking window.
 bool queue::ext_codeplay_supports_fusion() const { return false; }
+#endif
 
 sycl::detail::optional<event> queue::ext_oneapi_get_last_event_impl() const {
   if (!is_in_order())


### PR DESCRIPTION
This PR prepares for removal (once preview breaking changes are promoted) of the following queue APIs:
- `ext_codeplay_supports_fusion` which has been hardcoded to `false` for a while now. It is also marked as deprecated by this PR
- `device_has` internal API whose only use was dropped in #18310