### PR TITLE
[SYCL][E2E] Update UNSUPPORTED conditions

### DIFF
--- a/sycl/test-e2e/Basic/buffer/buffer_full_copy.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_full_copy.cpp
@@ -1,5 +1,8 @@
-// RUN: %{build} -o %t2.out
-// RUN: %{run} %t2.out
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
 
 //==------------- buffer_full_copy.cpp - SYCL buffer basic test ------------==//
 //

--- a/sycl/test-e2e/Basic/fill_accessor.cpp
+++ b/sycl/test-e2e/Basic/fill_accessor.cpp
@@ -1,6 +1,12 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
+
+// XFAIL: run-mode && linux && arch-intel_gpu_bmg_g21 && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19586
+
 #include <sycl/detail/core.hpp>
 
 #include <algorithm>

--- a/sycl/test-e2e/Basic/fill_accessor_ur.cpp
+++ b/sycl/test-e2e/Basic/fill_accessor_ur.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s
 
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
+
 // This test merely checks the use of the correct UR call. Its sister test
 // fill_accessor.cpp thoroughly checks the workings of the .fill() call.
 

--- a/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
+++ b/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
+
 //==- handler.cpp - SYCL handler explicit memory operations test -*- C++-*--==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/queue/queue_shortcut_functions.cpp
+++ b/sycl/test-e2e/Basic/queue/queue_shortcut_functions.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
+
 //==-- queue_shortcut_functions.cpp - SYCL queue shortcut functions test ---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/MemorySanitizer/track-origins/check_host_usm.cpp
+++ b/sycl/test-e2e/MemorySanitizer/track-origins/check_host_usm.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
 
 // RUN: %{build} %device_msan_flags -Xarch_device -fsanitize-memory-track-origins=1 -O0 -g -o %t1.out
 // RUN: env UR_LAYER_MSAN_OPTIONS=msan_check_host_and_shared_usm:1 %{run} %t1.out 2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-ORIGIN-STACK

--- a/sycl/test-e2e/MemorySanitizer/track-origins/check_host_usm_initialized_on_host.cpp
+++ b/sycl/test-e2e/MemorySanitizer/track-origins/check_host_usm_initialized_on_host.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
 
 // RUN: %{build} %device_msan_flags -Xarch_device -fsanitize-memory-track-origins=1 -O0 -g -o %t0.out
 // RUN: env UR_LAYER_MSAN_OPTIONS=msan_check_host_and_shared_usm:1 %{run} %t0.out 2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-ORIGIN-STACK

--- a/sycl/test-e2e/MemorySanitizer/track-origins/check_kernel_memcpy.cpp
+++ b/sycl/test-e2e/MemorySanitizer/track-origins/check_kernel_memcpy.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
 
 // RUN: %{build} %device_msan_flags -Xarch_device -fsanitize-memory-track-origins=1 -O2 -g -o %t1.out
 // RUN: env UR_LAYER_MSAN_OPTIONS=msan_check_host_and_shared_usm:1 %{run} %t1.out 2>&1 | FileCheck %s

--- a/sycl/test-e2e/MemorySanitizer/track-origins/check_kernel_memmove_no_overlap.cpp
+++ b/sycl/test-e2e/MemorySanitizer/track-origins/check_kernel_memmove_no_overlap.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
 
 // RUN: %{build} %device_msan_flags -Xarch_device -fsanitize-memory-track-origins=1 -O0 -g -o %t0.out
 // RUN: env UR_LAYER_MSAN_OPTIONS=msan_check_host_and_shared_usm:1 %{run} %t0.out 2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-ORIGIN-STACK

--- a/sycl/test-e2e/MemorySanitizer/track-origins/check_kernel_memmove_overlap.cpp
+++ b/sycl/test-e2e/MemorySanitizer/track-origins/check_kernel_memmove_overlap.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
 
 // RUN: %{build} %device_msan_flags -Xarch_device -fsanitize-memory-track-origins=1 -O0 -g -o %t0.out
 // RUN: env UR_LAYER_MSAN_OPTIONS=msan_check_host_and_shared_usm:1 %{run} %t0.out 2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-ORIGIN-STACK

--- a/sycl/test-e2e/MemorySanitizer/track-origins/check_shared_usm.cpp
+++ b/sycl/test-e2e/MemorySanitizer/track-origins/check_shared_usm.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
+// XFAIL: run-mode && linux && arch-intel_gpu_pvc && level_zero_v2_adapter
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19585
 
 // RUN: %{build} %device_msan_flags -Xarch_device -fsanitize-memory-track-origins=1 -O0 -g -o %t1.out
 // RUN: env UR_LAYER_MSAN_OPTIONS=msan_check_host_and_shared_usm:1 %{run} %t1.out 2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-ORIGIN-STACK


### PR DESCRIPTION
Actually these tests are failing only with level_zero_v2. Also adding `linux`, although we don't run win&level_zero_v2 tests anywhere, I don't know if they also fail there.