### PR TITLE
[UR][L0] Set pointer kernel arguments only for queue's associated device

### DIFF
--- a/sycl/test-e2e/MultiDevice/set_arg_pointer.cpp
+++ b/sycl/test-e2e/MultiDevice/set_arg_pointer.cpp
@@ -1,0 +1,63 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// UNSUPPORTED: level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: CMPLRLLVM-67039
+
+// Test that usm device pointer can be used in a kernel compiled for a context
+// with multiple devices.
+
+#include <iostream>
+#include <sycl/detail/core.hpp>
+#include <sycl/kernel_bundle.hpp>
+#include <sycl/platform.hpp>
+#include <sycl/usm.hpp>
+#include <vector>
+
+using namespace sycl;
+
+class AddIdxKernel;
+
+int main() {
+  sycl::platform plt;
+  std::vector<sycl::device> devices = plt.get_devices();
+  if (devices.size() < 2) {
+    std::cout << "Need at least 2 GPU devices for this test.\n";
+    return 0;
+  }
+
+  std::vector<sycl::device> ctx_devices{devices[0], devices[1]};
+  sycl::context ctx(ctx_devices);
+
+  constexpr size_t N = 16;
+  std::vector<std::vector<int>> results(ctx_devices.size(),
+                                        std::vector<int>(N, 0));
+
+  // Create a kernel bundle compiled for both devices in the context
+  auto kb = sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctx);
+
+  // For each device, create a queue and run a kernel using device USM
+  for (size_t i = 0; i < ctx_devices.size(); ++i) {
+    sycl::queue q(ctx, ctx_devices[i]);
+    int *data = sycl::malloc_device<int>(N, q);
+    q.fill(data, 1, N).wait();
+    q.submit([&](sycl::handler &h) {
+       h.use_kernel_bundle(kb);
+       h.parallel_for<AddIdxKernel>(
+           sycl::range<1>(N), [=](sycl::id<1> idx) { data[idx] += idx[0]; });
+     }).wait();
+    q.memcpy(results[i].data(), data, N * sizeof(int)).wait();
+    sycl::free(data, q);
+  }
+
+  for (size_t i = 0; i < ctx_devices.size(); ++i) {
+    std::cout << "Device " << i << " results: ";
+    for (size_t j = 0; j < N; ++j) {
+      if (results[i][j] != 1 + static_cast<int>(j)) {
+        return -1;
+      }
+      std::cout << results[i][j] << " ";
+    }
+  }
+  return 0;
+}

--- a/unified-runtime/source/adapters/level_zero/helpers/kernel_helpers.hpp
+++ b/unified-runtime/source/adapters/level_zero/helpers/kernel_helpers.hpp
@@ -71,3 +71,15 @@ inline void postSubmit(ze_kernel_handle_t hZeKernel,
     zeKernelSetGlobalOffsetExp(hZeKernel, 0, 0, 0);
   }
 }
+
+/**
+ * Helper to set kernel argument for ze_kernel_handle_t.
+ * @param[in] hZeKernel The handle to the Level-Zero kernel.
+ * @param[in] argIndex The index of the argument to set.
+ * @param[in] argSize The size of the argument to set.
+ * @param[in] pArgValue The pointer to the argument value.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
+ur_result_t setArgValueOnZeKernel(ze_kernel_handle_t hZeKernel,
+                                  uint32_t argIndex, size_t argSize,
+                                  const void *pArgValue);

--- a/unified-runtime/source/adapters/level_zero/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/kernel.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <unordered_set>
+#include <variant>
 
 #include "common.hpp"
 #include "common/ur_ref_count.hpp"
@@ -97,8 +98,10 @@ struct ur_kernel_handle_t_ : ur_object {
   struct ArgumentInfo {
     uint32_t Index;
     size_t Size;
-    // const ur_mem_handle_t_ *Value;
-    ur_mem_handle_t_ *Value;
+    // Value may be either a memory object or a raw pointer value (for pointer
+    // arguments). Resolve at enqueue time per-device to ensure correct handle
+    // is used for that device.
+    std::variant<ur_mem_handle_t, const void *> Value;
     ur_mem_handle_t_::access_mode_t AccessMode{ur_mem_handle_t_::unknown};
   };
   // Arguments that still need to be set (with zeKernelSetArgumentValue)


### PR DESCRIPTION
In multi-device context, ensure that pointer kernel arguments are set only for the device associated with the queue being used for kernel launch. Previously, arguments were set for all devices in the kernel's device map, which was unnecessary and potentially incorrect when launching on a specific device.

Same will be done for v2 adapter here: https://github.com/intel/llvm/pull/20179