### PR TITLE
[NFC][SYCL] Minor includes cleanup

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -20,7 +20,6 @@
 #include <cassert> // for assert
 #include <cstddef> // for size_t
 #include <cstdint>
-#include <string>      // for allocator, operator+
 #include <type_traits> // for enable_if_t
 #include <utility>     // for index_sequence, make_i...
 
@@ -199,10 +198,6 @@ private:
 #else
 #define __SYCL_ASSERT(x) assert(x)
 #endif // #ifdef __SYCL_DEVICE_ONLY__
-
-#define __SYCL_UR_ERROR_REPORT(backend)                                        \
-  std::string(sycl::detail::get_backend_name_no_vendor(backend)) +             \
-      " backend failed with error: "
 
 namespace sycl {
 inline namespace _V1 {

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -9,13 +9,7 @@
 #pragma once
 
 #include <sycl/detail/type_traits.hpp>
-#include <sycl/ext/oneapi/properties/property.hpp>       // for IsRuntimePr...
-#include <sycl/ext/oneapi/properties/property_utils.hpp> // for Sorted, Mer...
-#include <sycl/ext/oneapi/properties/property_value.hpp> // for property_value
-
-#include <tuple>       // for tuple, tupl...
-#include <type_traits> // for enable_if_t
-#include <variant>     // for tuple
+#include <sycl/ext/oneapi/properties/property_utils.hpp>
 
 namespace sycl {
 inline namespace _V1 {

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -11,11 +11,8 @@
 #include <sycl/ext/oneapi/properties/property.hpp>
 #include <sycl/ext/oneapi/properties/property_value.hpp>
 
-#include <array>       // for tuple_element
 #include <stddef.h>    // for size_t
-#include <tuple>       // for tuple
 #include <type_traits> // for false_type, true_...
-#include <variant>     // for tuple
 
 namespace sycl {
 inline namespace _V1 {

--- a/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
@@ -10,8 +10,6 @@
 
 #include <sycl/ext/oneapi/properties/property.hpp>
 
-#include <type_traits> // for enable_if_t
-
 namespace sycl {
 inline namespace _V1 {
 namespace ext::oneapi::experimental {

--- a/sycl/source/detail/adapter_impl.hpp
+++ b/sycl/source/detail/adapter_impl.hpp
@@ -24,6 +24,10 @@
 #include <memory>
 #include <mutex>
 
+#define __SYCL_UR_ERROR_REPORT(backend)                                        \
+  std::string(sycl::detail::get_backend_name_no_vendor(backend)) +             \
+      " backend failed with error: "
+
 #define __SYCL_CHECK_UR_CODE_NO_EXC(expr, backend)                             \
   {                                                                            \
     auto code = expr;                                                          \

--- a/sycl/unittests/helpers/ScopedEnvVar.hpp
+++ b/sycl/unittests/helpers/ScopedEnvVar.hpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <functional>
 #include <stdlib.h>
+#include <string>
 
 namespace sycl {
 inline namespace _V1 {


### PR DESCRIPTION
Trying to reduce compile-time for

```c++
namespace oneapi = sycl::ext::oneapi;

extern "C"
SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((oneapi::experimental::nd_range_kernel<1>))
void iota(float start, float *ptr) {
  size_t id = oneapi::this_work_item::get_nd_item<1>().get_global_linear_id();
  ptr[id] = start + static_cast<float>(id);
}
```