### PR TITLE
[SYCL] Fix multi_lib_app test to accommodate build/run diffs on Windows CI.

### DIFF
--- a/sycl/test-e2e/IntermediateLib/multi_lib_app.cpp
+++ b/sycl/test-e2e/IntermediateLib/multi_lib_app.cpp
@@ -1,8 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED-TRACKER: CMPLRLLVM-69415
 
-
-
 // DEFINE: %{fPIC_flag} =  %if windows %{%} %else %{-fPIC%}
 // DEFINE: %{shared_lib_ext} = %if windows %{dll%} %else %{so%}
 


### PR DESCRIPTION
Windows CI sometimes builds on one machine and runs on another, and the paths might differ. Fixing test to account for this.

Issue: https://github.com/intel/llvm/issues/20023