### PR TITLE
[SYCL] Cherry-pick of external semaphore fixes

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3710,11 +3710,17 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     auto OptWaitValue = SemWait->getWaitValue();
     uint64_t WaitValue = OptWaitValue.has_value() ? OptWaitValue.value() : 0;
 
-    return Adapter
-        .call_nocheck<UrApiKind::urBindlessImagesWaitExternalSemaphoreExp>(
+    if (auto Result = Adapter.call_nocheck<
+                      UrApiKind::urBindlessImagesWaitExternalSemaphoreExp>(
             MQueue->getHandleRef(), SemWait->getExternalSemaphore(),
             OptWaitValue.has_value(), WaitValue, RawEvents.size(),
             RawEvents.data(), Event);
+        Result != UR_RESULT_SUCCESS)
+      return Result;
+
+    SetEventHandleOrDiscard();
+
+    return UR_RESULT_SUCCESS;
   }
   case CGType::SemaphoreSignal: {
     assert(MQueue &&
@@ -3724,11 +3730,17 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     auto OptSignalValue = SemSignal->getSignalValue();
     uint64_t SignalValue =
         OptSignalValue.has_value() ? OptSignalValue.value() : 0;
-    return Adapter
-        .call_nocheck<UrApiKind::urBindlessImagesSignalExternalSemaphoreExp>(
+    if (auto Result = Adapter.call_nocheck<
+                      UrApiKind::urBindlessImagesSignalExternalSemaphoreExp>(
             MQueue->getHandleRef(), SemSignal->getExternalSemaphore(),
             OptSignalValue.has_value(), SignalValue, RawEvents.size(),
             RawEvents.data(), Event);
+        Result != UR_RESULT_SUCCESS)
+      return Result;
+
+    SetEventHandleOrDiscard();
+
+    return UR_RESULT_SUCCESS;
   }
   case CGType::AsyncAlloc: {
     // NO-OP. Async alloc calls adapter immediately in order to return a valid

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3713,7 +3713,8 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     return Adapter
         .call_nocheck<UrApiKind::urBindlessImagesWaitExternalSemaphoreExp>(
             MQueue->getHandleRef(), SemWait->getExternalSemaphore(),
-            OptWaitValue.has_value(), WaitValue, 0, nullptr, nullptr);
+            OptWaitValue.has_value(), WaitValue, RawEvents.size(),
+            RawEvents.data(), Event);
   }
   case CGType::SemaphoreSignal: {
     assert(MQueue &&
@@ -3726,7 +3727,8 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     return Adapter
         .call_nocheck<UrApiKind::urBindlessImagesSignalExternalSemaphoreExp>(
             MQueue->getHandleRef(), SemSignal->getExternalSemaphore(),
-            OptSignalValue.has_value(), SignalValue, 0, nullptr, nullptr);
+            OptSignalValue.has_value(), SignalValue, RawEvents.size(),
+            RawEvents.data(), Event);
   }
   case CGType::AsyncAlloc: {
     // NO-OP. Async alloc calls adapter immediately in order to return a valid

--- a/sycl/unittests/Extensions/BindlessImages/CMakeLists.txt
+++ b/sycl/unittests/Extensions/BindlessImages/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_sycl_unittest(BindlessImagesExtensionTests OBJECT
+  Semaphores.cpp
+)

--- a/sycl/unittests/Extensions/BindlessImages/Semaphores.cpp
+++ b/sycl/unittests/Extensions/BindlessImages/Semaphores.cpp
@@ -1,0 +1,161 @@
+#include <helpers/UrMock.hpp>
+
+#include <gtest/gtest.h>
+
+#include <detail/event_impl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/bindless_images.hpp>
+#include <sycl/ext/oneapi/bindless_images_interop.hpp>
+#include <sycl/queue.hpp>
+
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+constexpr uint64_t WaitValue = 42;
+constexpr uint64_t SignalValue = 24;
+
+thread_local int urBindlessImagesWaitExternalSemaphoreExp_counter = 0;
+thread_local bool urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue =
+    false;
+inline ur_result_t
+urBindlessImagesWaitExternalSemaphoreExp_replace(void *pParams) {
+  ++urBindlessImagesWaitExternalSemaphoreExp_counter;
+  ur_bindless_images_wait_external_semaphore_exp_params_t Params =
+      *reinterpret_cast<
+          ur_bindless_images_wait_external_semaphore_exp_params_t *>(pParams);
+  EXPECT_EQ(*Params.phasWaitValue,
+            urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue);
+  if (urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue) {
+    EXPECT_EQ(*Params.pwaitValue, WaitValue);
+  }
+  EXPECT_EQ(*Params.pnumEventsInWaitList, uint32_t{0});
+  EXPECT_EQ(*Params.pphEventWaitList, nullptr);
+  EXPECT_NE(*Params.pphEvent, nullptr);
+  return UR_RESULT_SUCCESS;
+}
+
+thread_local int urBindlessImagesSignalExternalSemaphoreExp_counter = 0;
+thread_local bool
+    urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = false;
+thread_local uint32_t
+    urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 0;
+inline ur_result_t
+urBindlessImagesSignalExternalSemaphoreExp_replace(void *pParams) {
+  ++urBindlessImagesSignalExternalSemaphoreExp_counter;
+  ur_bindless_images_signal_external_semaphore_exp_params_t Params =
+      *reinterpret_cast<
+          ur_bindless_images_signal_external_semaphore_exp_params_t *>(pParams);
+  EXPECT_EQ(*Params.phasSignalValue,
+            urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue);
+  if (urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue) {
+    EXPECT_EQ(*Params.psignalValue, SignalValue);
+  }
+  EXPECT_EQ(*Params.pnumEventsInWaitList,
+            urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents);
+  if (urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents) {
+    EXPECT_NE(*Params.pphEventWaitList, nullptr);
+  } else {
+    EXPECT_EQ(*Params.pphEventWaitList, nullptr);
+  }
+  EXPECT_NE(*Params.pphEvent, nullptr);
+  return UR_RESULT_SUCCESS;
+}
+
+TEST(BindlessImagesExtensionTests, ExternalSemaphoreWait) {
+  sycl::unittest::UrMock<> Mock;
+  mock::getCallbacks().set_replace_callback(
+      "urBindlessImagesWaitExternalSemaphoreExp",
+      &urBindlessImagesWaitExternalSemaphoreExp_replace);
+  urBindlessImagesWaitExternalSemaphoreExp_counter = 0;
+
+  sycl::queue Q;
+
+  // Create a dummy external semaphore and set the raw handle to some dummy.
+  // The mock implementation should never access the handle, so this is safe.
+  int DummyInt = 0;
+  syclexp::external_semaphore DummySemaphore{};
+  DummySemaphore.raw_handle =
+      reinterpret_cast<ur_exp_external_semaphore_handle_t>(&DummyInt);
+
+  DummySemaphore.handle_type =
+      syclexp::external_semaphore_handle_type::opaque_fd;
+
+  urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue = false;
+  Q.ext_oneapi_wait_external_semaphore(DummySemaphore);
+  EXPECT_EQ(urBindlessImagesWaitExternalSemaphoreExp_counter, 1);
+
+  DummySemaphore.handle_type =
+      syclexp::external_semaphore_handle_type::timeline_fd;
+
+  urBindlessImagesWaitExternalSemaphoreExp_expectHasWaitValue = true;
+  Q.ext_oneapi_wait_external_semaphore(DummySemaphore, WaitValue);
+  EXPECT_EQ(urBindlessImagesWaitExternalSemaphoreExp_counter, 2);
+}
+
+TEST(BindlessImagesExtensionTests, ExternalSemaphoreSignal) {
+  sycl::unittest::UrMock<> Mock;
+  mock::getCallbacks().set_replace_callback(
+      "urBindlessImagesSignalExternalSemaphoreExp",
+      &urBindlessImagesSignalExternalSemaphoreExp_replace);
+  urBindlessImagesSignalExternalSemaphoreExp_counter = 0;
+
+  sycl::queue Q;
+
+  // Create a dummy external semaphore and set the raw handle to some dummy.
+  // The mock implementation should never access the handle, so this is safe.
+  int DummyInt1 = 0, DummyInt2 = 0;
+  syclexp::external_semaphore DummySemaphore{};
+  DummySemaphore.raw_handle =
+      reinterpret_cast<ur_exp_external_semaphore_handle_t>(&DummyInt1);
+
+  // We create dummy events with dummy UR handles to make the runtime think we
+  // pass actual device events.
+  auto DummyEventImpl1 = sycl::detail::event_impl::create_device_event(
+      *sycl::detail::getSyclObjImpl(Q));
+  auto DummyEventImpl2 = sycl::detail::event_impl::create_device_event(
+      *sycl::detail::getSyclObjImpl(Q));
+  DummyEventImpl1->setHandle(reinterpret_cast<ur_event_handle_t>(&DummyInt1));
+  DummyEventImpl2->setHandle(reinterpret_cast<ur_event_handle_t>(&DummyInt2));
+  sycl::event DummyEvent1 =
+      sycl::detail::createSyclObjFromImpl<sycl::event>(DummyEventImpl1);
+  sycl::event DummyEvent2 =
+      sycl::detail::createSyclObjFromImpl<sycl::event>(DummyEventImpl2);
+  std::vector<sycl::event> DummyEventList{DummyEvent1, DummyEvent2};
+
+  DummySemaphore.handle_type =
+      syclexp::external_semaphore_handle_type::opaque_fd;
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = false;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 0;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 1);
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = false;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 1;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, DummyEvent1);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 2);
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = false;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 2;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, DummyEventList);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 3);
+
+  DummySemaphore.handle_type =
+      syclexp::external_semaphore_handle_type::timeline_fd;
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = true;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 0;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, SignalValue);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 4);
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = true;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 1;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, SignalValue,
+                                         DummyEvent1);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 5);
+
+  urBindlessImagesSignalExternalSemaphoreExp_expectHasSignalValue = true;
+  urBindlessImagesSignalExternalSemaphoreExp_expectedNumWaitEvents = 2;
+  Q.ext_oneapi_signal_external_semaphore(DummySemaphore, SignalValue,
+                                         DummyEventList);
+  EXPECT_EQ(urBindlessImagesSignalExternalSemaphoreExp_counter, 6);
+}

--- a/sycl/unittests/Extensions/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CMakeLists.txt
@@ -24,6 +24,7 @@ add_sycl_unittest(ExtensionsTests OBJECT
   RootGroup.cpp
 )
 
+add_subdirectory(BindlessImages)
 add_subdirectory(CommandGraph)
 add_subdirectory(VirtualFunctions)
 add_subdirectory(VirtualMemory)


### PR DESCRIPTION
Cherry picks of bindless images semaphore fixes:

- [SYCL][BindlessImages] Fix external semaphore dependencies and return events (https://github.com/intel/llvm/pull/20040) (b578d545dde02747cba524473d7d7635cf149a46)
- [SYCL][BindlessImages] Fix storing result events for semaphores (https://github.com/intel/llvm/pull/20080) (68f3fdf41ca373e413c74da2949d807d3d7d777f)