### PR TITLE
[SYCL][E2E] Fix `XPASS` in post-commit

### DIFF
--- a/sycl/test-e2e/bindless_images/copies/copy_subregion_2D.cpp
+++ b/sycl/test-e2e/bindless_images/copies/copy_subregion_2D.cpp
@@ -2,7 +2,7 @@
 // UNSUPPORTED: linux && arch-intel_gpu_bmg_g21
 // UNSUPPORTED-INTENDED: sporadic failure in CI
 //                       https://github.com/intel/llvm/issues/20006
-// XFAIL: linux && arch-intel_gpu_acm_g10
+// XFAIL: linux && arch-intel_gpu_acm_g10 && level_zero_v2_adapter
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20004
 // XFAIL: hip
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/19957


### PR DESCRIPTION
`copy_subregion_2D.cpp` fails on V2 L0 adapter (reported in intel/llvm#20004). In pre-commit we test both adapters, but in post-commit we only test the default one. As such, `XFAIL` without an adapter check causes `XPASS` in pre-commit which this PR is addressing.