### PR TITLE
[Benchmarks] Use GitProject for git operations

### DIFF
--- a/devops/scripts/benchmarks/CONTRIB.md
+++ b/devops/scripts/benchmarks/CONTRIB.md
@@ -191,12 +191,17 @@ The benchmark suite generates an interactive HTML dashboard that visualizes `Res
 
 ## Utilities
 
+* **`git_project.GitProject`:** Manages git repository cloning, building, and installation for benchmark suites:
+    * Automatically clones repositories to a specified directory and checks out specific commits/refs.
+    * Provides standardized directory structure with `src_dir`, `build_dir`, and `install_dir` properties.
+    * Handles incremental updates - only re-clones if the target commit has changed.
+    * Supports force rebuilds and custom directory naming via constructor options.
+    * Provides `configure()`, `build()`, and `install()` methods for CMake-based projects.
+    * Use this for benchmark suites that need to build from external git repositories (e.g., `ComputeBench`, `VelocityBench`).
 * **`utils.utils`:** Provides common helper functions:
     * `run()`: Executes shell commands with environment setup (SYCL paths, LD_LIBRARY_PATH).
-    * `git_clone()`: Clones/updates Git repositories.
     * `download()`: Downloads files via HTTP, checks checksums, optionally extracts tar/gz archives.
     * `prepare_workdir()`: Sets up the main working directory.
-    * `create_build_path()`: Creates a clean build directory.
 * **`utils.oneapi`:** Provides the `OneAPI` singleton class (`get_oneapi()`). Downloads and installs specified oneAPI components (oneDNN, oneMKL) into the working directory if needed, providing access to their paths (libs, includes, CMake configs). Use this if your benchmark depends on these components instead of requiring a system-wide install.
 * **`options.py`:** Defines and holds global configuration options, populated by `argparse` in `main.py`. Use options instead of defining your own global variables.
 * **`presets.py`:** Defines named sets of suites (`enabled_suites()`) used by the `--preset` argument.

--- a/devops/scripts/benchmarks/benches/base.py
+++ b/devops/scripts/benchmarks/benches/base.py
@@ -84,8 +84,8 @@ class Benchmark(ABC):
         """Returns whether tracing is enabled for the given type."""
         return (self.traceable(tr_type) or force_trace) and run_trace == tr_type
 
-    @abstractmethod
     def setup(self):
+        """Extra setup steps to be performed before running the benchmark."""
         pass
 
     @abstractmethod

--- a/devops/scripts/benchmarks/benches/base.py
+++ b/devops/scripts/benchmarks/benches/base.py
@@ -49,8 +49,7 @@ benchmark_tags_dict = {tag.name: tag for tag in benchmark_tags}
 
 
 class Benchmark(ABC):
-    def __init__(self, directory, suite):
-        self.directory = directory
+    def __init__(self, suite):
         self.suite = suite
 
     @abstractmethod
@@ -205,9 +204,9 @@ class Benchmark(ABC):
 
     def create_data_path(self, name, skip_data_dir=False):
         if skip_data_dir:
-            data_path = os.path.join(self.directory, name)
+            data_path = os.path.join(options.workdir, name)
         else:
-            data_path = os.path.join(self.directory, "data", name)
+            data_path = os.path.join(options.workdir, "data", name)
             if options.redownload and Path(data_path).exists():
                 shutil.rmtree(data_path)
 

--- a/devops/scripts/benchmarks/benches/benchdnn.py
+++ b/devops/scripts/benchmarks/benches/benchdnn.py
@@ -8,19 +8,16 @@ from pathlib import Path
 
 from .base import Suite, Benchmark, TracingType
 from options import options
-from utils.utils import git_clone, run, create_build_path
 from utils.result import Result
 from utils.oneapi import get_oneapi
 from utils.logger import log
 from .benchdnn_list import get_bench_dnn_list
+from git_project import GitProject
 
 
 class OneDnnBench(Suite):
     def __init__(self, directory):
-        self.directory = Path(directory).resolve()
-        build_path = create_build_path(self.directory, "onednn-build")
-        self.build_dir = Path(build_path)
-        self.src_dir = self.directory / "onednn-repo"
+        self.project = None
 
     def git_url(self):
         return "https://github.com/uxlfoundation/oneDNN.git"
@@ -62,36 +59,35 @@ class OneDnnBench(Suite):
         if options.sycl is None:
             return
 
-        self.src_dir = git_clone(
-            self.directory,
-            "onednn-repo",
-            self.git_url(),
-            self.git_tag(),
-        )
-
         self.oneapi = get_oneapi()
-        cmake_args = [
-            "cmake",
-            f"-S {self.src_dir}",
-            f"-B {self.build_dir}",
+        if self.project is None:
+            self.project = GitProject(
+                self.git_url(),
+                self.git_tag(),
+                Path(options.workdir),
+                "onednn",
+                force_rebuild=True,
+            )
+
+        extra_cmake_args = [
             f"-DCMAKE_PREFIX_PATH={options.sycl}",
             "-DCMAKE_CXX_COMPILER=clang++",
             "-DCMAKE_C_COMPILER=clang",
-            "-DCMAKE_BUILD_TYPE=Release",
             "-DDNNL_BUILD_TESTS=ON",
             "-DDNNL_BUILD_EXAMPLES=OFF",
             "-DDNNL_CPU_RUNTIME=NONE",  # Disable SYCL CPU support
             "-DDNNL_GPU_RUNTIME=SYCL",  # Enable SYCL GPU support
         ]
-        run(
-            cmake_args,
+        self.project.configure(
+            extra_cmake_args,
+            install_prefix=False,
             add_sycl=True,
         )
-
-        run(
-            f"cmake --build {self.build_dir} --target benchdnn -j {options.build_jobs}",
+        self.project.build(
+            target="benchdnn",
             add_sycl=True,
-            ld_library=[str(self.build_dir) + "/src"] + self.oneapi.ld_libraries(),
+            ld_library=[str(self.project.build_dir / "src")]
+            + self.oneapi.ld_libraries(),
             timeout=60 * 20,
         )
 
@@ -113,7 +109,10 @@ class OneDnnBenchmark(Benchmark):
             self.bench_args += " --execution-mode=direct"
             self.bench_name += "-eager"
         self.bench_args += f" {bench_args}"
-        self.bench_bin = suite.build_dir / "tests" / "benchdnn" / "benchdnn"
+
+    @property
+    def benchmark_bin(self) -> Path:
+        return self.suite.project.build_dir / "tests" / "benchdnn" / "benchdnn"
 
     def enabled(self):
         if options.sycl is None:
@@ -129,8 +128,8 @@ class OneDnnBenchmark(Benchmark):
         return self.exp_group
 
     def setup(self):
-        if not self.bench_bin.exists():
-            raise FileNotFoundError(f"Benchmark binary not found: {self.bench_bin}")
+        if not self.benchmark_bin.exists():
+            raise FileNotFoundError(f"Benchmark binary not found: {self.benchmark_bin}")
 
     def run(
         self,
@@ -145,12 +144,12 @@ class OneDnnBenchmark(Benchmark):
             extra_trace_opt = None
 
         command = [
-            str(self.bench_bin),
+            str(self.benchmark_bin),
             *self.bench_args.split(),
         ]
 
         ld_library = self.suite.oneapi.ld_libraries() + [
-            str(self.suite.build_dir / "src")
+            str(self.suite.project.build_dir / "src")
         ]
 
         env_vars = dict(env_vars) if env_vars else {}

--- a/devops/scripts/benchmarks/benches/benchdnn.py
+++ b/devops/scripts/benchmarks/benches/benchdnn.py
@@ -16,7 +16,7 @@ from git_project import GitProject
 
 
 class OneDnnBench(Suite):
-    def __init__(self, directory):
+    def __init__(self):
         self.project = None
 
     def git_url(self):

--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -49,7 +49,7 @@ def runtime_to_tag_name(runtime: RUNTIMES) -> str:
 
 
 class ComputeBench(Suite):
-    def __init__(self, directory):
+    def __init__(self):
         self.submit_graph_num_kernels = [4, 10, 32]
         self.project = None
 
@@ -359,7 +359,7 @@ class ComputeBenchmark(Benchmark):
         runtime: RUNTIMES = None,
         profiler_type: PROFILERS = PROFILERS.TIMER,
     ):
-        super().__init__(options.workdir, bench)
+        super().__init__(bench)
         self.bench = bench
         self.bench_name = name
         self.test = test

--- a/devops/scripts/benchmarks/benches/gromacs.py
+++ b/devops/scripts/benchmarks/benches/gromacs.py
@@ -9,14 +9,21 @@ import re
 
 from .base import Suite, Benchmark, TracingType
 from options import options
-from utils.utils import git_clone, download, run, create_build_path
+from utils.utils import download, run
 from utils.result import Result
 from utils.oneapi import get_oneapi
 from utils.logger import log
-from utils.unitrace import get_unitrace
+from git_project import GitProject
 
 
 class GromacsBench(Suite):
+    def __init__(self, directory):
+        self.project = None
+        model_path = str(Path(options.workdir) / self.grappa_file()).replace(
+            ".tar.gz", ""
+        )
+        self.grappa_dir = Path(model_path)
+
     def git_url(self):
         return "https://gitlab.com/gromacs/gromacs.git"
 
@@ -28,14 +35,6 @@ class GromacsBench(Suite):
 
     def grappa_file(self):
         return Path(os.path.basename(self.grappa_url()))
-
-    def __init__(self, directory):
-        self.directory = Path(directory).resolve()
-        model_path = str(self.directory / self.grappa_file()).replace(".tar.gz", "")
-        self.grappa_dir = Path(model_path)
-        build_path = create_build_path(self.directory, "gromacs-build")
-        self.gromacs_build_path = Path(build_path)
-        self.gromacs_src = self.directory / "gromacs-repo"
 
     def name(self):
         return "Gromacs Bench"
@@ -52,12 +51,14 @@ class GromacsBench(Suite):
         ]
 
     def setup(self) -> None:
-        self.gromacs_src = git_clone(
-            self.directory,
-            "gromacs-repo",
-            self.git_url(),
-            self.git_tag(),
-        )
+        if self.project is None:
+            self.project = GitProject(
+                self.git_url(),
+                self.git_tag(),
+                Path(options.workdir),
+                "gromacs",
+                force_rebuild=True,
+            )
 
         # TODO: Detect the GPU architecture and set the appropriate flags
 
@@ -65,11 +66,7 @@ class GromacsBench(Suite):
 
         self.oneapi = get_oneapi()
 
-        cmd_list = [
-            "cmake",
-            f"-S {self.gromacs_src}",
-            f"-B {self.gromacs_build_path}",
-            "-DCMAKE_BUILD_TYPE=Release",
+        extra_args = [
             "-DCMAKE_CXX_COMPILER=clang++",
             "-DCMAKE_C_COMPILER=clang",
             "-DGMX_GPU=SYCL",
@@ -84,21 +81,14 @@ class GromacsBench(Suite):
         ]
 
         if options.unitrace:
-            cmd_list.append("-DGMX_USE_ITT=ON")
+            extra_args.append("-DGMX_USE_ITT=ON")
 
-        run(
-            cmd_list,
-            add_sycl=True,
-        )
-        run(
-            f"cmake --build {self.gromacs_build_path} -j {options.build_jobs}",
-            add_sycl=True,
-            ld_library=self.oneapi.ld_libraries(),
-        )
+        self.project.configure(extra_args, install_prefix=False, add_sycl=True)
+        self.project.build(add_sycl=True, ld_library=self.oneapi.ld_libraries())
         download(
-            self.directory,
+            options.workdir,
             self.grappa_url(),
-            self.directory / self.grappa_file(),
+            options.workdir / self.grappa_file(),
             checksum="cc02be35ba85c8b044e47d097661dffa8bea57cdb3db8b5da5d01cdbc94fe6c8902652cfe05fb9da7f2af0698be283a2",
             untar=True,
         )
@@ -114,9 +104,7 @@ class GromacsBenchmark(Benchmark):
         self.type = type  # The type of benchmark ("pme" or "rf")
         self.option = option  # "graphs" or "eager"
 
-        self.gromacs_src = suite.gromacs_src
         self.grappa_dir = suite.grappa_dir
-        self.gmx_path = suite.gromacs_build_path / "bin" / "gmx"
 
         if self.type == "pme":
             self.extra_args = [
@@ -128,6 +116,10 @@ class GromacsBenchmark(Benchmark):
             ]
         else:
             self.extra_args = []
+
+    @property
+    def gmx_path(self) -> Path:
+        return self.suite.project.build_dir / "bin" / "gmx"
 
     def name(self):
         return f"gromacs-{self.model}-{self.type}-{self.option}"

--- a/devops/scripts/benchmarks/benches/gromacs.py
+++ b/devops/scripts/benchmarks/benches/gromacs.py
@@ -17,7 +17,7 @@ from git_project import GitProject
 
 
 class GromacsBench(Suite):
-    def __init__(self, directory):
+    def __init__(self):
         self.project = None
         model_path = str(Path(options.workdir) / self.grappa_file()).replace(
             ".tar.gz", ""

--- a/devops/scripts/benchmarks/benches/llamacpp.py
+++ b/devops/scripts/benchmarks/benches/llamacpp.py
@@ -5,19 +5,20 @@
 
 import csv
 import io
+import os
 from pathlib import Path
-from utils.utils import download, git_clone
+
+from utils.utils import download
 from .base import Benchmark, Suite, TracingType
 from utils.result import Result
-from utils.utils import run, create_build_path
 from options import options
 from utils.oneapi import get_oneapi
-import os
+from git_project import GitProject
 
 
 class LlamaCppBench(Suite):
     def __init__(self, directory):
-        self.directory = directory
+        self.project = None
 
     def name(self) -> str:
         return "llama.cpp bench"
@@ -32,18 +33,20 @@ class LlamaCppBench(Suite):
         if options.sycl is None:
             return
 
-        repo_path = git_clone(
-            self.directory,
-            "llamacpp-repo",
-            self.git_url(),
-            self.git_hash(),
-        )
+        if self.project is None:
+            self.project = GitProject(
+                self.git_url(),
+                self.git_hash(),
+                Path(options.workdir),
+                "llamacpp",
+                force_rebuild=True,
+            )
 
-        self.models_dir = os.path.join(self.directory, "models")
-        Path(self.models_dir).mkdir(parents=True, exist_ok=True)
+        models_dir = Path(options.workdir, "llamacpp-models")
+        models_dir.mkdir(parents=True, exist_ok=True)
 
         self.model = download(
-            self.models_dir,
+            models_dir,
             "https://huggingface.co/ggml-org/DeepSeek-R1-Distill-Qwen-1.5B-Q4_0-GGUF/resolve/main/deepseek-r1-distill-qwen-1.5b-q4_0.gguf",
             "deepseek-r1-distill-qwen-1.5b-q4_0.gguf",
             checksum="791f6091059b653a24924b9f2b9c3141c8f892ae13fff15725f77a2bf7f9b1b6b71c85718f1e9c0f26c2549aba44d191",
@@ -51,13 +54,7 @@ class LlamaCppBench(Suite):
 
         self.oneapi = get_oneapi()
 
-        self.build_path = create_build_path(self.directory, "llamacpp-build")
-
-        configure_command = [
-            "cmake",
-            f"-B {self.build_path}",
-            f"-S {repo_path}",
-            f"-DCMAKE_BUILD_TYPE=Release",
+        extra_args = [
             f"-DGGML_SYCL=ON",
             f"-DCMAKE_C_COMPILER=clang",
             f"-DCMAKE_CXX_COMPILER=clang++",
@@ -67,14 +64,8 @@ class LlamaCppBench(Suite):
             f"-DSYCL_COMPILER=ON",
             f"-DMKL_DIR={self.oneapi.mkl_cmake()}",
         ]
-
-        run(configure_command, add_sycl=True)
-
-        run(
-            f"cmake --build {self.build_path} -j {options.build_jobs}",
-            add_sycl=True,
-            ld_library=self.oneapi.ld_libraries(),
-        )
+        self.project.configure(extra_args, add_sycl=True)
+        self.project.build(add_sycl=True, ld_library=self.oneapi.ld_libraries())
 
     def benchmarks(self) -> list[Benchmark]:
         return [LlamaBench(self)]
@@ -82,8 +73,12 @@ class LlamaCppBench(Suite):
 
 class LlamaBench(Benchmark):
     def __init__(self, bench):
-        super().__init__(bench.directory, bench)
+        super().__init__(options.workdir, bench)
         self.bench = bench
+
+    @property
+    def benchmark_bin(self) -> Path:
+        return self.bench.project.build_dir / "bin" / "llama-bench"
 
     def enabled(self):
         if options.sycl is None:
@@ -91,9 +86,6 @@ class LlamaBench(Benchmark):
         if options.ur_adapter == "cuda" or options.ur_adapter == "hip":
             return False
         return True
-
-    def setup(self):
-        self.benchmark_bin = os.path.join(self.bench.build_path, "bin", "llama-bench")
 
     def model(self):
         return "DeepSeek-R1-Distill-Qwen-1.5B-Q4_0.gguf"
@@ -122,7 +114,7 @@ class LlamaBench(Benchmark):
         force_trace: bool = False,
     ) -> list[Result]:
         command = [
-            f"{self.benchmark_bin}",
+            str(self.benchmark_bin),
             "--output",
             "csv",
             "-n",

--- a/devops/scripts/benchmarks/benches/llamacpp.py
+++ b/devops/scripts/benchmarks/benches/llamacpp.py
@@ -17,7 +17,7 @@ from git_project import GitProject
 
 
 class LlamaCppBench(Suite):
-    def __init__(self, directory):
+    def __init__(self):
         self.project = None
 
     def name(self) -> str:
@@ -73,7 +73,7 @@ class LlamaCppBench(Suite):
 
 class LlamaBench(Benchmark):
     def __init__(self, bench):
-        super().__init__(options.workdir, bench)
+        super().__init__(bench)
         self.bench = bench
 
     @property

--- a/devops/scripts/benchmarks/benches/syclbench.py
+++ b/devops/scripts/benchmarks/benches/syclbench.py
@@ -5,17 +5,17 @@
 
 import os
 import csv
-import io
-from utils.utils import run, git_clone, create_build_path
+from pathlib import Path
+
 from .base import Benchmark, Suite, TracingType
 from utils.result import Result
 from options import options
+from git_project import GitProject
 
 
 class SyclBench(Suite):
     def __init__(self, directory):
-        self.directory = directory
-        return
+        self.project = None
 
     def name(self) -> str:
         return "SYCL-Bench"
@@ -30,38 +30,31 @@ class SyclBench(Suite):
         if options.sycl is None:
             return
 
-        build_path = create_build_path(self.directory, "sycl-bench-build")
-        repo_path = git_clone(
-            self.directory,
-            "sycl-bench-repo",
-            self.git_url(),
-            self.git_hash(),
-        )
+        if self.project is None:
+            self.project = GitProject(
+                self.git_url(),
+                self.git_hash(),
+                Path(options.workdir),
+                "sycl-bench",
+                force_rebuild=True,
+            )
 
-        configure_command = [
-            "cmake",
-            f"-B {build_path}",
-            f"-S {repo_path}",
-            f"-DCMAKE_BUILD_TYPE=Release",
+        extra_args = [
             f"-DCMAKE_CXX_COMPILER={options.sycl}/bin/clang++",
             f"-DCMAKE_C_COMPILER={options.sycl}/bin/clang",
             f"-DSYCL_IMPL=dpcpp",
         ]
-
         if options.ur_adapter == "cuda":
-            configure_command += [
+            extra_args += [
                 f"-DCMAKE_CXX_FLAGS=-fsycl -fsycl-targets=nvptx64-nvidia-cuda"
             ]
-
         if options.ur_adapter == "hip":
-            configure_command += [
+            extra_args += [
                 f"-DCMAKE_CXX_FLAGS=-fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch={options.hip_arch}"
             ]
 
-        run(configure_command, add_sycl=True)
-        run(f"cmake --build {build_path} -j {options.build_jobs}", add_sycl=True)
-
-        self.built = True
+        self.project.configure(extra_args, install_prefix=False, add_sycl=True)
+        self.project.build(add_sycl=True)
 
     def benchmarks(self) -> list[Benchmark]:
         return [
@@ -106,10 +99,14 @@ class SyclBench(Suite):
 
 class SyclBenchmark(Benchmark):
     def __init__(self, bench, name, test):
-        super().__init__(bench.directory, bench)
+        super().__init__(options.workdir, bench)
         self.bench = bench
         self.bench_name = name
         self.test = test
+
+    @property
+    def benchmark_bin(self) -> Path:
+        return self.bench.project.build_dir / self.bench_name
 
     def enabled(self) -> bool:
         return options.sycl is not None
@@ -132,21 +129,16 @@ class SyclBenchmark(Benchmark):
             base_tags.append("latency")
         return base_tags
 
-    def setup(self):
-        self.benchmark_bin = os.path.join(
-            self.directory, "sycl-bench-build", self.bench_name
-        )
-
     def run(
         self,
         env_vars,
         run_trace: TracingType = TracingType.NONE,
         force_trace: bool = False,
     ) -> list[Result]:
-        self.outputfile = os.path.join(self.bench.directory, self.test + ".csv")
+        self.outputfile = os.path.join(options.workdir, self.test + ".csv")
 
         command = [
-            f"{self.benchmark_bin}",
+            str(self.benchmark_bin),
             f"--warmup-run",
             f"--num-runs={options.iterations}",
             f"--output={self.outputfile}",

--- a/devops/scripts/benchmarks/benches/syclbench.py
+++ b/devops/scripts/benchmarks/benches/syclbench.py
@@ -14,7 +14,7 @@ from git_project import GitProject
 
 
 class SyclBench(Suite):
-    def __init__(self, directory):
+    def __init__(self):
         self.project = None
 
     def name(self) -> str:
@@ -99,7 +99,7 @@ class SyclBench(Suite):
 
 class SyclBenchmark(Benchmark):
     def __init__(self, bench, name, test):
-        super().__init__(options.workdir, bench)
+        super().__init__(bench)
         self.bench = bench
         self.bench_name = name
         self.test = test

--- a/devops/scripts/benchmarks/benches/test.py
+++ b/devops/scripts/benchmarks/benches/test.py
@@ -4,12 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import random
-from utils.utils import git_clone
 from .base import Benchmark, Suite, TracingType
 from utils.result import BenchmarkMetadata, Result
-from utils.utils import run, create_build_path
-from options import options
-import os
 
 
 class TestSuite(Suite):

--- a/devops/scripts/benchmarks/benches/test.py
+++ b/devops/scripts/benchmarks/benches/test.py
@@ -58,7 +58,7 @@ class TestSuite(Suite):
 
 class TestBench(Benchmark):
     def __init__(self, suite, name, value, diff, group="", notes=None, unstable=None):
-        super().__init__("", suite)
+        super().__init__(suite)
         self.bname = name
         self.value = value
         self.diff = diff

--- a/devops/scripts/benchmarks/benches/umf.py
+++ b/devops/scripts/benchmarks/benches/umf.py
@@ -20,9 +20,6 @@ def isUMFAvailable():
 
 
 class UMFSuite(Suite):
-    def __init__(self, directory):
-        self.directory = directory
-
     def name(self) -> str:
         return "UMF"
 
@@ -44,7 +41,7 @@ class UMFSuite(Suite):
 
 class GBench(Benchmark):
     def __init__(self, bench):
-        super().__init__(bench.directory, bench)
+        super().__init__(bench)
 
         self.bench = bench
         self.bench_name = "umf-benchmark"

--- a/devops/scripts/benchmarks/benches/velocity.py
+++ b/devops/scripts/benchmarks/benches/velocity.py
@@ -17,7 +17,7 @@ from git_project import GitProject
 
 
 class VelocityBench(Suite):
-    def __init__(self, directory) -> None:
+    def __init__(self) -> None:
         self.project = None
 
     def name(self) -> str:
@@ -57,7 +57,7 @@ class VelocityBench(Suite):
 
 class VelocityBase(Benchmark):
     def __init__(self, name: str, bin_name: str, vb: VelocityBench, unit: str):
-        super().__init__(options.workdir, vb)
+        super().__init__(vb)
         self.vb = vb
         self.bench_name = name
         self.bin_name = bin_name

--- a/devops/scripts/benchmarks/git_project.py
+++ b/devops/scripts/benchmarks/git_project.py
@@ -91,7 +91,7 @@ class GitProject:
     def configure(
         self,
         extra_args: list | None = None,
-        install_prefix=True,
+        install_prefix: bool = True,
         add_sycl: bool = False,
     ) -> None:
         """Configures the project."""

--- a/devops/scripts/benchmarks/main.py
+++ b/devops/scripts/benchmarks/main.py
@@ -195,13 +195,13 @@ def main(directory, additional_env_vars, compare_names, filter):
         options.extra_env_vars.update(cr.env_vars())
 
     suites = [
-        ComputeBench(directory),
-        VelocityBench(directory),
-        SyclBench(directory),
-        LlamaCppBench(directory),
-        UMFSuite(directory),
-        GromacsBench(directory),
-        OneDnnBench(directory),
+        ComputeBench(),
+        VelocityBench(),
+        SyclBench(),
+        LlamaCppBench(),
+        UMFSuite(),
+        GromacsBench(),
+        OneDnnBench(),
         TestSuite(),
     ]
 

--- a/devops/scripts/benchmarks/utils/unitrace.py
+++ b/devops/scripts/benchmarks/utils/unitrace.py
@@ -5,17 +5,18 @@
 import os
 import shutil
 
+from datetime import datetime, timezone
+from pathlib import Path
+
 from options import options
 from utils.utils import (
     run,
-    git_clone,
     prune_old_files,
     remove_by_prefix,
     remove_by_extension,
 )
 from utils.logger import log
-
-from datetime import datetime, timezone
+from git_project import GitProject
 
 
 class Unitrace:
@@ -29,14 +30,14 @@ class Unitrace:
         )
 
         log.info("Downloading and building Unitrace...")
-        repo_dir = git_clone(
-            options.workdir,
-            "pti-gpu-repo",
+        self.project = GitProject(
             "https://github.com/intel/pti-gpu.git",
             "pti-0.12.4",
+            Path(options.workdir),
+            "pti-gpu",
         )
         build_dir = os.path.join(options.workdir, "unitrace-build")
-        unitrace_src = os.path.join(repo_dir, "tools", "unitrace")
+        unitrace_src = self.project.src_dir / "tools" / "unitrace"
         os.makedirs(build_dir, exist_ok=True)
 
         unitrace_exe = os.path.join(build_dir, "unitrace")

--- a/devops/scripts/benchmarks/utils/utils.py
+++ b/devops/scripts/benchmarks/utils/utils.py
@@ -92,25 +92,6 @@ def run(
         raise
 
 
-def git_clone(dir, name, repo, commit):
-    repo_path = os.path.join(dir, name)
-    log.debug(f"Cloning {repo} into {repo_path} at commit {commit}")
-
-    if os.path.isdir(repo_path) and os.path.isdir(os.path.join(repo_path, ".git")):
-        run("git fetch", cwd=repo_path)
-        run("git reset --hard", cwd=repo_path)
-        run(f"git checkout {commit}", cwd=repo_path)
-    elif not os.path.exists(repo_path):
-        run(f"git clone --recursive {repo} {repo_path}")
-        run(f"git checkout {commit}", cwd=repo_path)
-    else:
-        raise Exception(
-            f"The directory {repo_path} exists but is not a git repository."
-        )
-    log.debug(f"Cloned {repo} into {repo_path} at commit {commit}")
-    return repo_path
-
-
 def prepare_bench_cwd(dir):
     # we need 2 deep to workaround a problem with a fixed relative paths in some velocity benchmarks
     options.benchmark_cwd = os.path.join(dir, "bcwd", "bcwd")
@@ -144,17 +125,6 @@ def prepare_workdir(dir, version):
 
     with open(version_file_path, "w") as version_file:
         version_file.write(version)
-
-
-def create_build_path(directory, name):
-    build_path = os.path.join(directory, name)
-
-    if options.rebuild and Path(build_path).exists():
-        shutil.rmtree(build_path)
-
-    Path(build_path).mkdir(parents=True, exist_ok=True)
-
-    return build_path
 
 
 def calculate_checksum(file_path):


### PR DESCRIPTION
Use GitProject for git operations instead of utility methods. Plus, remove `directory` path in suites' ctors as this path can be obtained from the `options` module.