### PR TITLE
[UR][Offload] Implement memory buffer get/create native handle

### DIFF
--- a/unified-runtime/source/adapters/offload/memory.hpp
+++ b/unified-runtime/source/adapters/offload/memory.hpp
@@ -17,7 +17,6 @@
 struct BufferMem {
   enum class AllocMode {
     Default,
-    UseHostPtr,
     CopyIn,
     AllocHostPtr,
   };
@@ -93,6 +92,7 @@ struct ur_mem_handle_t_ : RefCounted {
   ur_context_handle_t Context;
 
   ur_mem_flags_t MemFlags;
+  bool IsNativeHandleOwned;
 
   // For now we only support BufferMem. Eventually we'll support images, so use
   // a variant to store the underlying object.
@@ -101,7 +101,7 @@ struct ur_mem_handle_t_ : RefCounted {
   ur_mem_handle_t_(ur_context_handle_t Context, ur_mem_handle_t Parent,
                    ur_mem_flags_t MemFlags, BufferMem::AllocMode Mode,
                    void *Ptr, void *HostPtr, size_t Size)
-      : Context{Context}, MemFlags{MemFlags},
+      : Context{Context}, MemFlags{MemFlags}, IsNativeHandleOwned(true),
         Mem{BufferMem{Parent, Mode, Ptr, HostPtr, Size}} {
     urContextRetain(Context);
   };

--- a/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
+++ b/unified-runtime/source/adapters/offload/ur_interface_loader.cpp
@@ -151,10 +151,11 @@ urGetMemProcAddrTable(ur_api_version_t version, ur_mem_dditable_t *pDdiTable) {
   }
   pDdiTable->pfnBufferCreate = urMemBufferCreate;
   pDdiTable->pfnBufferPartition = urMemBufferPartition;
-  pDdiTable->pfnBufferCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnBufferCreateWithNativeHandle =
+      urMemBufferCreateWithNativeHandle;
   pDdiTable->pfnImageCreateWithNativeHandle = urMemImageCreateWithNativeHandle;
   pDdiTable->pfnGetInfo = urMemGetInfo;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetNativeHandle = urMemGetNativeHandle;
   pDdiTable->pfnImageCreate = urMemImageCreate;
   pDdiTable->pfnImageGetInfo = urMemImageGetInfo;
   pDdiTable->pfnRelease = urMemRelease;


### PR DESCRIPTION
Buffers are implemented under the hood using USM pointers, so return
USM pointers as the appropriate "native handle". With the info queries
from liboffload, we can recreate equivalent buffer objects from
arbitrary USM pointers.
