### PR TITLE
Fix KernelCompiler/sycl.cpp test

### DIFF
--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -884,11 +884,12 @@ jit_compiler::parseUserArgs(View<const char *> UserArgs) {
   // Check for options that are unsupported because they would interfere with
   // the in-memory pipeline.
   Arg *UnsupportedArg =
-      AL.getLastArg(OPT_Action_Group,     // Actions like -c or -S
-                    OPT_Link_Group,       // Linker flags
-                    OPT_o,                // Output file
-                    OPT_fsycl_targets_EQ, // AoT compilation
-                    OPT_fsycl_link_EQ,    // SYCL linker
+      AL.getLastArg(OPT_Action_Group,       // Actions like -c or -S
+                    OPT_Link_Group,         // Linker flags
+                    OPT_o,                  // Output file
+                    OPT_fsycl_targets_EQ,   // AoT compilation
+                    OPT_offload_targets_EQ, // AoT compilation
+                    OPT_fsycl_link_EQ,      // SYCL linker
                     OPT_fno_sycl_device_code_split_esimd, // invoke_simd
                     OPT_fsanitize_EQ                      // Sanitizer
       );

--- a/sycl/test-e2e/Basic/backend_info.cpp
+++ b/sycl/test-e2e/Basic/backend_info.cpp
@@ -1,6 +1,10 @@
 // UNSUPPORTED: preview-mode
 // UNSUPPORTED-INTENDED: Functionality is removed under
 //                       `-fpreview-breaking-changes`
+
+// XFAIL: native_cpu
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20127
+
 // RUN: %{build} -o %t.out -Wno-deprecated-declarations
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/KernelParams/has-special-captures.cpp
+++ b/sycl/test-e2e/KernelParams/has-special-captures.cpp
@@ -1,3 +1,6 @@
+// XFAIL: native_cpu
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20127
+
 // RUN: %{build} -fsyntax-only -o %t.out
 
 #include <sycl/detail/kernel_desc.hpp>

--- a/sycl/test-e2e/ProgramManager/uneven_kernel_split.cpp
+++ b/sycl/test-e2e/ProgramManager/uneven_kernel_split.cpp
@@ -3,6 +3,9 @@
 // UNSUPPORTED: linux
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17305
 
+// XFAIL: run-mode
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20127
+
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -I %S/Inputs/ %S/uneven_kernel_split.cpp -c -o %t.o
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -I %S/Inputs/ %S/Inputs/gpu_kernel1.cpp -c -o %t1.o
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -I %S/Inputs/ %S/Inputs/gpu_kernel2.cpp -c -o %t2.o


### PR DESCRIPTION
`-fsycl-targets=` is now an alias for `--offload-targets=` and hence `--offload-targets=` must also be added to the unsupported arg list as the Clang driver code checks for matching ID for `--offload-targets=` as well.

Fixes https://github.com/intel/llvm/issues/20127