### PR TITLE
[CMake] Pass SYCL_RT_ZSTD_AVAILABLE for no_cgh unittests

### DIFF
--- a/sycl/unittests/compression/CMakeLists.txt
+++ b/sycl/unittests/compression/CMakeLists.txt
@@ -2,4 +2,5 @@ add_sycl_unittest(CompressionTests OBJECT
   CompressionTests.cpp
 )
 target_compile_definitions(CompressionTests_non_preview PRIVATE SYCL_RT_ZSTD_AVAILABLE)
+target_compile_definitions(CompressionTests_no_cgh PRIVATE SYCL_RT_ZSTD_AVAILABLE)
 target_compile_definitions(CompressionTests_preview PRIVATE SYCL_RT_ZSTD_AVAILABLE __INTEL_PREVIEW_BREAKING_CHANGES)


### PR DESCRIPTION
intel/llvm#19294 added new _no_cgh version, need to pass the macros to
fix the build failures.
