### PR TITLE
[NFC][SYCL] Change `ExtOneapiBarrierOpt` to use `TEST_F`

### DIFF
--- a/sycl/unittests/Extensions/ExtOneapiBarrierOpt.cpp
+++ b/sycl/unittests/Extensions/ExtOneapiBarrierOpt.cpp
@@ -36,7 +36,7 @@ protected:
 // Check that ext_oneapi_submit_barrier works fine in the scenarios
 // when provided waitlist consists of only empty events.
 // Tets for https://github.com/intel/llvm/pull/12951
-TEST(ExtOneapiBarrierOptTest, EmptyEventTest) {
+TEST_F(ExtOneapiBarrierOptTest, EmptyEventTest) {
   sycl::queue q1{{sycl::property::queue::in_order()}};
 
   mock::getCallbacks().set_after_callback(


### PR DESCRIPTION
This unit test failed in sycl-rel and internal CI (see https://github.com/intel/llvm/actions/runs/18096621667/job/51489057567) because the test is using members of class `ExtOneapiBarrierOptTest`, and these members need to be re-initialized in between two test runs. `TEST_F` does exactly that.