### PR TITLE
[SYCL][E2E] minor clean up of test directives

### DIFF
--- a/sycl/test-e2e/ESIMD/regression/bit_shift_vector_compilation_test_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/regression/bit_shift_vector_compilation_test_pvc.cpp
@@ -6,7 +6,7 @@
 //
 //===---------------------------------------===//
 
-// RUN: %{build} -fsycl-device-code-split=per_kernel -std=c++20 -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 // REQUIRES: arch-intel_gpu_pvc
 

--- a/sycl/test-e2e/ESIMD/rotate_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/rotate_pvc.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %{build} -fsycl-device-code-split=per_kernel -std=c++20 -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -fsycl-device-code-split=per_kernel -std=c++20 -o %t1.out -DEXP
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t1.out -DEXP
 // RUN: %{run} %t1.out
 // REQUIRES: arch-intel_gpu_pvc
 


### PR DESCRIPTION
Remove `-std=c++20` from a couple of tests. It is not needed, and if it is then we should use `%cxx_std_optionc++20` instead, for Windows