### PR TITLE
[UR][L0][L0v2] Explicitly mark timestamped events

### DIFF
--- a/unified-runtime/source/adapters/level_zero/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/event.hpp
@@ -200,6 +200,9 @@ struct ur_event_handle_t_ : ur_object {
   // plugin.
   bool IsDiscarded = {false};
 
+  // Indicates that this is a timestamped event.
+  bool IsTimestamped = {false};
+
   // Indicates that this event is needed to be visible by multiple devices.
   // When possible, allocate Event from single device pool for optimal
   // performance
@@ -245,10 +248,6 @@ struct ur_event_handle_t_ : ur_object {
 
   // Tells if this event is with profiling capabilities.
   bool isProfilingEnabled() const;
-
-  // Tells if this event was created as a timestamp event, allowing profiling
-  // info even if profiling is not enabled.
-  bool isTimestamped() const;
 
   // Get the host-visible event or create one and enqueue its signal.
   ur_result_t getOrCreateHostVisibleEvent(ze_event_handle_t &HostVisibleEvent);

--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -73,6 +73,7 @@ void event_profiling_data_t::reset() {
   // possible.
   adjustedEventStartTimestamp = 0;
   adjustedEventEndTimestamp = 0;
+  timestampRecorded = false;
 }
 
 void event_profiling_data_t::recordStartTimestamp(ur_device_handle_t hDevice) {
@@ -85,18 +86,15 @@ void event_profiling_data_t::recordStartTimestamp(ur_device_handle_t hDevice) {
 
   assert(adjustedEventStartTimestamp == 0);
   adjustedEventStartTimestamp = deviceStartTimestamp;
+  timestampRecorded = true;
 }
 
 uint64_t event_profiling_data_t::getEventStartTimestmap() const {
   return adjustedEventStartTimestamp;
 }
 
-bool event_profiling_data_t::recordingEnded() const {
-  return adjustedEventEndTimestamp != 0;
-}
-
 bool event_profiling_data_t::recordingStarted() const {
-  return adjustedEventStartTimestamp != 0;
+  return timestampRecorded;
 }
 
 uint64_t *event_profiling_data_t::eventEndTimestampAddr() {

--- a/unified-runtime/source/adapters/level_zero/v2/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.hpp
@@ -34,7 +34,6 @@ struct event_profiling_data_t {
   uint64_t *eventEndTimestampAddr();
 
   bool recordingStarted() const;
-  bool recordingEnded() const;
 
   // clear the profiling data, allowing the event to be reused
   // for a new command
@@ -49,6 +48,8 @@ private:
 
   uint64_t zeTimerResolution = 0;
   uint64_t timestampMaxValue = 0;
+
+  bool timestampRecorded = false;
 };
 
 struct ur_event_handle_t_ : ur_object {


### PR DESCRIPTION
This is a workaround for a case where L0 driver fails to retrieve a timestamp but doesn't return an error. In such case, when event profiling info is queried we check the timestamp value and assume the event was not timestamped even though it was.
This scenario can happen on newer platform with not yet full driver support.