### PR TITLE
[SYCL][E2E] Disable Basic/submit_time.cpp for native_cpu

### DIFF
--- a/sycl/test-e2e/Basic/submit_time.cpp
+++ b/sycl/test-e2e/Basic/submit_time.cpp
@@ -8,6 +8,9 @@
 // Test fails on hip flakily, disable temprorarily.
 // UNSUPPORTED: hip
 
+// UNSUPPORTED: target-native_cpu
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20248
+
 #include <cassert>
 #include <iostream>
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
The Basic/submit_time.cpp E2E test fails sporadically for native_cpu. This commit temporarily disables it while it gets addressed.