### PR TITLE
[SYCL] Enable handler-less path in basic E2E tests

### DIFF
--- a/sycl/test-e2e/EnqueueFunctions/kernel_shortcuts.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/kernel_shortcuts.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
+// RUN: %{build} -o %t1.out
+// RUN: %{run} %t1.out
+// RUN: %{build} -D__DPCPP_ENABLE_UNFINISHED_NO_CGH_SUBMIT -o %t2.out
+// RUN: %{run} %t2.out
 
 // Tests the enqueue free function kernel shortcuts.
 

--- a/sycl/test-e2e/FreeFunctionCommands/launch_grouped.cpp
+++ b/sycl/test-e2e/FreeFunctionCommands/launch_grouped.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
+// RUN: %{build} -o %t1.out
+// RUN: %{run} %t1.out
+// RUN: %{build} -D__DPCPP_ENABLE_UNFINISHED_NO_CGH_SUBMIT -o %t2.out
+// RUN: %{run} %t2.out
 
 // This test checks whether the free function command launch grouped is valid.
 

--- a/sycl/test-e2e/InorderQueue/in_order_kernels.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_kernels.cpp
@@ -1,6 +1,8 @@
 //
-// RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
+// RUN: %{build} -o %t1.out
+// RUN: %{run} %t1.out
+// RUN: %{build} -D__DPCPP_ENABLE_UNFINISHED_NO_CGH_SUBMIT -o %t2.out
+// RUN: %{run} %t2.out
 
 // SYCL ordered queue kernel shortcut test
 //


### PR DESCRIPTION
Enable the handler-less kernel submission path in the following test groups:
- FreeFunctionCommands/launch_grouped.cpp
- EnqueueFunctions/kernel_shortcuts.cpp
- InorderQueue/in_order_kernels.cpp