### PR TITLE
[SYCL][NFC] Use raw ptr to kernel_impl in the emitKernelInstrumentationData

### DIFF
--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -739,7 +739,7 @@ ur_exp_command_buffer_sync_point_t exec_graph_impl::enqueueNodeDirect(
                                         CGExec->MFunctionName.c_str(),
                                         CGExec->MLine, CGExec->MColumn);
     std::tie(CmdTraceEvent, InstanceID) = emitKernelInstrumentationData(
-        StreamID, CGExec->MSyclKernel, CodeLoc, CGExec->MIsTopCodeLoc,
+        StreamID, CGExec->MSyclKernel.get(), CodeLoc, CGExec->MIsTopCodeLoc,
         CGExec->MDeviceKernelInfo, nullptr, CGExec->MNDRDesc,
         CGExec->MKernelBundle.get(), CGExec->MArgs);
     if (CmdTraceEvent)

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1970,10 +1970,11 @@ ExecCGCommand::ExecCGCommand(
 }
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
-std::string instrumentationGetKernelName(
-    const std::shared_ptr<detail::kernel_impl> &SyclKernel,
-    const std::string_view FunctionName, const std::string_view SyclKernelName,
-    void *&Address, std::optional<bool> &FromSource) {
+std::string instrumentationGetKernelName(const kernel_impl *SyclKernel,
+                                         const std::string_view FunctionName,
+                                         const std::string_view SyclKernelName,
+                                         void *&Address,
+                                         std::optional<bool> &FromSource) {
   std::string KernelName;
   if (SyclKernel && SyclKernel->isCreatedFromSource()) {
     FromSource = true;
@@ -1990,8 +1991,8 @@ std::string instrumentationGetKernelName(
 void instrumentationAddExtraKernelMetadata(
     xpti_td *&CmdTraceEvent, const NDRDescT &NDRDesc,
     detail::kernel_bundle_impl *KernelBundleImplPtr,
-    DeviceKernelInfo &DeviceKernelInfo,
-    const std::shared_ptr<detail::kernel_impl> &SyclKernel, queue_impl *Queue,
+    DeviceKernelInfo &DeviceKernelInfo, const kernel_impl *SyclKernel,
+    queue_impl *Queue,
     std::vector<ArgDesc> &CGArgs) // CGArgs are not const since they could be
                                   // sorted in this function
 {
@@ -2091,8 +2092,7 @@ void instrumentationFillCommonData(
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 std::pair<xpti_td *, uint64_t> emitKernelInstrumentationData(
-    xpti::stream_id_t StreamID,
-    const std::shared_ptr<detail::kernel_impl> &SyclKernel,
+    xpti::stream_id_t StreamID, const kernel_impl *SyclKernel,
     const detail::code_location &CodeLoc, bool IsTopCodeLoc,
     DeviceKernelInfo &DeviceKernelInfo, queue_impl *Queue,
     const NDRDescT &NDRDesc, detail::kernel_bundle_impl *KernelBundleImplPtr,
@@ -2163,7 +2163,7 @@ void ExecCGCommand::emitInstrumentationData() {
     auto KernelCG =
         reinterpret_cast<detail::CGExecKernel *>(MCommandGroup.get());
     KernelName = instrumentationGetKernelName(
-        KernelCG->MSyclKernel, MCommandGroup->MFunctionName,
+        KernelCG->MSyclKernel.get(), MCommandGroup->MFunctionName,
         KernelCG->getKernelName(), MAddress, FromSource);
   } break;
   default:
@@ -2192,8 +2192,8 @@ void ExecCGCommand::emitInstrumentationData() {
           reinterpret_cast<detail::CGExecKernel *>(MCommandGroup.get());
       instrumentationAddExtraKernelMetadata(
           CmdTraceEvent, KernelCG->MNDRDesc, KernelCG->getKernelBundle().get(),
-          KernelCG->MDeviceKernelInfo, KernelCG->MSyclKernel, MQueue.get(),
-          KernelCG->MArgs);
+          KernelCG->MDeviceKernelInfo, KernelCG->MSyclKernel.get(),
+          MQueue.get(), KernelCG->MArgs);
     }
 
     xptiNotifySubscribers(

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -688,8 +688,7 @@ private:
 // Very close to ExecCGCommand::emitInstrumentationData content.
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 std::pair<xpti_td *, uint64_t> emitKernelInstrumentationData(
-    xpti::stream_id_t StreamID,
-    const std::shared_ptr<detail::kernel_impl> &SyclKernel,
+    xpti::stream_id_t StreamID, const kernel_impl *SyclKernel,
     const detail::code_location &CodeLoc, bool IsTopCodeLoc,
     DeviceKernelInfo &DeviceKernelInfo, queue_impl *Queue,
     const NDRDescT &NDRDesc, detail::kernel_bundle_impl *KernelBundleImplPtr,

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -670,7 +670,7 @@ event handler::finalize() {
         const bool xptiEnabled = xptiCheckTraceEnabled(StreamID);
         if (xptiEnabled) {
           std::tie(CmdTraceEvent, InstanceID) = emitKernelInstrumentationData(
-              StreamID, MKernel, MCodeLoc, impl->MIsTopCodeLoc,
+              StreamID, MKernel.get(), MCodeLoc, impl->MIsTopCodeLoc,
               *impl->MKernelData.getDeviceKernelInfoPtr(),
               impl->get_queue_or_null(), impl->MKernelData.getNDRDesc(),
               KernelBundleImpPtr, impl->MKernelData.getArgs());


### PR DESCRIPTION
Minor refactoring to do use raw `const kernel_impl *` instead of `const std::shared_ptr<kernel_impl>&`.