### PR TITLE
[SYCL] Reintroduce barrier trivial event for empty in-order queue

### DIFF
--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -366,6 +366,14 @@ event queue::ext_oneapi_submit_barrier(const std::vector<event> &WaitList,
                !EventImpl.hasCommandGraph();
       });
 
+  // If we have an empty in-order queue and no dependencies, we can just return
+  // a trivially finished event.
+  if (is_in_order() && !impl->hasCommandGraph() && !impl->MIsProfilingEnabled &&
+      AllEventsEmptyOrNop && ext_oneapi_empty()) {
+    return detail::createSyclObjFromImpl<event>(
+        detail::event_impl::create_default_event());
+  }
+
   if (WaitList.empty() || AllEventsEmptyOrNop)
     return submit([=](handler &CGH) { CGH.ext_oneapi_barrier(); }, CodeLoc);
   else

--- a/sycl/test-e2e/InorderQueue/in_order_ext_oneapi_submit_barrier.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_ext_oneapi_submit_barrier.cpp
@@ -61,6 +61,16 @@ int main() {
     assert(*Res == 10);
   }
   {
+    // Test cast 3 - empty queue.
+    std::cout << "Test 3" << std::endl;
+    sycl::queue EmptyQ({sycl::property::queue::in_order{}});
+    auto BarrierEvent = EmptyQ.ext_oneapi_submit_barrier();
+    assert(
+        BarrierEvent.get_info<sycl::info::event::command_execution_status>() ==
+        sycl::info::event_command_status::complete);
+    BarrierEvent.wait();
+  }
+  {
     // Test cast 4 - graph.
     sycl::queue GQueue{sycl::property::queue::in_order{}};
 


### PR DESCRIPTION
The changes in https://github.com/intel/llvm/pull/20159 removed a test case checking that barriers on empty queues would be considered complete immediately. This commit reintroduces it with a fix for the case.