### PR TITLE
[SYCL][NFC] Fix debug printing of device binary

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -164,7 +164,7 @@ static bool isDeviceBinaryTypeSupported(context_impl &ContextImpl,
 [[maybe_unused]] auto VecToString = [](auto &Vec) -> std::string {
   std::ostringstream Out;
   Out << "{";
-  for (auto Elem : Vec)
+  for (const auto &Elem : Vec)
     Out << Elem << " ";
   Out << "}";
   return Out.str();


### PR DESCRIPTION
error: use of deleted function ‘sycl::_V1::detail::Managed<URResource>::Managed(const sycl::_V1::detail::Managed<URResource>&) [with URResource = ur_program_handle_t_*]’
  167 |   for (auto Elem : Vec)
      |   ^~~