### PR TITLE
[SYCL][Doc] Add spec to wait on a device

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_wait.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_wait.asciidoc
@@ -1,0 +1,141 @@
+= sycl_ext_oneapi_device_wait
+
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+:dpcpp: pass:[DPC++]
+:endnote: &#8212;{nbsp}end{nbsp}note
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+
+== Notice
+
+[%hardbreaks]
+Copyright (C) 2025 Intel Corporation.  All rights reserved.
+
+Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
+of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by
+permission by Khronos.
+
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/intel/llvm/issues
+
+
+== Dependencies
+
+This extension is written against the SYCL 2020 revision 10 specification.
+All references below to the "core SYCL specification" or to section numbers in
+the SYCL specification refer to that revision.
+
+
+== Status
+
+This is a proposed extension specification, intended to gather community
+feedback.
+Interfaces defined in this specification may not be implemented yet or may be in
+a preliminary state.
+The specification itself may also change in incompatible ways before it is
+finalized.
+*Shipping software products should not rely on APIs defined in this
+specification.*
+
+
+== Overview
+
+This extension adds a way for the host to wait for all commands submitted to a
+device to complete.
+This functionality is similar to the CUDA API `cudaDeviceSynchronize`.
+
+
+== Specification
+
+=== Feature test macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification.  An implementation supporting this extension must predefine the
+macro `SYCL_EXT_ONEAPI_DEVICE_WAIT` to one of the values defined in the table
+below.  Applications can test for the existence of this macro to determine if
+the implementation supports this feature, or applications can test the macro's
+value to determine which of the extension's features the implementation
+supports.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|The APIs of this experimental extension are not versioned, so the
+ feature-test macro always has this value.
+|===
+
+=== New member function for the device class
+
+This extension adds the following member functions to the `device` class.
+
+[source,c++]
+----
+namespace sycl {
+
+class device {
+  // ...
+  void ext_oneapi_wait_and_throw(async_handler h);
+  void ext_oneapi_wait_and_throw();
+};
+
+} // namespace sycl
+----
+
+'''
+
+[source,c++]
+----
+void ext_oneapi_wait_and_throw(async_handler h);
+----
+
+_Effects:_ Blocks the calling thread until all commands previously submitted to
+any queue on this device have completed.
+Any unconsumed asynchronous errors from these commands are reported to the
+`h` handler as defined in section 4.13.1.1 "Asynchronous error handler" of the
+core SYCL specification.
+
+'''
+
+[source,c++]
+----
+void ext_oneapi_wait_and_throw();
+----
+
+_Effects:_ Blocks the calling thread until all commands previously submitted to
+any queue on this device have completed.
+Any unconsumed asynchronous errors from these commands are reported to the
+default async handler as defined in section 4.13.1.2 "Behavior without an async
+handler" of the core SYCL specification.
+
+[_Note:_ The default async handler terminates the application when an
+asynchronous error occurs, so applications should use the other overload of
+`ext_oneapi_wait_and_throw` if they want to handle these errors.
+_{endnote}_]
+
+'''
+
+
+== Implementation notes
+
+Note that these functions wait for "commands", which includes host tasks and
+memory copy operations.
+The implementation and the tests should cover these cases too.


### PR DESCRIPTION
Add a proposed extension specification which allows the application to wait for all commands submitted to a device to complete.