### PR TITLE
[CI] Fail benchmark CI only onregressions in CPU instruction count

### DIFF
--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -212,8 +212,8 @@ runs:
         --name "$SAVE_NAME" \
         --compare-file "./llvm-ci-perf-results/results/${SAVE_NAME}_${SAVE_TIMESTAMP}.json" \
         --results-dir "./llvm-ci-perf-results/results/" \
-        --regression-filter '^[a-z_]+_sycl ' \
-        --regression-filter-type 'SYCL' \
+        --regression-filter '^[a-z_]+_sycl .* CPU count' \
+        --regression-filter-type 'SYCL benchmark (measured using CPU cycle count)' \
         --verbose \
         --produce-github-summary \
         ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} \

--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -463,6 +463,10 @@ class ComputeBenchmark(Benchmark):
         ret = []
         for label, median, stddev, unit in parsed_results:
             extra_label = " CPU count" if parse_unit_type(unit) == "instr" else ""
+            # Note: SYCL CI currently parses for on this "CPU count" value.
+            # Please update /devops/scripts/benchmarks/compare.py if this value
+            # is changed. See compare.py usage (w.r.t. --regression-filter) in
+            # /devops/actions/run-tests/benchmarks/action.yml.
             ret.append(
                 Result(
                     label=self.name() + extra_label,


### PR DESCRIPTION
Benchmark script changes in this PR are NFC.

Bit of a long overdue change: Wall time has proven to not be a good metric for stable performance numbers. This PR change regression filters to only fail on severe regressions in CPU instruction count. 