### PR TITLE
[SYCL][Graph][UR] Elide second barrier in finalizeCommandBuffer when possible

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_buffer.cpp
@@ -131,6 +131,8 @@ ur_result_t ur_exp_command_buffer_handle_t_::finalizeCommandBuffer() {
   auto commandListLocked = commandListManager.lock();
   UR_ASSERT(!isFinalized, UR_RESULT_ERROR_INVALID_OPERATION);
 
+  size_t numEventResets = 0;
+
   if (!isInOrder) {
     ZE2UR_CALL(zeCommandListAppendBarrier,
                (commandListLocked->getZeCommandList(), nullptr, 0, nullptr));
@@ -138,12 +140,15 @@ ur_result_t ur_exp_command_buffer_handle_t_::finalizeCommandBuffer() {
       if (!usedSyncPoints[i]) {
         continue;
       }
+      ++numEventResets;
       ZE2UR_CALL(
           zeCommandListAppendEventReset,
           (commandListLocked->getZeCommandList(), syncPoints[i]->getZeEvent()));
     }
-    ZE2UR_CALL(zeCommandListAppendBarrier,
-               (commandListLocked->getZeCommandList(), nullptr, 0, nullptr));
+
+    if (numEventResets)
+      ZE2UR_CALL(zeCommandListAppendBarrier,
+                      (commandListLocked->getZeCommandList(), nullptr, 0, nullptr));
   }
   // Close the command lists and have them ready for dispatch.
   ZE2UR_CALL(zeCommandListClose, (commandListLocked->getZeCommandList()));


### PR DESCRIPTION
Currently when finalizing an out-of-order command buffer, there are two barriers:

1. An initial barrier before all of the event resets for the sync points
2. A final barrier after all of the event resets for the sync points

However, when there are no sync points, then the second barrier is unnecessary. This PR removes the second barrier when there are no sync points.