### PR TITLE
[CMake] remove -fno-lifetime-dse from CAS

### DIFF
--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -1,3 +1,11 @@
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # We append -fno-lifetime-dse in HandleLLVMOptions.cmake
+  # append("-fno-lifetime-dse" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+  # But it is causing link failure with llvm::StdThreadPool::asyncEnqueue
+  string(REPLACE "-fno-lifetime-dse" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+endif ()
+
 add_llvm_component_library(LLVMCAS
   ActionCache.cpp
   ActionCaches.cpp


### PR DESCRIPTION
 We append -fno-lifetime-dse in HandleLLVMOptions.cmake due to GCC bug
But it is causing link failure with llvm::StdThreadPool::asyncEnqueue

Remove it from libCAS.