### PR TITLE
[SYCL][UR][L0v2] Mark interop-get-native-mem.cpp unsupported

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
@@ -7,6 +7,10 @@
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 
+// L0v2 adapter does not support integrated buffers yet
+// UNSUPPORTED: level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20280
+
 // Test get_native_mem for the Level Zero backend.
 
 // Level-Zero


### PR DESCRIPTION
The reasoning is explained in the issue tracker: https://github.com/intel/llvm/issues/20280.