### PR TITLE
[CI][UR] Bump MacOS version used in workflows

### DIFF
--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -24,7 +24,7 @@ permissions: read-all
 jobs:
   build:
     name: Build
-    runs-on: macos-13
+    runs-on: macos-latest
     env:
       CCACHE_DIR: $GITHUB_WORKSPACE/build_cache_${{ inputs.build_cache_suffix }}
       CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}

--- a/.github/workflows/ur-precommit.yml
+++ b/.github/workflows/ur-precommit.yml
@@ -112,7 +112,7 @@ jobs:
     if: ${{ always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur') }}
     strategy:
       matrix:
-        os: ['macos-13']
+        os: ['macos-latest']
     runs-on: ${{matrix.os}}
 
     steps:


### PR DESCRIPTION
MacOS 13 will soon be deprecated on GHA

// https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/