### PR TITLE
[SYCL][E2E] Move free_function_kernels.cpp to UNSUPPORTED

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/free_function_kernels.cpp
+++ b/sycl/test-e2e/KernelAndProgram/free_function_kernels.cpp
@@ -1,9 +1,7 @@
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// XFAIL: run-mode && (gpu-intel-gen12 || gpu-intel-pvc-1T || arch-intel_gpu_bmg_g21 )
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20244
-// UNSUPPORTED: run-mode && gpu-intel-dg2
+// UNSUPPORTED: run-mode && (gpu-intel-gen12 || gpu-intel-dg2 || gpu-intel-pvc-1T || arch-intel_gpu_bmg_g21 )
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20244
 // This test tests free function kernel code generation and execution.
 


### PR DESCRIPTION
It's causing all the hangs/fails on BMG in the nightly, I manually narrowed it down to this test.