### PR TITLE
[SYCL][E2E] Disable copy_subregion_2G on Windows BMG

### DIFF
--- a/sycl/test-e2e/bindless_images/copies/copy_subregion_2D.cpp
+++ b/sycl/test-e2e/bindless_images/copies/copy_subregion_2D.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images
-// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21
+// UNSUPPORTED: arch-intel_gpu_bmg_g21
 // UNSUPPORTED-INTENDED: sporadic failure in CI
 //                       https://github.com/intel/llvm/issues/20006
 // XFAIL: linux && arch-intel_gpu_acm_g10 && level_zero_v2_adapter


### PR DESCRIPTION
Also failing sporadically on Win, see issue report [here](https://github.com/intel/llvm/issues/20006#issuecomment-3351072372) and [here](https://github.com/intel/llvm/issues/20302).