### PR TITLE
[SYCL] "No last event mode" support for handler-less kernel submission

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -660,13 +660,8 @@ queue_impl::submit_direct(bool CallerNeedsEvent,
 
   // Synchronize with the "no last event mode", used by the handler-based
   // kernel submit path
-  if (isInOrder()) {
-    if (SchedulerBypass) {
-      MNoLastEventMode.store(true, std::memory_order_relaxed);
-    } else {
-      MNoLastEventMode.store(false, std::memory_order_relaxed);
-    }
-  }
+  MNoLastEventMode.store(isInOrder() && SchedulerBypass,
+                         std::memory_order_relaxed);
 
   EventImplPtr EventImpl = SubmitCommandFunc(CGData, SchedulerBypass);
 


### PR DESCRIPTION
The handler-based kernel submission uses a "no last event mode" atomic variable to mark, if the last event is recorded for the in order queue. The handler-less submission needs to update that variable, in order to support mixed APIs usage (handler-based and handler-less APIs, which might require synchronization).