### PR TITLE
[SYCL] Code location fix for handler-less kernel submission

### DIFF
--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -3286,7 +3286,7 @@ public:
                             const KernelType &>::value)) {
       return detail::submit_kernel_direct<KernelName, true>(
           *this, ext::oneapi::experimental::empty_properties_t{}, Range,
-          Rest...);
+          Rest..., TlsCodeLocCapture.query());
     } else
 #endif
     {


### PR DESCRIPTION
Capture the code location from the kernel compile-time info, for consistency with the handler-based submission, for parallel_for queue shortcuts.