### PR TITLE
[SYCL][E2E] Enable image_write.cpp in preview mode, disable normally

### DIFF
--- a/sycl/test-e2e/Basic/image/image_write.cpp
+++ b/sycl/test-e2e/Basic/image/image_write.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// XFAIL: linux && arch-intel_gpu_bmg_g21 && preview-mode
+// XFAIL: linux && arch-intel_gpu_bmg_g21
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20224
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
Now it's passing on preview, failing in normal. See nightly run [here](https://github.com/intel/llvm/actions/runs/18347777870/job/52263179514).