### PR TITLE
[UR][Offload] Let UR_OFFLOAD_INCLUDE_DIR work with upstream LLVM

### DIFF
--- a/unified-runtime/source/adapters/offload/CMakeLists.txt
+++ b/unified-runtime/source/adapters/offload/CMakeLists.txt
@@ -143,5 +143,6 @@ target_link_libraries(${TARGET_NAME} PRIVATE
 
 target_include_directories(${TARGET_NAME} PRIVATE
     "${UR_OFFLOAD_INCLUDE_DIR}/offload"
+    "${UR_OFFLOAD_INCLUDE_DIR}/"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../"
 )


### PR DESCRIPTION
Working on liboffload is annoying when you need to run `make install` after every small change to test it. This change lets you point the include dir to your LLVM source tree, so you don’t need to install it each time.