### PR TITLE
[SYCL][E2E] Don't link with L0 if not needed

### DIFF
--- a/sycl/test-e2e/Regression/reduction_resource_leak_dw.cpp
+++ b/sycl/test-e2e/Regression/reduction_resource_leak_dw.cpp
@@ -1,6 +1,6 @@
-// REQUIRES: level_zero, level_zero_dev_kit
+// REQUIRES: level_zero
 //
-// RUN: %{build} %level_zero_options -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s
 //
 // CHECK-NOT: LEAK

--- a/sycl/test-e2e/Regression/reduction_resource_leak_usm.cpp
+++ b/sycl/test-e2e/Regression/reduction_resource_leak_usm.cpp
@@ -1,8 +1,8 @@
-// REQUIRES: level_zero, level_zero_dev_kit
+// REQUIRES: level_zero
 // TODO: UR_L0_LEAKS_DEBUG=1 produces no output on Windows. Enable when fixed.
 // UNSUPPORTED: windows
 //
-// RUN: %{build} %level_zero_options -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:*" %{l0_leak_check}  %{run} %t.out 2>&1 | FileCheck %s
 //
 // CHECK-NOT: LEAK


### PR DESCRIPTION
One of those tests constantly hangs and there is a chance that it happens because it directly links to the `l0_loader`. Considering that those tests don't use any L0 API, there is no need for them to be linked with L0.