### PR TITLE
Revert "[E2E] Enable end-to-end tests supported by the SPIR-V backend"

### DIFF
--- a/sycl/test-e2e/Basic/device_event.cpp
+++ b/sycl/test-e2e/Basic/device_event.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.run
 // RUN: %{run} %t.run
 
+// UNSUPPORTED: spirv-backend
+// UNSUPPORTED-TRACKER: CMPLRLLVM-64705
+
 //==--------device_event.cpp - SYCL class device_event test ----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/image/image.cpp
+++ b/sycl/test-e2e/Basic/image/image.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: spirv-backend && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160589
-
 //==------------------- image.cpp - SYCL image basic test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/image/image_array.cpp
+++ b/sycl/test-e2e/Basic/image/image_array.cpp
@@ -3,9 +3,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: spirv-backend && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160589
-
 //==------------------- image.cpp - SYCL image basic test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/image/lit.local.cfg
+++ b/sycl/test-e2e/Basic/image/lit.local.cfg
@@ -5,7 +5,7 @@
 #
 # Legacy images aren't supported on AMD and also don't compile, so mark them
 # unsupported here. Bindless images should be used instead.
-config.unsupported_features += ['target-amd']
+config.unsupported_features += ['spirv-backend', 'target-amd']
 
 # Legacy images aren't supported on Native CPU. Bindless images should be used
 # instead when they are working.

--- a/sycl/test-e2e/NonUniformGroups/chunk_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/chunk_algorithms.cpp
@@ -11,6 +11,10 @@
 // UNSUPPORTED: target-amd
 // UNSUPPORTED-INTENDED: fixed_size_group aspect not available on amd
 
+// UNSUPPORTED: spirv-backend
+// UNSUPPORTED-TRACKER: CMPLRLLVM-64702
+// The test is disabled for spirv-backend while we investigate the root cause.
+
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
 

--- a/sycl/test-e2e/NonUniformGroups/fragment_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fragment_algorithms.cpp
@@ -13,6 +13,10 @@
 // UNSUPPORTED: cuda
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/12995
 
+// UNSUPPORTED: spirv-backend
+// UNSUPPORTED-TRACKER: CMPLRLLVM-64702
+// The test is disabled for spirv-backend while we investigate the root cause.
+
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/fragment.hpp>
 #include <sycl/group_algorithm.hpp>

--- a/sycl/test-e2e/Reduction/reduction_span.cpp
+++ b/sycl/test-e2e/Reduction/reduction_span.cpp
@@ -3,6 +3,10 @@
 
 // This test performs basic checks of reductions initialized with a sycl::span
 
+// Depends on SPIR-V Backend & run-time drivers version.
+// XFAIL: spirv-backend && cpu
+// XFAIL-TRACKER: CMPLRLLVM-64705
+
 #include <sycl/detail/core.hpp>
 
 #include <sycl/reduction.hpp>

--- a/sycl/test-e2e/Reduction/reduction_span_pack.cpp
+++ b/sycl/test-e2e/Reduction/reduction_span_pack.cpp
@@ -4,6 +4,10 @@
 // This test performs basic checks of reductions initialized with a pack
 // containing at least one sycl::span
 
+// Depends on SPIR-V Backend & run-time drivers version.
+// XFAIL: spirv-backend && cpu
+// XFAIL-TRACKER: CMPLRLLVM-64705
+
 #include <sycl/detail/core.hpp>
 
 #include <sycl/reduction.hpp>

--- a/sycl/test-e2e/Regression/group_load_fortified.cpp
+++ b/sycl/test-e2e/Regression/group_load_fortified.cpp
@@ -2,6 +2,10 @@
 // RUN: %{build} -D_FORTIFY_SOURCE=2 -o %t.out
 // RUN: %{run} %t.out
 
+// Depends on SPIR-V Backend & run-time drivers version.
+// XFAIL: spirv-backend && cpu
+// XFAIL-TRACKER: CMPLRLLVM-64705
+
 // Checks that group_load runs even when the source code is fortified. This
 // failed at one point due to the use of std::memcpy in the implementation,
 // which would hold an assert in device code when fortified, which would fail

--- a/sycl/test-e2e/Sampler/lit.local.cfg
+++ b/sycl/test-e2e/Sampler/lit.local.cfg
@@ -8,7 +8,7 @@
 #
 # Legacy images aren't supported on AMD and also don't compile, so mark them
 # unsupported here. Bindless images should be used instead.
-config.unsupported_features += ['target-amd']
+config.unsupported_features += ['spirv-backend', 'target-amd']
 
 # Legacy images aren't supported on Native CPU. Use bindless_images when working.
 # https://github.com/intel/llvm/issues/20142

--- a/sycl/test-e2e/ThreadSanitizer/aot/gpu.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/aot/gpu.cpp
@@ -13,6 +13,3 @@
 
 // RUN: %{run-aux} %{build} %device_tsan_aot_flags -O3 -g %S/Inputs/usm_data_race.cpp -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %S/Inputs/usm_data_race.cpp
-
-// XFAIL: spirv-backend && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160602

--- a/sycl/test-e2e/ThreadSanitizer/check_buffer.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_buffer.cpp
@@ -5,9 +5,6 @@
 // RUN: %{build} %device_tsan_flags -O2 -g -o %t2.out
 // RUN: %{run} %t2.out 2>&1 | FileCheck %s
 
-// XFAIL: spirv-backend && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160602
-
 #include <sycl/detail/core.hpp>
 
 static const int N = 128;

--- a/sycl/test-e2e/ThreadSanitizer/check_device_global.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_device_global.cpp
@@ -4,10 +4,6 @@
 // RUN: %{run} %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_tsan_flags -O2 -g -o %t2.out
 // RUN: %{run} %t2.out 2>&1 | FileCheck %s
-
-// XFAIL: spirv-backend && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160602
-
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/device_global/device_global.hpp>
 

--- a/sycl/test-e2e/ThreadSanitizer/check_device_usm.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_device_usm.cpp
@@ -2,10 +2,6 @@
 // ALLOW_RETRIES: 10
 // RUN: %{build} %device_tsan_flags -O0 -g -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
-
-// XFAIL: spirv-backend && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160602
-
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 

--- a/sycl/test-e2e/ThreadSanitizer/check_host_usm.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_host_usm.cpp
@@ -2,10 +2,6 @@
 // ALLOW_RETRIES: 10
 // RUN: %{build} %device_tsan_flags -O0 -g -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
-
-// XFAIL: spirv-backend && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160602
-
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 

--- a/sycl/test-e2e/ThreadSanitizer/check_shared_usm.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_shared_usm.cpp
@@ -2,10 +2,6 @@
 // ALLOW_RETRIES: 10
 // RUN: %{build} %device_tsan_flags -O0 -g -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
-
-// XFAIL: spirv-backend && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160602
-
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 

--- a/sycl/test-e2e/ThreadSanitizer/check_sub_buffer.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_sub_buffer.cpp
@@ -5,9 +5,6 @@
 // RUN: %{build} %device_tsan_flags -O2 -g -o %t2.out
 // RUN: %{run} %t2.out 2>&1 | FileCheck %s
 
-// XFAIL: spirv-backend && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160602
-
 #include <sycl/detail/core.hpp>
 
 int main() {

--- a/sycl/test-e2e/ThreadSanitizer/group_local_memory.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/group_local_memory.cpp
@@ -2,10 +2,6 @@
 // ALLOW_RETRIES: 10
 // RUN: %{build} %device_tsan_flags -O0 -g -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
-
-// XFAIL: spirv-backend && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160602
-
 #include "sycl/ext/oneapi/group_local_memory.hpp"
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"

--- a/sycl/test-e2e/ThreadSanitizer/lit.local.cfg
+++ b/sycl/test-e2e/ThreadSanitizer/lit.local.cfg
@@ -11,6 +11,9 @@ config.unsupported_features  += ['target-nvidia', 'target-amd']
 # TRACKER: https://github.com/intel/llvm/issues/16184
 config.unsupported_features += ['gpu-intel-gen12', 'gpu-intel-dg2']
 
+# CMPLRLLVM-64052
+config.unsupported_features += ['spirv-backend']
+
 # https://github.com/intel/llvm/issues/16920
 config.unsupported_features += ['arch-intel_gpu_bmg_g21']
 

--- a/sycl/test-e2e/ThreadSanitizer/local_accessor.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/local_accessor.cpp
@@ -2,10 +2,6 @@
 // ALLOW_RETRIES: 10
 // RUN: %{build} %device_tsan_flags -O0 -g -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
-
-// XFAIL: spirv-backend && arch-intel_gpu_pvc
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160602
-
 #include "sycl/detail/core.hpp"
 #include "sycl/usm.hpp"
 

--- a/sycl/test-e2e/USM/copy.cpp
+++ b/sycl/test-e2e/USM/copy.cpp
@@ -9,6 +9,9 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t1.out
 // RUN: %{run} %t1.out
 
+// UNSUPPORTED: spirv-backend && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: CMPLRLLVM-64705
+
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
@@ -13,9 +13,6 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/10157
 
-// XFAIL: spirv-backend && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160892
-
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::Host>(); }

--- a/sycl/test-e2e/USM/memops2d/lit.local.cfg
+++ b/sycl/test-e2e/USM/memops2d/lit.local.cfg
@@ -1,0 +1,5 @@
+# This feature refers to an unsupported capability in the SPIR-V Backend,
+# pending triaging and identifying required features/extensions.
+# Temporarily disabled until the failure is addressed:
+# https://github.com/llvm/llvm-project/issues/127791
+config.unsupported_features += ['spirv-backend']

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
@@ -13,9 +13,6 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/10157
 
-// XFAIL: spirv-backend && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160892
-
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::Host>(); }

--- a/sycl/test-e2e/bindless_images/array/read_write_unsampled_array.cpp
+++ b/sycl/test-e2e/bindless_images/array/read_write_unsampled_array.cpp
@@ -4,9 +4,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out
 
-// XFAIL: spirv-backend && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160893
-
 #include "../helpers/common.hpp"
 #include <iostream>
 #include <random>

--- a/sycl/test-e2e/bindless_images/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/lit.local.cfg
@@ -1,3 +1,7 @@
+# Support of this feature is waiting for the upstream PR
+# https://github.com/llvm/llvm-project/pull/127737 to be merged with intel/llvm.
+config.unsupported_features += ['spirv-backend']
+
 # https://github.com/intel/llvm/issues/20142
 config.unsupported_features += ['target-native_cpu']
 

--- a/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
@@ -6,9 +6,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out
 
-// XFAIL: spirv-backend && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/160893
-
 #include "helpers/common.hpp"
 #include <iostream>
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Reverts intel/llvm#20104

Post commit failed with

```
Failed Tests (6):
SYCL :: Basic/image/image.cpp
SYCL :: Basic/image/image_array.cpp
SYCL :: Basic/image/srgba-read.cpp
SYCL :: Regression/group_load_fortified.cpp
SYCL :: bindless_images/array/read_write_unsampled_array.cpp
SYCL :: bindless_images/read_write_unsampled.cpp
```