### PR TITLE
[SYCL][E2E] Disable tests that might be causing PVC hangs

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/arbitrary_access.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/arbitrary_access.cpp
@@ -4,6 +4,9 @@
 // RUN: %{build} %device_asan_flags -Xarch_device -mllvm=-asan-spir-shadow-bounds=1 -O2 -g -o %t3.out
 // RUN: %{run} not %t3.out 2>&1 | FileCheck %s
 
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20361
+
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/Assert/lit.local.cfg
+++ b/sycl/test-e2e/Assert/lit.local.cfg
@@ -1,3 +1,4 @@
 # https://github.com/intel/llvm/issues/17203
-config.unsupported_features += ['arch-intel_gpu_bmg_g21']
+# https://github.com/intel/llvm/issues/20361
+config.unsupported_features += ['arch-intel_gpu_bmg_g21','arch-intel_gpu_pvc']
 

--- a/sycl/test-e2e/SubGroup/reduce_spirv13.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_spirv13.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20361
+
 // This test verifies the correct work of SPIR-V 1.3 reduce algorithm
 // used with the operation MUL, bitwise OR, XOR, AND.
 

--- a/sycl/test-e2e/SubGroup/reduce_spirv13_fp16.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_spirv13_fp16.cpp
@@ -1,6 +1,9 @@
 // REQUIRES: aspect-fp16
 // REQUIRES: gpu
 
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20361
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/SubGroup/reduce_spirv13_fp64.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_spirv13_fp64.cpp
@@ -3,6 +3,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20361
+
 // This test verifies the correct work of SPIR-V 1.3 reduce algorithm
 // used with MUL operation.
 


### PR DESCRIPTION
These tests are mentioned in i915 kernel driver errors on multiple PVC machines, so just guessing they are related to the issue.