### PR TITLE
[SYCL] Fix memory leak for sub-devices

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -167,6 +167,12 @@ std::vector<device> device_impl::create_sub_devices(
                       MPlatform.getOrMakeDeviceImpl(a_ur_device));
                   res.push_back(sycl_device);
                 });
+  // urDevicePartition returns devices with their reference counts
+  // incremented. Each device_impl wrapper increments the reference count and
+  // decrements it on destruction (shared ownership). So, we have to decrement
+  // the reference count once here to release temporary handles.
+  for (ur_device_handle_t &SubDevice : SubDevices)
+    Adapter.call<UrApiKind::urDeviceRelease>(SubDevice);
   return res;
 }
 


### PR DESCRIPTION
Current `device_impl` implementation assumes shared ownership and manages the handle via `urRetain`/`urRelease` in constructor/destructor. Whenever we get temporary device handles via `urDeviceGet`/`urDevicePartition` (which implicitly return device handle with `refcount == 1`) and wrap those handles in `device_impl`, we have to release temporary handles at
 the end of scope to avoid memory leak.

It's done here for devices: https://github.com/intel/llvm/blob/6b29cf120c267118dc8ad737e54e8b844bfb4e06/sycl/source/detail/platform_impl.cpp#L560-L563

Same needs to be done when we create sub-devices. But currently we were missing release calls for temporary handles after creating `device_impl` objects wrapping those handles. This PR fixes that issue by releasing temporary handles at the end of the scope.