### PR TITLE
[SYCL] Use %t.dir for DeviceImageDependencies tests

### DIFF
--- a/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/dynamic.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/dynamic.cpp
@@ -9,13 +9,13 @@
 // RUN: %clangxx --offload-new-driver %{dynamic_lib_options} %S/Inputs/b.cpp %if windows %{%t.dir/libdevice_c.lib%} -o %t.dir/libdevice_b.%{dynamic_lib_suffix}
 // RUN: %clangxx --offload-new-driver %{dynamic_lib_options} %S/Inputs/a.cpp %if windows %{%t.dir/libdevice_b.lib%} -o %t.dir/libdevice_a.%{dynamic_lib_suffix}
 
-// RUN: %{build} --offload-new-driver -fsycl-allow-device-image-dependencies -I %S/Inputs -o %t.out            \
+// RUN: %{build} --offload-new-driver -fsycl-allow-device-image-dependencies -I %S/Inputs -o %t.dir/%{t:stem}.out            \
 // RUN: %if windows                                                                       \
 // RUN:   %{%t.dir/libdevice_a.lib%}                                                          \
 // RUN: %else                                                                             \
 // RUN:   %{-L%t.dir -ldevice_a -ldevice_b -ldevice_c -ldevice_d -Wl,-rpath=%t.dir%}
 
-// RUN: %{run} %t.out
+// RUN: %{run} %t.dir/%{t:stem}.out
 
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142

--- a/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/singleDynamicLibrary.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/NewOffloadDriver/singleDynamicLibrary.cpp
@@ -10,13 +10,13 @@
 // RUN:    %S/Inputs/wrapper.cpp                                                        \
 // RUN:    -o %if windows %{%t.dir/device_single.dll%} %else %{%t.dir/libdevice_single.so%}
 
-// RUN: %{build} --offload-new-driver -I%S/Inputs -o %t.out           \
+// RUN: %{build} --offload-new-driver -I%S/Inputs -o %t.dir/%{t:stem}.out           \
 // RUN: %if windows                              \
 // RUN:   %{%t.dir/device_single.lib%}               \
 // RUN: %else                                    \
 // RUN:   %{-L%t.dir -ldevice_single -Wl,-rpath=%t.dir%}
 
-// RUN: %{run} %t.out
+// RUN: %{run} %t.dir/%{t:stem}.out
 
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142

--- a/sycl/test-e2e/DeviceImageDependencies/dynamic.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/dynamic.cpp
@@ -9,13 +9,13 @@
 // RUN: %clangxx %{dynamic_lib_options} %S/Inputs/b.cpp %if windows %{%t.dir/libdevice_c.lib%} -o %t.dir/libdevice_b.%{dynamic_lib_suffix}
 // RUN: %clangxx %{dynamic_lib_options} %S/Inputs/a.cpp %if windows %{%t.dir/libdevice_b.lib%} -o %t.dir/libdevice_a.%{dynamic_lib_suffix}
 
-// RUN: %clangxx -fsycl %{sycl_target_opts} -fsycl-allow-device-image-dependencies -fsycl-device-code-split=per_kernel %S/Inputs/basic.cpp -o %t.out            \
+// RUN: %clangxx -fsycl %{sycl_target_opts} -fsycl-allow-device-image-dependencies -fsycl-device-code-split=per_kernel %S/Inputs/basic.cpp -o %t.dir/%{t:stem}.out            \
 // RUN: %if windows                                                                       \
 // RUN:   %{%t.dir/libdevice_a.lib%}                                                          \
 // RUN: %else                                                                             \
 // RUN:   %{-L%t.dir -ldevice_a -ldevice_b -ldevice_c -ldevice_d -Wl,-rpath=%t.dir%}
 
-// RUN: %{run} %t.out
+// RUN: %{run} %t.dir/%{t:stem}.out
 
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142

--- a/sycl/test-e2e/DeviceImageDependencies/singleDynamicLibrary.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/singleDynamicLibrary.cpp
@@ -10,13 +10,13 @@
 // RUN:    %S/Inputs/wrapper.cpp                                                        \
 // RUN:    -o %if windows %{%t.dir/device_single.dll%} %else %{%t.dir/libdevice_single.so%}
 
-// RUN: %{build} -I%S/Inputs -o %t.out           \
+// RUN: %{build} -I%S/Inputs -o %t.dir/%{t:stem}.out           \
 // RUN: %if windows                              \
 // RUN:   %{%t.dir/device_single.lib%}               \
 // RUN: %else                                    \
 // RUN:   %{-L%t.dir -ldevice_single -Wl,-rpath=%t.dir%}
 
-// RUN: %{run} %t.out
+// RUN: %{run} %t.dir/%{t:stem}.out
 
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142


### PR DESCRIPTION
Last pulldown pulled the deprecation of `%T` for llvm-lit, and DeviceImageDependencies tests were using it. It was reported that `%t.dir` wasn't working for these tests in the pulldown PR (https://github.com/intel/llvm/pull/20343#discussion_r2426535174), and a workaround was made to make them pass provisionally. This patch moves to `%t.dir` as it's the standard way after `%T` removal.