### PR TITLE
[SYCL][NativeCPU][E2E] Change barrier_with_work to UNSUPPORTED

### DIFF
--- a/sycl/test-e2e/Regression/barrier_with_work.cpp
+++ b/sycl/test-e2e/Regression/barrier_with_work.cpp
@@ -3,8 +3,8 @@
 // RUN: %{build} -DUSE_QUEUE_WIDE_BARRIER -o %t.queue_wide.out
 // RUN: %if gpu %{ env SYCL_PI_LEVEL_ZERO_USE_MULTIPLE_COMMANDLIST_BARRIERS=1 %} %{run} %t.queue_wide.out
 //
-// XFAIL: target-native_cpu
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
+// UNSUPPORTED: target-native_cpu
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20142
 //
 // Tests that barriers block all following execution on queues with active work.
 // For L0 we currently need to set


### PR DESCRIPTION
As observed in https://github.com/intel/llvm/pull/20369, the Regression/barrier_with_work.cpp E2E test may pass sporadically. As such it should be made UNSUPPORTED instead of XFAIL.