### PR TITLE
[SYCL][Docs] Remove exception from asynchronous throw

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_wait.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_wait.asciidoc
@@ -171,9 +171,6 @@ produced by any queue (or its associated context) on this device.
 If so, they are passed to the appropriate async_handler as described in section
 4.13.1.3 "Priorities of async handlers" of the core SYCL specification.
 
-_Throws:_ A synchronous `exception` with the `errc::feature_not_supported`
-error code if the device does not have `aspect::ext_oneapi_device_wait`.
-
 '''
 
 


### PR DESCRIPTION
This commit removes the requirement that devices need to have `aspect::ext_oneapi_device_wait` when calling the
`device::ext_oneapi_throw_asynchronous()` function.