### PR TITLE
[SYCL][E2E] Disable/enable tests failing/passing on new Win BMG driver

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/queue_profiling.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/queue_profiling.cpp
@@ -1,6 +1,9 @@
 // REQUIRES: gpu, level_zero
 // UNSUPPORTED: ze_debug
 
+// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20385
+
 // RUN: %{build} -o %t.out
 // RUN: env UR_L0_DEBUG=-1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --check-prefixes=WITHOUT %s
 // RUN: env UR_L0_DEBUG=-1 %{l0_leak_check} %{run} %t.out profile 2>&1 | FileCheck --check-prefixes=WITH %s

--- a/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: aspect-fp64
-// XFAIL: windows && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/17165
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
 

--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
@@ -5,6 +5,9 @@
 // UNSUPPORTED-INTENDED: Unknown issue with integrated GPU failing
 //                       when importing memory
 
+// XFAIL: windows && arch-intel_gpu_bmg_g21
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20384
+
 // RUN: %{build} %link-directx -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out
 

--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
@@ -5,6 +5,9 @@
 // UNSUPPORTED-INTENDED: Unknown issue with integrated GPU failing
 //                       when importing memory
 
+// XFAIL: windows && arch-intel_gpu_bmg_g21
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20384
+
 // RUN: %{build} %link-directx -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out
 


### PR DESCRIPTION
Passing run from runner with new driver [here](https://github.com/intel/llvm/actions/runs/18575908902/job/52961009868?pr=14114).

I didn't update the runner used in live CI yet so there will be faulures because of this PR.

 Will update live runner before I merge this.