### PR TITLE
[CI] Update `release_tests_binaries` Dockerfile to hardcode base image tag

### DIFF
--- a/devops/containers/release_tests_binaries.Dockerfile
+++ b/devops/containers/release_tests_binaries.Dockerfile
@@ -1,3 +1,5 @@
+# Freeze base image to avoid using newer GPU RT/IGC when updating 
+# the image due to changes in the release branch.
 ARG base_tag=1dcf3fd93f3c13b21e9931372fe405493f7e5a7bd5ba1fca192dece74f9b9188
 ARG base_image=ghcr.io/intel/llvm/ubuntu2404_intel_drivers
 


### PR DESCRIPTION
Before this PR: https://github.com/intel/llvm/actions/runs/18595720667/job/53022842454?pr=20391
After this PR: https://github.com/intel/llvm/actions/runs/18595720667/job/53040472511?pr=20391

This PR fixes the following test failures:
```
Failed Tests (2):
  SYCL :: Matrix/SG32/joint_matrix_bfloat16.cpp
********************
Unexpectedly Passed Tests (2):
  SYCL :: Matrix/joint_matrix_bfloat16_accumulator.cpp
  SYCL :: Matrix/joint_matrix_half_accumulator.cpp
```

Hardcoding image tag helps stabilizing igc driver and prevents E2E tests from failing on sycl-rel 6.3 compat testing, when sycl-rel docker image is re-build
