### PR TITLE
[CMake] Improve libdevice install logic

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -898,3 +898,13 @@ foreach(ftype IN LISTS filetypes)
     COMPONENT libsycldevice)
 endforeach()
 
+set(libsycldevice_build_targets)
+foreach(filetype IN LISTS filetypes)
+  list(APPEND libsycldevice_build_targets libsycldevice-${filetype})
+endforeach()
+
+add_custom_target(install-libsycldevice
+  COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_COMPONENT=libsycldevice -P ${CMAKE_BINARY_DIR}/cmake_install.cmake
+  DEPENDS ${libsycldevice_build_targets}
+)
+add_dependencies(deploy-sycl-toolchain install-libsycldevice)


### PR DESCRIPTION
See: https://github.com/intel/llvm/issues/6937
This patch ensures that all required objects are built before installation.