### PR TITLE
[E2E][sycl-rel 6.3] Make lit search tools in `bin/` directory

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -839,6 +839,14 @@ tools = [
     ),
     ToolSubst("sycl-ls", command=sycl_ls, unresolved="ignore"),
     ToolSubst("syclbin-dump", command=syclbin_dump, unresolved="ignore"),
+    ToolSubst("llvm-link", unresolved="fatal"),
+    ToolSubst("syclbin-dump", unresolved="fatal"),
+    ToolSubst("llvm-ar", unresolved="fatal"),
+    ToolSubst("clang-offload-bundler", unresolved="fatal"),
+    ToolSubst("clang-offload-wrapper", unresolved="fatal"),
+    ToolSubst("sycl-post-link", unresolved="fatal"),
+    ToolSubst("file-table-tform", unresolved="fatal"),
+    ToolSubst("llvm-foreach", unresolved="fatal"),
 ] + feature_tools
 
 # Try and find each of these tools in the DPC++ bin directory, in the llvm tools directory


### PR DESCRIPTION
Fixes E2E test failure in `SeperateCompile/test.cpp` in sycl-rel 6.3 ABI testing(https://github.com/intel/llvm/actions/runs/18599730732/job/53035028308#step:27:2964)
The test failure is because of lit using system-installed `sycl-post-link` instead of the newly built one. This PR forces lit to find and use tools from `<compiler build>/bin` directory.
These changes are already in `sycl` branch (brought in by https://github.com/intel/llvm/pull/19669)