### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-60ef894

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-e31e178",
-      "version": "e31e178",
-      "updated_at": "2025-10-15T23:43:09Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/4282933233/zip",
+      "github_tag": "igc-dev-60ef894",
+      "version": "60ef894",
+      "updated_at": "2025-10-18T21:45:14Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/4308548246/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift