### PR TITLE
[libspirv] delete mix with vector type `x` and scalar type `a`

### DIFF
--- a/libclc/libspirv/lib/generic/common/mix.inc
+++ b/libclc/libspirv/lib/generic/common/mix.inc
@@ -11,11 +11,3 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __spirv_ocl_mix(__CLC_GENTYPE x,
                                                      __CLC_GENTYPE a) {
   return __clc_mad(y - x, a, x);
 }
-
-#ifndef __CLC_SCALAR
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __spirv_ocl_mix(__CLC_GENTYPE x,
-                                                     __CLC_GENTYPE y,
-                                                     __CLC_SCALAR_GENTYPE a) {
-  return __spirv_ocl_mix(x, y, (__CLC_GENTYPE)a);
-}
-#endif


### PR DESCRIPTION
SPIR-V OpenCL.ExtendedInstructionSet.100 requires all of the operands must be the same type for mix.