### PR TITLE
[SYCL RTC] Add one forgotten `consumeError`

### DIFF
--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -434,19 +434,20 @@ class SYCLToolchain {
           return (void)UseCachedPreamble(PCHStorage);
         };
 
-        auto CacheOrErr =
+        llvm::Expected<llvm::FileCache> CacheOrErr =
             llvm::localCache("SYCL RTC Persistent Preambles", "syclrtc-tmp-",
                              PersistentPCHDir, CacheCallback);
 
         assert(CacheOrErr && "Don't see any code path returning Error");
-        auto AddStreamOrErr = (*CacheOrErr)(0, EncodedHash, "");
+        llvm::Expected<llvm::AddStreamFn> AddStreamOrErr =
+            (*CacheOrErr)(0, EncodedHash, "");
         if (!AddStreamOrErr) {
           // Not a hit, but we won't be able to store the data in the cache, so
           // no need to generate precompiled preamble.
           consumeError(AddStreamOrErr.takeError());
           return RunWithoutPCH();
         }
-        auto &AddStream = *AddStreamOrErr;
+        llvm::AddStreamFn &AddStream = *AddStreamOrErr;
         if (!AddStream) {
           // UseCachedPreamble was called by the cache after successfully
           // reading persistent auto-pch file.
@@ -467,9 +468,12 @@ class SYCLToolchain {
         // Any errors updating the persistent preambles cache won't affect
         // current compilation, so ignore any error below:
 
-        auto FileOrErr = AddStream(1, "");
-        if (!FileOrErr)
+        llvm::Expected<std::unique_ptr<llvm::CachedFileStream>> FileOrErr =
+            AddStream(1, "");
+        if (!FileOrErr) {
+          consumeError(FileOrErr.takeError());
           return Success;
+        }
 
         llvm::CachedFileStream *CFS = FileOrErr->get();
         raw_pwrite_stream &OS = *CFS->OS;


### PR DESCRIPTION
Follow-up for https://github.com/intel/llvm/pull/20374.

And as part of the change, spell out more `auto` types to make it clearer when such calls are necessary.