### PR TITLE
[SYCL][E2E] Fix enum parameter free function kernel test failure

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/enum_parameter.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/enum_parameter.cpp
@@ -42,30 +42,27 @@ int main() {
 
   bool flag1, flag2, flag3;
   flag1 = (flag2 = (flag3 = false));
+  rAccType acc1;
+  wAccType acc2;
+  rwAccType acc3;
   {
     sycl::buffer<bool, 1> flagBuffer1(&flag1, 1);
     sycl::buffer<bool, 1> flagBuffer2(&flag2, 1);
     sycl::buffer<bool, 1> flagBuffer3(&flag3, 1);
     Queue.submit([&](sycl::handler &Handler) {
       flagType flagAcc1{flagBuffer1, Handler};
-      rAccType acc1;
-      Handler.require(acc1);
       Handler.set_args(acc1, rMode, flagAcc1);
       Handler.single_task(Kernel1);
     });
 
     Queue.submit([&](sycl::handler &Handler) {
       flagType flagAcc2{flagBuffer2, Handler};
-      wAccType acc2;
-      Handler.require(acc2);
       Handler.set_args(acc2, wMode, flagAcc2);
       Handler.single_task(Kernel2);
     });
 
     Queue.submit([&](sycl::handler &Handler) {
       flagType flagAcc3{flagBuffer3, Handler};
-      rwAccType acc3;
-      Handler.require(acc3);
       Handler.set_args(acc3, rwMode, flagAcc3);
       Handler.single_task(Kernel3);
     });


### PR DESCRIPTION
Fix of #20225. 

I think that the issue here is that the default accessor is being passed by reference rather than by value to the  `set_arg` function which causes the handler object to sporadically have a corrupted copy of the accessor during its `finalize` function where some final checks are done. I suspect that with other types of accessors that are constructed using the command group handler, we can declare the accessor at any scope we want because some internal deep copy of the accessor is stored within the handler whereas with default constructed accessors we need a scope that will not die before the handler. This would explain the sporadic nature of the bug. 

An easy fix is to move the accessor outside the scope of the command group. Since this is a host-side issue, I played around with Valgrind and indeed, before the fix, I was seeing several reports of memory access inside a deallocated region that I traced back to the default constructed accessors and after the fix, nothing, so fingers crossed.

Closes #20225 