### PR TITLE
[SYCL RTC][NFC] Initialize StrLen variable

### DIFF
--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -117,7 +117,7 @@ struct auto_pch_key {
   Error read(llvm::BinaryStreamReader &Reader) {
     (void)AutoPCHError::ID;
     auto ReadStr = [&](std::string &Out) -> Error {
-      std::string::size_type StrLen;
+      std::string::size_type StrLen = 0;
 
       if (auto Err = Reader.readInteger(StrLen))
         return Err;


### PR DESCRIPTION
This commit adds an initialization to the StrLen variable in the auto_pch_key read function. This should avoid a warnings - turning error in RHEL - about potentially uninitialized variables, despite it being set by readInteger.