### PR TITLE
[UR][L0] Bump L0 loader header tag to 1.25.0

### DIFF
--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -13,7 +13,7 @@ find_package(PkgConfig QUIET)
 # so try using that to find the install and if it's not available
 # just try to search for the path.
 if(PkgConfig_FOUND)
-  pkg_check_modules(level-zero level-zero>=1.24.3)
+  pkg_check_modules(level-zero level-zero>=1.25.0)
   if(level-zero_FOUND)
     set(LEVEL_ZERO_INCLUDE_DIR "${level-zero_INCLUDEDIR}/level_zero")
     set(LEVEL_ZERO_LIBRARY_SRC "${level-zero_LIBDIR}")
@@ -50,7 +50,7 @@ if(NOT LEVEL_ZERO_LIB_NAME AND NOT LEVEL_ZERO_LIBRARY)
   set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
   # Remember to update the pkg_check_modules minimum version above when updating the
   # clone tag
-  set(UR_LEVEL_ZERO_LOADER_TAG v1.24.3)
+  set(UR_LEVEL_ZERO_LOADER_TAG v1.25.0)
 
   # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
   set(CMAKE_INCLUDE_CURRENT_DIR OFF)


### PR DESCRIPTION
This commit changes the Level Zero loader header github tag to use from 1.24.3 to 1.25.0.