### PR TITLE
[SYCL][E2E] Re-enable AtomicRef/atomic_memory_order_seq_cst.cpp e2e test

### DIFF
--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
@@ -1,7 +1,5 @@
 // RUN: %{build} -O3 -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
 // RUN: %{run} %t.out
-// UNSUPPORTED: arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/16924
 
 #include "atomic_memory_order.h"
 #include <cmath>


### PR DESCRIPTION
This PR removes `UNSUPPORTED` markings from `AtomicRef/atomic_memory_order_seq_cst.cpp` test because test passes locally.
Tested it on `Intel(R) oneAPI Unified Runtime over Level-Zero V2, Intel(R) Arc(TM) B580 Graphics 20.1.0 [1.6.35096+9] `