### PR TITLE
[CI] Add zizmor workflow

### DIFF
--- a/.github/workflows/sycl-zizmor.yml
+++ b/.github/workflows/sycl-zizmor.yml
@@ -3,9 +3,16 @@ name: Zizmor
 on:
   workflow_dispatch:
   push:
+    # Although workflow files (.yml) should only be placed in the
+    # .github/workflows directory, composite actions may be placed anywhere.
+    # Here in intel/llvm composite actions are placed in the devops/actions
+    # directory. In llvm/llvm-project composite actions are placed right in the
+    # .github/workflows directory. Therefore limiting the scanning to only these
+    # directories. BUT we may consider scanning the entire repository to enhance
+    # security.
     paths:
-      - '.github/workflows/**
-      - 'devops/actions/**'
+      - '.github/workflows/**/*.yml'
+      - 'devops/actions/**/*.yml'
 
 permissions: {}
 
@@ -21,8 +28,8 @@ jobs:
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
-            .github/workflows/
-            devops/actions/
+            .github/workflows/**/*.yml
+            devops/actions/**/*.yml
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0


### PR DESCRIPTION
Zizmor is a static analysis tool for GitHub Actions. See https://github.com/zizmorcore/zizmor

This is necessary to improve the security of the repository and releases. Analysis results can be found in the Security tab.