### PR TITLE
[NFC][LLVM] Remove duplication for zstd cmake config

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -209,18 +209,6 @@ if(LLVM_ENABLE_ZSTD)
   endif()
 endif()
 
-# If LLVM_USE_STATIC_ZSTD is specified, make sure we enable zstd only if static
-# libraries are found.
-if(LLVM_USE_STATIC_ZSTD AND NOT TARGET zstd::libzstd_static)
-  # Fail if LLVM_ENABLE_ZSTD is FORCE_ON.
-  if(LLVM_ENABLE_ZSTD STREQUAL FORCE_ON)
-      message(FATAL_ERROR "Failed to find static zstd libraries, but LLVM_USE_STATIC_ZSTD=ON and LLVM_ENABLE_ZSTD=FORCE_ON.")
-  endif()
-set(LLVM_ENABLE_ZSTD OFF)
-else()
-set(LLVM_ENABLE_ZSTD ${zstd_FOUND})
-endif()
-
 if(LLVM_ENABLE_LIBXML2)
   if(LLVM_ENABLE_LIBXML2 STREQUAL FORCE_ON)
     find_package(LibXml2 REQUIRED)


### PR DESCRIPTION
I suspect the duplication happened because I first made the change to intel/llvm and then upstream, which brought the change back again to intel/llvm