### PR TITLE
[SYCL][E2E] dynamic_compress.cpp fix

### DIFF
--- a/sycl/test-e2e/DeviceImageDependencies/dynamic_compress.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/dynamic_compress.cpp
@@ -35,4 +35,4 @@
 // RUN:   %else                                                                           \
 // RUN:     %{-L%t.dir -ldevicecompress_a -ldevicecompress_b -ldevicecompress_c -ldevicecompress_d -Wl,-rpath=%t.dir%}
 
-// RUN: %if windows %{env PATH=%t.dir;%PATH% %{run} %t.out%} %else %{ %{run} %t.out %}
+// RUN: %if windows %{ cmd /c "set PATH=%t.dir;%PATH% && %{run} %t.out" %} %else %{ %{run} %t.out %}


### PR DESCRIPTION
This test started failing after https://github.com/llvm/llvm-project/commit/7ff6973f1

We used to just build the libs in the same directory as the app, but now they are in a subdirectory. Picking up ALL the lib files like we do on Linux should work.  