### PR TITLE
[SYCL] Fix potential use-after-move

### DIFF
--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -977,11 +977,10 @@ public:
     if (!SelectedImage)
       return nullptr;
 
-    auto UrProgram = get_ur_program();
+    auto UrProgram = SelectedImage->get_ur_program();
     auto [Kernel, CacheMutex, ArgMask] =
         detail::ProgramManager::getInstance().getOrCreateKernel(
-            MContext, KernelID.get_name(), /*PropList=*/{},
-            UrProgram);
+            MContext, KernelID.get_name(), /*PropList=*/{}, UrProgram);
 
     return std::make_shared<kernel_impl>(
         std::move(Kernel), *detail::getSyclObjImpl(MContext),


### PR DESCRIPTION
This fixes a potential use-after-move problem in the kernel_bundle implementation.

Fixes https://github.com/intel/llvm/issues/20452