### PR TITLE
[SYCL][NFC] Drop confusing `std::move`

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -927,9 +927,8 @@ Command *Scheduler::GraphBuilder::addCG(
   std::vector<Requirement *> &Reqs = CommandGroup->getRequirements();
   std::vector<detail::EventImplPtr> &Events = CommandGroup->getEvents();
 
-  auto NewCmd = std::make_unique<ExecCGCommand>(std::move(CommandGroup), Queue,
-                                                EventNeeded, CommandBuffer,
-                                                std::move(Dependencies));
+  auto NewCmd = std::make_unique<ExecCGCommand>(
+      std::move(CommandGroup), Queue, EventNeeded, CommandBuffer, Dependencies);
 
   if (!NewCmd)
     throw exception(make_error_code(errc::memory_allocation),


### PR DESCRIPTION
Input argument for this `std::move` is `const &`, meaning that the result is `const &&`. `std::vector` does not have a move constructor from `const &&` and therefore it fallbacks to regular copy constructor taking `const &`.

Dropped that `std::move` to better describe what actually happens there. As a side effect, this change should help Coverity to stop stubmling upon this and complaining that some object is used after it was moved (see CID `535422`).