### PR TITLE
[SYCL] Update test-e2e/Clock/clock.cpp

### DIFF
--- a/sycl/test-e2e/Clock/clock.cpp
+++ b/sycl/test-e2e/Clock/clock.cpp
@@ -21,11 +21,11 @@ template <syclex::clock_scope scope> void test(sycl::queue &q) {
      if (idx == 0) {
        data[0] = syclex::clock<scope>();
        int sum = 0;
-       for (int i = 0; i < 1e6; ++i)
+       for (int i = 0; i < 1'000'000; ++i)
          sum += i;
        data[1] = syclex::clock<scope>();
        sum = 0;
-       for (int i = 0; i < 1e6; ++i)
+       for (int i = 0; i < 1'000'000; ++i)
          sum += i;
        data[2] = syclex::clock<scope>();
      }


### PR DESCRIPTION
1e6 requires the fp64 aspect. Switch to int.