### PR TITLE
[SYCL] Make include_deps tests more robust

### DIFF
--- a/sycl/test/include_deps/deps_known.sh
+++ b/sycl/test/include_deps/deps_known.sh
@@ -14,6 +14,7 @@ function deps() {
     clang++ -fsycl -fsycl-device-only -include "$HEADER" -c -x c++ /dev/null -o /dev/null  -MD -MF - \
         | sed 's@: /dev/null@: /dev/null\n@' \
         | grep 'include/sycl\|/dev/null\|CL/\|ur_\|:' \
+        | grep -v 'stl_wrappers' \
         | sed 's@.*/include/sycl/@@' \
         | sed 's@.*/include/CL/@CL/@' \
         | sed 's@.*/include/ur_@ur_@' \

--- a/sycl/test/include_deps/sycl_accessor.hpp.cpp
+++ b/sycl/test/include_deps/sycl_accessor.hpp.cpp
@@ -9,12 +9,9 @@
 // CHECK-NEXT: detail/defines_elementary.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_buffer.hpp.cpp
+++ b/sycl/test/include_deps/sycl_buffer.hpp.cpp
@@ -8,12 +8,9 @@
 // CHECK-NEXT: access/access.hpp
 // CHECK-NEXT: detail/defines_elementary.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_detail_core.hpp.cpp
+++ b/sycl/test/include_deps/sycl_detail_core.hpp.cpp
@@ -10,12 +10,9 @@
 // CHECK-NEXT: detail/defines_elementary.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_accessor.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_accessor.hpp.cpp
@@ -12,12 +12,9 @@
 // CHECK-NEXT: access/access.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_atomic.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_atomic.hpp.cpp
@@ -29,7 +29,6 @@
 // CHECK-NEXT: multi_ptr.hpp
 // CHECK-NEXT: detail/address_space_cast.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/memcpy.hpp
 // CHECK-NEXT: atomic_ref.hpp
 // CHECK-NEXT: aspects.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_buffer.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_buffer.hpp.cpp
@@ -11,12 +11,9 @@
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: access/access.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_context.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_context.hpp.cpp
@@ -10,7 +10,6 @@
 // CHECK-NEXT: feature_test.hpp
 // CHECK-NEXT: context.hpp
 // CHECK-NEXT: async_handler.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: backend_types.hpp
 // CHECK-NEXT: detail/export.hpp
 // CHECK-NEXT: detail/info_desc_helpers.hpp
@@ -56,8 +55,6 @@
 // CHECK-NEXT: info/sycl_backend_traits.def
 // CHECK-NEXT: detail/owner_less_base.hpp
 // CHECK-NEXT: detail/impl_utils.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: ext/oneapi/weak_object_base.hpp
 // CHECK-NEXT: property_list.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_device.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_device.hpp.cpp
@@ -14,7 +14,6 @@
 // CHECK-NEXT: info/aspects_deprecated.def
 // CHECK-NEXT: device.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/export.hpp
 // CHECK-NEXT: detail/info_desc_helpers.hpp
 // CHECK-NEXT: id.hpp
@@ -55,8 +54,6 @@
 // CHECK-NEXT: info/sycl_backend_traits.def
 // CHECK-NEXT: detail/owner_less_base.hpp
 // CHECK-NEXT: detail/impl_utils.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: ext/oneapi/weak_object_base.hpp
 // CHECK-NEXT: detail/string.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_event.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_event.hpp.cpp
@@ -10,7 +10,6 @@
 // CHECK-NEXT: feature_test.hpp
 // CHECK-NEXT: event.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/export.hpp
 // CHECK-NEXT: detail/info_desc_helpers.hpp
 // CHECK-NEXT: aspects.hpp
@@ -55,8 +54,6 @@
 // CHECK-NEXT: info/sycl_backend_traits.def
 // CHECK-NEXT: detail/owner_less_base.hpp
 // CHECK-NEXT: detail/impl_utils.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: ext/oneapi/weak_object_base.hpp
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_khr_includes_exception.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_exception.hpp.cpp
@@ -11,7 +11,6 @@
 // CHECK-NEXT: exception.hpp
 // CHECK-NEXT: detail/export.hpp
 // CHECK-NEXT: detail/string.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: exception_list.hpp
 // CHECK-NEXT: detail/iostream_proxy.hpp
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_khr_includes_functional.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_functional.hpp.cpp
@@ -9,5 +9,4 @@
 // CHECK-NEXT: detail/defines_elementary.hpp
 // CHECK-NEXT: feature_test.hpp
 // CHECK-NEXT: functional.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_khr_includes_group_algorithms.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_group_algorithms.hpp.cpp
@@ -25,12 +25,9 @@
 // CHECK-NEXT: detail/fwd/multi_ptr.hpp
 // CHECK-NEXT: exception.hpp
 // CHECK-NEXT: detail/string.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: functional.hpp
 // CHECK-NEXT: group.hpp
 // CHECK-NEXT: detail/common.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: detail/generic_type_traits.hpp
 // CHECK-NEXT: aliases.hpp
 // CHECK-NEXT: bit_cast.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_groups.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_groups.hpp.cpp
@@ -14,8 +14,6 @@
 // CHECK-NEXT: access/access.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/multi_ptr.hpp
 // CHECK-NEXT: detail/generic_type_traits.hpp
@@ -36,7 +34,6 @@
 // CHECK-NEXT: group_algorithm.hpp
 // CHECK-NEXT: exception.hpp
 // CHECK-NEXT: detail/string.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: functional.hpp
 // CHECK-NEXT: half_type.hpp
 // CHECK-NEXT: aspects.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_handler.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_handler.hpp.cpp
@@ -13,12 +13,9 @@
 // CHECK-NEXT: accessor.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_hierarchical_parallelism.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_hierarchical_parallelism.hpp.cpp
@@ -14,8 +14,6 @@
 // CHECK-NEXT: access/access.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/multi_ptr.hpp
 // CHECK-NEXT: detail/generic_type_traits.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_images.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_images.hpp.cpp
@@ -13,12 +13,9 @@
 // CHECK-NEXT: access/access.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_index_space.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_index_space.hpp.cpp
@@ -31,8 +31,6 @@
 // CHECK-NEXT: device_event.hpp
 // CHECK-NEXT: group.hpp
 // CHECK-NEXT: detail/common.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: pointers.hpp
 // CHECK-NEXT: nd_range.hpp
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_khr_includes_interop_handle.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_interop_handle.hpp.cpp
@@ -13,12 +13,9 @@
 // CHECK-NEXT: accessor.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_kernel_bundle.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_kernel_bundle.hpp.cpp
@@ -10,7 +10,6 @@
 // CHECK-NEXT: feature_test.hpp
 // CHECK-NEXT: kernel.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/export.hpp
 // CHECK-NEXT: detail/info_desc_helpers.hpp
 // CHECK-NEXT: aspects.hpp
@@ -55,8 +54,6 @@
 // CHECK-NEXT: info/sycl_backend_traits.def
 // CHECK-NEXT: detail/owner_less_base.hpp
 // CHECK-NEXT: detail/impl_utils.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: ext/oneapi/weak_object_base.hpp
 // CHECK-NEXT: detail/util.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_kernel_handler.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_kernel_handler.hpp.cpp
@@ -13,5 +13,4 @@
 // CHECK-NEXT: exception.hpp
 // CHECK-NEXT: detail/export.hpp
 // CHECK-NEXT: detail/string.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_khr_includes_marray.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_marray.hpp.cpp
@@ -12,8 +12,6 @@
 // CHECK-NEXT: aliases.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/half.hpp
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_khr_includes_math.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_math.hpp.cpp
@@ -34,10 +34,7 @@
 // CHECK-NEXT: vector.hpp
 // CHECK-NEXT: detail/named_swizzles_mixin.hpp
 // CHECK-NEXT: detail/vector_arith.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/common.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: marray.hpp
 // CHECK-NEXT: multi_ptr.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_multi_ptr.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_multi_ptr.hpp.cpp
@@ -18,5 +18,4 @@
 // CHECK-NEXT: detail/fwd/multi_ptr.hpp
 // CHECK-NEXT: detail/type_traits.hpp
 // CHECK-NEXT: detail/type_traits/vec_marray_traits.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_khr_includes_platform.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_platform.hpp.cpp
@@ -10,7 +10,6 @@
 // CHECK-NEXT: feature_test.hpp
 // CHECK-NEXT: platform.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/export.hpp
 // CHECK-NEXT: detail/info_desc_helpers.hpp
 // CHECK-NEXT: aspects.hpp
@@ -55,8 +54,6 @@
 // CHECK-NEXT: info/sycl_backend_traits.def
 // CHECK-NEXT: detail/owner_less_base.hpp
 // CHECK-NEXT: detail/impl_utils.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: ext/oneapi/weak_object_base.hpp
 // CHECK-NEXT: detail/string.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_property_list.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_property_list.hpp.cpp
@@ -14,6 +14,5 @@
 // CHECK-NEXT: exception.hpp
 // CHECK-NEXT: detail/export.hpp
 // CHECK-NEXT: detail/string.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: properties/property_traits.hpp
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_khr_includes_queue.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_queue.hpp.cpp
@@ -17,12 +17,9 @@
 // CHECK-NEXT: accessor.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_reduction.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_reduction.hpp.cpp
@@ -16,12 +16,9 @@
 // CHECK-NEXT: accessor.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_span.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_span.hpp.cpp
@@ -9,8 +9,5 @@
 // CHECK-NEXT: detail/defines_elementary.hpp
 // CHECK-NEXT: feature_test.hpp
 // CHECK-NEXT: sycl_span.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_khr_includes_stream.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_stream.hpp.cpp
@@ -13,12 +13,9 @@
 // CHECK-NEXT: accessor.hpp
 // CHECK-NEXT: buffer.hpp
 // CHECK-NEXT: backend_types.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_usm.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_usm.hpp.cpp
@@ -35,10 +35,7 @@
 // CHECK-NEXT: vector.hpp
 // CHECK-NEXT: detail/named_swizzles_mixin.hpp
 // CHECK-NEXT: detail/vector_arith.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/common.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: marray.hpp
 // CHECK-NEXT: multi_ptr.hpp

--- a/sycl/test/include_deps/sycl_khr_includes_vec.hpp.cpp
+++ b/sycl/test/include_deps/sycl_khr_includes_vec.hpp.cpp
@@ -19,11 +19,8 @@
 // CHECK-NEXT: detail/type_traits.hpp
 // CHECK-NEXT: detail/type_traits/vec_marray_traits.hpp
 // CHECK-NEXT: detail/fwd/multi_ptr.hpp
-// CHECK-NEXT: stl_wrappers/cstdlib
 // CHECK-NEXT: detail/common.hpp
 // CHECK-NEXT: detail/export.hpp
-// CHECK-NEXT: stl_wrappers/cassert
-// CHECK-NEXT: stl_wrappers/assert.h
 // CHECK-NEXT: __spirv/spirv_vars.hpp
 // CHECK-NEXT: detail/fwd/accessor.hpp
 // CHECK-NEXT: detail/defines.hpp


### PR DESCRIPTION
Dropped checking for includes under `stl_wrappers`. Standard C++ headers may include other standard headers. Whether or not they do that, what headers are included and in which order is unspecified, making tests depend on specific standard C++ headers available on a machine and thus non-portable.