### PR TITLE
[Pulldown] Restore missing `libc` files

### DIFF
--- a/libc/include/endian.h.def
+++ b/libc/include/endian.h.def
@@ -1,0 +1,17 @@
+//===-- POSIX header endian.h ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_ENDIAN_H
+#define LLVM_LIBC_ENDIAN_H
+
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/endian-macros.h"
+
+%%public_api()
+
+#endif // LLVM_LIBC_ENDIAN_H

--- a/libc/include/llvm-libc-macros/poll-macros.h
+++ b/libc/include/llvm-libc-macros/poll-macros.h
@@ -1,0 +1,16 @@
+//===-- Macros defined in poll.h header file ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_POLL_MACROS_H
+#define LLVM_LIBC_MACROS_POLL_MACROS_H
+
+#ifdef __linux__
+#include "linux/poll-macros.h"
+#endif
+
+#endif // LLVM_LIBC_MACROS_POLL_MACROS_H

--- a/libc/include/poll.h.def
+++ b/libc/include/poll.h.def
@@ -1,0 +1,17 @@
+//===-- C standard library header poll.h ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_POLL_H
+#define LLVM_LIBC_POLL_H
+
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/poll-macros.h"
+
+%%public_api()
+
+#endif // LLVM_LIBC_POLL_H

--- a/libc/test/src/stdfix/countlsk_test.cpp
+++ b/libc/test/src/stdfix/countlsk_test.cpp
@@ -1,0 +1,13 @@
+//===-- Unittests for countlsk --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CountlsTest.h"
+
+#include "src/stdfix/countlsk.h"
+
+LIST_COUNTLS_TESTS(accum, LIBC_NAMESPACE::countlsk);

--- a/libc/test/src/stdfix/countlslk_test.cpp
+++ b/libc/test/src/stdfix/countlslk_test.cpp
@@ -1,0 +1,13 @@
+//===-- Unittests for countlslk -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CountlsTest.h"
+
+#include "src/stdfix/countlslk.h"
+
+LIST_COUNTLS_TESTS(long accum, LIBC_NAMESPACE::countlslk);

--- a/libc/test/src/stdfix/countlsr_test.cpp
+++ b/libc/test/src/stdfix/countlsr_test.cpp
@@ -1,0 +1,13 @@
+//===-- Unittests for countlsr --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CountlsTest.h"
+
+#include "src/stdfix/countlsr.h"
+
+LIST_COUNTLS_TESTS(fract, LIBC_NAMESPACE::countlsr);


### PR DESCRIPTION
Not sure what went wrong during pulldowns, but somehow we're missing files in a sub-directory where no customizations are expected. Restored via

```shell
$ git checkout $(git merge-base origin/sycl origin/main) -- libc
```