### PR TITLE
[SYCL][NFC] Extend getKernelNamesUsingAssert to support general function names

### DIFF
--- a/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
@@ -111,7 +111,7 @@ static std::vector<StringRef>
 getKernelNamesUsingSpecialFunctions(const Module &M,
                                     const std::vector<StringRef> &FNames) {
   std::vector<Function *> SpecialFunctionVec;
-  for (auto Fn : FNames) {
+  for (const auto Fn : FNames) {
     Function *FPtr = M.getFunction(Fn);
     if (FPtr)
       SpecialFunctionVec.push_back(FPtr);


### PR DESCRIPTION
Currently, we have getKernelNamesUsingAssert to detect all SPIR kernels which use assert functions via BFS. This PR extend it in 2 points:
1.  Support passing a general function name to it for detecting all SPIR kernels using it
2.  Support passing a group of special function names for searching SPIR kernels using them.

We may need to check other special function and can easily call it instead of adding a new getKernelNamesUsingXXX.
