### PR TITLE
[CI][Bench] Install perf in proper version

### DIFF
--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -161,6 +161,13 @@ runs:
       sudo cmake --install build
 
       cd -
+  # Linux tools installed during docker creation may not match the self-hosted
+  # kernel version, so we need to install the correct version here.
+  - name: Install perf in version matching the host kernel
+    shell: bash
+    run: |
+      sudo apt-get update
+      sudo apt-get install -y linux-tools-$(uname -r)
   - name: Set env var for results branch
     shell: bash
     run: |

--- a/devops/scripts/benchmarks/utils/flamegraph.py
+++ b/devops/scripts/benchmarks/utils/flamegraph.py
@@ -67,7 +67,7 @@ class FlameGraph:
         """
         if not shutil.which("perf"):
             raise FileNotFoundError(
-                "perf command not found. Please install linux-tools or perf package."
+                "perf command not found. Please install linux-tools-$(uname -r) or perf package."
             )
 
         sanitized_suite_name = sanitize_filename(suite_name)


### PR DESCRIPTION
To fix issue: `WARNING: perf not found for kernel 6.17.0-6`
ref. https://github.com/intel/llvm/actions/runs/18870710633/job/53848872196#step:19:1241

For self-hosted machines kernel packages installed in docker may be unsuitable - install packages required for `perf` in each workflow run (to match the actual host).