### PR TITLE
Revert "[SYCL] Enable only selected SPIR-V extensions for SPIR-V backend."

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10490,35 +10490,16 @@ static void getSPIRVBackendOpts(const llvm::opt::ArgList &TCArgs,
       TCArgs.MakeArgString("--avoid-spirv-capabilities=Shader"));
   BackendArgs.push_back(
       TCArgs.MakeArgString("--translator-compatibility-mode"));
-
-  // Disable all the extensions by default
-  std::string ExtArg("-spirv-ext=-all");
-  std::string DefaultExtArg =
-      ",+SPV_EXT_shader_atomic_float_add,+SPV_EXT_shader_atomic_float_min_max"
-      ",+SPV_KHR_no_integer_wrap_decoration,+SPV_KHR_float_controls"
-      ",+SPV_KHR_expect_assume,+SPV_KHR_linkonce_odr";
-  std::string INTELExtArg = ",+SPV_INTEL_subgroups,+SPV_INTEL_media_block_io"
-                            ",+SPV_INTEL_function_pointers"
-                            ",+SPV_INTEL_inline_assembly"
-                            ",+SPV_INTEL_arbitrary_precision_integers"
-                            ",+SPV_INTEL_float_controls2"
-                            ",+SPV_INTEL_variable_length_array"
-                            ",+SPV_INTEL_long_composites"
-                            ",+SPV_INTEL_cache_controls"
-                            ",+SPV_KHR_shader_clock"
-                            ",+SPV_INTEL_bindless_images";
-  ExtArg = ExtArg + DefaultExtArg + INTELExtArg;
-  ExtArg += ",+SPV_INTEL_bfloat16_conversion"
-            ",+SPV_INTEL_joint_matrix"
-            ",+SPV_KHR_uniform_group_instructions"
-            ",+SPV_INTEL_tensor_float32_conversion"
-            ",+SPV_INTEL_optnone"
-            ",+SPV_KHR_non_semantic_info"
-            ",+SPV_KHR_cooperative_matrix"
-            ",+SPV_EXT_shader_atomic_float16_add"
-            ",+SPV_INTEL_fp_max_error";
-
-  BackendArgs.push_back(TCArgs.MakeArgString(ExtArg));
+  // TODO: A list of SPIR-V extensions that are supported by the SPIR-V backend
+  // is growing. Let's postpone the decision on which extensions to enable until
+  // - the list is stable, and
+  // - we decide on a mapping of user requested extensions into backend's ones.
+  // Meanwhile we enable all the SPIR-V backend extensions.
+  BackendArgs.push_back(TCArgs.MakeArgString("--spirv-ext=all"));
+  // TODO:
+  // - handle -Xspirv-translator option to avoid "argument unused during
+  // compilation" error
+  // - handle --spirv-ext=+<extension> and --spirv-ext=-<extension> options
 }
 
 // Utility function to gather all llvm-spirv options.

--- a/clang/test/Driver/sycl-spirv-backend.cpp
+++ b/clang/test/Driver/sycl-spirv-backend.cpp
@@ -3,4 +3,4 @@
 ///
 // RUN: %clangxx -fsycl -fsycl-use-spirv-backend-for-spirv-gen -### %s 2>&1 | FileCheck %s
 
-// CHECK: llc{{.*}} "-filetype=obj" "-mtriple=spirv64{{[^-]*}}-unknown-unknown" "--avoid-spirv-capabilities=Shader" "--translator-compatibility-mode" "-spirv-ext=-all,+SPV_EXT_shader_atomic_float_add,+SPV_EXT_shader_atomic_float_min_max,+SPV_KHR_no_integer_wrap_decoration,+SPV_KHR_float_controls,+SPV_KHR_expect_assume,+SPV_KHR_linkonce_odr,+SPV_INTEL_subgroups,+SPV_INTEL_media_block_io,+SPV_INTEL_function_pointers,+SPV_INTEL_inline_assembly,+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_float_controls2,+SPV_INTEL_variable_length_array,+SPV_INTEL_long_composites,+SPV_INTEL_cache_controls,+SPV_KHR_shader_clock,+SPV_INTEL_bindless_images,+SPV_INTEL_bfloat16_conversion,+SPV_INTEL_joint_matrix,+SPV_KHR_uniform_group_instructions,+SPV_INTEL_tensor_float32_conversion,+SPV_INTEL_optnone,+SPV_KHR_non_semantic_info,+SPV_KHR_cooperative_matrix,+SPV_EXT_shader_atomic_float16_add,+SPV_INTEL_fp_max_error"
+// CHECK: llc{{.*}} "-filetype=obj" "-mtriple=spirv64{{[^-]*}}-unknown-unknown" "--avoid-spirv-capabilities=Shader" "--translator-compatibility-mode" "--spirv-ext=


### PR DESCRIPTION
Reverts intel/llvm#20489

Build E2E is broken