### PR TITLE
[CI][Bench] Add names for steps in composite action

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -330,7 +330,8 @@ jobs:
     - run: which clang++ sycl-ls
     - run: sycl-ls --verbose
     - run: SYCL_UR_TRACE=1 sycl-ls
-    - run: |
+    - name: Print IGC version
+      run: |
           if [ -f /usr/local/lib/igc/IGCTAG.txt ]; then
             cat /usr/local/lib/igc/IGCTAG.txt
           fi

--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -38,6 +38,7 @@ inputs:
     required: False
 
 runs:
+  # composite actions don't make use of 'name', so copy-paste names as a comment in the first line of each step
   using: "composite"
   steps:
   - name: Check specified runner type / target backend
@@ -46,6 +47,7 @@ runs:
       TARGET_DEVICE: ${{ inputs.target_devices }}
       PRESET: ${{ inputs.preset }}
     run: |
+      # Check specified runner type / target backend
       case "$RUNNER_TAG" in
         '["PVC_PERF"]' ) ;;
         '["BMG_PERF"]' ) ;;
@@ -114,6 +116,7 @@ runs:
   - name: Build Unified Runtime
     shell: bash
     run: |
+      # Build Unified Runtime
       # Sparse-checkout UR at build ref:
       git clone --depth 1 --no-checkout https://github.com/intel/llvm ur
       cd ur
@@ -140,14 +143,16 @@ runs:
   - name: Checkout results repo
     shell: bash
     run: |
+      # Checkout results repo
       git clone -b unify-ci https://github.com/intel/llvm-ci-perf-results
-  - name: Run compute-benchmarks
+  - name: Build and run benchmarks
     env:
       # Need to append "_<device>_<backend>" to save name in order to follow
       # conventions:
       SAVE_PREFIX: ${{ inputs.save_name }}
     shell: bash
     run: |
+      # Build and run benchmarks
       # TODO generate summary + display helpful message here
       export CMPLR_ROOT=./toolchain
       echo "-----"
@@ -231,7 +236,8 @@ runs:
   - name: Cache changes and upload github summary
     if: always()
     shell: bash
-    run: | 
+    run: |
+      # Cache changes and upload github summary
       [ -f "github_summary.md" ] && cat github_summary.md >> $GITHUB_STEP_SUMMARY
 
       cd "./llvm-ci-perf-results"
@@ -244,6 +250,7 @@ runs:
     if: inputs.upload_results == 'true' && always()
     shell: bash
     run: |
+      # Push benchmarks results
       cd "./llvm-ci-perf-results"
       git config user.name "SYCL Benchmarking Bot"
       git config user.email "sys_sycl_benchmarks@intel.com"


### PR DESCRIPTION
When action is used as composite, its steps don't disaply the actual 'name' defined for each step. Instead a full command to execute is displayed. To work around it we can put name as a comment in the first line of the command.