### PR TITLE
[SYCL][Doc] Fix work_group_scratch_memory example

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_work_group_scratch_memory.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_work_group_scratch_memory.asciidoc
@@ -36,7 +36,7 @@ https://github.com/intel/llvm/issues
 
 == Dependencies
 
-This extension is written against the SYCL 2020 revision 10 specification.  All
+This extension is written against the SYCL 2020 revision 11 specification.  All
 references below to the "core SYCL specification" or to section numbers in the
 SYCL specification refer to that revision.
 
@@ -158,8 +158,8 @@ or other APIs such as `local_accessor`.
 #include <sycl/sycl.hpp>
 namespace syclex = sycl::ext::oneapi::experimental;
 
-constexpr size_t GLOBAL = 1024;
-constexpr size_t N = 256;
+size_t GLOBAL = 1024;
+size_t N = 256;
 
 int main() {
   sycl::queue q;


### PR DESCRIPTION
The example in the specification was using an old API that we removed in #14785.  Update the example and the spec wording to use `launch_config` from sycl_ext_oneapi_enqueue_functions to pass the property with the size of the scratch memory.