### PR TITLE
[SYCL][Doc] Add free function kernel spec example

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
@@ -1006,7 +1006,6 @@ how to pass a kernel launch parameter.
 [source,c++]
 ----
 #include <sycl/sycl.hpp>
-namespace syclext = sycl::ext::oneapi;
 namespace syclexp = sycl::ext::oneapi::experimental;
 
 static constexpr size_t NUM = 1024;


### PR DESCRIPTION
Add an example showing how to use sycl_ext_oneapi_work_group_scratch_memory from a free function kernel.