### PR TITLE
[SYCL] Install gdb printers for preview library

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -363,6 +363,13 @@ if (NOT WIN32)
     RENAME "libsycl.so.${SYCL_VERSION_STRING}-gdb.py"
     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/"
     COMPONENT sycl-headers-extras)
+  if (SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB)
+    install(FILES
+      "${CMAKE_CURRENT_SOURCE_DIR}/gdb/libsycl.so-gdb.py"
+      RENAME "libsycl-preview.so.${SYCL_VERSION_STRING}-gdb.py"
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/"
+      COMPONENT sycl-headers-extras)
+  endif()
 endif()
 
 if(SYCL_ENABLE_XPTI_TRACING AND


### PR DESCRIPTION
When GDB loads a shared library it looks for a python file of the same base name + "-gdb.py" by default. See:
https://sourceware.org/gdb/current/onlinedocs/gdb.html/objfile_002dgdbdotext-file.html

So, we have to install printers not only for regular sycl library, but also for sycl-preview library.