### PR TITLE
[SYCL][NFC] Fix uninitialized field in `SYCLMemObjT`

### DIFF
--- a/sycl/source/detail/sycl_mem_obj_t.hpp
+++ b/sycl/source/detail/sycl_mem_obj_t.hpp
@@ -56,8 +56,8 @@ public:
   SYCLMemObjT(const size_t SizeInBytes, const property_list &Props,
               std::unique_ptr<SYCLMemObjAllocator> Allocator)
       : MAllocator(std::move(Allocator)), MProps(Props), MInteropEvent(nullptr),
-        MInteropContext(nullptr), MInteropMemObject(nullptr),
-        MOpenCLInterop(false), MHostPtrReadOnly(false), MNeedWriteBack(true),
+        MInteropContext(nullptr), MOpenCLInterop(false),
+        MHostPtrReadOnly(false), MNeedWriteBack(true),
         MSizeInBytes(SizeInBytes), MUserPtr(nullptr), MShadowCopy(nullptr),
         MUploadDataFunctor(nullptr), MSharedPtrStorage(nullptr),
         MHostPtrProvided(false) {}
@@ -342,7 +342,7 @@ protected:
   std::shared_ptr<context_impl> MInteropContext;
   // Native backend memory object handle passed by user to interoperability
   // constructor.
-  ur_mem_handle_t MInteropMemObject;
+  ur_mem_handle_t MInteropMemObject = nullptr;
   // Indicates whether memory object is created using interoperability
   // constructor or not.
   bool MOpenCLInterop;


### PR DESCRIPTION
Addresses Coverity CIDs `519597` and `519499`.

Coverity results are available:
https://scan.coverity.com/projects/intel-llvm?tab=overview