### PR TITLE
[CI] Update Level Zero used in docker images

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.24.3",
-      "version": "v1.24.3",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.24.3",
+      "github_tag": "v1.25.2",
+      "version": "v1.25.2",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.25.2",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {

--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -13,7 +13,7 @@ find_package(PkgConfig QUIET)
 # so try using that to find the install and if it's not available
 # just try to search for the path.
 if(PkgConfig_FOUND)
-  pkg_check_modules(level-zero level-zero>=1.25.0)
+  pkg_check_modules(level-zero level-zero>=1.25.2)
   if(level-zero_FOUND)
     set(LEVEL_ZERO_INCLUDE_DIR "${level-zero_INCLUDEDIR}/level_zero")
     set(LEVEL_ZERO_LIBRARY_SRC "${level-zero_LIBDIR}")
@@ -50,7 +50,7 @@ if(NOT LEVEL_ZERO_LIB_NAME AND NOT LEVEL_ZERO_LIBRARY)
   set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
   # Remember to update the pkg_check_modules minimum version above when updating the
   # clone tag
-  set(UR_LEVEL_ZERO_LOADER_TAG v1.25.0)
+  set(UR_LEVEL_ZERO_LOADER_TAG v1.25.2)
 
   # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
   set(CMAKE_INCLUDE_CURRENT_DIR OFF)


### PR DESCRIPTION
This update is made to align with the level zero used in unified-runtime CMake files: https://github.com/intel/llvm/blob/5df5f45b6f0c62cd336f0becae1a39254ccc5e70/unified-runtime/cmake/FetchLevelZero.cmake#L50-L53

Also, latest Compute Benchmarks require Level Zero >=v1.25.0 (https://github.com/intel/llvm/actions/runs/18933687847/job/54055880756?pr=20500#step:19:1948):
```
last_event_latency_l0.cpp:(.text+0x106): undefined reference to `zeDriverGetDefaultContext'
/usr/bin/ld: last_event_latency_l0.cpp:(.text+0xcdb): undefined reference to `zeCommandListAppendLaunchKernelWithArguments'
/usr/bin/ld: last_event_latency_l0.cpp:(.text+0x121b): undefined reference to `zeCommandListAppendLaunchKernelWithArguments'
```