### PR TITLE
[CI][sycl-rel-6_3] Update clang version output

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -173,16 +173,18 @@ jobs:
         cd $GITHUB_WORKSPACE/build
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
-          --ci-defaults --use-zstd ${{ inputs.build_configure_extra_args }} \
+          --ci-defaults --use-zstd \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DLLVM_INSTALL_UTILS=ON \
           -DNATIVECPU_USE_OCK=Off \
-          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
+          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV \
+          ${{ inputs.build_configure_extra_args }}
     - name: Compile
       id: build
       # Emulate default value for manual dispatch as we've run out of available arguments.
       run: cmake --build $GITHUB_WORKSPACE/build --target ${{ inputs.build_target || 'sycl-toolchain' }}
+    - run: $GITHUB_WORKSPACE/build/bin/clang++ --version
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
       run: |

--- a/.github/workflows/sycl-rel-nightly.yml
+++ b/.github/workflows/sycl-rel-nightly.yml
@@ -2,6 +2,9 @@ name: SYCL Release Branch Nightly
 
 on:
   workflow_dispatch:
+    inputs:
+      release_version:
+        type: string
 
 permissions: read-all
 
@@ -12,7 +15,13 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      build_configure_extra_args: '-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib --disable-jit --no-assertions --add_security_flags=sanitize --hip --cuda'
+      build_configure_extra_args: |
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib \
+        --disable-jit --no-assertions --add_security_flags=sanitize --hip --cuda \
+        -DLLVM_VC_REPOSITORY="${{ github.repositoryUrl }}" \
+        -DCLANG_VC_REPOSITORY="${{ github.repositoryUrl }}" \
+        -DLLVM_VC_REVISION="${{ inputs.release_version || format('{0}:{1} Nightly build', github.ref_name, github.sha) }}" \
+        -DCLANG_VC_REVISION="${{ inputs.release_version || format('{0}:{1} Nightly build', github.ref_name, github.sha) }}"
       build_image: ghcr.io/intel/llvm/release_build:latest
       pack_release: 'true'
 
@@ -80,7 +89,13 @@ jobs:
   build-win:
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
-      build_configure_extra_args: '-DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off -DCMAKE_POSITION_INDEPENDENT_CODE=ON --disable-jit --no-assertions --add_security_flags=sanitize'
+      build_configure_extra_args: |
+        -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off -DCMAKE_POSITION_INDEPENDENT_CODE=ON ^
+        --disable-jit --no-assertions --add_security_flags=sanitize ^
+        -DLLVM_VC_REPOSITORY="${{ github.repositoryUrl }}" ^
+        -DCLANG_VC_REPOSITORY="${{ github.repositoryUrl }}" ^
+        -DLLVM_VC_REVISION="${{ inputs.release_version || format('{0}:{1} Nightly build', github.ref_name, github.sha) }}" ^
+        -DCLANG_VC_REVISION="${{ inputs.release_version || format('{0}:{1} Nightly build', github.ref_name, github.sha) }}"
       pack_release: 'true'
 
       # We upload both Linux/Windows build via Github's "Releases"

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -140,19 +140,21 @@ jobs:
         IF NOT EXIST D:\github\_work\cache MKDIR D:\github\_work\cache
         IF NOT EXIST D:\github\_work\cache\${{inputs.build_cache_suffix}} MKDIR D:\github\_work\cache\${{inputs.build_cache_suffix}}
         python.exe src/buildbot/configure.py -o build ^
-          --ci-defaults --use-zstd %ARGS% ^
+          --ci-defaults --use-zstd ^
           "-DCMAKE_C_COMPILER=${{inputs.cxx}}" ^
           "-DCMAKE_CXX_COMPILER=${{inputs.cxx}}" ^
           "-DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install" ^
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
           -DCMAKE_C_COMPILER_LAUNCHER=ccache ^
           -DLLVM_INSTALL_UTILS=ON ^
-          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV
+          -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV ^
+          %ARGS%
     - name: Build
       id: build
       shell: bash
       run: |
         cmake --build build --target ${{ inputs.build_target }}
+    - run: build/bin/clang++ --version
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
       shell: bash


### PR DESCRIPTION
For more details see: https://github.com/intel/llvm/pull/20520

This PR adds "branch:hash Nightly build" to nightly builds on release branches. It also allows to specify a custom version manually in case of official release builds, e.g. "6.3.0 release build".