### PR TITLE
[SYCL] Add extra allocation failure case to physical_mem

### DIFF
--- a/sycl/source/detail/physical_mem_impl.hpp
+++ b/sycl/source/detail/physical_mem_impl.hpp
@@ -48,7 +48,8 @@ public:
         &MPhysicalMem);
 
     if (Err == UR_RESULT_ERROR_OUT_OF_RESOURCES ||
-        Err == UR_RESULT_ERROR_OUT_OF_HOST_MEMORY)
+        Err == UR_RESULT_ERROR_OUT_OF_HOST_MEMORY ||
+        Err == UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY)
       throw sycl::exception(make_error_code(errc::memory_allocation),
                             "Failed to allocate physical memory.");
     Adapter.checkUrResult(Err);


### PR DESCRIPTION
This commit adds the case for UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY to the cases where the physical_mem ctor will throw an errc::memory_allocation exception.