### PR TITLE
[Benchmarks] Re-enable Host tasks for benchmarks

### DIFF
--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -222,7 +222,7 @@ class ComputeBench(Suite):
                     measure_completion_time,
                     use_events,
                     emulate_graphs,
-                    useHostTasks=0,
+                    useHostTasks=1 if runtime == RUNTIMES.SYCL else 0,
                 )
             )
             if runtime == RUNTIMES.SYCL:
@@ -236,7 +236,7 @@ class ComputeBench(Suite):
                         measure_completion_time,
                         use_events,
                         emulate_graphs,
-                        useHostTasks=0,
+                        useHostTasks=1,
                         profiler_type=PROFILERS.CPU_COUNTER,
                     )
                 )


### PR DESCRIPTION
This commit re-enables host tasks for SYCL benchmarks both for time and CPU measurements 