### PR TITLE
[Clang][CI] Extend clang version output

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -209,6 +209,7 @@ jobs:
       id: build
       # Emulate default value for manual dispatch as we've run out of available arguments.
       run: cmake --build $GITHUB_WORKSPACE/build --target ${{ inputs.build_target || 'sycl-toolchain' }}
+    - run: $GITHUB_WORKSPACE/build/bin/clang++ --version
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
       env:

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
     with:
       build_cache_root: "/__w/"
-      build_configure_extra_args: '--hip --cuda'
+      build_configure_extra_args: '--hip --cuda -DSYCL_BUILD_INFO="Nightly"'
       build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
 
       retention-days: 90
@@ -191,7 +191,7 @@ jobs:
       # functionality, make sure Linux/Windows names follow the same pattern.
       toolchain_artifact_filename: sycl_windows.tar.gz
       # Disable the spirv-dis requirement as to not require SPIR-V Tools.
-      build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off
+      build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off -DSYCL_BUILD_INFO="Nightly"
       build_target: all
 
   e2e-win:

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -159,6 +159,7 @@ jobs:
       shell: bash
       run: |
         cmake --build build --target ${{ inputs.build_target }}
+    - run: build/bin/clang++ --version
     - name: check-llvm
       if: always() && !cancelled() && contains(inputs.changes, 'llvm')
       shell: bash

--- a/clang/include/clang/Basic/Version.h
+++ b/clang/include/clang/Basic/Version.h
@@ -66,6 +66,9 @@ namespace clang {
   /// the CL_SYCL_LANGUAGE_VERSION and SYCL_LANGUAGE_VERSION macros.
   llvm::SmallVector<std::pair<llvm::StringRef, llvm::StringRef>, 2>
   getSYCLVersionMacros(const LangOptions &LangOpts);
+
+  /// Retrieves a string representing the Intel SYCL compiler build info.
+  std::string getSYCLBuildInfo();
 }
 
 #endif // LLVM_CLANG_BASIC_VERSION_H

--- a/clang/lib/Basic/CMakeLists.txt
+++ b/clang/lib/Basic/CMakeLists.txt
@@ -44,6 +44,10 @@ add_custom_command(OUTPUT "${version_inc}"
                            "-DLLVM_FORCE_VC_REPOSITORY=${LLVM_FORCE_VC_REPOSITORY}"
                            -P "${generate_vcs_version_script}")
 
+if(SYCL_BUILD_INFO)
+  file(APPEND ${version_inc} "#define SYCL_BUILD_INFO \"${SYCL_BUILD_INFO}\"\n")
+endif()
+
 # Mark the generated header as being generated.
 set_source_files_properties("${version_inc}"
   PROPERTIES GENERATED TRUE

--- a/clang/lib/Basic/Version.cpp
+++ b/clang/lib/Basic/Version.cpp
@@ -65,6 +65,14 @@ std::string getClangVendor() {
 #endif
 }
 
+std::string getSYCLBuildInfo() {
+#ifdef SYCL_BUILD_INFO
+  return SYCL_BUILD_INFO;
+#else
+  return "development";
+#endif
+}
+
 std::string getClangFullRepositoryVersion() {
   std::string buf;
   llvm::raw_string_ostream OS(buf);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2726,6 +2726,7 @@ void Driver::PrintSYCLToolHelp(const Compilation &C) const {
 }
 
 void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
+  OS << "Intel SYCL compiler " << getSYCLBuildInfo() << " build based on:\n";
   if (IsFlangMode()) {
     OS << getClangToolFullVersion("flang") << '\n';
   } else {


### PR DESCRIPTION
Previous attempt: https://github.com/intel/llvm/pull/20520. That one is kind of hacky, therefore proceeding with a more proper solution.

There is a customer request to make a clang version output more informative. This patch adds a string like this to the output: "Intel SYCL compiler X build based on:" - here goes a regular clang output. Where X is:
"development" by default,
"Nightly" for regular nightly builds,
"X.Y.Z Nightly" for nightly release-branch builds,
"X.Y.Z release" for official releases.