### PR TITLE
[UR] Fix warnings in appendKernelLaunchWithArgsExpNew()

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -1167,13 +1167,16 @@ ur_result_t ur_command_list_manager::appendKernelLaunchWithArgsExpNew(
   for (uint32_t argIndex = 0; argIndex < numArgs; argIndex++) {
     switch (pArgs[argIndex].type) {
     case UR_EXP_KERNEL_ARG_TYPE_LOCAL:
-      hKernel->kernelArgs[argIndex] = (void *)&pArgs[argIndex].size;
+      hKernel->kernelArgs[argIndex] =
+          reinterpret_cast<void *>(const_cast<size_t *>(&pArgs[argIndex].size));
       break;
     case UR_EXP_KERNEL_ARG_TYPE_VALUE:
-      hKernel->kernelArgs[argIndex] = (void *)pArgs[argIndex].value.value;
+      hKernel->kernelArgs[argIndex] =
+          const_cast<void *>(pArgs[argIndex].value.value);
       break;
     case UR_EXP_KERNEL_ARG_TYPE_POINTER:
-      hKernel->kernelArgs[argIndex] = (void *)&pArgs[argIndex].value.pointer;
+      hKernel->kernelArgs[argIndex] = reinterpret_cast<void *>(
+          const_cast<void **>(&pArgs[argIndex].value.pointer));
       break;
     case UR_EXP_KERNEL_ARG_TYPE_MEM_OBJ:
       // prepareForSubmission() will save zePtr in kernelMemObj[argIndex]


### PR DESCRIPTION
Fix the following warnings in appendKernelLaunchWithArgsExpNew():
```
warning: cast from type ‘X’ to type ‘void*’ casts away qualifiers [-Wcast-qual]
```
