### PR TITLE
[SYCL][E2E] Enable kernel-bundle-get-kernel-ids.cpp

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/kernel-bundle-get-kernel-ids.cpp
+++ b/sycl/test-e2e/KernelAndProgram/kernel-bundle-get-kernel-ids.cpp
@@ -4,9 +4,6 @@
 // This test checks that get_kernel_ids returns all the kernels defined
 // in the source regardless of whether they are expressed as lambdas,
 // function objects or free functions.
-//
-// UNSUPPORTED: ((intel_gpu_acm{{.*}} || intel_gpu_pvc || intel_gpu_bmg{{.*}} || cuda || hip) && (!level_zero)) || preview-mode
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19423
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/free_function_traits.hpp>


### PR DESCRIPTION
Can't reproduce locally, also passes the pre-commit testing. Likely was fixed.