### PR TITLE
[SYCL][Graph] Graph duplication optimizations in finalize()

### DIFF
--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -1300,8 +1300,8 @@ void exec_graph_impl::duplicateNodes() {
   // Subgraph nodes need special handling, we extract all subgraph nodes and
   // merge them into the main node list
   if (foundSubgraph) {
-      for (auto NewNodeIt = NewNodes.rbegin(); NewNodeIt != NewNodes.rend();
-        ++NewNodeIt) {
+    for (auto NewNodeIt = NewNodes.rbegin(); NewNodeIt != NewNodes.rend();
+         ++NewNodeIt) {
       auto NewNode = *NewNodeIt;
       if (NewNode->MNodeType != node_type::subgraph) {
         continue;
@@ -1316,8 +1316,8 @@ void exec_graph_impl::duplicateNodes() {
       for (node_impl &SubgraphNode : SubgraphNodes) {
         NewSubgraphNodes.push_back(std::make_shared<node_impl>(SubgraphNode));
         node_impl &NodeCopy = *NewSubgraphNodes.back();
-        // Associate the ID of the original subgraph node with all extracted node
-        // copies for future quick access.
+        // Associate the ID of the original subgraph node with all extracted
+        // node copies for future quick access.
         MIDCache.insert(std::make_pair(SubgraphNode.MID, &NodeCopy));
 
         SubgraphNodesMap.insert({&SubgraphNode, &NodeCopy});
@@ -1328,7 +1328,7 @@ void exec_graph_impl::duplicateNodes() {
       // Rebuild edges for new subgraph nodes
       auto OrigIt = SubgraphNodes.begin(), OrigEnd = SubgraphNodes.end();
       for (auto NewIt = NewSubgraphNodes.begin(); OrigIt != OrigEnd;
-          ++OrigIt, ++NewIt) {
+           ++OrigIt, ++NewIt) {
         node_impl &SubgraphNode = *OrigIt;
         node_impl &NodeCopy = **NewIt;
 
@@ -1374,9 +1374,9 @@ void exec_graph_impl::duplicateNodes() {
         auto &Predecessors = SuccNode.MPredecessors;
 
         // Remove the subgraph node from this nodes successors
-        Predecessors.erase(
-            std::remove(Predecessors.begin(), Predecessors.end(), NewNode.get()),
-            Predecessors.end());
+        Predecessors.erase(std::remove(Predecessors.begin(), Predecessors.end(),
+                                       NewNode.get()),
+                           Predecessors.end());
 
         // Add all Output nodes from the subgraph as predecessors for this node
         // instead


### PR DESCRIPTION
When invoking `auto g = graph.finalize()` on a graph with a moderate amount of nodes, duplicating the nodes of the modifiable graph into the executable graph takes a non-trivial amount of time. This PR introduces a few changes to improve the performance of `duplicateNodes()`:

1. Replace the `std::dequeue` with a `std::vector` so that it can be directly moved, omitting unnecessary O(n) allocations
2. Keep track of whether there are any subgraphs in the first pass of the graph and skip the second pass of the graph if there are no subgraphs
3. Add a `reserve()` for the vector of nodes and map that we are going to create, since we know the total number of nodes.

> Note that 1. optimizes the fast path when the graph does not contain a subgraph, but will likely make finalize slower for graphs that contain subgraphs.

The changes for 2. make the diff seem much larger than it actually is, but the majority of it is whitespace from moving the subgraph handling into an if statement.
