### PR TITLE
[UR] Do not create an extra vector in appendKernelLaunchWithArgsExpNew()

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -280,8 +280,7 @@ private:
       ur_kernel_handle_t hKernel, ze_kernel_handle_t hZeKernel,
       uint32_t workDim, const size_t *pGlobalWorkOffset,
       const size_t *pGlobalWorkSize, const size_t *pLocalWorkSize,
-      uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-      ur_event_handle_t phEvent, bool cooperative,
+      wait_list_view &waitListView, ur_event_handle_t phEvent, bool cooperative,
       std::vector<void *> *pKMemObj = nullptr, void *pNext = nullptr);
 
   ur_result_t appendKernelLaunchUnlocked(

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
@@ -94,6 +94,12 @@ public:
   ur_result_t addPendingPointerArgument(uint32_t argIndex,
                                         const void *pArgValue);
 
+  // Compute a zePtr pointer for the given memory handle and store it in *pZePtr
+  ur_result_t computeZePtr(ur_mem_handle_t hMem, ur_device_handle_t hDevice,
+                           ur_mem_buffer_t::device_access_mode_t accessMode,
+                           ze_command_list_handle_t zeCommandList,
+                           wait_list_view &waitListView, void **pZePtr);
+
   // Set all required values for the kernel before submission (including pending
   // memory allocations).
   // The kMemObj argument must be a non-empty vector
@@ -104,8 +110,7 @@ public:
                                    uint32_t workDim, uint32_t groupSizeX,
                                    uint32_t groupSizeY, uint32_t groupSizeZ,
                                    ze_command_list_handle_t cmdList,
-                                   wait_list_view &waitListView,
-                                   std::vector<void *> *kMemObj = nullptr);
+                                   wait_list_view &waitListView);
 
   // Get context of the kernel.
   ur_context_handle_t getContext() const { return hProgram->Context; }


### PR DESCRIPTION
Do not create an extra vector (do not call addPendingMemoryAllocation()) in appendKernelLaunchWithArgsExpNew().
It is an optimization - it removes adding new elements to the `pending_allocations` vector.