### PR TITLE
[CI] Use pinned action references

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -368,7 +368,7 @@ jobs:
       with:
         name: sycl_windows_default
     - name: Sign with sigstore/cosign
-      uses: sigstore/gh-action-sigstore-python@v3.1.0
+      uses: sigstore/gh-action-sigstore-python@f832326173235dcb00dd5d92cd3f353de3188e6c # v3.1.0
       with:
         inputs: sycl_linux.tar.gz sycl_windows.tar.gz
     - name: Compute tag
@@ -381,7 +381,7 @@ jobs:
           echo "TAG=$(date +'%Y-%m-%d')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
         fi
     - name: Upload binaries
-      uses: softprops/action-gh-release@v2.4.1
+      uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
       with:
         files: |
           sycl_linux.tar.gz

--- a/devops/actions/build_container/action.yml
+++ b/devops/actions/build_container/action.yml
@@ -26,15 +26,15 @@ runs:
   using: "composite"
   steps:
   - name: Login to GitHub Container Registry
-    uses: docker/login-action@v2
+    uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
     with:
       registry: ghcr.io
       username: ${{ inputs.username }}
       password: ${{ inputs.password }}
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v3.11.1
+    uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
   - name: Build and Push Container
-    uses: docker/build-push-action@v6.18.0
+    uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
     with:
       push: ${{ inputs.push }}
       tags: ${{ inputs.tags }}


### PR DESCRIPTION
It's unsafe to use unpinned action references. See: https://docs.zizmor.sh/audits/#unpinned-uses (note: official github actions can be used unpinned).