### PR TITLE
[SYCL][E2E] Re-enable free function kernels test

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/enum_parameter.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/enum_parameter.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21 && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20225
-
 // This test verifies that we can use scoped enum types as arguments in free
 // function kernels.
 


### PR DESCRIPTION
The failure of the E2E test `FreeFunctionKernels/enum_parameter.cpp` was patched by #20423 but it has not yet been re-enabled. This PR does just that.