### PR TITLE
[CI] Don't rely on `github.event_name` in `devops/actions/run-tests/e2e/action.yml`

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -135,6 +135,16 @@ on:
         default: 'false'
         required: False
 
+      in_workflow_call_mode:
+        description: |
+          Unlike `github.event_type` that captures the original trigger, we use
+          this to determine how this particular workflow has been called. This
+          isn't supposed to be specified by a caller and only relies on the
+          default value.
+        default: 'true'
+        required: False
+        type: string
+
   workflow_dispatch:
     inputs:
       runner:
@@ -332,7 +342,9 @@ jobs:
       timeout-minutes: 60
       with:
         ref: ${{ inputs.tests_ref || inputs.repo_ref || github.sha }}
-        binaries_artifact: ${{ inputs.binaries_artifact }}
+        binaries_artifact: ${{ inputs.in_workflow_call_mode && inputs.binaries_artifact
+                               || inputs.testing_mode == 'run-only' && 'in-container'
+                               || '' }}
         testing_mode: ${{ inputs.testing_mode }}
         extra_cmake_args: ${{ inputs.extra_cmake_args }}
         target_devices: ${{ inputs.target_devices }}
@@ -349,7 +361,9 @@ jobs:
         ref: ${{ inputs.tests_ref || 'main' }}
         extra_cmake_args: ${{ inputs.extra_cmake_args }}
         testing_mode: ${{ inputs.testing_mode }}
-        binaries_artifact: ${{ inputs.binaries_artifact }}
+        binaries_artifact: ${{ inputs.in_workflow_call_mode && inputs.binaries_artifact
+                               || inputs.testing_mode == 'run-only' && 'in-container'
+                               || '' }}
         target_devices: ${{ inputs.target_devices }}
         retention-days: ${{ inputs.retention-days }}
 

--- a/devops/actions/run-tests/e2e/action.yml
+++ b/devops/actions/run-tests/e2e/action.yml
@@ -4,9 +4,6 @@ inputs:
   ref:
     required: false
   binaries_artifact:
-    # Number of input parameters for manual 'workflow_dispatch' is limited, so
-    # we treat empty value as 'in-container' when in 'run-only' mode via
-    # 'workflow_dispatch'.
     required: false
   testing_mode:
     required: true
@@ -22,14 +19,12 @@ inputs:
   sycl_compiler:
     required: false
 
+
 runs:
   using: "composite"
   steps:
   - name: Checkout E2E tests
-    if: |
-      !(inputs.testing_mode == 'run-only'
-         && (inputs.binaries_artifact == 'in-container'
-             || github.event_name == 'workflow_dispatch'))
+    if: ${{ !(inputs.testing_mode == 'run-only' && inputs.binaries_artifact == 'in-container') }}
     uses: actions/checkout@v4
     with:
       path: llvm
@@ -38,28 +33,19 @@ runs:
         llvm/utils/lit
         sycl/test-e2e
   - name: Download E2E Binaries
-    if: |
-      inputs.testing_mode == 'run-only'
-      && !(inputs.binaries_artifact == 'in-container'
-           || github.event_name == 'workflow_dispatch')
+    if: ${{ inputs.testing_mode == 'run-only' && inputs.binaries_artifact != 'in-container' }}
     uses: actions/download-artifact@v4
     with:
       name: ${{ inputs.binaries_artifact }}
   - name: Extract E2E Binaries
-    if: |
-      inputs.testing_mode == 'run-only'
-      && !(inputs.binaries_artifact == 'in-container'
-           || github.event_name == 'workflow_dispatch')
+    if: ${{ inputs.testing_mode == 'run-only' && inputs.binaries_artifact != 'in-container' }}
     shell: bash
     run: |
       mkdir build-e2e
       tar -I 'zstd' -xf e2e_binaries.tar.zst -C build-e2e
 
   - name: Extract E2E tests from container image
-    if: |
-      inputs.testing_mode == 'run-only'
-      && (inputs.binaries_artifact == 'in-container'
-          || github.event_name == 'workflow_dispatch')
+    if: ${{ inputs.testing_mode == 'run-only' && inputs.binaries_artifact == 'in-container' }}
     shell: bash
     run: |
       mkdir build-e2e llvm


### PR DESCRIPTION

This effectively reverts

"[CI] Use E2E container binaries in `run-only` manual E2E task dispatch (#19744)"

The problem is that `github.event_name` corresponds to the top-level workflow, not how `.github/workflows/sycl-linux-run-tests.yml` was triggered, effectively doing the wrong thing for the manual dispatch of (at least) post-commit workflow.

Instead of that, add a new fake input parameter for the `workflow_call` trigger in `sycl-linux-run-tests.yml` to use as the condition.