### PR TITLE
[CI] Shorter top-job name in `sycl-containers.yaml`

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -28,7 +28,7 @@ permissions: read-all
 jobs:
   build_and_push_images:
     if: github.repository == 'intel/llvm'
-    name: Build and Push Docker Images
+    name: "Containers"
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
Otherwise GH interface hides the meaningful part of the matrix jobs' names.

I tried to experiment with putting " / " in different names to get the grouping similar to what we have in E2E jobs but wasn't able to make GH to perform any.