### PR TITLE
[clang][Driver][SYCL] Disable SYCL header search paths under `-nostd[lib]inc`

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5045,24 +5045,27 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
   if (IsMSVCHostCompiler)
     HostCompileArgs.push_back("/external:W0");
 
-  // Add default header search directories.
-  SmallString<128> BaseDir(C.getDriver().Dir);
-  llvm::sys::path::append(BaseDir, "..", "include");
-  SmallString<128> SYCLDir(BaseDir);
-  llvm::sys::path::append(SYCLDir, "sycl");
-  // This is used to provide our wrappers around STL headers that provide
-  // additional functions/template specializations when the user includes those
-  // STL headers in their programs (e.g., <complex>).
-  SmallString<128> STLWrappersDir(SYCLDir);
-  llvm::sys::path::append(STLWrappersDir, "stl_wrappers");
-  // Add the SYCL specific header directories as system directories for non
-  // MSVC compilers.
-  HostCompileArgs.push_back(IsMSVCHostCompiler ? "/external:I" : "-isystem");
-  HostCompileArgs.push_back(TCArgs.MakeArgString(SYCLDir));
-  HostCompileArgs.push_back(IsMSVCHostCompiler ? "/external:I" : "-isystem");
-  HostCompileArgs.push_back(TCArgs.MakeArgString(STLWrappersDir));
-  HostCompileArgs.push_back(IsMSVCHostCompiler ? "/external:I" : "-isystem");
-  HostCompileArgs.push_back(TCArgs.MakeArgString(BaseDir));
+  namespace options = clang::driver::options;
+  if (!TCArgs.hasArg(options::OPT_nostdlibinc, options::OPT_nostdinc)) {
+    // Add default header search directories.
+    SmallString<128> BaseDir(C.getDriver().Dir);
+    llvm::sys::path::append(BaseDir, "..", "include");
+    SmallString<128> SYCLDir(BaseDir);
+    llvm::sys::path::append(SYCLDir, "sycl");
+    // This is used to provide our wrappers around STL headers that provide
+    // additional functions/template specializations when the user includes
+    // those STL headers in their programs (e.g., <complex>).
+    SmallString<128> STLWrappersDir(SYCLDir);
+    llvm::sys::path::append(STLWrappersDir, "stl_wrappers");
+    // Add the SYCL specific header directories as system directories for non
+    // MSVC compilers.
+    HostCompileArgs.push_back(IsMSVCHostCompiler ? "/external:I" : "-isystem");
+    HostCompileArgs.push_back(TCArgs.MakeArgString(SYCLDir));
+    HostCompileArgs.push_back(IsMSVCHostCompiler ? "/external:I" : "-isystem");
+    HostCompileArgs.push_back(TCArgs.MakeArgString(STLWrappersDir));
+    HostCompileArgs.push_back(IsMSVCHostCompiler ? "/external:I" : "-isystem");
+    HostCompileArgs.push_back(TCArgs.MakeArgString(BaseDir));
+  }
 
   if (!OutputAdded) {
     // Add output file to the command line.  This is assumed to be prefaced

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -123,8 +123,10 @@ void SYCLInstallationDetector::getSYCLDeviceLibPath(
 
 void SYCLInstallationDetector::addSYCLIncludeArgs(
     const ArgList &DriverArgs, ArgStringList &CC1Args) const {
-  if (DriverArgs.hasArg(clang::driver::options::OPT_nobuiltininc))
+  namespace options = clang::driver::options;
+  if (DriverArgs.hasArg(options::OPT_nostdlibinc, options::OPT_nostdinc)) {
     return;
+  }
   // Add the SYCL header search locations in the specified order.
   //   ../include/sycl/stl_wrappers
   //   ../include

--- a/clang/test/Driver/sycl-nostdinc.cpp
+++ b/clang/test/Driver/sycl-nostdinc.cpp
@@ -1,0 +1,9 @@
+// RUN: %clangxx -fsycl -fsycl-device-only -nostdlibinc -fsyntax-only %s
+// RUN: %clangxx -fsycl -fsycl-device-only -nostdinc -fsyntax-only %s
+
+// RUN: %clangxx -fsycl -nostdlibinc -fsyntax-only %s
+// RUN: %clangxx -fsycl -nostdinc -fsyntax-only %s
+
+#if __has_include(<sycl/sycl.hpp>)
+#error "expected to *not* be able to find SYCL headers"
+#endif


### PR DESCRIPTION
That matches the intended behavior of those options.