### PR TITLE
[CI] Remove redundant always()

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -210,7 +210,7 @@ jobs:
       # Emulate default value for manual dispatch as we've run out of available arguments.
       run: cmake --build $GITHUB_WORKSPACE/build --target ${{ inputs.build_target || 'sycl-toolchain' }}
     - name: check-llvm
-      if: always() && !cancelled() && contains(inputs.changes, 'llvm')
+      if: ${{ !cancelled() && contains(inputs.changes, 'llvm') }}
       env:
         # Can't inline to support possible quotes inside:
         BUILD_CONFIGURE_EXTRA_ARGS: ${{ inputs.build_configure_extra_args }}
@@ -222,7 +222,7 @@ jobs:
 
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm
     - name: check-clang
-      if: always() && !cancelled() && contains(inputs.changes, 'clang')
+      if: ${{ !cancelled() && contains(inputs.changes, 'clang') }}
       env:
         # Can't inline to support possible quotes inside:
         BUILD_CONFIGURE_EXTRA_ARGS: ${{ inputs.build_configure_extra_args }}
@@ -235,49 +235,49 @@ jobs:
         fi
         cmake --build $GITHUB_WORKSPACE/build --target check-clang
     - name: check-sycl
-      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       run: |
         # TODO consider moving this to Dockerfile.
         export LD_LIBRARY_PATH=/usr/local/cuda/compat/:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
         cmake --build $GITHUB_WORKSPACE/build --target check-sycl
     - name: check-sycl-unittests
-      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       run: |
         # TODO consider moving this to Dockerfile.
         export LD_LIBRARY_PATH=/usr/local/cuda/compat/:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
         cmake --build $GITHUB_WORKSPACE/build --target check-sycl-unittests
     - name: check-llvm-spirv
-      if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
+      if: ${{ !cancelled() && contains(inputs.changes, 'llvm_spirv') }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm-spirv
     - name: check-xptifw
-      if: always() && !cancelled() && contains(inputs.changes, 'xptifw')
+      if: ${{ !cancelled() && contains(inputs.changes, 'xptifw') }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-xptifw
     - name: check-libclc
-      if: always() && !cancelled() && contains(inputs.changes, 'libclc')
+      if: ${{ !cancelled() && contains(inputs.changes, 'libclc') }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-libclc
     - name: check-libdevice
-      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-libdevice
     - name: Check E2E test requirements
-      if: always() && !cancelled() && !contains(inputs.changes, 'sycl')
+      if: ${{ !cancelled() && !contains(inputs.changes, 'sycl') }}
       run: |
         # TODO consider moving this to Dockerfile.
         export LD_LIBRARY_PATH=/usr/local/cuda/compat/:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
         LIT_OPTS="--allow-empty-runs" LIT_FILTER="e2e_test_requirements" cmake --build $GITHUB_WORKSPACE/build --target check-sycl
     - name: Install sycl-toolchain
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target deploy-sycl-toolchain
 
     - name: Pack toolchain release
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' && inputs.release_toolchain_artifact != '' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' && inputs.release_toolchain_artifact != '' }}
       run: tar -I '${{ steps.artifact_info.outputs.COMPRESS }}' -cf ${{ steps.artifact_info.outputs.ARCHIVE_NAME }} -C $GITHUB_WORKSPACE/toolchain .
     - name: Upload toolchain release
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' && inputs.release_toolchain_artifact != '' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' && inputs.release_toolchain_artifact != '' }}
       uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.release_toolchain_artifact }}
@@ -285,21 +285,21 @@ jobs:
         retention-days: ${{ inputs.retention-days }}
 
     - name: Install utilities
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target install-sycl-test-utilities
 
     - name: Additional Install for "--shared-libs" build
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' && contains(inputs.build_configure_extra_args, '--shared-libs') }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' && contains(inputs.build_configure_extra_args, '--shared-libs') }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target install-clang-libraries
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-libraries
 
     - name: Pack toolchain
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       run: tar -I '${{ steps.artifact_info.outputs.COMPRESS }}' -cf ${{ steps.artifact_info.outputs.ARCHIVE_NAME }} -C $GITHUB_WORKSPACE/toolchain .
     - name: Upload toolchain
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.toolchain_artifact }}
@@ -310,7 +310,7 @@ jobs:
     - name: Source OneAPI TBB vars.sh
       # Tasks that use the just built toolchain below, need extra environment
       # setup. No harm in it if all of those tasks would get skipped.
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       run: |
         # https://github.com/actions/runner/issues/1964 prevents us from using
         # the ENTRYPOINT in the image.
@@ -327,7 +327,7 @@ jobs:
         rm env_before env_after
 
     - name: Build E2E tests
-      if: ${{ inputs.e2e_binaries_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ inputs.e2e_binaries_artifact && !cancelled() && steps.build.conclusion == 'success' }}
       uses: ./devops/actions/run-tests/e2e
       with:
         ref: ${{ inputs.ref || github.sha }}
@@ -338,11 +338,11 @@ jobs:
         extra_lit_opts: --param sycl_build_targets="spir;nvidia;amd"
 
     - name: Remove E2E tests before spirv-backend run
-      if: ${{ inputs.e2e_binaries_spirv_backend_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ inputs.e2e_binaries_spirv_backend_artifact && !cancelled() && steps.build.conclusion == 'success' }}
       run: rm -rf build-e2e
 
     - name: Build E2E tests with SPIR-V Backend
-      if: ${{ inputs.e2e_binaries_spirv_backend_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ inputs.e2e_binaries_spirv_backend_artifact && !cancelled() && steps.build.conclusion == 'success' }}
       uses: ./devops/actions/run-tests/e2e
       with:
         ref: ${{ inputs.ref || github.sha }}
@@ -353,11 +353,11 @@ jobs:
         extra_lit_opts: --param spirv-backend=True
 
     - name: Remove E2E tests before preview-mode run
-      if: ${{ inputs.e2e_binaries_preview_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ inputs.e2e_binaries_preview_artifact && !cancelled() && steps.build.conclusion == 'success' }}
       run: rm -rf build-e2e
 
     - name: Build E2E tests in Preview Mode
-      if: ${{ inputs.e2e_binaries_preview_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ inputs.e2e_binaries_preview_artifact && !cancelled() && steps.build.conclusion == 'success' }}
       uses: ./devops/actions/run-tests/e2e
       with:
         ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -51,7 +51,7 @@ jobs:
   build:
     name: Self build
     needs: [detect_changes]
-    if: always() && success()
+    if: success()
     uses: ./.github/workflows/sycl-linux-build.yml
     with:
       build_ref: ${{ github.sha }}
@@ -70,7 +70,7 @@ jobs:
   # Build and run native cpu e2e tests separately as cannot currently
   # build all the e2e tests
   build_run_native_cpu_e2e_tests:
-    if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}  
+    if: ${{ !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
     runs-on: [Linux, build]
     needs: [build]
     container:
@@ -109,7 +109,7 @@ jobs:
   # The idea is to ensure that the code works with both CUDA versions.
   build_ubuntu2204:
     needs: [detect_changes]
-    if: always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur_cuda_adapter')
+    if: ${{ !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur_cuda_adapter') }}
     uses: ./.github/workflows/sycl-linux-build.yml
     with:
       build_ref: ${{ github.sha }}
@@ -143,7 +143,7 @@ jobs:
 
   E2E:
     needs: [build, detect_changes, compat_read_exclude]
-    if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
     permissions:
       contents: write
       packages: read
@@ -238,7 +238,7 @@ jobs:
       contents: write
       packages: read
     if: |
-      always() && !cancelled()
+      !cancelled()
       && needs.build.outputs.build_conclusion == 'success'
       && (contains(github.event.pull_request.labels.*.name, 'run-perf-tests')
           || contains(needs.detect_changes.outputs.filters, 'perf-tests'))

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -85,7 +85,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -175,7 +175,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: ${{ always() && !cancelled() && needs.ubuntu2404_oneapi_build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.ubuntu2404_oneapi_build.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: Intel PVC L0 oneAPI
@@ -204,8 +204,7 @@ jobs:
     needs: build-win
     # Continue if build was successful.
     if: |
-      always()
-      && !cancelled()
+      !cancelled()
       && needs.build-win.outputs.build_conclusion == 'success'
     strategy:
       fail-fast: false
@@ -228,7 +227,7 @@ jobs:
 
   cuda-aws-start:
     needs: [ubuntu2204_build]
-    if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-aws.yml
     secrets: inherit
     with:
@@ -239,7 +238,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: CUDA E2E
@@ -255,7 +254,7 @@ jobs:
 
   cuda-aws-stop:
     needs: [cuda-aws-start, cuda-run-tests]
-    if: always() && ${{ needs.cuda-aws-start.result != 'skipped' }}
+    if: ${{ needs.cuda-aws-start.result != 'skipped' }}
     uses: ./.github/workflows/sycl-aws.yml
     secrets: inherit
     with:
@@ -266,7 +265,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: Build SYCL-CTS for Linux
@@ -285,7 +284,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -315,7 +314,7 @@ jobs:
 
   build-sycl-cts-win:
     needs: build-win
-    if: ${{ always() && !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-windows-run-tests.yml
     with:
       name: Build SYCL-CTS for Windows
@@ -328,7 +327,7 @@ jobs:
 
   run-sycl-cts-win:
     needs: [build-win, build-sycl-cts-win]
-    if: ${{ always() && !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -47,7 +47,7 @@ jobs:
 
   e2e-lin:
     needs: [detect_changes, build-lin]
-    if: ${{ always() && !cancelled() && needs.build-lin.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.build-lin.outputs.build_conclusion == 'success' }}
     permissions:
       contents: write
       packages: read
@@ -111,9 +111,8 @@ jobs:
 
   build-win:
     if: |
-      always()
-      && success()
-      && github.repository == 'intel/llvm'
+      success() &&
+      github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
       cxx: icx
@@ -124,9 +123,8 @@ jobs:
     needs: build-win
     # Continue if build was successful.
     if: |
-      always()
-      && !cancelled()
-      && needs.build-win.outputs.build_conclusion == 'success'
+      !cancelled() &&
+      needs.build-win.outputs.build_conclusion == 'success'
     uses: ./.github/workflows/sycl-windows-run-tests.yml
     with:
       name: Intel GEN12 Graphics with Level Zero

--- a/.github/workflows/sycl-prebuilt-e2e-container.yml
+++ b/.github/workflows/sycl-prebuilt-e2e-container.yml
@@ -94,7 +94,7 @@ jobs:
     name: Run E2E tests with SYCL RT they were built with
     runs-on: [Linux, pvc]
     needs: [docker, build]
-    if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
     container:
       image: ghcr.io/${{ github.repository }}/sycl_prebuilt_tests:${{ inputs.ref || github.ref_name }}
       options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN

--- a/.github/workflows/sycl-trivy.yml
+++ b/.github/workflows/sycl-trivy.yml
@@ -32,7 +32,7 @@ jobs:
         run: ./bin/trivy config --format json --output trivy-report.json --ignorefile=devops/.trivyignore.yaml devops/containers --exit-code 1
 
       - name: Upload report artifact
-        if: always() && !cancelled()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v5
         with:
           name: trivy-report

--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -153,7 +153,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: always() && !cancelled() && needs.build_sycl_dispatch.outputs.build_conclusion == 'success'
+    if: ${{ !cancelled() && needs.build_sycl_dispatch.outputs.build_conclusion == 'success' }}
     strategy:
       matrix:
         include:
@@ -199,7 +199,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: always() && !cancelled() && needs.build_nightly.outputs.build_conclusion == 'success'
+    if: ${{ !cancelled() && needs.build_nightly.outputs.build_conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -250,7 +250,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: always() && !cancelled() && needs.build_pr.outputs.build_conclusion == 'success'
+    if: ${{ !cancelled() && needs.build_pr.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: 'Framework test: PVC_PERF, L0, Minimal preset'

--- a/.github/workflows/sycl-weekly.yml
+++ b/.github/workflows/sycl-weekly.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: Build SYCL-CTS
@@ -45,7 +45,7 @@ jobs:
     permissions:
       contents: write
       packages: read
-    if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -120,7 +120,7 @@ jobs:
         arch: amd64
     - name: Setup oneAPI env
       uses: ./devops/actions/setup_windows_oneapi_env
-      if: ${{ always() && !cancelled() && inputs.cxx == 'icx' }}
+      if: ${{ !cancelled() && inputs.cxx == 'icx' }}
     - name: Set env
       run: |
         git config --system core.longpaths true
@@ -160,58 +160,58 @@ jobs:
       run: |
         cmake --build build --target ${{ inputs.build_target }}
     - name: check-llvm
-      if: always() && !cancelled() && contains(inputs.changes, 'llvm')
+      if: ${{ !cancelled() && contains(inputs.changes, 'llvm') }}
       shell: bash
       run: |      
         cmake --build build --target check-llvm
     - name: check-clang
-      if: always() && !cancelled() && contains(inputs.changes, 'clang')
+      if: ${{ !cancelled() && contains(inputs.changes, 'clang') }}
       run: |
         cmake --build build --target check-clang
     - name: check-sycl
-      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       shell: bash
       run: |        
          cmake --build build --target check-sycl
     - name: check-sycl-unittests
-      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       run: |
         cmake --build build --target check-sycl-unittests
     - name: check-llvm-spirv
-      if: always() && !cancelled() && contains(inputs.changes, 'llvm_spirv')
+      if: ${{ !cancelled() && contains(inputs.changes, 'llvm_spirv') }}
       run: |
         cmake --build build --target check-llvm-spirv
     - name: check-xptifw
-      if: always() && !cancelled() && contains(inputs.changes, 'xptifw')
+      if: ${{ !cancelled() && contains(inputs.changes, 'xptifw') }}
       run: |
         cmake --build build --target check-xptifw
     - name: check-libdevice
-      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       run: |
         cmake --build build --target check-libdevice
     - name: Generate/diff new ABI symbols
-      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       shell: bash
       run: |
         LLVM_BIN_PATH="build/bin" python.exe src/sycl/tools/abi_check.py --mode dump_symbols --output build/new_sycl_symbols_windows.dump build/bin/sycl?.dll
         diff -Naur src/sycl/test/abi/sycl_symbols_windows.dump build/new_sycl_symbols_windows.dump || true
     - name: Upload new ABI symbols
-      if: always() && !cancelled() && contains(inputs.changes, 'sycl')
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       uses: actions/upload-artifact@v5
       with:
         name: sycl_windows_abi_symbols
         path: build/new_sycl_symbols_windows.dump
         retention-days: ${{ inputs.retention-days }}
     - name: Install sycl-toolchain
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       run: |
         cmake --build build --target deploy-sycl-toolchain
 
     - name: Pack toolchain release
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' && inputs.release_toolchain_artifact != '' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' && inputs.release_toolchain_artifact != '' }}
       run: tar -czf ${{ inputs.toolchain_artifact_filename }} -C install .
     - name: Upload toolchain release
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' && inputs.release_toolchain_artifact != '' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' && inputs.release_toolchain_artifact != '' }}
       uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.release_toolchain_artifact }}
@@ -219,18 +219,18 @@ jobs:
         retention-days: ${{ inputs.retention-days }}
 
     - name: Install utilities
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       shell: bash
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target install-sycl-test-utilities
 
     - name: Pack toolchain
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       shell: bash
       run: |
         tar -czf ${{ inputs.toolchain_artifact_filename }} -C install .
     - name: Upload toolchain
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       uses: actions/upload-artifact@v5
       with:
         name: sycl_windows_default
@@ -238,13 +238,13 @@ jobs:
         retention-days: ${{ inputs.retention-days }}
 
     - name: Setup SYCL toolchain
-      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       run: |
         echo "PATH=$env:GITHUB_WORKSPACE\\install\\bin;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "LIB=$env:GITHUB_WORKSPACE\\install\\lib;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Build E2E tests
-      if: ${{ inputs.e2e_binaries_artifact && always() && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ inputs.e2e_binaries_artifact && !cancelled() && steps.build.conclusion == 'success' }}
       uses: ./devops/actions/run-tests/windows/e2e
       with:
         ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/sycl-windows-precommit.yml
+++ b/.github/workflows/sycl-windows-precommit.yml
@@ -51,7 +51,7 @@ jobs:
   build:
     needs: [detect_changes]
     if: |
-      always() && success()
+      success()
       && github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl-windows-build.yml
     with:
@@ -62,8 +62,7 @@ jobs:
     needs: build
     # Continue if build was successful.
     if: |
-      always()
-      && !cancelled()
+      !cancelled()
       && needs.build.outputs.build_conclusion == 'success'
     strategy:
       fail-fast: false

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -105,7 +105,7 @@ jobs:
         arch: amd64
     - name: Setup oneAPI env
       uses: ./devops/actions/setup_windows_oneapi_env
-      if: ${{ always() && !cancelled() && inputs.cxx == 'icx' }}
+      if: ${{ !cancelled() && inputs.cxx == 'icx' }}
     - name: Set env
       run: |
         git config --system core.longpaths true

--- a/.github/workflows/ur-precommit.yml
+++ b/.github/workflows/ur-precommit.yml
@@ -43,13 +43,13 @@ jobs:
   source_checks:
     name: Source Checks
     needs: [detect_changes]
-    if: ${{ always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur') }}
+    if: ${{ !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur') }}
     uses: ./.github/workflows/ur-source-checks.yml
 
   adapters:
     name: Adapters
     needs: [detect_changes, source_checks]
-    if: ${{ always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur') }}
+    if: ${{ !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur') }}
     strategy:
       fail-fast: false
       matrix:
@@ -103,13 +103,13 @@ jobs:
 #  offload_build:
 #    name: Adapters (Offload)
 #    needs: [detect_changes, source_checks]
-#    if: ${{ always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur_offload_adapter') }}
+#    if: ${{ !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur_offload_adapter') }}
 #    uses: ./.github/workflows/ur-build-offload.yml
 
   macos:
     name: MacOS build only
     needs: [detect_changes, source_checks]
-    if: ${{ always() && !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur') }}
+    if: ${{ !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur') }}
     strategy:
       matrix:
         os: ['macos-latest']


### PR DESCRIPTION
Zizmor raised this alert - https://github.com/intel/llvm/security/code-scanning/2537

I looked deeper. We have lots of "always() && some_condition" where *some_condition* makes always() redundant.