### PR TITLE
[CI] Enable Windows DG2 testing in precommit and nightly

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -215,6 +215,10 @@ jobs:
             runner: '["Windows", "gen12"]'
             target_devices: level_zero:gpu
 
+          - name: Intel L0 Arc GPU
+            runner: '["Windows", arc"]'
+            target_devices: level_zero:gpu
+
           - name: Intel L0 Battlemage GPU
             runner: '["Windows", "bmg"]'
             target_devices: level_zero:gpu

--- a/.github/workflows/sycl-windows-precommit.yml
+++ b/.github/workflows/sycl-windows-precommit.yml
@@ -71,6 +71,8 @@ jobs:
         include:
           - name: Intel GEN12 Graphics with Level Zero
             runner: '["Windows","gen12"]'
+          - name: Intel Arc Graphics with Level Zero
+            runner: '["Windows","arc"]'
           - name: Intel Battlemage Graphics with Level Zero
             runner: '["Windows","bmg"]'
     uses: ./.github/workflows/sycl-windows-run-tests.yml

--- a/sycl/test-e2e/bindless_images/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/lit.local.cfg
@@ -4,3 +4,7 @@ config.unsupported_features += ['target-native_cpu']
 config.unsupported_features += ['spirv-backend']
 
 cl_options = 'cl_options' in config.available_features
+
+# https://github.com/intel/llvm/issues/20562
+if 'windows' in config.available_features:
+  config.unsupported_features += ['gpu-intel-dg2']


### PR DESCRIPTION
We got a new runner and I got testing to be fast and stable, so lets enable it.

Bindless images are totally borked, made https://github.com/intel/llvm/issues/20562

Precommit run [here](https://github.com/intel/llvm/actions/runs/19174891008/job/54819121816?pr=20588), the job takes 4 minutes so it's similar to Linux BMG where we only have one runner too.

Looks like a manual Nightly doesn't use my YAML, I'll test it after we merge.