### PR TITLE
[CI][Bench] Run nightly benchmarks after the nightly image was pushed

### DIFF
--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -5,8 +5,8 @@ name: SYCL Run Benchmarks
 
 on:
   schedule:
-    # 3 hours ahead of SYCL nightly
-    - cron: '0 0 * * *'
+    # 2 hours after SYCL nightly
+    - cron: '0 5 * * *'
   # Run on pull requests only when a benchmark-related files were changed.
   pull_request:
     # These paths are exactly the same as in sycl-linux/windows-precommit.yml (to ignore over there)


### PR DESCRIPTION
It's better to use the actually last nightly build in benchmarks.