### PR TITLE
[SYCL RTC][CMake] `libdevice` isn't an optional dependency

### DIFF
--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -9,14 +9,21 @@ else()
 set(SYCL_JIT_VIRTUAL_TOOLCHAIN_ROOT "/sycl-jit-toolchain/")
 endif()
 
-set(SYCL_JIT_RESOURCE_INSTALL_COMPONENTS sycl-headers OpenCL-Headers clang-resource-headers)
 
-if ("libclc" IN_LIST LLVM_ENABLE_PROJECTS)
-  list(APPEND SYCL_JIT_RESOURCE_INSTALL_COMPONENTS libspirv-builtins)
+if (NOT "libdevice" IN_LIST LLVM_ENABLE_PROJECTS)
+  message(FATAL_ERROR "libdevice is required for jit-compiler but not present in LLVM_ENABLE_PROJECTS")
 endif()
 
-if ("libdevice" IN_LIST LLVM_ENABLE_PROJECTS)
-  list(APPEND SYCL_JIT_RESOURCE_INSTALL_COMPONENTS libsycldevice)
+set(SYCL_JIT_RESOURCE_INSTALL_COMPONENTS
+  sycl-headers
+  OpenCL-Headers
+  clang-resource-headers
+  libsycldevice)
+
+if ("libclc" IN_LIST LLVM_ENABLE_PROJECTS)
+  # If some targets required `libclc` then we should embed it for the
+  # `sycl-jit`.
+  list(APPEND SYCL_JIT_RESOURCE_INSTALL_COMPONENTS libspirv-builtins)
 endif()
 
 set(SYCL_JIT_RESOURCE_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/rtc-resources-install)


### PR DESCRIPTION
We link it in for all targets inside SYCL RTC implementation, so it is required to be enabled.
On the other hand, `libclc` is only needed for CUDA/AMD targets, so we can build SYCL RTC without it if those targets aren't enabled for the whole project.