### PR TITLE
[NFC] XFAIL save-stats.ll added in community commit 96a5289

### DIFF
--- a/llvm/test/tools/llc/save-stats.ll
+++ b/llvm/test/tools/llc/save-stats.ll
@@ -1,3 +1,5 @@
+; XFAIL: *
+
 ; REQUIRES: asserts
 
 ; RUN: llc -mtriple=arm64-apple-macosx --save-stats=obj -o %t.s %s && cat %t.stats | FileCheck %s


### PR DESCRIPTION
The target triple is not supported by default build.