### PR TITLE
[UR][L0] Update L0 Version to v1.26.0 with static loader improvements

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.25.2",
-      "version": "v1.25.2",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.25.2",
+      "github_tag": "v1.26.0",
+      "version": "v1.26.0",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.26.0",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {

--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -13,7 +13,7 @@ find_package(PkgConfig QUIET)
 # so try using that to find the install and if it's not available
 # just try to search for the path.
 if(PkgConfig_FOUND)
-  pkg_check_modules(level-zero level-zero>=1.25.2)
+  pkg_check_modules(level-zero level-zero>=1.26.0)
   if(level-zero_FOUND)
     set(LEVEL_ZERO_INCLUDE_DIR "${level-zero_INCLUDEDIR}/level_zero")
     set(LEVEL_ZERO_LIBRARY_SRC "${level-zero_LIBDIR}")
@@ -50,7 +50,7 @@ if(NOT LEVEL_ZERO_LIB_NAME AND NOT LEVEL_ZERO_LIBRARY)
   set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
   # Remember to update the pkg_check_modules minimum version above when updating the
   # clone tag
-  set(UR_LEVEL_ZERO_LOADER_TAG v1.25.2)
+  set(UR_LEVEL_ZERO_LOADER_TAG v1.26.0)
 
   # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
   set(CMAKE_INCLUDE_CURRENT_DIR OFF)


### PR DESCRIPTION
- Update to using v1.26.0 for the level zero loader which provides for Level Zero performance improvements during zeInit/zeInitDrivers