### PR TITLE
Get ImplicitLocalArgPos from  DeviceKernelInfo instead of ProgramManager

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2470,8 +2470,7 @@ static ur_result_t SetKernelParamsAndLaunch(
   }
 
   std::optional<int> ImplicitLocalArg =
-      ProgramManager::getInstance().kernelImplicitLocalArgPos(
-          DeviceKernelInfo.Name);
+      DeviceKernelInfo.getImplicitLocalArgPos();
   // Set the implicit local memory buffer to support
   // get_work_group_scratch_memory. This is for backend not supporting
   // CUDA-style local memory setting. Note that we may have -1 as a position,


### PR DESCRIPTION
The performance regression was introduced in the #20316.
We should get the position of the implicit local arg from the deviceKernelInfo, not from the ProgramManager.