### PR TITLE
[SYCL][E2E] Disable bindless_images test on BMG Win

### DIFF
--- a/sycl/test-e2e/bindless_images/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/lit.local.cfg
@@ -7,4 +7,4 @@ cl_options = 'cl_options' in config.available_features
 
 # https://github.com/intel/llvm/issues/20562
 if 'windows' in config.available_features:
-  config.unsupported_features += ['gpu-intel-dg2']
+  config.unsupported_features += ['gpu-intel-dg2','arch-intel_gpu_bmg_g21']


### PR DESCRIPTION
Similar to DG2 Win, we are seeing a ton of sporadic failures in the entire E2E suite and they all go away if we disable bindless_images tests.