### PR TITLE
[SYCL][E2E] Make discard_events_l0_inorder.cpp to UNSUPPORTED

### DIFF
--- a/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/discard_events_l0_inorder.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/discard_events_l0_inorder.cpp
@@ -18,8 +18,8 @@
 // the discard_events property, if it doesn't pass then it's most likely a
 // general issue unrelated to discard_events.
 
-// XFAIL: linux && arch-intel_gpu_bmg_g21 && !igc-dev
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20601
+// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21 && !igc-dev
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20601
 
 #include <cassert>
 #include <iostream>


### PR DESCRIPTION
Seeing sporadic fails, ex [here](https://github.com/intel/llvm/actions/runs/19303575826/job/55206392071).