### PR TITLE
[SYCL][E2E][NFC] Drop copyright headers in SYCLBIN E2E tests

### DIFF
--- a/sycl/test-e2e/SYCLBIN/basic_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_executable.cpp
@@ -1,11 +1,3 @@
-//==--------- basic_executable.cpp --- SYCLBIN extension tests -------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // -- Basic test for compiling and loading a SYCLBIN kernel_bundle in executable

--- a/sycl/test-e2e/SYCLBIN/basic_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_input.cpp
@@ -1,11 +1,3 @@
-//==--------- basic_input.cpp --- SYCLBIN extension tests ------------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // UNSUPPORTED: cuda, hip

--- a/sycl/test-e2e/SYCLBIN/basic_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_object.cpp
@@ -1,11 +1,3 @@
-//==--------- basic_object.cpp --- SYCLBIN extension tests -----------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // UNSUPPORTED: cuda, hip

--- a/sycl/test-e2e/SYCLBIN/dae_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/dae_executable.cpp
@@ -1,11 +1,3 @@
-//==----------- dae_executable.cpp --- SYCLBIN extension tests -------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // -- Test for using a kernel from a SYCLBIN with a dead argument.

--- a/sycl/test-e2e/SYCLBIN/dae_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/dae_input.cpp
@@ -1,11 +1,3 @@
-//==----------- dae_input.cpp --- SYCLBIN extension tests ------------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // UNSUPPORTED: cuda, hip

--- a/sycl/test-e2e/SYCLBIN/dae_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/dae_object.cpp
@@ -1,11 +1,3 @@
-//==----------- dae_object.cpp --- SYCLBIN extension tests -----------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // UNSUPPORTED: cuda, hip

--- a/sycl/test-e2e/SYCLBIN/dg_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_executable.cpp
@@ -1,11 +1,3 @@
-//==---------- dg_executable.cpp --- SYCLBIN extension tests ---------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // -- Test for using device globals in SYCLBIN.

--- a/sycl/test-e2e/SYCLBIN/dg_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_input.cpp
@@ -1,11 +1,3 @@
-//==----------- dg_input.cpp --- SYCLBIN extension tests -------------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // UNSUPPORTED: cuda, hip

--- a/sycl/test-e2e/SYCLBIN/dg_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_object.cpp
@@ -1,11 +1,3 @@
-//==----------- dg_object.cpp --- SYCLBIN extension tests ------------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // UNSUPPORTED: cuda, hip

--- a/sycl/test-e2e/SYCLBIN/link_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_input.cpp
@@ -1,11 +1,3 @@
-//==-------------- link_input.cpp --- SYCLBIN extension tests --------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_shared_allocations
 
 // -- Test for linking two SYCLBIN kernel_bundle.

--- a/sycl/test-e2e/SYCLBIN/link_mixed_opt_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_mixed_opt_input.cpp
@@ -1,11 +1,3 @@
-//==--------- link_mixed_opt_input.cpp --- SYCLBIN extension tests ---------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_shared_allocations
 
 // -- Test for linking two SYCLBIN kernel_bundles with different optimization

--- a/sycl/test-e2e/SYCLBIN/link_mixed_opt_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_mixed_opt_object.cpp
@@ -1,11 +1,3 @@
-//==--------- link_mixed_opt_input.cpp --- SYCLBIN extension tests ---------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_shared_allocations
 
 // -- Test for linking two SYCLBIN kernel_bundle with different optimization

--- a/sycl/test-e2e/SYCLBIN/link_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_object.cpp
@@ -1,11 +1,3 @@
-//==-------------- link_input.cpp --- SYCLBIN extension tests --------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_shared_allocations
 
 // -- Test for linking two SYCLBIN kernel_bundle.

--- a/sycl/test-e2e/SYCLBIN/link_rtc_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_rtc_input.cpp
@@ -1,11 +1,3 @@
-//==------------ link_rtc_input.cpp --- SYCLBIN extension tests ------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: (opencl || level_zero)
 // REQUIRES: aspect-usm_shared_allocations
 

--- a/sycl/test-e2e/SYCLBIN/link_rtc_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_rtc_object.cpp
@@ -1,11 +1,3 @@
-//==------------ link_rtc_object.cpp --- SYCLBIN extension tests -----------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: (opencl || level_zero)
 // REQUIRES: aspect-usm_shared_allocations
 

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_executable.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_executable.cpp
@@ -1,11 +1,3 @@
-//==- optional_kernel_features_executable.cpp --- SYCLBIN extension tests --==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // -- Test for compiling and loading a kernel bundle with a SYCLBIN containing

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_input.cpp
@@ -1,11 +1,3 @@
-//==--- optional_kernel_features_input.cpp --- SYCLBIN extension tests -----==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // UNSUPPORTED: cuda, hip

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_object.cpp
@@ -1,12 +1,3 @@
-//==--- optional_kernel_features_object.cpp --- SYCLBIN extension tests
-//-----==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // REQUIRES: aspect-usm_device_allocations
 
 // UNSUPPORTED: cuda, hip


### PR DESCRIPTION
This commit removes the copyright headers from all tests in sycl/test-e2e/SYCLBIN to make them more similar to other E2E tests.