### PR TITLE
[CI][Benchmarks] Fix perf installation on Ubuntu 25.10

### DIFF
--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -177,7 +177,14 @@ runs:
   - name: Install perf in version matching the host kernel
     shell: bash
     run: |
+      # Install perf in version matching the host kernel
       echo "::group::install_linux_tools"
+      if [ "$RUNNER_TAG" = '["BMG_PERF"]' ]; then
+        echo "Adding repositories for Ubuntu 25.10 (Questing) on BMG_PERF runner"
+        echo "deb http://archive.ubuntu.com/ubuntu/ questing main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/questing.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ questing-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/questing.list
+        echo "deb http://security.ubuntu.com/ubuntu/ questing-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/questing.list
+      fi
       sudo apt-get update
       sudo apt-get install -y linux-tools-$(uname -r)
       echo "::endgroup::"


### PR DESCRIPTION
Add apt repositories from Ubuntu 25.10 (Questing) to install perf in docker images that use kernel from Ubuntu 25.10 (`BMG_PERF` machine).

A dispatched run that uses updated workflow from this PR: https://github.com/intel/llvm/actions/runs/19328996952.