### PR TITLE
[CI] Fix typo in nightly workflow

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -225,7 +225,7 @@ jobs:
             target_devices: level_zero:gpu
 
           - name: Intel L0 Arc GPU
-            runner: '["Windows", arc"]'
+            runner: '["Windows", "arc"]'
             target_devices: level_zero:gpu
 
           - name: Intel L0 Battlemage GPU


### PR DESCRIPTION
Windows Arc wasn't running in the nightly even though it was in the YAML and the YAML was valid.
The missing quote is valid in YAML but we use the runner name as JSON later and it's invalid there.