### PR TITLE
[Benchmarks] Add level-zero record-and-replay to set of SubmitGraph benchmarks

### DIFF
--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -215,7 +215,9 @@ class ComputeBench(Suite):
             elif runtime == RUNTIMES.UR:
                 emulate_graphs = [1]
             else:  # level-zero
-                emulate_graphs = [0, 1]
+                # SubmitGraph with L0 graph segfaults on PVC
+                device_arch = getattr(options, "device_architecture", "")
+                emulate_graphs = [1] if "pvc" in device_arch else [0, 1]
             for emulate_graph in emulate_graphs:
                 benches.append(
                     GraphApiSubmitGraph(


### PR DESCRIPTION
Level-zero `SubmitGraph` benchmarks support EmulateGraphs=0 (L0 record-and-replay) APIs and EmulateGraphs=1 (submitting command list to immediate command list). This PR adds the record-and-replay compute benchmark.