### PR TITLE
[NativeCPU] Avoid using vector_t in NativeCPU

### DIFF
--- a/libdevice/nativecpu_utils.cpp
+++ b/libdevice/nativecpu_utils.cpp
@@ -96,13 +96,13 @@ DefGenericCastToPtrExpl(ToGlobal, OCL_GLOBAL);
 
 namespace ncpu_types {
 template <typename DataT, int NumElements>
-using vector_t =
+using native_vector_t =
     sycl::detail::ConvertToOpenCLType_t<sycl::vec<DataT, NumElements>>;
 
 template <class T> struct vtypes {
-  using v2 = vector_t<T, 2>;
-  using v4 = vector_t<T, 4>;
-  using v8 = vector_t<T, 8>;
+  using v2 = native_vector_t<T, 2>;
+  using v4 = native_vector_t<T, 4>;
+  using v8 = native_vector_t<T, 8>;
 };
 } // namespace ncpu_types
 
@@ -228,7 +228,7 @@ DefineLogicalGroupOp(bool, bool, i1);
   }                                                                            \
                                                                                \
   DEVICE_EXTERNAL Type __spirv_GroupBroadcast(                                 \
-      int32_t g, Type v, ncpu_types::vector_t<IDType, 2> l) noexcept {         \
+      int32_t g, Type v, ncpu_types::native_vector_t<IDType, 2> l) noexcept {  \
     if (__spv::Scope::Flag::Subgroup == g)                                     \
       return __mux_sub_group_broadcast_##Sfx(v, l[0]);                         \
     else                                                                       \
@@ -236,7 +236,7 @@ DefineLogicalGroupOp(bool, bool, i1);
   }                                                                            \
                                                                                \
   DEVICE_EXTERNAL Type __spirv_GroupBroadcast(                                 \
-      int32_t g, Type v, ncpu_types::vector_t<IDType, 3> l) noexcept {         \
+      int32_t g, Type v, ncpu_types::native_vector_t<IDType, 3> l) noexcept {  \
     if (__spv::Scope::Flag::Subgroup == g)                                     \
       return __mux_sub_group_broadcast_##Sfx(v, l[0]);                         \
     else                                                                       \
@@ -314,8 +314,8 @@ DefShuffleINTEL_All(float, f32, float);
 DefShuffleINTEL_All(_Float16, f16, _Float16);
 
 #define DefineShuffleVec(T, N, Sfx, MuxType)                                   \
-  using vt##T##N = ncpu_types::vector_t<T, N>;                                 \
-  using vt##MuxType##N = ncpu_types::vector_t<MuxType, N>;                     \
+  using vt##T##N = ncpu_types::native_vector_t<T, N>;                          \
+  using vt##MuxType##N = ncpu_types::native_vector_t<MuxType, N>;              \
   DefShuffleINTEL_All(vt##T##N, v##N##Sfx, vt##MuxType##N)
 
 #define DefineShuffleVec2to16(Type, Sfx, MuxType)                              \


### PR DESCRIPTION
This commit avoid the use of the to-be-removed sycl::vec::vector_t in the native-cpu utilities.