### PR TITLE
[NFC][Clang] Update Clang's help message for `--offload-compress`

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1341,12 +1341,12 @@ def fgpu_sanitize : Flag<["-"], "fgpu-sanitize">, Group<f_Group>,
 def fno_gpu_sanitize : Flag<["-"], "fno-gpu-sanitize">, Group<f_Group>;
 
 def offload_compress : Flag<["--"], "offload-compress">,
-  HelpText<"Compress offload device binaries (HIP only)">;
+  HelpText<"Compress offload device binaries (HIP and SYCL only)">;
 def no_offload_compress : Flag<["--"], "no-offload-compress">;
 
 def offload_compression_level_EQ : Joined<["--"], "offload-compression-level=">,
   Flags<[HelpHidden]>,
-  HelpText<"Compression level for offload device binaries (HIP only)">;
+  HelpText<"Compression level for offload device binaries (HIP and SYCL only)">;
 
 def offload_jobs_EQ : Joined<["--"], "offload-jobs=">,
   HelpText<"Specify the number of threads to use for device offloading tasks "


### PR DESCRIPTION
`--offload-compress` works for SYCL as well. I forgot to update the help message of this flag when I initially added support for image compression (in https://github.com/intel/llvm/pull/15124).