### PR TITLE
[SYCL] Fix `queue::[khr|ext_oneapi]_empty()` for out-of-order queues

### DIFF
--- a/sycl/test-e2e/Basic/out_of_order_queue_status_ext_oneapi_empty.cpp
+++ b/sycl/test-e2e/Basic/out_of_order_queue_status_ext_oneapi_empty.cpp
@@ -46,24 +46,12 @@ void TestFunc(queue &Q) {
     });
   }
 
-  constexpr int InfiniteLoopPreventionThreshold = 400;
-  int InfiniteLoopPreventionCounter = 0;
-
-  // Wait for tasks created by parallel_for to actually start running. Otherwise
-  // ext_oneapi_empty may return true not because the queue is completed, but
-  // because tasks haven't been added to the queue.
-  do {
-    std::this_thread::sleep_for(std::chrono::milliseconds(300));
-    InfiniteLoopPreventionCounter++;
-  } while (Y[0] == 100 &&
-           InfiniteLoopPreventionCounter < InfiniteLoopPreventionThreshold);
-
   // Wait a bit to give a chance for tasks to complete.
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   // We expect that all submitted tasks are finished if ext_oneapi_empty is
   // true.
-  if (Q.ext_oneapi_empty() && Y[0] != 100)
+  if (Q.ext_oneapi_empty())
     CheckArray(Y, Size, 200);
 
   Q.wait();


### PR DESCRIPTION
Previously tests `out_of_order_queue_status_khr_empty.cpp` and `out_of_order_queue_status_ext_oneapi_empty.cpp` had flaky failures when multiple instances of them are run at the same time. The reason turns out to be that when we are checking the emptiness of out-of-order queues, we should check the status of all events in the associated event list, not only the events on host. This patch fixes flaky failures observed in the aforementioned tests.