### PR TITLE
[UR] Add `launchPropList` to arguments of `appendKernelLaunchWithArgsExpNew()`

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -1141,9 +1141,10 @@ ur_result_t ur_command_list_manager::appendKernelLaunchWithArgsExpNew(
     ur_kernel_handle_t hKernel, uint32_t workDim,
     const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
     const size_t *pLocalWorkSize, uint32_t numArgs,
-    const ur_exp_kernel_arg_properties_t *pArgs, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t phEvent,
-    bool cooperativeKernelLaunchRequested) {
+    const ur_exp_kernel_arg_properties_t *pArgs,
+    const ur_kernel_launch_ext_properties_t *launchPropList,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t phEvent) {
 
   ur_result_t checkResult = kernelLaunchChecks(hKernel, workDim);
   if (checkResult != UR_RESULT_SUCCESS) {
@@ -1155,10 +1156,31 @@ ur_result_t ur_command_list_manager::appendKernelLaunchWithArgsExpNew(
   ZeStruct<ze_command_list_append_launch_kernel_param_cooperative_desc_t>
       cooperativeDesc;
   cooperativeDesc.isCooperative = static_cast<ze_bool_t>(true);
-
   void *pNext = nullptr;
-  if (cooperativeKernelLaunchRequested) {
+  bool cooperativeKernelLaunchRequested = false;
+
+  ur_kernel_launch_ext_properties_t *_launchPropList =
+      const_cast<ur_kernel_launch_ext_properties_t *>(launchPropList);
+  if (_launchPropList &&
+      _launchPropList->flags & UR_KERNEL_LAUNCH_FLAG_COOPERATIVE) {
+    cooperativeKernelLaunchRequested = true;
     pNext = &cooperativeDesc;
+  }
+
+  if (_launchPropList &&
+      _launchPropList->flags & ~UR_KERNEL_LAUNCH_FLAG_COOPERATIVE) {
+    // We don't support any other flags.
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  }
+
+  while (_launchPropList != nullptr) {
+    if (_launchPropList->stype !=
+        as_stype<ur_kernel_launch_ext_properties_t>()) {
+      // We don't support any other properties.
+      return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+    _launchPropList = static_cast<ur_kernel_launch_ext_properties_t *>(
+        _launchPropList->pNext);
   }
 
   ze_kernel_handle_t hZeKernel = hKernel->getZeHandle(hDevice.get());
@@ -1225,25 +1247,10 @@ ur_result_t ur_command_list_manager::appendKernelLaunchWithArgsExp(
 
   ur_kernel_launch_ext_properties_t *_launchPropList =
       const_cast<ur_kernel_launch_ext_properties_t *>(launchPropList);
-  if (_launchPropList &&
-      _launchPropList->flags & ~UR_KERNEL_LAUNCH_FLAG_COOPERATIVE) {
-    // We don't support any other flags.
-    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-  }
 
   if (_launchPropList &&
       _launchPropList->flags & UR_KERNEL_LAUNCH_FLAG_COOPERATIVE) {
     cooperativeKernelLaunchRequested = true;
-  }
-
-  while (_launchPropList != nullptr) {
-    if (_launchPropList->stype !=
-        as_stype<ur_kernel_launch_ext_properties_t>()) {
-      // We don't support any other properties.
-      return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-    _launchPropList = static_cast<ur_kernel_launch_ext_properties_t *>(
-        _launchPropList->pNext);
   }
 
   ur_platform_handle_t hPlatform = hContext->getPlatform();
@@ -1259,8 +1266,8 @@ ur_result_t ur_command_list_manager::appendKernelLaunchWithArgsExp(
   if (RunNewPath) {
     return appendKernelLaunchWithArgsExpNew(
         hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize,
-        numArgs, pArgs, numEventsInWaitList, phEventWaitList, phEvent,
-        cooperativeKernelLaunchRequested);
+        numArgs, pArgs, launchPropList, numEventsInWaitList, phEventWaitList,
+        phEvent);
   } else {
     // We cannot pass cooperativeKernelLaunchRequested to
     // appendKernelLaunchWithArgsExpOld() because appendKernelLaunch() must

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -256,9 +256,10 @@ private:
       ur_kernel_handle_t hKernel, uint32_t workDim,
       const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
       const size_t *pLocalWorkSize, uint32_t numArgs,
-      const ur_exp_kernel_arg_properties_t *pArgs, uint32_t numEventsInWaitList,
-      const ur_event_handle_t *phEventWaitList, ur_event_handle_t phEvent,
-      bool cooperativeKernelLaunchRequested);
+      const ur_exp_kernel_arg_properties_t *pArgs,
+      const ur_kernel_launch_ext_properties_t *launchPropList,
+      uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+      ur_event_handle_t phEvent);
 
   ur_result_t appendGenericCommandListsExp(
       uint32_t numCommandLists, ze_command_list_handle_t *phCommandLists,


### PR DESCRIPTION
After replacing `urEnqueueKernelLaunch()` property list with `pNext` chain property structures (commit 66b3b53) the `appendKernelLaunchWithArgsExpNew()` function will need the list of properities, so add `launchPropList` to arguments of `appendKernelLaunchWithArgsExpNew()` (like it is in `appendKernelLaunchWithArgsExpOld()`).

It is a preparation for future changes.