### PR TITLE
[E2E][BINDLESS] reenable copy_subregion_2D.cpp

### DIFF
--- a/sycl/test-e2e/bindless_images/copies/copy_subregion_2D.cpp
+++ b/sycl/test-e2e/bindless_images/copies/copy_subregion_2D.cpp
@@ -1,5 +1,7 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images
-
+// UNSUPPORTED: gpu-intel-dg2
+// UNSUPPORTED-INTENDED: sporadic failure in CI
+//                       https://github.com/intel/llvm/issues/20006
 // XFAIL: linux && arch-intel_gpu_acm_g10 && level_zero_v2_adapter
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20004
 // XFAIL: hip


### PR DESCRIPTION
can't reproduce the failure seen https://github.com/intel/llvm/issues/20006 . Wanting to try it on CI again to see if still relevant.