### PR TITLE
[UR] Call zeCommandListAppendLaunchKernelWithArguments() directly

### DIFF
--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -527,9 +527,6 @@ ur_result_t ur_platform_handle_t_::initialize() {
       ZeMemGetPitchFor2dImageExt.zeMemGetPitchFor2dImage != nullptr;
 
   if (this->isDriverVersionNewerOrSimilar(1, 14, 36035)) {
-    ZeCommandListAppendLaunchKernelWithArgumentsExt
-        .zeCommandListAppendLaunchKernelWithArgumentsFunctionPtr =
-        zeCommandListAppendLaunchKernelWithArguments;
     ZeCommandListAppendLaunchKernelWithArgumentsExt.Supported = true;
   } else {
     ZeCommandListAppendLaunchKernelWithArgumentsExt.Supported = false;

--- a/unified-runtime/source/adapters/level_zero/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/platform.hpp
@@ -166,9 +166,5 @@ struct ur_platform_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter>,
   struct ZeCommandListAppendLaunchKernelWithArgumentsExtension {
     bool Supported = false;
     bool DriverSupportsCooperativeKernelLaunchWithArgs = false;
-    ze_result_t (*zeCommandListAppendLaunchKernelWithArgumentsFunctionPtr)(
-        ze_command_list_handle_t, ze_kernel_handle_t, const ze_group_count_t,
-        const ze_group_size_t, void **, const void *, ze_event_handle_t,
-        uint32_t, ze_event_handle_t *);
   } ZeCommandListAppendLaunchKernelWithArgumentsExt;
 };

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -175,9 +175,7 @@ ur_result_t ur_command_list_manager::appendKernelLaunchLocked(
     TRACK_SCOPE_LATENCY("ur_command_list_manager::"
                         "zeCommandListAppendLaunchKernelWithArguments");
     ze_group_size_t groupSize = {WG[0], WG[1], WG[2]};
-    ZE2UR_CALL(hContext->getPlatform()
-                   ->ZeCommandListAppendLaunchKernelWithArgumentsExt
-                   .zeCommandListAppendLaunchKernelWithArgumentsFunctionPtr,
+    ZE2UR_CALL(zeCommandListAppendLaunchKernelWithArguments,
                (getZeCommandList(), hZeKernel, zeThreadGroupDimensions,
                 groupSize, hKernel->kernelArgs.data(), pNext, zeSignalEvent,
                 waitListView.num, waitListView.handles));


### PR DESCRIPTION
Call `zeCommandListAppendLaunchKernelWithArguments()` directly (not using the pointer).