### PR TITLE
[SYCL] Bump SYCL_MAJOR_VERSION to "9"

### DIFF
--- a/clang/lib/Driver/CMakeLists.txt
+++ b/clang/lib/Driver/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 # This must be in sync with llvm/sycl/CMakeLists.txt.
 SET_SOURCE_FILES_PROPERTIES( ToolChains/MSVC.cpp ToolChains/Clang.cpp
-  PROPERTIES COMPILE_DEFINITIONS SYCL_MAJOR_VERSION="8" )
+  PROPERTIES COMPILE_DEFINITIONS SYCL_MAJOR_VERSION="9" )
 
 add_clang_library(clangDriver
   Action.cpp

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -91,7 +91,7 @@ include(BuildUnifiedRuntime)
 #
 # See doc/developer/ABIPolicyGuide.md for the meaning when in the middle of
 # development cycle.
-set(SYCL_MAJOR_VERSION 8)
+set(SYCL_MAJOR_VERSION 9)
 set(SYCL_MINOR_VERSION 0)
 set(SYCL_PATCH_VERSION 0)
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -576,7 +576,7 @@ if cl_options:
         (
             "%sycl_options",
             " "
-            + os.path.normpath(os.path.join(config.sycl_libs_dir + "/../lib/sycl8.lib"))
+            + os.path.normpath(os.path.join(config.sycl_libs_dir + "/../lib/sycl9.lib"))
             + " -Xclang -isystem -Xclang "
             + config.sycl_include
             + " -Xclang -isystem -Xclang "
@@ -594,7 +594,7 @@ else:
     config.substitutions.append(
         (
             "%sycl_options",
-            (" -lsycl8" if platform.system() == "Windows" else " -lsycl")
+            (" -lsycl9" if platform.system() == "Windows" else " -lsycl")
             + " -isystem "
             + config.sycl_include
             + " -isystem "

--- a/sycl/test/abi/sycl_symbols_windows.dump
+++ b/sycl/test/abi/sycl_symbols_windows.dump
@@ -3,7 +3,7 @@
 # DO NOT EDIT IT MANUALLY. Refer to sycl/doc/developer/ABIPolicyGuide.md for more info.
 ################################################################################
 
-# RUN: env LLVM_BIN_PATH=%llvm_build_bin_dir %python %sycl_tools_src_dir/abi_check.py --mode check_symbols --reference %s %llvm_build_bin_dir/sycl8.dll
+# RUN: env LLVM_BIN_PATH=%llvm_build_bin_dir %python %sycl_tools_src_dir/abi_check.py --mode check_symbols --reference %s %llvm_build_bin_dir/sycl9.dll
 # REQUIRES: windows
 # UNSUPPORTED: libcxx
 

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -138,7 +138,7 @@ for include_dir in [
 config.substitutions.append(("%fsycl-host-only", sycl_host_only_options))
 
 config.substitutions.append(
-    ("%sycl_lib", " -lsycl8" if platform.system() == "Windows" else "-lsycl")
+    ("%sycl_lib", " -lsycl9" if platform.system() == "Windows" else "-lsycl")
 )
 
 llvm_config.add_tool_substitutions(["llvm-spirv"], [config.sycl_tools_dir])


### PR DESCRIPTION
ABI breaking window has started and according to policy https://github.com/intel/llvm/blob/sycl/sycl/doc/developer/ABIPolicyGuide.md#abi-versioning-policy we bump the version at the start.