### PR TITLE
[NewOffloadModel]  Update clang-linker-wrapper test with issue fixes

### DIFF
--- a/clang/test/Driver/clang-linker-wrapper.cpp
+++ b/clang/test/Driver/clang-linker-wrapper.cpp
@@ -75,7 +75,7 @@
 // (happen when AOT device is specified via -Xsycl-target-backend '-device pvc' in clang), 
 // the target is not passed to sycl-post-link for filtering.
 // RUN: clang-linker-wrapper -sycl-embed-ir -sycl-device-libraries=%t1.devicelib.o -sycl-post-link-options="SYCL_POST_LINK_OPTIONS" -llvm-spirv-options="LLVM_SPIRV_OPTIONS" "--host-triple=x86_64-unknown-linux-gnu" "--gpu-tool-arg=-device pvc" "--linker-path=/usr/bin/ld" "--" HOST_LINKER_FLAGS "-dynamic-linker" HOST_DYN_LIB "-o" "a.out" HOST_LIB_PATH HOST_STAT_LIB %t1.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-NO-CMDS-AOT-GEN %s
-// CHK-NO-CMDS-AOT-GEN: sycl-post-link{{.*}} SYCL_POST_LINK_OPTIONS -o [[SYCLPOSTLINKOUT:[^,]*]].table [[LLVMLINKOUT:.*]].bc
+// CHK-NO-CMDS-AOT-GEN: sycl-post-link{{.*}} SYCL_POST_LINK_OPTIONS -o {{[^,]*}}.table {{.*}}.bc
 
 /// Check for list of commands for standalone clang-linker-wrapper run for sycl (AOT for Intel CPU)
 // -------


### PR DESCRIPTION
This pull request resolves a typo introduced in a recent modification of `clang/test/Driver/clang-linker-wrapper.cpp`. In addition, the test logic is improved by replacing the use of `CHK-NO-CMDS-AOT-GEN-NOT` with `CHK-NO-CMDS-AOT-GEN` to verify the behavior where the device name should not be passed to `sycl-post-link` when `clang-linker-wrapper` is called with the `--gpu-tool-arg=-device arch` argument. 

The previous PR introduced the mistake is https://github.com/intel/llvm/pull/20470