### PR TITLE
[SYCL] Disable check_abi_symbols in nightly

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -11,7 +11,8 @@ jobs:
   check_abi_symbols:
     name: Check ABI symbols tests match release branch
     runs-on: [Linux, build]
-    # We're in the ABI breaking window now, disabling until the next release.
+    # We're in the ABI breaking window now, disabling until the next major
+    # release.
     if: github.repository == 'intel/llvm' && false
     container: ghcr.io/intel/llvm/ubuntu2404_build
     steps:


### PR DESCRIPTION
The job is failing as *-sycl-rel-6_3.dump were deleted
https://github.com/intel/llvm/actions/runs/19524461612