### PR TITLE
[UR] Unify name of argument in signature of appendKernelLaunchLocked()

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -280,7 +280,7 @@ private:
       uint32_t workDim, const size_t *pGlobalWorkOffset,
       const size_t *pGlobalWorkSize, const size_t *pLocalWorkSize,
       wait_list_view &waitListView, ur_event_handle_t phEvent, bool cooperative,
-      bool withArgs = false, void *pNext = nullptr);
+      bool callWithArgs = false, void *pNext = nullptr);
 
   ur_result_t appendKernelLaunchUnlocked(
       ur_kernel_handle_t hKernel, uint32_t workDim,


### PR DESCRIPTION
Unify name of the `callWithArgs` argument in the signature of `appendKernelLaunchLocked()`.