### PR TITLE
[SYCL][E2E] Add AOT-only SYCLBIN tests

### DIFF
--- a/sycl/test-e2e/SYCLBIN/basic_executable_bmg_aot.cpp
+++ b/sycl/test-e2e/SYCLBIN/basic_executable_bmg_aot.cpp
@@ -1,0 +1,12 @@
+// REQUIRES: aspect-usm_device_allocations, ocloc, arch-intel_gpu_bmg_g21
+
+// -- Basic test for compiling and loading a SYCLBIN kernel_bundle in executable
+// -- state using only AOT target for BMG G21.
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=executable -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device bmg-g21" %S/Inputs/basic_kernel.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out %t.syclbin
+
+#define SYCLBIN_EXECUTABLE_STATE
+
+#include "Inputs/basic.hpp"

--- a/sycl/test-e2e/SYCLBIN/dae_executable_bmg_aot.cpp
+++ b/sycl/test-e2e/SYCLBIN/dae_executable_bmg_aot.cpp
@@ -1,0 +1,12 @@
+// REQUIRES: aspect-usm_device_allocations, ocloc, arch-intel_gpu_bmg_g21
+
+// -- Test for using a kernel from a SYCLBIN with a dead argument using only AOT
+// target for BMG G21.
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=executable -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device bmg-g21" %S/Inputs/dae_kernel.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out %t.syclbin
+
+#define SYCLBIN_EXECUTABLE_STATE
+
+#include "Inputs/dae.hpp"

--- a/sycl/test-e2e/SYCLBIN/dg_executable_bmg_aot.cpp
+++ b/sycl/test-e2e/SYCLBIN/dg_executable_bmg_aot.cpp
@@ -1,0 +1,18 @@
+// REQUIRES: aspect-usm_device_allocations, ocloc, arch-intel_gpu_bmg_g21
+
+// -- Test for using device globals in SYCLBIN using only AOT target for BMG
+// G21.
+
+// UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
+
+// UNSUPPORTED: cuda
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19533
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=executable -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device bmg-g21" %S/Inputs/dg_kernel.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out %t.syclbin
+
+#define SYCLBIN_EXECUTABLE_STATE
+
+#include "Inputs/dg.hpp"

--- a/sycl/test-e2e/SYCLBIN/optional_kernel_features_executable_bmg_aot.cpp
+++ b/sycl/test-e2e/SYCLBIN/optional_kernel_features_executable_bmg_aot.cpp
@@ -1,0 +1,12 @@
+// REQUIRES: aspect-usm_device_allocations, ocloc, arch-intel_gpu_bmg_g21
+
+// -- Test for compiling and loading a kernel bundle with a SYCLBIN containing
+//    the use of optional kernel features using only AOT target for BMG G21.
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=executable -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device bmg-g21" %S/Inputs/optional_kernel_features.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out %t.syclbin
+
+#define SYCLBIN_EXECUTABLE_STATE
+
+#include "Inputs/optional_kernel_features.hpp"


### PR DESCRIPTION
This commit adds variants to the executable target SYCLBIN tests that only creates SYCLBINs with AOT binary images for BMG G21. This is to help test that AOT works for SYCLBIN, avoiding tests always falling back to SPIR-V and giving the false impression that AOT works as intended.