### PR TITLE
[Driver][NFC] Fix test to not check for libspirv library

### DIFF
--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -237,7 +237,7 @@
 
 // Verify for multiple targets with -Xsycl-target-backend= with commas in the values
 // are passed correctly to llvm-offload-binary.
-// RUN: %clangxx -fsycl -### --offload-new-driver \
+// RUN: %clangxx -fsycl -### --offload-new-driver -fno-sycl-libspirv \
 // RUN:  -fsycl-targets=nvptx64-nvidia-cuda,amdgcn-amd-amdhsa,spir64_gen \
 // RUN:  -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908,gfx1010 \
 // RUN:  -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_86,sm_87,sm_89 \


### PR DESCRIPTION
Under certain testing conditions, the nvptx and amdgcn based libspirv libraries are not generated, causing a failure in the driver test sycl-offload-new-driver.c.  Update the test to not depend on these libraries as they are not important for the test.

Test fails with: clang: error: cannot find 'remangled-l64-signed_char.libspirv-nvptx64-nvidia-cuda.bc'; provide path to libspirv library via '-fsycl-libspirv-path', or pass '-fno-sycl-libspirv' to build without linking with libspirv

Test updated to use `-fno-sycl-libspirv` to prevent the inclusion of the libs.