### PR TITLE
[SYCL] Remove `std::runtime_error` that dimensionality of cluster, global and local ranges must be same for `sycl_ext_codeplay_cuda_cluster_group` extension

### DIFF
--- a/sycl/source/detail/ndrange_desc.hpp
+++ b/sycl/source/detail/ndrange_desc.hpp
@@ -86,7 +86,6 @@ public:
       : NDRDescT(Range, /*SetNumWorkGroups=*/false) {}
 
   template <int Dims_> void setClusterDimensions(sycl::range<Dims_> N) {
-
     for (int I = 0; I < Dims_; ++I)
       ClusterDimensions[I] = N[I];
   }


### PR DESCRIPTION
This PR removes `std::runtime_error` that dimensionality of cluster, global and local ranges must be same.

I don't think that this should be restriction. I can't find anything in https://docs.nvidia.com/cuda/cuda-c-programming-guide/#thread-block-clusters 

Here is spec for extension: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_codeplay_cuda_cluster_group.asciidoc
