### PR TITLE
[NFC][SYCLLowerIR] Align naming with LLVM Coding Standards

### DIFF
--- a/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
+++ b/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
@@ -601,9 +601,8 @@ PreservedAnalyses CompileTimePropertiesPass::run(Module &M,
 
     if (isHostPipeVariable(GV)) {
       auto VarName = getGlobalVariableUniqueId(GV);
-      MDOps.push_back(buildSpirvDecorMetadata(Ctx, SpirvHostAccessDecor,
-                                              SpirvHostAccessDefaultValue,
-                                              VarName));
+      MDOps.push_back(buildSpirvDecorMetadata(
+          Ctx, SpirvHostAccessDecor, SpirvHostAccessDefaultValue, VarName));
     }
 
     // Add the generated metadata to the variable
@@ -682,9 +681,8 @@ PreservedAnalyses CompileTimePropertiesPass::run(Module &M,
           SPIRVMetadata =
               buildSpirvDecorMetadata(Ctx, SpirvPipelineEnableDecor, 1);
           MDOps.push_back(SPIRVMetadata);
-          SPIRVMetadata =
-              buildSpirvDecorMetadata(Ctx, SpirvInitiationIntervalDecor,
-                                      PipelineOrInitiationInterval);
+          SPIRVMetadata = buildSpirvDecorMetadata(
+              Ctx, SpirvInitiationIntervalDecor, PipelineOrInitiationInterval);
         }
         MDOps.push_back(SPIRVMetadata);
       } else if (MDNode *SPIRVMetadata =


### PR DESCRIPTION
Removed unused constexprs.