### PR TITLE
Fix test fail after pulldown

### DIFF
--- a/sycl/test/esimd/regression/simd_wrapper.cpp
+++ b/sycl/test/esimd/regression/simd_wrapper.cpp
@@ -13,7 +13,7 @@ using namespace sycl::ext::intel::esimd;
 
 struct SimdWrapper {
   union {
-    // expected-note-re@+1 {{copy constructor of 'SimdWrapper' is implicitly deleted because variant field 'SimdWrapper::(anonymous struct at {{.*}})' has a non-trivial copy constructor}}
+    // expected-note-re@+1 {{copy constructor of 'SimdWrapper' is implicitly deleted because variant field 'SimdWrapper::(anonymous union)::(anonymous struct at {{.*}})' has a non-trivial copy constructor}}
     struct {
       simd<int, 4> v1;
     };


### PR DESCRIPTION
Most likely after commit bb1b82af395fe4a717c9b10948312e260b5ca666
diagnostics show entities nested inside anonymous unions when previously 
this nesting information was skipped over.