### PR TITLE
TEST BRANCH

### DIFF
--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -124,14 +124,14 @@ bool kernel_test_strncpy(sycl::queue &deviceQueue) {
   std::cout << "dst: " << dst[0][19] << " src: " << src[19] << std::endl;
 
   if (dst[0][19] != 'A') {
-      std::cout << "kernel_test_strncpy: test 1 failed" << std::endl;
-      return false;
-    }
+    std::cout << "kernel_test_strncpy: test 1 failed" << std::endl;
+    return false;
+  }
     
   std::cout << std::endl << "kernel_test_strncpy: test 2" << std::endl;
   for (idx = 0; idx < 20; ++idx) {
     std::cout << "dst: " << dst[1][idx] << " src: " << src[idx] << std::endl;
-    if (dst[1][idx] != src[idx]){
+    if (dst[1][idx] != src[idx]) {
       std::cout << "kernel_test_strncpy: test 2 failed" << std::endl;
       return false;
     }


### PR DESCRIPTION
 Additional output to isolate filing test case - kernel-test-strncpy failing issue: DeviceLib/string_test.cpp failing on CUDA in nightly #20338
