### PR TITLE
[SYCL RTC] Exclude libdevice's `.o/.spv` files from resources

### DIFF
--- a/sycl-jit/jit-compiler/utils/generate.py
+++ b/sycl-jit/jit-compiler/utils/generate.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 import glob
+import re
 
 
 def main():
@@ -33,6 +34,9 @@ const resource_file ToolchainFiles[] = {"""
         )
 
         def process_file(file_path):
+            # We only need .bc files from libdevice:
+            if re.search(r"[/\\]libsycl-.*\.(o|obj|spv)$", file_path):
+                return
             out.write(
                 f"""
 {{


### PR DESCRIPTION
We only use `.bc` files from libdevice. Another potential implementation for this was to update libdevice's CMakeLists.txt to have separate `libdevice-bc` and `libdevice-non-bc` install components and only install the former into `rtc-resoruce-install` directory. However, that would be intrusive to libdevice with zero benefit there, so I decided to do the filter on the sycl-jit's side inside `generate.py`.