### PR TITLE
[SYCL][NFC] Relax checks in abi/layout_handler.cpp

### DIFF
--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -14,13 +14,11 @@ void foo() {
 // The order of field declarations and their types are important.
 // CHECK:        0 | class sycl::handler
 // CHECK-NEXT:   0 |   class std::unique_ptr<class sycl::detail::handler_impl> implOwner
-// CHECK-NEXT:   0 |     struct std::__uniq_ptr_data<class sycl::detail::handler_impl, struct std::default_delete<class sycl::detail::handler_impl> > _M_t
+// CHECK-NEXT:   0 |     struct std::__uniq_ptr_data<class sycl::detail::handler_impl, struct std::default_delete<class sycl::detail::handler_impl> >
 // CHECK-NEXT:   0 |       class std::__uniq_ptr_impl<class sycl::detail::handler_impl, struct std::default_delete<class sycl::detail::handler_impl> > (base)
-// CHECK-NEXT:   0 |         class std::tuple<class sycl::detail::handler_impl *, struct std::default_delete<class sycl::detail::handler_impl> > _M_t
+// CHECK-NEXT:   0 |         class std::tuple<class sycl::detail::handler_impl *, struct std::default_delete<class sycl::detail::handler_impl> >
 // CHECK-NEXT:   0 |           struct std::_Tuple_impl<0, class sycl::detail::handler_impl *, struct std::default_delete<class sycl::detail::handler_impl> > (base)
 // CHECK-NEXT:   0 |             struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::handler_impl> > (base) (empty)
-// CHECK:        0 |               struct std::_Head_base<1, struct std::default_delete<class sycl::detail::handler_impl> > (base) (empty)
-// CHECK-NEXT:   0 |                 struct std::default_delete<class sycl::detail::handler_impl> _M_head_impl (empty)
 // CHECK:        0 |             struct std::_Head_base<0, class sycl::detail::handler_impl *> (base)
 // CHECK-NEXT:   0 |               class sycl::detail::handler_impl * _M_head_impl
 // CHECK-NEXT:   8 |   detail::handler_impl * impl
@@ -28,8 +26,6 @@ void foo() {
 // CHECK-NEXT:   16 |     struct std::_Vector_base<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > > (base)
 // CHECK-NEXT:   16 |       struct std::_Vector_base<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > >::_Vector_impl _M_impl
 // CHECK-NEXT:   16 |         class std::allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > (base) (empty)
-// CHECK-NEXT:   16 |           class std::__new_allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > (base) (empty)
-// CHECK-NEXT:   16 |         struct std::_Vector_base<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > >::_Vector_impl_data (base)
 // CHECK:        16 |           pointer _M_start
 // CHECK-NEXT:   24 |           pointer _M_finish
 // CHECK-NEXT:   32 |           pointer _M_end_of_storage
@@ -37,8 +33,6 @@ void foo() {
 // CHECK-NEXT:   40 |     struct std::_Vector_base<class std::shared_ptr<class sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class sycl::detail::stream_impl> > > (base)
 // CHECK-NEXT:   40 |       struct std::_Vector_base<class std::shared_ptr<class sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class sycl::detail::stream_impl> > >::_Vector_impl _M_impl
 // CHECK-NEXT:   40 |         class std::allocator<class std::shared_ptr<class sycl::detail::stream_impl> > (base) (empty)
-// CHECK-NEXT:   40 |           class std::__new_allocator<class std::shared_ptr<class sycl::detail::stream_impl> > (base) (empty)
-// CHECK-NEXT:   40 |         struct std::_Vector_base<class std::shared_ptr<class sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class sycl::detail::stream_impl> > >::_Vector_impl_data (base)
 // CHECK:        40 |           pointer _M_start
 // CHECK-NEXT:   48 |           pointer _M_finish
 // CHECK-NEXT:   56 |           pointer _M_end_of_storage
@@ -57,19 +51,15 @@ void foo() {
 // CHECK-NEXT:   112 |     struct std::_Vector_base<unsigned char, class std::allocator<unsigned char> > (base)
 // CHECK-NEXT:   112 |       struct std::_Vector_base<unsigned char, class std::allocator<unsigned char> >::_Vector_impl _M_impl
 // CHECK-NEXT:   112 |         class std::allocator<unsigned char> (base) (empty)
-// CHECK-NEXT:   112 |           class std::__new_allocator<unsigned char> (base) (empty)
-// CHECK-NEXT:   112 |         struct std::_Vector_base<unsigned char, class std::allocator<unsigned char> >::_Vector_impl_data (base)
 // CHECK:        112 |           pointer _M_start
 // CHECK-NEXT:   120 |           pointer _M_finish
 // CHECK-NEXT:   128 |           pointer _M_end_of_storage
 // CHECK-NEXT:   136 |   class std::unique_ptr<class sycl::detail::HostKernelBase> MHostKernel
-// CHECK-NEXT:   136 |     struct std::__uniq_ptr_data<class sycl::detail::HostKernelBase, struct std::default_delete<class sycl::detail::HostKernelBase> > _M_t
+// CHECK-NEXT:   136 |     struct std::__uniq_ptr_data<class sycl::detail::HostKernelBase, struct std::default_delete<class sycl::detail::HostKernelBase> >
 // CHECK:        136 |       class std::__uniq_ptr_impl<class sycl::detail::HostKernelBase, struct std::default_delete<class sycl::detail::HostKernelBase> > (base)
-// CHECK-NEXT:   136 |         class std::tuple<class sycl::detail::HostKernelBase *, struct std::default_delete<class sycl::detail::HostKernelBase> > _M_t
+// CHECK-NEXT:   136 |         class std::tuple<class sycl::detail::HostKernelBase *, struct std::default_delete<class sycl::detail::HostKernelBase> >
 // CHECK-NEXT:   136 |           struct std::_Tuple_impl<0, class sycl::detail::HostKernelBase *, struct std::default_delete<class sycl::detail::HostKernelBase> > (base)
 // CHECK-NEXT:   136 |             struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::HostKernelBase> > (base) (empty)
-// CHECK:        136 |               struct std::_Head_base<1, struct std::default_delete<class sycl::detail::HostKernelBase> > (base) (empty)
-// CHECK-NEXT:   136 |                 struct std::default_delete<class sycl::detail::HostKernelBase> _M_head_impl (empty)
 // CHECK:        136 |             struct std::_Head_base<0, class sycl::detail::HostKernelBase *> (base)
 // CHECK-NEXT:   136 |               class sycl::detail::HostKernelBase * _M_head_impl
 // CHECK-NEXT:   144 |   struct sycl::detail::code_location MCodeLoc


### PR DESCRIPTION
Relax checks to make sure that building/testing the project with more GCC/STL versions would pass.
(similar to https://github.com/intel/llvm/commit/d962d3c01bd50bec7b9d4af1861a938852c1a0e3)
There is no need to check stl internals.