### PR TITLE
[NFC][SYCL][E2E]Fix ocloc device command for multiple devices

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/lit.local.cfg
+++ b/sycl/test-e2e/AddressSanitizer/lit.local.cfg
@@ -3,7 +3,7 @@ config.substitutions.append(
 )
 # For GPU, DASAN only support pvc and dg2 currently
 config.substitutions.append(
-    ("%device_asan_aot_flags", "-Xarch_device -fsanitize=address %if cpu %{ -fsycl-targets=spir64_x86_64 %} %if gpu %{ -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen '-devices pvc,dg2' %}")
+    ("%device_asan_aot_flags", "-Xarch_device -fsanitize=address %if cpu %{ -fsycl-targets=spir64_x86_64 %} %if gpu %{ -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen '-device pvc,dg2' %}")
 )
 config.substitutions.append(
     ("%force_device_asan_rt", "env UR_ENABLE_LAYERS=UR_LAYER_ASAN")

--- a/sycl/test-e2e/MemorySanitizer/lit.local.cfg
+++ b/sycl/test-e2e/MemorySanitizer/lit.local.cfg
@@ -6,7 +6,7 @@ else:
     config.unsupported_features += ['igc-dev']
 
 config.substitutions.append(
-    ("%device_msan_aot_flags", "-Xarch_device -fsanitize=memory %if cpu %{ -fsycl-targets=spir64_x86_64 %} %if gpu %{ -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen '-devices pvc' %}")
+    ("%device_msan_aot_flags", "-Xarch_device -fsanitize=memory %if cpu %{ -fsycl-targets=spir64_x86_64 %} %if gpu %{ -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen '-device pvc' %}")
 )
 
 # MemorySanitizer is not currently supported for non-spir triples

--- a/sycl/test-e2e/ThreadSanitizer/lit.local.cfg
+++ b/sycl/test-e2e/ThreadSanitizer/lit.local.cfg
@@ -23,7 +23,7 @@ config.substitutions.append(
 
 # For GPU, DTSAN only support pvc currently
 config.substitutions.append(
-    ("%device_tsan_aot_flags", "-Xarch_device -fsanitize=thread %if cpu %{ -fsycl-targets=spir64_x86_64 %} %if gpu %{ -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen '-devices pvc' %}")
+    ("%device_tsan_aot_flags", "-Xarch_device -fsanitize=thread %if cpu %{ -fsycl-targets=spir64_x86_64 %} %if gpu %{ -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen '-device pvc' %}")
 )
 
 unsupported_san_flags = [


### PR DESCRIPTION
ocloc use -device instead of -devices.
Exposed by 046f67d.
