### PR TITLE
[SYCL][Graph][Test] Move `host_task_in_order_dependency` to unsupported with windows + gen12 + level_zero

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/host_task_in_order_dependency.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_in_order_dependency.cpp
@@ -3,6 +3,9 @@
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// UNSUPPORTED: level_zero && windows && gpu-intel-gen12
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20696
+//
 // REQUIRES: aspect-usm_host_allocations
 
 // Tests injected barrier between an in-order operation in no event mode and a


### PR DESCRIPTION
- `host_task_in_order.cpp` introduced in https://github.com/intel/llvm/pull/20690 sporadically fails on Windows + Gen12 due to reported L0 leaks
- Move to unsupported for the affected configuration and track resolution in https://github.com/intel/llvm/issues/20696 