### PR TITLE
[LTO] Extend CAS build workaround to LTO

### DIFF
--- a/llvm/lib/LTO/CMakeLists.txt
+++ b/llvm/lib/LTO/CMakeLists.txt
@@ -1,3 +1,10 @@
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # We append -fno-lifetime-dse in HandleLLVMOptions.cmake
+  # append("-fno-lifetime-dse" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+  # But it is causing link failure with llvm::StdThreadPool::asyncEnqueue
+  string(REPLACE "-fno-lifetime-dse" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+endif ()
+
 add_llvm_component_library(LLVMLTO
   LTO.cpp
   LTOBackend.cpp


### PR DESCRIPTION
Shared library build fails with the same error Jinsong saw and fixed in https://github.com/intel/llvm/commit/e676cb09f0b23ec572fefe09aa7882876797eb79 as part of the pulldown.