### PR TITLE
Added `--verbose` in the proper place in `compile.py`

### DIFF
--- a/buildbot/compile.py
+++ b/buildbot/compile.py
@@ -31,14 +31,17 @@ def do_compile(args):
         "cmake",
         "--build",
         abs_obj_dir,
+    ]
+
+    if args.verbose:
+        cmake_cmd.append("--verbose")
+
+    cmake_cmd += [
         "--",
         args.build_target,
         "-j",
         str(cpu_count),
     ]
-
-    if args.verbose:
-        cmake_cmd.append("--verbose")
 
     print("[Cmake Command]: {}".format(" ".join(cmake_cmd)))
 


### PR DESCRIPTION
When running `compile.py` (after `configure.py`) with the `--verbose` flag, the resulting cmake command is `cmake --build build <my_build_dir> -- deply-sycl-toolchain --verbose` which results in an error like this `/usr/bin/gmake: unrecognized option '--verbose'` when using Unix Makefiles as generator. To support both makefiles and ninja, a better and easier approach is to just place `--verbose` before the `--` in the final command.