### PR TITLE
[SYCL][E2E] Disable two image tests failing in nightly

### DIFF
--- a/sycl/test-e2e/Basic/image/image_read.cpp
+++ b/sycl/test-e2e/Basic/image/image_read.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: aspect-ext_intel_legacy_image
+// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20224
 // Temporarily add explicit '-O2' to avoid GPU hang issue with O0 optimization.
 // RUN: %{build} -O2 -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/image/image_sample.cpp
+++ b/sycl/test-e2e/Basic/image/image_sample.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: aspect-ext_intel_legacy_image
+// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20224
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Ex: https://github.com/intel/llvm/actions/runs/19951692323/job/57213956594