### PR TITLE
Update buildbot/configure.py

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -82,7 +82,7 @@ def do_configure(args, passthrough_args):
 
     libclc_enabled = args.cuda or args.hip or args.native_cpu
     if libclc_enabled:
-        llvm_enable_runtimes += ";libclc"
+        llvm_enable_projects += ";libclc"
 
     # DeviceRTL uses -fuse-ld=lld, so enable lld.
     if args.offload:
@@ -155,8 +155,8 @@ def do_configure(args, passthrough_args):
         if sys.platform != "darwin":
             # libclc is required for CI validation
             libclc_enabled = True
-            if "libclc" not in llvm_enable_runtimes:
-                llvm_enable_runtimes += ";libclc"
+            if "libclc" not in llvm_enable_projects:
+                llvm_enable_projects += ";libclc"
             # libclc passes `--nvvm-reflect-enable=false`, build NVPTX to enable it
             if "NVPTX" not in llvm_targets_to_build:
                 llvm_targets_to_build += ";NVPTX"

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -526,12 +526,17 @@ if("lld" IN_LIST LLVM_ENABLE_PROJECTS)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS lld)
 endif()
 
+if("libclc" IN_LIST LLVM_ENABLE_PROJECTS)
+  add_dependencies(sycl-toolchain libspirv-builtins)
+  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins)
+endif()
+
 if("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   # Ensure that libclc is enabled.
-  list(FIND LLVM_ENABLE_RUNTIMES  libclc LIBCLC_FOUND)
+  list(FIND LLVM_ENABLE_PROJECTS libclc LIBCLC_FOUND)
   if( LIBCLC_FOUND EQUAL -1 )
     message(FATAL_ERROR
-      "CUDA support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_RUNTIMES \"")
+      "CUDA support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
 
   add_dependencies(sycl-toolchain ur_adapter_cuda)
@@ -540,10 +545,10 @@ endif()
 
 if("hip" IN_LIST SYCL_ENABLE_BACKENDS)
   # Ensure that libclc is enabled.
-  list(FIND LLVM_ENABLE_RUNTIMES libclc LIBCLC_FOUND)
+  list(FIND LLVM_ENABLE_PROJECTS libclc LIBCLC_FOUND)
   if( LIBCLC_FOUND EQUAL -1 )
     message(FATAL_ERROR
-      "HIP support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_RUNTIMES \"")
+      "HIP support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
 
   if(NOT TARGET lld AND "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
@@ -611,5 +616,4 @@ add_custom_target(install-sycl-test-utilities
   # sycl/test-e2e/Basic/device_config_file_consistency.cpp.
   COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component DeviceConfigFile
   COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component compiler-rt
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component libclc
 )


### PR DESCRIPTION
This PR updates cmake configuration option based on this warning.
```
-- Detecting CXX compile features - done
CMake Warning at CMakeLists.txt:198 (message):
  Using LLVM_ENABLE_PROJECTS=compiler-rt is deprecated now, and will become a
  fatal error in a future release.  Please use
  -DLLVM_ENABLE_RUNTIMES=compiler-rt or see the instructions at
  https://compiler-rt.llvm.org/ for building the runtimes.
```

Not sure if it's right solution but with review I am waiting for suggestions.