### PR TITLE
[SYCL] optimize createSyclObjFromImpl calls to take rvalue-ref to shared_ptr

### DIFF
--- a/sycl/include/sycl/ext/oneapi/weak_object.hpp
+++ b/sycl/include/sycl/ext/oneapi/weak_object.hpp
@@ -73,7 +73,8 @@ public:
     auto MObjImplPtr = this->MObjWeakPtr.lock();
     if (!MObjImplPtr)
       return std::nullopt;
-    return sycl::detail::createSyclObjFromImpl<SYCLObjT>(MObjImplPtr);
+    return sycl::detail::createSyclObjFromImpl<SYCLObjT>(
+        std::move(MObjImplPtr));
   }
   SYCLObjT lock() const {
     std::optional<SYCLObjT> OptionalObj = try_lock();

--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -731,7 +731,8 @@ template <bundle_state State>
 kernel_bundle<State> get_empty_interop_kernel_bundle(const context &Ctx) {
   detail::KernelBundleImplPtr Impl =
       detail::get_empty_interop_kernel_bundle_impl(Ctx, Ctx.get_devices());
-  return detail::createSyclObjFromImpl<sycl::kernel_bundle<State>>(Impl);
+  return detail::createSyclObjFromImpl<sycl::kernel_bundle<State>>(
+      std::move(Impl));
 }
 } // namespace detail
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1723,10 +1723,8 @@ void ProgramManager::addImage(sycl_device_binary RawImg,
     // ... and create a unique kernel ID for the entry
     auto It = m_KernelName2KernelIDs.find(name);
     if (It == m_KernelName2KernelIDs.end()) {
-      std::shared_ptr<detail::kernel_id_impl> KernelIDImpl =
-          std::make_shared<detail::kernel_id_impl>(name);
-      sycl::kernel_id KernelID =
-          detail::createSyclObjFromImpl<sycl::kernel_id>(KernelIDImpl);
+      sycl::kernel_id KernelID = detail::createSyclObjFromImpl<sycl::kernel_id>(
+          std::make_shared<detail::kernel_id_impl>(name));
 
       It = m_KernelName2KernelIDs.emplace_hint(It, name, KernelID);
     }

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -81,7 +81,7 @@ prepareSYCLEventAssociatedWithQueue(detail::queue_impl &QueueImpl) {
   auto EventImpl = detail::event_impl::create_device_event(QueueImpl);
   EventImpl->setContextImpl(QueueImpl.getContextImpl());
   EventImpl->setStateIncomplete();
-  return detail::createSyclObjFromImpl<event>(EventImpl);
+  return detail::createSyclObjFromImpl<event>(std::move(EventImpl));
 }
 
 const std::vector<event> &
@@ -103,7 +103,8 @@ queue_impl::getExtendDependencyList(const std::vector<event> &DepEvents,
   if (ExternalEvent)
     MutableVec.push_back(*ExternalEvent);
   if (ExtraEvent)
-    MutableVec.push_back(detail::createSyclObjFromImpl<event>(ExtraEvent));
+    MutableVec.push_back(
+        detail::createSyclObjFromImpl<event>(std::move(ExtraEvent)));
   return MutableVec;
 }
 

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -348,7 +348,7 @@ public:
 
     detail::EventImplPtr ResEvent = submit_impl(CGF, /*CallerNeedsEvent=*/true,
                                                 Loc, IsTopCodeLoc, SubmitInfo);
-    return createSyclObjFromImpl<event>(ResEvent);
+    return createSyclObjFromImpl<event>(std::move(ResEvent));
   }
 
   event submit_kernel_direct_with_event(
@@ -361,7 +361,7 @@ public:
     detail::EventImplPtr EventImpl = submit_kernel_direct_impl(
         NDRDescT(RangeView), HostKernel, DeviceKernelInfo,
         /*CallerNeedsEvent*/ true, DepEvents, Props, CodeLoc, IsTopCodeLoc);
-    return createSyclObjFromImpl<event>(EventImpl);
+    return createSyclObjFromImpl<event>(std::move(EventImpl));
   }
 
   void submit_kernel_direct_without_event(

--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -516,7 +516,7 @@ obj_kb compile_from_source(
   kernel_bundle_impl &sourceImpl = *getSyclObjImpl(SourceKB);
   std::shared_ptr<kernel_bundle_impl> KBImpl = sourceImpl.compile_from_source(
       UniqueDevices, BuildOptions, LogPtr, RegisteredKernelNames);
-  auto result = sycl::detail::createSyclObjFromImpl<obj_kb>(KBImpl);
+  auto result = sycl::detail::createSyclObjFromImpl<obj_kb>(std::move(KBImpl));
   if (LogView)
     *LogView = Log;
   return result;

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -92,7 +92,8 @@ queue::ext_oneapi_get_graph() const {
 
   return sycl::detail::createSyclObjFromImpl<
       ext::oneapi::experimental::command_graph<
-          ext::oneapi::experimental::graph_state::modifiable>>(Graph);
+          ext::oneapi::experimental::graph_state::modifiable>>(
+      std::move(Graph));
 }
 
 void queue::throw_asynchronous() { impl->throw_asynchronous(); }


### PR DESCRIPTION
The optimization results in moving shared_pointer inside _createSyclObjFromImpl_ instead of copying and thanks to it we save two atomic operations (see e.g. [this SO thread](https://stackoverflow.com/a/41874953/1654158)).

I've applied it to all possible places in the code, leaving only these where copying is indeed needed (mostly for _context_impl_ use).

### Results summary

overhead over UR reduced by ~8% in scenarios using events. Other benchmarks also show visible improvements in many cases, including new pytorch multiqueue benchmarks which improved overall by 2.7%

### Results Examples
The new result is expressed by dots on the right sides of plots.

<img width="1548" height="735" alt="SubmitKernel out of order using events long kernel, CPU count(1)" src="https://github.com/user-attachments/assets/829ab30e-76f3-42a8-b6d9-c17714a5a145" />
old = 134.6, new = 132.8, UR baseline = 113, overhead over UR reduced by 8.3%

<img width="1548" height="735" alt="SubmitKernel out of order with completion using events, CPU count(4)" src="https://github.com/user-attachments/assets/17e9d7cf-c88d-455e-b116-39e2f1b8f04c" />

old = 140, new = 138.2, UR baseline = 118.1, **overhead over UR reduced by 8.1%**

<img width="1548" height="735" alt="SubmitKernel in order, CPU count(5)" src="https://github.com/user-attachments/assets/1e3f784a-efdb-47cc-8dea-bc516bdad33a" />

old = 122.3, new = 121.3, UR baseline = 108.1, **overhead over UR reduced by 7.0%**

<img width="1548" height="810" alt="SubmitKernel in order using events(2)" src="https://github.com/user-attachments/assets/e96770aa-9716-4293-a0b6-29babd25ee5e" />

old time = 13.91, new time = 13.58, **whole stack reduced by 2.4%**

And finally new pytorch microbenchmarks:

<img width="1548" height="735" alt="KernelSubmitMultiQueue small" src="https://github.com/user-attachments/assets/d23b3c40-ae0e-4528-9c5e-f2726e3030ce" />

old time = 1.81, new time = 1.76, L0 baseline = 1.44
whole stack reduced by 2.8%, **overhead over L0 reduced by 13.5%**