### PR TITLE
[SYCL][E2E] XFAIL string_test.cpp on Win DG2

### DIFF
--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -Wno-error=deprecated-declarations -Wno-error=pointer-to-int-cast -fno-builtin -o %t1.out
 // RUN: %{run} %t1.out
 
+// XFAIL: windows && gpu-intel-dg2
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20861
+
 #include <cassert>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
Failing after driver update, see https://github.com/intel/llvm/issues/20861