### PR TITLE
[SYCL] queue use perfect forwarding

### DIFF
--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -107,7 +107,7 @@ event queue::memset(void *Ptr, int Value, size_t Count,
 event queue::memset(void *Ptr, int Value, size_t Count, event DepEvent,
                     const detail::code_location &CodeLoc) {
   detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
-  return impl->memset(Ptr, Value, Count, {DepEvent},
+  return impl->memset(Ptr, Value, Count, {std::move(DepEvent)},
                       /*CallerNeedsEvent=*/true);
 }
 
@@ -129,7 +129,7 @@ event queue::memcpy(void *Dest, const void *Src, size_t Count,
 event queue::memcpy(void *Dest, const void *Src, size_t Count, event DepEvent,
                     const detail::code_location &CodeLoc) {
   detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
-  return impl->memcpy(Dest, Src, Count, {DepEvent},
+  return impl->memcpy(Dest, Src, Count, {std::move(DepEvent)},
                       /*CallerNeedsEvent=*/true, TlsCodeLocCapture.query());
 }
 
@@ -152,7 +152,7 @@ event queue::mem_advise(const void *Ptr, size_t Length, int Advice,
                         event DepEvent, const detail::code_location &CodeLoc) {
   detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
   return impl->mem_advise(Ptr, Length, ur_usm_advice_flags_t(Advice),
-                          {DepEvent},
+                          {std::move(DepEvent)},
                           /*CallerNeedsEvent=*/true);
 }
 


### PR DESCRIPTION
Use perfect forwarding in queue inline implementations. In the same place use event move if possible. For sake of performance.

As the change is small one. Most benchmarks show no performance improvement, but some have improved, e.g. (see difference between green lines above and two last points of red line marked in a circle)
<img width="1548" height="735" alt="SubmitKernel-out-of-order-using-events-long-kernel_perfect_forwarding" src="https://github.com/user-attachments/assets/dfada8dc-dab5-4629-975b-8cf2fd7558d5" />
<img width="1548" height="735" alt="SubmitKernel-out-of-order-with-completion_perfect_forwarding" src="https://github.com/user-attachments/assets/c1cb1e6b-6811-4441-9f1f-d134fcc728c0" />

Not using perfect forwarding in the API taking universal references is a wrong pattern. I want it to be fixed, in order to
- do not to wonder in the future whether if we are slow because of this or because of something else (quickly jump to "something else" branch)
- promote correct API for future calls, as people usually look around how things are written and write code in a similar way
- improve perf a bit, as it indeed improves it