### PR TITLE
[SYCL][clang] Apply default arg suppression for template of templates

### DIFF
--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1927,7 +1927,8 @@ void DeclPrinter::VisitNonTypeTemplateParmDecl(
 void DeclPrinter::VisitTemplateTemplateParmDecl(
     const TemplateTemplateParmDecl *TTPD) {
   VisitTemplateDecl(TTPD);
-  if (TTPD->hasDefaultArgument() && !TTPD->defaultArgumentWasInherited()) {
+  if (TTPD->hasDefaultArgument() && !Policy.SuppressDefaultTemplateArguments &&
+      !TTPD->defaultArgumentWasInherited()) {
     Out << " = ";
     TTPD->getDefaultArgument().getArgument().print(Policy, Out,
                                                    /*IncludeType=*/false);

--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -5,8 +5,9 @@
 //
 // CHECK: // Forward declarations of templated kernel function types:
 // CHECK: class first_kernel;
+// CHECK-NEXT: template <typename T> struct point;
 // CHECK-NEXT: namespace second_namespace {
-// CHECK-NEXT: template <typename T> class second_kernel;
+// CHECK-NEXT: template <typename T, template <typename> typename U> class second_kernel;
 // CHECK-NEXT: }
 // CHECK-NEXT: namespace template_arg_ns {
 // CHECK-NEXT: template <int DimX> struct namespaced_arg;
@@ -17,7 +18,7 @@
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
 // CHECK-NEXT:   "_ZTSZ4mainE12first_kernel",
-// CHECK-NEXT:   "_ZTSN16second_namespace13second_kernelIcEE",
+// CHECK-NEXT:   "_ZTSN16second_namespace13second_kernelIc5pointEE",
 // CHECK-NEXT:   "_ZTS13fourth_kernelIJN15template_arg_ns14namespaced_argILi1EEEEE"
 // CHECK-NEXT:   "_ZTSZ4mainE16accessor_in_base"
 // CHECK-NEXT:   "_ZTSZ4mainE15annotated_types"
@@ -36,7 +37,7 @@
 // CHECK-NEXT:   { kernel_param_kind_t::kind_accessor, 6112, 24 },
 // CHECK-NEXT:   { kernel_param_kind_t::kind_sampler, 8, 40 },
 // CHECK-EMPTY:
-// CHECK-NEXT:   //--- _ZTSN16second_namespace13second_kernelIcEE
+// CHECK-NEXT:   //--- _ZTSN16second_namespace13second_kernelIc5pointEE
 // CHECK-NEXT:   { kernel_param_kind_t::kind_std_layout, 4, 0 },
 // CHECK-NEXT:   { kernel_param_kind_t::kind_accessor, 6112, 4 },
 // CHECK-NEXT:   { kernel_param_kind_t::kind_sampler, 8, 16 },
@@ -66,7 +67,7 @@
 // CHECK-NEXT: };
 //
 // CHECK: template <> struct KernelInfo<first_kernel> {
-// CHECK: template <> struct KernelInfo<::second_namespace::second_kernel<char>> {
+// CHECK: template <> struct KernelInfo<::second_namespace::second_kernel<char, point>> {
 // CHECK: template <> struct KernelInfo<::fourth_kernel<::template_arg_ns::namespaced_arg<1>>> {
 
 #include "Inputs/sycl.hpp"
@@ -79,7 +80,7 @@ struct x {};
 template <typename T>
 struct point {};
 namespace second_namespace {
-template <typename T = int>
+template <typename T = int, template <typename> typename U = point>
 class second_kernel;
 }
 


### PR DESCRIPTION
The SuppressDefaultTemplateArguments is a printing policy argument local to intel/llvm, but is currently only applied to basic templates. This commit applies the suppression of default arguments to template of templates cases as well.