### PR TITLE
[UR][HIP] Make ur_context_handle_t_ destructor non-throwing

### DIFF
--- a/unified-runtime/source/adapters/cuda/context.hpp
+++ b/unified-runtime/source/adapters/cuda/context.hpp
@@ -108,18 +108,13 @@ struct ur_context_handle_t_ : ur::cuda::handle_base {
   };
 
   ~ur_context_handle_t_() noexcept {
-    try {
-      if (MemoryPoolHost) {
-        umfPoolDestroy(MemoryPoolHost);
-      }
-      if (MemoryProviderHost) {
-        umfMemoryProviderDestroy(MemoryProviderHost);
-      }
-      urAdapterRelease(ur::cuda::adapter);
-    } catch (...) {
-      UR_LOG(ERR, "Exception in context destructor");
-      assert(false && "Exception in context destructor");
+    if (MemoryPoolHost) {
+      umfPoolDestroy(MemoryPoolHost);
     }
+    if (MemoryProviderHost) {
+      umfMemoryProviderDestroy(MemoryProviderHost);
+    }
+    urAdapterRelease(ur::cuda::adapter);
   }
 
   void invokeExtendedDeleters() {

--- a/unified-runtime/source/adapters/hip/context.hpp
+++ b/unified-runtime/source/adapters/hip/context.hpp
@@ -96,14 +96,7 @@ struct ur_context_handle_t_ : ur::hip::handle_base {
     UR_CHECK_ERROR(urAdapterRetain(ur::hip::adapter));
   };
 
-  ~ur_context_handle_t_() noexcept {
-    try {
-      urAdapterRelease(ur::hip::adapter);
-    } catch (...) {
-      UR_LOG(ERR, "Exception in context destructor");
-      assert(false && "Exception in context destructor");
-    }
-  }
+  ~ur_context_handle_t_() noexcept { urAdapterRelease(ur::hip::adapter); }
 
   ur_context_handle_t_(const ur_context_handle_t_ &) = delete;
 


### PR DESCRIPTION
UR_CHECK_ERROR may throw or abort, which is unsafe to use from a destructor. If an exception escapes during stack unwinding, std::terminate would be called.

Replace UR_CHECK_ERROR in ur_context_handle_t_ destructor with a non-throwing, best-effort cleanup. In debug builds, failures are reported via assert/log, while release builds avoid throwing from the destructor.

fixes: https://github.com/intel/llvm/issues/20811
