### PR TITLE
[SYCL][E2E] XFAIL `structs_with_special_types_as_kernel_paramters.cpp` on CUDA

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/structs_with_special_types_as_kernel_paramters.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/structs_with_special_types_as_kernel_paramters.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: any-target-is-nvidia && build-mode
+// XFAIL: target-nvidia
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20908
 
 // This test verifies whether struct that contains either sycl::local_accesor or


### PR DESCRIPTION
This test started failing during compilation after https://github.com/intel/llvm/pull/20824