### PR TITLE
[SYCL][UR] Run MultiDevice/set_arg_pointer.cpp test on UR L0v2 adapter

### DIFF
--- a/sycl/test-e2e/MultiDevice/set_arg_pointer.cpp
+++ b/sycl/test-e2e/MultiDevice/set_arg_pointer.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: CMPLRLLVM-67039
-
 // Test that usm device pointer can be used in a kernel compiled for a context
 // with multiple devices.
 


### PR DESCRIPTION
Run the sycl/test-e2e/MultiDevice/set_arg_pointer.cpp test on UR L0v2 adapter.