### PR TITLE
[SYCL][E2E] Allow specification of xfail features in lit.local.cfg

### DIFF
--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -76,6 +76,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
         assert parsed["DEFINE:"] == script
         assert parsed["REDEFINE:"] == script
 
+        test.xfails += test.config.xfail_features
         test.xfails += parsed["XFAIL:"] or []
         test.requires += test.config.required_features
         test.requires += parsed["REQUIRES:"] or []

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -55,6 +55,7 @@ config.recursiveExpansionLimit = 10
 # To be filled by lit.local.cfg files.
 config.required_features = []
 config.unsupported_features = []
+config.xfail_features = []
 
 # test-mode: Set if tests should run normally or only build/run
 config.test_mode = lit_config.params.get("test-mode", "full")


### PR DESCRIPTION
With this, in a `lit.local.cfg` you can do `config.xfail_features += ['gpu-intel-dg2']` instead of having to add it to every test. There's already a way to do it for `UNSUPPORTED` and `REQUIRES`.