### PR TITLE
[SYCL][E2E][JM] Enable joint_matrix_bf16_fill_k_cache_SLM.cpp on DG2

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_SLM.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_SLM.cpp
@@ -9,9 +9,6 @@
 
 // REQUIRES: aspect-ext_intel_matrix, gpu
 
-// XFAIL: linux && gpu-intel-dg2 && !igc-dev
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20595
-
 // RUN: %{build} -o %t_gpu_vnni.out %fp-model-precise -DSLM -DVNNI
 // RUN: %{run} %t_gpu_vnni.out
 


### PR DESCRIPTION
Passing after new driver update.

https://github.com/intel/llvm/actions/runs/20282497960/job/58249026576

Driver update was done in https://github.com/intel/llvm/commit/6aa510d5e0a51b3f2177dab36f2812f5ce4f3b65