### PR TITLE
[UR][L0v2] Add hDevice argument to ur_kernel_handle_t_::setArgValue()

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -1123,19 +1123,20 @@ ur_result_t ur_command_list_manager::appendKernelLaunchWithArgsExpOld(
     wait_list_view &waitListView, ur_event_handle_t phEvent) {
   {
     std::scoped_lock<ur_shared_mutex> guard(hKernel->Mutex);
+    ur_device_handle_t hDevice = this->hDevice.get();
     for (uint32_t argIndex = 0; argIndex < numArgs; argIndex++) {
       switch (pArgs[argIndex].type) {
       case UR_EXP_KERNEL_ARG_TYPE_LOCAL:
-        UR_CALL(hKernel->setArgValue(pArgs[argIndex].index,
+        UR_CALL(hKernel->setArgValue(hDevice, pArgs[argIndex].index,
                                      pArgs[argIndex].size, nullptr, nullptr));
         break;
       case UR_EXP_KERNEL_ARG_TYPE_VALUE:
-        UR_CALL(hKernel->setArgValue(pArgs[argIndex].index,
+        UR_CALL(hKernel->setArgValue(hDevice, pArgs[argIndex].index,
                                      pArgs[argIndex].size, nullptr,
                                      pArgs[argIndex].value.value));
         break;
       case UR_EXP_KERNEL_ARG_TYPE_POINTER:
-        UR_CALL(hKernel->setArgPointer(pArgs[argIndex].index, nullptr,
+        UR_CALL(hKernel->setArgPointer(hDevice, pArgs[argIndex].index, nullptr,
                                        pArgs[argIndex].value.pointer));
         break;
       case UR_EXP_KERNEL_ARG_TYPE_MEM_OBJ:
@@ -1147,7 +1148,7 @@ ur_result_t ur_command_list_manager::appendKernelLaunchWithArgsExpOld(
         break;
       case UR_EXP_KERNEL_ARG_TYPE_SAMPLER: {
         UR_CALL(
-            hKernel->setArgValue(argIndex, sizeof(void *), nullptr,
+            hKernel->setArgValue(hDevice, argIndex, sizeof(void *), nullptr,
                                  &pArgs[argIndex].value.sampler->ZeSampler));
         break;
       }

--- a/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/kernel.hpp
@@ -67,13 +67,14 @@ public:
   const ze_kernel_properties_t &getProperties(ur_device_handle_t hDevice) const;
 
   // Implementation of urKernelSetArgValue.
-  ur_result_t setArgValue(uint32_t argIndex, size_t argSize,
+  ur_result_t setArgValue(ur_device_handle_t hDevice, uint32_t argIndex,
+                          size_t argSize,
                           const ur_kernel_arg_value_properties_t *pProperties,
                           const void *pArgValue);
 
   // Implementation of urKernelSetArgPointer.
   ur_result_t
-  setArgPointer(uint32_t argIndex,
+  setArgPointer(ur_device_handle_t hDevice, uint32_t argIndex,
                 const ur_kernel_arg_pointer_properties_t *pProperties,
                 const void *pArgValue);
 


### PR DESCRIPTION
Add `hDevice` argument to `ur_kernel_handle_t_::setArgValue()` to make it possible to set an argument only on the specified device.

It fixes the URT-1017 issue existing also on the sycl branch.
