### PR TITLE
[SYCL] Update aspect_selector fallback to default selector

### DIFF
--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -237,6 +237,12 @@ aspect_selector(const std::vector<aspect> &RequireList,
   return [=](const sycl::device &Dev) {
     auto DevHas = [&](const aspect &Asp) -> bool { return Dev.has(Asp); };
 
+    // SYCL 2020 4.6.1.1. Device selector:
+    // If no aspects are passed in, the generated selector behaves like
+    // default_selector_v.
+    if (RequireList.empty() && DenyList.empty())
+      return default_selector_v(Dev);
+
     // All aspects from require list are required.
     if (!std::all_of(RequireList.begin(), RequireList.end(), DevHas))
       return detail::REJECT_DEVICE_SCORE;
@@ -245,14 +251,7 @@ aspect_selector(const std::vector<aspect> &RequireList,
     if (std::any_of(DenyList.begin(), DenyList.end(), DevHas))
       return detail::REJECT_DEVICE_SCORE;
 
-    if (RequireList.size() > 0) {
-      return 1000 + detail::getDevicePreference(Dev);
-    } else {
-      // No required aspects specified.
-      // SYCL 2020 4.6.1.1 "If no aspects are passed in, the generated selector
-      // behaves like default_selector."
-      return default_selector_v(Dev);
-    }
+    return 1000 + detail::getDevicePreference(Dev);
   };
 }
 


### PR DESCRIPTION
SYCL 2020 spec says: "The free function aspect_selector has several overloads, each of which returns a selector object that selects a SYCL device from any supported [SYCL backend](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#backend) which contains all the requested aspects, i.e. for the specific device dev and each aspect devAspect from aspectList dev.has(devAspect) equals true. If no aspects are passed in, the generated selector behaves like default_selector_v."

So original impl in intel/llvm fallbacks to default selector when require aspect list is empty and disregards emptiness of deny list. (please don't get it like we return device with aspects in deny list, it is only about score).

Although it seems to be more correct that "the aspect selector is guaranteed to be the same as the default selector only in the case when there are no aspects in either list".