### PR TITLE
[SYCL][NFC] Refactor addSYCLDefaultTriple

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1194,7 +1194,7 @@ static bool addSYCLDefaultTriple(Compilation &C,
         SYCLTriple.isSPIROrSPIRV())
       return false;
     // If we encounter a known non-spir* target, do not add the default triple.
-    if (SYCLTriple.isNVPTX() || SYCLTriple.isAMDGCN())
+    if (!SYCLTriple.isSPIROrSPIRV())
       return false;
   }
   SYCLTriples.push_back(


### PR DESCRIPTION
This patch merges two loops traversing SYCL triples into one.
Also optimizes the usage of addSYCLDefaultTriple inside
CreateOffloadingDeviceToolChains. The default triple is guranted to be
added at the beginning of the list. Instead of building the default
triple again in CreateOffloadingDeviceToolChains, we re-use the value
added by addSYCLDefaultTriple to the list of the triples.