### PR TITLE
[SYCL] Disable scheduler unit tests on Windows

### DIFF
--- a/sycl/unittests/scheduler/CMakeLists.txt
+++ b/sycl/unittests/scheduler/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(WIN32)
+  # https://github.com/intel/llvm/issues/15049
+  return()
+endif()
 add_sycl_unittest(SchedulerTests OBJECT
     BlockedCommands.cpp
     Commands.cpp


### PR DESCRIPTION
Seeing sporadic fails.

Ex: https://github.com/intel/llvm/actions/runs/20344544188/job/58453108306
