### PR TITLE
[SYCL][NFC] Disable warn to error in preprocess test

### DIFF
--- a/sycl/test-e2e/NewOffloadDriver/preprocess_file.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/preprocess_file.cpp
@@ -6,7 +6,7 @@
 // RUN: %{build} --offload-new-driver -E -o %t.ii
 
 // Compile preprocessed file.
-// RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl %{sycl_target_opts} --offload-new-driver %t.ii -o %t.out
+// RUN: %clangxx -Wno-error -fsycl %{sycl_target_opts} --offload-new-driver %t.ii -o %t.out
 
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
The warn to error setting is not important for this test, as all we want to do is build the generated preprocessed file. Update the command line to use -Wno-error to allow for a successful compile. There is a possibility of certain generated preprocessed file conditions where warnings will be emitted that we want to not error on.