### PR TITLE
[libspirv] Fix function erase order in LibclcRemangler post-processing

### DIFF
--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -977,6 +977,7 @@ private:
         if (RenamedFunctions.count(Name.str())) {
           // Drop unuseful clone of the original or remangled function.
           Func->replaceAllUsesWith(ConstantPointerNull::get(Func->getType()));
+          Func->setName("");
           ToErase.push_back(Func);
         } else {
           // Name doesn't exist in the original module. Drop unuseful clone of


### PR DESCRIPTION
A non-current function cannot be erased while iterating through the LLVM module.