### PR TITLE
[clang] Accept non const static work_group_static variables in templates

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -8197,6 +8197,7 @@ NamedDecl *Sema::ActOnVariableDeclarator(
     // constexpr unless their types are decorated with global_variable_allowed
     // attribute.
     if (SCSpec == DeclSpec::SCS_static && !R.isConstant(Context) &&
+        !NewVD->getType()->isDependentType() &&
         !SYCL().isTypeDecoratedWithDeclAttribute<SYCLGlobalVariableAllowedAttr>(
             NewVD->getType()) &&
         !SYCL().isTypeDecoratedWithDeclAttribute<SYCLScopeAttr>(

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -228,7 +228,8 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
                              ObjCInterfaceDecl *ClassReceiver,
                              bool SkipTrailingRequiresClause) {
   if (getLangOpts().SYCLIsDevice) {
-    if (auto VD = dyn_cast<VarDecl>(D)) {
+    if (auto VD = dyn_cast<VarDecl>(D);
+        VD && !VD->getType()->isDependentType()) {
       bool IsConst = VD->getType().isConstant(Context);
       bool IsRuntimeEvaluated =
           ExprEvalContexts.empty() ||
@@ -239,6 +240,7 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
       if (IsRuntimeEvaluated && !IsEsimdPrivateGlobal && !IsConst &&
           VD->getStorageClass() == SC_Static &&
           !VD->hasAttr<SYCLGlobalVarAttr>() &&
+          !VD->getType()->isDependentType() &&
           !SemaSYCL::isTypeDecoratedWithDeclAttribute<
               SYCLGlobalVariableAllowedAttr>(VD->getType()) &&
           !SemaSYCL::isTypeDecoratedWithDeclAttribute<SYCLScopeAttr>(

--- a/clang/test/SemaSYCL/sycl_wg_scope.cpp
+++ b/clang/test/SemaSYCL/sycl_wg_scope.cpp
@@ -58,6 +58,8 @@ public:
   B12() = default;
   ~B12() = default;
   T obj;
+  operator T&() {return obj;}
+  T *operator&() noexcept { return &obj; }
 };
 
 B12<Valid> b12;
@@ -84,6 +86,19 @@ struct Wrap {
   static G1 g18;
 };
 
+template<int Index, typename T>
+struct MyClass {
+  static B12<T> slm;
+  T *ptr() {
+    return &slm;
+  }
+};
+
+template <typename T>
+void foo() {
+  static T m;
+}
+
 __attribute__((sycl_device)) void ref_func() {
   G1 g19;
   static G1 g20;
@@ -91,4 +106,7 @@ __attribute__((sycl_device)) void ref_func() {
   (void)g16;
   (void)g17;
   (void)Wrap::g18;
+  MyClass<1, int> c1;
+  (void)c1.ptr();
+  foo<B12<int>>();
 }


### PR DESCRIPTION
In general, SYCL doesn't allow non const static variables, but for some extensions like work_group_static it is allowed. This is done by checking presence of an attribute on the type of the variable. However detection of such cases worked incorrectly in template contexts since a dependent type may not yet have the attribute. This patch fixes the problem by not diagnosing variables with dependent types.