### PR TITLE
[SYCL][Cuda] Fix sycl-trace build issue caused by missing includes

### DIFF
--- a/sycl/tools/sycl-trace/CMakeLists.txt
+++ b/sycl/tools/sycl-trace/CMakeLists.txt
@@ -32,6 +32,9 @@ if ("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
     cuda_trace_collector
   )
   add_dependencies(sycl-trace cuda_trace_collector)
+  target_include_directories(cuda_trace_collector PRIVATE
+    "${sycl_inc_dir}"
+  )
 endif()
 
 add_library(sycl_ur_trace_collector SHARED


### PR DESCRIPTION
Add the missing SYCL include directory for cuda_trace_collector, mirroring the Level Zero collector

Closes #20946 