### PR TITLE
[SYCL][NFC] Remove outdated comment

### DIFF
--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -571,11 +571,6 @@ detail::EventImplPtr handler::finalize() {
   std::unique_ptr<detail::CG> CommandGroup;
   switch (type) {
   case detail::CGType::Kernel: {
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-    // Copy kernel name here instead of move so that it's available after
-    // running of this method by reductions implementation. This allows for
-    // assert feature to check if kernel uses assertions
-#endif
     CommandGroup.reset(new detail::CGExecKernel(
         impl->MKernelData.getNDRDesc(), std::move(MHostKernel),
         std::move(MKernel), std::move(impl->MKernelBundle),


### PR DESCRIPTION
fallback assert feature has been discarded, so I believe this comment is oudated.