### PR TITLE
[SYCL][ABI-break] Simplify `interop_handle` constructor

### DIFF
--- a/sycl/include/sycl/interop_handle.hpp
+++ b/sycl/include/sycl/interop_handle.hpp
@@ -205,19 +205,13 @@ private:
   friend class detail::DispatchHostTask;
   using ReqToMem = std::pair<detail::AccessorImplHost *, ur_mem_handle_t>;
 
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-  // Clean this up (no shared pointers). Not doing it right now because I expect
-  // there will be several iterations of simplifications possible and it would
-  // be hard to track which of them made their way into a minor public release
-  // and which didn't. Let's just clean it up once during ABI breaking window.
-#endif
   interop_handle(std::vector<ReqToMem> MemObjs,
                  const std::shared_ptr<detail::queue_impl> &Queue,
-                 detail::device_impl &Device,
-                 const std::shared_ptr<detail::context_impl> &Context,
                  ur_exp_command_buffer_handle_t Graph = nullptr)
-      : MQueue(Queue), MDevice(Device), MContext(Context), MGraph(Graph),
-        MMemObjs(std::move(MemObjs)) {}
+      : MQueue(Queue), MGraph(Graph), MMemObjs(std::move(MemObjs)) {
+    assert(MQueue != nullptr &&
+           "interop_handle must be associated with a valid queue");
+  }
 
   template <backend Backend, typename DataT, int Dims>
   backend_return_t<Backend, buffer<DataT, Dims>>
@@ -243,8 +237,6 @@ private:
   __SYCL_EXPORT ur_native_handle_t getNativeGraph() const;
 
   std::shared_ptr<detail::queue_impl> MQueue;
-  detail::device_impl &MDevice;
-  std::shared_ptr<detail::context_impl> MContext;
   ur_exp_command_buffer_handle_t MGraph;
 
   std::vector<ReqToMem> MMemObjs;

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -408,9 +408,7 @@ public:
       if (HostTask.MHostTask->isInteropTask()) {
         assert(HostTask.MQueue &&
                "Host task submissions should have an associated queue");
-        interop_handle IH{MReqToMem, HostTask.MQueue,
-                          HostTask.MQueue->getDeviceImpl(),
-                          HostTask.MQueue->getContextImpl().shared_from_this()};
+        interop_handle IH{MReqToMem, HostTask.MQueue};
         // TODO: should all the backends that support this entry point use this
         // for host task?
         auto &Queue = HostTask.MQueue;
@@ -3113,8 +3111,7 @@ ur_result_t ExecCGCommand::enqueueImpCommandBuffer() {
 
     ur_exp_command_buffer_handle_t InteropCommandBuffer =
         ChildCommandBuffer ? ChildCommandBuffer : MCommandBuffer;
-    interop_handle IH{std::move(ReqToMem), MQueue, DeviceImpl,
-                      ContextImpl.shared_from_this(), InteropCommandBuffer};
+    interop_handle IH{std::move(ReqToMem), MQueue, InteropCommandBuffer};
     CommandBufferNativeCommandData CustomOpData{
         std::move(IH), HostTask->MHostTask->MInteropTask};
 
@@ -3487,9 +3484,7 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     }
 
     EnqueueNativeCommandData CustomOpData{
-        interop_handle{std::move(ReqToMem), HostTask->MQueue,
-                       HostTask->MQueue->getDeviceImpl(),
-                       HostTask->MQueue->getContextImpl().shared_from_this()},
+        interop_handle{std::move(ReqToMem), HostTask->MQueue},
         HostTask->MHostTask->MInteropTask};
 
     ur_bool_t NativeCommandSupport = false;

--- a/sycl/source/interop_handle.cpp
+++ b/sycl/source/interop_handle.cpp
@@ -38,25 +38,24 @@ interop_handle::getNativeMem(detail::Requirement *Req) const {
   }
 
   detail::adapter_impl &Adapter = MQueue->getAdapter();
+  detail::device_impl &Device = MQueue->getDeviceImpl();
   ur_native_handle_t Handle;
   Adapter.call<detail::UrApiKind::urMemGetNativeHandle>(
-      Iter->second, MDevice.getHandleRef(), &Handle);
+      Iter->second, Device.getHandleRef(), &Handle);
   return Handle;
 }
 
 ur_native_handle_t interop_handle::getNativeDevice() const {
-  return MDevice.getNative();
+  return MQueue->getDeviceImpl().getNative();
 }
 
 ur_native_handle_t interop_handle::getNativeContext() const {
-  return MContext->getNative();
+  return MQueue->getContextImpl().getNative();
 }
 
 ur_native_handle_t
 interop_handle::getNativeQueue(int32_t &NativeHandleDesc) const {
-  if (MQueue != nullptr)
-    return MQueue->getNative(NativeHandleDesc);
-  return 0;
+  return MQueue->getNative(NativeHandleDesc);
 }
 
 ur_native_handle_t interop_handle::getNativeGraph() const {


### PR DESCRIPTION
According to spec "The interop_handle class is an abstraction over the queue which is being used to invoke the host task and its associated device and context." and currently interop_handle object is created internally at the time of submission to the queue, so queue is always supposed to be available. Device and context are the ones associated with the queue, so it seems that those parameters in the constructor are redundant.
We can't get rid of shared_ptr to the queue because interop_handle has copy/move constructors, so theoretically it can be copied/moved outside of the scope of the queue object.