### PR TITLE
[L0v2] add multiple submission modes in queue gtests

### DIFF
--- a/unified-runtime/test/adapters/level_zero/enqueue_alloc.cpp
+++ b/unified-runtime/test/adapters/level_zero/enqueue_alloc.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -160,7 +160,7 @@ struct urL0EnqueueAllocMultiQueueMultiDeviceTest
   std::vector<ur_queue_handle_t> queues;
 };
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urL0EnqueueAllocTest,
     ::testing::ValuesIn({
         EnqueueAllocTestParam{urEnqueueUSMHostAllocExp,
@@ -170,13 +170,11 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
         EnqueueAllocTestParam{urEnqueueUSMDeviceAllocExp,
                               uur::GetDeviceUSMDeviceSupport},
     }),
-    uur::deviceTestWithParamPrinter<EnqueueAllocTestParam>);
+    uur::deviceTestWithParamPrinterMulti<EnqueueAllocTestParam>);
 
 TEST_P(urL0EnqueueAllocTest, Success) {
-  const auto enqueueUSMAllocFunc =
-      std::get<1>(this->GetParam()).enqueueUSMAllocFunc;
-  const auto checkUSMSupportFunc =
-      std::get<1>(this->GetParam()).checkUSMSupportFunc;
+  const auto enqueueUSMAllocFunc = getParam().enqueueUSMAllocFunc;
+  const auto checkUSMSupportFunc = getParam().checkUSMSupportFunc;
 
   ur_device_usm_access_capability_flags_t USMSupport = 0;
   ASSERT_SUCCESS(checkUSMSupportFunc(device, USMSupport));
@@ -200,10 +198,8 @@ TEST_P(urL0EnqueueAllocTest, Success) {
 }
 
 TEST_P(urL0EnqueueAllocTest, SuccessReuse) {
-  const auto enqueueUSMAllocFunc =
-      std::get<1>(this->GetParam()).enqueueUSMAllocFunc;
-  const auto checkUSMSupportFunc =
-      std::get<1>(this->GetParam()).checkUSMSupportFunc;
+  const auto enqueueUSMAllocFunc = getParam().enqueueUSMAllocFunc;
+  const auto checkUSMSupportFunc = getParam().checkUSMSupportFunc;
 
   ur_device_usm_access_capability_flags_t USMSupport = 0;
   ASSERT_SUCCESS(checkUSMSupportFunc(device, USMSupport));
@@ -238,10 +234,8 @@ TEST_P(urL0EnqueueAllocTest, SuccessReuse) {
 }
 
 TEST_P(urL0EnqueueAllocTest, SuccessFromPool) {
-  const auto enqueueUSMAllocFunc =
-      std::get<1>(this->GetParam()).enqueueUSMAllocFunc;
-  const auto checkUSMSupportFunc =
-      std::get<1>(this->GetParam()).checkUSMSupportFunc;
+  const auto enqueueUSMAllocFunc = getParam().enqueueUSMAllocFunc;
+  const auto checkUSMSupportFunc = getParam().checkUSMSupportFunc;
 
   ur_device_usm_access_capability_flags_t USMSupport = 0;
   ASSERT_SUCCESS(checkUSMSupportFunc(device, USMSupport));
@@ -269,10 +263,8 @@ TEST_P(urL0EnqueueAllocTest, SuccessFromPool) {
 }
 
 TEST_P(urL0EnqueueAllocTest, SuccessWithKernel) {
-  const auto enqueueUSMAllocFunc =
-      std::get<1>(this->GetParam()).enqueueUSMAllocFunc;
-  const auto checkUSMSupportFunc =
-      std::get<1>(this->GetParam()).checkUSMSupportFunc;
+  const auto enqueueUSMAllocFunc = getParam().enqueueUSMAllocFunc;
+  const auto checkUSMSupportFunc = getParam().checkUSMSupportFunc;
 
   ur_device_usm_access_capability_flags_t USMSupport = 0;
   ASSERT_SUCCESS(checkUSMSupportFunc(device, USMSupport));
@@ -294,10 +286,8 @@ TEST_P(urL0EnqueueAllocTest, SuccessWithKernel) {
 }
 
 TEST_P(urL0EnqueueAllocTest, SuccessWithKernelRepeat) {
-  const auto enqueueUSMAllocFunc =
-      std::get<1>(this->GetParam()).enqueueUSMAllocFunc;
-  const auto checkUSMSupportFunc =
-      std::get<1>(this->GetParam()).checkUSMSupportFunc;
+  const auto enqueueUSMAllocFunc = getParam().enqueueUSMAllocFunc;
+  const auto checkUSMSupportFunc = getParam().checkUSMSupportFunc;
 
   ur_device_usm_access_capability_flags_t USMSupport = 0;
   ASSERT_SUCCESS(checkUSMSupportFunc(device, USMSupport));

--- a/unified-runtime/test/adapters/level_zero/urEnqueueMemBufferMapHostPtr.cpp
+++ b/unified-runtime/test/adapters/level_zero/urEnqueueMemBufferMapHostPtr.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -15,7 +15,7 @@
 using urEnqueueMemBufferMapTestWithParamL0 =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferMapTestWithParamL0,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemBufferMapTestWithParamL0>);

--- a/unified-runtime/test/adapters/level_zero/urEventCreateWithNativeHandle.cpp
+++ b/unified-runtime/test/adapters/level_zero/urEventCreateWithNativeHandle.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -17,8 +17,8 @@
 #include "ze_helpers.hpp"
 
 using namespace std::chrono_literals;
-using urLevelZeroEventNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urLevelZeroEventNativeHandleTest);
+using urLevelZeroEventNativeHandleTest = uur::urMultiQueueTypeTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urLevelZeroEventNativeHandleTest);
 
 #define TEST_MEMCPY_SIZE 4096
 

--- a/unified-runtime/test/adapters/level_zero/urKernelCreateWithNativeHandle.cpp
+++ b/unified-runtime/test/adapters/level_zero/urKernelCreateWithNativeHandle.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -12,8 +12,9 @@
 #include "ze_api.h"
 #include <uur/fixtures.h>
 
-using urLevelZeroKernelNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urLevelZeroKernelNativeHandleTest);
+using urLevelZeroKernelNativeHandleTest = uur::urMultiQueueTypeTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urLevelZeroKernelNativeHandleTest);
 
 TEST_P(urLevelZeroKernelNativeHandleTest, OwnedHandleRelease) {
   ze_context_handle_t native_context;

--- a/unified-runtime/test/adapters/level_zero/urMemBufferCreateWithNativeHandleShared.cpp
+++ b/unified-runtime/test/adapters/level_zero/urMemBufferCreateWithNativeHandleShared.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -13,8 +13,9 @@
 #include "ze_api.h"
 #include <uur/fixtures.h>
 
-using urMemBufferCreateWithNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemBufferCreateWithNativeHandleTest);
+using urMemBufferCreateWithNativeHandleTest = uur::urMultiQueueTypeTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urMemBufferCreateWithNativeHandleTest);
 
 TEST_P(urMemBufferCreateWithNativeHandleTest, SharedBufferIsUsedDirectly) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});

--- a/unified-runtime/test/adapters/level_zero/urProgramLink.cpp
+++ b/unified-runtime/test/adapters/level_zero/urProgramLink.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -11,7 +11,7 @@
 #include <uur/fixtures.h>
 
 using urLevelZeroProgramLinkTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urLevelZeroProgramLinkTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urLevelZeroProgramLinkTest);
 
 TEST_P(urLevelZeroProgramLinkTest, InvalidLinkOptionsPrintedInLog) {
   ur_program_handle_t linked_program = nullptr;

--- a/unified-runtime/test/adapters/level_zero/v2/deferred_kernel.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/deferred_kernel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -29,7 +29,7 @@ struct urEnqueueKernelLaunchTest : uur::urKernelExecutionTest {
   size_t global_offset = 0;
   size_t n_dimensions = 1;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urEnqueueKernelLaunchTest);
 
 TEST_P(urEnqueueKernelLaunchTest, DeferredKernelRelease) {
   ur_mem_handle_t buffer = nullptr;

--- a/unified-runtime/test/conformance/enqueue/helpers.h
+++ b/unified-runtime/test/conformance/enqueue/helpers.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,7 +7,9 @@
 #ifndef UUR_ENQUEUE_RECT_HELPERS_H_INCLUDED
 #define UUR_ENQUEUE_RECT_HELPERS_H_INCLUDED
 
+#include "ur_api.h"
 #include <cstring>
+#include <sstream>
 #include <uur/fixtures.h>
 
 namespace uur {
@@ -31,8 +33,33 @@ printRectTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
   // ParamType will be std::tuple<ur_device_handle_t, test_parameters_t>
   const auto device_handle = std::get<0>(info.param).device;
   const auto platform_device_name = GetPlatformAndDeviceName(device_handle);
-  const auto &test_name = std::get<1>(info.param).name;
-  return platform_device_name + "__" + test_name;
+
+  std::stringstream ss;
+  auto param_tuple = std::get<1>(info.param);
+  auto test_name = std::get<0>(param_tuple).name;
+  auto queue_mode = std::get<1>(param_tuple);
+
+  ss << platform_device_name << "__" << test_name << "__" << queue_mode;
+
+  return ss.str();
+}
+
+template <typename T>
+inline std::string printRectTestStringMultiQueue(
+    const testing::TestParamInfo<typename T::ParamType> &info) {
+  // ParamType will be std::tuple<ur_device_handle_t, test_parameters_t>
+  const auto device_handle = std::get<0>(info.param).device;
+  const auto platform_device_name = GetPlatformAndDeviceName(device_handle);
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+
+  auto queueMode = std::get<1>(paramTuple);
+
+  std::stringstream test_name;
+  test_name << platform_device_name;
+  test_name << param.name << "__" << queueMode;
+
+  return test_name.str();
 }
 
 // Performs host side equivalent of urEnqueueMemBufferReadRect,
@@ -74,13 +101,18 @@ print2DTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
   const auto platform_device_name =
       uur::GetPlatformAndDeviceName(device_handle);
   std::stringstream test_name;
-  const auto src_kind = std::get<1>(std::get<1>(info.param));
-  const auto dst_kind = std::get<2>(std::get<1>(info.param));
-  test_name << platform_device_name << "__pitch__"
-            << std::get<0>(std::get<1>(info.param)).pitch << "__width__"
-            << std::get<0>(std::get<1>(info.param)).width << "__height__"
-            << std::get<0>(std::get<1>(info.param)).height << "__src__"
-            << src_kind << "__dst__" << dst_kind;
+
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+  auto queueMode = std::get<1>(paramTuple);
+  const auto src_kind = std::get<1>(param);
+  const auto dst_kind = std::get<2>(param);
+  TestParameters2D testParams = std::get<0>(param);
+  test_name << platform_device_name << "__pitch__" << testParams.pitch
+            << "__width__" << testParams.width << "__height__"
+            << testParams.height << "__src__" << src_kind << "__dst__"
+            << dst_kind << "__" << queueMode;
+
   return test_name.str();
 }
 
@@ -122,10 +154,16 @@ inline std::string printMemBufferTestString(
   const auto device_handle = std::get<0>(info.param).device;
   const auto platform_device_name = GetPlatformAndDeviceName(device_handle);
 
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+  auto queueMode = std::get<1>(paramTuple);
+
   std::stringstream ss;
-  ss << std::get<1>(info.param).count;
+  ss << param.count;
   ss << "_";
-  ss << std::get<1>(info.param).mem_flag;
+  ss << param.mem_flag;
+  ss << "__";
+  ss << queueMode;
 
   return platform_device_name + "__" + ss.str();
 }
@@ -138,22 +176,31 @@ inline std::string printMemBufferMapWriteTestString(
   const auto device_handle = std::get<0>(info.param).device;
   const auto platform_device_name = GetPlatformAndDeviceName(device_handle);
 
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+  auto queueMode = std::get<1>(paramTuple);
+
   std::stringstream ss;
-  ss << std::get<1>(info.param).map_flag;
+  ss << param.map_flag << "__" << queueMode;
 
   return platform_device_name + "__" + ss.str();
 }
 
 template <typename T>
-inline std::string
-printFillTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
+inline std::string printFillTestStringMultiQueueType(
+    const testing::TestParamInfo<typename T::ParamType> &info) {
   const auto device_handle = std::get<0>(info.param).device;
   const auto platform_device_name =
       uur::GetPlatformAndDeviceName(device_handle);
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+
+  auto queueMode = std::get<1>(paramTuple);
+
   std::stringstream test_name;
-  test_name << platform_device_name << "__size__"
-            << std::get<1>(info.param).size << "__patternSize__"
-            << std::get<1>(info.param).pattern_size;
+  test_name << platform_device_name << "__size__" << param.size
+            << "__patternSize__" << param.pattern_size << "__" << queueMode;
+
   return test_name.str();
 }
 

--- a/unified-runtime/test/conformance/enqueue/urEnqueueDeviceGlobalVariableRead.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueDeviceGlobalVariableRead.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -8,10 +8,10 @@
 using urEnqueueDeviceGetGlobalVariableReadWithParamTest =
     uur::urGlobalVariableWithParamTest<uur::BoolTestParam>;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueDeviceGetGlobalVariableReadWithParamTest,
     testing::ValuesIn(uur::BoolTestParam::makeBoolParam("Blocking")),
-    uur::deviceTestWithParamPrinter<uur::BoolTestParam>);
+    uur::deviceTestWithParamPrinterMulti<uur::BoolTestParam>);
 
 TEST_P(urEnqueueDeviceGetGlobalVariableReadWithParamTest, Success) {
   bool is_blocking = getParam().value;
@@ -44,7 +44,8 @@ TEST_P(urEnqueueDeviceGetGlobalVariableReadWithParamTest, Success) {
 }
 
 using urEnqueueDeviceGetGlobalVariableReadTest = uur::urGlobalVariableTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueDeviceGetGlobalVariableReadTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urEnqueueDeviceGetGlobalVariableReadTest);
 
 TEST_P(urEnqueueDeviceGetGlobalVariableReadTest, InvalidNullHandleQueue) {
   ASSERT_EQ_RESULT(urEnqueueDeviceGlobalVariableRead(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueDeviceGlobalVariableWrite.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueDeviceGlobalVariableWrite.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -8,10 +8,10 @@
 using urEnqueueDeviceGetGlobalVariableWriteWithParamTest =
     uur::urGlobalVariableWithParamTest<uur::BoolTestParam>;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueDeviceGetGlobalVariableWriteWithParamTest,
     testing::ValuesIn(uur::BoolTestParam::makeBoolParam("Blocking")),
-    uur::deviceTestWithParamPrinter<uur::BoolTestParam>);
+    uur::deviceTestWithParamPrinterMulti<uur::BoolTestParam>);
 
 TEST_P(urEnqueueDeviceGetGlobalVariableWriteWithParamTest, Success) {
   bool is_blocking = getParam().value;
@@ -46,7 +46,8 @@ TEST_P(urEnqueueDeviceGetGlobalVariableWriteWithParamTest, Success) {
 }
 
 using urEnqueueDeviceGetGlobalVariableWriteTest = uur::urGlobalVariableTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueDeviceGetGlobalVariableWriteTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urEnqueueDeviceGetGlobalVariableWriteTest);
 
 TEST_P(urEnqueueDeviceGetGlobalVariableWriteTest, InvalidNullHandleQueue) {
   ASSERT_EQ_RESULT(urEnqueueDeviceGlobalVariableWrite(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -100,7 +100,8 @@ struct urEnqueueEventsWaitWithBarrierOrderingTest : uur::urProgramTest {
   ur_mem_handle_t buffer = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueEventsWaitWithBarrierOrderingTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urEnqueueEventsWaitWithBarrierOrderingTest);
 
 TEST_P(urEnqueueEventsWaitWithBarrierTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::NativeCPU{});

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -1,16 +1,19 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "helpers.h"
+#include "uur/utils.h"
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
 
-struct urEnqueueMemBufferCopyTestWithParam : uur::urQueueTestWithParam<size_t> {
+struct urEnqueueMemBufferCopyTestWithParam
+    : uur::urMultiQueueTypeTestWithParam<size_t> {
+
   void SetUp() override {
-    UUR_RETURN_ON_FATAL_FAILURE(urQueueTestWithParam::SetUp());
+    UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTypeTestWithParam::SetUp());
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
                                      nullptr, &src_buffer));
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
@@ -27,10 +30,10 @@ struct urEnqueueMemBufferCopyTestWithParam : uur::urQueueTestWithParam<size_t> {
     if (src_buffer) {
       EXPECT_SUCCESS(urMemRelease(dst_buffer));
     }
-    urQueueTestWithParam::TearDown();
+    urMultiQueueTypeTestWithParam::TearDown();
   }
 
-  const size_t count = std::get<1>(this->GetParam());
+  const size_t count = this->getParam();
   const size_t size = sizeof(uint32_t) * count;
   ur_mem_handle_t src_buffer = nullptr;
   ur_mem_handle_t dst_buffer = nullptr;
@@ -39,9 +42,9 @@ struct urEnqueueMemBufferCopyTestWithParam : uur::urQueueTestWithParam<size_t> {
 
 static std::vector<size_t> test_parameters{1024, 2500, 4096, 6000};
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(urEnqueueMemBufferCopyTestWithParam,
-                                 ::testing::ValuesIn(test_parameters),
-                                 uur::deviceTestWithParamPrinter<size_t>);
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
+    urEnqueueMemBufferCopyTestWithParam, ::testing::ValuesIn(test_parameters),
+    uur::deviceTestWithParamPrinterMulti<size_t>);
 
 TEST_P(urEnqueueMemBufferCopyTestWithParam, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -1,9 +1,10 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "helpers.h"
+#include "uur/fixtures.h"
 #include "uur/known_failure.h"
 #include <numeric>
 
@@ -70,12 +71,13 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
 }
 
 struct urEnqueueMemBufferCopyRectTestWithParam
-    : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
+    : public uur::urMultiQueueTypeTestWithParam<uur::test_parameters_t> {};
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferCopyRectTestWithParam,
     testing::ValuesIn(generateParameterizations()),
-    uur::printRectTestString<urEnqueueMemBufferCopyRectTestWithParam>);
+    uur::printRectTestStringMultiQueue<
+        urEnqueueMemBufferCopyRectTestWithParam>);
 
 TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
   const auto name = getParam().name;
@@ -143,9 +145,9 @@ TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
   ASSERT_SUCCESS(urMemRelease(dst_buffer));
 }
 
-struct urEnqueueMemBufferCopyRectTest : uur::urQueueTest {
+struct urEnqueueMemBufferCopyRectTest : uur::urMultiQueueTypeTest {
   void SetUp() override {
-    UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
+    UUR_RETURN_ON_FATAL_FAILURE(uur::urMultiQueueTypeTest::SetUp());
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
                                      nullptr, &src_buffer));
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
@@ -162,7 +164,7 @@ struct urEnqueueMemBufferCopyRectTest : uur::urQueueTest {
     if (src_buffer) {
       EXPECT_SUCCESS(urMemRelease(dst_buffer));
     }
-    urQueueTest::TearDown();
+    uur::urMultiQueueTypeTest::TearDown();
   }
 
   const size_t count = 1024;
@@ -178,7 +180,7 @@ struct urEnqueueMemBufferCopyRectTest : uur::urQueueTest {
   const size_t dst_row_pitch = size;
   size_t dst_slice_pitch = size;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemBufferCopyRectTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urEnqueueMemBufferCopyRectTest);
 
 TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleQueue) {
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -12,14 +12,14 @@ struct testParametersFill {
 };
 
 struct urEnqueueMemBufferFillTest
-    : uur::urQueueTestWithParam<testParametersFill> {
+    : uur::urMultiQueueTypeTestWithParam<testParametersFill> {
   void SetUp() override {
     // https://github.com/intel/llvm/issues/19604
     UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
     UUR_RETURN_ON_FATAL_FAILURE(
-        urQueueTestWithParam<testParametersFill>::SetUp());
-    size = std::get<1>(GetParam()).size;
-    pattern_size = std::get<1>(GetParam()).pattern_size;
+        uur::urMultiQueueTypeTestWithParam<testParametersFill>::SetUp());
+    size = getParam().size;
+    pattern_size = getParam().pattern_size;
     pattern = std::vector<uint8_t>(pattern_size);
     uur::generateMemFillPattern(pattern);
     auto ret = urMemBufferCreate(this->context, UR_MEM_FLAG_READ_WRITE, size,
@@ -36,7 +36,7 @@ struct urEnqueueMemBufferFillTest
       EXPECT_SUCCESS(urMemRelease(buffer));
     }
     UUR_RETURN_ON_FATAL_FAILURE(
-        urQueueTestWithParam<testParametersFill>::TearDown());
+        uur::urMultiQueueTypeTestWithParam<testParametersFill>::TearDown());
   }
 
   void verifyData(std::vector<uint8_t> &output, size_t verify_size) {
@@ -71,9 +71,9 @@ static std::vector<testParametersFill> test_cases{
     {256, 16},
     {256, 32}};
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferFillTest, testing::ValuesIn(test_cases),
-    uur::printFillTestString<urEnqueueMemBufferFillTest>);
+    uur::printFillTestStringMultiQueueType<urEnqueueMemBufferFillTest>);
 
 TEST_P(urEnqueueMemBufferFillTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
@@ -149,7 +149,8 @@ TEST_P(urEnqueueMemBufferFillTest, SuccessOffset) {
 
 using urEnqueueMemBufferFillNegativeTest = uur::urMemBufferQueueTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemBufferFillNegativeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urEnqueueMemBufferFillNegativeTest);
 
 TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidNullHandleQueue) {
   const uint32_t pattern = 0xdeadbeef;

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -10,7 +10,7 @@
 using urEnqueueMemBufferMapTestWithParam =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferMapTestWithParam,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemBufferMapTestWithParam>);
@@ -41,7 +41,7 @@ using urEnqueueMemBufferMapTestWithWriteFlagParam =
     uur::urMemBufferQueueTestWithParam<
         uur::mem_buffer_map_write_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferMapTestWithWriteFlagParam,
     ::testing::ValuesIn(map_write_test_parameters),
     uur::printMemBufferMapWriteTestString<

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -10,7 +10,7 @@
 using urEnqueueMemBufferReadTestWithParam =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferReadTestWithParam,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemBufferReadTestWithParam>);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -1,9 +1,10 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "helpers.h"
+#include "uur/fixtures.h"
 #include <numeric>
 #include <uur/known_failure.h>
 
@@ -71,12 +72,13 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
 }
 
 struct urEnqueueMemBufferReadRectTestWithParam
-    : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
+    : public uur::urMultiQueueTypeTestWithParam<uur::test_parameters_t> {};
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferReadRectTestWithParam,
     testing::ValuesIn(generateParameterizations()),
-    uur::printRectTestString<urEnqueueMemBufferReadRectTestWithParam>);
+    uur::printRectTestStringMultiQueue<
+        urEnqueueMemBufferReadRectTestWithParam>);
 
 TEST_P(urEnqueueMemBufferReadRectTestWithParam, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
@@ -132,7 +134,7 @@ struct urEnqueueMemBufferReadRectTest : public uur::urMemBufferQueueTest {
   size_t host_slice_pitch = size;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemBufferReadRectTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urEnqueueMemBufferReadRectTest);
 
 TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullHandleQueue) {
   std::vector<uint32_t> dst(count);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -10,7 +10,7 @@
 using urEnqueueMemBufferWriteTestWithParam =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferWriteTestWithParam,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemBufferWriteTestWithParam>);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -1,9 +1,10 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "helpers.h"
+#include "uur/fixtures.h"
 #include <numeric>
 #include <uur/known_failure.h>
 
@@ -70,12 +71,13 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
 }
 
 struct urEnqueueMemBufferWriteRectTestWithParam
-    : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
+    : public uur::urMultiQueueTypeTestWithParam<uur::test_parameters_t> {};
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferWriteRectTestWithParam,
     testing::ValuesIn(generateParameterizations()),
-    uur::printRectTestString<urEnqueueMemBufferWriteRectTestWithParam>);
+    uur::printRectTestStringMultiQueue<
+        urEnqueueMemBufferWriteRectTestWithParam>);
 
 TEST_P(urEnqueueMemBufferWriteRectTestWithParam, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
@@ -139,7 +141,7 @@ struct urEnqueueMemBufferWriteRectTest : public uur::urMemBufferQueueTest {
   size_t host_slice_pitch = size;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemBufferWriteRectTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urEnqueueMemBufferWriteRectTest);
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullHandleQueue) {
   std::vector<uint32_t> src(count);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageRead.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageRead.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -11,7 +11,7 @@ struct urEnqueueMemImageReadTest : uur::urMemImageQueueTest {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urMemImageQueueTest::SetUp());
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemImageReadTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urEnqueueMemImageReadTest);
 
 // Note that for each test, we multiply the size in pixels by 4 to account for
 // each channel in the RGBA image

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -11,7 +11,7 @@ struct urEnqueueMemImageWriteTest : uur::urMemImageQueueTest {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urMemImageQueueTest::SetUp());
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemImageWriteTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urEnqueueMemImageWriteTest);
 
 TEST_P(urEnqueueMemImageWriteTest, Success1D) {
   std::vector<uint32_t> input(width * 4, 42);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemUnmap.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemUnmap.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -24,7 +24,7 @@ struct urEnqueueMemUnmapTestWithParam
   uint32_t *map = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemUnmapTestWithParam,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemUnmapTestWithParam>);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,7 +7,7 @@
 
 using urEnqueueReadHostPipeTest = uur::urHostPipeTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueReadHostPipeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urEnqueueReadHostPipeTest);
 
 TEST_P(urEnqueueReadHostPipeTest, InvalidNullHandleQueue) {
   uint32_t numEventsInWaitList = 0;

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -18,22 +18,25 @@ printFillTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
   const auto device_handle = std::get<0>(info.param).device;
   const auto platform_device_name =
       uur::GetPlatformAndDeviceName(device_handle);
+
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+  auto queueMode = std::get<1>(paramTuple);
   std::stringstream test_name;
-  test_name << platform_device_name << "__size__"
-            << std::get<1>(info.param).size << "__patternSize__"
-            << std::get<1>(info.param).pattern_size;
+  test_name << platform_device_name << "__size__" << param.size
+            << "__patternSize__" << param.pattern_size << "__" << queueMode;
   return test_name.str();
 }
 
 struct urEnqueueUSMFillTestWithParam
-    : uur::urQueueTestWithParam<testParametersFill> {
+    : uur::urMultiQueueTypeTestWithParam<testParametersFill> {
 
   void SetUp() override {
-    UUR_RETURN_ON_FATAL_FAILURE(urQueueTestWithParam::SetUp());
+    UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTypeTestWithParam::SetUp());
 
-    size = std::get<1>(GetParam()).size;
+    size = getParam().size;
     host_mem = std::vector<uint8_t>(size);
-    pattern_size = std::get<1>(GetParam()).pattern_size;
+    pattern_size = getParam().pattern_size;
     pattern = std::vector<uint8_t>(pattern_size);
     uur::generateMemFillPattern(pattern);
 
@@ -52,7 +55,7 @@ struct urEnqueueUSMFillTestWithParam
       EXPECT_SUCCESS(urUSMFree(context, ptr));
     }
 
-    UUR_RETURN_ON_FATAL_FAILURE(urQueueTestWithParam::TearDown());
+    UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTypeTestWithParam::TearDown());
   }
 
   void verifyData() {
@@ -94,7 +97,7 @@ static std::vector<testParametersFill> test_cases{
     {256, 16},
     {256, 32}};
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueUSMFillTestWithParam, testing::ValuesIn(test_cases),
     printFillTestString<urEnqueueUSMFillTestWithParam>);
 

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -13,12 +13,12 @@ using TestParametersMemcpy2D =
     std::tuple<uur::TestParameters2D, ur_usm_type_t, ur_usm_type_t>;
 
 struct urEnqueueUSMMemcpy2DTestWithParam
-    : uur::urQueueTestWithParam<TestParametersMemcpy2D> {
+    : uur::urMultiQueueTypeTestWithParam<TestParametersMemcpy2D> {
   void SetUp() override {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
     UUR_RETURN_ON_FATAL_FAILURE(
-        uur::urQueueTestWithParam<TestParametersMemcpy2D>::SetUp());
+        uur::urMultiQueueTypeTestWithParam<TestParametersMemcpy2D>::SetUp());
 
     const auto [in2DParams, inSrcKind, inDstKind] = getParam();
     std::tie(src_pitch, dst_pitch, width, height, src_kind, dst_kind) =
@@ -67,7 +67,7 @@ struct urEnqueueUSMMemcpy2DTestWithParam
     if (pDst) {
       ASSERT_SUCCESS(urUSMFree(context, pDst));
     }
-    uur::urQueueTestWithParam<TestParametersMemcpy2D>::TearDown();
+    uur::urMultiQueueTypeTestWithParam<TestParametersMemcpy2D>::TearDown();
   }
 
   void verifyMemcpySucceeded() {
@@ -114,7 +114,7 @@ static std::vector<uur::TestParameters2D> test_sizes{
     /* Height == 1 && Pitch == width + 1 */
     {234, 233, 1}};
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueUSMMemcpy2DTestWithParam,
     ::testing::Combine(::testing::ValuesIn(test_sizes),
                        ::testing::Values(ur_usm_type_t::UR_USM_TYPE_DEVICE,
@@ -149,7 +149,7 @@ TEST_P(urEnqueueUSMMemcpy2DTestWithParam, SuccessNonBlocking) {
 }
 
 using urEnqueueUSMMemcpy2DNegativeTest = urEnqueueUSMMemcpy2DTestWithParam;
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueUSMMemcpy2DNegativeTest,
     ::testing::Values(TestParametersMemcpy2D{
         {1, 1, 1},

--- a/unified-runtime/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,7 +7,7 @@
 
 using urEnqueueWriteHostPipeTest = uur::urHostPipeTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueWriteHostPipeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urEnqueueWriteHostPipeTest);
 
 TEST_P(urEnqueueWriteHostPipeTest, InvalidNullHandleQueue) {
   uint32_t numEventsInWaitList = 0;

--- a/unified-runtime/test/conformance/event/urEventWait.cpp
+++ b/unified-runtime/test/conformance/event/urEventWait.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -84,9 +84,9 @@ TEST_P(urEventWaitTest, Success) {
   ASSERT_SUCCESS(urEventRelease(event2));
 }
 
-using urEventWaitNegativeTest = uur::urQueueTest;
+using urEventWaitNegativeTest = uur::urMultiQueueTypeTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventWaitNegativeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urEventWaitNegativeTest);
 
 TEST_P(urEventWaitNegativeTest, ZeroSize) {
   ur_event_handle_t event = nullptr;

--- a/unified-runtime/test/conformance/exp_command_buffer/commands.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/commands.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include "uur/fixtures.h"
 #include <array>
 
 struct urCommandBufferCommandsTest
@@ -216,7 +217,9 @@ struct urCommandBufferAppendKernelLaunchExpTest
   std::array<void *, 3> shared_ptrs = {nullptr, nullptr, nullptr};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferAppendKernelLaunchExpTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urCommandBufferAppendKernelLaunchExpTest);
+
 TEST_P(urCommandBufferAppendKernelLaunchExpTest, Basic) {
   ASSERT_SUCCESS(urCommandBufferAppendKernelLaunchExp(
       cmd_buf_handle, kernel, n_dimensions, &global_offset, &global_size,

--- a/unified-runtime/test/conformance/exp_command_buffer/copy.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/copy.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -21,10 +21,10 @@ struct urCommandBufferMemcpyCommandsTest
         uur::command_buffer::urCommandBufferExpTestWithParam<
             testParametersMemcpy>::SetUp());
 
-    size = std::get<1>(GetParam()).size;
-    offset_src = std::get<1>(GetParam()).offset_src;
-    offset_dst = std::get<1>(GetParam()).offset_dst;
-    copy_size = std::get<1>(GetParam()).copy_size;
+    size = getParam().size;
+    offset_src = getParam().offset_src;
+    offset_dst = getParam().offset_dst;
+    copy_size = getParam().copy_size;
     assert(size >= offset_src + copy_size);
     assert(size >= offset_dst + copy_size);
     // Allocate USM pointers
@@ -103,15 +103,20 @@ static std::string printMemcpyTestString(
   const auto platform_device_name =
       uur::GetPlatformAndDeviceName(device_handle);
   std::stringstream test_name;
-  test_name << platform_device_name << "__size__"
-            << std::get<1>(info.param).size << "__offset_src__"
-            << std::get<1>(info.param).offset_src << "__offset_src__"
-            << std::get<1>(info.param).offset_dst << "__copy_size__"
-            << std::get<1>(info.param).copy_size;
+
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+  auto queueMode = std::get<1>(paramTuple);
+
+  test_name << platform_device_name << "__size__" << param.size
+            << "__offset_src__" << param.offset_src << "__offset_src__"
+            << param.offset_dst << "__copy_size__" << param.copy_size << "__"
+            << queueMode;
+
   return test_name.str();
 }
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urCommandBufferMemcpyCommandsTest, testing::ValuesIn(test_cases),
     printMemcpyTestString<urCommandBufferMemcpyCommandsTest>);
 

--- a/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/enqueue.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -25,7 +25,7 @@ struct urEnqueueCommandBufferExpTest
         urCommandBufferExpExecutionTestWithParam::SetUp());
 
     // Create an in-order or out-of-order queue, depending on the passed parameter
-    ur_queue_flags_t queue_type = std::get<1>(GetParam());
+    ur_queue_flags_t queue_type = getParam();
     ur_queue_properties_t queue_properties = {
         UR_STRUCTURE_TYPE_QUEUE_PROPERTIES, nullptr, queue_type};
     ASSERT_SUCCESS(urQueueCreate(context, device, &queue_properties,
@@ -112,9 +112,12 @@ struct urEnqueueCommandBufferExpTest
 
 std::string deviceTestWithQueueTypePrinter(
     const ::testing::TestParamInfo<
-        std::tuple<uur::DeviceTuple, ur_queue_flags_t>> &info) {
+        std::tuple<uur::DeviceTuple, uur::MultiQueueParam<ur_queue_flags_t>>>
+        &info) {
   auto device = std::get<0>(info.param).device;
-  auto queue_type = std::get<1>(info.param);
+
+  auto paramTuple = std::get<1>(info.param);
+  auto queue_type = std::get<0>(paramTuple);
 
   std::stringstream ss;
 
@@ -131,11 +134,13 @@ std::string deviceTestWithQueueTypePrinter(
     ss << "UnspecifiedQueueType" << queue_type;
   }
 
+  ss << "__basic_queue_mode__" << std::get<1>(paramTuple);
+
   return uur::GetPlatformAndDeviceName(device) + "__" +
          uur::GTestSanitizeString(ss.str());
 }
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urEnqueueCommandBufferExpTest,
     testing::Values(0, UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE),
     deviceTestWithQueueTypePrinter);

--- a/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/fill.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -23,8 +23,8 @@ struct urCommandBufferFillCommandsTest
         uur::command_buffer::urCommandBufferExpTestWithParam<
             testParametersFill>::SetUp());
 
-    size = std::get<1>(GetParam()).size;
-    pattern_size = std::get<1>(GetParam()).pattern_size;
+    size = getParam().size;
+    pattern_size = getParam().pattern_size;
     pattern = std::vector<uint8_t>(pattern_size);
     uur::generateMemFillPattern(pattern);
 
@@ -99,13 +99,17 @@ printFillTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
   const auto platform_device_name =
       uur::GetPlatformAndDeviceName(device_handle);
   std::stringstream test_name;
-  test_name << platform_device_name << "__size__"
-            << std::get<1>(info.param).size << "__patternSize__"
-            << std::get<1>(info.param).pattern_size;
+
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+  auto queueMode = std::get<1>(paramTuple);
+  test_name << platform_device_name << "__size__" << param.size
+            << "__patternSize__" << param.pattern_size << "__" << queueMode;
+
   return test_name.str();
 }
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urCommandBufferFillCommandsTest, testing::ValuesIn(test_cases),
     printFillTestString<urCommandBufferFillCommandsTest>);
 

--- a/unified-runtime/test/conformance/exp_command_buffer/fixtures.h
+++ b/unified-runtime/test/conformance/exp_command_buffer/fixtures.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Intel Corporation
+// Copyright (C) 2022-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -68,9 +68,9 @@ struct urCommandBufferExpTest : uur::urContextTest {
 };
 
 template <class T>
-struct urCommandBufferExpTestWithParam : urQueueTestWithParam<T> {
+struct urCommandBufferExpTestWithParam : urMultiQueueTypeTestWithParam<T> {
   void SetUp() override {
-    UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());
+    UUR_RETURN_ON_FATAL_FAILURE(uur::urMultiQueueTypeTestWithParam<T>::SetUp());
 
     UUR_RETURN_ON_FATAL_FAILURE(checkCommandBufferSupport(this->device));
 
@@ -85,7 +85,8 @@ struct urCommandBufferExpTestWithParam : urQueueTestWithParam<T> {
     if (cmd_buf_handle) {
       EXPECT_SUCCESS(urCommandBufferReleaseExp(cmd_buf_handle));
     }
-    UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::TearDown());
+    UUR_RETURN_ON_FATAL_FAILURE(
+        uur::urMultiQueueTypeTestWithParam<T>::TearDown());
   }
 
   ur_exp_command_buffer_handle_t cmd_buf_handle = nullptr;
@@ -209,37 +210,6 @@ struct urUpdatableCommandBufferExpExecutionTest : uur::urKernelExecutionTest {
 
   ur_backend_t backend{};
   ur_exp_command_buffer_handle_t updatable_cmd_buf_handle = nullptr;
-};
-
-struct urCommandBufferCommandExpTest
-    : urUpdatableCommandBufferExpExecutionTest {
-  void SetUp() override {
-    UUR_RETURN_ON_FATAL_FAILURE(
-        urUpdatableCommandBufferExpExecutionTest::SetUp());
-
-    // Append 2 kernel commands to command-buffer and close command-buffer
-    ASSERT_SUCCESS(urCommandBufferAppendKernelLaunchExp(
-        updatable_cmd_buf_handle, kernel, n_dimensions, &global_offset,
-        &global_size, &local_size, 0, nullptr, 0, nullptr, 0, nullptr, nullptr,
-        nullptr, &command_handle));
-    ASSERT_NE(command_handle, nullptr);
-
-    ASSERT_SUCCESS(urCommandBufferAppendKernelLaunchExp(
-        updatable_cmd_buf_handle, kernel, n_dimensions, &global_offset,
-        &global_size, &local_size, 0, nullptr, 0, nullptr, 0, nullptr, nullptr,
-        nullptr, &command_handle_2));
-    ASSERT_NE(command_handle_2, nullptr);
-
-    ASSERT_SUCCESS(urCommandBufferFinalizeExp(updatable_cmd_buf_handle));
-  }
-
-  static constexpr size_t local_size = 4;
-  static constexpr size_t global_size = 32;
-  static constexpr size_t global_offset = 0;
-  static constexpr size_t n_dimensions = 1;
-
-  ur_exp_command_buffer_command_handle_t command_handle = nullptr;
-  ur_exp_command_buffer_command_handle_t command_handle_2 = nullptr;
 };
 
 struct TestKernel {

--- a/unified-runtime/test/conformance/exp_command_buffer/in-order.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/in-order.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include "uur/fixtures.h"
 #include <array>
 
 // Virtual base class for tests verifying that if the `isInOrder` field is
@@ -146,7 +147,7 @@ struct urInOrderUSMCommandBufferExpTest : urInOrderCommandBufferExpTest {
   std::array<void *, 3> device_ptrs = {nullptr, nullptr, nullptr};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urInOrderUSMCommandBufferExpTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urInOrderUSMCommandBufferExpTest);
 
 // Tests USM Fill, Copy, and Kernel commands to a command-buffer
 TEST_P(urInOrderUSMCommandBufferExpTest, WithoutHints) {

--- a/unified-runtime/test/conformance/exp_command_buffer/kernel_event_sync.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/kernel_event_sync.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include "uur/fixtures.h"
 #include <cstring>
 
 // Tests kernel commands using ur events for command level synchronization work
@@ -80,7 +81,7 @@ struct KernelCommandEventSyncTest
   static constexpr size_t A = 2;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(KernelCommandEventSyncTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(KernelCommandEventSyncTest);
 
 // Tests using a regular enqueue event as a dependency of a command-buffer
 // command, and having the signal event of that command-buffer command being

--- a/unified-runtime/test/conformance/exp_command_buffer/read.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/read.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -23,9 +23,9 @@ struct urCommandBufferReadCommandsTest
         uur::command_buffer::urCommandBufferExpTestWithParam<
             testParametersRead>::SetUp());
 
-    size = std::get<1>(GetParam()).size;
-    offset = std::get<1>(GetParam()).offset;
-    read_size = std::get<1>(GetParam()).read_size;
+    size = getParam().size;
+    offset = getParam().offset;
+    read_size = getParam().read_size;
     assert(size >= offset + read_size);
     // Allocate USM pointers
     ASSERT_SUCCESS(
@@ -83,14 +83,18 @@ printReadTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
   const auto platform_device_name =
       uur::GetPlatformAndDeviceName(device_handle);
   std::stringstream test_name;
-  test_name << platform_device_name << "__size__"
-            << std::get<1>(info.param).size << "__offset__"
-            << std::get<1>(info.param).offset << "__read_size__"
-            << std::get<1>(info.param).read_size;
+
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+  auto queueMode = std::get<1>(paramTuple);
+
+  test_name << platform_device_name << "__size__" << param.size << "__offset__"
+            << param.offset << "__read_size__" << param.read_size << "__"
+            << queueMode;
   return test_name.str();
 }
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urCommandBufferReadCommandsTest, testing::ValuesIn(test_cases),
     printReadTestString<urCommandBufferReadCommandsTest>);
 

--- a/unified-runtime/test/conformance/exp_command_buffer/rect_read.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/rect_read.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -114,7 +114,7 @@ struct urCommandBufferAppendMemBufferReadRectTestWithParam
   ur_mem_handle_t buffer = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urCommandBufferAppendMemBufferReadRectTestWithParam,
     testing::ValuesIn(generateParameterizations()),
     uur::printRectTestString<

--- a/unified-runtime/test/conformance/exp_command_buffer/rect_write.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/rect_write.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -114,7 +114,7 @@ struct urCommandBufferAppendMemBufferWriteRectTestWithParam
   ur_mem_handle_t buffer = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urCommandBufferAppendMemBufferWriteRectTestWithParam,
     testing::ValuesIn(generateParameterizations()),
     uur::printRectTestString<

--- a/unified-runtime/test/conformance/exp_command_buffer/regression/usm_copy.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/regression/usm_copy.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 
 // UR reproducer for SYCL-Graph E2E test "RecordReplay/usm_copy_in_order.cpp"
 // Note that the kernel code is different, in that this test uses the
@@ -76,7 +77,9 @@ struct urCommandBufferUSMCopyInOrderTest
   std::array<void *, 4> device_ptrs = {nullptr, nullptr, nullptr, nullptr};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferUSMCopyInOrderTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urCommandBufferUSMCopyInOrderTest);
+
 TEST_P(urCommandBufferUSMCopyInOrderTest, Success) {
   // https://github.com/intel/llvm/issues/19604
   UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});

--- a/unified-runtime/test/conformance/exp_command_buffer/update/buffer_fill_kernel_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/buffer_fill_kernel_update.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 
 // Test that updating a command-buffer with a single kernel command
 // taking USM arguments works correctly.
@@ -76,7 +77,7 @@ struct BufferFillCommandTest
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(BufferFillCommandTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(BufferFillCommandTest);
 
 // Update kernel arguments to fill with a new scalar value to a new output
 // buffer.

--- a/unified-runtime/test/conformance/exp_command_buffer/update/buffer_saxpy_kernel_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/buffer_saxpy_kernel_update.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 #include <array>
 
 // Test that updating a command-buffer with a single kernel command
@@ -129,7 +130,7 @@ struct BufferSaxpyKernelTest
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(BufferSaxpyKernelTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(BufferSaxpyKernelTest);
 
 TEST_P(BufferSaxpyKernelTest, UpdateParameters) {
   // Run command-buffer prior to update an verify output

--- a/unified-runtime/test/conformance/exp_command_buffer/update/enqueue_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/enqueue_update.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 #include <array>
 #include <cstring>
 
@@ -159,7 +160,8 @@ struct urUpdatableEnqueueCommandBufferExpTest
   std::array<void *, 3> shared_ptrs = {nullptr, nullptr};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUpdatableEnqueueCommandBufferExpTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urUpdatableEnqueueCommandBufferExpTest);
 
 // Tests that the same command-buffer submitted across different in-order
 // queues has an implicit dependency on first submission

--- a/unified-runtime/test/conformance/exp_command_buffer/update/invalid_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/invalid_update.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 #include <array>
 #include <cstring>
 #include <uur/known_failure.h>
@@ -69,7 +70,7 @@ struct InvalidUpdateTest
   bool finalized = false;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(InvalidUpdateTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(InvalidUpdateTest);
 
 // Test error code is returned if command-buffer not finalized
 TEST_P(InvalidUpdateTest, NotFinalizedCommandBuffer) {
@@ -392,7 +393,8 @@ struct InvalidUpdateCommandBufferExpExecutionTest : uur::urKernelExecutionTest {
       0;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(InvalidUpdateCommandBufferExpExecutionTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(
+    InvalidUpdateCommandBufferExpExecutionTest);
 
 // Test error reported if device doesn't support updating kernel args
 TEST_P(InvalidUpdateCommandBufferExpExecutionTest, KernelArg) {

--- a/unified-runtime/test/conformance/exp_command_buffer/update/kernel_event_sync.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/kernel_event_sync.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 #include <cstring>
 
 struct KernelCommandEventSyncUpdateTest
@@ -64,7 +65,7 @@ struct KernelCommandEventSyncUpdateTest
   static constexpr size_t A = 2;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(KernelCommandEventSyncUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(KernelCommandEventSyncUpdateTest);
 
 // Tests updating the signal and wait event dependencies of the saxpy
 // command in a command-buffer.

--- a/unified-runtime/test/conformance/exp_command_buffer/update/local_memory_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/local_memory_update.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 #include <array>
 #include <cstring>
 
@@ -134,7 +135,7 @@ struct LocalMemoryUpdateTest : LocalMemoryUpdateTestBase {
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(LocalMemoryUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(LocalMemoryUpdateTest);
 
 // Test updating A,X,Y parameters to new values and local memory parameters
 // to original values.
@@ -888,7 +889,7 @@ struct LocalMemoryMultiUpdateTest : LocalMemoryUpdateTestBase {
   std::array<ur_exp_command_buffer_command_handle_t, nodes> command_handles{};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(LocalMemoryMultiUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(LocalMemoryMultiUpdateTest);
 
 // Test updating A,X,Y parameters to new values and local memory parameters
 // to original values.
@@ -1191,7 +1192,7 @@ struct LocalMemoryUpdateTestOutOfOrder : LocalMemoryUpdateTestBaseOutOfOrder {
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(LocalMemoryUpdateTestOutOfOrder);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(LocalMemoryUpdateTestOutOfOrder);
 
 // Test updating A,X,Y parameters to new values and local memory to larger
 // values when the kernel arguments were added out of order.

--- a/unified-runtime/test/conformance/exp_command_buffer/update/ndrange_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/ndrange_update.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 #include <array>
 #include <cstring>
 
@@ -101,7 +102,7 @@ struct NDRangeUpdateTest
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(NDRangeUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(NDRangeUpdateTest);
 
 // Add a 3 dimension kernel command to the command-buffer and update the
 // local size and global offset

--- a/unified-runtime/test/conformance/exp_command_buffer/update/usm_fill_kernel_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/usm_fill_kernel_update.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 #include <array>
 #include <cstring>
 
@@ -75,7 +76,7 @@ struct USMFillCommandTest
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(USMFillCommandTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(USMFillCommandTest);
 
 // Test using a different global size to fill and larger USM output buffer
 TEST_P(USMFillCommandTest, UpdateParameters) {
@@ -317,7 +318,7 @@ struct USMMultipleFillCommandTest
       command_handles;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(USMMultipleFillCommandTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(USMMultipleFillCommandTest);
 
 // Test updating all the kernels commands in the command-buffer
 TEST_P(USMMultipleFillCommandTest, UpdateAllKernels) {

--- a/unified-runtime/test/conformance/exp_command_buffer/update/usm_saxpy_kernel_update.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/update/usm_saxpy_kernel_update.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "../fixtures.h"
+#include "uur/fixtures.h"
 #include <array>
 #include <cstring>
 
@@ -90,7 +91,7 @@ struct USMSaxpyKernelTest : USMSaxpyKernelTestBase {
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(USMSaxpyKernelTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(USMSaxpyKernelTest);
 
 TEST_P(USMSaxpyKernelTest, UpdateParameters) {
   // Run command-buffer prior to update an verify output
@@ -188,7 +189,7 @@ struct USMMultiSaxpyKernelTest : USMSaxpyKernelTestBase {
   std::array<ur_exp_command_buffer_command_handle_t, nodes> command_handles{};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(USMMultiSaxpyKernelTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(USMMultiSaxpyKernelTest);
 
 TEST_P(USMMultiSaxpyKernelTest, UpdateParameters) {
   // Run command-buffer prior to update an verify output

--- a/unified-runtime/test/conformance/exp_command_buffer/write.cpp
+++ b/unified-runtime/test/conformance/exp_command_buffer/write.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -24,9 +24,9 @@ struct urCommandBufferWriteCommandsTest
         uur::command_buffer::urCommandBufferExpTestWithParam<
             testParametersWrite>::SetUp());
 
-    size = std::get<1>(GetParam()).size;
-    offset = std::get<1>(GetParam()).offset;
-    write_size = std::get<1>(GetParam()).write_size;
+    size = getParam().size;
+    offset = getParam().offset;
+    write_size = getParam().write_size;
     assert(size >= offset + write_size);
     // Allocate USM pointers
     ASSERT_SUCCESS(
@@ -91,14 +91,18 @@ static std::string printWriteTestString(
   const auto platform_device_name =
       uur::GetPlatformAndDeviceName(device_handle);
   std::stringstream test_name;
-  test_name << platform_device_name << "__size__"
-            << std::get<1>(info.param).size << "__offset__"
-            << std::get<1>(info.param).offset << "__write_size__"
-            << std::get<1>(info.param).write_size;
+
+  auto paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+  auto queueMode = std::get<1>(paramTuple);
+
+  test_name << platform_device_name << "__size__" << param.size << "__offset__"
+            << param.offset << "__write_size__" << param.write_size << "__"
+            << queueMode;
   return test_name.str();
 }
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urCommandBufferWriteCommandsTest, testing::ValuesIn(test_cases),
     printWriteTestString<urCommandBufferWriteCommandsTest>);
 

--- a/unified-runtime/test/conformance/exp_enqueue_kernel_launch_with_args/urEnqueueKernelLaunchWithArgsExp.cpp
+++ b/unified-runtime/test/conformance/exp_enqueue_kernel_launch_with_args/urEnqueueKernelLaunchWithArgsExp.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -144,7 +144,8 @@ struct urEnqueueKernelLaunchWithArgsTest : uur::urKernelExecutionTest {
   ur_backend_t backend{};
   std::vector<ur_exp_kernel_arg_properties_t> args;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchWithArgsTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urEnqueueKernelLaunchWithArgsTest);
 
 TEST_P(urEnqueueKernelLaunchWithArgsTest, Success) {
   ASSERT_SUCCESS(urEnqueueKernelLaunchWithArgsExp(
@@ -284,7 +285,8 @@ struct urEnqueueKernelLaunchWithArgsMemObjTest : uur::urKernelExecutionTest {
   } accessor;
   std::vector<ur_exp_kernel_arg_properties_t> args;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchWithArgsMemObjTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urEnqueueKernelLaunchWithArgsMemObjTest);
 
 TEST_P(urEnqueueKernelLaunchWithArgsMemObjTest, Success) {
   ASSERT_SUCCESS(urEnqueueKernelLaunchWithArgsExp(

--- a/unified-runtime/test/conformance/kernel/urKernelCreate.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelCreate.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -26,7 +26,8 @@ struct urKernelCreateTest : uur::urProgramTest {
   std::string kernel_name;
   ur_kernel_handle_t kernel = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelCreateTest);
+
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelCreateTest);
 
 TEST_P(urKernelCreateTest, Success) {
   ASSERT_SUCCESS(urKernelCreate(program, kernel_name.data(), &kernel));

--- a/unified-runtime/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -25,7 +25,7 @@ struct urKernelCreateWithNativeHandleTest : uur::urKernelTest {
       false                                       /*isNativeHandleOwned*/
   };
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelCreateWithNativeHandleTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelCreateWithNativeHandleTest);
 
 TEST_P(urKernelCreateWithNativeHandleTest, Success) {
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urKernelCreateWithNativeHandle(

--- a/unified-runtime/test/conformance/kernel/urKernelGetGroupInfo.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelGetGroupInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -20,7 +20,8 @@ struct urKernelGetGroupInfoFixedWorkGroupSizeTest : uur::urKernelTest {
   // In UR, this is on the left, so we reverse the order of these values.
   std::array<size_t, 3> work_group_size{2, 4, 8};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetGroupInfoFixedWorkGroupSizeTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(
+    urKernelGetGroupInfoFixedWorkGroupSizeTest);
 
 TEST_P(urKernelGetGroupInfoFixedWorkGroupSizeTest,
        SuccessCompileWorkGroupSize) {
@@ -60,7 +61,8 @@ struct urKernelGetGroupInfoMaxWorkGroupSizeTest : uur::urKernelTest {
   std::array<size_t, 3> max_work_group_size{2, 4, 8};
   size_t max_linear_work_group_size{64};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetGroupInfoMaxWorkGroupSizeTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(
+    urKernelGetGroupInfoMaxWorkGroupSizeTest);
 
 TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
        SuccessCompileMaxWorkGroupSize) {
@@ -102,7 +104,7 @@ TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
 }
 
 using urKernelGetGroupInfoTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetGroupInfoTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelGetGroupInfoTest);
 
 TEST_P(urKernelGetGroupInfoTest, SuccessGlobalWorkSize) {
   const ur_kernel_group_info_t property_name =

--- a/unified-runtime/test/conformance/kernel/urKernelGetInfo.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelGetInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -9,7 +9,7 @@
 #include <uur/known_failure.h>
 
 using urKernelGetInfoTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetInfoTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelGetInfoTest);
 
 TEST_P(urKernelGetInfoTest, SuccessFunctionName) {
   const ur_kernel_info_t property_name = UR_KERNEL_INFO_FUNCTION_NAME;

--- a/unified-runtime/test/conformance/kernel/urKernelGetNativeHandle.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelGetNativeHandle.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urKernelGetNativeHandleTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetNativeHandleTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelGetNativeHandleTest);
 
 TEST_P(urKernelGetNativeHandleTest, Success) {
   ur_native_handle_t native_kernel_handle = 0;

--- a/unified-runtime/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -20,7 +20,8 @@ struct urKernelGetSubGroupInfoFixedSubGroupSizeTest : uur::urKernelTest {
   // This value correlates to sub_group_size<8> in fixed_sg_size.cpp.
   uint32_t num_sub_groups{8};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetSubGroupInfoFixedSubGroupSizeTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(
+    urKernelGetSubGroupInfoFixedSubGroupSizeTest);
 
 TEST_P(urKernelGetSubGroupInfoFixedSubGroupSizeTest,
        SuccessCompileNumSubGroups) {
@@ -46,7 +47,7 @@ TEST_P(urKernelGetSubGroupInfoFixedSubGroupSizeTest,
 struct urKernelGetSubGroupInfoTest : uur::urKernelTest {
   void SetUp() override { UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp()); }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetSubGroupInfoTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelGetSubGroupInfoTest);
 
 TEST_P(urKernelGetSubGroupInfoTest, SuccessMaxSubGroupSize) {
   const ur_kernel_sub_group_info_t property_name =

--- a/unified-runtime/test/conformance/kernel/urKernelRelease.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelRelease.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urKernelReleaseTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelReleaseTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelReleaseTest);
 
 TEST_P(urKernelReleaseTest, Success) {
   ASSERT_SUCCESS(urKernelRetain(kernel));

--- a/unified-runtime/test/conformance/kernel/urKernelRetain.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelRetain.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -8,7 +8,7 @@
 #include <uur/fixtures.h>
 
 using urKernelRetainTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelRetainTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelRetainTest);
 
 TEST_P(urKernelRetainTest, Success) {
   ASSERT_SUCCESS(urKernelRetain(kernel));

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgLocal.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgLocal.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -15,7 +15,7 @@ struct urKernelSetArgLocalTest : uur::urKernelTest {
   }
   size_t local_mem_size = 4 * sizeof(uint32_t);
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgLocalTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urKernelSetArgLocalTest);
 
 TEST_P(urKernelSetArgLocalTest, Success) {
   ASSERT_SUCCESS(urKernelSetArgLocal(kernel, 1, local_mem_size, nullptr));
@@ -147,7 +147,7 @@ struct urKernelSetArgLocalMultiTest : uur::urKernelExecutionTest {
   static constexpr uint64_t hip_local_offset = 0;
   ur_backend_t backend{};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgLocalMultiTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urKernelSetArgLocalMultiTest);
 
 TEST_P(urKernelSetArgLocalMultiTest, Basic) {
   ASSERT_SUCCESS(urEnqueueKernelLaunch(

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgMemObj.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgMemObj.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -25,7 +25,7 @@ struct urKernelSetArgMemObjTest : uur::urKernelTest {
 
   ur_mem_handle_t buffer = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgMemObjTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelSetArgMemObjTest);
 
 TEST_P(urKernelSetArgMemObjTest, Success) {
   ASSERT_SUCCESS(urKernelSetArgMemObj(kernel, 0, nullptr, buffer));

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgPointer.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgPointer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-1016 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -31,7 +31,7 @@ struct urKernelSetArgPointerTest : uur::urKernelExecutionTest {
   size_t allocation_size = array_size * sizeof(uint32_t);
   uint32_t data = 42;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgPointerTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urKernelSetArgPointerTest);
 
 TEST_P(urKernelSetArgPointerTest, SuccessHost) {
   ur_device_usm_access_capability_flags_t host_usm_flags = 0;

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgSampler.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgSampler.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -61,7 +61,7 @@ struct urKernelSetArgSamplerTestWithParam
   ur_sampler_handle_t sampler = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urKernelSetArgSamplerTestWithParam,
     ::testing::Combine(
         ::testing::Values(true, false),
@@ -72,7 +72,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
                           UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT),
         ::testing::Values(UR_SAMPLER_FILTER_MODE_NEAREST,
                           UR_SAMPLER_FILTER_MODE_LINEAR)),
-    uur::deviceTestWithParamPrinter<uur::SamplerCreateParamT>);
+    uur::deviceTestWithParamPrinterMulti<uur::SamplerCreateParamT>);
 
 TEST_P(urKernelSetArgSamplerTestWithParam, Success) {
   uint32_t arg_index = 2;
@@ -86,7 +86,7 @@ struct urKernelSetArgSamplerTest : uur::urBaseKernelTest {
     // the non-existant image_copy kernel)
     bool image_support = false;
     ASSERT_SUCCESS(
-        uur::GetDeviceImageSupport(GetParam().device, image_support));
+        uur::GetDeviceImageSupport(getParam().device, image_support));
     if (!image_support) {
       GTEST_SKIP() << "Device doesn't support images";
     }
@@ -123,7 +123,7 @@ struct urKernelSetArgSamplerTest : uur::urBaseKernelTest {
   ur_sampler_handle_t sampler = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgSamplerTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelSetArgSamplerTest);
 
 TEST_P(urKernelSetArgSamplerTest, SuccessWithProps) {
   ur_kernel_arg_sampler_properties_t props{

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgValue.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgValue.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -15,7 +15,7 @@ struct urKernelSetArgValueTest : uur::urKernelTest {
 
   uint32_t arg_value = 42;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgValueTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelSetArgValueTest);
 
 TEST_P(urKernelSetArgValueTest, Success) {
   ASSERT_SUCCESS(

--- a/unified-runtime/test/conformance/kernel/urKernelSetExecInfo.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetExecInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 using urKernelSetExecInfoTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetExecInfoTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelSetExecInfoTest);
 
 TEST_P(urKernelSetExecInfoTest, SuccessIndirectAccess) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
@@ -59,7 +59,7 @@ struct urKernelSetExecInfoUSMPointersTest : uur::urKernelTest {
   size_t allocation_size = 16;
   void *allocation = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetExecInfoUSMPointersTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urKernelSetExecInfoUSMPointersTest);
 
 TEST_P(urKernelSetExecInfoUSMPointersTest, SuccessHost) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
@@ -119,12 +119,12 @@ TEST_P(urKernelSetExecInfoUSMPointersTest, SuccessShared) {
 using urKernelSetExecInfoCacheConfigTest =
     uur::urKernelTestWithParam<ur_kernel_cache_config_t>;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
     urKernelSetExecInfoCacheConfigTest,
     ::testing::Values(UR_KERNEL_CACHE_CONFIG_DEFAULT,
                       UR_KERNEL_CACHE_CONFIG_LARGE_SLM,
                       UR_KERNEL_CACHE_CONFIG_LARGE_DATA),
-    uur::deviceTestWithParamPrinter<ur_kernel_cache_config_t>);
+    uur::deviceTestWithParamPrinterMulti<ur_kernel_cache_config_t>);
 
 TEST_P(urKernelSetExecInfoCacheConfigTest, Success) {
   auto property_value = getParam();

--- a/unified-runtime/test/conformance/kernel/urKernelSetSpecializationConstants.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetSpecializationConstants.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -24,7 +24,8 @@ struct urKernelSetSpecializationConstantsTest : uur::urBaseKernelExecutionTest {
   uint32_t spec_value = 42;
   ur_specialization_constant_info_t info = {0, sizeof(spec_value), &spec_value};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetSpecializationConstantsTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(
+    urKernelSetSpecializationConstantsTest);
 
 struct urKernelSetSpecializationConstantsNegativeTest
     : uur::urBaseKernelExecutionTest {
@@ -44,7 +45,7 @@ struct urKernelSetSpecializationConstantsNegativeTest
   uint32_t spec_value = 42;
   ur_specialization_constant_info_t info = {0, sizeof(spec_value), &spec_value};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(
     urKernelSetSpecializationConstantsNegativeTest);
 
 TEST_P(urKernelSetSpecializationConstantsTest, Success) {

--- a/unified-runtime/test/conformance/kernel/urKernelSuggestMaxCooperativeGroupCount.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSuggestMaxCooperativeGroupCount.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -27,7 +27,9 @@ struct urKernelSuggestMaxCooperativeGroupCountTest
   const uint32_t n_dimensions = 1;
   const size_t local_size = 1;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSuggestMaxCooperativeGroupCountTest);
+
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(
+    urKernelSuggestMaxCooperativeGroupCountTest);
 
 TEST_P(urKernelSuggestMaxCooperativeGroupCountTest, Success) {
   ASSERT_SUCCESS(urKernelSuggestMaxCooperativeGroupCount(

--- a/unified-runtime/test/conformance/program/urProgramBuild.cpp
+++ b/unified-runtime/test/conformance/program/urProgramBuild.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 using urProgramBuildTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramBuildTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramBuildTest);
 
 TEST_P(urProgramBuildTest, Success) {
   ASSERT_SUCCESS(urProgramBuild(context, program, nullptr));

--- a/unified-runtime/test/conformance/program/urProgramCompile.cpp
+++ b/unified-runtime/test/conformance/program/urProgramCompile.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -8,9 +8,10 @@
 
 using urProgramCompileWithParamTest = uur::urProgramTestWithParam<std::string>;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(urProgramCompileWithParamTest,
-                                 ::testing::Values("-O0", "-O1", "-O2", "-O3"),
-                                 uur::deviceTestWithParamPrinter<std::string>);
+UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(
+    urProgramCompileWithParamTest,
+    ::testing::Values("-O0", "-O1", "-O2", "-O3"),
+    uur::deviceTestWithParamPrinterMulti<std::string>);
 
 TEST_P(urProgramCompileWithParamTest, Success) {
   const char *platformOption = nullptr;
@@ -21,7 +22,7 @@ TEST_P(urProgramCompileWithParamTest, Success) {
 }
 
 using urProgramCompileTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramCompileTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramCompileTest);
 
 TEST_P(urProgramCompileTest, Success) {
   ASSERT_SUCCESS(urProgramCompile(context, program, nullptr));

--- a/unified-runtime/test/conformance/program/urProgramCreateWithBinary.cpp
+++ b/unified-runtime/test/conformance/program/urProgramCreateWithBinary.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -35,7 +35,8 @@ struct urProgramCreateWithBinaryTest : uur::urProgramTest {
   std::vector<uint8_t> binary;
   ur_program_handle_t binary_program = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramCreateWithBinaryTest);
+
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramCreateWithBinaryTest);
 
 TEST_P(urProgramCreateWithBinaryTest, Success) {
   auto size = binary.size();

--- a/unified-runtime/test/conformance/program/urProgramCreateWithNativeHandle.cpp
+++ b/unified-runtime/test/conformance/program/urProgramCreateWithNativeHandle.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -33,7 +33,8 @@ struct urProgramCreateWithNativeHandleTest : uur::urProgramTest {
   ur_native_handle_t native_program_handle = 0;
   ur_program_handle_t native_program = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramCreateWithNativeHandleTest);
+
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramCreateWithNativeHandleTest);
 
 TEST_P(urProgramCreateWithNativeHandleTest, Success) {
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urProgramCreateWithNativeHandle(

--- a/unified-runtime/test/conformance/program/urProgramGetBuildInfo.cpp
+++ b/unified-runtime/test/conformance/program/urProgramGetBuildInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -13,7 +13,8 @@ struct urProgramGetBuildInfoTest : uur::urProgramTest {
     ASSERT_SUCCESS(urProgramBuild(this->context, program, nullptr));
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetBuildInfoTest);
+
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramGetBuildInfoTest);
 
 TEST_P(urProgramGetBuildInfoTest, SuccessStatus) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});

--- a/unified-runtime/test/conformance/program/urProgramGetFunctionPointer.cpp
+++ b/unified-runtime/test/conformance/program/urProgramGetFunctionPointer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -18,7 +18,8 @@ struct urProgramGetFunctionPointerTest : uur::urProgramTest {
 
   std::string function_name;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetFunctionPointerTest);
+
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramGetFunctionPointerTest);
 
 TEST_P(urProgramGetFunctionPointerTest, Success) {
   void *function_pointer = nullptr;

--- a/unified-runtime/test/conformance/program/urProgramGetGlobalVariablePointer.cpp
+++ b/unified-runtime/test/conformance/program/urProgramGetGlobalVariablePointer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -8,7 +8,7 @@
 
 using urProgramGetGlobalVariablePointerTest = uur::urGlobalVariableTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetGlobalVariablePointerTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramGetGlobalVariablePointerTest);
 
 TEST_P(urProgramGetGlobalVariablePointerTest, Success) {
   size_t global_variable_size = 0;

--- a/unified-runtime/test/conformance/program/urProgramGetInfo.cpp
+++ b/unified-runtime/test/conformance/program/urProgramGetInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -15,7 +15,7 @@ struct urProgramGetInfoTest : uur::urProgramTest {
   }
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetInfoTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramGetInfoTest);
 
 TEST_P(urProgramGetInfoTest, SuccessReferenceCount) {
   size_t property_size = 0;

--- a/unified-runtime/test/conformance/program/urProgramGetNativeHandle.cpp
+++ b/unified-runtime/test/conformance/program/urProgramGetNativeHandle.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urProgramGetNativeHandleTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetNativeHandleTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramGetNativeHandleTest);
 
 TEST_P(urProgramGetNativeHandleTest, Success) {
   ur_backend_t backend;

--- a/unified-runtime/test/conformance/program/urProgramLink.cpp
+++ b/unified-runtime/test/conformance/program/urProgramLink.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -30,7 +30,7 @@ struct urProgramLinkTest : uur::urProgramTest {
 
   ur_program_handle_t linked_program = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramLinkTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramLinkTest);
 
 TEST_P(urProgramLinkTest, Success) {
   // This entry point isn't implemented for HIP.
@@ -77,11 +77,11 @@ TEST_P(urProgramLinkTest, SetOutputOnZeroCount) {
             reinterpret_cast<ur_program_handle_t>(&invalid_pointer));
 }
 
-struct urProgramLinkErrorTest : uur::urQueueTest {
+struct urProgramLinkErrorTest : uur::urMultiQueueTypeTest {
   const std::string linker_error_program_name = "linker_error";
 
   void SetUp() override {
-    UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
+    UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTypeTest::SetUp());
     // TODO: This should use a query for urProgramCreateWithIL support or
     // rely on UR_RESULT_ERROR_UNSUPPORTED_FEATURE being returned.
     ur_backend_t backend;
@@ -112,13 +112,13 @@ struct urProgramLinkErrorTest : uur::urQueueTest {
     if (linked_program) {
       EXPECT_SUCCESS(urProgramRelease(linked_program));
     }
-    UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::TearDown());
+    UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTypeTest::TearDown());
   }
 
   ur_program_handle_t program = nullptr;
   ur_program_handle_t linked_program = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramLinkErrorTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramLinkErrorTest);
 
 TEST_P(urProgramLinkErrorTest, LinkFailure) {
   ASSERT_EQ_RESULT(

--- a/unified-runtime/test/conformance/program/urProgramRelease.cpp
+++ b/unified-runtime/test/conformance/program/urProgramRelease.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urProgramReleaseTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramReleaseTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramReleaseTest);
 
 TEST_P(urProgramReleaseTest, Success) {
   ASSERT_SUCCESS(urProgramRetain(program));

--- a/unified-runtime/test/conformance/program/urProgramRetain.cpp
+++ b/unified-runtime/test/conformance/program/urProgramRetain.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urProgramRetainTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramRetainTest);
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urProgramRetainTest);
 
 TEST_P(urProgramRetainTest, Success) {
   uint32_t prevRefCount = 0;

--- a/unified-runtime/test/conformance/program/urProgramSetSpecializationConstants.cpp
+++ b/unified-runtime/test/conformance/program/urProgramSetSpecializationConstants.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -26,7 +26,8 @@ struct urProgramSetSpecializationConstantsTest : uur::urKernelExecutionTest {
   uint32_t default_spec_value = 1000; // Must match the one in the SYCL source
   ur_specialization_constant_info_t info = {0, sizeof(spec_value), &spec_value};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramSetSpecializationConstantsTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urProgramSetSpecializationConstantsTest);
 
 struct urProgramSetSpecializationConstantsNegativeTest
     : uur::urKernelExecutionTest {
@@ -48,7 +49,7 @@ struct urProgramSetSpecializationConstantsNegativeTest
   uint32_t default_spec_value = 1000; // Must match the one in the SYCL source
   ur_specialization_constant_info_t info = {0, sizeof(spec_value), &spec_value};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
     urProgramSetSpecializationConstantsNegativeTest);
 
 struct urProgramSetMultipleSpecializationConstantsTest
@@ -68,7 +69,7 @@ struct urProgramSetMultipleSpecializationConstantsTest
     }
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
     urProgramSetMultipleSpecializationConstantsTest);
 
 TEST_P(urProgramSetSpecializationConstantsTest, Success) {

--- a/unified-runtime/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
@@ -1,12 +1,13 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
 
-using urQueueCreateWithNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueCreateWithNativeHandleTest);
+using urQueueCreateWithNativeHandleTest = uur::urMultiQueueTypeTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(
+    urQueueCreateWithNativeHandleTest);
 
 TEST_P(urQueueCreateWithNativeHandleTest, Success) {
   ur_native_handle_t native_handle = 0;

--- a/unified-runtime/test/conformance/queue/urQueueFinish.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueFinish.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,8 +7,8 @@
 #include "uur/fixtures.h"
 #include "uur/raii.h"
 
-using urQueueFinishTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueFinishTest);
+using urQueueFinishTest = uur::urMultiQueueTypeTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urQueueFinishTest);
 
 TEST_P(urQueueFinishTest, Success) {
   constexpr size_t buffer_size = 1024;

--- a/unified-runtime/test/conformance/queue/urQueueFlush.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueFlush.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -8,8 +8,8 @@
 #include "uur/known_failure.h"
 #include "uur/raii.h"
 
-using urQueueFlushTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueFlushTest);
+using urQueueFlushTest = uur::urMultiQueueTypeTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urQueueFlushTest);
 
 TEST_P(urQueueFlushTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/unified-runtime/test/conformance/queue/urQueueGetNativeHandle.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueGetNativeHandle.cpp
@@ -1,12 +1,12 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
 
-using urQueueGetNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueGetNativeHandleTest);
+using urQueueGetNativeHandleTest = uur::urMultiQueueTypeTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urQueueGetNativeHandleTest);
 
 TEST_P(urQueueGetNativeHandleTest, Success) {
   ur_native_handle_t native_handle = 0;

--- a/unified-runtime/test/conformance/queue/urQueueRelease.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueRelease.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -6,8 +6,8 @@
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
 
-using urQueueReleaseTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueReleaseTest);
+using urQueueReleaseTest = uur::urMultiQueueTypeTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urQueueReleaseTest);
 
 TEST_P(urQueueReleaseTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/unified-runtime/test/conformance/queue/urQueueRetain.cpp
+++ b/unified-runtime/test/conformance/queue/urQueueRetain.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -6,8 +6,8 @@
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
 
-using urQueueRetainTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueRetainTest);
+using urQueueRetainTest = uur::urMultiQueueTypeTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urQueueRetainTest);
 
 TEST_P(urQueueRetainTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/unified-runtime/test/conformance/testing/source/fixtures.cpp
+++ b/unified-runtime/test/conformance/testing/source/fixtures.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -7,18 +7,6 @@
 #include "uur/fixtures.h"
 
 namespace uur {
-template <>
-std::string deviceTestWithParamPrinter<BoolTestParam>(
-    const ::testing::TestParamInfo<std::tuple<DeviceTuple, BoolTestParam>>
-        &info) {
-  auto device = std::get<0>(info.param).device;
-  auto &param = std::get<1>(info.param);
-
-  std::stringstream ss;
-  ss << param.name << (param.value ? "Enabled" : "Disabled");
-  return uur::GetPlatformAndDeviceName(device) + "__" + ss.str();
-}
-
 template <>
 std::string platformTestWithParamPrinter<BoolTestParam>(
     const ::testing::TestParamInfo<
@@ -50,6 +38,49 @@ std::string deviceTestWithParamPrinter<SamplerCreateParamT>(
     ss << "UNNORMALIZED_";
   }
   ss << addr_mode << "_" << filter_mode;
+  return uur::GetPlatformAndDeviceName(device) + "__" + ss.str();
+}
+
+template <>
+std::string deviceTestWithParamPrinterMulti<SamplerCreateParamT>(
+    const ::testing::TestParamInfo<
+        std::tuple<DeviceTuple, MultiQueueParam<uur::SamplerCreateParamT>>>
+        &info) {
+  auto device = std::get<0>(info.param).device;
+  auto &paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+
+  const auto normalized = std::get<0>(param);
+  const auto addr_mode = std::get<1>(param);
+  const auto filter_mode = std::get<2>(param);
+
+  auto queueMode = std::get<1>(paramTuple);
+
+  std::stringstream ss;
+
+  if (normalized) {
+    ss << "NORMALIZED_";
+  } else {
+    ss << "UNNORMALIZED_";
+  }
+  ss << addr_mode << "_" << filter_mode;
+  ss << "__" << queueMode;
+  return uur::GetPlatformAndDeviceName(device) + "__" + ss.str();
+}
+
+template <>
+std::string deviceTestWithParamPrinterMulti<BoolTestParam>(
+    const ::testing::TestParamInfo<
+        std::tuple<DeviceTuple, MultiQueueParam<BoolTestParam>>> &info) {
+  auto device = std::get<0>(info.param).device;
+  auto &paramTuple = std::get<1>(info.param);
+  auto param = std::get<0>(paramTuple);
+  auto queueMode = std::get<1>(paramTuple);
+
+  std::stringstream ss;
+  ss << param.name << (param.value ? "Enabled" : "Disabled");
+  ss << "__" << queueMode;
+
   return uur::GetPlatformAndDeviceName(device) + "__" + ss.str();
 }
 

--- a/unified-runtime/test/conformance/usm/urUSMFree.cpp
+++ b/unified-runtime/test/conformance/usm/urUSMFree.cpp
@@ -1,9 +1,11 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "ur_api.h"
+#include "gtest/gtest.h"
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
 
@@ -118,7 +120,8 @@ struct urUSMFreeDuringExecutionTest : uur::urKernelExecutionTest {
   uint32_t data = 42;
   size_t wg_offset = 0;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMFreeDuringExecutionTest);
+
+UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(urUSMFreeDuringExecutionTest);
 
 TEST_P(urUSMFreeDuringExecutionTest, SuccessHost) {
   // Causes an abort in liboffload


### PR DESCRIPTION
Modifications allow for running tests with different queue submission modes, either specified by the user or provided by default. This is made possible through the introduced macros:
- `UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(FIXTURE)`: instantiates the provided `FIXTURE` with the submission modes: `UR_QUEUE_FLAG_SUBMISSION_BATCHED` and `UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE`
- `UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM(FIXTURE, VALUES, PRINTER)`: similarly instantiates the `FIXTURE` with either batched or immediate submission modes, but additionally accepts parameters 
- `UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES(FIXTURE, MODES)`: instantiates the provided `FIXTURE` with queue submission modes provided by the user
- `UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE(FIXTURE)`: provides only one default submission mode (specified as 0); the exact mode is chosen by the device
- `UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES_PRINTER(FIXTURE, MODES, PRINTER)`: similar to `UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES`, but the user also provides the `PRINTER` function
- `UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES_AND_PARAM(FIXTURE, VALUES, MODES, PRINTER)`: similar to `UUR_MULTI_QUEUE_TYPE_TEST_SUITE_WITH_PARAM`, but the user also provides queue submission modes

At this moment, `UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES_AND_PARAM` is not used in any test. As a helper intended for parametrized tests, this macro is complementary to `UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES`, which enables the user to specify queue submission modes for unparametrized tests. Example usage:

```
UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES_AND_PARAM(
    urEnqueueMemBufferFillTest, testing::ValuesIn(test_cases), testing::ValuesIn(UR_QUEUE_FLAG_SUBMISSION_BATCHED,
                                        UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE),
    uur::printFillTestStringMultiQueueType<urEnqueueMemBufferFillTest>);
```

Tests that do not use any queue (like most of the urProgramTests, except for urProgramSetSpecializationConstantsTest) are instantiated using `UUR_DEVICE_TEST_SUITE_WITH_DEFAULT_QUEUE`. There might be more tests that do not need a queue, since the heuristic for determining whether the given test needs a queue consisted of checking whether the queue defined in the test class is mentioned in the test file (not checked per derived test class).

This patch introduces equivalents for `urQueueTest` for unparametrized tests and `urQueueTestWithParam`, which are `urMultiQueueTypeTest` and `urMultiQueueTypeTestWithParam`, respectively. Parametrized tests use a new parameter type: `MultiQueueParam (std::tuple<T, ur_queue_flag_t>)`. Similarly, the previously "unparametrized" tests, which were eventually parametrized with the `DeviceTuple`, now use `std::tuple<DeviceTuple, ur_queue_flag_t>` as their parameter type. 

Additionally, urCommandBufferCommandExpTest is removed since it is not referenced anywhere.