### PR TITLE
[SYCL][E2E] Move AOT tests off Gen12

### DIFF
--- a/sycl/test-e2e/AOT/fallback.cpp
+++ b/sycl/test-e2e/AOT/fallback.cpp
@@ -7,12 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: ocloc, gpu, target-spir
-// UNSUPPORTED: gpu-intel-gen12
+// UNSUPPORTED: gpu-intel-dg2
 // UNSUPPORTED-INTENDED: Remove support for platform used as compile target
 // since AOT image should be not applicable.
 
 // AOT-compiled image for absent gen platform, run on GPU.
-// RUN: %clangxx -fsycl -fsycl-targets=spir64,intel_gpu_tgl %S/Inputs/aot.cpp -o %t_spv_gpu.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64,intel_gpu_acm_g10 %S/Inputs/aot.cpp -o %t_spv_gpu.out
 // RUN: env ONEAPI_DEVICE_SELECTOR="*:gpu" SYCL_UR_TRACE=2 %{run-unfiltered-devices} %t_spv_gpu.out | FileCheck %s
 
 // CHECK: ---> urProgramCreateWithIL

--- a/sycl/test-e2e/AOT/half.cpp
+++ b/sycl/test-e2e/AOT/half.cpp
@@ -1,8 +1,9 @@
 // This test ensures that a program that has a kernel
 // using fp16 can be compiled AOT.
 
-// REQUIRES: ocloc, opencl-aot, any-device-is-cpu
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -o %t.tgllp.out %s
+// Don't run on Gen12 Windows as we don't use a driver that can AOT compile.
+// REQUIRES: ocloc, opencl-aot, any-device-is-cpu, (!gpu-intel-gen12 || linux)
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_acm_g10 -o %t.dg2.out %s
 
 // CPU AOT targets host isa, so we compile on the run system instead.
 // RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s

--- a/sycl/test-e2e/AOT/reqd-sg-size.cpp
+++ b/sycl/test-e2e/AOT/reqd-sg-size.cpp
@@ -1,8 +1,9 @@
 // This test ensures that a program that has a kernel
 // using various required sub-group sizes can be compiled AOT.
 
-// REQUIRES: ocloc, opencl-aot, any-device-is-cpu, opencl-cpu-rt
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -o %t.tgllp.out %s
+// Don't run on Gen12 Windows as we don't use a driver that can AOT compile.
+// REQUIRES: ocloc, opencl-aot, any-device-is-cpu, opencl-cpu-rt, (!gpu-intel-gen12 || linux)
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_acm_g10 -o %t.dg2.out %s
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
 
 // ocloc on windows does not have support for PVC, so this command will

--- a/sycl/test-e2e/BFloat16/bfloat16_example_aot.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example_aot.cpp
@@ -3,16 +3,16 @@
 /// both GPU and CPU.
 ///
 
-// REQUIRES: opencl-aot, ocloc, gpu-intel-gen12, any-device-is-cpu
+// REQUIRES: opencl-aot, ocloc, any-device-is-cpu, (!gpu-intel-gen12)
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64 %s -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xsycl-target-backend=spir64_gen "-device gen12lp" %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2" %s -o %t.out
 // RUN: %{run} %t.out
 
 // CPU AOT targets host isa, so we compile on the run system instead.
-// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device gen12lp" %s -o %t.out
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2" %s -o %t.out
 // RUN: %{run} %t.out
 
 #include "bfloat16_example.hpp"

--- a/sycl/test-e2e/BFloat16/bfloat16_example_aot_cpu.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example_aot_cpu.cpp
@@ -3,13 +3,13 @@
 /// CPU.
 ///
 
-// REQUIRES: opencl-aot, ocloc, gpu-intel-gen12, any-device-is-cpu
+// REQUIRES: opencl-aot, ocloc, gpu-intel-dg2, any-device-is-cpu
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2" %s -o %t.out
 // RUN: %if cpu %{ %{run} %t.out %}
 
 // CPU AOT targets host isa, so we compile on the run system instead.
-// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
+// RUN: %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2" %s -o %t.out
 // RUN: %if cpu %{ %{run} %t.out %}
 
 #include "bfloat16_example.hpp"

--- a/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example_aot_gpu.cpp
@@ -3,12 +3,12 @@
 /// GPU.
 ///
 
-// REQUIRES: opencl-aot, ocloc, gpu-intel-gen12, any-device-is-gpu
+// REQUIRES: opencl-aot, ocloc, gpu-intel-dg2, any-device-is-gpu
 
 // UNSUPPORTED: true
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17305
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend "-device gen12lp" %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend "-device dg2" %s -o %t.out
 // RUN: %if gpu %{%{run} %t.out %}
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend "-device *" %s -o %t.out

--- a/sycl/test-e2e/Basic/build_log.cpp
+++ b/sycl/test-e2e/Basic/build_log.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl || level_zero, gpu, ocloc
-// UNSUPPORTED: arch-intel_gpu_dg1
-//
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
+// UNSUPPORTED: arch-intel_gpu_dg2
+
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2" %s -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeviceCodeSplit/aot-gpu.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/aot-gpu.cpp
@@ -1,9 +1,9 @@
-// REQUIRES: ocloc, gpu, target-spir
+// REQUIRES: ocloc, gpu, target-spir, !gpu-intel-gen12
 //
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source \
 // RUN:   -fsycl-targets=spir64_gen \
 // RUN:   -Xsycl-target-backend=spir64_gen \
-// RUN:   "-device tgllp" -I %S/Inputs -o %t.out \
+// RUN:   "-device dg2" -I %S/Inputs -o %t.out \
 // RUN:   %S/split-per-source-main.cpp \
 // RUN:   %S/Inputs/split-per-source-second-file.cpp \
 // RUN:   -fsycl-dead-args-optimization

--- a/sycl/test-e2e/ESIMD/aot_mixed.cpp
+++ b/sycl/test-e2e/ESIMD/aot_mixed.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 // TODO: Enable on other GPUs once internal ticket is fixed
-// REQUIRES: ocloc && gpu-intel-gen12
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device tgllp" -o %t.sycl.out -DENABLE_SYCL=0 %s
+// REQUIRES: ocloc && gpu-intel-dg2
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2" -o %t.sycl.out -DENABLE_SYCL=0 %s
 // RUN: %{run} %t.sycl.out
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device tgllp" -o %t.out %s
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2" -o %t.out %s
 // RUN: %{run} %t.out
 
 // This test checks the following ESIMD ahead-of-time compilation scenarios:

--- a/sycl/test-e2e/ESIMD/hardware_dispatch.cpp
+++ b/sycl/test-e2e/ESIMD/hardware_dispatch.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: ocloc && arch-intel_gpu_tgllp
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp %s -o %t.out
+// REQUIRES: ocloc && gpu-intel-dg2
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_acm_g10 %s -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out
 
 // This is basic test to test hardware dispatch functionality with ESIMD.
@@ -36,30 +36,30 @@ int main() {
 
         // test if_architecture_is
         sycl::ext::oneapi::experimental::if_architecture_is<
-            sycl::ext::oneapi::experimental::architecture::intel_gpu_tgllp>(
+            sycl::ext::oneapi::experimental::architecture::intel_gpu_acm_g10>(
             [&]() { result[0] = 1; })
             .otherwise([&]() { result[0] = 0; });
 
         // test else_if_architecture_is
         sycl::ext::oneapi::experimental::if_architecture_is<
-            sycl::ext::oneapi::experimental::architecture::intel_gpu_dg1>(
+            sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc>(
             [&]() { result[1] = 0; })
-            .else_if_architecture_is<
-                sycl::ext::oneapi::experimental::architecture::intel_gpu_tgllp>(
+            .else_if_architecture_is<sycl::ext::oneapi::experimental::
+                                         architecture::intel_gpu_acm_g10>(
                 [&]() { result[1] = 2; })
             .otherwise([&]() { result[1] = 0; });
 
         // test otherwise
         sycl::ext::oneapi::experimental::if_architecture_is<
-            sycl::ext::oneapi::experimental::architecture::intel_gpu_dg1>(
+            sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc>(
             [&]() { result[2] = 0; })
             .otherwise([&]() { result[2] = 3; });
 
         // test more than one architecture template parameter is passed to
         // if_architecture_is
         sycl::ext::oneapi::experimental::if_architecture_is<
-            sycl::ext::oneapi::experimental::architecture::intel_gpu_dg1,
-            sycl::ext::oneapi::experimental::architecture::intel_gpu_tgllp>(
+            sycl::ext::oneapi::experimental::architecture::intel_gpu_pvc,
+            sycl::ext::oneapi::experimental::architecture::intel_gpu_acm_g10>(
             [&]() { result[3] = 4; })
             .otherwise([&]() { result[3] = 0; });
         result.copy_to(output_ptr);

--- a/sycl/test-e2e/NewOffloadDriver/aot-gpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/aot-gpu.cpp
@@ -1,10 +1,10 @@
-// REQUIRES: ocloc, gpu, target-spir
+// REQUIRES: ocloc, gpu, target-spir, !gpu-intel-gen12
 // Test with `--offload-new-driver`
 //
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source \
 // RUN:   -fsycl-targets=spir64_gen \
 // RUN:   -Xsycl-target-backend=spir64_gen \
-// RUN:   "-device tgllp" -I %S/Inputs -o %t.out \
+// RUN:   "-device dg2" -I %S/Inputs -o %t.out \
 // RUN:   %S/split-per-source-main.cpp \
 // RUN:   %S/Inputs/split-per-source-second-file.cpp \
 // RUN:   -fsycl-dead-args-optimization --offload-new-driver


### PR DESCRIPTION
This is a cherry-pick of intel/llvm#20643

On Windows, the GPU driver split into two, one that only supports GPUs after Gen12, and only that only supports GPUs before Gen12.

So for AOT we can't compile for BMG and Gen12 using the same `ocloc` executable.

Instead of having to add LIT infrastructure for two `ocloc` executables and installing two versions on all the runners, just use DG2 instead of Gen12 for AOT tests which is supported on the new driver.

Please make sure this change doesn't invalidate the test, for example if there is some capability difference between Gen12 and DG2 being tested that I broke.

---------

Patch-by: Nick Sarnie <nick.sarnie@intel.com>