### PR TITLE
[SYCL] Fix kernel name mangling for CUDA/HIP with Microsoft ABI host

### DIFF
--- a/sycl/test-e2e/Printf/mixed-address-space.cpp
+++ b/sycl/test-e2e/Printf/mixed-address-space.cpp
@@ -2,8 +2,6 @@
 // for constant and generic address space can be used in the same module.
 //
 // UNSUPPORTED: target-amd
-// XFAIL: cuda && windows
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14733
 // FIXME: Drop the test once generic AS support is considered stable and the
 //        dedicated constant AS overload of printf is removed from the library.
 //

--- a/sycl/test-e2e/Printf/percent-symbol.cpp
+++ b/sycl/test-e2e/Printf/percent-symbol.cpp
@@ -5,8 +5,6 @@
 // [1]: https://en.cppreference.com/w/cpp/io/c/fprintf
 //
 // UNSUPPORTED: target-amd
-// XFAIL: cuda && windows
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14733
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 // FIXME: Remove dedicated constant address space testing once generic AS


### PR DESCRIPTION
SYCL kernel names are generated during template instantiation using MangleContext, which produces different encodings based on target ABI. When host compilation uses Microsoft ABI and device compilation targets Itanium ABI (CUDA/HIP), this caused runtime kernel lookup failures:

  No kernel named _ZTSZZ21performIncrementationENK... was found

The issue occurred because SYCL kernel name generation in SemaSYCL::SetSYCLKernelNames() and SemaSYCL::finalizeFreeFunctionKernels() used ASTContext::createMangleContext(), which creates a mangling context for the primary target. In cross-ABI scenarios (Microsoft host + Itanium device), this produced Microsoft-style mangling on the host side, while device compilation always used Itanium mangling, resulting in name mismatches.

Solution:
Added createSYCLCrossABIMangleContext() helper in SemaSYCL.cpp that detects Microsoft-to-Itanium ABI cross-compilation scenarios
Checks if primary target uses Microsoft ABI (getCXXABI().isMicrosoft()) and auxiliary target (device) uses Itanium ABI (isItaniumFamily())
When detected, uses createDeviceMangleContext(*AuxTarget) to ensure Itanium mangling on both host and device sides
When same ABI or no offload target, falls back to standard createMangleContext()
Applied in two locations: SetSYCLKernelNames() and finalizeFreeFunctionKernels()

This ensures identical kernel names across host and device compilations, allowing runtime lookup to succeed.

Fixes: [#14733](https://github.com/intel/llvm/issues/14733)