### PR TITLE
[NFC][sycl-post-link] Refactor test to improve stability

### DIFF
--- a/llvm/test/tools/sycl-post-link/device-requirements/aspects.ll
+++ b/llvm/test/tools/sycl-post-link/device-requirements/aspects.ll
@@ -13,12 +13,12 @@
 ;   });
 ; }
 
-; RUN: sycl-post-link -properties -split=auto < %s -o %t.files.table
-; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP-AUTO-SPLIT
+; RUN: sycl-post-link -properties -split=auto < %s -o %t.auto.table
+; RUN: FileCheck %s -input-file=%t.auto_0.prop --check-prefix CHECK-PROP-AUTO-SPLIT
 
-; RUN: sycl-post-link -properties -split=kernel < %s -o %t.files.table
-; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP-KERNEL-SPLIT-1
-; RUN: FileCheck %s -input-file=%t.files_1.prop --check-prefix CHECK-PROP-KERNEL-SPLIT-0
+; RUN: sycl-post-link -properties -split=kernel < %s -o %t.kernel.table
+; RUN: FileCheck %s -input-file=%t.kernel_0.prop --check-prefix CHECK-PROP-KERNEL-SPLIT-1
+; RUN: FileCheck %s -input-file=%t.kernel_1.prop --check-prefix CHECK-PROP-KERNEL-SPLIT-0
 
 ; CHECK-PROP-AUTO-SPLIT: [SYCL/device requirements]
 ; CHECK-PROP-AUTO-SPLIT-NEXT: aspects=2|gCAAAAAAAAAAAAAABAAAAYAAAAQCAAAAMAAAAA


### PR DESCRIPTION
The test failed on Windows with the following error:

> sycl-post-link: error opening file llvm\test\tools\sycl-post-link\device-requirements\Output\aspects.ll.tmp.files.table: The requested operation cannot be performed on a file with a user-mapped section open.

To avoid this issue, we use different file names for sycl-post-link
runs.