### PR TITLE
[SYCL][E2E] Fix element_wise_ops test failure on LNL Windows machine

### DIFF
--- a/sycl/test-e2e/Matrix/element_wise_ops.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_ops.cpp
@@ -11,7 +11,7 @@
 
 // This test fails on LNL Windows machines with new driver versions.
 // XFAIL: windows && intel_gpu_lnl_m
-// XFAIL-TRACKER: CMPLRLLVM-72503
+// XFAIL-TRACKER: CMPLRLLVM-72111
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
The SYCL E2E test `Matrix/element_wise_ops.cpp` currently fails on LNL Windows machines with certain driver versions.
The test passes with older driver versions (level_zero:gpu - 1.6.34938, opencl:gpu - 32.0.101.8132) and newer driver versions (level_zero:gpu - 1.13.35716, opencl:gpu - 32.0.101.8331),.
This patch adds XFAIL to this test for LNL Windows machines.