### PR TITLE
[SYCL][Doc] Add option documentation for -fsycl-fp64-conv-emu

### DIFF
--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -392,6 +392,13 @@ and not recommended to use in production environment.
 
     NOTE: This flag is currently only supported with the CUDA and HIP targets.
 
+**`-fsycl-fp64-conv-emu`**
+
+    Use fp64 partial emulation for kernels with only fp64 conversion operations
+    and no fp64 computation operations.
+
+    NOTE: This requires an Intel GPU that supports fp64 partial emulation.
+
 **`-fsycl-dump-device-code=<path-to-device-build-artifacts-directory>`** [DEPRECATED]
 
     Enable dumping of device object files (SPIR-V and PTX files) during SYCL


### PR DESCRIPTION
When the option was added, the UserManual.md was not updated accordingly. Add the entry with a short description of behavior.