### PR TITLE
[CI] Fix Linux precommit E2E

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -215,7 +215,7 @@ jobs:
         ${{ !contains(matrix.target_devices, 'cuda') &&
         !contains(matrix.target_devices, 'hip') &&
         contains(needs.detect_changes.outputs.filters, 'drivers') }}
-      skip_run: ${{ matrix.skip_run }}
+      skip_run: ${{ matrix.skip_run || 'false' }}
       env: ${{ matrix.env || (contains(needs.detect_changes.outputs.filters, 'esimd') && '{}' || '{"LIT_FILTER_OUT":"ESIMD/"}') }}
 
   test-perf:


### PR DESCRIPTION
All E2E tests on Linux were skipped because `skip_run` isn't usually defined in the matrix. Accidentally removed when I removed igc-dev.