### PR TITLE
[SYCL] Fix rule-of-three in `platform_impl`

### DIFF
--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -42,8 +42,8 @@ class platform_impl : public std::enable_shared_from_this<platform_impl> {
   explicit platform_impl(ur_platform_handle_t APlatform, adapter_impl &Adapter);
 
   ~platform_impl();
-  platform_impl(const platform_impl &) = default;
-  platform_impl &operator=(const platform_impl &) = default;
+  platform_impl(const platform_impl &) = delete;
+  platform_impl &operator=(const platform_impl &) = delete;
 
 public:
   /// Checks if this platform supports extension.


### PR DESCRIPTION
Coverity is complaining about the missing copy and copy assignment operators.