### PR TITLE
[SYCL] Run EarlyCSEPass to eliminate redundant memory ops after SYCLLowerWGLocalMemoryPass

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1129,6 +1129,13 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
             // to current implementation restriction.
             MPM.addPass(SYCLLowerWGLocalMemoryPass());
           });
+      PB.registerVectorizerStartEPCallback(
+          [](FunctionPassManager &FPM, OptimizationLevel Level) {
+            // Eliminate redundant memory operations appearing after
+            // SYCLLowerWGLocalMemoryPass and AlwaysInlinerPass.
+            if (Level != OptimizationLevel::O0)
+              FPM.addPass(EarlyCSEPass());
+          });
     } else if (LangOpts.SYCLIsHost && !LangOpts.SYCLESIMDBuildHostCode) {
       PB.registerPipelineStartEPCallback(
           [&](ModulePassManager &MPM, OptimizationLevel Level) {

--- a/clang/test/CodeGenSYCL/kernel-early-optimization-pipeline.cpp
+++ b/clang/test/CodeGenSYCL/kernel-early-optimization-pipeline.cpp
@@ -13,6 +13,7 @@
 // CHECK: AlwaysInlinerPass
 // CHECK: ModuleInlinerWrapperPass
 // CHECK: SYCLLowerWGLocalMemoryPass
+// CHECK: EarlyCSEPass
 // CHECK: SYCLOptimizeBarriersPass
 // CHECK: ConstantMergePass
 // CHECK: SYCLMutatePrintfAddrspacePass


### PR DESCRIPTION
This fixes a regression from d8ba6b516fca: a missed optimization when target is SPIR-V.
In SYCL early optimization pipeline, EarlyCSEPass is currently missing after SYCLLowerWGLocalMemoryPass. This PR adds it to VectorizerStartEPCallback which is the first function pass callback following AlwaysInlinerPass.

In pytorch_microbench/kernel-submit-slm-size--1 (Jira GSD-12161), adding EarlyCSEPass can eliminates %4 and replace it with %2:
 store ptr addrspace(3) %2, ptr addrspace(3) @__sycl_dynamicLocalMemoryPlaceholder_GV
 %4 = load ptr addrspace(3), ptr addrspace(3) @__sycl_dynamicLocalMemoryPlaceholder_GV