### PR TITLE
[SYCL][Doc] Update --device-compiler option and remove FPGA support from OffloadDesign.md

### DIFF
--- a/sycl/doc/design/OffloadDesign.md
+++ b/sycl/doc/design/OffloadDesign.md
@@ -299,7 +299,7 @@ individually wrapped and linked into the final executable.
 
 Additionally, the syntax can be expanded to enable the ability to pass specific
 options to a specific device GPU target for spir64_gen.  The syntax will
-resemble `--device-compiler=sycl:spir64_gen-unknown-unknown==-device <arch> <arg>`.  This corresponds to the existing
+resemble `--device-compiler=sycl:spir64_gen-unknown-unknown=<arch> <arg>`.  This corresponds to the existing
 option syntax of `-fsycl-targets=intel_gpu_arch` where `arch` can be a fixed
 set of targets.
 


### PR DESCRIPTION
This PR modifies the backend compiler options passed to clang-linker-wrapper and removes FPGA descriptions from OffloadDesign.md. Detailed explanations are below:
1. In PR https://github.com/intel/llvm/pull/20691, we modified the link-time compiler option to be passed through `--device-compiler` instead of through `--cpu-tool-arg` and `--gpu-tool-arg`. We update OffloadDesign.md to include the usage and format of `--device-compiler`.
2. As described in https://github.com/intel/llvm/issues/16929 and PR https://github.com/intel/llvm/pull/16864, we are removing support for FPGA features and their related options from DPC++. We update OffloadDesign.md to remove any FPGA-related descriptions.