### PR TITLE
[sycl-rel-6_3] Update some E2E tests

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/ext_intel_cslice.cpp
@@ -4,6 +4,9 @@
 // XFAIL: gpu-intel-pvc-1T
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15699
 
+// XFAIL: gpu-intel-dg2
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
+
 // XFAIL: linux && run-mode && (arch-intel_gpu_bmg_g21 || gpu-intel-dg2) && !igc-dev
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
 

--- a/sycl/test-e2e/Adapters/level_zero/ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/ext_intel_queue_index.cpp
@@ -4,6 +4,9 @@
 // XFAIL: gpu-intel-pvc-1T
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15699
 
+// XFAIL: gpu-intel-dg2
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
+
 // XFAIL: linux && run-mode && (arch-intel_gpu_bmg_g21 || gpu-intel-dg2) && !igc-dev
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
 

--- a/sycl/test-e2e/Adapters/sycl-ls-uuid-subdevs.cpp
+++ b/sycl/test-e2e/Adapters/sycl-ls-uuid-subdevs.cpp
@@ -1,14 +1,10 @@
 /* Test to check that sycl-ls is outputting UUID and number of sub and sub-sub
  * devices. */
-// REQUIRES:  gpu, level_zero
+// REQUIRES:  gpu, level_zero, gpu-intel-pvc
 
-// XFAIL: linux && run-mode && (arch-intel_gpu_bmg_g21 || gpu-intel-dg2) && !igc-dev
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
-
-// XFAIL: windows && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
 // As of now, ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
 // which is the new default on PVC.
+// PVC is the only HW now that supports 4 CCS.
 
 // RUN: %{run-unfiltered-devices} env ONEAPI_DEVICE_SELECTOR="level_zero:*" env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE env ZEX_NUMBER_OF_CCS=0:4 sycl-ls --verbose | \
 // RUN: FileCheck %s

--- a/sycl/test-e2e/Basic/large-range.cpp
+++ b/sycl/test-e2e/Basic/large-range.cpp
@@ -2,6 +2,9 @@
 // RUN: %{build} -fno-sycl-id-queries-fit-in-int -O2 -o %t.out
 // RUN: env SYCL_PARALLEL_FOR_RANGE_ROUNDING_TRACE=1 %{run} %t.out
 
+// XFAIL: windows && arch-intel_gpu_bmg_g21
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20861
+
 #include <numeric>
 #include <sycl/atomic_ref.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -4,6 +4,9 @@
 // RUN: %if target-spir %{ %{build} -Wno-error=deprecated-declarations -Wno-error=pointer-to-int-cast -fno-builtin -fsycl-device-lib-jit-link -Wno-deprecated -o %t2.out %}
 // RUN: %if target-spir && !gpu %{ %{run} %t2.out %}
 
+// XFAIL: windows && gpu-intel-dg2
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20861
+
 #include <cassert>
 #include <cstdint>
 #include <cstring>

--- a/sycl/test-e2e/ProfilingTag/profile_tag_leak.cpp
+++ b/sycl/test-e2e/ProfilingTag/profile_tag_leak.cpp
@@ -1,5 +1,8 @@
 // REQUIRES: level_zero
-
+//
+// UNSUPPORTED: windows && level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20852
+//
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK
 

--- a/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
@@ -2,6 +2,8 @@
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17339
 // UNSUPPORTED: level_zero_v2_adapter
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19116
+// UNSUPPORTED: windows && gpu-intel-dg2
+// UNSUPPORTED-INTENDED: the test fails with the new driver.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // XFAIL: spirv-backend

--- a/sycl/test-e2e/bindless_images/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/lit.local.cfg
@@ -3,3 +3,7 @@
 config.unsupported_features += ['spirv-backend']
 
 cl_options = 'cl_options' in config.available_features
+
+# https://github.com/intel/llvm/issues/20562
+if 'windows' in config.available_features:
+  config.unsupported_features += ['gpu-intel-dg2']

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -3,8 +3,13 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-INTENDED: Returning non-FP values from sampling fails on HIP.
 
+// NOTE: on sycl all bindless_images tests were disabled on Win+BMG.
+// On sycl-rel-6_3 only this one is affected.
+// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20562
+
 // RUN: %{build} -o %t.out
-// RUN: %{run-unfiltered-devices} %t.out
+// RUN: %{run} %t.out
 
 // Print test names and pass status
 // #define VERBOSE_LV1


### PR DESCRIPTION
The new GPU driver breaks these tests. Align with the sycl branch.