### PR TITLE
[Bench] Fix torch benchmarks' passing profiler argument

### DIFF
--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024-2025 Intel Corporation
+# Copyright (C) 2024-2026 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -1027,9 +1027,11 @@ class TorchBenchmark(ComputeBenchmark):
 
     def _bin_args(self, run_trace: TracingType = TracingType.NONE) -> list[str]:
         iters = self._get_iters(run_trace)
-        return [f"--iterations={iters}"] + [
-            f"--{k}={v}" for k, v in self._torch_params.items()
-        ]
+        return (
+            [f"--iterations={iters}"]
+            + [f"--profilerType={self._profiler_type.value}"]
+            + [f"--{k}={v}" for k, v in self._torch_params.items()]
+        )
 
 
 class TorchSingleQueue(TorchBenchmark):

--- a/devops/scripts/benchmarks/main.py
+++ b/devops/scripts/benchmarks/main.py
@@ -107,8 +107,8 @@ def run_iterations(
     Unless options.exit_on_failure is set, then exception is raised.
     """
 
+    log.info(f"Running '{benchmark.name()}' {iters}x iterations...")
     for iter in range(iters):
-        log.info(f"running {benchmark.name()}, iteration {iter}... ")
         try:
             bench_results = benchmark.run(
                 env_vars, run_trace=run_trace, force_trace=force_trace
@@ -145,7 +145,7 @@ def run_iterations(
                 log.error(f"{failure_label}: verification failed: {str(e)}.")
                 continue
 
-    # Iterations completed successfully
+    log.info(f"Completed '{benchmark.name()}' {iters}x iterations")
     return True
 
 

--- a/devops/scripts/benchmarks/utils/utils.py
+++ b/devops/scripts/benchmarks/utils/utils.py
@@ -71,7 +71,7 @@ def run(
         command_str = " ".join(command)
         env_str = " ".join(f"{key}={value}" for key, value in env_vars.items())
         full_command_str = f"{env_str} {command_str}".strip()
-        log.debug(f"Running: {full_command_str}")
+        log.info(f"Running: {full_command_str}")
 
         for key, value in env_vars.items():
             # Only PATH and LD_LIBRARY_PATH should be prepended to existing values


### PR DESCRIPTION
- Fix missing param passing to torch benchmark bin (ref. #20978)
- Extend test case to check if the param is passed, as expected
- Move log with full command to execute from Debug to Info