### PR TITLE
[CI][UR] Use 1/3 of nproc instead of all in UR CI builds

### DIFF
--- a/.github/workflows/ur-build-hw.yml
+++ b/.github/workflows/ur-build-hw.yml
@@ -170,7 +170,7 @@ jobs:
 
     - name: Build
       # This is so that device binaries can find the sycl runtime library
-      run: cmake --build build -j $(nproc)
+      run: cmake --build build -j $(($(nproc)/3))
 
     - name: Install
       # This is to check that install command does not fail
@@ -182,7 +182,7 @@ jobs:
         LIT_OPTS: "--timeout 120"
         # These tests cause timeouts on CI
         LIT_FILTER_OUT: "(adapters/level_zero/memcheck.test|adapters/level_zero/v2/deferred_kernel_memcheck.test)"
-      run: cmake --build build -j $(nproc) -- check-unified-runtime-adapter
+      run: cmake --build build -j $(($(nproc)/3)) -- check-unified-runtime-adapter
       # Don't run adapter specific tests when building multiple adapters
       if: ${{ matrix.adapter.other_name == '' }}
 
@@ -190,7 +190,7 @@ jobs:
       env:
         ZE_ENABLE_LOADER_DEBUG_TRACE: 1
         LIT_OPTS: "--timeout 120"
-      run: cmake --build build -j $(nproc) -- check-unified-runtime-conformance
+      run: cmake --build build -j $(($(nproc)/3)) -- check-unified-runtime-conformance
 
     - name: Get information about platform
       if: ${{ always() }}

--- a/.github/workflows/ur-build-offload.yml
+++ b/.github/workflows/ur-build-offload.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Build
       # This is so that device binaries can find the sycl runtime library
-      run: cmake --build $GITHUB_WORKSPACE/build -j $(nproc)
+      run: cmake --build $GITHUB_WORKSPACE/build -j $(($(nproc)/3))
 
     - name: Install
       # This is to check that install command does not fail


### PR DESCRIPTION
Build with `-j $(($(nproc)/3))` instead of `-j $(nproc)` to prevent timeouts in CI builds.
This change regards only two following yaml files:
`.github/workflows/ur-build-hw.yml` and
`.github/workflows/ur-build-offload.yml`