### PR TITLE
[SYCL][E2E] Fix Coverage/device_code_coverage.cpp test

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -845,6 +845,8 @@ tools = [
     ToolSubst("sycl-post-link", unresolved="fatal"),
     ToolSubst("file-table-tform", unresolved="fatal"),
     ToolSubst("llvm-foreach", unresolved="fatal"),
+    ToolSubst("llvm-profdata", unresolved="fatal"),
+    ToolSubst("llvm-cov", unresolved="fatal"),
 ] + feature_tools
 
 # Try and find each of these tools in the DPC++ bin directory, in the llvm tools directory


### PR DESCRIPTION
This patch fixes the test above: if outdated versions of `llvm-profdata` and `llvm-cov` were installed on the machine in `PATH`, they had higher priority, so test failed with the mismatch of different versions. Added these tools to the testing config, so we have the correct binary searching order: first - our compiler `bin` folder, and only then - `PATH`.