### PR TITLE
[UR][L0v2] Enable copy offload using the flag hint

### DIFF
--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -586,6 +586,8 @@ ur_result_t ur_platform_handle_t_::initialize() {
   ZeHostTaskExt.Supported =
       ZeHostTaskExt.zeCommandListAppendHostFunction != nullptr;
 
+  ZeCopyOffloadFlagSupported = this->isDriverVersionNewerOrSimilar(1, 14, 0);
+
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/level_zero/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/platform.hpp
@@ -69,6 +69,7 @@ struct ur_platform_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter>,
   bool zeDriverImmediateCommandListAppendFound{false};
   bool ZeDriverEuCountExtensionFound{false};
   bool ZeCopyOffloadExtensionSupported{false};
+  bool ZeCopyOffloadFlagSupported{false};
   bool ZeBindlessImagesExtensionSupported{false};
   bool ZeLUIDSupported{false};
 

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_cache.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_cache.hpp
@@ -28,12 +28,14 @@ using command_list_unique_handle =
 
 struct supported_extensions_descriptor_t {
   supported_extensions_descriptor_t(bool ZeCopyOffloadExtensionSupported,
-                                    bool ZeMutableCmdListExtentionSupported)
+                                    bool ZeMutableCmdListExtentionSupported,
+                                    bool ZeCopyOffloadFlagSupported)
       : ZeCopyOffloadExtensionSupported(ZeCopyOffloadExtensionSupported),
-        ZeMutableCmdListExtentionSupported(ZeMutableCmdListExtentionSupported) {
-  }
+        ZeMutableCmdListExtentionSupported(ZeMutableCmdListExtentionSupported),
+        ZeCopyOffloadFlagSupported(ZeCopyOffloadFlagSupported) {}
   bool ZeCopyOffloadExtensionSupported;
   bool ZeMutableCmdListExtentionSupported;
+  bool ZeCopyOffloadFlagSupported;
 };
 
 struct command_list_desc_t {
@@ -98,6 +100,7 @@ private:
   ze_context_handle_t ZeContext;
   bool ZeCopyOffloadExtensionSupported;
   bool ZeMutableCmdListExtentionSupported;
+  bool ZeCopyOffloadFlagSupported;
   std::unordered_map<command_list_descriptor_t,
                      std::stack<raii::ze_command_list_handle_t>,
                      command_list_descriptor_hash_t>

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -77,7 +77,8 @@ ur_context_handle_t_::ur_context_handle_t_(ze_context_handle_t hContext,
       hDevices(uniqueDevices(numDevices, phDevices)),
       commandListCache(hContext,
                        {phDevices[0]->Platform->ZeCopyOffloadExtensionSupported,
-                        phDevices[0]->Platform->ZeMutableCmdListExt.Supported}),
+                        phDevices[0]->Platform->ZeMutableCmdListExt.Supported,
+                        phDevices[0]->Platform->ZeCopyOffloadFlagSupported}),
       eventPoolCacheImmediate(
           this, phDevices[0]->Platform->getNumDevices(),
           [context = this, platform = phDevices[0]->Platform](

--- a/unified-runtime/test/adapters/level_zero/v2/command_list_cache_test.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/command_list_cache_test.cpp
@@ -35,7 +35,8 @@ struct CommandListCacheTest : public uur::urContextTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(CommandListCacheTest);
 
 TEST_P(CommandListCacheTest, CanStoreAndRetriveImmediateAndRegularCmdLists) {
-  v2::supported_extensions_descriptor_t supportedExtensions(false, false);
+  v2::supported_extensions_descriptor_t supportedExtensions(false, false,
+                                                            false);
   v2::command_list_cache_t cache(context->getZeHandle(), supportedExtensions);
 
   bool IsInOrder = false;
@@ -91,7 +92,8 @@ TEST_P(CommandListCacheTest, CanStoreAndRetriveImmediateAndRegularCmdLists) {
 }
 
 TEST_P(CommandListCacheTest, ImmediateCommandListsHaveProperAttributes) {
-  v2::supported_extensions_descriptor_t supportedExtensions(false, false);
+  v2::supported_extensions_descriptor_t supportedExtensions(false, false,
+                                                            false);
   v2::command_list_cache_t cache(context->getZeHandle(), supportedExtensions);
 
   uint32_t numQueueGroups = 0;


### PR DESCRIPTION
Enable copy offload using the `ZE_COMMAND_QUEUE_FLAG_COPY_OFFLOAD_HINT` flag hint.