### PR TITLE
[libclc][NFC] Don't include opencl/include folder for libspirv

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -591,7 +591,6 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
         # Enable SPIR-V builtin function declarations, so they don't have to be
         # explicity declared in the soruce.
         -Xclang -fdeclare-spirv-builtins
-        -I${CMAKE_CURRENT_SOURCE_DIR}/opencl/include
         -I${CMAKE_CURRENT_SOURCE_DIR}/libspirv/include/
       )
 

--- a/libclc/libspirv/lib/amdgcn-amdhsa/images/image_common.h
+++ b/libclc/libspirv/lib/amdgcn-amdhsa/images/image_common.h
@@ -2,7 +2,8 @@
 #define CLC_SPIRV_IMAGE_COMMON
 
 #include <clc/clc_as_type.h>
-#include <clc/opencl/opencl-base.h>
+#include <clc/clcfunc.h>
+#include <clc/clctypes.h>
 
 #ifdef cl_khr_fp16
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable


### PR DESCRIPTION
libspirv shouldn't include any file from opencl folder. libspirv and opencl are two independent libraries.