### PR TITLE
[CI][UR] limit # of lit workers to 50

### DIFF
--- a/.github/workflows/ur-build-hw.yml
+++ b/.github/workflows/ur-build-hw.yml
@@ -179,7 +179,7 @@ jobs:
     - name: Test adapter specific
       env:
         ZE_ENABLE_LOADER_DEBUG_TRACE: 1
-        LIT_OPTS: "--timeout 120"
+        LIT_OPTS: "--timeout 120 -j 50"
         # These tests cause timeouts on CI
         LIT_FILTER_OUT: "(adapters/level_zero/memcheck.test|adapters/level_zero/v2/deferred_kernel_memcheck.test)"
       run: cmake --build build -j $(($(nproc)/3)) -- check-unified-runtime-adapter
@@ -189,7 +189,7 @@ jobs:
     - name: Test adapters
       env:
         ZE_ENABLE_LOADER_DEBUG_TRACE: 1
-        LIT_OPTS: "--timeout 120"
+        LIT_OPTS: "--timeout 120 -j 50"
       run: cmake --build build -j $(($(nproc)/3)) -- check-unified-runtime-conformance
 
     - name: Get information about platform


### PR DESCRIPTION
The CI jobs are regularly timing out, likely because of the heavy load on the hardware, from three different runners. This patch reduces the number of test workers in the interim, hopefully reducing the likelihood of time outs.