### PR TITLE
[libspirv] Remove -mcpu=gfx942 hack for amdgcn-amd-amdhsa target

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -216,13 +216,7 @@ function(get_libclc_device_info)
   if( ARG_DEVICE STREQUAL none
       OR ((ARCH STREQUAL spirv OR ARCH STREQUAL spirv64)
           AND NOT LIBCLC_USE_SPIRV_BACKEND) )
-    if( ARCH STREQUAL amdgcn )
-      # AMDGCN needs libclc to be compiled to high bc version since all atomic
-      # clang builtins need to be accessible
-      set( cpu gfx942 )
-    else()
-      set( cpu )
-    endif()
+    set( cpu )
     set( arch_suffix "${ARG_TRIPLE}" )
   else()
     set( cpu "${ARG_DEVICE}" )

--- a/libclc/utils/prepare-builtins.cpp
+++ b/libclc/utils/prepare-builtins.cpp
@@ -126,25 +126,6 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  // AMDGPU remove incompatible functions pass replaces all uses of functions
-  // that use GPU features incompatible with the current GPU with null then
-  // deletes the function. This didn't use to cause problems, as all of libclc
-  // functions were inlined prior to incompatible functions pass. Now that the
-  // inliner runs later in the pipeline we have to remove all of the target
-  // features, so libclc functions will not be earmarked for deletion.
-  //
-  // NativeCPU uses the same builtins for multiple host targets and should
-  // likewise not have features that limit the builtins to any particular
-  // target.
-  if (M->getTargetTriple().str().find("amdgcn") != std::string::npos ||
-      M->getTargetTriple().isNativeCPU()) {
-    AttributeMask AM;
-    AM.addAttribute("target-features");
-    AM.addAttribute("target-cpu");
-    for (auto &F : *M)
-      F.removeFnAttrs(AM);
-  }
-
   std::error_code EC;
   std::unique_ptr<ToolOutputFile> Out(
       new ToolOutputFile(OutputFilename, EC, sys::fs::OF_None));


### PR DESCRIPTION
The cpu=gfx942 hack exposes some atomic builtins, but these should be deprecated for libclc. The generic libclc implementation has moved to Clang’s scoped atomic builtins, which are the better path forward.

The hack also injects incompatible target-cpu/target-features attributes, making libspirv functions incompatible with user modules. Discarding target-features in libclc prepare-builtins tool is a poor w/a.