### PR TITLE
[SYCL][E2E] Limit `ZEX_NUMBER_OF_CCS` testing to PVC

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/ext_intel_cslice.cpp
@@ -1,20 +1,9 @@
 // REQUIRES: level_zero
 // REQUIRES: aspect-ext_intel_device_id
+// REQUIRES: arch-intel_gpu_pvc
 
 // XFAIL: gpu-intel-pvc-1T
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15699
-
-// XFAIL: gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
-
-// XFAIL: linux && run-mode && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
-
-// XFAIL: windows && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
-
-// XFAIL: linux && arch-intel_gpu_mtl_u
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20896
 
 // RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
 

--- a/sycl/test-e2e/Adapters/level_zero/ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/ext_intel_queue_index.cpp
@@ -1,20 +1,9 @@
 // REQUIRES: aspect-ext_intel_device_id
 // REQUIRES: level_zero
+// REQUIRES: arch-intel_gpu_pvc
 
 // XFAIL: gpu-intel-pvc-1T
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15699
-
-// XFAIL: gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
-
-// XFAIL: linux && run-mode && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
-
-// XFAIL: windows && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18576
-
-// XFAIL: linux && arch-intel_gpu_mtl_u
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20896
 
 // RUN: %{build} -o %t.out
 

--- a/sycl/test-e2e/Adapters/sycl-ls-uuid-subdevs.cpp
+++ b/sycl/test-e2e/Adapters/sycl-ls-uuid-subdevs.cpp
@@ -1,6 +1,6 @@
 /* Test to check that sycl-ls is outputting UUID and number of sub and sub-sub
  * devices. */
-// REQUIRES:  gpu, level_zero, gpu-intel-pvc
+// REQUIRES: level_zero, arch-intel_gpu_pvc
 
 // As of now, ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
 // which is the new default on PVC.


### PR DESCRIPTION
PVC is the only HW which supports values in format of `X:Y` in `ZEX_NUMBER_OF_CCS`. Other HW should use format `X`, or otherwise behavior is undefined.

Since this is a somewhat advanced feature, this commit limits all tests which use the env variable to PVC to avoid many unrelated failures.

Resolves intel/llvm#18576
Resolves intel/llvm#20896