### PR TITLE
[UR][L0v2] remove comment leftovers and fix testing macro

### DIFF
--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
@@ -112,13 +112,12 @@ bool operator==(urEnqueueMemImageCopyTest::rgba_pixel lhs,
 template <typename T>
 inline std::string printImageCopyTestString(
     const testing::TestParamInfo<typename T::ParamType> &info) {
-  // ParamType will be std::tuple<ur_device_handle_t, ur_mem_type_t>
   const auto device_handle = std::get<0>(info.param).device;
   const auto platform_device_name =
       uur::GetPlatformAndDeviceName(device_handle);
 
   auto paramTuple = std::get<1>(info.param);
-  const auto image_type = std::get<0>(paramTuple); //std::get<1>(info.param);
+  const auto image_type = std::get<0>(paramTuple);
   const auto queue_mode = std::get<1>(paramTuple);
   auto test_name = (image_type == UR_MEM_TYPE_IMAGE1D)   ? "1D"
                    : (image_type == UR_MEM_TYPE_IMAGE2D) ? "2D"

--- a/unified-runtime/test/conformance/testing/include/uur/fixtures.h
+++ b/unified-runtime/test/conformance/testing/include/uur/fixtures.h
@@ -373,9 +373,8 @@ struct urMemImageTest : urContextTest {
 
 #define UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES_AND_PARAM(FIXTURE, VALUES,      \
                                                          MODES, PRINTER)       \
-  UUR_DEVICE_TEST_SUITE_WITH_PARAM(                                            \
-      FIXTURE, testing::Combine(VALUES, ::testing::ValuesIn(queueModes)),      \
-      PRINTER)
+  UUR_DEVICE_TEST_SUITE_WITH_PARAM(FIXTURE, testing::Combine(VALUES, MODES),   \
+                                   PRINTER)
 
 #define UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES_PRINTER(FIXTURE, MODES,         \
                                                        PRINTER)                \


### PR DESCRIPTION
fix UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES_AND_PARAM

At this moment, this macro is not used in any tests. The helper is provided for future test extensions.

Example usage:
```
UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES_AND_PARAM(
urEnqueueMemBufferFillTest,
testing::ValuesIn(test_cases),
::testing::Values(UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE,
                 UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE),
uur::printFillTestStringMultiQueueType<urEnqueueMemBufferFillTest>);
```