### PR TITLE
[SYCL] Allow dynamic linking for AOT images with Level Zero

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -618,7 +618,7 @@ static bool checkLinkingSupport(const device_impl &DeviceImpl,
     return true;
   }
   if (strcmp(Target, __SYCL_DEVICE_BINARY_TARGET_SPIRV64_GEN) == 0) {
-    return DeviceImpl.is_gpu() && DeviceImpl.getBackend() == backend::opencl;
+    return DeviceImpl.is_gpu();
   }
   return false;
 }

--- a/sycl/unittests/program_manager/DynamicLinking/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking/DynamicLinking.cpp
@@ -253,20 +253,6 @@ TEST(DynamicLinking, AheadOfTime) {
             AOT_CASE_PRG_NATIVE * AOT_CASE_PRG_DEP_NATIVE);
 }
 
-TEST(DynamicLinking, AheadOfTimeUnsupported) {
-  try {
-    sycl::unittest::UrMock<sycl::backend::ext_oneapi_level_zero> Mock;
-    sycl::platform Plt = sycl::platform();
-    sycl::queue Q(Plt.get_devices()[0]);
-    Q.single_task<DynamicLinkingTest::AOTCaseKernel>([=]() {});
-    FAIL();
-  } catch (sycl::exception &e) {
-    EXPECT_EQ(e.code(), sycl::errc::feature_not_supported);
-    EXPECT_STREQ(e.what(), "Cannot resolve external symbols, linking is "
-                           "unsupported for the backend");
-  }
-}
-
 static ur_result_t redefined_urProgramCompileExp(void *pParams) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }


### PR DESCRIPTION
Together with https://github.com/intel/llvm/pull/21090, this should enable dynamic linking with AOT images on Level Zero backend once the required functionality is supported in Level Zero runtime (at which point, E2E testing will be added).