### PR TITLE
[SYCL][E2E] Disable host-task-failure.cpp on WIn BMG

### DIFF
--- a/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: linux && arch-intel_gpu_pvc
+// UNSUPPORTED: arch-intel_gpu_pvc || arch-intel_gpu_bmg_g21
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20961
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
It sporadically hangs, see https://github.com/intel/llvm/issues/20961

There is no PVC Windows driver so I just simplified the `UNSUPPORTED` check instead of making a new one for this since it's the same issue.