### PR TITLE
[DevSAN][E2E] Use 'not --crash' to run tests to avoid lit failure

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/aot/cpu.cpp
+++ b/sycl/test-e2e/AddressSanitizer/aot/cpu.cpp
@@ -1,13 +1,13 @@
 // REQUIRES: linux, opencl-aot, cpu
 
 // RUN: %{run-aux} %{build} %device_asan_aot_flags -O0 -g %S/Inputs/host-usm-oob.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
 
 // RUN: %{run-aux} %{build} %device_asan_aot_flags -O1 -g %S/Inputs/host-usm-oob.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
 
 // RUN: %{run-aux} %{build} %device_asan_aot_flags -O2 -g %S/Inputs/host-usm-oob.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
 
 // RUN: %{run-aux} %{build} %device_asan_aot_flags -O3 -g %S/Inputs/host-usm-oob.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp

--- a/sycl/test-e2e/AddressSanitizer/aot/gpu.cpp
+++ b/sycl/test-e2e/AddressSanitizer/aot/gpu.cpp
@@ -2,13 +2,13 @@
 // REQUIRES: (arch-intel_gpu_pvc || gpu-intel-dg2)
 
 // RUN: %{run-aux} %{build} %device_asan_aot_flags -O0 -g %S/Inputs/host-usm-oob.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
 
 // RUN: %{run-aux} %{build} %device_asan_aot_flags -O1 -g %S/Inputs/host-usm-oob.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
 
 // RUN: %{run-aux} %{build} %device_asan_aot_flags -O2 -g %S/Inputs/host-usm-oob.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
 
 // RUN: %{run-aux} %{build} %device_asan_aot_flags -O3 -g %S/Inputs/host-usm-oob.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/Inputs/host-usm-oob.cpp

--- a/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-host.cpp
+++ b/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-host.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t
-// RUN: %force_device_asan_rt %{run} not %t 2>&1 | FileCheck %s
+// RUN: %force_device_asan_rt %{run} not --crash %t 2>&1 | FileCheck %s
 #include <sycl/usm.hpp>
 
 constexpr size_t N = 64;

--- a/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-minus1.cpp
+++ b/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-minus1.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %force_device_asan_rt %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %force_device_asan_rt %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O0 -g -o %t2.out
-// RUN: %force_device_asan_rt %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %force_device_asan_rt %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O0 -g -o %t3.out
-// RUN: %force_device_asan_rt %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
+// RUN: %force_device_asan_rt %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
 #include <sycl/usm.hpp>
 
 constexpr size_t N = 64;

--- a/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-plus1.cpp
+++ b/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-plus1.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %force_device_asan_rt %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %force_device_asan_rt %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O0 -g -o %t2.out
-// RUN: %force_device_asan_rt %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %force_device_asan_rt %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O0 -g -o %t3.out
-// RUN: %force_device_asan_rt %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
+// RUN: %force_device_asan_rt %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
 #include <sycl/usm.hpp>
 
 constexpr size_t N = 64;

--- a/sycl/test-e2e/AddressSanitizer/common/demangle-kernel-name.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/demangle-kernel-name.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: %{run} not %t &> %t.txt ; FileCheck --input-file %t.txt %s
+// RUN: %{run} not --crash %t &> %t.txt ; FileCheck --input-file %t.txt %s
 #include <sycl/detail/core.hpp>
 
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/common/kernel-filter-aot-cpu.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/kernel-filter-aot-cpu.cpp
@@ -3,4 +3,4 @@
 // RUN: %{run-aux} %{build} %device_asan_aot_flags %S/kernel-filter.cpp -g -O2 -fsanitize-ignorelist=%p/ignorelist.txt -o %t1
 // RUN: %{run} %t1 2>&1 | FileCheck %S/kernel-filter.cpp --check-prefixes CHECK-IGNORE
 // RUN: %{run-aux} %{build} %device_asan_aot_flags %S/kernel-filter.cpp -g -O2 -o %t2
-// RUN: %{run} not %t2 2>&1 | FileCheck %S/kernel-filter.cpp
+// RUN: %{run} not --crash %t2 2>&1 | FileCheck %S/kernel-filter.cpp

--- a/sycl/test-e2e/AddressSanitizer/common/kernel-filter-aot-gpu.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/kernel-filter-aot-gpu.cpp
@@ -4,4 +4,4 @@
 // RUN: %{run-aux} %{build} %device_asan_aot_flags %S/kernel-filter.cpp -g -O2 -fsanitize-ignorelist=%p/ignorelist.txt -o %t1
 // RUN: %{run} %t1 2>&1 | FileCheck %S/kernel-filter.cpp --check-prefixes CHECK-IGNORE
 // RUN: %{run-aux} %{build} %device_asan_aot_flags %S/kernel-filter.cpp -g -O2 -o %t2
-// RUN: %{run} not %t2 2>&1 | FileCheck %S/kernel-filter.cpp
+// RUN: %{run} not --crash %t2 2>&1 | FileCheck %S/kernel-filter.cpp

--- a/sycl/test-e2e/AddressSanitizer/common/kernel-filter.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/kernel-filter.cpp
@@ -2,7 +2,7 @@
 // RUN: %{build} %device_asan_flags -g -O2 -fsanitize-ignorelist=%p/ignorelist.txt -o %t1
 // RUN: %{run} %t1 2>&1 | FileCheck %s --check-prefixes CHECK-IGNORE
 // RUN: %{build} %device_asan_flags -g -O2 -o %t2
-// RUN: %{run} not %t2 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/common/options-redzone.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/options-redzone.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DUNSAFE -O0 -g -o %t1.out
-// RUN: env UR_LAYER_ASAN_OPTIONS=redzone:4000 %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: env UR_LAYER_ASAN_OPTIONS=redzone:4000 %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -DSAFE -O0 -g -o %t2.out
 
 // clang-format off

--- a/sycl/test-e2e/AddressSanitizer/common/print-build-log.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/print-build-log.cpp
@@ -2,7 +2,7 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DGPU -o %t_gpu.out
 // RUN: %{build} %device_asan_flags -o %t.out
-// RUN: %{run} not %if gpu %{ %t_gpu.out %} %else %{ %t.out %} 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %if gpu %{ %t_gpu.out %} %else %{ %t.out %} 2>&1 | FileCheck %s
 
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/AddressSanitizer/double-free/double-free.cpp
+++ b/sycl/test-e2e/AddressSanitizer/double-free/double-free.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O0 -g -o %t2.out
-// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O0 -g -o %t3.out
-// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
+// RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:0" %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-SHARED %s
 #include <sycl/usm.hpp>
 
 constexpr size_t N = 64;

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/bad-device.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/bad-device.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu, any-device-is-level_zero
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O2 -g -o %t
-// RUN: env UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run-unfiltered-devices} not %t 2>&1 | FileCheck %s
+// RUN: env UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run-unfiltered-devices} not --crash %t 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: env UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
+// RUN: env UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} not --crash %t 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: env UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
+// RUN: env UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:1" %{run} not --crash %t 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/misaligned/misalign-int.cpp
+++ b/sycl/test-e2e/AddressSanitizer/misaligned/misalign-int.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/misaligned/misalign-long.cpp
+++ b/sycl/test-e2e/AddressSanitizer/misaligned/misalign-long.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/misaligned/misalign-short.cpp
+++ b/sycl/test-e2e/AddressSanitizer/misaligned/misalign-short.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
+++ b/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // UNSUPPORTED: gpu-intel-dg2
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15453

--- a/sycl/test-e2e/AddressSanitizer/nullpointer/private_nullptr.cpp
+++ b/sycl/test-e2e/AddressSanitizer/nullpointer/private_nullptr.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // FIXME: There's an issue in gfx driver, so this test pending here.
 // XFAIL: run-mode

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global.cpp
@@ -6,11 +6,11 @@
 // sanitizer does `exit(1)`.
 
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // Flakily timesout on PVC
 // UNSUPPORTED: arch-intel_gpu_pvc

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global_image_scope.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global_image_scope.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global_image_scope_unaligned.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/device_global_image_scope_unaligned.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/multi_device_images.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/DeviceGlobal/multi_device_images.cpp
@@ -2,7 +2,7 @@
 // RUN: %{build} %device_asan_flags -O2 -g -DUSER_CODE_1 -c -o %t1.o
 // RUN: %{build} %device_asan_flags -O2 -g -DUSER_CODE_2 -c -o %t2.o
 // RUN: %clangxx -fsycl %device_asan_flags -O2 -g %t1.o %t2.o -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %s
 
 // XFAIL: spirv-backend && run-mode
 // XFAIL-TRACKER: CMPLRLLVM-64059

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/arbitrary_access.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/arbitrary_access.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: linux, gpu && level_zero
 // RUN: %{build} %device_asan_flags -Xarch_device -mllvm=-asan-spir-shadow-bounds=1 -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -Xarch_device -mllvm=-asan-spir-shadow-bounds=1 -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/large_group_size.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/large_group_size.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: %{run} not %t 2>&1 | FileCheck --check-prefixes CHECK %s
+// RUN: %{run} not --crash %t 2>&1 | FileCheck --check-prefixes CHECK %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_char.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_char.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O2 -g -o %t4.out
-// RUN: %{run} not %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %{run} not --crash %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O2 -g -o %t5.out
-// RUN: %{run} not %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
+// RUN: %{run} not --crash %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_double.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_double.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: linux, cpu || (gpu && level_zero), aspect-fp64
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O2 -g -o %t4.out
-// RUN: %{run} not %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %{run} not --crash %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O2 -g -o %t5.out
-// RUN: %{run} not %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
+// RUN: %{run} not --crash %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_func.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_func.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O2 -g -o %t4.out
-// RUN: %{run} not %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %{run} not --crash %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O2 -g -o %t5.out
-// RUN: %{run} not %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
+// RUN: %{run} not --crash %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_int.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_int.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O2 -g -o %t4.out
-// RUN: %{run} not %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %{run} not --crash %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O2 -g -o %t5.out
-// RUN: %{run} not %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
+// RUN: %{run} not --crash %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_short.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_for_short.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O2 -g -o %t4.out
-// RUN: %{run} not %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %{run} not --crash %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O2 -g -o %t5.out
-// RUN: %{run} not %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
+// RUN: %{run} not --crash %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_no_local_size.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/parallel_no_local_size.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_DEVICE -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-DEVICE %s
 // RUN: %{build} %device_asan_flags -DMALLOC_HOST -O2 -g -o %t4.out
-// RUN: %{run} not %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
+// RUN: %{run} not --crash %t4.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK-HOST %s
 // RUN: %{build} %device_asan_flags -DMALLOC_SHARED -O2 -g -o %t5.out
-// RUN: %{run} not %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
+// RUN: %{run} not --crash %t5.out &> %t.txt ; FileCheck --check-prefixes CHECK,CHECK-SHARED --input-file %t.txt %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/string_func.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/string_func.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t.out
-// RUN: %{run} not %t.out memset 2>&1 | FileCheck --check-prefixes CHECK-MEMSET %s
-// RUN: %{run} not %t.out memcpy src 2>&1 | FileCheck --check-prefixes CHECK-MEMCPY-SRC %s
-// RUN: %{run} not %t.out memcpy dst 2>&1 | FileCheck --check-prefixes CHECK-MEMCPY-DST %s
-// RUN: %{run} not %t.out memmove src 2>&1 | FileCheck --check-prefixes CHECK-MEMMOVE-SRC %s
-// RUN: %{run} not %t.out memmove dst 2>&1 | FileCheck --check-prefixes CHECK-MEMMOVE-DST %s
+// RUN: %{run} not --crash %t.out memset 2>&1 | FileCheck --check-prefixes CHECK-MEMSET %s
+// RUN: %{run} not --crash %t.out memcpy src 2>&1 | FileCheck --check-prefixes CHECK-MEMCPY-SRC %s
+// RUN: %{run} not --crash %t.out memcpy dst 2>&1 | FileCheck --check-prefixes CHECK-MEMCPY-DST %s
+// RUN: %{run} not --crash %t.out memmove src 2>&1 | FileCheck --check-prefixes CHECK-MEMMOVE-SRC %s
+// RUN: %{run} not --crash %t.out memmove dst 2>&1 | FileCheck --check-prefixes CHECK-MEMMOVE-DST %s
 #include <sycl/detail/core.hpp>
 
 #include <sycl/usm.hpp>
@@ -84,7 +84,7 @@ void test_memmove(sycl::queue &Q, bool is_src_oob) {
 }
 
 int main(int argc, char **argv) {
-  assert(argc > 1 && "test is not specified");
+  assert(argc > 1 && "test is not --crash specified");
   sycl::queue Q;
 
   if (!strcmp(argv[1], "memset")) {

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/unaligned_shadow_memory.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/unaligned_shadow_memory.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -DTEST1 -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK1 %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK1 %s
 // RUN: %{build} %device_asan_flags -DTEST2 -O0 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK2 %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes CHECK,CHECK2 %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_2d.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_2d.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_3d.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_3d.cpp
@@ -2,11 +2,11 @@
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
 // OCL CPU has subgroup alignment issue with -O0, skip it for
 // now.(CMPLRLLVM-61493)
-// RUN: %{run} %if !cpu %{ not %t1.out 2>&1 | FileCheck %s %}
+// RUN: %{run} %if !cpu %{ not --crash %t1.out 2>&1 | FileCheck %s %}
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_copy_fill.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_copy_fill.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/subbuffer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/subbuffer.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/group_local_memory.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/group_local_memory.cpp
@@ -2,11 +2,11 @@
 // RUN: %{build} %device_asan_flags -g -O0 -o %t1.out
 // OCL CPU has subgroup alignment issue with -O0, skip it for
 // now.(CMPLRLLVM-61493)
-// RUN: %{run} %if !cpu %{ not %t1.out 2>&1 | FileCheck %s %}
+// RUN: %{run} %if !cpu %{ not --crash %t1.out 2>&1 | FileCheck %s %}
 // RUN: %{build} %device_asan_flags -g -O1 -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -g -O2 -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/group_local_memory_func.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/group_local_memory_func.cpp
@@ -2,11 +2,11 @@
 // OCL CPU has subgroup alignment issue with -O0, skip it for
 // now.(CMPLRLLVM-61493)
 // RUN: %{build} %device_asan_flags -g -O0 -o %t1.out
-// RUN: %{run} %if !cpu %{ not %t1.out 2>&1 | FileCheck %s %}
+// RUN: %{run} %if !cpu %{ not --crash %t1.out 2>&1 | FileCheck %s %}
 // RUN: %{build} %device_asan_flags -g -O1 -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -g -O2 -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/local_accessor_basic.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/local_accessor_basic.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -g -O0 -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -g -O1 -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -g -O2 -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 #include <sycl/usm.hpp>
 
 constexpr std::size_t N = 4;

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/local_accessor_function.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/local_accessor_function.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -g -O0 -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -g -O1 -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -g -O2 -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 #include <sycl/usm.hpp>
 #include <vector>
 

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/local_accessor_multiargs.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/local_accessor_multiargs.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -g -O0 -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -g -O1 -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -g -O2 -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 #include <sycl/usm.hpp>
 
 constexpr std::size_t N = 8;

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/multiple_source.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/local/multiple_source.cpp
@@ -2,7 +2,7 @@
 // RUN: %{build} %device_asan_flags -O2 -g -DUSER_CODE_1 -c -o %t1.o
 // RUN: %{build} %device_asan_flags -O2 -g -DUSER_CODE_2 -c -o %t2.o
 // RUN: %clangxx -fsycl %device_asan_flags -O2 -g %t1.o %t2.o -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %s
 
 // XFAIL: spirv-backend && run-mode
 // XFAIL-TRACKER: CMPLRLLVM-64059

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/private/multiple_private.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/private/multiple_private.cpp
@@ -1,16 +1,16 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} -Wno-error=array-bounds %device_asan_flags -DVAR=1 -O2 -g -o %t1
-// RUN: %{run} not %t1 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR1 %s
+// RUN: %{run} not --crash %t1 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR1 %s
 // RUN: %{build} -Wno-error=array-bounds %device_asan_flags -DVAR=2 -O2 -g -o %t2
-// RUN: %{run} not %t2 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR2 %s
+// RUN: %{run} not --crash %t2 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR2 %s
 // RUN: %{build} %device_asan_flags -DVAR=3 -O2 -g -o %t3
-// RUN: %{run} not %t3 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR3 %s
+// RUN: %{run} not --crash %t3 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR3 %s
 // RUN: %{build} %device_asan_flags -DVAR=4 -O2 -g -o %t4
-// RUN: %{run} not %t4 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR4 %s
+// RUN: %{run} not --crash %t4 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR4 %s
 // RUN: %{build} %device_asan_flags -DVAR=5 -O2 -g -o %t5
-// RUN: %{run} not %t5 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR5 %s
+// RUN: %{run} not --crash %t5 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR5 %s
 // RUN: %{build} %device_asan_flags -DVAR=6 -O2 -g -o %t6
-// RUN: %{run} not %t6 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR6 %s
+// RUN: %{run} not --crash %t6 2>&1 | FileCheck --check-prefixes CHECK,CHECK-VAR6 %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/private/single_private.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/private/single_private.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/use-after-free/quarantine-no-free.cpp
+++ b/sycl/test-e2e/AddressSanitizer/use-after-free/quarantine-no-free.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t
-// RUN: env UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:5;detect_kernel_arguments:0" UR_LOG_SANITIZER=level:info %{run} not %t 2>&1 | FileCheck %s
+// RUN: env UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:5;detect_kernel_arguments:0" UR_LOG_SANITIZER=level:info %{run} not --crash %t 2>&1 | FileCheck %s
 #include <sycl/usm.hpp>
 
 /// Quarantine Cache Test
@@ -34,7 +34,7 @@ int main() {
   temp =
       sycl::malloc_device<char>(N, Q); // allocated size: 1052672*4 <= 5242880
   sycl::free(temp, Q);
-  // Make sure the first allocated buffer is not freed
+  // Make sure the first allocated buffer is not --crash freed
   // CHECK-NOT: <SANITIZER>[INFO]: Quarantine Free
 
   Q.submit([&](sycl::handler &h) {

--- a/sycl/test-e2e/AddressSanitizer/use-after-free/use-after-free.cpp
+++ b/sycl/test-e2e/AddressSanitizer/use-after-free/use-after-free.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_asan_flags -O0 -g -o %t
-// RUN: env UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:5;detect_kernel_arguments:0" %{run} not %t 2>&1 | FileCheck %s
+// RUN: env UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:5;detect_kernel_arguments:0" %{run} not --crash %t 2>&1 | FileCheck %s
 #include <sycl/usm.hpp>
 
 constexpr size_t N = 1024;

--- a/sycl/test-e2e/MemorySanitizer/check_buffer.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_buffer.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -O0 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/MemorySanitizer/check_call.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_call.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -O0 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/MemorySanitizer/check_device_global.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_device_global.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux && (cpu || gpu && level_zero)
 // RUN: %{build} %device_msan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/device_global/device_global.hpp>

--- a/sycl/test-e2e/MemorySanitizer/check_divide.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_divide.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -O0 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/MemorySanitizer/check_large_access.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_large_access.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // XFAIL: spirv-backend
 // XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/122075

--- a/sycl/test-e2e/MemorySanitizer/check_usm.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_usm.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -O0 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // UNSUPPORTED: cpu
 // UNSUPPORTED-TRACKER: CMPLRLLVM-64618

--- a/sycl/test-e2e/MemorySanitizer/check_usm2d.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_usm2d.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -O0 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // UNSUPPORTED: cpu
 // UNSUPPORTED-TRACKER: CMPLRLLVM-64618

--- a/sycl/test-e2e/MemorySanitizer/cpu_aot.cpp
+++ b/sycl/test-e2e/MemorySanitizer/cpu_aot.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, opencl-aot, cpu
 
 // RUN: %{run-aux} %{build} %device_msan_aot_flags -O0 -g %S/check_divide.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/check_divide.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/check_divide.cpp
 
 // RUN: %{run-aux} %{build} %device_msan_aot_flags -O1 -g %S/check_divide.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/check_divide.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/check_divide.cpp
 
 // RUN: %{run-aux} %{build} %device_msan_aot_flags -O2 -g %S/check_divide.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/check_divide.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/check_divide.cpp

--- a/sycl/test-e2e/MemorySanitizer/gpu_aot.cpp
+++ b/sycl/test-e2e/MemorySanitizer/gpu_aot.cpp
@@ -2,10 +2,10 @@
 // REQUIRES: arch-intel_gpu_pvc
 
 // RUN: %{run-aux} %{build} %device_msan_aot_flags -O0 -g %S/check_divide.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/check_divide.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/check_divide.cpp
 
 // RUN: %{run-aux} %{build} %device_msan_aot_flags -O1 -g %S/check_divide.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/check_divide.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/check_divide.cpp
 
 // RUN: %{run-aux} %{build} %device_msan_aot_flags -O2 -g %S/check_divide.cpp -o %t.out
-// RUN: %{run} not %t.out 2>&1 | FileCheck %S/check_divide.cpp
+// RUN: %{run} not --crash %t.out 2>&1 | FileCheck %S/check_divide.cpp

--- a/sycl/test-e2e/MemorySanitizer/local/check_no_local_size.cpp
+++ b/sycl/test-e2e/MemorySanitizer/local/check_no_local_size.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -O0 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // XFAIL: spirv-backend && gpu && run-mode
 // XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/122075

--- a/sycl/test-e2e/MemorySanitizer/local/group_local_memory.cpp
+++ b/sycl/test-e2e/MemorySanitizer/local/group_local_memory.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -mllvm -msan-spir-privates=0 -g -O0 -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s --check-prefixes CHECK-O0
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s --check-prefixes CHECK-O0
 // RUN: %{build} %device_msan_flags -g -O2 -o %t2.out
 // RUN: %{run} %t2.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/MemorySanitizer/local/local_accessor.cpp
+++ b/sycl/test-e2e/MemorySanitizer/local/local_accessor.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -g -O0 -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -g -O1 -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -g -O2 -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // XFAIL: spirv-backend && gpu && run-mode
 // XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/122075

--- a/sycl/test-e2e/MemorySanitizer/local/parallel_for_work_group.cpp
+++ b/sycl/test-e2e/MemorySanitizer/local/parallel_for_work_group.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -g -O0 -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -g -O1 -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -g -O2 -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 // XFAIL: spirv-backend && gpu && run-mode
 // XFAIL-TRACKER: https://github.com/llvm/llvm-project/issues/122075

--- a/sycl/test-e2e/MemorySanitizer/private/single_private.cpp
+++ b/sycl/test-e2e/MemorySanitizer/private/single_private.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: %{build} %device_msan_flags -O0 -g -o %t1.out
-// RUN: %{run} not %t1.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O1 -g -o %t2.out
-// RUN: %{run} not %t2.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck %s
 // RUN: %{build} %device_msan_flags -O2 -g -o %t3.out
-// RUN: %{run} not %t3.out 2>&1 | FileCheck %s
+// RUN: %{run} not --crash %t3.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>


### PR DESCRIPTION
With community changes https://github.com/llvm/llvm-project/pull/174298, not tool exit with code '1' when program crash and will cause lit failure if doesn't use '--crash' argument.