### PR TITLE
[CI] Fix Linux Vulkan install in container

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -260,6 +260,10 @@ jobs:
         sudo -E bash devops/scripts/install_drivers.sh devops/dependencies.json --all
     - name: Source OneAPI TBB vars.sh
       uses: ./devops/actions/source-tbb
+    - name: Setup Vulkan environment
+      # Don't use Vulkan for PVC because it requires an out-of-tree userspace driver    
+      if: contains(fromJSON(inputs.runner), 'pvc') == false
+      uses: ./devops/actions/setup-vulkan/linux
     - name: Download SYCL toolchain
       if: inputs.toolchain_artifact != '' && github.event_name != 'workflow_run'
       uses: actions/download-artifact@v7

--- a/devops/actions/setup-vulkan/linux/action.yml
+++ b/devops/actions/setup-vulkan/linux/action.yml
@@ -1,0 +1,18 @@
+name: "Setup Vulkan environment"
+description: "Sources the Vulkan environment script and updates GITHUB_ENV."
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        # https://github.com/actions/runner/issues/1964 prevents us from using
+        # the ENTRYPOINT in the image.
+        env | sort > env_before
+        if [ -e /opt/vulkan/setup-env.sh ]; then
+          source /opt/vulkan/setup-env.sh;
+        else
+          echo "Could not find Vulkan environment setup script"
+        fi
+        env | sort > env_after
+        comm -13 env_before env_after >> $GITHUB_ENV
+        rm env_before env_after

--- a/devops/containers/ubuntu2204_base.Dockerfile
+++ b/devops/containers/ubuntu2204_base.Dockerfile
@@ -8,6 +8,9 @@ USER root
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
+COPY scripts/install_vulkan.sh /install_vulkan.sh
+RUN /install_vulkan.sh
+
 COPY scripts/create-sycl-user.sh /user-setup.sh
 RUN /user-setup.sh
 

--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -12,6 +12,9 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
+COPY scripts/install_vulkan.sh /install_vulkan.sh
+RUN /install_vulkan.sh
+
 # Install ROCM
 
 # Make the directory if it doesn't exist yet.

--- a/devops/containers/ubuntu2404_base.Dockerfile
+++ b/devops/containers/ubuntu2404_base.Dockerfile
@@ -13,6 +13,9 @@ RUN echo 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble main' > /etc/apt/s
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
+COPY scripts/install_vulkan.sh /install_vulkan.sh
+RUN /install_vulkan.sh
+
 # libzstd-dev installed by default on Ubuntu 24.04 is not compiled with -fPIC flag.
 # This causes linking errors when building SYCL runtime.
 # Bug: https://github.com/intel/llvm/issues/15935

--- a/devops/containers/ubuntu2404_build.Dockerfile
+++ b/devops/containers/ubuntu2404_build.Dockerfile
@@ -8,6 +8,9 @@ USER root
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
+COPY scripts/install_vulkan.sh /install_vulkan.sh
+RUN /install_vulkan.sh
+
 # libzstd-dev installed by default on Ubuntu 24.04 is not compiled with -fPIC flag.
 # This causes linking errors when building SYCL runtime.
 # Bug: https://github.com/intel/llvm/issues/15935

--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -36,9 +36,7 @@ apt update && apt install -yqq \
 # https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/cec12d6cf46306d0a015e883d5adb5a8200df1c0/.github/workflows/check-out-of-tree-build.yml#L59
 # pkg-config is required for llvm-spriv to detect spriv-tools installation.
 . /etc/os-release
-curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | apt-key add -
-echo "deb https://packages.lunarg.com/vulkan $VERSION_CODENAME main" | tee -a /etc/apt/sources.list
-apt update && apt install -yqq spirv-tools pkg-config
+apt update && apt install -yqq pkg-config
 
 if [[ "$VERSION_CODENAME" == "jammy" ]]; then
     apt-get install -yqq clang-14 libc++-14-dev

--- a/devops/scripts/install_vulkan.sh
+++ b/devops/scripts/install_vulkan.sh
@@ -1,0 +1,12 @@
+set -x
+VULKAN_VER="1.4.335.0"
+wget https://sdk.lunarg.com/sdk/download/$VULKAN_VER/linux/vulkansdk-linux-x86_64-$VULKAN_VER.tar.xz -O vulkan.tar.xz
+tar xf vulkan.tar.xz
+mv $VULKAN_VER vulkan
+cd vulkan
+sudo bash -c 'echo -e "APT::Get::Assume-Yes \"true\";\nAPT::Get::force-yes \"true\";" > /etc/apt/apt.conf.d/90forceyes'
+sudo DEBIAN_FRONTEND=noninteractive ./vulkansdk --maxjobs
+cd ..
+rm vulkan.tar.xz
+sudo rm /etc/apt/apt.conf.d/90forceyes
+sudo mv vulkan /opt/


### PR DESCRIPTION
The vulkan interop tests weren't running because the Vulkan SDK wasn't installed in the image.

There used to be .deb packages for this stuff but they are deprecated. Use the official Vulkan SDK install script to build+install the SDK, and then source the env script it installs at runtime to set up the environment.