### PR TITLE
[SYCL][E2E] Fix Vulkan interop test build on Windows

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/mipmaps.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/mipmaps.cpp
@@ -3,7 +3,7 @@
 // REQUIRES: aspect-ext_oneapi_mipmap
 // REQUIRES: vulkan
 
-// RUN: %{build} %link-vulkan -o %t.out
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 // RUN: %{run} %t.out
 
 // Uncomment to print additional test information

--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_USM.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_USM.cpp
@@ -2,7 +2,7 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import
 // REQUIRES: vulkan
 
-// RUN: %{build} %link-vulkan -o %t.out
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 // RUN: %{run} %t.out
 
 #include "../../CommonUtils/vulkan_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images_semaphore.cpp
@@ -2,7 +2,7 @@
 // REQUIRES: target-nvidia || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan
 
-// RUN: %{build} %link-vulkan -o %t.out
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 // RUN: %{run} %t.out
 
 #define TEST_SEMAPHORE_IMPORT

--- a/sycl/test-e2e/bindless_images/vulkan_interop/unsampled_images_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/unsampled_images_semaphore.cpp
@@ -3,7 +3,7 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import
 // REQUIRES: vulkan
 
-// RUN: %{build} %link-vulkan -o %t.out
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 // RUN: %{run} %t.out
 
 #define TEST_SEMAPHORE_IMPORT


### PR DESCRIPTION
We need to disable this warning. This is already done in most of the existing tests, but it was missed in these ones. 

Example in existing test [here](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/bindless_images/vulkan_interop/buffer_usm.cpp#L4).