### PR TITLE
[SYCL][E2E] Enable tests passing on new Win driver

### DIFF
--- a/sycl/test-e2e/Basic/large-range.cpp
+++ b/sycl/test-e2e/Basic/large-range.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} -fno-sycl-id-queries-fit-in-int -O2 -o %t.out
 // RUN: env SYCL_PARALLEL_FOR_RANGE_ROUNDING_TRACE=1 %{run} %t.out
 
-// XFAIL: windows && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20861
-
 #include <numeric>
 #include <sycl/atomic_ref.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -Wno-error=deprecated-declarations -Wno-error=pointer-to-int-cast -fno-builtin -o %t1.out
 // RUN: %{run} %t1.out
 
-// XFAIL: windows && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20861
-
 #include <cassert>
 #include <cstdint>
 #include <cstring>

--- a/sycl/test-e2e/DeviceWait/basic.cpp
+++ b/sycl/test-e2e/DeviceWait/basic.cpp
@@ -3,7 +3,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: windows && run-mode
+// XFAIL: windows && run-mode && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20927
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
I'm updating the driver and these pass now.

It will XFAIL here because I didn't actually update the machines yet, will fix before merge.