### PR TITLE
[SYCL][E2E] Disable export_memory_to_vulkan.cpp on Win

### DIFF
--- a/sycl/test-e2e/MemoryExport/export_memory_to_vulkan.cpp
+++ b/sycl/test-e2e/MemoryExport/export_memory_to_vulkan.cpp
@@ -2,6 +2,9 @@
 // REQUIRES: target-spir
 // REQUIRES: vulkan
 
+// XFAIL: windows && run-mode
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21125
+
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Fails at runtime.

https://github.com/intel/llvm/issues/21125