### PR TITLE
[CI] Fix compiler setup in containers

### DIFF
--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -29,7 +29,9 @@ apt update && apt install -yqq \
       linux-tools-generic \
       linux-tools-common \
       time \
-      numactl
+      numactl \
+      gcc-14 \
+      g++-14
 
 # To obtain latest release of spriv-tool.
 # Same as what's done in SPRIV-LLVM-TRANSLATOR:


### PR DESCRIPTION
The vulkan script installs gcc-14 but not g++-14 so clang tries to find libstdc++ which isn't there.