### PR TITLE
add pytorch tag to benchmarks page

### DIFF
--- a/devops/scripts/benchmarks/benches/base.py
+++ b/devops/scripts/benchmarks/benches/base.py
@@ -46,6 +46,7 @@ benchmark_tags = [
     BenchmarkTag("inference", "Tests ML/AI inference performance"),
     BenchmarkTag("image", "Image processing benchmark"),
     BenchmarkTag("simulation", "Physics or scientific simulation benchmark"),
+    BenchmarkTag("pytorch", "Tests workloads close to Pytorch ones"),
 ]
 
 benchmark_tags_dict = {tag.name: tag for tag in benchmark_tags}


### PR DESCRIPTION
<img width="1699" height="896" alt="pytorch-tag-missing" src="https://github.com/user-attachments/assets/cad95d9b-87db-466c-a168-9b17fd60798f" />
