### PR TITLE
[NewOffloadModel] Add support for passing backend options for multiple device architectures

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10450,8 +10450,6 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
       const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
       const toolchains::SYCLToolChain &SYCLTC =
           static_cast<const toolchains::SYCLToolChain &>(*TC);
-
-      
       SYCLTC.AddImpliedTargetArgs(TC->getTriple(), Args, BuildArgs, JA, *HostTC,
                                   Arch);
       SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, OffloadAction->getOffloadingArch());

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10450,12 +10450,14 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
       const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
       const toolchains::SYCLToolChain &SYCLTC =
           static_cast<const toolchains::SYCLToolChain &>(*TC);
+
+      
       SYCLTC.AddImpliedTargetArgs(TC->getTriple(), Args, BuildArgs, JA, *HostTC,
                                   Arch);
-      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs);
+      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, OffloadAction->getOffloadingArch());
       createArgString("compile-opts=");
       BuildArgs.clear();
-      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
+      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs, OffloadAction->getOffloadingArch());
       createArgString("link-opts=");
     }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11608,27 +11608,38 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       if (!TC->getTriple().isSPIROrSPIRV())
         continue;
       ArgStringList BuildArgs;
-      SmallString<128> BackendOptString;
+      SmallVector<SmallString<128>, 4> BackendOptStrings;
       SmallString<128> LinkOptString;
-      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs);
-      for (const auto &A : BuildArgs)
-        appendOption(BackendOptString, A);
 
-      BuildArgs.clear();
+      // Process each -Xsycl-target-backend individually
+      for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ)) {
+        StringRef Device = SYCL::gen::resolveGenDevice(A->getValue(0));
+        SmallString<128> BackendString;
+
+        SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, Device);
+        for (const auto &BA : BuildArgs) {
+          appendOption(BackendString, BA);
+        }
+
+        BuildArgs.clear();
+        BackendOptStrings.push_back(std::move(BackendString));
+      }
+
       SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
       for (const auto &A : BuildArgs) {
         if (TC->getTriple().getSubArch() == llvm::Triple::NoSubArch)
           appendOption(LinkOptString, A);
         else
-          // For AOT, combine the Backend and Linker strings into one.
-          appendOption(BackendOptString, A);
+        // For AOT, append linker args to every backend string
+        for (auto &BOS : BackendOptStrings)
+          appendOption(BOS, A);
       }
 
-      if (!BackendOptString.empty()) {
-        CmdArgs.push_back(Args.MakeArgString(
+      for (auto &BOS : BackendOptStrings) {
+         CmdArgs.push_back(Args.MakeArgString(
             "--device-compiler=" +
             Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +
-            TC->getTripleString() + "=" + BackendOptString));
+            TC->getTripleString() + "=" + BOS));
       }
       if (!LinkOptString.empty()) {
         CmdArgs.push_back(Args.MakeArgString(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11610,38 +11610,48 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       if (!TC->getTriple().isSPIROrSPIRV())
         continue;
       ArgStringList BuildArgs;
-      SmallVector<SmallString<128>, 4> BackendOptStrings;
+      llvm::SmallMapVector<StringRef, SmallString<128>, 4> BackendOptMap;
       SmallString<128> LinkOptString;
 
       // Process each -Xsycl-target-backend individually
       for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ)) {
-        StringRef Device = SYCL::gen::resolveGenDevice(A->getValue(0));
-        SmallString<128> BackendString;
+        StringRef Device;
+        StringRef TargetBackend = A->getValue();
+        if((TargetBackend == "spir64_gen")) {
+          Device = SYCL::gen::extractDeviceFromArgSimple(A->getValue(1));
+          llvm::errs() << "[DEBUG] Resolved device: " << Device << "\n";
+        } else {
+          Device = SYCL::gen::resolveGenDevice(TargetBackend);
+        }
 
+        SmallString<128> &BackendString = BackendOptMap[Device];
         SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, Device);
         for (const auto &BA : BuildArgs) {
           appendOption(BackendString, BA);
         }
 
         BuildArgs.clear();
-        BackendOptStrings.push_back(std::move(BackendString));
       }
 
       SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
       for (const auto &A : BuildArgs) {
         if (TC->getTriple().getSubArch() == llvm::Triple::NoSubArch)
           appendOption(LinkOptString, A);
-        else
-        // For AOT, append linker args to every backend string
-        for (auto &BOS : BackendOptStrings)
-          appendOption(BOS, A);
+        else {
+          // For AOT, append linker args to every backend string
+          for (auto &KV : BackendOptMap)
+            appendOption(KV.second, A);
+        }
       }
 
-      for (auto &BOS : BackendOptStrings) {
-         CmdArgs.push_back(Args.MakeArgString(
+      for (auto &KV : BackendOptMap) {
+        llvm::StringRef Device = KV.first;
+        llvm::SmallString<128> &Opts = KV.second;
+
+        CmdArgs.push_back(Args.MakeArgString(
             "--device-compiler=" +
             Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +
-            TC->getTripleString() + "=" + BOS));
+            TC->getTripleString() + ":" + Device + ":""=" + Opts));
       }
       if (!LinkOptString.empty()) {
         CmdArgs.push_back(Args.MakeArgString(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10455,7 +10455,7 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
       SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, OffloadAction->getOffloadingArch());
       createArgString("compile-opts=");
       BuildArgs.clear();
-      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs, OffloadAction->getOffloadingArch());
+      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
       createArgString("link-opts=");
     }
 
@@ -11613,21 +11613,17 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
       // Process each -Xsycl-target-backend individually
       for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ)) {
-        StringRef Device;
-        StringRef TargetBackend = A->getValue();
         SmallString<128> BackendArgs;
-        if((TargetBackend == "spir64_gen")) {
-          Device = SYCL::gen::extractDeviceFromArgSimple(A->getValue(1));
-        } else {
-          Device = SYCL::gen::resolveGenDevice(TargetBackend);
+        StringRef Device = SYCL::gen::resolveGenDevice(A->getValue());
+        if(!Device.empty())
           appendOption(BackendArgs, "-device " + Device.str());
-        }
+        else 
+          Device = SYCL::gen::extractDeviceFromArg(A->getValue(1));
 
         SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, Device);
         for (const auto &BA : BuildArgs) {
           appendOption(BackendArgs, BA);
         }
-
         BackendOptVec.push_back(std::move(BackendArgs));
         BuildArgs.clear();
       }
@@ -11637,13 +11633,13 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         if (TC->getTriple().getSubArch() == llvm::Triple::NoSubArch)
           appendOption(LinkOptString, A);
         else {
-          // For AOT, append linker args to every backend string
-          for (auto &BackendArgs : BackendOptVec)
+          // For AOT, combine the Backend and Linker strings into one.
+          for (SmallString<128> &BackendArgs : BackendOptVec)
             appendOption(BackendArgs, A);
         }
       }
 
-      for (auto &BackendArgs : BackendOptVec) {
+      for (SmallString<128> &BackendArgs : BackendOptVec) {
         CmdArgs.push_back(Args.MakeArgString(
             "--device-compiler=" +
             Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11611,14 +11611,16 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       std::vector<SmallString<128>> BackendOptVec;
       SmallString<128> LinkOptString;
 
-      // Construct backend options for each target passed via -Xsycl-target-backend
-      // in the form: "-device <arch> <backend_opt>"
-      StringRef Device = "";
-      for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ, options::OPT_Xsycl_backend)) {
+      // Construct backend options for each target passed via
+      // -Xsycl-target-backend in the form: "-device <arch> <backend_opt>"
+      for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ,
+                                        options::OPT_Xsycl_backend)) {
+        StringRef Device = "";
         SmallString<128> BackendArgs;
-        if(A->getNumValues() > 1) {
+        // Handle the OPT_Xsycl_backend case
+        if (A->getNumValues() > 1) {
           Device = SYCL::gen::resolveGenDevice(A->getValue());
-          if(Device.empty() && (A->getNumValues() > 1))
+          if (Device.empty())
             // If target is spir64_gen, the device name needs to be extracted
             // from the arguments.
             Device = SYCL::gen::extractDeviceFromArg(A->getValue(1));
@@ -11627,10 +11629,12 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
             // is appended to BackendArgs.
             appendOption(BackendArgs, "-device " + Device.str());
         }
-        SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, Device);
+        SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs,
+                                          Device);
         for (const auto &BA : BuildArgs) {
           appendOption(BackendArgs, BA);
         }
+        BackendOptVec.push_back(BackendArgs);
         BuildArgs.clear();
       }
 
@@ -11646,7 +11650,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       }
 
       for (SmallString<128> &BackendArgs : BackendOptVec) {
-        if(!BackendArgs.empty())
+        if (!BackendArgs.empty())
           CmdArgs.push_back(Args.MakeArgString(
               "--device-compiler=" +
               Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11610,26 +11610,27 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       if (!TC->getTriple().isSPIROrSPIRV())
         continue;
       ArgStringList BuildArgs;
-      llvm::SmallMapVector<StringRef, SmallString<128>, 4> BackendOptMap;
+      std::vector<SmallString<128>> BackendOptVec;
       SmallString<128> LinkOptString;
 
       // Process each -Xsycl-target-backend individually
       for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ)) {
         StringRef Device;
         StringRef TargetBackend = A->getValue();
+        SmallString<128> BackendArgs;
         if((TargetBackend == "spir64_gen")) {
           Device = SYCL::gen::extractDeviceFromArgSimple(A->getValue(1));
-          llvm::errs() << "[DEBUG] Resolved device: " << Device << "\n";
         } else {
           Device = SYCL::gen::resolveGenDevice(TargetBackend);
+          appendOption(BackendArgs, "-device " + Device.str());
         }
 
-        SmallString<128> &BackendString = BackendOptMap[Device];
         SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, Device);
         for (const auto &BA : BuildArgs) {
-          appendOption(BackendString, BA);
+          appendOption(BackendArgs, BA);
         }
 
+        BackendOptVec.push_back(std::move(BackendArgs));
         BuildArgs.clear();
       }
 
@@ -11639,19 +11640,16 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
           appendOption(LinkOptString, A);
         else {
           // For AOT, append linker args to every backend string
-          for (auto &KV : BackendOptMap)
-            appendOption(KV.second, A);
+          for (auto &BackendArgs : BackendOptVec)
+            appendOption(BackendArgs, A);
         }
       }
 
-      for (auto &KV : BackendOptMap) {
-        llvm::StringRef Device = KV.first;
-        llvm::SmallString<128> &Opts = KV.second;
-
+      for (auto &BackendArgs : BackendOptVec) {
         CmdArgs.push_back(Args.MakeArgString(
             "--device-compiler=" +
             Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +
-            TC->getTripleString() + ":" + Device + ":""=" + Opts));
+            TC->getTripleString() + "=" + BackendArgs));
       }
       if (!LinkOptString.empty()) {
         CmdArgs.push_back(Args.MakeArgString(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11314,6 +11314,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       OPT_flto,
       OPT_flto_partitions_EQ,
       OPT_flto_EQ,
+      OPT_Xsycl_backend_EQ,
       OPT_use_spirv_backend};
 
   const llvm::DenseSet<unsigned> LinkerOptions{OPT_mllvm, OPT_Zlinker_input};
@@ -11604,16 +11605,22 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         static_cast<const toolchains::SYCLToolChain &>(getToolChain());
     for (auto &ToolChainMember :
          llvm::make_range(ToolChainRange.first, ToolChainRange.second)) {
+      llvm::errs() << "[DEBUG] Processing toolchain for target: "
+                   << ToolChainMember.second->getTripleString() << "\n";
       const ToolChain *TC = ToolChainMember.second;
       if (!TC->getTriple().isSPIROrSPIRV())
         continue;
       ArgStringList BuildArgs;
       std::vector<SmallString<128>> BackendOptVec;
       SmallString<128> LinkOptString;
-
+      
+      llvm::errs() << "[DEBUG] Processing toolchain for target 2: "
+                   << ToolChainMember.second->getTripleString() << "\n";
       // Construct backend options for each target passed via -Xsycl-target-backend
       // in the form: "-device <arch> <backend_opt>"
       for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ)) {
+        llvm::errs() << "[DEBUG] Processing -Xsycl-target-backend argument: " << A->getAsString(Args)
+                     << "\n";
         SmallString<128> BackendArgs;
         StringRef Device = SYCL::gen::resolveGenDevice(A->getValue());
         if(Device.empty())

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10450,7 +10450,8 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
       const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
       const toolchains::SYCLToolChain &SYCLTC =
           static_cast<const toolchains::SYCLToolChain &>(*TC);
-      SYCLTC.AddImpliedTargetArgs(TC->getTriple(), Args, BuildArgs, JA, *HostTC);
+      SYCLTC.AddImpliedTargetArgs(TC->getTriple(), Args, BuildArgs, JA, *HostTC,
+                                  Arch);
       SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, Arch);
       createArgString("compile-opts=");
       BuildArgs.clear();
@@ -11603,8 +11604,6 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         static_cast<const toolchains::SYCLToolChain &>(getToolChain());
     for (auto &ToolChainMember :
          llvm::make_range(ToolChainRange.first, ToolChainRange.second)) {
-      llvm::errs() << "[DEBUG] Processing toolchain for target: "
-                   << ToolChainMember.second->getTripleString() << "\n";
       const ToolChain *TC = ToolChainMember.second;
       if (!TC->getTriple().isSPIROrSPIRV())
         continue;
@@ -11614,7 +11613,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
       // Construct backend options for each target passed via -Xsycl-target-backend
       // in the form: "-device <arch> <backend_opt>"
-      StringRef Device;
+      StringRef Device = "";
       for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ, options::OPT_Xsycl_backend)) {
         SmallString<128> BackendArgs;
         if(A->getNumValues() > 1) {
@@ -11632,7 +11631,6 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         for (const auto &BA : BuildArgs) {
           appendOption(BackendArgs, BA);
         }
-        BackendOptVec.push_back(std::move(BackendArgs));
         BuildArgs.clear();
       }
 
@@ -11648,10 +11646,11 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       }
 
       for (SmallString<128> &BackendArgs : BackendOptVec) {
-        CmdArgs.push_back(Args.MakeArgString(
-            "--device-compiler=" +
-            Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +
-            TC->getTripleString() + "=" + BackendArgs));
+        if(!BackendArgs.empty())
+          CmdArgs.push_back(Args.MakeArgString(
+              "--device-compiler=" +
+              Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +
+              TC->getTripleString() + "=" + BackendArgs));
       }
       if (!LinkOptString.empty()) {
         CmdArgs.push_back(Args.MakeArgString(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11611,8 +11611,10 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       SmallVector<SmallString<128>> BackendOptVec;
       SmallString<128> LinkOptString;
 
-      // Construct backend options for each target passed via
-      // -Xsycl-target-backend in the form: "-device <arch> <backend_opt>"
+      // Build backend options for each target passed via
+      // -Xsycl-target-backend or
+      // -Xsycl-target-backend=spir64_gen, spir64_x86_64, intel_gpu_*
+      // in the form: "-device <arch> <backend_opt>"
       for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ,
                                         options::OPT_Xsycl_backend)) {
         StringRef Device = "";

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11608,7 +11608,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       if (!TC->getTriple().isSPIROrSPIRV())
         continue;
       ArgStringList BuildArgs;
-      SmallVector<SmallString<0>> BackendOptVec;
+      SmallVector<SmallString<128>> BackendOptVec;
       SmallString<128> LinkOptString;
 
       // Construct backend options for each target passed via
@@ -11617,12 +11617,13 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
                                         options::OPT_Xsycl_backend)) {
         StringRef Device = "";
         SmallString<128> BackendArgs;
-        // Handle the OPT_Xsycl_backend case
+        // Handle the OPT_Xsycl_backend_EQ case
         if (A->getNumValues() > 1) {
           Device = SYCL::gen::resolveGenDevice(A->getValue());
           if (Device.empty()){
-            // If target is spir64_gen, the device name needs to be extracted
-            // from the arguments.
+            // If the target is spir64_gen, the device name needs to be extracted
+            // from the backend arguments. If the target is spir64_x86_64, the
+            // Device value returned by extractDeviceFromArg will be an empty string.
             Device = SYCL::gen::extractDeviceFromArg(A->getValue(1));
           } else {
             // If target is intel_gpu_*, "-device <arch>"

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11608,7 +11608,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       if (!TC->getTriple().isSPIROrSPIRV())
         continue;
       ArgStringList BuildArgs;
-      std::vector<SmallString<128>> BackendOptVec;
+      SmallVector<SmallString<0>> BackendOptVec;
       SmallString<128> LinkOptString;
 
       // Construct backend options for each target passed via
@@ -11620,14 +11620,15 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         // Handle the OPT_Xsycl_backend case
         if (A->getNumValues() > 1) {
           Device = SYCL::gen::resolveGenDevice(A->getValue());
-          if (Device.empty())
+          if (Device.empty()){
             // If target is spir64_gen, the device name needs to be extracted
             // from the arguments.
             Device = SYCL::gen::extractDeviceFromArg(A->getValue(1));
-          else
+          } else {
             // If target is intel_gpu_*, "-device <arch>"
             // is appended to BackendArgs.
             appendOption(BackendArgs, "-device " + Device.str());
+          }
         }
         SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs,
                                           Device);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10450,9 +10450,8 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
       const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
       const toolchains::SYCLToolChain &SYCLTC =
           static_cast<const toolchains::SYCLToolChain &>(*TC);
-      SYCLTC.AddImpliedTargetArgs(TC->getTriple(), Args, BuildArgs, JA, *HostTC,
-                                  Arch);
-      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, OffloadAction->getOffloadingArch());
+      SYCLTC.AddImpliedTargetArgs(TC->getTriple(), Args, BuildArgs, JA, *HostTC);
+      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, Arch);
       createArgString("compile-opts=");
       BuildArgs.clear();
       SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
@@ -11314,7 +11313,6 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       OPT_flto,
       OPT_flto_partitions_EQ,
       OPT_flto_EQ,
-      OPT_Xsycl_backend_EQ,
       OPT_use_spirv_backend};
 
   const llvm::DenseSet<unsigned> LinkerOptions{OPT_mllvm, OPT_Zlinker_input};
@@ -11613,25 +11611,23 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       ArgStringList BuildArgs;
       std::vector<SmallString<128>> BackendOptVec;
       SmallString<128> LinkOptString;
-      
-      llvm::errs() << "[DEBUG] Processing toolchain for target 2: "
-                   << ToolChainMember.second->getTripleString() << "\n";
+
       // Construct backend options for each target passed via -Xsycl-target-backend
       // in the form: "-device <arch> <backend_opt>"
-      for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ)) {
-        llvm::errs() << "[DEBUG] Processing -Xsycl-target-backend argument: " << A->getAsString(Args)
-                     << "\n";
+      StringRef Device;
+      for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ, options::OPT_Xsycl_backend)) {
         SmallString<128> BackendArgs;
-        StringRef Device = SYCL::gen::resolveGenDevice(A->getValue());
-        if(Device.empty())
-          // If target is spir64_gen, the device name needs to be extracted
-          // from the arguments.
-          Device = SYCL::gen::extractDeviceFromArg(A->getValue(1));
-        else
-          // If target is intel_gpu_*, "-device <arch>"
-          // is appended to BackendArgs.
-          appendOption(BackendArgs, "-device " + Device.str());
-
+        if(A->getNumValues() > 1) {
+          Device = SYCL::gen::resolveGenDevice(A->getValue());
+          if(Device.empty() && (A->getNumValues() > 1))
+            // If target is spir64_gen, the device name needs to be extracted
+            // from the arguments.
+            Device = SYCL::gen::extractDeviceFromArg(A->getValue(1));
+          else
+            // If target is intel_gpu_*, "-device <arch>"
+            // is appended to BackendArgs.
+            appendOption(BackendArgs, "-device " + Device.str());
+        }
         SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, Device);
         for (const auto &BA : BuildArgs) {
           appendOption(BackendArgs, BA);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11611,14 +11611,19 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       std::vector<SmallString<128>> BackendOptVec;
       SmallString<128> LinkOptString;
 
-      // Process each -Xsycl-target-backend individually
+      // Construct backend options for each target passed via -Xsycl-target-backend
+      // in the form: "-device <arch> <backend_opt>"
       for (const Arg *A : Args.filtered(options::OPT_Xsycl_backend_EQ)) {
         SmallString<128> BackendArgs;
         StringRef Device = SYCL::gen::resolveGenDevice(A->getValue());
-        if(!Device.empty())
-          appendOption(BackendArgs, "-device " + Device.str());
-        else 
+        if(Device.empty())
+          // If target is spir64_gen, the device name needs to be extracted
+          // from the arguments.
           Device = SYCL::gen::extractDeviceFromArg(A->getValue(1));
+        else
+          // If target is intel_gpu_*, "-device <arch>"
+          // is appended to BackendArgs.
+          appendOption(BackendArgs, "-device " + Device.str());
 
         SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs, Device);
         for (const auto &BA : BuildArgs) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11622,10 +11622,11 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         // Handle the OPT_Xsycl_backend_EQ case
         if (A->getNumValues() > 1) {
           Device = SYCL::gen::resolveGenDevice(A->getValue());
-          if (Device.empty()){
-            // If the target is spir64_gen, the device name needs to be extracted
-            // from the backend arguments. If the target is spir64_x86_64, the
-            // Device value returned by extractDeviceFromArg will be an empty string.
+          if (Device.empty()) {
+            // If the target is spir64_gen, the device name needs to be
+            // extracted from the backend arguments. If the target is
+            // spir64_x86_64, the Device value returned by extractDeviceFromArg
+            // will be an empty string.
             Device = SYCL::gen::extractDeviceFromArg(A->getValue(1));
           } else {
             // If target is intel_gpu_*, "-device <arch>"

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1083,6 +1083,8 @@ void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
     C.addCommand(std::move(Cmd));
 }
 
+// Extracts the device specified after "-device" from the backend
+// argument string provided via -Xsycl-target-backend.
 StringRef SYCL::gen::extractDeviceFromArg(llvm::StringRef Arg) {
   llvm::SmallVector<StringRef, 8> Arglist;
   Arg.split(Arglist, ' ');
@@ -1564,12 +1566,10 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::Triple &Triple,
     if (A->getOption().matches(Opt_EQ)) {
       const llvm::Triple OptTargetTriple =
           getDriver().getSYCLDeviceTriple(A->getValue(), A);
-      
       // Passing device args: -X<Opt>=<triple> -opt=val.
       StringRef GenDevice = SYCL::gen::resolveGenDevice(A->getValue());
       if(GenDevice.empty())
         GenDevice = SYCL::gen::extractDeviceFromArg(A->getValue(1));
-
       bool IsGenTriple = Triple.isSPIR() &&
                          Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
       if (IsGenTriple) {

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1578,7 +1578,7 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::Triple &Triple,
       bool IsGenTriple = Triple.isSPIR() &&
                          Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
       if (IsGenTriple) {
-        if (Device != GenDevice)
+        if (Device != GenDevice && !Device.empty())
           continue;
         if (OptTargetTriple != Triple && GenDevice.empty())
           // Triples do not match, but only skip when we know we are not

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1558,8 +1558,12 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::Triple &Triple,
       StringRef GenDevice = SYCL::gen::resolveGenDevice(A->getValue());
       bool IsGenTriple = Triple.isSPIR() &&
                          Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
+      llvm::errs() << "[DEBUG] Args: " << A->getAsString(Args)
+                   << " OptTargetTriple: " << OptTargetTriple.str()
+                   << ", Triple: " << Triple.str() << ", Device: " << Device
+                   << ", GenDevice: " << GenDevice << "\n";
       if (IsGenTriple) {
-        if (Device != GenDevice && !Device.empty())
+        if (Device != GenDevice)
           continue;
         if (OptTargetTriple != Triple && GenDevice.empty())
           // Triples do not match, but only skip when we know we are not
@@ -1678,7 +1682,9 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
     }
     // Check for any -device settings.
     std::string DevArg;
-    if (IsJIT || Device == "pvc" || hasPVCDevice(TargArgs, DevArg)) {
+    // if (IsJIT || Device == "pvc" || hasPVCDevice(TargArgs, DevArg)) {
+    llvm::errs() << "[DEBUG] AddImpliedTargetArgs Device " << Device << "\n";
+    if (IsJIT || Device == "pvc") {
       // The -device option passed in by the user may not be 'pvc'. Use the
       // value provided by the user if it was specified.
       StringRef DeviceName = "pvc";

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1689,7 +1689,8 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
     }
     // Check for any -device settings.
     std::string DevArg;
-    if (IsJIT || Device == "pvc") {
+    llvm::errs() << "[DEBUG] device is " << Device << "\n";
+    if (IsJIT || Device == "pvc" || hasPVCDevice(TargArgs, DevArg)) {
       // The -device option passed in by the user may not be 'pvc'. Use the
       // value provided by the user if it was specified.
       StringRef DeviceName = "pvc";

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1083,6 +1083,18 @@ void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
     C.addCommand(std::move(Cmd));
 }
 
+StringRef SYCL::gen::extractDeviceFromArgSimple(llvm::StringRef Arg) {
+  llvm::SmallVector<StringRef, 8> Tokens;
+  Arg.split(Tokens, ' ');
+
+  for (size_t I = 0; I + 1 < Tokens.size(); ++I) {
+    if (Tokens[I] == "-device")
+      return Tokens[I + 1];
+  }
+
+  return "";
+}
+
 StringRef SYCL::gen::resolveGenDevice(StringRef DeviceName) {
   StringRef Device;
   Device =
@@ -1555,24 +1567,23 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::Triple &Triple,
       const llvm::Triple OptTargetTriple =
           getDriver().getSYCLDeviceTriple(A->getValue(), A);
       // Passing device args: -X<Opt>=<triple> -opt=val.
-      StringRef GenDevice = SYCL::gen::resolveGenDevice(A->getValue());
+      StringRef GenDevice;
+      StringRef TargetBackend = A->getValue();
+      if((TargetBackend == "spir64_gen")) {
+        GenDevice = SYCL::gen::extractDeviceFromArgSimple(A->getValue(1));
+      } else {
+        GenDevice = SYCL::gen::resolveGenDevice(TargetBackend);
+      }
+
       bool IsGenTriple = Triple.isSPIR() &&
                          Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
-      // llvm::errs() << "[DEBUG] Args: " << A->getAsString(Args)
-      //              << " OptTargetTriple: " << OptTargetTriple.str()
-      //              << ", Triple: " << Triple.str() << ", Device: " << Device
-      //              << ", GenDevice: " << GenDevice << "\n";
+      llvm::errs() << "[DEBUG] Args: " << A->getAsString(Args)
+                   << " OptTargetTriple: " << OptTargetTriple.str()
+                   << ", Triple: " << Triple.str() << ", Device: " << Device
+                   << ", GenDevice: " << GenDevice << "\n";
       if (IsGenTriple) {
-        if (Device != GenDevice) {
-          if(!GenDevice.empty()) {
-            continue;
-          }
-          SmallString<64> DeviceOpt("-device ");
-          DeviceOpt += Device;
-          if (A->getAsString(Args).find(DeviceOpt.str()) == std::string::npos)
-            continue;
-        }
-        // if (Device != GenDevice && !Device.empty())
+        if (Device != GenDevice)
+          continue;
         if (OptTargetTriple != Triple && GenDevice.empty())
           // Triples do not match, but only skip when we know we are not
           // comparing against intel_gpu_*

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1577,10 +1577,6 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::Triple &Triple,
 
       bool IsGenTriple = Triple.isSPIR() &&
                          Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
-      llvm::errs() << "[DEBUG] Args: " << A->getAsString(Args)
-                   << " OptTargetTriple: " << OptTargetTriple.str()
-                   << ", Triple: " << Triple.str() << ", Device: " << Device
-                   << ", GenDevice: " << GenDevice << "\n";
       if (IsGenTriple) {
         if (Device != GenDevice)
           continue;

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1568,7 +1568,7 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::Triple &Triple,
           getDriver().getSYCLDeviceTriple(A->getValue(), A);
       // Passing device args: -X<Opt>=<triple> -opt=val.
       StringRef GenDevice = SYCL::gen::resolveGenDevice(A->getValue());
-      if(GenDevice.empty())
+      if (GenDevice.empty())
         GenDevice = SYCL::gen::extractDeviceFromArg(A->getValue(1));
       bool IsGenTriple = Triple.isSPIR() &&
                          Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
@@ -1689,7 +1689,6 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
     }
     // Check for any -device settings.
     std::string DevArg;
-    llvm::errs() << "[DEBUG] device is " << Device << "\n";
     if (IsJIT || Device == "pvc" || hasPVCDevice(TargArgs, DevArg)) {
       // The -device option passed in by the user may not be 'pvc'. Use the
       // value provided by the user if it was specified.

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -84,7 +84,7 @@ public:
                     const char *LinkingOutput) const override;
 };
 
-StringRef extractDeviceFromArgSimple(StringRef Arg);
+StringRef extractDeviceFromArg(StringRef Arg);
 StringRef resolveGenDevice(StringRef DeviceName);
 SmallString<64> getGenDeviceMacro(StringRef DeviceName);
 StringRef getGenGRFFlag(StringRef GRFMode);

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -84,6 +84,7 @@ public:
                     const char *LinkingOutput) const override;
 };
 
+StringRef extractDeviceFromArgSimple(StringRef Arg);
 StringRef resolveGenDevice(StringRef DeviceName);
 SmallString<64> getGenDeviceMacro(StringRef DeviceName);
 StringRef getGenGRFFlag(StringRef GRFMode);

--- a/clang/test/Driver/clang-linker-wrapper.cpp
+++ b/clang/test/Driver/clang-linker-wrapper.cpp
@@ -73,9 +73,9 @@
 
 // Check that when "--device-compiler=triple=-device pvc" is specified in clang-linker-wrapper
 // (happen when AOT device is specified via -Xsycl-target-backend '-device pvc' in clang), 
-// the target is not passed to sycl-post-link for filtering.
+// the target is passed to sycl-post-link for filtering.
 // RUN: clang-linker-wrapper -sycl-embed-ir -sycl-device-libraries=%t1.devicelib.o -sycl-post-link-options="SYCL_POST_LINK_OPTIONS" -llvm-spirv-options="LLVM_SPIRV_OPTIONS" "--host-triple=x86_64-unknown-linux-gnu" "--device-compiler=spir64_gen-unknown-unknown=-device pvc" "--linker-path=/usr/bin/ld" "--" HOST_LINKER_FLAGS "-dynamic-linker" HOST_DYN_LIB "-o" "a.out" HOST_LIB_PATH HOST_STAT_LIB %t1.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-NO-CMDS-AOT-GEN %s
-// CHK-NO-CMDS-AOT-GEN: sycl-post-link{{.*}} SYCL_POST_LINK_OPTIONS -o {{[^,]*}}.table {{.*}}.bc
+// CHK-NO-CMDS-AOT-GEN: sycl-post-link{{.*}} SYCL_POST_LINK_OPTIONS -o intel_gpu_pvc,{{.*}}.table {{.*}}.bc
 
 /// Check for list of commands for standalone clang-linker-wrapper run for sycl (AOT for Intel CPU)
 // -------

--- a/clang/test/Driver/clang-linker-wrapper.cpp
+++ b/clang/test/Driver/clang-linker-wrapper.cpp
@@ -77,6 +77,9 @@
 // RUN: clang-linker-wrapper -sycl-embed-ir -sycl-device-libraries=%t1.devicelib.o -sycl-post-link-options="SYCL_POST_LINK_OPTIONS" -llvm-spirv-options="LLVM_SPIRV_OPTIONS" "--host-triple=x86_64-unknown-linux-gnu" "--device-compiler=spir64_gen-unknown-unknown=-device pvc" "--linker-path=/usr/bin/ld" "--" HOST_LINKER_FLAGS "-dynamic-linker" HOST_DYN_LIB "-o" "a.out" HOST_LIB_PATH HOST_STAT_LIB %t1.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-NO-CMDS-AOT-GEN %s
 // CHK-NO-CMDS-AOT-GEN: sycl-post-link{{.*}} SYCL_POST_LINK_OPTIONS -o intel_gpu_pvc,{{.*}}.table {{.*}}.bc
 
+// RUN: clang-linker-wrapper -sycl-embed-ir -sycl-device-libraries=%t1.devicelib.o -sycl-post-link-options="SYCL_POST_LINK_OPTIONS" -llvm-spirv-options="LLVM_SPIRV_OPTIONS" "--host-triple=x86_64-unknown-linux-gnu" "--device-compiler=spir64_gen-unknown-unknown=-device pvc pvc_opt" "--device-compiler=spir64_gen-unknown-unknown=-device dg1 dg1_opt" "--linker-path=/usr/bin/ld" "--" HOST_LINKER_FLAGS "-dynamic-linker" HOST_DYN_LIB "-o" "a.out" HOST_LIB_PATH HOST_STAT_LIB %t1.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-CMDS-AOT-MULTIPLE-TARGET %s
+// CHK-CMDS-AOT-MULTIPLE-TARGET: sycl-post-link{{.*}} SYCL_POST_LINK_OPTIONS -o intel_gpu_pvc,{{.*}}.table {{.*}}.bc
+
 /// Check for list of commands for standalone clang-linker-wrapper run for sycl (AOT for Intel CPU)
 // -------
 // Generate .o file as linker wrapper input.

--- a/clang/test/Driver/clang-linker-wrapper.cpp
+++ b/clang/test/Driver/clang-linker-wrapper.cpp
@@ -77,9 +77,6 @@
 // RUN: clang-linker-wrapper -sycl-embed-ir -sycl-device-libraries=%t1.devicelib.o -sycl-post-link-options="SYCL_POST_LINK_OPTIONS" -llvm-spirv-options="LLVM_SPIRV_OPTIONS" "--host-triple=x86_64-unknown-linux-gnu" "--device-compiler=spir64_gen-unknown-unknown=-device pvc" "--linker-path=/usr/bin/ld" "--" HOST_LINKER_FLAGS "-dynamic-linker" HOST_DYN_LIB "-o" "a.out" HOST_LIB_PATH HOST_STAT_LIB %t1.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-NO-CMDS-AOT-GEN %s
 // CHK-NO-CMDS-AOT-GEN: sycl-post-link{{.*}} SYCL_POST_LINK_OPTIONS -o intel_gpu_pvc,{{.*}}.table {{.*}}.bc
 
-// RUN: clang-linker-wrapper -sycl-embed-ir -sycl-device-libraries=%t1.devicelib.o -sycl-post-link-options="SYCL_POST_LINK_OPTIONS" -llvm-spirv-options="LLVM_SPIRV_OPTIONS" "--host-triple=x86_64-unknown-linux-gnu" "--device-compiler=spir64_gen-unknown-unknown=-device pvc pvc_opt" "--device-compiler=spir64_gen-unknown-unknown=-device dg1 dg1_opt" "--linker-path=/usr/bin/ld" "--" HOST_LINKER_FLAGS "-dynamic-linker" HOST_DYN_LIB "-o" "a.out" HOST_LIB_PATH HOST_STAT_LIB %t1.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-CMDS-AOT-MULTIPLE-TARGET %s
-// CHK-CMDS-AOT-MULTIPLE-TARGET: sycl-post-link{{.*}} SYCL_POST_LINK_OPTIONS -o intel_gpu_pvc,{{.*}}.table {{.*}}.bc
-
 /// Check for list of commands for standalone clang-linker-wrapper run for sycl (AOT for Intel CPU)
 // -------
 // Generate .o file as linker wrapper input.

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -145,11 +145,11 @@
 // RUN:          -Xsycl-target-backend -backend-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_BACKEND %s
 // WRAPPER_OPTIONS_BACKEND: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64-unknown-unknown=-backend-opt"
-
+//
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
 // RUN:          -Xsycl-target-linker -link-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_LINK %s
-// WRAPPER_OPTIONS_LINK: clang-linker-wrapper{{.*}} "--device-linker=sycl:spir64-unknown-unknown=-link-opt"
+-// WRAPPER_OPTIONS_LINK: clang-linker-wrapper{{.*}} "--device-linker=sycl:spir64-unknown-unknown=-link-opt"
 
 /// Test option passing behavior for clang-offload-wrapper options for AOT.
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
@@ -161,6 +161,15 @@
 // WRAPPER_OPTIONS_BACKEND_AOT: clang-linker-wrapper{{.*}}  "--host-triple=x86_64-unknown-linux-gnu"
 // WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown=-backend-gen-opt"
 // WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--device-compiler=sycl:spir64_x86_64-unknown-unknown=-backend-cpu-opt"
+
+// Check that AOT backend compiler options passed via 
+// -Xsycl-target-backend=<target>,<option> are only applied to their specified target
+// RUN:  %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN:           -fsycl-targets=intel_gpu_dg1,spir64_gen \
+// RUN:           -Xsycl-target-backend=intel_gpu_dg1 "-options -extraopt_dg1" \
+// RUN:           -Xsycl-target-backend=spir64_gen "-device pvc -options -extraopt_pvc" %s -v 2>&1 \
+// RUN:    | FileCheck -check-prefixes=MULTI_TARGETS_OPTIONS_BACKEND_AOT %s
+// MULTI_TARGETS_OPTIONS_BACKEND_AOT: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64_gen-unknown-unknown=-device dg1 -options -extraopt_dg1" "--device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options -extraopt_pvc"
 
 /// Verify arch settings for nvptx and amdgcn targets
 // RUN: %clangxx -fsycl -### -fsycl-targets=amdgcn-amd-amdhsa -fno-sycl-libspirv \

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -145,11 +145,10 @@
 // RUN:          -Xsycl-target-backend -backend-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_BACKEND %s
 // WRAPPER_OPTIONS_BACKEND: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64-unknown-unknown=-backend-opt"
-//
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
 // RUN:          -Xsycl-target-linker -link-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_LINK %s
--// WRAPPER_OPTIONS_LINK: clang-linker-wrapper{{.*}} "--device-linker=sycl:spir64-unknown-unknown=-link-opt"
+// WRAPPER_OPTIONS_LINK: clang-linker-wrapper{{.*}} "--device-linker=sycl:spir64-unknown-unknown=-link-opt"
 
 /// Test option passing behavior for clang-offload-wrapper options for AOT.
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -163,7 +163,7 @@
 // WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--device-compiler=sycl:spir64_x86_64-unknown-unknown=-backend-cpu-opt"
 
 // Check that AOT backend compiler options passed via 
-// -Xsycl-target-backend=<target>,<option> are only applied to their specified target
+// -Xsycl-target-backend=<target>,<option> are passed to clang-linker-wrapper in the form: "-device <arch> <backend_opt>"
 // RUN:  %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
 // RUN:           -fsycl-targets=intel_gpu_dg1,spir64_gen \
 // RUN:           -Xsycl-target-backend=intel_gpu_dg1 "-options -extraopt_dg1" \

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -145,6 +145,7 @@
 // RUN:          -Xsycl-target-backend -backend-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_BACKEND %s
 // WRAPPER_OPTIONS_BACKEND: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64-unknown-unknown=-backend-opt"
+
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
 // RUN:          -Xsycl-target-linker -link-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_LINK %s
@@ -166,7 +167,7 @@
 // RUN:  %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
 // RUN:           -fsycl-targets=intel_gpu_dg1,spir64_gen \
 // RUN:           -Xsycl-target-backend=intel_gpu_dg1 "-options -extraopt_dg1" \
-// RUN:           -Xsycl-target-backend=spir64_gen "-device pvc -options -extraopt_pvc" %s -v 2>&1 \
+// RUN:           -Xsycl-target-backend=spir64_gen "-device pvc -options -extraopt_pvc" %s -### 2>&1 \
 // RUN:    | FileCheck -check-prefixes=MULTI_TARGETS_OPTIONS_BACKEND_AOT %s
 // MULTI_TARGETS_OPTIONS_BACKEND_AOT: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64_gen-unknown-unknown=-device dg1 -options -extraopt_dg1" "--device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options -extraopt_pvc"
 

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -720,12 +720,8 @@ getTripleBasedSYCLPostLinkOpts(const ArgList &Args,
 /// 'Args' encompasses all arguments required for linking and wrapping device
 /// code and will be parsed to generate options required to be passed into the
 /// sycl-post-link tool.
-/// 'IsDevicePassedWithSyclTargetBackend' indicates whether the device
-/// architecture is already specified through -Xsycl-target-backend=spir64_gen
-/// "-device <arch>" format.
 static Expected<std::vector<module_split::SplitModule>>
-runSYCLPostLinkTool(ArrayRef<StringRef> InputFiles, const ArgList &Args,
-                    bool IsDevicePassedWithSyclTargetBackend) {
+runSYCLPostLinkTool(ArrayRef<StringRef> InputFiles, const ArgList &Args) {
   Expected<std::string> SYCLPostLinkPath =
       findProgram("sycl-post-link", {getMainExecutable("sycl-post-link")});
   if (!SYCLPostLinkPath)
@@ -2297,14 +2293,9 @@ linkAndWrapDeviceFiles(ArrayRef<SmallVector<OffloadFile>> LinkerInputFiles,
       SmallVector<StringRef> InputFilesSYCL;
       InputFilesSYCL.emplace_back(*TmpOutputOrErr);
 
-      SmallVector<StringRef, 16> Args;
-      StringRef(CompileLinkOptionsOrErr->first).split(Args, ' ');
-      bool IsDevicePassedWithSyclTargetBackend =
-          std::find(Args.begin(), Args.end(), "-device") != Args.end();
       auto SplitModulesOrErr =
           UseSYCLPostLinkTool
-              ? sycl::runSYCLPostLinkTool(InputFilesSYCL, LinkerArgs,
-                                          IsDevicePassedWithSyclTargetBackend)
+              ? sycl::runSYCLPostLinkTool(InputFilesSYCL, LinkerArgs)
               : sycl::runSYCLSplitLibrary(InputFilesSYCL, LinkerArgs,
                                           *SYCLModuleSplitMode);
       if (!SplitModulesOrErr)

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -742,15 +742,20 @@ runSYCLPostLinkTool(ArrayRef<StringRef> InputFiles, const ArgList &Args,
   // when Intel GPU targets are passed in -fsycl-targets.
   const llvm::Triple Triple(Args.getLastArgValue(OPT_triple_EQ));
   StringRef Arch = Args.getLastArgValue(OPT_arch_EQ);
-  
-  // Prefix the output path with the target architecture(s),
+
+  // Prefix the output path with the target architectures,
   // e.g. intel_gpu_dg2,intel_gpu_pvc for arch = "dg2,pvc".
-  if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen && !Arch.empty() && Arch != "*") {
+  if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen && !Arch.empty() &&
+      Arch != "*") {
     SmallVector<StringRef, 8> ArchList;
     Arch.split(ArchList, ',');
-    std::string ArchString;
-    for (StringRef SingleArch : ArchList)
-      ArchString += "intel_gpu_" + SingleArch.str() + ",";
+    for (StringRef SingleArch : ArchList) {
+      // Handle cases where arch name contains a version, such as "bmg-g21"
+      std::string ArchString;
+      std::string arch = SingleArch.str();
+      std::replace(arch.begin(), arch.end(), '-', '_');
+      ArchString += "intel_gpu_" + arch + ",";
+    }
     OutputPathWithArch = ArchString + OutputPathWithArch;
   } else if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64)
     OutputPathWithArch = "spir64_x86_64," + OutputPathWithArch;
@@ -2183,7 +2188,8 @@ static void appendSYCLDeviceOptionsAtLinkTime(const DerivedArgList &LinkerArgs,
                                               std::string &CompileOptions,
                                               std::string &LinkOptions) {
   const StringRef TripleStr = LinkerArgs.getLastArgValue(OPT_triple_EQ);
-  auto processDeviceArgs = [&](unsigned OptID, std::string &Options, StringRef TargetArch = StringRef()) {
+  auto processDeviceArgs = [&](unsigned OptID, std::string &Options,
+                               StringRef TargetArch = StringRef()) {
     for (StringRef Arg : LinkerArgs.getAllArgValues(OptID)) {
       if (!TargetArch.empty()) {
         std::string DeviceArchPattern = "-device " + TargetArch.str();
@@ -2211,7 +2217,8 @@ static void appendSYCLDeviceOptionsAtLinkTime(const DerivedArgList &LinkerArgs,
     }
   };
 
-  processDeviceArgs(OPT_device_compiler_args_EQ, CompileOptions, LinkerArgs.getLastArgValue(OPT_arch_EQ));
+  processDeviceArgs(OPT_device_compiler_args_EQ, CompileOptions,
+                    LinkerArgs.getLastArgValue(OPT_arch_EQ));
   processDeviceArgs(OPT_device_linker_args_EQ, LinkOptions);
 }
 

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -749,9 +749,9 @@ runSYCLPostLinkTool(ArrayRef<StringRef> InputFiles, const ArgList &Args,
       Arch != "*") {
     SmallVector<StringRef, 8> ArchList;
     Arch.split(ArchList, ',');
+    std::string ArchString;
     for (StringRef SingleArch : ArchList) {
       // Handle cases where arch name contains a version, such as "bmg-g21"
-      std::string ArchString;
       std::string arch = SingleArch.str();
       std::replace(arch.begin(), arch.end(), '-', '_');
       ArchString += "intel_gpu_" + arch + ",";

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -742,7 +742,9 @@ runSYCLPostLinkTool(ArrayRef<StringRef> InputFiles, const ArgList &Args,
   // when Intel GPU targets are passed in -fsycl-targets.
   const llvm::Triple Triple(Args.getLastArgValue(OPT_triple_EQ));
   StringRef Arch = Args.getLastArgValue(OPT_arch_EQ);
-
+  
+  // Prefix the output path with the target architecture(s),
+  // e.g. intel_gpu_dg2,intel_gpu_pvc for arch = "dg2,pvc".
   if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen && !Arch.empty() && Arch != "*") {
     SmallVector<StringRef, 8> ArchList;
     Arch.split(ArchList, ',');
@@ -2173,7 +2175,7 @@ extractSYCLCompileLinkOptions(ArrayRef<OffloadFile> OffloadFiles) {
 }
 
 // Append SYCL device compiler and linker options specified at link time,
-// filtering by target triple and offload kind.
+// filtering by target triple, offload kind, and device architecture.
 // TODO: Consider how to refactor this function to merge it with getLinkerArgs()
 // and determine if it's possible to use OPT_compiler_arg_EQ and
 // OPT_linker_arg_EQ to handle device compiler/linker options

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -744,17 +744,12 @@ runSYCLPostLinkTool(ArrayRef<StringRef> InputFiles, const ArgList &Args,
   StringRef Arch = Args.getLastArgValue(OPT_arch_EQ);
 
   if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen && !Arch.empty() && Arch != "*") {
-    SmallVector<StringRef, 4> ArchList;
+    SmallVector<StringRef, 8> ArchList;
     Arch.split(ArchList, ',');
-
-    std::string ArchPaths;
-    for (StringRef SingleArch : ArchList) {
-      if (!ArchPaths.empty())
-        ArchPaths += ",";
-      ArchPaths += "intel_gpu_" + SingleArch.str();
-    }
-    if (!ArchPaths.empty())
-      OutputPathWithArch = ArchPaths + "," + OutputPathWithArch;
+    std::string ArchString;
+    for (StringRef SingleArch : ArchList)
+      ArchString += "intel_gpu_" + SingleArch.str() + ",";
+    OutputPathWithArch = ArchString + OutputPathWithArch;
   } else if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64)
     OutputPathWithArch = "spir64_x86_64," + OutputPathWithArch;
 

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -743,10 +743,19 @@ runSYCLPostLinkTool(ArrayRef<StringRef> InputFiles, const ArgList &Args,
   const llvm::Triple Triple(Args.getLastArgValue(OPT_triple_EQ));
   StringRef Arch = Args.getLastArgValue(OPT_arch_EQ);
 
-  if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen && !Arch.empty() &&
-      !IsDevicePassedWithSyclTargetBackend && Arch != "*")
-    OutputPathWithArch = "intel_gpu_" + Arch.str() + "," + OutputPathWithArch;
-  else if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64)
+  if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen && !Arch.empty() && Arch != "*") {
+    SmallVector<StringRef, 4> ArchList;
+    Arch.split(ArchList, ',');
+
+    std::string ArchPaths;
+    for (StringRef SingleArch : ArchList) {
+      if (!ArchPaths.empty())
+        ArchPaths += ",";
+      ArchPaths += "intel_gpu_" + SingleArch.str();
+    }
+    if (!ArchPaths.empty())
+      OutputPathWithArch = ArchPaths + "," + OutputPathWithArch;
+  } else if (Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64)
     OutputPathWithArch = "spir64_x86_64," + OutputPathWithArch;
 
   SmallVector<StringRef, 8> CmdArgs;
@@ -2177,8 +2186,13 @@ static void appendSYCLDeviceOptionsAtLinkTime(const DerivedArgList &LinkerArgs,
                                               std::string &CompileOptions,
                                               std::string &LinkOptions) {
   const StringRef TripleStr = LinkerArgs.getLastArgValue(OPT_triple_EQ);
-  auto processDeviceArgs = [&](unsigned OptID, std::string &Options) {
+  auto processDeviceArgs = [&](unsigned OptID, std::string &Options, StringRef TargetArch = StringRef()) {
     for (StringRef Arg : LinkerArgs.getAllArgValues(OptID)) {
+      if (!TargetArch.empty()) {
+        std::string DeviceArchPattern = "-device " + TargetArch.str();
+        if (Arg.find(DeviceArchPattern) == StringRef::npos)
+          continue;
+      }
       size_t ColonPos = Arg.find(':');
       if (ColonPos != StringRef::npos) {
         StringRef Kind = Arg.substr(0, ColonPos);
@@ -2200,7 +2214,7 @@ static void appendSYCLDeviceOptionsAtLinkTime(const DerivedArgList &LinkerArgs,
     }
   };
 
-  processDeviceArgs(OPT_device_compiler_args_EQ, CompileOptions);
+  processDeviceArgs(OPT_device_compiler_args_EQ, CompileOptions, LinkerArgs.getLastArgValue(OPT_arch_EQ));
   processDeviceArgs(OPT_device_linker_args_EQ, LinkOptions);
 }
 

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -105,16 +105,11 @@ struct TargetFilenamePairParser : public cl::basic_parser<TargetFilenamePair> {
   using cl::basic_parser<TargetFilenamePair>::basic_parser;
   bool parse(cl::Option &O, StringRef ArgName, StringRef &ArgValue,
              TargetFilenamePair &Val) const {
-    SmallVector<StringRef, 8> Parts;
-    ArgValue.split(Parts, ",");
-    if (Parts.size() == 1) {
-      Val.Targets = {};
-      Val.Filename = Parts[0].str();
-      return false;
-    }
-    Val.Filename = Parts.back().str();
-    for (size_t i = 0; i + 1 < Parts.size(); ++i)
-      Val.Targets.push_back(Parts[i].str());
+    SmallVector<StringRef, 8> ArgList;
+    ArgValue.split(ArgList, ",");
+    Val.Filename = ArgList.back().str();
+    for (size_t i = 0; i + 1 < ArgList.size(); ++i)
+      Val.Targets.push_back(ArgList[i].str());
     return false;
   }
 };
@@ -292,10 +287,7 @@ static void writeToFile(const StringRef Filename, const StringRef Content) {
 void saveModuleIR(Module &M, const StringRef Filename) {
   std::error_code EC;
   raw_fd_ostream Out{Filename, EC, sys::fs::OF_None};
-  llvm::errs() << "[DEBUG] trying to open file: " << Filename << "\n";
   checkError(EC, "error opening the file '" + Filename + "'");
-  llvm::errs() << "[DEBUG] successfully open file: " << Filename << "\n";
-
 
   ModulePassManager MPM;
   ModuleAnalysisManager MAM;
@@ -347,7 +339,6 @@ void saveModuleProperties(const module_split::ModuleDesc &MD,
 void saveModuleSymbolTable(const module_split::ModuleDesc &MD,
                            const StringRef Filename) {
   std::string SymT = computeModuleSymbolTable(MD.getModule(), MD.entries());
-  llvm::errs() << "[DEBUG] Saving module symbol table to file: " << Filename << "\n";
   writeToFile(Filename, SymT);
 }
 
@@ -402,17 +393,18 @@ void saveModule(
       GlobalBinImageProps Props = {EmitKernelParamInfo, EmitProgramMetadata,
                                    EmitKernelNames,     EmitExportedSymbols,
                                    EmitImportedSymbols, DeviceGlobals};
+      std::vector<std::string> Targets = OutputFile.Targets;
       std::string NewSuff = Suffix.str();
-      if (!OutputFile.Targets.empty()) {
+      if (!Targets.empty()) {
         std::string Joined;
-        for (auto &T : OutputFile.Targets)
+        for (auto &T : Targets)
           Joined += "_" + T;
         NewSuff = Joined;
       }
 
       CopyTriple.Prop =
           (OutputPrefix + NewSuff + "_" + Twine(I) + ".prop").str();
-      saveModuleProperties(MD, Props, CopyTriple.Prop, OutputFile.Targets);
+      saveModuleProperties(MD, Props, CopyTriple.Prop, Targets);
     }
     addTableRow(*Table, CopyTriple);
   }
@@ -474,7 +466,7 @@ bool isTargetCompatibleWithModule(const std::vector<std::string> &Targets,
   if (Targets.empty())
     return true;
   
-  for (const std::string &Target : Targets) {
+  for (const std::string Target : Targets) {
     llvm::errs() << "[DEBUG] Checking compatibility of target '" << Target
              << "' with module '" << IrMD.Name << "'\n";
     // TODO: If a target not found in the device config file is passed,

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -97,7 +97,7 @@ cl::opt<std::string> DeviceLibDir{
     cl::value_desc("dirname"), cl::cat(PostLinkCat)};
 
 struct TargetFilenamePair {
-  std::string Target;
+  std::vector<std::string> Targets;
   std::string Filename;
 };
 
@@ -105,10 +105,16 @@ struct TargetFilenamePairParser : public cl::basic_parser<TargetFilenamePair> {
   using cl::basic_parser<TargetFilenamePair>::basic_parser;
   bool parse(cl::Option &O, StringRef ArgName, StringRef &ArgValue,
              TargetFilenamePair &Val) const {
-    auto [Target, Filename] = ArgValue.split(",");
-    if (Filename == "")
-      std::swap(Target, Filename);
-    Val = {Target.str(), Filename.str()};
+    SmallVector<StringRef, 8> Parts;
+    ArgValue.split(Parts, ",");
+    if (Parts.size() == 1) {
+      Val.Targets = {};
+      Val.Filename = Parts[0].str();
+      return false;
+    }
+    Val.Filename = Parts.back().str();
+    for (size_t i = 0; i + 1 < Parts.size(); ++i)
+      Val.Targets.push_back(Parts[i].str());
     return false;
   }
 };
@@ -286,7 +292,10 @@ static void writeToFile(const StringRef Filename, const StringRef Content) {
 void saveModuleIR(Module &M, const StringRef Filename) {
   std::error_code EC;
   raw_fd_ostream Out{Filename, EC, sys::fs::OF_None};
+  llvm::errs() << "[DEBUG] trying to open file: " << Filename << "\n";
   checkError(EC, "error opening the file '" + Filename + "'");
+  llvm::errs() << "[DEBUG] successfully open file: " << Filename << "\n";
+
 
   ModulePassManager MPM;
   ModuleAnalysisManager MAM;
@@ -301,7 +310,7 @@ void saveModuleIR(Module &M, const StringRef Filename) {
 
 void saveModuleProperties(const module_split::ModuleDesc &MD,
                           const GlobalBinImageProps &GlobProps,
-                          const StringRef Filename, StringRef Target = "") {
+                          const StringRef Filename, const std::vector<std::string> &Targets) {
 
   PropSetRegTy PropSet;
 
@@ -324,9 +333,9 @@ void saveModuleProperties(const module_split::ModuleDesc &MD,
     PropSet.remove(PropSetRegTy::SYCL_DEVICE_REQUIREMENTS,
                    PropSetRegTy::PROPERTY_REQD_WORK_GROUP_SIZE);
 
-  if (!Target.empty())
-    PropSet.add(PropSetRegTy::SYCL_DEVICE_REQUIREMENTS, "compile_target",
-                Target);
+  for (const auto &T : Targets)
+    PropSet.add(PropSetRegTy::SYCL_DEVICE_REQUIREMENTS,
+                "compile_target", T);
 
   std::error_code EC;
   raw_fd_ostream SCOut(Filename, EC);
@@ -338,6 +347,7 @@ void saveModuleProperties(const module_split::ModuleDesc &MD,
 void saveModuleSymbolTable(const module_split::ModuleDesc &MD,
                            const StringRef Filename) {
   std::string SymT = computeModuleSymbolTable(MD.getModule(), MD.entries());
+  llvm::errs() << "[DEBUG] Saving module symbol table to file: " << Filename << "\n";
   writeToFile(Filename, SymT);
 }
 
@@ -385,21 +395,36 @@ void saveModule(
   }
 
   for (const auto &[Table, OutputFile] : zip_equal(OutTables, OutputFiles)) {
-    if (!isTargetCompatibleWithModule(OutputFile.Target, MD))
+    bool Compatible = false;
+    if (OutputFile.Targets.empty()) {
+      Compatible = true;
+    } else {
+      for (const auto &T : OutputFile.Targets) {
+        if (isTargetCompatibleWithModule(T, MD)) {
+          Compatible = true;
+          break;
+        }
+      }
+    }
+
+    if (!Compatible)
       continue;
     auto CopyTriple = BaseTriple;
     if (DoPropGen) {
       GlobalBinImageProps Props = {EmitKernelParamInfo, EmitProgramMetadata,
                                    EmitKernelNames,     EmitExportedSymbols,
                                    EmitImportedSymbols, DeviceGlobals};
-      StringRef Target = OutputFile.Target;
       std::string NewSuff = Suffix.str();
-      if (!Target.empty())
-        NewSuff = (Twine("_") + Target).str();
+      if (!OutputFile.Targets.empty()) {
+        std::string Joined;
+        for (auto &T : OutputFile.Targets)
+          Joined += "_" + T;
+        NewSuff = Joined;
+      }
 
       CopyTriple.Prop =
           (OutputPrefix + NewSuff + "_" + Twine(I) + ".prop").str();
-      saveModuleProperties(MD, Props, CopyTriple.Prop, Target);
+      saveModuleProperties(MD, Props, CopyTriple.Prop, OutputFile.Targets);
     }
     addTableRow(*Table, CopyTriple);
   }
@@ -458,6 +483,7 @@ bool isTargetCompatibleWithModule(const std::string &Target,
   // (e.g. -o out.table compared to -o intel_gpu_pvc,out-pvc.table)
   // Target will be empty and we will not want to perform any filtering, so
   // we return true here.
+  llvm::errs() << "[DEBUG] target: '" << Target << "'\n";
   if (Target.empty())
     return true;
 

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -351,7 +351,7 @@ void saveModuleSymbolTable(const module_split::ModuleDesc &MD,
   writeToFile(Filename, SymT);
 }
 
-bool isTargetCompatibleWithModule(const std::string &Target,
+bool isTargetCompatibleWithModule(const std::vector<std::string> &Targets,
                                   module_split::ModuleDesc &IrMD);
 
 void addTableRow(util::SimpleTable &Table,
@@ -395,19 +395,7 @@ void saveModule(
   }
 
   for (const auto &[Table, OutputFile] : zip_equal(OutTables, OutputFiles)) {
-    bool Compatible = false;
-    if (OutputFile.Targets.empty()) {
-      Compatible = true;
-    } else {
-      for (const auto &T : OutputFile.Targets) {
-        if (isTargetCompatibleWithModule(T, MD)) {
-          Compatible = true;
-          break;
-        }
-      }
-    }
-
-    if (!Compatible)
+    if (!isTargetCompatibleWithModule(OutputFile.Targets, MD))
       continue;
     auto CopyTriple = BaseTriple;
     if (DoPropGen) {
@@ -477,44 +465,47 @@ void addTableRow(util::SimpleTable &Table,
 // information comes from the device config file (DeviceConfigFile.td).
 // For example, the intel_gpu_tgllp target does not support fp64 - therefore,
 // a module using fp64 would *not* be compatible with intel_gpu_tgllp.
-bool isTargetCompatibleWithModule(const std::string &Target,
+bool isTargetCompatibleWithModule(const std::vector<std::string> &Targets,
                                   module_split::ModuleDesc &IrMD) {
   // When the user does not specify a target,
   // (e.g. -o out.table compared to -o intel_gpu_pvc,out-pvc.table)
   // Target will be empty and we will not want to perform any filtering, so
   // we return true here.
-  llvm::errs() << "[DEBUG] target: '" << Target << "'\n";
-  if (Target.empty())
+  if (Targets.empty())
     return true;
+  
+  for (const std::string &Target : Targets) {
+    llvm::errs() << "[DEBUG] Checking compatibility of target '" << Target
+             << "' with module '" << IrMD.Name << "'\n";
+    // TODO: If a target not found in the device config file is passed,
+    // to sycl-post-link, then we should probably throw an error. However,
+    // since not all the information for all the targets is filled out
+    // right now, we return true, having the affect that unrecognized
+    // targets have no filtering applied to them.
+    if (!is_contained(DeviceConfigFile::TargetTable, Target))
+      continue;
 
-  // TODO: If a target not found in the device config file is passed,
-  // to sycl-post-link, then we should probably throw an error. However,
-  // since not all the information for all the targets is filled out
-  // right now, we return true, having the affect that unrecognized
-  // targets have no filtering applied to them.
-  if (!is_contained(DeviceConfigFile::TargetTable, Target))
-    return true;
+    const DeviceConfigFile::TargetInfo &TargetInfo =
+        DeviceConfigFile::TargetTable[Target];
+    const SYCLDeviceRequirements &ModuleReqs =
+        IrMD.getOrComputeDeviceRequirements();
 
-  const DeviceConfigFile::TargetInfo &TargetInfo =
-      DeviceConfigFile::TargetTable[Target];
-  const SYCLDeviceRequirements &ModuleReqs =
-      IrMD.getOrComputeDeviceRequirements();
+    // Check to see if all the requirements of the input module
+    // are compatbile with the target.
+    for (const auto &Aspect : ModuleReqs.Aspects) {
+      if (!is_contained(TargetInfo.aspects, Aspect.Name))
+        return false;
+    }
 
-  // Check to see if all the requirements of the input module
-  // are compatbile with the target.
-  for (const auto &Aspect : ModuleReqs.Aspects) {
-    if (!is_contained(TargetInfo.aspects, Aspect.Name))
+    // Check if module sub group size is compatible with the target.
+    // For ESIMD, the reqd_sub_group_size will be 1; this is not
+    // a supported by any backend (e.g. no backend can support a kernel
+    // with sycl::reqd_sub_group_size(1)), but for ESIMD, this is
+    // a special case.
+    if (!IrMD.isESIMD() && ModuleReqs.SubGroupSize.has_value() &&
+        !is_contained(TargetInfo.subGroupSizes, *ModuleReqs.SubGroupSize))
       return false;
   }
-
-  // Check if module sub group size is compatible with the target.
-  // For ESIMD, the reqd_sub_group_size will be 1; this is not
-  // a supported by any backend (e.g. no backend can support a kernel
-  // with sycl::reqd_sub_group_size(1)), but for ESIMD, this is
-  // a special case.
-  if (!IrMD.isESIMD() && ModuleReqs.SubGroupSize.has_value() &&
-      !is_contained(TargetInfo.subGroupSizes, *ModuleReqs.SubGroupSize))
-    return false;
 
   return true;
 }

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -108,8 +108,10 @@ struct TargetFilenamePairParser : public cl::basic_parser<TargetFilenamePair> {
     SmallVector<StringRef, 8> ArgList;
     ArgValue.split(ArgList, ",");
     Val.Filename = ArgList.back().str();
-    for (size_t i = 0; i + 1 < ArgList.size(); ++i)
+    for (size_t i = 0; i + 1 < ArgList.size(); ++i) {
+      llvm::errs() << "  Target: " << ArgList[i] << "\n";
       Val.Targets.push_back(ArgList[i].str());
+    }
     return false;
   }
 };
@@ -302,7 +304,8 @@ void saveModuleIR(Module &M, const StringRef Filename) {
 
 void saveModuleProperties(const module_split::ModuleDesc &MD,
                           const GlobalBinImageProps &GlobProps,
-                          const StringRef Filename, const std::vector<std::string> &Targets) {
+                          const StringRef Filename,
+                          const std::vector<std::string> &Targets) {
 
   PropSetRegTy PropSet;
 
@@ -326,8 +329,7 @@ void saveModuleProperties(const module_split::ModuleDesc &MD,
                    PropSetRegTy::PROPERTY_REQD_WORK_GROUP_SIZE);
 
   for (const auto &T : Targets)
-    PropSet.add(PropSetRegTy::SYCL_DEVICE_REQUIREMENTS,
-                "compile_target", T);
+    PropSet.add(PropSetRegTy::SYCL_DEVICE_REQUIREMENTS, "compile_target", T);
 
   std::error_code EC;
   raw_fd_ostream SCOut(Filename, EC);
@@ -465,10 +467,8 @@ bool isTargetCompatibleWithModule(const std::vector<std::string> &Targets,
   // we return true here.
   if (Targets.empty())
     return true;
-  
+
   for (const std::string Target : Targets) {
-    llvm::errs() << "[DEBUG] Checking compatibility of target '" << Target
-             << "' with module '" << IrMD.Name << "'\n";
     // TODO: If a target not found in the device config file is passed,
     // to sycl-post-link, then we should probably throw an error. However,
     // since not all the information for all the targets is filled out

--- a/sycl/test-e2e/Basic/build_log.cpp
+++ b/sycl/test-e2e/Basic/build_log.cpp
@@ -1,7 +1,7 @@
-// REQUIRES: opencl || level_zero, gpu, ocloc, gpu-intel-dg2
+// REQUIRES: opencl || level_zero, gpu, ocloc, gpu-intel-pvc
 // UNSUPPORTED: arch-intel_gpu_dg2
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2_g10" %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device pvc" %s -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/build_log.cpp
+++ b/sycl/test-e2e/Basic/build_log.cpp
@@ -1,7 +1,7 @@
-// REQUIRES: opencl || level_zero, gpu, ocloc
+// REQUIRES: opencl || level_zero, gpu, ocloc, gpu-intel-dg2
 // UNSUPPORTED: arch-intel_gpu_dg2
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2" %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2-g10" %s -o %t.out --offload-new-driver
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/build_log.cpp
+++ b/sycl/test-e2e/Basic/build_log.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl || level_zero, gpu, ocloc, gpu-intel-dg2
 // UNSUPPORTED: arch-intel_gpu_dg2
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2-g10" %s -o %t.out --offload-new-driver
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg2_g10" %s -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeviceCodeSplit/aot-gpu.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/aot-gpu.cpp
@@ -1,9 +1,9 @@
-// REQUIRES: ocloc, gpu, target-spir, !gpu-intel-gen12
+// REQUIRES: ocloc, gpu, target-spir, gpu-intel-dg2
 //
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source \
 // RUN:   -fsycl-targets=spir64_gen \
 // RUN:   -Xsycl-target-backend=spir64_gen \
-// RUN:   "-device dg2" -I %S/Inputs -o %t.out \
+// RUN:   "-device dg2-g11" -I %S/Inputs -o %t.out \
 // RUN:   %S/split-per-source-main.cpp \
 // RUN:   %S/Inputs/split-per-source-second-file.cpp \
 // RUN:   -fsycl-dead-args-optimization

--- a/sycl/test-e2e/DeviceCodeSplit/aot-gpu.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/aot-gpu.cpp
@@ -3,7 +3,7 @@
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source \
 // RUN:   -fsycl-targets=spir64_gen \
 // RUN:   -Xsycl-target-backend=spir64_gen \
-// RUN:   "-device dg2-g11" -I %S/Inputs -o %t.out \
+// RUN:   "-device dg2_g10" -I %S/Inputs -o %t.out \
 // RUN:   %S/split-per-source-main.cpp \
 // RUN:   %S/Inputs/split-per-source-second-file.cpp \
 // RUN:   -fsycl-dead-args-optimization

--- a/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
+++ b/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
@@ -1,7 +1,7 @@
 // Don't use normal %{run} as we need to control cache directory removal and
 // cannot do that reliably when number of devices is unknown.
 //
-// REQUIRES: level_zero, ocloc
+// REQUIRES: level_zero, ocloc, gpu-intel-dg2
 //
 // DEFINE: %{cache_vars} = env SYCL_CACHE_PERSISTENT=1 SYCL_CACHE_TRACE=1 SYCL_CACHE_DIR=%t/cache_dir
 // DEFINE: %{build_cmd} = %{build}

--- a/sycl/test-e2e/NewOffloadDriver/aot-gpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/aot-gpu.cpp
@@ -4,7 +4,7 @@
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source \
 // RUN:   -fsycl-targets=spir64_gen \
 // RUN:   -Xsycl-target-backend=spir64_gen \
-// RUN:   "-device dg2-g11" -I %S/Inputs -o %t.out \
+// RUN:   "-device dg2_g10" -I %S/Inputs -o %t.out \
 // RUN:   %S/split-per-source-main.cpp \
 // RUN:   %S/Inputs/split-per-source-second-file.cpp \
 // RUN:   -fsycl-dead-args-optimization --offload-new-driver

--- a/sycl/test-e2e/NewOffloadDriver/aot-gpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/aot-gpu.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: ocloc, gpu, target-spir, !gpu-intel-gen12
+// REQUIRES: ocloc, gpu, target-spir, gpu-intel-dg2
 // Test with `--offload-new-driver`
 //
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source \

--- a/sycl/test-e2e/NewOffloadDriver/aot-gpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/aot-gpu.cpp
@@ -4,7 +4,7 @@
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source \
 // RUN:   -fsycl-targets=spir64_gen \
 // RUN:   -Xsycl-target-backend=spir64_gen \
-// RUN:   "-device dg2" -I %S/Inputs -o %t.out \
+// RUN:   "-device dg2-g11" -I %S/Inputs -o %t.out \
 // RUN:   %S/split-per-source-main.cpp \
 // RUN:   %S/Inputs/split-per-source-second-file.cpp \
 // RUN:   -fsycl-dead-args-optimization --offload-new-driver


### PR DESCRIPTION
This patch adds the support of passing different backend options through `-Xsycl-target-backend` for each of multiple device architectures. 
An example is like the following, where we are passing different options for `pvc` and `dg1`.
```
clang++ ... -fsycl-targets=intel_gpu_dg1,spir64_gen \
  -Xsycl-target-backend=spir64_gen "-device pvc -options -extraopt_pvc" \
  -Xsycl-target-backend=intel_gpu_dg1 "-options -extraopt_dg1" ...
```
The following changes are made to support this feature:

1. In `SYCL.cpp`, add a new function `extractDeviceFromArg` for extracting the device from the backend option when the SYCL target is `spir64_gen`. This allows finding the device architecture from arguments such as: `-Xsycl-target-backend=spir64_gen "-device pvc -options -extraopt_pvc"`
2. In `Clang.cpp`, we construct a `--device-compiler=...` argument to pass into `clang-linker-wrapper` for each SYCL target. The `--device-compiler` contains a `-device <arch>` to differentiate the device that the backend option is specified for. When the SYCL target is `spir64_gen` (not `intel_gpu_arch`), we call `extractDeviceFromArg` to extract the device architecture.
3. `clang-linker-wrapper` is updated to filter `OPT_device_compiler_args_EQ` based on the architecture, and specify each architecture when calling `sycl-post-link`.
4. `sycl-post-link` is updated to support multiple architectures being passed in, such that cases like: `-Xsycl-target-backend=spir64_gen "-device arch1,arch2"`
5. Added a new test in `sycl-offload-new-driver.cpp` to verify the changes.
6. A few SYCL E2E tests are updated because, when compiling AOT with
`-fsycl-targets=spir64_gen and -Xsycl-target-backend=spir64_gen "-device arch"`,
the compilation now targets only the specified architecture, rather than GPUs in general.