### PR TITLE
[CI][Devops] Fix Vulkan install for NVIDIA

### DIFF
--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -33,6 +33,14 @@ RUN apt update && apt install -yqq rocm-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
+# Fix Vulkan install inside container
+# https://stackoverflow.com/questions/74965945/vulkan-is-unable-to-detect-nvidia-gpu-from-within-a-docker-container-when-using
+RUN apt update && \
+    apt download libnvidia-gl-565 && \
+    dpkg-deb --extract libnvidia-gl-565*.deb extracted && \
+    cp -R ./extracted/usr/* /usr/ && \
+    rm -rf libnvidia-gl-565*.deb ./extracted
+
 COPY scripts/create-sycl-user.sh /user-setup.sh
 RUN /user-setup.sh
 

--- a/devops/containers/ubuntu2404_build.Dockerfile
+++ b/devops/containers/ubuntu2404_build.Dockerfile
@@ -41,6 +41,14 @@ RUN apt update && apt install -yqq rocm-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
+# Fix Vulkan install inside container
+# https://stackoverflow.com/questions/74965945/vulkan-is-unable-to-detect-nvidia-gpu-from-within-a-docker-container-when-using
+RUN apt update && \
+    apt download libnvidia-gl-565 && \
+    dpkg-deb --extract libnvidia-gl-565*.deb extracted && \
+    cp -R ./extracted/usr/* /usr/ && \
+    rm -rf libnvidia-gl-565*.deb ./extracted
+
 COPY scripts/create-sycl-user.sh /user-setup.sh
 RUN /user-setup.sh
 

--- a/sycl/test-e2e/bindless_images/vulkan_interop/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/lit.local.cfg
@@ -1,5 +1,5 @@
 # https://github.com/intel/llvm/issues/21134
-config.xfail_features += ['cuda']
+config.unsupported_features += ['cuda']
 
 # Our PVC runners don't have the userspace Vulkan driver installed
 config.unsupported_features += ['arch-intel_gpu_pvc']


### PR DESCRIPTION
Even though the Docker contained is based off NVIDIA's CUDA image, Vulkan isn't installed and we can't install it normally through the package manager because the original image did everything outside the package manager as well.

Closes: https://github.com/intel/llvm/issues/21134