### PR TITLE
Reenable the LLVM sandbox by default for direct clang -cc1 invocations.

### DIFF
--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -270,7 +270,7 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
     // out-of-process -cc1 invocations launched by the driver. For in-process
     // -cc1 invocations launched by the driver, the sandbox is enabled in
     // CC1Command::Execute() for better crash recovery.
-    // auto EnableSandbox = llvm::sys::sandbox::scopedEnable();
+    auto EnableSandbox = llvm::sys::sandbox::scopedEnable();
     return ExecuteCC1Tool(Args, ToolContext, VFS);
   }
 


### PR DESCRIPTION
The LLVM sandbox was enabled by default for direct clang -cc1 invocations by https://github.com/llvm/llvm-project/pull/174653. Subsequent build failures building the sycl_web branch of the intel/llvm repository lead to the default enablement being reverted in merge commit 63ea3d6ea334c5da30fb32661a0922909c5bfc38 to be investigated later. Subsequent investigation has not succeeded in reproducing the reported build failures. This change reenables the previous default behavior.

Jira: CMPLRLLVM-72683