### PR TITLE
[Bench] Minor, random fixes in bench scripts

### DIFF
--- a/devops/scripts/benchmarks/history.py
+++ b/devops/scripts/benchmarks/history.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024-2025 Intel Corporation
+# Copyright (C) 2024-2026 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -155,15 +155,13 @@ class BenchmarkHistory:
 
         # Check if RUNNER_NAME environment variable has been declared.
         #
-        # Github runners obfusicate hostnames, thus running socket.gethostname()
+        # Github runners obfuscate hostnames, thus running socket.gethostname()
         # twice produces two different hostnames. Since github runners always
         # define a RUNNER_NAME variable, use RUNNER_NAME instead if it exists:
         hostname = os.getenv("RUNNER_NAME")
         if hostname is None:
             hostname = socket.gethostname()
         else:
-            # Ensure RUNNER_NAME has not been tampered with:
-            # TODO is this overkill?
             Validate.runner_name(
                 hostname,
                 throw=ValueError("Illegal characters found in specified RUNNER_NAME."),
@@ -173,7 +171,7 @@ class BenchmarkHistory:
         if options.build_compute_runtime:
             compute_runtime = options.compute_runtime_tag
         elif options.detect_versions.compute_runtime:
-            log.info(f"Auto-detecting compute_runtime version...")
+            log.info("Auto-detecting compute_runtime version...")
             detect_res = DetectVersion.instance()
             compute_runtime = detect_res.get_compute_runtime_ver()
             if detect_res.get_compute_runtime_ver_cached() is None:

--- a/devops/scripts/benchmarks/utils/compute_runtime.py
+++ b/devops/scripts/benchmarks/utils/compute_runtime.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024-2025 Intel Corporation
+# Copyright (C) 2024-2026 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -56,7 +56,7 @@ class ComputeRuntime:
         project = GitProject(repo, commit, Path(options.workdir), "gmmlib")
         rebuilt = False
         if project.needs_rebuild():
-            project.configure()
+            project.configure(extra_args=["-DRUN_TEST_SUITE=0"])
             project.build()
             project.install()
             rebuilt = True
@@ -211,7 +211,6 @@ class ComputeRuntime:
 
             log.info("Building Compute Runtime...")
             extra_config_args = [
-                "-DNEO_ENABLE_i915_PRELIM_DETECTION=1",
                 "-DNEO_ENABLE_I915_PRELIM_DETECTION=1",
                 "-DNEO_SKIP_UNIT_TESTS=1",
                 f"-DGMM_DIR={self.gmmlib}",

--- a/devops/scripts/benchmarks/utils/detect_versions.py
+++ b/devops/scripts/benchmarks/utils/detect_versions.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2025-2026 Intel Corporation
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 import os
 import re
 import sys

--- a/devops/scripts/benchmarks/utils/validate.py
+++ b/devops/scripts/benchmarks/utils/validate.py
@@ -1,3 +1,8 @@
+# Copyright (C) 2025-2026 Intel Corporation
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 import re
 
 
@@ -27,7 +32,7 @@ class Validate:
         """
         Returns True if runner_name is clean (no illegal characters).
         """
-        return Validate.on_re(runner_name, r"^[a-zA-Z0-9_]+$", throw=throw)
+        return Validate.on_re(runner_name, r"^[a-zA-Z0-9_-]+$", throw=throw)
 
     @staticmethod
     def timestamp(t: str, throw: Exception = None):


### PR DESCRIPTION
including:
- add missing license headers,
- skip tests in gmmlib,
- remove redundant Compute Runtime configure param,
- misspells.