### PR TITLE
[UR] update lxml to work with python 3.14

### DIFF
--- a/unified-runtime/third_party/requirements.txt
+++ b/unified-runtime/third_party/requirements.txt
@@ -13,7 +13,7 @@ exhale==0.3.0
 idna==3.7
 imagesize==1.1.0
 Jinja2==3.1.6
-lxml==4.9.3
+lxml==6.0.2
 Mako==1.3.0
 MarkupSafe==2.1.5
 packaging==24.2


### PR DESCRIPTION
Older lxml causes venv creation with python 3.14 build failure.
Latest lxml requires python 3.8 which is luckily also the current requirement for llvm.
So it is safe to bump version.