### PR TITLE
[SYCL][E2E] Enable DirectX interop tests on Windows

### DIFF
--- a/sycl/test-e2e/bindless_images/dx11_interop/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/dx11_interop/lit.local.cfg
@@ -1,0 +1,3 @@
+if 'windows' in config.available_features:
+   config.unsupported_features.remove('gpu-intel-dg2')
+   config.unsupported_features.remove('arch-intel_gpu_bmg_g21')

--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
@@ -5,6 +5,9 @@
 // UNSUPPORTED-INTENDED: Unknown issue with integrated GPU failing
 //                       when importing memory
 
+// UNSUPPORTED: gpu-intel-dg2
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21159
+
 // XFAIL: windows && arch-intel_gpu_bmg_g21
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20384
 

--- a/sycl/test-e2e/bindless_images/dx12_interop/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/dx12_interop/lit.local.cfg
@@ -1,0 +1,3 @@
+if 'windows' in config.available_features:
+   config.unsupported_features.remove('gpu-intel-dg2')
+   config.unsupported_features.remove('arch-intel_gpu_bmg_g21')

--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
@@ -5,6 +5,9 @@
 // UNSUPPORTED-INTENDED: Unknown issue with integrated GPU failing
 //                       when importing memory
 
+// UNSUPPORTED: gpu-intel-dg2
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21159
+
 // XFAIL: windows && arch-intel_gpu_bmg_g21
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20384
 


### PR DESCRIPTION
`bindless_images` has a top level `lit.local.cfg` that disables all tests for BMG and DG2 on Win, but these tests should not be part of that, so remove them from unsupported features.

Disable the tests that fail (causing a hang so used `UNSUPPORTED`) and track them with a separate tracker.