### PR TITLE
[Bench] Separate group for native SubmitGraph cases and adjust naming

### DIFF
--- a/devops/scripts/benchmarks/benches/compute.py
+++ b/devops/scripts/benchmarks/benches/compute.py
@@ -1455,7 +1455,7 @@ class GraphApiSubmitGraph(ComputeBenchmark):
         self._use_host_tasks = useHostTasks
         self._emulate_graphs = emulate_graphs
         self._native_str = (
-            " native,"
+            " native recording"
             if self._emulate_graphs == 0
             and (runtime == RUNTIMES.UR or runtime == RUNTIMES.LEVEL_ZERO)
             else ""


### PR DESCRIPTION
Fixes the SubmitGraph display issues in the benchmark dashboard with the following adjustments:
- The "graph emulation" naming has been switched, and L0 / UR graph benchmarks are referred to as "native recording" to align with what we plan to call this feature in SYCL.
- Due to technical differences in the underlying APIs, native graph APIs are assigned their own grouping as cross-comparing may lead to false performance conclusions.