### PR TITLE
[CI] Don't run preview tests for sycl-rel-* branches

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -352,7 +352,7 @@ jobs:
         extra_lit_opts: --param spirv-backend=True
 
     - name: Build E2E tests in Preview Mode
-      if: ${{ inputs.e2e_binaries_preview_artifact && !cancelled() && steps.build.conclusion == 'success' }}
+      if: ${{ inputs.e2e_binaries_preview_artifact && !cancelled() && steps.build.conclusion == 'success' && !startsWith(github.base_ref, 'sycl-rel-') }}
       uses: ./devops/actions/run-tests/linux/e2e
       with:
         ref: ${{ inputs.ref || github.sha }}


### PR DESCRIPTION
Do not run preview tests if a target branch is sycl-rel-*.
It makes no sense to test breaking changes on release branches.