### PR TITLE
Revert "[CI][NFC] Define base image for intel_drivers image in Dockerfile"

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -46,15 +46,19 @@ jobs:
           - name: Base Ubuntu 22.04 Docker image
             file: ubuntu2204_base
             tag: latest
+            build_args: ""
           - name: Base Ubuntu 24.04 Docker image
             file: ubuntu2404_base
             tag: latest
+            build_args: ""
           - name: Build Ubuntu 22.04 Docker image
             file: ubuntu2204_build
             tag: latest
+            build_args: ""
           - name: Build Ubuntu 24.04 Docker image
             file: ubuntu2404_build
             tag: latest
+            build_args: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -88,16 +92,23 @@ jobs:
           - name: Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
             tag: latest
+            build_args: ""
           - name: Intel Drivers Ubuntu 24.04 Docker image
             file: ubuntu2404_intel_drivers
             tag: latest
+            build_args: ""
           - name: Build + Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
             tag: alldeps
+            build_args: |
+              base_image=ghcr.io/intel/llvm/ubuntu2204_build
+              base_tag=latest
           - name: Build + Intel Drivers Ubuntu 24.04 Docker image
             file: ubuntu2404_intel_drivers
             tag: alldeps
-
+            build_args: |
+              base_image=ghcr.io/intel/llvm/ubuntu2404_build
+              base_tag=latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -1,5 +1,5 @@
 ARG base_tag=latest
-ARG base_image=ghcr.io/intel/llvm/ubuntu2204_build
+ARG base_image=ghcr.io/intel/llvm/ubuntu2204_base
 
 FROM $base_image:$base_tag
 

--- a/devops/containers/ubuntu2404_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2404_intel_drivers.Dockerfile
@@ -1,5 +1,5 @@
 ARG base_tag=latest
-ARG base_image=ghcr.io/intel/llvm/ubuntu2404_build
+ARG base_image=ghcr.io/intel/llvm/ubuntu2404_base
 
 FROM $base_image:$base_tag
 


### PR DESCRIPTION
Reverts intel/llvm#21157

This patch is wrong and not NFC