### PR TITLE
[libclc] prepare-builtins: remove redundant metadata/linkage edits

### DIFF
--- a/libclc/utils/prepare-builtins.cpp
+++ b/libclc/utils/prepare-builtins.cpp
@@ -74,7 +74,6 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-
   SmallVector<Metadata *, 2> BannedFlags;
   // wchar_size flag can cause a mismatch between libclc libraries and
   // modules using them. Since wchar is not used by libclc we drop the flag


### PR DESCRIPTION
This is preparation for removing the utility entirely. See f07988ff3ec8 and 3f2c5987907b for rationale.

Remaining wchar_size handling will be addressed in https://github.com/llvm/llvm-project/pull/174454.