### PR TITLE
[SYCL][NFC] Retain the platform cache in StreamAUXCmdsWait unit test

### DIFF
--- a/sycl/unittests/scheduler/CMakeLists.txt
+++ b/sycl/unittests/scheduler/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(WIN32)
-  # https://github.com/intel/llvm/issues/15049
-  return()
-endif()
 add_sycl_unittest(SchedulerTests OBJECT
     BlockedCommands.cpp
     Commands.cpp

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -131,9 +131,9 @@ public:
 };
 
 TEST_F(SchedulerTest, StreamAUXCmdsWait) {
+  sycl::unittest::UrMock<> Mock;
 
   {
-    sycl::unittest::UrMock<> Mock;
     sycl::platform Plt = sycl::platform();
     sycl::queue Q(Plt.get_devices()[0]);
     auto &QueueImpl =
@@ -164,7 +164,6 @@ TEST_F(SchedulerTest, StreamAUXCmdsWait) {
   }
 
   {
-    sycl::unittest::UrMock<> Mock;
     sycl::platform Plt = sycl::platform();
     sycl::queue Q(Plt.get_devices()[0]);
     auto &QueueImpl =


### PR DESCRIPTION
This is a fix for [15049](https://github.com/intel/llvm/issues/15049).

It is a unit test fix. The issue was, that the global platform cache was cleaned in the second part of the unit test (when constructing the UrMock object instance), so during the global library cleanup (at the end of the test), the required platform did not exist anymore.