### PR TITLE
[CI] Remove redundant if-clause

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -52,7 +52,6 @@ jobs:
   build:
     name: Self build
     needs: [detect_changes]
-    if: success()
     uses: ./.github/workflows/sycl-linux-build.yml
     with:
       build_ref: ${{ github.sha }}


### PR DESCRIPTION
Likely some leftover. To proceed if the previous step/job is successful is GHA default behavior.