### PR TITLE
[SYCL] add e2e tests for batched queues in L0v1 and L0v2

### DIFF
--- a/sycl/test-e2e/Basic/buffer/buffer.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t2.out
 // RUN: %{run} %t2.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t2.out %}
 
 //==------------------- buffer.cpp - SYCL buffer basic test ----------------==//
 //

--- a/sycl/test-e2e/Basic/buffer/buffer_full_copy.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_full_copy.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 //==------------- buffer_full_copy.cpp - SYCL buffer basic test ------------==//
 //

--- a/sycl/test-e2e/Basic/handler/handler_copy_with_offset.cpp
+++ b/sycl/test-e2e/Basic/handler/handler_copy_with_offset.cpp
@@ -1,5 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
+
 //==--- handler_copy_with_offset.cpp - SYCL handler copy with offset test --==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/in_order_queue_status_ext_oneapi_empty.cpp
+++ b/sycl/test-e2e/Basic/in_order_queue_status_ext_oneapi_empty.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 // Test checks that queue::ext_oneapi_empty() returns status of the in-order
 // queue.

--- a/sycl/test-e2e/Basic/queue/queue.cpp
+++ b/sycl/test-e2e/Basic/queue/queue.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 //==--------------- queue.cpp - SYCL queue test ----------------------------==//
 //

--- a/sycl/test-e2e/Basic/queue/queue_parallel_for_generic.cpp
+++ b/sycl/test-e2e/Basic/queue/queue_parallel_for_generic.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 //=-queue_parallel_for_generic.cpp - SYCL queue parallel_for generic lambda-=//
 //

--- a/sycl/test-e2e/Basic/submit_barrier.cpp
+++ b/sycl/test-e2e/Basic/submit_barrier.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 #include <stdlib.h>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/vector/load_store.cpp
+++ b/sycl/test-e2e/Basic/vector/load_store.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 // RUN: %{build} -D__SYCL_USE_LIBSYCL8_VEC_IMPL=1 -o %t2.out
 // RUN: %{run} %t2.out

--- a/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
@@ -1,5 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
+
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 

--- a/sycl/test-e2e/InorderQueue/in_order_buffs.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_buffs.cpp
@@ -1,5 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
+
 //==-------- ordered_buffs.cpp - SYCL buffers in ordered queues test--------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/InorderQueue/in_order_kernels.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_kernels.cpp
@@ -1,6 +1,7 @@
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 // SYCL ordered queue kernel shortcut test
 //

--- a/sycl/test-e2e/InorderQueue/in_order_usm_explicit.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_usm_explicit.cpp
@@ -1,5 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
+
 // SYCL in ordered queues explicit USM test.
 // Simple test checking explicit USM functionality using a Queue with the
 // in_order property.

--- a/sycl/test-e2e/Prefetch/prefetch.cpp
+++ b/sycl/test-e2e/Prefetch/prefetch.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: gpu && (level_zero || opencl)
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 #include <numeric>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/USM/memcpy.cpp
+++ b/sycl/test-e2e/USM/memcpy.cpp
@@ -8,6 +8,7 @@
 //
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t1.out %}
 
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>


### PR DESCRIPTION
This patch adds a new `RUN` directive in selected SYCL e2e tests, in order to check the support for batched queue submissions in L0v2. Batched queue submissions are introduced to L0v2 and described in the following PR: #19769.

The directive contains the environment variables which are specific to either L0v1 or L0v2 and are responsible for forcing batched submissions:

`// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}`

When executing tests with L0v1, `UR_L0_V2_FORCE_BATCHED` is ignored and only `SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS` is used. Conversely, L0v2 ignores `SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS` and uses only `UR_L0_V2_FORCE_BATCHED`. This way batched submissions are forced regardless of the available L0 adapter version.

Although the tests are added to verify the new functionality in L0v2, at this moment, it is not possible to restrict the test scope only to L0v2. The keyword `level_zero_v2_adapter`, used with the `UNSUPPORTED` directive, is not recognized inside the `RUN` directive. Additionally, `%if level_zero` recognizes both L0v1 and L0v2. In the following example:

```
// RUN: %{run} %t.out
// RUN: %if level_zero %{env UR_L0_V2_FORCE_BATCHED=1 %{run}  %t.out %}
```

in case of L0v1, we duplicate the test execution without any change. In case of L0v2, the first line executes the test with an immediate queue, whereas the second line executes with a batched queue. When adding `SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0` to force batched submissions for L0v1 as well, the second `RUN` for L0v1 becomes a different test case: batched queues are used instead of immediate queues and repeating the unmodified scenario from the first `RUN` is avoided. 