### PR TITLE
[Devops] Append to runtimes in configure.py

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -149,7 +149,7 @@ def do_configure(args, passthrough_args):
 
         # For clang-format, clang-tidy and code coverage
         llvm_enable_projects += ";clang-tools-extra"
-        llvm_enable_runtimes = "compiler-rt"
+        llvm_enable_runtimes += "compiler-rt"
         if sys.platform != "darwin":
             # libclc is required for CI validation
             libclc_enabled = True


### PR DESCRIPTION
We should append instead of assign.

We can't do `;compiler-rt` like we do with other variables because the variable is empty by default and ";compiler-rt" causes a CMake error.

With this it will error if someone defines a runtime before this (so the var will be like "offloadcompiler-rt" which is invalid and will error), but that is better than it silently getting dropped in this assign.


Context: https://github.com/intel/llvm/pull/21177