### PR TITLE
[SYCL][Doc] Update sycl_ext_oneapi_dot_accumulate

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_dot_accumulate.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_dot_accumulate.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2026 Intel Corporation.  All rights reserved.
+Copyright (C) 2020 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by
@@ -48,7 +48,7 @@ This extension is implemented and fully supported by {dpcpp}.
 == Overview
 
 This extension adds new SYCL built-in functions that may simplify development
-and provide access specialized hardware instructions when a SYCL kernel needs
+and provide access to specialized hardware instructions when a SYCL kernel needs
 to perform a dot product of two vectors followed by a scalar accumulation.
 
 == Specification
@@ -74,38 +74,12 @@ supports.
 
 === New geometric functions
 
-[cols="4a,4",options="header"]
-|====
-| *Function*
-| *Description*
+This extension adds the following new functions.
 
-|[source,c]
-----
-int32_t dot_acc(vec<int8_t,4>  a,
-                vec<int8_t,4>  b,
-                int32_t c)
-int32_t dot_acc(vec<int8_t,4>  a,
-                vec<uint8_t,4> b,
-                int32_t c)
-int32_t dot_acc(vec<uint8_t,4> a,
-                vec<int8_t,4>  b,
-                int32_t c)
-int32_t dot_acc(vec<uint8_t,4> a,
-                vec<uint8_t,4> b,
-                int32_t c)
-----
-
-|Performs a four-component integer dot product accumulate operation. +
-{blank}
-The value that is returned is equivalent to +
-{blank}
-*dot*(_a_, _b_) + _c_
-
-|====
+'''
 
 [source,c++]
 ----
-
 namespace sycl::ext::oneapi {
 
 int32_t dot_acc(vec<int8_t,4>  a, vec<int8_t,4>  b, int32_t c);
@@ -113,10 +87,26 @@ int32_t dot_acc(vec<int8_t,4>  a, vec<uint8_t,4> b, int32_t c);
 int32_t dot_acc(vec<uint8_t,4> a, vec<int8_t,4>  b, int32_t c);
 int32_t dot_acc(vec<uint8_t,4> a, vec<uint8_t,4> b, int32_t c);
 
+} // namespace sycl::ext::oneapi
+----
+
+_Returns:_ The four-component integer dot product accumulate operation
+`dot(a, b) + c`, where `dot` computes the dot product of two vectors.
+
+'''
+
+[source,c++]
+----
+namespace sycl::ext::oneapi {
+
 int32_t dot_acc(int32_t a, int32_t b, int32_t c);
 int32_t dot_acc(int32_t a, uint32_t b, int32_t c);
 int32_t dot_acc(uint32_t a, int32_t b, int32_t c);
 int32_t dot_acc(uint32_t a, uint32_t b, int32_t c);
 
-}
+} // namespace sycl::ext::oneapi
 ----
+
+_Returns:_ The four-component integer dot product accumulate operation, where
+`a` and `b` are both interpreted as `vec<int8_t,4>` for `int32_t` or as
+`vec<uint8_t,4>` for `uint32_t`.


### PR DESCRIPTION
Rewrite against SYCL2020.
The extension is already supported.
In general it's just a copy-paste of the existing spec into the new extension template.