### PR TITLE
[NFC][clang-linker-wrapper] Remove unnecessary data copy.

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1323,9 +1323,8 @@ runWrapperAndCompile(std::vector<module_split::SplitModule> &SplitModules,
 /// 'Args' encompasses all arguments required for linking and wrapping device
 /// code and will be parsed to generate options required to be passed into the
 /// llvm-link tool.
-static Expected<StringRef>
-linkDeviceInputFiles(ArrayRef<StringRef> InputFiles,
-                     const ArgList &Args) {
+static Expected<StringRef> linkDeviceInputFiles(ArrayRef<StringRef> InputFiles,
+                                                const ArgList &Args) {
   llvm::TimeTraceScope TimeScope("SYCL LinkDeviceInputFiles");
 
   const char *LinkerExecutable = "llvm-link";


### PR DESCRIPTION
This patch changes `sycl::linkDeviceInputFiles` parameter type from
`SmallVectorImpl<StringRef>` to `ArrayRef<StringRef>` to avoid copying
from `linkDevice` argument to a local variable.