### PR TITLE
[UR][L0] Fix several issues when linking native images

### DIFF
--- a/unified-runtime/source/adapters/level_zero/program.cpp
+++ b/unified-runtime/source/adapters/level_zero/program.cpp
@@ -436,7 +436,6 @@ ur_result_t urProgramLinkExp(
           return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
         }
       }
-
     }
 
     // For SPIR-V input programs, previous calls to urProgramCompile did not


### PR DESCRIPTION
Addresses a few issues that slipped through before the support for native input modules was implemented for the module program extension in the L0 runtime.