### PR TITLE
[SYCL][E2E] Enable sampled_images.cpp on CUDA

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
@@ -5,6 +5,9 @@
 // XFAIL: linux
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21131
 
+// UNSUPPORTED: cuda
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21131
+
 // UNSUPPORTED: linux && (gpu-intel-dg2 || arch-intel_gpu_bmg_g21)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21136
 


### PR DESCRIPTION
It XPASSes in the nightly similar to other related tests, the problem is already captured in the GH issue [here](https://github.com/intel/llvm/issues/21131#issuecomment-3820376214).