### PR TITLE
[CI] Disable vulkan interop tests on CUDA AWS

### DIFF
--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -80,6 +80,9 @@ jobs:
       toolchain_artifact_filename: llvm_sycl.tar.zst
       toolchain_decompress_command: zstd
 
+      # The AWS runner is not set up to use vulkan and it's out of our control.
+      extra_lit_opts: --filter-out bindless_images/vulkan_interop
+
   update-check:
     needs: [create-check, e2e-cuda]
     if: always()

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -315,6 +315,9 @@ jobs:
       toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
       toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
+      # The AWS runner is not set up to use vulkan and it's out of our control.
+      extra_lit_opts: --filter-out bindless_images/vulkan_interop
+
   cuda-aws-stop:
     needs: [cuda-aws-start, cuda-run-tests]
     if: ${{ needs.cuda-aws-start.result != 'skipped' }}


### PR DESCRIPTION
The AWS machines have a host OS that isn't set up for Vulkan, so we need to disable related tests.

Example of pass with this change [here](https://github.com/intel/llvm/actions/runs/21682114055/job/62527909347).