### PR TITLE
[CI] Build clang-tidy in sycl-linux-build.yml

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -44,10 +44,6 @@ on:
         default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc]'
         required: false
 
-      build_clang_tidy:
-        type: boolean
-        default: false
-
       # Artifacts:
 
       retention-days:
@@ -293,10 +289,7 @@ jobs:
       if: ${{ !cancelled() && steps.build.conclusion == 'success' }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target install-sycl-test-utilities
-
-    - name: Install clang-tidy
-      if: ${{ !cancelled() && steps.build.conclusion == 'success' && inputs.build_clang_tidy == 'true' }}
-      run: cmake --build $GITHUB_WORKSPACE/build --target install-clang-tidy
+        cmake --build $GITHUB_WORKSPACE/build --target install-clang-tidy
 
     - name: Additional Install for "--shared-libs" build
       if: ${{ !cancelled() && steps.build.conclusion == 'success' && contains(inputs.build_configure_extra_args, '--shared-libs') }}

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -49,9 +49,6 @@ jobs:
       # prefer widespread gzip compression.
       toolchain_artifact_filename: sycl_linux.tar.gz
 
-      build_target: "sycl-toolchain clang-tidy"
-      build_clang_tidy: true
-
   # Build used for performance testing only: not intended for testing
   linux_shared_build:
     if: github.repository == 'intel/llvm'


### PR DESCRIPTION
To have clang-tidy as part of nightly container.
Tested here: https://github.com/intel/llvm/actions/runs/21686159301