### PR TITLE
[CI] Check load average before running Test adapters step

### DIFF
--- a/.github/workflows/ur-health-check.yml
+++ b/.github/workflows/ur-health-check.yml
@@ -1,0 +1,129 @@
+# This workflow monitors runners' health by checking their load average. 
+# It collects data from all runners before specific jobs and aggregates it into a JSON file from the whole day.  
+
+name: UR Health Monitoring
+
+on:
+  workflow_call:
+    inputs:
+      runner_name:
+        required: true
+        type: string
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at midnight
+
+permissions: {}
+
+jobs:
+  health-check:
+    if: github.event_name == 'workflow_call'
+    runs-on: ${{ inputs.runner_name }}
+    env: 
+      RUNNER_NAME: ${{ inputs.runner_name }}
+    steps:
+      - name: Check load average
+        id: check
+        run: |
+          DATE=$(date +"%Y-%m-%d_%H-%M-%S")
+          echo "DATE=$DATE" >> $GITHUB_ENV
+          echo "DATE=$DATE" >> $GITHUB_OUTPUT
+          mkdir -p artifacts
+          echo "Directory created, verifying..."
+          ls -la artifacts/
+          uptime | awk -F'load average:' '{ print $2 }' > artifacts/${DATE}_${RUNNER_NAME}.txt
+          echo "File created, verifying contents..."
+          cat artifacts/${DATE}_${RUNNER_NAME}.txt
+          echo "File path: artifacts/${DATE}_${RUNNER_NAME}.txt"
+          ls -lh artifacts/${DATE}_${RUNNER_NAME}.txt
+      - name: Upload load average artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ env.DATE }}_${{ env.RUNNER_NAME }}_load-average
+          path: artifacts/${{ env.DATE }}_${{ env.RUNNER_NAME }}.txt
+
+  aggregate-load-data:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Calculate yesterday's date
+        id: date
+        run: |
+          YESTERDAY=$(date -d "yesterday" +'%Y-%m-%d')
+          echo "YESTERDAY=$YESTERDAY" >> $GITHUB_ENV
+          echo "YESTERDAY=$YESTERDAY" >> $GITHUB_OUTPUT
+          echo "Date for artifact search: $YESTERDAY"
+      
+      - name: Download all artifacts from yesterday's health-check runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Searching for all workflow runs from $YESTERDAY"
+
+          curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ur-health-check.yml/runs?status=success&created=$YESTERDAY" \
+            | jq -r '.workflow_runs[].id' > run_ids.txt
+          
+          mkdir -p artifacts
+          
+          # Download artifacts from each run
+          while read run_id; do
+            echo "Downloading artifacts from run $run_id"
+            gh run download "$run_id" \
+              --dir artifacts \
+              --pattern "$YESTERDAY*" \
+              --repo "${{ github.repository }}" || echo "No matching artifacts in run $run_id"
+          done < run_ids.txt
+          
+          echo "All artifacts downloaded:"
+
+      - name: Process and aggregate data
+        run: |
+          echo "Processing artifacts from $YESTERDAY"
+          ls -laR artifacts/
+          echo "{" > aggregated_${YESTERDAY}.json
+          first_data=true
+
+          for artifact_dir in artifacts/*/; do
+            for file in "$artifact_dir"*.txt; do
+              if [[ -f "$file" ]]; then
+                filename=$(basename "$file" .txt)
+                load=$(cat "$file" | xargs)
+                
+                if [ "$first_data" = true ]; then
+                  echo "  \"$filename\": \"$load\"" >> aggregated_${YESTERDAY}.json
+                  first_data=false
+                else
+                  echo ",  \"$filename\": \"$load\"" >> aggregated_${YESTERDAY}.json
+                fi
+              fi 
+            done
+          done
+
+          echo "}" >> aggregated_${YESTERDAY}.json
+          
+          cat aggregated_${YESTERDAY}.json
+
+      - name: Check if data exists
+        id: check_data
+        run: |
+          content=$(cat aggregated_${YESTERDAY}.json | tr -d ' \n')
+          if [ "$content" = "{}" ]; then
+            echo "has_data=false" >> $GITHUB_OUTPUT
+            echo "No data found, skipping artifact upload"
+          else
+            echo "has_data=true" >> $GITHUB_OUTPUT
+            echo "Data found, will upload artifact"
+          fi
+
+      - name: Upload aggregated data artifact
+        if: steps.check_data.outputs.has_data == 'true'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: aggregated_data_${{ env.YESTERDAY }}
+          path: aggregated_${{ env.YESTERDAY }}.json


### PR DESCRIPTION
This is enhancement to monitor UR machines' load average before Test adapters job. It gathers info from the runner which runs this job. 
The results from every run from the day before are collected into one JSON file which is saved as an artifact. 
Also, the results from every run will be added to Grafana monitoring tool and when the load extends set value, the alert via Teams will be send to our team.