### PR TITLE
[SYCL] Update dot_accumulate implementation

### DIFF
--- a/sycl/include/sycl/ext/oneapi/dot_product.hpp
+++ b/sycl/include/sycl/ext/oneapi/dot_product.hpp
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <sycl/detail/defines_elementary.hpp>
 #include <sycl/vector.hpp>
 
 namespace sycl {

--- a/sycl/source/feature_test.hpp.in
+++ b/sycl/source/feature_test.hpp.in
@@ -119,6 +119,7 @@ inline namespace _V1 {
 #define SYCL_EXT_ONEAPI_TANGLE 1
 #define SYCL_EXT_ONEAPI_INTER_PROCESS_COMMUNICATION 1
 #define SYCL_EXT_ONEAPI_USM_SHORTCUTS 1
+#define SYCL_EXT_ONEAPI_DOT_ACCUMULATE 1
 
 // Unfinished KHR extensions. These extensions are only available if the
 // __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS macro is defined.


### PR DESCRIPTION
The extension spec was re-written against SYCL2020, adding the macro and removing the redundant include.
Spec change: e0652db0666071d32fba7b3d08f7ebe54fc39389