### PR TITLE
[SYCL][NFC] Add -ftarget-export-symbols to the dynamic_aot.cpp test

### DIFF
--- a/sycl/test-e2e/DeviceImageDependencies/dynamic_aot.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/dynamic_aot.cpp
@@ -3,7 +3,7 @@
 // REQUIRES: ocloc, gpu, target_spir
 
 // DEFINE: %{aot_options} = -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -DUSE_AOT
-// DEFINE: %{dynamic_lib_options} = %{aot_options} %fPIC %shared_lib -fsycl-allow-device-image-dependencies -I %S/Inputs %if windows %{-DMAKE_DLL %}
+// DEFINE: %{dynamic_lib_options} = %{aot_options} %fPIC %shared_lib -fsycl-allow-device-image-dependencies -ftarget-export-symbols -I %S/Inputs %if windows %{-DMAKE_DLL %}
 // DEFINE: %{dynamic_lib_suffix} = %if windows %{dll%} %else %{so%}
 
 // RUN: rm -rf %t.dir; mkdir -p %t.dir


### PR DESCRIPTION
The flag is required to export non-kernel symbols in the AOT images.