### PR TITLE
[UR][L0v2] replace submitted kernels vector with an unordered_set

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -1061,8 +1061,10 @@ ur_result_t ur_command_list_manager::appendNativeCommandExp(
 
 void ur_command_list_manager::recordSubmittedKernel(
     ur_kernel_handle_t hKernel) {
-  submittedKernels.push_back(hKernel);
-  hKernel->RefCount.retain();
+  auto [_, inserted] = submittedKernels.insert(hKernel);
+  if (inserted) {
+    hKernel->RefCount.retain();
+  }
 }
 
 ze_command_list_handle_t ur_command_list_manager::getZeCommandList() {

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -15,6 +15,7 @@
 #include "event_pool_cache.hpp"
 #include "queue_api.hpp"
 #include "ur_api.h"
+#include <unordered_set>
 #include <ze_api.h>
 
 struct ur_mem_buffer_t;
@@ -331,7 +332,7 @@ private:
   v2::raii::ur_context_handle_t hContext;
   v2::raii::ur_device_handle_t hDevice;
 
-  std::vector<ur_kernel_handle_t> submittedKernels;
+  std::unordered_set<ur_kernel_handle_t> submittedKernels;
   v2::raii::command_list_unique_handle zeCommandList;
   std::vector<ze_event_handle_t> waitList;
 


### PR DESCRIPTION
L0v2 avoids internally tracking each kernel submission through an event for lifetime management. Instead, when a kernel is submitted to the queue, its handle is added to a vector, to be removed at the next queue synchronization point, urQueueFinish(). This is a much more efficient way of handling kernel tracking, since it avoids taking and storing an event. However, if the application never synchronizes the queue, this vector of submitted kernels will grow unbounded.

This is mostly an issue when an application submits many identical kernels. Using an unordered_set eliminates the unbounded growth issue because duplicates are not going to be recorded twice.