### PR TITLE
[SYCL] Add support for liboffload Level Zero plugin

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -3425,6 +3425,11 @@ bool doesImageTargetMatchDevice(const RTDeviceBinaryImage &Img,
         return (strcmp(Target, __SYCL_DEVICE_BINARY_TARGET_AMDGCN) == 0 ||
                 strcmp(Target, __SYCL_DEVICE_BINARY_TARGET_LLVM_AMDGCN) == 0);
       }
+      if (PlatformName == "LEVEL_ZERO") {
+        return (strcmp(Target, __SYCL_DEVICE_BINARY_TARGET_SPIRV64) == 0 ||
+                strcmp(Target, __SYCL_DEVICE_BINARY_TARGET_SPIRV64_GEN) == 0);
+      }
+
       assert(false && "Unhandled liboffload platform");
       return false;
     }

--- a/unified-runtime/source/adapters/offload/device.cpp
+++ b/unified-runtime/source/adapters/offload/device.cpp
@@ -53,7 +53,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_VERSION:
     return ReturnValue("");
   case UR_DEVICE_INFO_EXTENSIONS:
-    return ReturnValue("");
+    // todo: use offload API to query supported extensions
+    return ReturnValue("cl_khr_il_program");
   case UR_DEVICE_INFO_USE_NATIVE_ASSERT:
     return ReturnValue(false);
   case UR_DEVICE_INFO_TYPE:


### PR DESCRIPTION
Until now, only CUDA and HIP were supported through the liboffload adapter. This change adds the necessary support to enable SYCL via the liboffload Level Zero plugin, using the UR offload adapter.