### PR TITLE
[SYCL] Fix build with disabled preview library

### DIFF
--- a/sycl/cmake/modules/AddSYCLUnitTest.cmake
+++ b/sycl/cmake/modules/AddSYCLUnitTest.cmake
@@ -163,5 +163,7 @@ endfunction()
 #   `config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, <...>)`
 macro(add_sycl_unittest test_name_prefix link_variant)
   add_sycl_unittest_internal(${test_name_prefix}_Non_Preview_Tests ${link_variant} FALSE ${ARGN})
-  add_sycl_unittest_internal(${test_name_prefix}_Preview_Tests ${link_variant} TRUE ${ARGN})
+  if(SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB)
+    add_sycl_unittest_internal(${test_name_prefix}_Preview_Tests ${link_variant} TRUE ${ARGN})
+  endif()
 endmacro()

--- a/sycl/unittests/Extensions/InterProcessCommunication/CMakeLists.txt
+++ b/sycl/unittests/Extensions/InterProcessCommunication/CMakeLists.txt
@@ -3,6 +3,8 @@ if("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
     Memory.cpp
   )
 
-  target_compile_features(IPCTests_Preview_Tests PUBLIC cxx_std_20)
+  if(SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB)
+    target_compile_features(IPCTests_Preview_Tests PUBLIC cxx_std_20)
+  endif()
   target_compile_features(IPCTests_Non_Preview_Tests PUBLIC cxx_std_20)
 endif()

--- a/sycl/unittests/compression/CMakeLists.txt
+++ b/sycl/unittests/compression/CMakeLists.txt
@@ -2,4 +2,6 @@ add_sycl_unittest(CompressionTests OBJECT
   CompressionTests.cpp
 )
 target_compile_definitions(CompressionTests_Non_Preview_Tests PRIVATE SYCL_RT_ZSTD_AVAILABLE)
-target_compile_definitions(CompressionTests_Preview_Tests PRIVATE SYCL_RT_ZSTD_AVAILABLE __INTEL_PREVIEW_BREAKING_CHANGES)
+if(SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB)
+  target_compile_definitions(CompressionTests_Preview_Tests PRIVATE SYCL_RT_ZSTD_AVAILABLE __INTEL_PREVIEW_BREAKING_CHANGES)
+endif()

--- a/sycl/unittests/kernel-and-program/CMakeLists.txt
+++ b/sycl/unittests/kernel-and-program/CMakeLists.txt
@@ -12,4 +12,6 @@ add_sycl_unittest(KernelAndProgramTests OBJECT
   KernelInfoShortcuts.cpp
 )
 target_compile_definitions(KernelAndProgramTests_Non_Preview_Tests PRIVATE __SYCL_INTERNAL_API)
-target_compile_definitions(KernelAndProgramTests_Preview_Tests PRIVATE __SYCL_INTERNAL_API __INTEL_PREVIEW_BREAKING_CHANGES)
+if(SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB)
+  target_compile_definitions(KernelAndProgramTests_Preview_Tests PRIVATE __SYCL_INTERNAL_API __INTEL_PREVIEW_BREAKING_CHANGES)
+endif()

--- a/sycl/unittests/ur/CMakeLists.txt
+++ b/sycl/unittests/ur/CMakeLists.txt
@@ -6,5 +6,7 @@ add_sycl_unittest(UrTests OBJECT
 
 add_dependencies(UrTests_Non_Preview_Tests sycl)
 target_include_directories(UrTests_Non_Preview_Tests PRIVATE SYSTEM ${sycl_inc_dir})
-add_dependencies(UrTests_Preview_Tests sycl)
-target_include_directories(UrTests_Preview_Tests PRIVATE SYSTEM ${sycl_inc_dir})
+if(SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB)
+  add_dependencies(UrTests_Preview_Tests sycl)
+  target_include_directories(UrTests_Preview_Tests PRIVATE SYSTEM ${sycl_inc_dir})
+endif()

--- a/sycl/unittests/xpti_trace/CMakeLists.txt
+++ b/sycl/unittests/xpti_trace/CMakeLists.txt
@@ -7,4 +7,6 @@ add_sycl_unittest(XptiTraceTests OBJECT
     QueueIDCheck.cpp
 )
 target_link_libraries(XptiTraceTests_Non_Preview_Tests PRIVATE xpti xptitest_subscriber)
-target_link_libraries(XptiTraceTests_Preview_Tests PRIVATE xpti xptitest_subscriber)
+if(SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB)
+    target_link_libraries(XptiTraceTests_Preview_Tests PRIVATE xpti xptitest_subscriber)
+endif()


### PR DESCRIPTION
Currently configure.py fails if
`-DSYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB=Off` is passed.
This patch enables preview unittests only if `SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB` is ON.