### PR TITLE
[SYCL][Graph][E2E] Add missing set_arg call to dyn_cgf_accessor_spv.cpp

### DIFF
--- a/sycl/test-e2e/Graph/Update/dyn_cgf_accessor_spv.cpp
+++ b/sycl/test-e2e/Graph/Update/dyn_cgf_accessor_spv.cpp
@@ -38,6 +38,7 @@ int main(int, char **argv) {
 
   int PatternA = 42;
   int PatternB = 0xA;
+  int AccOffset = 0;
 
   auto AccA = BufA.get_access();
   auto AccB = BufB.get_access();
@@ -52,6 +53,7 @@ int main(int, char **argv) {
   auto CGFA = [&](handler &CGH) {
     CGH.require(AccA);
     CGH.set_arg(0, AccA);
+    CGH.set_arg(1, AccOffset);
     CGH.set_arg(2, PatternA);
     CGH.parallel_for(sycl::range<1>(Size), kernelA);
   };
@@ -59,6 +61,7 @@ int main(int, char **argv) {
   auto CGFB = [&](handler &CGH) {
     CGH.require(AccB);
     CGH.set_arg(0, AccB);
+    CGH.set_arg(1, AccOffset);
     CGH.set_arg(2, PatternB);
     CGH.parallel_for(sycl::range<1>(Size), kernelB);
   };


### PR DESCRIPTION
`dyn_cgf_accessor_spv.cpp` was previously relying on UB to set arg index 1 to 0 when the kernel is launched. To fix, this we explicitly call `handler::set_arg`.