### PR TITLE
[CI] Move to AWS SDK 3

### DIFF
--- a/devops/actions/aws-ec2/action.yml
+++ b/devops/actions/aws-ec2/action.yml
@@ -71,5 +71,5 @@ inputs:
     default: "us-east-1" # North Virginia
 
 runs:
-  using: node16
+  using: node24
   main: ./aws-ec2.js

--- a/devops/actions/aws-ec2/aws-ec2.js
+++ b/devops/actions/aws-ec2/aws-ec2.js
@@ -1,6 +1,6 @@
 const core   = require('@actions/core');
 const github = require('@actions/github');
-const AWS    = require('aws-sdk');
+const { EC2, waitUntilInstanceRunning } = require("@aws-sdk/client-ec2");
 
 // shortcut to reference current repo
 const repo = `${github.context.repo.owner}/${github.context.repo.repo}`;
@@ -35,7 +35,14 @@ let reg_token;
 
 // starts AWS EC2 instance that will spawn Github runner for a given label
 async function start(param_type, param_label, param_ami, param_spot, param_disk, param_timebomb, param_onejob) {
-  const ec2 = new AWS.EC2();
+  const ec2 = new EC2({
+    credentials: {
+      accessKeyId:     core.getInput("AWS_ACCESS_KEY"),
+      secretAccessKey: core.getInput("AWS_SECRET_KEY")
+    },
+
+    region:          core.getInput("aws-region")
+  });
 
   reg_token = reg_token ? reg_token : await getGithubRegToken();
   const ec2types     = typeof param_type     === 'string' ? [ param_type ] : param_type;
@@ -87,7 +94,7 @@ async function start(param_type, param_label, param_ami, param_spot, param_disk,
           const items = ec2disk.split(':');
           params.BlockDeviceMappings = [ {DeviceName: items[0], Ebs: {VolumeSize: items[1]}} ];
         }
-        const result = await ec2.runInstances(params).promise();
+        const result = await ec2.runInstances(params);
         ec2id = result.Instances[0].InstanceId;
         core.info(`Created AWS EC2 ${spot_str} instance ${ec2id} of ${ec2type} type with ${label} label`);
         break;
@@ -107,9 +114,12 @@ async function start(param_type, param_label, param_ami, param_spot, param_disk,
   // wait untill instance will be found running before continuing (spot instance
   // can be created but never run and will be in pending state untill
   // termination)
-  let p = ec2.waitFor("instanceRunning", {
+  let p = waitUntilInstanceRunning({
+    client: ec2,
+    maxWaitTime: 200
+  }, {
     Filters: [ { Name: "tag:Label", Values: [ label ] } ]
-  }).promise();
+  });
   for (let i = 0; i < 2; i++) {
     p = p.catch(function() {
       core.warning(`Error searching for running AWS EC2 instance ${ec2id} with ${label} label. Will retry.`);
@@ -129,7 +139,14 @@ async function start(param_type, param_label, param_ami, param_spot, param_disk,
 async function stop(param_label) {
   // last error that will be thrown in case something will break here
   let last_error;
-  const ec2 = new AWS.EC2();
+  const ec2 = new EC2({
+    credentials: {
+      accessKeyId:     core.getInput("AWS_ACCESS_KEY"),
+      secretAccessKey: core.getInput("AWS_SECRET_KEY")
+    },
+
+    region:          core.getInput("aws-region")
+  });
 
   const label = typeof param_label === 'string' ? param_label : param_label[0];
 
@@ -138,7 +155,7 @@ async function stop(param_label) {
   try {
     instances = await ec2.describeInstances({
       Filters: [ { Name: "tag:Label", Values: [ label ] } ]
-    }).promise();
+    });
     core.info(`Searched for AWS EC2 instance with label ${label}`);
   } catch (error) {
     core.error(`Error searching for AWS EC2 instance with label ${label}: ${error}`);
@@ -150,7 +167,7 @@ async function stop(param_label) {
     for (const reservation of instances.Reservations) {
       for (const instance of reservation.Instances) {
         try {
-          await ec2.terminateInstances({ InstanceIds: [ instance.InstanceId ] }).promise();
+          await ec2.terminateInstances({ InstanceIds: [ instance.InstanceId ] });
           core.info(`Terminated AWS EC2 instance ${instance.InstanceId} with label ${label}`);
         } catch (error) {
           core.error(`Error terminating AWS EC2 instance ${instance.InstanceId} with label ${label}: ${error}`);
@@ -202,12 +219,6 @@ async function stop(param_label) {
 
 (async function() {
   try {
-    // provide AWS credentials
-    AWS.config.update({
-      accessKeyId:     core.getInput("AWS_ACCESS_KEY"),
-      secretAccessKey: core.getInput("AWS_SECRET_KEY"),
-      region:          core.getInput("aws-region")
-    });
     // mode is start or stop
     const mode = core.getInput("mode");
     const runs_on_list = core.getInput("runs-on-list") ? JSON.parse(core.getInput("runs-on-list")) : [];

--- a/devops/actions/aws-ec2/package.json
+++ b/devops/actions/aws-ec2/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "@actions/core": "1.10.0",
     "@actions/github": "5.0.3",
-    "aws-sdk": "2.1179.0"
+    "@aws-sdk/client-ec2": "3.987.0"
   }
 }


### PR DESCRIPTION
This ended up being pretty trivial because AWS released a v2 to v3 conversion [tool](https://www.npmjs.com/package/aws-sdk-js-codemod). 

I just ran the tool and removed newly dead code. I also updated the dependency/node versions.

Log of it working [here](https://github.com/intel/llvm/actions/runs/21883049373/job/63171777328).

Closes: https://github.com/intel/llvm/issues/21254