### PR TITLE
[SYCL] Update GDB debug info for `sycl::handler`

### DIFF
--- a/sycl/gdb/libsycl.so-gdb.py
+++ b/sycl/gdb/libsycl.so-gdb.py
@@ -1011,7 +1011,7 @@ class SYCLHandlerPrinter(SYCLPrinter):
         super().__init__(gdb_value)
 
     def impl_ptr(self):
-        return self.gdb_value()["impl"]["_M_ptr"]
+        return self.gdb_value()["impl"]
 
     def to_string(self):
         return self.type_name(self.gdb_type())


### PR DESCRIPTION
https://github.com/intel/llvm/pull/17319 changed `sycl::handler` to store raw pointer of `handler_impl` instead of shared pointer. However, to get handler type in GDB, we still assume `handler->impl` to be a shared pointer, which is wrong. This PR fixes that.

Refer  CMPLRLLVM-72040