### PR TITLE
[SYCL][CUDA] fix NVVM wg size annotations typo

### DIFF
--- a/llvm/lib/SYCLLowerIR/SYCLCreateNVVMAnnotations.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLCreateNVVMAnnotations.cpp
@@ -72,7 +72,7 @@ SYCLCreateNVVMAnnotationsPass::run(Module &M, ModuleAnalysisManager &MAM) {
 
     constexpr static std::pair<const char *, std::array<const char *, 3>>
         WGAnnotations[] = {
-            {"reqd_work_group_size", {"reqntidx", "reqntidy", "reqntidx"}},
+            {"reqd_work_group_size", {"reqntidx", "reqntidy", "reqntidz"}},
             {"max_work_group_size", {"maxntidx", "maxntidy", "maxntidz"}}};
 
     for (auto &[MDName, Annotations] : WGAnnotations) {

--- a/llvm/test/SYCLLowerIR/nvvm-annotations.ll
+++ b/llvm/test/SYCLLowerIR/nvvm-annotations.ll
@@ -94,13 +94,13 @@ define ptx_kernel void @foo_maxwgpermp() !max_work_groups_per_mp !3 {
 ;.
 ; CHECK: [[META0:![0-9]+]] = !{ptr @foo_reqd0, !"reqntidx", i32 4}
 ; CHECK: [[META1:![0-9]+]] = !{ptr @foo_reqd0, !"reqntidy", i32 8}
-; CHECK: [[META2:![0-9]+]] = !{ptr @foo_reqd0, !"reqntidx", i32 16}
+; CHECK: [[META2:![0-9]+]] = !{ptr @foo_reqd0, !"reqntidz", i32 16}
 ; CHECK: [[META3:![0-9]+]] = !{ptr @foo_reqd1, !"reqntidx", i32 4}
 ; CHECK: [[META4:![0-9]+]] = !{ptr @foo_reqd2, !"reqntidx", i32 4}
 ; CHECK: [[META5:![0-9]+]] = !{ptr @foo_reqd2, !"reqntidy", i32 8}
 ; CHECK: [[META6:![0-9]+]] = !{ptr @foo_reqd3, !"reqntidx", i32 4}
 ; CHECK: [[META7:![0-9]+]] = !{ptr @foo_reqd3, !"reqntidy", i32 8}
-; CHECK: [[META8:![0-9]+]] = !{ptr @foo_reqd3, !"reqntidx", i32 16}
+; CHECK: [[META8:![0-9]+]] = !{ptr @foo_reqd3, !"reqntidz", i32 16}
 ; CHECK: [[META9:![0-9]+]] = !{ptr @foo_reqd4, !"reqntidx", i32 4}
 ; CHECK: [[META10:![0-9]+]] = !{ptr @foo_max0, !"maxntidx", i32 4}
 ; CHECK: [[META11:![0-9]+]] = !{ptr @foo_max1, !"maxntidx", i32 4}


### PR DESCRIPTION
Correct a typo in the NVVM annotation mapping for reqd_work_group_size.

During CUDA 13 testing, I noticed that the following tests fail because of it:
- Basic/reqd_work_group_size.cpp
- Basic/work_group_size_prop.cpp
- Graph/Explicit/work_group_size_prop.cpp
- Graph/RecordReplay/work_group_size_prop.cpp
- Regression/no-split-reqd-wg-size.cpp