### PR TITLE
Revert "[SYCL][Graph][E2E] Disable regression_accessor_spv.cpp on PVC (#21236)"

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/regression_accessor_spv.cpp
+++ b/sycl/test-e2e/Graph/Explicit/regression_accessor_spv.cpp
@@ -5,9 +5,6 @@
 
 // REQUIRES: level_zero
 
-// UNSUPPORTED: arch-intel_gpu_pvc
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21235
-
 // Modified version of Update/update_with_indices_accessor_spv.cpp that does
 // not require the full graph aspect, test was hanging after some changes to
 // kernel bundles so adding this test for the CI which doesn't support update


### PR DESCRIPTION
This reverts commit 9b36da32a47ef5bc9ff62da7c124ca446dc09e7f.
The issue #21235 has been fixed by #21242.

Closes: #21235
