### PR TITLE
[SYCL] Fix rule-of-three Coverity hit

### DIFF
--- a/sycl/include/sycl/detail/cg_types.hpp
+++ b/sycl/include/sycl/detail/cg_types.hpp
@@ -173,6 +173,7 @@ public:
   HostKernelRefBase() = default;
   HostKernelRefBase(const HostKernelRefBase &) = delete;
   HostKernelRefBase &operator=(const HostKernelRefBase &) = delete;
+  ~HostKernelRefBase() = default;
 
   virtual std::unique_ptr<HostKernelBase> takeOrCopyOwnership() const = 0;
 };


### PR DESCRIPTION
Coverity complains:
`sycl::detail::HostKernelRefBase` has a user definition for at least one special function (copy constructor, copy assignment, destructor) but not all. If one of these functions requires a user definition then the others likely do as well.

This PR explicitly adds default destructor to `HostKernelRefBase`