### PR TITLE
[CI] Update oneAPI on Linux

### DIFF
--- a/devops/actions/setup_linux_oneapi_env/action.yml
+++ b/devops/actions/setup_linux_oneapi_env/action.yml
@@ -11,7 +11,7 @@ runs:
         | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
         sudo echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
         | sudo tee /etc/apt/sources.list.d/oneAPI.list && \
-        sudo apt update && sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-2025.0
+        sudo apt update && sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-2025.3
 
         env_before=$(env | sort)         
         source /opt/intel/oneapi/setvars.sh


### PR DESCRIPTION
New version fixes the issues reported in the below bug.

Example run [here](https://github.com/intel/llvm/actions/runs/21920494480/job/63299572644).

Closes: https://github.com/intel/llvm/issues/20879