### PR TITLE
[SYCL] Fix validation layers for Vulkan in bindless images interop tests

### DIFF
--- a/sycl/test-e2e/CommonUtils/vulkan_common.hpp
+++ b/sycl/test-e2e/CommonUtils/vulkan_common.hpp
@@ -179,19 +179,19 @@ VkResult setupInstance() {
   ci.pApplicationInfo = &ai;
   ci.enabledExtensionCount = requiredInstanceExtensions.size();
   ci.ppEnabledExtensionNames = requiredInstanceExtensions.data();
-  std::vector<const char *> layers;
-  bool hasValidationLayer = std::any_of(
-      availableLayers.begin(), availableLayers.end(), [](const auto &layer) {
-        return strcmp(layer.layerName, "VK_LAYER_KHRONOS_validation") == 0;
+  const char *validationLayerName = "VK_LAYER_KHRONOS_validation";
+  bool validationLayerAvailable = std::any_of(
+      availableLayers.begin(), availableLayers.end(), [&](const auto &layer) {
+        return strcmp(layer.layerName, validationLayerName) == 0;
       });
-  if (hasValidationLayer) {
-    layers.push_back("VK_LAYER_KHRONOS_validation");
+
+  if (validationLayerAvailable) {
+    ci.enabledLayerCount = 1;
+    ci.ppEnabledLayerNames = &validationLayerName;
   } else {
-    std::cerr << "Validation layer not available!\n";
-    assert(false);
+    std::cerr
+        << "VK_LAYER_KHRONOS_validation not present, validation is disabled \n";
   }
-  ci.enabledLayerCount = layers.size();
-  ci.ppEnabledLayerNames = layers.data();
 
   VK_CHECK_CALL_RET(vkCreateInstance(&ci, nullptr, &vk_instance));
 


### PR DESCRIPTION
This PR fixes issue which we always had false for `return layer.layerName == "VK_LAYER_KHRONOS_validation"`  because it's comparison of C-style char array to a string literal. The content is ommited.

I removed that whole check. We need for CI always Vulkan validation layers to check for issues on Vulkan side in bindless interop tests.