### PR TITLE
[SYCL][NFC] Enable host-task-failure test

### DIFF
--- a/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: arch-intel_gpu_pvc || arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20961
-
 #include <sycl/detail/core.hpp>
 
 using namespace sycl;


### PR DESCRIPTION
Enable host-task-failure test, as the issue was not reproduced by manual testing.