### PR TITLE
[UR][L0] Query timer resolution in cycles/sec for accurate timestamp

### DIFF
--- a/unified-runtime/source/adapters/level_zero/common.cpp
+++ b/unified-runtime/source/adapters/level_zero/common.cpp
@@ -239,7 +239,7 @@ template <> ze_structure_type_t getZeStructureType<ze_driver_properties_t>() {
   return ZE_STRUCTURE_TYPE_DRIVER_PROPERTIES;
 }
 template <> ze_structure_type_t getZeStructureType<ze_device_properties_t>() {
-  return ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+  return ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2;
 }
 template <>
 ze_structure_type_t getZeStructureType<ze_device_p2p_properties_t>() {

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -586,8 +586,7 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue(static_cast<ur_bool_t>(
         Device->ZeDeviceProperties->flags & ZE_DEVICE_PROPERTY_FLAG_ECC));
   case UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION:
-    return ReturnValue(
-        static_cast<size_t>(Device->ZeDeviceProperties->timerResolution));
+    return ReturnValue(static_cast<size_t>(Device->getTimerResolution()));
   case UR_DEVICE_INFO_LOCAL_MEM_TYPE:
     return ReturnValue(UR_DEVICE_LOCAL_MEM_TYPE_LOCAL);
   case UR_DEVICE_INFO_MAX_CONSTANT_ARGS:
@@ -1772,8 +1771,7 @@ ur_result_t urDeviceGetGlobalTimestamps(
 #endif
   }
 
-  const uint64_t &ZeTimerResolution =
-      Device->ZeDeviceProperties->timerResolution;
+  const double ZeTimerResolution = Device->getTimerResolution();
   const uint64_t TimestampMaxCount = Device->getTimestampMask();
   uint64_t DeviceClockCount, Dummy;
 

--- a/unified-runtime/source/adapters/level_zero/device.hpp
+++ b/unified-runtime/source/adapters/level_zero/device.hpp
@@ -226,6 +226,13 @@ struct ur_device_handle_t_ : ur_object {
     return ValidBits == 64 ? ~0ULL : (1ULL << ValidBits) - 1ULL;
   }
 
+  // Get timer resolution in nanoseconds.
+  // With ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2, timerResolution is in
+  // cycles/sec, so we convert to nanoseconds.
+  double getTimerResolution() {
+    return 1000000000.0 / ZeDeviceProperties->timerResolution;
+  }
+
   // Cache of the immutable device properties.
   ZeCache<ZeStruct<ze_device_properties_t>> ZeDeviceProperties;
   ZeCache<ZeStruct<ze_device_compute_properties_t>> ZeDeviceComputeProperties;

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -539,7 +539,7 @@ ur_result_t urEventGetProfilingInfo(
   ur_device_handle_t Device =
       Event->UrQueue ? Event->UrQueue->Device : Event->Context->Devices[0];
 
-  uint64_t ZeTimerResolution = Device->ZeDeviceProperties->timerResolution;
+  const double ZeTimerResolution = Device->getTimerResolution();
   const uint64_t TimestampMaxValue = Device->getTimestampMask();
 
   UrReturnHelper ReturnValue(PropValueSize, PropValue, PropValueSizeRet);

--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -1618,7 +1618,7 @@ ur_result_t ur_queue_handle_t_::active_barriers::clear() {
 }
 
 void ur_queue_handle_t_::clearEndTimeRecordings() {
-  uint64_t ZeTimerResolution = Device->ZeDeviceProperties->timerResolution;
+  const double ZeTimerResolution = Device->getTimerResolution();
   const uint64_t TimestampMaxValue = Device->getTimestampMask();
 
   for (auto Entry : EndTimeRecordings) {

--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -23,7 +23,7 @@
 static uint64_t adjustEndEventTimestamp(uint64_t adjustedStartTimestamp,
                                         uint64_t endTimestamp,
                                         uint64_t timestampMaxValue,
-                                        uint64_t timerResolution) {
+                                        double timerResolution) {
   // End time needs to be adjusted for resolution and valid bits.
   uint64_t adjustedTimestamp =
       (endTimestamp & timestampMaxValue) * timerResolution;
@@ -78,7 +78,7 @@ void event_profiling_data_t::reset() {
 }
 
 void event_profiling_data_t::recordStartTimestamp(ur_device_handle_t hDevice) {
-  zeTimerResolution = hDevice->ZeDeviceProperties->timerResolution;
+  zeTimerResolution = hDevice->getTimerResolution();
   timestampMaxValue = hDevice->getTimestampMask();
 
   uint64_t deviceStartTimestamp = 0;
@@ -349,7 +349,7 @@ ur_result_t urEventGetProfilingInfo(
 
   ze_kernel_timestamp_result_t tsResult;
 
-  auto zeTimerResolution = hDevice->ZeDeviceProperties->timerResolution;
+  auto zeTimerResolution = hDevice->getTimerResolution();
   auto timestampMaxValue = hDevice->getTimestampMask();
 
   switch (propName) {

--- a/unified-runtime/source/adapters/level_zero/v2/event.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.hpp
@@ -48,7 +48,8 @@ private:
   uint64_t recordEventEndTimestamp = 0;
   uint64_t adjustedEventEndTimestamp = 0;
 
-  uint64_t zeTimerResolution = 0;
+  // Timer resolution in nanoseconds (converted from cycles/sec)
+  double zeTimerResolution = 0;
   uint64_t timestampMaxValue = 0;
 
   bool timestampRecorded = false;


### PR DESCRIPTION
According to [Level Zero spec](https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/api.html#_CPPv4N22ze_device_properties_t15timerResolutionE) the meaning of `timerResolution` depends on `stype`:
- `ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES` -> units are nanoseconds (`uint64`, already rounded)
- `ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2` -> units are cycles/sec (exact value)

Previously we queried using `ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES` and used the integer nanosecond value, which introduced rounding error and reduced timestamp accuracy. 
Instead, query `timerResolution` with `ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2` (cycles/sec) and compute nanoseconds-per-cycle as a double to preserve precision.

This fix improves the accuracy of timestamp reported from `urDeviceGetGlobalTimestamps` and others.