### PR TITLE
[sycl_ext_oneapi_clock] implement NVPTX case

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/clock.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/clock.hpp
@@ -26,15 +26,18 @@ enum class clock_scope : int {
 namespace detail {
 template <clock_scope Scope> inline uint64_t clock_impl() {
 #ifdef __SYCL_DEVICE_ONLY__
+// here note that __builtin_readcyclecounter is used as fallback.
+// this is due to potential higher overhead compared to a native API call
+// see : https://github.com/ROCm/ROCm/issues/1288
 #if defined(__NVPTX__)
   if constexpr (Scope == work_group || Scope == sub_group) {
     return __nvvm_read_ptx_sreg_clock64();
   } else {
-    return 0;
+    return __builtin_readcyclecounter();
   }
 #elif defined(__AMDGCN__)
-  // Currently clock() is not supported on AMDGCN.
-  return 0;
+  // No direct variant of clock() is currently implemented for AMDGCN
+  return __builtin_readcyclecounter();
 #else
   return __spirv_ReadClockKHR(static_cast<int>(Scope));
 #endif // defined(__NVPTX__) || defined(__AMDGCN__)

--- a/sycl/include/sycl/ext/oneapi/experimental/clock.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/clock.hpp
@@ -26,8 +26,14 @@ enum class clock_scope : int {
 namespace detail {
 template <clock_scope Scope> inline uint64_t clock_impl() {
 #ifdef __SYCL_DEVICE_ONLY__
-#if defined(__NVPTX__) || defined(__AMDGCN__)
-  // Currently clock() is not supported on NVPTX and AMDGCN.
+#if defined(__NVPTX__)
+  if constexpr (Scope == work_group || Scope == sub_group) {
+    return __nvvm_read_ptx_sreg_clock64();
+  } else {
+    return 0;
+  }
+#else if defined(__AMDGCN__)
+  // Currently clock() is not supported on AMDGCN.
   return 0;
 #else
   return __spirv_ReadClockKHR(static_cast<int>(Scope));

--- a/sycl/include/sycl/ext/oneapi/experimental/clock.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/clock.hpp
@@ -32,7 +32,7 @@ template <clock_scope Scope> inline uint64_t clock_impl() {
   } else {
     return 0;
   }
-#else if defined(__AMDGCN__)
+#elif defined(__AMDGCN__)
   // Currently clock() is not supported on AMDGCN.
   return 0;
 #else


### PR DESCRIPTION
Hi after suggestion from @zjin-lcf here is a PR (context: https://github.com/KhronosGroup/SYCL-Docs/issues/958).
It implements the NVPTX variant of clock() using the `%%clock64` special register from PTX.

https://docs.nvidia.com/cuda/archive/10.1/parallel-thread-execution/index.html?utm_source=chatgpt.com#special-registers-clock64
```
PTX ISA Notes
Introduced in PTX ISA version 2.0.
```
So it is safe to assume that the register is supported regardless of the PTX version used since intel llvm assume >5.0 if I recall correctly.

reference for usage internally to llvm (on this repo actually, nice :) )
https://github.com/intel/llvm/blob/2705b67a216fda7b32648a2f42d3c2d69d4b6fe3/clang/lib/Headers/__clang_cuda_device_functions.h#L1558

(there is a typo in the PR which is already corrected by a commit, but i don't why it is not updating in the PR ...)