### PR TITLE
[SYCL][DOC] Queue priority extension document

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_queue_priority.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_queue_priority.asciidoc
@@ -103,6 +103,8 @@ commands in queues with lower priority on this device. If the user specifies
 `sycl::ext::oneapi::info::device::priority_range` for the device associated
 with the queue, `priority_value` will be clamped down or up to the lowest or
 highest priority in the range. Lower numbers imply greater priorities.
+If the property is not set for a queue, the default priority for that queue is
+assumed to be 0.
 
 === New device information descriptor
 


### PR DESCRIPTION
Added a document describing the queue priority extension. The extension allows to specify a priority as a number when the queue is created, and allows to query the supported priority range.

The original PR: [#7228](https://github.com/intel/llvm/pull/7228)