### PR TITLE
[SYCL][E2E] Add RUN-IF lit keyword

### DIFF
--- a/sycl/test-e2e/NonUniformGroups/chunk.cpp
+++ b/sycl/test-e2e/NonUniformGroups/chunk.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 //
 // Test CPU AOT as well when possible.
-// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
-// RUN: %if cpu && opencl-aot %{ %{run} %t.x86.out %}
+// RUN-IF: any-device-is-cpu && opencl-aot, %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
+// RUN-IF: cpu, %{run} %t.x86.out
 //
 // REQUIRES: cpu || gpu
 // REQUIRES: sg-32

--- a/sycl/test-e2e/NonUniformGroups/chunk_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/chunk_algorithms.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 //
 // Test CPU AOT as well when possible.
-// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-device-code-split=per_kernel -o %t.x86.out %s %}
-// RUN: %if cpu && opencl-aot %{ %{run} %t.x86.out %}
+// RUN-IF: any-device-is-cpu && opencl-aot, %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-device-code-split=per_kernel -o %t.x86.out %s
+// RUN-IF: cpu, %{run} %t.x86.out
 //
 // REQUIRES: cpu || gpu
 // REQUIRES: sg-32

--- a/sycl/test-e2e/NonUniformGroups/fragment.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fragment.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 //
 // Test CPU AOT as well when possible.
-// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
-// RUN: %if cpu && opencl-aot %{ %{run} %t.x86.out %}
+// RUN-IF: any-device-is-cpu && opencl-aot, %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
+// RUN-IF: cpu, %{run} %t.x86.out
 //
 // REQUIRES: cpu || gpu
 // REQUIRES: aspect-ext_oneapi_fragment

--- a/sycl/test-e2e/NonUniformGroups/fragment_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fragment_algorithms.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 //
 // Test CPU AOT as well when possible.
-// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
-// RUN: %if cpu && opencl-aot %{ %{run} %t.x86.out %}
+// RUN-IF: any-device-is-cpu && opencl-aot, %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
+// RUN-IF: cpu, %{run} %t.x86.out
 //
 // REQUIRES: cpu || gpu
 // REQUIRES: sg-32

--- a/sycl/test-e2e/NonUniformGroups/opportunistic.cpp
+++ b/sycl/test-e2e/NonUniformGroups/opportunistic.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 //
 // Test CPU AOT as well when possible.
-// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
-// RUN: %if cpu && opencl-aot %{ %{run} %t.x86.out %}
+// RUN-IF: any-device-is-cpu && opencl-aot, %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
+// RUN-IF: cpu, %{run} %t.x86.out
 //
 // REQUIRES: cpu || gpu
 // REQUIRES: aspect-ext_oneapi_fragment

--- a/sycl/test-e2e/NonUniformGroups/opportunistic_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/opportunistic_algorithms.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 //
 // Test CPU AOT as well when possible.
-// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s %}
-// RUN: %if cpu && opencl-aot %{ %{run} %t.x86.out %}
+// RUN-IF: any-device-is-cpu && opencl-aot, %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
+// RUN-IF: cpu, %{run} %t.x86.out
 //
 // REQUIRES: cpu || gpu
 // REQUIRES: sg-32

--- a/sycl/test-e2e/NonUniformGroups/tangle.cpp
+++ b/sycl/test-e2e/NonUniformGroups/tangle.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 //
 // Test CPU AOT as well when possible.
-// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s %}
-// RUN: %if cpu && opencl-aot %{ %{run} %t.x86.out %}
+// RUN-IF: any-device-is-cpu && opencl-aot, %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s
+// RUN-IF: cpu, %{run} %t.x86.out
 //
 // REQUIRES: cpu || gpu
 // REQUIRES: aspect-ext_oneapi_tangle

--- a/sycl/test-e2e/NonUniformGroups/tangle_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/tangle_algorithms.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 //
 // Test CPU AOT as well when possible.
-// RUN: %if any-device-is-cpu && opencl-aot %{ %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s %}
-// RUN: %if cpu && opencl-aot %{ %{run} %t.x86.out %}
+// RUN-IF: any-device-is-cpu && opencl-aot, %{run-aux} %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fno-sycl-early-optimizations -o %t.x86.out %s
+// RUN-IF: cpu, %{run} %t.x86.out
 //
 // REQUIRES: sg-32
 // REQUIRES: aspect-ext_oneapi_tangle

--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -11,6 +11,7 @@
   * [llvm-lit parameters](#llvm-lit-parameters)
   * [Marking tests as expected to fail](#marking-tests-as-expected-to-fail)
   * [Marking tests as unsupported](#marking-tests-as-unsupported)
+  * [RUN-IF](#RUN-IF)
 * [SYCL core header file](#sycl-core-header-file)
 * [Compiling and executing tests on separate systems](#compiling-and-executing-tests-on-separate-systems)
   * [Run only mode](#run-only-mode)
@@ -395,6 +396,21 @@ Note: please avoid using `REQUIRES: TEMPORARY_DISABLED` for this purpose, it's a
 non-standard mechanism. Use `UNSUPPORTED: true` instead, we track `UNSUPPORTED`
 tests using the mechanism described above. Otherwise the test risks remaining
 untraceable.
+
+#### RUN-IF
+
+As a convenience, we provide the `RUN-IF` lit keyword, which simplifies running
+commands conditionally.  The syntax is:
+  
+```bash
+RUN-IF: condition, command
+```
+
+A full example would be:
+
+```bash
+RUN-IF: cpu, %{run} %t_cpu.out
+```
 
 ### SYCL core header file
 

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -51,6 +51,47 @@ def parse_min_intel_driver_req(line_number, line, output):
     return output
 
 
+def parse_run_if(line_number, line, output):
+    """
+    Parse RUN-IF directive in the format:
+    // RUN-IF: condition, command
+    where condition is a boolean expression and command is the command to execute.
+    Returns a CommandDirective with the condition embedded in the command as %if.
+    """
+    if not output:
+        output = []
+
+    # Split on first comma to separate condition from command
+    parts = line.split(",", 1)
+    if len(parts) != 2:
+        raise ValueError(
+            f"Line {line_number}: RUN-IF directive must have format: condition, command"
+        )
+
+    condition = parts[0].strip()
+    command = parts[1].strip()
+
+    if not condition or not command:
+        raise ValueError(
+            f"Line {line_number}: RUN-IF directive has empty condition or command"
+        )
+
+    # Strip outer %{ %} if present to avoid nested braces
+    if command.startswith("%{") and command.endswith("%}"):
+        command = command[2:-2].strip()
+
+    # Convert RUN-IF to a RUN command with %if condition
+    # This leverages lit's built-in conditional support
+    conditional_command = f"%if {condition} %{{ {command} %}}"
+
+    output.append(
+        lit.TestRunner.CommandDirective(
+            line_number, line_number, "RUN:", conditional_command
+        )
+    )
+    return output
+
+
 class SYCLEndToEndTest(lit.formats.ShTest):
     def parseTestScript(self, test):
         """This is based on lit.TestRunner.parseIntegratedTestScript but we
@@ -66,15 +107,28 @@ class SYCLEndToEndTest(lit.formats.ShTest):
                         "REQUIRES-INTEL-DRIVER:",
                         ParserKind.CUSTOM,
                         parse_min_intel_driver_req,
-                    )
+                    ),
+                    IntegratedTestKeywordParser(
+                        "RUN-IF:", ParserKind.CUSTOM, parse_run_if
+                    ),
                 ],
-                require_script=True,
+                require_script=False,
             )
         except ValueError as e:
             return lit.Test.Result(lit.Test.UNRESOLVED, str(e))
         script = parsed["RUN:"] or []
         assert parsed["DEFINE:"] == script
         assert parsed["REDEFINE:"] == script
+
+        # Add RUN-IF commands to the script
+        if parsed["RUN-IF:"]:
+            script.extend(parsed["RUN-IF:"])
+
+        # Ensure we have at least one command (RUN or RUN-IF)
+        if not script:
+            return lit.Test.Result(
+                lit.Test.UNRESOLVED, "Test has no 'RUN:' or 'RUN-IF:' line"
+            )
 
         test.xfails += test.config.xfail_features
         test.xfails += parsed["XFAIL:"] or []


### PR DESCRIPTION
Add a new LIT keyword, `RUN-IF`, to simplify conditional commands in LIT tests.

This is useful for when you have a single test but need to do different things depending on the environment.

You can arleady to this today, but the syntax is verbose, something like `RUN: %if condition %{ case %} %else %{ another_case %}` 

We are planning to use the immediately in interop tests.

I modified some exists tests using the verbose syntax to lock down this new syntax.