### PR TITLE
[L0v2][SYCL] fix: use command lists in map and unmap for integrated buffers

### DIFF
--- a/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
+++ b/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 //==- handler.cpp - SYCL handler explicit memory operations test -*- C++-*--==//
 //

--- a/sycl/test-e2e/Basic/queue/queue_shortcut_functions.cpp
+++ b/sycl/test-e2e/Basic/queue/queue_shortcut_functions.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if level_zero %{ env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_V2_FORCE_BATCHED=1 %{run} %t.out %}
 
 //==-- queue_shortcut_functions.cpp - SYCL queue shortcut functions test ---==//
 //

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -148,10 +148,9 @@ void *ur_integrated_buffer_handle_t::mapHostPtr(
 
     if (flags & UR_MAP_FLAG_READ) {
       // Use Level Zero copy for USM HOST memory to ensure GPU visibility
-       ZE_CALL_NOCHECK(zeCommandListAppendMemoryCopy,
-             (cmdList, mappedPtr,
-                                       ur_cast<char *>(ptr.get()) + offset,
-                                       mapSize, nullptr, 0, nullptr));
+      ZE_CALL_NOCHECK(zeCommandListAppendMemoryCopy,
+                      (cmdList, mappedPtr, ur_cast<char *>(ptr.get()) + offset,
+                       mapSize, nullptr, 0, nullptr));
     }
 
     // Track this mapping for unmap
@@ -184,9 +183,10 @@ void ur_integrated_buffer_handle_t::unmapHostPtr(
     if (mappedRegion->flags &
         (UR_MAP_FLAG_WRITE | UR_MAP_FLAG_WRITE_INVALIDATE_REGION)) {
       // Use Level Zero copy for USM HOST memory to ensure GPU visibility
-      ZE_CALL_NOCHECK(zeCommandListAppendMemoryCopy,
-             (cmdList, ur_cast<char *>(ptr.get()) + mappedRegion->offset,
-          mappedRegion->ptr.get(), mappedRegion->size, nullptr, 0, nullptr));
+      ZE_CALL_NOCHECK(
+          zeCommandListAppendMemoryCopy,
+          (cmdList, ur_cast<char *>(ptr.get()) + mappedRegion->offset,
+           mappedRegion->ptr.get(), mappedRegion->size, nullptr, 0, nullptr));
     }
 
     mappedRegions.erase(mappedRegion);


### PR DESCRIPTION
ur_integrated_buffer_handle_t::mapHostPtr and
ur_integrated_buffer_handle_t::unmapHostPtr used to ignore command
lists passed as arguments, instead creating additional command lists
for memory copy, which led to copying the buffer content before
the completion of operations enqueued on the command lists. Now memory copy
is enqueued on the provided command lists, following previously
submitted tasks and ensuring the correct order of operations.

This fix applies to all queue types.

Moreover, this patch adds SYCL e2e tests for batched queues, which would have failed before the introduced fix.