### PR TITLE
[SYCL][Doc] Less verbose name for proposed FP4,8

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp4.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp4.asciidoc
@@ -192,7 +192,7 @@ The following table provides the special values of the E2M1 type.
 
 |====
 
-This extension adds the `fp4_e2m1` type, which represents a set of packed E2M1
+This extension adds the `fp4_e2m1_x` type, which represents a set of packed E2M1
 values and provides various conversions to other types.
 The number of packed elements is defined by the `N` template parameter, which
 must be either 1 or 2.
@@ -202,87 +202,87 @@ must be either 1 or 2.
 namespace sycl::ext::oneapi::experimental {
 
 template<size_t N>
-class fp4_e2m1 {
+class fp4_e2m1_x {
  public:
-  fp4_e2m1() = default;
-  fp4_e2m1(const fp4_e2m1 &) = default;
-  ~fp4_e2m1() = default;
-  fp4_e2m1& operator=(const fp4_e2m1&) = default;
+  fp4_e2m1_x() = default;
+  fp4_e2m1_x(const fp4_e2m1_x &) = default;
+  ~fp4_e2m1_x() = default;
+  fp4_e2m1_x& operator=(const fp4_e2m1_x&) = default;
 
   // Construct from pack of half, bfloat16, float, double.
   // Available only when the size of the pack is equal to N.
 
   // Available only when each type in the pack is half.
   template<typename... Halfs>
-  explicit fp4_e2m1(Halfs... vals);
+  explicit fp4_e2m1_x(Halfs... vals);
 
   // Available only when each type in the pack is bfloat16.
   template<typename... Bfloats>
-  explicit fp4_e2m1(Bfloats... vals);
+  explicit fp4_e2m1_x(Bfloats... vals);
 
   // Available only when each type in the pack is float.
   template<typename... Floats>
-  explicit fp4_e2m1(Floats... vals);
+  explicit fp4_e2m1_x(Floats... vals);
 
   // Available only when each type in the pack is double.
   template<typename... Doubles>
-  explicit fp4_e2m1(Doubles... vals);
+  explicit fp4_e2m1_x(Doubles... vals);
 
   // Construct from an array of half, bfloat16, float, double.
 
-  explicit fp4_e2m1(half const (&vals)[N], rounding r = rounding::to_even);
-  explicit fp4_e2m1(bfloat16 const (&vals)[N], rounding r = rounding::to_even);
-  explicit fp4_e2m1(float const (&vals)[N], rounding r = rounding::to_even);
-  explicit fp4_e2m1(double const (&vals)[N]);
+  explicit fp4_e2m1_x(half const (&vals)[N], rounding r = rounding::to_even);
+  explicit fp4_e2m1_x(bfloat16 const (&vals)[N], rounding r = rounding::to_even);
+  explicit fp4_e2m1_x(float const (&vals)[N], rounding r = rounding::to_even);
+  explicit fp4_e2m1_x(double const (&vals)[N]);
 
   // Construct from an marray of half, bfloat16, float, double.
 
-  explicit fp4_e2m1(const marray<half,N>& vals, rounding r = rounding::to_even);
-  explicit fp4_e2m1(const marray<bfloat16,N>& vals, rounding r = rounding::to_even);
-  explicit fp4_e2m1(const marray<float,N>& vals, rounding r = rounding::to_even);
-  explicit fp4_e2m1(const marray<double,N>& vals);
+  explicit fp4_e2m1_x(const marray<half,N>& vals, rounding r = rounding::to_even);
+  explicit fp4_e2m1_x(const marray<bfloat16,N>& vals, rounding r = rounding::to_even);
+  explicit fp4_e2m1_x(const marray<float,N>& vals, rounding r = rounding::to_even);
+  explicit fp4_e2m1_x(const marray<double,N>& vals);
 
   // Construct with stochastic rounding with user provided seed from an array of
   // half, bfloat16, float.
 
-  explicit fp4_e2m1(half const (&vals)[N], const stochastic_seed& seed);
-  explicit fp4_e2m1(bfloat16 const (&vals)[N], const stochastic_seed& seed);
-  explicit fp4_e2m1(float const (&vals)[N], const stochastic_seed& seed);
+  explicit fp4_e2m1_x(half const (&vals)[N], const stochastic_seed& seed);
+  explicit fp4_e2m1_x(bfloat16 const (&vals)[N], const stochastic_seed& seed);
+  explicit fp4_e2m1_x(float const (&vals)[N], const stochastic_seed& seed);
 
   // Construct with stochastic rounding with user provided seed from an marray
   // of half, bfloat16, float.
 
-  explicit fp4_e2m1(const marray<half,N>& vals, const stochastic_seed& seed);
-  explicit fp4_e2m1(const marray<bfloat16,N>& vals, const stochastic_seed& seed);
-  explicit fp4_e2m1(const marray<float,N>& vals, const stochastic_seed& seed);
+  explicit fp4_e2m1_x(const marray<half,N>& vals, const stochastic_seed& seed);
+  explicit fp4_e2m1_x(const marray<bfloat16,N>& vals, const stochastic_seed& seed);
+  explicit fp4_e2m1_x(const marray<float,N>& vals, const stochastic_seed& seed);
 
   // Construct from integer types.
   // Available only when N==1.
 
-  explicit fp4_e2m1(short val);
-  explicit fp4_e2m1(int val);
-  explicit fp4_e2m1(long val);
-  explicit fp4_e2m1(long long val);
-  explicit fp4_e2m1(unsigned short val);
-  explicit fp4_e2m1(unsigned int val);
-  explicit fp4_e2m1(unsigned long val);
-  explicit fp4_e2m1(unsigned long long val);
+  explicit fp4_e2m1_x(short val);
+  explicit fp4_e2m1_x(int val);
+  explicit fp4_e2m1_x(long val);
+  explicit fp4_e2m1_x(long long val);
+  explicit fp4_e2m1_x(unsigned short val);
+  explicit fp4_e2m1_x(unsigned int val);
+  explicit fp4_e2m1_x(unsigned long val);
+  explicit fp4_e2m1_x(unsigned long long val);
 
   // Assign (operator) from half, bfloat16, float, double, and integer types.
   // Available only when N==1.
 
-  fp4_e2m1& operator=(half val);
-  fp4_e2m1& operator=(bfloat16 val);
-  fp4_e2m1& operator=(float val);
-  fp4_e2m1& operator=(double val);
-  fp4_e2m1& operator=(short val);
-  fp4_e2m1& operator=(int val);
-  fp4_e2m1& operator=(long val);
-  fp4_e2m1& operator=(long long val);
-  fp4_e2m1& operator=(unsigned short val);
-  fp4_e2m1& operator=(unsigned int val);
-  fp4_e2m1& operator=(unsigned long val);
-  fp4_e2m1& operator=(unsigned long long val);
+  fp4_e2m1_x& operator=(half val);
+  fp4_e2m1_x& operator=(bfloat16 val);
+  fp4_e2m1_x& operator=(float val);
+  fp4_e2m1_x& operator=(double val);
+  fp4_e2m1_x& operator=(short val);
+  fp4_e2m1_x& operator=(int val);
+  fp4_e2m1_x& operator=(long val);
+  fp4_e2m1_x& operator=(long long val);
+  fp4_e2m1_x& operator=(unsigned short val);
+  fp4_e2m1_x& operator=(unsigned int val);
+  fp4_e2m1_x& operator=(unsigned long val);
+  fp4_e2m1_x& operator=(unsigned long long val);
 
   // Convert to half, bfloat16, float, double.
   // Available only when N==1.
@@ -325,7 +325,11 @@ class fp4_e2m1 {
 
 // Deduction guide available only when the size of the pack is greater than zero.
 template<typename... Ts>
-fp4_e2m1(Ts...) -> fp4_e2m1<sizeof...(Ts)>;
+fp4_e2m1_x(Ts...) -> fp4_e2m1_x<sizeof...(Ts)>;
+
+// Convenience aliases
+using fp4_e2m1 = fp4_e2m1_x<1>;
+using fp4_e2m1_x2 = fp4_e2m1_x<2>;
 
 } // namespace sycl::ext::oneapi::experimental
 ----
@@ -334,10 +338,10 @@ fp4_e2m1(Ts...) -> fp4_e2m1<sizeof...(Ts)>;
 
 [source,c++]
 ----
-fp4_e2m1() = default;
-fp4_e2m1(const fp4_e2m1 &) = default;
-~fp4_e2m1() = default;
-fp4_e2m1& operator=(const fp4_e2m1&) = default;
+fp4_e2m1_x() = default;
+fp4_e2m1_x(const fp4_e2m1_x &) = default;
+~fp4_e2m1_x() = default;
+fp4_e2m1_x& operator=(const fp4_e2m1_x&) = default;
 ----
 
 The default constructor, copy constructor, destructor, and copy assignment
@@ -347,17 +351,17 @@ operator are all trivial.
 
 [source,c++]
 ----
-template<typename... Halfs>          (1)
-explicit fp4_e2m1(Halfs... vals);
+template<typename... Halfs>            (1)
+explicit fp4_e2m1_x(Halfs... vals);
 
-template<typename... Bfloats>        (2)
-explicit fp4_e2m1(Bfloats... vals);
+template<typename... Bfloats>          (2)
+explicit fp4_e2m1_x(Bfloats... vals);
 
-template<typename... Floats>         (3)
-explicit fp4_e2m1(Floats... vals);
+template<typename... Floats>           (3)
+explicit fp4_e2m1_x(Floats... vals);
 
-template<typename... Doubles>        (4)
-explicit fp4_e2m1(Doubles... vals);
+template<typename... Doubles>          (4)
+explicit fp4_e2m1_x(Doubles... vals);
 ----
 
 _Constraints_ (1): The size of the `Halfs` pack is `N` and each type in this
@@ -372,7 +376,7 @@ pack is `float`.
 _Constraints_ (4): The size of the `Doubles` pack is `N` and each type in this
 pack is `double`.
 
-_Effects:_ Initializes each element of this `fp4_e2m1` object from the
+_Effects:_ Initializes each element of this `fp4_e2m1_x` object from the
 corresponding value in the `vals` pack.
 Each value is converted using the `rounding::to_even` rounding mode.
 
@@ -380,13 +384,13 @@ Each value is converted using the `rounding::to_even` rounding mode.
 
 [source,c++]
 ----
-explicit fp4_e2m1(half const (&vals)[N], rounding r = rounding::to_even);      (1)
-explicit fp4_e2m1(bfloat16 const (&vals)[N], rounding r = rounding::to_even);  (2)
-explicit fp4_e2m1(float const (&vals)[N], rounding r = rounding::to_even);     (3)
-explicit fp4_e2m1(double const (&vals)[N]);                                    (4)
+explicit fp4_e2m1_x(half const (&vals)[N], rounding r = rounding::to_even);      (1)
+explicit fp4_e2m1_x(bfloat16 const (&vals)[N], rounding r = rounding::to_even);  (2)
+explicit fp4_e2m1_x(float const (&vals)[N], rounding r = rounding::to_even);     (3)
+explicit fp4_e2m1_x(double const (&vals)[N]);                                    (4)
 ----
 
-_Effects:_ Initializes each element of this `fp4_e2m1` object from the
+_Effects:_ Initializes each element of this `fp4_e2m1_x` object from the
 corresponding element in the array `vals`.
 In overloads (1) - (3), each value is converted using the `r` rounding mode.
 In overload (4), each value is converted using the `rounding::to_even` rounding
@@ -402,13 +406,13 @@ _Target Support:_ The rounding mode `r` has the following restrictions:
 
 [source,c++]
 ----
-explicit fp4_e2m1(const marray<half,N>& vals, rounding r = rounding::to_even);      (1)
-explicit fp4_e2m1(const marray<bfloat16,N>& vals, rounding r = rounding::to_even);  (2)
-explicit fp4_e2m1(const marray<float,N>& vals, rounding r = rounding::to_even);     (3)
-explicit fp4_e2m1(const marray<double,N>& vals);                                    (4)
+explicit fp4_e2m1_x(const marray<half,N>& vals, rounding r = rounding::to_even);      (1)
+explicit fp4_e2m1_x(const marray<bfloat16,N>& vals, rounding r = rounding::to_even);  (2)
+explicit fp4_e2m1_x(const marray<float,N>& vals, rounding r = rounding::to_even);     (3)
+explicit fp4_e2m1_x(const marray<double,N>& vals);                                    (4)
 ----
 
-_Effects:_ Initializes each element of this `fp4_e2m1` object from the
+_Effects:_ Initializes each element of this `fp4_e2m1_x` object from the
 corresponding element in the `marray` object `vals`.
 In overloads (1) - (3), each value is converted using the `r` rounding mode.
 In overload (4), each value is converted using the `rounding::to_even` rounding
@@ -424,12 +428,12 @@ _Target Support:_ The rounding mode `r` has the following restrictions:
 
 [source,c++]
 ----
-explicit fp4_e2m1(half const (&vals)[N], const stochastic_seed& seed);
-explicit fp4_e2m1(bfloat16 const (&vals)[N], const stochastic_seed& seed);
-explicit fp4_e2m1(float const (&vals)[N], const stochastic_seed& seed);
+explicit fp4_e2m1_x(half const (&vals)[N], const stochastic_seed& seed);
+explicit fp4_e2m1_x(bfloat16 const (&vals)[N], const stochastic_seed& seed);
+explicit fp4_e2m1_x(float const (&vals)[N], const stochastic_seed& seed);
 ----
 
-_Effects:_ Initializes each element of this `fp4_e2m1` object from the
+_Effects:_ Initializes each element of this `fp4_e2m1_x` object from the
 corresponding value in the array `vals` using stochastic rounding.
 The pseudo-random biases are created deterministically using the seed value
 referenced by the helper object `seed`.
@@ -449,12 +453,12 @@ They are only supported in device code as follows:
 
 [source,c++]
 ----
-explicit fp4_e2m1(const marray<half,N>& vals, const stochastic_seed& seed);
-explicit fp4_e2m1(const marray<bfloat16,N>& vals, const stochastic_seed& seed);
-explicit fp4_e2m1(const marray<float,N>& vals, const stochastic_seed& seed);
+explicit fp4_e2m1_x(const marray<half,N>& vals, const stochastic_seed& seed);
+explicit fp4_e2m1_x(const marray<bfloat16,N>& vals, const stochastic_seed& seed);
+explicit fp4_e2m1_x(const marray<float,N>& vals, const stochastic_seed& seed);
 ----
 
-_Effects:_ Initializes each element of this `fp4_e2m1` object from the
+_Effects:_ Initializes each element of this `fp4_e2m1_x` object from the
 corresponding value in the `marray` object `vals` using stochastic rounding.
 The pseudo-random biases are created deterministically using the seed value
 referenced by the helper object `seed`.
@@ -474,19 +478,19 @@ They are only supported in device code as follows:
 
 [source,c++]
 ----
-explicit fp4_e2m1(short val);
-explicit fp4_e2m1(int val);
-explicit fp4_e2m1(long val);
-explicit fp4_e2m1(long long val);
-explicit fp4_e2m1(unsigned short val);
-explicit fp4_e2m1(unsigned int val);
-explicit fp4_e2m1(unsigned long val);
-explicit fp4_e2m1(unsigned long long val);
+explicit fp4_e2m1_x(short val);
+explicit fp4_e2m1_x(int val);
+explicit fp4_e2m1_x(long val);
+explicit fp4_e2m1_x(long long val);
+explicit fp4_e2m1_x(unsigned short val);
+explicit fp4_e2m1_x(unsigned int val);
+explicit fp4_e2m1_x(unsigned long val);
+explicit fp4_e2m1_x(unsigned long long val);
 ----
 
 _Constraints:_ `N == 1`.
 
-_Effects:_ Initializes the single element of this `fp4_e2m1` object from `val`.
+_Effects:_ Initializes the single element of this `fp4_e2m1_x` object from `val`.
 The value `val` is converted using the `rounding::to_even` rounding mode.
 
 '''
@@ -495,26 +499,26 @@ The value `val` is converted using the `rounding::to_even` rounding mode.
 
 [source,c++]
 ----
-fp4_e2m1& operator=(half val);
-fp4_e2m1& operator=(bfloat16 val);
-fp4_e2m1& operator=(float val);
-fp4_e2m1& operator=(double val);
-fp4_e2m1& operator=(short val);
-fp4_e2m1& operator=(int val);
-fp4_e2m1& operator=(long val);
-fp4_e2m1& operator=(long long val);
-fp4_e2m1& operator=(unsigned short val);
-fp4_e2m1& operator=(unsigned int val);
-fp4_e2m1& operator=(unsigned long val);
-fp4_e2m1& operator=(unsigned long long val);
+fp4_e2m1_x& operator=(half val);
+fp4_e2m1_x& operator=(bfloat16 val);
+fp4_e2m1_x& operator=(float val);
+fp4_e2m1_x& operator=(double val);
+fp4_e2m1_x& operator=(short val);
+fp4_e2m1_x& operator=(int val);
+fp4_e2m1_x& operator=(long val);
+fp4_e2m1_x& operator=(long long val);
+fp4_e2m1_x& operator=(unsigned short val);
+fp4_e2m1_x& operator=(unsigned int val);
+fp4_e2m1_x& operator=(unsigned long val);
+fp4_e2m1_x& operator=(unsigned long long val);
 ----
 
 _Constraints:_ `N == 1`.
 
-_Effects:_ Assigns the single element of this `fp4_e2m1` object to `val`.
+_Effects:_ Assigns the single element of this `fp4_e2m1_x` object to `val`.
 The value `val` is converted using the `rounding::to_even` rounding mode.
 
-_Returns:_ A reference to this `fp4_e2m1` object.
+_Returns:_ A reference to this `fp4_e2m1_x` object.
 
 ==== Conversion operators
 
@@ -528,7 +532,7 @@ explicit operator double() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The single element of this `fp4_e2m1` object is converted to the
+_Returns_: The single element of this `fp4_e2m1_x` object is converted to the
 operator's respective type.
 
 [_Note:_ These conversions are exact, so there is no rounding mode.
@@ -553,7 +557,7 @@ explicit operator unsigned long long() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The single element of this `fp4_e2m1` object is converted to the
+_Returns_: The single element of this `fp4_e2m1_x` object is converted to the
 operator's respective type using the `rounding::toward_zero` rounding mode.
 
 '''
@@ -565,7 +569,7 @@ explicit operator bool() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The value `false` if the single element of this `fp4_e2m1` is either
+_Returns_: The value `false` if the single element of this `fp4_e2m1_x` is either
 +0 or -0.
 Otherwise, returns the value `true`.
 
@@ -578,7 +582,7 @@ explicit operator marray<bfloat16,N>() const;  (2)
 explicit operator marray<float,N>() const;     (3)
 ----
 
-_Returns:_ The values of this `fp4_e2m1` object are converted to an `marray` of
+_Returns:_ The values of this `fp4_e2m1_x` object are converted to an `marray` of
 `half`, `ext::oneapi::bfloat16`, or `float`.
 
 [_Note:_ These conversions are exact, so there is no rounding mode.
@@ -593,7 +597,7 @@ _{endnote}_]
 uint8_t vals[(N+1)/2];
 ----
 
-Provides direct access to the storage of the E2M1 values in this `fp4_e2m1`
+Provides direct access to the storage of the E2M1 values in this `fp4_e2m1_x`
 object.
 Element 0 is in the low 4 bits of `vals[0]`.
 Element 1 (if it exists) is in the high 4 bits of `vals[0]`.
@@ -603,10 +607,20 @@ Element 1 (if it exists) is in the high 4 bits of `vals[0]`.
 [source,c++]
 ----
 template<typename... Ts>
-fp4_e2m1(Ts...) -> fp4_e2m1<sizeof...(Ts)>;
+fp4_e2m1_x(Ts...) -> fp4_e2m1_x<sizeof...(Ts)>;
 ----
 
 _Constraints:_ The size of the `Ts` pack is greater than zero.
+
+==== Convenience aliases
+
+[source,c++]
+----
+using fp4_e2m1 = fp4_e2m1_x<1>;
+using fp4_e2m1_x2 = fp4_e2m1_x<2>;
+----
+
+These aliases provide less verbose syntax for common use cases.
 
 ==== Non-stochastic rounding modes
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
@@ -244,7 +244,7 @@ The following table provides the special values of the E4M3 type.
 | S.1111.111
 |====
 
-This extension adds the `fp8_e4m3` type, which represents a set of packed E4M3
+This extension adds the `fp8_e4m3_x` type, which represents a set of packed E4M3
 values and provides various conversions to other types.
 The number of packed elements is defined by the `N` template parameter, which
 must be either 1 or 2.
@@ -254,73 +254,73 @@ must be either 1 or 2.
 namespace sycl::ext::oneapi::experimental {
 
 template<size_t N>
-class fp8_e4m3 {
+class fp8_e4m3_x {
  public:
-  fp8_e4m3() = default;
-  fp8_e4m3(const fp8_e4m3 &) = default;
-  ~fp8_e4m3() = default;
-  fp8_e4m3& operator=(const fp8_e4m3&) = default;
+  fp8_e4m3_x() = default;
+  fp8_e4m3_x(const fp8_e4m3_x &) = default;
+  ~fp8_e4m3_x() = default;
+  fp8_e4m3_x& operator=(const fp8_e4m3_x&) = default;
 
   // Construct from pack of half, bfloat16, float, double.
   // Available only when the size of the pack is equal to N.
 
   // Available only when each type in the pack is half.
   template<typename... Halfs>
-  explicit fp8_e4m3(Halfs... vals);
+  explicit fp8_e4m3_x(Halfs... vals);
 
   // Available only when each type in the pack is bfloat16.
   template<typename... Bfloats>
-  explicit fp8_e4m3(Bfloats... vals);
+  explicit fp8_e4m3_x(Bfloats... vals);
 
   // Available only when each type in the pack is float.
   template<typename... Floats>
-  explicit fp8_e4m3(Floats... vals);
+  explicit fp8_e4m3_x(Floats... vals);
 
   // Available only when each type in the pack is double.
   template<typename... Doubles>
-  explicit fp8_e4m3(Doubles... vals);
+  explicit fp8_e4m3_x(Doubles... vals);
 
   // Construct from an array of half, bfloat16, float, double.
 
-  explicit fp8_e4m3(half const (&vals)[N], rounding r = rounding::to_even);
-  explicit fp8_e4m3(bfloat16 const (&vals)[N], rounding r = rounding::to_even);
-  explicit fp8_e4m3(float const (&vals)[N], rounding r = rounding::to_even);
-  explicit fp8_e4m3(double const (&vals)[N]);
+  explicit fp8_e4m3_x(half const (&vals)[N], rounding r = rounding::to_even);
+  explicit fp8_e4m3_x(bfloat16 const (&vals)[N], rounding r = rounding::to_even);
+  explicit fp8_e4m3_x(float const (&vals)[N], rounding r = rounding::to_even);
+  explicit fp8_e4m3_x(double const (&vals)[N]);
 
   // Construct from an marray of half, bfloat16, float, double.
 
-  explicit fp8_e4m3(const marray<half,N>& vals, rounding r = rounding::to_even);
-  explicit fp8_e4m3(const marray<bfloat16,N>& vals, rounding r = rounding::to_even);
-  explicit fp8_e4m3(const marray<float,N>& vals, rounding r = rounding::to_even);
-  explicit fp8_e4m3(const marray<double,N>& vals);
+  explicit fp8_e4m3_x(const marray<half,N>& vals, rounding r = rounding::to_even);
+  explicit fp8_e4m3_x(const marray<bfloat16,N>& vals, rounding r = rounding::to_even);
+  explicit fp8_e4m3_x(const marray<float,N>& vals, rounding r = rounding::to_even);
+  explicit fp8_e4m3_x(const marray<double,N>& vals);
 
   // Construct from integer types.
   // Available only when N==1.
 
-  explicit fp8_e4m3(short val);
-  explicit fp8_e4m3(int val);
-  explicit fp8_e4m3(long val);
-  explicit fp8_e4m3(long long val);
-  explicit fp8_e4m3(unsigned short val);
-  explicit fp8_e4m3(unsigned int val);
-  explicit fp8_e4m3(unsigned long val);
-  explicit fp8_e4m3(unsigned long long val);
+  explicit fp8_e4m3_x(short val);
+  explicit fp8_e4m3_x(int val);
+  explicit fp8_e4m3_x(long val);
+  explicit fp8_e4m3_x(long long val);
+  explicit fp8_e4m3_x(unsigned short val);
+  explicit fp8_e4m3_x(unsigned int val);
+  explicit fp8_e4m3_x(unsigned long val);
+  explicit fp8_e4m3_x(unsigned long long val);
 
   // Assign (operator) from half, bfloat16, float, double, and integer types.
   // Available only when N==1.
 
-  fp8_e4m3& operator=(half val);
-  fp8_e4m3& operator=(bfloat16 val);
-  fp8_e4m3& operator=(float val);
-  fp8_e4m3& operator=(double val);
-  fp8_e4m3& operator=(short val);
-  fp8_e4m3& operator=(int val);
-  fp8_e4m3& operator=(long val);
-  fp8_e4m3& operator=(long long val);
-  fp8_e4m3& operator=(unsigned short val);
-  fp8_e4m3& operator=(unsigned int val);
-  fp8_e4m3& operator=(unsigned long val);
-  fp8_e4m3& operator=(unsigned long long val);
+  fp8_e4m3_x& operator=(half val);
+  fp8_e4m3_x& operator=(bfloat16 val);
+  fp8_e4m3_x& operator=(float val);
+  fp8_e4m3_x& operator=(double val);
+  fp8_e4m3_x& operator=(short val);
+  fp8_e4m3_x& operator=(int val);
+  fp8_e4m3_x& operator=(long val);
+  fp8_e4m3_x& operator=(long long val);
+  fp8_e4m3_x& operator=(unsigned short val);
+  fp8_e4m3_x& operator=(unsigned int val);
+  fp8_e4m3_x& operator=(unsigned long val);
+  fp8_e4m3_x& operator=(unsigned long long val);
 
   // Convert to half, bfloat16, float, double.
   // Available only when N==1.
@@ -363,7 +363,11 @@ class fp8_e4m3 {
 
 // Deduction guide available only when the size of the pack is greater than zero.
 template<typename... Ts>
-fp8_e4m3(Ts...) -> fp8_e4m3<sizeof...(Ts)>;
+fp8_e4m3_x(Ts...) -> fp8_e4m3_x<sizeof...(Ts)>;
+
+// Convenience aliases
+using fp8_e4m3 = fp8_e4m3_x<1>;
+using fp8_e4m3_x2 = fp8_e4m3_x<2>;
 
 } // namespace sycl::ext::oneapi::experimental
 ----
@@ -372,10 +376,10 @@ fp8_e4m3(Ts...) -> fp8_e4m3<sizeof...(Ts)>;
 
 [source,c++]
 ----
-fp8_e4m3() = default;
-fp8_e4m3(const fp8_e4m3 &) = default;
-~fp8_e4m3() = default;
-fp8_e4m3& operator=(const fp8_e4m3&) = default;
+fp8_e4m3_x() = default;
+fp8_e4m3_x(const fp8_e4m3_x &) = default;
+~fp8_e4m3_x() = default;
+fp8_e4m3_x& operator=(const fp8_e4m3_x&) = default;
 ----
 
 The default constructor, copy constructor, destructor, and copy assignment
@@ -385,17 +389,17 @@ operator are all trivial.
 
 [source,c++]
 ----
-template<typename... Halfs>          (1)
-explicit fp8_e4m3(Halfs... vals);
+template<typename... Halfs>            (1)
+explicit fp8_e4m3_x(Halfs... vals);
 
-template<typename... Bfloats>        (2)
-explicit fp8_e4m3(Bfloats... vals);
+template<typename... Bfloats>          (2)
+explicit fp8_e4m3_x(Bfloats... vals);
 
-template<typename... Floats>         (3)
-explicit fp8_e4m3(Floats... vals);
+template<typename... Floats>           (3)
+explicit fp8_e4m3_x(Floats... vals);
 
-template<typename... Doubles>        (4)
-explicit fp8_e4m3(Doubles... vals);
+template<typename... Doubles>          (4)
+explicit fp8_e4m3_x(Doubles... vals);
 ----
 
 _Constraints_ (1): The size of the `Halfs` pack is `N` and each type in this
@@ -410,7 +414,7 @@ pack is `float`.
 _Constraints_ (4): The size of the `Doubles` pack is `N` and each type in this
 pack is `double`.
 
-_Effects:_ Initializes each element of this `fp8_e4m3` object from the
+_Effects:_ Initializes each element of this `fp8_e4m3_x` object from the
 corresponding value in the `vals` pack.
 Each value is converted using the `rounding::to_even` rounding mode and the
 `saturation::finite` saturation mode.
@@ -419,13 +423,13 @@ Each value is converted using the `rounding::to_even` rounding mode and the
 
 [source,c++]
 ----
-explicit fp8_e4m3(half const (&vals)[N], rounding r = rounding::to_even);      (1)
-explicit fp8_e4m3(bfloat16 const (&vals)[N], rounding r = rounding::to_even);  (2)
-explicit fp8_e4m3(float const (&vals)[N], rounding r = rounding::to_even);     (3)
-explicit fp8_e4m3(double const (&vals)[N]);                                    (4)
+explicit fp8_e4m3_x(half const (&vals)[N], rounding r = rounding::to_even);      (1)
+explicit fp8_e4m3_x(bfloat16 const (&vals)[N], rounding r = rounding::to_even);  (2)
+explicit fp8_e4m3_x(float const (&vals)[N], rounding r = rounding::to_even);     (3)
+explicit fp8_e4m3_x(double const (&vals)[N]);                                    (4)
 ----
 
-_Effects:_ Initializes each element of this `fp8_e4m3` object from the
+_Effects:_ Initializes each element of this `fp8_e4m3_x` object from the
 corresponding element in the array `vals`.
 In overloads (1) - (3), each value is converted using the `r` rounding mode and
 the `saturation::finite` saturation mode.
@@ -442,13 +446,13 @@ _Target Support:_ The rounding mode `r` value has the following restrictions:
 
 [source,c++]
 ----
-explicit fp8_e4m3(const marray<half,N>& vals, rounding r = rounding::to_even);      (1)
-explicit fp8_e4m3(const marray<bfloat16,N>& vals, rounding r = rounding::to_even);  (2)
-explicit fp8_e4m3(const marray<float,N>& vals, rounding r = rounding::to_even);     (3)
-explicit fp8_e4m3(const marray<double,N>& vals);                                    (4)
+explicit fp8_e4m3_x(const marray<half,N>& vals, rounding r = rounding::to_even);      (1)
+explicit fp8_e4m3_x(const marray<bfloat16,N>& vals, rounding r = rounding::to_even);  (2)
+explicit fp8_e4m3_x(const marray<float,N>& vals, rounding r = rounding::to_even);     (3)
+explicit fp8_e4m3_x(const marray<double,N>& vals);                                    (4)
 ----
 
-_Effects:_ Initializes each element of this `fp8_e4m3` object from the
+_Effects:_ Initializes each element of this `fp8_e4m3_x` object from the
 corresponding element in the `marray` object `vals`.
 In overloads (1) - (3), each value is converted using the `r` rounding mode and
 the `saturation::finite` saturation mode.
@@ -465,19 +469,19 @@ _Target Support:_ The rounding mode `r` value has the following restrictions:
 
 [source,c++]
 ----
-explicit fp8_e4m3(short val);
-explicit fp8_e4m3(int val);
-explicit fp8_e4m3(long val);
-explicit fp8_e4m3(long long val);
-explicit fp8_e4m3(unsigned short val);
-explicit fp8_e4m3(unsigned int val);
-explicit fp8_e4m3(unsigned long val);
-explicit fp8_e4m3(unsigned long long val);
+explicit fp8_e4m3_x(short val);
+explicit fp8_e4m3_x(int val);
+explicit fp8_e4m3_x(long val);
+explicit fp8_e4m3_x(long long val);
+explicit fp8_e4m3_x(unsigned short val);
+explicit fp8_e4m3_x(unsigned int val);
+explicit fp8_e4m3_x(unsigned long val);
+explicit fp8_e4m3_x(unsigned long long val);
 ----
 
 _Constraints:_ `N == 1`.
 
-_Effects:_ Initializes the single element of this `fp8_e4m3` object from `val`.
+_Effects:_ Initializes the single element of this `fp8_e4m3_x` object from `val`.
 The value `val` is converted using the `rounding::to_even` rounding mode and the
 `saturation::finite` saturation mode.
 
@@ -487,27 +491,27 @@ The value `val` is converted using the `rounding::to_even` rounding mode and the
 
 [source,c++]
 ----
-fp8_e4m3& operator=(half val);
-fp8_e4m3& operator=(bfloat16 val);
-fp8_e4m3& operator=(float val);
-fp8_e4m3& operator=(double val);
-fp8_e4m3& operator=(short val);
-fp8_e4m3& operator=(int val);
-fp8_e4m3& operator=(long val);
-fp8_e4m3& operator=(long long val);
-fp8_e4m3& operator=(unsigned short val);
-fp8_e4m3& operator=(unsigned int val);
-fp8_e4m3& operator=(unsigned long val);
-fp8_e4m3& operator=(unsigned long long val);
+fp8_e4m3_x& operator=(half val);
+fp8_e4m3_x& operator=(bfloat16 val);
+fp8_e4m3_x& operator=(float val);
+fp8_e4m3_x& operator=(double val);
+fp8_e4m3_x& operator=(short val);
+fp8_e4m3_x& operator=(int val);
+fp8_e4m3_x& operator=(long val);
+fp8_e4m3_x& operator=(long long val);
+fp8_e4m3_x& operator=(unsigned short val);
+fp8_e4m3_x& operator=(unsigned int val);
+fp8_e4m3_x& operator=(unsigned long val);
+fp8_e4m3_x& operator=(unsigned long long val);
 ----
 
 _Constraints:_ `N == 1`.
 
-_Effects:_ Assigns the single element of this `fp8_e4m3` object to `val`.
+_Effects:_ Assigns the single element of this `fp8_e4m3_x` object to `val`.
 The value `val` is converted using the `rounding::to_even` rounding mode and the
 `saturation::finite` saturation mode.
 
-_Returns:_ A reference to this `fp8_e4m3` object.
+_Returns:_ A reference to this `fp8_e4m3_x` object.
 
 ==== Conversion operators
 
@@ -521,7 +525,7 @@ explicit operator double() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The single element of this `fp8_e4m3` object is converted to the
+_Returns_: The single element of this `fp8_e4m3_x` object is converted to the
 operator's respective type.
 
 [_Note:_ These conversions are exact, so there is no rounding mode.
@@ -546,7 +550,7 @@ explicit operator unsigned long long() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The single element of this `fp8_e4m3` object is converted to the
+_Returns_: The single element of this `fp8_e4m3_x` object is converted to the
 operator's respective type using the `rounding::toward_zero` rounding mode.
 
 '''
@@ -558,7 +562,7 @@ explicit operator bool() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The value `false` if the single element of this `fp8_e4m3` is either
+_Returns_: The value `false` if the single element of this `fp8_e4m3_x` is either
 +0 or -0.
 Otherwise, returns the value `true`.
 
@@ -571,7 +575,7 @@ explicit operator marray<bfloat16,N>() const;  (2)
 explicit operator marray<float,N>() const;     (3)
 ----
 
-_Returns:_ The values of this `fp8_e4m3` object are converted to an `marray` of
+_Returns:_ The values of this `fp8_e4m3_x` object are converted to an `marray` of
 `half`, `ext::oneapi::bfloat16`, or `float`.
 
 [_Note:_ These conversions are exact, so there is no rounding mode.
@@ -586,7 +590,7 @@ _{endnote}_]
 uint8_t vals[N];
 ----
 
-Provides direct access to the storage of the E4M3 values in this `fp8_e4m3`
+Provides direct access to the storage of the E4M3 values in this `fp8_e4m3_x`
 object.
 
 ==== Deduction guide
@@ -594,10 +598,20 @@ object.
 [source,c++]
 ----
 template<typename... Ts>
-fp8_e4m3(Ts...) -> fp8_e4m3<sizeof...(Ts)>;
+fp8_e4m3_x(Ts...) -> fp8_e4m3_x<sizeof...(Ts)>;
 ----
 
 _Constraints:_ The size of the `Ts` pack is greater than zero.
+
+==== Convenience aliases
+
+[source,c++]
+----
+using fp8_e4m3 = fp8_e4m3_x<1>;
+using fp8_e4m3_x2 = fp8_e4m3_x<2>;
+----
+
+These aliases provide less verbose syntax for common use cases.
 
 ==== Non-stochastic rounding modes with saturation
 
@@ -660,7 +674,7 @@ The following table provides the special values of the E5M2 type.
 
 |====
 
-This extension adds the `fp8_e5m2` type, which represents a set of packed E5M2
+This extension adds the `fp8_e5m2_x` type, which represents a set of packed E5M2
 values and provides various conversions to other types.
 The number of packed elements is defined by the `N` template parameter, which
 must be either 1 or 2.
@@ -670,99 +684,99 @@ must be either 1 or 2.
 namespace sycl::ext::oneapi::experimental {
 
 template<size_t N>
-class fp8_e5m2 {
+class fp8_e5m2_x {
  public:
-  fp8_e5m2() = default;
-  fp8_e5m2(const fp8_e5m2 &) = default;
-  ~fp8_e5m2() = default;
-  fp8_e5m2& operator=(const fp8_e5m2&) = default;
+  fp8_e5m2_x() = default;
+  fp8_e5m2_x(const fp8_e5m2_x &) = default;
+  ~fp8_e5m2_x() = default;
+  fp8_e5m2_x& operator=(const fp8_e5m2_x&) = default;
 
   // Construct from pack of half, bfloat16, float, double.
   // Available only when the size of the pack is equal to N.
 
   // Available only when each type in the pack is half.
   template<typename... Halfs>
-  explicit fp8_e5m2(Halfs... vals);
+  explicit fp8_e5m2_x(Halfs... vals);
 
   // Available only when each type in the pack is bfloat16.
   template<typename... Bfloats>
-  explicit fp8_e5m2(Bfloats... vals);
+  explicit fp8_e5m2_x(Bfloats... vals);
 
   // Available only when each type in the pack is float.
   template<typename... Floats>
-  explicit fp8_e5m2(Floats... vals);
+  explicit fp8_e5m2_x(Floats... vals);
 
   // Available only when each type in the pack is double.
   template<typename... Doubles>
-  explicit fp8_e5m2(Doubles... vals);
+  explicit fp8_e5m2_x(Doubles... vals);
 
   // Construct from an array of half, bfloat16, float, double.
 
-  explicit fp8_e5m2(half const (&vals)[N], rounding r = rounding::to_even,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(bfloat16 const (&vals)[N], rounding r = rounding::to_even,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(float const (&vals)[N], rounding r = rounding::to_even,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(double const (&vals)[N]);
+  explicit fp8_e5m2_x(half const (&vals)[N], rounding r = rounding::to_even,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(bfloat16 const (&vals)[N], rounding r = rounding::to_even,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(float const (&vals)[N], rounding r = rounding::to_even,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(double const (&vals)[N]);
 
   // Construct from an marray of half, bfloat16, float, double.
 
-  explicit fp8_e5m2(const marray<half,N>& vals, rounding r = rounding::to_even,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(const marray<bfloat16,N>& vals, rounding r = rounding::to_even,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(const marray<float,N>& vals, rounding r = rounding::to_even,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(const marray<double,N>& vals);
+  explicit fp8_e5m2_x(const marray<half,N>& vals, rounding r = rounding::to_even,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(const marray<bfloat16,N>& vals, rounding r = rounding::to_even,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(const marray<float,N>& vals, rounding r = rounding::to_even,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(const marray<double,N>& vals);
 
   // Construct with stochastic rounding with user provided seed from an array of
   // half, bfloat16, float.
 
-  explicit fp8_e5m2(half const (&vals)[N], const stochastic_seed& seed,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(bfloat16 const (&vals)[N], const stochastic_seed& seed,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(double const (&vals)[N], const stochastic_seed& seed,
-                    saturation s = saturation::finite);
+  explicit fp8_e5m2_x(half const (&vals)[N], const stochastic_seed& seed,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(bfloat16 const (&vals)[N], const stochastic_seed& seed,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(double const (&vals)[N], const stochastic_seed& seed,
+                      saturation s = saturation::finite);
 
   // Construct with stochastic rounding with user provided seed from an marray
   // of half, bfloat16, float.
 
-  explicit fp8_e5m2(const marray<half,N>& vals, const stochastic_seed& seed,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(const marray<bfloat16,N>& vals, const stochastic_seed& seed,
-                    saturation s = saturation::finite);
-  explicit fp8_e5m2(const marray<double,N>& vals, const stochastic_seed& seed,
-                    saturation s = saturation::finite);
+  explicit fp8_e5m2_x(const marray<half,N>& vals, const stochastic_seed& seed,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(const marray<bfloat16,N>& vals, const stochastic_seed& seed,
+                      saturation s = saturation::finite);
+  explicit fp8_e5m2_x(const marray<double,N>& vals, const stochastic_seed& seed,
+                      saturation s = saturation::finite);
 
   // Construct from integer types.
   // Available only when N==1.
 
-  explicit fp8_e5m2(short val);
-  explicit fp8_e5m2(int val);
-  explicit fp8_e5m2(long val);
-  explicit fp8_e5m2(long long val);
-  explicit fp8_e5m2(unsigned short val);
-  explicit fp8_e5m2(unsigned int val);
-  explicit fp8_e5m2(unsigned long val);
-  explicit fp8_e5m2(unsigned long long val);
+  explicit fp8_e5m2_x(short val);
+  explicit fp8_e5m2_x(int val);
+  explicit fp8_e5m2_x(long val);
+  explicit fp8_e5m2_x(long long val);
+  explicit fp8_e5m2_x(unsigned short val);
+  explicit fp8_e5m2_x(unsigned int val);
+  explicit fp8_e5m2_x(unsigned long val);
+  explicit fp8_e5m2_x(unsigned long long val);
 
   // Assign (operator) from half, bfloat16, float, double, and integer types.
   // Available only when N==1.
 
-  fp8_e5m2& operator=(half val);
-  fp8_e5m2& operator=(bfloat16 val);
-  fp8_e5m2& operator=(float val);
-  fp8_e5m2& operator=(double val);
-  fp8_e5m2& operator=(short val);
-  fp8_e5m2& operator=(int val);
-  fp8_e5m2& operator=(long val);
-  fp8_e5m2& operator=(long long val);
-  fp8_e5m2& operator=(unsigned short val);
-  fp8_e5m2& operator=(unsigned int val);
-  fp8_e5m2& operator=(unsigned long val);
-  fp8_e5m2& operator=(unsigned long long val);
+  fp8_e5m2_x& operator=(half val);
+  fp8_e5m2_x& operator=(bfloat16 val);
+  fp8_e5m2_x& operator=(float val);
+  fp8_e5m2_x& operator=(double val);
+  fp8_e5m2_x& operator=(short val);
+  fp8_e5m2_x& operator=(int val);
+  fp8_e5m2_x& operator=(long val);
+  fp8_e5m2_x& operator=(long long val);
+  fp8_e5m2_x& operator=(unsigned short val);
+  fp8_e5m2_x& operator=(unsigned int val);
+  fp8_e5m2_x& operator=(unsigned long val);
+  fp8_e5m2_x& operator=(unsigned long long val);
 
   // Convert to half, bfloat16, float, double.
   // Available only when N==1.
@@ -805,7 +819,11 @@ class fp8_e5m2 {
 
 // Deduction guide available only when the size of the pack is greater than zero.
 template<typename... Ts>
-fp8_e5m2(Ts...) -> fp8_e5m2<sizeof...(Ts)>;
+fp8_e5m2_x(Ts...) -> fp8_e5m2_x<sizeof...(Ts)>;
+
+// Convenience aliases
+using fp8_e5m2 = fp8_e5m2_x<1>;
+using fp8_e5m2_x2 = fp8_e5m2_x<2>;
 
 } // namespace sycl::ext::oneapi::experimental
 ----
@@ -814,10 +832,10 @@ fp8_e5m2(Ts...) -> fp8_e5m2<sizeof...(Ts)>;
 
 [source,c++]
 ----
-fp8_e5m2() = default;
-fp8_e5m2(const fp8_e5m2 &) = default;
-~fp8_e5m2() = default;
-fp8_e5m2& operator=(const fp8_e5m2&) = default;
+fp8_e5m2_x() = default;
+fp8_e5m2_x(const fp8_e5m2_x &) = default;
+~fp8_e5m2_x() = default;
+fp8_e5m2_x& operator=(const fp8_e5m2_x&) = default;
 ----
 
 The default constructor, copy constructor, destructor, and copy assignment
@@ -827,17 +845,17 @@ operator are all trivial.
 
 [source,c++]
 ----
-template<typename... Halfs>          (1)
-explicit fp8_e5m2(Halfs... vals);
+template<typename... Halfs>            (1)
+explicit fp8_e5m2_x(Halfs... vals);
 
-template<typename... Bfloats>        (2)
-explicit fp8_e5m2(Bfloats... vals);
+template<typename... Bfloats>          (2)
+explicit fp8_e5m2_x(Bfloats... vals);
 
-template<typename... Floats>         (3)
-explicit fp8_e5m2(Floats... vals);
+template<typename... Floats>           (3)
+explicit fp8_e5m2_x(Floats... vals);
 
-template<typename... Doubles>        (4)
-explicit fp8_e5m2(Doubles... vals);
+template<typename... Doubles>          (4)
+explicit fp8_e5m2_x(Doubles... vals);
 ----
 
 _Constraints_ (1): The size of the `Halfs` pack is `N` and each type in this
@@ -852,7 +870,7 @@ pack is `float`.
 _Constraints_ (4): The size of the `Doubles` pack is `N` and each type in this
 pack is `double`.
 
-_Effects:_ Initializes each element of this `fp8_e5m2` object from the
+_Effects:_ Initializes each element of this `fp8_e5m2_x` object from the
 corresponding value in the `vals` pack.
 Each value is converted using the `rounding::to_even` rounding mode and the
 `saturation::finite` saturation mode.
@@ -861,16 +879,16 @@ Each value is converted using the `rounding::to_even` rounding mode and the
 
 [source,c++]
 ----
-explicit fp8_e5m2(half const (&vals)[N], rounding r = rounding::to_even,      (1)
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(bfloat16 const (&vals)[N], rounding r = rounding::to_even,  (2)
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(float const (&vals)[N], rounding r = rounding::to_even,     (3)
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(double const (&vals)[N]);                                   (4)
+explicit fp8_e5m2_x(half const (&vals)[N], rounding r = rounding::to_even,      (1)
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(bfloat16 const (&vals)[N], rounding r = rounding::to_even,  (2)
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(float const (&vals)[N], rounding r = rounding::to_even,     (3)
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(double const (&vals)[N]);                                   (4)
 ----
 
-_Effects:_ Initializes each element of this `fp8_e5m2` object from the
+_Effects:_ Initializes each element of this `fp8_e5m2_x` object from the
 corresponding element in the array `vals`.
 In overloads (1) - (3), each value is converted using the `r` rounding mode and
 the `s` saturation mode.
@@ -888,16 +906,16 @@ following restrictions:
 
 [source,c++]
 ----
-explicit fp8_e5m2(const marray<half,N>& vals, rounding r = rounding::to_even,      (1)
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(const marray<bfloat16,N>& vals, rounding r = rounding::to_even,  (2)
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(const marray<float,N>& vals, rounding r = rounding::to_even,     (3)
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(const marray<double,N>& vals);                                   (4)
+explicit fp8_e5m2_x(const marray<half,N>& vals, rounding r = rounding::to_even,      (1)
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(const marray<bfloat16,N>& vals, rounding r = rounding::to_even,  (2)
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(const marray<float,N>& vals, rounding r = rounding::to_even,     (3)
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(const marray<double,N>& vals);                                   (4)
 ----
 
-_Effects:_ Initializes each element of this `fp8_e5m2` object from the
+_Effects:_ Initializes each element of this `fp8_e5m2_x` object from the
 corresponding element in the `marray` object `vals`.
 In overloads (1) - (3), each value is converted using the `r` rounding mode and
 the `s` saturation mode.
@@ -915,15 +933,15 @@ following restrictions:
 
 [source,c++]
 ----
-explicit fp8_e5m2(half const (&vals)[N], const stochastic_seed& seed,
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(bfloat16 const (&vals)[N], const stochastic_seed& seed,
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(double const (&vals)[N], const stochastic_seed& seed,
-                  saturation s = saturation::finite);
+explicit fp8_e5m2_x(half const (&vals)[N], const stochastic_seed& seed,
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(bfloat16 const (&vals)[N], const stochastic_seed& seed,
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(double const (&vals)[N], const stochastic_seed& seed,
+                    saturation s = saturation::finite);
 ----
 
-_Effects:_ Initializes each element of this `fp8_e5m2` object from the
+_Effects:_ Initializes each element of this `fp8_e5m2_x` object from the
 corresponding value in the array `vals` using stochastic rounding.
 The pseudo-random biases are created deterministically using the seed value
 referenced by the helper object `seed`.
@@ -944,15 +962,15 @@ They are only supported in device code as follows:
 
 [source,c++]
 ----
-explicit fp8_e5m2(const marray<half,N>& vals, const stochastic_seed& seed,
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(const marray<bfloat16,N>& vals, const stochastic_seed& seed,
-                  saturation s = saturation::finite);
-explicit fp8_e5m2(const marray<double,N>& vals, const stochastic_seed& seed,
-                  saturation s = saturation::finite);
+explicit fp8_e5m2_x(const marray<half,N>& vals, const stochastic_seed& seed,
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(const marray<bfloat16,N>& vals, const stochastic_seed& seed,
+                    saturation s = saturation::finite);
+explicit fp8_e5m2_x(const marray<double,N>& vals, const stochastic_seed& seed,
+                    saturation s = saturation::finite);
 ----
 
-_Effects:_ Initializes each element of this `fp8_e5m2` object from the
+_Effects:_ Initializes each element of this `fp8_e5m2_x` object from the
 corresponding value in the `marray` object `vals` using stochastic rounding.
 The pseudo-random biases are created deterministically using the seed value
 referenced by the helper object `seed`.
@@ -973,19 +991,19 @@ They are only supported in device code as follows:
 
 [source,c++]
 ----
-explicit fp8_e5m2(short val);
-explicit fp8_e5m2(int val);
-explicit fp8_e5m2(long val);
-explicit fp8_e5m2(long long val);
-explicit fp8_e5m2(unsigned short val);
-explicit fp8_e5m2(unsigned int val);
-explicit fp8_e5m2(unsigned long val);
-explicit fp8_e5m2(unsigned long long val);
+explicit fp8_e5m2_x(short val);
+explicit fp8_e5m2_x(int val);
+explicit fp8_e5m2_x(long val);
+explicit fp8_e5m2_x(long long val);
+explicit fp8_e5m2_x(unsigned short val);
+explicit fp8_e5m2_x(unsigned int val);
+explicit fp8_e5m2_x(unsigned long val);
+explicit fp8_e5m2_x(unsigned long long val);
 ----
 
 _Constraints:_ `N == 1`.
 
-_Effects:_ Initializes the single element of this `fp8_e5m2` object from `val`.
+_Effects:_ Initializes the single element of this `fp8_e5m2_x` object from `val`.
 The value `val` is converted using the `rounding::to_even` rounding mode and the
 `saturation::finite` saturation mode.
 
@@ -995,27 +1013,27 @@ The value `val` is converted using the `rounding::to_even` rounding mode and the
 
 [source,c++]
 ----
-fp8_e5m2& operator=(half val);
-fp8_e5m2& operator=(bfloat16 val);
-fp8_e5m2& operator=(float val);
-fp8_e5m2& operator=(double val);
-fp8_e5m2& operator=(short val);
-fp8_e5m2& operator=(int val);
-fp8_e5m2& operator=(long val);
-fp8_e5m2& operator=(long long val);
-fp8_e5m2& operator=(unsigned short val);
-fp8_e5m2& operator=(unsigned int val);
-fp8_e5m2& operator=(unsigned long val);
-fp8_e5m2& operator=(unsigned long long val);
+fp8_e5m2_x& operator=(half val);
+fp8_e5m2_x& operator=(bfloat16 val);
+fp8_e5m2_x& operator=(float val);
+fp8_e5m2_x& operator=(double val);
+fp8_e5m2_x& operator=(short val);
+fp8_e5m2_x& operator=(int val);
+fp8_e5m2_x& operator=(long val);
+fp8_e5m2_x& operator=(long long val);
+fp8_e5m2_x& operator=(unsigned short val);
+fp8_e5m2_x& operator=(unsigned int val);
+fp8_e5m2_x& operator=(unsigned long val);
+fp8_e5m2_x& operator=(unsigned long long val);
 ----
 
 _Constraints:_ `N == 1`.
 
-_Effects:_ Assigns the single element of this `fp8_e5m2` object to `val`.
+_Effects:_ Assigns the single element of this `fp8_e5m2_x` object to `val`.
 The value `val` is converted using the `rounding::to_even` rounding mode and the
 `saturation::finite` saturation mode.
 
-_Returns:_ A reference to this `fp8_e5m2` object.
+_Returns:_ A reference to this `fp8_e5m2_x` object.
 
 ==== Conversion operators
 
@@ -1029,7 +1047,7 @@ explicit operator double() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The single element of this `fp8_e5m2` object is converted to the
+_Returns_: The single element of this `fp8_e5m2_x` object is converted to the
 operator's respective type.
 
 [_Note:_ These conversions are exact, so there is no rounding or saturation
@@ -1055,7 +1073,7 @@ explicit operator unsigned long long() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The single element of this `fp8_e5m2` object is converted to the
+_Returns_: The single element of this `fp8_e5m2_x` object is converted to the
 operator's respective type using the `rounding::toward_zero` rounding mode.
 
 '''
@@ -1067,7 +1085,7 @@ explicit operator bool() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The value `false` if the single element of this `fp8_e5m2` is either
+_Returns_: The value `false` if the single element of this `fp8_e5m2_x` is either
 +0 or -0.
 Otherwise, returns the value `true`.
 
@@ -1080,7 +1098,7 @@ explicit operator marray<bfloat16,N>() const;  (2)
 explicit operator marray<float,N>() const;     (3)
 ----
 
-_Returns:_ The values of this `fp8_e5m2` object are converted to an `marray` of
+_Returns:_ The values of this `fp8_e5m2_x` object are converted to an `marray` of
 `half`, `ext::oneapi::bfloat16`, or `float`.
 
 [_Note:_ These conversions are exact, so there is no rounding or saturation
@@ -1096,7 +1114,7 @@ _{endnote}_]
 uint8_t vals[N];
 ----
 
-Provides direct access to the storage of the E5M2 values in this `fp8_e5m2`
+Provides direct access to the storage of the E5M2 values in this `fp8_e5m2_x`
 object.
 
 ==== Deduction guide
@@ -1104,10 +1122,20 @@ object.
 [source,c++]
 ----
 template<typename... Ts>
-fp8_e5m2(Ts...) -> fp8_e5m2<sizeof...(Ts)>;
+fp8_e5m2_x(Ts...) -> fp8_e5m2_x<sizeof...(Ts)>;
 ----
 
 _Constraints:_ The size of the `Ts` pack is greater than zero.
+
+==== Convenience aliases
+
+[source,c++]
+----
+using fp8_e5m2 = fp8_e5m2_x<1>;
+using fp8_e5m2_x2 = fp8_e5m2_x<2>;
+----
+
+These aliases provide less verbose syntax for common use cases.
 
 ==== Non-stochastic rounding modes with saturation
 
@@ -1218,7 +1246,7 @@ The following table provides the special values of the E8M0 type.
 
 |====
 
-This extension adds the `fp8_e8m0` type, which represents a set of packed E8M0
+This extension adds the `fp8_e8m0_x` type, which represents a set of packed E8M0
 values and provides various conversions to other types.
 The number of packed elements is defined by the `N` template parameter, which
 must be either 1 or 2.
@@ -1228,73 +1256,73 @@ must be either 1 or 2.
 namespace sycl::ext::oneapi::experimental {
 
 template<size_t N>
-class fp8_e8m0 {
+class fp8_e8m0_x {
  public:
-  fp8_e8m0() = default;
-  fp8_e8m0(const fp8_e8m0 &) = default;
-  ~fp8_e8m0() = default;
-  fp8_e8m0& operator=(const fp8_e8m0&) = default;
+  fp8_e8m0_x() = default;
+  fp8_e8m0_x(const fp8_e8m0_x &) = default;
+  ~fp8_e8m0_x() = default;
+  fp8_e8m0_x& operator=(const fp8_e8m0_x&) = default;
 
   // Construct from pack of half, bfloat16, float, double.
   // Available only when the size of the pack is equal to N.
 
   // Available only when each type in the pack is half.
   template<typename... Halfs>
-  explicit fp8_e8m0(Halfs... vals);
+  explicit fp8_e8m0_x(Halfs... vals);
 
   // Available only when each type in the pack is bfloat16.
   template<typename... Bfloats>
-  explicit fp8_e8m0(Bfloats... vals);
+  explicit fp8_e8m0_x(Bfloats... vals);
 
   // Available only when each type in the pack is float.
   template<typename... Floats>
-  explicit fp8_e8m0(Floats... vals);
+  explicit fp8_e8m0_x(Floats... vals);
 
   // Available only when each type in the pack is double.
   template<typename... Doubles>
-  explicit fp8_e8m0(Doubles... vals);
+  explicit fp8_e8m0_x(Doubles... vals);
 
   // Construct from an array of half, bfloat16, float, double.
 
-  explicit fp8_e8m0(half const (&vals)[N], rounding r = rounding::upward);
-  explicit fp8_e8m0(bfloat16 const (&vals)[N], rounding r = rounding::upward);
-  explicit fp8_e8m0(float const (&vals)[N], rounding r = rounding::upward);
-  explicit fp8_e8m0(double const (&vals)[N]);
+  explicit fp8_e8m0_x(half const (&vals)[N], rounding r = rounding::upward);
+  explicit fp8_e8m0_x(bfloat16 const (&vals)[N], rounding r = rounding::upward);
+  explicit fp8_e8m0_x(float const (&vals)[N], rounding r = rounding::upward);
+  explicit fp8_e8m0_x(double const (&vals)[N]);
 
   // Construct from an marray of half, bfloat16, float, double.
 
-  explicit fp8_e8m0(const marray<half,N>& vals, rounding r = rounding::upward);
-  explicit fp8_e8m0(const marray<bfloat16,N>& vals, rounding r = rounding::upward);
-  explicit fp8_e8m0(const marray<float,N>& vals, rounding r = rounding::upward);
-  explicit fp8_e8m0(const marray<double,N>& vals);
+  explicit fp8_e8m0_x(const marray<half,N>& vals, rounding r = rounding::upward);
+  explicit fp8_e8m0_x(const marray<bfloat16,N>& vals, rounding r = rounding::upward);
+  explicit fp8_e8m0_x(const marray<float,N>& vals, rounding r = rounding::upward);
+  explicit fp8_e8m0_x(const marray<double,N>& vals);
 
   // Construct from integer types.
   // Available only when N==1.
 
-  explicit fp8_e8m0(short val);
-  explicit fp8_e8m0(int val);
-  explicit fp8_e8m0(long val);
-  explicit fp8_e8m0(long long val);
-  explicit fp8_e8m0(unsigned short val);
-  explicit fp8_e8m0(unsigned int val);
-  explicit fp8_e8m0(unsigned long val);
-  explicit fp8_e8m0(unsigned long long val);
+  explicit fp8_e8m0_x(short val);
+  explicit fp8_e8m0_x(int val);
+  explicit fp8_e8m0_x(long val);
+  explicit fp8_e8m0_x(long long val);
+  explicit fp8_e8m0_x(unsigned short val);
+  explicit fp8_e8m0_x(unsigned int val);
+  explicit fp8_e8m0_x(unsigned long val);
+  explicit fp8_e8m0_x(unsigned long long val);
 
   // Assign (operator) from half, bfloat16, float, double, and integer types.
   // Available only when N==1.
 
-  fp8_e8m0& operator=(half val);
-  fp8_e8m0& operator=(bfloat16 val);
-  fp8_e8m0& operator=(float val);
-  fp8_e8m0& operator=(double val);
-  fp8_e8m0& operator=(short val);
-  fp8_e8m0& operator=(int val);
-  fp8_e8m0& operator=(long val);
-  fp8_e8m0& operator=(long long val);
-  fp8_e8m0& operator=(unsigned short val);
-  fp8_e8m0& operator=(unsigned int val);
-  fp8_e8m0& operator=(unsigned long val);
-  fp8_e8m0& operator=(unsigned long long val);
+  fp8_e8m0_x& operator=(half val);
+  fp8_e8m0_x& operator=(bfloat16 val);
+  fp8_e8m0_x& operator=(float val);
+  fp8_e8m0_x& operator=(double val);
+  fp8_e8m0_x& operator=(short val);
+  fp8_e8m0_x& operator=(int val);
+  fp8_e8m0_x& operator=(long val);
+  fp8_e8m0_x& operator=(long long val);
+  fp8_e8m0_x& operator=(unsigned short val);
+  fp8_e8m0_x& operator=(unsigned int val);
+  fp8_e8m0_x& operator=(unsigned long val);
+  fp8_e8m0_x& operator=(unsigned long long val);
 
   // Convert to half, bfloat16, float, double.
   // Available only when N==1.
@@ -1337,7 +1365,11 @@ class fp8_e8m0 {
 
 // Deduction guide available only when the size of the pack is greater than zero.
 template<typename... Ts>
-fp8_e8m0(Ts...) -> fp8_e8m0<sizeof...(Ts)>;
+fp8_e8m0_x(Ts...) -> fp8_e8m0_x<sizeof...(Ts)>;
+
+// Convenience aliases
+using fp8_e8m0 = fp8_e8m0_x<1>;
+using fp8_e8m0_x2 = fp8_e8m0_x<2>;
 
 } // namespace sycl::ext::oneapi::experimental
 ----
@@ -1346,10 +1378,10 @@ fp8_e8m0(Ts...) -> fp8_e8m0<sizeof...(Ts)>;
 
 [source,c++]
 ----
-fp8_e8m0() = default;
-fp8_e8m0(const fp8_e8m0 &) = default;
-~fp8_e8m0() = default;
-fp8_e8m0& operator=(const fp8_e8m0&) = default;
+fp8_e8m0_x() = default;
+fp8_e8m0_x(const fp8_e8m0_x &) = default;
+~fp8_e8m0_x() = default;
+fp8_e8m0_x& operator=(const fp8_e8m0_x&) = default;
 ----
 
 The default constructor, copy constructor, destructor, and copy assignment
@@ -1359,17 +1391,17 @@ operator are all trivial.
 
 [source,c++]
 ----
-template<typename... Halfs>          (1)
-explicit fp8_e8m0(Halfs... vals);
+template<typename... Halfs>            (1)
+explicit fp8_e8m0_x(Halfs... vals);
 
-template<typename... Bfloats>        (2)
-explicit fp8_e8m0(Bfloats... vals);
+template<typename... Bfloats>          (2)
+explicit fp8_e8m0_x(Bfloats... vals);
 
-template<typename... Floats>         (3)
-explicit fp8_e8m0(Floats... vals);
+template<typename... Floats>           (3)
+explicit fp8_e8m0_x(Floats... vals);
 
-template<typename... Doubles>        (4)
-explicit fp8_e8m0(Doubles... vals);
+template<typename... Doubles>          (4)
+explicit fp8_e8m0_x(Doubles... vals);
 ----
 
 _Constraints_ (1): The size of the `Halfs` pack is `N` and each type in this
@@ -1384,7 +1416,7 @@ pack is `float`.
 _Constraints_ (4): The size of the `Doubles` pack is `N` and each type in this
 pack is `double`.
 
-_Effects:_ Initializes each element of this `fp8_e8m0` object from the
+_Effects:_ Initializes each element of this `fp8_e8m0_x` object from the
 corresponding value in the `vals` pack.
 Each value is converted using the `rounding::upward` rounding mode and the
 `saturation::finite` saturation mode.
@@ -1393,13 +1425,13 @@ Each value is converted using the `rounding::upward` rounding mode and the
 
 [source,c++]
 ----
-explicit fp8_e8m0(half const (&vals)[N], rounding r = rounding::upward);      (1)
-explicit fp8_e8m0(bfloat16 const (&vals)[N], rounding r = rounding::upward);  (2)
-explicit fp8_e8m0(float const (&vals)[N], rounding r = rounding::upward);     (3)
-explicit fp8_e8m0(double const (&vals)[N]);                                   (4)
+explicit fp8_e8m0_x(half const (&vals)[N], rounding r = rounding::upward);      (1)
+explicit fp8_e8m0_x(bfloat16 const (&vals)[N], rounding r = rounding::upward);  (2)
+explicit fp8_e8m0_x(float const (&vals)[N], rounding r = rounding::upward);     (3)
+explicit fp8_e8m0_x(double const (&vals)[N]);                                   (4)
 ----
 
-_Effects:_ Initializes each element of this `fp8_e8m0` object from the
+_Effects:_ Initializes each element of this `fp8_e8m0_x` object from the
 corresponding element in the array `vals`.
 In overloads (1) - (3), each value is converted using the `r` rounding mode and
 the `saturation::finite` saturation mode.
@@ -1413,13 +1445,13 @@ _Target Support:_ Host and device code support only `rounding::upward` and
 
 [source,c++]
 ----
-explicit fp8_e8m0(const marray<half,N>& vals, rounding r = rounding::upward);      (1)
-explicit fp8_e8m0(const marray<bfloat16,N>& vals, rounding r = rounding::upward);  (2)
-explicit fp8_e8m0(const marray<float,N>& vals, rounding r = rounding::upward);     (3)
-explicit fp8_e8m0(const marray<double,N>& vals);                                   (4)
+explicit fp8_e8m0_x(const marray<half,N>& vals, rounding r = rounding::upward);      (1)
+explicit fp8_e8m0_x(const marray<bfloat16,N>& vals, rounding r = rounding::upward);  (2)
+explicit fp8_e8m0_x(const marray<float,N>& vals, rounding r = rounding::upward);     (3)
+explicit fp8_e8m0_x(const marray<double,N>& vals);                                   (4)
 ----
 
-_Effects:_ Initializes each element of this `fp8_e8m0` object from the
+_Effects:_ Initializes each element of this `fp8_e8m0_x` object from the
 corresponding element in the `marray` object `vals`.
 In overloads (1) - (3), each value is converted using the `r` rounding mode and
 the `saturation::finite` saturation mode.
@@ -1433,19 +1465,19 @@ _Target Support:_ Host and device code support only `rounding::upward` and
 
 [source,c++]
 ----
-explicit fp8_e8m0(short val);
-explicit fp8_e8m0(int val);
-explicit fp8_e8m0(long val);
-explicit fp8_e8m0(long long val);
-explicit fp8_e8m0(unsigned short val);
-explicit fp8_e8m0(unsigned int val);
-explicit fp8_e8m0(unsigned long val);
-explicit fp8_e8m0(unsigned long long val);
+explicit fp8_e8m0_x(short val);
+explicit fp8_e8m0_x(int val);
+explicit fp8_e8m0_x(long val);
+explicit fp8_e8m0_x(long long val);
+explicit fp8_e8m0_x(unsigned short val);
+explicit fp8_e8m0_x(unsigned int val);
+explicit fp8_e8m0_x(unsigned long val);
+explicit fp8_e8m0_x(unsigned long long val);
 ----
 
 _Constraints:_ `N == 1`.
 
-_Effects:_ Initializes the single element of this `fp8_e8m0` object from `val`.
+_Effects:_ Initializes the single element of this `fp8_e8m0_x` object from `val`.
 The value `val` is converted using the `rounding::upward` rounding mode and the
 `saturation::finite` saturation mode.
 
@@ -1455,27 +1487,27 @@ The value `val` is converted using the `rounding::upward` rounding mode and the
 
 [source,c++]
 ----
-fp8_e8m0& operator=(half val);
-fp8_e8m0& operator=(bfloat16 val);
-fp8_e8m0& operator=(float val);
-fp8_e8m0& operator=(double val);
-fp8_e8m0& operator=(short val);
-fp8_e8m0& operator=(int val);
-fp8_e8m0& operator=(long val);
-fp8_e8m0& operator=(long long val);
-fp8_e8m0& operator=(unsigned short val);
-fp8_e8m0& operator=(unsigned int val);
-fp8_e8m0& operator=(unsigned long val);
-fp8_e8m0& operator=(unsigned long long val);
+fp8_e8m0_x& operator=(half val);
+fp8_e8m0_x& operator=(bfloat16 val);
+fp8_e8m0_x& operator=(float val);
+fp8_e8m0_x& operator=(double val);
+fp8_e8m0_x& operator=(short val);
+fp8_e8m0_x& operator=(int val);
+fp8_e8m0_x& operator=(long val);
+fp8_e8m0_x& operator=(long long val);
+fp8_e8m0_x& operator=(unsigned short val);
+fp8_e8m0_x& operator=(unsigned int val);
+fp8_e8m0_x& operator=(unsigned long val);
+fp8_e8m0_x& operator=(unsigned long long val);
 ----
 
 _Constraints:_ `N == 1`.
 
-_Effects:_ Assigns the single element of this `fp8_e8m0` object to `val`.
+_Effects:_ Assigns the single element of this `fp8_e8m0_x` object to `val`.
 The value `val` is converted using the `rounding::upward` rounding mode and the
 `saturation::finite` saturation mode.
 
-_Returns:_ A reference to this `fp8_e8m0` object.
+_Returns:_ A reference to this `fp8_e8m0_x` object.
 
 ==== Conversion operators
 
@@ -1489,7 +1521,7 @@ explicit operator double() const;    (4)
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The single element of this `fp8_e8m0` object is assumed to be a
+_Returns_: The single element of this `fp8_e8m0_x` object is assumed to be a
 positive number and is converted to the operator's respective type.
 
 Conversion (1) uses `rounding::to_even` rounding mode.
@@ -1519,7 +1551,7 @@ explicit operator unsigned long long() const;
 
 _Constraints:_ `N == 1`.
 
-_Returns_: The single element of this `fp8_e8m0` object is assumed to be a
+_Returns_: The single element of this `fp8_e8m0_x` object is assumed to be a
 positive number and is converted to the operator's respective type using the
 `rounding::toward_zero` rounding mode.
 
@@ -1547,7 +1579,7 @@ explicit operator marray<bfloat16,N>() const;  (2)
 explicit operator marray<float,N>() const;     (3)
 ----
 
-_Returns:_ The values of this `fp8_e8m0` object are assumed to be positive
+_Returns:_ The values of this `fp8_e8m0_x` object are assumed to be positive
 numbers and are converted to an `marray` of `half`, `ext::oneapi::bfloat16`, or
 `float`.
 
@@ -1568,7 +1600,7 @@ _{endnote}_]
 uint8_t vals[N];
 ----
 
-Provides direct access to the storage of the E8M0 values in this `fp8_e8m0`
+Provides direct access to the storage of the E8M0 values in this `fp8_e8m0_x`
 object.
 
 ==== Deduction guide
@@ -1576,10 +1608,20 @@ object.
 [source,c++]
 ----
 template<typename... Ts>
-fp8_e8m0(Ts...) -> fp8_e8m0<sizeof...(Ts)>;
+fp8_e8m0_x(Ts...) -> fp8_e8m0_x<sizeof...(Ts)>;
 ----
 
 _Constraints:_ The size of the `Ts` pack is greater than zero.
+
+==== Convenience aliases
+
+[source,c++]
+----
+using fp8_e8m0 = fp8_e8m0_x<1>;
+using fp8_e8m0_x2 = fp8_e8m0_x<2>;
+----
+
+These aliases provide less verbose syntax for common use cases.
 
 ==== Non-stochastic rounding modes with saturation
 
@@ -1603,23 +1645,6 @@ Conversions from E8M0 to non-boolean integral types work as follows:
 
 
 == Issues
-
-* Will it be very common to use the 1-element versions of the FP8 types?
-  If so, it might be tedious for users to type `<1>` whenever they declare
-  variables of this type.
-  The best solution in this case would be to rename the class templates as
-  `fp8_e4m3_x` and also add alias(es) like `fp8_e4m3` and `fp8_e4m3_x2`.
-  This would allow usage like this:
-+
-```
-fp8_e4m3 s;         // 1-element
-fp8_e4m3_x2 v2;     // 2-element
-fp8_e4m3_x<2> v2b;  // Also 2-element
-```
-+
-If we do this, we should rename all of the low-precision FP types (even the
-FP4 ones) because it's important for the names of all these types to follow
-a consistent pattern.
 
 * What is the behavior if the device does *not* support subnormal fp16 (`half`)
   values and the user up-converts from E5M2 to `half`?


### PR DESCRIPTION
Update the class names for all the FP8 and FP4 types to follow this pattern:

```
template<size_t N>
class fp8_e4m3_x {/*...*/};

using fp8_e4m3 = fp8_e4m3_x<1>;
using fp8_e4m3_x2 = fp8_e4m3_x<2>;
```

This is less verbose in the common case where the user knows they want either 1 or 2 elements.  For anyone writing generic code, where the number of elements is a parameter, you can still use the `fp8_e4m3_x<N>` form.