### PR TITLE
[UR][L0v2] Add graph support for batched queue

### DIFF
--- a/unified-runtime/source/adapters/level_zero/common.cpp
+++ b/unified-runtime/source/adapters/level_zero/common.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "common.hpp"
+#include "external/driver_experimental/zex_graph.h"
 #include "logger/ur_logger.hpp"
 #include "usm.hpp"
 
@@ -348,6 +349,12 @@ template <>
 ze_structure_type_ext_t
 getZexStructureType<ze_intel_xe_device_exp_properties_t>() {
   return ZE_STRUCTURE_TYPE_INTEL_XE_DEVICE_EXP_PROPERTIES;
+}
+
+template <>
+ze_structure_type_ext_t
+getZexStructureType<ze_record_replay_graph_exp_properties_t>() {
+  return ZE_STRUCTURE_TYPE_RECORD_REPLAY_GRAPH_EXP_PROPERTIES;
 }
 
 // Global variables for ZER_EXT_RESULT_ADAPTER_SPECIFIC_ERROR

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1574,14 +1574,29 @@ ur_result_t urDeviceGetInfo(
   case UR_DEVICE_INFO_IS_INTEGRATED_GPU:
     return ReturnValue(static_cast<ur_bool_t>(Device->isIntegrated() != 0));
   case UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP:
-    // TODO: Re-enable when platform requirements are defined for graph record
-    // and replay
+#ifdef UR_ADAPTER_LEVEL_ZERO_V2
+  {
+    if (!Device->Platform->ZeGraphExt.Supported) {
+      return ReturnValue(false);
+    }
+
+    ze_record_replay_graph_exp_properties_t GraphProperties{};
+    GraphProperties.stype =
+        ZE_STRUCTURE_TYPE_RECORD_REPLAY_GRAPH_EXP_PROPERTIES;
+    GraphProperties.pNext = nullptr;
+    ZeStruct<ze_device_properties_t> DeviceProperties;
+    DeviceProperties.pNext = &GraphProperties;
+    ZE2UR_CALL(zeDeviceGetProperties, (ZeDevice, &DeviceProperties));
+
+    constexpr ze_record_replay_graph_exp_flags_t GraphModeMask =
+        ZE_RECORD_REPLAY_GRAPH_EXP_FLAG_IMMUTABLE_GRAPH |
+        ZE_RECORD_REPLAY_GRAPH_EXP_FLAG_MUTABLE_GRAPH;
+    return ReturnValue(static_cast<ur_bool_t>(
+        (GraphProperties.graphFlags & GraphModeMask) != 0));
+  }
+#else
     return ReturnValue(false);
-    // #ifdef UR_ADAPTER_LEVEL_ZERO_V2
-    //     return ReturnValue(Device->Platform->ZeGraphExt.Supported);
-    // #else
-    //     return ReturnValue(false);
-    // #endif
+#endif
   case UR_DEVICE_INFO_ENQUEUE_HOST_TASK_SUPPORT_EXP:
 #ifdef UR_ADAPTER_LEVEL_ZERO_V2
     return ReturnValue(Device->Platform->ZeHostTaskExt.Supported);

--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1574,11 +1574,14 @@ ur_result_t urDeviceGetInfo(
   case UR_DEVICE_INFO_IS_INTEGRATED_GPU:
     return ReturnValue(static_cast<ur_bool_t>(Device->isIntegrated() != 0));
   case UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP:
-#ifdef UR_ADAPTER_LEVEL_ZERO_V2
-    return ReturnValue(Device->Platform->ZeGraphExt.Supported);
-#else
+    // TODO: Re-enable when platform requirements are defined for graph record
+    // and replay
     return ReturnValue(false);
-#endif
+    // #ifdef UR_ADAPTER_LEVEL_ZERO_V2
+    //     return ReturnValue(Device->Platform->ZeGraphExt.Supported);
+    // #else
+    //     return ReturnValue(false);
+    // #endif
   case UR_DEVICE_INFO_ENQUEUE_HOST_TASK_SUPPORT_EXP:
 #ifdef UR_ADAPTER_LEVEL_ZERO_V2
     return ReturnValue(Device->Platform->ZeHostTaskExt.Supported);

--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -305,6 +305,12 @@ ur_result_t ur_platform_handle_t_::initialize() {
     zeDriverExtensionMap[extension.name] = extension.version;
   }
 
+  const auto GraphExtension =
+      zeDriverExtensionMap.find(ZE_RECORD_REPLAY_GRAPH_EXP_NAME);
+  const bool ZeGraphExtensionSupported =
+      GraphExtension != zeDriverExtensionMap.end() &&
+      GraphExtension->second >= ZE_RECORD_REPLAY_GRAPH_EXP_VERSION_1_0;
+
   ZE2UR_CALL(zelLoaderTranslateHandle, (ZEL_HANDLE_DRIVER, ZeDriver,
                                         (void **)&ZeDriverHandleExpTranslated));
 
@@ -561,53 +567,58 @@ ur_result_t ur_platform_handle_t_::initialize() {
   ZeMemGetPitchFor2dImageExt.Supported =
       ZeMemGetPitchFor2dImageExt.zeMemGetPitchFor2dImage != nullptr;
 
-  // Populate Graph Extension structure. Mandatory graph functions.
-  std::unordered_map<std::string, void **> ZeGraphFuncNameToAddrMap = {
-      {"zeGraphCreateExp",
-       reinterpret_cast<void **>(&ZeGraphExt.zeGraphCreateExp)},
-      {"zeCommandListBeginGraphCaptureExp",
-       reinterpret_cast<void **>(
-           &ZeGraphExt.zeCommandListBeginGraphCaptureExp)},
-      {"zeCommandListBeginCaptureIntoGraphExp",
-       reinterpret_cast<void **>(
-           &ZeGraphExt.zeCommandListBeginCaptureIntoGraphExp)},
-      {"zeCommandListEndGraphCaptureExp",
-       reinterpret_cast<void **>(&ZeGraphExt.zeCommandListEndGraphCaptureExp)},
-      {"zeCommandListInstantiateGraphExp",
-       reinterpret_cast<void **>(&ZeGraphExt.zeCommandListInstantiateGraphExp)},
-      {"zeCommandListAppendGraphExp",
-       reinterpret_cast<void **>(&ZeGraphExt.zeCommandListAppendGraphExp)},
-      {"zeGraphDestroyExp",
-       reinterpret_cast<void **>(&ZeGraphExt.zeGraphDestroyExp)},
-      {"zeExecutableGraphDestroyExp",
-       reinterpret_cast<void **>(&ZeGraphExt.zeExecutableGraphDestroyExp)},
-      {"zeCommandListIsGraphCaptureEnabledExp",
-       reinterpret_cast<void **>(
-           &ZeGraphExt.zeCommandListIsGraphCaptureEnabledExp)},
-      {"zeGraphIsEmptyExp",
-       reinterpret_cast<void **>(&ZeGraphExt.zeGraphIsEmptyExp)},
-      {"zeGraphDumpContentsExp",
-       reinterpret_cast<void **>(&ZeGraphExt.zeGraphDumpContentsExp)},
-  };
+  if (ZeGraphExtensionSupported) {
+    // Populate Graph Extension structure. Mandatory graph functions.
+    std::unordered_map<std::string, void **> ZeGraphFuncNameToAddrMap = {
+        {"zeGraphCreateExp",
+         reinterpret_cast<void **>(&ZeGraphExt.zeGraphCreateExp)},
+        {"zeCommandListBeginGraphCaptureExp",
+         reinterpret_cast<void **>(
+             &ZeGraphExt.zeCommandListBeginGraphCaptureExp)},
+        {"zeCommandListBeginCaptureIntoGraphExp",
+         reinterpret_cast<void **>(
+             &ZeGraphExt.zeCommandListBeginCaptureIntoGraphExp)},
+        {"zeCommandListEndGraphCaptureExp",
+         reinterpret_cast<void **>(
+             &ZeGraphExt.zeCommandListEndGraphCaptureExp)},
+        {"zeCommandListInstantiateGraphExp",
+         reinterpret_cast<void **>(
+             &ZeGraphExt.zeCommandListInstantiateGraphExp)},
+        {"zeCommandListAppendGraphExp",
+         reinterpret_cast<void **>(&ZeGraphExt.zeCommandListAppendGraphExp)},
+        {"zeGraphDestroyExp",
+         reinterpret_cast<void **>(&ZeGraphExt.zeGraphDestroyExp)},
+        {"zeExecutableGraphDestroyExp",
+         reinterpret_cast<void **>(&ZeGraphExt.zeExecutableGraphDestroyExp)},
+        {"zeCommandListIsGraphCaptureEnabledExp",
+         reinterpret_cast<void **>(
+             &ZeGraphExt.zeCommandListIsGraphCaptureEnabledExp)},
+        {"zeGraphIsEmptyExp",
+         reinterpret_cast<void **>(&ZeGraphExt.zeGraphIsEmptyExp)},
+        {"zeGraphDumpContentsExp",
+         reinterpret_cast<void **>(&ZeGraphExt.zeGraphDumpContentsExp)},
+    };
 
-  ZeGraphExt.Supported = true;
-  for (auto &[funcName, funcAddr] : ZeGraphFuncNameToAddrMap) {
-    ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
-                    (ZeDriver, funcName.c_str(), funcAddr));
-    ZeGraphExt.Supported &= (*funcAddr != nullptr);
-  }
+    ZeGraphExt.Supported = true;
+    for (auto &[funcName, funcAddr] : ZeGraphFuncNameToAddrMap) {
+      ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
+                      (ZeDriver, funcName.c_str(), funcAddr));
+      ZeGraphExt.Supported &= (*funcAddr != nullptr);
+    }
 
-  // Optional graph functions. If the function is not supported due to driver
-  // version, then still mark graphs as supported and only return unsupported
-  // code in affected function.
-  std::unordered_map<std::string, void **> ZeGraphOptionalFuncNameToAddrMap = {
-      {"zeCommandListGetGraphExp",
-       reinterpret_cast<void **>(&ZeGraphExt.zeCommandListGetGraphExp)},
-  };
+    // Optional graph functions. If the function is not supported due to driver
+    // version, then still mark graphs as supported and only return unsupported
+    // code in affected function.
+    std::unordered_map<std::string, void **> ZeGraphOptionalFuncNameToAddrMap =
+        {
+            {"zeCommandListGetGraphExp",
+             reinterpret_cast<void **>(&ZeGraphExt.zeCommandListGetGraphExp)},
+        };
 
-  for (auto &[funcName, funcAddr] : ZeGraphOptionalFuncNameToAddrMap) {
-    ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
-                    (ZeDriver, funcName.c_str(), funcAddr));
+    for (auto &[funcName, funcAddr] : ZeGraphOptionalFuncNameToAddrMap) {
+      ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
+                      (ZeDriver, funcName.c_str(), funcAddr));
+    }
   }
 
   if (this->isDriverVersionNewerOrSimilar(1, 14, 36035)) {

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -1401,7 +1401,7 @@ ur_command_list_manager::appendGraph(ur_exp_executable_graph_handle_t hGraph,
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t ur_command_list_manager::isGraphCaptureActive(bool *pResult) {
+ur_result_t ur_command_list_manager::queryGraphCaptureActive(bool *pResult) {
   if (!checkGraphExtensionSupport(hContext.get())) {
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -1320,7 +1320,7 @@ ur_result_t ur_command_list_manager::appendKernelLaunchWithArgsExp(
   } else {
     // We cannot pass cooperativeKernelLaunchRequested to
     // appendKernelLaunchWithArgsExpOld() because appendKernelLaunch() must
-    // check it on its own since it is called also from enqueueKernelLaunch().
+    // check it on its own since it is called from other kernel launch paths.
     return appendKernelLaunchWithArgsExpOld(
         hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize,
         numArgs, pArgs, launchPropList, waitListView, phEvent);

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.hpp
@@ -258,7 +258,7 @@ struct ur_command_list_manager {
   ur_result_t beginGraphCapture();
   ur_result_t beginCaptureIntoGraph(ur_exp_graph_handle_t hGraph);
   ur_result_t endGraphCapture(ur_exp_graph_handle_t *phGraph);
-  ur_result_t isGraphCaptureActive(bool *pResult);
+  ur_result_t queryGraphCaptureActive(bool *pResult);
   ur_result_t getGraph(ur_exp_graph_handle_t *phGraph);
 
   v2::raii::command_list_unique_handle &&releaseCommandList();

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -1014,8 +1014,14 @@ ur_result_t ur_queue_batched_t::enqueueGraphExp(
   }
 
   auto batchLocked = currentCmdLists.lock();
-  return batchLocked->getListManager().appendGraph(
+  ur_result_t appendResult = batchLocked->getListManager().appendGraph(
       hGraph, waitListView, getEvent(batchLocked, phEvent));
+
+  if (appendResult != UR_RESULT_SUCCESS) {
+    return appendResult;
+  }
+
+  return markIssuedCommandInBatch(batchLocked);
 }
 
 ur_result_t ur_queue_batched_t::queueBeginGraphCapteExp() {

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -1068,7 +1068,7 @@ ur_result_t ur_queue_batched_t::enqueueHostTaskExp(
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
   wait_list_view waitListView =
-      wait_list_view(phEventWaitList, numEventsInWaitList);
+      wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto batchLocked = currentCmdLists.lock();
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -1,5 +1,6 @@
 //===--------------- queue_batched.cpp - Level Zero Adapter ---------------===//
 //
+// Copyright (C) 2025-2026 Intel Corporation
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM
 // Exceptions. See https://llvm.org/LICENSE.txt for license information.
@@ -102,6 +103,26 @@ ur_event_handle_t ur_queue_batched_t::createEventAndRetainRegular(
   return hEvent;
 }
 
+ur_event_handle_t
+ur_queue_batched_t::getEvent(locked<batch_manager> &batchLocked,
+                             ur_event_handle_t *phEvent) {
+  if (batchLocked->isGraphCaptureActive()) {
+    return createEventIfRequested(eventPoolImmediate.get(), phEvent, this);
+  }
+  return createEventIfRequestedRegular(phEvent,
+                                       batchLocked->getCurrentGeneration());
+}
+
+ur_event_handle_t
+ur_queue_batched_t::getEventAndRetain(locked<batch_manager> &batchLocked,
+                                      ur_event_handle_t *phEvent) {
+  if (batchLocked->isGraphCaptureActive()) {
+    return createEventAndRetain(eventPoolImmediate.get(), phEvent, this);
+  }
+  return createEventAndRetainRegular(phEvent,
+                                     batchLocked->getCurrentGeneration());
+}
+
 ur_result_t batch_manager::renewRegularUnlocked(
     v2::raii::command_list_unique_handle &&newRegularBatch) {
   TRACK_SCOPE_LATENCY("batch_manager::renewRegularUnlocked");
@@ -172,6 +193,28 @@ ur_result_t ur_queue_batched_t::markIssuedCommandInBatch(
   }
 
   batchLocked->markNextIssuedCommand();
+
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t ur_queue_batched_t::enqueueKernelLaunch(
+    ur_kernel_handle_t hKernel, uint32_t workDim,
+    const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
+    const size_t *pLocalWorkSize,
+    const ur_kernel_launch_ext_properties_t *launchPropList,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+
+  wait_list_view waitListView =
+      wait_list_view(phEventWaitList, numEventsInWaitList, this);
+
+  TRACK_SCOPE_LATENCY("ur_queue_batched_t::enqueueKernelLaunch");
+  auto lockedBatch = currentCmdLists.lock();
+  markIssuedCommandInBatch(lockedBatch);
+
+  UR_CALL(lockedBatch->getListManager().appendKernelLaunch(
+      hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize,
+      launchPropList, waitListView, getEvent(lockedBatch, phEvent)));
 
   return UR_RESULT_SUCCESS;
 }
@@ -265,10 +308,9 @@ ur_result_t ur_queue_batched_t::enqueueMemBufferRead(
 
     markIssuedCommandInBatch(lockedBatches);
 
-    UR_CALL(lockedBatches->getActiveBatch().appendMemBufferRead(
+    UR_CALL(lockedBatches->getListManager().appendMemBufferRead(
         hBuffer, false, offset, size, pDst, waitListView,
-        createEventIfRequestedRegular(phEvent,
-                                      lockedBatches->getCurrentGeneration())));
+        getEvent(lockedBatches, phEvent)));
 
     if (blockingRead) {
       UR_CALL(queueFinishUnlocked(lockedBatches));
@@ -290,13 +332,11 @@ ur_result_t ur_queue_batched_t::enqueueMemBufferWrite(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatches = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatches);
 
-  UR_CALL(lockedBatches->getActiveBatch().appendMemBufferWrite(
+  UR_CALL(lockedBatches->getListManager().appendMemBufferWrite(
       hBuffer, false, offset, size, pSrc, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatches->getCurrentGeneration())));
+      getEvent(lockedBatches, phEvent)));
 
   if (blockingWrite) {
     UR_CALL(queueFinishUnlocked(lockedBatches));
@@ -315,13 +355,11 @@ ur_result_t ur_queue_batched_t::enqueueDeviceGlobalVariableWrite(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendDeviceGlobalVariableWrite(
+  UR_CALL(lockedBatch->getListManager().appendDeviceGlobalVariableWrite(
       hProgram, name, false, count, offset, pSrc, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+      getEvent(lockedBatch, phEvent)));
 
   if (blockingWrite) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -337,13 +375,11 @@ ur_result_t ur_queue_batched_t::enqueueDeviceGlobalVariableRead(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendDeviceGlobalVariableRead(
+  UR_CALL(lockedBatch->getListManager().appendDeviceGlobalVariableRead(
       hProgram, name, false, count, offset, pDst, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+      getEvent(lockedBatch, phEvent)));
 
   if (blockingRead) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -361,13 +397,11 @@ ur_result_t ur_queue_batched_t::enqueueMemBufferFill(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendMemBufferFill(
+  return lockedBatch->getListManager().appendMemBufferFill(
       hBuffer, pPattern, patternSize, offset, size, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      getEvent(lockedBatch, phEvent));
 
 } catch (...) {
   return exceptionToResult(std::current_exception());
@@ -380,13 +414,10 @@ ur_result_t ur_queue_batched_t::enqueueUSMMemcpy(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendUSMMemcpy(
-      false, pDst, pSrc, size, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+  UR_CALL(lockedBatch->getListManager().appendUSMMemcpy(
+      false, pDst, pSrc, size, waitListView, getEvent(lockedBatch, phEvent)));
 
   if (blocking) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -401,13 +432,10 @@ ur_result_t ur_queue_batched_t::enqueueUSMFreeExp(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendUSMFreeExp(
-      this, pPool, pMem, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+  UR_CALL(lockedBatch->getListManager().appendUSMFreeExp(
+      this, pPool, pMem, waitListView, getEvent(lockedBatch, phEvent)));
 
   return renewBatchUnlocked(lockedBatch);
 }
@@ -421,14 +449,11 @@ ur_result_t ur_queue_batched_t::enqueueMemBufferMap(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendMemBufferMap(
+  UR_CALL(lockedBatch->getListManager().appendMemBufferMap(
       hBuffer, false, mapFlags, offset, size, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()),
-      ppRetMap));
+      getEvent(lockedBatch, phEvent), ppRetMap));
 
   if (blockingMap) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -443,13 +468,10 @@ ur_result_t ur_queue_batched_t::enqueueMemUnmap(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendMemUnmap(
-      hMem, pMappedPtr, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+  return lockedBatch->getListManager().appendMemUnmap(
+      hMem, pMappedPtr, waitListView, getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::enqueueMemBufferReadRect(
@@ -461,14 +483,12 @@ ur_result_t ur_queue_batched_t::enqueueMemBufferReadRect(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendMemBufferReadRect(
+  UR_CALL(lockedBatch->getListManager().appendMemBufferReadRect(
       hBuffer, false, bufferOrigin, hostOrigin, region, bufferRowPitch,
       bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+      getEvent(lockedBatch, phEvent)));
 
   if (blockingRead) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -487,14 +507,12 @@ ur_result_t ur_queue_batched_t::enqueueMemBufferWriteRect(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendMemBufferWriteRect(
+  UR_CALL(lockedBatch->getListManager().appendMemBufferWriteRect(
       hBuffer, false, bufferOrigin, hostOrigin, region, bufferRowPitch,
       bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+      getEvent(lockedBatch, phEvent)));
 
   if (blockingWrite) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -509,13 +527,10 @@ ur_result_t ur_queue_batched_t::enqueueUSMAdvise(const void *pMem, size_t size,
   wait_list_view emptyWaitList = wait_list_view(nullptr, 0, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendUSMAdvise(
-      pMem, size, advice, emptyWaitList,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+  return lockedBatch->getListManager().appendUSMAdvise(
+      pMem, size, advice, emptyWaitList, getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::enqueueUSMMemcpy2D(
@@ -525,13 +540,11 @@ ur_result_t ur_queue_batched_t::enqueueUSMMemcpy2D(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendUSMMemcpy2D(
+  UR_CALL(lockedBatch->getListManager().appendUSMMemcpy2D(
       false, pDst, dstPitch, pSrc, srcPitch, width, height, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+      getEvent(lockedBatch, phEvent)));
 
   if (blocking) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -547,13 +560,11 @@ ur_result_t ur_queue_batched_t::enqueueUSMFill2D(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendUSMFill2D(
+  return lockedBatch->getListManager().appendUSMFill2D(
       pMem, pitch, patternSize, pPattern, width, height, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::enqueueUSMPrefetch(
@@ -563,13 +574,10 @@ ur_result_t ur_queue_batched_t::enqueueUSMPrefetch(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendUSMPrefetch(
-      pMem, size, flags, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+  return lockedBatch->getListManager().appendUSMPrefetch(
+      pMem, size, flags, waitListView, getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::enqueueMemBufferCopyRect(
@@ -582,14 +590,12 @@ ur_result_t ur_queue_batched_t::enqueueMemBufferCopyRect(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendMemBufferCopyRect(
+  return lockedBatch->getListManager().appendMemBufferCopyRect(
       hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch,
       srcSlicePitch, dstRowPitch, dstSlicePitch, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::enqueueEventsWaitWithBarrier(
@@ -598,17 +604,14 @@ ur_result_t ur_queue_batched_t::enqueueEventsWaitWithBarrier(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
   if ((flags & UR_QUEUE_FLAG_PROFILING_ENABLE) != 0) {
-    UR_CALL(lockedBatch->getActiveBatch().appendEventsWaitWithBarrier(
-        waitListView, createEventIfRequestedRegular(
-                          phEvent, lockedBatch->getCurrentGeneration())));
+    UR_CALL(lockedBatch->getListManager().appendEventsWaitWithBarrier(
+        waitListView, getEvent(lockedBatch, phEvent)));
   } else {
-    UR_CALL(lockedBatch->getActiveBatch().appendEventsWait(
-        waitListView, createEventIfRequestedRegular(
-                          phEvent, lockedBatch->getCurrentGeneration())));
+    UR_CALL(lockedBatch->getListManager().appendEventsWait(
+        waitListView, getEvent(lockedBatch, phEvent)));
   }
 
   return renewBatchUnlocked(lockedBatch);
@@ -622,12 +625,10 @@ ur_queue_batched_t::enqueueEventsWait(uint32_t numEventsInWaitList,
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendEventsWait(
-      waitListView, createEventIfRequestedRegular(
-                        phEvent, lockedBatch->getCurrentGeneration())));
+  UR_CALL(lockedBatch->getListManager().appendEventsWait(
+      waitListView, getEvent(lockedBatch, phEvent)));
 
   return renewBatchUnlocked(lockedBatch);
 }
@@ -640,13 +641,11 @@ ur_result_t ur_queue_batched_t::enqueueMemBufferCopy(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendMemBufferCopy(
+  return lockedBatch->getListManager().appendMemBufferCopy(
       hBufferSrc, hBufferDst, srcOffset, dstOffset, size, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::enqueueUSMFill(
@@ -657,13 +656,11 @@ ur_result_t ur_queue_batched_t::enqueueUSMFill(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendUSMFill(
+  return lockedBatch->getListManager().appendUSMFill(
       pMem, patternSize, pPattern, size, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::enqueueMemImageRead(
@@ -675,13 +672,11 @@ ur_result_t ur_queue_batched_t::enqueueMemImageRead(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendMemImageRead(
+  UR_CALL(lockedBatch->getListManager().appendMemImageRead(
       hImage, false, origin, region, rowPitch, slicePitch, pDst, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+      getEvent(lockedBatch, phEvent)));
 
   if (blockingRead) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -699,13 +694,11 @@ ur_result_t ur_queue_batched_t::enqueueMemImageWrite(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendMemImageWrite(
+  UR_CALL(lockedBatch->getListManager().appendMemImageWrite(
       hImage, false, origin, region, rowPitch, slicePitch, pSrc, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+      getEvent(lockedBatch, phEvent)));
 
   if (blockingWrite) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -722,13 +715,11 @@ ur_result_t ur_queue_batched_t::enqueueMemImageCopy(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendMemImageCopy(
+  return lockedBatch->getListManager().appendMemImageCopy(
       hImageSrc, hImageDst, srcOrigin, dstOrigin, region, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::enqueueReadHostPipe(
@@ -739,13 +730,11 @@ ur_result_t ur_queue_batched_t::enqueueReadHostPipe(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendReadHostPipe(
+  UR_CALL(lockedBatch->getListManager().appendReadHostPipe(
       hProgram, pipe_symbol, false, pDst, size, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+      getEvent(lockedBatch, phEvent)));
 
   if (blocking) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -762,13 +751,11 @@ ur_result_t ur_queue_batched_t::enqueueWriteHostPipe(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendWriteHostPipe(
+  UR_CALL(lockedBatch->getListManager().appendWriteHostPipe(
       hProgram, pipe_symbol, false, pSrc, size, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+      getEvent(lockedBatch, phEvent)));
 
   if (blocking) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -786,14 +773,11 @@ ur_result_t ur_queue_batched_t::enqueueUSMDeviceAllocExp(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendUSMAllocHelper(
+  UR_CALL(lockedBatch->getListManager().appendUSMAllocHelper(
       this, pPool, size, pProperties, waitListView, ppMem,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()),
-      UR_USM_TYPE_DEVICE));
+      getEvent(lockedBatch, phEvent), UR_USM_TYPE_DEVICE));
 
   return renewBatchUnlocked(lockedBatch);
 }
@@ -808,14 +792,11 @@ ur_result_t ur_queue_batched_t::enqueueUSMSharedAllocExp(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendUSMAllocHelper(
+  UR_CALL(lockedBatch->getListManager().appendUSMAllocHelper(
       this, pPool, size, pProperties, waitListView, ppMem,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()),
-      UR_USM_TYPE_SHARED));
+      getEvent(lockedBatch, phEvent), UR_USM_TYPE_SHARED));
 
   return renewBatchUnlocked(lockedBatch);
 }
@@ -829,14 +810,11 @@ ur_result_t ur_queue_batched_t::enqueueUSMHostAllocExp(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendUSMAllocHelper(
+  UR_CALL(lockedBatch->getListManager().appendUSMAllocHelper(
       this, pPool, size, pProperties, waitListView, ppMem,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()),
-      UR_USM_TYPE_HOST));
+      getEvent(lockedBatch, phEvent), UR_USM_TYPE_HOST));
 
   return renewBatchUnlocked(lockedBatch);
 }
@@ -856,15 +834,12 @@ ur_result_t ur_queue_batched_t::bindlessImagesImageCopyExp(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().bindlessImagesImageCopyExp(
+  return lockedBatch->getListManager().bindlessImagesImageCopyExp(
       pSrc, pDst, pSrcImageDesc, pDstImageDesc, pSrcImageFormat,
       pDstImageFormat, pCopyRegion, imageCopyFlags, imageCopyInputTypes,
-      waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      waitListView, getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::bindlessImagesWaitExternalSemaphoreExp(
@@ -875,13 +850,11 @@ ur_result_t ur_queue_batched_t::bindlessImagesWaitExternalSemaphoreExp(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().bindlessImagesWaitExternalSemaphoreExp(
+  return lockedBatch->getListManager().bindlessImagesWaitExternalSemaphoreExp(
       hSemaphore, hasWaitValue, waitValue, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::bindlessImagesSignalExternalSemaphoreExp(
@@ -892,13 +865,11 @@ ur_result_t ur_queue_batched_t::bindlessImagesSignalExternalSemaphoreExp(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().bindlessImagesSignalExternalSemaphoreExp(
+  return lockedBatch->getListManager().bindlessImagesSignalExternalSemaphoreExp(
       hSemaphore, hasSignalValue, signalValue, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      getEvent(lockedBatch, phEvent));
 }
 
 // In case of queues with batched submissions, which use regular command lists
@@ -919,13 +890,10 @@ ur_result_t ur_queue_batched_t::enqueueTimestampRecordingExp(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  UR_CALL(lockedBatch->getActiveBatch().appendTimestampRecordingExp(
-      false, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration())));
+  UR_CALL(lockedBatch->getListManager().appendTimestampRecordingExp(
+      false, waitListView, getEvent(lockedBatch, phEvent)));
 
   if (blocking) {
     UR_CALL(queueFinishUnlocked(lockedBatch));
@@ -966,14 +934,11 @@ ur_result_t ur_queue_batched_t::enqueueNativeCommandExp(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendNativeCommandExp(
+  return lockedBatch->getListManager().appendNativeCommandExp(
       pfnNativeEnqueue, data, numMemsInMemList, phMemList, pProperties,
-      waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      waitListView, getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::enqueueKernelLaunchWithArgsExp(
@@ -989,14 +954,12 @@ ur_result_t ur_queue_batched_t::enqueueKernelLaunchWithArgsExp(
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   auto lockedBatch = currentCmdLists.lock();
-
   markIssuedCommandInBatch(lockedBatch);
 
-  return lockedBatch->getActiveBatch().appendKernelLaunchWithArgsExp(
+  return lockedBatch->getListManager().appendKernelLaunchWithArgsExp(
       hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize,
       numArgs, pArgs, launchPropList, waitListView,
-      createEventIfRequestedRegular(phEvent,
-                                    lockedBatch->getCurrentGeneration()));
+      getEvent(lockedBatch, phEvent));
 }
 
 ur_result_t ur_queue_batched_t::queueGetInfo(ur_queue_info_t propName,
@@ -1060,6 +1023,57 @@ ur_result_t ur_queue_batched_t::queueFlush() {
   } else {
     return renewBatchUnlocked(batchLocked);
   }
+}
+
+ur_result_t ur_queue_batched_t::enqueueGraphExp(
+    ur_exp_executable_graph_handle_t hGraph, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  wait_list_view waitListView =
+      wait_list_view(phEventWaitList, numEventsInWaitList);
+
+  bool isGraphCaptureActive = false;
+  ur_result_t result = queueIsGraphCapteEnabledExp(&isGraphCaptureActive);
+  if (result == UR_RESULT_SUCCESS && !isGraphCaptureActive) {
+    return UR_RESULT_ERROR_INVALID_OPERATION;
+  }
+
+  auto batchLocked = currentCmdLists.lock();
+  return batchLocked->getListManager().appendGraph(
+      hGraph, waitListView, getEvent(batchLocked, phEvent));
+}
+
+ur_result_t ur_queue_batched_t::queueBeginGraphCapteExp() {
+  return currentCmdLists.lock()->getListManager().beginGraphCapture();
+}
+
+ur_result_t
+ur_queue_batched_t::queueBeginCapteIntoGraphExp(ur_exp_graph_handle_t hGraph) {
+  return currentCmdLists.lock()->getListManager().beginCaptureIntoGraph(hGraph);
+}
+
+ur_result_t
+ur_queue_batched_t::queueEndGraphCapteExp(ur_exp_graph_handle_t *phGraph) {
+  return currentCmdLists.lock()->getListManager().endGraphCapture(phGraph);
+}
+
+ur_result_t ur_queue_batched_t::queueIsGraphCapteEnabledExp(bool *pResult) {
+  return currentCmdLists.lock()->getListManager().queryGraphCaptureActive(
+      pResult);
+}
+
+ur_result_t ur_queue_batched_t::enqueueHostTaskExp(
+    ur_exp_host_task_function_t pfnHostTask, void *data,
+    const ur_exp_host_task_properties_t *pProperties,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  wait_list_view waitListView =
+      wait_list_view(phEventWaitList, numEventsInWaitList);
+
+  auto batchLocked = currentCmdLists.lock();
+
+  return batchLocked->getListManager().appendHostTaskExp(
+      pfnHostTask, data, pProperties, waitListView,
+      this->getEvent(batchLocked, phEvent));
 }
 
 } // namespace v2

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -1019,18 +1019,26 @@ ur_result_t ur_queue_batched_t::enqueueGraphExp(
 }
 
 ur_result_t ur_queue_batched_t::queueBeginGraphCapteExp() {
-  currentCmdLists.lock()->setGraphCapture(true);
-  return currentCmdLists.lock()->getListManager().beginGraphCapture();
+  auto lockedBatch = currentCmdLists.lock();
+  lockedBatch->setGraphCapture(true);
+  return lockedBatch->getListManager().beginGraphCapture();
 }
 
 ur_result_t
 ur_queue_batched_t::queueBeginCapteIntoGraphExp(ur_exp_graph_handle_t hGraph) {
-  return currentCmdLists.lock()->getListManager().beginCaptureIntoGraph(hGraph);
+  auto lockedBatch = currentCmdLists.lock();
+  lockedBatch->setGraphCapture(true);
+  return lockedBatch->getListManager().beginCaptureIntoGraph(hGraph);
 }
 
 ur_result_t
 ur_queue_batched_t::queueEndGraphCapteExp(ur_exp_graph_handle_t *phGraph) {
-  return currentCmdLists.lock()->getListManager().endGraphCapture(phGraph);
+  auto lockedBatch = currentCmdLists.lock();
+  ur_result_t result = lockedBatch->getListManager().endGraphCapture(phGraph);
+  if (result == UR_RESULT_SUCCESS) {
+    lockedBatch->setGraphCapture(false);
+  }
+  return result;
 }
 
 ur_result_t ur_queue_batched_t::queueIsGraphCapteEnabledExp(bool *pResult) {

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -223,6 +223,12 @@ ur_result_t batch_manager::batchFinish() {
 
 ur_result_t
 ur_queue_batched_t::queueFinishUnlocked(locked<batch_manager> &batchLocked) {
+  // During graph capture, operations are recorded to the immediate list.
+  // Synchronization doesn't apply to graph recording - return early.
+  if (batchLocked->isGraphCaptureActive()) {
+    return UR_RESULT_SUCCESS;
+  }
+
   if (!batchLocked->isActiveBatchEmpty()) {
     UR_CALL(batchLocked->enqueueCurrentBatchUnlocked());
   }
@@ -978,6 +984,12 @@ ur_queue_batched_t::queueGetNativeHandle(ur_queue_native_desc_t * /*pDesc*/,
 ur_result_t ur_queue_batched_t::queueFlush() {
   auto batchLocked = currentCmdLists.lock();
 
+  // During graph capture, operations are recorded to the immediate list.
+  // Flushing doesn't apply to graph recording - return early.
+  if (batchLocked->isGraphCaptureActive()) {
+    return UR_RESULT_SUCCESS;
+  }
+
   if (batchLocked->isActiveBatchEmpty()) {
     return UR_RESULT_SUCCESS;
   } else {
@@ -1044,6 +1056,8 @@ ur_queue_batched_t::queueEndGraphCapteExp(ur_exp_graph_handle_t *phGraph) {
 }
 
 ur_result_t ur_queue_batched_t::queueIsGraphCapteEnabledExp(bool *pResult) {
+  // The returned command list doesn't matter, because they share the same
+  // context which is retrieved and checked in the queryGraphCaptureActive.
   return currentCmdLists.lock()->getListManager().queryGraphCaptureActive(
       pResult);
 }

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -1019,6 +1019,7 @@ ur_result_t ur_queue_batched_t::enqueueGraphExp(
 }
 
 ur_result_t ur_queue_batched_t::queueBeginGraphCapteExp() {
+  currentCmdLists.lock()->setGraphCapture(true);
   return currentCmdLists.lock()->getListManager().beginGraphCapture();
 }
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -162,6 +162,12 @@ ur_queue_batched_t::onEventWaitListUse(ur_event_generation_t batch_generation) {
 
 ur_result_t ur_queue_batched_t::markIssuedCommandInBatch(
     locked<batch_manager> &batchLocked) {
+  // During graph capture, commands are appended to an immediate command list,
+  // not to the batch. Skip batch tracking in this case.
+  if (batchLocked->isGraphCaptureActive()) {
+    return UR_RESULT_SUCCESS;
+  }
+
   if (batchLocked->isLimitOfEnqueuedCommandsReached()) {
     UR_CALL(queueFinishUnlocked(batchLocked));
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -1032,6 +1032,13 @@ ur_result_t ur_queue_batched_t::enqueueGraphExp(
 
 ur_result_t ur_queue_batched_t::queueBeginGraphCapteExp() {
   auto lockedBatch = currentCmdLists.lock();
+
+  // Firstly, enqueue the current batch (a regular list) to preserve the order
+  // of operations before switching to immediate list mode for graph capture
+  if (!lockedBatch->isActiveBatchEmpty()) {
+    UR_CALL(renewBatchUnlocked(lockedBatch));
+  }
+
   lockedBatch->setGraphCapture(true);
   return lockedBatch->getListManager().beginGraphCapture();
 }
@@ -1039,6 +1046,13 @@ ur_result_t ur_queue_batched_t::queueBeginGraphCapteExp() {
 ur_result_t
 ur_queue_batched_t::queueBeginCapteIntoGraphExp(ur_exp_graph_handle_t hGraph) {
   auto lockedBatch = currentCmdLists.lock();
+
+  // Firstly, enqueue the current batch (a regular list) to preserve the order
+  // of operations before switching to immediate list mode for graph capture
+  if (!lockedBatch->isActiveBatchEmpty()) {
+    UR_CALL(renewBatchUnlocked(lockedBatch));
+  }
+
   lockedBatch->setGraphCapture(true);
   return lockedBatch->getListManager().beginCaptureIntoGraph(hGraph);
 }

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -1013,21 +1013,19 @@ ur_result_t ur_queue_batched_t::enqueueGraphExp(
   wait_list_view waitListView =
       wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
-  bool isGraphCaptureActive = false;
-  ur_result_t result = queueIsGraphCapteEnabledExp(&isGraphCaptureActive);
-  if (result == UR_RESULT_SUCCESS && !isGraphCaptureActive) {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
+  auto lockedBatch = currentCmdLists.lock();
+
+  // Flush the current batch to preserve order of operations
+  if (!lockedBatch->isActiveBatchEmpty()) {
+    UR_CALL(renewBatchUnlocked(lockedBatch));
   }
 
-  auto batchLocked = currentCmdLists.lock();
-  ur_result_t appendResult = batchLocked->getListManager().appendGraph(
-      hGraph, waitListView, getEvent(batchLocked, phEvent));
-
-  if (appendResult != UR_RESULT_SUCCESS) {
-    return appendResult;
-  }
-
-  return markIssuedCommandInBatch(batchLocked);
+  // Graph execution must use immediate command list, similar to command buffer
+  // execution. Level Zero requires graphs to be executed on the same type of
+  // list used during capture.
+  return lockedBatch->getImmediateManager().appendGraph(
+      hGraph, waitListView,
+      createEventAndRetain(eventPoolImmediate.get(), phEvent, this));
 }
 
 ur_result_t ur_queue_batched_t::queueBeginGraphCapteExp() {

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -89,20 +89,6 @@ ur_event_handle_t ur_queue_batched_t::createEventIfRequestedRegular(
   return (*phEvent);
 }
 
-ur_event_handle_t ur_queue_batched_t::createEventAndRetainRegular(
-    ur_event_handle_t *phEvent, ur_event_generation_t batch_generation) {
-  auto hEvent = eventPoolRegular->allocate();
-  hEvent->setQueue(this);
-  hEvent->setBatch(batch_generation);
-
-  if (phEvent) {
-    (*phEvent) = hEvent;
-    hEvent->retain();
-  }
-
-  return hEvent;
-}
-
 ur_event_handle_t
 ur_queue_batched_t::getEvent(locked<batch_manager> &batchLocked,
                              ur_event_handle_t *phEvent) {
@@ -111,16 +97,6 @@ ur_queue_batched_t::getEvent(locked<batch_manager> &batchLocked,
   }
   return createEventIfRequestedRegular(phEvent,
                                        batchLocked->getCurrentGeneration());
-}
-
-ur_event_handle_t
-ur_queue_batched_t::getEventAndRetain(locked<batch_manager> &batchLocked,
-                                      ur_event_handle_t *phEvent) {
-  if (batchLocked->isGraphCaptureActive()) {
-    return createEventAndRetain(eventPoolImmediate.get(), phEvent, this);
-  }
-  return createEventAndRetainRegular(phEvent,
-                                     batchLocked->getCurrentGeneration());
 }
 
 ur_result_t batch_manager::renewRegularUnlocked(

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -179,28 +179,6 @@ ur_result_t ur_queue_batched_t::markIssuedCommandInBatch(
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t ur_queue_batched_t::enqueueKernelLaunch(
-    ur_kernel_handle_t hKernel, uint32_t workDim,
-    const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
-    const size_t *pLocalWorkSize,
-    const ur_kernel_launch_ext_properties_t *launchPropList,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
-
-  wait_list_view waitListView =
-      wait_list_view(phEventWaitList, numEventsInWaitList, this);
-
-  TRACK_SCOPE_LATENCY("ur_queue_batched_t::enqueueKernelLaunch");
-  auto lockedBatch = currentCmdLists.lock();
-  markIssuedCommandInBatch(lockedBatch);
-
-  UR_CALL(lockedBatch->getListManager().appendKernelLaunch(
-      hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize,
-      launchPropList, waitListView, getEvent(lockedBatch, phEvent)));
-
-  return UR_RESULT_SUCCESS;
-}
-
 ur_result_t batch_manager::hostSynchronize() {
   TRACK_SCOPE_LATENCY("ur_queue_batched_t::hostSynchronize");
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.cpp
@@ -1005,7 +1005,7 @@ ur_result_t ur_queue_batched_t::enqueueGraphExp(
     ur_exp_executable_graph_handle_t hGraph, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   wait_list_view waitListView =
-      wait_list_view(phEventWaitList, numEventsInWaitList);
+      wait_list_view(phEventWaitList, numEventsInWaitList, this);
 
   bool isGraphCaptureActive = false;
   ur_result_t result = queueIsGraphCapteEnabledExp(&isGraphCaptureActive);

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.hpp
@@ -200,15 +200,8 @@ private:
   createEventIfRequestedRegular(ur_event_handle_t *phEvent,
                                 ur_event_generation_t generation_number);
 
-  ur_event_handle_t
-  createEventAndRetainRegular(ur_event_handle_t *phEvent,
-                              ur_event_generation_t batch_generation);
-
   ur_event_handle_t getEvent(locked<batch_manager> &batchLocked,
                              ur_event_handle_t *phEvent);
-
-  ur_event_handle_t getEventAndRetain(locked<batch_manager> &batchLocked,
-                                      ur_event_handle_t *phEvent);
 
   ur_result_t queueFinishPoolsUnlocked();
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.hpp
@@ -89,6 +89,8 @@ private:
   // Whether any operation has been enqueued on the current batch
   uint64_t enqueuedOperationsCounter = 0;
 
+  bool graphCaptureActive = false;
+
 public:
   batch_manager(ur_context_handle_t context, ur_device_handle_t device,
                 v2::raii::command_list_unique_handle &&commandListRegular,
@@ -114,9 +116,15 @@ public:
 
   ur_result_t enqueueCurrentBatchUnlocked();
 
-  ur_command_list_manager &getActiveBatch() { return activeBatch; }
-
   ur_command_list_manager &getImmediateManager() { return immediateList; }
+
+  // Graph recording can be performed only on immediate command list.
+  // When graph capture is active, the batch manager should return the immediate
+  // command list manager for enqueueing operations, otherwise the regular
+  // command list manager is returned.
+  ur_command_list_manager &getListManager() {
+    return isGraphCaptureActive() ? immediateList : activeBatch;
+  }
 
   ur_event_generation_t getCurrentGeneration() {
     return regularGenerationNumber;
@@ -145,6 +153,8 @@ public:
   bool isLimitOfEnqueuedCommandsReached() {
     return maxNumberOfEnqueuedOperations <= enqueuedOperationsCounter;
   }
+
+  bool isGraphCaptureActive() const { return graphCaptureActive; }
 };
 
 struct ur_queue_batched_t : ur_object, ur_queue_t_ {
@@ -193,6 +203,12 @@ private:
   ur_event_handle_t
   createEventAndRetainRegular(ur_event_handle_t *phEvent,
                               ur_event_generation_t batch_generation);
+
+  ur_event_handle_t getEvent(locked<batch_manager> &batchLocked,
+                             ur_event_handle_t *phEvent);
+
+  ur_event_handle_t getEventAndRetain(locked<batch_manager> &batchLocked,
+                                      ur_event_handle_t *phEvent);
 
   ur_result_t queueFinishPoolsUnlocked();
 
@@ -456,30 +472,19 @@ public:
       uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
       ur_event_handle_t *phEvent) override;
 
-  ur_result_t queueBeginGraphCapteExp() override {
-    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-  }
+  ur_result_t enqueueGraphExp(ur_exp_executable_graph_handle_t hGraph,
+                              uint32_t numEventsInWaitList,
+                              const ur_event_handle_t *phEventWaitList,
+                              ur_event_handle_t *phEvent) override;
+
+  ur_result_t queueBeginGraphCapteExp() override;
 
   ur_result_t
-  queueBeginCapteIntoGraphExp(ur_exp_graph_handle_t /* hGraph */) override {
-    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-  }
+  queueBeginCapteIntoGraphExp(ur_exp_graph_handle_t hGraph) override;
 
-  ur_result_t
-  queueEndGraphCapteExp(ur_exp_graph_handle_t * /* phGraph */) override {
-    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-  }
+  ur_result_t queueEndGraphCapteExp(ur_exp_graph_handle_t *phGraph) override;
 
-  ur_result_t enqueueGraphExp(ur_exp_executable_graph_handle_t /* hGraph */,
-                              uint32_t /* numEventsInWaitList */,
-                              const ur_event_handle_t * /* phEventWaitList */,
-                              ur_event_handle_t * /* phEvent */) override {
-    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-  }
-
-  ur_result_t queueIsGraphCapteEnabledExp(bool * /* pResult */) override {
-    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-  }
+  ur_result_t queueIsGraphCapteEnabledExp(bool *pResult) override;
 
   ur_result_t queueGetGraphExp(ur_exp_graph_handle_t * /* phGraph */) override {
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -490,14 +495,7 @@ public:
                      const ur_exp_host_task_properties_t *pProperties,
                      uint32_t numEventsInWaitList,
                      const ur_event_handle_t *phEventWaitList,
-                     ur_event_handle_t *phEvent) override {
-    wait_list_view waitListView =
-        wait_list_view(phEventWaitList, numEventsInWaitList);
-
-    return currentCmdLists.lock()->getActiveBatch().appendHostTaskExp(
-        pfnHostTask, data, pProperties, waitListView,
-        createEventIfRequested(eventPoolRegular.get(), phEvent, this));
-  }
+                     ur_event_handle_t *phEvent) override;
 
   bool isInOrder() override { return true; }
 

--- a/unified-runtime/source/adapters/level_zero/v2/queue_batched.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_batched.hpp
@@ -155,6 +155,8 @@ public:
   }
 
   bool isGraphCaptureActive() const { return graphCaptureActive; }
+
+  void setGraphCapture(bool active) { graphCaptureActive = active; }
 };
 
 struct ur_queue_batched_t : ur_object, ur_queue_t_ {

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -559,7 +559,7 @@ public:
   }
 
   ur_result_t queueIsGraphCapteEnabledExp(bool *pResult) override {
-    return commandListManager.lock()->isGraphCaptureActive(pResult);
+    return commandListManager.lock()->queryGraphCaptureActive(pResult);
   }
 
   ur_result_t queueGetGraphExp(ur_exp_graph_handle_t *phGraph) override {

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
@@ -49,12 +49,12 @@ private:
   std::array<ur_event_handle_t, numCommandLists> barrierEvents;
 
   uint32_t getNextCommandListId() {
-    bool isGraphCaptureActive;
+    bool captureActive;
     auto &cmdListManager =
         (*commandListManagers.get_no_lock())[captureCmdListManagerIdx];
-    cmdListManager.isGraphCaptureActive(&isGraphCaptureActive);
+    cmdListManager.queryGraphCaptureActive(&captureActive);
 
-    return isGraphCaptureActive
+    return captureActive
                ? captureCmdListManagerIdx
                : commandListIndex.fetch_add(1, std::memory_order_relaxed) %
                      numCommandLists;
@@ -628,7 +628,7 @@ public:
 
   ur_result_t queueIsGraphCapteEnabledExp(bool *pResult) override {
     return commandListManagers.lock()[captureCmdListManagerIdx]
-        .isGraphCaptureActive(pResult);
+        .queryGraphCaptureActive(pResult);
   }
 
   ur_result_t queueGetGraphExp(ur_exp_graph_handle_t *phGraph) override {

--- a/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
@@ -117,6 +117,17 @@ struct urBatchedQueueTest : uur::urContextTest {
     }
   }
 
+  void skipIfNoGraphSupport() {
+    ur_bool_t graph_supported = false;
+    ASSERT_SUCCESS(urDeviceGetInfo(
+        device, UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP,
+        sizeof(graph_supported), &graph_supported, nullptr));
+
+    if (!graph_supported) {
+      GTEST_SKIP() << "EXP graph record and replay feature is not supported.";
+    }
+  }
+
   ur_queue_properties_t batched_queue_properties = {
       UR_STRUCTURE_TYPE_QUEUE_PROPERTIES, nullptr,
       UR_QUEUE_FLAG_SUBMISSION_BATCHED};
@@ -541,4 +552,80 @@ TEST_P(urBatchedQueueTest, FlushBatchAfterEnqueuedOperationsLimitIsReached) {
   for (uint64_t j = 0; j < v2::maxNumberOfEnqueuedOperations + 1; j++) {
     ASSERT_SUCCESS(urEventRelease(events[j]));
   }
+}
+
+// Graph capture is not active by default
+TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsFalseByDefault) {
+  ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
+
+  bool isEnabled = false;
+  ASSERT_SUCCESS(urQueueIsGraphCaptureEnabledExp(queue1, &isEnabled));
+  ASSERT_FALSE(isEnabled);
+}
+
+// After beginning graph capture, isGraphCaptureActive should return true.
+// This test is expected to FAIL until the bug is fixed:
+// batch_manager::graphCaptureActive is never set to true, so
+// getListManager() returns the regular batch instead of the immediate list,
+// and queryGraphCaptureActive is called on the wrong command list.
+TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsTrueAfterBeginCapture) {
+  ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
+
+  ASSERT_SUCCESS(urQueueBeginGraphCaptureExp(queue1));
+
+  bool isEnabled = false;
+  ASSERT_SUCCESS(urQueueIsGraphCaptureEnabledExp(queue1, &isEnabled));
+  ASSERT_TRUE(isEnabled);
+
+  ur_exp_graph_handle_t graph = nullptr;
+  ASSERT_SUCCESS(urQueueEndGraphCaptureExp(queue1, &graph));
+  ASSERT_NE(graph, nullptr);
+  ASSERT_SUCCESS(urGraphDestroyExp(graph));
+}
+
+// After ending graph capture, isGraphCaptureActive should return false again.
+TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsFalseAfterEndCapture) {
+  ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
+
+  ASSERT_SUCCESS(urQueueBeginGraphCaptureExp(queue1));
+
+  ur_exp_graph_handle_t graph = nullptr;
+  ASSERT_SUCCESS(urQueueEndGraphCaptureExp(queue1, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  bool isEnabled = true;
+  ASSERT_SUCCESS(urQueueIsGraphCaptureEnabledExp(queue1, &isEnabled));
+  ASSERT_FALSE(isEnabled);
+
+  ASSERT_SUCCESS(urGraphDestroyExp(graph));
+}
+
+// During graph capture, operations should be enqueued on the immediate command
+// list (not the regular batch). Events created for operations on the immediate
+// list have no batch generation number (getBatch() == std::nullopt).
+// This test is expected to FAIL until the bug is fixed:
+// since graphCaptureActive is never set to true, getListManager() returns the
+// regular batch and getEvent() creates events with a batch generation number.
+TEST_P(urBatchedQueueTest, EnqueueDuringGraphCaptureUsesImmediateList) {
+  ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
+
+  ASSERT_SUCCESS(urQueueBeginGraphCaptureExp(queue1));
+
+  ur_event_handle_t event = nullptr;
+  std::vector<uint8_t> data(buffer_size, 42);
+  ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, buffer, /* isBlocking */ false,
+                                         0, buffer_size, data.data(), 0,
+                                         nullptr, &event));
+
+  // During graph capture, the operation should go through the immediate command
+  // list path (like command buffer enqueue), so the event should have no batch
+  // generation number
+  ASSERT_EQ(event->getBatch(), std::nullopt);
+
+  ur_exp_graph_handle_t graph = nullptr;
+  ASSERT_SUCCESS(urQueueEndGraphCaptureExp(queue1, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  ASSERT_SUCCESS(urEventRelease(event));
+  ASSERT_SUCCESS(urGraphDestroyExp(graph));
 }

--- a/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
@@ -564,10 +564,6 @@ TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsFalseByDefault) {
 }
 
 // After beginning graph capture, isGraphCaptureActive should return true.
-// This test is expected to FAIL until the bug is fixed:
-// batch_manager::graphCaptureActive is never set to true, so
-// getListManager() returns the regular batch instead of the immediate list,
-// and queryGraphCaptureActive is called on the wrong command list.
 TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsTrueAfterBeginCapture) {
   ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
 
@@ -603,9 +599,6 @@ TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsFalseAfterEndCapture) {
 // During graph capture, operations should be enqueued on the immediate command
 // list (not the regular batch). Events created for operations on the immediate
 // list have no batch generation number (getBatch() == std::nullopt).
-// This test is expected to FAIL until the bug is fixed:
-// since graphCaptureActive is never set to true, getListManager() returns the
-// regular batch and getEvent() creates events with a batch generation number.
 TEST_P(urBatchedQueueTest, EnqueueDuringGraphCaptureUsesImmediateList) {
   ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
 

--- a/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
@@ -117,15 +117,12 @@ struct urBatchedQueueTest : uur::urContextTest {
     }
   }
 
-  void skipIfNoGraphSupport() {
+  bool isGraphSupported() {
     ur_bool_t graph_supported = false;
-    ASSERT_SUCCESS(urDeviceGetInfo(
+    auto result = urDeviceGetInfo(
         device, UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP,
-        sizeof(graph_supported), &graph_supported, nullptr));
-
-    if (!graph_supported) {
-      GTEST_SKIP() << "EXP graph record and replay feature is not supported.";
-    }
+        sizeof(graph_supported), &graph_supported, nullptr);
+    return result == UR_RESULT_SUCCESS && graph_supported;
   }
 
   ur_queue_properties_t batched_queue_properties = {
@@ -556,7 +553,9 @@ TEST_P(urBatchedQueueTest, FlushBatchAfterEnqueuedOperationsLimitIsReached) {
 
 // Graph capture is not active by default
 TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsFalseByDefault) {
-  ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
+  if (!isGraphSupported()) {
+    GTEST_SKIP() << "EXP graph record and replay feature is not supported.";
+  }
 
   bool isEnabled = false;
   ASSERT_SUCCESS(urQueueIsGraphCaptureEnabledExp(queue1, &isEnabled));
@@ -565,7 +564,9 @@ TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsFalseByDefault) {
 
 // After beginning graph capture, isGraphCaptureActive should return true.
 TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsTrueAfterBeginCapture) {
-  ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
+  if (!isGraphSupported()) {
+    GTEST_SKIP() << "EXP graph record and replay feature is not supported.";
+  }
 
   ASSERT_SUCCESS(urQueueBeginGraphCaptureExp(queue1));
 
@@ -581,7 +582,9 @@ TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsTrueAfterBeginCapture) {
 
 // After ending graph capture, isGraphCaptureActive should return false again.
 TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsFalseAfterEndCapture) {
-  ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
+  if (!isGraphSupported()) {
+    GTEST_SKIP() << "EXP graph record and replay feature is not supported.";
+  }
 
   ASSERT_SUCCESS(urQueueBeginGraphCaptureExp(queue1));
 
@@ -600,7 +603,9 @@ TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsFalseAfterEndCapture) {
 // list (not the regular batch). Events created for operations on the immediate
 // list have no batch generation number (getBatch() == std::nullopt).
 TEST_P(urBatchedQueueTest, EnqueueDuringGraphCaptureUsesImmediateList) {
-  ASSERT_NO_FATAL_FAILURE(skipIfNoGraphSupport());
+  if (!isGraphSupported()) {
+    GTEST_SKIP() << "EXP graph record and replay feature is not supported.";
+  }
 
   ASSERT_SUCCESS(urQueueBeginGraphCaptureExp(queue1));
 

--- a/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
@@ -18,6 +18,7 @@
 #include "event_provider.hpp"
 #include "event_provider_counter.hpp"
 #include "event_provider_normal.hpp"
+#include "level_zero/external/driver_experimental/zex_graph.h"
 #include "queue_batched.hpp"
 #include "queue_handle.hpp"
 #include "unified-runtime/ur_api.h"
@@ -125,7 +126,10 @@ struct urBatchedQueueTest : uur::urContextTest {
     auto result = urDeviceGetInfo(
         device, UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP,
         sizeof(graph_supported), &graph_supported, nullptr);
-    return result == UR_RESULT_SUCCESS && graph_supported;
+    if (result != UR_RESULT_SUCCESS || !graph_supported) {
+      return false;
+    }
+    return true;
   }
 
   ur_queue_properties_t batched_queue_properties = {

--- a/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/batched_queue_test.cpp
@@ -23,12 +23,15 @@
 #include "unified-runtime/ur_api.h"
 #include "uur/checks.h"
 #include "uur/fixtures.h"
+#include "uur/utils.h"
 #include "ze_api.h"
 
 #include "gtest/gtest.h"
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <gtest/gtest.h>
+#include <iostream>
 #include <optional>
 #include <vector>
 
@@ -599,31 +602,81 @@ TEST_P(urBatchedQueueTest, GraphCaptureActiveReturnsFalseAfterEndCapture) {
   ASSERT_SUCCESS(urGraphDestroyExp(graph));
 }
 
-// During graph capture, operations should be enqueued on the immediate command
-// list (not the regular batch). Events created for operations on the immediate
-// list have no batch generation number (getBatch() == std::nullopt).
+// Graph capture may be started on a batched queue, but captured operations
+// should still be submitted on an immediate command list for execution. Events created for
+// those operations have no batch generation number (getBatch() == std::nullopt).
 TEST_P(urBatchedQueueTest, EnqueueDuringGraphCaptureUsesImmediateList) {
   if (!isGraphSupported()) {
     GTEST_SKIP() << "EXP graph record and replay feature is not supported.";
   }
 
-  ASSERT_SUCCESS(urQueueBeginGraphCaptureExp(queue1));
+  ur_queue_handle_t captureQueue = queue1;
+  ur_queue_handle_t submitQueue = nullptr;
 
+  ur_queue_properties_t immediate_queue_properties = {
+      UR_STRUCTURE_TYPE_QUEUE_PROPERTIES, nullptr,
+      UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE};
+
+  ASSERT_SUCCESS(urQueueCreate(context, device, &immediate_queue_properties,
+                               &submitQueue));
+  ASSERT_NE(submitQueue, nullptr);
+  ASSERT_SUCCESS(urQueueBeginGraphCaptureExp(captureQueue));
+
+  // Graph capture records the copy source address. Use USM shared memory so
+  // the pointer stays valid for device access on discrete GPUs (e.g. PVC);
+  // plain host stack/heap pointers can fault on synchronize/replay.
   ur_event_handle_t event = nullptr;
+  void *usmSrc = nullptr;
   std::vector<uint8_t> data(buffer_size, 42);
-  ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, buffer, /* isBlocking */ false,
-                                         0, buffer_size, data.data(), 0,
-                                         nullptr, &event));
+  ASSERT_SUCCESS(urUSMSharedAlloc(context, device, nullptr, nullptr,
+                                  buffer_size, &usmSrc));
+  ASSERT_NE(usmSrc, nullptr);
+  std::memcpy(usmSrc, data.data(), buffer_size);
 
-  // During graph capture, the operation should go through the immediate command
-  // list path (like command buffer enqueue), so the event should have no batch
-  // generation number
+  ASSERT_SUCCESS(urEnqueueMemBufferWrite(captureQueue, buffer,
+                                         /* isBlocking */ true, 0, buffer_size,
+                                         usmSrc, 0, nullptr, &event));
+
+  // The capture operation should not be associated with the batched queue's
+  // regular batch generation.
   ASSERT_EQ(event->getBatch(), std::nullopt);
 
   ur_exp_graph_handle_t graph = nullptr;
-  ASSERT_SUCCESS(urQueueEndGraphCaptureExp(queue1, &graph));
+  ASSERT_SUCCESS(urQueueEndGraphCaptureExp(captureQueue, &graph));
   ASSERT_NE(graph, nullptr);
 
+  bool graphIsEmpty = true;
+  ASSERT_SUCCESS(urGraphIsEmptyExp(graph, &graphIsEmpty));
+  ASSERT_FALSE(graphIsEmpty)
+      << "recorded graph should contain the captured mem buffer write";
+
+  // Prove replay from an immediate queue performs the write: clear the buffer,
+  // then run the executable graph and read back the original pattern.
+  const uint8_t clearByte = 0;
+  ASSERT_SUCCESS(urEnqueueMemBufferFill(submitQueue, buffer, &clearByte,
+                                        sizeof(clearByte), 0, buffer_size, 0,
+                                        nullptr, nullptr));
+  ASSERT_SUCCESS(urQueueFinish(submitQueue));
+
+  ur_exp_executable_graph_handle_t exGraph = nullptr;
+  ASSERT_SUCCESS(urGraphInstantiateGraphExp(graph, &exGraph));
+  ASSERT_NE(exGraph, nullptr);
+
+  ASSERT_SUCCESS(urEnqueueGraphExp(submitQueue, exGraph, 0, nullptr, nullptr));
+  ASSERT_SUCCESS(urQueueFinish(submitQueue));
+
+  std::vector<uint8_t> output(buffer_size, 0);
+  ASSERT_SUCCESS(urEnqueueMemBufferRead(submitQueue, buffer,
+                                        /* isBlocking */ true, 0, buffer_size,
+                                        output.data(), 0, nullptr, nullptr));
+
+  for (size_t i = 0; i < buffer_size; i++) {
+    ASSERT_EQ(output[i], data[i]) << "mismatch at byte " << i;
+  }
+
+  ASSERT_SUCCESS(urGraphExecutableGraphDestroyExp(exGraph));
   ASSERT_SUCCESS(urEventRelease(event));
   ASSERT_SUCCESS(urGraphDestroyExp(graph));
+  ASSERT_SUCCESS(urUSMFree(context, usmSrc));
+  ASSERT_SUCCESS(urQueueRelease(submitQueue));
 }


### PR DESCRIPTION
  This PR adds support for graph capture and execution in the Level Zero v2 batched queue implementation.                

  Changes:
  - Add command list determination mechanism that switches between immediate and regular command lists based on graph
  capture state
  - Implement previously unsupported graph API methods:
    - queueBeginGraphCapteExp() - begin graph capture
    - queueBeginCapteIntoGraphExp() - begin capture into existing graph
    - queueEndGraphCapteExp() - end graph capture
    - queueIsGraphCapteEnabledExp() - check capture status
    - enqueueGraphExp() - execute captured graph
  - Update operations to use appropriate command list and event pool during graph capture