### PR TITLE
[UR][L0] fix event lifetime associated with async free

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -966,6 +966,12 @@ ur_result_t ur_command_list_manager::appendUSMFreeExp(
                (getZeCommandList(), zeSignalEvent));
   }
 
+  // If event is specified, it's also going to be inserted
+  // into the async pool, so it needs to be retained.
+  if (phEvent) {
+    phEvent->retain();
+  }
+
   // Insert must be done after the signal event is appended.
   usmPool->asyncPool.insert(pMem, size, phEvent, Queue);
 

--- a/unified-runtime/source/adapters/level_zero/v2/event_pool.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event_pool.hpp
@@ -74,20 +74,31 @@ createEventIfRequested(event_pool *eventPool, ur_event_handle_t *phEvent,
 }
 
 // Always creates an event (used in functions that need to store the event
-// internally). If event was requested by the user, also increase ref count of
-// that event to avoid pre-mature release.
-static inline ur_event_handle_t createEventAndRetain(event_pool *eventPool,
-                                                     ur_event_handle_t *phEvent,
-                                                     ur_queue_t_ *queue) {
+// internally).
+static inline ur_event_handle_t createEvent(event_pool *eventPool,
+                                            ur_event_handle_t *phEvent,
+                                            ur_queue_t_ *queue) {
   auto hEvent = eventPool->allocate();
   hEvent->setQueue(queue);
 
   if (phEvent) {
     (*phEvent) = hEvent;
-    hEvent->retain();
   }
 
   return hEvent;
+}
+
+// Always creates an event (used in functions that need to store the event
+// internally). If event was requested by the user, also increase ref count of
+// that event to avoid pre-mature release.
+static inline ur_event_handle_t createEventAndRetain(event_pool *eventPool,
+                                                     ur_event_handle_t *phEvent,
+                                                     ur_queue_t_ *queue) {
+  auto *event = createEvent(eventPool, phEvent, queue);
+  if (phEvent) {
+    (*phEvent)->retain();
+  }
+  return event;
 }
 
 } // namespace v2

--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
@@ -499,7 +499,7 @@ public:
     auto commandListId = getNextCommandListId();
     return commandListManagers.lock()[commandListId].appendUSMFreeExp(
         this, pPool, pMem, waitListView,
-        createEventAndRetain(eventPool.get(), phEvent, this));
+        createEvent(eventPool.get(), phEvent, this));
   }
 
   ur_result_t bindlessImagesImageCopyExp(


### PR DESCRIPTION
A recent patch #21320, changed how events are allocated for async allocations. Instead of always allocating an event, we now allocate it optionally, depending on whether user specified it. But that changed did not update how event refcounts are updated, in the case that the event is actually allocated. This could lead to potential use-after-free.
This patch moves the refcount management into command list manager, and correctly increments it when required.