### PR TITLE
[CI]Update Dockerfile to CUDA 12.6.3

### DIFF
--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.1.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.6.3-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
The update is needed due to the update another Dockerfile to CUDA 13 in the nearest future. 