### PR TITLE
[SYCL][E2E] Enable Regression/barrier_with_work.cpp on Linux

### DIFF
--- a/sycl/test-e2e/Regression/barrier_with_work.cpp
+++ b/sycl/test-e2e/Regression/barrier_with_work.cpp
@@ -6,9 +6,6 @@
 // UNSUPPORTED: target-native_cpu
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20142
 //
-// UNSUPPORTED: linux && (gpu-intel-dg2 || arch-intel_gpu_bmg_g21 || arch-intel_gpu_pvc)
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20600
-//
 // Tests that barriers block all following execution on queues with active work.
 // For L0 we currently need to set
 // SYCL_PI_LEVEL_ZERO_USE_MULTIPLE_COMMANDLIST_BARRIERS to enable fix on certain


### PR DESCRIPTION
https://github.com/intel/llvm/pull/21251 fixed a bug that could have been the reason for failures. That PR also enabled the test Windows because it no longer XFAIL-ed. I wasn't able to reproduce failures manually on either PVC or BMG with a 100 runs each.

Fixes: #20600