### PR TITLE
[CI] Fix CUDA AWS

### DIFF
--- a/.github/workflows/sycl-aws.yml
+++ b/.github/workflows/sycl-aws.yml
@@ -14,7 +14,7 @@ on:
         # See devops/actions/aws-ec2/action.yml for more details.
         description: "JSON string with array of objects with aws-type, runs-on, aws-ami, aws-spot, aws-disk, aws-timebomb, one-job properties"
         type: string
-        default: '[{"runs-on":"aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}","aws-ami":"ami-01cb0573cb039ab24","aws-type":["g5.2xlarge","g5.4xlarge"],"aws-disk":"/dev/sda1:64","aws-spot":"false"}]'
+        default: '[{"runs-on":"aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}","aws-ami":"ami-0c8316819ad1cbdb4","aws-type":["g5.2xlarge","g5.4xlarge"],"aws-disk":"/dev/sda1:128","aws-spot":"false"}]'
       ref:
         type: string
         required: false


### PR DESCRIPTION
We updated the base 22.04 Docker image in https://github.com/intel/llvm/pull/21326 and now the OS install we used on the AWS runner was using a CUDA driver that was too old so the GPU wasn't showing up in `sycl-ls`, so I updated the driver and made a new OS image on AWS.

I also updated the mapped partition size from 64GB to 128GB as I got some error about that.

Working CI run with this change [here](https://github.com/intel/llvm/actions/runs/22239592845/job/64342675504).