### PR TITLE
[UR][L0v2] Implement urGraphDumpContentsExp

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/graph.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/graph.cpp
@@ -135,12 +135,8 @@ ur_result_t urGraphDumpContentsExp(ur_exp_graph_handle_t hGraph,
       hContext->getPlatform()->ZeGraphExt.zeGraphDumpContentsExp,
       (hGraph->getZeHandle(), filePath, nullptr));
 
-  // Errors related to File IO
-  if (zeResult == ZE_RESULT_ERROR_UNKNOWN) {
-    return UR_RESULT_ERROR_UNKNOWN;
-  }
-
-  return UR_RESULT_SUCCESS;
+  // Level-zero returns ZE_RESULT_ERROR_UNKNOWN with errors related to file IO
+  return ze2urResult(zeResult);
 }
 
 } // namespace ur::level_zero

--- a/unified-runtime/source/adapters/level_zero/v2/graph.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/graph.cpp
@@ -131,12 +131,10 @@ ur_result_t urGraphDumpContentsExp(ur_exp_graph_handle_t hGraph,
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  ze_result_t zeResult = ZE_CALL_NOCHECK(
-      hContext->getPlatform()->ZeGraphExt.zeGraphDumpContentsExp,
-      (hGraph->getZeHandle(), filePath, nullptr));
+  ZE2UR_CALL(hContext->getPlatform()->ZeGraphExt.zeGraphDumpContentsExp,
+             (hGraph->getZeHandle(), filePath, nullptr));
 
-  // Level-zero returns ZE_RESULT_ERROR_UNKNOWN with errors related to file IO
-  return ze2urResult(zeResult);
+  return UR_RESULT_SUCCESS;
 }
 
 } // namespace ur::level_zero

--- a/unified-runtime/source/adapters/level_zero/v2/graph.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/graph.cpp
@@ -1,6 +1,6 @@
 //===--------- graph.cpp - Level Zero Adapter -----------------------------===//
 //
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 //
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
@@ -124,9 +124,23 @@ ur_result_t urGraphIsEmptyExp(ur_exp_graph_handle_t hGraph, bool *pIsEmpty) {
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t urGraphDumpContentsExp(ur_exp_graph_handle_t, const char *) {
-  UR_LOG(ERR, "{} function not implemented!", __FUNCTION__);
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ur_result_t urGraphDumpContentsExp(ur_exp_graph_handle_t hGraph,
+                                   const char *filePath) {
+  ur_context_handle_t hContext = hGraph->getContext();
+  if (!checkGraphExtensionSupport(hContext)) {
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  }
+
+  ze_result_t zeResult = ZE_CALL_NOCHECK(
+      hContext->getPlatform()->ZeGraphExt.zeGraphDumpContentsExp,
+      (hGraph->getZeHandle(), filePath, nullptr));
+
+  // Errors related to File IO
+  if (zeResult == ZE_RESULT_ERROR_UNKNOWN) {
+    return UR_RESULT_ERROR_UNKNOWN;
+  }
+
+  return UR_RESULT_SUCCESS;
 }
 
 } // namespace ur::level_zero

--- a/unified-runtime/test/conformance/exp_graph/CMakeLists.txt
+++ b/unified-runtime/test/conformance/exp_graph/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2025-2026 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -7,6 +7,7 @@ add_conformance_devices_test(exp_graph
   urEnqueueGraphExp.cpp
   urGraphCreateExp.cpp
   urGraphDestroyExp.cpp
+  urGraphDumpContentsExp.cpp
   urGraphInstantiateGraphExp.cpp
   urGraphIsEmptyExp.cpp
   urQueueBeginCaptureIntoGraphExp.cpp

--- a/unified-runtime/test/conformance/exp_graph/urGraphDumpContentsExp.cpp
+++ b/unified-runtime/test/conformance/exp_graph/urGraphDumpContentsExp.cpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See LICENSE.TXT
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "fixtures.h"
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+using urGraphDumpContentsExpTest = uur::urGraphPopulatedExpTest;
+
+UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES(
+    urGraphDumpContentsExpTest,
+    ::testing::Values(0 /* In-Order */,
+                      UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE));
+
+TEST_P(urGraphDumpContentsExpTest, Success) {
+  const char *filePath = "test_graph_dump.dot";
+
+  ASSERT_SUCCESS(urGraphDumpContentsExp(graph, filePath));
+
+  std::ifstream file(filePath);
+  ASSERT_TRUE(file.good());
+
+  std::string content((std::istreambuf_iterator<char>(file)),
+                      std::istreambuf_iterator<char>());
+  ASSERT_NE(content.find("digraph"), std::string::npos);
+
+  file.close();
+  std::remove(filePath);
+}
+
+TEST_P(urGraphDumpContentsExpTest, SuccessEmptyGraph) {
+  const char *filePath = "test_empty_graph_dump.dot";
+
+  ur_exp_graph_handle_t emptyGraph = nullptr;
+  ASSERT_SUCCESS(urGraphCreateExp(context, &emptyGraph));
+  ASSERT_SUCCESS(urGraphDumpContentsExp(graph, filePath));
+
+  std::ifstream file(filePath);
+  ASSERT_TRUE(file.good());
+
+  std::string content((std::istreambuf_iterator<char>(file)),
+                      std::istreambuf_iterator<char>());
+  ASSERT_NE(content.find("digraph"), std::string::npos);
+
+  file.close();
+
+  std::remove(filePath);
+  ASSERT_SUCCESS(urGraphDestroyExp(emptyGraph));
+}
+
+TEST_P(urGraphDumpContentsExpTest, InvalidNullHandleGraph) {
+  const char *filePath = "test_graph_dump.dot";
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                   urGraphDumpContentsExp(nullptr, filePath));
+}
+
+TEST_P(urGraphDumpContentsExpTest, InvalidNullPointerFilePath) {
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                   urGraphDumpContentsExp(graph, nullptr));
+}
+
+TEST_P(urGraphDumpContentsExpTest, InvalidFilePath) {
+  const char *invalidPath = "/invalid/path/that/does/not/exist/graph.dot";
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNKNOWN,
+                   urGraphDumpContentsExp(graph, invalidPath));
+}

--- a/unified-runtime/test/conformance/exp_graph/urGraphDumpContentsExp.cpp
+++ b/unified-runtime/test/conformance/exp_graph/urGraphDumpContentsExp.cpp
@@ -38,7 +38,7 @@ TEST_P(urGraphDumpContentsExpTest, SuccessEmptyGraph) {
 
   ur_exp_graph_handle_t emptyGraph = nullptr;
   ASSERT_SUCCESS(urGraphCreateExp(context, &emptyGraph));
-  ASSERT_SUCCESS(urGraphDumpContentsExp(graph, filePath));
+  ASSERT_SUCCESS(urGraphDumpContentsExp(emptyGraph, filePath));
 
   std::ifstream file(filePath);
   ASSERT_TRUE(file.good());

--- a/unified-runtime/test/conformance/exp_graph/urGraphDumpContentsExp.cpp
+++ b/unified-runtime/test/conformance/exp_graph/urGraphDumpContentsExp.cpp
@@ -8,7 +8,10 @@
 #include <cstdio>
 #include <fstream>
 #include <iterator>
+#include <sstream>
 #include <string>
+#include <thread>
+#include <ur_util.hpp>
 
 using urGraphDumpContentsExpTest = uur::urGraphPopulatedExpTest;
 
@@ -17,12 +20,21 @@ UUR_DEVICE_TEST_SUITE_WITH_QUEUE_TYPES(
     ::testing::Values(0 /* In-Order */,
                       UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE));
 
+// Lit runs in parallel, so embedding pid + thread id prevents concurrent
+// read / write to the same file.
+std::string getUniqueTestFilename(const std::string &base_name) {
+  std::stringstream ss;
+  ss << base_name << "_" << ur_getpid() << "_" << std::this_thread::get_id()
+     << ".dot";
+  return ss.str();
+}
+
 TEST_P(urGraphDumpContentsExpTest, Success) {
-  const char *filePath = "test_graph_dump.dot";
+  std::string filename = getUniqueTestFilename("graph_dump");
 
-  ASSERT_SUCCESS(urGraphDumpContentsExp(graph, filePath));
+  ASSERT_SUCCESS(urGraphDumpContentsExp(graph, filename.c_str()));
 
-  std::ifstream file(filePath);
+  std::ifstream file(filename);
   ASSERT_TRUE(file.good());
 
   std::string content((std::istreambuf_iterator<char>(file)),
@@ -30,17 +42,18 @@ TEST_P(urGraphDumpContentsExpTest, Success) {
   ASSERT_NE(content.find("digraph"), std::string::npos);
 
   file.close();
-  std::remove(filePath);
+  std::remove(filename.c_str());
 }
 
 TEST_P(urGraphDumpContentsExpTest, SuccessEmptyGraph) {
-  const char *filePath = "test_empty_graph_dump.dot";
+  std::string filename = getUniqueTestFilename("empty_graph_dump");
 
   ur_exp_graph_handle_t emptyGraph = nullptr;
   ASSERT_SUCCESS(urGraphCreateExp(context, &emptyGraph));
-  ASSERT_SUCCESS(urGraphDumpContentsExp(emptyGraph, filePath));
 
-  std::ifstream file(filePath);
+  ASSERT_SUCCESS(urGraphDumpContentsExp(emptyGraph, filename.c_str()));
+
+  std::ifstream file(filename);
   ASSERT_TRUE(file.good());
 
   std::string content((std::istreambuf_iterator<char>(file)),
@@ -48,8 +61,7 @@ TEST_P(urGraphDumpContentsExpTest, SuccessEmptyGraph) {
   ASSERT_NE(content.find("digraph"), std::string::npos);
 
   file.close();
-
-  std::remove(filePath);
+  std::remove(filename.c_str());
   ASSERT_SUCCESS(urGraphDestroyExp(emptyGraph));
 }
 


### PR DESCRIPTION
This functionality is important for SYCL graph native recording to be spec compliant. 