### PR TITLE
[SYCL][E2E] Disable cuda_record_async_malloc.cpp on CUDA

### DIFF
--- a/sycl/test-e2e/Graph/NativeCommand/cuda_record_async_malloc.cpp
+++ b/sycl/test-e2e/Graph/NativeCommand/cuda_record_async_malloc.cpp
@@ -2,6 +2,9 @@
 // RUN: %{run} %t.out
 // REQUIRES: target-nvidia, cuda_dev_kit
 
+// UNSUPPORTED: cuda
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21343
+
 #include <cuda.h>
 #include <sycl/backend.hpp>
 #include <sycl/ext/oneapi/experimental/graph.hpp>


### PR DESCRIPTION
The test has a runtime CUDA version check that always fails on our self-hosted runners.

I updated the AWS image to use a newer CUDA, and we use the AWS machines for one job in the nighty. 

There, the runtime check passes, but the test still fails.

We have no way in LIT to check for CUDA version, so we can't only disable it on AWS, so just disable it on CUDA in general. It's not like it was doing anything on the self-hosted runners anyway, the runtime check fails so it does nothing.

https://github.com/intel/llvm/issues/21343