### PR TITLE
[NFC][Driver] Replace underscores with hyphens in sycl-lto test

### DIFF
--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -1,21 +1,21 @@
 // Verify the usage of -foffload-lto with SYCL.
 
 // Verify we error when using the old offload driver.
-// RUN: not %clangxx -fsycl -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_ERROR %s
-// CHECK_ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
+// RUN: not %clangxx -fsycl -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK-ERROR %s
+// CHECK-ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
 
 // Verify we error when using the new offload driver but with device code split set to off.
-// RUN: not %clangxx -fsycl --offload-new-driver -foffload-lto=thin -fsycl-device-code-split=off %s -### 2>&1 | FileCheck -check-prefix=CHECK_SPLIT_ERROR %s
-// CHECK_SPLIT_ERROR: '-fsycl-device-code-split=off' is not supported when '-foffload-lto=thin' is set with '-fsycl'
+// RUN: not %clangxx -fsycl --offload-new-driver -foffload-lto=thin -fsycl-device-code-split=off %s -### 2>&1 | FileCheck -check-prefix=CHECK-SPLIT-ERROR %s
+// CHECK-SPLIT-ERROR: '-fsycl-device-code-split=off' is not supported when '-foffload-lto=thin' is set with '-fsycl'
 
 // Verify there's no error and we see the expected cc1 flags and tool invocations with the new offload driver.
 // RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | \
-// RUN: FileCheck -check-prefix=CHECK_SUPPORTED -implicit-check-not=-emit-only-kernels-as-entry-points %s
-// CHECK_SUPPORTED: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"
-// CHECK_SUPPORTED: sycl-post-link
-// CHECK_SUPPORTED-NOT: -properties
-// CHECK_SUPPORTED-NEXT: file-table-tform{{.*}}
-// CHECK_SUPPORTED-NEXT: llvm-foreach{{.*}} "--" {{.*}}clang{{.*}} "-fsycl-is-device"{{.*}} "-flto=thin" "-flto-unit"
-// CHECK_SUPPORTED-NEXT: file-table-tform{{.*}}
-// CHECK_SUPPORTED-NEXT: llvm-offload-binary{{.*}} "-o" "{{.*}}" "--image=file=@{{.*}}"
-// CHECK_SUPPORTED: clang-linker-wrapper{{.*}} "-sycl-thin-lto"
+// RUN: FileCheck -check-prefix=CHECK-SUPPORTED -implicit-check-not=-emit-only-kernels-as-entry-points %s
+// CHECK-SUPPORTED: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"
+// CHECK-SUPPORTED: sycl-post-link
+// CHECK-SUPPORTED-NOT: -properties
+// CHECK-SUPPORTED-NEXT: file-table-tform{{.*}}
+// CHECK-SUPPORTED-NEXT: llvm-foreach{{.*}} "--" {{.*}}clang{{.*}} "-fsycl-is-device"{{.*}} "-flto=thin" "-flto-unit"
+// CHECK-SUPPORTED-NEXT: file-table-tform{{.*}}
+// CHECK-SUPPORTED-NEXT: llvm-offload-binary{{.*}} "-o" "{{.*}}" "--image=file=@{{.*}}"
+// CHECK-SUPPORTED: clang-linker-wrapper{{.*}} "-sycl-thin-lto"


### PR DESCRIPTION
Hyphens align more with internal FileCheck directives like CHECK-NEXT,
CHECK-SAME, CHECK-NOT, etc.