### PR TITLE
[Benches] enable filtering of all compute benchmarks with tags

### DIFF
--- a/devops/scripts/benchmarks/benches/compute_metadata.py
+++ b/devops/scripts/benchmarks/benches/compute_metadata.py
@@ -131,6 +131,7 @@ class ComputeMetadataGenerator:
 
         Args:
             group_name: Name of the benchmark group
+            tags: Set of tags associated with benchmarks in this group
 
         Returns:
             BenchmarkMetadata: Metadata object describing the specified benchmark group.


### PR DESCRIPTION
Allow for filtering of all of compute benchmarks in comparison charts