### PR TITLE
[CI] Remove WindowsCILock

### DIFF
--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -102,7 +102,6 @@ jobs:
   build:
     name: Build + LIT
     runs-on: [Windows, build]
-    environment: WindowsCILock
     outputs:
       build_conclusion: ${{ steps.build.conclusion }}
     steps:

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -83,7 +83,6 @@ jobs:
   run:
     name: ${{ inputs.name }}
     runs-on: ${{ fromJSON(inputs.runner) }}
-    environment: WindowsCILock
     env: ${{ fromJSON(inputs.env) }}
     steps:
     - name:  Detect hung tests


### PR DESCRIPTION
I believe this was originally added to add a timer between Win CI runs but I don't see a use for it anymore and it just causes extra output on PRs.