### PR TITLE
[SYCL] Improve cachability when building with ccache

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -55,8 +55,9 @@ if(MSVC)
   include(CheckLinkerFlag)
   check_linker_flag(CXX "LINKER:/DEBUG" LINKER_SUPPORTS_DEBUG)
   if(LINKER_SUPPORTS_DEBUG)
-    # sccache is not compatible with /Zi flag
-    if (CMAKE_CXX_COMPILER_LAUNCHER STREQUAL "sccache")
+    # (s)ccache is not compatible with /Zi flag
+    if (CMAKE_CXX_COMPILER_LAUNCHER STREQUAL "ccache" OR
+	CMAKE_CXX_COMPILER_LAUNCHER STREQUAL "sccache")
       # CMake may put /Zi by default
       if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")

--- a/sycl/cmake/modules/BuildUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/BuildUnifiedRuntime.cmake
@@ -62,7 +62,7 @@ if(WIN32)
   # FIXME: Unified runtime build fails with /DUNICODE
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /UUNICODE")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /UUNICODE")
-  # USE_Z7 forces use of /Z7 instead of /Zi which is broken with sccache
+  # USE_Z7 forces use of /Z7 instead of /Zi which is broken with (s)ccache
   set(USE_Z7 ON)
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")


### PR DESCRIPTION
We already had a workaround for `sccache` but `ccache` has the same limitation and we don't use `sccache` anymore in CI.

In my experiments for the compiler build step on a completely unchanged module:

Before `2m56`
After `2m0s`

