### PR TITLE
[SYCL][XPTI] Emit extra kernel metadata only for debug stream

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2135,9 +2135,9 @@ void ExecCGCommand::emitInstrumentationData() {
         auto KernelCG =
             reinterpret_cast<detail::CGExecKernel *>(MCommandGroup.get());
         instrumentationAddExtraKernelMetadata(
-            CmdTraceEvent, KernelCG->MNDRDesc, KernelCG->getKernelBundle().get(),
-            KernelCG->MDeviceKernelInfo, KernelCG->MSyclKernel.get(),
-            MQueue.get(), KernelCG->MArgs);
+            CmdTraceEvent, KernelCG->MNDRDesc,
+            KernelCG->getKernelBundle().get(), KernelCG->MDeviceKernelInfo,
+            KernelCG->MSyclKernel.get(), MQueue.get(), KernelCG->MArgs);
       }
     }
 


### PR DESCRIPTION
We already have similar guard here (used in non-scheduler path): https://github.com/intel/llvm/blob/9d9ea8d4b2e7c86636e7c3cab4cda8dae288bf04/sycl/source/detail/scheduler/commands.cpp#L2080-L2081

but it was missed for the case when we submit kernel via scheduler.