### PR TITLE
[SYCL][Graph][E2E] Disable failing dynamic CGF test

### DIFF
--- a/sycl/test-e2e/Graph/Update/dyn_cgf_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Update/dyn_cgf_host_task_accessor.cpp
@@ -2,6 +2,9 @@
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
+// XFAIL: windows && (arch-intel_gpu_ptl_u || arch-intel_gpu_ptl_h || arch-intel_gpu_wcl)
+// XFAIL-TRACKER: GSD-12328
 
 // Tests using dynamic command groups to update a host task node that also uses
 // buffers/accessors


### PR DESCRIPTION
This test has been reported failing on PTL and WCL on Windows. Need to confirm.