### PR TITLE
[UR][Offload] update arguments for olInit()

### DIFF
--- a/unified-runtime/source/adapters/offload/adapter.cpp
+++ b/unified-runtime/source/adapters/offload/adapter.cpp
@@ -24,7 +24,7 @@ ur_adapter_handle_t Adapter = nullptr;
 
 // Initialize liboffload and perform the initial platform and device discovery
 ur_result_t ur_adapter_handle_t_::init() {
-  auto Res = olInit();
+  auto Res = olInit(nullptr);
   (void)Res;
 
   // Discover every platform and device


### PR DESCRIPTION
Add `NULL` as an argument for all `olInit()` references in Unified Runtime. `NULL` indicates the default configuration for initialization of the Offload Library.

Arguments in Unified Runtime were missing after llvm/llvm-project#181872