### PR TITLE
[SYCL][E2E] Disable `bindless_images/copies/copy_subregion_2D.cpp` for MTL on Windows

### DIFF
--- a/sycl/test-e2e/bindless_images/copies/copy_subregion_2D.cpp
+++ b/sycl/test-e2e/bindless_images/copies/copy_subregion_2D.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images
+// UNSUPPORTED: windows && arch-intel_gpu_mtl_h
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21380
 // XFAIL: hip
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/19957
 


### PR DESCRIPTION
This PR disable test because it fails on Windows newer driver.
https://github.com/intel/llvm/issues/21380