### PR TITLE
[UR][L0] Update UR_LEVEL_ZERO_LOADER_TAG to v1.28.0

### DIFF
--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -55,7 +55,7 @@ if(NOT LEVEL_ZERO_LIB_NAME AND NOT LEVEL_ZERO_LIBRARY)
   set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
   # Remember to update the pkg_check_modules minimum version above when updating the
   # clone tag
-  set(UR_LEVEL_ZERO_LOADER_TAG v1.26.0)
+  set(UR_LEVEL_ZERO_LOADER_TAG v1.28.0)
 
   # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
   set(CMAKE_INCLUDE_CURRENT_DIR OFF)

--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -130,7 +130,7 @@ if(L0_COMPUTE_RUNTIME_HEADERS)
     set(COMPUTE_RUNTIME_REPO_PATH "${L0_COMPUTE_RUNTIME_HEADERS}")
 else()
     set(UR_COMPUTE_RUNTIME_REPO "https://github.com/intel/compute-runtime.git")
-    set(UR_COMPUTE_RUNTIME_TAG 25.35.35096.9)
+    set(UR_COMPUTE_RUNTIME_TAG 26.05.37020.3)
 
     include(FetchContent)
     # Sparse fetch only the dir with level zero headers for experimental features to avoid pulling in the entire compute-runtime.


### PR DESCRIPTION
Update UR_LEVEL_ZERO_LOADER_TAG to v1.28.0 to support L0 Spec v1.15.31.
Update UR_COMPUTE_RUNTIME_TAG to 26.05.37020.3.