### PR TITLE
[Benches] Fix compare script failure

### DIFF
--- a/devops/scripts/benchmarks/compare.py
+++ b/devops/scripts/benchmarks/compare.py
@@ -154,10 +154,10 @@ class Compare:
                     }
 
                 # Add every benchmark run to average_aggregate:
-                if test_run.name not in average_aggregate:
-                    average_aggregate[test_run.name] = reset_aggregate()
+                if test_run.label not in average_aggregate:
+                    average_aggregate[test_run.label] = reset_aggregate()
                 else:
-                    average_aggregate[test_run.name]["aggregate"].add(test_run.value)
+                    average_aggregate[test_run.label]["aggregate"].add(test_run.value)
 
         return {
             name: BenchmarkHistoricAverage(


### PR DESCRIPTION
The `name` field have been removed recently from the `Result` object. Update `compare.py` to use the `label` field instead.

Ref. #21233