### PR TITLE
[SYCL][JM] Support different types for the store

### DIFF
--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
@@ -339,11 +339,11 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
 #endif // defined(__SYCL_DEVICE_ONLY__)
 }
 
-template <typename Group, typename T, size_t NumRows, size_t NumCols,
+template <typename Group, typename S, typename T, size_t NumRows, size_t NumCols,
           access::address_space Space, access::decorated IsDecorated>
 inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
     Group sg,
-    const joint_matrix<Group, T, use::accumulator, NumRows, NumCols,
+    const joint_matrix<Group, S, use::accumulator, NumRows, NumCols,
                        sycl::ext::oneapi::experimental::matrix::layout::dynamic>
         &src,
     multi_ptr<T, Space, IsDecorated> dst, size_t stride,
@@ -365,7 +365,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
   using DecorT = typename sycl::detail::DecoratedType<T, Space>::type;
   DecorT *Ptr = sycl::detail::getDecorated<DecorT>(dst);
   __spirv_CooperativeMatrixStoreKHR<
-      DecorT, T, NumRows, NumCols,
+      DecorT, S, NumRows, NumCols,
       spv_matrix_use_traits<use::accumulator>::value,
       spv_matrix_layout_traits<layout::dynamic>::value>(
       Ptr, src.spvm, sycl::detail::joint_matrix_layout_to_spv(Layout), stride);
@@ -381,11 +381,11 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
 #endif // defined(__SYCL_DEVICE_ONLY__)
 }
 
-template <typename Group, typename T, size_t NumRows, size_t NumCols,
+template <typename Group, typename S, typename T, size_t NumRows, size_t NumCols,
           typename PropertyListT>
 inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
     Group sg,
-    const joint_matrix<Group, T, use::accumulator, NumRows, NumCols,
+    const joint_matrix<Group, S, use::accumulator, NumRows, NumCols,
                        sycl::ext::oneapi::experimental::matrix::layout::dynamic>
         &src,
     ext::oneapi::experimental::annotated_ptr<T, PropertyListT> dst,
@@ -402,7 +402,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
   (void)sg;
   T *Ptr = dst.get();
   __spirv_CooperativeMatrixStoreKHR<
-      T, T, NumRows, NumCols, spv_matrix_use_traits<use::accumulator>::value,
+      T, S, NumRows, NumCols, spv_matrix_use_traits<use::accumulator>::value,
       spv_matrix_layout_traits<layout::dynamic>::value>(
       Ptr, src.spvm, sycl::detail::joint_matrix_layout_to_spv(Layout), stride);
 #endif // defined(__NVPTX__)

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
@@ -339,8 +339,9 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
 #endif // defined(__SYCL_DEVICE_ONLY__)
 }
 
-template <typename Group, typename S, typename T, size_t NumRows, size_t NumCols,
-          access::address_space Space, access::decorated IsDecorated>
+template <typename Group, typename S, typename T, size_t NumRows,
+          size_t NumCols, access::address_space Space,
+          access::decorated IsDecorated>
 inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
     Group sg,
     const joint_matrix<Group, S, use::accumulator, NumRows, NumCols,
@@ -381,8 +382,8 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
 #endif // defined(__SYCL_DEVICE_ONLY__)
 }
 
-template <typename Group, typename S, typename T, size_t NumRows, size_t NumCols,
-          typename PropertyListT>
+template <typename Group, typename S, typename T, size_t NumRows,
+          size_t NumCols, typename PropertyListT>
 inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
     Group sg,
     const joint_matrix<Group, S, use::accumulator, NumRows, NumCols,

--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_store_diff_types_impl.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_store_diff_types_impl.hpp
@@ -1,0 +1,82 @@
+#include <sycl/usm.hpp>
+
+template <typename T, size_t NUM_ROWS, size_t NUM_COLS>
+void assert_ref(T *mat, const float ref) {
+  for (size_t i = 0; i < NUM_ROWS; i++)
+    for (size_t j = 0; j < NUM_COLS; j++) {
+      float diff;
+      diff = ((float *)mat)[i * NUM_COLS + j] - ref;
+      assert(std::fabs(static_cast<float>(diff)) <
+             std::numeric_limits<float>::epsilon());
+    }
+}
+
+template <typename T, unsigned int ROWS, unsigned int COLS> class st;
+
+template <typename Tjm, typename Tp, size_t SUB_ROWS, size_t SUB_COLS>
+void store(const float ref) {
+
+  queue q;
+  static constexpr size_t NUM_ROWS = SUB_ROWS * 2;
+  static constexpr size_t NUM_COLS = SUB_COLS * 2;
+  std::cout << SUB_ROWS << "x" << SUB_COLS << "\n";
+
+  Tp *A = sycl::malloc_shared<Tp>(NUM_ROWS * NUM_COLS * sizeof(Tp), q);
+  size_t sg_size = get_sg_size<st<Tp, SUB_ROWS, SUB_COLS>>(q);
+  q.submit([&](handler &cgh) {
+     cgh.parallel_for<st<Tp, SUB_ROWS, SUB_COLS>>(
+         nd_range<2>({NUM_ROWS / SUB_ROWS, NUM_COLS / SUB_COLS * sg_size},
+                     {1, 1 * sg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[sycl::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
+           auto pA =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  access::decorated::yes>((float *)A);
+
+           const auto global_idx = spmd_item.get_global_id(0);
+           const auto global_idy = spmd_item.get_global_id(1);
+           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+
+           sub_group sg = spmd_item.get_sub_group();
+           joint_matrix<sub_group, Tjm, use::accumulator, SUB_ROWS, SUB_COLS>
+               sub_mat;
+           joint_matrix_fill(sg, sub_mat, ref);
+           joint_matrix_store(sg, sub_mat,
+
+                              pA + (sg_startx * SUB_ROWS) * NUM_COLS +
+                                  sg_starty / sg_size * SUB_COLS,
+                              NUM_COLS, layout::row_major);
+         }); // parallel for
+   }).wait();
+  assert_ref<Tp, NUM_ROWS, NUM_COLS>(A, ref);
+}
+
+template <typename T, size_t ROWS, size_t COLS, class name> class ewops_c {};
+
+int main() {
+  queue q;
+  std::vector<combination> combinations =
+      q.get_device()
+          .get_info<sycl::ext::oneapi::experimental::info::device::
+                        matrix_combinations>();
+
+  for (auto &combination : combinations) {
+    if (combination.nsize == 0 ||
+        combination.nsize == 16) { // Intel AMX or architecture::intel_gpu_pvc
+
+      store<float, half, 8, 16>(7.0);
+      store<float, bfloat16, 8, 16>(7.0);
+      break;
+    }
+    if (combination.nsize == 8) { // architecture::intel_gpu_dg2*
+      store<float, half, 8, 8>(7.0);
+      store<float, bfloat16, 8, 8>(7.0);
+      break;
+    }
+  }
+  return 0;
+}

--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_store_diff_types_impl.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_store_diff_types_impl.hpp
@@ -1,11 +1,18 @@
+//===---joint_matrix_store_diff_types_impl.hpp - DPC++ joint_matrix--------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include <sycl/usm.hpp>
 
 template <typename T, size_t NUM_ROWS, size_t NUM_COLS>
 void assert_ref(T *mat, const float ref) {
   for (size_t i = 0; i < NUM_ROWS; i++)
     for (size_t j = 0; j < NUM_COLS; j++) {
-      float diff;
-      diff = ((float *)mat)[i * NUM_COLS + j] - ref;
+      auto diff = mat[i * NUM_COLS + j] - ref;
       assert(std::fabs(static_cast<float>(diff)) <
              std::numeric_limits<float>::epsilon());
     }
@@ -13,7 +20,7 @@ void assert_ref(T *mat, const float ref) {
 
 template <typename T, unsigned int ROWS, unsigned int COLS> class st;
 
-template <typename Tjm, typename Tp, size_t SUB_ROWS, size_t SUB_COLS>
+template <typename Tp, size_t SUB_ROWS, size_t SUB_COLS>
 void store(const float ref) {
 
   queue q;
@@ -21,7 +28,7 @@ void store(const float ref) {
   static constexpr size_t NUM_COLS = SUB_COLS * 2;
   std::cout << SUB_ROWS << "x" << SUB_COLS << "\n";
 
-  Tp *A = sycl::malloc_shared<Tp>(NUM_ROWS * NUM_COLS * sizeof(Tp), q);
+  Tp *A = sycl::malloc_shared<Tp>(NUM_ROWS * NUM_COLS, q);
   size_t sg_size = get_sg_size<st<Tp, SUB_ROWS, SUB_COLS>>(q);
   q.submit([&](handler &cgh) {
      cgh.parallel_for<st<Tp, SUB_ROWS, SUB_COLS>>(
@@ -34,7 +41,7 @@ void store(const float ref) {
          {
            auto pA =
                address_space_cast<sycl::access::address_space::global_space,
-                                  access::decorated::yes>((float *)A);
+                                  access::decorated::yes>(A);
 
            const auto global_idx = spmd_item.get_global_id(0);
            const auto global_idy = spmd_item.get_global_id(1);
@@ -42,11 +49,10 @@ void store(const float ref) {
            const auto sg_starty = global_idy - spmd_item.get_local_id(1);
 
            sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, Tjm, use::accumulator, SUB_ROWS, SUB_COLS>
+           joint_matrix<sub_group, float, use::accumulator, SUB_ROWS, SUB_COLS>
                sub_mat;
            joint_matrix_fill(sg, sub_mat, ref);
            joint_matrix_store(sg, sub_mat,
-
                               pA + (sg_startx * SUB_ROWS) * NUM_COLS +
                                   sg_starty / sg_size * SUB_COLS,
                               NUM_COLS, layout::row_major);
@@ -68,13 +74,13 @@ int main() {
     if (combination.nsize == 0 ||
         combination.nsize == 16) { // Intel AMX or architecture::intel_gpu_pvc
 
-      store<float, half, 8, 16>(7.0);
-      store<float, bfloat16, 8, 16>(7.0);
+      store<half, 8, 16>(7.0);
+      store<bfloat16, 8, 16>(7.0);
       break;
     }
     if (combination.nsize == 8) { // architecture::intel_gpu_dg2*
-      store<float, half, 8, 8>(7.0);
-      store<float, bfloat16, 8, 8>(7.0);
+      store<half, 8, 8>(7.0);
+      store<bfloat16, 8, 8>(7.0);
       break;
     }
   }

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_store_diff_types.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_store_diff_types.cpp
@@ -1,0 +1,21 @@
+//==-------- joint_matrix_store_diff_types.cpp  - DPC++ joint_matrix--------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// REQUIRES: target-spir
+
+// REQUIRES: aspect-ext_intel_matrix
+
+// SG size = 32 is not currently supported for SYCL Joint Matrix by IGC on DG2
+// UNSUPPORTED: gpu-intel-dg2
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include "common.hpp"
+#define SG_SZ 32
+
+#include "joint_matrix_store_diff_types_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_store_diff_types.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_store_diff_types.cpp
@@ -11,6 +11,8 @@
 
 // SG size = 32 is not currently supported for SYCL Joint Matrix by IGC on DG2
 // UNSUPPORTED: gpu-intel-dg2
+// UNSUPPORTED-INTENDED: SG size = 32 is not currently supported for SYCL Joint
+// Matrix by IGC on DG2
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Matrix/joint_matrix_store_diff_types.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_store_diff_types.cpp
@@ -1,0 +1,16 @@
+//==---- joint_matrix_store_different_types.cpp  - DPC++ joint_matrix------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// REQUIRES: target-spir
+
+// REQUIRES: aspect-ext_intel_matrix
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include "common.hpp"
+#include "joint_matrix_store_diff_types_impl.hpp"


### PR DESCRIPTION
Complete the implementation of joint_matrix_store as in the spec, types of pointer and matrix can be different. See https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_matrix/sycl_ext_oneapi_matrix.asciidoc#store 
But in current implementation, we only support one type for both.
This PR adds this distinction. 