### PR TITLE
[libclc] Work around libclc-remangler ABI mismatch on RHEL 8

### DIFF
--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -812,13 +812,10 @@ public:
 
   void Initialize(ASTContext &C) override {
     ASTCtx = &C;
-    std::unique_ptr<MemoryBuffer> const Buff = ExitOnErr(
-        errorOrToExpected(MemoryBuffer::getFileOrSTDIN(InputIRFilename)));
 
     SMDiagnostic Err;
-    std::unique_ptr<llvm::Module> const M =
-        parseIR(Buff.get()->getMemBufferRef(), Err, LLVMCtx);
-
+    std::unique_ptr<llvm::Module> M =
+        parseIRFile(StringRef(InputIRFilename), Err, LLVMCtx);
     if (!M) {
       Err.print("libclc-remangler", errs());
       exit(1);


### PR DESCRIPTION
Fix libclc runtime regression from f3962f6eb6d1 (CMPLRLLVM-73868).
intel/llvm nightly builds fail on RHEL 8.0 with GCC 7.5.0 due to an ABI mismatch in the host tool `libclc-remangler`.

`libclc-remangler` links against Clang/LLVM libraries built with the host compiler, but the tool itself is built with the just-built Clang. This causes an ABI issue around `std::optional` parameter in `MemoryBuffer::getFileOrSTDIN`.

As a workaround, replace the `getFileOrSTDIN` + `parseIR` buffer path with `llvm::parseIRFile(InputIRFilename, ...)`, avoiding the problematic interface.

This is a temporary fix; the proper long-term solution is to move `libclc-remangler` out of libclc (runtime) or remove it.