### PR TITLE
[SYCL][E2E][Doc] Add Qualcomm device architecture

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
@@ -783,6 +783,26 @@ amd_gpu_gfx1201
 ----
 |-
 |AMD RDNA 4 architecture.
+
+3+^|*Qualcomm GPU family*
+
+a|
+[source]
+----
+qcom_gpu_x1_85
+----
+|-
+|Qualcomm X1 architecture.
+
+a|
+[source]
+----
+qcom_gpu_x2_85
+qcom_gpu_x2_90
+----
+|-
+|Qualcomm X2 architecture.
+
 |===
 
 The enumerators are guaranteed to be partially ordered, which means that some
@@ -866,6 +886,16 @@ amd_gpu
 |
 Any AMD GPU device.
 This category includes all device architectures in the AMD GPU family.
+
+a|
+[source]
+----
+qcom_gpu
+----
+|-
+|
+Any Qualcomm GPU device.
+This category includes all device architectures in the Qualcomm GPU family.
 |===
 
 === New free functions to query the architecture in device code

--- a/sycl/include/sycl/ext/oneapi/experimental/device_architecture.def
+++ b/sycl/include/sycl/ext/oneapi/experimental/device_architecture.def
@@ -152,6 +152,14 @@ __SYCL_ARCHITECTURE(amd_gpu_gfx1151, 0x0200000000115100)
 __SYCL_ARCHITECTURE(amd_gpu_gfx1200, 0x0200000000120000)
 __SYCL_ARCHITECTURE(amd_gpu_gfx1201, 0x0200000000120100)
 //
+// Qualcomm architectures
+//
+// AA is 04,
+// CCCCCCCC is the GPU version of that architecture
+__SYCL_ARCHITECTURE(qcom_gpu_x1_85, 0x0400000000018500) // Qualcomm(R) Adreno X1-85
+__SYCL_ARCHITECTURE(qcom_gpu_x2_85, 0x0400000000028500) // Qualcomm(R) Adreno X2-85
+__SYCL_ARCHITECTURE(qcom_gpu_x2_90, 0x0400000000029000) // Qualcomm(R) Adreno X2-90
+//
 // Aliases for Intel graphics architectures
 //
 __SYCL_ARCHITECTURE_ALIAS(intel_gpu_8_0_0, intel_gpu_bdw)

--- a/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
@@ -61,6 +61,7 @@ enum class arch_category {
   nvidia_gpu = 1,
   amd_gpu = 2,
   // TODO: add intel_cpu = 3,
+  qcom_gpu = 4,
 };
 
 } // namespace ext::oneapi::experimental
@@ -87,6 +88,13 @@ static constexpr ext::oneapi::experimental::architecture
 static constexpr ext::oneapi::experimental::architecture
     max_amd_gpu_architecture =
         ext::oneapi::experimental::architecture::amd_gpu_gfx1201;
+
+static constexpr ext::oneapi::experimental::architecture
+    min_qcom_gpu_architecture =
+        ext::oneapi::experimental::architecture::qcom_gpu_x1_85;
+static constexpr ext::oneapi::experimental::architecture
+    max_qcom_gpu_architecture =
+        ext::oneapi::experimental::architecture::qcom_gpu_x2_90;
 
 #ifndef __SYCL_TARGET_INTEL_X86_64__
 #define __SYCL_TARGET_INTEL_X86_64__ 0
@@ -361,6 +369,15 @@ static constexpr ext::oneapi::experimental::architecture
 #ifndef __SYCL_TARGET_AMD_GPU_GFX1201__
 #define __SYCL_TARGET_AMD_GPU_GFX1201__ 0
 #endif
+#ifndef __SYCL_TARGET_QCOM_GPU_X1_85__
+#define __SYCL_TARGET_QCOM_GPU_X1_85__ 0
+#endif
+#ifndef __SYCL_TARGET_QCOM_GPU_X2_85__
+#define __SYCL_TARGET_QCOM_GPU_X2_85__ 0
+#endif
+#ifndef __SYCL_TARGET_QCOM_GPU_X2_90__
+#define __SYCL_TARGET_QCOM_GPU_X2_90__ 0
+#endif
 
 // This is true when the translation unit is compiled in AOT mode with target
 // names that supports the "if_architecture_is" features.  If an unsupported
@@ -458,7 +475,10 @@ static constexpr bool is_allowable_aot_mode =
     (__SYCL_TARGET_AMD_GPU_GFX1150__ == 1) ||
     (__SYCL_TARGET_AMD_GPU_GFX1151__ == 1) ||
     (__SYCL_TARGET_AMD_GPU_GFX1200__ == 1) ||
-    (__SYCL_TARGET_AMD_GPU_GFX1201__ == 1);
+    (__SYCL_TARGET_AMD_GPU_GFX1201__ == 1) ||
+    (__SYCL_TARGET_QCOM_GPU_X1_85__ == 1) ||
+    (__SYCL_TARGET_QCOM_GPU_X2_85__ == 1) ||
+    (__SYCL_TARGET_QCOM_GPU_X2_90__ == 1);
 
 constexpr static std::optional<ext::oneapi::experimental::architecture>
 get_current_architecture_aot() {
@@ -737,6 +757,15 @@ get_current_architecture_aot() {
 #if __SYCL_TARGET_AMD_GPU_GFX1201__
   return ext::oneapi::experimental::architecture::amd_gpu_gfx1201;
 #endif
+#if __SYCL_TARGET_QCOM_GPU_X1_85__
+  return ext::oneapi::experimental::architecture::qcom_gpu_x1_85;
+#endif
+#if __SYCL_TARGET_QCOM_GPU_X2_85__
+  return ext::oneapi::experimental::architecture::qcom_gpu_x2_85;
+#endif
+#if __SYCL_TARGET_QCOM_GPU_X2_90__
+  return ext::oneapi::experimental::architecture::qcom_gpu_x2_90;
+#endif
   return std::nullopt;
 }
 
@@ -773,6 +802,8 @@ get_category_min_architecture(
     return min_nvidia_gpu_architecture;
   } else if (Category == ext::oneapi::experimental::arch_category::amd_gpu) {
     return min_amd_gpu_architecture;
+  } else if (Category == ext::oneapi::experimental::arch_category::qcom_gpu) {
+    return min_qcom_gpu_architecture;
   } // add "else if " when adding new category, "else" not needed
   return std::nullopt;
 }
@@ -786,6 +817,8 @@ get_category_max_architecture(
     return max_nvidia_gpu_architecture;
   } else if (Category == ext::oneapi::experimental::arch_category::amd_gpu) {
     return max_amd_gpu_architecture;
+  } else if (Category == ext::oneapi::experimental::arch_category::qcom_gpu) {
+    return max_qcom_gpu_architecture;
   } // add "else if " when adding new category, "else" not needed
   return std::nullopt;
 }

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -1850,6 +1850,14 @@ public:
             {"gfx1201", oneapi_exp_arch::amd_gpu_gfx1201},
         };
 
+    // Only for Qualcomm GPU architectures
+    constexpr std::pair<const char *, oneapi_exp_arch>
+        QualcommGPUArchitectures[] = {
+            {"X1-85", oneapi_exp_arch::qcom_gpu_x1_85},
+            {"X2-85", oneapi_exp_arch::qcom_gpu_x2_85},
+            {"X2-90", oneapi_exp_arch::qcom_gpu_x2_90},
+        };
+
     // Only for Intel GPU architectures
     constexpr std::pair<const int, oneapi_exp_arch> IntelGPUArchitectures[] = {
         {0x02000000, oneapi_exp_arch::intel_gpu_bdw},
@@ -1919,8 +1927,8 @@ public:
         {10, oneapi_exp_arch::intel_cpu_dmr},
     };
     backend CurrentBackend = getBackend();
-    auto LookupIPVersion = [&, this](auto &ArchList)
-        -> std::optional<ext::oneapi::experimental::architecture> {
+    auto LookupIPVersion =
+        [&, this](auto &ArchList) -> std::optional<oneapi_exp_arch> {
       auto DeviceIp = get_info_impl_nocheck<UR_DEVICE_INFO_IP_VERSION>();
       if (!DeviceIp.has_val()) {
         ur_result_t Err = DeviceIp.error();
@@ -1939,30 +1947,57 @@ public:
       return std::nullopt;
     };
 
+    auto MapQualcommArchIDToArchName = [&](const char *arch) {
+      for (const auto &Item : QualcommGPUArchitectures) {
+        if (std::string_view(Item.first) == arch)
+          return Item.second;
+      }
+      return oneapi_exp_arch::unknown;
+    };
+
+    auto MapNvidiaOrAMDArchIDToArchName = [&](const char *arch) {
+      for (const auto &Item : NvidiaAmdGPUArchitectures) {
+        if (std::string_view(Item.first) == arch)
+          return Item.second;
+      }
+      return oneapi_exp_arch::unknown;
+    };
+
     if (is_gpu() && (backend::ext_oneapi_level_zero == CurrentBackend ||
                      backend::opencl == CurrentBackend)) {
-      return LookupIPVersion(IntelGPUArchitectures)
-          .value_or(ext::oneapi::experimental::architecture::unknown);
-    } else if (is_gpu() && (backend::ext_oneapi_cuda == CurrentBackend ||
-                            backend::ext_oneapi_hip == CurrentBackend)) {
-      auto MapArchIDToArchName = [&](const char *arch) {
-        for (const auto &Item : NvidiaAmdGPUArchitectures) {
-          if (std::string_view(Item.first) == arch)
-            return Item.second;
-        }
-        return ext::oneapi::experimental::architecture::unknown;
-      };
-      std::string DeviceArch =
+      // Check if device is Intel architecture.
+      oneapi_exp_arch DeviceArch = LookupIPVersion(IntelGPUArchitectures)
+                                        .value_or(oneapi_exp_arch::unknown);
+      if (DeviceArch != oneapi_exp_arch::unknown) {
+        return DeviceArch;
+      }
+
+      // Otherwise, check if device is Qualcomm architecture.
+      // If not, return `oneapi_exp_arch::unknown`.
+
+      // Qualcomm architecture doesn't support LevelZero.
+      if (backend::ext_oneapi_level_zero == CurrentBackend) {
+        return oneapi_exp_arch::unknown;
+      }
+
+      std::string DeviceArchStr =
           get_info_impl<UrInfoCode<info::device::version>::value>();
       std::string_view DeviceArchSubstr =
-          std::string_view{DeviceArch}.substr(0, DeviceArch.find(":"));
-      return MapArchIDToArchName(DeviceArchSubstr.data());
+          std::string_view{DeviceArchStr}.substr(0, DeviceArchStr.find(":"));
+      return MapQualcommArchIDToArchName(DeviceArchSubstr.data());
+    } else if (is_gpu() && (backend::ext_oneapi_cuda == CurrentBackend ||
+                            backend::ext_oneapi_hip == CurrentBackend)) {
+      std::string DeviceArchStr =
+          get_info_impl<UrInfoCode<info::device::version>::value>();
+      std::string_view DeviceArchSubstr =
+          std::string_view{DeviceArchStr}.substr(0, DeviceArchStr.find(":"));
+      return MapNvidiaOrAMDArchIDToArchName(DeviceArchSubstr.data());
     } else if (is_cpu() && backend::opencl == CurrentBackend) {
       return LookupIPVersion(IntelCPUArchitectures)
-          .value_or(ext::oneapi::experimental::architecture::x86_64);
+          .value_or(oneapi_exp_arch::x86_64);
     } // else is not needed
     // TODO: add support of other architectures by extending with else if
-    return ext::oneapi::experimental::architecture::unknown;
+    return oneapi_exp_arch::unknown;
   }
 
   std::vector<ext::oneapi::experimental::matrix::combination>

--- a/sycl/test-e2e/DeviceArchitecture/device_architecture_comparison_on_host.cpp
+++ b/sycl/test-e2e/DeviceArchitecture/device_architecture_comparison_on_host.cpp
@@ -1,11 +1,5 @@
 // REQUIRES: gpu
 
-// UNSUPPORTED: cuda, hip
-// UNSUPPORTED-INTENDED: This test is written only for Intel architectures. It
-// is expected that this test will fail on NVIDIA and AMD as the checks for
-// ext_oneapi_architecture_is host API expect that device architecture is Intel
-// GPU.
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -17,9 +11,22 @@ int main() {
   sycl::queue q;
   sycl::device dev = q.get_device();
 
-  assert(dev.ext_oneapi_architecture_is(syclex::arch_category::intel_gpu));
-  assert(!dev.ext_oneapi_architecture_is(syclex::arch_category::nvidia_gpu));
-  assert(!dev.ext_oneapi_architecture_is(syclex::arch_category::amd_gpu));
+  bool isArchKnown = dev.get_info<syclex::info::device::architecture>() !=
+                     syclex::architecture::unknown;
+
+  // If architecture is known, it must be part of one, and only one, of the
+  // known device architecture categories.
+  if (isArchKnown) {
+    int32_t isArchIntel =
+        dev.ext_oneapi_architecture_is(syclex::arch_category::intel_gpu);
+    int32_t isArchNvidia =
+        dev.ext_oneapi_architecture_is(syclex::arch_category::nvidia_gpu);
+    int32_t isArchAmd =
+        dev.ext_oneapi_architecture_is(syclex::arch_category::amd_gpu);
+    int32_t isArchQcom =
+        dev.ext_oneapi_architecture_is(syclex::arch_category::qcom_gpu);
+    assert((isArchIntel + isArchNvidia + isArchAmd + isArchQcom) == 1);
+  }
 
   syclex::architecture intel_gpu_arch = syclex::architecture::intel_gpu_ehl;
   assert(intel_gpu_arch < syclex::architecture::intel_gpu_pvc);
@@ -38,6 +45,12 @@ int main() {
   assert(amd_gpu_arch <= syclex::architecture::amd_gpu_gfx1031);
   assert(amd_gpu_arch > syclex::architecture::amd_gpu_gfx810);
   assert(amd_gpu_arch >= syclex::architecture::amd_gpu_gfx908);
+
+  syclex::architecture qcom_gpu_arch = syclex::architecture::qcom_gpu_x2_85;
+  assert(qcom_gpu_arch < syclex::architecture::qcom_gpu_x2_90);
+  assert(qcom_gpu_arch <= syclex::architecture::qcom_gpu_x2_85);
+  assert(qcom_gpu_arch > syclex::architecture::qcom_gpu_x1_85);
+  assert(qcom_gpu_arch >= syclex::architecture::qcom_gpu_x1_85);
 
   return 0;
 }

--- a/sycl/test-e2e/USM/allocator_rebind.cpp
+++ b/sycl/test-e2e/USM/allocator_rebind.cpp
@@ -1,3 +1,4 @@
+// XFAIL: arch-qcom_gpu_x1_85 && arch-qcom_gpu_x2_85 && arch-qcom_gpu_x2_90
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
 


### PR DESCRIPTION
A new device architecture has been added for
Qualcomm GPUs. This enables Qualcomm GPUs to be
queried for their architecture at runtime, and
as an example, disable E2E tests which are not
supported on a specific Qualcomm architecture.

The `sycl_ext_oneapi_device_architecture`
extension document has been updated to add the
Qualcomm GPU family.

The `USM/allocator_rebind.cpp` E2E test has been
set as XFAIL for the newly added Qualcomm
architecture (`qcom_gpu_x1_85`).