### PR TITLE
[UR][CI] add liboffload build workflow

### DIFF
--- a/.github/workflows/ur-build-offload.yml
+++ b/.github/workflows/ur-build-offload.yml
@@ -18,37 +18,50 @@ jobs:
       image: 'ghcr.io/intel/llvm/ubuntu2404_build'
 
     steps:
+    - name: Checkout LLVM-project
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        repository: llvm/llvm-project
+        persist-credentials: false
+        path: llvm-project
+
     - name: Checkout LLVM
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        path: llvm
+        persist-credentials: false
 
-    - name: Install liboffload
-      run: sudo apt-get update -qq && sudo apt-get install --no-install-recommends -yqq liboffload-21 liboffload-21-dev
+    - name: Configure llvm-project
+      run: >
+        cmake -S llvm-project/llvm -B llvm-project/build -G Ninja
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        -DLLVM_TARGETS_TO_BUILD='host;SPIRV;NVPTX'
+        -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lldb;lld'
+        -DLLVM_ENABLE_RUNTIMES='offload;openmp;libc'
+        -DLIBOMPTARGET_PLUGINS_TO_BUILD="level_zero;cuda"
+        -DLLVM_PARALLEL_LINK_JOBS=20
+        -DLLVM_BUILD_TESTS=ON
+        -DLLVM_INCLUDE_TESTS=on
+        '-DLLVM_LIT_ARGS=-v -vv'
+        -DCMAKE_INSTALL_PREFIX=./llvm-project-install
 
-    - name: Configure Unified Runtime project
+
+    - name: Build and install llvm-project
+      run: ninja -C llvm-project/build -j $(($(nproc)/3)) install
+
+    - name: Configure intel/llvm
       # ">" is used to avoid adding "\" at the end of each line; this command is quite long
       run: >
-        cmake
-        -S unified-runtime
-        -B $GITHUB_WORKSPACE/build
-        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
-        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
-        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
-        -DUR_ENABLE_TRACING=ON
-        -DUR_DEVELOPER_MODE=ON
-        -DUR_BUILD_TESTS=OFF
-        -DUR_BUILD_ADAPTER_OFFLOAD=ON
-        -DUR_OFFLOAD_INSTALL_DIR="/usr/lib/llvm-21"
-        -DUR_OFFLOAD_INCLUDE_DIR="/usr/lib/llvm-21/include"
-        -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install
+        python3 llvm/buildbot/configure.py
+        --offload
+        --cuda
+        -t ${{matrix.build_type}}
+        --liboffload-path=./llvm-project-install
 
-    - name: Build
+    - name: Build intel/llvm
       # This is so that device binaries can find the sycl runtime library
-      run: cmake --build $GITHUB_WORKSPACE/build -j $(($(nproc)/3))
-
-    - name: Install
-      # This is to check that install command does not fail
-      run: cmake --install $GITHUB_WORKSPACE/build
+      run: python3 llvm/buildbot/compile.py
 
     - name: Get information about platform
       if: ${{ always() }}
-      run: devops/scripts/get_system_info.sh
+      run: ./llvm/devops/scripts/get_system_info.sh

--- a/.github/workflows/ur-precommit.yml
+++ b/.github/workflows/ur-precommit.yml
@@ -97,12 +97,11 @@ jobs:
       image_options: ${{ matrix.image_options || '' }}
       install_igc_driver: ${{ contains(needs.detect_changes.outputs.filters, 'drivers') }}
 
-# TODO: Enable once the apt package at https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-snapshot/ is updated
-#  offload_build:
-#    name: Adapters (Offload)
-#    needs: [detect_changes, source_checks]
-#    if: ${{ !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur_offload_adapter') }}
-#    uses: ./.github/workflows/ur-build-offload.yml
+  offload_build:
+    name: Adapters (Offload)
+    needs: [detect_changes, source_checks]
+    if: ${{ !cancelled() && contains(needs.detect_changes.outputs.filters, 'ur_offload_adapter') }}
+    uses: ./.github/workflows/ur-build-offload.yml
 
   macos:
     name: MacOS build only


### PR DESCRIPTION
This patch re-enables `UR - Build offload adapter` workflow and updates the original file to use the recent methods for building liboffload. Currently, `intel/llvm` is built from actions/checkout instead of from downloading artifacts, which might be subject to change in future patches.

The workflow is triggered after detecting changes in the following files and directories:
- `unified-runtime/include/**`
- `unified-runtime/source/adapters/offload/**`
- `.github/workflows/ur-build-offload.yml`

The trigger has been verified [in the provided run](https://github.com/intel/llvm/actions/runs/22776027813/job/66071537563?pr=21414), where the `on: pull_request` trigger was removed from `ur-offload-build.yml` and `llvm/unified-runtime/source/adapters/offload/adapter.cpp` was modified ([commit](https://github.com/intel/llvm/commit/423e5b4ae1bf0a453f8bb52ae9ee05c5eb4bd590)).