### PR TITLE
[SYCL] Replace SPIR-V INTEL shuffles with generic version

### DIFF
--- a/libdevice/nativecpu_utils.cpp
+++ b/libdevice/nativecpu_utils.cpp
@@ -331,39 +331,47 @@ DefineShuffleVec2to16(float, f32, float);
 
 #define DefGroupNonUniformShuffle(Type, Sfx, MuxType)                          \
   DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_##Sfx(MuxType val,           \
-                                                        int32_t lid);          \
+                                                        int32_t lid) noexcept; \
   DEVICE_EXTERNAL Type __spirv_GroupNonUniformShuffle(                         \
-      , Type data, unsigned value) noexcept {                                  \
-    return (Type)__mux_sub_group_shuffle_##Sfx((MuxType)data, value);          \
+      int32_t scope, Type data, unsigned value) noexcept {                     \
+    if (__spv::Scope::Flag::Subgroup == scope)                                 \
+      return (Type)__mux_sub_group_shuffle_##Sfx((MuxType)data, value);        \
+    return (Type)0;                                                            \
   }                                                                            \
   static_assert(true)
 
 #define DefGroupNonUniformShuffleUp(Type, Sfx, MuxType)                        \
   DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_up_##Sfx(                    \
-      MuxType prev, MuxType curr, int32_t delta);                              \
+      MuxType prev, MuxType curr, int32_t delta) noexcept;                     \
   DEVICE_EXTERNAL Type __spirv_GroupNonUniformShuffleUp(                       \
-      , Type data, unsigned delta) noexcept {                                  \
-    return (Type)__mux_sub_group_shuffle_up_##Sfx((MuxType)data,               \
-                                                  (MuxType)data, delta);       \
+      int32_t scope, Type data, unsigned delta) noexcept {                     \
+    if (__spv::Scope::Flag::Subgroup == scope)                                 \
+      return (Type)__mux_sub_group_shuffle_up_##Sfx((MuxType)data,             \
+                                                    (MuxType)data, delta);     \
+    return (Type)0;                                                            \
   }                                                                            \
   static_assert(true)
 
 #define DefGroupNonUniformShuffleDown(Type, Sfx, MuxType)                      \
   DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_down_##Sfx(                  \
-      MuxType curr, MuxType next, int32_t delta);                              \
+      MuxType curr, MuxType next, int32_t delta) noexcept;                     \
   DEVICE_EXTERNAL Type __spirv_GroupNonUniformShuffleDown(                     \
-      , Type data, unsigned delta) noexcept {                                  \
-    return (Type)__mux_sub_group_shuffle_down_##Sfx((MuxType)data,             \
-                                                    (MuxType)data, delta);     \
+      int32_t scope, Type data, unsigned delta) noexcept {                     \
+    if (__spv::Scope::Flag::Subgroup == scope)                                 \
+      return (Type)__mux_sub_group_shuffle_down_##Sfx((MuxType)data,           \
+                                                      (MuxType)data, delta);   \
+    return (Type)0;                                                            \
   }                                                                            \
   static_assert(true)
 
 #define DefGroupNonUniformShuffleXor(Type, Sfx, MuxType)                       \
-  DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_xor_##Sfx(MuxType val,       \
-                                                            int32_t xor_val);  \
+  DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_xor_##Sfx(                   \
+      MuxType val, int32_t xor_val) noexcept;                                  \
   DEVICE_EXTERNAL Type __spirv_GroupNonUniformShuffleXor(                      \
-      , Type data, unsigned value) noexcept {                                  \
-    return (Type)__mux_sub_group_shuffle_xor_##Sfx((MuxType)data, value);      \
+      int32_t scope, Type data, unsigned value) noexcept {                     \
+    if (__spv::Scope::Flag::Subgroup == scope)                                 \
+      return (Type)__mux_sub_group_shuffle_xor_##Sfx((MuxType)data, value);    \
+    return (Type)0;                                                            \
   }                                                                            \
   static_assert(true)
 

--- a/libdevice/nativecpu_utils.cpp
+++ b/libdevice/nativecpu_utils.cpp
@@ -329,6 +329,77 @@ DefineShuffleVec2to16(int32_t, i32, int32_t);
 DefineShuffleVec2to16(uint32_t, i32, int32_t);
 DefineShuffleVec2to16(float, f32, float);
 
+#define DefGroupNonUniformShuffle(Type, Sfx, MuxType)                          \
+  DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_##Sfx(MuxType val,           \
+                                                        int32_t lid);          \
+  DEVICE_EXTERNAL Type __spirv_GroupNonUniformShuffle(                         \
+      , Type data, unsigned value) noexcept {                                  \
+    return (Type)__mux_sub_group_shuffle_##Sfx((MuxType)data, value);          \
+  }                                                                            \
+  static_assert(true)
+
+#define DefGroupNonUniformShuffleUp(Type, Sfx, MuxType)                        \
+  DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_up_##Sfx(                    \
+      MuxType prev, MuxType curr, int32_t delta);                              \
+  DEVICE_EXTERNAL Type __spirv_GroupNonUniformShuffleUp(                       \
+      , Type data, unsigned delta) noexcept {                                  \
+    return (Type)__mux_sub_group_shuffle_up_##Sfx((MuxType)data,               \
+                                                  (MuxType)data, delta);       \
+  }                                                                            \
+  static_assert(true)
+
+#define DefGroupNonUniformShuffleDown(Type, Sfx, MuxType)                      \
+  DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_down_##Sfx(                  \
+      MuxType curr, MuxType next, int32_t delta);                              \
+  DEVICE_EXTERNAL Type __spirv_GroupNonUniformShuffleDown(                     \
+      , Type data, unsigned delta) noexcept {                                  \
+    return (Type)__mux_sub_group_shuffle_down_##Sfx((MuxType)data,             \
+                                                    (MuxType)data, delta);     \
+  }                                                                            \
+  static_assert(true)
+
+#define DefGroupNonUniformShuffleXor(Type, Sfx, MuxType)                       \
+  DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_xor_##Sfx(MuxType val,       \
+                                                            int32_t xor_val);  \
+  DEVICE_EXTERNAL Type __spirv_GroupNonUniformShuffleXor(                      \
+      , Type data, unsigned value) noexcept {                                  \
+    return (Type)__mux_sub_group_shuffle_xor_##Sfx((MuxType)data, value);      \
+  }                                                                            \
+  static_assert(true)
+
+#define DefGroupNonUniformShuffle_All(Type, Sfx, MuxType)                      \
+  DefGroupNonUniformShuffle(Type, Sfx, MuxType);                               \
+  DefGroupNonUniformShuffleUp(Type, Sfx, MuxType);                             \
+  DefGroupNonUniformShuffleDown(Type, Sfx, MuxType);                           \
+  DefGroupNonUniformShuffleXor(Type, Sfx, MuxType);
+
+DefGroupNonUniformShuffle_All(uint64_t, i64, int64_t);
+DefGroupNonUniformShuffle_All(int64_t, i64, int64_t);
+DefGroupNonUniformShuffle_All(int32_t, i32, int32_t);
+DefGroupNonUniformShuffle_All(uint32_t, i32, int32_t);
+DefGroupNonUniformShuffle_All(int16_t, i16, int16_t);
+DefGroupNonUniformShuffle_All(uint16_t, i16, int16_t);
+DefGroupNonUniformShuffle_All(int8_t, i8, int8_t);
+DefGroupNonUniformShuffle_All(uint8_t, i8, int8_t);
+DefGroupNonUniformShuffle_All(double, f64, double);
+DefGroupNonUniformShuffle_All(float, f32, float);
+DefGroupNonUniformShuffle_All(_Float16, f16, _Float16);
+
+#define DefineGroupNonUniformShuffleVec(T, N, Sfx, MuxType) \
+  using vt##T##N = ncpu_types::native_vector_t<T, N>; \
+  using vt##MuxType##N = ncpu_types::native_vector_t<MuxType, N>; \
+  DefGroupNonUniformShuffle_All(vt##T##N, v##N##Sfx, vt##MuxType##N)
+
+#define DefineGroupNonUniformShuffleVec2to16(Type, Sfx, MuxType) \
+ DefineGroupNonUniformShuffleVec(Type, 2, Sfx, MuxType); \
+ DefineGroupNonUniformShuffleVec(Type, 4, Sfx, MuxType); \
+ DefineGroupNonUniformShuffleVec(Type, 8, Sfx, MuxType); \
+ DefineGroupNonUniformShuffleVec(Type, 16, Sfx, MuxType)
+
+DefineGroupNonUniformShuffleVec2to16(int32_t, i32, int32_t);
+DefineGroupNonUniformShuffleVec2to16(uint32_t, i32, int32_t);
+DefineGroupNonUniformShuffleVec2to16(float, f32, float);
+
 #define GET_PROPS __attribute__((pure))
 #define GEN_u32(bname, muxname)                                                \
   DEVICE_EXTERN_C GET_PROPS uint32_t muxname();                                \

--- a/libdevice/nativecpu_utils.cpp
+++ b/libdevice/nativecpu_utils.cpp
@@ -365,8 +365,8 @@ DefineShuffleVec2to16(float, f32, float);
   static_assert(true)
 
 #define DefGroupNonUniformShuffleXor(Type, Sfx, MuxType)                       \
-  DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_xor_##Sfx(                   \
-      MuxType val, int32_t xor_val) noexcept;                                  \
+  DEVICE_EXTERN_C MuxType __mux_sub_group_shuffle_xor_##Sfx(MuxType val,       \
+                                                            int32_t xor_val);  \
   DEVICE_EXTERNAL Type __spirv_GroupNonUniformShuffleXor(                      \
       int32_t scope, Type data, unsigned value) noexcept {                     \
     if (__spv::Scope::Flag::Subgroup == scope)                                 \

--- a/libdevice/nativecpu_utils.cpp
+++ b/libdevice/nativecpu_utils.cpp
@@ -393,16 +393,16 @@ DefGroupNonUniformShuffle_All(double, f64, double);
 DefGroupNonUniformShuffle_All(float, f32, float);
 DefGroupNonUniformShuffle_All(_Float16, f16, _Float16);
 
-#define DefineGroupNonUniformShuffleVec(T, N, Sfx, MuxType) \
-  using vt##T##N = ncpu_types::native_vector_t<T, N>; \
-  using vt##MuxType##N = ncpu_types::native_vector_t<MuxType, N>; \
+#define DefineGroupNonUniformShuffleVec(T, N, Sfx, MuxType)                    \
+  using vt##T##N = ncpu_types::native_vector_t<T, N>;                          \
+  using vt##MuxType##N = ncpu_types::native_vector_t<MuxType, N>;              \
   DefGroupNonUniformShuffle_All(vt##T##N, v##N##Sfx, vt##MuxType##N)
 
-#define DefineGroupNonUniformShuffleVec2to16(Type, Sfx, MuxType) \
- DefineGroupNonUniformShuffleVec(Type, 2, Sfx, MuxType); \
- DefineGroupNonUniformShuffleVec(Type, 4, Sfx, MuxType); \
- DefineGroupNonUniformShuffleVec(Type, 8, Sfx, MuxType); \
- DefineGroupNonUniformShuffleVec(Type, 16, Sfx, MuxType)
+#define DefineGroupNonUniformShuffleVec2to16(Type, Sfx, MuxType)               \
+  DefineGroupNonUniformShuffleVec(Type, 2, Sfx, MuxType);                      \
+  DefineGroupNonUniformShuffleVec(Type, 4, Sfx, MuxType);                      \
+  DefineGroupNonUniformShuffleVec(Type, 8, Sfx, MuxType);                      \
+  DefineGroupNonUniformShuffleVec(Type, 16, Sfx, MuxType)
 
 DefineGroupNonUniformShuffleVec2to16(int32_t, i32, int32_t);
 DefineGroupNonUniformShuffleVec2to16(uint32_t, i32, int32_t);

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -940,8 +940,8 @@ EnableIfNativeShuffle<T> Shuffle(GroupT g, T x, id<1> local_id) {
         group_scope<GroupT>::value, convertToOpenCLType(x), LocalId));
   } else {
     // Subgroup.
-    return convertFromOpenCLTypeFor<T>(
-        __spirv_SubgroupShuffleINTEL(convertToOpenCLType(x), LocalId));
+    return convertFromOpenCLTypeFor<T>(__spirv_GroupNonUniformShuffle(
+        __spv::Scope::Subgroup, convertToOpenCLType(x), LocalId));
   }
 #else
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
@@ -978,8 +978,9 @@ EnableIfNativeShuffle<T> ShuffleXor(GroupT g, T x, id<1> mask) {
                                           convertToOpenCLType(x), TargetId);
   } else {
     // Subgroup.
-    return convertFromOpenCLTypeFor<T>(__spirv_SubgroupShuffleXorINTEL(
-        convertToOpenCLType(x), static_cast<uint32_t>(mask.get(0))));
+    return convertFromOpenCLTypeFor<T>(__spirv_GroupNonUniformShuffleXor(
+        __spv::Scope::Subgroup, convertToOpenCLType(x),
+        static_cast<uint32_t>(mask.get(0))));
   }
 #else
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
@@ -1025,8 +1026,8 @@ EnableIfNativeShuffle<T> ShuffleDown(GroupT g, T x, uint32_t delta) {
                                           convertToOpenCLType(x), TargetId);
   } else {
     // Subgroup.
-    return convertFromOpenCLTypeFor<T>(__spirv_SubgroupShuffleDownINTEL(
-        convertToOpenCLType(x), convertToOpenCLType(x), delta));
+    return convertFromOpenCLTypeFor<T>(__spirv_GroupNonUniformShuffleDown(
+        __spv::Scope::Subgroup, convertToOpenCLType(x), delta));
   }
 #else
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
@@ -1069,8 +1070,8 @@ EnableIfNativeShuffle<T> ShuffleUp(GroupT g, T x, uint32_t delta) {
                                           convertToOpenCLType(x), TargetId);
   } else {
     // Subgroup.
-    return convertFromOpenCLTypeFor<T>(__spirv_SubgroupShuffleUpINTEL(
-        convertToOpenCLType(x), convertToOpenCLType(x), delta));
+    return convertFromOpenCLTypeFor<T>(__spirv_GroupNonUniformShuffleUp(
+        __spv::Scope::Subgroup, convertToOpenCLType(x), delta));
   }
 #else
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -786,30 +786,21 @@ AtomicMax(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
 //   variants for all scalar types
 #ifndef __NVPTX__
 
-template <typename T>
-struct VecTypeIsProhibitedForNativeShuffle
-    : std::bool_constant<
-          (detail::get_vec_size<T>::size > 1) &&
-          check_type_in_v<vector_element_t<T>, double, long, long long,
-                          unsigned long, unsigned long long, half>> {};
-
-// Native shuffle is supported if T is scalar arithmetic type or vector type
-// with arithmetic element type which is not in prohibited list.
-// detail::is_arithmetic looks through pointer, marray and vec into the element
-// type, so we have to exclude marray and pointer types.
+// Note: Although SPIR-V supports vector shuffles, the OpenCL specification only
+//       allows scalars in the operations. As such, we scalarize those too, then
+//       expect vectorization from the device compiler if possible.
+// https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Env.html#_cl_khr_subgroup_shuffle
 template <typename T>
 struct NativeShuffle
     : std::bool_constant<detail::is_arithmetic<T>::value &&
-                         !VecTypeIsProhibitedForNativeShuffle<T>::value &&
-                         !detail::is_marray_v<T> && !detail::is_pointer_v<T>> {
-};
+                         !detail::is_marray_v<T> && !detail::is_vec_v<T> &&
+                         !detail::is_pointer_v<T>> {};
 
 // Non-scalar shuffle (emulation via loop + scalar shuffle) is used if we have a
 // vector type for which native shuffle is not supported or for marray type.
 template <typename T>
 struct NonScalarShuffle
-    : std::bool_constant<!NativeShuffle<T>::value &&
-                         (detail::is_vec_v<T> || detail::is_marray_v<T>)> {};
+    : std::bool_constant<detail::is_marray_v<T> || detail::is_vec_v<T>> {};
 
 template <typename T>
 using EnableIfNativeShuffle = std::enable_if_t<NativeShuffle<T>::value, T>;
@@ -925,24 +916,8 @@ EnableIfNativeShuffle<T> Shuffle(GroupT g, T x, id<1> local_id) {
   uint32_t LocalId = MapShuffleID(g, local_id);
 #ifndef __NVPTX__
   (void)g;
-  if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
-                    GroupT> &&
-                detail::is_vec<T>::value) {
-    // Temporary work-around due to a bug in IGC.
-    // TODO: Remove when IGC bug is fixed.
-    T result;
-    for (int s = 0; s < x.size(); ++s)
-      result[s] = Shuffle(g, x[s], local_id);
-    return result;
-  } else if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
-                           GroupT>) {
-    return convertFromOpenCLTypeFor<T>(__spirv_GroupNonUniformShuffle(
-        group_scope<GroupT>::value, convertToOpenCLType(x), LocalId));
-  } else {
-    // Subgroup.
-    return convertFromOpenCLTypeFor<T>(__spirv_GroupNonUniformShuffle(
-        __spv::Scope::Subgroup, convertToOpenCLType(x), LocalId));
-  }
+  return convertFromOpenCLTypeFor<T>(__spirv_GroupNonUniformShuffle(group_scope<GroupT>::value,
+                                        convertToOpenCLType(x), LocalId));
 #else
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
                     GroupT>) {
@@ -959,16 +934,7 @@ EnableIfNativeShuffle<T> ShuffleXor(GroupT g, T x, id<1> mask) {
 #ifndef __NVPTX__
   (void)g;
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
-                    GroupT> &&
-                detail::is_vec<T>::value) {
-    // Temporary work-around due to a bug in IGC.
-    // TODO: Remove when IGC bug is fixed.
-    T result;
-    for (int s = 0; s < x.size(); ++s)
-      result[s] = ShuffleXor(g, x[s], mask);
-    return result;
-  } else if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
-                           GroupT>) {
+                    GroupT>) {
     // Since the masks are relative to the groups, we could either try to adjust
     // the mask or simply do the xor ourselves. Latter option is efficient,
     // general, and simple so we go with that.
@@ -1006,16 +972,7 @@ template <typename GroupT, typename T>
 EnableIfNativeShuffle<T> ShuffleDown(GroupT g, T x, uint32_t delta) {
 #ifndef __NVPTX__
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
-                    GroupT> &&
-                detail::is_vec<T>::value) {
-    // Temporary work-around due to a bug in IGC.
-    // TODO: Remove when IGC bug is fixed.
-    T result;
-    for (int s = 0; s < x.size(); ++s)
-      result[s] = ShuffleDown(g, x[s], delta);
-    return result;
-  } else if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
-                           GroupT>) {
+                    GroupT>) {
     id<1> TargetLocalId = g.get_local_id();
     // ID outside the group range is UB, so we just keep the current item ID
     // unchanged.
@@ -1051,16 +1008,7 @@ template <typename GroupT, typename T>
 EnableIfNativeShuffle<T> ShuffleUp(GroupT g, T x, uint32_t delta) {
 #ifndef __NVPTX__
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
-                    GroupT> &&
-                detail::is_vec<T>::value) {
-    // Temporary work-around due to a bug in IGC.
-    // TODO: Remove when IGC bug is fixed.
-    T result;
-    for (int s = 0; s < x.size(); ++s)
-      result[s] = ShuffleUp(g, x[s], delta);
-    return result;
-  } else if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
-                           GroupT>) {
+                    GroupT>) {
     id<1> TargetLocalId = g.get_local_id();
     // Underflow is UB, so we just keep the current item ID unchanged.
     if (TargetLocalId[0] >= delta)

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -916,8 +916,8 @@ EnableIfNativeShuffle<T> Shuffle(GroupT g, T x, id<1> local_id) {
   uint32_t LocalId = MapShuffleID(g, local_id);
 #ifndef __NVPTX__
   (void)g;
-  return convertFromOpenCLTypeFor<T>(__spirv_GroupNonUniformShuffle(group_scope<GroupT>::value,
-                                        convertToOpenCLType(x), LocalId));
+  return convertFromOpenCLTypeFor<T>(__spirv_GroupNonUniformShuffle(
+      group_scope<GroupT>::value, convertToOpenCLType(x), LocalId));
 #else
   if constexpr (ext::oneapi::experimental::is_user_constructed_group_v<
                     GroupT>) {

--- a/sycl/test/check_device_code/group_shuffle.cpp
+++ b/sycl/test/check_device_code/group_shuffle.cpp
@@ -27,7 +27,7 @@ using namespace sycl::ext::oneapi;
 // CHECK-NEXT:    [[IDXPROM_I_I_I:%.*]] = zext nneg i32 [[S_0_I_I]] to i64
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[AGG_TMP14_I]], i64 [[IDXPROM_I_I_I]]
 // CHECK-NEXT:    [[TMP1:%.*]] = load i16, ptr [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA16:![0-9]+]], !noalias [[META18:![0-9]+]]
-// CHECK-NEXT:    [[CALL3_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @_Z28__spirv_SubgroupShuffleINTELtj(i16 noundef zeroext [[TMP1]], i32 noundef 1) #[[ATTR6:[0-9]+]], !noalias [[META19:![0-9]+]]
+// CHECK-NEXT:    [[CALL3_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @_Z30__spirv_GroupNonUniformShuffleitj(i32 noundef 3, i16 noundef zeroext [[TMP1]], i32 noundef 1) #[[ATTR6:[0-9]+]], !noalias [[META19:![0-9]+]]
 // CHECK-NEXT:    [[ARRAYIDX_I12_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[REF_TMP]], i64 [[IDXPROM_I_I_I]]
 // CHECK-NEXT:    store i16 [[CALL3_I_I_I_I]], ptr [[ARRAYIDX_I12_I_I]], align 2, !tbaa [[TBAA16]], !alias.scope [[META18]]
 // CHECK-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[S_0_I_I]], 1
@@ -65,7 +65,7 @@ SYCL_EXTERNAL void test_shuffle1(sycl::sub_group &sg, vec<bfloat16, 4> *buf,
 // CHECK-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[S_0_I_I]] to i64
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[AGG_TMP14_I]], i64 [[CONV_I_I]]
 // CHECK-NEXT:    [[TMP1:%.*]] = load i16, ptr [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA16]], !noalias [[META31:![0-9]+]]
-// CHECK-NEXT:    [[CALL3_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @_Z28__spirv_SubgroupShuffleINTELtj(i16 noundef zeroext [[TMP1]], i32 noundef 1) #[[ATTR6]], !noalias [[META32:![0-9]+]]
+// CHECK-NEXT:    [[CALL3_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @_Z30__spirv_GroupNonUniformShuffleitj(i32 noundef 3, i16 noundef zeroext [[TMP1]], i32 noundef 1) #[[ATTR6]], !noalias [[META32:![0-9]+]]
 // CHECK-NEXT:    [[ARRAYIDX_I13_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[REF_TMP]], i64 [[CONV_I_I]]
 // CHECK-NEXT:    store i16 [[CALL3_I_I_I_I]], ptr [[ARRAYIDX_I13_I_I]], align 2, !tbaa [[TBAA16]], !alias.scope [[META31]]
 // CHECK-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[S_0_I_I]], 1
@@ -102,7 +102,7 @@ SYCL_EXTERNAL void test_shuffle2(sycl::sub_group &sg, marray<bfloat16, 4> *buf,
 // CHECK-NEXT:    [[CONV_I_I:%.*]] = zext nneg i32 [[S_0_I_I]] to i64
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[AGG_TMP14_I]], i64 [[CONV_I_I]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr [[ARRAYIDX_I_I_I]], align 2, !tbaa [[TBAA16]], !noalias [[META42:![0-9]+]]
-// CHECK-NEXT:    [[CALL3_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @_Z28__spirv_SubgroupShuffleINTELtj(i16 noundef zeroext [[TMP0]], i32 noundef 1) #[[ATTR6]], !noalias [[META43:![0-9]+]]
+// CHECK-NEXT:    [[CALL3_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @_Z30__spirv_GroupNonUniformShuffleitj(i32 noundef 3, i16 noundef zeroext [[TMP0]], i32 noundef 1) #[[ATTR6]], !noalias [[META43:![0-9]+]]
 // CHECK-NEXT:    [[ARRAYIDX_I13_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[REF_TMP]], i64 [[CONV_I_I]]
 // CHECK-NEXT:    store i16 [[CALL3_I_I_I_I]], ptr [[ARRAYIDX_I13_I_I]], align 2, !tbaa [[TBAA16]], !alias.scope [[META42]]
 // CHECK-NEXT:    [[INC_I_I]] = add nuw nsw i32 [[S_0_I_I]], 1
@@ -119,13 +119,12 @@ SYCL_EXTERNAL void test_shuffle3(sycl::sub_group &sg, marray<bfloat16, 5> *buf,
   buf[id] = sycl::select_from_group(sg, ItemVal, 1);
 }
 
-//
 // CHECK-LABEL: @_Z13test_shuffle4RN4sycl3_V19sub_groupEPPim(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds nuw [8 x i8], ptr addrspace(4) [[BUF:%.*]], i64 [[ID:%.*]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ARRAYIDX]], align 8, !tbaa [[TBAA48:![0-9]+]]
 // CHECK-NEXT:    [[TMP1:%.*]] = ptrtoint ptr addrspace(4) [[TMP0]] to i64
-// CHECK-NEXT:    [[CALL3_I_I_I:%.*]] = tail call spir_func noundef i64 @_Z28__spirv_SubgroupShuffleINTELmj(i64 noundef [[TMP1]], i32 noundef 1) #[[ATTR6]]
+// CHECK-NEXT:    [[CALL3_I_I_I:%.*]] = tail call spir_func noundef i64 @_Z30__spirv_GroupNonUniformShuffleimj(i32 noundef 3, i64 noundef [[TMP1]], i32 noundef 1) #[[ATTR6]]
 // CHECK-NEXT:    [[TMP2:%.*]] = inttoptr i64 [[CALL3_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    store ptr addrspace(4) [[TMP2]], ptr addrspace(4) [[ARRAYIDX]], align 8, !tbaa [[TBAA48]]
 // CHECK-NEXT:    ret void
@@ -140,7 +139,7 @@ SYCL_EXTERNAL void test_shuffle4(sycl::sub_group &sg, int **buf, size_t id) {
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds nuw [8 x i8], ptr addrspace(4) [[BUF:%.*]], i64 [[ID:%.*]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[ARRAYIDX]], align 8, !tbaa [[TBAA48]]
 // CHECK-NEXT:    [[TMP1:%.*]] = ptrtoint ptr addrspace(4) [[TMP0]] to i64
-// CHECK-NEXT:    [[CALL3_I_I_I:%.*]] = tail call spir_func noundef i64 @_Z28__spirv_SubgroupShuffleINTELmj(i64 noundef [[TMP1]], i32 noundef 1) #[[ATTR6]]
+// CHECK-NEXT:    [[CALL3_I_I_I:%.*]] = tail call spir_func noundef i64 @_Z30__spirv_GroupNonUniformShuffleimj(i32 noundef 3, i64 noundef [[TMP1]], i32 noundef 1) #[[ATTR6]]
 // CHECK-NEXT:    [[TMP2:%.*]] = inttoptr i64 [[CALL3_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    store ptr addrspace(4) [[TMP2]], ptr addrspace(4) [[ARRAYIDX]], align 8, !tbaa [[TBAA48]]
 // CHECK-NEXT:    ret void


### PR DESCRIPTION
Replaced __spirv_SubgroupShuffleINTEL, __spirv_SubgroupShuffleXorINTEL, __spirv_SubgroupShuffleDownINTEL and __spirv_SubgroupShuffleUpINT with __spirv_GroupNonUniformShuffle... generic versions.
According to the [OpenCL Specification](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Env.html#_cl_khr_subgroup_shuffle), these operations only accept scalars, so we force vectorization of vectors.

Additionally this provides a nativecpu implementation mimicking the behavior of intel_subgroup's, only the subgroup scope has been implemented.