### PR TITLE
[Bench] Bump Compute Benchmark version for nightly benchmarking

### DIFF
--- a/devops/scripts/benchmarks/benches/compute/compute.py
+++ b/devops/scripts/benchmarks/benches/compute/compute.py
@@ -40,8 +40,8 @@ class ComputeBench(Suite):
         return "https://github.com/intel/compute-benchmarks.git"
 
     def git_hash(self) -> str:
-        # Feb 20, 2026
-        return "27a3133d298a95af35e69173b06f6030ae33d742"
+        # Mar 03, 2026
+        return "48504d2957a83ad32deff78563e855eeb6855dae"
 
     def setup(self) -> None:
         if options.sycl is None:
@@ -319,10 +319,11 @@ class ComputeBench(Suite):
                         profiler_type,
                         **{
                             **kwargs,
-                            "kernelBatchSize": 512,
-                            "kernelName": "Add",
-                            "kernelParamsNum": 5,
-                            "kernelSubmitPattern": "Single",
+                            "KernelBatchSize": 512,
+                            "KernelName": "Add",
+                            "KernelParamsNum": 5,
+                            "KernelSubmitPattern": "Single",
+                            "Profiling": 0,
                             "UseEvents": 0,
                         },
                     )
@@ -330,39 +331,39 @@ class ComputeBench(Suite):
                 benches += [
                     createTorchSingleQueueBench(
                         "Int32Large",
-                        kernelDataType="Int32",
-                        kernelWGCount=4096,
-                        kernelWGSize=512,
+                        KernelDataType="Int32",
+                        KernelWGCount=4096,
+                        KernelWGSize=512,
                     ),
                     createTorchSingleQueueBench(
                         "Int32Medium",
-                        kernelDataType="Int32",
-                        kernelWGCount=512,
-                        kernelWGSize=256,
+                        KernelDataType="Int32",
+                        KernelWGCount=512,
+                        KernelWGSize=256,
                     ),
                     createTorchSingleQueueBench(
                         "Int32Small",
-                        kernelDataType="Int32",
-                        kernelWGCount=256,
-                        kernelWGSize=128,
+                        KernelDataType="Int32",
+                        KernelWGCount=256,
+                        KernelWGSize=128,
                     ),
                     createTorchSingleQueueBench(
                         "MixedLarge",
-                        kernelDataType="Mixed",
-                        kernelWGCount=4096,
-                        kernelWGSize=512,
+                        KernelDataType="Mixed",
+                        KernelWGCount=4096,
+                        KernelWGSize=512,
                     ),
                     createTorchSingleQueueBench(
                         "MixedMedium",
-                        kernelDataType="Mixed",
-                        kernelWGCount=512,
-                        kernelWGSize=256,
+                        KernelDataType="Mixed",
+                        KernelWGCount=512,
+                        KernelWGSize=256,
                     ),
                     createTorchSingleQueueBench(
                         "MixedSmall",
-                        kernelDataType="Mixed",
-                        kernelWGCount=256,
-                        kernelWGSize=128,
+                        KernelDataType="Mixed",
+                        KernelWGCount=256,
+                        KernelWGSize=128,
                     ),
                 ]
 
@@ -379,10 +380,10 @@ class ComputeBench(Suite):
                         measure_completion,
                         **{
                             **kwargs,
-                            "kernelWGCount": 512,
-                            "kernelWGSize": 256,
-                            "useProfiling": 0,
-                            "measureCompletion": measure_completion,
+                            "KernelWGCount": 512,
+                            "KernelWGSize": 256,
+                            "MeasureCompletionTime": measure_completion,
+                            "Profiling": 0,
                             "UseEvents": 0,
                         },
                     )
@@ -390,15 +391,15 @@ class ComputeBench(Suite):
                 benches += [
                     createTorchMultiQueueBench(
                         "large",
-                        kernelsPerQueue=20,
+                        KernelsPerQueue=20,
                     ),
                     createTorchMultiQueueBench(
                         "medium",
-                        kernelsPerQueue=10,
+                        KernelsPerQueue=10,
                     ),
                     createTorchMultiQueueBench(
                         "small",
-                        kernelsPerQueue=4,
+                        KernelsPerQueue=4,
                     ),
                 ]
 
@@ -415,24 +416,24 @@ class ComputeBench(Suite):
                         measure_completion,
                         **{
                             **kwargs,
-                            "kernelBatchSize": 512,
-                            "measureCompletion": measure_completion,
-                            "useProfiling": 0,
+                            "KernelBatchSize": 512,
+                            "MeasureCompletionTime": measure_completion,
+                            "Profiling": 0,
                         },
                     )
 
                 benches += [
                     createTorchSlmSizeBench(
                         "small",
-                        slmNum=1,
+                        SlmNum=1,
                     ),
                     createTorchSlmSizeBench(
                         "medium",
-                        slmNum=1024,
+                        SlmNum=1024,
                     ),
                     createTorchSlmSizeBench(
                         "large",
-                        slmNum=16384,
+                        SlmNum=16384,
                     ),
                 ]
 
@@ -452,27 +453,31 @@ class ComputeBench(Suite):
                 benches += [
                     createTorchMemoryReuseBench(
                         "Int32Large",
-                        kernelBatchSize=4096,
-                        kernelDataType="Int32",
+                        KernelBatchSize=4096,
+                        KernelDataType="Int32",
                         UseEvents=0,
+                        Profiling=0,
                     ),
                     createTorchMemoryReuseBench(
                         "Int32Medium",
-                        kernelBatchSize=512,
-                        kernelDataType="Int32",
+                        KernelBatchSize=512,
+                        KernelDataType="Int32",
                         UseEvents=0,
+                        Profiling=0,
                     ),
                     createTorchMemoryReuseBench(
                         "FloatLarge",
-                        kernelBatchSize=4096,
-                        kernelDataType="Float",
+                        KernelBatchSize=4096,
+                        KernelDataType="Float",
                         UseEvents=0,
+                        Profiling=0,
                     ),
                     createTorchMemoryReuseBench(
                         "FloatMedium",
-                        kernelBatchSize=512,
-                        kernelDataType="Float",
+                        KernelBatchSize=512,
+                        KernelDataType="Float",
                         UseEvents=0,
+                        Profiling=0,
                     ),
                 ]
 
@@ -488,30 +493,31 @@ class ComputeBench(Suite):
                         profiler_type,
                         **{
                             **kwargs,
-                            "kernelBatchSize": 512,
+                            "KernelBatchSize": 512,
+                            "Profiling": 0,
                         },
                     )
 
                 benches += [
                     createTorchLinearKernelSizeBench(
                         "array32",
-                        kernelSize=32,
+                        KernelSize=32,
                     ),
                     createTorchLinearKernelSizeBench(
                         "array128",
-                        kernelSize=128,
+                        KernelSize=128,
                     ),
                     createTorchLinearKernelSizeBench(
                         "array512",
-                        kernelSize=512,
+                        KernelSize=512,
                     ),
                     createTorchLinearKernelSizeBench(
                         "array1024",
-                        kernelSize=1024,
+                        KernelSize=1024,
                     ),
                     createTorchLinearKernelSizeBench(
                         "array5120",
-                        kernelSize=5120,
+                        KernelSize=5120,
                     ),
                 ]
 
@@ -532,10 +538,10 @@ class ComputeBench(Suite):
                             profiler_type,
                             **{
                                 **kwargs,
-                                "kernelName": kernel_name.value,
-                                "kernelWGCount": 512,
-                                "kernelWGSize": 256,
-                                "useProfiling": 0,
+                                "KernelName": kernel_name.value,
+                                "KernelWGCount": 512,
+                                "KernelWGSize": 256,
+                                "Profiling": 0,
                                 "UseEvents": 0,
                             },
                         )
@@ -543,18 +549,18 @@ class ComputeBench(Suite):
                     benches += [
                         createTorchGraphSingleQueueBench(
                             "small",
-                            kernelGroupsCount=10,
-                            kernelBatchSize=10,
+                            KernelsPerQueue=10,
+                            KernelBatchSize=10,
                         ),
                         createTorchGraphSingleQueueBench(
                             "medium",
-                            kernelGroupsCount=32,
-                            kernelBatchSize=32,
+                            KernelsPerQueue=32,
+                            KernelBatchSize=32,
                         ),
                         createTorchGraphSingleQueueBench(
                             "large",
-                            kernelGroupsCount=64,
-                            kernelBatchSize=64,
+                            KernelsPerQueue=64,
+                            KernelBatchSize=64,
                         ),
                     ]
 
@@ -1229,7 +1235,7 @@ class GraphApiSubmitGraph(ComputeBenchmark):
         )
 
     def name(self):
-        return f"graph_api_benchmark_{self._runtime.value} SubmitGraph{self._native_str}{self._use_events_str}{self._host_tasks_str} numKernels:{self._num_kernels} ioq {self._in_order_queue} measureCompletion {self._measure_completion_time}{self._cpu_count_str()}"
+        return f"graph_api_benchmark_{self._runtime.value} SubmitGraph{self._native_str}{self._use_events_str}{self._host_tasks_str} numKernels:{self._num_kernels} ioq {self._in_order_queue} MeasureCompletionTime {self._measure_completion_time}{self._cpu_count_str()}"
 
     def display_name(self) -> str:
         return f"{self._runtime.value.upper()} SubmitGraph{self._native_str} {self._ioq_str}{self._measure_str}{self._use_events_str}{self._host_tasks_str}, {self._num_kernels} kernels{self._cpu_count_str(separator=',')}"

--- a/devops/scripts/benchmarks/tests/test_integration.py
+++ b/devops/scripts/benchmarks/tests/test_integration.py
@@ -213,46 +213,46 @@ class TestE2E(unittest.TestCase):
 
     def test_torch_l0(self):
         self._checkCase(
-            "torch_benchmark_l0 KernelSubmitSingleQueue UseEvents 0, kernelBatchSize 512, kernelDataType Int32, kernelName Add, kernelParamsNum 5, kernelSubmitPattern Single, kernelWGCount 4096, kernelWGSize 512",
+            "torch_benchmark_l0 KernelSubmitSingleQueue KernelBatchSize 512, KernelDataType Int32, KernelName Add, KernelParamsNum 5, KernelSubmitPattern Single, KernelWGCount 4096, KernelWGSize 512, Profiling 0, UseEvents 0",
             "KernelSubmitSingleQueue Int32Large",
             {"pytorch", "L0"},
             "--test=KernelSubmitSingleQueue.*--profilerType=timer",
         )
         self._checkCase(
-            "torch_benchmark_l0 KernelSubmitSingleQueue UseEvents 0, kernelBatchSize 512, kernelDataType Int32, kernelName Add, kernelParamsNum 5, kernelSubmitPattern Single, kernelWGCount 4096, kernelWGSize 512 CPU count",
+            "torch_benchmark_l0 KernelSubmitSingleQueue KernelBatchSize 512, KernelDataType Int32, KernelName Add, KernelParamsNum 5, KernelSubmitPattern Single, KernelWGCount 4096, KernelWGSize 512, Profiling 0, UseEvents 0 CPU count",
             "KernelSubmitSingleQueue Int32Large, CPU count",
             {"pytorch", "L0"},
             "--test=KernelSubmitSingleQueue.*--profilerType=cpuCounter",
         )
         self._checkCase(
-            "torch_benchmark_l0 KernelSubmitMultiQueue UseEvents 0, kernelWGCount 512, kernelWGSize 256, kernelsPerQueue 20, measureCompletion 0, useProfiling 0",
+            "torch_benchmark_l0 KernelSubmitMultiQueue KernelWGCount 512, KernelWGSize 256, KernelsPerQueue 20, MeasureCompletionTime 0, Profiling 0, UseEvents 0",
             "KernelSubmitMultiQueue large",
             {"pytorch", "L0"},
         )
         self._checkCase(
-            "torch_benchmark_l0 KernelSubmitMultiQueue UseEvents 0, kernelWGCount 512, kernelWGSize 256, kernelsPerQueue 20, measureCompletion 1, useProfiling 0 CPU count",
+            "torch_benchmark_l0 KernelSubmitMultiQueue KernelWGCount 512, KernelWGSize 256, KernelsPerQueue 20, MeasureCompletionTime 1, Profiling 0, UseEvents 0 CPU count",
             "KernelSubmitMultiQueue large with measure completion, CPU count",
             {"pytorch", "L0"},
         )
         self._checkCase(
-            "torch_benchmark_l0 KernelSubmitSlmSize kernelBatchSize 512, measureCompletion 1, slmNum 1, useProfiling 0",
+            "torch_benchmark_l0 KernelSubmitSlmSize KernelBatchSize 512, MeasureCompletionTime 1, Profiling 0, SlmNum 1",
             "KernelSubmitSlmSize small with measure completion",
             {"pytorch", "L0"},
         )
         self._checkCase(
-            "torch_benchmark_l0 KernelSubmitLinearKernelSize kernelBatchSize 512, kernelSize 32",
+            "torch_benchmark_l0 KernelSubmitLinearKernelSize KernelBatchSize 512, KernelSize 32, Profiling 0",
             "KernelSubmitLinearKernelSize array32",
             {"pytorch", "L0"},
         )
         self._checkCase(
-            "torch_benchmark_l0 KernelSubmitMemoryReuse UseEvents 0, kernelBatchSize 4096, kernelDataType Int32",
+            "torch_benchmark_l0 KernelSubmitMemoryReuse KernelBatchSize 4096, KernelDataType Int32, Profiling 0, UseEvents 0",
             "KernelSubmitMemoryReuse Int32Large",
             {"pytorch", "L0"},
         )
         # FIXME: Graph benchmarks segfault on pvc
         if not ("pvc" in self.device_arch.lower()):
             self._checkCase(
-                "torch_benchmark_l0 KernelSubmitGraphSingleQueue UseEvents 0, kernelBatchSize 10, kernelGroupsCount 10, kernelName Add, kernelWGCount 512, kernelWGSize 256, useProfiling 0 CPU count",
+                "torch_benchmark_l0 KernelSubmitGraphSingleQueue KernelBatchSize 10, KernelName Add, KernelWGCount 512, KernelWGSize 256, KernelsPerQueue 10, Profiling 0, UseEvents 0 CPU count",
                 "KernelSubmitGraphSingleQueue small, CPU count",
                 {"pytorch", "L0"},
             )
@@ -264,39 +264,39 @@ class TestE2E(unittest.TestCase):
 
     def test_torch_sycl(self):
         self._checkCase(
-            "torch_benchmark_sycl KernelSubmitSingleQueue UseEvents 0, kernelBatchSize 512, kernelDataType Mixed, kernelName Add, kernelParamsNum 5, kernelSubmitPattern Single, kernelWGCount 512, kernelWGSize 256",
+            "torch_benchmark_sycl KernelSubmitSingleQueue KernelBatchSize 512, KernelDataType Mixed, KernelName Add, KernelParamsNum 5, KernelSubmitPattern Single, KernelWGCount 512, KernelWGSize 256, Profiling 0, UseEvents 0",
             "KernelSubmitSingleQueue MixedMedium",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_sycl KernelSubmitMultiQueue UseEvents 0, kernelWGCount 512, kernelWGSize 256, kernelsPerQueue 10, measureCompletion 1, useProfiling 0",
+            "torch_benchmark_sycl KernelSubmitMultiQueue KernelWGCount 512, KernelWGSize 256, KernelsPerQueue 10, MeasureCompletionTime 1, Profiling 0, UseEvents 0",
             "KernelSubmitMultiQueue medium with measure completion",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_sycl KernelSubmitSlmSize kernelBatchSize 512, measureCompletion 0, slmNum 16384, useProfiling 0",
+            "torch_benchmark_sycl KernelSubmitSlmSize KernelBatchSize 512, MeasureCompletionTime 0, Profiling 0, SlmNum 16384",
             "KernelSubmitSlmSize large",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_sycl KernelSubmitSlmSize kernelBatchSize 512, measureCompletion 1, slmNum 16384, useProfiling 0 CPU count",
+            "torch_benchmark_sycl KernelSubmitSlmSize KernelBatchSize 512, MeasureCompletionTime 1, Profiling 0, SlmNum 16384 CPU count",
             "KernelSubmitSlmSize large with measure completion, CPU count",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_sycl KernelSubmitLinearKernelSize kernelBatchSize 512, kernelSize 5120",
+            "torch_benchmark_sycl KernelSubmitLinearKernelSize KernelBatchSize 512, KernelSize 5120, Profiling 0",
             "KernelSubmitLinearKernelSize array5120",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_sycl KernelSubmitMemoryReuse UseEvents 0, kernelBatchSize 4096, kernelDataType Float",
+            "torch_benchmark_sycl KernelSubmitMemoryReuse KernelBatchSize 4096, KernelDataType Float, Profiling 0, UseEvents 0",
             "KernelSubmitMemoryReuse FloatLarge",
             {"pytorch", "SYCL"},
         )
         # FIXME: Graph benchmarks segfault on pvc
         if not ("pvc" in self.device_arch.lower()):
             self._checkCase(
-                "torch_benchmark_sycl KernelSubmitGraphSingleQueue UseEvents 0, kernelBatchSize 32, kernelGroupsCount 32, kernelName Add, kernelWGCount 512, kernelWGSize 256, useProfiling 0",
+                "torch_benchmark_sycl KernelSubmitGraphSingleQueue KernelBatchSize 32, KernelName Add, KernelWGCount 512, KernelWGSize 256, KernelsPerQueue 32, Profiling 0, UseEvents 0",
                 "KernelSubmitGraphSingleQueue medium",
                 {"pytorch", "SYCL"},
             )
@@ -308,44 +308,44 @@ class TestE2E(unittest.TestCase):
 
     def test_torch_syclpreview(self):
         self._checkCase(
-            "torch_benchmark_syclpreview KernelSubmitSingleQueue UseEvents 0, kernelBatchSize 512, kernelDataType Mixed, kernelName Add, kernelParamsNum 5, kernelSubmitPattern Single, kernelWGCount 256, kernelWGSize 128",
+            "torch_benchmark_syclpreview KernelSubmitSingleQueue KernelBatchSize 512, KernelDataType Mixed, KernelName Add, KernelParamsNum 5, KernelSubmitPattern Single, KernelWGCount 256, KernelWGSize 128, Profiling 0, UseEvents 0",
             "KernelSubmitSingleQueue MixedSmall",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_syclpreview KernelSubmitMultiQueue UseEvents 0, kernelWGCount 512, kernelWGSize 256, kernelsPerQueue 4, measureCompletion 1, useProfiling 0",
+            "torch_benchmark_syclpreview KernelSubmitMultiQueue KernelWGCount 512, KernelWGSize 256, KernelsPerQueue 4, MeasureCompletionTime 1, Profiling 0, UseEvents 0",
             "KernelSubmitMultiQueue small with measure completion",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_syclpreview KernelSubmitSlmSize kernelBatchSize 512, measureCompletion 1, slmNum 1024, useProfiling 0",
+            "torch_benchmark_syclpreview KernelSubmitSlmSize KernelBatchSize 512, MeasureCompletionTime 1, Profiling 0, SlmNum 1024",
             "KernelSubmitSlmSize medium with measure completion",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_syclpreview KernelSubmitLinearKernelSize kernelBatchSize 512, kernelSize 512",
+            "torch_benchmark_syclpreview KernelSubmitLinearKernelSize KernelBatchSize 512, KernelSize 512, Profiling 0",
             "KernelSubmitLinearKernelSize array512",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_syclpreview KernelSubmitLinearKernelSize kernelBatchSize 512, kernelSize 512 CPU count",
+            "torch_benchmark_syclpreview KernelSubmitLinearKernelSize KernelBatchSize 512, KernelSize 512, Profiling 0 CPU count",
             "KernelSubmitLinearKernelSize array512, CPU count",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_syclpreview KernelSubmitMemoryReuse UseEvents 0, kernelBatchSize 512, kernelDataType Float",
+            "torch_benchmark_syclpreview KernelSubmitMemoryReuse KernelBatchSize 512, KernelDataType Float, Profiling 0, UseEvents 0",
             "KernelSubmitMemoryReuse FloatMedium",
             {"pytorch", "SYCL"},
         )
         self._checkCase(
-            "torch_benchmark_syclpreview KernelSubmitMemoryReuse UseEvents 0, kernelBatchSize 512, kernelDataType Float CPU count",
+            "torch_benchmark_syclpreview KernelSubmitMemoryReuse KernelBatchSize 512, KernelDataType Float, Profiling 0, UseEvents 0 CPU count",
             "KernelSubmitMemoryReuse FloatMedium, CPU count",
             {"pytorch", "SYCL"},
         )
         # FIXME: Graph benchmarks segfault on pvc
         if not ("pvc" in self.device_arch.lower()):
             self._checkCase(
-                "torch_benchmark_syclpreview KernelSubmitGraphSingleQueue UseEvents 0, kernelBatchSize 64, kernelGroupsCount 64, kernelName Add, kernelWGCount 512, kernelWGSize 256, useProfiling 0",
+                "torch_benchmark_syclpreview KernelSubmitGraphSingleQueue KernelBatchSize 64, KernelName Add, KernelWGCount 512, KernelWGSize 256, KernelsPerQueue 64, Profiling 0, UseEvents 0",
                 "KernelSubmitGraphSingleQueue large",
                 {"pytorch", "SYCL"},
             )


### PR DESCRIPTION
- enable using new ur/* headers,
- update benchmarks' framework after the refactor.