### PR TITLE
[UR][CUDA] Add xfail for urUSMContextMemcpyExpTestDevice::Success

### DIFF
--- a/unified-runtime/test/conformance/exp_usm_context_memcpy/urUSMContextMemcpyExp.cpp
+++ b/unified-runtime/test/conformance/exp_usm_context_memcpy/urUSMContextMemcpyExp.cpp
@@ -81,6 +81,8 @@ struct urUSMContextMemcpyExpTestDevice : urUSMContextMemcpyExpTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urUSMContextMemcpyExpTestDevice);
 
 TEST_P(urUSMContextMemcpyExpTestDevice, Success) {
+  // https://github.com/intel/llvm/issues/19688
+  UUR_KNOWN_FAILURE_ON(uur::CUDA{});
   ASSERT_SUCCESS(
       urUSMContextMemcpyExp(context, dst_ptr, src_ptr, allocation_size));
   verifyData();


### PR DESCRIPTION
This test fails on CUDA backend.
Refs: https://github.com/intel/llvm/issues/19688