### PR TITLE
[UR][L0v2] Fix graph capture and tests with out-of-order queues

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/queue_immediate_out_of_order.hpp
@@ -615,20 +615,19 @@ public:
   }
 
   ur_result_t queueBeginGraphCapteExp() override {
-    auto commandListId = getNextCommandListId();
-    return commandListManagers.lock()[commandListId].beginGraphCapture();
+    return commandListManagers.lock()[captureCmdListManagerIdx]
+        .beginGraphCapture();
   }
 
   ur_result_t
   queueBeginCapteIntoGraphExp(ur_exp_graph_handle_t hGraph) override {
-    auto commandListId = getNextCommandListId();
-    return commandListManagers.lock()[commandListId].beginCaptureIntoGraph(
-        hGraph);
+    return commandListManagers.lock()[captureCmdListManagerIdx]
+        .beginCaptureIntoGraph(hGraph);
   }
 
   ur_result_t queueEndGraphCapteExp(ur_exp_graph_handle_t *phGraph) override {
-    auto commandListId = getNextCommandListId();
-    return commandListManagers.lock()[commandListId].endGraphCapture(phGraph);
+    return commandListManagers.lock()[captureCmdListManagerIdx].endGraphCapture(
+        phGraph);
   }
 
   ur_result_t enqueueGraphExp(ur_exp_executable_graph_handle_t hGraph,
@@ -645,9 +644,8 @@ public:
   }
 
   ur_result_t queueIsGraphCapteEnabledExp(bool *pResult) override {
-    auto commandListId = getNextCommandListId();
-    return commandListManagers.lock()[commandListId].isGraphCaptureActive(
-        pResult);
+    return commandListManagers.lock()[captureCmdListManagerIdx]
+        .isGraphCaptureActive(pResult);
   }
 
   ur_result_t

--- a/unified-runtime/test/conformance/exp_graph/fixtures.h
+++ b/unified-runtime/test/conformance/exp_graph/fixtures.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -13,9 +13,9 @@
 
 namespace uur {
 
-struct urGraphSupportedExpTest : uur::urQueueTest {
+struct urGraphSupportedExpTest : uur::urMultiQueueTypeTest {
   void SetUp() override {
-    UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
+    UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTypeTest::SetUp());
 
     ur_bool_t graph_supported = false;
     ASSERT_SUCCESS(urDeviceGetInfo(

--- a/unified-runtime/test/conformance/exp_graph/urQueueEndGraphCaptureExp.cpp
+++ b/unified-runtime/test/conformance/exp_graph/urQueueEndGraphCaptureExp.cpp
@@ -24,6 +24,7 @@ TEST_P(urQueueEndGraphCaptureExpTest, SuccessSameGraph) {
 // would use different command lists.
 TEST_P(urQueueEndGraphCaptureExpTest, SuccessAfterQueueOperations) {
   ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, nullptr));
+  ASSERT_SUCCESS(urQueueFinish(queue));
 
   ASSERT_SUCCESS(urQueueBeginCaptureIntoGraphExp(queue, graph));
   ur_exp_graph_handle_t capturedGraph = nullptr;

--- a/unified-runtime/test/conformance/exp_graph/urQueueEndGraphCaptureExp.cpp
+++ b/unified-runtime/test/conformance/exp_graph/urQueueEndGraphCaptureExp.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT
 //
@@ -18,6 +18,17 @@ TEST_P(urQueueEndGraphCaptureExpTest, SuccessSameGraph) {
   ur_exp_graph_handle_t sameGraph = nullptr;
   ASSERT_SUCCESS(urQueueEndGraphCaptureExp(queue, &sameGraph));
   ASSERT_EQ(graph, sameGraph);
+}
+
+// Regression test for out-of-order queue bug where begin/end capture
+// would use different command lists.
+TEST_P(urQueueEndGraphCaptureExpTest, SuccessAfterQueueOperations) {
+  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, nullptr));
+
+  ASSERT_SUCCESS(urQueueBeginCaptureIntoGraphExp(queue, graph));
+  ur_exp_graph_handle_t capturedGraph = nullptr;
+  ASSERT_SUCCESS(urQueueEndGraphCaptureExp(queue, &capturedGraph));
+  ASSERT_EQ(graph, capturedGraph);
 }
 
 TEST_P(urQueueEndGraphCaptureExpTest, InvalidNullHandleQueue) {


### PR DESCRIPTION
Fixes out-of-order queue issues discovered during SYCL graph testing:
- Performing a queue operation followed by a graph capture would begin and end capture on separate command lists. This is because `getNextCommandListId()` is called before the command list actually begins recording. We now directly use `captureCmdListManagerIdx` which also removes extra L0 is capturing calls.
- Out-of-order queue testing was being silently skipped because we inherited `uur::urQueueTest` in the test fixture which hardcodes 0 as the queue flag. Inheriting `uur::urMultiQueueTypeTest` instead uses the provided parameter to set the out-of-order queue flag.