### PR TITLE
[SYCL] Fix DirectX 11 interop test failures

### DIFF
--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
@@ -256,7 +256,7 @@ int runTest(D3D11ProgramState &d3d11ProgramState, sycl::queue syclQueue,
   // import it from SYCL side. Hence, in light of this restriction, instead of
   // using ArraySize > 1 to simulate 3D textures, we simulate them by simply
   // collapsing the depth dimension onto the height dimension and set ArraySize
-  // to 1. 
+  // to 1.
   // Create a shared texture
   ComPtr<ID3D11Texture2D1> texture;
   // Initialize the texture description.


### PR DESCRIPTION
The test `read_write_unsampled.cpp` implicitly relies on the assumption that a 2D texture in DirectX 11 has the row major layout in memory. This is because the test, in the absence of a DirectX 11 API to query texture allocation information, attempts to calculate the allocation size of the texture the best it can manually by simply multiplying all the dimensions of the texture. This is then passed to the SYCL external memory import functions to make a SYCL image out of the texture. 

This assumption, which was not at all mandated by the spec, seems to have fallen apart recently as the layout for a default usage texture in DirectX 11 has been changed to no longer be row major in certain conditions and I suspect this broke many test cases embedded in the test.

This PR attempts to fix this by utilizing the newer DirectX 11.3 API which allows us to explicitly request the textures to be laid out in row major order in memory.