### PR TITLE
[SYCL][Doc] Specify that invalid host_access_enum values are ill-formed

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_global.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_global.asciidoc
@@ -736,6 +736,9 @@ The following values are supported:
 * `read_write`: The user provides no assertions, and the host code may either
   copy to or copy from the variable.  This is the default.
 
+If the property is instantiated with a numeric value that does not correspond
+to one of the above values, then the application is ill-formed, no diagnostic required.
+
 |===
 
 [NOTE]


### PR DESCRIPTION
Currently code like this is accepted by DPC++:
```cpp
device_global<int, decltype(host_access_key::value_t<static_cast<host_access_enum>(42)>)> var;
```
and results in the generated SPIR-V with a `HostAccess` property set to 42, which is not a valid value.

In another change I'm looking to make this an error in some *but not all*, cases, but nothing in the spec currently prohibits this code in my reading.
Add a sentence to make it ill-formed, no diagnostic required. We could make it a required hard error, but that is surprisingly difficult to implement for little benefit: in practice I don't expect any users to be actually doing this.