### PR TITLE
[SYCL][E2E] Disable submit_time.cpp on PVC

### DIFF
--- a/sycl/test-e2e/Basic/submit_time.cpp
+++ b/sycl/test-e2e/Basic/submit_time.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // There is an issue with reported device time for the L0 backend. No such
 // problems for other backends.
-// RUN: %if (!level_zero) %{ %{run} %t.out %}
+// RUN-IF: !level_zero, %{run} %t.out
 
 // Check that submission time is calculated properly.
 


### PR DESCRIPTION
Seems it fails on PVC too sometimes

https://github.com/intel/llvm/actions/runs/22736449204/job/66068452637?pr=14114