### PR TITLE
[libclc] build libclc as LLVM runtime (#21221)

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -81,7 +81,7 @@ def do_configure(args, passthrough_args):
 
     libclc_enabled = args.cuda or args.hip or args.native_cpu
     if libclc_enabled:
-        llvm_enable_projects += ";libclc"
+        llvm_enable_runtimes += ";libclc"
 
     # DeviceRTL uses -fuse-ld=lld, so enable lld.
     if args.offload:
@@ -149,12 +149,12 @@ def do_configure(args, passthrough_args):
 
         # For clang-format, clang-tidy and code coverage
         llvm_enable_projects += ";clang-tools-extra"
-        llvm_enable_runtimes += "compiler-rt"
+        llvm_enable_runtimes += ";compiler-rt"
         if sys.platform != "darwin":
             # libclc is required for CI validation
             libclc_enabled = True
-            if "libclc" not in llvm_enable_projects:
-                llvm_enable_projects += ";libclc"
+            if "libclc" not in llvm_enable_runtimes:
+                llvm_enable_runtimes += ";libclc"
             # libclc passes `--nvvm-reflect-enable=false`, build NVPTX to enable it
             if "NVPTX" not in llvm_targets_to_build:
                 llvm_targets_to_build += ";NVPTX"
@@ -216,7 +216,7 @@ def do_configure(args, passthrough_args):
     if llvm_enable_runtimes:
         cmake_cmd.extend(
             [
-                "-DLLVM_ENABLE_RUNTIMES={}".format(llvm_enable_runtimes),
+                "-DLLVM_ENABLE_RUNTIMES={}".format(llvm_enable_runtimes.lstrip(";")),
             ]
         )
 

--- a/libclc/utils/libclc-remangler/CMakeLists.txt
+++ b/libclc/utils/libclc-remangler/CMakeLists.txt
@@ -10,6 +10,8 @@ set(LLVM_LINK_COMPONENTS
   TargetParser
   )
 
+list( PREPEND CMAKE_MODULE_PATH ${LIBCLC_SOURCE_DIR}/../clang/cmake/modules )
+include( AddClang )
 add_clang_tool(libclc-remangler LibclcRemangler.cpp)
 
 setup_host_tool( libclc-remangler LIBCLC_REMANGLER
@@ -17,7 +19,7 @@ setup_host_tool( libclc-remangler LIBCLC_REMANGLER
 
 target_include_directories(libclc-remangler PRIVATE
   ${CMAKE_SOURCE_DIR}/../clang/include
-  ${CMAKE_BINARY_DIR}/tools/clang/include)
+  ${LLVM_BINARY_DIR}/tools/clang/include)
 
 clang_target_link_libraries(libclc-remangler
   PRIVATE

--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -812,13 +812,10 @@ public:
 
   void Initialize(ASTContext &C) override {
     ASTCtx = &C;
-    std::unique_ptr<MemoryBuffer> const Buff = ExitOnErr(
-        errorOrToExpected(MemoryBuffer::getFileOrSTDIN(InputIRFilename)));
 
     SMDiagnostic Err;
-    std::unique_ptr<llvm::Module> const M =
-        parseIR(Buff.get()->getMemBufferRef(), Err, LLVMCtx);
-
+    std::unique_ptr<llvm::Module> M =
+        parseIRFile(StringRef(InputIRFilename), Err, LLVMCtx);
     if (!M) {
       Err.print("libclc-remangler", errs());
       exit(1);

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 # This allows an easy way of setting up a build directory for llvm and another
 # one for llvm+clang+... using the same sources.
 # These projects will be included when "all" is included in LLVM_ENABLE_PROJECTS.
-set(LLVM_ALL_PROJECTS "bolt;clang;clang-tools-extra;cross-project-tests;libclc;lld;lldb;mlir;polly")
+set(LLVM_ALL_PROJECTS "bolt;clang;clang-tools-extra;cross-project-tests;lld;lldb;mlir;polly")
 set(LLVM_ALL_PROJECTS "${LLVM_ALL_PROJECTS};${LLVM_EXTERNAL_PROJECTS}")
 
 # The libc and compiler-rt projects are not part of LLVM_ALL_PROJECTS, because
@@ -140,7 +140,7 @@ endforeach()
 #
 # As we migrate runtimes to using the bootstrapping build, the set of default runtimes
 # should grow as we remove those runtimes from LLVM_ENABLE_PROJECTS above.
-set(LLVM_DEFAULT_RUNTIMES "libcxx;libcxxabi;libunwind;compiler-rt;openmp")
+set(LLVM_DEFAULT_RUNTIMES "libcxx;libcxxabi;libunwind;libclc;compiler-rt;openmp")
 set(LLVM_SUPPORTED_RUNTIMES "libc;libunwind;libcxxabi;libcxx;compiler-rt;openmp;llvm-libgcc;offload;flang-rt;libclc;libsycl;orc-rt")
 set(LLVM_ENABLE_RUNTIMES "" CACHE STRING
   "Semicolon-separated list of runtimes to build, or \"all\" (${LLVM_DEFAULT_RUNTIMES}). Supported runtimes are ${LLVM_SUPPORTED_RUNTIMES}.")

--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SYCL_JIT_RESOURCE_INSTALL_COMPONENTS
   clang-resource-headers
   libsycldevice)
 
-if ("libclc" IN_LIST LLVM_ENABLE_PROJECTS)
+if ("libclc" IN_LIST LLVM_ENABLE_RUNTIMES)
   # If some targets required `libclc` then we should embed it for the
   # `sycl-jit`.
   list(APPEND SYCL_JIT_RESOURCE_INSTALL_COMPONENTS libspirv-builtins)
@@ -29,13 +29,20 @@ endif()
 set(SYCL_JIT_RESOURCE_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/rtc-resources-install)
 
 set(SYCL_JIT_PREPARE_RESOURCE_COMMANDS)
+set(RUNTIMES_BINARY_DIR ${CMAKE_BINARY_DIR}/runtimes/runtimes-bins)
 foreach(component IN LISTS SYCL_JIT_RESOURCE_INSTALL_COMPONENTS)
+  set(BINARY_DIR ${CMAKE_BINARY_DIR})
+  if("${component}" STREQUAL "libspirv-builtins")
+    set(BINARY_DIR ${RUNTIMES_BINARY_DIR})
+    list(APPEND SYCL_JIT_RESOURCE_DEPS libclc)
+  else()
+    list(APPEND SYCL_JIT_RESOURCE_DEPS ${component})
+  endif()
   list(APPEND SYCL_JIT_PREPARE_RESOURCE_COMMANDS
-    COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix ${SYCL_JIT_RESOURCE_INSTALL_DIR} --component "${component}"
+    COMMAND ${CMAKE_COMMAND} --install ${BINARY_DIR} --prefix ${SYCL_JIT_RESOURCE_INSTALL_DIR} --component "${component}"
   )
 endforeach()
 
-set(SYCL_JIT_RESOURCE_DEPS ${SYCL_JIT_RESOURCE_INSTALL_COMPONENTS})
   # OpenCL-Headers doesn't have a corresponding build target:
 list(FILTER SYCL_JIT_RESOURCE_DEPS EXCLUDE REGEX "^OpenCL-Headers$")
 

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -527,14 +527,14 @@ if("lld" IN_LIST LLVM_ENABLE_PROJECTS)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS lld)
 endif()
 
-if("libclc" IN_LIST LLVM_ENABLE_PROJECTS)
-  add_dependencies(sycl-toolchain libspirv-builtins)
+if("libclc" IN_LIST LLVM_ENABLE_RUNTIMES)
+  add_dependencies(sycl-toolchain libclc)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins)
 endif()
 
 if("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   # Ensure that libclc is enabled.
-  list(FIND LLVM_ENABLE_PROJECTS libclc LIBCLC_FOUND)
+  list(FIND LLVM_ENABLE_RUNTIMES libclc LIBCLC_FOUND)
   if( LIBCLC_FOUND EQUAL -1 )
     message(FATAL_ERROR
       "CUDA support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
@@ -546,7 +546,7 @@ endif()
 
 if("hip" IN_LIST SYCL_ENABLE_BACKENDS)
   # Ensure that libclc is enabled.
-  list(FIND LLVM_ENABLE_PROJECTS libclc LIBCLC_FOUND)
+  list(FIND LLVM_ENABLE_RUNTIMES libclc LIBCLC_FOUND)
   if( LIBCLC_FOUND EQUAL -1 )
     message(FATAL_ERROR
       "HIP support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
@@ -578,15 +578,22 @@ add_custom_command(OUTPUT __force_it
 set(__chain_dep __force_it)
 
 set(manifest_list)
+set(RUNTIMES_INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/runtimes/runtimes-bins/cmake_install.cmake")
 foreach( comp ${SYCL_TOOLCHAIN_DEPLOY_COMPONENTS} )
+  set(INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+  set(RUNTIME_TARGET)
+  if("${comp}" STREQUAL "libspirv-builtins")
+    set(RUNTIME_TARGET libclc)
+    set(INSTALL_SCRIPT ${RUNTIMES_INSTALL_SCRIPT})
+  endif()
   message( STATUS "Adding component ${comp} to deploy")
 
   set (manifest_file ${CMAKE_CURRENT_BINARY_DIR}/install_manifest_${comp}.txt)
   add_custom_command(OUTPUT ${manifest_file}
     COMMAND "${CMAKE_COMMAND}"
     "-DCMAKE_INSTALL_COMPONENT=${comp}"
-    -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-    DEPENDS  ${__chain_dep}
+    -P "${INSTALL_SCRIPT}"
+    DEPENDS  ${__chain_dep} ${RUNTIME_TARGET}
     COMMENT "Deploying component ${comp}"
     USES_TERMINAL
   )


### PR DESCRIPTION
Cherry-pick upstream commit a3a15f3252de which moves libclc from LLVM_ALL_PROJECTS to LLVM_DEFAULT_RUNTIMES.

Update configure, build and deploy to enable libclc runtime build. jira: CMPLRLLVM-73202

(cherry picked from commit f3962f6eb6d13ab19972fa4c6acad3c9f6ff203d)

Also cherry-pick from #21403 to w/a libclc-remangler ABI mismatch on RHEL 8.

This PR is temporary fix to unblock sycl-web and I'll follow-up in sycl branch to remove libclc-remangler tool.