### PR TITLE
Revert "[SYCL][E2E] Disable submit_time.cpp on PVC"

### DIFF
--- a/sycl/test-e2e/Basic/submit_time.cpp
+++ b/sycl/test-e2e/Basic/submit_time.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
-// There is an issue with reported device time for the L0 backend. No such
-// problems for other backends.
-// RUN-IF: !level_zero, %{run} %t.out
+// There is an issue with reported device time for the L0 backend, works only on
+// pvc for now. No such problems for other backends.
+// RUN: %if (!level_zero || arch-intel_gpu_pvc) %{ %{run} %t.out %}
 
 // Check that submission time is calculated properly.
 


### PR DESCRIPTION
Reverts intel/llvm#21460

It was a runner issue in the case that was failing