### PR TITLE
[SYCL] Add Support for Precompiled Headers

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -448,8 +448,6 @@ def err_drv_expecting_fsycl_with_sycl_opt : Error<
   "'%0' must be used in conjunction with '-fsycl' to enable offloading">;
 def err_drv_fsycl_with_c_type : Error<
   "'%0' must not be used in conjunction with '-fsycl', which expects C++ source">;
-def err_drv_fsycl_with_pch : Error<
-  "precompiled header generation is not supported with '-fsycl'">;
 def warn_drv_opt_requires_opt
   : Warning<"'%0' should be used only in conjunction with '%1'">, InGroup<UnusedCommandLineArgument>;
 def err_drv_sycl_missing_amdgpu_arch : Error<

--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -728,11 +728,17 @@ class OffloadPackagerExtractJobAction : public JobAction {
   void anchor() override;
 
 public:
-  OffloadPackagerExtractJobAction(ActionList &Inputs, types::ID Type);
+  OffloadPackagerExtractJobAction(ActionList &Inputs, types::ID Type,
+                                  const ToolChain *TC = nullptr);
 
   static bool classof(const Action *A) {
     return A->getKind() == OffloadPackagerExtractJobClass;
   }
+
+  const ToolChain *getToolChain() const { return OPEToolChain; }
+
+private:
+  const ToolChain *OPEToolChain = nullptr;
 };
 
 class OffloadDepsJobAction final : public JobAction {

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -880,6 +880,11 @@ private:
   mutable llvm::StringMap<const std::pair<StringRef, StringRef>>
       IntegrationFileList;
 
+  /// A list of triples and their corresponding unbundled precompiled header
+  /// file names.  This is generated when unbundling the fat precompiled
+  /// header file, and consumed by the host and the device compilations.
+  mutable llvm::StringMap<StringRef> SYCLPrecompiledHeaderFileList;
+
   /// Unique ID used for SYCL compilations.  Each file will use a different
   /// unique ID, but the same ID will be used for different compilation
   /// targets.
@@ -929,6 +934,19 @@ public:
   /// isSYCLDefaultTripleImplied - The default SYCL triple (spir64) has been
   /// added or should be added given proper criteria.
   bool isSYCLDefaultTripleImplied() const { return SYCLDefaultTripleImplied; };
+
+  /// addSYCLPrecompiledHeaderFiles - Add the precompiled header files
+  /// that were unbundled for each triple.
+  void addSYCLPrecompiledHeaderFiles(StringRef Triple,
+                                     StringRef FileName) const {
+    SYCLPrecompiledHeaderFileList.insert({Triple, FileName});
+  }
+
+  /// getSYCLPrecompiledHeaderFile - Get the precompiled header file
+  /// for a specific triple.
+  StringRef getSYCLPrecompiledHeaderFile(StringRef Triple) const {
+    return SYCLPrecompiledHeaderFileList[Triple];
+  }
 
   /// addIntegrationFiles - Add the integration files that will be populated
   /// by the device compilation and used by the host compile.

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -7841,6 +7841,9 @@ def fsycl_fp64_conv_emu : Flag<["-"], "fsycl-fp64-conv-emu">,
            "conversion operations and no fp64 computation operations (requires "
            "Intel GPU backend supporting fp64 partial emulation).">,
   MarshallingInfoFlag<CodeGenOpts<"FP64ConvEmu">>;
+def fno_sycl_use_header : Flag<["-"], "fno-sycl-use-header">,
+  HelpText<"Disable usage of the integration header during SYCL enabled "
+           "compilations.">;
 def fno_sycl_use_footer : Flag<["-"], "fno-sycl-use-footer">,
   HelpText<"Disable usage of the integration footer during SYCL enabled "
            "compilations.">;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -7841,9 +7841,6 @@ def fsycl_fp64_conv_emu : Flag<["-"], "fsycl-fp64-conv-emu">,
            "conversion operations and no fp64 computation operations (requires "
            "Intel GPU backend supporting fp64 partial emulation).">,
   MarshallingInfoFlag<CodeGenOpts<"FP64ConvEmu">>;
-def fno_sycl_use_header : Flag<["-"], "fno-sycl-use-header">,
-  HelpText<"Disable usage of the integration header during SYCL enabled "
-           "compilations.">;
 def fno_sycl_use_footer : Flag<["-"], "fno-sycl-use-footer">,
   HelpText<"Disable usage of the integration footer during SYCL enabled "
            "compilations.">;

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -503,7 +503,7 @@ OffloadPackagerJobAction::OffloadPackagerJobAction(ActionList &Inputs,
 void OffloadPackagerExtractJobAction::anchor() {}
 
 OffloadPackagerExtractJobAction::OffloadPackagerExtractJobAction(
-    ActionList &Inputs, types::ID Type, const clang::driver::ToolChain* TC)
+    ActionList &Inputs, types::ID Type, const clang::driver::ToolChain *TC)
     : JobAction(OffloadPackagerExtractJobClass, Inputs, Type),
       OPEToolChain(TC) {}
 

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -90,14 +90,16 @@ void Action::propagateDeviceOffloadInfo(OffloadKind OKind, const char *OArch,
   // Deps job uses the host kinds.
   if (Kind == OffloadDepsJobClass)
     return;
-  // Packaging actions can use host kinds for preprocessing.  When packaging
-  // preprocessed files, these packaged files will contain both host and device
-  // files, where the host side does not have any device info to propagate.
-  bool hasPreprocessJob =
+  // Packaging actions can use host kinds for preprocessing or generating
+  // PCH files.  When packaging such files, these packaged files will contain
+  // both host and device files, where the host side does not have any device
+  // info to propagate.
+  bool hasPreprocessOrPCHJob =
       std::any_of(Inputs.begin(), Inputs.end(), [](const Action *A) {
-        return A->getKind() == PreprocessJobClass || A->getKind() == PrecompileJobClass;
+        return A->getKind() == PreprocessJobClass ||
+               A->getKind() == PrecompileJobClass;
       });
-  if (Kind == OffloadPackagerJobClass && hasPreprocessJob)
+  if (Kind == OffloadPackagerJobClass && hasPreprocessOrPCHJob)
     return;
 
   assert((OffloadingDeviceKind == OKind || OffloadingDeviceKind == OFK_None) &&
@@ -501,8 +503,9 @@ OffloadPackagerJobAction::OffloadPackagerJobAction(ActionList &Inputs,
 void OffloadPackagerExtractJobAction::anchor() {}
 
 OffloadPackagerExtractJobAction::OffloadPackagerExtractJobAction(
-    ActionList &Inputs, types::ID Type)
-    : JobAction(OffloadPackagerExtractJobClass, Inputs, Type) {}
+    ActionList &Inputs, types::ID Type, const clang::driver::ToolChain* TC)
+    : JobAction(OffloadPackagerExtractJobClass, Inputs, Type), OPEToolChain(TC)
+{}
 
 void OffloadDepsJobAction::anchor() {}
 

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -504,8 +504,8 @@ void OffloadPackagerExtractJobAction::anchor() {}
 
 OffloadPackagerExtractJobAction::OffloadPackagerExtractJobAction(
     ActionList &Inputs, types::ID Type, const clang::driver::ToolChain* TC)
-    : JobAction(OffloadPackagerExtractJobClass, Inputs, Type), OPEToolChain(TC)
-{}
+    : JobAction(OffloadPackagerExtractJobClass, Inputs, Type),
+      OPEToolChain(TC) {}
 
 void OffloadDepsJobAction::anchor() {}
 

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -95,7 +95,7 @@ void Action::propagateDeviceOffloadInfo(OffloadKind OKind, const char *OArch,
   // files, where the host side does not have any device info to propagate.
   bool hasPreprocessJob =
       std::any_of(Inputs.begin(), Inputs.end(), [](const Action *A) {
-        return A->getKind() == PreprocessJobClass;
+        return A->getKind() == PreprocessJobClass || A->getKind() == PrecompileJobClass;
       });
   if (Kind == OffloadPackagerJobClass && hasPreprocessJob)
     return;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -10440,9 +10440,8 @@ std::string Driver::GetClPchPath(Compilation &C, StringRef BaseName) const {
   } else {
     if (Arg *YcArg = C.getArgs().getLastArg(options::OPT__SLASH_Yc))
       Output = YcArg->getValue();
-    if (Output.empty()) {
+    if (Output.empty())
       Output = BaseName;
-    }
     llvm::sys::path::replace_extension(Output, ".pch");
   }
   return std::string(Output);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7150,6 +7150,31 @@ shouldBundleHIPAsmWithNewDriver(const Compilation &C,
   }
   return HasAMDGCNHIPDevice;
 }
+  
+static void unbundlePCH(Compilation &C, DerivedArgList &Args, ActionList &AL,
+                        const ToolChain *TC) {
+  if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
+      !Args.hasArg(options::OPT_offload_targets_EQ))
+    return;
+  bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);
+  bool isYuArg = Args.hasArg(options::OPT__SLASH_Yu);
+  assert((isIncludePCHArg || isYuArg) && "Invalid PCH unbundle");
+  SmallString<128> PCHArgValue;
+  if (isIncludePCHArg)
+    PCHArgValue = Args.getLastArg(options::OPT_include_pch)->getValue();
+  else {
+    // /Yu accepts a header file as its argument.
+    PCHArgValue = Args.getLastArg(options::OPT__SLASH_Yu)->getValue();
+    llvm::sys::path::replace_extension(PCHArgValue, "pch");
+  }
+  Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
+                               Args.MakeArgString(PCHArgValue));
+  Action *A = C.MakeAction<InputAction>(*InputArg, types::TY_PCH);
+  AL.push_back(A);
+  auto UnbundlingHostAction =
+      C.MakeAction<OffloadPackagerExtractJobAction>(AL, A->getType(), TC);
+  AL.push_back(UnbundlingHostAction);
+}
 
 void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
                           const InputList &Inputs, ActionList &Actions) const {
@@ -7273,14 +7298,20 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     }
 
     ActionList HIPAsmDeviceActions;
+    if (Args.hasArg(options::OPT_include_pch) ||
+        Args.getLastArg(options::OPT__SLASH_Yu)) {
+      // Unbundles the fat PCH file for the host.
+      if (!UseNewOffloadingDriver)
+        OffloadBuilder->unbundlePCH(C, Actions, Args, InputArg);
+      else
+        unbundlePCH(C, Args, Actions, nullptr);
+    }
 
     // Use the current host action in any of the offloading actions, if
     // required.
     if (!UseNewOffloadingDriver) {
-      if (Args.hasArg(options::OPT_include_pch) ||
-          Args.getLastArg(options::OPT__SLASH_Yu))
-        OffloadBuilder->unbundlePCH(C, Actions, Args, InputArg);
-      if (OffloadBuilder->addHostDependenceToDeviceActions(Current, InputArg, Args))
+      if (OffloadBuilder->addHostDependenceToDeviceActions(
+                              Current, InputArg, Args))
         break;
     }
 
@@ -7903,6 +7934,7 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
   const Action::OffloadKind OffloadKinds[] = {
       Action::OFK_OpenMP, Action::OFK_Cuda, Action::OFK_HIP, Action::OFK_SYCL};
 
+  SmallVector<std::pair<const ToolChain *, StringRef>> TCAndArchs;
   for (Action::OffloadKind Kind : OffloadKinds) {
     SmallVector<const ToolChain *, 2> ToolChains;
     ActionList DeviceActions;
@@ -7923,20 +7955,13 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
       continue;
 
     // Get the product of all bound architectures and toolchains.
-    SmallVector<std::pair<const ToolChain *, StringRef>> TCAndArchs;
     for (const ToolChain *TC : ToolChains) {
       for (StringRef Arch : getOffloadArchs(C, C.getArgs(), Kind, *TC)) {
         TCAndArchs.push_back(std::make_pair(TC, Arch));
         // Check if the InputArg is a preprocessed file that is created by the
         // llvm-offload-binary.
-	printf("%d %d\n", (int)InputType, (int)types::TY_PCH);
-        printf("%s\n", InputArg->getAsString(Args).c_str());
-	if (Args.hasArg(options::OPT_include_pch)) printf("Look into here\n");
-#if 1
         if (InputType == types::TY_PP_CXX &&
             isOffloadBinaryFile(InputArg->getAsString(Args))) {
-#else
-#endif
           // Extract the specific preprocessed file given the current arch
           // and triple.  Add to DeviceActions if one was extracted.
           ActionList PPActions;
@@ -7945,47 +7970,26 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
           PPActions.push_back(IA);
           Action *PackagerAction =
               C.MakeAction<OffloadPackagerExtractJobAction>(PPActions,
-#if 1
                                                             types::TY_PP_CXX);
-#else
-#endif
           DDep.add(*PackagerAction,
                    *C.getSingleOffloadToolChain<Action::OFK_Host>(), nullptr,
                    C.getActiveOffloadKinds());
           DeviceActions.push_back(PackagerAction);
           continue;
         }
-#if 1
-	SmallString<128> PCHArgValue;
-
-	if (Args.hasArg(options::OPT_include_pch)) {
-		printf("Here 1\n");
-        if (isOffloadBinaryFile(Args.getLastArg(options::OPT_include_pch)->getValue())) {
-		printf("Here 2\n");
-          // Extract the specific preprocessed file given the current arch
-          // and triple.  Add to DeviceActions if one was extracted.
-          ActionList PPActions;
-          OffloadAction::DeviceDependences DDep;
-    PCHArgValue = Args.getLastArg(options::OPT_include_pch)->getValue();
-    InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
-                                 Args.MakeArgString(PCHArgValue));
-    InputType = types::TY_PCH;
-    Action *A = C.MakeAction<InputAction>(*InputArg, types::TY_PCH, CUID);
-//          Action *IA = C.MakeAction<InputAction>(*InputArg, InputType, CUID);
-          PPActions.push_back(A);
-          Action *PackagerAction =
-              C.MakeAction<OffloadPackagerExtractJobAction>(PPActions,
-                                                            types::TY_PCH);
-          DDep.add(*PackagerAction,
-                   *C.getSingleOffloadToolChain<Action::OFK_Host>(), nullptr,
-                   C.getActiveOffloadKinds());
-          DeviceActions.push_back(PackagerAction);
-          continue;
-        }
-	}
-#endif
         DeviceActions.push_back(
             C.MakeAction<InputAction>(*InputArg, InputType, CUID));
+      }
+    }
+
+    // Unbundle the fat PCH files for the offloading devices.
+    bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);
+    bool isYuArg = Args.hasArg(options::OPT__SLASH_Yu);
+    SmallString<128> PCHArgValue;
+    if (isIncludePCHArg || isYuArg) {
+      for (auto *TCAndArch = TCAndArchs.begin();
+           TCAndArch != TCAndArchs.end(); ++TCAndArch) {
+        unbundlePCH(C, Args, OffloadActions, TCAndArch->first);
       }
     }
 
@@ -8164,13 +8168,11 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
              nullptr, C.getActiveOffloadKinds());
     return C.MakeAction<OffloadAction>(DDep, types::TY_Nothing);
   } else if (C.isOffloadingHostKind(Action::OFK_SYCL) &&
-             isa<PrecompileJobAction>(HostAction) &&
-             Args.hasArg(options::OPT_o, options::OPT__SLASH_P,
-                         options::OPT__SLASH_o)) {
+             isa<PrecompileJobAction>(HostAction)) {
     // Performing precompilation only. Take the host and device preprocessed
     // files and package them together.
     ActionList PackagerActions;
-    // Only add the preprocess actions from the device side.  When one is
+    // Only add the precompile actions from the device side.  When one is
     // found, add an additional compilation to generate the integration
     // header/footer that is used for the host compile.
     for (auto OA : OffloadActions) {
@@ -8181,15 +8183,15 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
               if (isa<PrecompileJobAction>(A)) {
                 PackagerActions.push_back(OA);
                 A->setCannotBeCollapsedWithNextDependentAction();
-                // The input to the compilation job is the preprocessed job.
+                // The input to the compilation job is the precompiled job.
                 // Take that input action (it should be one input) which is
                 // the source file and compile that file to generate the
                 // integration header/footer.
-                ActionList PreprocInputs = A->getInputs();
-                assert(PreprocInputs.size() == 1 &&
-                       "Single input size to preprocess action expected.");
+                ActionList PCHInputs = A->getInputs();
+                assert(PCHInputs.size() == 1 &&
+                       "Single input size to PCH action expected.");
                 Action *CompileAction = C.MakeAction<CompileJobAction>(
-                    PreprocInputs.front(), types::TY_Nothing);
+                    PCHInputs.front(), types::TY_Nothing);
                 DDeps.add(*CompileAction, *TC, BoundArch, Action::OFK_SYCL);
               }
             });
@@ -8420,14 +8422,13 @@ Action *Driver::ConstructPhaseAction(
     // we will compile.
     if (getUseNewOffloadingDriver() &&
         TargetDeviceOffloadKind == Action::OFK_None &&
-        Input->getType() == types::TY_PCH) {
-	    printf("Do we get here?\n");
+        Input->getType() == types::TY_PP_CXX) {
       const InputAction *IA = dyn_cast<InputAction>(Input);
       if (IA && isOffloadBinaryFile(IA->getInputArg().getAsString(Args))) {
         ActionList PPActions;
         PPActions.push_back(Input);
         Action *PackagerAction = C.MakeAction<OffloadPackagerExtractJobAction>(
-            PPActions, types::TY_PCH);
+            PPActions, types::TY_PP_CXX);
         return C.MakeAction<CompileJobAction>(PackagerAction,
                                               types::TY_LLVM_BC);
       }
@@ -9564,6 +9565,10 @@ InputInfoList Driver::BuildJobsForActionNoCache(
     // FIXME: Clean this up.
     bool SubJobAtTopLevel =
         AtTopLevel && (isa<DsymutilJobAction>(A) || isa<VerifyJobAction>(A));
+#if 0
+    JATC = (Input->getType() == types::TY_PCH &&
+            Input->getKind() == clang::driver::Action::OffloadPackagerExtractJobClass) ? TC : JATC;
+#endif
     InputInfos.append(BuildJobsForAction(
         C, Input, JATC, DA ? DA->getOffloadingArch() : BoundArch,
         SubJobAtTopLevel, MultipleArchs, LinkingOutput, CachedResults,
@@ -9973,16 +9978,19 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     }
   }
 
-  // When generating preprocessed files (-E) with offloading enabled, redirect
-  // the output to a properly named output file.
-#if 1
-  if ((JA.getType() == types::TY_PP_CXX ||
-       JA.getType() == types::TY_PCH) && isa<OffloadPackagerJobAction>(JA)) {
+  // When generating preprocessed files (-E) or PCH files with offloading
+  // enabled, redirect the output to a properly named output file.
+  if ((JA.getType() == types::TY_PP_CXX || JA.getType() == types::TY_PCH) &&
+      isa<OffloadPackagerJobAction>(JA)) {
     if (Arg *FinalOutput =
             C.getArgs().getLastArg(options::OPT_o, options::OPT__SLASH_o))
       return C.addResultFile(FinalOutput->getValue(), &JA);
+    if (JA.getType() == types::TY_PCH) {
+      SmallString<128> BaseName = llvm::sys::path::filename(BaseInput);
+      llvm::sys::path::replace_extension(BaseName, ".pch");
+      return C.addResultFile(C.getArgs().MakeArgString(BaseName), &JA);
+    }
   }
-#endif
 
   // Default to writing to stdout?
   if (AtTopLevel && !CCGenDiagnostics && HasPreprocessOutput(JA)) {
@@ -10068,6 +10076,17 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
   const bool FoInvalidForOffload =
       HasFo && (!IsHostOffloading || isa<OffloadUnbundlingJobAction>(JA) ||
                 JA.getOffloadingHostActiveKinds() > Action::OFK_Host);
+
+  if (JA.getType() == types::TY_PCH &&
+      isa<OffloadPackagerExtractJobAction>(JA) && !SaveTempsEnabled) {
+    StringRef Name = llvm::sys::path::filename(BaseInput);
+    std::pair<StringRef, StringRef> Split = Name.split('.');
+    const char *Suffix =
+        types::getTypeTempSuffix(JA.getType(), IsCLMode() || IsDXCMode());
+    return CreateTempFile(C, Split.first, Suffix, MultipleArchs, BoundArch,
+                          JA.getType(), false);
+  }
+
   // Output to a temporary file?
   if ((!AtTopLevel && !SaveTempsEnabled && (!HasFo || FoInvalidForOffload)) ||
       CCGenDiagnostics) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -9554,10 +9554,6 @@ InputInfoList Driver::BuildJobsForActionNoCache(
     // FIXME: Clean this up.
     bool SubJobAtTopLevel =
         AtTopLevel && (isa<DsymutilJobAction>(A) || isa<VerifyJobAction>(A));
-#if 0
-    JATC = (Input->getType() == types::TY_PCH &&
-            Input->getKind() == clang::driver::Action::OffloadPackagerExtractJobClass) ? TC : JATC;
-#endif
     InputInfos.append(BuildJobsForAction(
         C, Input, JATC, DA ? DA->getOffloadingArch() : BoundArch,
         SubJobAtTopLevel, MultipleArchs, LinkingOutput, CachedResults,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -8188,7 +8188,7 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
     }
     PackagerActions.push_back(HostAction);
     Action *PackagerAction =
-       C.MakeAction<OffloadPackagerJobAction>(PackagerActions, types::TY_PCH);
+        C.MakeAction<OffloadPackagerJobAction>(PackagerActions, types::TY_PCH);
     DDeps.add(*PackagerAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
               nullptr, C.getActiveOffloadKinds());
   } else if (C.isOffloadingHostKind(Action::OFK_SYCL) &&

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7892,7 +7892,8 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
   // preprocessing only ignore embedding.  When needing to do bundling for
   // SYCL, allow the building of offloading actions to add the device side to
   // the bundle.
-  if (!(isa<CompileJobAction>(HostAction) || SYCLBundleFile ||
+  if (!(isa<CompileJobAction>(HostAction) ||
+        isa<PrecompileJobAction>(HostAction) || SYCLBundleFile ||
         getFinalPhase(Args) == phases::Preprocess))
     return HostAction;
 
@@ -7928,8 +7929,14 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
         TCAndArchs.push_back(std::make_pair(TC, Arch));
         // Check if the InputArg is a preprocessed file that is created by the
         // llvm-offload-binary.
+	printf("%d %d\n", (int)InputType, (int)types::TY_PCH);
+        printf("%s\n", InputArg->getAsString(Args).c_str());
+	if (Args.hasArg(options::OPT_include_pch)) printf("Look into here\n");
+#if 1
         if (InputType == types::TY_PP_CXX &&
             isOffloadBinaryFile(InputArg->getAsString(Args))) {
+#else
+#endif
           // Extract the specific preprocessed file given the current arch
           // and triple.  Add to DeviceActions if one was extracted.
           ActionList PPActions;
@@ -7938,13 +7945,45 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
           PPActions.push_back(IA);
           Action *PackagerAction =
               C.MakeAction<OffloadPackagerExtractJobAction>(PPActions,
+#if 1
                                                             types::TY_PP_CXX);
+#else
+#endif
           DDep.add(*PackagerAction,
                    *C.getSingleOffloadToolChain<Action::OFK_Host>(), nullptr,
                    C.getActiveOffloadKinds());
           DeviceActions.push_back(PackagerAction);
           continue;
         }
+#if 1
+	SmallString<128> PCHArgValue;
+
+	if (Args.hasArg(options::OPT_include_pch)) {
+		printf("Here 1\n");
+        if (isOffloadBinaryFile(Args.getLastArg(options::OPT_include_pch)->getValue())) {
+		printf("Here 2\n");
+          // Extract the specific preprocessed file given the current arch
+          // and triple.  Add to DeviceActions if one was extracted.
+          ActionList PPActions;
+          OffloadAction::DeviceDependences DDep;
+    PCHArgValue = Args.getLastArg(options::OPT_include_pch)->getValue();
+    InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
+                                 Args.MakeArgString(PCHArgValue));
+    InputType = types::TY_PCH;
+    Action *A = C.MakeAction<InputAction>(*InputArg, types::TY_PCH, CUID);
+//          Action *IA = C.MakeAction<InputAction>(*InputArg, InputType, CUID);
+          PPActions.push_back(A);
+          Action *PackagerAction =
+              C.MakeAction<OffloadPackagerExtractJobAction>(PPActions,
+                                                            types::TY_PCH);
+          DDep.add(*PackagerAction,
+                   *C.getSingleOffloadToolChain<Action::OFK_Host>(), nullptr,
+                   C.getActiveOffloadKinds());
+          DeviceActions.push_back(PackagerAction);
+          continue;
+        }
+	}
+#endif
         DeviceActions.push_back(
             C.MakeAction<InputAction>(*InputArg, InputType, CUID));
       }
@@ -8124,6 +8163,43 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
     DDep.add(*LinkAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
              nullptr, C.getActiveOffloadKinds());
     return C.MakeAction<OffloadAction>(DDep, types::TY_Nothing);
+  } else if (C.isOffloadingHostKind(Action::OFK_SYCL) &&
+             isa<PrecompileJobAction>(HostAction) &&
+             Args.hasArg(options::OPT_o, options::OPT__SLASH_P,
+                         options::OPT__SLASH_o)) {
+    // Performing precompilation only. Take the host and device preprocessed
+    // files and package them together.
+    ActionList PackagerActions;
+    // Only add the preprocess actions from the device side.  When one is
+    // found, add an additional compilation to generate the integration
+    // header/footer that is used for the host compile.
+    for (auto OA : OffloadActions) {
+      if (const OffloadAction *CurOA = dyn_cast<OffloadAction>(OA)) {
+        CurOA->doOnEachDependence(
+            [&](Action *A, const ToolChain *TC, const char *BoundArch) {
+              assert(TC && "Unknown toolchain");
+              if (isa<PrecompileJobAction>(A)) {
+                PackagerActions.push_back(OA);
+                A->setCannotBeCollapsedWithNextDependentAction();
+                // The input to the compilation job is the preprocessed job.
+                // Take that input action (it should be one input) which is
+                // the source file and compile that file to generate the
+                // integration header/footer.
+                ActionList PreprocInputs = A->getInputs();
+                assert(PreprocInputs.size() == 1 &&
+                       "Single input size to preprocess action expected.");
+                Action *CompileAction = C.MakeAction<CompileJobAction>(
+                    PreprocInputs.front(), types::TY_Nothing);
+                DDeps.add(*CompileAction, *TC, BoundArch, Action::OFK_SYCL);
+              }
+            });
+      }
+    }
+    PackagerActions.push_back(HostAction);
+    Action *PackagerAction = C.MakeAction<OffloadPackagerJobAction>(
+        PackagerActions, types::TY_PCH);
+    DDeps.add(*PackagerAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
+              nullptr, C.getActiveOffloadKinds());
   } else if (C.isOffloadingHostKind(Action::OFK_SYCL) &&
              isa<PreprocessJobAction>(HostAction) &&
              getFinalPhase(Args) == phases::Preprocess &&
@@ -8344,13 +8420,14 @@ Action *Driver::ConstructPhaseAction(
     // we will compile.
     if (getUseNewOffloadingDriver() &&
         TargetDeviceOffloadKind == Action::OFK_None &&
-        Input->getType() == types::TY_PP_CXX) {
+        Input->getType() == types::TY_PCH) {
+	    printf("Do we get here?\n");
       const InputAction *IA = dyn_cast<InputAction>(Input);
       if (IA && isOffloadBinaryFile(IA->getInputArg().getAsString(Args))) {
         ActionList PPActions;
         PPActions.push_back(Input);
         Action *PackagerAction = C.MakeAction<OffloadPackagerExtractJobAction>(
-            PPActions, types::TY_PP_CXX);
+            PPActions, types::TY_PCH);
         return C.MakeAction<CompileJobAction>(PackagerAction,
                                               types::TY_LLVM_BC);
       }
@@ -9898,11 +9975,14 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
 
   // When generating preprocessed files (-E) with offloading enabled, redirect
   // the output to a properly named output file.
-  if (JA.getType() == types::TY_PP_CXX && isa<OffloadPackagerJobAction>(JA)) {
+#if 1
+  if ((JA.getType() == types::TY_PP_CXX ||
+       JA.getType() == types::TY_PCH) && isa<OffloadPackagerJobAction>(JA)) {
     if (Arg *FinalOutput =
             C.getArgs().getLastArg(options::OPT_o, options::OPT__SLASH_o))
       return C.addResultFile(FinalOutput->getValue(), &JA);
   }
+#endif
 
   // Default to writing to stdout?
   if (AtTopLevel && !CCGenDiagnostics && HasPreprocessOutput(JA)) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7139,7 +7139,7 @@ unbundlePCH(bool UseNewOffloadingDriver, OffloadingActionBuilder *OAB,
     llvm::sys::path::replace_extension(PCHArgValue, "pch");
   }
 
-  Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
+  Arg *InputArg = makeInputArg(Args, C.getDriver().getOpts(),
                                Args.MakeArgString(PCHArgValue));
   Action *A = C.MakeAction<InputAction>(*InputArg, types::TY_PCH);
   if (!UseNewOffloadingDriver) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7113,15 +7113,15 @@ shouldBundleHIPAsmWithNewDriver(const Compilation &C,
   }
   return HasAMDGCNHIPDevice;
 }
-  
+
 /// This routine unbundles individual PCH files from a fat PCH bundle.
 /// In the old offloading driver model, this routine invokes the clang
 /// offload bundler; in the new offloading driver model, it invokes the
 /// llvm offload binary.
-static void
-unbundlePCH(bool UseNewOffloadingDriver, OffloadingActionBuilder *OAB,
-            Compilation &C, DerivedArgList &Args, ActionList &AL,
-            const ToolChain *TC, const Arg *MainArg) {
+static void unbundlePCH(bool UseNewOffloadingDriver,
+                        OffloadingActionBuilder *OAB, Compilation &C,
+                        DerivedArgList &Args, ActionList &AL,
+                        const ToolChain *TC, const Arg *MainArg) {
   // Unbundle a fat PCH file.
   if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
       !Args.hasArg(options::OPT_offload_targets_EQ))
@@ -7291,16 +7291,16 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     if (Args.hasArg(options::OPT_include_pch) ||
         Args.getLastArg(options::OPT__SLASH_Yu)) {
       // Unbundles the fat PCH file for the host.
-      unbundlePCH(UseNewOffloadingDriver, OffloadBuilder.get(),
-                  C, Args, Actions, /*ToolChain=*/nullptr,
+      unbundlePCH(UseNewOffloadingDriver, OffloadBuilder.get(), C, Args,
+                  Actions, /*ToolChain=*/nullptr,
                   UseNewOffloadingDriver ? nullptr : InputArg);
     }
 
     // Use the current host action in any of the offloading actions, if
     // required.
     if (!UseNewOffloadingDriver) {
-      if (OffloadBuilder->addHostDependenceToDeviceActions(
-                              Current, InputArg, Args))
+      if (OffloadBuilder->addHostDependenceToDeviceActions(Current, InputArg,
+                                                           Args))
         break;
     }
 
@@ -7975,10 +7975,10 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
     bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);
     bool isYuArg = Args.hasArg(options::OPT__SLASH_Yu);
     if (isIncludePCHArg || isYuArg) {
-      for (auto *TCAndArch = TCAndArchs.begin();
-           TCAndArch != TCAndArchs.end(); ++TCAndArch) {
-        unbundlePCH(/*Offloading New Driver=*/true, /*Builder=*/nullptr,
-                    C, Args, OffloadActions, TCAndArch->first, nullptr);
+      for (auto *TCAndArch = TCAndArchs.begin(); TCAndArch != TCAndArchs.end();
+           ++TCAndArch) {
+        unbundlePCH(/*Offloading New Driver=*/true, /*Builder=*/nullptr, C,
+                    Args, OffloadActions, TCAndArch->first, nullptr);
       }
     }
 
@@ -8187,8 +8187,8 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
       }
     }
     PackagerActions.push_back(HostAction);
-    Action *PackagerAction = C.MakeAction<OffloadPackagerJobAction>(
-        PackagerActions, types::TY_PCH);
+    Action *PackagerAction =
+       C.MakeAction<OffloadPackagerJobAction>(PackagerActions, types::TY_PCH);
     DDeps.add(*PackagerAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
               nullptr, C.getActiveOffloadKinds());
   } else if (C.isOffloadingHostKind(Action::OFK_SYCL) &&

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6879,43 +6879,6 @@ public:
     return C.MakeAction<OffloadAction>(HDep, DDeps);
   }
 
-  // Unbundle a fat PCH file.
-  void unbundlePCH(Compilation &C, ActionList &AL, DerivedArgList &Args,
-                   const Arg *MainArg) {
-    // This function is modeled after unbundleStaticArchives.
-    if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
-        !Args.hasArg(options::OPT_offload_targets_EQ))
-      return;
-    bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);
-    bool isYuArg = Args.hasArg(options::OPT__SLASH_Yu);
-    assert((isIncludePCHArg || isYuArg) && "Invalid PCH unbundle");
-    SmallString<128> PCHArgValue;
-    if (isIncludePCHArg)
-      PCHArgValue = Args.getLastArg(options::OPT_include_pch)->getValue();
-    else {
-      // /Yu accepts a header file as its argument.
-      PCHArgValue = Args.getLastArg(options::OPT__SLASH_Yu)->getValue();
-      llvm::sys::path::replace_extension(PCHArgValue, "pch");
-    }
-    Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
-                                 Args.MakeArgString(PCHArgValue));
-    Action *A = C.MakeAction<InputAction>(*InputArg, types::TY_PCH);
-    auto UnbundlingHostAction =
-        C.MakeAction<OffloadUnbundlingJobAction>(A, A->getType());
-    UnbundlingHostAction->registerDependentActionInfo(
-        C.getSingleOffloadToolChain<Action::OFK_Host>(),
-        /*BoundArch=*/StringRef(), Action::OFK_Host);
-    addHostDependenceToDeviceActions(A, MainArg, Args);
-    auto PL = types::getCompilationPhases(types::TY_PCH);
-    addDeviceDependencesToHostAction(A, MainArg, phases::Compile, PL.back(),
-                                     PL);
-    AL.push_back(A);
-    OffloadAction::DeviceDependences DDep;
-    DDep.add(*UnbundlingHostAction,
-             *C.getSingleOffloadToolChain<Action::OFK_Host>(), nullptr,
-             C.getActiveOffloadKinds());
-  }
-
   void unbundleStaticArchives(Compilation &C, DerivedArgList &Args) {
     if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false))
       return;
@@ -7151,11 +7114,19 @@ shouldBundleHIPAsmWithNewDriver(const Compilation &C,
   return HasAMDGCNHIPDevice;
 }
   
-static void unbundlePCH(Compilation &C, DerivedArgList &Args, ActionList &AL,
-                        const ToolChain *TC) {
+/// This routine unbundles individual PCH files from a fat PCH bundle.
+/// In the old offloading driver model, this routine invokes the clang
+/// offload bundler; in the new offloading driver model, it invokes the
+/// llvm offload binary.
+static void
+unbundlePCH(bool UseNewOffloadingDriver, OffloadingActionBuilder *OAB,
+            Compilation &C, DerivedArgList &Args, ActionList &AL,
+            const ToolChain *TC, const Arg *MainArg) {
+  // Unbundle a fat PCH file.
   if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
       !Args.hasArg(options::OPT_offload_targets_EQ))
     return;
+
   bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);
   bool isYuArg = Args.hasArg(options::OPT__SLASH_Yu);
   assert((isIncludePCHArg || isYuArg) && "Invalid PCH unbundle");
@@ -7167,13 +7138,32 @@ static void unbundlePCH(Compilation &C, DerivedArgList &Args, ActionList &AL,
     PCHArgValue = Args.getLastArg(options::OPT__SLASH_Yu)->getValue();
     llvm::sys::path::replace_extension(PCHArgValue, "pch");
   }
+
   Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
                                Args.MakeArgString(PCHArgValue));
   Action *A = C.MakeAction<InputAction>(*InputArg, types::TY_PCH);
-  AL.push_back(A);
-  auto UnbundlingHostAction =
-      C.MakeAction<OffloadPackagerExtractJobAction>(AL, A->getType(), TC);
-  AL.push_back(UnbundlingHostAction);
+  if (!UseNewOffloadingDriver) {
+    assert(OAB && "Non-null builder expected in the old offload driver model");
+    auto UnbundlingHostAction =
+        C.MakeAction<OffloadUnbundlingJobAction>(A, A->getType());
+    UnbundlingHostAction->registerDependentActionInfo(
+        C.getSingleOffloadToolChain<Action::OFK_Host>(),
+        /*BoundArch=*/StringRef(), Action::OFK_Host);
+    OAB->addHostDependenceToDeviceActions(A, MainArg, Args);
+    auto PL = types::getCompilationPhases(types::TY_PCH);
+    OAB->addDeviceDependencesToHostAction(A, MainArg, phases::Compile,
+                                          PL.back(), PL);
+    AL.push_back(A);
+    OffloadAction::DeviceDependences DDep;
+    DDep.add(*UnbundlingHostAction,
+             *C.getSingleOffloadToolChain<Action::OFK_Host>(), nullptr,
+             C.getActiveOffloadKinds());
+  } else {
+    AL.push_back(A);
+    auto PackagerAction =
+        C.MakeAction<OffloadPackagerExtractJobAction>(AL, A->getType(), TC);
+    AL.push_back(PackagerAction);
+  }
 }
 
 void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
@@ -7301,10 +7291,9 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     if (Args.hasArg(options::OPT_include_pch) ||
         Args.getLastArg(options::OPT__SLASH_Yu)) {
       // Unbundles the fat PCH file for the host.
-      if (!UseNewOffloadingDriver)
-        OffloadBuilder->unbundlePCH(C, Actions, Args, InputArg);
-      else
-        unbundlePCH(C, Args, Actions, nullptr);
+      unbundlePCH(UseNewOffloadingDriver, OffloadBuilder.get(),
+                  C, Args, Actions, /*ToolChain=*/nullptr,
+                  UseNewOffloadingDriver ? nullptr : InputArg);
     }
 
     // Use the current host action in any of the offloading actions, if
@@ -7985,11 +7974,11 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
     // Unbundle the fat PCH files for the offloading devices.
     bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);
     bool isYuArg = Args.hasArg(options::OPT__SLASH_Yu);
-    SmallString<128> PCHArgValue;
     if (isIncludePCHArg || isYuArg) {
       for (auto *TCAndArch = TCAndArchs.begin();
            TCAndArch != TCAndArchs.end(); ++TCAndArch) {
-        unbundlePCH(C, Args, OffloadActions, TCAndArch->first);
+        unbundlePCH(/*Offloading New Driver=*/true, /*Builder=*/nullptr,
+                    C, Args, OffloadActions, TCAndArch->first, nullptr);
       }
     }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6891,25 +6891,24 @@ public:
     assert((isIncludePCHArg || isYuArg) && "Invalid PCH unbundle");
     SmallString<128> PCHArgValue;
     if (isIncludePCHArg)
-        PCHArgValue = Args.getLastArg(options::OPT_include_pch)->getValue();
+      PCHArgValue = Args.getLastArg(options::OPT_include_pch)->getValue();
     else {
-        // /Yu accepts a header file as its argument.
-        PCHArgValue = Args.getLastArg(options::OPT__SLASH_Yu)->getValue();
-			            PCHArgValue.c_str();
-        llvm::sys::path::replace_extension(PCHArgValue, "pch");
+      // /Yu accepts a header file as its argument.
+      PCHArgValue = Args.getLastArg(options::OPT__SLASH_Yu)->getValue();
+      llvm::sys::path::replace_extension(PCHArgValue, "pch");
     }
     Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
                                  Args.MakeArgString(PCHArgValue));
     Action *A = C.MakeAction<InputAction>(*InputArg, types::TY_PCH);
-    auto UnbundlingHostAction = C.MakeAction<OffloadUnbundlingJobAction>(
-        A, A->getType());
+    auto UnbundlingHostAction =
+        C.MakeAction<OffloadUnbundlingJobAction>(A, A->getType());
     UnbundlingHostAction->registerDependentActionInfo(
-          C.getSingleOffloadToolChain<Action::OFK_Host>(),
-          /*BoundArch=*/StringRef(), Action::OFK_Host);
+        C.getSingleOffloadToolChain<Action::OFK_Host>(),
+        /*BoundArch=*/StringRef(), Action::OFK_Host);
     addHostDependenceToDeviceActions(A, MainArg, Args);
     auto PL = types::getCompilationPhases(types::TY_PCH);
-    addDeviceDependencesToHostAction(A, MainArg, phases::Compile,
-                                     PL.back(), PL);
+    addDeviceDependencesToHostAction(A, MainArg, phases::Compile, PL.back(),
+                                     PL);
     AL.push_back(A);
     OffloadAction::DeviceDependences DDep;
     DDep.add(*UnbundlingHostAction,
@@ -7179,8 +7178,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     }
     for (auto &I : Inputs) {
       std::string SrcFileName(I.second->getAsString(Args));
-      bool isHeaderFile = I.first == types::TY_CHeader ||
-                          I.first == types::TY_CXXHeader;
+      bool IsHeaderFile =
+          I.first == types::TY_CHeader || I.first == types::TY_CXXHeader;
       if ((I.first == types::TY_PP_C || I.first == types::TY_PP_CXX ||
            types::isSrcFile(I.first))) {
         // Unique ID is generated for source files and preprocessed files.
@@ -7197,7 +7196,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       // If we are compiling a header file, the PCH will contain references
       // to the integration header/footer files.  Those files need to be
       // accessible at the time of PCH use, so they cannot be temporary.
-      if (IsSaveTemps || isHeaderFile) {
+      if (IsSaveTemps || IsHeaderFile) {
         TmpFileNameHeader.append(C.getDriver().GetUniquePath(
             OutFileDir.c_str() + StemmedSrcFileName + "-header", "h"));
         TmpFileNameFooter.append(C.getDriver().GetUniquePath(
@@ -7209,32 +7208,23 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
             C.getDriver().GetTemporaryPath(StemmedSrcFileName + "-footer", "h");
       }
       // Also, do not add the integration files to the removal list.
-#if 0
-      const char *TmpFileHeaderName =
-          C.getArgs().MakeArgString(TmpFileNameHeader);
-      const char *TmpFileFooterName =
-          C.getArgs().MakeArgString(TmpFileNameHeader);
-      StringRef TmpFileHeader = isHeaderFile
-	  ? TmpFileHeaderName : C.addTempFile(TmpFileHeaderName);
-      StringRef TmpFileFooter = isHeaderFile
-	  ? TmpFileFooterName : C.addTempFile(TmpFileFooterName);
-#else
-      StringRef TmpFileHeader = isHeaderFile
-	  ? C.getArgs().MakeArgString(TmpFileNameHeader)
-	  : C.addTempFile(C.getArgs().MakeArgString(TmpFileNameHeader));
-      StringRef TmpFileFooter = isHeaderFile
-	  ? C.getArgs().MakeArgString(TmpFileNameFooter)
-	  : C.addTempFile(C.getArgs().MakeArgString(TmpFileNameFooter));
-#endif
+      StringRef TmpFileHeader =
+          IsHeaderFile
+              ? C.getArgs().MakeArgString(TmpFileNameHeader)
+              : C.addTempFile(C.getArgs().MakeArgString(TmpFileNameHeader));
+      StringRef TmpFileFooter =
+          IsHeaderFile
+              ? C.getArgs().MakeArgString(TmpFileNameFooter)
+              : C.addTempFile(C.getArgs().MakeArgString(TmpFileNameFooter));
       // Use of -fsycl-footer-path puts the integration footer into that
       // specified location.
       if (Arg *A = C.getArgs().getLastArg(options::OPT_fsycl_footer_path_EQ)) {
         SmallString<128> OutName(A->getValue());
         llvm::sys::path::append(OutName,
                                 llvm::sys::path::filename(TmpFileNameFooter));
-        TmpFileFooter = isHeaderFile
-            ? C.getArgs().MakeArgString(OutName)
-            : C.addTempFile(C.getArgs().MakeArgString(OutName));
+        TmpFileFooter = IsHeaderFile
+                            ? C.getArgs().MakeArgString(OutName)
+                            : C.addTempFile(C.getArgs().MakeArgString(OutName));
       }
       addIntegrationFiles(TmpFileHeader, TmpFileFooter, SrcFileName);
     }
@@ -7287,8 +7277,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     // Use the current host action in any of the offloading actions, if
     // required.
     if (!UseNewOffloadingDriver) {
-      if (Args.hasArg(options::OPT_include_pch)
-	  || Args.getLastArg(options::OPT__SLASH_Yu))
+      if (Args.hasArg(options::OPT_include_pch) ||
+          Args.getLastArg(options::OPT__SLASH_Yu))
         OffloadBuilder->unbundlePCH(C, Actions, Args, InputArg);
       if (OffloadBuilder->addHostDependenceToDeviceActions(Current, InputArg, Args))
         break;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6879,6 +6879,44 @@ public:
     return C.MakeAction<OffloadAction>(HDep, DDeps);
   }
 
+  // Unbundle a fat PCH file.
+  void unbundlePCH(Compilation &C, ActionList &AL, DerivedArgList &Args,
+                   const Arg *MainArg) {
+    // This function is modeled after unbundleStaticArchives.
+    if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
+        !Args.hasArg(options::OPT_offload_targets_EQ))
+      return;
+    bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);
+    bool isYuArg = Args.hasArg(options::OPT__SLASH_Yu);
+    assert((isIncludePCHArg || isYuArg) && "Invalid PCH unbundle");
+    SmallString<128> PCHArgValue;
+    if (isIncludePCHArg)
+        PCHArgValue = Args.getLastArg(options::OPT_include_pch)->getValue();
+    else {
+        // /Yu accepts a header file as its argument.
+        PCHArgValue = Args.getLastArg(options::OPT__SLASH_Yu)->getValue();
+			            PCHArgValue.c_str();
+        llvm::sys::path::replace_extension(PCHArgValue, "pch");
+    }
+    Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
+                                 Args.MakeArgString(PCHArgValue));
+    Action *A = C.MakeAction<InputAction>(*InputArg, types::TY_PCH);
+    auto UnbundlingHostAction = C.MakeAction<OffloadUnbundlingJobAction>(
+        A, A->getType());
+    UnbundlingHostAction->registerDependentActionInfo(
+          C.getSingleOffloadToolChain<Action::OFK_Host>(),
+          /*BoundArch=*/StringRef(), Action::OFK_Host);
+    addHostDependenceToDeviceActions(A, MainArg, Args);
+    auto PL = types::getCompilationPhases(types::TY_PCH);
+    addDeviceDependencesToHostAction(A, MainArg, phases::Compile,
+                                     PL.back(), PL);
+    AL.push_back(A);
+    OffloadAction::DeviceDependences DDep;
+    DDep.add(*UnbundlingHostAction,
+             *C.getSingleOffloadToolChain<Action::OFK_Host>(), nullptr,
+             C.getActiveOffloadKinds());
+  }
+
   void unbundleStaticArchives(Compilation &C, DerivedArgList &Args) {
     if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false))
       return;
@@ -7141,6 +7179,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     }
     for (auto &I : Inputs) {
       std::string SrcFileName(I.second->getAsString(Args));
+      bool isHeaderFile = I.first == types::TY_CHeader ||
+                          I.first == types::TY_CXXHeader;
       if ((I.first == types::TY_PP_C || I.first == types::TY_PP_CXX ||
            types::isSrcFile(I.first))) {
         // Unique ID is generated for source files and preprocessed files.
@@ -7154,7 +7194,10 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       std::string TmpFileNameHeader;
       std::string TmpFileNameFooter;
       auto StemmedSrcFileName = llvm::sys::path::stem(SrcFileName).str();
-      if (IsSaveTemps) {
+      // If we are compiling a header file, the PCH will contain references
+      // to the integration header/footer files.  Those files need to be
+      // accessible at the time of PCH use, so they cannot be temporary.
+      if (IsSaveTemps || isHeaderFile) {
         TmpFileNameHeader.append(C.getDriver().GetUniquePath(
             OutFileDir.c_str() + StemmedSrcFileName + "-header", "h"));
         TmpFileNameFooter.append(C.getDriver().GetUniquePath(
@@ -7165,17 +7208,33 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
         TmpFileNameFooter =
             C.getDriver().GetTemporaryPath(StemmedSrcFileName + "-footer", "h");
       }
-      StringRef TmpFileHeader =
-          C.addTempFile(C.getArgs().MakeArgString(TmpFileNameHeader));
-      StringRef TmpFileFooter =
-          C.addTempFile(C.getArgs().MakeArgString(TmpFileNameFooter));
+      // Also, do not add the integration files to the removal list.
+#if 0
+      const char *TmpFileHeaderName =
+          C.getArgs().MakeArgString(TmpFileNameHeader);
+      const char *TmpFileFooterName =
+          C.getArgs().MakeArgString(TmpFileNameHeader);
+      StringRef TmpFileHeader = isHeaderFile
+	  ? TmpFileHeaderName : C.addTempFile(TmpFileHeaderName);
+      StringRef TmpFileFooter = isHeaderFile
+	  ? TmpFileFooterName : C.addTempFile(TmpFileFooterName);
+#else
+      StringRef TmpFileHeader = isHeaderFile
+	  ? C.getArgs().MakeArgString(TmpFileNameHeader)
+	  : C.addTempFile(C.getArgs().MakeArgString(TmpFileNameHeader));
+      StringRef TmpFileFooter = isHeaderFile
+	  ? C.getArgs().MakeArgString(TmpFileNameFooter)
+	  : C.addTempFile(C.getArgs().MakeArgString(TmpFileNameFooter));
+#endif
       // Use of -fsycl-footer-path puts the integration footer into that
       // specified location.
       if (Arg *A = C.getArgs().getLastArg(options::OPT_fsycl_footer_path_EQ)) {
         SmallString<128> OutName(A->getValue());
         llvm::sys::path::append(OutName,
                                 llvm::sys::path::filename(TmpFileNameFooter));
-        TmpFileFooter = C.addTempFile(C.getArgs().MakeArgString(OutName));
+        TmpFileFooter = isHeaderFile
+            ? C.getArgs().MakeArgString(OutName)
+            : C.addTempFile(C.getArgs().MakeArgString(OutName));
       }
       addIntegrationFiles(TmpFileHeader, TmpFileFooter, SrcFileName);
     }
@@ -7227,9 +7286,13 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
 
     // Use the current host action in any of the offloading actions, if
     // required.
-    if (!UseNewOffloadingDriver)
+    if (!UseNewOffloadingDriver) {
+      if (Args.hasArg(options::OPT_include_pch)
+	  || Args.getLastArg(options::OPT__SLASH_Yu))
+        OffloadBuilder->unbundlePCH(C, Actions, Args, InputArg);
       if (OffloadBuilder->addHostDependenceToDeviceActions(Current, InputArg, Args))
         break;
+    }
 
     for (phases::ID Phase : PL) {
 
@@ -10144,11 +10207,6 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     }
   }
 
-  // Emit an error if PCH(Pre-Compiled Header) file generation is forced in
-  // -fsycl mode.
-  if (C.getArgs().hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
-      JA.getType() == types::TY_PCH)
-    Diag(clang::diag::err_drv_fsycl_with_pch);
   // As an annoying special case, PCH generation doesn't strip the pathname.
   if (JA.getType() == types::TY_PCH && !IsCLMode()) {
     llvm::sys::path::remove_filename(BasePath);
@@ -10392,8 +10450,9 @@ std::string Driver::GetClPchPath(Compilation &C, StringRef BaseName) const {
   } else {
     if (Arg *YcArg = C.getArgs().getLastArg(options::OPT__SLASH_Yc))
       Output = YcArg->getValue();
-    if (Output.empty())
+    if (Output.empty()) {
       Output = BaseName;
+    }
     llvm::sys::path::replace_extension(Output, ".pch");
   }
   return std::string(Output);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7298,11 +7298,9 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
 
     // Use the current host action in any of the offloading actions, if
     // required.
-    if (!UseNewOffloadingDriver) {
-      if (OffloadBuilder->addHostDependenceToDeviceActions(Current, InputArg,
-                                                           Args))
+    if (!UseNewOffloadingDriver)
+      if (OffloadBuilder->addHostDependenceToDeviceActions(Current, InputArg, Args))
         break;
-    }
 
     for (phases::ID Phase : PL) {
 

--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -1542,6 +1542,8 @@ CreateFileHandler(MemoryBuffer &FirstInput,
     return CreateObjectFileHandler(FirstInput, BundlerConfig);
   if (FilesType == "gch")
     return std::make_unique<BinaryFileHandler>(BundlerConfig);
+  if (FilesType == "pch")
+    return std::make_unique<BinaryFileHandler>(BundlerConfig);
   if (FilesType == "ast")
     return std::make_unique<BinaryFileHandler>(BundlerConfig);
   if (FilesTypeIsArchive(FilesType))

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5768,8 +5768,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // action to determine this.
       if (types::getPreprocessedType(Input.getType()) != types::TY_INVALID &&
           !Header.empty()) {
-        // Add the -include-internal-header option to add the integration
-        // header.
+        // Add the -include-internal-header option to add the integration header
         CmdArgs.push_back("-include-internal-header");
         CmdArgs.push_back(Args.MakeArgString(Header));
         // When creating dependency information, filter out the generated
@@ -5783,8 +5782,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       StringRef Footer = D.getIntegrationFooter(Input.getBaseInput());
       if (types::getPreprocessedType(Input.getType()) != types::TY_INVALID &&
           !Args.hasArg(options::OPT_fno_sycl_use_footer) && !Footer.empty()) {
-        // Add the -include-internal-footer option to add the integration
-        // footer.
+        // Add the -include-internal-footer option to add the integration footer
         CmdArgs.push_back("-include-internal-footer");
         CmdArgs.push_back(Args.MakeArgString(Footer));
         // When creating dependency information, filter out the generated

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10838,8 +10838,8 @@ void OffloadPackagerExtract::ConstructJob(Compilation &C, const JobAction &JA,
   const Action *OffloadAction = Inputs[0].getAction();
   const ToolChain *TC =
       isa<OffloadPackagerExtractJobAction>(JA)
-      ? cast<OffloadPackagerExtractJobAction>(JA).getToolChain()
-      : OffloadAction->getOffloadingToolChain();
+          ? cast<OffloadPackagerExtractJobAction>(JA).getToolChain()
+          : OffloadAction->getOffloadingToolChain();
   if (!TC)
     TC = &C.getDefaultToolChain();
   const ArgList &TCArgs =

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1072,7 +1072,7 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
       // If a PCH file is being used, use the unbundled versions for SYCL.
       if (YuArg && JA.isOffloading(Action::OFK_SYCL))
         PCHHeader = D.getSYCLPrecompiledHeaderFile(
-                        getToolChain().getTriple().getTriple());
+            getToolChain().getTriple().getTriple());
       // If a PCH file is available, include it.
       if (!isa<PrecompileJobAction>(JA)) {
         CmdArgs.push_back("-include-pch");
@@ -1116,8 +1116,7 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
       // files from the fat binary, so use that instead.
       if (JA.isOffloading(Action::OFK_SYCL)) {
         SmallString<128> SYCLPCHFile = D.getSYCLPrecompiledHeaderFile(
-                                           getToolChain().getTriple()
-					       .getTriple());
+            getToolChain().getTriple().getTriple());
         if (D.getVFS().exists(SYCLPCHFile)) {
           P = SYCLPCHFile;
           FoundPCH = true;
@@ -10423,8 +10422,8 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   for (unsigned I = 0; I < Outputs.size(); ++I) {
     SmallString<128> UB;
     UB += "-output=";
-    std::string IFName = DepInfo[I].DependentToolChain->
-                             getInputFilename(Outputs[I]);
+    std::string IFName =
+        DepInfo[I].DependentToolChain->getInputFilename(Outputs[I]);
     UB += IFName;
     CmdArgs.push_back(TCArgs.MakeArgString(UB));
     /* If this is a bundled PCH file, save the triple-filename pair. */

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10837,9 +10837,9 @@ void OffloadPackagerExtract::ConstructJob(Compilation &C, const JobAction &JA,
   ArgStringList CmdArgs;
   const Action *OffloadAction = Inputs[0].getAction();
   const ToolChain *TC =
-      isa<OffloadPackagerExtractJobAction>(JA) ?
-      cast<OffloadPackagerExtractJobAction>(JA).getToolChain() :
-      OffloadAction->getOffloadingToolChain();
+      isa<OffloadPackagerExtractJobAction>(JA)
+      ? cast<OffloadPackagerExtractJobAction>(JA).getToolChain()
+      : OffloadAction->getOffloadingToolChain();
   if (!TC)
     TC = &C.getDefaultToolChain();
   const ArgList &TCArgs =
@@ -10869,9 +10869,9 @@ void OffloadPackagerExtract::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back(Args.MakeArgString("--image=" + llvm::join(Parts, ",")));
 
   if (Inputs[0].getType() == types::TY_PCH) {
-      C.getDriver().addSYCLPrecompiledHeaderFiles(
-          TCArgs.MakeArgString(TC->getTripleString().data()),
-          TCArgs.MakeArgString(File.str()));
+    C.getDriver().addSYCLPrecompiledHeaderFiles(
+        TCArgs.MakeArgString(TC->getTripleString().data()),
+        TCArgs.MakeArgString(File.str()));
   }
 
   C.addCommand(std::make_unique<Command>(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10715,6 +10715,9 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Create the inputs to bundle the needed metadata.
   for (const InputInfo &Input : Inputs) {
+    // Do not bundle input PCH files into anything other than a PCH file.
+    if (Output.getType() != types::TY_PCH && Input.getType() == types::TY_PCH)
+      continue;
     const Action *OffloadAction = Input.getAction();
     const ToolChain *TC = OffloadAction->getOffloadingToolChain();
     if (!TC)
@@ -10835,7 +10838,10 @@ void OffloadPackagerExtract::ConstructJob(Compilation &C, const JobAction &JA,
                                           const char *LinkingOutput) const {
   ArgStringList CmdArgs;
   const Action *OffloadAction = Inputs[0].getAction();
-  const ToolChain *TC = OffloadAction->getOffloadingToolChain();
+  const ToolChain *TC =
+      isa<OffloadPackagerExtractJobAction>(JA) ?
+      cast<OffloadPackagerExtractJobAction>(JA).getToolChain() :
+      OffloadAction->getOffloadingToolChain();
   if (!TC)
     TC = &C.getDefaultToolChain();
   const ArgList &TCArgs =
@@ -10863,6 +10869,12 @@ void OffloadPackagerExtract::ConstructJob(Compilation &C, const JobAction &JA,
       "kind=" + Kind.str(),
   };
   CmdArgs.push_back(Args.MakeArgString("--image=" + llvm::join(Parts, ",")));
+
+  if (Inputs[0].getType() == types::TY_PCH) {
+      C.getDriver().addSYCLPrecompiledHeaderFiles(
+          TCArgs.MakeArgString(TC->getTripleString().data()),
+          TCArgs.MakeArgString(File.str()));
+  }
 
   C.addCommand(std::make_unique<Command>(
       JA, *this, ResponseFileSupport::None(),

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -875,8 +875,6 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
                                     const InputInfo &Output,
                                     const InputInfoList &Inputs) const {
   const bool IsIAMCU = getToolChain().getTriple().isOSIAMCU();
-  bool SYCLDeviceCompilation = JA.isOffloading(Action::OFK_SYCL) &&
-                               JA.isDeviceOffloading(Action::OFK_SYCL);
 
   CheckPreprocessingOptions(D, Args);
 
@@ -1070,15 +1068,17 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
 
     if (YcArg || YuArg) {
       StringRef ThroughHeader = YcArg ? YcArg->getValue() : YuArg->getValue();
-      // If PCH file is available, include it while performing
-      // host compilation (-fsycl-is-host) in SYCL mode (-fsycl).
-      // as well as in non-sycl mode.
-
-      if (!isa<PrecompileJobAction>(JA) && !SYCLDeviceCompilation) {
+      StringRef PCHHeader = ThroughHeader;
+      // If a PCH file is being used, use the unbundled versions for SYCL.
+      if (YuArg && JA.isOffloading(Action::OFK_SYCL))
+        PCHHeader = D.getSYCLPrecompiledHeaderFile(
+                        getToolChain().getTriple().getTriple());
+      // If a PCH file is available, include it.
+      if (!isa<PrecompileJobAction>(JA)) {
         CmdArgs.push_back("-include-pch");
         CmdArgs.push_back(Args.MakeArgString(D.GetClPchPath(
-            C, !ThroughHeader.empty()
-                   ? ThroughHeader
+            C, !PCHHeader.empty()
+                   ? PCHHeader
                    : llvm::sys::path::filename(Inputs[0].getBaseInput()))));
       }
 
@@ -1112,16 +1112,27 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
       if (D.getVFS().exists(P))
         FoundPCH = true;
 
+      // If this is a SYCL compilation, we would have unbundled the PCH
+      // files from the fat binary, so use that instead.
+      if (JA.isOffloading(Action::OFK_SYCL)) {
+        SmallString<128> SYCLPCHFile = D.getSYCLPrecompiledHeaderFile(
+                                           getToolChain().getTriple()
+					       .getTriple());
+        if (D.getVFS().exists(SYCLPCHFile)) {
+          P = SYCLPCHFile;
+          FoundPCH = true;
+        }
+      }
+      if (!FoundPCH && D.getVFS().exists(P))
+        FoundPCH = true;
+
       if (!FoundPCH) {
         // For GCC compat, probe for a file or directory ending in .gch instead.
         llvm::sys::path::replace_extension(P, "gch");
         FoundPCH = gchProbe(D, P.str());
       }
-      // If PCH file is available, include it while performing
-      // host compilation (-fsycl-is-host) in SYCL mode (-fsycl).
-      // as well as in non-sycl mode.
-
-      if (FoundPCH && !SYCLDeviceCompilation) {
+      // If a PCH file is available, include it.
+      if (FoundPCH) {
         if (IsFirstImplicitInclude) {
           A->claim();
           CmdArgs.push_back("-include-pch");
@@ -5687,12 +5698,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-Wno-sycl-strict");
       }
 
-      // Add the integration header option to generate the header.
-      StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
-      if (!Header.empty()) {
-        SmallString<128> HeaderOpt("-fsycl-int-header=");
-        HeaderOpt.append(Header);
-        CmdArgs.push_back(Args.MakeArgString(HeaderOpt));
+      if (!Args.hasArg(options::OPT_fno_sycl_use_header)) {
+        // Add the integration header option to generate the header.
+        StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
+        if (!Header.empty()) {
+          SmallString<128> HeaderOpt("-fsycl-int-header=");
+          HeaderOpt.append(Header);
+          CmdArgs.push_back(Args.MakeArgString(HeaderOpt));
+        }
       }
 
       if (!Args.hasArg(options::OPT_fno_sycl_use_footer)) {
@@ -5760,24 +5773,24 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // integration footer has been applied.  Check for the append job
       // action to determine this.
       if (types::getPreprocessedType(Input.getType()) != types::TY_INVALID &&
-          !Header.empty()) {
-        // Add the -include-internal-header option to add the integration header
+          !Args.hasArg(options::OPT_fno_sycl_use_header) && !Header.empty()) {
+        // Add the -include-internal-header option to add the integration
+        // header.
         CmdArgs.push_back("-include-internal-header");
         CmdArgs.push_back(Args.MakeArgString(Header));
         // When creating dependency information, filter out the generated
         // header file.
         CmdArgs.push_back("-dependency-filter");
         CmdArgs.push_back(Args.MakeArgString(Header));
-
         // Since this is a host compilation and the integration header is
         // included, enable the integration header based diagnostics.
         CmdArgs.push_back("-fsycl-enable-int-header-diags");
       }
-
       StringRef Footer = D.getIntegrationFooter(Input.getBaseInput());
       if (types::getPreprocessedType(Input.getType()) != types::TY_INVALID &&
           !Args.hasArg(options::OPT_fno_sycl_use_footer) && !Footer.empty()) {
-        // Add the -include-internal-footer option to add the integration footer
+        // Add the -include-internal-footer option to add the integration
+        // footer.
         CmdArgs.push_back("-include-internal-footer");
         CmdArgs.push_back(Args.MakeArgString(Footer));
         // When creating dependency information, filter out the generated
@@ -10381,11 +10394,14 @@ void OffloadBundler::ConstructJobMultipleOutputs(
     }
   }
   std::string TargetString(UA.getTargetString());
+  StringRef TargetTriples = Triples;
+  SmallVector<StringRef> Archs;
   if (!TargetString.empty()) {
     // The target string was provided, we will override the defaults and use
     // the string provided.
     SmallString<128> TSTriple("-targets=");
     TSTriple += TargetString;
+    TargetTriples = TargetString;
     CmdArgs.push_back(TCArgs.MakeArgString(TSTriple));
   } else {
     CmdArgs.push_back(TCArgs.MakeArgString(Triples));
@@ -10395,12 +10411,28 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   CmdArgs.push_back(
       TCArgs.MakeArgString(Twine("-input=") + InputFileName));
 
+  /* Save the individual arch triples for PCH. */
+  if (InputType == types::TY_PCH) {
+    auto TripleString = TargetTriples.split('=').second;
+    TripleString.split(Archs, ',');
+    assert(Archs.size() == Outputs.size() &&
+           "expected same number of triples as outputs");
+  }
+
   // Get unbundled files command.
   for (unsigned I = 0; I < Outputs.size(); ++I) {
     SmallString<128> UB;
     UB += "-output=";
-    UB += DepInfo[I].DependentToolChain->getInputFilename(Outputs[I]);
+    std::string IFName = DepInfo[I].DependentToolChain->
+                             getInputFilename(Outputs[I]);
+    UB += IFName;
     CmdArgs.push_back(TCArgs.MakeArgString(UB));
+    /* If this is a bundled PCH file, save the triple-filename pair. */
+    if (InputType == types::TY_PCH) {
+      StringRef ArchName = Archs[I].split('-').second;
+      C.getDriver().addSYCLPrecompiledHeaderFiles(
+          TCArgs.MakeArgString(ArchName), TCArgs.MakeArgString(IFName));
+    }
   }
   CmdArgs.push_back("-unbundle");
   CmdArgs.push_back("-allow-missing-bundles");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5694,14 +5694,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-Wno-sycl-strict");
       }
 
-      if (!Args.hasArg(options::OPT_fno_sycl_use_header)) {
-        // Add the integration header option to generate the header.
-        StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
-        if (!Header.empty()) {
-          SmallString<128> HeaderOpt("-fsycl-int-header=");
-          HeaderOpt.append(Header);
-          CmdArgs.push_back(Args.MakeArgString(HeaderOpt));
-        }
+      // Add the integration header option to generate the header.
+      StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
+      if (!Header.empty()) {
+        SmallString<128> HeaderOpt("-fsycl-int-header=");
+        HeaderOpt.append(Header);
+        CmdArgs.push_back(Args.MakeArgString(HeaderOpt));
       }
 
       if (!Args.hasArg(options::OPT_fno_sycl_use_footer)) {
@@ -5769,7 +5767,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // integration footer has been applied.  Check for the append job
       // action to determine this.
       if (types::getPreprocessedType(Input.getType()) != types::TY_INVALID &&
-          !Args.hasArg(options::OPT_fno_sycl_use_header) && !Header.empty()) {
+          !Header.empty()) {
         // Add the -include-internal-header option to add the integration
         // header.
         CmdArgs.push_back("-include-internal-header");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1109,9 +1109,6 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
       // so that replace_extension does the right thing.
       P += ".dummy";
       llvm::sys::path::replace_extension(P, "pch");
-      if (D.getVFS().exists(P))
-        FoundPCH = true;
-
       // If this is a SYCL compilation, we would have unbundled the PCH
       // files from the fat binary, so use that instead.
       if (JA.isOffloading(Action::OFK_SYCL)) {

--- a/clang/test/Driver/sycl-pch-create.cpp
+++ b/clang/test/Driver/sycl-pch-create.cpp
@@ -1,0 +1,79 @@
+// This test checks that a PCH(Precompiled Header) file is
+// created while performing host and device compilations in
+// -fsycl mode.
+
+// RUN: echo "// Header file" > %t.h
+
+// Linux
+// RUN: %clang -fsycl -x c++-header -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE %s
+// LX_CREATE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE-SAME: "-include-internal-header" "[[HEADER1]]"
+// LX_CREATE-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// LX_CREATE-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE: clang-offload-bundler{{.*}} "-type=pch"
+// LX_CREATE: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
+
+// RUN: %clang -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_TARGETS %s
+// LX_CREATE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_TARGETS-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1]]"{{.*}} "-fsycl-int-footer=[[FOOTER1]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_TARGETS-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_TARGETS-SAME: "-include-internal-header" "[[HEADER1]]"
+// LX_CREATE_TARGETS-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// LX_CREATE_TARGETS-SAME: "-o" "[[PCHFILE3:.+pch]]"
+// LX_CREATE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
+// LX_CREATE_TARGETS: "-targets=sycl-spir64{{.*}},sycl-spir64_gen{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]" "-input=[[PCHFILE3]]"
+
+// RUN: %clang -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_NOHF %s
+// LX_CREATE_NOHF: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_NOHF-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
+// LX_CREATE_NOHF-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_NOHF: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_NOHF-NOT: "-include-internal-header"
+// LX_CREATE_NOHF-NOT: "-include-internal-footer"
+// LX_CREATE_NOHF-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_NOHF: clang-offload-bundler{{.*}} "-type=pch"
+// LX_CREATE_NOHF: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
+
+// Windows
+// RUN: %clang_cl -fsycl -x c++-header %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE %s
+// WS_CREATE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE-SAME: "-include-internal-header" "[[HEADER1]]"
+// WS_CREATE-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// WS_CREATE-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE: clang-offload-bundler{{.*}} "-type=pch"
+// WS_CREATE: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
+
+// RUN: %clang_cl -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_TARGETS %s
+// WS_CREATE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_TARGETS-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1]]"{{.*}} "-fsycl-int-footer=[[FOOTER1]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_TARGETS-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_TARGETS-SAME: "-include-internal-header" "[[HEADER1]]"
+// WS_CREATE_TARGETS-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// WS_CREATE_TARGETS-SAME: "-o" "[[PCHFILE3:.+pch]]"
+// WS_CREATE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
+// WS_CREATE_TARGETS: "-targets=sycl-spir64{{.*}},sycl-spir64_gen{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]" "-input=[[PCHFILE3]]"
+
+// RUN: %clang_cl -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_NOHF %s
+// WS_CREATE_NOHF: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_NOHF-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
+// WS_CREATE_NOHF-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_NOHF: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_NOHF-NOT: "-include-internal-header"
+// WS_CREATE_NOHF-NOT: "-include-internal-footer"
+// WS_CREATE_NOHF-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_NOHF: clang-offload-bundler{{.*}} "-type=pch"
+// WS_CREATE_NOHF: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"

--- a/clang/test/Driver/sycl-pch-create.cpp
+++ b/clang/test/Driver/sycl-pch-create.cpp
@@ -55,28 +55,6 @@
 // LX_CREATE_TARGETS_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
 // LX_CREATE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}" "--image=file=[[PCHFILE3]]{{.*}}"
 
-// RUN: %clang -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_NOHF %s
-// LX_CREATE_NOHF: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
-// LX_CREATE_NOHF-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
-// LX_CREATE_NOHF-SAME: "-o" "[[PCHFILE1:.+pch]]"
-// LX_CREATE_NOHF: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
-// LX_CREATE_NOHF-NOT: "-include-internal-header"
-// LX_CREATE_NOHF-NOT: "-include-internal-footer"
-// LX_CREATE_NOHF-SAME: "-o" "[[PCHFILE2:.+pch]]"
-// LX_CREATE_NOHF: clang-offload-bundler{{.*}} "-type=pch"
-// LX_CREATE_NOHF: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
-
-// RUN: %clang --offload-new-driver -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_NOHF_OND %s
-// LX_CREATE_NOHF_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
-// LX_CREATE_NOHF_OND-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
-// LX_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
-// LX_CREATE_NOHF_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
-// LX_CREATE_NOHF_OND-NOT: "-include-internal-header"
-// LX_CREATE_NOHF_OND-NOT: "-include-internal-footer"
-// LX_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
-// LX_CREATE_NOHF_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
-// LX_CREATE_NOHF_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"
-
 // Windows
 // RUN: %clang_cl -fsycl -x c++-header %t.h -### 2>&1 | FileCheck -check-prefix=WS_CREATE %s
 // WS_CREATE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
@@ -127,25 +105,3 @@
 // WS_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE3:.+pch]]"
 // WS_CREATE_TARGETS_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
 // WS_CREATE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}" "--image=file=[[PCHFILE3]]{{.*}}"
-
-// RUN: %clang_cl -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_NOHF %s
-// WS_CREATE_NOHF: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
-// WS_CREATE_NOHF-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
-// WS_CREATE_NOHF-SAME: "-o" "[[PCHFILE1:.+pch]]"
-// WS_CREATE_NOHF: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
-// WS_CREATE_NOHF-NOT: "-include-internal-header"
-// WS_CREATE_NOHF-NOT: "-include-internal-footer"
-// WS_CREATE_NOHF-SAME: "-o" "[[PCHFILE2:.+pch]]"
-// WS_CREATE_NOHF: clang-offload-bundler{{.*}} "-type=pch"
-// WS_CREATE_NOHF: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
-
-// RUN: %clang_cl --offload-new-driver -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_NOHF_OND %s
-// WS_CREATE_NOHF_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
-// WS_CREATE_NOHF_OND-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
-// WS_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
-// WS_CREATE_NOHF_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
-// WS_CREATE_NOHF_OND-NOT: "-include-internal-header"
-// WS_CREATE_NOHF_OND-NOT: "-include-internal-footer"
-// WS_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
-// WS_CREATE_NOHF_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
-//  WS_CREATE_NOHF_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"

--- a/clang/test/Driver/sycl-pch-create.cpp
+++ b/clang/test/Driver/sycl-pch-create.cpp
@@ -16,7 +16,18 @@
 // LX_CREATE: clang-offload-bundler{{.*}} "-type=pch"
 // LX_CREATE: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
 
-// RUN: %clang -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_TARGETS %s
+// RUN: %clang --offload-new-driver -fsycl -x c++-header -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_OND %s
+// LX_CREATE_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_OND-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_OND-SAME: "-include-internal-header" "[[HEADER1]]"
+// LX_CREATE_OND-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// LX_CREATE_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// LX_CREATE_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"
+
+// RUN: %clang -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h -### 2>&1 | FileCheck -check-prefix=LX_CREATE_TARGETS %s
 // LX_CREATE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
 // LX_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
 // LX_CREATE_TARGETS-SAME: "-o" "[[PCHFILE1:.+pch]]"
@@ -30,6 +41,20 @@
 // LX_CREATE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
 // LX_CREATE_TARGETS: "-targets=sycl-spir64{{.*}},sycl-spir64_gen{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]" "-input=[[PCHFILE3]]"
 
+// RUN: %clang --offload-new-driver -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h -### 2>&1 | FileCheck -check-prefix=LX_CREATE_TARGETS_OND %s
+// LX_CREATE_TARGETS_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_TARGETS_OND-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_TARGETS_OND: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_TARGETS_OND-SAME: "-fsycl-int-header=[[HEADER1]]"{{.*}} "-fsycl-int-footer=[[FOOTER1]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_TARGETS_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_TARGETS_OND-SAME: "-include-internal-header" "[[HEADER1]]"
+// LX_CREATE_TARGETS_OND-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// LX_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE3:.+pch]]"
+// LX_CREATE_TARGETS_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// LX_CREATE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}" "--image=file=[[PCHFILE3]]{{.*}}"
+
 // RUN: %clang -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_NOHF %s
 // LX_CREATE_NOHF: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
 // LX_CREATE_NOHF-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
@@ -41,8 +66,19 @@
 // LX_CREATE_NOHF: clang-offload-bundler{{.*}} "-type=pch"
 // LX_CREATE_NOHF: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
 
+// RUN: %clang --offload-new-driver -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_NOHF_OND %s
+// LX_CREATE_NOHF_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_NOHF_OND-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
+// LX_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_NOHF_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_NOHF_OND-NOT: "-include-internal-header"
+// LX_CREATE_NOHF_OND-NOT: "-include-internal-footer"
+// LX_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_NOHF_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// LX_CREATE_NOHF_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"
+
 // Windows
-// RUN: %clang_cl -fsycl -x c++-header %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE %s
+// RUN: %clang_cl -fsycl -x c++-header %t.h -### 2>&1 | FileCheck -check-prefix=WS_CREATE %s
 // WS_CREATE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
 // WS_CREATE-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
 // WS_CREATE-SAME: "-o" "[[PCHFILE1:.+pch]]"
@@ -52,6 +88,17 @@
 // WS_CREATE-SAME: "-o" "[[PCHFILE2:.+pch]]"
 // WS_CREATE: clang-offload-bundler{{.*}} "-type=pch"
 // WS_CREATE: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
+//
+// RUN: %clang_cl --offload-new-driver -fsycl -x c++-header %t.h -### 2>&1 | FileCheck -check-prefix=WS_CREATE_OND %s
+// WS_CREATE_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_OND-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_OND-SAME: "-include-internal-header" "[[HEADER1]]"
+// WS_CREATE_OND-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// WS_CREATE_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// WS_CREATE_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"
 
 // RUN: %clang_cl -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_TARGETS %s
 // WS_CREATE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
@@ -67,6 +114,20 @@
 // WS_CREATE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
 // WS_CREATE_TARGETS: "-targets=sycl-spir64{{.*}},sycl-spir64_gen{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]" "-input=[[PCHFILE3]]"
 
+// RUN: %clang_cl --offload-new-driver -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_TARGETS_OND %s
+// WS_CREATE_TARGETS_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_TARGETS_OND-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_TARGETS_OND: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_TARGETS_OND-SAME: "-fsycl-int-header=[[HEADER1]]"{{.*}} "-fsycl-int-footer=[[FOOTER1]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_TARGETS_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_TARGETS_OND-SAME: "-include-internal-header" "[[HEADER1]]"
+// WS_CREATE_TARGETS_OND-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// WS_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE3:.+pch]]"
+// WS_CREATE_TARGETS_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// WS_CREATE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}" "--image=file=[[PCHFILE3]]{{.*}}"
+
 // RUN: %clang_cl -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_NOHF %s
 // WS_CREATE_NOHF: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
 // WS_CREATE_NOHF-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
@@ -77,3 +138,14 @@
 // WS_CREATE_NOHF-SAME: "-o" "[[PCHFILE2:.+pch]]"
 // WS_CREATE_NOHF: clang-offload-bundler{{.*}} "-type=pch"
 // WS_CREATE_NOHF: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
+
+// RUN: %clang_cl --offload-new-driver -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_NOHF_OND %s
+// WS_CREATE_NOHF_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_NOHF_OND-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
+// WS_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_NOHF_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_NOHF_OND-NOT: "-include-internal-header"
+// WS_CREATE_NOHF_OND-NOT: "-include-internal-footer"
+// WS_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_NOHF_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+//  WS_CREATE_NOHF_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"

--- a/clang/test/Driver/sycl-pch-error.cpp
+++ b/clang/test/Driver/sycl-pch-error.cpp
@@ -1,19 +1,15 @@
-// This test checks that an error is emitted when 
-// PCH(Precompiled Header) file generation is forced in -fsycl mode.
+// This test checks that an error is emitted when
+// an invalid PCH(Precompiled Header) file is used in -fsycl mode.
 
 // RUN: touch %t.h
 
 // Linux
-// RUN: not %clang -c -fsycl -x c++-header %t.h -###  %s 2> %t1.txt
+// RUN: not %clang -c -fsycl -include-pch %t.h %s 2> %t1.txt
 // RUN: FileCheck %s -input-file=%t1.txt
-// CHECK: precompiled header generation is not supported with '-fsycl'
+// CHECK: input is not a PCH file
 
 // Windows
-// RUN: not %clang_cl -c -fsycl -x c++-header %t.h -### -- %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-ERROR %s
-// CHECK-ERROR: precompiled header generation is not supported with '-fsycl'
-
-// /Yc
-// RUN: not %clang_cl -fsycl /Ycpchfile.h /FIpchfile.h /c -### -- %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-YC %s
-// CHECK-YC: precompiled header generation is not supported with '-fsycl'
+// /Yu
+// RUN: not %clang_cl -fsycl /Yu%t.h /c -- %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-YU %s
+// CHECK-YU: No such file or directory

--- a/clang/test/Driver/sycl-pch-error.cpp
+++ b/clang/test/Driver/sycl-pch-error.cpp
@@ -7,9 +7,16 @@
 // RUN: not %clang -c -fsycl -include-pch %t.h %s 2> %t1.txt
 // RUN: FileCheck %s -input-file=%t1.txt
 // CHECK: input is not a PCH file
+//
+// RUN: not %clang --offload-new-driver -c -fsycl -include-pch %t.h %s 2> %t1.txt
+// RUN: FileCheck -check-prefix=CHECK-OND %s -input-file=%t1.txt
+// CHECK-OND: input is not a PCH file
 
 // Windows
 // /Yu
 // RUN: not %clang_cl -fsycl /Yu%t.h /c -- %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-YU %s
 // CHECK-YU: No such file or directory
+// RUN: not %clang_cl --offload-new-driver -fsycl /Yu%t.h /c -- %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-YU-OND %s
+// CHECK-YU-OND: No such file or directory

--- a/clang/test/Driver/sycl-pch-inlude.cpp
+++ b/clang/test/Driver/sycl-pch-inlude.cpp
@@ -1,5 +1,6 @@
-// This test checks that a PCH(Precompiled Header) file is 
-// included while performing host compilation in -fsycl mode.
+// This test checks that a PCH(Precompiled Header) file is
+// included while performing host and device compilation in
+// -fsycl mode.
 
 // RUN: touch %t.h
 
@@ -11,7 +12,7 @@
 // RUN: %clang -fsycl -include %t.h -###  %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHECK-SYCL-HOST,CHECK-SYCL-DEVICE %s
 // CHECK-SYCL-DEVICE: -fsycl-is-device
-// CHECK-SYCL-DEVICE-NOT: -include-pch
+// CHECK-SYCL-DEVICE-SAME: -include-pch
 // CHECK-SYCL-HOST: -fsycl-is-host
 // CHECK-SYCL-HOST-SAME: -include-pch
 
@@ -20,7 +21,7 @@
 // RUN: %clang -fsycl -include-pch %t.h.gch -###  %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHECK-PCH-HOST,CHECK-PCH-DEVICE %s
 // CHECK-PCH-DEVICE: -fsycl-is-device
-// CHECK-PCH-DEVICE-NOT: -include-pch
+// CHECK-PCH-DEVICE-SAME: -include-pch
 // CHECK-PCH-HOST: -fsycl-is-host
 // CHECK-PCH-HOST-SAME: -include-pch
 
@@ -28,6 +29,6 @@
 // RUN: %clang_cl -fsycl --target=x86_64-unknown-linux-gnu /Yupchfile.h /FIpchfile.h -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHECK-YU-HOST,CHECK-YU-DEVICE %s
 // CHECK-YU-DEVICE: -fsycl-is-device
-// CHECK-YU-DEVICE-NOT: -include-pch 
+// CHECK-YU-DEVICE-SAME: -include-pch
 // CHECK-YU-HOST: -fsycl-is-host
 // CHECK-YU-HOST-SAME: -include-pch

--- a/clang/test/Driver/sycl-pch-use.cpp
+++ b/clang/test/Driver/sycl-pch-use.cpp
@@ -1,0 +1,45 @@
+// This test checks that a PCH(Precompiled Header) file is 
+// used while performing host and device compilations in
+// -fsycl mode.
+
+// RUN: echo "" > %t.h
+// RUN: %clang -c -x c++-header %t.h
+
+// Linux
+// RUN: %clang -fsycl -c -include-pch %t.h.pch %s -### 2>&1 | FileCheck -check-prefix=LX_USE %s
+// LX_USE: clang-offload-bundler{{.*}} "-type=pch"
+// LX_USE-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE1:.+\.pch]]" "-output=[[PCHFILE2:.+\.pch]]" "-unbundle"
+// LX_USE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// LX_USE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_USE-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
+// RUN: %clang -fsycl -c -include-pch %t.h.pch -fsycl-targets=spir64,spir64_gen %s -### 2>&1 | FileCheck -check-prefix=LX_USE_TARGETS %s
+// LX_USE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
+// LX_USE_TARGETS-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}},sycl-spir64_gen{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE3:.+\.pch]]" "-output=[[PCHFILE4:.+\.pch]]" "-output=[[PCHFILE5:.+\.pch]]" "-unbundle"
+// LX_USE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE4]]"{{.*}}
+// LX_USE_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE5]]"{{.*}}
+// LX_USE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+
+// Windows
+// RUN: %clang_cl -fsycl -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE %s
+// WS_USE: clang-offload-bundler{{.*}} "-type=pch"
+// WS_USE-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE1:.+\.pch]]" "-output=[[PCHFILE2:.+\.pch]]" "-unbundle"
+// WS_USE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// WS_USE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
+/ Windows
+// RUN: %clang_cl -fsycl -fsycl-targets=spir64,spir64_gen -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_TARGETS %s
+// WS_USE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
+// WS_USE_TARGETS-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}},sycl-spir64_gen{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE3:.+\.pch]]" "-output=[[PCHFILE4:.+\.pch]]" "-output=[[PCHFILE5:.+\.pch]]" "-unbundle"
+// WS_USE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE4]]"{{.*}}
+// WS_USE_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE5]]"{{.*}}
+// WS_USE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}

--- a/clang/test/Driver/sycl-pch-use.cpp
+++ b/clang/test/Driver/sycl-pch-use.cpp
@@ -14,6 +14,16 @@
 // LX_USE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
 // LX_USE-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
 
+// RUN: %clang --offload-new-driver -fsycl -c -include-pch %t.h.pch %s -### 2>&1 | FileCheck -check-prefix=LX_USE_OND %s
+// LX_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// LX_USE_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
+// LX_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"
+// LX_USE_OND-SAME: "--image=file=[[PCHFILE2:.+\.pch]],triple=spir64{{.*}},arch=generic,kind=sycl"
+// LX_USE_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_OND-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// LX_USE_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_USE_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
 // RUN: %clang -fsycl -c -include-pch %t.h.pch -fsycl-targets=spir64,spir64_gen %s -### 2>&1 | FileCheck -check-prefix=LX_USE_TARGETS %s
 // LX_USE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
 // LX_USE_TARGETS-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}},sycl-spir64_gen{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE3:.+\.pch]]" "-output=[[PCHFILE4:.+\.pch]]" "-output=[[PCHFILE5:.+\.pch]]" "-unbundle"
@@ -24,6 +34,20 @@
 // LX_USE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
 // LX_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
 
+// RUN: %clang --offload-new-driver -fsycl -c -include-pch %t.h.pch -fsycl-targets=spir64,spir64_gen %s -### 2>&1 | FileCheck -check-prefix=LX_USE_TARGETS_OND %s
+// LX_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// LX_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
+// LX_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// LX_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE2:.+\.pch]],triple=spir64{{.*}},arch=generic,kind=sycl"
+// LX_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// LX_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE3:.+\.pch]],triple=spir64_gen{{.*}},arch=generic,kind=sycl"
+// LX_USE_TARGETS_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// LX_USE_TARGETS_OND: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+// LX_USE_TARGETS_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
 // Windows
 // RUN: %clang_cl -fsycl -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE %s
 // WS_USE: clang-offload-bundler{{.*}} "-type=pch"
@@ -33,7 +57,17 @@
 // WS_USE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
 // WS_USE-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
 
-/ Windows
+// RUN: %clang_cl --offload-new-driver -fsycl -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_OND %s
+// WS_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// WS_USE_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
+// WS_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"
+// WS_USE_OND-SAME: "--image=file=[[PCHFILE2:.+\.pch]],triple=spir64{{.*}},arch=generic,kind=sycl"
+// WS_USE_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_OND-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// WS_USE_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
+// Windows
 // RUN: %clang_cl -fsycl -fsycl-targets=spir64,spir64_gen -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_TARGETS %s
 // WS_USE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
 // WS_USE_TARGETS-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}},sycl-spir64_gen{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE3:.+\.pch]]" "-output=[[PCHFILE4:.+\.pch]]" "-output=[[PCHFILE5:.+\.pch]]" "-unbundle"
@@ -43,3 +77,23 @@
 // WS_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE5]]"{{.*}}
 // WS_USE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
 // WS_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+
+// RUN: %clang_cl --offload-new-driver -fsycl -fsycl-targets=spir64,spir64_gen -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_TARGETS_OND %s
+// WS_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// WS_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
+// WS_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"
+// WS_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE2:.+\.pch]],triple=spir64{{.*}},arch=generic,kind=sycl"
+// WS_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"
+// WS_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE3:.+\.pch]],triple=spir64_gen{{.*}},arch=generic,kind=sycl"
+// WS_USE_TARGETS_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// WS_USE_TARGETS_OND: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+// WS_USE_TARGETS_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+// WS_USE_TARGETS_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS_TARGETS-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// WS_USE_TARGETS_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS_TARGETS-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+// WS_USE_TARGETS_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE_TARGETS_TARGETS-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}

--- a/sycl/test/basic_tests/head.hpp
+++ b/sycl/test/basic_tests/head.hpp
@@ -1,0 +1,3 @@
+#include <cassert>
+#include <iostream>
+#include <sycl/sycl.hpp>

--- a/sycl/test/basic_tests/pch.cpp
+++ b/sycl/test/basic_tests/pch.cpp
@@ -11,6 +11,6 @@
 using namespace std;
 int main() {
   sycl::range<3> three_dim_range(64, 1, 2);
-  assert(three_dim_range.size() ==128);
+  assert(three_dim_range.size() == 128);
   cout << "three_dim_range passed " << endl;
 }

--- a/sycl/test/basic_tests/pch.cpp
+++ b/sycl/test/basic_tests/pch.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang -fsycl -c -x c++-header %S/head.hpp -o %S/head.pchi
+// RUN: %clang -fsycl -c -include-pch %S/head.pchi %s
+
+// Verify a PCH file created from the header file can be
+// successfully included in a source file compilation.
+
+// expected-no-diagnostics
+
+#include "head.hpp"
+
+using namespace std;
+int main() {
+  sycl::range<3> three_dim_range(64, 1, 2);
+  assert(three_dim_range.size() ==128);
+  cout << "three_dim_range passed " << endl;
+}

--- a/sycl/test/basic_tests/pch.cpp
+++ b/sycl/test/basic_tests/pch.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang -fsycl -c -x c++-header %S/head.hpp -o %S/head.pchi
-// RUN: %clang -fsycl -c -include-pch %S/head.pchi %s
+// RUN: %clang -fsycl -c -x c++-header %S/head.hpp -o %S/head.pch
+// RUN: %clang -fsycl -c -include-pch %S/head.pch %s
 
 // Verify a PCH file created from the header file can be
 // successfully included in a source file compilation.

--- a/sycl/test/basic_tests/pch.cpp
+++ b/sycl/test/basic_tests/pch.cpp
@@ -1,6 +1,9 @@
 // RUN: %clang -fsycl -c -x c++-header %S/head.hpp -o %S/head.pch
 // RUN: %clang -fsycl -c -include-pch %S/head.pch %s
 
+// RUN: %clang --offload-new-driver -fsycl -c -x c++-header %S/head.hpp -o %S/head.pch
+// RUN: %clang --offload-new-driver -fsycl -c -include-pch %S/head.pch %s
+
 // Verify a PCH file created from the header file can be
 // successfully included in a source file compilation.
 


### PR DESCRIPTION
[SYCL] Add Support for Precompiled Headers
Remove the restriction of using PCH with SYCL.

PCH files can be created with:
``clang -fsycl -c -x c++-header header.h``

This precompiles the header file header.h once for the device
target, and once for the host.  The individual pch files
generated are then bundled to form a fat header.pchi binary.

PCH files can be used with:
``clang -fsycl -c -include-pch header.pchi file.cpp``

This unbundles the fat header.pchi file into its respective
target components and uses the unbundled pchi files in the
device target and host compilations.