### PR TITLE
[SYCL][E2E] Propagate XDG_CACHE_HOME env var in lit.cfg.py

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -121,6 +121,7 @@ llvm_config.with_system_environment(
         "SYCL_DEVICE_ALLOWLIST",
         "SYCL_CONFIG_FILE_NAME",
         "VK_ADD_LAYER_PATH",
+        "XDG_CACHE_HOME",
     ]
 )
 


### PR DESCRIPTION
Add XDG_CACHE_HOME to the list of environment variables propagated from the host environment in sycl/test-e2e/lit.cfg.py. This ensures tests respect the user's XDG cache directory setting.