### PR TITLE
[SYCL][E2E] Disable Memops2D tests on Win DG2

### DIFF
--- a/sycl/test-e2e/USM/memops2d/lit.local.cfg
+++ b/sycl/test-e2e/USM/memops2d/lit.local.cfg
@@ -3,3 +3,7 @@
 # Temporarily disabled until the failure is addressed:
 # https://github.com/llvm/llvm-project/issues/127791
 config.unsupported_features += ['spirv-backend']
+
+# https://github.com/intel/llvm/issues/21501
+if 'windows' in config.available_features:
+   config.unsupported_features += ['gpu-intel-dg2']


### PR DESCRIPTION
Disabling these tests seems to fix the Windows DG2 instability. 

It was previously disabled for similar reasons and re-enabled [here](https://github.com/intel/llvm/pull/20249), but it seems to be sporadically failing again.

GH issue for this https://github.com/intel/llvm/issues/21501