### PR TITLE
[CODEOWNERS] Move `DiagnosticDriverKinds.td` to Driver folks ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@ clang/ @intel/dpcpp-cfe-reviewers
 
 # Clang driver
 clang/**/Driver/ @intel/dpcpp-clang-driver-reviewers
+clang/include/clang/Basic/DiagnosticDriverKinds.td  @intel/dpcpp-clang-driver-reviewers
 
 # Clang tools
 clang-tools-extra/ @intel/dpcpp-cfe-reviewers


### PR DESCRIPTION
It probably doesn't make sense to ask cfe to review driver diagnostics