### PR TITLE
[CI][Bench] Don't build and install "custom" UR in workflow

### DIFF
--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -201,53 +201,6 @@ runs:
       ref: ${{ steps.establish_outputs.outputs.BENCHMARK_RESULTS_BRANCH }}
       path: ${{ steps.establish_outputs.outputs.BENCHMARK_RESULTS_REPO_PATH }}
       persist-credentials: true
-  # Compute-benchmarks relies on UR static libraries, cmake config files, etc.
-  # DPC++ doesn't ship with these files. The easiest way of obtaining these
-  # files is to build from scratch.
-  #
-  # TODO This is not the best place for this. We should come up with
-  # alternatives. A suggestion: Output UR builds as artifacts in ur_build_hw.yml
-  # and unpack it here instead.
-  #
-  # If we insist on not building the UR again, sycl_linux_build.yml can be
-  # modified output the entire sycl build dir as an artifact, in which the
-  # intermediate files required can be stitched together from the build files.
-  # However, this is not exactly "clean" or "fun to maintain"...
-  - name: Clone and build Unified Runtime
-    shell: bash
-    run: |
-      # Clone and build Unified Runtime
-      echo "::group::checkout_llvm_ur"
-
-      # Sparse-checkout UR at build ref:
-      git clone --depth 1 --no-checkout https://github.com/intel/llvm ur
-      cd ur
-      git sparse-checkout init
-      git sparse-checkout set unified-runtime
-      git fetch origin ${{ inputs.build_ref }}
-      git checkout FETCH_HEAD
-
-      echo "::endgroup::"
-      echo "::group::configure_llvm_ur"
-
-      mkdir build install
-      cmake -DCMAKE_BUILD_TYPE=Release \
-        -Sunified-runtime \
-        -Bbuild \
-        -DCMAKE_INSTALL_PREFIX=install \
-        -DUR_BUILD_TESTS=OFF \
-        -DUR_BUILD_ADAPTER_L0=ON \
-        -DUR_BUILD_ADAPTER_L0_V2=ON
-
-      echo "::endgroup::"
-      echo "::group::build_and_install_llvm_ur"
-
-      cmake --build build -j "$(nproc)" 
-      cmake --install build
-
-      cd -
-
-      echo "::endgroup::"
   - name: Install dependencies
     shell: bash
     env:
@@ -345,7 +298,7 @@ runs:
       numactl --cpunodebind "$NUMA_NODE" --membind "$NUMA_NODE" \
       ./devops/scripts/benchmarks/main.py "$BENCH_WORKDIR" \
         --sycl "$(realpath $CMPLR_ROOT)" \
-        --ur "$(realpath ./ur/install)" \
+        --ur "$(realpath $CMPLR_ROOT)" \
         --adapter "$FORCELOAD_ADAPTER" \
         --save "$SAVE_NAME" \
         --output-html remote \

--- a/devops/scripts/benchmarks/benches/compute/compute.py
+++ b/devops/scripts/benchmarks/benches/compute/compute.py
@@ -40,8 +40,8 @@ class ComputeBench(Suite):
         return "https://github.com/intel/compute-benchmarks.git"
 
     def git_hash(self) -> str:
-        # Mar 13, 2026
-        return "0237dade20798127c6432635b47c6bdb2f9d59b0"
+        # Mar 23, 2026
+        return "86d86fd37d703db4f0f75779ccdfd50193e0ab3d"
 
     def setup(self) -> None:
         if options.sycl is None:
@@ -84,7 +84,7 @@ class ComputeBench(Suite):
         if options.ur is not None:
             extra_args += [
                 f"-DBUILD_UR=ON",
-                f"-Dunified-runtime_DIR={options.ur}/lib/cmake/unified-runtime",
+                f"-DCMAKE_PREFIX_PATH={options.ur}",
             ]
 
         self._project.configure(extra_args, add_sycl=True)


### PR DESCRIPTION
Reuse already built SYCL instead. From time to time this was causing issues of mismatched SYCL and UR.
We've built UR on our own, as there's no UR's cmake files delivered in the "toolchain".
We fixed that on Compute Benchmarks side so now just ur libs and headers are required.