### PR TITLE
[SYCL][E2E] bump used CUDA shader model to 75

### DIFF
--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -O3 -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
+// RUN: %{build} -O3 -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // NOTE: Tests fetch_add for acquire and release memory ordering.

--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -O3 -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
+// RUN: %{build} -O3 -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 #include "atomic_memory_order.h"

--- a/sycl/test-e2e/GroupAlgorithm/root_group.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/root_group.cpp
@@ -2,7 +2,7 @@
 // XFAIL: (opencl && !cpu)
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/14641
 
-// RUN: %{build} -I . -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
+// RUN: %{build} -I . -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // Disabled temporarily while investigation into the failure is ongoing.

--- a/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm70.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm70.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: target-nvidia
-// RUN: %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_70 -o %t.out
+// RUN: %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_75 -o %t.out
 // RUN: %{run} %t.out
 //
 // This tests the unified matrix extension interfaces for the cuda backend.

--- a/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm72.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_tensorcores_sm72.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: target-nvidia
-// RUN: %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_72 -o %t.out
+// RUN: %{build} -Xsycl-target-backend --cuda-gpu-arch=sm_75 -o %t.out
 // RUN: %{run} %t.out
 //
 // This tests the unified matrix extension interfaces for the cuda backend.

--- a/sycl/test-e2e/Reduction/reduction_range_1d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_dw.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -DENABLE_64_BIT=false -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -DENABLE_64_BIT=false -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 #include "reduction_utils.hpp"

--- a/sycl/test-e2e/Reduction/reduction_range_1d_dw_64bit.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_dw_64bit.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -DENABLE_64_BIT=true -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -DENABLE_64_BIT=true -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 #include "reduction_range_1d_dw.cpp"

--- a/sycl/test-e2e/Reduction/reduction_range_1d_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_reducer_skip.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // This test performs basic checks of parallel_for(range<1>, reduction, func)

--- a/sycl/test-e2e/Reduction/reduction_range_1d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_rw.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // This test performs basic checks of parallel_for(range<1>, reduction, func)

--- a/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // This test performs basic checks of parallel_for(range<2>, reduction, func)

--- a/sycl/test-e2e/Reduction/reduction_range_2d_dw_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_dw_reducer_skip.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // This test performs basic checks of parallel_for(range<2>, reduction, func)

--- a/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // This test performs basic checks of parallel_for(range<2>, reduction, func)

--- a/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // This test performs basic checks of parallel_for(range<3>, reduction, func)

--- a/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // This test performs basic checks of parallel_for(range<3>, reduction, func)

--- a/sycl/test-e2e/Reduction/reduction_range_3d_rw_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_rw_reducer_skip.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 // This test performs basic checks of parallel_for(range<3>, reduction, func)

--- a/sycl/test-e2e/Reduction/reduction_range_usm_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_usm_dw.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
+// RUN: %{build} -o %t.out %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %}
 // RUN: %{run} %t.out
 
 #include "reduction_utils.hpp"

--- a/sycl/test-e2e/USM/P2P/p2p_atomics.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_atomics.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: cuda || hip || level_zero
-// RUN:  %{build} %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_61 %} -o %t.out
+// RUN:  %{build} %if target-nvidia %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75 %} -o %t.out
 // RUN:  %{run} %t.out
 
 #include <cassert>


### PR DESCRIPTION
Bump the CUDA shader model to 75. 
This is required to run these tests on the CUDA 13 driver, where SM_75 is the lowest supported shader model.
