### PR TITLE
[SYCL][UR][E2E] Use the new cuCtxCreate for CUDA 13 in tests

### DIFF
--- a/sycl/test-e2e/Adapters/interop-cuda-experimental.cpp
+++ b/sycl/test-e2e/Adapters/interop-cuda-experimental.cpp
@@ -88,7 +88,11 @@ int main() {
   // Create new context
   CUcontext curr_ctx, cu_ctx;
   CUDA_CHECK(cuCtxGetCurrent(&curr_ctx));
+#if CUDA_VERSION >= 13000
+  CUDA_CHECK(cuCtxCreate(&cu_ctx, nullptr, CU_CTX_MAP_HOST, cu_dev));
+#else
   CUDA_CHECK(cuCtxCreate(&cu_ctx, CU_CTX_MAP_HOST, cu_dev));
+#endif
   CUDA_CHECK(cuCtxSetCurrent(curr_ctx));
 
   auto sycl_ctx = sycl::make_context<sycl::backend::ext_oneapi_cuda>(cu_ctx);

--- a/unified-runtime/test/adapters/cuda/context_tests.cpp
+++ b/unified-runtime/test/adapters/cuda/context_tests.cpp
@@ -46,7 +46,12 @@ TEST_P(cudaUrContextCreateTest, CreateWithChildThread) {
 TEST_P(cudaUrContextCreateTest, ContextLifetimeExisting) {
   // start by setting up a CUDA context on the thread
   CUcontext original;
+#if CUDA_VERSION >= 13000
+  ASSERT_SUCCESS_CUDA(
+      cuCtxCreate(&original, nullptr, CU_CTX_MAP_HOST, device->get()));
+#else
   ASSERT_SUCCESS_CUDA(cuCtxCreate(&original, CU_CTX_MAP_HOST, device->get()));
+#endif
 
   // ensure the CUDA context is active
   CUcontext current = nullptr;


### PR DESCRIPTION
CUDA 12.x introduces the new `params` argument in `cuCtxCreate(pctx, params, flags, dev)`, and this version of `cuCtxCreate` becomes the default entry point starting with CUDA 13