### PR TITLE
[SYCL][E2E] disable e2e root_group test on CUDA

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/root_group.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/root_group.cpp
@@ -11,6 +11,10 @@
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
 
+// Fails on CUDA 13, enable when fixed.
+// XFAIL: target-nvidia
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21525
+
 #include <cassert>
 #include <cstdlib>
 #include <type_traits>


### PR DESCRIPTION
Disable e2e root_group test on CUDA - it fails on CUDA 13.
Tracker: https://github.com/intel/llvm/issues/21525
