### PR TITLE
[SYCL][Graph][E2E] Disable flaky graph update + host task tests

### DIFF
--- a/sycl/test-e2e/Graph/Update/Explicit/whole_update_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Update/Explicit/whole_update_host_task_accessor.cpp
@@ -6,7 +6,7 @@
 // XFAIL: arch-intel_gpu_ptl_u || arch-intel_gpu_ptl_h || arch-intel_gpu_wcl
 // XFAIL-TRACKER: CMPLRTST-27275
 // XFAIL-TRACKER: CMPLRLLVM-72055
-// XFAIL-TRACKER: GSD-12323
+// XFAIL-TRACKER: CMPLRTST-28665
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_host_task_accessor.cpp
@@ -6,7 +6,7 @@
 // XFAIL: arch-intel_gpu_ptl_u || arch-intel_gpu_ptl_h || arch-intel_gpu_wcl
 // XFAIL-TRACKER: CMPLRTST-27275
 // XFAIL-TRACKER: CMPLRLLVM-72055
-// XFAIL-TRACKER: GSD-12323
+// XFAIL-TRACKER: CMPLRTST-28665
 
 #define GRAPH_E2E_RECORD_REPLAY
 


### PR DESCRIPTION
These tests were failing on Windows. Now they are starting to fail in a flaky way on Linux as well.