### PR TITLE
[UR][CMake] Fix detection of preinstalled OpenCL

### DIFF
--- a/unified-runtime/cmake/FetchOpenCL.cmake
+++ b/unified-runtime/cmake/FetchOpenCL.cmake
@@ -5,18 +5,6 @@ if(TARGET OpenCL)
   return()
 endif()
 
-# Repo URLs
-
-set(OCL_HEADERS_REPO
-  "https://github.com/KhronosGroup/OpenCL-Headers.git")
-set(OCL_LOADER_REPO
-  "https://github.com/KhronosGroup/OpenCL-ICD-Loader.git")
-
-# Repo tags/hashes
-
-set(OCL_HEADERS_TAG v2025.07.22)
-set(OCL_LOADER_TAG v2025.07.22)
-
 # We have a unique use case where even if we find a system install with the
 # correct OpenCL version, it may not support the extension we need.
 # We can't use find_package because that doesn't allow us to undefine targets if it
@@ -57,46 +45,46 @@ if(OpenCL_INCLUDE_DIR AND
     add_library(OpenCL INTERFACE)
     target_include_directories(OpenCL INTERFACE ${OpenCL_INCLUDE_DIR})
     target_link_libraries(OpenCL INTERFACE ${OpenCL_LIBRARY_CAND})
-    # Signal to callers that we are using a system OpeNCL install so OpenCL
+    # Signal to callers that we are using a system OpenCL install so OpenCL
     # doesn't need to be installed as part of their install step.
     set(OpenCL_FOUND TRUE CACHE BOOL "" FORCE)
+  else()
+    # Remove the system include set from find_path now that we decided
+    # the system install is not suitable.
+    set(OpenCL_INCLUDE_DIR "")
   endif()
 endif()
 
-# OpenCL Headers
+# If we can't use the system OpenCL install, build it ourselves.
 if(NOT TARGET OpenCL)
+  # Repo URLs
+  set(OCL_HEADERS_REPO
+    "https://github.com/KhronosGroup/OpenCL-Headers.git")
+  set(OCL_LOADER_REPO
+    "https://github.com/KhronosGroup/OpenCL-ICD-Loader.git")
+
+  # Repo tags/hashes
+  set(OCL_HEADERS_TAG v2025.07.22)
+  set(OCL_LOADER_TAG v2025.07.22)
+
+  # OpenCL Headers
   FetchContent_Declare(ocl-headers
       GIT_REPOSITORY    ${OCL_HEADERS_REPO}
       GIT_TAG           ${OCL_HEADERS_TAG}
   )
   FetchContent_GetProperties(ocl-headers)
-
-  if(NOT ocl-headers_POPULATED)
-    message(STATUS "Will fetch OpenCL headers from ${OCL_HEADERS_REPO}")
-  endif()
   FetchContent_MakeAvailable(ocl-headers)
   set(OpenCL_INCLUDE_DIR ${ocl-headers_SOURCE_DIR} CACHE PATH "" FORCE)
-else()
-  message(STATUS "Using OpenCL headers at ${OpenCL_INCLUDE_DIR}")
-endif()
 
-# OpenCL Library (ICD Loader)
+  set(BUILD_SHARED_LIBS ON)
 
-set(BUILD_SHARED_LIBS ON)
-
-if(NOT TARGET OpenCL)
+  # OpenCL ICD Loader
   FetchContent_Declare(ocl-icd
       GIT_REPOSITORY    ${OCL_LOADER_REPO}
       GIT_TAG           ${OCL_LOADER_TAG}
   )
   FetchContent_GetProperties(ocl-icd)
-  if(NOT ocl-icd_POPULATED)
-    message(STATUS "Will fetch OpenCL ICD Loader from ${OCL_LOADER_REPO}")
-  endif()
   FetchContent_MakeAvailable(ocl-icd)
-else()
-  message(STATUS
-    "Using OpenCL ICD Loader at ${OpenCL_LIBRARY}")
 endif()
 
 add_library(OpenCL-Headers INTERFACE)
@@ -104,3 +92,12 @@ target_include_directories(OpenCL-Headers INTERFACE ${OpenCL_INCLUDE_DIR})
 target_compile_definitions(OpenCL-Headers INTERFACE -DCL_TARGET_OPENCL_VERSION=300 -DCL_USE_DEPRECATED_OPENCL_1_2_APIS=1)
 
 set(OpenCL_LIBRARY OpenCL CACHE PATH "" FORCE)
+
+if(OpenCL_FOUND)
+  get_target_property(OpenCL_LIBRARY_DIR OpenCL INTERFACE_LINK_LIBRARIES)
+  message(STATUS "Using OpenCL headers at ${OpenCL_INCLUDE_DIR}")
+  message(STATUS "Using OpenCL ICD Loader at ${OpenCL_LIBRARY_DIR}")
+else()
+  message(STATUS "Will fetch OpenCL headers from ${OCL_HEADERS_REPO}")
+  message(STATUS "Will fetch OpenCL ICD Loader from ${OCL_LOADER_REPO}")
+endif()


### PR DESCRIPTION
There were a couple problems with the OpenCL detection.

1) System install detection didn't work because I had to add the `NO_CMAKE_PACKAGE_REGISTRY` argument to `find_package` to prevent it finding the `FetchContent` checkout on subsequent calls. This CMake module is called at least twice, one for `opencl-aot` and once for the UR OpenCL adapter.

2) If we remove `NO_CMAKE_PACKAGE_REGISTRY` to fix system install detection, then we hit a problem where if there is a system install, but it fails the `check_cxx_source_compiles` check because it doesn't support `cl_khr_spirv_queries`, we had no way to not use the system install it found, so we can't use `find_package` at all. Use `find_path` and `find_library`, whcih is what `find_package(OpenCL)` does internally anyway. Those two functions have nice validator functions we can use that do exactly what we need, to determine if the found OpenCL install is suitable, and if not, don't use it. However, this function is only available with CMake 3.25 (released in 2022) or later, and we currently require `3.20`, but I think saying we don't support system installs with older CMake is reasonable, it still fetches and builds OpenCL from upstream fine.


Also do some minor cleanup like making sure there is always a target named `OpenCL` that callers can rely on.

Tested the following 3 cases manually:
a) No system OpenCL install
b) System OpenCL install that's too old
c) Working system OpenCL install
and all work as expected.

Closes: https://github.com/intel/llvm/issues/21513


