### PR TITLE
Revert "[libspirv] Fix ptx bindless image builtins to be Itanium-compliant"

### DIFF
--- a/libclc/libspirv/lib/ptx-nvidiacl/images/image.cl
+++ b/libclc/libspirv/lib/ptx-nvidiacl/images/image.cl
@@ -4326,35 +4326,13 @@ _CLC_DEFINE_TEXTURE_ARRAY_BINDLESS_THUNK_READS_BUILTIN(half, float, f16,
 #define MANGLE_FUNC_IMG_HANDLE_HELPER(size, name, prefix, postfix)             \
   MANGLE_FUNC_IMG_HANDLE(size, name, prefix, postfix)
 
-// Per spec: coords are always int (1D) or vec2<int> (2D) for fetch/write.
-// Coord type depends ONLY on dimension, not on return element type.
-#define FETCH_COORD_1 iET_T0_T1_i
-#define FETCH_COORD_2 Dv2_iET_T0_T1_i
-// Parametric macros for most cases: coord type depends only on dimension.
-#define FETCH_COORD_1_1_(e) FETCH_COORD_1
-#define FETCH_COORD_1_2_(e) FETCH_COORD_2
-#define FETCH_COORD_2_1_(e) FETCH_COORD_1
-#define FETCH_COORD_4_1_(e) FETCH_COORD_1
-#define FETCH_COORD_4_2_(e) FETCH_COORD_2
-// Special case: vec_size=2, dimension=2, uses indirection for Itanium ABI S0_.
-// S0_ substitution when return type also vec2<int>.
-#define FETCH_COORD_2_2_(e) FETCH_COORD_2_2_##e
-#define FETCH_COORD_2_2_i S0_ET_T0_T1_i
-#define FETCH_COORD_2_2_j FETCH_COORD_2
-#define FETCH_COORD_2_2_s FETCH_COORD_2
-#define FETCH_COORD_2_2_t FETCH_COORD_2
-#define FETCH_COORD_2_2_a FETCH_COORD_2
-#define FETCH_COORD_2_2_h FETCH_COORD_2
-#define FETCH_COORD_2_2_f FETCH_COORD_2
-#define FETCH_COORD_2_2_Dh FETCH_COORD_2
-
 #define _CLC_DEFINE_IMAGE_ARRAY_BINDLESS_READ_BUILTIN(                         \
     elem_t, vec_size, dimension, ocl_elem_t_mangled, nvvm_elem_t_mangled,      \
     elem_t_size)                                                               \
   _CLC_DEF ELEM_VEC_##vec_size(elem_t) MANGLE_FUNC_IMG_HANDLE_HELPER(          \
       23, __spirv_ImageArrayFetch,                                             \
       DVEC_SIZE_##vec_size(I, ocl_elem_t_mangled, ),                           \
-      CONCAT(FETCH_COORD_##vec_size##_##dimension, _(ocl_elem_t_mangled)))(    \
+      DVEC_SIZE_##dimension(, i, ET_T0_T1_i))(                                 \
       ulong imageHandle, COORD_INPUT_##dimension##D(int), int idx) {           \
     return NVVM_FUNC(suld, dimension,                                          \
                      VEC_SIZE_##vec_size(nvvm_elem_t_mangled, elem_t_size))(   \
@@ -4362,32 +4340,12 @@ _CLC_DEFINE_TEXTURE_ARRAY_BINDLESS_THUNK_READS_BUILTIN(half, float, f16,
         COORD_PARAMS_##dimension##D(ELEM_VEC_##vec_size(elem_t)));             \
   }
 
-// Itanium C++ ABI: vec2 coord with vec2 color -> S0_ (only when types match!).
-// All cases use DVEC_SIZE_, except special case: dim=2, vec_size=2, mangled=i.
-#define WRITE_COLOR(vec_size, mangled)                                         \
-  DVEC_SIZE_##vec_size(, mangled, EvT_T0_iT1_)
-#define WRITE_COLOR_1_1_(e) WRITE_COLOR(1, e)
-#define WRITE_COLOR_1_2_(e) WRITE_COLOR(2, e)
-#define WRITE_COLOR_1_4_(e) WRITE_COLOR(4, e)
-#define WRITE_COLOR_2_1_(e) WRITE_COLOR(1, e)
-#define WRITE_COLOR_2_4_(e) WRITE_COLOR(4, e)
-// Special case: vec_size=2, dim=2, uses indirection to handle 'i' differently.
-#define WRITE_COLOR_2_2_(e) WRITE_COLOR_2_2_##e
-#define WRITE_COLOR_2_2_i S0_EvT_T0_iT1_
-#define WRITE_COLOR_2_2_j WRITE_COLOR(2, j)
-#define WRITE_COLOR_2_2_s WRITE_COLOR(2, s)
-#define WRITE_COLOR_2_2_t WRITE_COLOR(2, t)
-#define WRITE_COLOR_2_2_a WRITE_COLOR(2, a)
-#define WRITE_COLOR_2_2_h WRITE_COLOR(2, h)
-#define WRITE_COLOR_2_2_f WRITE_COLOR(2, f)
-#define WRITE_COLOR_2_2_Dh WRITE_COLOR(2, Dh)
-
 #define _CLC_DEFINE_IMAGE_ARRAY_BINDLESS_WRITE_BUILTIN(                        \
     elem_t, vec_size, dimension, elem_t_mangled, write_mangled, elem_t_size)   \
   _CLC_DEF void MANGLE_FUNC_IMG_HANDLE_HELPER(                                 \
       23, __spirv_ImageArrayWrite, I,                                          \
       CONCAT(DVEC_SIZE_##dimension(, i, ),                                     \
-             WRITE_COLOR_##dimension##_##vec_size##_(elem_t_mangled)))(        \
+             DVEC_SIZE_##vec_size(, elem_t_mangled, EvT_T0_iT1_)))(            \
       ulong imageHandle, COORD_INPUT_##dimension##D(int), int idx,             \
       ELEM_VEC_##vec_size(elem_t) c) {                                         \
     NVVM_FUNC(sust, dimension,                                                 \
@@ -4449,35 +4407,13 @@ _CLC_DEFINE_IMAGE_ARRAY_BINDLESS_BUILTIN_ALL(half, Dh, f, 16)
 #define _NVVM_FUNC(name, dimension, vec_size_mangled)                          \
   __nvvm_##name##_##dimension##d_array_##vec_size_mangled
 
-// Per spec: sampled read coords are always float (1D) or vec2<float> (2D).
-// Coord type depends ONLY on dimension, not on return element type.
-#define READ_COORD_1 fET_T0_T1_i
-#define READ_COORD_2 Dv2_fET_T0_T1_i
-// Parametric macros for most cases: coord type depends only on dimension.
-#define READ_COORD_1_1_(e) READ_COORD_1
-#define READ_COORD_1_2_(e) READ_COORD_2
-#define READ_COORD_2_1_(e) READ_COORD_1
-#define READ_COORD_4_1_(e) READ_COORD_1
-#define READ_COORD_4_2_(e) READ_COORD_2
-// Special case: vec_size=2, dimension=2, uses indirection for Itanium ABI S0_.
-// S0_ substitution when return type also vec2<float>.
-#define READ_COORD_2_2_(e) READ_COORD_2_2_##e
-#define READ_COORD_2_2_i READ_COORD_2
-#define READ_COORD_2_2_j READ_COORD_2
-#define READ_COORD_2_2_s READ_COORD_2
-#define READ_COORD_2_2_t READ_COORD_2
-#define READ_COORD_2_2_a READ_COORD_2
-#define READ_COORD_2_2_h READ_COORD_2
-#define READ_COORD_2_2_f S0_ET_T0_T1_i
-#define READ_COORD_2_2_Dh READ_COORD_2
-
 #define _CLC_DEFINE_SAMPLED_IMAGE_ARRAY_BINDLESS_READ_BUILTIN(                 \
     elem_t, vec_size, dimension, ocl_elem_t_mangled, nvvm_elem_t_mangled,      \
     elem_t_size)                                                               \
   _CLC_DEF ELEM_VEC_##vec_size(elem_t) MANGLE_FUNC_IMG_HANDLE_HELPER(          \
       22, __spirv_ImageArrayRead,                                              \
       DVEC_SIZE_##vec_size(I, ocl_elem_t_mangled, ),                           \
-      CONCAT(READ_COORD_##vec_size##_##dimension, _(ocl_elem_t_mangled)))(     \
+      DVEC_SIZE_##dimension(, f, ET_T0_T1_i))(                                 \
       ulong imageHandle, COORD_INPUT_##dimension##D(float), int idx) {         \
     return NVVM_FUNC(                                                          \
         tex_unified, dimension,                                                \
@@ -4486,14 +4422,13 @@ _CLC_DEFINE_IMAGE_ARRAY_BINDLESS_BUILTIN_ALL(half, Dh, f, 16)
         COORD_PARAMS_##dimension##D(ELEM_VEC_##vec_size(elem_t)));             \
   }
 
-// SampledImageArrayFetch uses same (int) coord mangling as ImageArrayFetch.
 #define _CLC_DEFINE_SAMPLED_IMAGE_ARRAY_BINDLESS_FETCH_BUILTIN(                \
     elem_t, vec_size, dimension, ocl_elem_t_mangled, nvvm_elem_t_mangled,      \
     elem_t_size)                                                               \
   _CLC_DEF ELEM_VEC_##vec_size(elem_t) MANGLE_FUNC_IMG_HANDLE_HELPER(          \
       30, __spirv_SampledImageArrayFetch,                                      \
       DVEC_SIZE_##vec_size(I, ocl_elem_t_mangled, ),                           \
-      CONCAT(FETCH_COORD_##vec_size##_##dimension, _(ocl_elem_t_mangled)))(    \
+      DVEC_SIZE_##dimension(, i, ET_T0_T1_i))(                                 \
       ulong imageHandle, COORD_INPUT_##dimension##D(int), int idx) {           \
     return NVVM_FUNC(                                                          \
         tex_unified, dimension,                                                \


### PR DESCRIPTION
Reverts intel/llvm#21466

It caused new build fail:
Unable to demangle name: _Z23__spirv_ImageArrayFetchIDv2_cmFETCH_COORD_2_2_c