### PR TITLE
[UR][CUDA] add UR_CONFORMANCE_NVIDIA_ARCH option to set shader model for NVIDIA CTS

### DIFF
--- a/unified-runtime/CMakeLists.txt
+++ b/unified-runtime/CMakeLists.txt
@@ -67,6 +67,7 @@ set(UR_SYCL_LIBRARY_DIR "" CACHE PATH
 set(UR_CONFORMANCE_TARGET_TRIPLES "" CACHE STRING
     "List of sycl targets to build CTS device binaries for")
 set(UR_CONFORMANCE_AMD_ARCH "" CACHE STRING "AMD device target ID to build CTS binaries for")
+set(UR_CONFORMANCE_NVIDIA_ARCH "" CACHE STRING "NVIDIA shader model to build CTS binaries for")
 set(UR_CONFORMANCE_SELECTOR "" CACHE STRING "If nonempty, the device selector for conformance tests")
 option(UR_USE_DEBUG_POSTFIX "Enable debug postfix 'd' for libraries" OFF)
 set(UR_ADAPTER_LEVEL_ZERO_SOURCE_DIR "" CACHE PATH

--- a/unified-runtime/README.md
+++ b/unified-runtime/README.md
@@ -128,6 +128,7 @@ List of options provided by CMake:
 | UR_ENABLE_SANITIZER | Enable device sanitizer layer | ON/OFF | ON |
 | UR_CONFORMANCE_TARGET_TRIPLES | SYCL triples to build CTS device binaries for | Comma-separated list | spir64 |
 | UR_CONFORMANCE_AMD_ARCH | AMD device target ID to build CTS binaries for | string | `""` |
+| UR_CONFORMANCE_NVIDIA_ARCH | NVIDIA shader model to build CTS binaries for | string | `""` |
 | UR_CONFORMANCE_SELECTOR | `ONEAPI_DEVICE_SELECTOR` for conformance testing | string | All enabled adapters |
 | UR_BUILD_ADAPTER_L0     | Build the Level-Zero adapter            | ON/OFF     | OFF     |
 | UR_BUILD_ADAPTER_OPENCL | Build the OpenCL adapter                | ON/OFF     | OFF     |

--- a/unified-runtime/test/conformance/device_code/CMakeLists.txt
+++ b/unified-runtime/test/conformance/device_code/CMakeLists.txt
@@ -68,13 +68,17 @@ macro(add_device_binary SOURCE_FILE)
         set(BIN_PATH "${DEVICE_BINARY_DIR}/${TRIPLE}.bin.0")
 
         if(${TRIPLE} MATCHES "amd")
-            set(AMD_TARGET_BACKEND -Xsycl-target-backend=${TRIPLE})
-            set(AMD_OFFLOAD_ARCH  --offload-arch=${AMD_ARCH})
-            set(AMD_NOGPULIB -nogpulib)
+            set(TARGET_BACKEND -Xsycl-target-backend=${TRIPLE})
+            set(TARGET_ARCH  --offload-arch=${AMD_ARCH})
+            set(TARGET_NOGPULIB -nogpulib)
+        elseif(${TRIPLE} MATCHES "nvptx" AND NOT "${UR_CONFORMANCE_NVIDIA_ARCH}" STREQUAL "")
+            set(TARGET_BACKEND -Xsycl-target-backend=${TRIPLE})
+            set(TARGET_ARCH --cuda-gpu-arch=${UR_CONFORMANCE_NVIDIA_ARCH})
+            set(TARGET_NOGPULIB)
         else()
-            set(AMD_TARGET_BACKEND)
-            set(AMD_OFFLOAD_ARCH)
-            set(AMD_NOGPULIB)
+            set(TARGET_BACKEND)
+            set(TARGET_ARCH)
+            set(TARGET_NOGPULIB)
         endif()
         # images are not yet supported in sycl on AMD
         if(${TRIPLE} MATCHES "amd" AND ${KERNEL_NAME} MATCHES "image_copy")
@@ -107,8 +111,8 @@ macro(add_device_binary SOURCE_FILE)
         add_custom_command(OUTPUT ${BIN_PATH}
             COMMAND LD_LIBRARY_PATH=${UR_SYCL_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH} 
             ${UR_FOUND_DPCXX} -fsycl -fsycl-targets=${TRIPLE}
-            -fsycl-device-code-split=off ${AMD_TARGET_BACKEND}
-            ${AMD_OFFLOAD_ARCH} ${AMD_NOGPULIB} ${DPCXX_BUILD_FLAGS_LIST}
+            -fsycl-device-code-split=off ${TARGET_BACKEND}
+            ${TARGET_ARCH} ${TARGET_NOGPULIB} ${DPCXX_BUILD_FLAGS_LIST}
             ${SOURCE_FILE} -o ${EXE_PATH}
 
             COMMAND ${CMAKE_COMMAND} -E env ${EXTRA_ENV} ${UR_FOUND_DEVICE_CODE_EXTRACTOR} -q --stem="${TRIPLE}.bin" ${EXE_PATH}


### PR DESCRIPTION
Add UR CONFORMANCE_NVIDIA_ARCH option to set shader model for NVIDIA CTS.
