### PR TITLE
[UR][TEST][CUDA][HIP] Clarify known-failure rationale for CUDA/HIP kernel index checks

### DIFF
--- a/unified-runtime/test/conformance/kernel/urKernelSetArgLocal.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgLocal.cpp
@@ -27,6 +27,15 @@ TEST_P(urKernelSetArgLocalTest, InvalidNullHandleKernel) {
 }
 
 TEST_P(urKernelSetArgLocalTest, InvalidKernelArgumentIndex) {
+  // XFAIL rationale (CUDA/HIP):
+  // This test assumes UR_KERNEL_INFO_NUM_ARGS reflects the kernel's source-level
+  // parameter count and can be used to validate out-of-range argument indices.
+  // That assumption is not valid for CUDA/HIP adapters: the backend APIs do not
+  // provide a reliable direct query of declared kernel parameter count, so
+  // UR_KERNEL_INFO_NUM_ARGS is derived from adapter-maintained argument state.
+  // This value reflects currently tracked arguments (initially none), not the
+  // true kernel signature; therefore these invalid-index expectations are not
+  // meaningful on these backends, and no adapter-side fix is planned.
   UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
 
   uint32_t num_kernel_args = 0;

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgMemObj.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgMemObj.cpp
@@ -37,6 +37,15 @@ TEST_P(urKernelSetArgMemObjTest, InvalidNullHandleKernel) {
 }
 
 TEST_P(urKernelSetArgMemObjTest, InvalidKernelArgumentIndex) {
+  // XFAIL rationale (CUDA/HIP):
+  // This test assumes UR_KERNEL_INFO_NUM_ARGS reflects the kernel's source-level
+  // parameter count and can be used to validate out-of-range argument indices.
+  // That assumption is not valid for CUDA/HIP adapters: the backend APIs do not
+  // provide a reliable direct query of declared kernel parameter count, so
+  // UR_KERNEL_INFO_NUM_ARGS is derived from adapter-maintained argument state.
+  // This value reflects currently tracked arguments (initially none), not the
+  // true kernel signature; therefore these invalid-index expectations are not
+  // meaningful on these backends, and no adapter-side fix is planned.
   UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
 
   uint32_t num_kernel_args = 0;

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgPointer.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgPointer.cpp
@@ -140,6 +140,15 @@ TEST_P(urKernelSetArgPointerNegativeTest, InvalidNullHandleKernel) {
 }
 
 TEST_P(urKernelSetArgPointerNegativeTest, InvalidKernelArgumentIndex) {
+  // XFAIL rationale (CUDA/HIP):
+  // This test assumes UR_KERNEL_INFO_NUM_ARGS reflects the kernel's source-level
+  // parameter count and can be used to validate out-of-range argument indices.
+  // That assumption is not valid for CUDA/HIP adapters: the backend APIs do not
+  // provide a reliable direct query of declared kernel parameter count, so
+  // UR_KERNEL_INFO_NUM_ARGS is derived from adapter-maintained argument state.
+  // This value reflects currently tracked arguments (initially none), not the
+  // true kernel signature; therefore these invalid-index expectations are not
+  // meaningful on these backends, and no adapter-side fix is planned.
   UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
 
   uint32_t num_kernel_args = 0;

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgSampler.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgSampler.cpp
@@ -143,6 +143,15 @@ TEST_P(urKernelSetArgSamplerTest, InvalidNullHandleArgValue) {
 }
 
 TEST_P(urKernelSetArgSamplerTest, InvalidKernelArgumentIndex) {
+  // XFAIL rationale:
+  // This test assumes UR_KERNEL_INFO_NUM_ARGS reflects the kernel's source-level
+  // parameter count and can be used to validate out-of-range argument indices.
+  // That assumption is not valid for the CUDA adapter: the backend API does not
+  // provide a reliable direct query of declared kernel parameter count, so
+  // UR_KERNEL_INFO_NUM_ARGS is derived from adapter-maintained argument state.
+  // This value reflects currently tracked arguments (initially none), not the
+  // true kernel signature; therefore these invalid-index expectations are not
+  // meaningful on this backend, and no adapter-side fix is planned.
   UUR_KNOWN_FAILURE_ON(uur::CUDA{});
 
   uint32_t num_kernel_args = 0;

--- a/unified-runtime/test/conformance/kernel/urKernelSetArgValue.cpp
+++ b/unified-runtime/test/conformance/kernel/urKernelSetArgValue.cpp
@@ -35,6 +35,15 @@ TEST_P(urKernelSetArgValueTest, InvalidNullPointerArgValue) {
 }
 
 TEST_P(urKernelSetArgValueTest, InvalidKernelArgumentIndex) {
+  // XFAIL rationale (CUDA/HIP):
+  // This test assumes UR_KERNEL_INFO_NUM_ARGS reflects the kernel's source-level
+  // parameter count and can be used to validate out-of-range argument indices.
+  // That assumption is not valid for CUDA/HIP adapters: the backend APIs do not
+  // provide a reliable direct query of declared kernel parameter count, so
+  // UR_KERNEL_INFO_NUM_ARGS is derived from adapter-maintained argument state.
+  // This value reflects currently tracked arguments (initially none), not the
+  // true kernel signature; therefore these invalid-index expectations are not
+  // meaningful on these backends, and no adapter-side fix is planned.
   UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
 
   uint32_t num_kernel_args = 0;


### PR DESCRIPTION
Add a comment explaining why InvalidKernelArgumentIndex expectations in urKernelSetArgValue, urKernelSetArgLocal, urKernelSetArgSampler, urKernelSetArgMemObj, and urKernelSetArgPointer
are not meaningful for CUDA/HIP.