### PR TITLE
[UR] fix mock adapter discovery when statically linking unittests

### DIFF
--- a/unified-runtime/source/loader/ur_adapter_registry.hpp
+++ b/unified-runtime/source/loader/ur_adapter_registry.hpp
@@ -390,6 +390,8 @@ public:
 
     std::vector<fs::path> loadPaths;
     auto adapterNamePath = fs::path{mockAdapterName};
+    loadPaths.emplace_back(adapterNamePath);
+
     auto loaderLibPathOpt = getLoaderLibPath();
     if (loaderLibPathOpt.has_value()) {
       const auto &loaderLibPath = loaderLibPathOpt.value();


### PR DESCRIPTION
The mock adapter was hardcoded to always load from the applications / library path. In the case of a fully statically linked program, like a unittest, which resides in a different directory than the rest of UR libraries, this resulted in a failure to load the adapter.

This patch fixes the issue by also attempting to load the mock adapter by its name, letting the dynamic loader resolve the full path.