### PR TITLE
[SYCL][E2E] Disable tests sporadically failing on Win Gen12

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/batch_event_status.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/batch_event_status.cpp
@@ -1,5 +1,9 @@
 // See https://github.com/intel/llvm-test-suite/issues/906
 // REQUIRES: gpu, level_zero
+
+// UNSUPPORTED: windows && gpu-intel-gen12
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
+
 // UNSUPPORTED: level_zero_v2_adapter
 // UNSUPPORTED-INTENDED: v2 adapter does not support regular cmd lists
 

--- a/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
+++ b/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
@@ -1,5 +1,9 @@
 // REQUIRES: level_zero
 // UNSUPPORTED: ze_debug
+
+// UNSUPPORTED: windows && gpu-intel-gen12
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
+
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_UR_TRACE=2 UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 //


### PR DESCRIPTION
They seem sporadically failing after driver update too.

Ref: #21556
Ref: #21557