### PR TITLE
[SYCL][E2E] Make root_group.cpp UNSUPPORTED for target-nvidia

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/root_group.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/root_group.cpp
@@ -12,8 +12,8 @@
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
 
 // Fails on CUDA 13, enable when fixed.
-// XFAIL: target-nvidia
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21525
+// UNSUPPORTED: target-nvidia
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21525
 
 #include <cassert>
 #include <cstdlib>


### PR DESCRIPTION
XPASSing in the nightly

https://github.com/intel/llvm/actions/runs/23328205786