### PR TITLE
[SYCL] add an e2e test that passes for liboffload with L0

### DIFF
--- a/sycl/test-e2e/Basic/queue/queue_parallel_for_without_context.cpp
+++ b/sycl/test-e2e/Basic/queue/queue_parallel_for_without_context.cpp
@@ -1,0 +1,35 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/usm.hpp>
+
+using namespace sycl; // (optional) avoids need for "sycl::" before SYCL names
+
+int main() {
+  //  Create a default queue to enqueue work to the default device
+  queue myQueue;
+
+  if (!(myQueue.get_device())
+           .get_info<sycl::info::device::usm_shared_allocations>()) {
+    return 0;
+  }
+
+  // Allocate shared memory bound to the device and context associated to the
+  // queue.
+  int *data = sycl::malloc_shared<int>(1024, myQueue);
+
+  myQueue.parallel_for(1024, [=](id<1> idx) {
+    // Initialize each buffer element with its own rank number starting at 0
+    data[idx] = idx;
+  }); // End of the kernel function
+
+  // Explicitly wait for kernel execution since there is no accessor involved
+  myQueue.wait();
+
+  for (int i = 0; i < 1024; i++)
+    assert(data[i] == i);
+
+  sycl::free(data, myQueue);
+
+  return 0;
+}

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -351,6 +351,10 @@ class SYCLEndToEndTest(lit.formats.ShTest):
             if "cuda:gpu" in sycl_devices:
                 extra_env.append("SYCL_UR_CUDA_ENABLE_IMAGE_SUPPORT=1")
 
+            # At this point, liboffload does not work with multiple GPUs
+            if "offload:gpu" in sycl_devices:
+                extra_env.append("ZE_AFFINITY_MASK=1")
+
             return extra_env
 
         extra_env = get_extra_env(remove_level_zero_suffix(devices_for_test))

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -35,6 +35,9 @@ config.backend_to_triple = {
     k: config.target_to_triple.get(v) for k, v in config.backend_to_target.items()
 }
 
+# The backend set by the user has precedence over backends set during the parsing of the sycl-ls output
+is_offload_preferred_backend_set = config.backend_to_target["offload"] != ""
+
 # name: The name of this test suite.
 config.name = "SYCL"
 
@@ -1014,6 +1017,7 @@ for full_name, sycl_device in zip(
     is_intel_driver = False
     intel_driver_ver = {}
     sycl_ls_sp = get_sycl_ls_verbose(sycl_device, env)
+    offload_assigned_backend = ""
     for line in sycl_ls_sp.stdout.splitlines():
         if re.match(r" *Vendor *: Intel\(R\) Corporation", line):
             is_intel_driver = True
@@ -1052,6 +1056,17 @@ for full_name, sycl_device in zip(
             architectures.add(architecture.strip())
         if re.match(r" *Name *:", line) and "Level-Zero V2" in line:
             features.add("level_zero_v2_adapter")
+
+        # TODO change to the set of backends
+        if re.match(r"\[offload:.*", line) and not is_offload_preferred_backend_set:
+            if re.match(".*Level[ _]Zero.*", line, re.IGNORECASE):
+                offload_assigned_backend = config.backend_to_target["level_zero"]
+                is_offload_preferred_backend_set = True
+            elif re.match(".*nvidia.*", line, re.IGNORECASE):
+                offload_assigned_backend = config.backend_to_target["cuda"]
+
+    if offload_assigned_backend != "":
+        config.backend_to_target["offload"] = offload_assigned_backend
 
     if dev_aspects == []:
         lit_config.error(


### PR DESCRIPTION
The liboffload phase 0 program is added as one of SYCL e2e tests. Moreover, lit configuration files are modified so that the liboffload backend is determined according to `sycl-ls` output, while the backend specified by the user preserves its precedence. When choosing between devices listed by `sycl-ls`, the Level Zero backend is preferred.

The tests would not work without this change when liboffload is built, even with `llvm-lit --param sycl_devices="offload:gpu" <path>`. The backend for liboffload would still be undetermined: the tests are not compiled with the `OFFLOAD_BUILD_TARGET` option, therefore there is only `""` left as a value in the dictionary mapping from backends to targets, resulting in a KeyError. Additionally, `OFFLOAD_BUILD_TARGET` is never mentioned in any CMakeLists.txt, therefore it has been impossible to use liboffload.