### PR TITLE
[CI] Add timeout 5 minutes per each file to clang-tidy

### DIFF
--- a/.github/workflows/sycl-clang-tidy.yml
+++ b/.github/workflows/sycl-clang-tidy.yml
@@ -74,6 +74,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/src"
           python3 "$GITHUB_WORKSPACE/src/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py" \
             -clang-tidy-binary "/opt/sycl/bin/clang-tidy" \
+            -timeout 300 \
             -p 1 \
             -path "$GITHUB_WORKSPACE/build" \
             -checks "clang-analyzer-*,bugprone-*,performance-*,-bugprone-std-namespace-modification" \


### PR DESCRIPTION
Add timeout 5 minutes per each file to clang-tidy
in order to prevent a CI job hang-up.

Ref: #21550