### PR TITLE
[CI][Bench] Bump compute-runtime

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -1,15 +1,15 @@
 {
   "linux": {
     "compute_runtime": {
-      "github_tag": "26.05.37020.3",
-      "version": "26.05.37020.3",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/26.05.37020.3",
+      "github_tag": "26.09.37435.1",
+      "version": "26.09.37435.1",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/26.09.37435.1",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "v2.28.4",
-      "version": "v2.28.4",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/v2.28.4",
+      "github_tag": "v2.30.1",
+      "version": "v2.30.1",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/v2.30.1",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {


### PR DESCRIPTION
This version of compute-runtime brings performance improvements. See test runs: https://intel.github.io/llvm/benchmarks/?runs=patkamin_test_regression_BMG_L0v2%2CBaseline_BMG_L0v2 