### PR TITLE
[SYCL][E2E] Disable device_config_file_consistency.cpp on SPIR-V backend

### DIFF
--- a/sycl/test-e2e/Basic/device_config_file_consistency.cpp
+++ b/sycl/test-e2e/Basic/device_config_file_consistency.cpp
@@ -12,6 +12,9 @@
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
 
+// UNSUPPORTED: spirv-backend
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21594
+
 #include <map>
 
 #include <llvm/SYCLLowerIR/DeviceConfigFile.hpp>


### PR DESCRIPTION
Sporadically failing

https://github.com/intel/llvm/issues/21594