### PR TITLE
[UR][CUDA] Fix IL_VERSION query to include null terminator

### DIFF
--- a/unified-runtime/source/adapters/cuda/device.cpp
+++ b/unified-runtime/source/adapters/cuda/device.cpp
@@ -1027,7 +1027,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
 
-    return ReturnValue(ILVersion.data(), ILVersion.size());
+    return ReturnValue(ILVersion.c_str());
   }
   case UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP: {
     // Maximum number of 32-bit registers available to a thread block.

--- a/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
@@ -1113,7 +1113,7 @@ TEST_P(urDeviceGetInfoTest, SuccessReferenceCount) {
 }
 
 TEST_P(urDeviceGetInfoTest, SuccessILVersion) {
-  UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::NativeCPU{});
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_IL_VERSION;


### PR DESCRIPTION
The UR_DEVICE_INFO_IL_VERSION query was returning PTX ISA version string using ILVersion.data() and ILVersion.size(), which did not include the null terminator. This caused test failures because the conformance test expects the returned string to be null-terminated.

Changed to use ILVersion.c_str() to return a properly null-terminated string, consistent with other string properties in the same file.

This fix enables the SuccessILVersion conformance test for CUDA adapter.