### PR TITLE
[TEST] Run urUSMContextMemcpyExpTestDevice to reproduce #19688

### DIFF
--- a/unified-runtime/test/conformance/exp_usm_context_memcpy/urUSMContextMemcpyExp.cpp
+++ b/unified-runtime/test/conformance/exp_usm_context_memcpy/urUSMContextMemcpyExp.cpp
@@ -81,11 +81,20 @@ struct urUSMContextMemcpyExpTestDevice : urUSMContextMemcpyExpTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_MULTI_QUEUE(urUSMContextMemcpyExpTestDevice);
 
 TEST_P(urUSMContextMemcpyExpTestDevice, Success) {
+  // Testing without xfail to reproduce sporadic failure
+  // Run multiple iterations to increase chance of catching race condition
   // https://github.com/intel/llvm/issues/19688
-  UUR_KNOWN_FAILURE_ON(uur::CUDA{});
-  ASSERT_SUCCESS(
-      urUSMContextMemcpyExp(context, dst_ptr, src_ptr, allocation_size));
-  verifyData();
+  constexpr int NumIterations = 20;
+  for (int i = 0; i < NumIterations; ++i) {
+    ASSERT_SUCCESS(
+        urUSMContextMemcpyExp(context, dst_ptr, src_ptr, allocation_size));
+    verifyData();
+
+    // Re-initialize for next iteration
+    if (i < NumIterations - 1) {
+      initAllocations();
+    }
+  }
 }
 
 // Arbitrarily do the negative tests with device allocations. These are mostly a


### PR DESCRIPTION
This is a test PR to verify if the sporadic failure in issue #19688 can be reproduced on CI.

Changes:
- Remove UUR_KNOWN_FAILURE_ON(uur::CUDA{}) to enable the test
- Add loop with 20 iterations to increase probability of hitting the race condition
- Re-initialize allocations between iterations