### PR TITLE
[SYCL][E2E] Disable Regression/queue_submit.cpp

### DIFF
--- a/sycl/test-e2e/Regression/queue_submit.cpp
+++ b/sycl/test-e2e/Regression/queue_submit.cpp
@@ -3,7 +3,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: arch-intel_gpu_pvc || target-native_cpu
+// UNSUPPORTED: run-mode
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21095
 
 // This test submits same kernel via multiple threads to the same queue.


### PR DESCRIPTION
Also failing [sporadically](https://github.com/intel/llvm/actions/runs/23458143824/job/68255428683?pr=21599) on BMG, adding to the existing sporadic fails on PVC and Native CPU. 

Just disable it everywhere, clearly there's some fundamental issue.

https://github.com/intel/llvm/issues/21095