### PR TITLE
[CI][Bench] Unify build params for dispatch and nightly jobs

### DIFF
--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -186,8 +186,6 @@ jobs:
       build_cache_suffix: "prod_noassert"
       build_configure_extra_args: "--no-assertions"
       build_image: "ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest"
-      cc: clang
-      cxx: clang++
       changes: '[]'
       toolchain_artifact: sycl_linux_prod_noassert
 
@@ -230,14 +228,13 @@ jobs:
     name: '[Nightly] Build SYCL'
     if: ${{ github.repository == 'intel/llvm' && (github.event_name == 'schedule' || inputs.trigger_nightly == 'true') }}
     uses: ./.github/workflows/sycl-linux-build.yml
-    secrets: inherit
     with:
       build_cache_root: "/__w/"
+      build_cache_suffix: "prod_noassert"
       build_configure_extra_args: '--no-assertions'
-      build_image: ghcr.io/intel/llvm/ubuntu2404_build:latest
-
-      toolchain_artifact: sycl_linux_default
-      toolchain_artifact_filename: sycl_linux.tar.gz
+      build_image: ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest
+      changes: '[]'
+      toolchain_artifact: sycl_linux_prod_noassert
 
   benchmark_nightly:
     name: '[Nightly] Benchmarks'


### PR DESCRIPTION
Most importantly use the same docker image, compiler, and configure's extra args