### PR TITLE
[SYCL] Add pre-release indicator

### DIFF
--- a/clang/lib/Basic/Version.cpp
+++ b/clang/lib/Basic/Version.cpp
@@ -152,7 +152,7 @@ std::string getDPCPPFullCPPVersion() {
   llvm::raw_string_ostream OS(buf);
   OS << "DPC++ " DPCPP_VERSION;
 #if PRE_RELEASE
-      OS << " (pre-release)";
+  OS << " (pre-release)";
 #endif
   std::string repo = getClangFullRepositoryVersion();
   if (!repo.empty()) {


### PR DESCRIPTION
This is a follow-up PR after- https://github.com/intel/llvm/pull/21572 to add pre-release indicator to the text of the __VERSION__ macro so that it matches the --version output.