### PR TITLE
[UR][CTS] Disable mem buffer read tests

### DIFF
--- a/unified-runtime/test/conformance/enqueue/CMakeLists.txt
+++ b/unified-runtime/test/conformance/enqueue/CMakeLists.txt
@@ -15,8 +15,10 @@ add_conformance_kernels_test(enqueue
     urEnqueueMemBufferCopy.cpp
     urEnqueueMemBufferFill.cpp
     urEnqueueMemBufferMap.cpp
-    urEnqueueMemBufferRead.cpp
-    urEnqueueMemBufferReadRect.cpp
+    # Enqueue memory buffer read tests ran simultenously lead to timeouts.
+    # Tracker: https://jira.devtools.intel.com/browse/URT-1026
+    # urEnqueueMemBufferRead.cpp
+    # urEnqueueMemBufferReadRect.cpp
     urEnqueueMemBufferWrite.cpp
     urEnqueueMemBufferWriteRect.cpp
     urEnqueueMemImageCopy.cpp
@@ -31,7 +33,5 @@ add_conformance_kernels_test(enqueue
     urEnqueueUSMPrefetch.cpp
     urEnqueueReadHostPipe.cpp
     urEnqueueWriteHostPipe.cpp
-    # Enqueue timestamp leads to timeouts
-    # Tracker: https://jira.devtools.intel.com/browse/URT-1026
-    #urEnqueueTimestampRecording.cpp
+    urEnqueueTimestampRecording.cpp
 )


### PR DESCRIPTION
When the tests from urEnqueueMemBufferRead.cpp and urEnqueueMemBufferReadRect.cpp are run simultaneously, the platform running them occasionally hangs.