### PR TITLE
[clang][SYCL] Skip allocation diagnostic in unevaluated contexts

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2644,7 +2644,8 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
       return ExprError();
     MarkFunctionReferenced(StartLoc, OperatorNew);
     if (getLangOpts().SYCLIsDevice &&
-        OperatorNew->isReplaceableGlobalAllocationFunction())
+        OperatorNew->isReplaceableGlobalAllocationFunction() &&
+        !isUnevaluatedContext())
       SYCL().DiagIfDeviceCode(StartLoc, diag::err_sycl_restrict)
           << SemaSYCL::KernelAllocateStorage;
   }

--- a/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
+++ b/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
@@ -78,6 +78,18 @@ void actual_array_allocation() {
   int *ptr = new int[10];
 }
 
+template <typename T>
+void actual_allocation() {
+  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
+  T *ptr = new T;
+}
+
+template <typename T>
+void actual_array_allocation() {
+  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
+  T *ptr = new T[10];
+}
+
 
 int main() {
   sycl::queue q;
@@ -109,6 +121,20 @@ int main() {
     h.single_task<class TestActualArrayAlloc>([&]() {
       // expected-note@Inputs/sycl.hpp:322 {{called by 'kernel_single_task<TestActualArrayAlloc}}
       actual_array_allocation(); // expected-note {{called by 'operator()'}}
+    });
+  });
+
+  q.submit([&](sycl::handler &h) {
+    h.single_task<class TestTemplatedAlloc>([&]() {
+      // expected-note@Inputs/sycl.hpp:* {{called by 'kernel_single_task}}
+      actual_allocation<int>(); // expected-note {{called by 'operator()'}}
+    });
+  });
+
+  q.submit([&](sycl::handler &h) {
+    h.single_task<class TestTemplatedArrayAlloc>([&]() {
+      // expected-note@Inputs/sycl.hpp:* {{called by 'kernel_single_task}}
+      actual_array_allocation<float>(); // expected-note {{called by 'operator()'}}
     });
   });
 

--- a/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
+++ b/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
@@ -97,8 +97,6 @@ int main() {
   q.submit([&](sycl::handler &h) {
     h.single_task<class TestConcepts>([]() {
       // These should all work without errors
-      static_assert(Allocatable<int>);
-      static_assert(AllocatableArray<double>);
 
       test_requires_clause<int>();
       test_requires_clause_array<float>();

--- a/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
+++ b/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
@@ -16,9 +16,6 @@ void *operator new(std::size_t) {
   return reinterpret_cast<void *>(1);
 }
 
-// ===========================================================================
-// Test C++20 concepts - should NOT emit diagnostic
-// ===========================================================================
 
 template <typename T>
 concept Allocatable = requires {
@@ -35,9 +32,6 @@ concept AllocatableArray = requires {
 static_assert(Allocatable<int>);
 static_assert(AllocatableArray<int>);
 
-// ===========================================================================
-// Test requires clauses - should NOT emit diagnostic
-// ===========================================================================
 
 template <typename T>
   requires requires { ::new T; }
@@ -47,9 +41,6 @@ template <typename T>
   requires requires { ::new T[5]; }
 void test_requires_clause_array() {}
 
-// ===========================================================================
-// Test decltype - should NOT emit diagnostic
-// ===========================================================================
 
 void test_decltype() {
   // No error expected - inside decltype
@@ -57,9 +48,6 @@ void test_decltype() {
   decltype(new int[10]) ptr2;
 }
 
-// ===========================================================================
-// Test sizeof - should NOT emit diagnostic
-// ===========================================================================
 
 void test_sizeof() {
   // No error expected - inside sizeof
@@ -67,9 +55,6 @@ void test_sizeof() {
   constexpr std::size_t s2 = sizeof(new int[10]);
 }
 
-// ===========================================================================
-// Test alignof with new expression types - should NOT emit diagnostic
-// ===========================================================================
 
 void test_alignof() {
   // No error expected - inside alignof of the result type
@@ -78,16 +63,11 @@ void test_alignof() {
   constexpr std::size_t a2 = alignof(PtrType);
 }
 
-// ===========================================================================
-// Test noexcept specification - should NOT emit diagnostic
-// ===========================================================================
 
 void test_noexcept() noexcept(noexcept(new int)) {}
 
-// ===========================================================================
-// Test actual usage in kernel - SHOULD emit diagnostic
-// ===========================================================================
 
+// Usage in kernel should emit diagnostic
 void actual_allocation() {
   // expected-error@+1 {{SYCL kernel cannot allocate storage}}
   int *ptr = new int;
@@ -98,9 +78,6 @@ void actual_array_allocation() {
   int *ptr = new int[10];
 }
 
-// ===========================================================================
-// Main test function
-// ===========================================================================
 
 int main() {
   sycl::queue q;

--- a/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
+++ b/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
@@ -1,0 +1,139 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -verify -fsyntax-only -std=c++20 -triple spir64 -Wno-unused-value %s
+
+// Tests that the "SYCL kernel cannot allocate storage" diagnostic is not
+// emitted in unevaluated contexts such as C++20 concepts, requires clauses,
+// decltype, sizeof, etc.
+
+#include "sycl.hpp"
+
+namespace std {
+class type_info;
+typedef __typeof__(sizeof(int)) size_t;
+} // namespace std
+
+// Stub implementation for operator new
+void *operator new(std::size_t) {
+  return reinterpret_cast<void *>(1);
+}
+
+// ===========================================================================
+// Test C++20 concepts - should NOT emit diagnostic
+// ===========================================================================
+
+template <typename T>
+concept Allocatable = requires {
+  // No error expected - this is in an unevaluated context
+  ::new T;
+};
+
+template <typename T>
+concept AllocatableArray = requires {
+  // No error expected - this is in an unevaluated context
+  ::new T[10];
+};
+
+static_assert(Allocatable<int>);
+static_assert(AllocatableArray<int>);
+
+// ===========================================================================
+// Test requires clauses - should NOT emit diagnostic
+// ===========================================================================
+
+template <typename T>
+  requires requires { ::new T; }
+void test_requires_clause() {}
+
+template <typename T>
+  requires requires { ::new T[5]; }
+void test_requires_clause_array() {}
+
+// ===========================================================================
+// Test decltype - should NOT emit diagnostic
+// ===========================================================================
+
+void test_decltype() {
+  // No error expected - inside decltype
+  decltype(new int) ptr1;
+  decltype(new int[10]) ptr2;
+}
+
+// ===========================================================================
+// Test sizeof - should NOT emit diagnostic
+// ===========================================================================
+
+void test_sizeof() {
+  // No error expected - inside sizeof
+  constexpr std::size_t s1 = sizeof(new int);
+  constexpr std::size_t s2 = sizeof(new int[10]);
+}
+
+// ===========================================================================
+// Test alignof with new expression types - should NOT emit diagnostic
+// ===========================================================================
+
+void test_alignof() {
+  // No error expected - inside alignof of the result type
+  constexpr std::size_t a1 = alignof(int*);
+  using PtrType = decltype(new int);
+  constexpr std::size_t a2 = alignof(PtrType);
+}
+
+// ===========================================================================
+// Test noexcept specification - should NOT emit diagnostic
+// ===========================================================================
+
+void test_noexcept() noexcept(noexcept(new int)) {}
+
+// ===========================================================================
+// Test actual usage in kernel - SHOULD emit diagnostic
+// ===========================================================================
+
+void actual_allocation() {
+  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
+  int *ptr = new int;
+}
+
+void actual_array_allocation() {
+  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
+  int *ptr = new int[10];
+}
+
+// ===========================================================================
+// Main test function
+// ===========================================================================
+
+int main() {
+  sycl::queue q;
+
+  q.submit([&](sycl::handler &h) {
+    h.single_task<class TestConcepts>([]() {
+      // These should all work without errors
+      static_assert(Allocatable<int>);
+      static_assert(AllocatableArray<double>);
+
+      test_requires_clause<int>();
+      test_requires_clause_array<float>();
+
+      test_decltype();
+      test_sizeof();
+      test_alignof();
+      test_noexcept();
+    });
+  });
+
+  q.submit([&](sycl::handler &h) {
+    h.single_task<class TestActualAlloc>([&]() {
+      // expected-note@Inputs/sycl.hpp:322 {{called by 'kernel_single_task<TestActualAlloc}}
+      actual_allocation(); // expected-note {{called by 'operator()'}}
+    });
+  });
+
+  q.submit([&](sycl::handler &h) {
+    h.single_task<class TestActualArrayAlloc>([&]() {
+      // expected-note@Inputs/sycl.hpp:322 {{called by 'kernel_single_task<TestActualArrayAlloc}}
+      actual_array_allocation(); // expected-note {{called by 'operator()'}}
+    });
+  });
+
+  return 0;
+}

--- a/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
+++ b/clang/test/SemaSYCL/new-operator-unevaluated-context.cpp
@@ -29,10 +29,6 @@ concept AllocatableArray = requires {
   ::new T[10];
 };
 
-static_assert(Allocatable<int>);
-static_assert(AllocatableArray<int>);
-
-
 template <typename T>
   requires requires { ::new T; }
 void test_requires_clause() {}
@@ -97,6 +93,8 @@ int main() {
   q.submit([&](sycl::handler &h) {
     h.single_task<class TestConcepts>([]() {
       // These should all work without errors
+      static_assert(Allocatable<int>);
+      static_assert(AllocatableArray<double>);
 
       test_requires_clause<int>();
       test_requires_clause_array<float>();


### PR DESCRIPTION
This patch adds a check to avoid emitting "SYCL kernel cannot allocate storage" diagnostic in unevaluated contexts, such as for operator new expressions in C++20 concepts and requires clauses.

This fixes false positive errors with GCC 13's standard library which uses concepts with ::new expressions.