### PR TITLE
[CI] Fix SYCL CTS build

### DIFF
--- a/devops/actions/run-tests/linux/cts/action.yml
+++ b/devops/actions/run-tests/linux/cts/action.yml
@@ -61,6 +61,7 @@ runs:
       -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="$cts_exclude_filter" \
       -DSYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS=OFF \
       -DDPCPP_INSTALL_DIR="$(dirname $(which clang++))/.." \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
       $CMAKE_EXTRA_ARGS
       # Ignore errors so that if one category build fails others still have a
       # chance to finish and be executed at the run stage. Note that


### PR DESCRIPTION
We updated the CMake version and I guess the SYCL-CTS minimum CMake is really old so the new CMake throws some error saying it might not work but it works fine so just pass the flag telling it not to error.

Run: https://github.com/intel/llvm/actions/runs/23501554073/job/68411748256