### PR TITLE
[Bench] Fix CMake error in Velocity benchmark

### DIFF
--- a/devops/scripts/benchmarks/benches/velocity.py
+++ b/devops/scripts/benchmarks/benches/velocity.py
@@ -128,6 +128,7 @@ class VelocityBase(Benchmark):
             f"-S {self.src_dir}",
             f"-B {self.build_dir}",
             "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
         ]
         cmd += self.extra_cmake_args()
         run(cmd, {"CC": "clang", "CXX": "clang++"}, add_sycl=True)


### PR DESCRIPTION

We updated the CMake version - pass the flag, it should work fine.