### PR TITLE
[DOC] Rename oneAPI DPC++ -> DPC++

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 This is the Intel staging area for llvm.org contributions and the home for
 Intel LLVM-based projects:
 
-- [oneAPI DPC++ compiler](#oneapi-dpc-compiler)
+- [DPC++ compiler](#dpc-compiler)
 - [Late-outline OpenMP and OpenMP Offload](#late-outline-openmp-and-openmp-offload)
 
 For general contribution process see [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-## oneAPI DPC++ compiler
-
-[![oneAPI logo](https://spec.oneapi.io/oneapi-logo-white-scaled.jpg)](https://www.oneapi.io/)
+## DPC++ compiler
 
 [![SYCL Post Commit](https://github.com/intel/llvm/actions/workflows/sycl-post-commit.yml/badge.svg?branch=sycl)](https://github.com/intel/llvm/actions/workflows/sycl-post-commit.yml)
 [![Generate Doxygen documentation](https://github.com/intel/llvm/actions/workflows/sycl-docs.yml/badge.svg?branch=sycl)](https://github.com/intel/llvm/actions/workflows/sycl-docs.yml)

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -1,4 +1,4 @@
-# Getting Started with oneAPI DPC++
+# Getting Started with DPC++
 
 The DPC++ Compiler compiles C++ and SYCL\* source files with code for both CPU
 and GPU.
@@ -685,7 +685,7 @@ More Native CPU build options can be found in [SYCLNativeCPU.md](design/SYCLNati
 The results are correct!
 ```
 
-**NOTE**: oneAPI DPC++/SYCL developers can specify SYCL device for execution
+**NOTE**: DPC++/SYCL developers can specify SYCL device for execution
 using device selectors (e.g. `sycl::cpu_selector_v`, `sycl::gpu_selector_v`)
 as explained in following section
 [Code the program for a specific GPU](#code-the-program-for-a-specific-gpu).


### PR DESCRIPTION
As was decided during the discussion, to distinguish this compiler from the proprietary one, we drop the oneAPI word.

This patch only changes README.md and GetStartedGuide.md. There are still dozens of mentions in other files.