### PR TITLE
[CI][UR][CUDA] Remove NVML xfails after driver update + NVML version check for NVIDIA (new workflow)

### DIFF
--- a/.github/workflows/ur-build-hw.yml
+++ b/.github/workflows/ur-build-hw.yml
@@ -113,6 +113,43 @@ jobs:
       run: |
         sudo -E bash devops/scripts/install_drivers.sh devops/dependencies.json --igfx
 
+    - name: Check NVML version compatibility
+      if: ${{ inputs.adapter_name == 'CUDA' }}
+      run: |
+        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n1 | tr -d '[:space:]')
+        if [ -z "$DRIVER_VERSION" ]; then
+          echo "::error::Failed to get NVIDIA driver version"
+          echo "ERROR: nvidia-smi command failed or returned empty version"
+          exit 1
+        fi
+        
+        NVML_LIB=$(find /usr -name "libnvidia-ml.so.1" 2>/dev/null | head -n1)
+        NVML_VERSION=$(readlink -f "$NVML_LIB" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' || echo "unknown")
+        
+        if [ -z "$NVML_LIB" ] || [ "$NVML_VERSION" = "unknown" ]; then
+          echo "::error::NVML library not found in container"
+          echo "ERROR: libnvidia-ml.so.1 not found or version could not be determined"
+          exit 1
+        fi
+        
+        DRIVER_MAJOR=$(echo "$DRIVER_VERSION" | cut -d. -f1)
+        NVML_MAJOR=$(echo "$NVML_VERSION" | cut -d. -f1)
+        
+        if [ "$DRIVER_MAJOR" != "$NVML_MAJOR" ]; then
+          echo "::error::NVML version mismatch - Driver: ${DRIVER_VERSION}, Library: ${NVML_VERSION}"
+          echo "ERROR: Major versions differ (${DRIVER_MAJOR} vs ${NVML_MAJOR})"
+          exit 1
+        fi
+        
+        # Check if library version > driver version (library must be <= driver)
+        if [ "$(printf '%s\n' "$NVML_VERSION" "$DRIVER_VERSION" | sort -V | head -n1)" != "$NVML_VERSION" ]; then
+          echo "::error::NVML version mismatch - Driver: ${DRIVER_VERSION}, Library: ${NVML_VERSION}"
+          echo "ERROR: Library version ($NVML_VERSION) is newer than driver ($DRIVER_VERSION)"
+          exit 1
+        fi
+        
+        echo "NVML version check passed: Driver ${DRIVER_VERSION}, Library ${NVML_VERSION}"
+
     - name: Configure Unified Runtime project
       # ">" is used to avoid adding "\" at the end of each line; this command is quite long
       run: >

--- a/.github/workflows/ur-build-hw.yml
+++ b/.github/workflows/ur-build-hw.yml
@@ -115,40 +115,7 @@ jobs:
 
     - name: Check NVML version compatibility
       if: ${{ inputs.adapter_name == 'CUDA' }}
-      run: |
-        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n1 | tr -d '[:space:]')
-        if [ -z "$DRIVER_VERSION" ]; then
-          echo "::error::Failed to get NVIDIA driver version"
-          echo "ERROR: nvidia-smi command failed or returned empty version"
-          exit 1
-        fi
-        
-        NVML_LIB=$(find /usr -name "libnvidia-ml.so.1" 2>/dev/null | head -n1)
-        NVML_VERSION=$(readlink -f "$NVML_LIB" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' || echo "unknown")
-        
-        if [ -z "$NVML_LIB" ] || [ "$NVML_VERSION" = "unknown" ]; then
-          echo "::error::NVML library not found in container"
-          echo "ERROR: libnvidia-ml.so.1 not found or version could not be determined"
-          exit 1
-        fi
-        
-        DRIVER_MAJOR=$(echo "$DRIVER_VERSION" | cut -d. -f1)
-        NVML_MAJOR=$(echo "$NVML_VERSION" | cut -d. -f1)
-        
-        if [ "$DRIVER_MAJOR" != "$NVML_MAJOR" ]; then
-          echo "::error::NVML version mismatch - Driver: ${DRIVER_VERSION}, Library: ${NVML_VERSION}"
-          echo "ERROR: Major versions differ (${DRIVER_MAJOR} vs ${NVML_MAJOR})"
-          exit 1
-        fi
-        
-        # Check if library version > driver version (library must be <= driver)
-        if [ "$(printf '%s\n' "$NVML_VERSION" "$DRIVER_VERSION" | sort -V | head -n1)" != "$NVML_VERSION" ]; then
-          echo "::error::NVML version mismatch - Driver: ${DRIVER_VERSION}, Library: ${NVML_VERSION}"
-          echo "ERROR: Library version ($NVML_VERSION) is newer than driver ($DRIVER_VERSION)"
-          exit 1
-        fi
-        
-        echo "NVML version check passed: Driver ${DRIVER_VERSION}, Library ${NVML_VERSION}"
+      run: python3 devops/scripts/check_nvml_version.py
 
     - name: Configure Unified Runtime project
       # ">" is used to avoid adding "\" at the end of each line; this command is quite long

--- a/devops/scripts/check_nvml_version.py
+++ b/devops/scripts/check_nvml_version.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Intel Corporation
+#
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Check NVML library and NVIDIA driver version compatibility."""
+
+import subprocess
+import sys
+import re
+from pathlib import Path
+from typing import Optional, Tuple
+
+COMMAND_TIMEOUT = 30
+NVML_SEARCH_PATHS = ['/usr/lib', '/usr/lib64', '/usr/local/lib']
+
+
+def get_driver_version() -> Optional[str]:
+    """Get NVIDIA driver version from nvidia-smi."""
+    try:
+        result = subprocess.run(
+            ['nvidia-smi', '--query-gpu=driver_version',
+             '--format=csv,noheader'],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=COMMAND_TIMEOUT
+        )
+        version = result.stdout.strip()
+        if not version:
+            print("::error::Failed to get NVIDIA driver version")
+            print("ERROR: nvidia-smi returned empty version", file=sys.stderr)
+            return None
+        return version
+    except subprocess.CalledProcessError as e:
+        print("::error::Failed to run nvidia-smi")
+        print(f"ERROR: Command failed: {e}", file=sys.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        print("::error::nvidia-smi timeout")
+        print(f"ERROR: Command timed out after {COMMAND_TIMEOUT}s", file=sys.stderr)
+        return None
+    except FileNotFoundError:
+        print("::error::nvidia-smi not found")
+        print("ERROR: Not installed or not in PATH", file=sys.stderr)
+        return None
+
+
+def find_nvml_library() -> Optional[str]:
+    """Find NVML library and extract its version."""
+    for search_path in NVML_SEARCH_PATHS:
+        try:
+            path = Path(search_path)
+            if not path.exists():
+                continue
+            
+            for lib_file in path.rglob('libnvidia-ml.so.1'):
+                real_path = lib_file.resolve()
+                version_match = re.search(
+                    r'\.so\.(\d+\.\d+(?:\.\d+)?)',
+                    str(real_path)
+                )
+                if version_match:
+                    return version_match.group(1)
+        except (OSError, PermissionError):
+            continue
+    
+    print("::error::NVML library not found in container")
+    print(f"ERROR: libnvidia-ml.so.1 not found in {NVML_SEARCH_PATHS}", file=sys.stderr)
+    return None
+
+
+def parse_version(version: str) -> Optional[Tuple[int, ...]]:
+    """Parse version string into tuple of integers."""
+    try:
+        return tuple(int(x) for x in version.split('.'))
+    except (ValueError, AttributeError):
+        return None
+
+
+def compare_versions(driver_version: str, nvml_version: str) -> bool:
+    """Check if NVML library version is compatible with driver version."""
+    driver_parts = parse_version(driver_version)
+    nvml_parts = parse_version(nvml_version)
+    
+    if not driver_parts or not nvml_parts:
+        print("::error::Failed to parse version numbers")
+        print(
+            f"ERROR: Driver: {driver_version}, Library: {nvml_version}",
+            file=sys.stderr
+        )
+        return False
+    
+    driver_major = driver_parts[0]
+    nvml_major = nvml_parts[0]
+    
+    if driver_major != nvml_major:
+        print(
+            f"::error::NVML version mismatch - "
+            f"Driver: {driver_version}, Library: {nvml_version}"
+        )
+        print(
+            f"ERROR: Major versions differ ({driver_major} vs {nvml_major})",
+            file=sys.stderr
+        )
+        return False
+    
+    if nvml_parts > driver_parts:
+        print(
+            f"::error::NVML version mismatch - "
+            f"Driver: {driver_version}, Library: {nvml_version}"
+        )
+        print(
+            f"ERROR: Library version ({nvml_version}) "
+            f"is newer than driver ({driver_version})",
+            file=sys.stderr
+        )
+        return False
+    
+    return True
+
+
+def main() -> int:
+    """Main entry point."""
+    driver_version = get_driver_version()
+    if not driver_version:
+        return 1
+    
+    nvml_version = find_nvml_library()
+    if not nvml_version:
+        return 1
+    
+    if not compare_versions(driver_version, nvml_version):
+        return 1
+    
+    print(
+        f"NVML version check passed: "
+        f"Driver {driver_version}, Library {nvml_version}"
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/devops/scripts/check_nvml_version.py
+++ b/devops/scripts/check_nvml_version.py
@@ -8,7 +8,7 @@
 
 """Check NVML library and NVIDIA driver version compatibility."""
 
-import subprocess
+import subprocess  # nosec B404
 import sys
 import re
 from pathlib import Path
@@ -21,7 +21,8 @@ NVML_SEARCH_PATHS = ['/usr/lib', '/usr/lib64', '/usr/local/lib']
 def get_driver_version() -> Optional[str]:
     """Get NVIDIA driver version from nvidia-smi."""
     try:
-        result = subprocess.run(
+        # Use nvidia-smi with fixed arguments - no user input, safe to use
+        result = subprocess.run(  # nosec B603 B607
             ['nvidia-smi', '--query-gpu=driver_version',
              '--format=csv,noheader'],
             capture_output=True,

--- a/devops/scripts/check_nvml_version.py
+++ b/devops/scripts/check_nvml_version.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 COMMAND_TIMEOUT = 30
-NVML_SEARCH_PATHS = ['/usr/lib', '/usr/lib64', '/usr/local/lib']
+NVML_SEARCH_PATHS = ["/usr/lib", "/usr/lib64", "/usr/local/lib"]
 
 
 def get_driver_version() -> Optional[str]:
@@ -23,12 +23,11 @@ def get_driver_version() -> Optional[str]:
     try:
         # Use nvidia-smi with fixed arguments - no user input, safe to use
         result = subprocess.run(  # nosec B603 B607
-            ['nvidia-smi', '--query-gpu=driver_version',
-             '--format=csv,noheader'],
+            ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
             capture_output=True,
             text=True,
             check=True,
-            timeout=COMMAND_TIMEOUT
+            timeout=COMMAND_TIMEOUT,
         )
         version = result.stdout.strip()
         if not version:
@@ -57,18 +56,15 @@ def find_nvml_library() -> Optional[str]:
             path = Path(search_path)
             if not path.exists():
                 continue
-            
-            for lib_file in path.rglob('libnvidia-ml.so.1'):
+
+            for lib_file in path.rglob("libnvidia-ml.so.1"):
                 real_path = lib_file.resolve()
-                version_match = re.search(
-                    r'\.so\.(\d+\.\d+(?:\.\d+)?)',
-                    str(real_path)
-                )
+                version_match = re.search(r"\.so\.(\d+\.\d+(?:\.\d+)?)", str(real_path))
                 if version_match:
                     return version_match.group(1)
         except (OSError, PermissionError):
             continue
-    
+
     print("::error::NVML library not found in container")
     print(f"ERROR: libnvidia-ml.so.1 not found in {NVML_SEARCH_PATHS}", file=sys.stderr)
     return None
@@ -77,7 +73,7 @@ def find_nvml_library() -> Optional[str]:
 def parse_version(version: str) -> Optional[Tuple[int, ...]]:
     """Parse version string into tuple of integers."""
     try:
-        return tuple(int(x) for x in version.split('.'))
+        return tuple(int(x) for x in version.split("."))
     except (ValueError, AttributeError):
         return None
 
@@ -86,18 +82,17 @@ def compare_versions(driver_version: str, nvml_version: str) -> bool:
     """Check if NVML library version is compatible with driver version."""
     driver_parts = parse_version(driver_version)
     nvml_parts = parse_version(nvml_version)
-    
+
     if not driver_parts or not nvml_parts:
         print("::error::Failed to parse version numbers")
         print(
-            f"ERROR: Driver: {driver_version}, Library: {nvml_version}",
-            file=sys.stderr
+            f"ERROR: Driver: {driver_version}, Library: {nvml_version}", file=sys.stderr
         )
         return False
-    
+
     driver_major = driver_parts[0]
     nvml_major = nvml_parts[0]
-    
+
     if driver_major != nvml_major:
         print(
             f"::error::NVML version mismatch - "
@@ -105,10 +100,10 @@ def compare_versions(driver_version: str, nvml_version: str) -> bool:
         )
         print(
             f"ERROR: Major versions differ ({driver_major} vs {nvml_major})",
-            file=sys.stderr
+            file=sys.stderr,
         )
         return False
-    
+
     if nvml_parts > driver_parts:
         print(
             f"::error::NVML version mismatch - "
@@ -117,10 +112,10 @@ def compare_versions(driver_version: str, nvml_version: str) -> bool:
         print(
             f"ERROR: Library version ({nvml_version}) "
             f"is newer than driver ({driver_version})",
-            file=sys.stderr
+            file=sys.stderr,
         )
         return False
-    
+
     return True
 
 
@@ -129,14 +124,14 @@ def main() -> int:
     driver_version = get_driver_version()
     if not driver_version:
         return 1
-    
+
     nvml_version = find_nvml_library()
     if not nvml_version:
         return 1
-    
+
     if not compare_versions(driver_version, nvml_version):
         return 1
-    
+
     print(
         f"NVML version check passed: "
         f"Driver {driver_version}, Library {nvml_version}"
@@ -144,5 +139,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/devops/scripts/check_nvml_version.py
+++ b/devops/scripts/check_nvml_version.py
@@ -27,11 +27,21 @@ def get_driver_version() -> Optional[str]:
             check=True,
             timeout=COMMAND_TIMEOUT,
         )
-        version = result.stdout.strip()
-        if not version:
+        versions = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        if not versions:
             print("::error::Failed to get NVIDIA driver version")
             print("ERROR: nvidia-smi returned empty version", file=sys.stderr)
             return None
+
+        version = versions[0]
+        if any(candidate != version for candidate in versions[1:]):
+            print("::error::Inconsistent NVIDIA driver versions reported")
+            print(
+                f"ERROR: nvidia-smi reported multiple driver versions: {versions}",
+                file=sys.stderr,
+            )
+            return None
+
         return version
     except subprocess.CalledProcessError as e:
         print("::error::Failed to run nvidia-smi")

--- a/devops/scripts/check_nvml_version.py
+++ b/devops/scripts/check_nvml_version.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
 # Copyright (C) 2026 Intel Corporation
-#
-# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
-# See LICENSE.TXT
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Check NVML library and NVIDIA driver version compatibility."""

--- a/devops/scripts/check_nvml_version.py
+++ b/devops/scripts/check_nvml_version.py
@@ -46,6 +46,10 @@ def get_driver_version() -> Optional[str]:
     except subprocess.CalledProcessError as e:
         print("::error::Failed to run nvidia-smi")
         print(f"ERROR: Command failed: {e}", file=sys.stderr)
+        if e.stdout and e.stdout.strip():
+            print(f"ERROR: nvidia-smi stdout: {e.stdout.strip()}", file=sys.stderr)
+        if e.stderr and e.stderr.strip():
+            print(f"ERROR: nvidia-smi stderr: {e.stderr.strip()}", file=sys.stderr)
         return None
     except subprocess.TimeoutExpired:
         print("::error::nvidia-smi timeout")

--- a/devops/scripts/check_nvml_version.py
+++ b/devops/scripts/check_nvml_version.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2026 Intel Corporation
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
@@ -2561,10 +2561,6 @@ TEST_P(urDeviceGetInfoTest, SuccessBfloat16ConversionsNative) {
 }
 
 TEST_P(urDeviceGetInfoTest, SuccessThrottleReasons) {
-  // TODO: enable when driver/library version mismatch is fixed in CI.
-  // See https://github.com/intel/llvm/issues/17614
-  UUR_KNOWN_FAILURE_ON(uur::CUDA{});
-
   size_t property_size = 0;
   const ur_device_info_t property_name =
       UR_DEVICE_INFO_CURRENT_CLOCK_THROTTLE_REASONS;
@@ -2582,10 +2578,6 @@ TEST_P(urDeviceGetInfoTest, SuccessThrottleReasons) {
 }
 
 TEST_P(urDeviceGetInfoTest, SuccessFanSpeed) {
-  // TODO: enable when driver/library version mismatch is fixed in CI.
-  // See https://github.com/intel/llvm/issues/17614
-  UUR_KNOWN_FAILURE_ON(uur::CUDA{});
-
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_FAN_SPEED;
 
@@ -2603,10 +2595,6 @@ TEST_P(urDeviceGetInfoTest, SuccessFanSpeed) {
 }
 
 TEST_P(urDeviceGetInfoTest, SuccessMaxPowerLimit) {
-  // TODO: enable when driver/library version mismatch is fixed in CI.
-  // See https://github.com/intel/llvm/issues/17614
-  UUR_KNOWN_FAILURE_ON(uur::CUDA{});
-
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_POWER_LIMIT;
 
@@ -2624,10 +2612,6 @@ TEST_P(urDeviceGetInfoTest, SuccessMaxPowerLimit) {
 }
 
 TEST_P(urDeviceGetInfoTest, SuccessMinPowerLimit) {
-  // TODO: enable when driver/library version mismatch is fixed in CI.
-  // See https://github.com/intel/llvm/issues/17614
-  UUR_KNOWN_FAILURE_ON(uur::CUDA{});
-
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_MIN_POWER_LIMIT;
 

--- a/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
@@ -2560,6 +2560,8 @@ TEST_P(urDeviceGetInfoTest, SuccessBfloat16ConversionsNative) {
                              property_value);
 }
 
+// If this test fails with NVML driver/library version mismatch,
+// update NVIDIA driver on CI host to match container's NVML version.
 TEST_P(urDeviceGetInfoTest, SuccessThrottleReasons) {
   size_t property_size = 0;
   const ur_device_info_t property_name =
@@ -2577,6 +2579,8 @@ TEST_P(urDeviceGetInfoTest, SuccessThrottleReasons) {
   ASSERT_EQ(property_value & UR_DEVICE_THROTTLE_REASONS_FLAGS_MASK, 0);
 }
 
+// If this test fails with NVML driver/library version mismatch,
+// update NVIDIA driver on CI host to match container's NVML version.
 TEST_P(urDeviceGetInfoTest, SuccessFanSpeed) {
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_FAN_SPEED;
@@ -2594,6 +2598,8 @@ TEST_P(urDeviceGetInfoTest, SuccessFanSpeed) {
                              property_value);
 }
 
+// If this test fails with NVML driver/library version mismatch,
+// update NVIDIA driver on CI host to match container's NVML version.
 TEST_P(urDeviceGetInfoTest, SuccessMaxPowerLimit) {
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_POWER_LIMIT;
@@ -2611,6 +2617,8 @@ TEST_P(urDeviceGetInfoTest, SuccessMaxPowerLimit) {
                              property_value);
 }
 
+// If this test fails with NVML driver/library version mismatch,
+// update NVIDIA driver on CI host to match container's NVML version.
 TEST_P(urDeviceGetInfoTest, SuccessMinPowerLimit) {
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_MIN_POWER_LIMIT;

--- a/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
@@ -2560,8 +2560,7 @@ TEST_P(urDeviceGetInfoTest, SuccessBfloat16ConversionsNative) {
                              property_value);
 }
 
-// If this test fails with NVML driver/library version mismatch,
-// update NVIDIA driver on CI host to match container's NVML version.
+// This test uses NVML which requires driver/library version match.
 TEST_P(urDeviceGetInfoTest, SuccessThrottleReasons) {
   size_t property_size = 0;
   const ur_device_info_t property_name =
@@ -2579,8 +2578,7 @@ TEST_P(urDeviceGetInfoTest, SuccessThrottleReasons) {
   ASSERT_EQ(property_value & UR_DEVICE_THROTTLE_REASONS_FLAGS_MASK, 0);
 }
 
-// If this test fails with NVML driver/library version mismatch,
-// update NVIDIA driver on CI host to match container's NVML version.
+// This test uses NVML which requires driver/library version match.
 TEST_P(urDeviceGetInfoTest, SuccessFanSpeed) {
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_FAN_SPEED;
@@ -2598,8 +2596,7 @@ TEST_P(urDeviceGetInfoTest, SuccessFanSpeed) {
                              property_value);
 }
 
-// If this test fails with NVML driver/library version mismatch,
-// update NVIDIA driver on CI host to match container's NVML version.
+// This test uses NVML which requires driver/library version match.
 TEST_P(urDeviceGetInfoTest, SuccessMaxPowerLimit) {
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_POWER_LIMIT;
@@ -2617,8 +2614,7 @@ TEST_P(urDeviceGetInfoTest, SuccessMaxPowerLimit) {
                              property_value);
 }
 
-// If this test fails with NVML driver/library version mismatch,
-// update NVIDIA driver on CI host to match container's NVML version.
+// This test uses NVML which requires driver/library version match.
 TEST_P(urDeviceGetInfoTest, SuccessMinPowerLimit) {
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_MIN_POWER_LIMIT;


### PR DESCRIPTION
**Remove xfails from 4 CUDA conformance tests that require NVML:**
- SuccessThrottleReasons (UR_DEVICE_INFO_CURRENT_CLOCK_THROTTLE_REASONS)
- SuccessFanSpeed (UR_DEVICE_INFO_FAN_SPEED)
- SuccessMaxPowerLimit (UR_DEVICE_INFO_MAX_POWER_LIMIT)
- SuccessMinPowerLimit (UR_DEVICE_INFO_MIN_POWER_LIMIT)

These tests were failing with 'Driver/library version mismatch' due to incompatibility between libnvidia-ml.so in the container (550.144) and the NVIDIA driver on the CI host.

**Add Early NVML Version Check in CI**
New workflow step that validates compatibility before running tests:
- Detects host driver version via nvidia-smi
- Detects container NVML library version from libnvidia-ml.so.1
- Tests compatibility by running nvidia-smi from container
- Fails fast with clear error message if versions are incompatible
- Uses GitHub Actions error annotations for high visibility

**NVML Version Compatibility Rules**
Per NVIDIA NVML API documentation:

- Major version must match: Driver 550.x requires libNVML 550.x
- Library version ≤ Driver version: Library cannot be newer than driver
- Different major versions always fail: Driver 550.x + libNVML 565.x = mismatch
- Examples:

✅ Driver 550.90.07 + libNVML 550.90.07 (exact match)
✅ Driver 550.90.07 + libNVML 550.54.15 (older library minor version)
❌ Driver 550.90.07 + libNVML 565.57.01 (different major version)
❌ Driver 550.54.15 + libNVML 550.90.07 (newer library minor version)
The check uses nvidia-smi to validate compatibility, which implements NVIDIA's official version checking logic.
