### PR TITLE
[UR] Fix validation of arguments of urKernelLaunchWithArgsExp()

### DIFF
--- a/unified-runtime/include/unified-runtime/ur_api.h
+++ b/unified-runtime/include/unified-runtime/ur_api.h
@@ -8735,11 +8735,12 @@ typedef struct ur_exp_kernel_arg_properties_t {
 ///     - ::UR_RESULT_ERROR_IN_EVENT_LIST_EXEC_STATUS
 ///         + An event in `phEventWaitList` has ::UR_EVENT_STATUS_ERROR.
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
-///         + `pGlobalWorkSize[0] == 0 || pGlobalWorkSize[1] == 0 ||
-///         pGlobalWorkSize[2] == 0`
+///         + `pGlobalWorkSize[0] == 0 || (workDim >= 2 && pGlobalWorkSize[1] ==
+///         0) || (workDim >= 3 && pGlobalWorkSize[2] == 0)`
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
-///         + `pLocalWorkSize && (pLocalWorkSize[0] == 0 || pLocalWorkSize[1] ==
-///         0 || pLocalWorkSize[2] == 0)`
+///         + `pLocalWorkSize && (pLocalWorkSize[0] == 0 || (workDim >= 2 &&
+///         pLocalWorkSize[1] == 0) || (workDim >= 3 && pLocalWorkSize[2] ==
+///         0))`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS - "The kernel argument values
 ///     have not been specified."

--- a/unified-runtime/scripts/core/exp-enqueue-kernel-launch-with-args.yml
+++ b/unified-runtime/scripts/core/exp-enqueue-kernel-launch-with-args.yml
@@ -152,9 +152,9 @@ returns:
     - $X_RESULT_ERROR_IN_EVENT_LIST_EXEC_STATUS:
         - "An event in `phEventWaitList` has $X_EVENT_STATUS_ERROR."
     - $X_RESULT_ERROR_INVALID_WORK_DIMENSION:
-        - "`pGlobalWorkSize[0] == 0 || pGlobalWorkSize[1] == 0 || pGlobalWorkSize[2] == 0`"
+        - "`pGlobalWorkSize[0] == 0 || (workDim >= 2 && pGlobalWorkSize[1] == 0) || (workDim >= 3 && pGlobalWorkSize[2] == 0)`"
     - $X_RESULT_ERROR_INVALID_WORK_GROUP_SIZE:
-        - "`pLocalWorkSize && (pLocalWorkSize[0] == 0 || pLocalWorkSize[1] == 0 || pLocalWorkSize[2] == 0)`"
+        - "`pLocalWorkSize && (pLocalWorkSize[0] == 0 || (workDim >= 2 && pLocalWorkSize[1] == 0) || (workDim >= 3 && pLocalWorkSize[2] == 0))`"
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_KERNEL_ARGS
         - "The kernel argument values have not been specified."

--- a/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
+++ b/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
@@ -6196,12 +6196,13 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchWithArgsExp(
     if (phEventWaitList != NULL && numEventsInWaitList == 0)
       return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
 
-    if (pGlobalWorkSize[0] == 0 || pGlobalWorkSize[1] == 0 ||
-        pGlobalWorkSize[2] == 0)
+    if (pGlobalWorkSize[0] == 0 || (workDim >= 2 && pGlobalWorkSize[1] == 0) ||
+        (workDim >= 3 && pGlobalWorkSize[2] == 0))
       return UR_RESULT_ERROR_INVALID_WORK_DIMENSION;
 
-    if (pLocalWorkSize && (pLocalWorkSize[0] == 0 || pLocalWorkSize[1] == 0 ||
-                           pLocalWorkSize[2] == 0))
+    if (pLocalWorkSize &&
+        (pLocalWorkSize[0] == 0 || (workDim >= 2 && pLocalWorkSize[1] == 0) ||
+         (workDim >= 3 && pLocalWorkSize[2] == 0)))
       return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
 
     if (phEventWaitList != NULL && numEventsInWaitList > 0) {

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -6166,11 +6166,12 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 ///     - ::UR_RESULT_ERROR_IN_EVENT_LIST_EXEC_STATUS
 ///         + An event in `phEventWaitList` has ::UR_EVENT_STATUS_ERROR.
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
-///         + `pGlobalWorkSize[0] == 0 || pGlobalWorkSize[1] == 0 ||
-///         pGlobalWorkSize[2] == 0`
+///         + `pGlobalWorkSize[0] == 0 || (workDim >= 2 && pGlobalWorkSize[1] ==
+///         0) || (workDim >= 3 && pGlobalWorkSize[2] == 0)`
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
-///         + `pLocalWorkSize && (pLocalWorkSize[0] == 0 || pLocalWorkSize[1] ==
-///         0 || pLocalWorkSize[2] == 0)`
+///         + `pLocalWorkSize && (pLocalWorkSize[0] == 0 || (workDim >= 2 &&
+///         pLocalWorkSize[1] == 0) || (workDim >= 3 && pLocalWorkSize[2] ==
+///         0))`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS - "The kernel argument values
 ///     have not been specified."

--- a/unified-runtime/source/ur_api.cpp
+++ b/unified-runtime/source/ur_api.cpp
@@ -5441,11 +5441,12 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 ///     - ::UR_RESULT_ERROR_IN_EVENT_LIST_EXEC_STATUS
 ///         + An event in `phEventWaitList` has ::UR_EVENT_STATUS_ERROR.
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
-///         + `pGlobalWorkSize[0] == 0 || pGlobalWorkSize[1] == 0 ||
-///         pGlobalWorkSize[2] == 0`
+///         + `pGlobalWorkSize[0] == 0 || (workDim >= 2 && pGlobalWorkSize[1] ==
+///         0) || (workDim >= 3 && pGlobalWorkSize[2] == 0)`
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
-///         + `pLocalWorkSize && (pLocalWorkSize[0] == 0 || pLocalWorkSize[1] ==
-///         0 || pLocalWorkSize[2] == 0)`
+///         + `pLocalWorkSize && (pLocalWorkSize[0] == 0 || (workDim >= 2 &&
+///         pLocalWorkSize[1] == 0) || (workDim >= 3 && pLocalWorkSize[2] ==
+///         0))`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS - "The kernel argument values
 ///     have not been specified."


### PR DESCRIPTION
The validation layer in ur_valddi.cpp (generated from YAML spec)
checked pGlobalWorkSize[0], [1], and [2] and
pLocalWorkSize[0], [1], and [2] regardless of workDim.
For 1D kernels, indices [1] and [2] read out-of-bounds memory,
causing spurious UR_RESULT_ERROR_INVALID_WORK_DIMENSION errors.

Removed the hardcoded 3-element validation expressions
for pGlobalWorkSize and pLocalWorkSize that couldn't account for workDim.