### PR TITLE
[UR][L0v2] Check for external memory mapping extension before use

### DIFF
--- a/unified-runtime/source/adapters/level_zero/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/platform.cpp
@@ -297,6 +297,12 @@ ur_result_t ur_platform_handle_t_::initialize() {
         ZeLUIDSupported = true;
       }
     }
+    if (strncmp(extension.name, ZE_EXTERNAL_MEMORY_MAPPING_EXT_NAME,
+                strlen(ZE_EXTERNAL_MEMORY_MAPPING_EXT_NAME) + 1) == 0) {
+      if (extension.version == ZE_EXTERNAL_MEMMAP_SYSMEM_EXT_VERSION_CURRENT) {
+        ZeExternalMemoryMappingExtensionSupported = true;
+      }
+    }
     zeDriverExtensionMap[extension.name] = extension.version;
   }
 

--- a/unified-runtime/source/adapters/level_zero/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/platform.hpp
@@ -74,6 +74,7 @@ struct ur_platform_handle_t_ : ur::handle_base<ur::level_zero::ddi_getter>,
   bool ZeCopyOffloadQueueFlagSupported{false};
   bool ZeCopyOffloadListFlagSupported{false};
   bool ZeBindlessImagesExtensionSupported{false};
+  bool ZeExternalMemoryMappingExtensionSupported{false};
   bool ZeLUIDSupported{false};
 
   // Cache UR devices for reuse

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -847,6 +847,10 @@ ur_result_t UR_APICALL urUSMContextMemcpyExp(ur_context_handle_t hContext,
 ur_result_t urUSMHostAllocRegisterExp(
     ur_context_handle_t hContext, void *pHostMem, size_t size,
     const ur_exp_usm_host_alloc_register_properties_t * /*pProperties*/) {
+  if (!hContext->getPlatform()->ZeExternalMemoryMappingExtensionSupported) {
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  }
+
   ze_external_memmap_sysmem_ext_desc_t sysMemDesc = {
       ZE_STRUCTURE_TYPE_EXTERNAL_MEMMAP_SYSMEM_EXT_DESC, nullptr, pHostMem,
       size};

--- a/unified-runtime/source/adapters/level_zero/v2/usm.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/usm.cpp
@@ -868,6 +868,10 @@ ur_result_t urUSMHostAllocRegisterExp(
 
 ur_result_t urUSMHostAllocUnregisterExp(ur_context_handle_t hContext,
                                         void *pHostMem) {
+  if (!hContext->getPlatform()->ZeExternalMemoryMappingExtensionSupported) {
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  }
+
   ZE2UR_CALL(zeMemFree, (hContext->getZeHandle(), pHostMem));
 
   return UR_RESULT_SUCCESS;

--- a/unified-runtime/test/conformance/exp_usm_host_mem_register/urUSMHostMemRegister.cpp
+++ b/unified-runtime/test/conformance/exp_usm_host_mem_register/urUSMHostMemRegister.cpp
@@ -43,10 +43,8 @@ struct urUSMHostMemRegisterTest : uur::urQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMHostMemRegisterTest);
 
 TEST_P(urUSMHostMemRegisterTest, Success) {
-  // https://github.com/intel/llvm/issues/21633
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
-
-  ASSERT_SUCCESS(urUSMHostAllocRegisterExp(context, alloc, allocSize, nullptr));
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urUSMHostAllocRegisterExp(context, alloc, allocSize, nullptr));
 
   void *alloc2 = nullptr;
   ASSERT_SUCCESS(urUSMHostAlloc(context, nullptr, nullptr, allocSize, &alloc2));


### PR DESCRIPTION
urUSMHostAllocRegisterExp in the L0v2 adapter was unconditionally using
the ZE_extension_external_memmap_sysmem extension to register host
memory, causing zeMemAllocHost to return ZE_RESULT_ERROR_INVALID_ARGUMENT
on drivers that do not support this extension. This resulted in
UR_RESULT_ERROR_INVALID_VALUE being returned instead of the expected
UR_RESULT_ERROR_UNSUPPORTED_FEATURE.

Add a platform-level check for ZE_EXTERNAL_MEMORY_MAPPING_EXT_NAME
during driver extension enumeration, and return
UR_RESULT_ERROR_UNSUPPORTED_FEATURE early from urUSMHostAllocRegisterExp
when the extension is not available.

Update the conformance test to use UUR_ASSERT_SUCCESS_OR_UNSUPPORTED so
it gracefully skips when the driver does not support the extension,
rather than failing.