### PR TITLE
[SYCL][NFC] remove default label from switches over enums

### DIFF
--- a/llvm/lib/SYCLLowerIR/SpecConstants.cpp
+++ b/llvm/lib/SYCLLowerIR/SpecConstants.cpp
@@ -848,9 +848,9 @@ StringRef SpecConstantsPass::convertHandlingModeToString(HandlingMode Mode) {
     return "emulation";
   case SpecConstantsPass::HandlingMode::default_values:
     return "default_values";
-  default:
-    llvm_unreachable("unknown value");
   }
+
+  llvm_unreachable("uncovered input value");
 }
 
 PreservedAnalyses SpecConstantsPass::run(Module &M,

--- a/llvm/lib/SYCLPostLink/ModuleSplitter.cpp
+++ b/llvm/lib/SYCLPostLink/ModuleSplitter.cpp
@@ -492,9 +492,9 @@ StringRef convertSplitModeToString(IRSplitMode Mode) {
     return "auto";
   case IRSplitMode::SPLIT_NONE:
     return "none";
-  default:
-    llvm_unreachable("unknown value");
   }
+
+  llvm_unreachable("uncovered input value");
 }
 
 bool isESIMDFunction(const Function &F) {


### PR DESCRIPTION
The patch adjusts the handling of uncovered values according to LLVM guideline -https://llvm.org/docs/CodingStandards.html#don-t-use-default-labels-in-fully-covered-switches-over-enumerations