### PR TITLE
[UR] Set INSTALL_RPATH to $ORIGIN for adapter shared libraries

### DIFF
--- a/unified-runtime/source/adapters/CMakeLists.txt
+++ b/unified-runtime/source/adapters/CMakeLists.txt
@@ -20,6 +20,11 @@ function(add_ur_adapter name)
         )
     elseif(APPLE)
         target_compile_options(${name} PRIVATE "-fvisibility=hidden")
+        # @loader_path is the macOS equivalent of $ORIGIN: it resolves
+        # relative to the directory containing the loading library.
+        set_target_properties(${name} PROPERTIES
+            INSTALL_RPATH "@loader_path"
+        )
     else()
         set(TARGET_LIBNAME lib${name}_${PROJECT_VERSION_MAJOR}.0)
         string(TOUPPER ${TARGET_LIBNAME} TARGET_LIBNAME)
@@ -32,6 +37,15 @@ function(add_ur_adapter name)
         )
         target_link_options(${name} PRIVATE
             "-Wl,--version-script=${ADAPTER_VERSION_SCRIPT}"
+        )
+        # Set the install RPATH so installed adapters can find co-located
+        # dependencies (e.g. libumf.so, libze_loader.so) without requiring
+        # LD_LIBRARY_PATH. BUILD_WITH_INSTALL_RPATH is intentionally not set:
+        # CMAKE_BUILD_RPATH already points to the build output directory for
+        # the build tree, and $ORIGIN is only correct at install time when
+        # all libraries reside in the same directory.
+        set_target_properties(${name} PROPERTIES
+            INSTALL_RPATH "\$ORIGIN"
         )
     endif()
     add_dependencies(ur_loader ${name})


### PR DESCRIPTION
UR adapter shared libraries (libur_adapter_*.so) depend on libumf.so
but lack RUNPATH, causing them to fail to find libumf.so when
LD_LIBRARY_PATH is not set. This breaks deployed SYCL applications
that redistribute the libraries without setting LD_LIBRARY_PATH.

Set INSTALL_RPATH to $ORIGIN in the add_ur_adapter() CMake function
so all adapter shared libraries can find their dependencies (libumf.so,
libze_loader.so, etc.) in the same directory, matching how libsycl.so
already sets RUNPATH to find libur_loader.so.

Fixes: intel/llvm#21650
