### PR TITLE
[UR] Mark urUSMHostMemRegisterTest as known failure on L0v2

### DIFF
--- a/unified-runtime/test/conformance/exp_usm_host_mem_register/urUSMHostMemRegister.cpp
+++ b/unified-runtime/test/conformance/exp_usm_host_mem_register/urUSMHostMemRegister.cpp
@@ -43,6 +43,9 @@ struct urUSMHostMemRegisterTest : uur::urQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMHostMemRegisterTest);
 
 TEST_P(urUSMHostMemRegisterTest, Success) {
+  // https://github.com/intel/llvm/issues/21633
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
+
   ASSERT_SUCCESS(urUSMHostAllocRegisterExp(context, alloc, allocSize, nullptr));
 
   void *alloc2 = nullptr;


### PR DESCRIPTION
The urUSMHostMemRegisterTest.Success test intermittently fails on
Level-Zero V2 with UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY during
urEnqueueUSMMemcpy after registering host memory.

Add uur::LevelZeroV2{} to the UUR_KNOWN_FAILURE_ON list to disable
this test on L0v2 until the root cause is resolved.

Ref: intel/llvm#21633
