### PR TITLE
[UR][L0v2] Always set NON_IMMEDIATE flag on counter-based events

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/event_provider_counter.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event_provider_counter.cpp
@@ -52,9 +52,9 @@ static zex_counter_based_event_exp_flags_t createZeFlags(queue_type queueType,
 
   if (queueType == QUEUE_IMMEDIATE) {
     zeFlags |= ZEX_COUNTER_BASED_EVENT_FLAG_IMMEDIATE;
-  } else {
-    zeFlags |= ZEX_COUNTER_BASED_EVENT_FLAG_NON_IMMEDIATE;
   }
+  // Always set non immediate flag for compatibility with graph record & replay
+  zeFlags |= ZEX_COUNTER_BASED_EVENT_FLAG_NON_IMMEDIATE;
 
   return zeFlags;
 }


### PR DESCRIPTION
Set `ZEX_COUNTER_BASED_EVENT_FLAG_NON_IMMEDIATE` unconditionally so that counter-based events are compatible with Level Zero graph record & replay, which requires both immediate and non-immediate flags to be set.

Part of https://github.com/intel/llvm/pull/21626.