### PR TITLE
[UR][CTS] Replace urEnqueueEventsWait with dummy event in waitlist tests

### DIFF
--- a/unified-runtime/test/conformance/enqueue/CMakeLists.txt
+++ b/unified-runtime/test/conformance/enqueue/CMakeLists.txt
@@ -15,10 +15,8 @@ add_conformance_kernels_test(enqueue
     urEnqueueMemBufferCopy.cpp
     urEnqueueMemBufferFill.cpp
     urEnqueueMemBufferMap.cpp
-    # Enqueue memory buffer read tests ran simultenously lead to timeouts.
-    # Tracker: https://jira.devtools.intel.com/browse/URT-1026
-    # urEnqueueMemBufferRead.cpp
-    # urEnqueueMemBufferReadRect.cpp
+    urEnqueueMemBufferRead.cpp
+    urEnqueueMemBufferReadRect.cpp
     urEnqueueMemBufferWrite.cpp
     urEnqueueMemBufferWriteRect.cpp
     urEnqueueMemImageCopy.cpp

--- a/unified-runtime/test/conformance/enqueue/urEnqueueEventsWait.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueEventsWait.cpp
@@ -6,6 +6,7 @@
 
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct urEnqueueEventsWaitTest : uur::urMultiQueueTest {
   void SetUp() override {
@@ -108,15 +109,14 @@ TEST_P(urEnqueueEventsWaitTest, InvalidNullPtrEventWaitList) {
   ASSERT_EQ_RESULT(urEnqueueEventsWait(queue1, 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue1, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
-  ASSERT_EQ_RESULT(urEnqueueEventsWait(queue1, 0, &validEvent, nullptr),
+  ASSERT_EQ_RESULT(urEnqueueEventsWait(queue1, 0, eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
   ASSERT_EQ_RESULT(urEnqueueEventsWait(queue1, 1, &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueEventsWait.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueEventsWait.cpp
@@ -110,8 +110,7 @@ TEST_P(urEnqueueEventsWaitTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueEventsWait(queue1, 0, eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 enum class BarrierType {
   Normal,
@@ -150,17 +151,16 @@ TEST_P(urEnqueueEventsWaitWithBarrierTest, InvalidNullPtrEventWaitList) {
   ASSERT_EQ_RESULT(EnqueueBarrier(queue1, 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue1, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
-  ASSERT_EQ_RESULT(EnqueueBarrier(queue1, 0, &validEvent, nullptr),
+  ASSERT_EQ_RESULT(EnqueueBarrier(queue1, 0, eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
   ASSERT_EQ_RESULT(EnqueueBarrier(queue1, 1, &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueEventsWaitWithBarrierOrderingTest,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
@@ -152,8 +152,7 @@ TEST_P(urEnqueueEventsWaitWithBarrierTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(EnqueueBarrier(queue1, 0, eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunchWithArgsExp.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunchWithArgsExp.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct urEnqueueKernelLaunchNoArgs3DTest : uur::urKernelExecutionTest {
   void SetUp() override {
@@ -187,13 +188,14 @@ TEST_P(urEnqueueKernelLaunchTest, InvalidNullPtrEventWaitList) {
                                        nullptr, nullptr, 1, nullptr, nullptr),
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueKernelLaunchWithArgsExp(
                        queue, kernel, n_dimensions, &global_offset,
                        &global_size, nullptr, 0, nullptr, nullptr, 0,
-                       &validEvent, nullptr),
+                       eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
@@ -202,7 +204,6 @@ TEST_P(urEnqueueKernelLaunchTest, InvalidNullPtrEventWaitList) {
                                        &global_offset, &global_size, nullptr, 0,
                                        nullptr, nullptr, 1, &inv_evt, nullptr),
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueKernelLaunchTest, InvalidWorkDimension) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunchWithArgsExp.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueKernelLaunchWithArgsExp.cpp
@@ -189,8 +189,7 @@ TEST_P(urEnqueueKernelLaunchTest, InvalidNullPtrEventWaitList) {
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueKernelLaunchWithArgsExp(
                        queue, kernel, n_dimensions, &global_offset,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -8,6 +8,7 @@
 #include "uur/utils.h"
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct urEnqueueMemBufferCopyTestWithParam
     : uur::urMultiQueueTypeTestWithParam<size_t> {
@@ -82,19 +83,18 @@ TEST_P(urEnqueueMemBufferCopyTestWithParam, InvalidNullPtrEventWaitList) {
                                           size, 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
-                                          size, 0, &validEvent, nullptr),
+                                          size, 0, eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
   ASSERT_EQ_RESULT(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
                                           size, 1, &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferCopyTestWithParam, InvalidSize) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -84,8 +84,7 @@ TEST_P(urEnqueueMemBufferCopyTestWithParam, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
                                           size, 0, eventDummy.ptr(), nullptr),

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -7,6 +7,7 @@
 #include "uur/fixtures.h"
 #include "uur/known_failure.h"
 #include <numeric>
+#include <uur/raii.h>
 
 static std::vector<uur::test_parameters_t> generateParameterizations() {
   std::vector<uur::test_parameters_t> parameterizations;
@@ -214,14 +215,15 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullPtrEventWaitList) {
                        src_region, size, size, size, size, 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
-  ASSERT_EQ_RESULT(urEnqueueMemBufferCopyRect(queue, src_buffer, dst_buffer,
-                                              src_origin, dst_origin,
-                                              src_region, size, size, size,
-                                              size, 0, &validEvent, nullptr),
-                   UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+  ASSERT_EQ_RESULT(
+      urEnqueueMemBufferCopyRect(queue, src_buffer, dst_buffer, src_origin,
+                                 dst_origin, src_region, size, size, size, size,
+                                 0, eventDummy.ptr(), nullptr),
+      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
   ASSERT_EQ_RESULT(urEnqueueMemBufferCopyRect(queue, src_buffer, dst_buffer,
@@ -229,8 +231,6 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullPtrEventWaitList) {
                                               src_region, size, size, size,
                                               size, 1, &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 TEST_P(urEnqueueMemBufferCopyRectTest, InvalidSize) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -216,8 +216,7 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(
       urEnqueueMemBufferCopyRect(queue, src_buffer, dst_buffer, src_origin,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "helpers.h"
 #include <uur/fixtures.h>
+#include <uur/raii.h>
 
 struct testParametersFill {
   size_t size;
@@ -184,12 +185,13 @@ TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidNullPtrEventWaitList) {
                                           nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferFill(queue, buffer, &pattern,
                                           sizeof(uint32_t), 0, size, 0,
-                                          &validEvent, nullptr),
+                                          eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
@@ -197,8 +199,6 @@ TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidNullPtrEventWaitList) {
                                           sizeof(uint32_t), 0, size, 1,
                                           &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidSize) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -186,8 +186,7 @@ TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferFill(queue, buffer, &pattern,
                                           sizeof(uint32_t), 0, size, 0,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -6,6 +6,7 @@
 #include "helpers.h"
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 using urEnqueueMemBufferMapTestWithParam =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
@@ -280,12 +281,13 @@ TEST_P(urEnqueueMemBufferMapTestWithParam, InvalidNullPtrEventWaitList) {
                                          0, size, 1, nullptr, nullptr, &map),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferMap(queue, buffer, true,
                                          UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
-                                         0, size, 0, &validEvent, nullptr,
+                                         0, size, 0, eventDummy.ptr(), nullptr,
                                          &map),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
@@ -294,8 +296,6 @@ TEST_P(urEnqueueMemBufferMapTestWithParam, InvalidNullPtrEventWaitList) {
                                          UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
                                          0, size, 1, &inv_evt, nullptr, &map),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferMapTestWithParam, InvalidSize) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -282,8 +282,7 @@ TEST_P(urEnqueueMemBufferMapTestWithParam, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferMap(queue, buffer, true,
                                          UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -6,6 +6,7 @@
 #include "helpers.h"
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 using urEnqueueMemBufferReadTestWithParam =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
@@ -50,11 +51,12 @@ TEST_P(urEnqueueMemBufferReadTestWithParam, InvalidNullPtrEventWaitList) {
                                           output.data(), 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, &validEvent,
+                                          output.data(), 0, eventDummy.ptr(),
                                           nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
@@ -62,8 +64,6 @@ TEST_P(urEnqueueMemBufferReadTestWithParam, InvalidNullPtrEventWaitList) {
   ASSERT_EQ_RESULT(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
                                           output.data(), 1, &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferReadTestWithParam, InvalidSize) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -52,8 +52,7 @@ TEST_P(urEnqueueMemBufferReadTestWithParam, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
                                           output.data(), 0, eventDummy.ptr(),

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -7,6 +7,7 @@
 #include "uur/fixtures.h"
 #include <numeric>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 // Choose parameters so that we get good coverage and catch some edge cases.
 static std::vector<uur::test_parameters_t> generateParameterizations() {
@@ -175,13 +176,15 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPtrEventWaitList) {
                        host_slice_pitch, dst.data(), 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferReadRect(
                        queue, buffer, true, buffer_offset, host_offset, region,
                        buffer_row_pitch, buffer_slice_pitch, host_row_pitch,
-                       host_slice_pitch, dst.data(), 0, &validEvent, nullptr),
+                       host_slice_pitch, dst.data(), 0, eventDummy.ptr(),
+                       nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t invalidEvent = nullptr;
@@ -190,8 +193,6 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPtrEventWaitList) {
                        buffer_row_pitch, buffer_slice_pitch, host_row_pitch,
                        host_slice_pitch, dst.data(), 1, &invalidEvent, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferReadRectTest, InvalidSize) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -177,8 +177,7 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferReadRect(
                        queue, buffer, true, buffer_offset, host_offset, region,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
@@ -6,6 +6,7 @@
 #include "helpers.h"
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 using urEnqueueMemBufferWriteTestWithParam =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
@@ -62,11 +63,12 @@ TEST_P(urEnqueueMemBufferWriteTestWithParam, InvalidNullPtrEventWaitList) {
                                            input.data(), 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, &validEvent,
+                                           input.data(), 0, eventDummy.ptr(),
                                            nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
@@ -74,8 +76,6 @@ TEST_P(urEnqueueMemBufferWriteTestWithParam, InvalidNullPtrEventWaitList) {
   ASSERT_EQ_RESULT(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
                                            input.data(), 1, &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferWriteTestWithParam, InvalidSize) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
@@ -64,8 +64,7 @@ TEST_P(urEnqueueMemBufferWriteTestWithParam, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
                                            input.data(), 0, eventDummy.ptr(),

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -7,6 +7,7 @@
 #include "uur/fixtures.h"
 #include <numeric>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 static std::vector<uur::test_parameters_t> generateParameterizations() {
   std::vector<uur::test_parameters_t> parameterizations;
@@ -178,13 +179,14 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPtrEventWaitList) {
                        size, size, size, size, src.data(), 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(
       urEnqueueMemBufferWriteRect(queue, buffer, true, buffer_offset,
                                   host_offset, region, size, size, size, size,
-                                  src.data(), 0, &validEvent, nullptr),
+                                  src.data(), 0, eventDummy.ptr(), nullptr),
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
@@ -193,8 +195,6 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPtrEventWaitList) {
                                   host_offset, region, size, size, size, size,
                                   src.data(), 1, &inv_evt, nullptr),
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidSize) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -180,8 +180,7 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(
       urEnqueueMemBufferWriteRect(queue, buffer, true, buffer_offset,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct urEnqueueMemImageCopyTest
     : public uur::urMultiQueueTypeTestWithParam<ur_mem_type_t> {
@@ -243,11 +244,12 @@ TEST_P(urEnqueueMemImageCopyTest, InvalidNullPtrEventWaitList) {
                                          {0, 0, 0}, size, 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemImageCopy(queue, srcImage, dstImage, {0, 0, 0},
-                                         {0, 0, 0}, size, 0, &validEvent,
+                                         {0, 0, 0}, size, 0, eventDummy.ptr(),
                                          nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
@@ -255,8 +257,6 @@ TEST_P(urEnqueueMemImageCopyTest, InvalidNullPtrEventWaitList) {
   ASSERT_EQ_RESULT(urEnqueueMemImageCopy(queue, srcImage, dstImage, {0, 0, 0},
                                          {0, 0, 0}, size, 1, &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemImageCopyTest, InvalidSize) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
@@ -245,8 +245,7 @@ TEST_P(urEnqueueMemImageCopyTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemImageCopy(queue, srcImage, dstImage, {0, 0, 0},
                                          {0, 0, 0}, size, 0, eventDummy.ptr(),

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageRead.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageRead.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct urEnqueueMemImageReadTest : uur::urMemImageQueueTest {
   void SetUp() override {
@@ -67,12 +68,13 @@ TEST_P(urEnqueueMemImageReadTest, InvalidNullPtrEventWaitList) {
                                          nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemImageRead(queue, image1D, true, origin, region1D,
-                                         0, 0, output.data(), 0, &validEvent,
-                                         nullptr),
+                                         0, 0, output.data(), 0,
+                                         eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
@@ -80,8 +82,6 @@ TEST_P(urEnqueueMemImageReadTest, InvalidNullPtrEventWaitList) {
                                          0, 0, output.data(), 1, &inv_evt,
                                          nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemImageReadTest, InvalidOrigin1D) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageRead.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageRead.cpp
@@ -69,8 +69,7 @@ TEST_P(urEnqueueMemImageReadTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemImageRead(queue, image1D, true, origin, region1D,
                                          0, 0, output.data(), 0,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct urEnqueueMemImageWriteTest : uur::urMemImageQueueTest {
   void SetUp() override {
@@ -65,12 +66,13 @@ TEST_P(urEnqueueMemImageWriteTest, InvalidNullPtrEventWaitList) {
                                           nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemImageWrite(queue, image1D, true, origin,
                                           region1D, 0, 0, input.data(), 0,
-                                          &validEvent, nullptr),
+                                          eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
@@ -78,8 +80,6 @@ TEST_P(urEnqueueMemImageWriteTest, InvalidNullPtrEventWaitList) {
                                           region1D, 0, 0, input.data(), 1,
                                           &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemImageWriteTest, InvalidOrigin1D) {

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
@@ -67,8 +67,7 @@ TEST_P(urEnqueueMemImageWriteTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueMemImageWrite(queue, image1D, true, origin,
                                           region1D, 0, 0, input.data(), 0,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemUnmap.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemUnmap.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "helpers.h"
 #include <uur/fixtures.h>
+#include <uur/raii.h>
 
 struct urEnqueueMemUnmapTestWithParam
     : uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t> {
@@ -56,16 +57,15 @@ TEST_P(urEnqueueMemUnmapTestWithParam, InvalidNullPtrEventWaitList) {
   ASSERT_EQ_RESULT(urEnqueueMemUnmap(queue, buffer, map, 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(
-      urEnqueueMemUnmap(queue, buffer, map, 0, &validEvent, nullptr),
+      urEnqueueMemUnmap(queue, buffer, map, 0, eventDummy.ptr(), nullptr),
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
   ASSERT_EQ_RESULT(urEnqueueMemUnmap(queue, buffer, map, 1, &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemUnmap.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemUnmap.cpp
@@ -58,8 +58,7 @@ TEST_P(urEnqueueMemUnmapTestWithParam, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(
       urEnqueueMemUnmap(queue, buffer, map, 0, eventDummy.ptr(), nullptr),

--- a/unified-runtime/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
+#include <uur/raii.h>
 
 using urEnqueueReadHostPipeTest = uur::urHostPipeTest;
 
@@ -70,19 +71,18 @@ TEST_P(urEnqueueReadHostPipeTest, InvalidEventWaitList) {
                                          /*blocking*/ true, &buffer, size, 0,
                                          &phEventWaitList, phEvent));
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
                    urEnqueueReadHostPipe(queue, program, pipe_symbol,
                                          /*blocking*/ true, &buffer, size, 0,
-                                         &validEvent, nullptr));
+                                         eventDummy.ptr(), nullptr));
 
   ur_event_handle_t inv_evt = nullptr;
   ASSERT_EQ_RESULT(urEnqueueReadHostPipe(queue, program, pipe_symbol,
                                          /*blocking*/ true, &buffer, size, 1,
                                          &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
@@ -72,8 +72,7 @@ TEST_P(urEnqueueReadHostPipeTest, InvalidEventWaitList) {
                                          &phEventWaitList, phEvent));
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
                    urEnqueueReadHostPipe(queue, program, pipe_symbol,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct urEnqueueTimestampRecordingExpTest : uur::urMultiQueueTypeTest {
   void SetUp() override {
@@ -152,12 +153,12 @@ TEST_P(urEnqueueTimestampRecordingExpTest, InvalidNullPtrEventWaitList) {
       urEnqueueTimestampRecordingExp(queue, true, 1, nullptr, &event),
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
   ASSERT_EQ_RESULT(
-      urEnqueueTimestampRecordingExp(queue, true, 0, &validEvent, &event),
+      urEnqueueTimestampRecordingExp(queue, true, 0, eventDummy.ptr(), &event),
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 
   ur_event_handle_t invalidEvent = nullptr;
   ASSERT_EQ_RESULT(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
@@ -154,8 +154,7 @@ TEST_P(urEnqueueTimestampRecordingExpTest, InvalidNullPtrEventWaitList) {
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
   ASSERT_EQ_RESULT(
       urEnqueueTimestampRecordingExp(queue, true, 0, eventDummy.ptr(), &event),
       UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -6,6 +6,7 @@
 
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct testParametersFill {
   size_t size;
@@ -216,16 +217,16 @@ TEST_P(urEnqueueUSMFillNegativeTest, InvalidEventWaitList) {
                                     size, 1, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
-                                    size, 0, &validEvent, nullptr),
+                                    size, 0, eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
   ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
                                     size, 1, &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -218,8 +218,7 @@ TEST_P(urEnqueueUSMFillNegativeTest, InvalidEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
                                     size, 0, eventDummy.ptr(), nullptr),

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -8,6 +8,7 @@
 
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct testParametersFill2D {
   size_t pitch;
@@ -288,12 +289,13 @@ TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidNullPtrEventWaitList) {
                                       nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
-                                      pattern.data(), width, 1, 0, &validEvent,
-                                      nullptr),
+                                      pattern.data(), width, 1, 0,
+                                      eventDummy.ptr(), nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ur_event_handle_t inv_evt = nullptr;
@@ -301,5 +303,4 @@ TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidNullPtrEventWaitList) {
                                       pattern.data(), width, 1, 1, &inv_evt,
                                       nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -290,8 +290,7 @@ TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
                                       pattern.data(), width, 1, 0,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
@@ -6,6 +6,7 @@
 
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
+#include <uur/raii.h>
 
 struct urEnqueueUSMPrefetchWithParamTest
     : uur::urUSMDeviceAllocTestWithParam<ur_usm_migration_flag_t> {
@@ -143,19 +144,18 @@ TEST_P(urEnqueueUSMPrefetchTest, InvalidEventWaitList) {
                                         UR_USM_MIGRATION_FLAG_HOST_TO_DEVICE, 1,
                                         nullptr, nullptr));
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
                    urEnqueueUSMPrefetch(queue, ptr, allocation_size,
                                         UR_USM_MIGRATION_FLAG_HOST_TO_DEVICE, 0,
-                                        &validEvent, nullptr));
+                                        eventDummy.ptr(), nullptr));
 
   ur_event_handle_t inv_evt = nullptr;
   ASSERT_EQ_RESULT(urEnqueueUSMPrefetch(queue, ptr, allocation_size,
                                         UR_USM_MIGRATION_FLAG_HOST_TO_DEVICE, 1,
                                         &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
@@ -145,8 +145,7 @@ TEST_P(urEnqueueUSMPrefetchTest, InvalidEventWaitList) {
                                         nullptr, nullptr));
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
                    urEnqueueUSMPrefetch(queue, ptr, allocation_size,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
+#include <uur/raii.h>
 
 using urEnqueueWriteHostPipeTest = uur::urHostPipeTest;
 
@@ -70,19 +71,18 @@ TEST_P(urEnqueueWriteHostPipeTest, InvalidEventWaitList) {
                                           /*blocking*/ true, &buffer, size, 0,
                                           &phEventWaitList, phEvent));
 
-  ur_event_handle_t validEvent;
-  ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+  uur::raii::Event eventDummy = nullptr;
+  ASSERT_SUCCESS(
+      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
                    urEnqueueWriteHostPipe(queue, program, pipe_symbol,
                                           /*blocking*/ true, &buffer, size, 0,
-                                          &validEvent, nullptr));
+                                          eventDummy.ptr(), nullptr));
 
   ur_event_handle_t inv_evt = nullptr;
   ASSERT_EQ_RESULT(urEnqueueWriteHostPipe(queue, program, pipe_symbol,
                                           /*blocking*/ true, &buffer, size, 1,
                                           &inv_evt, nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
-
-  ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/unified-runtime/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
@@ -72,8 +72,7 @@ TEST_P(urEnqueueWriteHostPipeTest, InvalidEventWaitList) {
                                           &phEventWaitList, phEvent));
 
   uur::raii::Event eventDummy = nullptr;
-  ASSERT_SUCCESS(
-      urEventCreateWithNativeHandle(0, context, nullptr, eventDummy.ptr()));
+  ASSERT_SUCCESS(uur::MakeDummyEventForWaitList(context, eventDummy.ptr()));
 
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
                    urEnqueueWriteHostPipe(queue, program, pipe_symbol,

--- a/unified-runtime/test/conformance/testing/include/uur/utils.h
+++ b/unified-runtime/test/conformance/testing/include/uur/utils.h
@@ -560,6 +560,16 @@ MakeValueArgProp(uint32_t index, const void *data, size_t size) {
           val};
 }
 
+// Creates a UR event handle from a null native handle. The returned event is
+// NOT a valid event - it cannot be waited on, profiled, or otherwise used.
+// Its only purpose is to provide a non-null ur_event_handle_t so that the
+// validation layer's wait-list argument checks can be exercised in tests
+// without enqueuing any real work on the queue.
+inline ur_result_t MakeDummyEventForWaitList(ur_context_handle_t hContext,
+                                             ur_event_handle_t *phEvent) {
+  return urEventCreateWithNativeHandle(0, hContext, nullptr, phEvent);
+}
+
 } // namespace uur
 
 #endif // UR_CONFORMANCE_INCLUDE_UTILS_H_INCLUDED


### PR DESCRIPTION
InvalidNullPtrEventWaitList tests used urEnqueueEventsWait as the first
operation on a queue to create a valid event for validation testing.
This triggers a hang in the L0 driver when multiple test shards
concurrently call zeCommandListAppendSignalEvent +
zeCommandListHostSynchronize on immediate command lists.

Replace with urEventCreateWithNativeHandle(0, ...) which creates a
dummy event without enqueuing any work, avoiding the L0 driver
concurrency issue entirely. The validation layer rejects invalid
waitlist arguments before reaching the adapter, so the dummy event
is sufficient for these tests.