### PR TITLE
[SYCL] Don't use std::optional<device> in level_zero.hpp header

### DIFF
--- a/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
+++ b/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
@@ -64,12 +64,16 @@ inline context make_context<backend::ext_oneapi_level_zero>(
 }
 
 namespace detail {
-inline std::optional<sycl::device> find_matching_descendent_device(
-    sycl::device d,
+inline bool find_matching_descendent_device(
+    const sycl::device &d,
     const backend_input_t<backend::ext_oneapi_level_zero, device>
-        &BackendObject) {
-  if (get_native<backend::ext_oneapi_level_zero>(d) == BackendObject)
-    return d;
+        &BackendObject,
+    sycl::device &Out) {
+  if (get_native<backend::ext_oneapi_level_zero>(d) == BackendObject) {
+    Out = d;
+    return true;
+  }
+
   std::vector<info::partition_property> partition_props =
       d.get_info<info::device::partition_properties>();
 
@@ -79,14 +83,13 @@ inline std::optional<sycl::device> find_matching_descendent_device(
           info::partition_property::partition_by_affinity_domain>(
           info::partition_affinity_domain::next_partitionable);
       for (auto &sub_dev : sub_devices) {
-        if (auto maybe_device =
-                find_matching_descendent_device(sub_dev, BackendObject))
-          return maybe_device;
+        if (find_matching_descendent_device(sub_dev, BackendObject, Out))
+          return true;
       }
     }
   }
 
-  return {};
+  return false;
 }
 } // namespace detail
 
@@ -113,9 +116,10 @@ inline device make_device<backend::ext_oneapi_level_zero>(
       continue;
 
     for (auto &d : p.get_devices()) {
-      if (auto maybe_device =
-              detail::find_matching_descendent_device(d, BackendObject))
-        return *maybe_device;
+      sycl::device FoundDevice;
+      if (detail::find_matching_descendent_device(d, BackendObject,
+                                                  FoundDevice))
+        return FoundDevice;
     }
   }
 


### PR DESCRIPTION
sycl::device has recently become not trivially copy-constructible and usage of `std::optional` in `level_zero.hpp` header makes sycl apps not buildable with `gcc <= 8.2.0`. So, remove usage of `std::optional` from that header.

Workaround for the bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87855