### PR TITLE
Fix stale device global initializers on RTC program reuse

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -269,7 +269,7 @@ void context_impl::removeDeviceGlobalInitializer(
   for (auto It = MDeviceGlobalInitializers.begin();
        It != MDeviceGlobalInitializers.end();) {
     const bool ProgramMatches = It->first.first == Program;
-    const bool ImageMatches = !BinImage || It->second.MBinImage == BinImage;
+    const bool ImageMatches = It->second.MBinImage == BinImage;
 
     if (!ProgramMatches || !ImageMatches) {
       ++It;

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -262,6 +262,31 @@ void context_impl::addDeviceGlobalInitializer(
   }
 }
 
+void context_impl::removeDeviceGlobalInitializer(
+    ur_program_handle_t Program, const RTDeviceBinaryImage *BinImage) {
+  std::lock_guard<std::mutex> Lock(MDeviceGlobalInitializersMutex);
+
+  for (auto It = MDeviceGlobalInitializers.begin();
+       It != MDeviceGlobalInitializers.end();) {
+    const bool ProgramMatches = It->first.first == Program;
+    const bool ImageMatches = !BinImage || It->second.MBinImage == BinImage;
+
+    if (!ProgramMatches || !ImageMatches) {
+      ++It;
+      continue;
+    }
+
+    {
+      std::lock_guard<std::mutex> InitLock(It->second.MDeviceGlobalInitMutex);
+      if (!It->second.MDeviceGlobalsFullyInitialized)
+        --MDeviceGlobalNotInitializedCnt;
+      It->second.ClearEvents(getAdapter());
+    }
+
+    It = MDeviceGlobalInitializers.erase(It);
+  }
+}
+
 std::vector<ur_event_handle_t> context_impl::initializeDeviceGlobals(
     ur_program_handle_t NativePrg, queue_impl &QueueImpl,
     detail::kernel_bundle_impl *KernelBundleImplPtr) {

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -194,11 +194,9 @@ public:
                                   devices_range Devs,
                                   const RTDeviceBinaryImage *BinImage);
 
-  /// Removes device global initializers for a program. If BinImage is not
-  /// null, only initializers associated with that image are removed.
-  void
-  removeDeviceGlobalInitializer(ur_program_handle_t Program,
-                                const RTDeviceBinaryImage *BinImage = nullptr);
+  /// Removes device global initializers for a program.
+  void removeDeviceGlobalInitializer(ur_program_handle_t Program,
+                                     const RTDeviceBinaryImage *BinImage);
 
   /// Returns the number of programs with device globals not yet initialized.
   size_t getDeviceGlobalNotInitializedCnt() const {

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -200,6 +200,11 @@ public:
   removeDeviceGlobalInitializer(ur_program_handle_t Program,
                                 const RTDeviceBinaryImage *BinImage = nullptr);
 
+  /// Returns the number of programs with device globals not yet initialized.
+  size_t getDeviceGlobalNotInitializedCnt() const {
+    return MDeviceGlobalNotInitializedCnt.load(std::memory_order_relaxed);
+  }
+
   /// Initializes device globals for a program on the associated queue.
   std::vector<ur_event_handle_t>
   initializeDeviceGlobals(ur_program_handle_t NativePrg, queue_impl &QueueImpl,

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -194,6 +194,12 @@ public:
                                   devices_range Devs,
                                   const RTDeviceBinaryImage *BinImage);
 
+  /// Removes device global initializers for a program. If BinImage is not
+  /// null, only initializers associated with that image are removed.
+  void
+  removeDeviceGlobalInitializer(ur_program_handle_t Program,
+                                const RTDeviceBinaryImage *BinImage = nullptr);
+
   /// Initializes device globals for a program on the associated queue.
   std::vector<ur_event_handle_t>
   initializeDeviceGlobals(ur_program_handle_t NativePrg, queue_impl &QueueImpl,

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1846,6 +1846,7 @@ void ProgramManager::removeImages(sycl_device_binaries DeviceBinary) {
         auto CurIt = It++;
         if (CurIt->second.second == Img) {
           if (auto ContextImpl = CurIt->second.first.lock()) {
+            ContextImpl->removeDeviceGlobalInitializer(CurIt->first, Img);
             ContextImpl->getKernelProgramCache().removeAllRelatedEntries(
                 Img->getImageID());
           }

--- a/sycl/unittests/program_manager/Cleanup.cpp
+++ b/sycl/unittests/program_manager/Cleanup.cpp
@@ -369,4 +369,66 @@ TEST(ImageRemoval, NativePrograms) {
   EXPECT_TRUE(PM.getNativePrograms().count(ProgramA) > 0);
   EXPECT_TRUE(PM.getNativePrograms().count(ProgramB) > 0);
 }
+
+// Verify that removeImages cleans up device global initializer entries so that
+// a reused program handle does not collide with stale state.
+TEST(ImageRemoval, DeviceGlobalInitializerCleanupOnRemoveImages) {
+  ProgramManagerExposed PM;
+
+  // An image with device globals that we will add and then remove.
+  sycl_device_binary_struct NativeImagesForRemoval[ImagesToRemove.size()];
+  sycl_device_binaries_struct TestBinaries;
+  convertAndAddImages(PM, ImagesToRemove, NativeImagesForRemoval, TestBinaries);
+
+  PM.addOrInitDeviceGlobalEntry(&DeviceGlobalC,
+                                generateRefName("C", "DeviceGlobal").c_str());
+
+  sycl::unittest::UrMock<> Mock;
+  sycl::platform Plt = sycl::platform();
+  const sycl::device Dev = Plt.get_devices()[0];
+  sycl::queue Queue{Dev};
+  auto Ctx = Queue.get_context();
+  auto CtxImpl = sycl::detail::getSyclObjImpl(Ctx);
+
+  // Grab the RTDeviceBinaryImage* for the "C" image that was just added.
+  ASSERT_EQ(PM.getDeviceImages().size(), 1u);
+  const sycl::detail::RTDeviceBinaryImage *BinImg =
+      PM.getDeviceImages().begin()->second.get();
+
+  ur_program_handle_t FakeProgram =
+      reinterpret_cast<ur_program_handle_t>(static_cast<uintptr_t>(0xDEADBEEF));
+
+  // Register the fake program in NativePrograms so that removeImages can find
+  // it and trigger removeDeviceGlobalInitializer, mirroring what
+  // ProgramManager::build() does.
+  PM.getNativePrograms().insert({FakeProgram, {CtxImpl, BinImg}});
+
+  CtxImpl->addDeviceGlobalInitializer(FakeProgram, CtxImpl->getDevices(),
+                                      BinImg);
+
+  EXPECT_EQ(CtxImpl->getDeviceGlobalNotInitializedCnt(), 1u)
+      << "Counter should be 1 after adding the initializer";
+
+  // Simulate program teardown.
+  PM.removeImages(&TestBinaries);
+
+  EXPECT_EQ(CtxImpl->getDeviceGlobalNotInitializedCnt(), 0u)
+      << "Counter should be 0 after removeImages cleans up the initializer";
+
+  // Re-add the same BinImg under the same (reused) program handle — this is
+  // what happens when the adapter allocates a fresh program with the same
+  // handle value. The counter must go back up to 1 cleanly.
+  sycl_device_binary_struct NativeImagesSecond[ImagesToRemove.size()];
+  sycl_device_binaries_struct TestBinariesSecond;
+  convertAndAddImages(PM, ImagesToRemove, NativeImagesSecond,
+                      TestBinariesSecond);
+  const sycl::detail::RTDeviceBinaryImage *BinImgSecond =
+      PM.getDeviceImages().begin()->second.get();
+
+  CtxImpl->addDeviceGlobalInitializer(FakeProgram, CtxImpl->getDevices(),
+                                      BinImgSecond);
+
+  EXPECT_EQ(CtxImpl->getDeviceGlobalNotInitializedCnt(), 1u)
+      << "Counter should be 1 after re-registering the reused program handle";
+}
 } // anonymous namespace


### PR DESCRIPTION
Prevent stale MDeviceGlobalInitializers entries from colliding with new entries when program handles are reused in RuntimeCompiled kernel loops. Implement explicit cleanup via removeDeviceGlobalInitializer() during program teardown.