### PR TITLE
[CI] Move yarpgen to standalone workflow

### DIFF
--- a/.github/workflows/sycl-weekly.yml
+++ b/.github/workflows/sycl-weekly.yml
@@ -20,6 +20,8 @@ jobs:
       toolchain_artifact: sycl_linux_default
 
   # This job builds SYCL-CTS with -fsycl-use-spirv-backend-for-spirv-gen.
+  # TODO: Usually there are no new changes on weekends. Consider removing
+  # the ubuntu2204_build job and switching to nightly build instead.
   build-sycl-cts:
     needs: ubuntu2204_build
     permissions:
@@ -72,45 +74,3 @@ jobs:
       toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
       toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
       binaries_artifact: sycl_cts_bin
-
-  yarpgen:
-    if: ${{ !cancelled() }}
-    runs-on: ["Linux", "gen12"]
-    container:
-      # This workflow runs on Sundays, so in almost all cases there are no new
-      # commits on Saturday, and therefore the latest nightly can be used.
-      # TODO: Consider switching sycl-cts run to nightly build.
-      image: ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest
-      # Is it the minimum set of options to get a working toolchain?
-      options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
-    steps:
-    - name: Checkout actions/source-tbb
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        sparse-checkout: |
-          devops/actions/source-tbb
-        sparse-checkout-cone-mode: false
-    - name: Source OneAPI TBB vars.sh
-      uses: ./devops/actions/source-tbb
-    - name: Set up yarpgen
-      run: |
-        git clone https://github.com/intel/yarpgen.git
-        cmake -B yarpgen/build -G Ninja yarpgen/
-        ninja -C yarpgen/build
-    - run: sycl-ls
-    - name: Run yarpgen
-      run: |
-        cd yarpgen
-        python3 --version
-        # A system hits OOM when using all available threads.
-        python3 scripts/run_gen.py --target dpcpp --std sycl -t 60 -j 2
-    - name: Pack results
-      run: tar -czf yarpgen_results.tar.gz yarpgen/testing
-    - uses: actions/upload-artifact@v6
-      with:
-        name: yarpgen_results
-        path: yarpgen_results.tar.gz
-        retention-days: 7
-    - name: Clean up
-      if: always()
-      run: rm -rf devops yarpgen yarpgen_results.tar.gz

--- a/.github/workflows/sycl-yarpgen.yml
+++ b/.github/workflows/sycl-yarpgen.yml
@@ -34,6 +34,7 @@ jobs:
         sparse-checkout: |
           devops/actions/source-tbb
         sparse-checkout-cone-mode: false
+        persist-credentials: false
 
     - name: Source OneAPI TBB vars.sh
       uses: ./devops/actions/source-tbb
@@ -75,7 +76,7 @@ jobs:
     - name: Pack results
       run: tar -czf yarpgen_results.tar.gz yarpgen/testing
 
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: yarpgen_results
         path: yarpgen_results.tar.gz

--- a/.github/workflows/sycl-yarpgen.yml
+++ b/.github/workflows/sycl-yarpgen.yml
@@ -71,7 +71,8 @@ jobs:
       run: |
         cd yarpgen
         # A system hits OOM when using all available threads.
-        python3 scripts/run_gen.py --target dpcpp --std sycl -t 60 -j 2
+        python3 scripts/run_gen.py --target dpcpp --std sycl -t 60 -j 2 | tee yarpgen_run.log
+        awk '/^YARPGEN runs stat:/{found=1} found {print}' yarpgen_run.log >> $GITHUB_STEP_SUMMARY
 
     - name: Pack results
       run: tar -czf yarpgen_results.tar.gz yarpgen/testing

--- a/.github/workflows/sycl-yarpgen.yml
+++ b/.github/workflows/sycl-yarpgen.yml
@@ -1,0 +1,86 @@
+name: SYCL Yarpgen
+
+on:
+  workflow_dispatch:
+    inputs:
+      toolchain_run_id:
+        description: |
+          Run ID of a workflow run to download the toolchain artifact from.
+          If not set, the toolchain pre-installed in the container image is used.
+        type: string
+        default: ''
+      toolchain_artifact:
+        description: Name of the artifact to download.
+        type: string
+        default: 'sycl_linux_default'
+  schedule:
+    # At 00:00 on Sunday.
+    - cron: '0 0 * * 0'
+
+permissions: read-all
+
+jobs:
+  yarpgen:
+    runs-on: ["Linux", "gen12"]
+    container:
+      # This workflow runs on Sundays, so in almost all cases there are no new
+      # commits on Saturday, and therefore the latest nightly can be used.
+      image: ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest
+      options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
+    steps:
+    - name: Checkout actions/source-tbb
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        sparse-checkout: |
+          devops/actions/source-tbb
+        sparse-checkout-cone-mode: false
+
+    - name: Source OneAPI TBB vars.sh
+      uses: ./devops/actions/source-tbb
+
+    - name: Download SYCL toolchain
+      if: inputs.toolchain_run_id != ''
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh run download ${{ inputs.toolchain_run_id }} \
+          -n ${{ inputs.toolchain_artifact }} \
+          -R ${{ github.repository }}
+
+    - name: Extract/Setup SYCL toolchain
+      if: inputs.toolchain_run_id != ''
+      run: |
+        mkdir toolchain
+        tar -xf ${{ inputs.toolchain_artifact }}/sycl_linux.tar.gz \
+          -C toolchain
+        echo PATH=$PWD/toolchain/bin/:$PATH >> $GITHUB_ENV
+        echo LD_LIBRARY_PATH=$PWD/toolchain/lib/:$LD_LIBRARY_PATH >> $GITHUB_ENV
+
+    - run: clang++ --version
+
+    - run: sycl-ls
+
+    - name: Set up yarpgen
+      run: |
+        git clone https://github.com/intel/yarpgen.git
+        cmake -B yarpgen/build -G Ninja yarpgen/
+        ninja -C yarpgen/build
+
+    - name: Run yarpgen
+      run: |
+        cd yarpgen
+        # A system hits OOM when using all available threads.
+        python3 scripts/run_gen.py --target dpcpp --std sycl -t 60 -j 2
+
+    - name: Pack results
+      run: tar -czf yarpgen_results.tar.gz yarpgen/testing
+
+    - uses: actions/upload-artifact@v6
+      with:
+        name: yarpgen_results
+        path: yarpgen_results.tar.gz
+        retention-days: 7
+
+    - name: Clean up
+      if: always()
+      run: rm -rf devops yarpgen yarpgen_results.tar.gz


### PR DESCRIPTION
The idea is to make yarpgen a standalone workflow, so it'd possible to launch custom yarpgen runs with other than nightly builds (e.g. release builds).
In general it's a copy-paste of what we had before + some adjustments to make it work with specific artifacts.