### PR TITLE
[SYCL] Remove redundant include from the test.

### DIFF
--- a/sycl/test/regression/grf_properties_wa.cpp
+++ b/sycl/test/regression/grf_properties_wa.cpp
@@ -3,7 +3,6 @@
 // Test for a workaround to a bug in clang causing some constexpr lambda
 // expressions to not be identified as returning a bool.
 
-#include <sycl/ext/intel/experimental/grf_size_properties.hpp>
 #include <sycl/sycl.hpp>
 
 int main() {


### PR DESCRIPTION
This PR removes redundant include from the test.
It's no longer needed after this change: https://github.com/intel/llvm/pull/21721