### PR TITLE
[SYCL][Graph][E2E] Remove XFAIL from passing interop-level-zero-get-native-mem tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/Explicit/interop-level-zero-get-native-mem.cpp
@@ -4,8 +4,6 @@
 // for native L0 API calls.
 // UNSUPPORTED: linux && (gpu-intel-dg2 || arch-intel_gpu_bmg_g21) && run-mode
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
-// XFAIL: arch-intel_gpu_ptl_u || arch-intel_gpu_ptl_h
-// XFAIL-TRACKER: CMPLRTST-27745
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-get-native-mem.cpp
@@ -4,8 +4,6 @@
 // for native L0 API calls.
 // UNSUPPORTED: linux && (gpu-intel-dg2 || arch-intel_gpu_bmg_g21) && run-mode
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/18273
-// XFAIL: arch-intel_gpu_ptl_u || arch-intel_gpu_ptl_h
-// XFAIL-TRACKER: CMPLRTST-27745
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Tests on `arch-intel_gpu_ptl_u` and `arch-intel_gpu_ptl_h` are now passing.