### PR TITLE
[SYCL] Fix MangleUtils ambiguous type error with LLVM_ENABLE_PCH=ON

### DIFF
--- a/llvm/lib/SYCLLowerIR/MangleUtils.cpp
+++ b/llvm/lib/SYCLLowerIR/MangleUtils.cpp
@@ -15,8 +15,8 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
-using namespace llvm::SPIR;
+namespace llvm {
+namespace SPIR {
 
 namespace {
 
@@ -291,3 +291,6 @@ void NameMangler::mangle(StringRef Name, ArrayRef<RefParamType> Params,
   for (const auto &P : Params)
     P->accept(&Visitor);
 }
+
+} // namespace SPIR
+} // namespace llvm


### PR DESCRIPTION
Define functions in SPIR namespace.

Fixes #21734