### PR TITLE
[NVPTX] Remove redundant cl_khr_3d_image_writes from getSupportedOpenCLOpts

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -183,7 +183,6 @@ public:
     Opts["cl_khr_int64_base_atomics"] = true;
     Opts["cl_khr_int64_extended_atomics"] = true;
     Opts["cl_khr_fp16"] = true;
-    Opts["cl_khr_3d_image_writes"] = true;
 
     Opts["__opencl_c_images"] = true;
     Opts["__opencl_c_3d_image_writes"] = true;


### PR DESCRIPTION
It is misalignement between local 944586038ed4 and upstream 0538d0a2e5b4.