### PR TITLE
[SYCL][E2E][Graph] Move two sporadically passing tests to UNSUPPORTED

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/compile_time_local_memory.cpp
+++ b/sycl/test-e2e/Graph/Explicit/compile_time_local_memory.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-// XFAIL: opencl && cpu
-// XFAIL-TRACKER: CMPLRLLVM-67486
+// UNSUPPORTED: opencl && cpu
+// UNSUPPORTED-TRACKER: CMPLRLLVM-67486
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/RecordReplay/compile_time_local_memory.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/compile_time_local_memory.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-// XFAIL: opencl && cpu
-// XFAIL-TRACKER: CMPLRLLVM-67486
+// UNSUPPORTED: opencl && cpu
+// UNSUPPORTED-TRACKER: CMPLRLLVM-67486
 
 #define GRAPH_E2E_RECORD_REPLAY
 


### PR DESCRIPTION
They are marked `XFAIL` but pass sporadically, see [here](https://github.com/intel/llvm/actions/runs/24298259505).