### PR TITLE
[CI] Fix check-sycl with oneAPI-built compiler

### DIFF
--- a/devops/actions/setup_linux_oneapi_env/action.yml
+++ b/devops/actions/setup_linux_oneapi_env/action.yml
@@ -13,10 +13,12 @@ runs:
         | sudo tee /etc/apt/sources.list.d/oneAPI.list && \
         sudo apt update && sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-2025.3
 
-        env_before=$(env | sort)         
+        env_before=$(env | sort)
         source /opt/intel/oneapi/setvars.sh
         env_after=$(env | sort)
         changed_envvars=$(comm -13 <(echo "$env_before") <(echo "$env_after"))
         while IFS= read -r line; do
-          echo "$line" >> $GITHUB_ENV
+          if [[ ! "$line" =~ ^CMAKE_PREFIX_PATH= ]]; then
+            echo "$line" >> $GITHUB_ENV
+          fi
         done <<< "$changed_envvars"

--- a/devops/actions/setup_windows_oneapi_env/action.yml
+++ b/devops/actions/setup_windows_oneapi_env/action.yml
@@ -20,9 +20,11 @@ runs:
             if ($envVar -match "^(.*?)=(.*)$") {
                 $name = $matches[1]
                 $value = $matches[2]
-                $envBeforeVar = $envBefore | Where-Object { $_ -like "$name=*" }
-                if (-not $envBeforeVar -or $envBeforeVar -ne "$name=$value") {
-                    Add-Content -Path $githubEnvFilePath -Value "$name=$value"
+                if ($name -ne "CMAKE_PREFIX_PATH") {
+                    $envBeforeVar = $envBefore | Where-Object { $_ -like "$name=*" }
+                    if (-not $envBeforeVar -or $envBeforeVar -ne "$name=$value") {
+                        Add-Content -Path $githubEnvFilePath -Value "$name=$value"
+                    }
                 }
             }
          }


### PR DESCRIPTION
When setting up the oneAPI env we source the `setupvars.sh` script which sets many envvars including `CMAKE_PREFIX_PATH`, which messes up our environment for building the compiler. Just don't set it.

Fail: https://github.com/intel/llvm/actions/runs/24325175633/job/71018931276
Working with fix (only oneAPI job matters): https://github.com/intel/llvm/actions/runs/24352663962/job/71111116646

`check-clang` fail is not related.