### PR TITLE
[CI] Make dependabot upd composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,24 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      # Required to update composite actions.
+      # See: https://github.com/dependabot/dependabot-core/issues/6704
+      - "/devops/actions/aws-ec2"
+      - "/devops/actions/build_container"
+      - "/devops/actions/cached_checkout"
+      - "/devops/actions/cleanup"
+      - "/devops/actions/reset_gpu"
+      - "/devops/actions/run-tests/benchmark"
+      - "/devops/actions/run-tests/linux/cts"
+      - "/devops/actions/run-tests/linux/e2e"
+      - "/devops/actions/run-tests/windows/cts"
+      - "/devops/actions/run-tests/windows/e2e"
+      - "/devops/actions/setup-vulkan/linux"
+      - "/devops/actions/setup_linux_oneapi_env"
+      - "/devops/actions/setup_windows_oneapi_env"
+      - "/devops/actions/source-tbb"
     schedule:
       interval: "monthly"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,7 @@ updates:
       - "/"
       # Required to update composite actions.
       # See: https://github.com/dependabot/dependabot-core/issues/6704
-      - "/devops/actions/aws-ec2"
-      - "/devops/actions/build_container"
-      - "/devops/actions/cached_checkout"
-      - "/devops/actions/cleanup"
-      - "/devops/actions/reset_gpu"
-      - "/devops/actions/run-tests/benchmark"
-      - "/devops/actions/run-tests/linux/cts"
-      - "/devops/actions/run-tests/linux/e2e"
-      - "/devops/actions/run-tests/windows/cts"
-      - "/devops/actions/run-tests/windows/e2e"
-      - "/devops/actions/setup-vulkan/linux"
-      - "/devops/actions/setup_linux_oneapi_env"
-      - "/devops/actions/setup_windows_oneapi_env"
-      - "/devops/actions/source-tbb"
+      - "/devops/actions/**"
     schedule:
       interval: "monthly"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       - "/devops/actions/*"
       - "/devops/actions/*/*"
       - "/devops/actions/*/*/*"
+      # 3 asterisks are enough at the moment, adding more just in case:
+      - "/devops/actions/*/*/*/*"
+      - "/devops/actions/*/*/*/*/*"
+      
     schedule:
       interval: "monthly"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@ updates:
       - "/"
       # Required to update composite actions.
       # See: https://github.com/dependabot/dependabot-core/issues/6704
-      - "/devops/actions/**"
+      - "/devops/actions/*"
+      - "/devops/actions/*/*"
+      - "/devops/actions/*/*/*"
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
https://github.com/dependabot/dependabot-core/issues/6704 prevents dependabot from updating all .yml files in the repo. Paths other than .github/workflows should be specified.
Example PR: https://github.com/KornevNikita/llvm/pull/15