### PR TITLE
[SYCL][E2E] Disable device_scope_events.cpp on Win Gen12

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/device_scope_events.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/device_scope_events.cpp
@@ -2,6 +2,9 @@
 // UNSUPPORTED: ze_debug, level_zero_v2_adapter
 // UNSUPPORTED-INTENDED: V1-only
 
+// UNSUPPORTED: windows && gpu-intel-gen12
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21766
+
 // RUN: %{build} -o %t.out
 // RUN: env UR_L0_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_DEVICE_SCOPE_EVENTS=1 SYCL_UR_TRACE=2 UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck --check-prefixes=MODE1 %s
 // RUN: env UR_L0_USE_IMMEDIATE_COMMANDLISTS=0 UR_L0_DEVICE_SCOPE_EVENTS=2 SYCL_UR_TRACE=2 UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck --check-prefixes=MODE2 %s


### PR DESCRIPTION
Failing sporadically, see GH issue.