### PR TITLE
[SYCL][NFC] Remove an incorrect unordered_map emplace hint

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1731,9 +1731,9 @@ void ProgramManager::addImage(sycl_device_binary RawImg,
       sycl::kernel_id KernelID = detail::createSyclObjFromImpl<sycl::kernel_id>(
           std::make_shared<detail::kernel_id_impl>(name));
       CompileTimeKernelInfoTy DefaultCompileTimeInfo{std::string_view(name)};
-      It = m_DeviceKernelInfoMap.emplace_hint(
-          It, std::piecewise_construct, std::forward_as_tuple(name),
-          std::forward_as_tuple(DefaultCompileTimeInfo, KernelID));
+      It = m_DeviceKernelInfoMap.emplace(
+          std::piecewise_construct, std::forward_as_tuple(name),
+          std::forward_as_tuple(DefaultCompileTimeInfo, KernelID)).first;
     }
     m_KernelIDs2BinImage.insert(
         std::make_pair(It->second.getKernelID(), Img.get()));

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1731,9 +1731,10 @@ void ProgramManager::addImage(sycl_device_binary RawImg,
       sycl::kernel_id KernelID = detail::createSyclObjFromImpl<sycl::kernel_id>(
           std::make_shared<detail::kernel_id_impl>(name));
       CompileTimeKernelInfoTy DefaultCompileTimeInfo{std::string_view(name)};
-      It = m_DeviceKernelInfoMap.emplace(
-          std::piecewise_construct, std::forward_as_tuple(name),
-          std::forward_as_tuple(DefaultCompileTimeInfo, KernelID)).first;
+      It = m_DeviceKernelInfoMap
+               .emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                        std::forward_as_tuple(DefaultCompileTimeInfo, KernelID))
+               .first;
     }
     m_KernelIDs2BinImage.insert(
         std::make_pair(It->second.getKernelID(), Img.get()));


### PR DESCRIPTION
Removes an incorrect (and redundant) end iterator hint.