### PR TITLE
[SYCL][NFC] Remove dead code

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -756,10 +756,6 @@ protected:
 
   ConcreteASPtrType getQualifiedPtr() const noexcept { return MData; }
 
-#ifndef __SYCL_DEVICE_ONLY__
-  using AccessorBaseHost::impl;
-#endif
-
 public:
   // Default constructor for objects later initialized with __init member.
   accessor()


### PR DESCRIPTION
Removes a line of code within nested contradictory ifdefs.