### PR TITLE
[SYCL] Switch to unordered_map for kernel-image tracking

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2186,7 +2186,7 @@ ProgramManager::getSYCLDeviceImagesWithCompatibleState(
     using StateImagesPairT =
         std::pair<bundle_state, std::vector<const RTDeviceBinaryImage *>>;
     using KernelImageMapT =
-        std::map<kernel_id, StateImagesPairT, LessByNameComp>;
+        std::unordered_map<kernel_id, StateImagesPairT>;
     KernelImageMapT KernelImageMap;
     if (!KernelIDs.empty())
       for (const kernel_id &KernelID : KernelIDs)

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2185,8 +2185,7 @@ ProgramManager::getSYCLDeviceImagesWithCompatibleState(
     // Track the highest image state for each requested kernel.
     using StateImagesPairT =
         std::pair<bundle_state, std::vector<const RTDeviceBinaryImage *>>;
-    using KernelImageMapT =
-        std::unordered_map<kernel_id, StateImagesPairT>;
+    using KernelImageMapT = std::unordered_map<kernel_id, StateImagesPairT>;
     KernelImageMapT KernelImageMap;
     if (!KernelIDs.empty())
       for (const kernel_id &KernelID : KernelIDs)


### PR DESCRIPTION
std::map negatively impacts performance here, and there's no need to keep this container ordered.