### PR TITLE
[SYCL][E2E] Disable regression_accessor_spv.cpp on Linux BMG

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/regression_accessor_spv.cpp
+++ b/sycl/test-e2e/Graph/Explicit/regression_accessor_spv.cpp
@@ -5,6 +5,9 @@
 
 // REQUIRES: level_zero
 
+// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21769
+
 // Modified version of Update/update_with_indices_accessor_spv.cpp that does
 // not require the full graph aspect, test was hanging after some changes to
 // kernel bundles so adding this test for the CI which doesn't support update


### PR DESCRIPTION
Same issue as in https://github.com/intel/llvm/pull/21770, similar test. Updated the GH issue with info for this test.