### PR TITLE
[SYCL][CUDA][e2e] disable tests failing on CUDA 13

### DIFF
--- a/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
@@ -1,9 +1,14 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17339
-// RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
+
 // XFAIL: spirv-backend
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/18230
+
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21806
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
 
 #include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -6,6 +6,9 @@
 // UNSUPPORTED: linux && arch-intel_gpu_bmg_g21 && level_zero_v2_adapter
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20223
 
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21807
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
@@ -1,3 +1,6 @@
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21808
+
 // REQUIRES: aspect-ext_oneapi_bindless_images
 // REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
@@ -1,4 +1,7 @@
 
+// XFAIL: cuda
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21808
+
 // REQUIRES: aspect-ext_oneapi_bindless_images
 // REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan


### PR DESCRIPTION
After enabling CUDA 13 workflow (see https://github.com/intel/llvm/pull/21564) few tests are failing:

```
sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
sycl/test-e2e/bindless_images/read_sampled.cpp
sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
```
