### PR TITLE
[SYCL][NewOffload] Enable E2E testing with NewOffloadModel for ESIMD and InvokeSimd tests.

### DIFF
--- a/sycl/test-e2e/ESIMD/lit.local.cfg
+++ b/sycl/test-e2e/ESIMD/lit.local.cfg
@@ -28,5 +28,3 @@ config.unsupported_features += ['spirv-backend']
 # https://github.com/intel/llvm/issues/20142
 config.unsupported_features += ['target-native_cpu']
 
-# https://github.com/intel/llvm/issues/20797
-config.unsupported_features += ['new-offload-model']

--- a/sycl/test-e2e/InvokeSimd/lit.local.cfg
+++ b/sycl/test-e2e/InvokeSimd/lit.local.cfg
@@ -13,5 +13,3 @@ config.unsupported_features += ['spirv-backend']
 # https://github.com/intel/llvm/issues/20142.
 config.unsupported_features += ['target-native_cpu']
 
-# https://github.com/intel/llvm/issues/20797
-config.unsupported_features += ['new-offload-model']


### PR DESCRIPTION
Addresses a part of #20797