### PR TITLE
[SYCL][LIT] Fix mock_opencl.cpp warning

### DIFF
--- a/sycl/unittests/mock_opencl/mock_opencl.cpp
+++ b/sycl/unittests/mock_opencl/mock_opencl.cpp
@@ -52,7 +52,7 @@ EXPORT size_t mockOpenCLNumContextRetains() { return contextRetains; }
 
 EXPORT size_t mockOpenCLNumDeviceRetains() { return deviceRetains; }
 
-EXPORT size_t mockOpenCLNumEventRetains() { return deviceRetains; }
+EXPORT size_t mockOpenCLNumEventRetains() { return eventRetains; }
 }
 
 namespace sycl {


### PR DESCRIPTION
Warning is 
```
/__w/llvm/llvm/src/sycl/unittests/mock_opencl/mock_opencl.cpp:8:15: error: variable 'eventRetains' set but not used [-Werror,-Wunused-but-set-global]
    8 | static size_t eventRetains = 0;

```

Seems like a copy-and-paste bug, use the correct variable.