### PR TITLE
[SYCL][Doc] Remove stochastic "float" from FP4/FP8

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp4.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp4.asciidoc
@@ -243,18 +243,16 @@ class fp4_e2m1_x {
   explicit fp4_e2m1_x(const marray<double,N>& vals);
 
   // Construct with stochastic rounding with user provided seed from an array of
-  // half, bfloat16, float.
+  // half, bfloat16.
 
   explicit fp4_e2m1_x(half const (&vals)[N], const stochastic_seed& seed);
   explicit fp4_e2m1_x(bfloat16 const (&vals)[N], const stochastic_seed& seed);
-  explicit fp4_e2m1_x(float const (&vals)[N], const stochastic_seed& seed);
 
   // Construct with stochastic rounding with user provided seed from an marray
-  // of half, bfloat16, float.
+  // of half, bfloat16.
 
   explicit fp4_e2m1_x(const marray<half,N>& vals, const stochastic_seed& seed);
   explicit fp4_e2m1_x(const marray<bfloat16,N>& vals, const stochastic_seed& seed);
-  explicit fp4_e2m1_x(const marray<float,N>& vals, const stochastic_seed& seed);
 
   // Construct from integer types.
   // Available only when N==1.
@@ -430,7 +428,6 @@ _Target Support:_ The rounding mode `r` has the following restrictions:
 ----
 explicit fp4_e2m1_x(half const (&vals)[N], const stochastic_seed& seed);
 explicit fp4_e2m1_x(bfloat16 const (&vals)[N], const stochastic_seed& seed);
-explicit fp4_e2m1_x(float const (&vals)[N], const stochastic_seed& seed);
 ----
 
 _Effects:_ Initializes each element of this `fp4_e2m1_x` object from the
@@ -455,7 +452,6 @@ They are only supported in device code as follows:
 ----
 explicit fp4_e2m1_x(const marray<half,N>& vals, const stochastic_seed& seed);
 explicit fp4_e2m1_x(const marray<bfloat16,N>& vals, const stochastic_seed& seed);
-explicit fp4_e2m1_x(const marray<float,N>& vals, const stochastic_seed& seed);
 ----
 
 _Effects:_ Initializes each element of this `fp4_e2m1_x` object from the

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
@@ -731,23 +731,19 @@ class fp8_e5m2_x {
   explicit fp8_e5m2_x(const marray<double,N>& vals);
 
   // Construct with stochastic rounding with user provided seed from an array of
-  // half, bfloat16, float.
+  // half, bfloat16.
 
   explicit fp8_e5m2_x(half const (&vals)[N], const stochastic_seed& seed,
                       saturation s = saturation::finite);
   explicit fp8_e5m2_x(bfloat16 const (&vals)[N], const stochastic_seed& seed,
                       saturation s = saturation::finite);
-  explicit fp8_e5m2_x(float const (&vals)[N], const stochastic_seed& seed,
-                      saturation s = saturation::finite);
 
   // Construct with stochastic rounding with user provided seed from an marray
-  // of half, bfloat16, float.
+  // of half, bfloat16.
 
   explicit fp8_e5m2_x(const marray<half,N>& vals, const stochastic_seed& seed,
                       saturation s = saturation::finite);
   explicit fp8_e5m2_x(const marray<bfloat16,N>& vals, const stochastic_seed& seed,
-                      saturation s = saturation::finite);
-  explicit fp8_e5m2_x(const marray<float,N>& vals, const stochastic_seed& seed,
                       saturation s = saturation::finite);
 
   // Construct from integer types.
@@ -937,8 +933,6 @@ explicit fp8_e5m2_x(half const (&vals)[N], const stochastic_seed& seed,
                     saturation s = saturation::finite);
 explicit fp8_e5m2_x(bfloat16 const (&vals)[N], const stochastic_seed& seed,
                     saturation s = saturation::finite);
-explicit fp8_e5m2_x(float const (&vals)[N], const stochastic_seed& seed,
-                    saturation s = saturation::finite);
 ----
 
 _Effects:_ Initializes each element of this `fp8_e5m2_x` object from the
@@ -965,8 +959,6 @@ They are only supported in device code as follows:
 explicit fp8_e5m2_x(const marray<half,N>& vals, const stochastic_seed& seed,
                     saturation s = saturation::finite);
 explicit fp8_e5m2_x(const marray<bfloat16,N>& vals, const stochastic_seed& seed,
-                    saturation s = saturation::finite);
-explicit fp8_e5m2_x(const marray<float,N>& vals, const stochastic_seed& seed,
                     saturation s = saturation::finite);
 ----
 


### PR DESCRIPTION
CRI supports these conversions from `bfloat16` and `half`, so remove the `float` versions.