### PR TITLE
[SYCL][Doc] Add "decay" to FP4, FP8 constraints

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp4.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp4.asciidoc
@@ -364,17 +364,17 @@ template<typename... Doubles>          (4)
 explicit fp4_e2m1_x(Doubles... vals);
 ----
 
-_Constraints_ (1): The size of the `Halfs` pack is `N` and each type in this
-pack is `half`.
+_Constraints_ (1): The size of the `Halfs` pack is `N` and `std::decay_t` of
+each type in this pack is `half`.
 
-_Constraints_ (2): The size of the `Bfloats` pack is `N` and each type in this
-pack is `ext::oneapi::bfloat16`.
+_Constraints_ (2): The size of the `Bfloats` pack is `N` and `std::decay_t` of
+each type in this pack is `ext::oneapi::bfloat16`.
 
-_Constraints_ (3): The size of the `Floats` pack is `N` and each type in this
-pack is `float`.
+_Constraints_ (3): The size of the `Floats` pack is `N` and `std::decay_t` of
+each type in this pack is `float`.
 
-_Constraints_ (4): The size of the `Doubles` pack is `N` and each type in this
-pack is `double`.
+_Constraints_ (4): The size of the `Doubles` pack is `N` and `std::decay_t` of
+each type in this pack is `double`.
 
 _Effects:_ Initializes each element of this `fp4_e2m1_x` object from the
 corresponding value in the `vals` pack.

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
@@ -402,17 +402,17 @@ template<typename... Doubles>          (4)
 explicit fp8_e4m3_x(Doubles... vals);
 ----
 
-_Constraints_ (1): The size of the `Halfs` pack is `N` and each type in this
-pack is `half`.
+_Constraints_ (1): The size of the `Halfs` pack is `N` and `std::decay_t` of
+each type in this pack is `half`.
 
-_Constraints_ (2): The size of the `Bfloats` pack is `N` and each type in this
-pack is `ext::oneapi::bfloat16`.
+_Constraints_ (2): The size of the `Bfloats` pack is `N` and `std::decay_t` of
+each type in this pack is `ext::oneapi::bfloat16`.
 
-_Constraints_ (3): The size of the `Floats` pack is `N` and each type in this
-pack is `float`.
+_Constraints_ (3): The size of the `Floats` pack is `N` and `std::decay_t` of
+each type in this pack is `float`.
 
-_Constraints_ (4): The size of the `Doubles` pack is `N` and each type in this
-pack is `double`.
+_Constraints_ (4): The size of the `Doubles` pack is `N` and `std::decay_t` of
+each type in this pack is `double`.
 
 _Effects:_ Initializes each element of this `fp8_e4m3_x` object from the
 corresponding value in the `vals` pack.
@@ -858,17 +858,17 @@ template<typename... Doubles>          (4)
 explicit fp8_e5m2_x(Doubles... vals);
 ----
 
-_Constraints_ (1): The size of the `Halfs` pack is `N` and each type in this
-pack is `half`.
+_Constraints_ (1): The size of the `Halfs` pack is `N` and `std::decay_t` of
+each type in this pack is `half`.
 
-_Constraints_ (2): The size of the `Bfloats` pack is `N` and each type in this
-pack is `ext::oneapi::bfloat16`.
+_Constraints_ (2): The size of the `Bfloats` pack is `N` and `std::decay_t` of
+each type in this pack is `ext::oneapi::bfloat16`.
 
-_Constraints_ (3): The size of the `Floats` pack is `N` and each type in this
-pack is `float`.
+_Constraints_ (3): The size of the `Floats` pack is `N` and `std::decay_t` of
+each type in this pack is `float`.
 
-_Constraints_ (4): The size of the `Doubles` pack is `N` and each type in this
-pack is `double`.
+_Constraints_ (4): The size of the `Doubles` pack is `N` and `std::decay_t` of
+each type in this pack is `double`.
 
 _Effects:_ Initializes each element of this `fp8_e5m2_x` object from the
 corresponding value in the `vals` pack.
@@ -1404,17 +1404,17 @@ template<typename... Doubles>          (4)
 explicit fp8_e8m0_x(Doubles... vals);
 ----
 
-_Constraints_ (1): The size of the `Halfs` pack is `N` and each type in this
-pack is `half`.
+_Constraints_ (1): The size of the `Halfs` pack is `N` and `std::decay_t` of
+each type in this pack is `half`.
 
-_Constraints_ (2): The size of the `Bfloats` pack is `N` and each type in this
-pack is `ext::oneapi::bfloat16`.
+_Constraints_ (2): The size of the `Bfloats` pack is `N` and `std::decay_t` of
+each type in this pack is `ext::oneapi::bfloat16`.
 
-_Constraints_ (3): The size of the `Floats` pack is `N` and each type in this
-pack is `float`.
+_Constraints_ (3): The size of the `Floats` pack is `N` and `std::decay_t` of
+each type in this pack is `float`.
 
-_Constraints_ (4): The size of the `Doubles` pack is `N` and each type in this
-pack is `double`.
+_Constraints_ (4): The size of the `Doubles` pack is `N` and `std::decay_t` of
+each type in this pack is `double`.
 
 _Effects:_ Initializes each element of this `fp8_e8m0_x` object from the
 corresponding value in the `vals` pack.


### PR DESCRIPTION
For the FP4 and FP8 constructors that take a parameter pack, change the constraints to use `std::decay_t` on the input types.  This allows, for example, the application to construct from `float &` in addition to constructing from plain `float`.