### PR TITLE
[SYCL][Doc] Remove unneeded FP4 / FP8 callouts

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp4.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp4.asciidoc
@@ -577,9 +577,9 @@ Otherwise, returns the value `true`.
 
 [source,c++]
 ----
-explicit operator marray<half,N>() const;      (1)
-explicit operator marray<bfloat16,N>() const;  (2)
-explicit operator marray<float,N>() const;     (3)
+explicit operator marray<half,N>() const;
+explicit operator marray<bfloat16,N>() const;
+explicit operator marray<float,N>() const;
 ----
 
 _Returns:_ The values of this `fp4_e2m1_x` object are converted to an `marray` of

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
@@ -570,9 +570,9 @@ Otherwise, returns the value `true`.
 
 [source,c++]
 ----
-explicit operator marray<half,N>() const;      (1)
-explicit operator marray<bfloat16,N>() const;  (2)
-explicit operator marray<float,N>() const;     (3)
+explicit operator marray<half,N>() const;
+explicit operator marray<bfloat16,N>() const;
+explicit operator marray<float,N>() const;
 ----
 
 _Returns:_ The values of this `fp8_e4m3_x` object are converted to an `marray` of
@@ -1093,9 +1093,9 @@ Otherwise, returns the value `true`.
 
 [source,c++]
 ----
-explicit operator marray<half,N>() const;      (1)
-explicit operator marray<bfloat16,N>() const;  (2)
-explicit operator marray<float,N>() const;     (3)
+explicit operator marray<half,N>() const;
+explicit operator marray<bfloat16,N>() const;
+explicit operator marray<float,N>() const;
 ----
 
 _Returns:_ The values of this `fp8_e5m2_x` object are converted to an `marray` of


### PR DESCRIPTION
This is an editorial change to the specifications, which removes some unnecessary callouts from the synopses.