### PR TITLE
[SYCL][E2E] Fix queue_profiling.cpp test

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/queue_profiling.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/queue_profiling.cpp
@@ -1,9 +1,6 @@
 // REQUIRES: gpu, level_zero
 // UNSUPPORTED: ze_debug
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20385
-
 // RUN: %{build} -o %t.out
 // RUN: env UR_L0_DEBUG=-1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --check-prefixes=WITHOUT %s
 // RUN: env UR_L0_DEBUG=-1 %{l0_leak_check} %{run} %t.out profile 2>&1 | FileCheck --check-prefixes=WITH %s
@@ -14,21 +11,20 @@
 // Check the expected output when queue::enable_profiling is not specified
 //
 // WITHOUT: ze_event_pool_desc_t flags set to: 1
-// WITHOUT: SYCL exception caught: Profiling information is unavailable as the queue associated with the event does not have the 'enable_profiling' property.
 
 // Check the expected output when queue::enable_profiling is specified
 //
 // WITH: ze_event_pool_desc_t flags set to: 5
-// WITH: Device kernel time:
 // clang-format on
 //
 
-#include <iostream>
+#include <cassert>
+#include <cstring>
 #include <sycl/detail/core.hpp>
 #include <sycl/properties/all_properties.hpp>
 using namespace sycl;
 
-int foo(queue &q, int n) {
+void foo(queue &q, int n, bool profiling_enabled) {
   for (int i = 0; i < n; i++) {
 
     sycl::event queue_event = q.submit([&](handler &cgh) {
@@ -44,16 +40,21 @@ int foo(queue &q, int n) {
           sycl::info::event_profiling::command_start>();
       auto endk = queue_event.template get_profiling_info<
           sycl::info::event_profiling::command_end>();
-      auto kernel_time =
-          (float)(endk - startk) * 1e-9f; // to seconds, 1e-6f to milliseconds
-      printf("Device kernel time: %.12fs\n", (float)kernel_time);
-
+      (void)startk;
+      (void)endk;
+      assert(profiling_enabled &&
+             "Expected exception when profiling is not enabled");
     } catch (const sycl::exception &e) {
-      std::cout << "SYCL exception caught: " << e.what() << '\n';
-      return 0;
+      assert(!profiling_enabled &&
+             "Unexpected exception when profiling is enabled");
+      const char *expected_msg =
+          "Profiling information is unavailable as the "
+          "queue associated with the event does not have "
+          "the 'enable_profiling' property.";
+      assert(std::strcmp(e.what(), expected_msg) == 0 &&
+             "Exception message does not match expected message");
     }
   }
-  return n;
 }
 
 int main(int argc, char **argv) {
@@ -67,7 +68,7 @@ int main(int argc, char **argv) {
 
     queue q(gpu_selector_v, propList);
     // Perform the computation
-    foo(q, 2);
+    foo(q, 2, profiling);
   } // SYCL scope
 
   return 0;


### PR DESCRIPTION
Test fails sporadically on windows because output is not getting flushed automatically, presumably because of the Windows shutdown issues.
Modify test to not print anything at all.

Resolves: https://github.com/intel/llvm/issues/20385