### PR TITLE
[SYCL][Doc] Updates to the "root group" extension

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_free_function_kernels.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_free_function_kernels.asciidoc
@@ -720,7 +720,7 @@ a@
 ----
 namespace sycl::ext::oneapi::experimental {
 
-template<auto *Func, typename Param,                              (1)
+template<auto *Func, typename Param,                                       (1)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
@@ -728,7 +728,7 @@ typename Param::return_type get_kernel_info(const context& ctxt,
                                             size_t bytes = 0,
                                             LaunchProperties props = {});
 
-template<auto *Func, typename Param,                              (2)
+template<auto *Func, typename Param,                                       (2)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
@@ -736,7 +736,7 @@ typename Param::return_type get_kernel_info(const context& ctxt,
                                             size_t bytes = 0,
                                             LaunchProperties props = {});
 
-template<auto *Func, typename Param,                              (3)
+template<auto *Func, typename Param,                                       (3)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
@@ -744,21 +744,21 @@ typename Param::return_type get_kernel_info(const context& ctxt,
                                             size_t bytes = 0,
                                             LaunchProperties props = {});
 
-template<auto *Func, typename Param,                              (4)
+template<auto *Func, typename Param,                                       (4)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<1> r,
                                             size_t bytes = 0,
                                             LaunchProperties props = {});
 
-template<auto *Func, typename Param,                              (5)
+template<auto *Func, typename Param,                                       (5)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<2> r,
                                             size_t bytes = 0,
                                             LaunchProperties props = {});
 
-template<auto *Func, typename Param,                              (6)
+template<auto *Func, typename Param,                                       (6)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<3> r,

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_free_function_kernels.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_free_function_kernels.asciidoc
@@ -725,45 +725,45 @@ template<auto *Func, typename Param,                                       (1)
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<1> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<auto *Func, typename Param,                                       (2)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<2> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<auto *Func, typename Param,                                       (3)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<3> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<auto *Func, typename Param,                                       (4)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<1> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<auto *Func, typename Param,                                       (5)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<2> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<auto *Func, typename Param,                                       (6)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<3> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 } // namespace sycl::ext::oneapi::experimental
 ----
@@ -792,7 +792,7 @@ _Returns_ (1) - (3): The same value `ret` that would be computed by:
 auto bundle =
   sycl::get_kernel_bundle<Func, sycl::bundle_state::executable>(ctxt);
 sycl::kernel k = bundle.ext_oneapi_get_kernel<Func>();
-auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes, props);
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, props, bytes);
 ----
 
 _Returns_ (4) - (6): The same value `ret` that would be computed by:
@@ -804,7 +804,7 @@ sycl::device dev = q.get_device();
 auto bundle =
   sycl::get_kernel_bundle<Func, sycl::bundle_state::executable>(ctxt);
 sycl::kernel k = bundle.ext_oneapi_get_kernel<Func>();
-auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes, props);
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, props, bytes);
 ----
 
 _Remarks:_ An implementation provides these functions only if it also implements

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_free_function_kernels.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_free_function_kernels.asciidoc
@@ -626,7 +626,7 @@ which can be used by the `kernel::get_info()` overload.
 
 _Returns:_ The same value `ret` that would be computed by:
 
-[source,c++]
+[source,c++,indent=2]
 ----
 auto bundle =
   sycl::get_kernel_bundle<Func, sycl::bundle_state::executable>(ctxt);
@@ -664,7 +664,7 @@ The kernel `Func` must be compatible with the device `dev` as defined by
 
 _Returns:_ The same value `ret` that would be computed by:
 
-[source,c++]
+[source,c++,indent=2]
 ----
 auto bundle =
   sycl::get_kernel_bundle<Func, sycl::bundle_state::executable>(ctxt);
@@ -683,7 +683,7 @@ a@
 ----
 namespace sycl::ext::oneapi::experimental {
 
-template<typename Func, typename Param>
+template<auto *Func, typename Param>
 typename Param::return_type get_kernel_info(const queue& q);
 
 } // namespace sycl::ext::oneapi::experimental
@@ -699,7 +699,7 @@ with `q` as defined by `is_compatible`.
 
 _Returns:_ The same value `ret` that would be computed by:
 
-[source,c++]
+[source,c++,indent=2]
 ----
 sycl::context ctxt = q.get_context();
 sycl::device dev = q.get_device();
@@ -710,6 +710,90 @@ auto ret = bundle.ext_oneapi_get_kernel<Func>().get_info<Param>(dev);
 
 _Remarks:_ Each information descriptor may specify additional preconditions,
 exceptions that are thrown, etc.
+
+'''
+
+[frame=all,grid=none,separator="@"]
+!====
+a@
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental {
+
+template<auto *Func, typename Param>                              (1)
+typename Param::return_type get_kernel_info(const context& ctxt,
+                                            const device& dev,
+                                            sycl::range<1> r,
+                                            size_t bytes = 0);
+
+template<auto *Func, typename Param>                              (2)
+typename Param::return_type get_kernel_info(const context& ctxt,
+                                            const device& dev,
+                                            sycl::range<2> r,
+                                            size_t bytes = 0);
+
+template<auto *Func, typename Param>                              (3)
+typename Param::return_type get_kernel_info(const context& ctxt,
+                                            const device& dev,
+                                            sycl::range<3> r,
+                                            size_t bytes = 0);
+
+template<auto *Func, typename Param>                              (4)
+typename Param::return_type get_kernel_info(const queue& q,
+                                            sycl::range<1> r,
+                                            size_t bytes = 0);
+
+template<auto *Func, typename Param>                              (5)
+typename Param::return_type get_kernel_info(const queue& q,
+                                            sycl::range<2> r,
+                                            size_t bytes = 0);
+
+template<auto *Func, typename Param>                              (6)
+typename Param::return_type get_kernel_info(const queue& q,
+                                            sycl::range<3> r,
+                                            size_t bytes = 0);
+
+} // namespace sycl::ext::oneapi::experimental
+----
+!====
+
+_Constraints_: Available only if `is_kernel_v<Func>` is `true`.
+Available only if `Param` is
+`ext::oneapi::experimental::info::kernel::max_num_work_groups_sync`.
+
+_Preconditions_ (1) - (3): The device `dev` must be one of the devices contained
+by `ctxt` or must be a descendent device of some device in `ctxt`.
+The kernel `Func` must be compatible with the device `dev` as defined by
+`is_compatible`.
+
+_Preconditions_ (4) - (6): The kernel `Func` must be compatible with the device
+associated with `q` as defined by `is_compatible`.
+
+_Returns_ (1) - (3): The same value `ret` that would be computed by:
+
+[source,c++,indent=2]
+----
+auto bundle =
+  sycl::get_kernel_bundle<Func, sycl::bundle_state::executable>(ctxt);
+sycl::kernel k = bundle.ext_oneapi_get_kernel<Func>();
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes);
+----
+
+_Returns_ (4) - (6): The same value `ret` that would be computed by:
+
+[source,c++,indent=2]
+----
+sycl::context ctxt = q.get_context();
+sycl::device dev = q.get_device();
+auto bundle =
+  sycl::get_kernel_bundle<Func, sycl::bundle_state::executable>(ctxt);
+sycl::kernel k = bundle.ext_oneapi_get_kernel<Func>();
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes);
+----
+
+_Remarks:_ An implementation provides these functions only if it also implements
+the link:../experimental/sycl_ext_oneapi_root_group.asciidoc[
+sycl_ext_oneapi_root_group] extension.
 
 === Behavior with kernel bundle functions in the core SYCL specification
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_free_function_kernels.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_free_function_kernels.asciidoc
@@ -720,46 +720,62 @@ a@
 ----
 namespace sycl::ext::oneapi::experimental {
 
-template<auto *Func, typename Param>                              (1)
+template<auto *Func, typename Param,                              (1)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<1> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<auto *Func, typename Param>                              (2)
+template<auto *Func, typename Param,                              (2)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<2> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<auto *Func, typename Param>                              (3)
+template<auto *Func, typename Param,                              (3)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<3> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<auto *Func, typename Param>                              (4)
+template<auto *Func, typename Param,                              (4)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<1> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<auto *Func, typename Param>                              (5)
+template<auto *Func, typename Param,                              (5)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<2> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<auto *Func, typename Param>                              (6)
+template<auto *Func, typename Param,                              (6)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<3> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
 } // namespace sycl::ext::oneapi::experimental
 ----
 !====
 
-_Constraints_: Available only if `is_kernel_v<Func>` is `true`.
-Available only if `Param` is
-`ext::oneapi::experimental::info::kernel::max_num_work_groups_sync`.
+_Constraints_: Available only if:
+
+* `is_kernel_v<Func>` is `true`,
+* `Param` is
+  `ext::oneapi::experimental::info::kernel::max_num_work_groups_sync`, and
+* `LaunchProperties` is a property list that contains only kernel launch
+  properties.
 
 _Preconditions_ (1) - (3): The device `dev` must be one of the devices contained
 by `ctxt` or must be a descendent device of some device in `ctxt`.
@@ -776,7 +792,7 @@ _Returns_ (1) - (3): The same value `ret` that would be computed by:
 auto bundle =
   sycl::get_kernel_bundle<Func, sycl::bundle_state::executable>(ctxt);
 sycl::kernel k = bundle.ext_oneapi_get_kernel<Func>();
-auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes);
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes, props);
 ----
 
 _Returns_ (4) - (6): The same value `ret` that would be computed by:
@@ -788,7 +804,7 @@ sycl::device dev = q.get_device();
 auto bundle =
   sycl::get_kernel_bundle<Func, sycl::bundle_state::executable>(ctxt);
 sycl::kernel k = bundle.ext_oneapi_get_kernel<Func>();
-auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes);
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes, props);
 ----
 
 _Remarks:_ An implementation provides these functions only if it also implements

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
@@ -123,11 +123,12 @@ int main() {
 
   // When a kernel uses root-group synchronization, the total number of
   // work-groups is limited.  This limit is specific to the kernel, the device,
-  // the work-group size (which is 32 in this example), and the amount of
-  // dynamically allocated work-group local memory (which is zero in this
-  // example).
-  auto maxWGs = syclex::get_kernel_info<
-    syclex::info::kernel::max_num_work_groups_sync>(q, 32, 0);
+  // the work-group size (which is 32 in this example), the launch parameters,
+  // and the amount of dynamically allocated work-group local memory (which is
+  // zero in this example).
+  syclex::properties props{syclex::use_root_sync};
+  auto maxWGs = syclex::get_kernel_info<KernelName,
+    syclex::info::kernel::max_num_work_groups_sync>(q, 32, props, 0);
 
   // Construct an nd-range which launches the maximum number of work-groups.
   auto ndr = sycl::nd_range<1>{maxWGs * 32, 32};
@@ -135,7 +136,7 @@ int main() {
   // When a kernel uses root-group synchronization, it must be launched with the
   // "use_root_sync" property.  Construct a launch configuration with this
   // property.
-  syclex::launch_config cfg{ndr, syclex::properties{syclex::use_root_sync}};
+  syclex::launch_config cfg{ndr, props};
 
   size_t *data = sycl::malloc_device<size_t>(maxWGs * 32, q);
   syclex::nd_launch(q, cfg, KernelName{data});
@@ -196,20 +197,20 @@ class kernel {
   template <typename Param, typename LaunchProperties = empty_properties_t>
   typename Param::return_type ext_oneapi_get_info(const device& dev,
                                                   sycl::range<1> r,
-                                                  size_t bytes = 0,
-                                                  LaunchProperties props = {}) const;
+                                                  LaunchProperties props = {},
+                                                  size_t bytes = 0) const;
 
   template <typename Param, typename LaunchProperties = empty_properties_t>
   typename Param::return_type ext_oneapi_get_info(const device& dev,
                                                   sycl::range<2> r,
-                                                  size_t bytes = 0,
-                                                  LaunchProperties props = {}) const;
+                                                  LaunchProperties props = {},
+                                                  size_t bytes = 0) const;
 
   template <typename Param, typename LaunchProperties = empty_properties_t>
   typename Param::return_type ext_oneapi_get_info(const device& dev,
                                                   sycl::range<3> r,
-                                                  size_t bytes = 0,
-                                                  LaunchProperties props = {}) const;
+                                                  LaunchProperties props = {},
+                                                  size_t bytes = 0) const;
 };
 
 } // namespace sycl
@@ -224,10 +225,18 @@ _Constraints:_
 
 _Returns:_ The maximum number of work-groups that are allowed when the kernel
 uses root-group synchronization, assuming the kernel is launched with a
-work-group size of `r`, `bytes` bytes of dynamic work-group local memory, and
-with kernel launch properties `props`.
+work-group size of `r`, kernel launch properties `props`, and `bytes` bytes of
+dynamic work-group local memory.
 If the kernel can be submitted to the device without an error, the minimum value
 returned by this query is 1, otherwise it is 0.
+
+If the kernel uses
+link:../experimental/sycl_ext_oneapi_work_group_scratch_memory.asciidoc[
+sycl_ext_oneapi_work_group_scratch_memory] to allocate dynamic work-group local
+memory, the amount of that memory can be specified either by including
+`work_group_scratch_size` in `props` or by specifying the size via `bytes`.
+It should only be specified in one of these ways, though, because the query adds
+these value together to get the total amount of dynamic work-group local memory.
 
 _Remarks:_ This query implicitly assumes that the kernel will be launched with
 the `use_root_sync` kernel launch property.
@@ -248,45 +257,45 @@ template<typename KernelName, typename Param,                              (1)
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<1> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<typename KernelName, typename Param,                              (2)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<2> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<typename KernelName, typename Param,                              (3)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<3> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<typename KernelName, typename Param,                              (4)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<1> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<typename KernelName, typename Param,                              (5)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<2> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 template<typename KernelName, typename Param,                              (6)
          typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<3> r,
-                                            size_t bytes = 0,
-                                            LaunchProperties props = {});
+                                            LaunchProperties props = {},
+                                            size_t bytes = 0);
 
 } // namespace sycl::ext::oneapi::experimental
 ----
@@ -317,7 +326,7 @@ _Returns_ (1) - (3): The same value `ret` that would be computed by:
 auto bundle =
   sycl::get_kernel_bundle<KernelName, sycl::bundle_state::executable>(ctxt);
 sycl::kernel k = bundle.get_kernel<KernelName>();
-auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes, props);
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, props, bytes);
 ----
 
 _Returns_ (4) - (6): The same value `ret` that would be computed by:
@@ -329,7 +338,7 @@ sycl::device dev = q.get_device();
 auto bundle =
   sycl::get_kernel_bundle<KernelName, sycl::bundle_state::executable>(ctxt);
 sycl::kernel k = bundle.get_kernel<KernelName>();
-auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes, props);
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, props, bytes);
 ----
 
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
@@ -46,8 +46,6 @@ This extension also depends on the following other SYCL extensions:
   sycl_ext_oneapi_properties]
 * link:../experimental/sycl_ext_oneapi_kernel_properties.asciidoc[
   sycl_ext_oneapi_kernel_properties]
-* link:../proposed/sycl_ext_oneapi_launch_queries.asciidoc[
-  sycl_ext_oneapi_launch_queries]
 
 
 == Status
@@ -117,12 +115,6 @@ struct KernelName {
     sycl::group_barrier(root);
   }
 
-  auto get(syclex::properties_tag) const {
-    // Kernels that use root-group synchronization must be decorated with the
-    // "use_root_sync" kernel property.
-    return syclex::properties{syclex::use_root_sync};
-  }
-
   size_t *data;
 };
 
@@ -130,23 +122,24 @@ int main() {
   sycl::queue q;
 
   // When a kernel uses root-group synchronization, the total number of
-  // work-groups is limited.  This limit can vary depending on the kernel,
-  // so get a "kernel" object representing the kernel when plan to launch.
-  auto bundle = sycl::get_kernel_bundle<KernelName, sycl::bundle_state::executable>(
-    q.get_context());
-  auto kernel = bundle.get_kernel<KernelName>();
-
-  // Get the maximum number of work-groups for this kernel.  The limit also
-  // depends on the size of each work-group (which is 32 in this example), and
-  // on the amount of work-group local memory (which is 0 in this example).
-  auto maxWGs = kernel.ext_oneapi_get_info<
-    syclex::info::kernel_queue_specific::max_num_work_groups>(q, 32, 0);
+  // work-groups is limited.  This limit is specific to the kernel, the device,
+  // the work-group size (which is 32 in this example), and the amount of
+  // dynamically allocated work-group local memory (which is zero in this
+  // example).
+  auto maxWGs = syclex::get_kernel_info<
+    syclex::info::kernel::max_num_work_groups_sync>(q, 32, 0);
 
   // Construct an nd-range which launches the maximum number of work-groups.
   auto ndr = sycl::nd_range<1>{maxWGs * 32, 32};
 
+  // When a kernel uses root-group synchronization, it must be launched with the
+  // "use_root_sync" property.  Construct a launch configuration with this
+  // property.
+  syclex::launch_config cfg{ndr, syclex::properties{syclex::use_root_sync}};
+
   size_t *data = sycl::malloc_device<size_t>(maxWGs * 32, q);
-  q.parallel_for(ndr, KernelName{data}).wait();
+  syclex::nd_launch(q, cfg, KernelName{data});
+  q.wait();
 }
 ----
 
@@ -174,7 +167,147 @@ supports.
 |===
 
 
-=== Kernel properties
+=== Kernel information descriptor
+
+This extension adds the following kernel information descriptor.
+
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental::info::kernel {
+
+struct max_num_work_groups_sync {
+  using return_type = size_t;
+}
+
+} // namespace sycl::ext::oneapi::experimental
+----
+
+
+=== Kernel information descriptor queries
+
+This extension adds the following member functions to the `kernel` class.
+
+[source,c++]
+----
+namespace sycl {
+
+class kernel {
+ public:
+  template <typename Param>
+  typename Param::return_type ext_oneapi_get_info(const device& dev,
+                                                  sycl::range<1> r,
+                                                  size_t bytes = 0) const;
+
+  template <typename Param>
+  typename Param::return_type ext_oneapi_get_info(const device& dev,
+                                                  sycl::range<2> r,
+                                                  size_t bytes = 0) const;
+
+  template <typename Param>
+  typename Param::return_type ext_oneapi_get_info(const device& dev,
+                                                  sycl::range<3> r,
+                                                  size_t bytes = 0) const;
+};
+
+} // namespace sycl
+----
+
+_Constraints:_ `Param` is
+`ext::oneapi::experimental::info::kernel::max_num_work_groups_sync`.
+
+_Returns:_ The maximum number of work-groups that are allowed when the kernel
+uses root-group synchronization, assuming the kernel is launched with a
+work-group size of `r` and with the specified amount of dynamic work-group local
+memory (in bytes).
+If the kernel can be submitted to the device without an error, the minimum value
+returned by this query is 1, otherwise it is 0.
+
+'''
+
+This extension also adds the following shortcut functions to query a kernel's
+information descriptor.
+
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental {
+
+template<typename KernelName, typename Param>                     (1)
+typename Param::return_type get_kernel_info(const context& ctxt,
+                                            const device& dev,
+                                            sycl::range<1> r,
+                                            size_t bytes = 0);
+
+template<typename KernelName, typename Param>                     (2)
+typename Param::return_type get_kernel_info(const context& ctxt,
+                                            const device& dev,
+                                            sycl::range<2> r,
+                                            size_t bytes = 0);
+
+template<typename KernelName, typename Param>                     (3)
+typename Param::return_type get_kernel_info(const context& ctxt,
+                                            const device& dev,
+                                            sycl::range<3> r,
+                                            size_t bytes = 0);
+
+template<typename KernelName, typename Param>                     (4)
+typename Param::return_type get_kernel_info(const queue& q,
+                                            sycl::range<1> r,
+                                            size_t bytes = 0);
+
+template<typename KernelName, typename Param>                     (5)
+typename Param::return_type get_kernel_info(const queue& q,
+                                            sycl::range<2> r,
+                                            size_t bytes = 0);
+
+template<typename KernelName, typename Param>                     (6)
+typename Param::return_type get_kernel_info(const queue& q,
+                                            sycl::range<3> r,
+                                            size_t bytes = 0);
+
+} // namespace sycl::ext::oneapi::experimental
+----
+
+_Constraints:_ `Param` is
+`ext::oneapi::experimental::info::kernel::max_num_work_groups_sync`.
+
+_Preconditions_ (1) - (3): The `KernelName` must be the type kernel name of a
+kernel that is defined in the application.
+The device `dev` must be one of the devices contained by `ctxt` or must be a
+descendent device of some device in `ctxt`.
+The kernel `KernelName` must be compatible with the device `dev` as defined by
+`is_compatible`.
+
+_Preconditions_ (4) - (6): The `KernelName` must be the type kernel name of a
+kernel that is defined in the application.
+The kernel `KernelName` must be compatible with the device associated with `q`
+as defined by `is_compatible`.
+
+_Returns_ (1) - (3): The same value `ret` that would be computed by:
+
+[source,c++,indent=2]
+----
+auto bundle =
+  sycl::get_kernel_bundle<KernelName, sycl::bundle_state::executable>(ctxt);
+sycl::kernel k = bundle.get_kernel<KernelName>();
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes);
+----
+
+_Returns_ (4) - (6): The same value `ret` that would be computed by:
+
+[source,c++,indent=2]
+----
+sycl::context ctxt = q.get_context();
+sycl::device dev = q.get_device();
+auto bundle =
+  sycl::get_kernel_bundle<KernelName, sycl::bundle_state::executable>(ctxt);
+sycl::kernel k = bundle.get_kernel<KernelName>();
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes);
+----
+
+
+=== Kernel launch property
+
+This extension adds the following kernel launch property.
 
 [source,c++]
 ----
@@ -195,16 +328,16 @@ inline constexpr use_root_sync_key::value_t use_root_sync;
 |The `use_root_sync` property adds the requirement that the kernel must be
  launched in a manner that is compatible with using a root-group in group
  functions and algorithms. If the `sycl::nd_range` parameter used to launch the
- kernel is incompatible with the results of the launch queries described in the
- sycl_ext_oneapi_launch_queries extension, an implementation must throw a
- synchronous exception with the `errc::nd_range` error code.
+ kernel is incompatible with the maximum number of work-groups returned by the
+ `max_num_work_groups_sync` query, an implementation must throw a synchronous
+ exception with the `errc::nd_range` error code.
 |===
 
 
 === The `root_group` class
 
 The `root_group` class implements all member functions common to the
-`sycl::group` and `sycl::sub_group` classes and also contains own
+`sycl::group` and `sycl::sub_group` classes and also contains its own
 additional functions.
 
 [source,c++]
@@ -436,13 +569,13 @@ NOTE: Support for passing the `root_group` to other group functions and
 algorithms may be added in a future version of this extension.
 
 These group functions and algorithms act as synchronization points, and can
-only be used in kernels decorated with the `use_root_sync` property.
-Attempting to call these functions in kernels that were not decorated with the
+only be used in kernels launched with the `use_root_sync` property.
+Attempting to call these functions in kernels that were not launched with the
 `use_root_sync` property results in undefined behavior.
 
 NOTE: Implementations are encouraged to throw a synchronous error with the
 `errc::invalid` error code if they are able to detect that a developer has
-attempted to synchronize a `root_group` from an incompatible kernel.
+attempted to synchronize a `root_group` from an incompatible kernel launch.
 
 
 === Accessing the `root_group` instance

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
@@ -193,34 +193,46 @@ namespace sycl {
 
 class kernel {
  public:
-  template <typename Param>
+  template <typename Param, typename LaunchProperties = empty_properties_t>
   typename Param::return_type ext_oneapi_get_info(const device& dev,
                                                   sycl::range<1> r,
-                                                  size_t bytes = 0) const;
+                                                  size_t bytes = 0,
+                                                  LaunchProperties props = {}) const;
 
-  template <typename Param>
+  template <typename Param, typename LaunchProperties = empty_properties_t>
   typename Param::return_type ext_oneapi_get_info(const device& dev,
                                                   sycl::range<2> r,
-                                                  size_t bytes = 0) const;
+                                                  size_t bytes = 0,
+                                                  LaunchProperties props = {}) const;
 
-  template <typename Param>
+  template <typename Param, typename LaunchProperties = empty_properties_t>
   typename Param::return_type ext_oneapi_get_info(const device& dev,
                                                   sycl::range<3> r,
-                                                  size_t bytes = 0) const;
+                                                  size_t bytes = 0,
+                                                  LaunchProperties props = {}) const;
 };
 
 } // namespace sycl
 ----
 
-_Constraints:_ `Param` is
-`ext::oneapi::experimental::info::kernel::max_num_work_groups_sync`.
+_Constraints:_
+
+* `Param` is
+  `ext::oneapi::experimental::info::kernel::max_num_work_groups_sync`, and
+* `LaunchProperties` is a property list that contains only kernel launch
+  properties.
 
 _Returns:_ The maximum number of work-groups that are allowed when the kernel
 uses root-group synchronization, assuming the kernel is launched with a
-work-group size of `r` and with the specified amount of dynamic work-group local
-memory (in bytes).
+work-group size of `r`, `bytes` bytes of dynamic work-group local memory, and
+with kernel launch properties `props`.
 If the kernel can be submitted to the device without an error, the minimum value
 returned by this query is 1, otherwise it is 0.
+
+_Remarks:_ This query implicitly assumes that the kernel will be launched with
+the `use_root_sync` kernel launch property.
+It is not necessary to include this property in `props`, but there is no harm in
+doing so.
 
 '''
 
@@ -231,44 +243,60 @@ information descriptor.
 ----
 namespace sycl::ext::oneapi::experimental {
 
-template<typename KernelName, typename Param>                     (1)
+template<typename KernelName, typename Param,                              (1)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<1> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<typename KernelName, typename Param>                     (2)
+template<typename KernelName, typename Param,                              (2)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<2> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<typename KernelName, typename Param>                     (3)
+template<typename KernelName, typename Param,                              (3)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const context& ctxt,
                                             const device& dev,
                                             sycl::range<3> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<typename KernelName, typename Param>                     (4)
+template<typename KernelName, typename Param,                              (4)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<1> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<typename KernelName, typename Param>                     (5)
+template<typename KernelName, typename Param,                              (5)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<2> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
-template<typename KernelName, typename Param>                     (6)
+template<typename KernelName, typename Param,                              (6)
+         typename LaunchProperties = empty_properties_t>
 typename Param::return_type get_kernel_info(const queue& q,
                                             sycl::range<3> r,
-                                            size_t bytes = 0);
+                                            size_t bytes = 0,
+                                            LaunchProperties props = {});
 
 } // namespace sycl::ext::oneapi::experimental
 ----
 
-_Constraints:_ `Param` is
-`ext::oneapi::experimental::info::kernel::max_num_work_groups_sync`.
+_Constraints:_
+
+* `Param` is
+  `ext::oneapi::experimental::info::kernel::max_num_work_groups_sync`, and
+* `LaunchProperties` is a property list that contains only kernel launch
+  properties.
 
 _Preconditions_ (1) - (3): The `KernelName` must be the type kernel name of a
 kernel that is defined in the application.
@@ -289,7 +317,7 @@ _Returns_ (1) - (3): The same value `ret` that would be computed by:
 auto bundle =
   sycl::get_kernel_bundle<KernelName, sycl::bundle_state::executable>(ctxt);
 sycl::kernel k = bundle.get_kernel<KernelName>();
-auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes);
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes, props);
 ----
 
 _Returns_ (4) - (6): The same value `ret` that would be computed by:
@@ -301,7 +329,7 @@ sycl::device dev = q.get_device();
 auto bundle =
   sycl::get_kernel_bundle<KernelName, sycl::bundle_state::executable>(ctxt);
 sycl::kernel k = bundle.get_kernel<KernelName>();
-auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes);
+auto ret = k.ext_oneapi_get_info<Param>(dev, r, bytes, props);
 ----
 
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
@@ -90,11 +90,17 @@ the kernel in a natural way.
 
 An instance of the `root_group` class can be accessed by any ND-range kernel,
 since all information it exposes via its member functions is equivalent to
-information already available via members of `sycl::nd_item`. Functionality
-requiring cross-work-group synchronization is only supported in kernels with
-a compatible launch configuration: it is a user's responsibility to provide
-the requisite properties and to determine an appropriate `sycl::nd_range`
-using device queries, as shown in the example below.
+information already available via members of `sycl::nd_item`.
+
+A kernel may only use the cross-work-group synchronization features described in
+this extension if it is launched with the `use_root_sync` property, and the
+kernel must be launched with a limited number of work-groups.
+Therefore, this extension also provides queries that allow the application to
+determine this limit.
+
+The following example illustrates a simple kernel that uses cross-work-group
+synchronization.
+There are additional examples at the end of this specification.
 
 [source,c++]
 ----
@@ -683,6 +689,58 @@ template <int Dimensions>
 root_group<Dimensions> get_root_group();
 ----
 _Effects_: Equivalent to `return this_work_item::get_root_group()`.
+
+
+== Example
+
+The following example illustrates how to use cross-work-group synchronization in
+a free function kernel using the syntax provided by
+link:../experimental/sycl_ext_oneapi_free_function_kernels.asciidoc[
+sycl_ext_oneapi_free_function_kernels].
+
+[source,c++]
+----
+#include <sycl/sycl.hpp>
+namespace syclex = sycl::ext::oneapi::experimental;
+
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclex::nd_range_kernel<1>))
+void mykernel(size_t *data) {
+  // Get a handle to the root-group.
+  auto root = syclex::get_root_group<1>();
+
+  // Write to some global memory location.
+  data[root.get_local_linear_id()] = root.get_local_linear_id();
+
+  // Synchronize all work-items executing the kernel, making all writes visible.
+  sycl::group_barrier(root);
+}
+
+int main() {
+  sycl::queue q;
+
+  // When a kernel uses root-group synchronization, the total number of
+  // work-groups is limited.  This limit is specific to the kernel, the device,
+  // the work-group size (which is 32 in this example), the launch parameters,
+  // and the amount of dynamically allocated work-group local memory (which is
+  // zero in this example).
+  syclex::properties props{syclex::use_root_sync};
+  auto maxWGs = syclex::get_kernel_info<mykernel,
+    syclex::info::kernel::max_num_work_groups_sync>(q, 32, props, 0);
+
+  // Construct an nd-range which launches the maximum number of work-groups.
+  auto ndr = sycl::nd_range<1>{maxWGs * 32, 32};
+
+  // When a kernel uses root-group synchronization, it must be launched with the
+  // "use_root_sync" property.  Construct a launch configuration with this
+  // property.
+  syclex::launch_config cfg{ndr, props};
+
+  size_t *data = sycl::malloc_device<size_t>(maxWGs * 32, q);
+  syclex::nd_launch(q, cfg, syclexp::kernel_function<mykernel>, data);
+  q.wait();
+}
+----
+
 
 == Implementation notes
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
@@ -706,7 +706,7 @@ namespace syclex = sycl::ext::oneapi::experimental;
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclex::nd_range_kernel<1>))
 void mykernel(size_t *data) {
   // Get a handle to the root-group.
-  auto root = syclex::get_root_group<1>();
+  auto root = syclex::this_work_item::get_root_group<1>();
 
   // Write to some global memory location.
   data[root.get_local_linear_id()] = root.get_local_linear_id();
@@ -736,7 +736,7 @@ int main() {
   syclex::launch_config cfg{ndr, props};
 
   size_t *data = sycl::malloc_device<size_t>(maxWGs * 32, q);
-  syclex::nd_launch(q, cfg, syclexp::kernel_function<mykernel>, data);
+  syclex::nd_launch(q, cfg, syclex::kernel_function<mykernel>, data);
   q.wait();
 }
 ----


### PR DESCRIPTION
* Change the `use_root_sync` property from a "kernel property" to a "kernel launch property".  This is necessary because we want it to be possible to determine at runtime on a per-launch basis whether a kernel is launched in the special way that allows root-group synchronization.  Kernels are allowed to statically contain a call to `group_barrier` with `root_group` even if they are not launched this way.  However, the kernel must only dynamically call `group_barrier` with `root_group` if it is launched in the special way.  This behavior is not possible if `use_root_sync` is a "kernel property" because kernel properties are the immutable from launch to launch.

* No longer depend on "sycl_ext_oneapi_launch_queries" for the query that tells the maximum number of work-groups when using root-group synchronization.  Instead, add a new kernel information descriptor `max_num_work_groups_sync` and new overloads of `kernel::get_info` that provide this information.  We decided that the generality of "sycl_ext_oneapi_launch_queries" was overkill.

* Change the query so that it take the set of "launch properties".  This is necessary because some kernel launch properties like `cache_config` can affect the result of the query.

* Add shortcut functions that allow an application to query `max_num_work_groups_sync` without first getting a kernel bundle. This is similar to existing shortcuts we provide already via "sycl_ext_oneapi_get_kernel_info".  Add these shortcuts both for kernels defined with a type-name and for kernels defined as free-function kernels.