### PR TITLE
[libclc] Switch to LLVM_RUNTIME_TARGETS build

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -29,7 +29,7 @@ def do_configure(args, passthrough_args):
     if sys.platform != "darwin":
         llvm_external_projects += ";libdevice"
 
-    libclc_amd_target_names = ";amdgcn-amd-amdhsa"
+    libclc_amd_target_names = ";amdgcn-amd-amdhsa-llvm"
     libclc_nvidia_target_names = ";nvptx64-nvidia-cuda"
 
     sycl_enable_jit = "OFF"
@@ -49,8 +49,7 @@ def do_configure(args, passthrough_args):
     jit_dir = os.path.join(abs_src_dir, "sycl-jit")
     llvm_targets_to_build = args.host_target + ";SPIRV"
     llvm_enable_projects = "clang;" + llvm_external_projects
-    libclc_build_native = "OFF"
-    libclc_targets_to_build = ""
+    runtime_targets = "default" # for non-libclc runtimes
     sycl_build_ur_hip_platform = "AMD"
     sycl_clang_extra_flags = ""
     sycl_werror = "OFF"
@@ -79,8 +78,6 @@ def do_configure(args, passthrough_args):
             sycl_enabled_backends.append("level_zero_v2")
 
     libclc_enabled = args.cuda or args.hip or args.native_cpu
-    if libclc_enabled:
-        llvm_enable_runtimes += ";libclc"
 
     # DeviceRTL uses -fuse-ld=lld, so enable lld.
     if args.offload:
@@ -89,26 +86,23 @@ def do_configure(args, passthrough_args):
 
     if args.cuda:
         llvm_targets_to_build += ";NVPTX"
-        libclc_targets_to_build = libclc_nvidia_target_names
+        runtime_targets += libclc_nvidia_target_names
         sycl_enabled_backends.append("cuda")
 
     if args.hip:
         if args.hip_platform == "AMD":
             llvm_targets_to_build += ";AMDGPU"
-            libclc_targets_to_build += libclc_amd_target_names
+            runtime_targets += libclc_amd_target_names
 
         elif args.hip_platform == "NVIDIA" and not args.cuda:
             llvm_targets_to_build += ";NVPTX"
-            libclc_targets_to_build += libclc_nvidia_target_names
+            runtime_targets += libclc_nvidia_target_names
 
         sycl_build_ur_hip_platform = args.hip_platform
         sycl_enabled_backends.append("hip")
 
     if args.native_cpu:
-        if args.native_cpu_libclc_targets:
-            libclc_targets_to_build += ";" + args.native_cpu_libclc_targets
-        else:
-            libclc_build_native = "ON"
+        runtime_targets += ";native_cpu"
         sycl_enabled_backends.append("native_cpu")
 
     # all llvm compiler targets don't require 3rd party dependencies, so can be
@@ -149,14 +143,12 @@ def do_configure(args, passthrough_args):
         if sys.platform != "darwin":
             # libclc is required for CI validation
             libclc_enabled = True
-            if "libclc" not in llvm_enable_runtimes:
-                llvm_enable_runtimes += ";libclc"
             # libclc passes `--nvvm-reflect-enable=false`, build NVPTX to enable it
             if "NVPTX" not in llvm_targets_to_build:
                 llvm_targets_to_build += ";NVPTX"
             # Add NVIDIA libclc targets
-            if libclc_nvidia_target_names not in libclc_targets_to_build:
-                libclc_targets_to_build += libclc_nvidia_target_names
+            if libclc_nvidia_target_names not in runtime_targets:
+                runtime_targets += libclc_nvidia_target_names
             spirv_enable_dis = "ON"
 
     if args.enable_backends:
@@ -232,10 +224,17 @@ def do_configure(args, passthrough_args):
             )
 
     if libclc_enabled:
+        for target in runtime_targets.split(";"):
+            if target == "default":
+                continue
+            cmake_cmd.extend(
+                [
+                    f"-DRUNTIMES_{target}_LLVM_ENABLE_RUNTIMES=libclc",
+                ]
+            )
         cmake_cmd.extend(
             [
-                "-DLIBCLC_TARGETS_TO_BUILD={}".format(libclc_targets_to_build),
-                "-DLIBCLC_NATIVECPU_HOST_TARGET={}".format(libclc_build_native),
+                "-DLLVM_RUNTIME_TARGETS={}".format(runtime_targets),
             ]
         )
 

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -35,19 +35,7 @@ set( LIBCLC_TARGETS_ALL
   spirv64-mesa3d-
 )
 
-# Handle both LLVM_RUNTIMES_TARGET (per-target builds) and LIBCLC_TARGETS_TO_BUILD (multi-target builds)
-if(LLVM_RUNTIMES_TARGET)
-  set(LIBCLC_TARGET ${LLVM_RUNTIMES_TARGET})
-elseif(LIBCLC_TARGETS_TO_BUILD)
-  # For multi-target builds, use the first target from the list
-  list(GET LIBCLC_TARGETS_TO_BUILD 0 LIBCLC_TARGET)
-  # Handle empty first element (from leading semicolon)
-  if(NOT LIBCLC_TARGET AND LIBCLC_TARGETS_TO_BUILD)
-    list(GET LIBCLC_TARGETS_TO_BUILD 1 LIBCLC_TARGET)
-  endif()
-else()
-  message(FATAL_ERROR "Neither LLVM_RUNTIMES_TARGET nor LIBCLC_TARGETS_TO_BUILD is set\n")
-endif()
+set(LIBCLC_TARGET ${LLVM_RUNTIMES_TARGET})
 
 if(NOT LIBCLC_TARGET)
   message(FATAL_ERROR "libclc target is empty\n")
@@ -165,8 +153,8 @@ add_custom_target( libclc ALL )
 add_custom_target( libclc-opencl-builtins COMMENT "Build libclc OpenCL builtins" )
 add_dependencies( libclc libclc-opencl-builtins )
 
-add_custom_target( libspirv-builtins COMMENT "Build libspirv builtins" )
-add_dependencies( libclc libspirv-builtins )
+add_custom_target(libspirv-builtins COMMENT "Build libspirv builtins")
+add_dependencies(libclc libspirv-builtins)
 
 # Determine the clang target triple.
 set(clang_triple ${LIBCLC_TARGET})
@@ -264,6 +252,23 @@ else()
     ${OPENCL_GENERIC_SOURCES} ${_opencl_overrides})
 endif()
 
+set(BUILD_LIBSPIRV FALSE)
+if (ARCH STREQUAL amdgcn OR ARCH STREQUAL nvptx64 OR ARCH STREQUAL native_cpu)
+  set(BUILD_LIBSPIRV TRUE)
+
+  # Collect libspirv sources.
+  set(_libspirv_overrides)
+  if(ARCH STREQUAL amdgcn)
+    list(APPEND _libspirv_overrides ${LISPIRV_AMDGCN_SOURCES})
+  elseif(ARCH STREQUAL nvptx64)
+    list(APPEND _libspirv_overrides ${LISPIRV_PTX_NVIDIACL_SOURCES})
+  elseif(ARCH STREQUAL native_cpu)
+    list(APPEND _libspirv_overrides ${LISPIRV_NATIVE_CPU_SOURCES})
+  endif()
+  libclc_merge_sources(libspirv_sources
+    ${LISPIRV_GENERIC_SOURCES} ${_libspirv_overrides})
+endif()
+
 # Common compile options shared by CLC and OpenCL libraries.
 set(compile_flags
   -flto
@@ -316,26 +321,6 @@ add_libclc_library(libclc-${LIBCLC_TARGET}
   OUTPUT_FILENAME libclc
   PARENT_TARGET libclc-opencl-builtins
 )
-
-# Build libspirv for SYCL-specific targets (amdgcn-amd-amdhsa-llvm, nvptx64-nvidia-cuda, native_cpu)
-set(BUILD_LIBSPIRV FALSE)
-if(LIBCLC_TARGET STREQUAL "amdgcn-amd-amdhsa-llvm" OR
-   LIBCLC_TARGET STREQUAL "nvptx64-nvidia-cuda" OR
-   LIBCLC_TARGET STREQUAL "native_cpu")
-  set(BUILD_LIBSPIRV TRUE)
-
-  # Collect libspirv sources.
-  set(_libspirv_overrides)
-  if(ARCH STREQUAL amdgcn)
-    list(APPEND _libspirv_overrides ${LISPIRV_AMDGCN_SOURCES})
-  elseif(ARCH STREQUAL nvptx64)
-    list(APPEND _libspirv_overrides ${LISPIRV_PTX_NVIDIACL_SOURCES})
-  elseif(LIBCLC_TARGET STREQUAL "native_cpu")
-    list(APPEND _libspirv_overrides ${LISPIRV_NATIVE_CPU_SOURCES})
-  endif()
-  libclc_merge_sources(libspirv_sources
-    ${LISPIRV_GENERIC_SOURCES} ${_libspirv_overrides})
-endif()
 
 if(BUILD_LIBSPIRV)
   # Build base libspirv library

--- a/libclc/test/CMakeLists.txt
+++ b/libclc/test/CMakeLists.txt
@@ -1,6 +1,5 @@
 # required by lit.site.cfg.py.in
 set(LIBCLC_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(LIBCLC_PERTARGET_TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/targets)
 set(LLVM_TOOLS_DIR ${LLVM_TOOLS_BINARY_DIR})
 
 configure_lit_site_cfg(
@@ -17,6 +16,7 @@ set(LIBCLC_TEST_DEPS
   clang
   count
   libclc-opencl-builtins
+  libspirv-builtins
 )
 
 umbrella_lit_testsuite_begin(check-libclc)
@@ -35,16 +35,14 @@ if(ARCH MATCHES "amdgcn|nvptx64")
     # The solution is to create a separate directory for each target,
     # and copy the lit.site.cfg.py file there; the name of the
     # directory will be used as the target name.
-    file(MAKE_DIRECTORY ${LIBCLC_PERTARGET_TEST_DIR}/${LIBCLC_TARGET})
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${LIBCLC_TARGET})
     file(COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
-                   ${LIBCLC_PERTARGET_TEST_DIR}/${LIBCLC_TARGET}/lit.site.cfg.py)
+                   ${CMAKE_CURRENT_BINARY_DIR}/${LIBCLC_TARGET}/lit.site.cfg.py)
 
     add_lit_testsuite(check-libclc-spirv-${LIBCLC_TARGET}
       "Running libclc spirv-${LIBCLC_TARGET} regression tests"
-      ${LIBCLC_PERTARGET_TEST_DIR}/${LIBCLC_TARGET}
-      DEPENDS
-        ${LIBCLC_TEST_DEPS}
-        libspirv-builtins
+      ${CMAKE_CURRENT_BINARY_DIR}/${LIBCLC_TARGET}
+      DEPENDS ${LIBCLC_TEST_DEPS}
       )
 endif()
 

--- a/libclc/test/CMakeLists.txt
+++ b/libclc/test/CMakeLists.txt
@@ -21,11 +21,7 @@ set(LIBCLC_TEST_DEPS
 
 umbrella_lit_testsuite_begin(check-libclc)
 
-foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
-    if (t STREQUAL native_cpu)
-      continue()
-    endif()
-
+if(ARCH MATCHES "amdgcn|nvptx64")
     # Each target gets own lit testsuite directory.
     # This is done because all suites passed to add_lit_testsuite
     # are collected into a single invocation of lit, for example:
@@ -39,18 +35,18 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     # The solution is to create a separate directory for each target,
     # and copy the lit.site.cfg.py file there; the name of the
     # directory will be used as the target name.
-    file(MAKE_DIRECTORY ${LIBCLC_PERTARGET_TEST_DIR}/${t})
+    file(MAKE_DIRECTORY ${LIBCLC_PERTARGET_TEST_DIR}/${LIBCLC_TARGET})
     file(COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
-                   ${LIBCLC_PERTARGET_TEST_DIR}/${t}/lit.site.cfg.py)
+                   ${LIBCLC_PERTARGET_TEST_DIR}/${LIBCLC_TARGET}/lit.site.cfg.py)
 
-    add_lit_testsuite(check-libclc-spirv-${t}
-      "Running libclc spirv-${t} regression tests"
-      ${LIBCLC_PERTARGET_TEST_DIR}/${t}
+    add_lit_testsuite(check-libclc-spirv-${LIBCLC_TARGET}
+      "Running libclc spirv-${LIBCLC_TARGET} regression tests"
+      ${LIBCLC_PERTARGET_TEST_DIR}/${LIBCLC_TARGET}
       DEPENDS
         ${LIBCLC_TEST_DEPS}
         libspirv-builtins
       )
-endforeach( t )
+endif()
 
 # Testing unresolved symbols.
 # Skip nvptx, clspv, spirv targets

--- a/libclc/test/lit.cfg.py
+++ b/libclc/test/lit.cfg.py
@@ -19,9 +19,6 @@ def quote(s):
 
 # Configuration file for the 'lit' test runner.
 
-if config.libclc_target is None:
-    lit_config.fatal("libclc_target parameter must be set when running directly")
-
 # name: The name of this test suite.
 config.name = f"LIBCLC-{config.libclc_target.upper()}"
 
@@ -47,7 +44,7 @@ config.test_exec_root = os.path.join(
     config.libclc_pertarget_test_dir, config.libclc_target
 )
 
-config.target_triple = None
+config.target_triple = config.libclc_target
 
 llvm_config.use_default_substitutions()
 
@@ -66,7 +63,7 @@ clang_flags = [
     "-nogpulib",
 ]
 
-if config.libclc_target == "amdgcn-amd-amdhsa":
+if config.libclc_target == "amdgcn-amd-amdhsa-llvm":
     # libclc for amdgcn is currently built for tahiti which doesn't support
     # fp16 so disable the extension for the tests
     clang_flags += ["-Xclang", "-cl-ext=-cl_khr_fp16"]

--- a/libclc/test/lit.cfg.py
+++ b/libclc/test/lit.cfg.py
@@ -22,12 +22,6 @@ def quote(s):
 if config.libclc_target is None:
     lit_config.fatal("libclc_target parameter must be set when running directly")
 
-if config.libclc_target not in config.libclc_targets_to_test:
-    lit_config.fatal(
-        f"libclc_target '{config.libclc_target}' is not built. "
-        f"Available targets: {', '.join(quote(s) for s in config.libclc_targets_to_test)}"
-    )
-
 # name: The name of this test suite.
 config.name = f"LIBCLC-{config.libclc_target.upper()}"
 
@@ -52,6 +46,8 @@ libclc_inc = os.path.join(config.libclc_root, "libspirv", "include")
 config.test_exec_root = os.path.join(
     config.libclc_pertarget_test_dir, config.libclc_target
 )
+
+config.target_triple = None
 
 llvm_config.use_default_substitutions()
 

--- a/libclc/test/lit.site.cfg.py.in
+++ b/libclc/test/lit.site.cfg.py.in
@@ -10,19 +10,16 @@ config.llvm_shlib_dir = "@SHLIBDIR@"
 config.llvm_plugin_ext = "@LLVM_PLUGIN_EXT@"
 config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
 config.host_triple = "@LLVM_HOST_TRIPLE@"
-config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.host_arch = "@HOST_ARCH@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 config.libclc_root = "@LIBCLC_SOURCE_DIR@"
-config.libclc_targets_to_test = "@LIBCLC_TARGETS_TO_BUILD@".split(";")
+config.libclc_target = "@LIBCLC_TARGET@"
 config.libclc_output_dir = "@LIBCLC_OUTPUT_LIBRARY_DIR@"
 config.libclc_pertarget_test_dir = "@LIBCLC_PERTARGET_TEST_DIR@"
 config.libclc_obj_root = "@LIBCLC_TARGET_TEST_DIR@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)
-
-config.libclc_target = lit_config.params.get("libclc_target")
 
 if config.libclc_target is None:
     # This file is copied to per-target test directories by cmake,

--- a/libclc/test/lit.site.cfg.py.in
+++ b/libclc/test/lit.site.cfg.py.in
@@ -21,12 +21,5 @@ config.libclc_obj_root = "@LIBCLC_TARGET_TEST_DIR@"
 import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
-if config.libclc_target is None:
-    # This file is copied to per-target test directories by cmake,
-    # use the name of the directory containing this file as the target name.
-    dirname = os.path.dirname(__file__)
-    if os.path.realpath(dirname) != os.path.realpath("@CMAKE_CURRENT_BINARY_DIR@"):
-        config.libclc_target = os.path.basename(dirname)
-
 # Let the main config do the real work.
 lit_config.load_config(config, "@LIBCLC_TEST_SOURCE_DIR@/lit.cfg.py")

--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -20,7 +20,15 @@ set(SYCL_JIT_RESOURCE_INSTALL_COMPONENTS
   clang-resource-headers
   libsycldevice)
 
-if ("libclc" IN_LIST LLVM_ENABLE_RUNTIMES)
+set(libclc_enabled FALSE)
+foreach(target IN LISTS LLVM_RUNTIME_TARGETS)
+  if("libclc" IN_LIST RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES)
+    set(libclc_enabled TRUE)
+    break()
+  endif()
+endforeach()
+
+if (libclc_enabled)
   # If some targets required `libclc` then we should embed it for the
   # `sycl-jit`.
   list(APPEND SYCL_JIT_RESOURCE_INSTALL_COMPONENTS libspirv-builtins)
@@ -29,18 +37,26 @@ endif()
 set(SYCL_JIT_RESOURCE_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/rtc-resources-install)
 
 set(SYCL_JIT_PREPARE_RESOURCE_COMMANDS)
-set(RUNTIMES_BINARY_DIR ${CMAKE_BINARY_DIR}/runtimes/runtimes-bins)
+
+function(sycl_jit_add_install_command component binary_dir)
+  list(APPEND SYCL_JIT_PREPARE_RESOURCE_COMMANDS
+    COMMAND ${CMAKE_COMMAND} --install ${binary_dir} --prefix ${SYCL_JIT_RESOURCE_INSTALL_DIR} --component "${component}"
+  )
+  set(SYCL_JIT_PREPARE_RESOURCE_COMMANDS "${SYCL_JIT_PREPARE_RESOURCE_COMMANDS}" PARENT_SCOPE)
+endfunction()
+
 foreach(component IN LISTS SYCL_JIT_RESOURCE_INSTALL_COMPONENTS)
-  set(BINARY_DIR ${CMAKE_BINARY_DIR})
   if("${component}" STREQUAL "libspirv-builtins")
-    set(BINARY_DIR ${RUNTIMES_BINARY_DIR})
     list(APPEND SYCL_JIT_RESOURCE_DEPS libclc)
+    foreach(tgt IN LISTS LLVM_RUNTIME_TARGETS)
+      if("libclc" IN_LIST RUNTIMES_${tgt}_LLVM_ENABLE_RUNTIMES)
+        sycl_jit_add_install_command("${component}" "${CMAKE_BINARY_DIR}/runtimes/runtimes-${tgt}-bins/libclc")
+      endif()
+    endforeach()
   else()
     list(APPEND SYCL_JIT_RESOURCE_DEPS ${component})
+    sycl_jit_add_install_command("${component}" "${CMAKE_BINARY_DIR}")
   endif()
-  list(APPEND SYCL_JIT_PREPARE_RESOURCE_COMMANDS
-    COMMAND ${CMAKE_COMMAND} --install ${BINARY_DIR} --prefix ${SYCL_JIT_RESOURCE_INSTALL_DIR} --component "${component}"
-  )
 endforeach()
 
   # OpenCL-Headers doesn't have a corresponding build target:

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -593,7 +593,6 @@ function(sycl_add_install_command component manifest_suffix install_script deps)
     COMMAND "${CMAKE_COMMAND}"
     "-DCMAKE_INSTALL_COMPONENT=${component}"
     -P "${install_script}"
-    # Fix: Use the deps variable passed into the function
     DEPENDS ${__chain_dep} ${deps}
     COMMENT "Deploying component ${component} (${manifest_suffix})"
     USES_TERMINAL
@@ -608,7 +607,7 @@ endfunction()
 
 foreach(component IN LISTS SYCL_TOOLCHAIN_DEPLOY_COMPONENTS)
   message(STATUS "Adding component ${component} to deploy")
-  if("${component}" STREQUAL "libspirv-builtins")
+  if("${component}" MATCHES "libspirv-builtins")
     foreach(tgt IN LISTS LLVM_RUNTIME_TARGETS)
       if("libclc" IN_LIST RUNTIMES_${tgt}_LLVM_ENABLE_RUNTIMES)
         set(INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/runtimes/runtimes-${tgt}-bins/libclc/cmake_install.cmake")

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -529,15 +529,22 @@ if("lld" IN_LIST LLVM_ENABLE_PROJECTS)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS lld)
 endif()
 
-if("libclc" IN_LIST LLVM_ENABLE_RUNTIMES)
+set(libclc_enabled FALSE)
+foreach(target IN LISTS LLVM_RUNTIME_TARGETS)
+  if("libclc" IN_LIST RUNTIMES_${target}_LLVM_ENABLE_RUNTIMES)
+    set(libclc_enabled TRUE)
+    break()
+  endif()
+endforeach()
+
+if(libclc_enabled)
   add_dependencies(sycl-toolchain libclc)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins)
 endif()
 
 if("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   # Ensure that libclc is enabled.
-  list(FIND LLVM_ENABLE_RUNTIMES libclc LIBCLC_FOUND)
-  if( LIBCLC_FOUND EQUAL -1 )
+  if(NOT libclc_enabled)
     message(FATAL_ERROR
       "CUDA support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
@@ -548,8 +555,7 @@ endif()
 
 if("hip" IN_LIST SYCL_ENABLE_BACKENDS)
   # Ensure that libclc is enabled.
-  list(FIND LLVM_ENABLE_RUNTIMES libclc LIBCLC_FOUND)
-  if( LIBCLC_FOUND EQUAL -1 )
+  if(NOT libclc_enabled)
     message(FATAL_ERROR
       "HIP support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
@@ -579,29 +585,41 @@ add_custom_command(OUTPUT __force_it
 #Serialize installation to avoid missing components due to build race conditions
 set(__chain_dep __force_it)
 
-set(manifest_list)
-set(RUNTIMES_INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/runtimes/runtimes-bins/cmake_install.cmake")
-foreach( comp ${SYCL_TOOLCHAIN_DEPLOY_COMPONENTS} )
-  set(INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/cmake_install.cmake")
-  set(RUNTIME_TARGET)
-  if("${comp}" STREQUAL "libspirv-builtins")
-    set(RUNTIME_TARGET libclc)
-    set(INSTALL_SCRIPT ${RUNTIMES_INSTALL_SCRIPT})
-  endif()
-  message( STATUS "Adding component ${comp} to deploy")
+set(manifest_list "")
+function(sycl_add_install_command component manifest_suffix install_script deps)
+  set(manifest_file "${CMAKE_CURRENT_BINARY_DIR}/install_manifest_${manifest_suffix}.txt")
 
-  set (manifest_file ${CMAKE_CURRENT_BINARY_DIR}/install_manifest_${comp}.txt)
-  add_custom_command(OUTPUT ${manifest_file}
+  add_custom_command(OUTPUT "${manifest_file}"
     COMMAND "${CMAKE_COMMAND}"
-    "-DCMAKE_INSTALL_COMPONENT=${comp}"
-    -P "${INSTALL_SCRIPT}"
-    DEPENDS  ${__chain_dep} ${RUNTIME_TARGET}
-    COMMENT "Deploying component ${comp}"
+    "-DCMAKE_INSTALL_COMPONENT=${component}"
+    -P "${install_script}"
+    # Fix: Use the deps variable passed into the function
+    DEPENDS ${__chain_dep} ${deps}
+    COMMENT "Deploying component ${component} (${manifest_suffix})"
     USES_TERMINAL
   )
-  list(APPEND manifest_list ${manifest_file})
-  set(__chain_dep ${manifest_file})
-endforeach( comp )
+
+  list(APPEND manifest_list "${manifest_file}")
+  set(__chain_dep "${manifest_file}")
+
+  set(manifest_list "${manifest_list}" PARENT_SCOPE)
+  set(__chain_dep "${__chain_dep}" PARENT_SCOPE)
+endfunction()
+
+foreach(component IN LISTS SYCL_TOOLCHAIN_DEPLOY_COMPONENTS)
+  message(STATUS "Adding component ${component} to deploy")
+  if("${component}" STREQUAL "libspirv-builtins")
+    foreach(tgt IN LISTS LLVM_RUNTIME_TARGETS)
+      if("libclc" IN_LIST RUNTIMES_${tgt}_LLVM_ENABLE_RUNTIMES)
+        set(INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/runtimes/runtimes-${tgt}-bins/libclc/cmake_install.cmake")
+        sycl_add_install_command("${component}" "${component}_${tgt}" "${INSTALL_SCRIPT}" "libclc")
+      endif()
+    endforeach()
+  else()
+    set(INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+    sycl_add_install_command("${component}" "${component}" "${INSTALL_SCRIPT}" "")
+  endif()
+endforeach()
 
 add_custom_target(deploy-sycl-toolchain
   DEPENDS sycl-toolchain ${manifest_list}


### PR DESCRIPTION
Following 121f5a96ff38, this PR removes deprecated `LLVM_ENABLE_RUNTIMES=libclc` build approach from SYCL toolchain.

For nvptx64-nvidia-cuda build, pass following options to cmake configure:
    -DRUNTIMES_nvptx64-nvidia-cuda_LLVM_ENABLE_RUNTIMES=libclc
    -DLLVM_RUNTIME_TARGETS="nvptx64-nvidia-cuda"

Submit this PR to sycl-web to avoid a gap with a downstream branch
which has transitioned to LLVM_RUNTIME_TARGETS build.