### PR TITLE
[SYCL][E2E] Disable host_task_in_order_dependency.cpp on Win DG2

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/host_task_in_order_dependency.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_in_order_dependency.cpp
@@ -3,7 +3,7 @@
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// UNSUPPORTED: level_zero && windows && gpu-intel-gen12
+// UNSUPPORTED: level_zero && windows && (gpu-intel-gen12 || gpu-intel-dg2)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20696
 //
 // REQUIRES: aspect-usm_host_allocations


### PR DESCRIPTION
Failing with the same symptom on Win DG2. Added more info to the linked GH tracker.