### PR TITLE
[NFC][SYCL][E2E] Split long tests

### DIFF
--- a/sycl/test-e2e/WorkGroupMemory/basic_usage_common.hpp
+++ b/sycl/test-e2e/WorkGroupMemory/basic_usage_common.hpp
@@ -1,22 +1,20 @@
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17339
-// RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
-// XFAIL: spirv-backend
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18230
+// Shared implementation for the work-group memory basic usage tests.
+
+#pragma once
 
 #include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/work_group_memory.hpp>
 #include <sycl/group_barrier.hpp>
 #include <sycl/half_type.hpp>
+#include <sycl/queue.hpp>
 
 #include <cassert>
 #include <cstring>
 
 namespace syclexp = sycl::ext::oneapi::experimental;
 
-sycl::queue q;
+extern sycl::queue q;
 
 // This test performs a swap of two scalars/arrays inside a kernel using a
 // work_group_memory object as a temporary buffer. The test is done for scalar
@@ -406,20 +404,4 @@ template <typename T> void test_ptr() {
     swap_array_1d(arr1[i], arr2[i], 8);
   }
   swap_array_2d(arr1, arr2, 8);
-}
-
-int main() {
-  test<int>();
-  test<char>();
-  test<uint16_t>();
-  if (q.get_device().has(sycl::aspect::fp16))
-    test<sycl::half>();
-  test_ptr<float *>();
-  test_ptr<int *>();
-  test_ptr<char *>();
-  test_ptr<uint16_t *>();
-  if (q.get_device().has(sycl::aspect::fp16))
-    test_ptr<sycl::half *>();
-  test_ptr<float *>();
-  return 0;
 }

--- a/sycl/test-e2e/WorkGroupMemory/basic_usage_test.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/basic_usage_test.cpp
@@ -1,0 +1,26 @@
+// Non-pointer types version of the basic usage test.
+
+// UNSUPPORTED: hip
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17339
+
+// XFAIL: spirv-backend
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18230
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/queue.hpp>
+
+#include "./basic_usage_common.hpp"
+
+sycl::queue q;
+
+int main() {
+  test<float>();
+  test<int>();
+  test<char>();
+  test<uint16_t>();
+  if (q.get_device().has(sycl::aspect::fp16))
+    test<sycl::half>();
+  return 0;
+}

--- a/sycl/test-e2e/WorkGroupMemory/basic_usage_test_ptr.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/basic_usage_test_ptr.cpp
@@ -1,0 +1,26 @@
+// Pointer-types version of the basic usage test.
+
+// UNSUPPORTED: hip
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17339
+
+// XFAIL: spirv-backend
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/18230
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/queue.hpp>
+
+#include "./basic_usage_common.hpp"
+
+sycl::queue q;
+
+int main() {
+  test_ptr<float *>();
+  test_ptr<int *>();
+  test_ptr<char *>();
+  test_ptr<uint16_t *>();
+  if (q.get_device().has(sycl::aspect::fp16))
+    test_ptr<sycl::half *>();
+  return 0;
+}

--- a/sycl/test-e2e/bindless_images/read_sampled_1d.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled_1d.cpp
@@ -1,0 +1,31 @@
+// 1D version of sampled image read test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+
+// UNSUPPORTED: hip
+// UNSUPPORTED-INTENDED: Returning non-FP values from sampling fails on HIP.
+
+// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21 && level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20223
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include "./read_sampled_common.hpp"
+
+int main() {
+  const int int seed = 0;
+  const float offset = 20.0f;
+
+  std::cout << "Running 1D Sampled Image Tests!\n";
+  bool result1D = runAll1D(offset, seed);
+
+  if (result1D) {
+    std::cout << "All tests passed!\n";
+  } else {
+    std::cerr << "An error has occurred!\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/sycl/test-e2e/bindless_images/read_sampled_2d.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled_2d.cpp
@@ -1,0 +1,34 @@
+// 2D version of sampled image read test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+
+// UNSUPPORTED: hip
+// UNSUPPORTED-INTENDED: Returning non-FP values from sampling fails on HIP.
+
+// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21 && level_zero_v2_adapter
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20223
+
+// XFAIL: cuda && cuda-major-ge-13
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21807
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include "./read_sampled_common.hpp"
+
+int main() {
+  const int seed = 0;
+  const float offset = 20.0f;
+
+  std::cout << "Running 2D Sampled Image Tests!\n";
+  bool result2D = runAll2D(offset, seed);
+
+  if (result2D) {
+    std::cout << "All tests passed!\n";
+  } else {
+    std::cerr << "An error has occurred!\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/sycl/test-e2e/bindless_images/read_sampled_common.hpp
+++ b/sycl/test-e2e/bindless_images/read_sampled_common.hpp
@@ -1,13 +1,6 @@
-// REQUIRES: aspect-ext_oneapi_bindless_images
+// Shared implementation for the sampled image read tests.
 
-// UNSUPPORTED: hip
-// UNSUPPORTED-INTENDED: Returning non-FP values from sampling fails on HIP.
-
-// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21 && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20223
-
-// RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
+#pragma once
 
 // Print test names and pass status
 // #define VERBOSE_LV1
@@ -26,6 +19,8 @@
 #include <iostream>
 #include <sycl/accessor_image.hpp>
 #include <sycl/detail/core.hpp>
+#include <sycl/image.hpp>
+#include <type_traits>
 
 #include <sycl/ext/oneapi/bindless_images.hpp>
 
@@ -488,7 +483,7 @@ bool runTests(sycl::range<2> dims, sycl::range<2> localSize, float offset,
               int seed, sycl::coordinate_normalization_mode normMode) {
 
   // addressing_mode::none currently removed due to
-  // inconsistent behavour when switching between
+  // inconsistent behaviour when switching between
   // normalized and unnormalized coords.
   sycl::addressing_mode addrModes[4] = {
       sycl::addressing_mode::repeat, sycl::addressing_mode::mirrored_repeat,
@@ -718,22 +713,10 @@ bool runAll(sycl::range<NDims> dims, sycl::range<NDims> localSize, float offset,
   return offsetPassed && noOffsetPassed;
 }
 
-int main() {
+inline bool runAll1D(float offset, int seed) {
+  return runAll<1>(sycl::range<1>{128}, sycl::range<1>{32}, offset, seed);
+}
 
-  const unsigned int seed = 0;
-  const float offset = 20.0;
-
-  std::cout << "Running 1D Sampled Image Tests!\n";
-  bool result1D = runAll<1>({128}, {32}, offset, seed);
-  std::cout << "Running 2D Sampled Image Tests!\n";
-  bool result2D = runAll<2>({16, 16}, {8, 8}, offset, seed);
-
-  if (result1D && result2D) {
-    std::cout << "All tests passed!\n";
-  } else {
-    std::cerr << "An error has occurred!\n";
-    return 1;
-  }
-
-  return 0;
+inline bool runAll2D(float offset, int seed) {
+  return runAll<2>(sycl::range<2>{16, 16}, sycl::range<2>{8, 8}, offset, seed);
 }

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d_channels.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d_channels.cpp
@@ -1,0 +1,39 @@
+// Unsampled version of the Vulkan/SYCL 1D image read interop test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// clang-format off
+// RUN: %{run} %t.out --type float --channels 1 32
+// RUN: %{run} %t.out --type float --channels 2 32
+// RUN: %{run} %t.out --type float --channels 4 32
+// RUN: %{run} %t.out --type half --channels 1 32
+// RUN: %{run} %t.out --type half --channels 2 32
+// RUN: %{run} %t.out --type half --channels 4 32
+// RUN: %{run} %t.out --type int32 --channels 1 32
+// RUN: %{run} %t.out --type int32 --channels 2 32
+// RUN: %{run} %t.out --type int32 --channels 4 32
+// RUN: %{run} %t.out --type uint32 --channels 1 32
+// RUN: %{run} %t.out --type uint32 --channels 2 32
+// RUN: %{run} %t.out --type uint32 --channels 4 32
+// RUN: %{run} %t.out --type int16 --channels 1 32
+// RUN: %{run} %t.out --type int16 --channels 2 32
+// RUN: %{run} %t.out --type int16 --channels 4 32
+// RUN: %{run} %t.out --type uint16 --channels 1 32
+// RUN: %{run} %t.out --type uint16 --channels 2 32
+// RUN: %{run} %t.out --type uint16 --channels 4 32
+// RUN: %{run} %t.out --type uint8 --channels 1 32
+// RUN: %{run} %t.out --type uint8 --channels 2 32
+// RUN: %{run} %t.out --type uint8 --channels 4 32
+// RUN: %{run} %t.out --type int8 --channels 1 32
+// RUN: %{run} %t.out --type int8 --channels 2 32
+// RUN: %{run} %t.out --type int8 --channels 4 32
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 1 32
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 32
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 4 32
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_read_1d_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d_common.hpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d_common.hpp
@@ -1,136 +1,61 @@
-// REQUIRES: aspect-ext_oneapi_bindless_images
-// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
-// REQUIRES: vulkan
-
-// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+// Shared implementation for the Vulkan/SYCL 1D image read interop tests.
 
 /*
-    Run ALL the vulkan formats through the gauntlet. sampled and unsampled.
-    This entire test takes less than 30 seconds on a slow machine.  MUCH faster
-   (and more complete coveraage) than SFINAE based approach.
+  Run ALL the vulkan formats through the gauntlet. sampled and unsampled.
+  This entire test takes less than 30 seconds on a slow machine.  MUCH faster
+  (and more complete coveraage) than SFINAE based approach.
 
-    IF a particular variant is having problems on some platform, please do NOT
-   just disable the whole test, instead use   RUN~IF (SOMETHING) yadda-yadda
-    to enable/disable that variant.
+  IF a particular variant is having problems on some platform, please do NOT
+  just disable the whole test, instead use   RUN~IF (SOMETHING) yadda-yadda
+  to enable/disable that variant.
 
-    For semaphore testing, we run just a sampling. Note, that on Linux if there
-   is a failure in the first section, then likely ALL semaphore tests afterwards
-   will fail. This is being tracked as a separate issue.
-
+  For semaphore testing, we run just a sampling. Note, that on Linux if there
+  is a failure in the first section, then likely ALL semaphore tests afterwards
+  will fail. This is being tracked as a separate issue.
 */
+
+/*
+  The block above tests these formats, sampled and unsampled, with and without
+  semaphores
+
+  VK_FORMAT_R32_SFLOAT
+  VK_FORMAT_R32G32_SFLOAT
+  VK_FORMAT_R32G32B32A32_SFLOAT
+  VK_FORMAT_R16_SFLOAT
+  VK_FORMAT_R16G16_SFLOAT
+  VK_FORMAT_R16G16B16A16_SFLOAT
+  VK_FORMAT_R32_SINT
+  VK_FORMAT_R32G32_SINT
+  VK_FORMAT_R32G32B32A32_SINT
+  VK_FORMAT_R32_UINT
+  VK_FORMAT_R32G32_UINT
+  VK_FORMAT_R32G32B32A32_UINT
+  VK_FORMAT_R16_SINT
+  VK_FORMAT_R16G16_SINT
+  VK_FORMAT_R16G16B16A16_SINT
+  VK_FORMAT_R16_UINT
+  VK_FORMAT_R16G16_UINT
+  VK_FORMAT_R16G16B16A16_UINT
+  VK_FORMAT_R8_UINT
+  VK_FORMAT_R8G8_UINT
+  VK_FORMAT_R8G8B8A8_UINT
+  VK_FORMAT_R8_SINT
+  VK_FORMAT_R8G8_SINT
+  VK_FORMAT_R8G8B8A8_SINT
+  VK_FORMAT_R8_UNORM
+  VK_FORMAT_R8G8_UNORM
+  VK_FORMAT_R8G8B8A8_UNORM
+*/
+
 // clang-format off
-// RUN: %{run} %t.out --type float --channels 1 32
-// RUN: %{run} %t.out --type float --channels 2 32
-// RUN: %{run} %t.out --type float --channels 4 32
-// RUN: %{run} %t.out --type half --channels 1 32
-// RUN: %{run} %t.out --type half --channels 2 32
-// RUN: %{run} %t.out --type half --channels 4 32
-// RUN: %{run} %t.out --type int32 --channels 1 32
-// RUN: %{run} %t.out --type int32 --channels 2 32
-// RUN: %{run} %t.out --type int32 --channels 4 32
-// RUN: %{run} %t.out --type uint32 --channels 1 32
-// RUN: %{run} %t.out --type uint32 --channels 2 32
-// RUN: %{run} %t.out --type uint32 --channels 4 32
-// RUN: %{run} %t.out --type int16 --channels 1 32
-// RUN: %{run} %t.out --type int16 --channels 2 32
-// RUN: %{run} %t.out --type int16 --channels 4 32
-// RUN: %{run} %t.out --type uint16 --channels 1 32
-// RUN: %{run} %t.out --type uint16 --channels 2 32
-// RUN: %{run} %t.out --type uint16 --channels 4 32
-// RUN: %{run} %t.out --type uint8 --channels 1 32
-// RUN: %{run} %t.out --type uint8 --channels 2 32
-// RUN: %{run} %t.out --type uint8 --channels 4 32
-// RUN: %{run} %t.out --type int8 --channels 1 32
-// RUN: %{run} %t.out --type int8 --channels 2 32
-// RUN: %{run} %t.out --type int8 --channels 4 32
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 1 32
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 32
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 4 32
-// RUN: %{run} %t.out --type float --channels 1 --sampled 32
-// RUN: %{run} %t.out --type float --channels 2 --sampled 32
-// RUN: %{run} %t.out --type float --channels 4 --sampled 32
-// RUN: %{run} %t.out --type half --channels 1 --sampled 32
-// RUN: %{run} %t.out --type half --channels 2 --sampled 32
-// RUN: %{run} %t.out --type half --channels 4 --sampled 32
-// RUN: %{run} %t.out --type int32 --channels 1 --sampled 32
-// RUN: %{run} %t.out --type int32 --channels 2 --sampled 32
-// RUN: %{run} %t.out --type int32 --channels 4 --sampled 32
-// RUN: %{run} %t.out --type uint32 --channels 1 --sampled 32
-// RUN: %{run} %t.out --type uint32 --channels 2 --sampled 32
-// RUN: %{run} %t.out --type uint32 --channels 4 --sampled 32
-// RUN: %{run} %t.out --type int16 --channels 1 --sampled 32
-// RUN: %{run} %t.out --type int16 --channels 2 --sampled 32
-// RUN: %{run} %t.out --type int16 --channels 4 --sampled 32
-// RUN: %{run} %t.out --type uint16 --channels 1 --sampled 32
-// RUN: %{run} %t.out --type uint16 --channels 2 --sampled 32
-// RUN: %{run} %t.out --type uint16 --channels 4 --sampled 32
-// RUN: %{run} %t.out --type uint8 --channels 1 --sampled 32
-// RUN: %{run} %t.out --type uint8 --channels 2 --sampled 32
-// RUN: %{run} %t.out --type uint8 --channels 4 --sampled 32
-// RUN: %{run} %t.out --type int8 --channels 1 --sampled 32
-// RUN: %{run} %t.out --type int8 --channels 2 --sampled 32
-// RUN: %{run} %t.out --type int8 --channels 4 --sampled 32
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 1 --sampled 32
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 --sampled 32
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 4 --sampled 32
-
-// RUN: %{run} %t.out --type float --channels 1 32 --semaphores
-// RUN: %{run} %t.out --type float --channels 2 32 --semaphores
-// RUN: %{run} %t.out --type float --channels 4 32 --semaphores
-// RUN: %{run} %t.out --type half --channels 1 32 --semaphores
-// RUN: %{run} %t.out --type int32 --channels 2 32 --semaphores
-// RUN: %{run} %t.out --type uint32 --channels 4 32 --semaphores
-// RUN: %{run} %t.out --type int16 --channels 1 32 --semaphores
-// RUN: %{run} %t.out --type uint16 --channels 2 32 --semaphores
-// RUN: %{run} %t.out --type uint8 --channels 4 32 --semaphores
-// RUN: %{run} %t.out --type int8 --channels 1 32 --semaphores
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 32 --semaphores
-// RUN: %{run} %t.out --type float --channels 4 --sampled 32 --semaphores
-// RUN: %{run} %t.out --type int16 --channels 4 --sampled 32 --semaphores
-// RUN: %{run} %t.out --type int8 --channels 4 --sampled 32 --semaphores
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 4 --sampled 32 --semaphores
-
-/*
-
-The block above tests these formats, sampled and unsampled, with and without
-semaphores
-
-VK_FORMAT_R32_SFLOAT
-VK_FORMAT_R32G32_SFLOAT
-VK_FORMAT_R32G32B32A32_SFLOAT
-VK_FORMAT_R16_SFLOAT
-VK_FORMAT_R16G16_SFLOAT
-VK_FORMAT_R16G16B16A16_SFLOAT
-VK_FORMAT_R32_SINT
-VK_FORMAT_R32G32_SINT
-VK_FORMAT_R32G32B32A32_SINT
-VK_FORMAT_R32_UINT
-VK_FORMAT_R32G32_UINT
-VK_FORMAT_R32G32B32A32_UINT
-VK_FORMAT_R16_SINT
-VK_FORMAT_R16G16_SINT
-VK_FORMAT_R16G16B16A16_SINT
-VK_FORMAT_R16_UINT
-VK_FORMAT_R16G16_UINT
-VK_FORMAT_R16G16B16A16_UINT
-VK_FORMAT_R8_UINT
-VK_FORMAT_R8G8_UINT
-VK_FORMAT_R8G8B8A8_UINT
-VK_FORMAT_R8_SINT
-VK_FORMAT_R8G8_SINT
-VK_FORMAT_R8G8B8A8_SINT
-VK_FORMAT_R8_UNORM
-VK_FORMAT_R8G8_UNORM
-VK_FORMAT_R8G8B8A8_UNORM
-
-*/
-
 /*
   Vulkan/SYCL 1D Image Read Test (Sampled + Unsampled)
 
-  clang++ -fsycl -o vsr_1d_test.bin vulkan_sycl_image_interop_read_1d.cpp -lvulkan -I$VULKAN_SDK/include -L$VULKAN_SDK/lib
+  clang++ -fsycl -o vsr_1d_test.bin vulkan_sycl_image_interop_read_1d.cpp
+  -lvulkan -I$VULKAN_SDK/include -L$VULKAN_SDK/lib
 
-  clang++ -fsycl -o vsr_1d_test.exe vulkan_sycl_image_interop_read_1d.cpp -Wno-ignored-attributes  -lvulkan-1 -I$VULKAN_SDK/Include -L$VULKAN_SDK/Lib
+  clang++ -fsycl -o vsr_1d_test.exe vulkan_sycl_image_interop_read_1d.cpp
+  -Wno-ignored-attributes  -lvulkan-1 -I$VULKAN_SDK/Include -L$VULKAN_SDK/Lib
 
   USAGE:
     ./vsr_1d_test.bin [FLAGS] [Wx]
@@ -140,8 +65,9 @@ VK_FORMAT_R8G8B8A8_UNORM
     --semaphores   Use Vulkan Semaphores for SYCL Interop Sync
     --linear       Use LINEAR tiling for the Vulkan Image (default is OPTIMAL)
     --channels X   Set number of channels (1, 2, or 4). Default is 4 (RGBA)
-    --type XXX     Set data type (float, half, uint32, int32, uint16, int16, uint8, int8, unorm8). Default is float 
-    Wx             Set custom Width (e.g. 64x)
+    --type XXX     Set data type (float, half, uint32, int32, uint16, int16,
+  uint8, int8, unorm8). Default is float Wx             Set custom Width (e.g.
+  64x)
 
   EXAMPLES:
     ./vsr_1d_test.bin
@@ -151,6 +77,8 @@ VK_FORMAT_R8G8B8A8_UNORM
     ./vsr_1d_test.bin --linear --type unorm8 128x
 */
 // clang-format on
+
+#pragma once
 
 #include "vulkan_setup.hpp"
 

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d_sampled.cpp
@@ -1,0 +1,39 @@
+// Sampled-only version of the Vulkan/SYCL 1D image read interop test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// clang-format off
+// RUN: %{run} %t.out --type float --channels 1 --sampled 32
+// RUN: %{run} %t.out --type float --channels 2 --sampled 32
+// RUN: %{run} %t.out --type float --channels 4 --sampled 32
+// RUN: %{run} %t.out --type half --channels 1 --sampled 32
+// RUN: %{run} %t.out --type half --channels 2 --sampled 32
+// RUN: %{run} %t.out --type half --channels 4 --sampled 32
+// RUN: %{run} %t.out --type int32 --channels 1 --sampled 32
+// RUN: %{run} %t.out --type int32 --channels 2 --sampled 32
+// RUN: %{run} %t.out --type int32 --channels 4 --sampled 32
+// RUN: %{run} %t.out --type uint32 --channels 1 --sampled 32
+// RUN: %{run} %t.out --type uint32 --channels 2 --sampled 32
+// RUN: %{run} %t.out --type uint32 --channels 4 --sampled 32
+// RUN: %{run} %t.out --type int16 --channels 1 --sampled 32
+// RUN: %{run} %t.out --type int16 --channels 2 --sampled 32
+// RUN: %{run} %t.out --type int16 --channels 4 --sampled 32
+// RUN: %{run} %t.out --type uint16 --channels 1 --sampled 32
+// RUN: %{run} %t.out --type uint16 --channels 2 --sampled 32
+// RUN: %{run} %t.out --type uint16 --channels 4 --sampled 32
+// RUN: %{run} %t.out --type uint8 --channels 1 --sampled 32
+// RUN: %{run} %t.out --type uint8 --channels 2 --sampled 32
+// RUN: %{run} %t.out --type uint8 --channels 4 --sampled 32
+// RUN: %{run} %t.out --type int8 --channels 1 --sampled 32
+// RUN: %{run} %t.out --type int8 --channels 2 --sampled 32
+// RUN: %{run} %t.out --type int8 --channels 4 --sampled 32
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 1 --sampled 32
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 --sampled 32
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 4 --sampled 32
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_read_1d_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d_semaphores.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d_semaphores.cpp
@@ -1,0 +1,27 @@
+// Semaphore version of the Vulkan/SYCL 1D image read interop test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// clang-format off
+// RUN: %{run} %t.out --type float --channels 1 32 --semaphores
+// RUN: %{run} %t.out --type float --channels 2 32 --semaphores
+// RUN: %{run} %t.out --type float --channels 4 32 --semaphores
+// RUN: %{run} %t.out --type half --channels 1 32 --semaphores
+// RUN: %{run} %t.out --type int32 --channels 2 32 --semaphores
+// RUN: %{run} %t.out --type uint32 --channels 4 32 --semaphores
+// RUN: %{run} %t.out --type int16 --channels 1 32 --semaphores
+// RUN: %{run} %t.out --type uint16 --channels 2 32 --semaphores
+// RUN: %{run} %t.out --type uint8 --channels 4 32 --semaphores
+// RUN: %{run} %t.out --type int8 --channels 1 32 --semaphores
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 32 --semaphores
+// RUN: %{run} %t.out --type float --channels 4 --sampled 32 --semaphores
+// RUN: %{run} %t.out --type int16 --channels 4 --sampled 32 --semaphores
+// RUN: %{run} %t.out --type int8 --channels 4 --sampled 32 --semaphores
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 4 --sampled 32 --semaphores
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_read_1d_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_2d_channels.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_2d_channels.cpp
@@ -1,0 +1,43 @@
+// Unsampled channel-coverage version of the Vulkan/SYCL 2D image read interop
+// test
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// UNSUPPORTED: linux
+// UNSUPPORTED-TRACKER: GSD-12357
+
+// clang-format off
+// RUN: %{run} %t.out --type float --channels 1 32x33
+// RUN: %{run} %t.out --type float --channels 2 32x33
+// RUN: %{run} %t.out --type float --channels 4 32x33
+// RUN: %{run} %t.out --type half --channels 1 32x33
+// RUN: %{run} %t.out --type half --channels 2 32x33
+// RUN: %{run} %t.out --type half --channels 4 32x33
+// RUN: %{run} %t.out --type int32 --channels 1 32x33
+// RUN: %{run} %t.out --type int32 --channels 2 32x33
+// RUN: %{run} %t.out --type int32 --channels 4 32x33
+// RUN: %{run} %t.out --type uint32 --channels 1 32x33
+// RUN: %{run} %t.out --type uint32 --channels 2 32x33
+// RUN: %{run} %t.out --type uint32 --channels 4 32x33
+// RUN: %{run} %t.out --type int16 --channels 1 32x33
+// RUN: %{run} %t.out --type int16 --channels 2 32x33
+// RUN: %{run} %t.out --type int16 --channels 4 32x33
+// RUN: %{run} %t.out --type uint16 --channels 1 32x33
+// RUN: %{run} %t.out --type uint16 --channels 2 32x33
+// RUN: %{run} %t.out --type uint16 --channels 4 32x33
+// RUN: %{run} %t.out --type uint8 --channels 1 32x33
+// RUN: %{run} %t.out --type uint8 --channels 2 32x33
+// RUN: %{run} %t.out --type uint8 --channels 4 32x33
+// RUN: %{run} %t.out --type int8 --channels 1 32x33
+// RUN: %{run} %t.out --type int8 --channels 2 32x33
+// RUN: %{run} %t.out --type int8 --channels 4 32x33
+// RUN: %{run} %t.out --type unorm8 --channels 1 32x33
+// RUN: %{run} %t.out --type unorm8 --channels 2 32x33
+// RUN: %{run} %t.out --type unorm8 --channels 4 32x33
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_read_2d_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_2d_common.hpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_2d_common.hpp
@@ -1,93 +1,18 @@
-// REQUIRES: aspect-ext_oneapi_bindless_images
-// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
-// REQUIRES: vulkan
-
-// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
-
-// UNSUPPORTED: linux
-// UNSUPPORTED-TRACKER: GSD-12357
+// Shared implementation for the Vulkan/SYCL 2D image read interop tests.
 
 /*
-    Run ALL the vulkan formats through the gauntlet. sampled and unsampled.
-    This entire test takes less than 30 seconds on a slow machine.  MUCH faster
-   (and more complete coveraage) than SFINAE based approach.
+  Run ALL the vulkan formats through the gauntlet. sampled and unsampled.
+  This entire test takes less than 30 seconds on a slow machine.  MUCH faster
+  (and more complete coveraage) than SFINAE based approach.
 
-    IF a particular variant is having problems on some platform, please do NOT
-   just disable the whole test, instead use   RUN~IF (SOMETHING) yadda-yadda
-    to enable/disable that variant.
+  IF a particular variant is having problems on some platform, please do NOT
+  just disable the whole test, instead use   RUN~IF (SOMETHING) yadda-yadda
+  to enable/disable that variant.
 
-    For semaphore testing, we run just a sampling. Note, that on Linux if there
-   is a failure in the first section, then likely ALL semaphore tests afterwards
-   will fail. This is being tracked as a separate issue.
-
+  For semaphore testing, we run just a sampling. Note, that on Linux if there
+  is a failure in the first section, then likely ALL semaphore tests afterwards
+  will fail. This is being tracked as a separate issue.
 */
-
-// RUN: %{run} %t.out --type float --channels 1 32x33
-// RUN: %{run} %t.out --type float --channels 2 32x33
-// RUN: %{run} %t.out --type float --channels 4 32x33
-// RUN: %{run} %t.out --type half --channels 1 32x33
-// RUN: %{run} %t.out --type half --channels 2 32x33
-// RUN: %{run} %t.out --type half --channels 4 32x33
-// RUN: %{run} %t.out --type int32 --channels 1 32x33
-// RUN: %{run} %t.out --type int32 --channels 2 32x33
-// RUN: %{run} %t.out --type int32 --channels 4 32x33
-// RUN: %{run} %t.out --type uint32 --channels 1 32x33
-// RUN: %{run} %t.out --type uint32 --channels 2 32x33
-// RUN: %{run} %t.out --type uint32 --channels 4 32x33
-// RUN: %{run} %t.out --type int16 --channels 1 32x33
-// RUN: %{run} %t.out --type int16 --channels 2 32x33
-// RUN: %{run} %t.out --type int16 --channels 4 32x33
-// RUN: %{run} %t.out --type uint16 --channels 1 32x33
-// RUN: %{run} %t.out --type uint16 --channels 2 32x33
-// RUN: %{run} %t.out --type uint16 --channels 4 32x33
-// RUN: %{run} %t.out --type uint8 --channels 1 32x33
-// RUN: %{run} %t.out --type uint8 --channels 2 32x33
-// RUN: %{run} %t.out --type uint8 --channels 4 32x33
-// RUN: %{run} %t.out --type int8 --channels 1 32x33
-// RUN: %{run} %t.out --type int8 --channels 2 32x33
-// RUN: %{run} %t.out --type int8 --channels 4 32x33
-// RUN: %{run} %t.out --type unorm8 --channels 1 32x33
-// RUN: %{run} %t.out --type unorm8 --channels 2 32x33
-// RUN: %{run} %t.out --type unorm8 --channels 4 32x33
-// RUN: %{run} %t.out --type float --channels 1 --sampled 32x33
-// RUN: %{run} %t.out --type float --channels 2 --sampled 32x33
-// RUN: %{run} %t.out --type float --channels 4 --sampled 32x33
-// RUN: %{run} %t.out --type half --channels 1 --sampled 32x33
-// RUN: %{run} %t.out --type half --channels 2 --sampled 32x33
-// RUN: %{run} %t.out --type half --channels 4 --sampled 32x33
-// RUN: %{run} %t.out --type int32 --channels 1 --sampled 32x33
-// RUN: %{run} %t.out --type int32 --channels 2 --sampled 32x33
-// RUN: %{run} %t.out --type int32 --channels 4 --sampled 32x33
-// RUN: %{run} %t.out --type uint32 --channels 1 --sampled 32x33
-// RUN: %{run} %t.out --type uint32 --channels 2 --sampled 32x33
-// RUN: %{run} %t.out --type uint32 --channels 4 --sampled 32x33
-// RUN: %{run} %t.out --type int16 --channels 1 --sampled 32x33
-// RUN: %{run} %t.out --type int16 --channels 2 --sampled 32x33
-// RUN: %{run} %t.out --type int16 --channels 4 --sampled 32x33
-// RUN: %{run} %t.out --type uint16 --channels 1 --sampled 32x33
-// RUN: %{run} %t.out --type uint16 --channels 2 --sampled 32x33
-// RUN: %{run} %t.out --type uint16 --channels 4 --sampled 32x33
-// RUN: %{run} %t.out --type uint8 --channels 1 --sampled 32x33
-// RUN: %{run} %t.out --type uint8 --channels 2 --sampled 32x33
-// RUN: %{run} %t.out --type uint8 --channels 4 --sampled 32x33
-// RUN: %{run} %t.out --type int8 --channels 1 --sampled 32x33
-// RUN: %{run} %t.out --type int8 --channels 2 --sampled 32x33
-// RUN: %{run} %t.out --type int8 --channels 4 --sampled 32x33
-// RUN: %{run} %t.out --type unorm8 --channels 1 --sampled 32x33
-// RUN: %{run} %t.out --type unorm8 --channels 2 --sampled 32x33
-// RUN: %{run} %t.out --type unorm8 --channels 4 --sampled 32x33
-
-// RUN: %{run} %t.out --type float --channels 1 32x33 --semaphores
-// RUN: %{run} %t.out --type float --channels 4 32x33 --semaphores
-// RUN: %{run} %t.out --type half --channels 1 32x33 --semaphores
-// RUN: %{run} %t.out --type uint32 --channels 4 32x33 --semaphores
-// RUN: %{run} %t.out --type uint16 --channels 2 32x33 --semaphores
-// RUN: %{run} %t.out --type int8 --channels 1 32x33 --semaphores
-// RUN: %{run} %t.out --type float --channels 4 --sampled 32x33 --semaphores
-// RUN: %{run} %t.out --type int32 --channels 4 --sampled 32x33 --semaphores
-// RUN: %{run} %t.out --type int16 --channels 4 --sampled 32x33 --semaphores
-// RUN: %{run} %t.out --type uint8 --channels 2 --sampled 32x33 --semaphores
-// RUN: %{run} %t.out --type unorm8 --channels 4 --sampled 32x33 --semaphores
 
 // clang-format off
 /*
@@ -119,6 +44,8 @@
   NOTE: --linear is not currently working with 2D images on Linux
 */
 // clang-format on
+
+#pragma once
 
 #include "vulkan_setup.hpp"
 

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_2d_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_2d_sampled.cpp
@@ -1,0 +1,42 @@
+// Sampled-only version of the Vulkan/SYCL 2D image read interop test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// UNSUPPORTED: linux
+// UNSUPPORTED-TRACKER: GSD-12357
+
+// clang-format off
+// RUN: %{run} %t.out --type float --channels 1 --sampled 32x33
+// RUN: %{run} %t.out --type float --channels 2 --sampled 32x33
+// RUN: %{run} %t.out --type float --channels 4 --sampled 32x33
+// RUN: %{run} %t.out --type half --channels 1 --sampled 32x33
+// RUN: %{run} %t.out --type half --channels 2 --sampled 32x33
+// RUN: %{run} %t.out --type half --channels 4 --sampled 32x33
+// RUN: %{run} %t.out --type int32 --channels 1 --sampled 32x33
+// RUN: %{run} %t.out --type int32 --channels 2 --sampled 32x33
+// RUN: %{run} %t.out --type int32 --channels 4 --sampled 32x33
+// RUN: %{run} %t.out --type uint32 --channels 1 --sampled 32x33
+// RUN: %{run} %t.out --type uint32 --channels 2 --sampled 32x33
+// RUN: %{run} %t.out --type uint32 --channels 4 --sampled 32x33
+// RUN: %{run} %t.out --type int16 --channels 1 --sampled 32x33
+// RUN: %{run} %t.out --type int16 --channels 2 --sampled 32x33
+// RUN: %{run} %t.out --type int16 --channels 4 --sampled 32x33
+// RUN: %{run} %t.out --type uint16 --channels 1 --sampled 32x33
+// RUN: %{run} %t.out --type uint16 --channels 2 --sampled 32x33
+// RUN: %{run} %t.out --type uint16 --channels 4 --sampled 32x33
+// RUN: %{run} %t.out --type uint8 --channels 1 --sampled 32x33
+// RUN: %{run} %t.out --type uint8 --channels 2 --sampled 32x33
+// RUN: %{run} %t.out --type uint8 --channels 4 --sampled 32x33
+// RUN: %{run} %t.out --type int8 --channels 1 --sampled 32x33
+// RUN: %{run} %t.out --type int8 --channels 2 --sampled 32x33
+// RUN: %{run} %t.out --type int8 --channels 4 --sampled 32x33
+// RUN: %{run} %t.out --type unorm8 --channels 1 --sampled 32x33
+// RUN: %{run} %t.out --type unorm8 --channels 2 --sampled 32x33
+// RUN: %{run} %t.out --type unorm8 --channels 4 --sampled 32x33
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_read_2d_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_2d_semaphores.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_2d_semaphores.cpp
@@ -1,0 +1,26 @@
+// Semaphore version of the Vulkan/SYCL 2D image read interop test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// UNSUPPORTED: linux
+// UNSUPPORTED-TRACKER: GSD-12357
+
+// clang-format off
+// RUN: %{run} %t.out --type float --channels 1 32x33 --semaphores
+// RUN: %{run} %t.out --type float --channels 4 32x33 --semaphores
+// RUN: %{run} %t.out --type half --channels 1 32x33 --semaphores
+// RUN: %{run} %t.out --type uint32 --channels 4 32x33 --semaphores
+// RUN: %{run} %t.out --type uint16 --channels 2 32x33 --semaphores
+// RUN: %{run} %t.out --type int8 --channels 1 32x33 --semaphores
+// RUN: %{run} %t.out --type float --channels 4 --sampled 32x33 --semaphores
+// RUN: %{run} %t.out --type int32 --channels 4 --sampled 32x33 --semaphores
+// RUN: %{run} %t.out --type int16 --channels 4 --sampled 32x33 --semaphores
+// RUN: %{run} %t.out --type uint8 --channels 2 --sampled 32x33 --semaphores
+// RUN: %{run} %t.out --type unorm8 --channels 4 --sampled 32x33 --semaphores
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_read_2d_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled_channels.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled_channels.cpp
@@ -1,0 +1,42 @@
+// Channel coverage version of the Vulkan/SYCL 1D unsampled write interop test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// UNSUPPORTED: windows
+// UNSUPPORTED-TRACKER: CMPLRLLVM-73525
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// clang-format off
+// RUN: %{run} %t.out --type float --channels 1 32
+// RUN: %{run} %t.out --type float --channels 2 32
+// RUN: %{run} %t.out --type float --channels 4 32
+// RUN: %{run} %t.out --type half --channels 1 32
+// RUN: %{run} %t.out --type half --channels 2 32
+// RUN: %{run} %t.out --type half --channels 4 32
+// RUN: %{run} %t.out --type int32 --channels 1 32
+// RUN: %{run} %t.out --type int32 --channels 2 32
+// RUN: %{run} %t.out --type int32 --channels 4 32
+// RUN: %{run} %t.out --type uint32 --channels 1 32
+// RUN: %{run} %t.out --type uint32 --channels 2 32
+// RUN: %{run} %t.out --type uint32 --channels 4 32
+// RUN: %{run} %t.out --type int16 --channels 1 32
+// RUN: %{run} %t.out --type int16 --channels 2 32
+// RUN: %{run} %t.out --type int16 --channels 4 32
+// RUN: %{run} %t.out --type uint16 --channels 1 32
+// RUN: %{run} %t.out --type uint16 --channels 2 32
+// RUN: %{run} %t.out --type uint16 --channels 4 32
+// RUN: %{run} %t.out --type uint8 --channels 1 32
+// RUN: %{run} %t.out --type uint8 --channels 2 32
+// RUN: %{run} %t.out --type uint8 --channels 4 32
+// RUN: %{run} %t.out --type int8 --channels 1 32
+// RUN: %{run} %t.out --type int8 --channels 2 32
+// RUN: %{run} %t.out --type int8 --channels 4 32
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 1 32
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 32
+// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 4 32
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_write_1d_unsampled_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled_common.hpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled_common.hpp
@@ -1,85 +1,45 @@
-// REQUIRES: aspect-ext_oneapi_bindless_images
-// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
-// REQUIRES: vulkan
-
-// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
-
-// UNSUPPORTED: linux
-// UNSUPPORTED-TRACKER: GSD-12357
+// Shared implementation for the Vulkan/SYCL 1D unsampled write interop tests.
 
 /*
-    Run all the vulkan formats through a write test. Note this is unsampled
-   only, you can't "write" with the image sampler.
+  Run all the vulkan formats through a write test. Note this is unsampled only,
+  you can't "write" with the image sampler.
 
-    IF a particular variant is having problems on some platform, please do NOT
-   just disable the whole test, instead use   RUN~IF: (SOMETHING) yadda-yadda
-    to enable/disable that variant.
+  IF a particular variant is having problems on some platform, please do NOT
+  just disable the whole test, instead use   RUN~IF: (SOMETHING) yadda-yadda
+  to enable/disable that variant.
 
-    For semaphore testing, we run just a sampling. Note, that on Linux if there
-   is a failure in the first section, then likely ALL semaphore tests afterwards
-   will fail. This is being tracked as a separate issue.
-
+  For semaphore testing, we run just a sampling. Note, that on Linux if there
+  is a failure in the first section, then likely ALL semaphore tests afterwards
+  will fail. This is being tracked as a separate issue.
 */
-
-// RUN: %{run} %t.out --type float --channels 1 32x33
-// RUN: %{run} %t.out --type float --channels 2 32x33
-// RUN: %{run} %t.out --type float --channels 4 32x33
-// RUN: %{run} %t.out --type half --channels 1 32x33
-// RUN: %{run} %t.out --type half --channels 2 32x33
-// RUN: %{run} %t.out --type half --channels 4 32x33
-// RUN: %{run} %t.out --type int32 --channels 1 32x33
-// RUN: %{run} %t.out --type int32 --channels 2 32x33
-// RUN: %{run} %t.out --type int32 --channels 4 32x33
-// RUN: %{run} %t.out --type uint32 --channels 1 32x33
-// RUN: %{run} %t.out --type uint32 --channels 2 32x33
-// RUN: %{run} %t.out --type uint32 --channels 4 32x33
-// RUN: %{run} %t.out --type int16 --channels 1 32x33
-// RUN: %{run} %t.out --type int16 --channels 2 32x33
-// RUN: %{run} %t.out --type int16 --channels 4 32x33
-// RUN: %{run} %t.out --type uint16 --channels 1 32x33
-// RUN: %{run} %t.out --type uint16 --channels 2 32x33
-// RUN: %{run} %t.out --type uint16 --channels 4 32x33
-// RUN: %{run} %t.out --type uint8 --channels 1 32x33
-// RUN: %{run} %t.out --type uint8 --channels 2 32x33
-// RUN: %{run} %t.out --type uint8 --channels 4 32x33
-// RUN: %{run} %t.out --type int8 --channels 1 32x33
-// RUN: %{run} %t.out --type int8 --channels 2 32x33
-// RUN: %{run} %t.out --type int8 --channels 4 32x33
-// RUN: %{run} %t.out --type unorm8 --channels 1 32x33
-// RUN: %{run} %t.out --type unorm8 --channels 2 32x33
-// RUN: %{run} %t.out --type unorm8 --channels 4 32x33
-
-// RUN: %{run} %t.out --type float --channels 1 32x33 --semaphores
-// RUN: %{run} %t.out --type half --channels 2 32x33 --semaphores
-// RUN: %{run} %t.out --type int32 --channels 4 32x33 --semaphores
-// RUN: %{run} %t.out --type uint32 --channels 1 32x33 --semaphores
-// RUN: %{run} %t.out --type int16 --channels 2 32x33 --semaphores
-// RUN: %{run} %t.out --type uint16 --channels 4 32x33 --semaphores
-// RUN: %{run} %t.out --type uint8 --channels 1 32x33 --semaphores
-// RUN: %{run} %t.out --type int8 --channels 2 32x33 --semaphores
-// RUN: %{run} %t.out --type unorm8 --channels 4 32x33 --semaphores
 
 // clang-format off
 /*
-  clang++ -fsycl -o vsw_2d_test.bin vulkan_sycl_image_interop_write_2d_unsampled.cpp -lvulkan -I$VULKAN_SDK/include -L$VULKAN_SDK/lib
+  Vulkan/SYCL 1D Unsampled Write Image
 
-  clang++ -fsycl -o vsw_2d_test.exe vulkan_sycl_image_interop_write_2d_unsampled.cpp -Wno-ignored-attributes -lvulkan-1 -I$VULKAN_SDK/Include -L$VULKAN_SDK/Lib
+  clang++ -fsycl -o vsw_1d_test.bin vulkan_sycl_image_interop_write_1d_unsampled.cpp -lvulkan -I$VULKAN_SDK/include -L$VULKAN_SDK/lib
 
-    ./vsw_2d_test.bin
+  clang++ -fsycl -o vsw_1d_test.exe vulkan_sycl_image_interop_write_1d_unsampled.cpp -Wno-ignored-attributes -lvulkan-1 -I$VULKAN_SDK/Include -L$VULKAN_SDK/Lib
 
-    FLAGS
+  USAGE:
+    ./vsw_1d_test.bin
+    ./vsw_1d_test.bin --semaphores
+  
+  FLAGS:
     --sampled      ERROR: Sampled image writes are not supported
     --semaphores   Use Vulkan Semaphores for SYCL Interop Sync
     --linear       Use LINEAR tiling for the Vulkan Image (default is OPTIMAL)
     --channels  X  Set number of channels (1, 2, or 4). Default is 4 (RGBA)
-    --type  XXX    Set data type (float, half, uint32, int32, uint16, int16, uint8, int8, unorm8). 
-                   Default is float 
-    WxH            Set custom Width x Height (e.g. 8x4)
-
-    ./vsw_2d_test.bin --semaphores --channels 2 --linear 8x4
+    --type  XXX    Set data type (float, half, uint32, int32, uint16, int16, uint8, int8, unorm8). Default is float 
+    Wx             Set custom Width .  Put "x" after
+  
+  EXAMPLES:
+    ./vsw_1d_test.bin --semaphores --channels 2 --linear 64x
 
 */
 // clang-format on
+
+#pragma once
 
 #include "vulkan_setup.hpp"
 
@@ -140,10 +100,11 @@ template <> inline sycl::image_channel_type getSyclChannelType<sycl::half>() {
 // ---------------------------------------------------------
 template <typename T>
 int runTest(
-    int width, int height, int channels, bool useLinear, bool useSemaphores,
+    int width, int channels, bool useLinear, bool useSemaphores,
     VkFormat fmtOverride = VK_FORMAT_UNDEFINED,
     std::optional<sycl::image_channel_type> syclOverride = std::nullopt) {
 
+  // Default to OPTIMAL unless --linear is passed (Expect failure on 1D)
   VkImageTiling tiling =
       useLinear ? VK_IMAGE_TILING_LINEAR : VK_IMAGE_TILING_OPTIMAL;
   VkFormat vkFormat = (fmtOverride != VK_FORMAT_UNDEFINED)
@@ -152,9 +113,9 @@ int runTest(
   std::cout << "VK Format: " << getFormatString(vkFormat) << std::endl;
 
   VulkanContext vkCtx = createVulkanContext();
-  VkExtent3D extent = {(uint32_t)width, (uint32_t)height, 1};
+  VkExtent3D extent = {(uint32_t)width, 1, 1};
   ImageResources imgRes =
-      createExportableImage(vkCtx, extent, vkFormat, VK_IMAGE_TYPE_2D, tiling);
+      createExportableImage(vkCtx, extent, vkFormat, VK_IMAGE_TYPE_1D, tiling);
 
   // Initial Transition to GENERAL
   {
@@ -195,7 +156,7 @@ int runTest(
   if (useSemaphores)
     vkSem = createExportableSemaphore(vkCtx);
 
-  // Initial clear/upload (Sanity Check)
+  // Initial clear/upload
   if (!uploadAndVerify<T>(vkCtx, imgRes, vkSem, channels)) {
     std::cerr << "Vulkan Upload Failed!" << std::endl;
     return 1;
@@ -239,71 +200,56 @@ int runTest(
     sycl::image_channel_type syclType = syclOverride.has_value()
                                             ? syclOverride.value()
                                             : getSyclChannelType<T>();
-    // bindless image ranges use (x,y,z) order,
-    // differening from SYCL 2020 "fastest incrementing" convention.
-    syclexp::image_descriptor imgDesc(sycl::range<2>(width, height), channels,
+    syclexp::image_descriptor imgDesc(sycl::range<1>(width), channels,
                                       syclType);
     syclexp::image_mem_handle devHandle = syclexp::map_external_image_memory(
         extMem, imgDesc, q.get_device(), q.get_context());
     syclexp::unsampled_image_handle unsampledHandle = syclexp::create_image(
         devHandle, imgDesc, q.get_device(), q.get_context());
 
-    // SYCL KERNEL
     sycl::event kernelEvent = q.submit([&](sycl::handler &h) {
-      // ranges for parallel_for use "fastest incrementing" order (z,y,x),
-      // but bindless images ranges use (x,y,z) order.
-      h.parallel_for(sycl::range<2>(height, width), [=](sycl::item<2> item) {
-        int x = item.get_id(1);
-        int y = item.get_id(0);
+      h.parallel_for(sycl::range<1>(width), [=](sycl::item<1> item) {
+        int x = item.get_id(0);
 
-        size_t index = y * width + x;
-        size_t totalPixels = width * height;
+        // Use generateTestValue directly
 
-        // UNORM is a special snowflake
+        // UNORM is special snowflake
         bool isUnorm = (syclType == sycl::image_channel_type::unorm_int8);
         if (isUnorm) {
           if (channels == 1) {
-            float v =
-                (float)generateTestValue<T>(index, 0, totalPixels) / 255.0f;
-            syclexp::write_image(unsampledHandle, sycl::int2(x, y), v);
+            float v = (float)generateTestValue<T>(x, 0, width) / 255.0f;
+            syclexp::write_image(unsampledHandle, x, v);
           } else if (channels == 2) {
-            float v1 =
-                (float)generateTestValue<T>(index, 0, totalPixels) / 255.0f;
-            float v2 =
-                (float)generateTestValue<T>(index, 1, totalPixels) / 255.0f;
-            syclexp::write_image(unsampledHandle, sycl::int2(x, y),
-                                 sycl::float2(v1, v2));
+            float v1 = (float)generateTestValue<T>(x, 0, width) / 255.0f;
+            float v2 = (float)generateTestValue<T>(x, 1, width) / 255.0f;
+            syclexp::write_image(unsampledHandle, x, sycl::float2(v1, v2));
           } else { // 4
-            float v1 =
-                (float)generateTestValue<T>(index, 0, totalPixels) / 255.0f;
-            float v2 =
-                (float)generateTestValue<T>(index, 1, totalPixels) / 255.0f;
-            float v3 =
-                (float)generateTestValue<T>(index, 2, totalPixels) / 255.0f;
-            float v4 =
-                (float)generateTestValue<T>(index, 3, totalPixels) / 255.0f;
-            syclexp::write_image(unsampledHandle, sycl::int2(x, y),
+            float v1 = (float)generateTestValue<T>(x, 0, width) / 255.0f;
+            float v2 = (float)generateTestValue<T>(x, 1, width) / 255.0f;
+            float v3 = (float)generateTestValue<T>(x, 2, width) / 255.0f;
+            float v4 = (float)generateTestValue<T>(x, 3, width) / 255.0f;
+            syclexp::write_image(unsampledHandle, x,
                                  sycl::float4(v1, v2, v3, v4));
           }
-          return; // Early exit. special snowflake gets to leave early.
+          return;
         }
 
         // Standard Path
         if (channels == 1) {
-          T val = generateTestValue<T>(index, 0, totalPixels);
-          syclexp::write_image(unsampledHandle, sycl::int2(x, y), val);
+          T val = generateTestValue<T>(x, 0, width);
+          syclexp::write_image(unsampledHandle, x, val);
         } else if (channels == 2) {
           using Vec2 = sycl::vec<T, 2>;
-          Vec2 px(generateTestValue<T>(index, 0, totalPixels),
-                  generateTestValue<T>(index, 1, totalPixels));
-          syclexp::write_image(unsampledHandle, sycl::int2(x, y), px);
+          Vec2 px(generateTestValue<T>(x, 0, width),
+                  generateTestValue<T>(x, 1, width));
+          syclexp::write_image(unsampledHandle, x, px);
         } else {
           using Vec4 = sycl::vec<T, 4>;
-          Vec4 px(generateTestValue<T>(index, 0, totalPixels),
-                  generateTestValue<T>(index, 1, totalPixels),
-                  generateTestValue<T>(index, 2, totalPixels),
-                  generateTestValue<T>(index, 3, totalPixels));
-          syclexp::write_image(unsampledHandle, sycl::int2(x, y), px);
+          Vec4 px(generateTestValue<T>(x, 0, width),
+                  generateTestValue<T>(x, 1, width),
+                  generateTestValue<T>(x, 2, width),
+                  generateTestValue<T>(x, 3, width));
+          syclexp::write_image(unsampledHandle, x, px);
         }
       });
     });
@@ -331,7 +277,7 @@ int runTest(
   vkDeviceWaitIdle(vkCtx.device);
   VkBuffer verifyBuffer;
   VkDeviceMemory verifyMem;
-  size_t dataSize = width * height * channels * sizeof(T);
+  size_t dataSize = width * channels * sizeof(T);
   VkBufferCreateInfo bi = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
   bi.size = dataSize;
   bi.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
@@ -387,12 +333,8 @@ int runTest(
   T *vData = (T *)ptr;
   bool passed = true;
   int errorCount = 0;
-  size_t totalPixels = width * height;
-
-  for (size_t i = 0; i < totalPixels * channels; ++i) {
-    size_t pixelIdx = i / channels;
-    int ch = i % channels;
-    T expected = generateTestValue<T>(pixelIdx, ch, totalPixels);
+  for (size_t i = 0; i < width * channels; ++i) {
+    T expected = generateTestValue<T>(i / channels, i % channels, width);
     if (!checkValue(vData[i], expected)) {
       passed = false;
       if (errorCount++ < 5)
@@ -411,11 +353,12 @@ int runTest(
   if (useSemaphores)
     vkDestroySemaphore(vkCtx.device, vkSem, nullptr);
   cleanupVulkan(vkCtx, imgRes);
+
   return passed ? 0 : 1;
 }
 
 int main(int argc, char **argv) {
-  int width = 4, height = 4, channels = 4;
+  int width = 16, channels = 4;
   bool useLinear = false, useSemaphores = false;
   std::string type = "float";
 
@@ -437,41 +380,38 @@ int main(int argc, char **argv) {
       channels = std::stoi(argv[++i]);
     else if (arg == "--type" && i + 1 < argc)
       type = argv[++i];
-    else if (arg.find("x") != std::string::npos) {
-      size_t xPos = arg.find("x");
+    else {
       try {
-        width = std::stoi(arg.substr(0, xPos));
-        height = std::stoi(arg.substr(xPos + 1));
+        width = std::stoi(arg);
       } catch (...) {
       }
     }
   }
 
-  std::cout << "Running UNSAMPLED 2D Write Test | Type: " << type
-            << " | Size: " << width << "x" << height
+  std::cout << "Running UNSAMPLED 1D Write Test | Type: " << type
+            << " | Size: " << width << "x"
             << " | Channels: " << channels
             << " | Tiling: " << (useLinear ? "LINEAR" : "OPTIMAL")
             << " | Semaphores: " << (useSemaphores ? "ON" : "OFF") << std::endl;
 
   if (type == "float")
-    return runTest<float>(width, height, channels, useLinear, useSemaphores);
+    return runTest<float>(width, channels, useLinear, useSemaphores);
   if (type == "half")
-    return runTest<sycl::half>(width, height, channels, useLinear,
-                               useSemaphores);
+    return runTest<sycl::half>(width, channels, useLinear, useSemaphores);
   if (type == "int32")
-    return runTest<int32_t>(width, height, channels, useLinear, useSemaphores);
+    return runTest<int32_t>(width, channels, useLinear, useSemaphores);
   if (type == "uint32")
-    return runTest<uint32_t>(width, height, channels, useLinear, useSemaphores);
+    return runTest<uint32_t>(width, channels, useLinear, useSemaphores);
   if (type == "int16")
-    return runTest<int16_t>(width, height, channels, useLinear, useSemaphores);
+    return runTest<int16_t>(width, channels, useLinear, useSemaphores);
   if (type == "uint16")
-    return runTest<uint16_t>(width, height, channels, useLinear, useSemaphores);
+    return runTest<uint16_t>(width, channels, useLinear, useSemaphores);
   if (type == "uint8")
-    return runTest<uint8_t>(width, height, channels, useLinear, useSemaphores);
+    return runTest<uint8_t>(width, channels, useLinear, useSemaphores);
   if (type == "int8")
-    return runTest<int8_t>(width, height, channels, useLinear, useSemaphores);
+    return runTest<int8_t>(width, channels, useLinear, useSemaphores);
   if (type == "unorm8")
-    return runTest<uint8_t>(width, height, channels, useLinear, useSemaphores,
+    return runTest<uint8_t>(width, channels, useLinear, useSemaphores,
                             getUnorm8Format(channels),
                             sycl::image_channel_type::unorm_int8);
   return 1;

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled_semaphores.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled_semaphores.cpp
@@ -1,0 +1,26 @@
+// Semaphore coverage version of the Vulkan/SYCL 1D unsampled write interop
+// test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// UNSUPPORTED: windows
+// UNSUPPORTED-TRACKER: CMPLRLLVM-73525
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// clang-format off
+// RUN-IF: !level_zero, %{run} %t.out --type float --channels 1 32 --semaphores
+// RUN-IF: !level_zero, %{run} %t.out --type half --channels 2 32 --semaphores
+// RUN-IF: !level_zero, %{run} %t.out --type int32 --channels 4 32 --semaphores
+// RUN-IF: !level_zero, %{run} %t.out --type uint32 --channels 1 32 --semaphores
+// RUN-IF: !level_zero, %{run} %t.out --type int16 --channels 2 32 --semaphores
+// RUN-IF: !level_zero, %{run} %t.out --type uint16 --channels 4 32 --semaphores
+// RUN-IF: !level_zero, %{run} %t.out --type uint8 --channels 1 32 --semaphores
+// RUN-IF: !level_zero, %{run} %t.out --type int8 --channels 4 32 --semaphores
+// CUDA doesn't support unorm8, level_zero has issues with semaphores
+// XXX-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 32 --semaphores
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_write_1d_unsampled_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled_channels.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled_channels.cpp
@@ -1,0 +1,42 @@
+// Channel coverage version of the Vulkan/SYCL 2D unsampled write interop test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// UNSUPPORTED: linux
+// UNSUPPORTED-TRACKER: GSD-12357
+
+// clang-format off
+// RUN: %{run} %t.out --type float --channels 1 32x33
+// RUN: %{run} %t.out --type float --channels 2 32x33
+// RUN: %{run} %t.out --type float --channels 4 32x33
+// RUN: %{run} %t.out --type half --channels 1 32x33
+// RUN: %{run} %t.out --type half --channels 2 32x33
+// RUN: %{run} %t.out --type half --channels 4 32x33
+// RUN: %{run} %t.out --type int32 --channels 1 32x33
+// RUN: %{run} %t.out --type int32 --channels 2 32x33
+// RUN: %{run} %t.out --type int32 --channels 4 32x33
+// RUN: %{run} %t.out --type uint32 --channels 1 32x33
+// RUN: %{run} %t.out --type uint32 --channels 2 32x33
+// RUN: %{run} %t.out --type uint32 --channels 4 32x33
+// RUN: %{run} %t.out --type int16 --channels 1 32x33
+// RUN: %{run} %t.out --type int16 --channels 2 32x33
+// RUN: %{run} %t.out --type int16 --channels 4 32x33
+// RUN: %{run} %t.out --type uint16 --channels 1 32x33
+// RUN: %{run} %t.out --type uint16 --channels 2 32x33
+// RUN: %{run} %t.out --type uint16 --channels 4 32x33
+// RUN: %{run} %t.out --type uint8 --channels 1 32x33
+// RUN: %{run} %t.out --type uint8 --channels 2 32x33
+// RUN: %{run} %t.out --type uint8 --channels 4 32x33
+// RUN: %{run} %t.out --type int8 --channels 1 32x33
+// RUN: %{run} %t.out --type int8 --channels 2 32x33
+// RUN: %{run} %t.out --type int8 --channels 4 32x33
+// RUN: %{run} %t.out --type unorm8 --channels 1 32x33
+// RUN: %{run} %t.out --type unorm8 --channels 2 32x33
+// RUN: %{run} %t.out --type unorm8 --channels 4 32x33
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_write_2d_unsampled_common.hpp"

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled_common.hpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled_common.hpp
@@ -1,94 +1,45 @@
-
-// REQUIRES: aspect-ext_oneapi_bindless_images
-// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
-// REQUIRES: vulkan
-
-// UNSUPPORTED: windows
-// UNSUPPORTED-TRACKER: CMPLRLLVM-73525
-
-// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+// Shared implementation for the Vulkan/SYCL 2D unsampled write interop tests.
 
 /*
-  Run all the vulkan formats through a write test. Note this is unsampled only,
-  you can't "write" with the image sampler.
+
+  Run all the vulkan formats through a write test. Note this is unsampled
+  only, you can't "write" with the image sampler.
 
   IF a particular variant is having problems on some platform, please do NOT
   just disable the whole test, instead use   RUN~IF: (SOMETHING) yadda-yadda
-    to enable/disable that variant.
+  to enable/disable that variant.
 
-    For semaphore testing, we run just a sampling. Note, that on Linux if there
+  For semaphore testing, we run just a sampling. Note, that on Linux if there
   is a failure in the first section, then likely ALL semaphore tests afterwards
   will fail. This is being tracked as a separate issue.
 
 */
+
 // clang-format off
-
-// RUN: %{run} %t.out --type float --channels 1 32
-// RUN: %{run} %t.out --type float --channels 2 32
-// RUN: %{run} %t.out --type float --channels 4 32
-// RUN: %{run} %t.out --type half --channels 1 32
-// RUN: %{run} %t.out --type half --channels 2 32
-// RUN: %{run} %t.out --type half --channels 4 32
-// RUN: %{run} %t.out --type int32 --channels 1 32
-// RUN: %{run} %t.out --type int32 --channels 2 32
-// RUN: %{run} %t.out --type int32 --channels 4 32
-// RUN: %{run} %t.out --type uint32 --channels 1 32
-// RUN: %{run} %t.out --type uint32 --channels 2 32
-// RUN: %{run} %t.out --type uint32 --channels 4 32
-// RUN: %{run} %t.out --type int16 --channels 1 32
-// RUN: %{run} %t.out --type int16 --channels 2 32
-// RUN: %{run} %t.out --type int16 --channels 4 32
-// RUN: %{run} %t.out --type uint16 --channels 1 32
-// RUN: %{run} %t.out --type uint16 --channels 2 32
-// RUN: %{run} %t.out --type uint16 --channels 4 32
-// RUN: %{run} %t.out --type uint8 --channels 1 32
-// RUN: %{run} %t.out --type uint8 --channels 2 32
-// RUN: %{run} %t.out --type uint8 --channels 4 32
-// RUN: %{run} %t.out --type int8 --channels 1 32
-// RUN: %{run} %t.out --type int8 --channels 2 32
-// RUN: %{run} %t.out --type int8 --channels 4 32
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 1 32
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 32
-// RUN-IF: !cuda, %{run} %t.out --type unorm8 --channels 4 32
-
-// On Linux L0, there are problem with semaphores and latest drivers.
-// GSD-12371 GSD-12339
-
-// RUN-IF: !level_zero, %{run} %t.out --type float --channels 1 32 --semaphores
-// RUN-IF: !level_zero, %{run} %t.out --type half --channels 2 32 --semaphores
-// RUN-IF: !level_zero, %{run} %t.out --type int32 --channels 4 32 --semaphores
-// RUN-IF: !level_zero, %{run} %t.out --type uint32 --channels 1 32 --semaphores
-// RUN-IF: !level_zero, %{run} %t.out --type int16 --channels 2 32 --semaphores
-// RUN-IF: !level_zero, %{run} %t.out --type uint16 --channels 4 32 --semaphores
-// RUN-IF: !level_zero, %{run} %t.out --type uint8 --channels 1 32 --semaphores
-// RUN-IF: !level_zero, %{run} %t.out --type int8 --channels 4 32 --semaphores
-// CUDA doesn't support unorm8, level_zero has issues with semaphores
-// XXX-IF: !cuda, %{run} %t.out --type unorm8 --channels 2 32 --semaphores
-
-
 /*
-  Vulkan/SYCL  1D Unsampled Write Image
+  clang++ -fsycl -o vsw_2d_test.bin vulkan_sycl_image_interop_write_2d_unsampled.cpp -lvulkan -I$VULKAN_SDK/include -L$VULKAN_SDK/lib
 
+  clang++ -fsycl -o vsw_2d_test.exe vulkan_sycl_image_interop_write_2d_unsampled.cpp -Wno-ignored-attributes -lvulkan-1 -I$VULKAN_SDK/Include -L$VULKAN_SDK/Lib
 
-  clang++ -fsycl -o vsw_1d_test.bin vulkan_sycl_image_interop_write_1d_unsampled.cpp -lvulkan -I$VULKAN_SDK/include -L$VULKAN_SDK/lib
+  USAGE:
+    ./vsw_2d_test.bin
 
-  clang++ -fsycl -o vsw_1d_test.exe vulkan_sycl_image_interop_write_1d_unsampled.cpp -Wno-ignored-attributes -lvulkan-1 -I$VULKAN_SDK/Include -L$VULKAN_SDK/Lib
-
-
-    ./vsw_1d_test.bin
-    ./vsw_1d_test.bin --semaphores
-    FLAGS
+  FLAGS:
     --sampled      ERROR: Sampled image writes are not supported
     --semaphores   Use Vulkan Semaphores for SYCL Interop Sync
     --linear       Use LINEAR tiling for the Vulkan Image (default is OPTIMAL)
     --channels  X  Set number of channels (1, 2, or 4). Default is 4 (RGBA)
-    --type  XXX    Set data type (float, half, uint32, int32, uint16, int16, uint8, int8, unorm8). Default is float 
-    Wx             Set custom Width .  Put "x" after
+    --type  XXX    Set data type (float, half, uint32, int32, uint16, int16, uint8, int8, unorm8). 
+                   Default is float 
+    WxH            Set custom Width x Height (e.g. 8x4)
 
-    ./vsw_1d_test.bin --semaphores --channels 2 --linear 64x
+  EXAMPLES:
+    ./vsw_2d_test.bin --semaphores --channels 2 --linear 8x4
 
- */
+*/
 // clang-format on
+
+#pragma once
 
 #include "vulkan_setup.hpp"
 
@@ -149,11 +100,10 @@ template <> inline sycl::image_channel_type getSyclChannelType<sycl::half>() {
 // ---------------------------------------------------------
 template <typename T>
 int runTest(
-    int width, int channels, bool useLinear, bool useSemaphores,
+    int width, int height, int channels, bool useLinear, bool useSemaphores,
     VkFormat fmtOverride = VK_FORMAT_UNDEFINED,
     std::optional<sycl::image_channel_type> syclOverride = std::nullopt) {
 
-  // Default to OPTIMAL unless --linear is passed (Expect failure on 1D)
   VkImageTiling tiling =
       useLinear ? VK_IMAGE_TILING_LINEAR : VK_IMAGE_TILING_OPTIMAL;
   VkFormat vkFormat = (fmtOverride != VK_FORMAT_UNDEFINED)
@@ -162,9 +112,9 @@ int runTest(
   std::cout << "VK Format: " << getFormatString(vkFormat) << std::endl;
 
   VulkanContext vkCtx = createVulkanContext();
-  VkExtent3D extent = {(uint32_t)width, 1, 1};
+  VkExtent3D extent = {(uint32_t)width, (uint32_t)height, 1};
   ImageResources imgRes =
-      createExportableImage(vkCtx, extent, vkFormat, VK_IMAGE_TYPE_1D, tiling);
+      createExportableImage(vkCtx, extent, vkFormat, VK_IMAGE_TYPE_2D, tiling);
 
   // Initial Transition to GENERAL
   {
@@ -205,7 +155,7 @@ int runTest(
   if (useSemaphores)
     vkSem = createExportableSemaphore(vkCtx);
 
-  // Initial clear/upload
+  // Initial clear/upload (Sanity Check)
   if (!uploadAndVerify<T>(vkCtx, imgRes, vkSem, channels)) {
     std::cerr << "Vulkan Upload Failed!" << std::endl;
     return 1;
@@ -249,56 +199,71 @@ int runTest(
     sycl::image_channel_type syclType = syclOverride.has_value()
                                             ? syclOverride.value()
                                             : getSyclChannelType<T>();
-    syclexp::image_descriptor imgDesc(sycl::range<1>(width), channels,
+    // bindless image ranges use (x,y,z) order,
+    // differening from SYCL 2020 "fastest incrementing" convention.
+    syclexp::image_descriptor imgDesc(sycl::range<2>(width, height), channels,
                                       syclType);
     syclexp::image_mem_handle devHandle = syclexp::map_external_image_memory(
         extMem, imgDesc, q.get_device(), q.get_context());
     syclexp::unsampled_image_handle unsampledHandle = syclexp::create_image(
         devHandle, imgDesc, q.get_device(), q.get_context());
 
+    // SYCL KERNEL
     sycl::event kernelEvent = q.submit([&](sycl::handler &h) {
-      h.parallel_for(sycl::range<1>(width), [=](sycl::item<1> item) {
-        int x = item.get_id(0);
+      // ranges for parallel_for use "fastest incrementing" order (z,y,x),
+      // but bindless images ranges use (x,y,z) order.
+      h.parallel_for(sycl::range<2>(height, width), [=](sycl::item<2> item) {
+        int x = item.get_id(1);
+        int y = item.get_id(0);
 
-        // Use generateTestValue directly
+        size_t index = y * width + x;
+        size_t totalPixels = width * height;
 
-        // UNORM is special snowflake
+        // UNORM is a special snowflake
         bool isUnorm = (syclType == sycl::image_channel_type::unorm_int8);
         if (isUnorm) {
           if (channels == 1) {
-            float v = (float)generateTestValue<T>(x, 0, width) / 255.0f;
-            syclexp::write_image(unsampledHandle, x, v);
+            float v =
+                (float)generateTestValue<T>(index, 0, totalPixels) / 255.0f;
+            syclexp::write_image(unsampledHandle, sycl::int2(x, y), v);
           } else if (channels == 2) {
-            float v1 = (float)generateTestValue<T>(x, 0, width) / 255.0f;
-            float v2 = (float)generateTestValue<T>(x, 1, width) / 255.0f;
-            syclexp::write_image(unsampledHandle, x, sycl::float2(v1, v2));
+            float v1 =
+                (float)generateTestValue<T>(index, 0, totalPixels) / 255.0f;
+            float v2 =
+                (float)generateTestValue<T>(index, 1, totalPixels) / 255.0f;
+            syclexp::write_image(unsampledHandle, sycl::int2(x, y),
+                                 sycl::float2(v1, v2));
           } else { // 4
-            float v1 = (float)generateTestValue<T>(x, 0, width) / 255.0f;
-            float v2 = (float)generateTestValue<T>(x, 1, width) / 255.0f;
-            float v3 = (float)generateTestValue<T>(x, 2, width) / 255.0f;
-            float v4 = (float)generateTestValue<T>(x, 3, width) / 255.0f;
-            syclexp::write_image(unsampledHandle, x,
+            float v1 =
+                (float)generateTestValue<T>(index, 0, totalPixels) / 255.0f;
+            float v2 =
+                (float)generateTestValue<T>(index, 1, totalPixels) / 255.0f;
+            float v3 =
+                (float)generateTestValue<T>(index, 2, totalPixels) / 255.0f;
+            float v4 =
+                (float)generateTestValue<T>(index, 3, totalPixels) / 255.0f;
+            syclexp::write_image(unsampledHandle, sycl::int2(x, y),
                                  sycl::float4(v1, v2, v3, v4));
           }
-          return;
+          return; // Early exit. special snowflake gets to leave early.
         }
 
         // Standard Path
         if (channels == 1) {
-          T val = generateTestValue<T>(x, 0, width);
-          syclexp::write_image(unsampledHandle, x, val);
+          T val = generateTestValue<T>(index, 0, totalPixels);
+          syclexp::write_image(unsampledHandle, sycl::int2(x, y), val);
         } else if (channels == 2) {
           using Vec2 = sycl::vec<T, 2>;
-          Vec2 px(generateTestValue<T>(x, 0, width),
-                  generateTestValue<T>(x, 1, width));
-          syclexp::write_image(unsampledHandle, x, px);
+          Vec2 px(generateTestValue<T>(index, 0, totalPixels),
+                  generateTestValue<T>(index, 1, totalPixels));
+          syclexp::write_image(unsampledHandle, sycl::int2(x, y), px);
         } else {
           using Vec4 = sycl::vec<T, 4>;
-          Vec4 px(generateTestValue<T>(x, 0, width),
-                  generateTestValue<T>(x, 1, width),
-                  generateTestValue<T>(x, 2, width),
-                  generateTestValue<T>(x, 3, width));
-          syclexp::write_image(unsampledHandle, x, px);
+          Vec4 px(generateTestValue<T>(index, 0, totalPixels),
+                  generateTestValue<T>(index, 1, totalPixels),
+                  generateTestValue<T>(index, 2, totalPixels),
+                  generateTestValue<T>(index, 3, totalPixels));
+          syclexp::write_image(unsampledHandle, sycl::int2(x, y), px);
         }
       });
     });
@@ -326,7 +291,7 @@ int runTest(
   vkDeviceWaitIdle(vkCtx.device);
   VkBuffer verifyBuffer;
   VkDeviceMemory verifyMem;
-  size_t dataSize = width * channels * sizeof(T);
+  size_t dataSize = width * height * channels * sizeof(T);
   VkBufferCreateInfo bi = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
   bi.size = dataSize;
   bi.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
@@ -382,8 +347,12 @@ int runTest(
   T *vData = (T *)ptr;
   bool passed = true;
   int errorCount = 0;
-  for (size_t i = 0; i < width * channels; ++i) {
-    T expected = generateTestValue<T>(i / channels, i % channels, width);
+  size_t totalPixels = width * height;
+
+  for (size_t i = 0; i < totalPixels * channels; ++i) {
+    size_t pixelIdx = i / channels;
+    int ch = i % channels;
+    T expected = generateTestValue<T>(pixelIdx, ch, totalPixels);
     if (!checkValue(vData[i], expected)) {
       passed = false;
       if (errorCount++ < 5)
@@ -402,12 +371,11 @@ int runTest(
   if (useSemaphores)
     vkDestroySemaphore(vkCtx.device, vkSem, nullptr);
   cleanupVulkan(vkCtx, imgRes);
-
   return passed ? 0 : 1;
 }
 
 int main(int argc, char **argv) {
-  int width = 16, channels = 4;
+  int width = 4, height = 4, channels = 4;
   bool useLinear = false, useSemaphores = false;
   std::string type = "float";
 
@@ -429,38 +397,41 @@ int main(int argc, char **argv) {
       channels = std::stoi(argv[++i]);
     else if (arg == "--type" && i + 1 < argc)
       type = argv[++i];
-    else {
+    else if (arg.find("x") != std::string::npos) {
+      size_t xPos = arg.find("x");
       try {
-        width = std::stoi(arg);
+        width = std::stoi(arg.substr(0, xPos));
+        height = std::stoi(arg.substr(xPos + 1));
       } catch (...) {
       }
     }
   }
 
-  std::cout << "Running UNSAMPLED 1D Write Test | Type: " << type
-            << " | Size: " << width << "x"
+  std::cout << "Running UNSAMPLED 2D Write Test | Type: " << type
+            << " | Size: " << width << "x" << height
             << " | Channels: " << channels
             << " | Tiling: " << (useLinear ? "LINEAR" : "OPTIMAL")
             << " | Semaphores: " << (useSemaphores ? "ON" : "OFF") << std::endl;
 
   if (type == "float")
-    return runTest<float>(width, channels, useLinear, useSemaphores);
+    return runTest<float>(width, height, channels, useLinear, useSemaphores);
   if (type == "half")
-    return runTest<sycl::half>(width, channels, useLinear, useSemaphores);
+    return runTest<sycl::half>(width, height, channels, useLinear,
+                               useSemaphores);
   if (type == "int32")
-    return runTest<int32_t>(width, channels, useLinear, useSemaphores);
+    return runTest<int32_t>(width, height, channels, useLinear, useSemaphores);
   if (type == "uint32")
-    return runTest<uint32_t>(width, channels, useLinear, useSemaphores);
+    return runTest<uint32_t>(width, height, channels, useLinear, useSemaphores);
   if (type == "int16")
-    return runTest<int16_t>(width, channels, useLinear, useSemaphores);
+    return runTest<int16_t>(width, height, channels, useLinear, useSemaphores);
   if (type == "uint16")
-    return runTest<uint16_t>(width, channels, useLinear, useSemaphores);
+    return runTest<uint16_t>(width, height, channels, useLinear, useSemaphores);
   if (type == "uint8")
-    return runTest<uint8_t>(width, channels, useLinear, useSemaphores);
+    return runTest<uint8_t>(width, height, channels, useLinear, useSemaphores);
   if (type == "int8")
-    return runTest<int8_t>(width, channels, useLinear, useSemaphores);
+    return runTest<int8_t>(width, height, channels, useLinear, useSemaphores);
   if (type == "unorm8")
-    return runTest<uint8_t>(width, channels, useLinear, useSemaphores,
+    return runTest<uint8_t>(width, height, channels, useLinear, useSemaphores,
                             getUnorm8Format(channels),
                             sycl::image_channel_type::unorm_int8);
   return 1;

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled_semaphores.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled_semaphores.cpp
@@ -1,0 +1,25 @@
+// Semaphore coverage version of the Vulkan/SYCL 2D unsampled write interop
+// test.
+
+// REQUIRES: aspect-ext_oneapi_bindless_images
+// REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
+// REQUIRES: vulkan
+
+// RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
+
+// UNSUPPORTED: linux
+// UNSUPPORTED-TRACKER: GSD-12357
+
+// clang-format off
+// RUN: %{run} %t.out --type float --channels 1 32x33 --semaphores
+// RUN: %{run} %t.out --type half --channels 2 32x33 --semaphores
+// RUN: %{run} %t.out --type int32 --channels 4 32x33 --semaphores
+// RUN: %{run} %t.out --type uint32 --channels 1 32x33 --semaphores
+// RUN: %{run} %t.out --type int16 --channels 2 32x33 --semaphores
+// RUN: %{run} %t.out --type uint16 --channels 4 32x33 --semaphores
+// RUN: %{run} %t.out --type uint8 --channels 1 32x33 --semaphores
+// RUN: %{run} %t.out --type int8 --channels 2 32x33 --semaphores
+// RUN: %{run} %t.out --type unorm8 --channels 4 32x33 --semaphores
+// clang-format on
+
+#include "./vulkan_sycl_image_interop_write_2d_unsampled_common.hpp"


### PR DESCRIPTION
This PR splits a long‑running test that could time out on slower machines (e.g. new system used for testing CUDA 13):

- sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
- sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_2d_common.hpp
- sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled_common.hpp
- sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled_common.hpp
- sycl/test-e2e/bindless_images/read_sampled_common.hpp
- sycl/test-e2e/WorkGroupMemory/basic_usage_common.hpp