### PR TITLE
[XPTI] Add per-subscriber stream detail level control

### DIFF
--- a/xpti/include/xpti/xpti_data_types.h
+++ b/xpti/include/xpti/xpti_data_types.h
@@ -352,6 +352,24 @@ enum class payload_flag_t {
 
 using stream_id_t = uint8_t;
 
+/// @enum stream_detail_level_t
+/// @brief Defines detail level for optional stream data emission.
+/// Values are ordered to allow threshold checks. Effective level is the
+/// maximum requested across all subscribers for a stream.
+enum class stream_detail_level_t : uint8_t {
+  XPTI_STREAM_DETAIL_LEVEL_NONE = 0,   ///< No optional data
+  XPTI_STREAM_DETAIL_LEVEL_BASIC = 1,  ///< Basic optional data
+  XPTI_STREAM_DETAIL_LEVEL_NORMAL = 2, ///< Normal detail (default)
+  XPTI_STREAM_DETAIL_LEVEL_VERBOSE = 3 ///< Maximum detail
+};
+
+/// @def XPTI_HAS_STREAM_DETAIL_LEVEL
+/// @brief Feature detection macro for stream detail level support.
+/// Subscribers can use this macro to conditionally compile code that uses
+/// stream_detail_level_t, xptiQuerySubscriberStreamDetailLevel, and
+/// xptiGetEffectiveStreamDetailLevel.
+#define XPTI_HAS_STREAM_DETAIL_LEVEL 1
+
 //
 //  Helper macros for creating new tracepoint and
 //  event types
@@ -1246,6 +1264,16 @@ typedef void (*plugin_init_t)(unsigned int, unsigned int, const char *,
                               const char *);
 typedef void (*plugin_fini_t)(const char *);
 
+/// @typedef query_subscriber_stream_detail_level_t
+/// @brief Optional callback for querying subscriber's requested detail level
+/// per stream.
+/// @param stream_name Stream name being queried.
+/// @param level Output: subscriber's desired detail level for the stream.
+/// @return true if level was set, false otherwise.
+/// @note If not implemented, defaults to NORMAL for all streams.
+typedef bool (*query_subscriber_stream_detail_level_t)(
+    const char *stream_name, xpti::stream_detail_level_t *level);
+
 constexpr uint16_t trace_task_begin =
     static_cast<uint16_t>(xpti::trace_point_type_t::task_begin);
 constexpr uint16_t trace_task_end =
@@ -1445,4 +1473,15 @@ XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
 /// subscribed to this stream can now free up all internal data structures and
 /// memory that has been allocated to manage the stream data.
 XPTI_CALLBACK_API void xptiTraceFinish(const char *stream_name);
+
+/// @brief Optional callback for querying subscriber's stream detail level
+/// preference. Called by framework during stream initialization to compute
+/// effective detail level.
+/// @param stream_name Stream name being queried.
+/// @param level Output: subscriber's requested detail level.
+/// @return true if level was set, false otherwise.
+/// @note Optional. If not implemented, defaults to NORMAL.
+XPTI_CALLBACK_API bool
+xptiQuerySubscriberStreamDetailLevel(const char *stream_name,
+                                     xpti::stream_detail_level_t *level);
 }

--- a/xpti/include/xpti/xpti_trace_framework.h
+++ b/xpti/include/xpti/xpti_trace_framework.h
@@ -1003,6 +1003,13 @@ XPTI_EXPORT_API bool xptiCheckTracepointScopeNotification();
 /// @param e The event for which associated data will be removed
 XPTI_EXPORT_API void xptiReleaseEvent(xpti::trace_event_data_t *e);
 
+/// @brief Gets effective stream detail level (max across all subscribers).
+/// @param stream Stream ID to query.
+/// @return Effective detail level. Defaults to NORMAL if not set.
+/// @note Lock-free; safe to call in hot paths.
+XPTI_EXPORT_API xpti::stream_detail_level_t
+xptiGetEffectiveStreamDetailLevel(xpti::stream_id_t stream);
+
 typedef xpti::result_t (*xpti_framework_initialize_t)();
 typedef xpti::result_t (*xpti_framework_finalize_t)();
 typedef xpti::result_t (*xpti_initialize_t)(const char *, uint32_t, uint32_t,
@@ -1072,4 +1079,6 @@ typedef xpti_tracepoint_t *(*xpti_create_tracepoint_t)(const char *,
                                                        const char *, uint32_t,
                                                        uint32_t, void *);
 typedef xpti::result_t (*xpti_delete_tracepoint_t)(xpti_tracepoint_t *);
+typedef xpti::stream_detail_level_t (*xpti_get_effective_stream_detail_level_t)(
+    xpti::stream_id_t);
 }

--- a/xpti/src/xpti_proxy.cpp
+++ b/xpti/src/xpti_proxy.cpp
@@ -62,6 +62,7 @@ enum functions_t : unsigned {
   XPTI_SET_DEFAULT_EVENT_TYPE,
   XPTI_GET_DEFAULT_TRACE_TYPE,
   XPTI_SET_DEFAULT_TRACE_TYPE,
+  XPTI_GET_EFFECTIVE_STREAM_DETAIL_LEVEL,
   // All additional functions need to appear before
   // the XPTI_FW_API_COUNT enum
   XPTI_FW_API_COUNT ///< This enum must always be the last one in the list
@@ -119,7 +120,9 @@ class ProxyLoader {
       {XPTI_SET_DEFAULT_EVENT_TYPE, "xptiSetDefaultEventType"},
       {XPTI_GET_DEFAULT_TRACE_TYPE, "xptiGetDefaultTraceType"},
       {XPTI_SET_DEFAULT_TRACE_TYPE, "xptiSetDefaultTraceType"},
-      {XPTI_RELEASE_EVENT, "xptiReleaseEvent"}};
+      {XPTI_RELEASE_EVENT, "xptiReleaseEvent"},
+      {XPTI_GET_EFFECTIVE_STREAM_DETAIL_LEVEL,
+       "xptiGetEffectiveStreamDetailLevel"}};
 
 public:
   typedef std::vector<xpti_plugin_function_t> dispatch_table_t;
@@ -749,4 +752,16 @@ xptiSetDefaultTraceType(xpti::trace_point_type_t trace_type) {
     }
   }
   return xpti::result_t::XPTI_RESULT_FAIL;
+}
+
+XPTI_EXPORT_API xpti::stream_detail_level_t
+xptiGetEffectiveStreamDetailLevel(xpti::stream_id_t stream) {
+  if (xpti::ProxyLoader::instance().noErrors()) {
+    auto f = xpti::ProxyLoader::instance().functionByIndex(
+        XPTI_GET_EFFECTIVE_STREAM_DETAIL_LEVEL);
+    if (f) {
+      return (*(xpti_get_effective_stream_detail_level_t)f)(stream);
+    }
+  }
+  return xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL;
 }

--- a/xptifw/doc/XPTI_Framework.md
+++ b/xptifw/doc/XPTI_Framework.md
@@ -20,6 +20,13 @@
       - [`xptiMakeEvent`](#xptimakeevent)
       - [Notifying the registered listeners](#notifying-the-registered-listeners)
       - [`xptiNotifySubscribers`](#xptinotifysubscribers)
+    - [Stream Detail Level Control](#stream-detail-level-control)
+      - [Overview](#overview-1)
+      - [Detail Level Enum](#detail-level-enum)
+      - [Aggregation Rule](#aggregation-rule)
+      - [Subscriber Usage](#subscriber-usage)
+      - [Producer Usage](#producer-usage)
+      - [API Reference](#api-reference)
   - [Performance of the Framework](#performance-of-the-framework)
   - [Modeling and projection](#modeling-and-projection)
     - [Computing the cost incurred in the framework](#computing-the-cost-incurred-in-the-framework)
@@ -119,7 +126,8 @@ functional: (1) `xptiTraceInit`, (2) `xptiTraceFinish` and (3) callback
 handlers. The `xptiTraceInit` and `xptiTraceFinish` API calls are used by the
 dispatcher loading the subscriber dynamically to determine if the subscriber
 is a valid subscriber. If these entry points are not present, then the
-subscriber is not loaded.
+subscriber is not loaded. Optionally, subscriber may implement
+`xptiQuerySubscriberStreamDetailLevel` to control detail level per stream.
 
 The `xptiTraceInit` callback is called by the dispatcher when the generator of
 a new stream of data makes a call to `xptiInitialize` for the new stream. The
@@ -173,6 +181,27 @@ allocated to handle the stream. The `xptiTraceFinish` call is made by the
 dispatcher when the instrumented code is winding down a data stream by calling
  `xptiFinalize` for the stream.
 
+In addition to the per-stream callbacks, subscribers may optionally implement
+a detail level query callback to control the amount of optional data emitted:
+
+```cpp
+XPTI_CALLBACK_API bool xptiQuerySubscriberStreamDetailLevel(
+    const char *stream_name, xpti::stream_detail_level_t *level) {
+  if (level) {
+    if (std::string(stream_name) == "sycl") {
+      *level = xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_VERBOSE;
+    } else {
+      *level = xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL;
+    }
+    return true;
+  }
+  return false;
+}
+```
+
+Called during stream initialization. Framework uses max level across all subscribers.
+Defaults to NORMAL if not implemented.
+
 The implementation of the callbacks is where attention needs to be given to the
 handshake protocol or specification for a given stream the subscriber wants to
 attach to and consume the data. The instrumented library may send additional
@@ -217,6 +246,7 @@ invariant across all instances of that tracepoint.
 
 > **NOTE:** A subscriber **must** implement the `xptiTraceInit` and
 > `xptiTraceFinish` APIs for the dispatcher to successfully load the subscriber.
+> Optionally, implement `xptiQuerySubscriberStreamDetailLevel` to control detail level.
 
 > **NOTE:** The specification for a given event stream **must** be consulted
 > before implementing the callback handlers for various trace types.
@@ -698,6 +728,108 @@ void function1() {
   }
 }
 ```
+
+### Stream Detail Level Control
+
+Subscribers can request different detail levels per stream to control optional data emission.
+Effective level is the max across all subscribers.
+
+**Feature Detection**: Use `#ifdef XPTI_HAS_STREAM_DETAIL_LEVEL` to conditionally compile code
+that depends on this feature. This ensures backward compatibility with older XPTI versions.
+
+**Important**: Stream detail level controls the amount of *optional metadata* emitted for trace
+points on a stream. It does not replace or affect `xptiCheckTraceEnabled()`, which remains the
+primary mechanism for deciding whether a trace notification is emitted at all. If a subscriber
+requests a detail level for a stream but does not subscribe to any trace points on that stream,
+no trace points will be emitted - the requested detail level only affects the amount of optional
+data attached to trace points that are already being emitted due to active subscriptions.
+
+#### Detail Level Enum
+
+The `xpti::stream_detail_level_t` enum defines four ordered levels:
+
+```cpp
+enum class stream_detail_level_t : uint8_t {
+  XPTI_STREAM_DETAIL_LEVEL_NONE = 0,     // No optional data
+  XPTI_STREAM_DETAIL_LEVEL_BASIC = 1,    // Basic optional data
+  XPTI_STREAM_DETAIL_LEVEL_NORMAL = 2,   // Normal detail (default)
+  XPTI_STREAM_DETAIL_LEVEL_VERBOSE = 3   // Maximum detail
+};
+```
+
+The values are ordered to support threshold checks in producer code:
+
+```cpp
+auto level = xptiGetEffectiveStreamDetailLevel(stream_id);
+if (level >= xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL) {
+  // Emit normal-level optional data
+}
+if (level >= xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_VERBOSE) {
+  // Emit verbose-level optional data
+}
+```
+
+#### Aggregation Rule
+
+Effective level = max across all subscribers. Defaults to NORMAL if not set.
+
+#### Subscriber Usage
+
+Use `XPTI_HAS_STREAM_DETAIL_LEVEL` for backward compatibility:
+
+```cpp
+#ifdef XPTI_HAS_STREAM_DETAIL_LEVEL
+XPTI_CALLBACK_API bool xptiQuerySubscriberStreamDetailLevel(
+    const char *stream_name, xpti::stream_detail_level_t *level) {
+  if (!level) return false;
+  if (std::string(stream_name) == "sycl") {
+    *level = xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_VERBOSE;
+  } else {
+    *level = xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL;
+  }
+  return true;
+}
+#endif
+```
+
+#### Producer Usage
+
+Producers should query the effective detail level before emitting optional data.
+Use `XPTI_HAS_STREAM_DETAIL_LEVEL` to ensure backward compatibility:
+
+```cpp
+void emit_trace_data(xpti::stream_id_t stream_id, const TraceData& data) {
+  // Always emit essential trace points
+  xptiNotifySubscribers(stream_id, trace_type, parent, event, instance, &data);
+
+#ifdef XPTI_HAS_STREAM_DETAIL_LEVEL
+  // Check if we should emit optional metadata
+  auto level = xptiGetEffectiveStreamDetailLevel(stream_id);
+
+  if (level >= xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL) {
+    // Emit normal-level optional metadata
+    xpti::object_id_t value_id = xptiRegisterObject(&data.optional_info,
+                                                     sizeof(data.optional_info),
+                                                     0);
+    xptiAddMetadata(event, "optional_info", value_id);
+  }
+
+  if (level >= xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_VERBOSE) {
+    // Emit verbose-level optional metadata (potentially expensive)
+    compute_and_emit_detailed_analysis(event);
+  }
+#endif
+}
+```
+
+#### API Reference
+
+##### `xptiQuerySubscriberStreamDetailLevel` (Subscriber Callback)
+Optional callback queried during stream init. Returns requested detail level per stream.
+Defaults to NORMAL if not implemented.
+
+##### `xptiGetEffectiveStreamDetailLevel`
+Returns max detail level across all subscribers for a stream. Lock-free; suitable for hot paths.
 
 ## Performance of the Framework
 

--- a/xptifw/samples/basic_collector/basic_collector.cpp
+++ b/xptifw/samples/basic_collector/basic_collector.cpp
@@ -111,6 +111,20 @@ XPTI_CALLBACK_API void xptiTraceFinish(const char *stream_name) {
   // We do nothing here
 }
 
+// Optional: query callback for stream detail level (defaults to NORMAL if
+// omitted). Use XPTI_HAS_STREAM_DETAIL_LEVEL for backward compatibility.
+#ifdef XPTI_HAS_STREAM_DETAIL_LEVEL
+XPTI_CALLBACK_API bool
+xptiQuerySubscriberStreamDetailLevel(const char *stream_name,
+                                     xpti::stream_detail_level_t *level) {
+  if (level) {
+    *level = xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_VERBOSE;
+    return true;
+  }
+  return false;
+}
+#endif
+
 XPTI_CALLBACK_API void tpCallback(uint16_t TraceType,
                                   xpti::trace_event_data_t *Parent,
                                   xpti::trace_event_data_t *Event,

--- a/xptifw/src/xpti_trace_framework.cpp
+++ b/xptifw/src/xpti_trace_framework.cpp
@@ -392,6 +392,8 @@ public:
     xpti::plugin_init_t init = nullptr;
     /// The finalization entry point
     xpti::plugin_fini_t fini = nullptr;
+    /// Optional callback for querying stream detail level (optional)
+    xpti::query_subscriber_stream_detail_level_t query_detail_level = nullptr;
     /// The name of the shared object (in UTF8?))
     std::string name;
     /// indicates whether the data structure is valid
@@ -399,7 +401,7 @@ public:
   };
 
   // Data structures defined to hold the plugin data that can be looked up by
-  // plugin name or the handle
+  // plugin name or library handle
   using plugin_handle_lut_t = std::map<xpti_plugin_handle_t, plugin_data_t>;
   using plugin_name_lut_t = std::map<std::string, plugin_data_t>;
 
@@ -463,13 +465,20 @@ public:
           g_helper.findFunction(Handle, "xptiTraceFinish"));
       if (InitFunc && FiniFunc) {
         //  We appear to have loaded a valid plugin, so we will insert the
-        //  plugin information into the two maps guarded by a lock
+        //  plugin information into the maps guarded by a lock
         plugin_data_t Data;
         Data.valid = true;
         Data.handle = Handle;
         Data.name = Path;
         Data.init = InitFunc;
         Data.fini = FiniFunc;
+
+        // Look for optional detail level query callback
+        Data.query_detail_level =
+            reinterpret_cast<xpti::query_subscriber_stream_detail_level_t>(
+                g_helper.findFunction(Handle,
+                                      "xptiQuerySubscriberStreamDetailLevel"));
+
         {
           std::lock_guard<std::mutex> Lock(MMutex);
           MNameLUT[Path] = Data;
@@ -585,6 +594,28 @@ public:
     }
     MHandleLUT.clear();
     MNameLUT.clear();
+  }
+
+  /// Query all subscribers for requested detail level, return max.
+  xpti::stream_detail_level_t
+  querySubscribersForStreamDetailLevel(const char *stream_name) {
+    std::lock_guard<std::mutex> Lock(MMutex);
+
+    xpti::stream_detail_level_t max_level =
+        xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NONE;
+
+    for (const auto &handle_entry : MHandleLUT) {
+      const plugin_data_t &plugin = handle_entry.second;
+      xpti::stream_detail_level_t sub_level =
+          xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL;
+      if (plugin.query_detail_level)
+        plugin.query_detail_level(stream_name, &sub_level);
+
+      if (static_cast<uint8_t>(sub_level) > static_cast<uint8_t>(max_level))
+        max_level = sub_level;
+    }
+
+    return max_level;
   }
 
 private:
@@ -1979,6 +2010,15 @@ public:
     MSubscribers.loadFromEnvironmentVariable();
     MTraceEnabled =
         (g_helper.checkTraceEnv() && MSubscribers.hasValidSubscribers());
+
+    // Initialize all effective stream detail levels to default (NORMAL)
+    for (size_t i = 0; i < 256; ++i) {
+      MEffectiveStreamDetailLevels[i].store(
+          static_cast<uint8_t>(
+              xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL),
+          std::memory_order_relaxed);
+    }
+
     //  We create a default stream "xpti.framework" and save it in
     //  `g_default_stream
     g_default_stream_id = registerStream(g_default_stream);
@@ -2000,6 +2040,13 @@ public:
     MTracepoints.clear();
     MStringTableRef.clear();
     MNotifier.clear();
+    // Reset all effective levels to default
+    for (size_t i = 0; i < 256; ++i) {
+      MEffectiveStreamDetailLevels[i].store(
+          static_cast<uint8_t>(
+              xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL),
+          std::memory_order_relaxed);
+    }
   }
 
   /// @brief Enables or disables tracing globally.
@@ -2271,8 +2318,15 @@ public:
     if (!Stream || !VersionString)
       return xpti::result_t::XPTI_RESULT_INVALIDARG;
 
+    // Initialize subscribers for the stream
     MSubscribers.initializeForStream(Stream, MajorRevision, MinorRevision,
                                      VersionString);
+
+    // Query subscribers for their requested detail level and compute effective
+    // level
+    xpti::stream_id_t stream_id = registerStream(Stream);
+    computeEffectiveStreamDetailLevel(stream_id, Stream);
+
     return xpti::result_t::XPTI_RESULT_SUCCESS;
   }
 
@@ -2474,6 +2528,42 @@ public:
 
   bool hasSubscribers() { return MSubscribers.hasValidSubscribers(); }
 
+  /// @brief Computes effective detail level by querying all subscribers.
+  ///
+  /// Queries all registered subscribers for their requested detail level for
+  /// the given stream and caches the maximum (most verbose) level requested.
+  /// This allows lock-free reads via getEffectiveStreamDetailLevel.
+  ///
+  /// @param stream The stream ID to compute.
+  /// @param stream_name The stream name for querying subscribers.
+  void computeEffectiveStreamDetailLevel(xpti::stream_id_t stream,
+                                         const char *stream_name) {
+    // Query all subscribers for their requested detail level for this stream
+    xpti::stream_detail_level_t max_level =
+        MSubscribers.querySubscribersForStreamDetailLevel(stream_name);
+
+    // Update the cached effective level atomically
+    MEffectiveStreamDetailLevels[stream].store(static_cast<uint8_t>(max_level),
+                                               std::memory_order_release);
+  }
+
+  /// @brief Gets the effective stream detail level for a stream.
+  ///
+  /// The effective detail level is the maximum requested level across all
+  /// subscribers for the given stream. If no subscriber has set a level for
+  /// the stream, the default (NORMAL) is returned.
+  ///
+  /// @param stream The stream ID for which the effective detail level is
+  ///               requested.
+  ///
+  /// @return The effective detail level for the stream.
+  xpti::stream_detail_level_t
+  getEffectiveStreamDetailLevel(xpti::stream_id_t stream) {
+    uint8_t level =
+        MEffectiveStreamDetailLevels[stream].load(std::memory_order_acquire);
+    return static_cast<xpti::stream_detail_level_t>(level);
+  }
+
   xpti::result_t finalizeStream(const char *Stream) {
     if (!Stream)
       return xpti::result_t::XPTI_RESULT_INVALIDARG;
@@ -2577,6 +2667,10 @@ private:
   xpti::Tracepoints MTracepoints;
   /// Flag indicates whether tracing should be enabled
   bool MTraceEnabled;
+  /// Cached effective detail levels per stream (indexed by stream_id)
+  /// Lock-free array of atomics for fast reads by producers
+  /// stream_id is uint8_t, so we need 256 entries
+  std::array<std::atomic<uint8_t>, 256> MEffectiveStreamDetailLevels;
 };
 
 /// @var static int GFrameworkReferenceCounter
@@ -3730,6 +3824,11 @@ xptiSetDefaultTraceType(xpti::trace_point_type_t DefaultTraceType) {
 
 XPTI_EXPORT_API void xptiReleaseEvent(xpti::trace_event_data_t *Event) {
   return xpti::Framework::instance().releaseEvent(Event);
+}
+
+XPTI_EXPORT_API xpti::stream_detail_level_t
+xptiGetEffectiveStreamDetailLevel(xpti::stream_id_t stream) {
+  return xpti::Framework::instance().getEffectiveStreamDetailLevel(stream);
 }
 
 } // extern "C"

--- a/xptifw/src/xpti_trace_framework.cpp
+++ b/xptifw/src/xpti_trace_framework.cpp
@@ -140,6 +140,12 @@ xpti::utils::SpinLock g_framework_mutex;
 /// This variable represents the default stream ID in the XPTI trace framework.
 uint8_t g_default_stream_id = 0;
 
+/// @var STREAM_ID_MAX
+/// @brief This variable represents the maximum stream ID in the XPTI trace
+/// framework, inclusive. Since stream IDs are represented as uint8_t, the
+/// maximum value is 255.
+constexpr uint8_t STREAM_ID_MAX = 255;
+
 /// @var g_default_event_type
 /// @brief A variable of type xpti::trace_event_type_t, initialized with
 /// xpti::trace_event_type_t::algorithm. This variable represents the default
@@ -2012,7 +2018,7 @@ public:
         (g_helper.checkTraceEnv() && MSubscribers.hasValidSubscribers());
 
     // Initialize all effective stream detail levels to default (NORMAL)
-    for (size_t i = 0; i < 256; ++i) {
+    for (size_t i = 0; i <= STREAM_ID_MAX; ++i) {
       MEffectiveStreamDetailLevels[i].store(
           static_cast<uint8_t>(
               xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL),
@@ -2041,7 +2047,7 @@ public:
     MStringTableRef.clear();
     MNotifier.clear();
     // Reset all effective levels to default
-    for (size_t i = 0; i < 256; ++i) {
+    for (size_t i = 0; i <= STREAM_ID_MAX; ++i) {
       MEffectiveStreamDetailLevels[i].store(
           static_cast<uint8_t>(
               xpti::stream_detail_level_t::XPTI_STREAM_DETAIL_LEVEL_NORMAL),
@@ -2669,8 +2675,8 @@ private:
   bool MTraceEnabled;
   /// Cached effective detail levels per stream (indexed by stream_id)
   /// Lock-free array of atomics for fast reads by producers
-  /// stream_id is uint8_t, so we need 256 entries
-  std::array<std::atomic<uint8_t>, 256> MEffectiveStreamDetailLevels;
+  std::array<std::atomic<uint8_t>, STREAM_ID_MAX + 1>
+      MEffectiveStreamDetailLevels;
 };
 
 /// @var static int GFrameworkReferenceCounter


### PR DESCRIPTION
Introduces a mechanism for subscribers to request different levels of optional data emission from producers on a per-stream basis, enabling fine-grained control over tracing overhead:

- Added stream_detail_level_t enum (NONE, BASIC, NORMAL, VERBOSE)
- Added optional xptiQuerySubscriberStreamDetailLevel subscriber callback
- Added xptiGetEffectiveStreamDetailLevel producer API
- Aggregation rule: effective level = max across all subscribers

Producers can use threshold checks to conditionally emit expensive optional data based on the effective detail level.

Also add XPTI_HAS_STREAM_DETAIL_LEVEL macro to enable compile-time feature detection for stream detail level functionality.

This approach allows to stay fully backward compatible: subscribers that define new xptiQuerySubscriberStreamDetailLevel callback can work with both old frameworks (that will ignore the callback) and new frameworks (that will recognize the callback).

Assisted-By: Claude Sonnet 4.5