### PR TITLE
[SYCL][E2E][TEST] Unplug sycl_device_globals on NVIDIA RTX 3090

### DIFF
--- a/sycl/test-e2e/KernelCompiler/sycl_device_globals.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_device_globals.cpp
@@ -11,6 +11,9 @@
 // UNSUPPORTED: opencl && gpu
 // UNSUPPORTED-TRACKER: GSD-4287
 
+// UNSUPPORTED: gpu-nvidia-geforce-rtx-3090
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20408
+
 // RUN: %{build} -o %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{l0_leak_check} %{run} %t.out
 

--- a/sycl/test-e2e/KernelCompiler/sycl_device_globals.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_device_globals.cpp
@@ -80,7 +80,7 @@ int test_device_global() {
   auto checkVal = [&](int32_t expected) {
     val = -1;
     q.memcpy(&val, dgAddr, dgSize).wait();
-    std::cout << "val: " << val << " == " << expected << '\n';
+    std::cout << "val: " << val << " == " << expected << std::endl;
     assert(val == expected);
   };
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -1014,6 +1014,7 @@ for full_name, sycl_device in zip(
     dev_aspects = []
     dev_sg_sizes = []
     architectures = set()
+    device_names = set()
     # See format.py's parse_min_intel_driver_req for explanation.
     is_intel_driver = False
     intel_driver_ver = {}
@@ -1055,8 +1056,11 @@ for full_name, sycl_device in zip(
         if re.match(r" *Architecture:", line):
             _, architecture = line.strip().split(":", 1)
             architectures.add(architecture.strip())
-        if re.match(r" *Name *:", line) and "Level-Zero V2" in line:
-            features.add("level_zero_v2_adapter")
+        if re.match(r" *Name *:", line):
+            _, device_name_str = line.strip().split(":", 1)
+            device_names.add(device_name_str.strip())
+            if "Level-Zero V2" in line:
+                features.add("level_zero_v2_adapter")
 
         # TODO change to the set of backends
         if re.match(r"\[offload:.*", line) and not is_offload_preferred_backend_set:
@@ -1124,10 +1128,24 @@ for full_name, sycl_device in zip(
             )
         )
 
+    # Add a normalized device-name feature, e.g. "gpu-nvidia-geforce-rtx-3090"
+    # derived from the "Name :" field reported by sycl-ls --verbose.
+    device_name_features = set(
+        "gpu-" + re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+        for name in device_names
+    )
+    if device_name_features:
+        lit_config.note(
+            "Device name features for {}: {}".format(
+                sycl_device, ", ".join(device_name_features)
+            )
+        )
+
     features.update(aspect_features)
     features.update(sg_size_features)
     features.update(architecture_feature)
     features.update(device_family)
+    features.update(device_name_features)
 
     be, dev = sycl_device.split(":")
     if dev.isdigit():


### PR DESCRIPTION
Temporarily disable sycl_device_globals on NVIDIA RTX 3090

The test is expected to work on this device, but is currently experiencing a high rate of intermittent failures (https://github.com/intel/llvm/issues/20408). To avoid blocking contributors whose changes are unrelated to this issue, execution is being turned off on RTX 3090 until the root cause is identified and fixed.

Additionally, occurrences of "\n" in print statements have been replaced with std::endl to ensure output is flushed immediately and remains visible in test logs in the future.