### PR TITLE
[SYCL][Graph] Support `sycl::queue::ext_oneapi_get_graph` with native recording

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -248,6 +248,32 @@ void context_impl::removeAssociatedDeviceGlobal(const void *DeviceGlobalPtr) {
   MAssociatedDeviceGlobals.erase(DeviceGlobalPtr);
 }
 
+void context_impl::registerNativeGraph(
+    ur_exp_graph_handle_t UrGraphHandle,
+    std::shared_ptr<sycl::ext::oneapi::experimental::detail::graph_impl>
+        Graph) {
+  assert(UrGraphHandle != nullptr && Graph != nullptr);
+  std::lock_guard<std::mutex> Lock(MNativeGraphRegistryMutex);
+  MNativeGraphRegistry.try_emplace(UrGraphHandle, Graph);
+}
+
+std::shared_ptr<sycl::ext::oneapi::experimental::detail::graph_impl>
+context_impl::getNativeGraph(ur_exp_graph_handle_t UrGraphHandle) const {
+  assert(UrGraphHandle != nullptr);
+  std::lock_guard<std::mutex> Lock(MNativeGraphRegistryMutex);
+  auto It = MNativeGraphRegistry.find(UrGraphHandle);
+  if (It != MNativeGraphRegistry.end()) {
+    return It->second.lock();
+  }
+  return nullptr;
+}
+
+void context_impl::deregisterNativeGraph(ur_exp_graph_handle_t UrGraphHandle) {
+  assert(UrGraphHandle != nullptr);
+  std::lock_guard<std::mutex> Lock(MNativeGraphRegistryMutex);
+  MNativeGraphRegistry.erase(UrGraphHandle);
+}
+
 void context_impl::addDeviceGlobalInitializer(
     ur_program_handle_t Program, devices_range Devs,
     const RTDeviceBinaryImage *BinImage) {

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -29,6 +29,18 @@ inline namespace _V1 {
 // Forward declaration
 class device;
 namespace detail {
+class context_impl;
+} // namespace detail
+namespace ext {
+namespace oneapi {
+namespace experimental {
+namespace detail {
+class graph_impl;
+} // namespace detail
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
+namespace detail {
 class context_impl : public std::enable_shared_from_this<context_impl> {
   struct private_tag {
     explicit private_tag() = default;
@@ -240,6 +252,24 @@ public:
   get_default_memory_pool(const context &Context, const device &Device,
                           const usm::alloc &Kind);
 
+  /// Register a native UR graph handle with its SYCL graph implementation.
+  /// @param UrGraphHandle The native UR graph handle to register
+  /// @param Graph The SYCL graph implementation to associate with the handle
+  void registerNativeGraph(
+      ur_exp_graph_handle_t UrGraphHandle,
+      std::shared_ptr<sycl::ext::oneapi::experimental::detail::graph_impl>
+          Graph);
+
+  /// Lookup a SYCL graph implementation from a native UR graph handle.
+  /// @param UrGraphHandle The native UR graph handle to look up
+  /// @return Shared pointer to graph_impl if found, nullptr otherwise
+  std::shared_ptr<sycl::ext::oneapi::experimental::detail::graph_impl>
+  getNativeGraph(ur_exp_graph_handle_t UrGraphHandle) const;
+
+  /// Deregister a native UR graph handle.
+  /// @param UrGraphHandle The native UR graph handle to deregister
+  void deregisterNativeGraph(ur_exp_graph_handle_t UrGraphHandle);
+
 private:
   bool MOwnedByRuntime;
   async_handler MAsyncHandler;
@@ -318,6 +348,16 @@ private:
            std::unique_ptr<std::byte[]>>
       MDeviceGlobalUnregisteredData;
   std::mutex MDeviceGlobalUnregisteredDataMutex;
+
+  // Native graph registry mapping UR handles to their originating SYCL graph
+  // object. Enables command_graph lookup in cases where direct backend
+  // submissions (e.g. L0) bypass SYCL and cause a queue to transition to
+  // recording without our knowledge.
+  std::unordered_map<
+      ur_exp_graph_handle_t,
+      std::weak_ptr<sycl::ext::oneapi::experimental::detail::graph_impl>>
+      MNativeGraphRegistry;
+  mutable std::mutex MNativeGraphRegistryMutex;
 
   void verifyProps(const property_list &Props) const;
 };

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -371,6 +371,8 @@ graph_impl::~graph_impl() {
       context_impl &ContextImpl = *sycl::detail::getSyclObjImpl(MContext);
       sycl::detail::adapter_impl &Adapter = ContextImpl.getAdapter();
 
+      ContextImpl.deregisterNativeGraph(MNativeGraphHandle);
+
       ur_result_t Result =
           Adapter.call_nocheck<sycl::detail::UrApiKind::urGraphDestroyExp>(
               MNativeGraphHandle);
@@ -2095,18 +2097,33 @@ modifiable_command_graph::modifiable_command_graph(
     const sycl::context &SyclContext, const sycl::device &SyclDevice,
     const sycl::property_list &PropList)
     : impl(std::make_shared<detail::graph_impl>(SyclContext, SyclDevice,
-                                                PropList)) {}
+                                                PropList)) {
+  if (auto UrNativeHandle = impl->getNativeGraphHandle()) {
+    auto &ContextImpl = *sycl::detail::getSyclObjImpl(SyclContext);
+    ContextImpl.registerNativeGraph(UrNativeHandle, impl);
+  }
+}
 
 modifiable_command_graph::modifiable_command_graph(
     const sycl::queue &SyclQueue, const sycl::property_list &PropList)
     : impl(std::make_shared<detail::graph_impl>(
-          SyclQueue.get_context(), SyclQueue.get_device(), PropList)) {}
+          SyclQueue.get_context(), SyclQueue.get_device(), PropList)) {
+  if (auto UrNativeHandle = impl->getNativeGraphHandle()) {
+    auto &ContextImpl = *sycl::detail::getSyclObjImpl(SyclQueue.get_context());
+    ContextImpl.registerNativeGraph(UrNativeHandle, impl);
+  }
+}
 
 modifiable_command_graph::modifiable_command_graph(
     const sycl::device &SyclDevice, const sycl::property_list &PropList)
     : impl(std::make_shared<detail::graph_impl>(
           SyclDevice.get_platform().khr_get_default_context(), SyclDevice,
-          PropList)) {}
+          PropList)) {
+  if (auto UrNativeHandle = impl->getNativeGraphHandle()) {
+    auto &ContextImpl = *sycl::detail::getSyclObjImpl(impl->getContext());
+    ContextImpl.registerNativeGraph(UrNativeHandle, impl);
+  }
+}
 
 node modifiable_command_graph::addImpl(dynamic_command_group &DynCGF,
                                        const std::vector<node> &Deps) {

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -553,25 +553,34 @@ std::shared_ptr<ext::oneapi::experimental::detail::graph_impl>
 queue_impl::ext_oneapi_get_graph_impl() const {
   auto Graph = getCommandGraph();
   if (!Graph) {
-    ur_exp_graph_handle_t UrGraphHandle = nullptr;
-    ur_result_t Result =
-        getAdapter().call_nocheck<UrApiKind::urQueueGetGraphExp>(
-            MQueue, &UrGraphHandle);
-    if (Result == UR_RESULT_ERROR_INVALID_OPERATION) {
-      throw sycl::exception(
-          make_error_code(errc::invalid),
-          "ext_oneapi_get_graph() can only be called on recording queues.");
-    } else if (Result != UR_RESULT_SUCCESS) {
-      throw sycl::exception(make_error_code(errc::runtime),
-                            "Failed to query native UR graph from queue.");
-    }
+    ur_bool_t SupportsGraphRecordReplay = false;
+    ur_result_t QueryResult =
+        getAdapter().call_nocheck<UrApiKind::urDeviceGetInfo>(
+            getDeviceImpl().getHandleRef(),
+            UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP,
+            sizeof(ur_bool_t), &SupportsGraphRecordReplay, nullptr);
 
-    Graph = getContextImpl().getNativeGraph(UrGraphHandle);
-    if (!Graph) {
-      throw sycl::exception(
-          make_error_code(errc::invalid),
-          "ext_oneapi_get_graph() can only be called on recording queues.");
+    if (QueryResult == UR_RESULT_SUCCESS && SupportsGraphRecordReplay) {
+      ur_exp_graph_handle_t UrGraphHandle = nullptr;
+      ur_result_t Result =
+          getAdapter().call_nocheck<UrApiKind::urQueueGetGraphExp>(
+              MQueue, &UrGraphHandle);
+
+      if (Result == UR_RESULT_SUCCESS) {
+        Graph = getContextImpl().getNativeGraph(UrGraphHandle);
+      } else if (Result != UR_RESULT_ERROR_INVALID_OPERATION) {
+        throw sycl::exception(make_error_code(errc::runtime),
+                              "Failed to query native UR graph from queue.");
+      }
+    } else if (QueryResult != UR_RESULT_SUCCESS) {
+      throw sycl::exception(make_error_code(errc::runtime),
+                            "Failed to query device info.");
     }
+  }
+  if (!Graph) {
+    throw sycl::exception(
+        make_error_code(errc::invalid),
+        "ext_oneapi_get_graph() can only be called on recording queues.");
   }
   return Graph;
 }

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -549,6 +549,31 @@ queue_impl::ext_oneapi_get_state_impl() const {
   return ext::oneapi::experimental::queue_state::executing;
 }
 
+std::shared_ptr<ext::oneapi::experimental::detail::graph_impl>
+queue_impl::ext_oneapi_get_graph_impl() const {
+  auto Graph = getCommandGraph();
+  if (!Graph) {
+    ur_exp_graph_handle_t UrGraphHandle = nullptr;
+    ur_result_t Result =
+        getAdapter().call_nocheck<UrApiKind::urQueueGetGraphExp>(
+            MQueue, &UrGraphHandle);
+
+    if (Result != UR_RESULT_SUCCESS || !UrGraphHandle) {
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "ext_oneapi_get_graph() can only be called on recording queues.");
+    }
+
+    Graph = getContextImpl().getNativeGraph(UrGraphHandle);
+    if (!Graph) {
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "ext_oneapi_get_graph() can only be called on recording queues.");
+    }
+  }
+  return Graph;
+}
+
 EventImplPtr queue_impl::submit_command_to_graph(
     ext::oneapi::experimental::detail::graph_impl &GraphImpl,
     std::unique_ptr<detail::CG> CommandGroup, sycl::detail::CGType CGType,

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -557,11 +557,13 @@ queue_impl::ext_oneapi_get_graph_impl() const {
     ur_result_t Result =
         getAdapter().call_nocheck<UrApiKind::urQueueGetGraphExp>(
             MQueue, &UrGraphHandle);
-
-    if (Result != UR_RESULT_SUCCESS || !UrGraphHandle) {
+    if (Result == UR_RESULT_ERROR_INVALID_OPERATION) {
       throw sycl::exception(
           make_error_code(errc::invalid),
           "ext_oneapi_get_graph() can only be called on recording queues.");
+    } else if (Result != UR_RESULT_SUCCESS) {
+      throw sycl::exception(make_error_code(errc::runtime),
+                            "Failed to query native UR graph from queue.");
     }
 
     Graph = getContextImpl().getNativeGraph(UrGraphHandle);

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -552,29 +552,17 @@ queue_impl::ext_oneapi_get_state_impl() const {
 std::shared_ptr<ext::oneapi::experimental::detail::graph_impl>
 queue_impl::ext_oneapi_get_graph_impl() const {
   auto Graph = getCommandGraph();
-  if (!Graph) {
-    ur_bool_t SupportsGraphRecordReplay = false;
-    ur_result_t QueryResult =
-        getAdapter().call_nocheck<UrApiKind::urDeviceGetInfo>(
-            getDeviceImpl().getHandleRef(),
-            UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP,
-            sizeof(ur_bool_t), &SupportsGraphRecordReplay, nullptr);
+  if (!Graph && isNativeRecording()) {
+    ur_exp_graph_handle_t UrGraphHandle = nullptr;
+    ur_result_t Result =
+        getAdapter().call_nocheck<UrApiKind::urQueueGetGraphExp>(
+            MQueue, &UrGraphHandle);
 
-    if (QueryResult == UR_RESULT_SUCCESS && SupportsGraphRecordReplay) {
-      ur_exp_graph_handle_t UrGraphHandle = nullptr;
-      ur_result_t Result =
-          getAdapter().call_nocheck<UrApiKind::urQueueGetGraphExp>(
-              MQueue, &UrGraphHandle);
-
-      if (Result == UR_RESULT_SUCCESS) {
-        Graph = getContextImpl().getNativeGraph(UrGraphHandle);
-      } else if (Result != UR_RESULT_ERROR_INVALID_OPERATION) {
-        throw sycl::exception(make_error_code(errc::runtime),
-                              "Failed to query native UR graph from queue.");
-      }
-    } else if (QueryResult != UR_RESULT_SUCCESS) {
+    if (Result == UR_RESULT_SUCCESS) {
+      Graph = getContextImpl().getNativeGraph(UrGraphHandle);
+    } else if (Result != UR_RESULT_ERROR_INVALID_OPERATION) {
       throw sycl::exception(make_error_code(errc::runtime),
-                            "Failed to query device info.");
+                            "Failed to query native UR graph from queue.");
     }
   }
   if (!Graph) {

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -650,6 +650,9 @@ public:
 
   ext::oneapi::experimental::queue_state ext_oneapi_get_state_impl() const;
 
+  std::shared_ptr<ext::oneapi::experimental::detail::graph_impl>
+  ext_oneapi_get_graph_impl() const;
+
   EventImplPtr submit_command_to_graph(
       ext::oneapi::experimental::detail::graph_impl &GraphImpl,
       std::unique_ptr<detail::CG> CommandGroup, sycl::detail::CGType CGType,

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -82,16 +82,10 @@ ext::oneapi::experimental::queue_state queue::ext_oneapi_get_state() const {
 ext::oneapi::experimental::command_graph<
     ext::oneapi::experimental::graph_state::modifiable>
 queue::ext_oneapi_get_graph() const {
-  auto Graph = impl->getCommandGraph();
-  if (!Graph)
-    throw sycl::exception(
-        make_error_code(errc::invalid),
-        "ext_oneapi_get_graph() can only be called on recording queues.");
-
   return sycl::detail::createSyclObjFromImpl<
       ext::oneapi::experimental::command_graph<
           ext::oneapi::experimental::graph_state::modifiable>>(
-      std::move(Graph));
+      impl->ext_oneapi_get_graph_impl());
 }
 
 void queue::throw_asynchronous() { impl->throw_asynchronous(); }

--- a/sycl/test-e2e/Graph/Inputs/get_graph_multi_queue.cpp
+++ b/sycl/test-e2e/Graph/Inputs/get_graph_multi_queue.cpp
@@ -1,0 +1,54 @@
+// Test ext_oneapi_get_graph() with multiple queues (fork-join pattern)
+
+#include "../graph_common.hpp"
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  device Dev;
+  context Ctx{Dev};
+
+  queue Queue1{Ctx, Dev, {property::queue::in_order{}}};
+  queue Queue2{Ctx, Dev, {property::queue::in_order{}}};
+
+#ifdef GRAPH_E2E_NATIVE_RECORDING
+  exp_ext::command_graph Graph{
+      Ctx, Dev, {exp_ext::property::graph::enable_native_recording{}}};
+#else
+  exp_ext::command_graph Graph{Ctx, Dev};
+#endif
+
+  assert(expectException([&]() { Queue1.ext_oneapi_get_graph(); },
+                         "Queue1.ext_oneapi_get_graph() before begin_recording",
+                         sycl::errc::invalid) &&
+         "Expected exception on Queue1 before begin_recording");
+  assert(expectException([&]() { Queue2.ext_oneapi_get_graph(); },
+                         "Queue2.ext_oneapi_get_graph() before begin_recording",
+                         sycl::errc::invalid) &&
+         "Expected exception on Queue2 before begin_recording");
+
+  Graph.begin_recording(Queue1);
+
+  auto RetrievedGraph1 = Queue1.ext_oneapi_get_graph();
+  assert(RetrievedGraph1 == Graph);
+
+  auto ForkEvent = Queue1.ext_oneapi_submit_barrier();
+  auto JoinEvent = Queue2.ext_oneapi_submit_barrier({ForkEvent});
+
+  auto RetrievedGraph2 = Queue2.ext_oneapi_get_graph();
+  assert(RetrievedGraph2 == Graph);
+
+  Queue1.ext_oneapi_submit_barrier({JoinEvent});
+
+  Graph.end_recording();
+
+  assert(expectException([&]() { Queue1.ext_oneapi_get_graph(); },
+                         "Queue1.ext_oneapi_get_graph() after end_recording",
+                         sycl::errc::invalid) &&
+         "Expected exception on Queue1 after end_recording");
+  assert(expectException([&]() { Queue2.ext_oneapi_get_graph(); },
+                         "Queue2.ext_oneapi_get_graph() after end_recording",
+                         sycl::errc::invalid) &&
+         "Expected exception on Queue2 after end_recording");
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Inputs/get_graph_single_queue.cpp
+++ b/sycl/test-e2e/Graph/Inputs/get_graph_single_queue.cpp
@@ -1,0 +1,35 @@
+// Test ext_oneapi_get_graph() with single queue
+
+#include "../graph_common.hpp"
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  queue Queue{property::queue::in_order{}};
+
+#ifdef GRAPH_E2E_NATIVE_RECORDING
+  exp_ext::command_graph Graph{
+      Queue.get_context(),
+      Queue.get_device(),
+      {exp_ext::property::graph::enable_native_recording{}}};
+#else
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+#endif
+  assert(expectException([&]() { Queue.ext_oneapi_get_graph(); },
+                         "Queue.ext_oneapi_get_graph() before begin_recording",
+                         sycl::errc::invalid) &&
+         "Expected exception on Queue before begin_recording");
+
+  Graph.begin_recording(Queue);
+
+  auto RetrievedGraph1 = Queue.ext_oneapi_get_graph();
+  assert(RetrievedGraph1 == Graph);
+
+  Graph.end_recording(Queue);
+
+  assert(expectException([&]() { Queue.ext_oneapi_get_graph(); },
+                         "Queue.ext_oneapi_get_graph() after end_recording",
+                         sycl::errc::invalid) &&
+         "Expected exception on Queue1 after end_recording");
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/get_graph_multi_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/get_graph_multi_queue.cpp
@@ -1,0 +1,16 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+// REQUIRES: linux
+// REQUIRES-INTEL-DRIVER: lin: 38146
+
+// TODO: The windows minimum driver version is currently unclear. This should be
+// updated in the future.
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+#define GRAPH_E2E_RECORD_REPLAY
+#define GRAPH_E2E_NATIVE_RECORDING
+
+#include "../../Inputs/get_graph_multi_queue.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/get_graph_single_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/get_graph_single_queue.cpp
@@ -1,0 +1,12 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+// REQUIRES-INTEL-DRIVER: lin: 37561, win: 101.8724
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+#define GRAPH_E2E_RECORD_REPLAY
+#define GRAPH_E2E_NATIVE_RECORDING
+
+#include "../../Inputs/get_graph_single_queue.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/get_graph_multi_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/get_graph_multi_queue.cpp
@@ -1,0 +1,8 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+#define GRAPH_E2E_RECORD_REPLAY
+
+#include "../Inputs/get_graph_multi_queue.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/get_graph_single_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/get_graph_single_queue.cpp
@@ -1,0 +1,8 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+#define GRAPH_E2E_RECORD_REPLAY
+
+#include "../Inputs/get_graph_single_queue.cpp"


### PR DESCRIPTION
- Queries UR to fetch queue associated graph handle from native API in order to support queue transitions from direct backend command submissions (e.g. L0)
- Introduces a map in context_impl linking UR graph handles to modifiable command graphs. `queue::ext_oneapi_get_graph` uses this map for lookup after calling `urQueueGetGraphExp` .
- Two test cases are added for command buffer and native recording paths. For native recording, minimum driver versions are added to ensure support for underlying L0 API and L0 bugfixes for fork-join.