### PR TITLE
[UR][L0] Fix event refcount bugs in L0 v1 adapter barrier handling

### DIFF
--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -198,9 +198,10 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
       [&Queue](ur_command_list_ptr_t CmdList, ur_ze_event_list_t &EventWaitList,
                ur_event_handle_t &Event, bool IsInternal,
                bool InterruptBasedEventsEnabled) {
+        (void)InterruptBasedEventsEnabled;
         UR_CALL(createEventAndAssociateQueue(
             Queue, &Event, UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, CmdList,
-            IsInternal, InterruptBasedEventsEnabled));
+            IsInternal, /* IsMultiDevice */ false));
 
         Event->WaitList = EventWaitList;
 
@@ -893,15 +894,11 @@ urEventRelease(/** [in] handle of the event object */ ur_event_handle_t Event) {
   UR_CALL(urEventReleaseInternal(Event, &isEventDeleted));
   // If this is a Completed Event Wait Out Event, then we need to cleanup the
   // event at user release and not at the time of completion.
-  // If the event is labelled as completed and no additional references are
-  // removed, then we still need to decrement the event, but not mark as
-  // completed.
+  // Use CleanupCompletedEvent which is a no-op if the event was already
+  // cleaned up (e.g. by CleanupEventListFromResetCmdList), preventing a
+  // double-release of the internal reference count.
   if (isEventsWaitCompleted & !isEventDeleted) {
-    if (Event->CleanedUp) {
-      UR_CALL(urEventReleaseInternal(Event));
-    } else {
-      UR_CALL(CleanupCompletedEvent((Event), false, false));
-    }
+    UR_CALL(CleanupCompletedEvent((Event), false, false));
   }
 
   return UR_RESULT_SUCCESS;


### PR DESCRIPTION
Fixes three issues in the Level Zero v1 adapter that caused urEventWait to be called for an internal event crashes and segfaults when mixing multiple in-order queues with ext_oneapi_submit_barrier.

1. Fix insertBarrierIntoCmdList passing InterruptBasedEventsEnabled as IsMultiDevice to createEventAndAssociateQueue. Barrier events do not need multi-device visibility; pass false instead.

2. In urEventWait, replace die() with continue when hasExternalRefs() is false. A recycled event (RefCountExternal == 0) was already completed before recycling, so skipping the wait is safe.

3. In urEventRelease, use CleanupCompletedEvent (which is a no-op when CleanedUp is true) instead of calling urEventReleaseInternal directly. The old code double-released the internal refcount when CleanupEventListFromResetCmdList had already cleaned the event.

UR_L0_SERIALIZE=2 masked the race by forcing synchronous execution. UR_L0_DISABLE_EVENTS_CACHING=1 turned the recycling into a delete, escalating the bug from a stale-data read to a segfault.

Fixes: https://github.com/intel/llvm/issues/21704