### PR TITLE
[CMake][opencl-aot] Support standalone builds

### DIFF
--- a/opencl/CMakeLists.txt
+++ b/opencl/CMakeLists.txt
@@ -15,6 +15,11 @@ endif()
 # library.
 set(BUILD_SHARED_LIBS ON)
 
+if(NOT LLVM_MAIN_SRC_DIR)
+  find_package(LLVM REQUIRED CONFIG)
+  include(AddLLVM)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../unified-runtime/cmake")
 
 include(FetchOpenCL)


### PR DESCRIPTION
When building opencl-aot as part of a monolithic build, it gets LLVM libs automatically. When building standalone, it needs to be pulled in explicitly. This commit adds in LLVM via find_package if opencl-aot is being built as a standalone project.

Part of #21877

