### PR TITLE
[SYCL RTC] Exclude CMake files

### DIFF
--- a/sycl-jit/jit-compiler/utils/generate.py
+++ b/sycl-jit/jit-compiler/utils/generate.py
@@ -37,6 +37,11 @@ const resource_file ToolchainFiles[] = {"""
             # We only need .bc files from libdevice:
             if re.search(r"[/\\]libsycl-.*\.(o|obj|spv)$", file_path):
                 return
+            # Avoid leaking paths to the build directory:
+            if re.search(
+                r"[/\\](CMakeLists\.txt|cmake_install\.cmake|.*\.cmake)$", file_path
+            ):
+                return
             out.write(
                 f"""
 {{


### PR DESCRIPTION
At the moment, `sycl-jit` embeds various files at build-time. Among these are some CMake build files, which contain absolute paths to the build directory.
This leaks details about the build environment to the final binaries, which also introduces a small reproducibility issue, where building from different folders causes the final binary to change.

As far as I can tell, nothing expects the CMake files to be bundled and it's safe to skip then, so that's what this PR does: skip any CMake files during embedding.