### PR TITLE
[SYCL][NFC] Enable bindless_images/read_write_unsampled.cpp

### DIFF
--- a/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
@@ -3,8 +3,8 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-INTENDED: Returning non fp[32/16] values from sampling fails.
 
-// UNSUPPORTED: linux && arch-intel_gpu_acm_g10 && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20004
+// NOTE: if the test fails on Linux+ARL+L0V2 - the right issue is
+// https://github.com/intel/llvm/issues/21097
 
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out


### PR DESCRIPTION
The driver has been updated; the issue may have been resolved.