### PR TITLE
[SYCL][E2E] Add O0 feature detection for lit tests

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -995,6 +995,10 @@ if lit_config.params.get("enable_new_offload_model", "False") != "False":
     config.available_features.add("new-offload-model")
     config.cxx_flags += " --offload-new-driver "
 
+# Add O0 feature for unoptimized builds
+if re.search(r'(^|\s)(-O0|/Od)(\s|$)', config.cxx_flags):
+    config.available_features.add("O0")
+
 # That has to be executed last so that all device-independent features have been
 # discovered already.
 config.sycl_dev_features = {}

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -996,7 +996,7 @@ if lit_config.params.get("enable_new_offload_model", "False") != "False":
     config.cxx_flags += " --offload-new-driver "
 
 # Add O0 feature for unoptimized builds
-if re.search(r'(^|\s)(-O0|/Od)(\s|$)', config.cxx_flags):
+if re.search(r"(^|\s)(-O0|/Od)(\s|$)", config.cxx_flags):
     config.available_features.add("O0")
 
 # That has to be executed last so that all device-independent features have been


### PR DESCRIPTION
Add feature detection for unoptimized builds in lit test configuration.
Tests can now use REQUIRES: O0 to conditionally run when building with
-O0 (Linux/Clang) or /Od (Windows/MSVC) flags.

For XFAILs like: https://github.com/intel/llvm/pull/21141
