### PR TITLE
Fix merge with "[SYCL][Driver] Set -std=c++17 as default for SYCL compilations (#194014)"

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5437,11 +5437,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   const llvm::Triple *AuxTriple =
-<<<<<<< HEAD
-      (IsSYCL || IsCuda || IsHIP) ? TC.getAuxTriple() : nullptr;
-=======
       (IsCuda || IsHIP || IsSYCL) ? TC.getAuxTriple() : nullptr;
->>>>>>> 0052113fb692b9a7c96f7b642c8e65071878d823
   bool IsWindowsMSVC = RawTriple.isWindowsMSVCEnvironment();
   bool IsUEFI = RawTriple.isUEFI();
   bool IsIAMCU = RawTriple.isOSIAMCU();
@@ -7369,15 +7365,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       else
         CmdArgs.push_back("-std=c89");
     else {
-<<<<<<< HEAD
-      if (Args.hasArg(options::OPT_fsycl)) {
-        // Use of -std= with 'C' is not supported for SYCL.
-        const LangStandard *LangStd =
-            LangStandard::getLangStandardForName(Std->getValue());
-        if (LangStd && LangStd->getLanguage() == Language::C)
-          D.Diag(diag::err_drv_argument_not_allowed_with)
-              << Std->getAsString(Args) << "-fsycl";
-=======
       if (IsSYCL) {
         const LangStandard *LangStd =
             LangStandard::getLangStandardForName(Std->getValue());
@@ -7390,7 +7377,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
           else if (LangStd->isCPlusPlus() && !LangStd->isCPlusPlus17())
             D.Diag(diag::err_drv_sycl_requires_cxx17) << Std->getAsString(Args);
         }
->>>>>>> 0052113fb692b9a7c96f7b642c8e65071878d823
       }
       Std->render(Args, CmdArgs);
     }
@@ -7419,16 +7405,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       ImplyVCPPCXXVer = true;
 
     if (IsSYCL && types::isCXX(InputType) &&
-<<<<<<< HEAD
-        !Args.hasArg(options::OPT__SLASH_std))
-      // For DPC++, we default to -std=c++17 for all compilations.  Use of -std
-      // on the command line will override.
-=======
         !Args.hasArg(options::OPT__SLASH_std) && !IsWindowsMSVC)
       // For SYCL, we default to -std=c++17 for all compilations. Use of -std
       // on the command line will override. On Windows MSVC, this is handled
       // by the ImplyVCPPCXXVer path below.
->>>>>>> 0052113fb692b9a7c96f7b642c8e65071878d823
       CmdArgs.push_back("-std=c++17");
 
     Args.AddLastArg(CmdArgs, options::OPT_ftrigraphs,
@@ -8372,11 +8352,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
     if (LanguageStandard.empty()) {
       if (IsSYCL)
-<<<<<<< HEAD
-        // For DPC++, C++17 is the default.
-=======
         // For SYCL, C++17 is the default.
->>>>>>> 0052113fb692b9a7c96f7b642c8e65071878d823
         LanguageStandard = "-std=c++17";
       else if (IsMSVC2015Compatible)
         LanguageStandard = "-std=c++14";


### PR DESCRIPTION
Choosing upstream mostly