### PR TITLE
[Driver] [SYCL] Update tests to use valid -std=C++ value.

### DIFF
--- a/clang/test/Driver/sycl-libspirv-invalid.cpp
+++ b/clang/test/Driver/sycl-libspirv-invalid.cpp
@@ -1,34 +1,34 @@
 /// Test that `-fsycl-libspirv-path=` produces a diagnostic when the library is not found.
 // UNSUPPORTED: system-windows
 
-// RUN: not %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl -nocudalib \
+// RUN: not %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl -nocudalib \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc %s 2>&1 \
 // RUN: | FileCheck --check-prefix=ERR-CUDA %s
 // ERR-CUDA: cannot find 'libspirv.l64.signed_char.bc';
 // ERR-CUDA-SAME: provide path to libspirv library via '-fsycl-libspirv-path', or pass '-fno-sycl-libspirv' to build without linking with libspirv
 
-// RUN: not %clangxx -### -std=c++11 -target x86_64-unknown-windows-msvc -fsycl -nocudalib \
+// RUN: not %clangxx -### -std=c++17 -target x86_64-unknown-windows-msvc -fsycl -nocudalib \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc %s 2>&1 \
 // RUN: | FileCheck --check-prefix=ERR-CUDA-WIN %s
 // ERR-CUDA-WIN: cannot find 'libspirv.l32.signed_char.bc';
 // ERR-CUDA-WIN-SAME: provide path to libspirv library via '-fsycl-libspirv-path', or pass '-fno-sycl-libspirv' to build without linking with libspirv
 
-// RUN: not %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl -nogpulib \
+// RUN: not %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl -nogpulib \
 // RUN: -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc %s 2>&1 \
 // RUN: | FileCheck --check-prefix=ERR-HIP %s
 // ERR-HIP: cannot find 'libspirv.l64.signed_char.bc';
 // ERR-HIP-SAME: provide path to libspirv library via '-fsycl-libspirv-path', or pass '-fno-sycl-libspirv' to build without linking with libspirv
 
-// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck --check-prefix=OK-CUDA %s
 // OK-CUDA-NOT: cannot find suitable 'libspirv.l64.signed_char.bc'
 
-// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl -nogpulib \
+// RUN: %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl -nogpulib \
 // RUN: -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/no-libspirv-exists-here.bc -fno-sycl-libspirv %s 2>&1 \
 // RUN: | FileCheck --check-prefix=OK-HIP %s

--- a/clang/test/Driver/sycl-libspirv.cpp
+++ b/clang/test/Driver/sycl-libspirv.cpp
@@ -1,7 +1,7 @@
 /// Test that `-fsycl-libspirv-path=` adds `-mlink-builtin-bitcode` when the library is found.
 // UNSUPPORTED: system-windows
 
-// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/libspirv.bc %s 2>&1 \
 // RUN: | FileCheck %s

--- a/clang/test/Driver/sycl-offload-nvptx.cpp
+++ b/clang/test/Driver/sycl-offload-nvptx.cpp
@@ -5,7 +5,7 @@
 // DEFINE: %{resource_dir} = %/S/Inputs/SYCL/lib/clang/resource_dir
 
 /// Check action graph.
-// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
 // RUN: -resource-dir %{resource_dir} %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-ACTIONS %s
@@ -15,7 +15,7 @@
 // RUN: -resource-dir %{resource_dir} %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-ACTIONS-WIN %s
 
-// CHK-ACTIONS: "-cc1" "-triple" "nvptx64-nvidia-cuda" "-{{.*}}"-aux-triple" "x86_64-unknown-linux-gnu"{{.*}} "-fsycl-is-device"{{.*}} "-Wno-sycl-strict"{{.*}} "-sycl-std=2020" {{.*}} "-emit-llvm-bc" {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libspirv.l64.signed_char.bc"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libdevice{{.*}}.10.bc"{{.*}} "-target-sdk-version=[[CUDA_VERSION:[0-9.]+]]"{{.*}} "-target-cpu" "sm_75"{{.*}} "-target-feature" "+ptx63"{{.*}} "-std=c++11"{{.*}}
+// CHK-ACTIONS: "-cc1" "-triple" "nvptx64-nvidia-cuda" "-{{.*}}"-aux-triple" "x86_64-unknown-linux-gnu"{{.*}} "-fsycl-is-device"{{.*}} "-Wno-sycl-strict"{{.*}} "-sycl-std=2020" {{.*}} "-emit-llvm-bc" {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libspirv.l64.signed_char.bc"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libdevice{{.*}}.10.bc"{{.*}} "-target-sdk-version=[[CUDA_VERSION:[0-9.]+]]"{{.*}} "-target-cpu" "sm_75"{{.*}} "-target-feature" "+ptx63"{{.*}} "-std=c++17"{{.*}}
 // CHK-ACTIONS: sycl-post-link
 // CHK-ACTIONS-NOT: -split
 // CHK-ACTIONS-SAME: -o
@@ -41,7 +41,7 @@
 // CHK-ACTIONS-WIN: clang{{.*}} "--target=[[HOST_TARGET]]" "-c"
 
 /// Check phases w/out specifying a compute capability.
-// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL -std=c++11 \
+// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL -std=c++17 \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl --no-offloadlib \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
 // RUN: -resource-dir %{resource_dir} \
@@ -74,7 +74,7 @@
 // CHK-PHASES-NO-CC: 21: linker, {8, 20}, image, (host-sycl)
 //
 /// Check phases specifying a compute capability.
-// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL -std=c++11 \
+// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL -std=c++17 \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl --no-offloadlib \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda \
 // RUN: -resource-dir %{resource_dir} \
@@ -114,7 +114,7 @@
 // CHK-PREPROC: 2: offload, "device-sycl (nvptx64-nvidia-cuda:sm_[[CUDA_VERSION]])" {1}, c++-cpp-output
 // CHK-PREPROC: 4: compiler, {0}, none, (device-sycl, sm_[[CUDA_VERSION]])
 //
-// RUN: not %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: not %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/no/CUDA/path/here \
 // RUN: -resource-dir %{resource_dir} %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-CUDA-PATH-ERROR %s
@@ -127,7 +127,7 @@
 // CHK-CUDA-PATH-ERROR: provide path to different CUDA installation via '--cuda-path', or pass '-nocudalib' to build without linking with libdevice
 //
 //
-// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/no/CUDA/path/here \
 // RUN: -resource-dir %{resource_dir} -nocudalib %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-CUDA-NO-LIB %s
@@ -141,7 +141,7 @@
 //
 
 // Check that flags linked to fsycl-cuda-compatibility are set correctly
-// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl -fsycl-cuda-compatibility \
+// RUN: %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl -fsycl-cuda-compatibility \
 // RUN: -fsycl-targets=nvptx64-nvidia-cuda --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
 // RUN: -resource-dir %{resource_dir} %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-ACTIONS-CUDA-COMPAT %s

--- a/clang/test/Driver/sycl-offload-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-old-model.cpp
@@ -816,10 +816,10 @@
 // CHECK-STD: clang{{.*}} "-emit-obj" {{.*}} "-std=c++17"
 
 // -std=c++17 override check
-// RUN: %clangxx -### -c -fsycl --no-offload-new-driver -std=c++14 -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
-// RUN: %clang_cl -### -c -fsycl --no-offload-new-driver /std:c++14 -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
-// CHECK-STD-OVR: clang{{.*}} "-emit-llvm-bc" {{.*}} "-std=c++14"
-// CHECK-STD-OVR: clang{{.*}} "-emit-obj" {{.*}} "-std=c++14"
+// RUN: %clangxx -### -c -fsycl --no-offload-new-driver -std=c++20 -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
+// RUN: %clang_cl -### -c -fsycl --no-offload-new-driver /std:c++20 -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
+// CHECK-STD-OVR: clang{{.*}} "-emit-llvm-bc" {{.*}} "-std=c++20"
+// CHECK-STD-OVR: clang{{.*}} "-emit-obj" {{.*}} "-std=c++20"
 // CHECK-STD-OVR-NOT: clang{{.*}} "-std=c++17"
 
 // Check sycl-post-link optimization level.

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -504,10 +504,10 @@
 // CHECK-STD: clang{{.*}} "-emit-obj" {{.*}} "-std=c++17"
 
 // -std=c++17 override check
-// RUN: %clangxx -### -c -fsycl --offload-new-driver -std=c++14 -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
-// RUN: %clang_cl -### -c -fsycl --offload-new-driver /std:c++14 -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
-// CHECK-STD-OVR: clang{{.*}} "-emit-llvm-bc" {{.*}} "-std=c++14"
-// CHECK-STD-OVR: clang{{.*}} "-emit-obj" {{.*}} "-std=c++14"
+// RUN: %clangxx -### -c -fsycl --offload-new-driver -std=c++20 -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
+// RUN: %clang_cl -### -c -fsycl --offload-new-driver /std:c++20 -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
+// CHECK-STD-OVR: clang{{.*}} "-emit-llvm-bc" {{.*}} "-std=c++20"
+// CHECK-STD-OVR: clang{{.*}} "-emit-obj" {{.*}} "-std=c++20"
 // CHECK-STD-OVR-NOT: clang{{.*}} "-std=c++17"
 
 // Check sycl-post-link optimization level.

--- a/sycl/test/basic_tests/stdcpp_compat.cpp
+++ b/sycl/test/basic_tests/stdcpp_compat.cpp
@@ -1,20 +1,12 @@
-// RUN: %clangxx -std=c++14 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify-ignore-unexpected=error,note,warning -Xclang -verify=expected,cxx14 %s
-// RUN: %clangxx -std=c++14 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify-ignore-unexpected=error,note,warning -Xclang -verify=cxx14,warning_extension,expected  %s
 // RUN: %clangxx -std=c++17 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify %s
 // RUN: %clangxx -std=c++20 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify %s
 // RUN: %clangxx            -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify %s
 
-// The test checks SYCL headers C++ compiance and that a warning is emitted
-// when compiling in < C++17 mode.
+// The test checks SYCL headers C++ compliance with C++17 and later standards.
 
 #include <sycl/sycl.hpp>
 
 // clang-format off
-// cxx14-error@* {{static assertion failed due to requirement '201402L >= 201703L'}}
-//
-// The next warning is not emitted in device compilation for some reason
-// warning_extension-warning@* 0-1 {{#warning is a C++2b extension}}
-//
 // The next warning is emitted for windows only
 // expected-warning@* 0-1 {{Alignment of class vec is not in accordance with SYCL specification requirements, a limitation of the MSVC compiler(Error C2719).Requested alignment applied, limited at 64.}}
 // clang-format on


### PR DESCRIPTION
Adapts tests following upstream PR #190715 which adds driver-level enforcement that SYCL requires C++17 or later. 
Updates test cases that were using -std=c++11 or -std=c++14 to use -std=c++17, and updates standard override tests to use -std=c++20. 
Removes redundant C++14 tests from stdcpp_compat.cpp since the driver diagnostic is already tested in sycl-std-default.cpp.