### PR TITLE
[SYCL][Graph][E2E] Mark flaky host_task tests as unsupported on BMG/PTL

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-// XFAIL: windows && level_zero && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: CMPLRLLVM-74630
+// UNSUPPORTED: windows && level_zero && (arch-intel_gpu_bmg_g21 || arch-intel_gpu_ptl_u || arch-intel_gpu_ptl_h)
+// UNSUPPORTED-TRACKER: CMPLRLLVM-74630
 
 // REQUIRES: aspect-usm_shared_allocations
 

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_in_order.cpp
@@ -2,8 +2,8 @@
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-// XFAIL: windows && level_zero && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: CMPLRLLVM-74630
+// UNSUPPORTED: windows && level_zero && (arch-intel_gpu_bmg_g21 || arch-intel_gpu_ptl_u || arch-intel_gpu_ptl_h)
+// UNSUPPORTED-TRACKER: CMPLRLLVM-74630
 
 // REQUIRES: aspect-usm_shared_allocations
 


### PR DESCRIPTION
Reported as failing on PTL in the same ticket.

Changing from xfail to unsupported because it is a flaky failure.