### PR TITLE
[CI][Devops] Install GPU raytracing library in Blender image and rename archive

### DIFF
--- a/devops/containers/ubuntu2404_blender.Dockerfile
+++ b/devops/containers/ubuntu2404_blender.Dockerfile
@@ -10,6 +10,14 @@ USER root
 COPY scripts/download_blender.sh /download_blender.sh
 RUN /download_blender.sh
 
+# Install the GPU ray tracing library which is not part of the standard driver install.
+# The official repo provides no binaries, so instead use the intel-graphics PPA build.
+# This depends on other components from the GPU driver but we installed them outside
+# of the package manager, so use dpkg --force-all to ignore dependency errors.
+RUN wget https://launchpadlibrarian.net/847063136/libze-intel-gpu-raytracing_1.2.2-1~24.04~ppa1_amd64.deb -O rt.deb && \
+    sudo dpkg --force-all -i rt.deb && \
+    rm rt.deb
+
 USER sycl
 
 ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]

--- a/devops/containers/ubuntu2404_blender.Dockerfile
+++ b/devops/containers/ubuntu2404_blender.Dockerfile
@@ -15,7 +15,7 @@ RUN /download_blender.sh
 # This depends on other components from the GPU driver but we installed them outside
 # of the package manager, so use dpkg --force-all to ignore dependency errors.
 RUN wget https://launchpadlibrarian.net/847063136/libze-intel-gpu-raytracing_1.2.2-1~24.04~ppa1_amd64.deb -O rt.deb && \
-    sudo dpkg --force-all -i rt.deb && \
+    dpkg --force-all -i rt.deb && \
     rm rt.deb
 
 USER sycl

--- a/devops/scripts/download_blender.sh
+++ b/devops/scripts/download_blender.sh
@@ -17,6 +17,6 @@ rm -rf lib/linux_x64/level-zero
 rm -rf lib/linux_x64/openimagedenoise
 cd ..
 
-tar -cJf blender_5_1_0.tar.xz blender
+zip -qr blender_5_1_0.zip blender
 rm -rf blender /var/lib/apt/lists/* /var/cache/apt/archives/*.deb
-mv blender_5_1_0.tar.xz /opt/
+mv blender_5_1_0.zip /opt/


### PR DESCRIPTION
We need the raytracing library for blender, and using a `zip` for the Blender source allows us to share code with Windows.