### PR TITLE
[SYCL-Unit]Fix segfault in DeviceGlobalProgramHandle test due to static initialization order

### DIFF
--- a/sycl/unittests/thread_safety/DeviceGlobalProgramHandle.cpp
+++ b/sycl/unittests/thread_safety/DeviceGlobalProgramHandle.cpp
@@ -81,9 +81,6 @@ struct KernelInfo<DevGlobHandleTestKernel>
 static sycl::unittest::MockDeviceImage generateHandleTestImage() {
   using namespace sycl::unittest;
 
-  sycl::detail::device_global_map::add(&g_TestDevGlobal,
-                                       DevGlobHandleTestGlobalName);
-
   MockPropertySet PropSet;
   MockProperty DevGlobInfo =
       makeDeviceGlobalInfo(DevGlobHandleTestGlobalName, sizeof(DevGlobElem),
@@ -159,6 +156,11 @@ static ur_result_t blocking_urProgramBuildExp(void *) {
 class DeviceGlobalProgramHandleTest : public ::testing::Test {
 protected:
   void SetUp() override {
+    // Register the device_global here rather than during static initialization
+    // to avoid static initialization order fiasco with GlobalHandler
+    sycl::detail::device_global_map::add(&g_TestDevGlobal,
+                                         DevGlobHandleTestGlobalName);
+
     {
       std::lock_guard<std::mutex> HLock(g_HandlesMtx);
       g_CapturedHandles.clear();


### PR DESCRIPTION
Fix regression introduced by 1ae0fe6aecf1bd85fd59281b3342498cf385a4ef.

The test was calling device_global_map::add() during static initialization
(in generateHandleTestImage() which was used to initialize g_Imgs array).
This caused a segfault because device_global_map::add() tries to access
ProgramManager via GlobalHandler::instance().getProgramManager(), but
the GlobalHandler's member variables (specifically the SpinLock in
InstWithLock<ProgramManager>) may not be fully initialized yet during
static initialization, leading to undefined behavior.

The fix moves the device_global_map::add() call from the static
initialization path into the test fixture's SetUp() method, ensuring
it runs during test execution when all runtime components are properly
initialized.

This is a classic static initialization order fiasco where the order
of initialization between translation units is undefined, and we
cannot guarantee that GlobalHandler will be fully initialized before
the test's static initializers run.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
