### PR TITLE
[SYCL][E2E] Disable missing_launch_property.cpp on CUDA

### DIFF
--- a/sycl/test-e2e/WorkGroupScratchMemory/missing_launch_property.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/missing_launch_property.cpp
@@ -2,6 +2,9 @@
 // RUN: %{run} %t.out
 //
 
+// UNSUPPORTED: cuda
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21924
+
 // XFAIL: target-native-cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
 


### PR DESCRIPTION
Passing in precommit but failing in nightly, see https://github.com/intel/llvm/issues/21924