### PR TITLE
[CI] Use devel branch commit for OIDN when building Blender

### DIFF
--- a/devops/actions/blender/oidn/action.yml
+++ b/devops/actions/blender/oidn/action.yml
@@ -24,7 +24,7 @@ runs:
       uses: ./devops/actions/cached_checkout
       with:
         repository: 'RenderKit/oidn'
-        ref: 'v2.4.1'
+        ref: 'fbd9370fe3f863400dc201ce7115d2e7be0d0cb4' # Switch to release branch after next release, see https://github.com/intel/llvm/issues/21893
         path: 'oidn-src'
         cache_path: "D:\\\\github\\\\_work\\\\repo_cache\\\\"
 


### PR DESCRIPTION
Compiler changes broke the OIDN build, but the in-development version has the failing code removed so just use that. 

I chose a specific commit (the one that has the fix) in the `devel` branch instead of just the `devel` branch overall as we want to lock down everything except the compiler in these CI jobs. Cherrypicking the patch didn't apply.

See https://github.com/intel/llvm/issues/21893 for more info.

Passing CI with this change [here](https://github.com/intel/llvm/actions/runs/25325343724/job/74250227322) 