### PR TITLE
[SYCL][Graph] Cache native recording state in queue

### DIFF
--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -670,6 +670,7 @@ void graph_impl::clearQueues(bool NeedsLock) {
                                 "Failed to end native graph capture");
         }
         // CapturedGraph should be the same as MNativeGraphHandle
+        ValidQueue->setNativeRecordingActive(false);
       } else {
         // Only call setCommandGraph for traditional recording
         ValidQueue->setCommandGraph(nullptr);
@@ -845,6 +846,7 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
         throw sycl::exception(sycl::make_error_code(errc::runtime),
                               "Failed to begin native UR graph capture");
       }
+      Queue.setNativeRecordingActive(true);
     } else {
       // Non-native recording path
       if (AcquireQueueLock) {
@@ -2248,6 +2250,7 @@ void modifiable_command_graph::end_recording(queue &RecordingQueue) {
       assert(CapturedGraph == impl->getNativeGraphHandle() &&
              "Captured graph handle must match the graph's native handle");
       impl->removeQueue(QueueImpl);
+      QueueImpl.setNativeRecordingActive(false);
     }
   } else {
     // Traditional recording path

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -615,13 +615,6 @@ queue_impl::submit_barrier_direct_impl(sycl::span<const event> DepEvents,
                        /*InsertBarrierForInOrderCommand*/ false);
 }
 
-bool queue_impl::isNativeRecording() const {
-  bool IsGraphCaptureEnabled = false;
-  ur_result_t Result =
-      getAdapter().call_nocheck<UrApiKind::urQueueIsGraphCaptureEnabledExp>(
-          MQueue, &IsGraphCaptureEnabled);
-  return Result == UR_RESULT_SUCCESS && IsGraphCaptureEnabled;
-}
 
 ext::oneapi::experimental::queue_state
 queue_impl::ext_oneapi_get_state_impl() const {

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -651,7 +651,13 @@ public:
 
   bool hasCommandGraph() const { return !MGraph.expired(); }
 
-  bool isNativeRecording() const;
+  bool isNativeRecording() const {
+    return MNativeRecordingActive.load(std::memory_order_acquire);
+  }
+
+  void setNativeRecordingActive(bool Value) noexcept {
+    MNativeRecordingActive.store(Value, std::memory_order_release);
+  }
 
   ext::oneapi::experimental::queue_state ext_oneapi_get_state_impl() const;
 
@@ -1101,6 +1107,11 @@ protected:
 
   // Used exclusively in getLastEvent and queue_empty() implementations
   std::atomic<bool> MEmpty = true;
+
+  // Tracks whether the queue is currently under native UR graph capture
+  // (urQueueBeginCaptureIntoGraphExp called but not yet ended). Avoids
+  // a cross-layer UR call on every buffer-accessor submission.
+  std::atomic<bool> MNativeRecordingActive{false};
 
   std::vector<EventImplPtr> MStreamsServiceEvents;
   std::mutex MStreamsServiceEventsMutex;


### PR DESCRIPTION
When finalizing a handler, we issue a call to urQueueIsGraphCaptureEnabledExp if the command group contains a host task or depends on buffers/accessors.

In order to avoid issuing calls to UR, we add a std::atomic<bool> flag managed by queue_impl.