### PR TITLE
[SYCL] Add /OPT:NOREF on Windows when -fsycl-allow-device-image-dependencies is used

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -370,6 +370,19 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   TC.addProfileRTLibs(Args, CmdArgs);
 
+  // -fsycl-allow-device-image-dependencies explicitly indicates that device
+  // code may depend on external device images contained in linked libraries. On
+  // Windows, /OPT:REF can incorrectly discard those libraries when no host-side
+  // symbol references exist, because the dependency is only visible through
+  // device-side usage. Adding /OPT:NOREF here (after user arguments) ensures it
+  // overrides any user-specified /OPT:REF, preserving required dependencies and
+  // preventing runtime failures such as "No device image found."
+  if (Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
+      Args.hasFlag(options::OPT_fsycl_allow_device_image_dependencies,
+                   options::OPT_fno_sycl_allow_device_image_dependencies,
+                   false))
+    CmdArgs.push_back("/OPT:NOREF");
+
   std::vector<const char *> Environment;
 
   // We need to special case some linker paths. In the case of the regular msvc

--- a/clang/test/Driver/sycl-allow-device-image-deps-win.cpp
+++ b/clang/test/Driver/sycl-allow-device-image-deps-win.cpp
@@ -1,0 +1,35 @@
+/// Test that /OPT:NOREF is correctly added when -fsycl-allow-device-image-dependencies
+/// is specified on Windows. This prevents the MSVC linker from removing device image
+/// DLLs that have no directly referenced host symbols.
+
+// REQUIRES: system-windows
+
+/// Check that /OPT:NOREF is passed to the MSVC linker when both -fsycl and
+/// -fsycl-allow-device-image-dependencies are specified.
+// RUN: %clang_cl -fsycl --offload-new-driver \
+// RUN:          -fsycl-allow-device-image-dependencies /O2 -### -- %s 2>&1 \
+// RUN:  | FileCheck -check-prefix CHECK_OPT_NOREF %s
+// CHECK_OPT_NOREF: link.exe{{.*}} "/OPT:NOREF"
+
+/// Check that /OPT:NOREF is NOT passed when -fsycl-allow-device-image-dependencies
+/// is not set (even with -fsycl present).
+// RUN: %clang_cl -fsycl --offload-new-driver /O2 -### -- %s 2>&1 \
+// RUN:  | FileCheck -check-prefix CHECK_NO_OPT_NOREF %s
+// CHECK_NO_OPT_NOREF-NOT: "/OPT:NOREF"
+
+/// Check that /OPT:NOREF is NOT passed when -fsycl is not set (even with
+/// -fsycl-allow-device-image-dependencies present).
+// RUN: %clang_cl --offload-new-driver \
+// RUN:          -fsycl-allow-device-image-dependencies /O2 -### -- %s 2>&1 \
+// RUN:  | FileCheck -check-prefix CHECK_NO_FSYCL %s
+// CHECK_NO_FSYCL-NOT: "/OPT:NOREF"
+
+/// Check that our /OPT:NOREF comes after user-specified /OPT:REF, ensuring
+/// our flag overrides the user's optimization setting for correctness.
+// RUN: %clang_cl -fsycl --offload-new-driver \
+// RUN:          -fsycl-allow-device-image-dependencies /O2 \
+// RUN:          -### -- %s /link /OPT:REF 2>&1 \
+// RUN:  | FileCheck -check-prefix CHECK_OPT_ORDER %s
+// CHECK_OPT_ORDER: clang-linker-wrapper
+// CHECK_OPT_ORDER-SAME: "/OPT:REF"
+// CHECK_OPT_ORDER-SAME: "/OPT:NOREF"

--- a/clang/test/Driver/sycl-allow-device-image-deps-win.cpp
+++ b/clang/test/Driver/sycl-allow-device-image-deps-win.cpp
@@ -28,7 +28,7 @@
 /// our flag overrides the user's optimization setting for correctness.
 // RUN: %clang_cl -fsycl --offload-new-driver \
 // RUN:          -fsycl-allow-device-image-dependencies /O2 \
-// RUN:          -### -- %s /link /OPT:REF 2>&1 \
+// RUN:          -### %s /link /OPT:REF 2>&1 \
 // RUN:  | FileCheck -check-prefix CHECK_OPT_ORDER %s
 // CHECK_OPT_ORDER: clang-linker-wrapper
 // CHECK_OPT_ORDER-SAME: "/OPT:REF"


### PR DESCRIPTION
When `-fsycl-allow-device-image-dependencies` is used, linked libraries may
contain device-side symbols that are required only for SYCL device image
resolution and are not referenced directly from host code.

On Windows, linker optimization `/OPT:REF` may discard such seemingly unused
import-library references, causing required device image dependencies to be
dropped from the final executable. This can lead to runtime failures such
as "No device image found" when external device images (for example from
oneMKL device API DLLs) are needed.

Add `/OPT:NOREF` when `-fsycl-allow-device-image-dependencies` is present to preserve these
dependencies and ensure correct runtime device image discovery.