### PR TITLE
[sycl-jit] Allow GCC host builds by not elevating -Wconversion to errors

### DIFF
--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -188,6 +188,9 @@ if(WIN32)
 endif()
 
 target_compile_options(sycl-jit PRIVATE ${SYCL_JIT_WARNING_FLAGS})
+# Host GCC can hit -Werror=conversion on Clang headers in DeviceCompilation.cpp;
+target_compile_options(sycl-jit PRIVATE
+  $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=conversion>)
 
 # Mark LLVM and SPIR-V headers as system headers to ignore warnigns in them.
 # This classification remains intact even if the same paths are added as normal


### PR DESCRIPTION
## Summary
Add `-Wno-error=conversion` **only** for the `sycl-jit` target under g++ compiler so the SYCL JIT library can be built when the LLVM/SYCL tree is configured with **GNU `g++` as the host C++ compiler**, while keeping `-Wconversion` and the rest of `SYCL_JIT_WARNING_FLAGS` / `-Werror` behavior for other diagnostics or for other compilers.

## Problem
With `SYCL_JIT_ENABLE_WERROR` on (default), `sycl-jit` uses `-Wall -Wextra -Wconversion -Werror`. Compiling `lib/rtc/DeviceCompilation.cpp` pulls in Clang headers (e.g. via the Driver). Under **g++ 13.3.0** (`/usr/bin/g++`, Ubuntu `13.3.0-6ubuntu2~24.04.1`), those headers trigger a large number of **`-Wconversion`** warnings, which **fail the build** under `-Werror`.

## Solution
`target_compile_options(sycl-jit PRIVATE -Wno-error=conversion)` in `sycl-jit/jit-compiler/CMakeLists.txt`: conversion issues are still reported as **warnings** for g++, but no longer abort the `sycl-jit` build.
## Compilation errors observed (representative)
The build stopped on `DeviceCompilation.cpp` with warnings treated as errors, for example:
```text
FAILED: tools/sycl-jit/jit-compiler/CMakeFiles/sycl-jit.dir/lib/rtc/DeviceCompilation.cpp.o
.../install_.../include/clang/Basic/FileEntry.h:251:22: error: conversion from 'size_t' {aka 'long unsigned int'} to 'unsigned int' may change value [-Werror=conversion]
.../install_.../include/clang/Basic/DiagnosticIDs.h:124:23: error: conversion from 'unsigned int' to 'unsigned char:3' may change value [-Werror=conversion]
.../install_.../include/clang/Basic/LangOptions.h:688:12: error: conversion from 'unsigned int' to 'unsigned char:2' may change value [-Werror=conversion]
.../install_.../include/clang/Basic/TargetInfo.h:559:51: error: conversion from 'uint64_t' {aka 'long unsigned int'} to 'unsigned int' may change value [-Werror=conversion]
.../install_.../include/clang/Frontend/FrontendOptions.h:188:22: error: conversion from 'unsigned int' to 'unsigned char:3' may change value [-Werror=conversion]
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```

## Host toolchain
CMAKE_CXX_COMPILER=/usr/bin/g++
g++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0

## Testing
Reconfigured and rebuilt the project with the existing configure/build workflow; sycl-jit and SYCL install steps complete with this change.