### PR TITLE
[clang][SYCL] Fix conflict resolution with 94ca490

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13701,7 +13701,6 @@ def err_sycl_restrict : Error<
   "|call through a function pointer"
   "|allocate storage"
   "|use inline assembly"
-  "|call a variadic function"
   "|call an undefined function without SYCL_EXTERNAL attribute"
   "|use a const static or global variable that is neither zero-initialized "
   "nor constant-initialized"

--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -377,7 +377,6 @@ public:
     KernelCallFunctionPointer,
     KernelAllocateStorage,
     KernelUseAssembly,
-    KernelCallVariadicFunction,
     KernelCallUndefinedFunction,
     KernelConstStaticVariable
   };

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5741,14 +5741,13 @@ bool Sema::CheckCallingConvAttr(const ParsedAttr &Attrs, CallingConv &CC,
     }
   }
 
-  const TargetInfo &TI = Context.getTargetInfo();
   bool IsTargetDefaultMSABI =
       Context.getTargetInfo().getTriple().isOSWindows() ||
       Context.getTargetInfo().getTriple().isUEFI();
   // TODO: diagnose uses of these conventions on the wrong target.
   switch (Attrs.getKind()) {
   case ParsedAttr::AT_CDecl:
-    CC = TI.getDefaultCallingConv();
+    CC = CC_C;
     break;
   case ParsedAttr::AT_FastCall:
     CC = CC_X86FastCall;
@@ -5859,6 +5858,7 @@ bool Sema::CheckCallingConvAttr(const ParsedAttr &Attrs, CallingConv &CC,
 
   TargetInfo::CallingConvCheckResult A = TargetInfo::CCCR_OK;
   auto *Aux = Context.getAuxTargetInfo();
+  const TargetInfo &TI = Context.getTargetInfo();
   // CUDA functions may have host and/or device attributes which indicate
   // their targeted execution environment, therefore the calling convention
   // of functions in CUDA should be checked against the target deduced based

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5891,9 +5891,10 @@ bool Sema::CheckCallingConvAttr(const ParsedAttr &Attrs, CallingConv &CC,
   } else if (LangOpts.SYCLIsDevice) {
     // In SYCL we may meet unsupported calling conventions in host code,
     // especially inside of included headers. Now we don't know if they will be
-    // emitted, so we just defer any diagnostics. Everything is still emitted
-    // for the host, which will check calling conventions properly.
-    A = TargetInfo::CCCR_OK;
+    // emitted, so we just defer any diagnostics. Check for the host triple if
+    // we have one, since everything is still emitted for the host.
+    if (Aux)
+      A = Aux->checkCallingConvention(CC);
   } else {
     A = TI.checkCallingConvention(CC);
   }

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8403,8 +8403,7 @@ static bool handleFunctionTypeAttr(TypeProcessingState &state, ParsedAttr &attr,
   // much ability to diagnose it later.
   if (!supportsVariadicCall(CC)) {
     const FunctionProtoType *FnP = dyn_cast<FunctionProtoType>(fn);
-    // Disable these diagnostics for SYCL
-    if (FnP && FnP->isVariadic() && !S.getLangOpts().SYCLIsDevice) {
+    if (FnP && FnP->isVariadic()) {
       // stdcall and fastcall are ignored with a warning for GCC and MS
       // compatibility.
       if (CC == CC_X86StdCall || CC == CC_X86FastCall)

--- a/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-emit.cpp
@@ -33,7 +33,7 @@ int calledFromKernel(int a) {
   // expected-error@+1 {{'__float128' is not supported on this target}}
   __float128 malFloat = 40;
 
-  //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  //expected-error@+1 {{SYCL device code does not support variadic functions}}
   variadic(5);
 
   return a + 20;
@@ -164,7 +164,7 @@ void setup_sycl_operation(const T VA[]) {
       foo<__int128_t>();
 
       // ========= variadic
-      //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+      //expected-error@+1 {{SYCL device code does not support variadic functions}}
       variadic(5);
     });
   });
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
       // expected-error@+1 {{'__float128' is not supported on this target}}
       __float128 badFloat = 40; // this SHOULD  trigger a diagnostic
 
-      //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+      //expected-error@+1 {{SYCL device code does not support variadic functions}}
       variadic(5);
 
       // expected-note@+1 {{called by 'operator()'}}

--- a/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-varargs-cconv.cpp
@@ -50,22 +50,22 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
 extern "C" int printf(const char *fmt, ...);
 
 int main() {
-  //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  //expected-error@+1 {{SYCL device code does not support variadic functions}}
   kernel_single_task<class fake_kernel>([]() { foo(6); });
-  //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  //expected-error@+1 {{SYCL device code does not support variadic functions}}
   kernel_single_task<class fake_kernel>([]() { bar(9.0); });
 
 #if defined(PRINTF_INVALID_DECL)
-  //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  //expected-error@+1 {{SYCL device code does not support variadic functions}}
   kernel_single_task<class fake_kernel>([]() { A::__spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
-  //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  //expected-error@+1 {{SYCL device code does not support variadic functions}}
   kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
 
   // Check that default printf is not allowed.
-  //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  //expected-error@+1 {{SYCL device code does not support variadic functions}}
   kernel_single_task<class fake_kernel>([]() { printf("Hello world! %d%d\n", 4, 2); });
 #elif defined(PRINTF_INVALID_DEF)
-  //expected-error@+1 {{SYCL kernel cannot call a variadic function}}
+  //expected-error@+1 {{SYCL device code does not support variadic functions}}
   kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });
 #else
   kernel_single_task<class fake_kernel>([]() { __spirv_ocl_printf("Hello world! %d%d\n", 4, 2); });


### PR DESCRIPTION
This change reverts downstream modifications that served the same
purpose as the mentioned patch, returns SemaDeclAttr.cpp to community
state after conflict resolution and fixes a couple of tests.