### PR TITLE
[SYCL][Bindless][E2E] Fix bindless test bugs

### DIFF
--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_1D_USM_host.cpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_1D_USM_host.cpp
@@ -13,10 +13,10 @@
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/usm.hpp>
 
-class kernel_sampled_fetch;
-
 // Uncomment to print additional test information
 // #define VERBOSE_PRINT
+
+class kernel_sampled_fetch;
 
 int main() {
   sycl::device dev;

--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_1D_USM_shared.cpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_1D_USM_shared.cpp
@@ -12,6 +12,9 @@
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/usm.hpp>
 
+// Uncomment to print additional test information
+// #define VERBOSE_PRINT
+
 class kernel_sampled_fetch;
 
 int main() {

--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_2D.hpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_2D.hpp
@@ -2,6 +2,9 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>
 
+// Uncomment to print additional test information
+// #define VERBOSE_PRINT
+
 class kernel_sampled_fetch;
 
 int test() {
@@ -29,7 +32,7 @@ int test() {
 
   try {
     syclexp::bindless_image_sampler samp(
-        sycl::addressing_mode::repeat,
+        sycl::addressing_mode::clamp,
         sycl::coordinate_normalization_mode::unnormalized,
         sycl::filtering_mode::nearest);
 

--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_2D_USM_device.cpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_2D_USM_device.cpp
@@ -11,6 +11,9 @@
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/usm.hpp>
 
+// Uncomment to print additional test information
+// #define VERBOSE_PRINT
+
 namespace {
 
 template <typename T, sycl::image_channel_type ChanType>

--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_3D.cpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_3D.cpp
@@ -10,6 +10,9 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>
 
+// Uncomment to print additional test information
+// #define VERBOSE_PRINT
+
 class kernel_sampled_fetch;
 
 int main() {
@@ -44,7 +47,7 @@ int main() {
                                    sycl::image_channel_type::fp32);
 
     syclexp::bindless_image_sampler samp(
-        sycl::addressing_mode::repeat,
+        sycl::addressing_mode::clamp,
         sycl::coordinate_normalization_mode::unnormalized,
         sycl::filtering_mode::nearest);
 


### PR DESCRIPTION
- Change addressing mode from repeat to clamp in fetch tests (OpenCL repeat/mirrored repeat addressing modes are undefined with unnormalized coordinates - per the OpenCL C Kernel Language Specification §6.15.15.1.)
- Add missing VERBOSE_PRINT comments for debugging