### PR TITLE
[SYCL][NFC] Remove duplicate UR manifest_file generation

### DIFF
--- a/sycl/cmake/modules/BuildUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/BuildUnifiedRuntime.cmake
@@ -270,7 +270,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     install(
       FILES ${URD_INSTALL_DIR}/bin/ur_adapter_${adapter}d.dll
       DESTINATION "bin" COMPONENT ur_adapter_${adapter})
-    add_dependencies(install-sycl-ur-adapter-${adapter} unified-runtimed)
   endforeach()
   if(UMF_BUILD_SHARED_LIBRARY)
     # Also install umfd.dll

--- a/sycl/cmake/modules/BuildUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/BuildUnifiedRuntime.cmake
@@ -127,19 +127,6 @@ function(add_sycl_ur_adapter NAME)
     LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT ur_adapter_${NAME}
     RUNTIME DESTINATION "bin" COMPONENT ur_adapter_${NAME})
 
-  set(manifest_file
-    ${CMAKE_CURRENT_BINARY_DIR}/install_manifest_ur_adapter_${NAME}.txt)
-  add_custom_command(OUTPUT ${manifest_file}
-    COMMAND "${CMAKE_COMMAND}"
-    "-DCMAKE_INSTALL_COMPONENT=ur_adapter_${NAME}"
-    -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-    COMMENT "Deploying component ur_adapter_${NAME}"
-    USES_TERMINAL
-  )
-  add_custom_target(install-sycl-ur-adapter-${NAME}
-    DEPENDS ${manifest_file} ur_adapter_${NAME}
-  )
-
   set_property(GLOBAL APPEND PROPERTY
     SYCL_TOOLCHAIN_INSTALL_COMPONENTS ur_adapter_${NAME})
 endfunction()


### PR DESCRIPTION
The same manifest file was being generated using identical cmake command in two places: BuildUnifiedRuntime.cmake and sycl/CMakeLists.txt.

The redundancy caused cmake error
```
  Attempt to add a custom rule to output
    build/tools/sycl/install_manifest_ur_adapter_level_zero.txt.rule
  which already has a custom rule.
```
if the cmake commands (generating the manifest file) in both locations diverge, e.g. when cmake command in sycl/CMakeLists.txt is updated.

ur_adapter_* install command in deploy-sycl-toolchain still installs
debug DLL on Windows because install component is the same.