### PR TITLE
[CMake][NFC] Remove dead code add_llvm_external_project(libclc)

### DIFF
--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -51,7 +51,6 @@ add_llvm_external_project(bolt)
 # file as external projects.
 add_llvm_implicit_projects()
 
-add_llvm_external_project(libclc)
 add_llvm_external_project(polly)
 
 # libclc depends on clang


### PR DESCRIPTION
It was added in 7a9a4251f57f7.
libclc has now switched to runtime build.