### PR TITLE
[clang][SYCL] Fix libclc_call calling convention

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5950,15 +5950,25 @@ bool Sema::CheckCallingConvAttr(const ParsedAttr &Attrs, CallingConv &CC,
     if (A == TargetInfo::CCCR_OK && CheckDevice && DeviceTI)
       A = DeviceTI->checkCallingConvention(CC);
   } else if (LangOpts.SYCLIsDevice) {
-    // In SYCL we may meet unsupported calling conventions in host code,
-    // especially inside of included headers. Now we don't know if they will be
-    // emitted, so we just defer any diagnostics. Check for the host triple if
-    // we have one, since everything is still emitted for the host.
+    // During device compilation, calling conventions that are valid for the
+    // host, for the device, and for both the host and the device may be
+    // encountered. Diagnostics are desired for cases where the calling
+    // convention is not supported by either the host or the device. If Aux is
+    // null (which should rarely be the case), it isn't possible to check
+    // whether the calling convention is supported by the host, so just assume
+    // that it is. If the calling convention is supported for the device, there
+    // is no need to check the host; the device target gets priority since this
+    // check is only performed during device compilation.
     A = TI.checkCallingConvention(CC);
-    if (A != TargetInfo::CCCR_OK && Aux)
+    if (Aux && A == TargetInfo::CCCR_Warning) {
+      // If the calling convention would provoke a warning for the device, check
+      // the host and preserve the warning only if the calling convention would
+      // provoke an error for the host. Otherwise, assume this calling
+      // convention is only used for host only functions.
       A = Aux->checkCallingConvention(CC);
-    else
-      A = TargetInfo::CCCR_OK;
+      if (A == TargetInfo::CCCR_Error)
+        A = TargetInfo::CCCR_Warning;
+    }
   } else {
     A = TI.checkCallingConvention(CC);
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5954,8 +5954,11 @@ bool Sema::CheckCallingConvAttr(const ParsedAttr &Attrs, CallingConv &CC,
     // especially inside of included headers. Now we don't know if they will be
     // emitted, so we just defer any diagnostics. Check for the host triple if
     // we have one, since everything is still emitted for the host.
-    if (Aux)
+    A = TI.checkCallingConvention(CC);
+    if (A != TargetInfo::CCCR_OK && Aux)
       A = Aux->checkCallingConvention(CC);
+    else
+      A = TargetInfo::CCCR_OK;
   } else {
     A = TI.checkCallingConvention(CC);
   }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5968,6 +5968,9 @@ bool Sema::CheckCallingConvAttr(const ParsedAttr &Attrs, CallingConv &CC,
       A = Aux->checkCallingConvention(CC);
       if (A == TargetInfo::CCCR_Error)
         A = TargetInfo::CCCR_Warning;
+    } else if (Aux && A == TargetInfo::CCCR_Error) {
+      // Assume this calling convention is only used for host only functions.
+      A = Aux->checkCallingConvention(CC);
     }
   } else {
     A = TI.checkCallingConvention(CC);

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -18,7 +18,7 @@ void bar() {
 template <typename name, typename Func>
 // expected-no-warning@+1
 __cdecl __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
-  // expected-error@+1 2{{SYCL kernel cannot call a variadic function}}
+  // expected-error@+1 2{{SYCL device code does not support variadic functions}}
   printf("cannot call from here\n");
   // expected-no-error@+1
   moo();
@@ -26,9 +26,25 @@ __cdecl __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelF
   kernelFunc();
 }
 
+template<typename KN, typename...Args>
+void sycl_kernel_launch(Args ...args) {}
+
+template<typename KN, typename K>
+[[clang::sycl_kernel_entry_point(KN)]]
+__cdecl void sycl_entry_point(K k) {
+  k(); // expected-note {{called by}}
+}
+
 int main() {
   //expected-error@+1 {{SYCL device code does not support variadic functions}}
   sycl_entry_point<class kn>([]() { printf("world\n");
+     moo();
+  //expected-error@+1 {{SYCL device code does not support variadic functions}}
+     foo(1,2); });
+
+  //expected-note@+2 {{in instantiation of}}
+  //expected-error@+1 {{SYCL device code does not support variadic functions}}
+  kernel_single_task<class kn>([]() { printf("world\n");
      moo();
   //expected-error@+1 {{SYCL device code does not support variadic functions}}
      foo(1,2); });

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -1,22 +1,29 @@
 // RUN: %clang_cc1 -isystem %S/Inputs/ -fsycl-is-device -triple spirv64 -aux-triple x86_64-pc-windows-msvc -fsyntax-only -verify %s
-// RUN: %clang_cc1 -isystem %S/Inputs/ -fsycl-is-device -triple spirv64 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -isystem %S/Inputs/ -fsycl-is-device -triple spirv64 -fsyntax-only -verify=expected,no-aux %s
 
 // Check that there is no error/warning emitted for cdecl functions compiled for
 // SYCL device. Make sure variadic calls from within device code are diagnosed.
 
+// no-aux-warning@+2 {{'__cdecl' calling convention is not supported for this target}}
+// no-aux-error@+1 {{variadic function cannot use spir_function calling convention}}
 __inline __cdecl int printf(char const* const _Format, ...) { return 0; }
 
 // FIXME: that should be diagnosed.
 [[clang::sycl_external]] int foo(int, ...) { return 0; }
 
+// no-aux-warning@+1 {{'__cdecl' calling convention is not supported for this target}}
 __inline __cdecl int moo() { return 0; }
 
 void bar() {
   printf("hello\n");
 }
 
+// Check some weird calling convention that is not supported even by x86_64 aux.
+// no-aux-warning@+1 {{'__swiftasynccall__' calling convention is not supported for this target}}
+void __attribute__((__swiftasynccall__)) g(void) {}
+
 template <typename name, typename Func>
-// expected-no-warning@+1
+// no-aux-warning@+1 {{'__cdecl' calling convention is not supported for this target}}
 __cdecl __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // expected-error@+1 2{{SYCL device code does not support variadic functions}}
   printf("cannot call from here\n");
@@ -31,6 +38,7 @@ void sycl_kernel_launch(Args ...args) {}
 
 template<typename KN, typename K>
 [[clang::sycl_kernel_entry_point(KN)]]
+// no-aux-warning@+1 {{'__cdecl' calling convention is not supported for this target}}
 __cdecl void sycl_entry_point(K k) {
   k(); // expected-note {{called by}}
 }


### PR DESCRIPTION
We have device-specific calling convention libclc_call here in the downstream added by 5b5fd84692bf14b8ff6eeb605c40bab0320dcfe6 which was not expected by the upstream patch 94ca49099ef77751a33e4babe41b2ae03ff228e1, so we ended up ignoring the calling convention attribute because the host target doesn't support it. This makes a little tweak in SemaDeclAttr to save the calling convention and also fixes sycl-cconv.cpp which was strangely half-merged after 94ca49099ef77751a33e4babe41b2ae03ff228e1.