### PR TITLE
[Driver] Restore replace_extension for ftime-trace in non-dumpdir SYCL path

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -9206,6 +9206,7 @@ static void handleTimeTrace(Compilation &C, const ArgList &Args,
         Path = addOffloadingPrefixToPath(Path, OffloadingPrefix);
       }
     }
+    llvm::sys::path::replace_extension(Path, "json");
   }
   const char *ResultFile = C.getArgs().MakeArgString(Path);
   C.addTimeTraceFile(ResultFile, JA);


### PR DESCRIPTION
The upstream commit 4ff87c01c2e5 moved the shared replace_extension call into per-branch additions, but the merge lost the .json extension for the SYCL else branch (no -ftime-trace=, no -dumpdir). This fixes the Clang :: Driver/ftime-trace.cpp test failure.