### PR TITLE
[SYCL][E2E] Move more instructions that link Shared Library to run in Linux

### DIFF
--- a/sycl/test-e2e/DeviceImageDependencies/dynamic_aot.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/dynamic_aot.cpp
@@ -12,6 +12,7 @@
 // RUN: %clangxx %{dynamic_lib_options} %S/Inputs/b.cpp %if windows %{%t.dir/libdevice_c.lib%} -o %t.dir/libdevice_b.%{dynamic_lib_suffix}
 // RUN: %clangxx %{dynamic_lib_options} %S/Inputs/a.cpp %if windows %{%t.dir/libdevice_b.lib%} -o %t.dir/libdevice_a.%{dynamic_lib_suffix}
 
+// RUN: %if !windows %{%{run-aux}%} \
 // RUN: %clangxx -fsycl %{aot_options} -fsycl-allow-device-image-dependencies -fsycl-device-code-split=per_kernel %S/Inputs/basic.cpp -o %t.dir/%{t:stem}.out            \
 // RUN: %if windows                                                                       \
 // RUN:   %{%t.dir/libdevice_a.lib%}                                                      \

--- a/sycl/test-e2e/IntermediateLib/dynamic_app_linux.cpp
+++ b/sycl/test-e2e/IntermediateLib/dynamic_app_linux.cpp
@@ -5,7 +5,7 @@
 // RUN: %clangxx -fsycl -fPIC %shared_lib -o %t.dir/simple_lib.so %S/Inputs/simple_lib.cpp
 
 // build app
-// RUN: %clangxx -DSO_PATH="%t.dir/simple_lib.so" -o %t.out %s %if preview-mode %{-Wno-unused-command-line-argument%}
+// RUN: %{run-aux} %clangxx -DSO_PATH="%t.dir/simple_lib.so" -o %t.out %s %if preview-mode %{-Wno-unused-command-line-argument%}
 
 // RUN: %{run} %t.out
 // RUN: env UR_L0_LEAKS_DEBUG=1 %{run} %t.out


### PR DESCRIPTION
Like with https://github.com/intel/llvm/pull/21182, this commit moves items that link shared libraries in Linux to the run phase. Again, the shared libraries' path may be invalid when the workspace location is changed.