### PR TITLE
[SYCL][E2E] Disable buffer_create.cpp on Win Gen12

### DIFF
--- a/sycl/test-e2e/Basic/buffer/buffer_create.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_create.cpp
@@ -8,6 +8,9 @@
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
 // UNSUPPORTED: ze_debug
 
+// UNSUPPORTED: windows && gpu-intel-gen12
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21954
+
 #include <iostream>
 #include <level_zero/ze_api.h>
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Sporadically failing, see https://github.com/intel/llvm/issues/21954