### PR TITLE
[OffloadArch] Fix IsIntelGPUOffloadArch to include LAST entry

### DIFF
--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -194,7 +194,7 @@ static inline bool IsIntelCPUOffloadArch(OffloadArch Arch) {
 }
 
 static inline bool IsIntelGPUOffloadArch(OffloadArch Arch) {
-  return Arch >= OffloadArch::BDW && Arch < OffloadArch::LAST;
+  return Arch >= OffloadArch::BDW && Arch <= OffloadArch::LAST;
 }
 
 static inline bool IsIntelOffloadArch(OffloadArch Arch) {


### PR DESCRIPTION
After upstream commit 8d9ee493b8df changed LAST from a past-the-end sentinel to an alias of the final entry, the < comparison excludes the last Intel GPU arch (LNL_M). Use <= to match the upstream intent. This fixes incorrect conflict resolution when merging into sycl-web.