### PR TITLE
[SYCL][ESIMD] Fix sycl-post-link to exit with non-zero code on errors

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -2106,6 +2106,9 @@ PreservedAnalyses SYCLLowerESIMDPass::run(Module &M,
   // Check validity of slm_init calls.
   checkSLMInit(M);
 
+  if (M.getContext().getDiagHandlerPtr()->HasErrors)
+    return PreservedAnalyses::all();
+
   // AlwaysInlinerPass is required for correctness.
   bool ForceInline = prepareForAlwaysInliner(M);
   if (ForceInline) {

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDSlmReservation.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDSlmReservation.cpp
@@ -555,6 +555,9 @@ TraversalResult findMaxSLMUsageAlongAllPaths(const ScopedCallGraph::Node *Cur,
 
 PreservedAnalyses
 ESIMDLowerSLMReservationCalls::run(Module &M, ModuleAnalysisManager &MAM) {
+  if (M.getContext().getDiagHandlerPtr()->HasErrors)
+    return PreservedAnalyses::all();
+
   // Create a detailed "scoped" call graph. Scope start/end is marked with
   // x = __esimd_slm_alloc / __esimd_slm_free(x)
   //

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -681,6 +681,9 @@ int main(int argc, char **argv) {
   std::vector<std::unique_ptr<util::SimpleTable>> Tables =
       processInputModule(std::move(M), OutputPrefix);
 
+  if (Context.getDiagHandlerPtr()->HasErrors)
+    return 1;
+
   // Input module was processed and a single output file was requested.
   if (IROutputOnly)
     return 0;


### PR DESCRIPTION
sycl-post-link never checked whether passes emitted errors via LLVMContext::emitError(), so it always exited 0 even when checkSLMInit reported invalid slm_init usage. This caused the clang driver to consider the compilation successful despite the error diagnostic.

Previously this was masked because after emitError() the pass pipeline continued processing the malformed module, and would would eventually crash, making clang exit non-zero. Recent sycl-post-link refactoring (f49271daaa00, a8dff34478c9) made those code paths more robust, eliminating the accidental downstream failures and unmasking this latent bug.

Add HasErrors check after pass execution, and bail out early from ESIMD passes when prior errors exist to avoid crashes in downstream passes.
Fixes: 
SYCL::esimd/slm_init_check.cpp
SYCL::esimd/slm_init_invoke_simd.cpp
SYCL::esimd/slm_init_local_accessor_parameter.cpp
SYCL::esimd/slm_init_local_accessor_subscript.cpp
SYCL::esimd/slm_init_noinline_check.cpp
in sycl-web.