### PR TITLE
[TEST][E2E][CUDA] Fix WorkGroupScratchMemory/missing_launch_property.cpp failure

### DIFF
--- a/llvm/lib/SYCLLowerIR/LowerWGLocalMemory.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerWGLocalMemory.cpp
@@ -83,7 +83,9 @@ SmallVector<StringRef>
 sycl::getKernelNamesUsingWorkGroupDynamicMem(const Module &M) {
   SmallVector<StringRef> SPIRKernelNames;
   llvm::for_each(M.functions(), [&](const Function &F) {
-    if (F.getCallingConv() == CallingConv::SPIR_KERNEL &&
+    // PTX_Kernel covers CUDA targets.
+    if ((F.getCallingConv() == CallingConv::SPIR_KERNEL ||
+         F.getCallingConv() == CallingConv::PTX_Kernel) &&
         F.hasFnAttribute(WORK_GROUP_SCRATCH_ATTR)) {
       SPIRKernelNames.emplace_back(F.getName());
     }
@@ -182,7 +184,8 @@ static void lowerLocalMemCall(Function *LocalMemAllocFunc,
           !F->hasFnAttribute(WORK_GROUP_STATIC_ATTR))
         F->addFnAttr(WORK_GROUP_STATIC_ATTR);
 
-      if (F->getCallingConv() == CallingConv::SPIR_KERNEL &&
+      if ((F->getCallingConv() == CallingConv::SPIR_KERNEL ||
+           F->getCallingConv() == CallingConv::PTX_Kernel) &&
           LocalMemAllocFunc->getName() == SYCL_DYNAMIC_LOCALMEM_CALL &&
           !F->hasFnAttribute(WORK_GROUP_SCRATCH_ATTR))
         F->addFnAttr(WORK_GROUP_SCRATCH_ATTR);

--- a/llvm/test/SYCLLowerIR/work_group_scratch_cuda.ll
+++ b/llvm/test/SYCLLowerIR/work_group_scratch_cuda.ll
@@ -1,0 +1,40 @@
+; RUN: opt -S -passes=sycllowerwglocalmemory < %s | FileCheck %s
+
+; Test that ptx_kernel (CUDA) kernels using dynamic work-group local memory are
+; lowered correctly. Specifically, calls to __sycl_dynamicLocalMemoryPlaceholder
+; must be replaced by references to a real shared-memory global, and each
+; kernel must be stamped with the "sycl-work-group-scratch" attribute so that
+; the host-side launch code knows to wire up the dynamic shared memory size
+; when invoking cudaLaunchKernel.
+
+target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
+target triple = "nvptx64-nvidia-cuda"
+
+; CHECK: @__sycl_dynamicLocalMemoryPlaceholder_GV = external local_unnamed_addr addrspace(3) global [0 x i8]
+
+; CHECK-LABEL: @kernel_a(
+define ptx_kernel void @kernel_a(ptr addrspace(1) %0) #0 {
+entry:
+; CHECK-NOT: call {{.*}} @__sycl_dynamicLocalMemoryPlaceholder
+; CHECK: getelementptr inbounds i8, ptr addrspace(3) @__sycl_dynamicLocalMemoryPlaceholder_GV
+  %1 = call ptr addrspace(3) @__sycl_dynamicLocalMemoryPlaceholder(i64 128) #1
+  %2 = getelementptr inbounds i8, ptr addrspace(3) %1, i64 4
+  store i8 0, ptr addrspace(3) %2
+  ret void
+}
+
+; CHECK-LABEL: @kernel_b(
+define ptx_kernel void @kernel_b(ptr addrspace(1) %0) #1 {
+entry:
+  %1 = call ptr addrspace(3) @__sycl_dynamicLocalMemoryPlaceholder(i64 64) #1
+  ret void
+}
+
+declare ptr addrspace(3) @__sycl_dynamicLocalMemoryPlaceholder(i64) #1
+
+attributes #0 = { convergent norecurse }
+attributes #1 = { convergent }
+
+; Both ptx_kernel functions must receive "sycl-work-group-scratch".
+; CHECK-DAG: attributes #{{[0-9]+}} = { convergent norecurse "sycl-work-group-scratch" }
+; CHECK-DAG: attributes #{{[0-9]+}} = { convergent "sycl-work-group-scratch" }

--- a/sycl/test-e2e/WorkGroupScratchMemory/missing_launch_property.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/missing_launch_property.cpp
@@ -2,9 +2,6 @@
 // RUN: %{run} %t.out
 //
 
-// UNSUPPORTED: cuda
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21924
-
 // XFAIL: target-native-cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
 


### PR DESCRIPTION
Fixes the WorkGroupScratchMemory/missing_launch_property.cpp E2E test failure on CUDA (tracked in #21924).

Extends two conditional checks to also handle PTX_Kernel calling convention alongside SPIR_KERNEL. This ensures that work-group scratch memory attributes (WORK_GROUP_SCRATCH_ATTR) are correctly detected and applied for CUDA kernels, not just SPIR kernels.

Adds a LIT test verifying that ptx_kernel (CUDA) functions calling __sycl_dynamicLocalMemoryPlaceholder are correctly lowered by sycllowerwglocalmemory: the placeholder call is replaced by a reference to a real shared-memory global, and the "sycl-work-group-scratch" attribute is stamped on the kernel so the host-side launcher knows to wire up dynamic shared memory at launch.