### PR TITLE
[CMake] Add pkgconfig and CMake config files for xpti and xptifw (#21599)

### DIFF
--- a/xpti/CMakeLists.txt
+++ b/xpti/CMakeLists.txt
@@ -89,3 +89,51 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/xpti
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   COMPONENT xpti
 )
+
+# Install CMake config files.
+include(CMakePackageConfigHelpers)
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX})
+set(CONFIG_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/xpti)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/xptiConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/xptiConfig.cmake
+  INSTALL_DESTINATION ${CONFIG_INSTALL_DIR}
+  PATH_VARS INCLUDE_INSTALL_DIR
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/xptiConfigVersion.cmake
+  VERSION ${XPTI_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT xptiTargets
+  FILE xptiTargets.cmake
+  NAMESPACE xpti::
+  DESTINATION ${CONFIG_INSTALL_DIR}
+  COMPONENT xpti
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/xptiConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/xptiConfigVersion.cmake
+  DESTINATION ${CONFIG_INSTALL_DIR}
+  COMPONENT xpti
+)
+
+if(NOT WIN32)
+  # Install pkg-config file
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/xpti.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/xpti.pc
+    @ONLY
+  )
+  
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/xpti.pc
+    DESTINATION ${LIB_INSTALL_DIR}/pkgconfig
+    COMPONENT xpti
+  )
+endif()

--- a/xpti/src/CMakeLists.txt
+++ b/xpti/src/CMakeLists.txt
@@ -2,15 +2,26 @@ include(GNUInstallDirs)
 
 macro(add_xpti_lib target_name)
   add_library(${target_name} STATIC ${ARGN})
-  target_compile_definitions(${target_name} PRIVATE -DXPTI_STATIC_LIBRARY)
-  target_include_directories(${target_name} PRIVATE ${XPTI_DIR}/include)
+  add_library(xpti::${target_name} ALIAS ${target_name})
+  target_compile_definitions(${target_name} PUBLIC XPTI_STATIC_LIBRARY)
+  target_include_directories(${target_name}
+    PUBLIC
+    $<BUILD_INTERFACE:${XPTI_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
 
   if (MSVC)
     target_compile_options(${target_name} PRIVATE /EHsc)
   endif()
 
-  # Set the location of the library installation
+  # Set library version for the generated library.
+  set_target_properties(${target_name} PROPERTIES
+    VERSION ${XPTI_VERSION}
+  )
+
+  # Set the location of the library installation.
   install(TARGETS ${target_name}
+    EXPORT xptiTargets
     RUNTIME DESTINATION bin COMPONENT xpti
     LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT xpti
     ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT xpti
@@ -27,7 +38,7 @@ add_xpti_lib(xpti ${SOURCES})
 # creating a debug version of the static library that uses the flags used by
 # the SYCL runtime
 if (MSVC)
-  add_xpti_lib(xptid STATIC ${SOURCES})
+  add_xpti_lib(xptid ${SOURCES})
   target_compile_options(xptid PRIVATE ${XPTI_CXX_FLAGS_DEBUG})
   target_compile_options(xpti PRIVATE ${XPTI_CXX_FLAGS_RELEASE})
 endif()

--- a/xpti/xpti.pc.in
+++ b/xpti/xpti.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+libdir=${prefix}/lib@LLVM_LIBDIR_SUFFIX@
+
+Name: XPTI
+Description: XPTI Proxy Library
+URL: https://github.com/intel/llvm
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lxpti
+Cflags: -I${includedir}

--- a/xpti/xptiConfig.cmake.in
+++ b/xpti/xptiConfig.cmake.in
@@ -1,0 +1,23 @@
+@PACKAGE_INIT@
+
+set(XPTI_VERSION_MAJOR @PROJECT_VERSION_MAJOR@)
+set(XPTI_VERSION_MINOR @PROJECT_VERSION_MINOR@)
+set(XPTI_VERSION_PATCH @PROJECT_VERSION_PATCH@)
+set(XPTI_VERSION @PROJECT_VERSION@)
+
+get_filename_component(XPTI_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+list(APPEND CMAKE_MODULE_PATH "${XPTI_CMAKE_DIR}")
+
+if(NOT TARGET xpti::xpti)
+  include("${XPTI_CMAKE_DIR}/xptiTargets.cmake")
+endif()
+
+if(MSVC)
+  set(XPTI_LIBRARIES "$<IF:$<CONFIG:Debug>,xpti::xptid,xpti::xpti>")
+else()
+  set(XPTI_LIBRARIES xpti::xpti)
+endif()
+
+set(XPTI_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+
+check_required_components(xpti)

--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.20.0)
 
-set(XPTI_VERSION 1.0.1)
+set(XPTIFW_VERSION 1.0.1)
 
-project (xptifw VERSION "${XPTI_VERSION}" LANGUAGES CXX)
+project (xptifw VERSION "${XPTIFW_VERSION}" LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 set(XPTIFW_DIR ${CMAKE_CURRENT_LIST_DIR})
@@ -74,4 +74,52 @@ endif()
 
 if (XPTI_BUILD_BENCHMARK)
   add_subdirectory(benchmark)
+endif()
+
+# Install CMake config files
+include(CMakePackageConfigHelpers)
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX})
+set(CONFIG_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/xptifw)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/xptifwConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/xptifwConfig.cmake
+  INSTALL_DESTINATION ${CONFIG_INSTALL_DIR}
+  PATH_VARS INCLUDE_INSTALL_DIR
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/xptifwConfigVersion.cmake
+  VERSION ${XPTIFW_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT xptifwTargets
+  FILE xptifwTargets.cmake
+  NAMESPACE xptifw::
+  DESTINATION ${CONFIG_INSTALL_DIR}
+  COMPONENT xptifw
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/xptifwConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/xptifwConfigVersion.cmake
+  DESTINATION ${CONFIG_INSTALL_DIR}
+  COMPONENT xptifw
+  )
+
+if(NOT WIN32)
+  # Install pkg-config file
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/xptifw.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/xptifw.pc
+    @ONLY
+  )
+
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/xptifw.pc
+    DESTINATION ${LIB_INSTALL_DIR}/pkgconfig
+    COMPONENT xptifw
+  )
 endif()

--- a/xptifw/src/CMakeLists.txt
+++ b/xptifw/src/CMakeLists.txt
@@ -51,6 +51,7 @@ file(GLOB SOURCES *.cpp)
 function(add_xpti_library LIB_NAME)
   remove_definitions(-DXPTI_STATIC_LIBRARY)
   add_library(${LIB_NAME} SHARED ${SOURCES})
+  add_library(xptifw::${LIB_NAME} ALIAS ${LIB_NAME})
 
   if (${LIB_NAME} MATCHES "xptifwd")
     set_property(TARGET ${LIB_NAME} PROPERTY
@@ -61,11 +62,16 @@ function(add_xpti_library LIB_NAME)
   endif()
 
   target_compile_definitions(${LIB_NAME} PRIVATE -DXPTI_API_EXPORTS)
-  target_include_directories(${LIB_NAME} PUBLIC
+  target_include_directories(${LIB_NAME}
+    PUBLIC
     $<BUILD_INTERFACE:${XPTIFW_DIR}/include>
-    $<BUILD_INTERFACE:${XPTIFW_PARALLEL_HASHMAP_HEADERS}>
     $<BUILD_INTERFACE:${XPTI_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    PRIVATE
+    $<BUILD_INTERFACE:${XPTIFW_PARALLEL_HASHMAP_HEADERS}>
   )
+
+  add_dependencies(${LIB_NAME} xpti)
 
   target_link_libraries(${LIB_NAME} PUBLIC $<BUILD_INTERFACE:emhash::emhash>)
 
@@ -78,9 +84,15 @@ function(add_xpti_library LIB_NAME)
     target_link_libraries(${LIB_NAME} PUBLIC $<BUILD_INTERFACE:tbb>)
   endif()
 
+  # Set library version so the generated library is versioned.
+  set_target_properties(${LIB_NAME} PROPERTIES
+    VERSION ${XPTIFW_VERSION}
+  )
+
   # Set the location of the library installation
   include(GNUInstallDirs)
   install(TARGETS ${LIB_NAME}
+    EXPORT xptifwTargets
     RUNTIME DESTINATION bin COMPONENT xptifw
     LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT xptifw
     ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT xptifw

--- a/xptifw/xptifw.pc.in
+++ b/xptifw/xptifw.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+libdir=${prefix}/lib@LLVM_LIBDIR_SUFFIX@
+
+Name: XPTIFW
+Description: XPTI Framework Library
+URL: https://github.com/intel/llvm
+Version: @PROJECT_VERSION@
+Requires: xpti
+Libs: -L${libdir} -lxptifw -ldl -lpthread
+Cflags: -I${includedir}

--- a/xptifw/xptifwConfig.cmake.in
+++ b/xptifw/xptifwConfig.cmake.in
@@ -1,0 +1,26 @@
+@PACKAGE_INIT@
+
+set(XPTIFW_VERSION_MAJOR @PROJECT_VERSION_MAJOR@)
+set(XPTIFW_VERSION_MINOR @PROJECT_VERSION_MINOR@)
+set(XPTIFW_VERSION_PATCH @PROJECT_VERSION_PATCH@)
+set(XPTIFW_VERSION @PROJECT_VERSION@)
+
+# Find required dependencies
+include(CMakeFindDependencyMacro)
+find_dependency(xpti)
+find_dependency(Threads)
+if (XPTI_ENABLE_TBB)
+  find_dependency(tbb)
+endif()
+
+get_filename_component(XPTIFW_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+list(APPEND CMAKE_MODULE_PATH "${XPTIFW_CMAKE_DIR}")
+
+if(NOT TARGET xptifw::xptifw)
+  include("${XPTIFW_CMAKE_DIR}/xptifwTargets.cmake")
+endif()
+
+set(XPTIFW_LIBRARIES "$<IF:$<CONFIG:Debug>,xptifw::xptifwd,xptifw::xptifw>")
+set(XPTIFW_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+
+check_required_components(xptifw)


### PR DESCRIPTION
Cherry pick of c80095cec990c2d0b56bee02d7587ce41933c247
--------------------------------------------
We have some downstream code looking for `xpti`/`xptifw` directly, so provide CMake config files and pkgconfig files that will provide the information they need.

Also set the `VERSION` target property so the generated libraries are versioned. For some reason setting the `project` version doesn't automatically do this.

I tested the CMake config files on Linux and Win and the pkgconfig files on Linux (as we don't generate them for Win).

Closes: https://github.com/intel/llvm/issues/21507

---------