### PR TITLE
[CI] Add Blender Linux testing job to nightly

### DIFF
--- a/.github/workflows/sycl-blender-build-and-test.yml
+++ b/.github/workflows/sycl-blender-build-and-test.yml
@@ -15,10 +15,6 @@ on:
         description: 'ccache directory'
         required: true
         type: string
-      blender_classroom_dir:
-        description: 'Blender classroom demo directory'
-        required: true
-        type: string
       toolchain_artifact:
         description: 'Artifact name for toolchain download'
         required: true
@@ -28,14 +24,12 @@ on:
         required: true
         type: string
 
-env:
-  OIDN_INSTALL_DIR: "${{ github.workspace }}/oidn-install"
-  EMBREE_INSTALL_DIR: "${{ github.workspace }}/embree-install"
-  BLENDER_INSTALL_DIR: "${{ github.workspace }}/blender-install"
-
 jobs:
   blender:
     runs-on: ${{ fromJSON(inputs.runner) }}
+    container:
+      image: ${{ contains(inputs.runner, 'Linux') && 'ghcr.io/intel/llvm/ubuntu2404_blender' || '' }}
+      options: ${{ contains(inputs.runner, 'Linux') && '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' || '' }}
     name: Build and Test Blender on ${{ contains(inputs.runner, 'Windows') && 'Windows' || 'Linux' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,6 +37,17 @@ jobs:
           sparse-checkout: |
             devops/
           persist-credentials: false
+
+      - name: Setup Environment Variables
+        shell: bash
+        run: |
+          # We can't do this in a normal 'env:' section because the github.workspace variable
+          # is wrong when using containers, only the Bash variable GITHUB_WORKSPACE is correct.
+          echo "OIDN_INSTALL_DIR=$GITHUB_WORKSPACE/oidn-install" >> $GITHUB_ENV
+          echo "EMBREE_INSTALL_DIR=$GITHUB_WORKSPACE/embree-install" >> $GITHUB_ENV
+          echo "BLENDER_INSTALL_DIR=$GITHUB_WORKSPACE/blender-install" >> $GITHUB_ENV
+          echo "SYCL_INSTALL_DIR=$GITHUB_WORKSPACE/install" >> $GITHUB_ENV
+
       - name: Download Toolchain
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -62,15 +67,15 @@ jobs:
         uses: ./devops/actions/blender/oidn
         with:
           cmake_install_prefix: ${{ env.OIDN_INSTALL_DIR }}
-          c_compiler: ${{ github.workspace }}/install/bin/clang${{ runner.os == 'Windows' && '.exe' }}
-          cxx_compiler: ${{ github.workspace }}/install/bin/clang++${{ runner.os == 'Windows' && '.exe' }}
+          c_compiler: ${{ env.SYCL_INSTALL_DIR }}/bin/clang${{ runner.os == 'Windows' && '.exe' || '' }}
+          cxx_compiler: ${{ env.SYCL_INSTALL_DIR }}/bin/clang++${{ runner.os == 'Windows' && '.exe' || '' }}
 
       - name: Build Embree
         uses: ./devops/actions/blender/embree
         with:
           cmake_install_prefix: ${{ env.EMBREE_INSTALL_DIR }}
-          c_compiler: ${{ github.workspace }}/install/bin/clang${{ runner.os == 'Windows' && '.exe' }}
-          cxx_compiler: ${{ github.workspace }}/install/bin/clang++${{ runner.os == 'Windows' && '.exe' }}
+          c_compiler: ${{ env.SYCL_INSTALL_DIR }}/bin/clang${{ runner.os == 'Windows' && '.exe' || '' }}
+          cxx_compiler: ${{ env.SYCL_INSTALL_DIR }}/bin/clang++${{ runner.os == 'Windows' && '.exe' || '' }}
 
       - name: Build Blender
         uses: ./devops/actions/blender/blender-build
@@ -79,18 +84,16 @@ jobs:
           embree_dir: ${{ env.EMBREE_INSTALL_DIR }}
           level_zero_dir: ${{ inputs.level_zero_dir }}
           cmake_install_prefix: ${{ env.BLENDER_INSTALL_DIR }}
-          sycl_dir: ${{ github.workspace }}/install
+          sycl_dir: ${{ env.SYCL_INSTALL_DIR }}
           ccache_dir: ${{ inputs.ccache_dir }}
 
       - name: Run Blender Classroom Demo
         uses: ./devops/actions/blender/blender-demo
         with:
-          blender_dir: ${{ github.workspace }}/blender-install
-          blender_classroom_dir: ${{ inputs.blender_classroom_dir }}
+          blender_dir: ${{ env.BLENDER_INSTALL_DIR }}
 
       - name: Cleanup
-        shell: cmd
+        shell: bash
         if: always()
         run: |
-         rmdir /q /s "${{ env.OIDN_INSTALL_DIR }}" "${{ env.EMBREE_INSTALL_DIR }}" "${{ env.BLENDER_INSTALL_DIR }}"
-  
+          rm -rf "$OIDN_INSTALL_DIR" "$EMBREE_INSTALL_DIR" "$BLENDER_INSTALL_DIR"

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -428,9 +428,22 @@ jobs:
       runner: '["Windows","blender"]'
       level_zero_dir: "D:\\github\\level-zero_win-sdk"
       ccache_dir: "D:\\github\\_work\\cache\\blender"
-      blender_classroom_dir: "D:\\github\\classroom-demo"
       toolchain_artifact: sycl_windows_default
       toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
+
+  build_and_test_blender_linux:
+    name: Build and Test Blender on Linux
+    needs: ubuntu2204_build
+    if: |
+      !cancelled()
+      && needs.ubuntu2204_build.outputs.build_conclusion == 'success'
+    uses: ./.github/workflows/sycl-blender-build-and-test.yml
+    with:
+      runner: '["Linux","bmg"]'
+      level_zero_dir: ""
+      ccache_dir: "/__w/build_cache_blender"
+      toolchain_artifact: sycl_linux_default
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
 
   # Verification example:
   # cosign-windows-amd64.exe verify-blob sycl_linux.tar.gz \

--- a/devops/actions/blender/blender-build/action.yml
+++ b/devops/actions/blender/blender-build/action.yml
@@ -19,17 +19,17 @@ inputs:
     required: true
   cmake_install_prefix:
     description: 'CMAKE_INSTALL_PREFIX for Blender build'
-    required: false
-    default: '${{ github.workspace }}/blender-install'
+    required: true
 
 runs:
   using: "composite"
   steps:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      if: runner.os == 'Windows'
       with:
         arch: amd64
 
-    - name: Setup environment
+    - name: Setup environment (Windows)
       shell: powershell
       if: runner.os == 'Windows'
       env:
@@ -42,8 +42,24 @@ runs:
         echo "LIB=$env:LIB;$env:SYCL_DIR_INPUT\lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "CMAKE_EXTRA_ARGS=-DWITH_WINDOWS_SCCACHE=ON" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-    - name: Checkout Blender
+    - name: Setup environment (Linux)
       shell: bash
+      if: runner.os == 'Linux'
+      env:
+        CCACHE_DIR_INPUT: ${{ inputs.ccache_dir }}
+      run: |
+        echo "CCACHE_DIR=$CCACHE_DIR_INPUT" >> $GITHUB_ENV
+        echo "CCACHE_MAXSIZE=10G" >> $GITHUB_ENV
+        echo "CMAKE_EXTRA_ARGS=-DWITH_COMPILER_CCACHE=ON" >> $GITHUB_ENV
+
+        # The default GCC in the container is 13 but Blender requires 14 or later.
+        # 14 is already installed, just not default.
+        echo "CC=gcc-14" >> $GITHUB_ENV
+        echo "CXX=g++-14" >> $GITHUB_ENV
+
+    - name: Checkout Blender (Windows)
+      shell: bash
+      if: runner.os == 'Windows'
       env:
         EMBREE_DIR_INPUT: ${{ inputs.embree_dir }}
         OIDN_DIR_INPUT: ${{ inputs.oidn_dir }}
@@ -58,8 +74,24 @@ runs:
        # CMake seems to override PATH leading to this file not being found by llvm-spirv.
        cp "$(which SPIRV-Tools-shared.dll)" "$SYCL_DIR_INPUT/bin/"
 
-       # Apply source patches.
-       patch -p1 -d blender-src -i "${{ github.action_path }}/patches/Fix-build.patch"
+    - name: Checkout Blender (Linux)
+      shell: bash
+      if: runner.os == 'Linux'
+      env:
+        EMBREE_DIR_INPUT: ${{ inputs.embree_dir }}
+        OIDN_DIR_INPUT: ${{ inputs.oidn_dir }}
+        SYCL_DIR_INPUT: ${{ inputs.sycl_dir }}
+      run: |
+       unzip /opt/blender_5_1_0.zip -d .
+       mv blender blender-src
+       # Work around CMake issue using preinstalled Embree/OIDN.
+       cp -r "$EMBREE_DIR_INPUT" "blender-src/lib/linux_x64/embree"
+       cp -r "$OIDN_DIR_INPUT" "blender-src/lib/linux_x64/OpenImageDenoise"
+
+    - name: Apply source patches
+      shell: bash
+      run: |
+       patch -p1 -d blender-src -i "$GITHUB_WORKSPACE/devops/actions/blender/blender-build/patches/Fix-build.patch"
 
     - name: Configure Blender
       shell: bash
@@ -70,12 +102,30 @@ runs:
         EMBREE_DIR_INPUT: ${{ inputs.embree_dir }}
         LEVEL_ZERO_DIR_INPUT: ${{ inputs.level_zero_dir }}
       run: |
-        # Unify the path style to avoid CMake issues.
-        INSTALL_PREFIX=$(cygpath -m "$INSTALL_PREFIX_INPUT")
-        SYCL_DIR=$(cygpath -m "$SYCL_DIR_INPUT")
-        OIDN_DIR=$(cygpath -m "$OIDN_DIR_INPUT")
-        EMBREE_DIR=$(cygpath -m "$EMBREE_DIR_INPUT")
-        LEVEL_ZERO_DIR=$(cygpath -m "$LEVEL_ZERO_DIR_INPUT")
+        EXTRA_CMAKE_ARGS=""
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          # Unify the path style to avoid CMake issues (Windows needs cygpath).
+          INSTALL_PREFIX=$(cygpath -m "$INSTALL_PREFIX_INPUT")
+          SYCL_DIR=$(cygpath -m "$SYCL_DIR_INPUT")
+          OIDN_DIR=$(cygpath -m "$OIDN_DIR_INPUT")
+          EMBREE_DIR=$(cygpath -m "$EMBREE_DIR_INPUT")
+          LEVEL_ZERO_DIR=$(cygpath -m "$LEVEL_ZERO_DIR_INPUT")
+        else
+          # We aren't using the GUI so disable X11 dependencies.
+          EXTRA_CMAKE_ARGS="-DWITH_X11_XINPUT=OFF -DWITH_X11_XFIXES=OFF -DWITH_X11_ALPHA=OFF"
+
+          # The paths are all the same on Linux so just pass through the inputs.
+          INSTALL_PREFIX="$INSTALL_PREFIX_INPUT"
+          SYCL_DIR="$SYCL_DIR_INPUT"
+          OIDN_DIR="$OIDN_DIR_INPUT"
+          EMBREE_DIR="$EMBREE_DIR_INPUT"
+          LEVEL_ZERO_DIR="$LEVEL_ZERO_DIR_INPUT"
+        fi
+
+        LEVEL_ZERO_ARGS=""
+        if [[ -n "$LEVEL_ZERO_DIR" ]]; then
+          LEVEL_ZERO_ARGS="-DLEVEL_ZERO_ROOT_DIR=$LEVEL_ZERO_DIR"
+        fi
 
         cmake -GNinja -B blender-build -S blender-src \
           $CMAKE_EXTRA_ARGS \
@@ -85,13 +135,14 @@ runs:
           -DWITH_CYCLES_DEVICE_ONEAPI=ON \
           -DOPENIMAGEDENOISE_ROOT_DIR="$OIDN_DIR" \
           -DEMBREE_ROOT_DIR="$EMBREE_DIR" \
-          -DLEVEL_ZERO_ROOT_DIR="$LEVEL_ZERO_DIR" \
+          $LEVEL_ZERO_ARGS \
           -DWITH_CYCLES_EMBREE=ON \
           -DEMBREE_SYCL_SUPPORT=ON \
           -DWITH_OPENIMAGEDENOISE=ON \
           -DWITH_CYCLES_DEVICE_HIP=OFF \
           -DWITH_CYCLES_DEVICE_CUDA=OFF \
-          -DWITH_CYCLES_DEVICE_OPTIX=OFF
+          -DWITH_CYCLES_DEVICE_OPTIX=OFF \
+          $EXTRA_CMAKE_ARGS
 
     - name: Build Blender
       shell: bash
@@ -102,7 +153,7 @@ runs:
       run: cmake --install blender-build --config Release
 
     - name: Cleanup
-      shell: cmd
+      shell: bash
       if: always()
       run: |
-        rmdir /q /s blender-build blender-src
+        rm -rf blender-build blender-src

--- a/devops/actions/blender/blender-demo/action.yml
+++ b/devops/actions/blender/blender-demo/action.yml
@@ -5,17 +5,35 @@ inputs:
   blender_dir:
     description: 'Blender installation directory'
     required: true
-  blender_classroom_dir:
-    description: 'Blender classroom demo directory'
-    required: true
 runs:
   using: "composite"
   steps:
+    - name: Download Classroom Demo
+      shell: bash
+      run: |
+        CLASSROOM_URL="https://download.blender.org/demo/test/classroom.zip"
+        curl -L -o classroom.zip "$CLASSROOM_URL"
+        unzip -q classroom.zip
+        CLASSROOM_DIR="$PWD/classroom"
+        echo "CLASSROOM_DIR=$CLASSROOM_DIR" >> $GITHUB_ENV
+
+    - name: Setup environment (Linux)
+      shell: bash
+      if: runner.os == 'Linux'
+      env:
+        CCACHE_DIR_INPUT: ${{ inputs.ccache_dir }}
+      run: |
+       echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OIDN_INSTALL_DIR/lib:$EMBREE_INSTALL_DIR/lib:$SYCL_INSTALL_DIR/lib:$BLENDER_INSTALL_DIR/lib" >> $GITHUB_ENV
+       # Shader compile takes ~20 minutes, so save the cache outside the Docker container so it can be reused.
+       # Entire program takes ~25 seconds with the cache.
+       # Windows doesn't use a container so we don't need to do anything.
+       echo "SYCL_CACHE_DIR=/__w/shader_cache/sycl" >> $GITHUB_ENV
+       echo "NEO_CACHE_DIR=/__w/shader_cache/level_zero" >> $GITHUB_ENV
+
     - name: Render Classroom Scene
       shell: bash
       env:
         BLENDER_DIR: ${{ inputs.blender_dir }}
-        CLASSROOM_DIR: ${{ inputs.blender_classroom_dir }}
+        BLENDER_EXE: blender${{ runner.os == 'Windows' && '.exe' || '' }}
       run: |
-        BLENDER_EXE="$BLENDER_DIR/blender$([[ "${{ runner.os }}" == "Windows" ]] && echo ".exe")"
-        "$BLENDER_EXE" -b -noaudio --debug-cycles --verbose 3 --engine CYCLES "$CLASSROOM_DIR/classroom.blend" -f 1 -- --cycles-device ONEAPI
+        "$BLENDER_DIR/$BLENDER_EXE" -b -noaudio --debug-cycles --verbose 3 --engine CYCLES "$CLASSROOM_DIR/classroom.blend" -f 1 -- --cycles-device ONEAPI

--- a/devops/actions/blender/embree/action.yml
+++ b/devops/actions/blender/embree/action.yml
@@ -4,8 +4,7 @@ description: 'Clone and build Embree for Intel GPU with SYCL support'
 inputs:
   cmake_install_prefix:
     description: 'CMAKE_INSTALL_PREFIX for Embree build'
-    required: false
-    default: '${{ github.workspace }}/embree-install'
+    required: true
   c_compiler:
     description: 'Path to C compiler'
     required: true
@@ -17,6 +16,7 @@ runs:
   using: "composite"
   steps:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      if: runner.os == 'Windows'
       with:
         arch: amd64
 
@@ -26,13 +26,18 @@ runs:
         repository: 'RenderKit/embree'
         ref: 'v4.4.0'
         path: 'embree-src'
-        cache_path: "D:\\\\github\\\\_work\\\\repo_cache\\\\"
+        cache_path: ${{ runner.os == 'Windows' && 'D:\\github\\_work\\repo_cache\\' || '/__w/repo_cache/' }}
 
     - name: Update Embree Submodules
       shell: bash
       run: |
         cd embree-src
         git submodule update --init --recursive
+
+    - name: Apply source patches
+      shell: bash
+      run: |
+        patch -p1 -d embree-src -i "$GITHUB_WORKSPACE/devops/actions/blender/embree/patches/Fix-build.patch"
 
     - name: Configure Embree
       shell: bash
@@ -59,7 +64,7 @@ runs:
       run: cmake --install embree-build --config Release
 
     - name: Cleanup
-      shell: cmd
+      shell: bash
       if: always()
       run: |
-        rmdir /q /s embree-build embree-src
+        rm -rf embree-build embree-src

--- a/devops/actions/blender/embree/patches/Fix-build.patch
+++ b/devops/actions/blender/embree/patches/Fix-build.patch
@@ -1,0 +1,33 @@
+From b5a7bc268d968dd5f289c08612dcff52aa8a921e Mon Sep 17 00:00:00 2001
+From: Nick Sarnie <nick.sarnie@intel.com>
+Date: Tue, 5 May 2026 07:54:47 -0700
+Subject: [PATCH] Remove unused subgroup functions
+
+These are unused and cause compiler errors.
+
+Signed-off-by: Nick Sarnie <nick.sarnie@intel.com>
+---
+ common/sys/sycl.h | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/common/sys/sycl.h b/common/sys/sycl.h
+index 6bef829fc..a8b7c95a6 100644
+--- a/common/sys/sycl.h
++++ b/common/sys/sycl.h
+@@ -281,14 +281,6 @@ namespace embree
+   template <typename T, class BinaryOperation> __forceinline T sub_group_inclusive_scan(T x, BinaryOperation binary_op, T init) {
+     return sycl::inclusive_scan_over_group(this_sub_group(),x,binary_op,init);
+   }
+-
+-  template <typename T> __forceinline T sub_group_load(const void* src) {
+-    return this_sub_group().load(sycl::multi_ptr<T,sycl::access::address_space::global_space>((T*)src));
+-  }
+-
+-  template <typename T> __forceinline void sub_group_store(void* dst, const T& x) {
+-    this_sub_group().store(sycl::multi_ptr<T,sycl::access::address_space::global_space>((T*)dst),x);
+-  }
+ }
+ 
+ #if __SYCL_COMPILER_VERSION < 20210801
+-- 
+2.53.0

--- a/devops/actions/blender/oidn/action.yml
+++ b/devops/actions/blender/oidn/action.yml
@@ -4,8 +4,7 @@ description: 'Clone and build OIDN for Intel GPU with SYCL support'
 inputs:
   cmake_install_prefix:
     description: 'CMAKE_INSTALL_PREFIX for OIDN build'
-    required: false
-    default: '${{ github.workspace }}/oidn-install'
+    required: true
   c_compiler:
     description: 'Path to C compiler'
     required: true
@@ -17,8 +16,13 @@ runs:
   using: "composite"
   steps:
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      if: runner.os == 'Windows'
       with:
         arch: amd64
+
+    - name: Source OneAPI TBB vars.sh
+      if: runner.os == 'Linux'
+      uses: ./devops/actions/source-tbb
 
     - name: Checkout OIDN
       uses: ./devops/actions/cached_checkout
@@ -26,7 +30,7 @@ runs:
         repository: 'RenderKit/oidn'
         ref: 'fbd9370fe3f863400dc201ce7115d2e7be0d0cb4' # Switch to release branch after next release, see https://github.com/intel/llvm/issues/21893
         path: 'oidn-src'
-        cache_path: "D:\\\\github\\\\_work\\\\repo_cache\\\\"
+        cache_path: ${{ runner.os == 'Windows' && 'D:\\github\\_work\\repo_cache\\' || '/__w/repo_cache/' }}
 
     - name: Update OIDN Submodules
       shell: bash
@@ -59,7 +63,7 @@ runs:
       run: cmake --install oidn-build --config Release
 
     - name: Cleanup
-      shell: cmd
+      shell: bash
       if: always()
       run: |
-        rmdir /q /s oidn-build oidn-src
+        rm -rf oidn-build oidn-src


### PR DESCRIPTION
We already have a Windows run, add one for Linux.

Nightly run: https://github.com/intel/llvm/actions/runs/25560879393/job/75049389576

Signed-off-by: Nick Sarnie <nick.sarnie@intel.com>