### PR TITLE
[SYCL][NVPTX][AMDGPU] Use __builtin_nearbyint in cmath wrapper

### DIFF
--- a/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
+++ b/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
@@ -199,16 +199,9 @@ __SYCL_SPIRV_MAP_UNARY_C(rint);
 // unsupported: lrint, llrint (no spirv mapping)
 
 // unsupported (partially, no spirv mapping): nearbyint
-#if defined(__NVPTX__)
-extern "C" SYCL_EXTERNAL float __nv_nearbyintf(float);
-extern "C" SYCL_EXTERNAL double __nv_nearbyint(double);
-__SYCL_DEVICE_C float nearbyintf(float x) { return __nv_nearbyintf(x); }
-__SYCL_DEVICE_C double nearbyint(double x) { return __nv_nearbyintf(x); }
-#elif defined(__AMDGCN__)
-extern "C" SYCL_EXTERNAL float __ocml_nearbyint_f32(float);
-extern "C" SYCL_EXTERNAL double __ocml_nearbyint_f64(double);
-__SYCL_DEVICE_C float nearbyintf(float x) { return __ocml_nearbyint_f32(x); }
-__SYCL_DEVICE_C double nearbyint(double x) { return __ocml_nearbyint_f64(x); }
+#if defined(__NVPTX__) || defined(__AMDGCN__)
+__SYCL_DEVICE_C float nearbyintf(float x) { return __builtin_nearbyintf(x); }
+__SYCL_DEVICE_C double nearbyint(double x) { return __builtin_nearbyint(x); }
 #endif
 
 /// Floating-point manipulation functions
@@ -389,14 +382,8 @@ __SYCL_SPIRV_MAP_UNARY_CXX(rint);
 #if defined(__NVPTX__) || defined(__AMDGCN__)
 using ::nearbyint;
 using ::nearbyintf;
-#endif
 
-#if defined(__NVPTX__)
-__SYCL_DEVICE float nearbyint(float x) { return __nv_nearbyintf(x); }
-#endif
-
-#if defined(__AMDGCN__)
-__SYCL_DEVICE float nearbyint(float x) { return __ocml_nearbyint_f32(x); }
+__SYCL_DEVICE float nearbyint(float x) { return __builtin_nearbyintf(x); }
 #endif
 
 // Floating-point manipulation functions

--- a/sycl/test/regression/include_cmath_no_rdc.cpp
+++ b/sycl/test/regression/include_cmath_no_rdc.cpp
@@ -1,9 +1,5 @@
-// REQUIRES: cuda || hip
-
-// RUN: %if cuda %{ %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fsycl-device-only -fno-sycl-rdc %s %}
-// RUN: %if cuda %{ %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fsycl-device-only -fsycl-rdc    %s %}
-// RUN: %if hip  %{ %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa   -fsycl-device-only -fno-sycl-rdc %s %}
-// RUN: %if hip  %{ %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa   -fsycl-device-only -fsycl-rdc    %s %}
+// RUN: %clangxx -fsycl -fsycl-rdc    -fsycl-targets=%sycl_triple -fsycl-device-only -fsyntax-only %s
+// RUN: %clangxx -fsycl -fno-sycl-rdc -fsycl-targets=%sycl_triple -fsycl-device-only -fsyntax-only %s
 
 #include <cmath>
 

--- a/sycl/test/regression/include_cmath_no_rdc.cpp
+++ b/sycl/test/regression/include_cmath_no_rdc.cpp
@@ -1,0 +1,10 @@
+// REQUIRES: cuda || hip
+
+// RUN: %if cuda %{ %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fsycl-device-only -fno-sycl-rdc %s %}
+// RUN: %if cuda %{ %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fsycl-device-only -fsycl-rdc    %s %}
+// RUN: %if hip  %{ %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa   -fsycl-device-only -fno-sycl-rdc %s %}
+// RUN: %if hip  %{ %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa   -fsycl-device-only -fsycl-rdc    %s %}
+
+#include <cmath>
+
+int main() {}


### PR DESCRIPTION
Instead of using `__nv_nearbyint` and `__ocml_nearbyint` from device libraries, use `__builtin_nearbyint` in the cmath wrapper. Both targets have native support for nearbyint so we don't need to call out to the device library. Both CUDA and HIP compilation already does this in `__clang_{cuda,hip}_math.h`. We can then also remove `SYCL_EXTERNAL` use from this header, to fix #21652.

Fixes #21652.