### PR TITLE
[SYCL][Graph] Align spec and implementation for native recording mode

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -2623,7 +2623,7 @@ exception if attempted:
 
 | Out-of-order queue
 | Native recording requires an in-order queue backed by an immediate command list.
-| `invalid`
+| `feature_not_supported`
 
 |===
 

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -823,7 +823,7 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
 
   // Native recording limitation: in-order queues only
   if (MNativeGraphHandle && !Queue.isInOrder()) {
-    throw sycl::exception(make_error_code(errc::feature_not_supported),
+    throw sycl::exception(make_error_code(errc::invalid),
                           "Native recording only works with in-order queues");
   }
 
@@ -1094,6 +1094,11 @@ exec_graph_impl::exec_graph_impl(sycl::context Context,
   // Create native UR executable graph if the modifiable graph uses native
   // recording
   if (isNativeRecordingEnabledForGraph(*GraphImpl)) {
+    if (MIsUpdatable) {
+      throw sycl::exception(
+          sycl::make_error_code(errc::feature_not_supported),
+          "Updatable graphs are not supported in native recording mode");
+    }
     context_impl &ContextImpl = *sycl::detail::getSyclObjImpl(MContext);
     sycl::detail::adapter_impl &Adapter = ContextImpl.getAdapter();
     ur_result_t Result =
@@ -1649,12 +1654,6 @@ void exec_graph_impl::duplicateNodes() {
 }
 
 void exec_graph_impl::update(std::shared_ptr<graph_impl> GraphImpl) {
-  if (MNativeExecutableGraphHandle) {
-    throw sycl::exception(
-        sycl::make_error_code(errc::feature_not_supported),
-        "Graph update is not supported in native recording mode");
-  }
-
   if (MDevice != GraphImpl->getDevice()) {
     throw sycl::exception(
         sycl::make_error_code(errc::invalid),
@@ -1726,11 +1725,6 @@ void exec_graph_impl::update(node_impl &Node) {
 }
 
 void exec_graph_impl::update(nodes_range Nodes) {
-  if (MNativeExecutableGraphHandle) {
-    throw sycl::exception(
-        sycl::make_error_code(errc::feature_not_supported),
-        "Graph update is not supported in native recording mode");
-  }
   if (!MIsUpdatable) {
     throw sycl::exception(sycl::make_error_code(errc::invalid),
                           "update() cannot be called on a executable graph "

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -823,7 +823,7 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
 
   // Native recording limitation: in-order queues only
   if (MNativeGraphHandle && !Queue.isInOrder()) {
-    throw sycl::exception(make_error_code(errc::invalid),
+    throw sycl::exception(make_error_code(errc::feature_not_supported),
                           "Native recording only works with in-order queues");
   }
 

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_out_of_order_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_out_of_order_queue.cpp
@@ -18,7 +18,7 @@ int main() {
 
   if (!expectException([&]() { Graph.begin_recording(OutOfOrderQueue); },
                        "begin_recording with out-of-order queue",
-                       sycl::errc::feature_not_supported)) {
+                       sycl::errc::invalid)) {
     std::cerr << "Out-of-order queue should throw exception" << std::endl;
     return 1;
   }

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_out_of_order_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_out_of_order_queue.cpp
@@ -18,7 +18,7 @@ int main() {
 
   if (!expectException([&]() { Graph.begin_recording(OutOfOrderQueue); },
                        "begin_recording with out-of-order queue",
-                       sycl::errc::invalid)) {
+                       sycl::errc::feature_not_supported)) {
     std::cerr << "Out-of-order queue should throw exception" << std::endl;
     return 1;
   }

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_update.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_update.cpp
@@ -5,7 +5,8 @@
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-// Test that update() throws when called on a graph in native recording mode
+// Test that finalize() throws when both enable_native_recording and updatable
+// properties are set on the same graph.
 
 #include "../../graph_common.hpp"
 
@@ -28,18 +29,9 @@ int main() {
   });
   Graph.end_recording();
 
-  auto ExecGraph = Graph.finalize({exp_ext::property::graph::updatable{}});
-
-  if (!expectException([&]() { ExecGraph.update(Graph); },
-                       "update(graph) with native recording enabled",
-                       sycl::errc::feature_not_supported)) {
-    free(Data, Queue);
-    return 1;
-  }
-
   if (!expectException(
-          [&]() { ExecGraph.update(std::vector<exp_ext::node>{}); },
-          "update(nodes) with native recording enabled",
+          [&]() { Graph.finalize({exp_ext::property::graph::updatable{}}); },
+          "finalize() with enable_native_recording and updatable",
           sycl::errc::feature_not_supported)) {
     free(Data, Queue);
     return 1;


### PR DESCRIPTION
- Changed the exception thrown for out-of-order queues + native recording from `feature_not_supported` to `invalid`
- Throw `feature_not_supported` in `finalize()` for native recording instead of `update()`

Closes https://github.com/intel/llvm/issues/21920.