### PR TITLE
[SYCL][NewOffloadModel][E2E] adjust separate_compile.cpp test to SeparateCompile/test.cpp

### DIFF
--- a/sycl/test-e2e/NewOffloadDriver/separate_compile.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/separate_compile.cpp
@@ -23,7 +23,7 @@
 // RUN: %{run-aux} %clangxx --offload-new-driver -fsycl -fsycl-targets=spir64 -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT -DB_CPP=1 -fno-sycl-dead-args-optimization -c %s -o b.o -Wno-sycl-strict
 //
 // >> ---- link the full hetero app
-// RUN: %{run-aux} %clangxx --offload-new-driver -fsycl -fsycl-targets=spir64 a.o b.o -o app.exe %sycl_options
+// RUN: %{run-aux} %clangxx --offload-new-driver -Wno-unused-command-line-argument -fsycl -fsycl-targets=spir64 a.o b.o -o app.exe %sycl_options
 //
 // RUN: %{run} ./app.exe
 

--- a/sycl/test-e2e/NewOffloadDriver/separate_compile.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/separate_compile.cpp
@@ -24,7 +24,6 @@
 //
 // >> ---- link the full hetero app
 // RUN: %{run-aux} %clangxx --offload-new-driver -Wno-unused-command-line-argument -fsycl -fsycl-targets=spir64 a.o b.o -o app.exe %sycl_options
-//
 // RUN: %{run} ./app.exe
 
 #ifdef B_CPP


### PR DESCRIPTION
These 2 tests are related. However, the one for NewOffloadModel lost `-Wno-unused-command-line-argument` flag leading to compilation error in Windows environment.

fixes: CMPLRLLVM-74117