### PR TITLE
[UR][CTS] Add logging for optional queries

### DIFF
--- a/unified-runtime/include/unified-runtime/ur_api.h
+++ b/unified-runtime/include/unified-runtime/ur_api.h
@@ -2204,8 +2204,7 @@ typedef enum ur_device_info_t {
   /// It is unsuitable for general use in applications. This feature is
   /// provided for identifying memory leaks.
   UR_DEVICE_INFO_REFERENCE_COUNT = 64,
-  /// [char[]][optional-query] null-terminated IL version. Optional as not
-  /// all adapters support IL (e.g., NativeCPU).
+  /// [char[]][optional-query] null-terminated IL version.
   UR_DEVICE_INFO_IL_VERSION = 65,
   /// [char[]] null-terminated device name
   UR_DEVICE_INFO_NAME = 66,

--- a/unified-runtime/scripts/core/device.yml
+++ b/unified-runtime/scripts/core/device.yml
@@ -333,7 +333,7 @@ etors:
             The reference count returned should be considered immediately stale.
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: IL_VERSION
-      desc: "[char[]][optional-query] null-terminated IL version. Optional as not all adapters support IL (e.g., NativeCPU)."
+      desc: "[char[]][optional-query] null-terminated IL version."
     - name: NAME
       desc: "[char[]] null-terminated device name"
     - name: VENDOR

--- a/unified-runtime/test/conformance/testing/include/uur/checks.h
+++ b/unified-runtime/test/conformance/testing/include/uur/checks.h
@@ -92,9 +92,7 @@ inline bool stringPropertyIsValid(const char *property,
 #define EXPECT_SUCCESS(ACTUAL) EXPECT_EQ_RESULT(UR_RESULT_SUCCESS, ACTUAL)
 #endif
 
-// This macro is intended to be used for the first call to a GetInfo query, it
-// gracefully handles cases where the adapter doesn't support a query marked
-// [optional-query] in the spec by returning early.
+// Handles optional queries by skipping the test if the adapter doesn't support them.
 #ifndef ASSERT_SUCCESS_OR_OPTIONAL_QUERY
 #define ASSERT_SUCCESS_OR_OPTIONAL_QUERY(CALL, QUERY)                          \
   do {                                                                         \
@@ -102,7 +100,8 @@ inline bool stringPropertyIsValid(const char *property,
     if (result != UR_RESULT_SUCCESS) {                                         \
       ASSERT_EQ_RESULT(result, UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);       \
       ASSERT_TRUE(uur::isQueryOptional(QUERY));                                \
-      return;                                                                  \
+      GTEST_SKIP() << "Query " << #QUERY                                       \
+                   << " is not supported by this adapter";                     \
     }                                                                          \
   } while (0)
 #endif


### PR DESCRIPTION
Changing ASSERT_SUCCESS_OR_OPTIONAL_QUERY macro to use GTEST_SKIP()
  with descriptive message instead of silent return