### PR TITLE
[SYCL][E2E] Disable assert_in_simultaneously_multiple_tus.cpp on Gen12

### DIFF
--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
@@ -4,6 +4,9 @@
 // XFAIL: (opencl && gpu)
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/11364
 //
+// UNSUPPORTED: gpu-intel-gen12
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21023
+//
 // RUN: %{build} -I %S/Inputs %S/Inputs/kernels_in_file2.cpp -o %t.out %threads_lib
 //
 // Since this is a multi-threaded application enable memory tracking and


### PR DESCRIPTION
Sporadically times out on both Linux and Win. See GH [issue](https://github.com/intel/llvm/issues/21023).