### PR TITLE
[SYCL][E2E] Move vulkan_sycl_image_interop_write_2d_unsampled.cpp to UNSUPPORTED on Win BMG

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled.cpp
@@ -10,8 +10,8 @@
 // XFAIL: windows && gpu-intel-dg2
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21985
 
-// XFAIL: windows && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21986
+// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21986
 
 /*
     Run all the vulkan formats through a write test. Note this is unsampled


### PR DESCRIPTION
Seems to sporadically pass

https://github.com/intel/llvm/actions/runs/25757177551/job/75653694485