### PR TITLE
[SYCL][E2E] reenable bindless image 2D vulkan interop test on BMG Win.

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled.cpp
@@ -10,9 +10,6 @@
 // XFAIL: windows && gpu-intel-dg2
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21985
 
-// XFAIL: windows && arch-intel_gpu_bmg_g21
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21986
-
 /*
     Run all the vulkan formats through a write test. Note this is unsampled
    only, you can't "write" with the image sampler.


### PR DESCRIPTION
hooray, driver updated and test seems to be passing now on Win BMG. We can probably close https://github.com/intel/llvm/issues/21986