### PR TITLE
[UR] Fix isPVC() to handle unsupported UR_DEVICE_INFO_DEVICE_ID

### DIFF
--- a/unified-runtime/test/conformance/testing/include/uur/utils.h
+++ b/unified-runtime/test/conformance/testing/include/uur/utils.h
@@ -522,9 +522,11 @@ inline void isQueueBatched(ur_queue_handle_t queue, bool *info) {
 // when that is stable.
 static inline bool isPVC(ur_device_handle_t hDevice) {
   uint32_t deviceId;
-  EXPECT_EQ(urDeviceGetInfo(hDevice, UR_DEVICE_INFO_DEVICE_ID, sizeof(uint32_t),
-                            &deviceId, nullptr),
-            UR_RESULT_SUCCESS);
+  ur_result_t result = urDeviceGetInfo(hDevice, UR_DEVICE_INFO_DEVICE_ID,
+                                       sizeof(uint32_t), &deviceId, nullptr);
+  if (result != UR_RESULT_SUCCESS) {
+    return false;
+  }
   return (deviceId & 0xff0) == 0xbd0 || (deviceId & 0xff0) == 0xb60;
 }
 


### PR DESCRIPTION
The isPVC() utility used EXPECT_EQ which recorded a test failure when
the adapter does not support UR_DEVICE_INFO_DEVICE_ID (e.g. Native
CPU).  This caused the test to be marked FAILED even though it would
subsequently skip via GTEST_SKIP().

Return false instead of asserting when the query fails — if the adapter
cannot report a device ID, the device is clearly not a PVC.
