### PR TITLE
[UR][L0] Fix event_pool_test to properly release events through DDI table

### DIFF
--- a/unified-runtime/test/adapters/level_zero/v2/event_pool_test.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/event_pool_test.cpp
@@ -14,6 +14,7 @@
 
 #include "level_zero/common.hpp"
 #include "level_zero/device.hpp"
+#include "level_zero/ur_interface_loader.hpp"
 
 #include "../ze_helpers.hpp"
 #include "context.hpp"
@@ -37,8 +38,8 @@ using namespace v2;
 static constexpr size_t MAX_DEVICES = 10;
 
 const ur_dditable_t *ur::level_zero::ddi_getter::value() {
-  // Return a blank dditable
   static ur_dditable_t table{};
+  table.Event.pfnRelease = ur::level_zero::urEventRelease;
   return &table;
 };
 
@@ -147,6 +148,7 @@ struct EventPoolTest : public uur::urQueueTestWithParam<ProviderParams> {
   }
   void TearDown() override {
     cache.reset();
+    mockVec.clear();
     UUR_RETURN_ON_FATAL_FAILURE(urQueueTestWithParam::TearDown());
   }
 


### PR DESCRIPTION
The event_pool_test's mock DDI table was blank, causing urEventRelease
(called through the loader) to return UR_RESULT_ERROR_UNINITIALIZED
instead of actually releasing the event back to the pool. This made the
Basic and ProviderNormalUseMostFreePool tests fail because events were
never recycled.

Fix by populating the DDI table with the adapter's urEventRelease, and
clearing the global mockVec in TearDown to prevent cross-test pollution
between different device backends.