### PR TITLE
[SYCL][E2E] Disable vulkan_sycl_image_unsampled_timeline_semaphore.cpp on ARL

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_unsampled_timeline_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_unsampled_timeline_semaphore.cpp
@@ -2,7 +2,7 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan
 
-// UNSUPPORTED: linux && gpu-intel-dg2
+// UNSUPPORTED: linux && (gpu-intel-dg2 || arch-intel_gpu_mtl_u)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21764
 
 // XFAIL: windows && gpu-intel-dg2


### PR DESCRIPTION
Failing sporadically, see [here](https://github.com/intel/llvm/issues/21764#issuecomment-4437248742).