### PR TITLE
[SYCL] Fix use-after-free in ProgramManager::removeImages on dlclose

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1360,7 +1360,7 @@ ProgramManager::getDeviceImage(std::string_view KernelName,
   std::optional<kernel_id> FoundKernelID;
   {
     std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
-    if (auto It = m_DeviceKernelInfoMap.find(KernelName);
+    if (auto It = m_DeviceKernelInfoMap.find(std::string(KernelName));
         It != m_DeviceKernelInfoMap.end()) {
       FoundKernelID = It->second.getKernelID();
       Img = getBinImageFromMultiMap(m_KernelIDs2BinImage, *FoundKernelID,
@@ -1568,7 +1568,7 @@ void ProgramManager::cacheKernelWorkGroupDynamicLocalMem(
 DeviceKernelInfo &
 ProgramManager::getDeviceKernelInfo(const CompileTimeKernelInfoTy &Info) {
   std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
-  auto It = m_DeviceKernelInfoMap.find(Info.Name);
+  auto It = m_DeviceKernelInfoMap.find(std::string(Info.Name));
   assert(It != m_DeviceKernelInfoMap.end());
   It->second.setCompileTimeInfoIfNeeded(Info);
   return It->second;
@@ -1577,7 +1577,7 @@ ProgramManager::getDeviceKernelInfo(const CompileTimeKernelInfoTy &Info) {
 DeviceKernelInfo &
 ProgramManager::getDeviceKernelInfo(std::string_view KernelName) {
   std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
-  auto It = m_DeviceKernelInfoMap.find(KernelName);
+  auto It = m_DeviceKernelInfoMap.find(std::string(KernelName));
   assert(It != m_DeviceKernelInfoMap.end());
   return It->second;
 }
@@ -1585,7 +1585,7 @@ ProgramManager::getDeviceKernelInfo(std::string_view KernelName) {
 DeviceKernelInfo *
 ProgramManager::tryGetDeviceKernelInfo(std::string_view KernelName) {
   std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
-  auto It = m_DeviceKernelInfoMap.find(KernelName);
+  auto It = m_DeviceKernelInfoMap.find(std::string(KernelName));
   return It != m_DeviceKernelInfoMap.end() ? &It->second : nullptr;
 }
 
@@ -1778,7 +1778,7 @@ void ProgramManager::addImage(sycl_device_binary RawImg,
     if (m_ExportedSymbolImages.find(name) != m_ExportedSymbolImages.end())
       continue;
 
-    auto It = m_DeviceKernelInfoMap.find(std::string_view(name));
+    auto It = m_DeviceKernelInfoMap.find(name);
     if (It == m_DeviceKernelInfoMap.end()) {
       sycl::kernel_id KernelID = detail::createSyclObjFromImpl<sycl::kernel_id>(
           std::make_shared<detail::kernel_id_impl>(name));
@@ -1920,7 +1920,7 @@ void ProgramManager::removeImages(sycl_device_binaries DeviceBinary) {
         continue;
       }
 
-      auto DKIIt = m_DeviceKernelInfoMap.find(Name);
+      auto DKIIt = m_DeviceKernelInfoMap.find(std::string(Name));
       assert(DKIIt != m_DeviceKernelInfoMap.end());
       removeFromMultimapByVal(m_KernelIDs2BinImage, DKIIt->second.getKernelID(),
                               Img);
@@ -2052,8 +2052,7 @@ std::vector<kernel_id> ProgramManager::getAllSYCLKernelIDs() {
 
   std::vector<sycl::kernel_id> AllKernelIDs;
   AllKernelIDs.reserve(m_DeviceKernelInfoMap.size());
-  for (const std::pair<const std::string_view, DeviceKernelInfo> &Pair :
-       m_DeviceKernelInfoMap) {
+  for (const auto &Pair : m_DeviceKernelInfoMap) {
     AllKernelIDs.push_back(Pair.second.getKernelID());
   }
   return AllKernelIDs;

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -223,7 +223,7 @@ public:
   tryGetSYCLKernelID(std::string_view KernelName) const {
     std::lock_guard<std::mutex> Guard(m_DeviceKernelInfoMapMutex);
 
-    auto It = m_DeviceKernelInfoMap.find(KernelName);
+    auto It = m_DeviceKernelInfoMap.find(std::string(KernelName));
     if (It == m_DeviceKernelInfoMap.end())
       return std::nullopt;
 
@@ -509,7 +509,9 @@ protected:
 
   // Map for storing device kernel information. Runtime lookup should be avoided
   // by caching the pointers when possible.
-  std::unordered_map<std::string_view, DeviceKernelInfo> m_DeviceKernelInfoMap;
+  // Uses std::string keys (not string_view) because the backing storage for
+  // kernel names lives in DSO offload tables that may be unmapped on dlclose.
+  std::unordered_map<std::string, DeviceKernelInfo> m_DeviceKernelInfoMap;
 
   // Protects m_DeviceKernelInfoMap.
   mutable std::mutex m_DeviceKernelInfoMapMutex;

--- a/sycl/unittests/program_manager/Cleanup.cpp
+++ b/sycl/unittests/program_manager/Cleanup.cpp
@@ -50,7 +50,7 @@ public:
     return NativePrograms;
   }
 
-  std::unordered_map<std::string_view, sycl::detail::DeviceKernelInfo> &
+  std::unordered_map<std::string, sycl::detail::DeviceKernelInfo> &
   getDeviceKernelInfoMap() {
     return m_DeviceKernelInfoMap;
   }


### PR DESCRIPTION
When multiple DSOs define kernels with the same name, m_DeviceKernelInfoMap shared a single entry keyed by a string_view pointing into the first DSO's offload table. After that DSO was dlclosed and unmapped, the dangling key caused a segfault on subsequent map lookups during the second dlclose.

Change the map key from std::string_view to std::string so ProgramManager owns the kernel name strings, matching the approach already used by m_ExportedSymbolImages.

Assisted-By: Claude Opus 4.6