### PR TITLE
Debug DX12 external semaphore test

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -33,6 +33,8 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <iomanip>
+#include <sstream>
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 #include <detail/xpti_registry.hpp>
@@ -856,6 +858,7 @@ void Command::emitInstrumentation(uint16_t Type, const char *Txt) {
 
 bool Command::enqueue(EnqueueResultT &EnqueueResult, BlockingT Blocking,
                       std::vector<Command *> &ToCleanUp) {
+  std::cerr << "[SYCL] ENTER: Command::enqueue(EnqueueResultT &, BlockingT, std::vector<Command *> &)\n";
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   // If command is enqueued from host task thread - it will not have valid
   // submission code location set. So we set it manually to properly trace
@@ -867,14 +870,19 @@ bool Command::enqueue(EnqueueResultT &EnqueueResult, BlockingT Blocking,
   }
 #endif
   // Exit if already enqueued
-  if (MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess)
+  if (MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess) {
+    std::cerr << "[SYCL]    -enqueue: Command is already enqueued(1), skipping enqueueing again.\n";
+    std::cerr << "[SYCL] LEAVE: Command::enqueue(EnqueueResultT &, BlockingT, std::vector<Command *> &) --> true\n";
     return true;
+  }
 
   // If the command is blocked from enqueueing
   if (MIsBlockable && MEnqueueStatus == EnqueueResultT::SyclEnqueueBlocked) {
     // Exit if enqueue type is not blocking
     if (!Blocking) {
       EnqueueResult = EnqueueResultT(EnqueueResultT::SyclEnqueueBlocked, this);
+      std::cerr << "[SYCL]    -enqueue: Command is blocked, skipping enqueueing.\n";
+      std::cerr << "[SYCL] LEAVE: Command::enqueue(EnqueueResultT &, BlockingT, std::vector<Command *> &) --> false\n";
       return false;
     }
 
@@ -888,6 +896,7 @@ bool Command::enqueue(EnqueueResultT &EnqueueResult, BlockingT Blocking,
 #endif
 
     // Wait if blocking
+    std::cerr << "[SYCL]    -enqueue: Command is blocked, waiting for it to  be unblocked.\n";
     while (MEnqueueStatus == EnqueueResultT::SyclEnqueueBlocked)
       ;
 #ifdef XPTI_ENABLE_INSTRUMENTATION
@@ -898,8 +907,11 @@ bool Command::enqueue(EnqueueResultT &EnqueueResult, BlockingT Blocking,
   std::lock_guard<std::mutex> Lock(MEnqueueMtx);
 
   // Exit if the command is already enqueued
-  if (MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess)
+  if (MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess) {
+    std::cerr << "[SYCL]    -enqueue: Command is already enqueued(2), skipping enqueueing again.\n";
+    std::cerr << "[SYCL] LEAVE: Command::enqueue(EnqueueResultT &, BlockingT, std::vector<Command *> &) --> true\n";
     return true;
+  }
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   emitInstrumentation(xpti::trace_task_begin, nullptr);
@@ -907,6 +919,8 @@ bool Command::enqueue(EnqueueResultT &EnqueueResult, BlockingT Blocking,
 
   if (MEnqueueStatus == EnqueueResultT::SyclEnqueueFailed) {
     EnqueueResult = EnqueueResultT(EnqueueResultT::SyclEnqueueFailed, this);
+    std::cerr << "[SYCL]    -enqueue: enqueue failed.\n";
+    std::cerr << "[SYCL] LEAVE: Command::enqueue(EnqueueResultT &, BlockingT, std::vector<Command *> &) --> false\n";
     return false;
   }
 
@@ -915,7 +929,9 @@ bool Command::enqueue(EnqueueResultT &EnqueueResult, BlockingT Blocking,
   // This will avoid execution of the same failed command twice.
   MEnqueueStatus = EnqueueResultT::SyclEnqueueFailed;
   MShouldCompleteEventIfPossible = true;
+  std::cerr << "[SYCL]    -enqueue: calling enqueue implementation.\n";
   ur_result_t Res = enqueueImp();
+  std::cerr << "[SYCL]    -enqueue: enqueue implementation finished --> result = " << static_cast<int>(Res) << ".\n";
 
   if (UR_RESULT_SUCCESS != Res)
     EnqueueResult =
@@ -3118,14 +3134,22 @@ ur_result_t ExecCGCommand::enqueueImpCommandBuffer() {
 }
 
 ur_result_t ExecCGCommand::enqueueImp() {
+  std::cerr << "[SYCL] ENTER: ExecCGCommand::enqueueImp()\n";
   if (MCommandBuffer) {
-    return enqueueImpCommandBuffer();
+    std::cerr << "[SYCL]    -enqueueImp: Using command buffer.\n";
+    ur_result_t ret = enqueueImpCommandBuffer();
+    std::cerr << "[SYCL] LEAVE: ExecCGCommand::enqueueImp() --> " << static_cast<int>(ret) << ".\n";
+    return ret;
   } else {
-    return enqueueImpQueue();
+    std::cerr << "[SYCL]    -enqueueImp: Using queue.\n";
+    ur_result_t ret = enqueueImpQueue();
+    std::cerr << "[SYCL] LEAVE: ExecCGCommand::enqueueImp() --> " << static_cast<int>(ret) << ".\n";
+    return ret;
   }
 }
 
 ur_result_t ExecCGCommand::enqueueImpQueue() {
+  std::cerr << "[SYCL] ENTER: ExecCGCommand::enqueueImpQueue()\n";
   if (getCG().getType() != CGType::CodeplayHostTask)
     waitForPreparedHostEvents();
   std::vector<EventImplPtr> EventImpls = MPreparedDepsEvents;
@@ -3145,6 +3169,7 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     }
   };
 
+  std::cerr << "[SYCL]    -enqueueImpQueue: Submitting command group of type " << static_cast<int>(MCommandGroup->getType()) << "\n";
   switch (MCommandGroup->getType()) {
 
   case CGType::UpdateHost: {
@@ -3672,6 +3697,7 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
   case CGType::SemaphoreWait: {
     assert(MQueue &&
            "Semaphore wait submissions should have an associated queue");
+    std::cerr << "[SYCL]    -enqueueImpQueue: processing semaphore wait\n";
     CGSemaphoreWait *SemWait = (CGSemaphoreWait *)MCommandGroup.get();
     detail::adapter_impl &Adapter = MQueue->getAdapter();
     auto OptWaitValue = SemWait->getWaitValue();
@@ -3682,16 +3708,19 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
             MQueue->getHandleRef(), SemWait->getExternalSemaphore(),
             OptWaitValue.has_value(), WaitValue, RawEvents.size(),
             RawEvents.data(), Event);
-        Result != UR_RESULT_SUCCESS)
+        Result != UR_RESULT_SUCCESS) {
+      std::cerr << "[SYCL] LEAVE: ExecCGCommand::enqueueImpQueue() --> " << static_cast<int>(Result) << "\n";
       return Result;
-
+    }
     SetEventHandleOrDiscard();
 
+    std::cerr << "[SYCL] LEAVE: ExecCGCommand::enqueueImpQueue() --> UR_RESULT_SUCCESS\n";
     return UR_RESULT_SUCCESS;
   }
   case CGType::SemaphoreSignal: {
     assert(MQueue &&
            "Semaphore signal submissions should have an associated queue");
+    std::cerr << "[SYCL]    -enqueueImpQueue: processing semaphore signal\n";
     CGSemaphoreSignal *SemSignal = (CGSemaphoreSignal *)MCommandGroup.get();
     detail::adapter_impl &Adapter = MQueue->getAdapter();
     auto OptSignalValue = SemSignal->getSignalValue();
@@ -3702,11 +3731,13 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
             MQueue->getHandleRef(), SemSignal->getExternalSemaphore(),
             OptSignalValue.has_value(), SignalValue, RawEvents.size(),
             RawEvents.data(), Event);
-        Result != UR_RESULT_SUCCESS)
+        Result != UR_RESULT_SUCCESS) {
+      std::cerr << "[SYCL] LEAVE: ExecCGCommand::enqueueImpQueue() --> " << static_cast<int>(Result) << "\n";
       return Result;
-
+    }
     SetEventHandleOrDiscard();
 
+    std::cerr << "[SYCL] LEAVE: ExecCGCommand::enqueueImpQueue() --> UR_RESULT_SUCCESS\n";
     return UR_RESULT_SUCCESS;
   }
   case CGType::AsyncAlloc: {

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -12,10 +12,29 @@
 
 #include <memory>
 #include <vector>
+#include <iostream>
 
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
+
+// Using the names being generated and the string are subject to change to
+// something more meaningful to end-users as this will be visible in analysis
+// tools that subscribe to this data
+static std::string commandToName(Command::CommandType Type) {
+  switch (Type) {
+  case Command::CommandType::RUN_CG            : return "Command Group Action";
+  case Command::CommandType::COPY_MEMORY       : return "Memory Transfer (Copy)";
+  case Command::CommandType::ALLOCA            : return "Memory Allocation";
+  case Command::CommandType::ALLOCA_SUB_BUF    : return "Sub Buffer Creation";
+  case Command::CommandType::RELEASE           : return "Memory Deallocation";
+  case Command::CommandType::MAP_MEM_OBJ       : return "Memory Transfer (Map)";
+  case Command::CommandType::UNMAP_MEM_OBJ     : return "Memory Transfer (Unmap)";
+  case Command::CommandType::UPDATE_REQUIREMENT: return "Host Accessor Creation/Buffer Lock";
+  case Command::CommandType::EMPTY_TASK        : return "Host Accessor Destruction/Buffer Lock Release";
+  default: return "Unknown Action";
+  }
+}
 
 void Scheduler::GraphProcessor::waitForEvent(event_impl &Event,
                                              ReadLockT &GraphReadLock,
@@ -32,7 +51,7 @@ void Scheduler::GraphProcessor::waitForEvent(event_impl &Event,
       enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd, BLOCKING);
   if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
     // TODO: Reschedule commands.
-    throw exception(make_error_code(errc::runtime), "Enqueue process failed.");
+    throw exception(make_error_code(errc::runtime), "Enqueue process failed(0).");
 
   assert(Cmd->getEvent().get() == &Event);
 
@@ -69,24 +88,39 @@ bool Scheduler::GraphProcessor::enqueueCommand(
     Command *Cmd, ReadLockT &GraphReadLock, EnqueueResultT &EnqueueResult,
     std::vector<Command *> &ToCleanUp, Command *RootCommand,
     BlockingT Blocking) {
-  if (!Cmd)
+  std::cerr << "[SYCL] ENTER: Scheduler::GraphProcessor::enqueueCommand(Command *, ReadLockT &, ...)\n";
+  if (!Cmd) {
+    std::cerr << "[SYCL]    -enqueueCommand: Cmd is nullptr --> return true\n";
     return true;
-  if (Cmd->isSuccessfullyEnqueued())
-    return handleBlockingCmd(Cmd, EnqueueResult, RootCommand, Blocking);
+  }
+  std::cerr << "[SYCL]    -enqueueCommand: Cmd = " << commandToName(Cmd->getType()) << "\n";
+  if (Cmd->isSuccessfullyEnqueued()) {
+    auto ret = handleBlockingCmd(Cmd, EnqueueResult, RootCommand, Blocking);
+    std::cerr << "[SYCL]    -enqueueCommand: Cmd is successfully enqueued --> \n";
+    std::cerr << "[SYCL] LEAVE: Scheduler::GraphProcessor::enqueueCommand(Command *, ReadLockT &, ...) --> " << (ret ? "true" : "false") << "\n";
+    return ret;
+  }
 
   // Exit early if the command is blocked and the enqueue type is non-blocking
   if (Cmd->isEnqueueBlocked() && !Blocking) {
     EnqueueResult = EnqueueResultT(EnqueueResultT::SyclEnqueueBlocked, Cmd);
+    std::cerr << "[SYCL]    -enqueueCommand: Cmd is enqueue blocked --> Result = {" << static_cast<int>(EnqueueResult.MResult) << ", " << static_cast<int>(EnqueueResult.MErrCode) << "}\n";
+    std::cerr << "[SYCL] LEAVE: Scheduler::GraphProcessor::enqueueCommand(Command *, ReadLockT &, ...) --> false\n";
     return false;
   }
 
   // Recursively enqueue all the implicit + explicit backend level dependencies
   // first and exit immediately if any of the commands cannot be enqueued.
   for (const EventImplPtr &Event : Cmd->getPreparedDepsEvents()) {
-    if (Command *DepCmd = Event->getCommand())
+    if (Command *DepCmd = Event->getCommand()) {
+      std::cerr << "[SYCL]    -enqueueCommand: enqueueing backend dependency command --> " << (DepCmd ? commandToName(DepCmd->getType()) : "nullptr") << "\n";
       if (!enqueueCommand(DepCmd, GraphReadLock, EnqueueResult, ToCleanUp,
-                          RootCommand, Blocking))
+                          RootCommand, Blocking)) {
+        std::cerr << "[SYCL]    -enqueueCommand: failed to enqueue command --> Result = {" << static_cast<int>(EnqueueResult.MResult) << ", " << static_cast<int>(EnqueueResult.MErrCode) << "}\n";
+        std::cerr << "[SYCL] LEAVE: Scheduler::GraphProcessor::enqueueCommand(Command *, ReadLockT &, ...) --> false\n";
         return false;
+      }
+    }
   }
 
   // Recursively enqueue all the implicit + explicit host dependencies and
@@ -96,10 +130,15 @@ bool Scheduler::GraphProcessor::enqueueCommand(
   // MHostDepsEvents. TO FIX: implement enqueue of blocked commands on host task
   // completion stage and eliminate this event waiting in enqueue.
   for (const EventImplPtr &Event : Cmd->getPreparedHostDepsEvents()) {
-    if (Command *DepCmd = Event->getCommand())
+    if (Command *DepCmd = Event->getCommand()) {
+      std::cerr << "[SYCL]    -enqueueCommand: enqueueing host dependency command --> " << (DepCmd ? commandToName(DepCmd->getType()) : "nullptr") << "\n";
       if (!enqueueCommand(DepCmd, GraphReadLock, EnqueueResult, ToCleanUp,
-                          RootCommand, Blocking))
+                          RootCommand, Blocking)) {
+        std::cerr << "[SYCL]    -enqueueCommand: failed to enqueue command --> Result = {" << static_cast<int>(EnqueueResult.MResult) << ", " << static_cast<int>(EnqueueResult.MErrCode) << "}\n";
+        std::cerr << "[SYCL] LEAVE: Scheduler::GraphProcessor::enqueueCommand(Command *, ReadLockT &, ...) --> false\n";
         return false;
+      }
+    }
   }
 
   // Only graph read lock is to be held here.
@@ -115,9 +154,15 @@ bool Scheduler::GraphProcessor::enqueueCommand(
   // on completion of C and starts cleanup process. This thread is still in the
   // middle of enqueue of B. The other thread modifies dependency list of A by
   // removing C out of it. Iterators become invalid.
+  std::cerr << "[SYCL]    -enqueueCommand: enqueueing source command --> " << (Cmd ? commandToName(Cmd->getType()) : "nullptr") << "\n";
   bool Result = Cmd->enqueue(EnqueueResult, Blocking, ToCleanUp);
-  if (Result)
+  if (Result) {
+    std::cerr << "[SYCL]    -enqueueCommand: check if command blocks dependent commands\n";
     Result = handleBlockingCmd(Cmd, EnqueueResult, RootCommand, Blocking);
+    std::cerr << "[SYCL]    -enqueueCommand: has blocking command result --> " << (Result ? "true" : "false") << "\n";
+  }
+  std::cerr << "[SYCL]    -enqueueCommand: final enqueue result --> Result = {" << static_cast<int>(EnqueueResult.MResult) << ", " << static_cast<int>(EnqueueResult.MErrCode) << "}\n";
+  std::cerr << "[SYCL] LEAVE: Scheduler::GraphProcessor::enqueueCommand(Command *, ReadLockT &, ...) --> " << (Result ? "true" : "false") << "\n";
   return Result;
 }
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -62,7 +62,7 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
         GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
       throw exception(make_error_code(errc::runtime),
-                      "Enqueue process failed.");
+                      "Enqueue process failed(1).");
 #ifdef XPTI_ENABLE_INSTRUMENTATION
     // Capture the dependencies
     DepCommands.insert(Cmd);
@@ -78,7 +78,7 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
         GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
       throw exception(make_error_code(errc::runtime),
-                      "Enqueue process failed.");
+                      "Enqueue process failed(2).");
 #ifdef XPTI_ENABLE_INSTRUMENTATION
     DepCommands.insert(Cmd);
 #endif
@@ -91,7 +91,7 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
                                                    Res, ToCleanUp, ReleaseCmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
       throw exception(make_error_code(errc::runtime),
-                      "Enqueue process failed.");
+                      "Enqueue process failed(3).");
 #ifdef XPTI_ENABLE_INSTRUMENTATION
     // Report these dependencies to the Command so these dependencies can be
     // reported as edges
@@ -198,7 +198,7 @@ void Scheduler::enqueueCommandForCG(event_impl &Event,
           throw sycl::detail::set_ur_error(
               sycl::exception(
                   sycl::make_error_code(errc::runtime),
-                  std::string("Enqueue process failed.\n") +
+                  std::string("Enqueue process failed(4).\n") +
                       __SYCL_UR_ERROR_REPORT(
                           NewCmd->getWorkerContext()->getBackend()) +
                       sycl::detail::codeToString(Res.MErrCode)),
@@ -244,7 +244,7 @@ EventImplPtr Scheduler::addCopyBack(Requirement *Req) {
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult) {
         CopyBackCmdsFailed |= Res.MCmd == Cmd;
         throw exception(make_error_code(errc::runtime),
-                        "Enqueue process failed.");
+                        "Enqueue process failed(5).");
       }
     }
 
@@ -253,7 +253,7 @@ EventImplPtr Scheduler::addCopyBack(Requirement *Req) {
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult) {
       CopyBackCmdsFailed |= Res.MCmd == NewCmd;
       throw exception(make_error_code(errc::runtime),
-                      "Enqueue process failed.");
+                      "Enqueue process failed(6).");
     }
   } catch (...) {
     if (CopyBackCmdsFailed) {
@@ -360,7 +360,7 @@ EventImplPtr Scheduler::addHostAccessor(Requirement *Req) {
       Enqueued = GraphProcessor::enqueueCommand(Cmd, Lock, Res, ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
         throw exception(make_error_code(errc::runtime),
-                        "Enqueue process failed.");
+                        "Enqueue process failed(7).");
     }
 
     if (Command *NewCmd = NewCmdEvent->getCommand()) {
@@ -368,7 +368,7 @@ EventImplPtr Scheduler::addHostAccessor(Requirement *Req) {
           GraphProcessor::enqueueCommand(NewCmd, Lock, Res, ToCleanUp, NewCmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
         throw exception(make_error_code(errc::runtime),
-                        "Enqueue process failed.");
+                        "Enqueue process failed(8).");
     }
   }
 
@@ -403,7 +403,7 @@ void Scheduler::enqueueLeavesOfReqUnlocked(const Requirement *const Req,
                                                      ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
         throw exception(make_error_code(errc::runtime),
-                        "Enqueue process failed.");
+                        "Enqueue process failed(9).");
     }
   };
 
@@ -423,7 +423,7 @@ void Scheduler::enqueueUnblockedCommands(events_range ToEnqueue,
         GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
       throw exception(make_error_code(errc::runtime),
-                      "Enqueue process failed.");
+                      "Enqueue process failed(10).");
   }
 }
 
@@ -668,7 +668,7 @@ EventImplPtr Scheduler::addCommandGraphUpdate(
       Enqueued = GraphProcessor::enqueueCommand(Cmd, Lock, Res, ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
         throw exception(make_error_code(errc::runtime),
-                        "Enqueue process failed.");
+                        "Enqueue process failed(11).");
     }
 
     if (Command *NewCmd = NewCmdEvent->getCommand()) {
@@ -676,7 +676,7 @@ EventImplPtr Scheduler::addCommandGraphUpdate(
           GraphProcessor::enqueueCommand(NewCmd, Lock, Res, ToCleanUp, NewCmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
         throw exception(make_error_code(errc::runtime),
-                        "Enqueue process failed.");
+                        "Enqueue process failed(12).");
     }
   }
 

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -1373,6 +1373,12 @@ void handler::ext_oneapi_wait_external_semaphore(
 void handler::ext_oneapi_wait_external_semaphore(
     sycl::ext::oneapi::experimental::external_semaphore ExtSemaphore,
     uint64_t WaitValue) {
+  std::cerr << "[SYCL] ENTER: handler::ext_oneapi_wait_external_semaphore(external_semaphore, uint64_t)\n";
+  std::cerr << "[SYCL]    -ext_oneapi_wait_external_semaphore: semaphore type       = "
+            << static_cast<int>(ExtSemaphore.handle_type) << "\n";
+  std::cerr << "[SYCL]    -ext_oneapi_wait_external_semaphore: semaphore raw handle = "
+            << static_cast<void *>(ExtSemaphore.raw_handle) << "\n";
+  std::cerr << "[SYCL]    -ext_oneapi_wait_external_semaphore: wait value         = " << WaitValue << "\n";
   throwIfGraphAssociated<
       ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
           sycl_ext_oneapi_bindless_images>();
@@ -1397,6 +1403,7 @@ void handler::ext_oneapi_wait_external_semaphore(
       (ur_exp_external_semaphore_handle_t)ExtSemaphore.raw_handle;
   impl->MWaitValue = WaitValue;
   setType(detail::CGType::SemaphoreWait);
+  std::cerr << "[SYCL] LEAVE: handler::ext_oneapi_wait_external_semaphore(external_semaphore, uint64_t)\n";
 }
 
 void handler::ext_oneapi_signal_external_semaphore(
@@ -1423,11 +1430,18 @@ void handler::ext_oneapi_signal_external_semaphore(
       (ur_exp_external_semaphore_handle_t)ExtSemaphore.raw_handle;
   impl->MSignalValue = {};
   setType(detail::CGType::SemaphoreSignal);
+  std::cerr << "[SYCL] LEAVE: handler::ext_oneapi_signal_external_semaphore(external_semaphore, uint64_t)\n";
 }
 
 void handler::ext_oneapi_signal_external_semaphore(
     sycl::ext::oneapi::experimental::external_semaphore ExtSemaphore,
     uint64_t SignalValue) {
+  std::cerr << "[SYCL] ENTER: handler::ext_oneapi_signal_external_semaphore(external_semaphore, uint64_t)\n";
+  std::cerr << "[SYCL]    -ext_oneapi_signal_external_semaphore: semaphore type       = "
+            << static_cast<int>(ExtSemaphore.handle_type) << "\n";
+  std::cerr << "[SYCL]    -ext_oneapi_signal_external_semaphore: semaphore raw handle = "
+            << static_cast<void *>(ExtSemaphore.raw_handle) << "\n";
+  std::cerr << "[SYCL]    -ext_oneapi_signal_external_semaphore: signal value         = " << SignalValue << "\n";
   throwIfGraphAssociated<
       ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
           sycl_ext_oneapi_bindless_images>();
@@ -1452,6 +1466,7 @@ void handler::ext_oneapi_signal_external_semaphore(
       (ur_exp_external_semaphore_handle_t)ExtSemaphore.raw_handle;
   impl->MSignalValue = SignalValue;
   setType(detail::CGType::SemaphoreSignal);
+  std::cerr << "[SYCL] LEAVE: handler::ext_oneapi_signal_external_semaphore(external_semaphore, uint64_t)\n";
 }
 
 void handler::use_kernel_bundle(

--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
@@ -21,6 +21,7 @@
 #include <d3d11_3.h>
 
 #include <limits>
+#include <iostream>
 
 using namespace dx11_interop;
 namespace syclexp = sycl::ext::oneapi::experimental;
@@ -369,15 +370,19 @@ int runTest(D3D11ProgramState &d3d11ProgramState, sycl::queue syclQueue,
 
 int main() {
   // Create SYCL queue, relying on SYCL device selection
+  std::cout << "======== Running tests for SYCL-DX11 texture sharing interoperability...\n";
+  std::cout << "======== Get SYCL queue and device...\n";
   sycl::queue syclQueue;
   sycl::device syclDevice = syclQueue.get_device();
 
   // Initialize D3D11 and create DX11 programs state from the SYCL device
+  std::cout << "======== Initialize D3D11 and create DX11 programs state from the SYCL device...\n";
   D3D11ProgramState d3d11ProgramState{syclDevice};
 
   int errors = 0;
 
   // Test 1D texture interop
+  std::cout << "======== Running 1D texture interop tests...\n";
 #ifdef TEST_SMALL_IMAGE_SIZE
   const sycl::range<1> globalSize1D{1024};
 #else
@@ -400,6 +405,7 @@ int main() {
                                       globalSize1D, sycl::range{256});
 
   // Test 2D texture interop
+  std::cout << "======== Running 2D texture interop tests...\n";
 #ifdef TEST_SMALL_IMAGE_SIZE
   const sycl::range<2> globalSize2D[] = {
       sycl::range{64, 64}, sycl::range{64, 64}, sycl::range{64, 64},
@@ -426,6 +432,7 @@ int main() {
                                       globalSize2D[4], sycl::range{16, 16});
 
 // Test 3D texture interop
+std::cout << "======== Running 3D texture interop tests...\n";
 #ifdef TEST_SMALL_IMAGE_SIZE
   const sycl::range<3> globalSize3D[] = {
       sycl::range{64, 16, 4}, sycl::range{64, 16, 4}, sycl::range{64, 64, 4},

--- a/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_timeline_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_timeline_semaphore.cpp
@@ -47,9 +47,12 @@
 
 #include "d3d12_setup.hpp"
 #include <iostream>
+#include <iomanip>
+#include <sstream>
 #include <string>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>
+#include <sycl/properties/queue_properties.hpp>
 #include <vector>
 
 #define WIN32_LEAN_AND_MEAN
@@ -57,42 +60,67 @@
 
 namespace syclexp = sycl::ext::oneapi::experimental;
 
+//----------------------------------------------------------------------------//
+void pause() {
+  std::cin.clear(); // Clear any potential previous input left in the buffer.
+  // std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  std::cout << "\n\nPress Enter to continue . . .\n";   
+  std::cin.get(); 
+}
+//----------------------------------------------------------------------------//
 int main(int argc, char **argv) {
-  bool useSemaphores = true;
-  int iterations = 100;
-  size_t numElements = 1024;
+  bool   useSemaphores = true;
+  bool   useTags       = false;
+  int    iterations    = 100;
+  size_t numElements   = 1024;
+
+  // pause();
+
+  DWORD pid = GetCurrentProcessId();
+  std::ostringstream oss, pidStr;
+  pidStr << "[" << std::setw(6) << pid << ":  0a] ";
+  std::string pidTag = pidStr.str();
+# define INCR_PID_TAG pidTag[11]++
 
   for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
-    if (arg == "--no-sem")
-      useSemaphores = false;
-    if (arg == "--iterations" && i + 1 < argc)
-      iterations = std::stoi(argv[++i]);
-    if (arg == "--size" && i + 1 < argc)
-      numElements = std::stoi(argv[++i]);
+    if      (arg == "--no-sem") useSemaphores = false;
+    else if (arg == "--use-tags") useTags = true;
+    else if (i + 1 < argc) {
+      if      (arg == "--iterations") iterations = std::stoi(argv[++i]);
+      else if (arg == "--size")      numElements = std::stoi(argv[++i]);
+    }
   }
+
+  const char *stop = (useTags ? "\n" : "");
 
   size_t bufferSize = numElements * sizeof(uint32_t);
 
-  std::cout << "Running SYCL D3D12 Buffer + Timeline Fence Stress Test\n";
-  std::cout << "Elements: " << numElements << " | Iterations: " << iterations
-            << " | Semaphores: " << (useSemaphores ? "ON" : "OFF") << "\n";
+  oss.str("");  oss.clear();
+  oss << pidTag << "Running SYCL D3D12 Buffer + Timeline Fence Stress Test\n";
+  INCR_PID_TAG;
+
+  oss << pidTag << "Elements: " << numElements << " | Iterations: " << iterations
+      << " | Semaphores: " << (useSemaphores ? "ON" : "OFF") << "\n";
+  INCR_PID_TAG;
 
   // D3D12 SETUP
   D3D12Context d3dCtx = createD3D12Context();
 
   // Exportable device-local buffers
-  D3D12BufferResources inBuf = createExportableBuffer(d3dCtx, bufferSize);
-  D3D12BufferResources outBuf = createExportableBuffer(d3dCtx, bufferSize);
+  D3D12BufferResources srcBuf = createExportableBuffer(d3dCtx, bufferSize);
+  D3D12BufferResources dstBuf = createExportableBuffer(d3dCtx, bufferSize);
 
   // Host-visible staging buffers
-  D3D12BufferResources inStaging = createUploadBuffer(d3dCtx, bufferSize);
-  D3D12BufferResources outStaging = createReadbackBuffer(d3dCtx, bufferSize);
+  D3D12BufferResources srcStage = createUploadBuffer(d3dCtx, bufferSize);
+  D3D12BufferResources dstStage = createReadbackBuffer(d3dCtx, bufferSize);
 
   // Interop Timeline Fence
   D3D12ExportableFence extFence;
   if (useSemaphores) {
     extFence = createExportableFence(d3dCtx);
+    oss << pidTag << "Created exportable fence\n";  INCR_PID_TAG;
   }
 
   // Set initial buffer states explicitly to COPY_DEST to avoid generic read
@@ -101,14 +129,14 @@ int main(int argc, char **argv) {
   d3dCtx.cmdList->Reset(d3dCtx.cmdAlloc.Get(), nullptr);
   D3D12_RESOURCE_BARRIER initialBarriers[2] = {};
   initialBarriers[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-  initialBarriers[0].Transition.pResource = inBuf.resource.Get();
+  initialBarriers[0].Transition.pResource = srcBuf.resource.Get();
   initialBarriers[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
   initialBarriers[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
   initialBarriers[0].Transition.Subresource =
       D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
 
   initialBarriers[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-  initialBarriers[1].Transition.pResource = outBuf.resource.Get();
+  initialBarriers[1].Transition.pResource = dstBuf.resource.Get();
   initialBarriers[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
   initialBarriers[1].Transition.StateAfter =
       D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
@@ -117,28 +145,35 @@ int main(int argc, char **argv) {
   d3dCtx.cmdList->ResourceBarrier(2, initialBarriers);
   d3dCtx.cmdList->Close();
   executeAndWait(d3dCtx);
+  oss << pidTag << "Initial buffer state setup done\n";  INCR_PID_TAG;
+  std::cout << oss.str();  oss.str("");  oss.clear();
 
   // SYCL INTEROP
   try {
-    sycl::queue q;
+    sycl::queue q{sycl::ext::intel::property::queue::immediate_command_list{}};
+    // sycl::queue q;
     auto device = q.get_device();
     auto context = q.get_context();
 
-    std::cout << "[SYCL] Device: "
-              << device.get_info<sycl::info::device::name>() << "\n";
+    oss << pidTag << "[SYCL] Device: " << device.get_info<sycl::info::device::name>() << "\n";
+    INCR_PID_TAG;
+    std::cout << oss.str();  oss.str("");  oss.clear();
 
     // Import buffers
     syclexp::external_mem_descriptor<syclexp::resource_win32_handle> inDesc{
-        inBuf.sharedHandle, syclexp::external_mem_handle_type::win32_nt_handle,
+        srcBuf.sharedHandle, syclexp::external_mem_handle_type::win32_nt_handle,
         bufferSize};
     syclexp::external_mem inExtMem =
         syclexp::import_external_memory(inDesc, device, context);
 
     syclexp::external_mem_descriptor<syclexp::resource_win32_handle> outDesc{
-        outBuf.sharedHandle, syclexp::external_mem_handle_type::win32_nt_handle,
+        dstBuf.sharedHandle, syclexp::external_mem_handle_type::win32_nt_handle,
         bufferSize};
     syclexp::external_mem outExtMem =
         syclexp::import_external_memory(outDesc, device, context);
+    oss << pidTag << "[SYCL] Imported external memory\n";
+    INCR_PID_TAG;
+    std::cout << oss.str();  oss.str("");  oss.clear();
 
     // Import timeline fence
     syclexp::external_semaphore syclSem{};
@@ -155,31 +190,43 @@ int main(int argc, char **argv) {
     uint32_t *outPtr = static_cast<uint32_t *>(
         syclexp::map_external_linear_memory(outExtMem, 0, bufferSize, q));
 
-    std::cout << "[Test] Starting " << iterations
-              << " iteration stress test...\n";
+    oss << pidTag << "[Test] Starting " << iterations<< " iteration stress test...\n";
+    INCR_PID_TAG;
+    std::cout << oss.str();  oss.str("");  oss.clear();
 
     for (int i = 1; i <= iterations; ++i) {
-      uint64_t d3dSignalVal = (uint64_t)(2 * i - 1);
+      if (useTags) std::cout << "------------------------- Iteration " << std::setw(4) << i << " -------------------------\n";
+      uint64_t dx12SignalVal = (uint64_t)(2 * i - 1);
       uint64_t syclSignalVal = (uint64_t)(2 * i);
+      std::ostringstream idStream;
+      std::ostringstream dx12ValStream;
+      std::ostringstream syclValStream;
+      idStream      << "[" << std::setw(6) << pid << ":" << std::setw(3) << i << "a] ";
+      dx12ValStream << std::setw(4) << dx12SignalVal;
+      syclValStream << std::setw(4) << syclSignalVal;
+      std::string      idStr =      idStream.str();
+      std::string dx12ValStr = dx12ValStream.str();
+      std::string syclValStr = syclValStream.str();
+#     define INCR_LID_TAG (useTags ? idStr[11]++ : 0)
 
       // D3D12: Upload and copy
       void *mapped;
-      inStaging.resource->Map(0, nullptr, &mapped);
+      srcStage.resource->Map(0, nullptr, &mapped);
       auto *data = static_cast<uint32_t *>(mapped);
       for (size_t j = 0; j < numElements; ++j)
         data[j] = (uint32_t)i;
-      inStaging.resource->Unmap(0, nullptr);
+      srcStage.resource->Unmap(0, nullptr);
 
       d3dCtx.cmdAlloc->Reset();
       d3dCtx.cmdList->Reset(d3dCtx.cmdAlloc.Get(), nullptr);
 
-      d3dCtx.cmdList->CopyBufferRegion(inBuf.resource.Get(), 0,
-                                       inStaging.resource.Get(), 0, bufferSize);
+      d3dCtx.cmdList->CopyBufferRegion(srcBuf.resource.Get(), 0,
+                                       srcStage.resource.Get(), 0, bufferSize);
 
       // Barrier: CopyDest -> UAV
       D3D12_RESOURCE_BARRIER barrier = {};
       barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-      barrier.Transition.pResource = inBuf.resource.Get();
+      barrier.Transition.pResource = srcBuf.resource.Get();
       barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
       barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
       barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
@@ -190,7 +237,14 @@ int main(int argc, char **argv) {
       d3dCtx.cmdQueue->ExecuteCommandLists(1, ppCommandLists);
 
       if (useSemaphores) {
-        d3dCtx.cmdQueue->Signal(extFence.fence.Get(), d3dSignalVal);
+        oss << idStr << "D3D12 context command queue signal(" << dx12ValStr << "), " << stop;  INCR_LID_TAG;
+        std::cout << oss.str() << std::flush;
+        oss.str("");  oss.clear();
+        if (!useTags) idStr = "";
+        d3dCtx.cmdQueue->Signal(extFence.fence.Get(), dx12SignalVal);
+        oss << idStr <<"ok, " << stop;  INCR_LID_TAG;
+        std::cout << oss.str() << std::flush;
+        oss.str("");  oss.clear();
       }
 
       // Host wait for upload to finish using the generic context fence
@@ -199,13 +253,20 @@ int main(int argc, char **argv) {
       d3dCtx.fence->SetEventOnCompletion(d3dCtx.fenceValue, d3dCtx.fenceEvent);
       WaitForSingleObject(d3dCtx.fenceEvent, INFINITE);
 
-      std::cout << "  [" << i << "] D3D12 upload done" << std::flush;
+      oss << idStr << "D3D12 upload done, " << stop;  INCR_LID_TAG;
+      std::cout << oss.str() << std::flush;
+      oss.str("");  oss.clear();
+      if (!useTags) idStr = "";
 
       // SYCL: Wait, execute, signal
       if (useSemaphores) {
-        std::cout << ", SYCL sem-wait(" << d3dSignalVal << ")..." << std::flush;
-        q.ext_oneapi_wait_external_semaphore(syclSem, d3dSignalVal);
-        std::cout << "ok" << std::flush;
+        oss << idStr << "SYCL sem-wait(" << dx12ValStr << ")..." << stop;  INCR_LID_TAG;
+        std::cout << oss.str() << std::flush;
+        oss.str("");  oss.clear();
+        q.ext_oneapi_wait_external_semaphore(syclSem, dx12SignalVal);
+        oss << idStr <<"ok, " << stop;  INCR_LID_TAG;
+        std::cout << oss.str() << std::flush;
+        oss.str("");  oss.clear();
       }
 
       q.submit([&](sycl::handler &h) {
@@ -216,13 +277,18 @@ int main(int argc, char **argv) {
       });
 
       if (useSemaphores) {
-        std::cout << ", SYCL sem-signal(" << syclSignalVal << ")..."
-                  << std::flush;
+        oss << idStr << "SYCL sem-signal(" << syclValStr << ")..." << stop;  INCR_LID_TAG;
+        std::cout << oss.str() << std::flush;
+        oss.str("");  oss.clear();
         q.ext_oneapi_signal_external_semaphore(syclSem, syclSignalVal);
-        std::cout << "ok" << std::flush;
+        oss << idStr << "ok, " << stop;  INCR_LID_TAG;
+        std::cout << oss.str() << std::flush;
+        oss.str("");  oss.clear();
       }
       q.wait();
-      std::cout << ", SYCL done" << std::flush;
+      oss << idStr << "SYCL done, " << stop;  INCR_LID_TAG;
+      std::cout << oss.str() << std::flush;
+      oss.str("");  oss.clear();
 
       // D3D12: Readback and verify
       if (useSemaphores) {
@@ -233,15 +299,15 @@ int main(int argc, char **argv) {
       d3dCtx.cmdList->Reset(d3dCtx.cmdAlloc.Get(), nullptr);
 
       // Barrier: UAV -> CopySource
-      barrier.Transition.pResource = outBuf.resource.Get();
+      barrier.Transition.pResource = dstBuf.resource.Get();
       barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
       barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
       d3dCtx.cmdList->ResourceBarrier(1, &barrier);
 
-      d3dCtx.cmdList->CopyBufferRegion(outStaging.resource.Get(), 0,
-                                       outBuf.resource.Get(), 0, bufferSize);
+      d3dCtx.cmdList->CopyBufferRegion(dstStage.resource.Get(), 0,
+                                       dstBuf.resource.Get(), 0, bufferSize);
 
-      // Barrier: revert outBuf back to UAV for next iteration
+      // Barrier: revert dstBuf back to UAV for next iteration
       barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
       barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
       d3dCtx.cmdList->ResourceBarrier(1, &barrier);
@@ -250,54 +316,56 @@ int main(int argc, char **argv) {
       d3dCtx.cmdQueue->ExecuteCommandLists(1, ppCommandLists);
 
       // Host wait for readback
-      std::cout << ", d3d-fence..." << std::flush;
+      oss << idStr << "D3D12 fence..." << stop;  INCR_LID_TAG;
+      std::cout << oss.str() << std::flush;
+      oss.str("");  oss.clear();
       d3dCtx.fenceValue++;
       d3dCtx.cmdQueue->Signal(d3dCtx.fence.Get(), d3dCtx.fenceValue);
       d3dCtx.fence->SetEventOnCompletion(d3dCtx.fenceValue, d3dCtx.fenceEvent);
 
       if (WaitForSingleObject(d3dCtx.fenceEvent, 5000) == WAIT_TIMEOUT) {
-        std::cerr << "\nTIMEOUT on host wait!\n";
+        std::cerr << "\n" << idStr << "TIMEOUT on host wait!\n";
         return 1;
       }
-      std::cout << "ok" << std::flush;
-
+      oss << idStr << "ok --> " << stop;  INCR_LID_TAG;
+      std::cout << oss.str() << std::flush;
+      oss.str("");  oss.clear();
       // Verify data
-      outStaging.resource->Map(0, nullptr, &mapped);
+      dstStage.resource->Map(0, nullptr, &mapped);
       auto *outData = static_cast<uint32_t *>(mapped);
       uint32_t expected = (uint32_t)i * 2;
       int errors = 0;
       for (size_t j = 0; j < numElements; ++j) {
         if (outData[j] != expected) {
           if (errors++ < 5)
-            std::cerr << "  [" << j << "]: got " << outData[j] << " expected "
+            std::cerr << idStr << "(" << j << "): got " << outData[j] << " expected "
                       << expected << "\n";
         }
       }
-      outStaging.resource->Unmap(0, nullptr);
+      dstStage.resource->Unmap(0, nullptr);
 
       if (errors > 0) {
-        std::cerr << "\nFAILURE at iteration " << i << ": " << errors
-                  << " mismatches\n";
+        std::cerr << "\n" << pidTag << "FAILURE at iteration " << i << ": " << errors
+                  << " mismatches\n";  INCR_PID_TAG;
         return 1;
       }
 
-      // Reset inBuf state to COPY_DEST for next iteration
+      // Reset srcBuf state to COPY_DEST for next iteration
       d3dCtx.cmdAlloc->Reset();
       d3dCtx.cmdList->Reset(d3dCtx.cmdAlloc.Get(), nullptr);
-      barrier.Transition.pResource = inBuf.resource.Get();
+      barrier.Transition.pResource = srcBuf.resource.Get();
       barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
       barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
       d3dCtx.cmdList->ResourceBarrier(1, &barrier);
       d3dCtx.cmdList->Close();
       executeAndWait(d3dCtx); // Use generic helper to submit and wait
 
-      if (i % 25 == 0 || i == 1)
-        std::cout << " PASS\n";
-      else
-        std::cout << " ok\n";
+      oss << idStr << "PASS\n";
+      std::cout << oss.str();  oss.str("");  oss.clear();
     }
 
-    std::cout << "SUCCESS! All " << iterations << " iterations passed.\n";
+    oss << pidTag << "SUCCESS! All " << iterations << " iterations passed.\n";  INCR_PID_TAG;
+    std::cout << oss.str();  oss.str("");  oss.clear();
 
     // SYCL Cleanup
     syclexp::unmap_external_linear_memory(inPtr, q);
@@ -308,20 +376,26 @@ int main(int argc, char **argv) {
     syclexp::release_external_memory(outExtMem, device, context);
 
   } catch (sycl::exception &e) {
-    std::cerr << "SYCL Exception: " << e.what() << "\n";
+    std::cerr << pidTag << "SYCL Exception: " << e.what() << "\n";
     return 1;
   }
 
   // D3D12 Cleanup
   if (useSemaphores)
     cleanupExportableFence(extFence);
-  cleanupBuffer(inBuf);
-  cleanupBuffer(outBuf);
-  cleanupBuffer(inStaging);
-  cleanupBuffer(outStaging);
+  cleanupBuffer(srcBuf);
+  cleanupBuffer(dstBuf);
+  cleanupBuffer(srcStage);
+  cleanupBuffer(dstStage);
   // Clean up the generic context event directly
   if (d3dCtx.fenceEvent)
     CloseHandle(d3dCtx.fenceEvent);
 
+  oss << pidTag << "**** TEST COMPLETE **** -- Elements: " << numElements 
+      << " | Iterations: " << iterations
+      << " | Semaphores: " << (useSemaphores ? "ON" : "OFF") << "\n";
+  std::cout << oss.str();  oss.str("");  oss.clear();
+
   return 0;
 }
+//----------------------------------------------------------------------------//

--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -19,6 +19,8 @@
 
 #include "loader/ze_loader.h"
 
+#include <iostream>
+
 namespace ur::level_zero {
 
 ur_result_t urBindlessImagesImageCopyExp(
@@ -108,11 +110,13 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ur_exp_external_semaphore_handle_t hSemaphore,
     bool hasValue, uint64_t waitValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::cerr << "[SYCL] ENTER: urBindlessImagesWaitExternalSemaphoreExp(ur_queue_handle_t, ur_exp_external_semaphore_handle_t, ...)\n";
   auto UrPlatform = hQueue->Context->getPlatform();
   if (UrPlatform->ZeExternalSemaphoreExt.Supported == false) {
     UR_LOG_LEGACY(ERR,
                   logger::LegacyMessage("[UR][L0] {} function not supported!"),
                   "{} function not supported!", __FUNCTION__);
+    std::cerr << "[SYCL] LEAVE: urBindlessImagesWaitExternalSemaphoreExp(ur_queue_handle_t, ur_exp_external_semaphore_handle_t, ...) --> UR_RESULT_ERROR_UNSUPPORTED_FEATURE\n";
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
@@ -121,16 +125,19 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
   // We want to batch these commands to avoid extra submissions (costly)
   bool OkToBatch = true;
 
+  std::cerr << "[SYCL]    -urBindlessImagesWaitExternalSemaphoreExp: calling createAndRetainUrZeEventList\n";
   ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       numEventsInWaitList, phEventWaitList, hQueue, UseCopyEngine));
 
   // Get a new command list to be used on this call
+  std::cerr << "[SYCL]    -urBindlessImagesWaitExternalSemaphoreExp: calling getAvailableCommandList\n";
   ur_command_list_ptr_t CommandList{};
   UR_CALL(hQueue->Context->getAvailableCommandList(
       hQueue, CommandList, UseCopyEngine, numEventsInWaitList, phEventWaitList,
       OkToBatch, nullptr /*ForcedCmdQueue*/));
 
+  std::cerr << "[SYCL]    -urBindlessImagesWaitExternalSemaphoreExp: calling createEventAndAssociateQueue\n";
   ze_event_handle_t ZeEvent = nullptr;
   ur_event_handle_t InternalEvent;
   bool IsInternal = phEvent == nullptr;
@@ -139,6 +146,7 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
                                        UR_COMMAND_EXTERNAL_SEMAPHORE_WAIT_EXP,
                                        CommandList, IsInternal,
                                        /*IsMultiDevice*/ false));
+  std::cerr << "[SYCL]    -urBindlessImagesWaitExternalSemaphoreExp: calling setSignalEvent\n";
   UR_CALL(setSignalEvent(hQueue, UseCopyEngine, &ZeEvent, Event,
                          numEventsInWaitList, phEventWaitList,
                          CommandList->second.ZeQueue));
@@ -147,18 +155,28 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
   const auto &ZeCommandList = CommandList->first;
   const auto &WaitList = (*Event)->WaitList;
 
+  std::cerr << "[SYCL]    -urBindlessImagesWaitExternalSemaphoreExp: calling zexCommandListAppendWaitExternalSemaphoresExp\n";
   ze_external_semaphore_wait_params_ext_t WaitParams = {
       ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXT, nullptr, 0};
   WaitParams.value = hasValue ? waitValue : 0;
   ze_external_semaphore_ext_handle_t hExtSemaphore =
       reinterpret_cast<ze_external_semaphore_ext_handle_t>(hSemaphore);
-  ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
-                 .zexCommandListAppendWaitExternalSemaphoresExp,
-             (ZeCommandList, 1, &hExtSemaphore, &WaitParams, ZeEvent,
-              WaitList.Length, WaitList.ZeEventList));
+//   ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt
+//                  .zexCommandListAppendWaitExternalSemaphoresExp,
+//              (ZeCommandList, 1, &hExtSemaphore, &WaitParams, ZeEvent, WaitList.Length, WaitList.ZeEventList));
+  {
+    ze_result_t ZeResult = UrPlatform->ZeExternalSemaphoreExt.zexCommandListAppendWaitExternalSemaphoresExp(ZeCommandList, 1, &hExtSemaphore, &WaitParams, ZeEvent, WaitList.Length, WaitList.ZeEventList);
+    std::cerr << "[SYCL]    -urBindlessImagesWaitExternalSemaphoreExp: zexCommandListAppendWaitExternalSemaphoresExp returned " << ZeResult << "\n";
+    if (ZeResult) {
+      std::cerr << "[SYCL] LEAVE: urBindlessImagesWaitExternalSemaphoreExp(ur_queue_handle_t, ur_exp_external_semaphore_handle_t, ...) --> " << ze2urResult(ZeResult) << "\n";
+      return ze2urResult(ZeResult);
+    }
+  }
 
+  std::cerr << "[SYCL]    -urBindlessImagesWaitExternalSemaphoreExp: calling executeCommandList\n";
   UR_CALL(hQueue->executeCommandList(CommandList, false, OkToBatch));
 
+  std::cerr << "[SYCL] LEAVE: urBindlessImagesWaitExternalSemaphoreExp(ur_queue_handle_t, ur_exp_external_semaphore_handle_t, ...) --> UR_RESULT_SUCCESS\n";
   return UR_RESULT_SUCCESS;
 }
 
@@ -166,11 +184,13 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ur_exp_external_semaphore_handle_t hSemaphore,
     bool hasValue, uint64_t signalValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::cerr << "[SYCL] ENTER: urBindlessImagesSignalExternalSemaphoreExp(ur_queue_handle_t, ur_exp_external_semaphore_handle_t, ...)\n";
   auto UrPlatform = hQueue->Context->getPlatform();
   if (UrPlatform->ZeExternalSemaphoreExt.Supported == false) {
     UR_LOG_LEGACY(ERR,
                   logger::LegacyMessage("[UR][L0] {} function not supported!"),
                   "{} function not supported!", __FUNCTION__);
+    std::cerr << "[SYCL] LEAVE: urBindlessImagesSignalExternalSemaphoreExp(ur_queue_handle_t, ur_exp_external_semaphore_handle_t, ...) --> UR_RESULT_ERROR_UNSUPPORTED_FEATURE\n";
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 


### PR DESCRIPTION
Fix to the issue of external semaphores not working on DG2 due to SYCL selecting regular command lists.

Related-To: GSD-12428