### PR TITLE
fix: DX12 external semaphore on DG2

### DIFF
--- a/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_timeline_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_timeline_semaphore.cpp
@@ -50,6 +50,7 @@
 #include <string>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>
+#include <sycl/properties/queue_properties.hpp>
 #include <vector>
 
 #define WIN32_LEAN_AND_MEAN
@@ -120,7 +121,9 @@ int main(int argc, char **argv) {
 
   // SYCL INTEROP
   try {
-    sycl::queue q;
+    sycl::property_list props{useSemaphores ? sycl::ext::intel::property::queue::immediate_command_list{}
+                                            : sycl::property_list{}};
+    sycl::queue q{props};
     auto device = q.get_device();
     auto context = q.get_context();
 

--- a/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_timeline_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_timeline_semaphore.cpp
@@ -121,8 +121,10 @@ int main(int argc, char **argv) {
 
   // SYCL INTEROP
   try {
-    sycl::property_list props{useSemaphores ? sycl::ext::intel::property::queue::immediate_command_list{}
-                                            : sycl::property_list{}};
+    sycl::property_list props{
+        useSemaphores
+            ? sycl::ext::intel::property::queue::immediate_command_list{}
+            : sycl::property_list{}};
     sycl::queue q{props};
     auto device = q.get_device();
     auto context = q.get_context();


### PR DESCRIPTION
Fix to the issue of external semaphores not working on DG2 due to SYCL selecting regular command lists.

Related-To: GSD-12428