### PR TITLE
[SYCL][E2E] Disable host-task-failure.cpp on BMG Win

### DIFF
--- a/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14613
+
 #include <sycl/detail/core.hpp>
 
 using namespace sycl;


### PR DESCRIPTION
Sporadic timeouts, see https://github.com/intel/llvm/issues/14613.