### PR TITLE
[SYCL][E2E] Disable D3D12_sycl_buffer_win32_name_native.cpp on BMG Win

### DIFF
--- a/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_win32_name_native.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_win32_name_native.cpp
@@ -8,6 +8,9 @@
 // UNSUPPORTED: gpu-intel-gen12
 // UNSUPPORTED-TRACKER: GSD-12427
 
+// UNSUPPORTED: arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22028
+
 // RUN: %{build} %link-directx -o %t.exe %if target-spir %{ -Wno-ignored-attributes %}
 // RUN: %{run} %t.exe --no-sem
 // RUN: %{run} %t.exe


### PR DESCRIPTION
Sporadic hang, see GH issue [here](https://github.com/intel/llvm/issues/22028).