### PR TITLE
[SYCL][E2E] Disable barrier_optimization.cpp on Win Gen12

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/barrier_optimization.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/barrier_optimization.cpp
@@ -2,6 +2,9 @@
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_UR_TRACE=2 UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 
+// UNSUPPORTED: windows && gpu-intel-gen12
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22033
+
 // Test to check that we don't insert unnecessary L0 commands for
 // queue::ext_oneapi_submit_barrier() when we have in-order queue.
 


### PR DESCRIPTION
Sporadically failing, see https://github.com/intel/llvm/issues/22033