### PR TITLE
[SYCL][E2E] Disable accessor.cpp on OCL CPU Gen12

### DIFF
--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: opencl && (arch-intel_gpu_pvc || arch-intel_gpu_bmg_g21)
+// UNSUPPORTED: opencl && (arch-intel_gpu_pvc || arch-intel_gpu_bmg_g21 || gpu-intel-gen12)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17251
 
 //==----------------accessor.cpp - SYCL accessor basic test ----------------==//


### PR DESCRIPTION
Fails on Gen12 CPU also.