### PR TITLE
[SYCL][NFC] Drop <optional> from half_type.hpp / bfloat16.hpp

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -34,10 +34,9 @@
 #include <sycl/range.hpp>                             // for range
 
 #include <cstddef>     // for size_t
-#include <functional>  // for hash
 #include <iterator>    // for reverse_iterator
 #include <limits>      // for numeric_limits
-#include <memory>      // for shared_ptr
+#include <memory>      // for shared_ptr, hash
 #include <type_traits> // for enable_if_t
 
 /// \file accessor.hpp

--- a/sycl/include/sycl/ext/oneapi/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/bfloat16.hpp
@@ -636,10 +636,11 @@ inline bfloat16 getBfloat16WithRoundingMode(const Ty &a) {
 // Specialization of some functions in namespace `std`.
 namespace std {
 
-// Specialization of `std::hash<sycl::ext::oneapi::bfloat16>`.
+// Specialization of `std::hash<sycl::ext::oneapi::bfloat16>`. See
+// half_type.hpp for the rationale on avoiding `std::hash<uint16_t>`.
 template <> struct hash<sycl::ext::oneapi::bfloat16> {
   size_t operator()(sycl::ext::oneapi::bfloat16 const &Key) const noexcept {
-    return hash<uint16_t>{}(sycl::bit_cast<uint16_t>(Key));
+    return static_cast<size_t>(sycl::bit_cast<uint16_t>(Key));
   }
 };
 

--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -10,9 +10,9 @@
 
 #include <sycl/detail/half_type_impl.hpp>
 
-// For std::hash, seems to be the most lightweight header provide it under
-// C++17:
-#include <optional>
+namespace std {
+template <class> struct hash;
+}
 
 #ifdef __SYCL_DEVICE_ONLY__
 #include <iosfwd>
@@ -50,10 +50,16 @@ inline std::istream &operator>>(std::istream &I, sycl::half &rhs) {
 // Partial specialization of some functions in namespace `std`
 namespace std {
 
-// Partial specialization of `std::hash<sycl::half>`
+// Partial specialization of `std::hash<sycl::half>`. Avoid calling
+// `std::hash<uint16_t>` so we don't need <functional>/<optional> for the
+// primary template definition; the bit pattern of a 16-bit half hashes
+// to itself zero-extended into a size_t (identity on the underlying
+// integer is what libstdc++/libc++ do for std::hash<uint16_t> too).
 template <> struct hash<sycl::half> {
   size_t operator()(sycl::half const &Key) const noexcept {
-    return hash<uint16_t>{}(reinterpret_cast<const uint16_t &>(Key));
+    uint16_t Bits = 0;
+    __builtin_memcpy(&Bits, &Key, sizeof(Bits));
+    return static_cast<size_t>(Bits);
   }
 };
 

--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -57,9 +57,7 @@ namespace std {
 // integer is what libstdc++/libc++ do for std::hash<uint16_t> too).
 template <> struct hash<sycl::half> {
   size_t operator()(sycl::half const &Key) const noexcept {
-    uint16_t Bits = 0;
-    __builtin_memcpy(&Bits, &Key, sizeof(Bits));
-    return static_cast<size_t>(Bits);
+    return static_cast<size_t>(sycl::bit_cast<uint16_t>(Key));
   }
 };
 


### PR DESCRIPTION
half_type.hpp included <optional> only to make std::hash's primary template visible for the std::hash<sycl::half> specialization. Replace with a forward declaration (`namespace std { template <class> struct hash; }`) and inline the hash body so it no longer calls std::hash<uint16_t>{}, which requires the primary definition. Same treatment in bfloat16.hpp (already had sycl::bit_cast in scope).

Saves the <optional> transitive chain (~30 ms parse + 60+ headers) on every TU that pulls sycl::half.