### PR TITLE
[CI] Upd token sycl-check-ready-to-merge-prs.yml

### DIFF
--- a/.github/workflows/sycl-check-ready-to-merge-prs.yml
+++ b/.github/workflows/sycl-check-ready-to-merge-prs.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Check
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GATEKEEPER_NOTIFICATION_TOKEN }}
         run: |
           # Number of days before repeating the gatekeepers ping
           days=3

--- a/.github/workflows/sycl-check-ready-to-merge-prs.yml
+++ b/.github/workflows/sycl-check-ready-to-merge-prs.yml
@@ -44,15 +44,6 @@ jobs:
               continue
             fi
 
-            # Looks like GH doesn't issue a notification/email if the team was mentioned by the github-actions bot.
-            # Therefore, ensure the gatekeepers are added as reviewers.
-            has_gatekeepers=$(gh pr view "$pr" --repo intel/llvm --json reviewRequests \
-              --jq '([.reviewRequests[]?.login, .reviewRequests[]?.slug, .reviewRequests[]?.name, (.reviewRequests[]?.users[]?.login), (.reviewRequests[]?.teams[]?.slug), (.reviewRequests[]?.teams[]? | (.organization.login + "/" + .slug))] | map(select(. != null)) | any(. == "intel/llvm-gatekeepers" or . == "llvm-gatekeepers"))')
-            if [[ "$has_gatekeepers" != "true" ]]; then
-              gh pr edit "$pr" --repo intel/llvm --add-reviewer intel/llvm-gatekeepers
-              echo "Added intel/llvm-gatekeepers to reviewers for https://github.com/intel/llvm/pull/$pr"
-            fi
-
             # Get the timestamp of the latest comment mentioning @intel/llvm-gatekeepers
             latest_ts=$(gh pr view $pr --repo intel/llvm --json comments \
               --jq '[.comments[] | select(.body | test("@intel/llvm-gatekeepers")) | .createdAt] | last')


### PR DESCRIPTION
This workflow doesn't actually ping gatekeepers as the regular GHA token
doesn't allow to do this (altough there is a comment from GHA bot,
gatekeepers don't receive a notification/email). Use specific token and comment on behalf of
sys-ce-bb. Test: https://github.com/intel/llvm/pull/21981

Also revert the previous unsuccessful WA.