### PR TITLE
[SYCL][Driver][NFC] Tests involving device libraries require updating

### DIFF
--- a/clang/test/Driver/clang-linker-wrapper.cpp
+++ b/clang/test/Driver/clang-linker-wrapper.cpp
@@ -1,4 +1,5 @@
 /// Check for list of commands for standalone clang-linker-wrapper run for sycl
+// REQUIRES: libdevice
 // -------
 // Generate .o file as linker wrapper input.
 //

--- a/clang/test/Driver/sycl-c-warn.c
+++ b/clang/test/Driver/sycl-c-warn.c
@@ -1,8 +1,8 @@
 // Emit warning for treating 'c' input as 'c++' when -fsycl is used
 // RUN: %clang -### -fsycl %s 2>&1 | FileCheck -check-prefix FSYCL-CHECK %s
 // RUN: %clang_cl -### -fsycl %s 2>&1 | FileCheck -check-prefix FSYCL-CHECK %s
-// RUN: %clang -### -fsycl --offload-new-driver  %s 2>&1 | FileCheck -check-prefix FSYCL-CHECK %s
-// RUN: %clang_cl -### -fsycl --offload-new-driver  %s 2>&1 | FileCheck -check-prefix FSYCL-CHECK %s
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL --no-offloadlib %s 2>&1 | FileCheck -check-prefix FSYCL-CHECK %s
+// RUN: %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL --no-offloadlib %s 2>&1 | FileCheck -check-prefix FSYCL-CHECK %s
 // RUN: %clang -### -fsycl --no-offload-new-driver  %s 2>&1 | FileCheck -check-prefix FSYCL-CHECK %s
 // RUN: %clang_cl -### -fsycl --no-offload-new-driver  %s 2>&1 | FileCheck -check-prefix FSYCL-CHECK %s
 // FSYCL-CHECK: warning: treating 'c' input as 'c++' when -fsycl is used [-Wexpected-file-type]

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -1,11 +1,11 @@
 /// Check that optimizations for sycl device are enabled by default:
-// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-only %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-only %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-device-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
 // CHECK-DEFAULT-NOT: "-fno-sycl-early-optimizations"
 // CHECK-DEFAULT-NOT: "-disable-llvm-passes"
@@ -13,36 +13,36 @@
 // CHECK-DEFAULT-SAME: "-O2"
 
 /// Check "-fno-sycl-early-optimizations" is passed to the front-end:
-// RUN:   %clang -### -fsycl --offload-new-driver -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-early-optimizations %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fno-sycl-early-optimizations %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-device-only -fno-sycl-early-optimizations %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-EARLY-OPTS %s
 // CHECK-NO-SYCL-EARLY-OPTS: "-fno-sycl-early-optimizations"
 
 /// Check that Dead Parameter Elimination Optimization is enabled
-// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DAE %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-DAE %s
 // CHECK-DAE: clang{{.*}} "-fenable-sycl-dae"
 
 /// Check that Dead Parameter Elimination Optimization is disabled
-// RUN:   %clang -### -fsycl --offload-new-driver -fno-sycl-dead-args-optimization %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-dead-args-optimization %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-DAE %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fno-sycl-dead-args-optimization %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fno-sycl-dead-args-optimization %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-DAE %s
 // CHECK-NO-DAE-NOT: clang{{.*}} "-fenable-sycl-dae"
 
 // Check "-fgpu-inline-threshold" is passed to the front-end:
-// RUN:   %clang -### -fsycl --offload-new-driver -fgpu-inline-threshold=100000 %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fgpu-inline-threshold=100000 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-THRESH %s
 // CHECK-THRESH: "-mllvm" "-inline-threshold=100000"
 
-// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-THRESH %s
 // CHECK-NO-THRESH-NOT: "-mllvm" "-inline-threshold
 

--- a/clang/test/Driver/sycl-device-post-link-opt.cpp
+++ b/clang/test/Driver/sycl-device-post-link-opt.cpp
@@ -2,13 +2,13 @@
 /// Tests for -Xdevice-post-link
 ///
 
-// RUN: %clangxx -fsycl --offload-new-driver -Xdevice-post-link "foo" -### %s 2>&1 | \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xdevice-post-link "foo" -### %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET
 
-// RUN: %clangxx -fsycl --offload-new-driver -Xdevice-post-link=spir64_gen "foo" -### %s 2>&1 | \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xdevice-post-link=spir64_gen "foo" -### %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET-UNUSED --implicit-check-not 'sycl-post-link{{.*}} "foo"'
 
-// RUNx: %clangxx -fsycl --offload-new-driver -fsycl-targets=spir64,spir64_gen -Xdevice-post-link=spir64_gen "foo" -Xdevice-post-link=spir64 "bar" -### %s 2>&1 | \
+// RUNx: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64,spir64_gen -Xdevice-post-link=spir64_gen "foo" -Xdevice-post-link=spir64 "bar" -### %s 2>&1 | \
 // RUNx:  FileCheck %s -check-prefix CHECK-MULTIPLE-TARGET --implicit-check-not 'sycl-post-link{{.*}} "foo" "bar"'
 
 // CHECK-SINGLE-TARGET: clang-linker-wrapper{{.*}} {{.*}}--sycl-post-link-options={{.*}}foo{{.*}}

--- a/clang/test/Driver/sycl-device-traits-macros.cpp
+++ b/clang/test/Driver/sycl-device-traits-macros.cpp
@@ -10,7 +10,7 @@
 /// occurrences of the macro definition, one for host and one for device.
 // RUN:   %clang -fsycl --no-offload-new-driver -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-ENABLED %s
-// RUN:   %clang -fsycl --offload-new-driver -### %s 2>&1 \
+// RUN:   %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-ENABLED %s
 // CHECK-ENABLED-COUNT-2: "-D__SYCL_ANY_DEVICE_HAS_ANY_ASPECT__=1"
 
@@ -20,7 +20,7 @@
 /// definition, one for host and one for each of the two devices.
 // RUN:   %clang -fsycl --no-offload-new-driver -fsycl-targets=spir64,spir64_gen -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-SYCL-TARGETS %s
-// RUN:   %clang -fsycl --offload-new-driver -fsycl-targets=spir64,spir64_gen -### %s 2>&1 \
+// RUN:   %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64,spir64_gen -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-SYCL-TARGETS %s
 // CHECK-SYCL-TARGETS-COUNT-3: "-D__SYCL_ANY_DEVICE_HAS_ANY_ASPECT__=1"
 
@@ -42,7 +42,7 @@
 // RUN: %clangxx -fsycl --no-offload-new-driver -nogpulib -fsycl-targets=intel_gpu_pvc,amd_gpu_gfx906 \
 // RUN:   -fsycl-libspirv-path=%S/Inputs/SYCL/libspirv.bc -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-SYCL-TARGETS-NO-MAY-SUPPORT-OTHER-ASPECTS %s
-// RUN: %clangxx -fsycl --offload-new-driver -nogpulib -fsycl-targets=intel_gpu_pvc,amd_gpu_gfx906 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -nogpulib -fsycl-targets=intel_gpu_pvc,amd_gpu_gfx906 \
 // RUN:   -fsycl-libspirv-path=%S/Inputs/SYCL/libspirv.bc -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-SYCL-TARGETS-NO-MAY-SUPPORT-OTHER-ASPECTS %s
 // CHECK-SYCL-TARGETS-NO-MAY-SUPPORT-OTHER-ASPECTS-NOT: "-D__SYCL_ANY_DEVICE_HAS_ANY_ASPECT__=1"

--- a/clang/test/Driver/sycl-esimd-force-stateless-mem.cpp
+++ b/clang/test/Driver/sycl-esimd-force-stateless-mem.cpp
@@ -4,14 +4,14 @@
 
 // Case1: Check that the enforcing is turned on by default.
 // Actually, only sycl-post-link gets an additional flag in this case.
-// RUN: %clang -### -fsycl --offload-new-driver %s 2>&1 | FileCheck -check-prefix=CHECK-DEFAULT %s
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck -check-prefix=CHECK-DEFAULT %s
 // CHECK-DEFAULT-NOT: clang{{.*}} "sycl-esimd-force-stateless-mem"
 // CHECK-DEFAULT-NOT: clang{{.*}} "-fsycl-is-host" {{.*}}"sycl-esimd-force-stateless-mem"
 // CHECK-DEFAULT-NOT: clang-linker-wrapper{{.*}} "--sycl-post-link-options={{.*}}-lower-esimd-force-stateless-mem=false{{.*}}"
 
 // Case2: Check that -fno-sycl-esimd-force-stateless-mem is handled correctly -
 // i.e. sycl-post-link gets nothing and clang gets corresponding -fno... option.
-// RUN: %clang -### -fsycl --offload-new-driver -fno-sycl-esimd-force-stateless-mem %s 2>&1 | FileCheck -check-prefix=CHECK-NEG %s
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-esimd-force-stateless-mem %s 2>&1 | FileCheck -check-prefix=CHECK-NEG %s
 // CHECK-NEG: clang{{.*}} "-fno-sycl-esimd-force-stateless-mem"
 // CHECK-NEG-NOT: clang{{.*}} "-fsycl-is-host" {{.*}}"sycl-esimd-force-stateless-mem"
 // CHECK-NEG: clang-linker-wrapper{{.*}} "--sycl-post-link-options={{.*}}-lower-esimd-force-stateless-mem=false{{.*}}"

--- a/clang/test/Driver/sycl-foffload-fp32-prec-div.cpp
+++ b/clang/test/Driver/sycl-foffload-fp32-prec-div.cpp
@@ -1,10 +1,10 @@
 // Test SYCL -foffload-fp32-prec-div
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -foffload-fp32-prec-div %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=AOT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -foffload-fp32-prec-div %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=JIT %s
 

--- a/clang/test/Driver/sycl-foffload-fp32-prec-sqrt.cpp
+++ b/clang/test/Driver/sycl-foffload-fp32-prec-sqrt.cpp
@@ -1,10 +1,10 @@
 // Test SYCL -foffload-fp32-prec-sqrt
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -foffload-fp32-prec-sqrt %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=AOT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -foffload-fp32-prec-sqrt %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=JIT %s
 

--- a/clang/test/Driver/sycl-fsyclbin.cpp
+++ b/clang/test/Driver/sycl-fsyclbin.cpp
@@ -7,18 +7,18 @@
 
 /// -fsyclbin -fsycl-device-only usage.  -fsycl-device-only will 'win' and
 /// -fsyclbin is effectively ignored.
-// RUN: %clangxx -fsycl-device-only -fsyclbin --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsycl-device-only -fsyclbin --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=SYCLBIN_UNUSED
-// RUN: %clang_cl -fsycl-device-only -fsyclbin --offload-new-driver %s -### 2>&1 \
+// RUN: %clang_cl -fsycl-device-only -fsyclbin --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=SYCLBIN_UNUSED
 // SYCLBIN_UNUSED: warning: argument unused during compilation: '-fsyclbin'
 
 /// Check tool invocation contents.
-// RUN: %clangxx -fsycl -fsyclbin=input --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsycl -fsyclbin=input --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_INPUT
-// RUN: %clangxx -fsyclbin=input --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsyclbin=input --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_INPUT
-// RUN: %clang_cl -fsycl -fsyclbin=input --offload-new-driver %s -### 2>&1 \
+// RUN: %clang_cl -fsycl -fsyclbin=input --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_INPUT
 // CHECK_TOOLS_INPUT: llvm-offload-binary
 // CHECK_TOOLS_INPUT-SAME: --image=file={{.*}}.bc,triple=spir64-unknown-unknown
@@ -26,11 +26,11 @@
 // CHECK_TOOLS_INPUT: clang-linker-wrapper
 // CHECK_TOOLS_INPUT-SAME: --syclbin=input
 
-// RUN: %clangxx -fsycl -fsyclbin=object --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsycl -fsyclbin=object --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_OBJECT
-// RUN: %clangxx -fsyclbin=object --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsyclbin=object --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_OBJECT
-// RUN: %clang_cl -fsycl -fsyclbin=object --offload-new-driver %s -### 2>&1 \
+// RUN: %clang_cl -fsycl -fsyclbin=object --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_OBJECT
 // CHECK_TOOLS_OBJECT: llvm-offload-binary
 // CHECK_TOOLS_OBJECT-SAME: --image=file={{.*}}.bc,triple=spir64-unknown-unknown
@@ -38,17 +38,17 @@
 // CHECK_TOOLS_OBJECT: clang-linker-wrapper
 // CHECK_TOOLS_OBJECT-SAME: --syclbin=object
 
-// RUN: %clangxx -fsycl -fsyclbin=executable --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsycl -fsyclbin=executable --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_EXECUTABLE
-// RUN: %clangxx -fsyclbin=executable --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsyclbin=executable --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_EXECUTABLE
-// RUN: %clang_cl -fsycl -fsyclbin=executable --offload-new-driver %s -### 2>&1 \
+// RUN: %clang_cl -fsycl -fsyclbin=executable --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_EXECUTABLE
-// RUN: %clangxx -fsycl -fsyclbin --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsycl -fsyclbin --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_EXECUTABLE
-// RUN: %clangxx -fsyclbin --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsyclbin --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_EXECUTABLE
-// RUN: %clang_cl -fsycl -fsyclbin --offload-new-driver %s -### 2>&1 \
+// RUN: %clang_cl -fsycl -fsyclbin --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_TOOLS_EXECUTABLE
 // CHECK_TOOLS_EXECUTABLE: llvm-offload-binary
 // CHECK_TOOLS_EXECUTABLE-SAME: --image=file={{.*}}.bc,triple=spir64-unknown-unknown
@@ -58,10 +58,10 @@
 
 /// Check compilation phases, only device compile should be performed
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl -fsyclbin \
-// RUN:   --offload-new-driver %s -ccc-print-phases 2>&1 \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -ccc-print-phases 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_PHASES
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsyclbin \
-// RUN:   --offload-new-driver %s -ccc-print-phases 2>&1 \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -ccc-print-phases 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_PHASES
 // CHECK_PHASES: 0: input, "{{.*}}", c++, (device-sycl)
 // CHECK_PHASES: 1: preprocessor, {0}, c++-cpp-output, (device-sycl)
@@ -74,26 +74,26 @@
 
 /// Check the output file names (file.syclbin, or -o <file>)
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsyclbin \
-// RUN:   --offload-new-driver -o file.syclbin %s -### 2>&1 \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL -o file.syclbin %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_NAMED_OUTPUT
 // CHECK_NAMED_OUTPUT: clang-linker-wrapper
 // CHECK_NAMED_OUTPUT-SAME: "-o" "file.syclbin"
 
-// RUN: %clang_cl -fsyclbin --offload-new-driver -o file.syclbin %s -### 2>&1 \
+// RUN: %clang_cl -fsyclbin --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -o file.syclbin %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_NAMED_OUTPUT_WIN
 // CHECK_NAMED_OUTPUT_WIN: clang-linker-wrapper
 // CHECK_NAMED_OUTPUT_WIN-SAME: "-out:file.syclbin"
 
 /// For Linux - the default is 'a.out' so the syclbin file is 'a.syclbin'
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsyclbin \
-// RUN:   --offload-new-driver %s -### 2>&1 \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_LINUX_DEFAULT_OUTPUT
 // CHECK_LINUX_DEFAULT_OUTPUT: clang-linker-wrapper
 // CHECK_LINUX_DEFAULT_OUTPUT-SAME: "-o" "a.syclbin"
 
 /// For Windows - the default is based on the source file so the syclbin file
 /// is 'fsyclbin.syclbin'
-// RUN: %clang_cl -fsyclbin --offload-new-driver %s -### 2>&1 \
+// RUN: %clang_cl -fsyclbin --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_WIN_DEFAULT_OUTPUT
 // CHECK_WIN_DEFAULT_OUTPUT: clang-linker-wrapper
 // CHECK_WIN_DEFAULT_OUTPUT-SAME: "-out:{{.*}}fsyclbin.syclbin"

--- a/clang/test/Driver/sycl-ftarget-compile-fast.cpp
+++ b/clang/test/Driver/sycl-ftarget-compile-fast.cpp
@@ -1,19 +1,19 @@
 // Test -ftarget-compile-fast behaviors
 
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-compile-fast %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=TARGET_COMPILE_FAST_GEN %s
-// RUN: %clang_cl -### --target=x86_64-pc-windows-msvc -fsycl --offload-new-driver \
+// RUN: %clang_cl -### --target=x86_64-pc-windows-msvc -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL \
 // RUN:     -fsycl-targets=spir64_gen -ftarget-compile-fast %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=TARGET_COMPILE_FAST_GEN %s
 
 // TARGET_COMPILE_FAST_GEN: llvm-offload-binary
 // TARGET_COMPILE_FAST_GEN: compile-opts={{.*}}-options -igc_opts 'PartitionUnit=1,compile-opts=SubroutineThreshold=50000'
 
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -ftarget-compile-fast %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=TARGET_COMPILE_FAST_JIT %s
-// RUN: %clang_cl -### --target=x86_64-pc-windows-msvc -fsycl --offload-new-driver \
+// RUN: %clang_cl -### --target=x86_64-pc-windows-msvc -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL \
 // RUN:     -ftarget-compile-fast %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=TARGET_COMPILE_FAST_JIT %s
 

--- a/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
+++ b/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
@@ -1,95 +1,95 @@
 // Test SYCL -ftarget-register-alloc-mode
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:auto %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=AUTO_AOT %s -DDEVICE=pvc
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:large %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=LARGE_AOT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:small %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=SMALL_AOT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:default %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=DEFAULT_AOT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device pvc" %s 2>&1 \
 // RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -Xsycl-target-backend "-device pvc" %s 2>&1 \
 // RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device pvc" %s 2>&1 \
 // RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 0x0BD5" %s 2>&1 \
 // RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 12.60.7" %s 2>&1 \
 // RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=12.60.7
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device pvc,mtl-s" %s 2>&1 \
 // RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:small,pvc:large %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=MULTIPLE_ARGS_AOT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -ftarget-register-alloc-mode=pvc:auto %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=AUTO_JIT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -ftarget-register-alloc-mode=pvc:large %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=LARGE_JIT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -ftarget-register-alloc-mode=pvc:small %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=SMALL_JIT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -ftarget-register-alloc-mode=pvc:default %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=DEFAULT_JIT %s
 
-// RUN: %clang -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_JIT %} %else %{ -check-prefix=AUTO_JIT %} %s
 
-// RUN: %clang -### -fsycl --offload-new-driver \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -ftarget-register-alloc-mode=pvc:small,pvc:large %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=MULTIPLE_ARGS_JIT %s
 
-// RUN: not %clang -### -fsycl --offload-new-driver \
+// RUN: not %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=dg2:auto %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=BAD_DEVICE %s
 
-// RUN: not %clang -### -fsycl --offload-new-driver \
+// RUN: not %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:superlarge %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=BAD_MODE %s
 
-// RUN: not %clang -### -fsycl --offload-new-driver \
+// RUN: not %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=dg2:superlarge %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=BAD_BOTH %s
 
-// RUN: %clangxx -### -fsycl --offload-new-driver -fsycl-targets=spir64_gen -Xs "-device bdw" \
+// RUN: %clangxx -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64_gen -Xs "-device bdw" \
 // RUN:          %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=NO_PVC %s
 
 // TODO: Test fails on Windows due to improper temporary file creation given
 //       the -device * value.  Re-enable when this is fixed.
-// RUNx: %clangxx -### -fsycl --offload-new-driver -fsycl-targets=spir64_gen -Xs "-device *" \
+// RUNx: %clangxx -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64_gen -Xs "-device *" \
 // RUNx:          %s 2>&1 \
 // RUNx:   | FileCheck -check-prefix=NO_PVC %s
 
-// RUN: %clangxx -### -fsycl --offload-new-driver -fsycl-targets=spir64_gen -Xs "-device pvc:mtl-s" \
+// RUN: %clangxx -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64_gen -Xs "-device pvc:mtl-s" \
 // RUN:          %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=NO_PVC %s
 

--- a/clang/test/Driver/sycl-host-compiler.cpp
+++ b/clang/test/Driver/sycl-host-compiler.cpp
@@ -2,7 +2,7 @@
 // with the new offload model.
 
 /// Enabling with -fsycl-host-compiler
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-host-compiler=/some/dir/g++ %s -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-host-compiler=/some/dir/g++ %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_COMPILER %s
 // HOST_COMPILER: clang{{.*}} "-fsycl-is-device"
 // HOST_COMPILER-SAME: "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\.h]]"
@@ -19,7 +19,7 @@
 // HOST_COMPILER: clang-offload-bundler{{.*}} "-output=[[BUNDLEOBJ:.+\.o]]" "-input=[[DEVICEBC]]" "-input=[[HOSTOBJ]]"
 // HOST_COMPILER: clang-linker-wrapper{{.*}} "[[BUNDLEOBJ]]"
 
-// RUN: %clang_cl -fsycl --offload-new-driver -fsycl-host-compiler=/some/dir/cl %s -### 2>&1 \
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-host-compiler=/some/dir/cl %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_COMPILER_CL %s
 // HOST_COMPILER_CL: clang{{.*}} "-fsycl-is-device"
 // HOST_COMPILER_CL-SAME: "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\.h]]"
@@ -36,51 +36,51 @@
 // HOST_COMPILER_CL: clang-linker-wrapper{{.*}} "[[BUNDLEOBJ]]"
 
 /// Check for additional host options.
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-host-compiler=g++ -fsycl-host-compiler-options="-DFOO -DBAR" %s -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-host-compiler=g++ -fsycl-host-compiler-options="-DFOO -DBAR" %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_OPTIONS %s
 // HOST_OPTIONS: g++{{.*}} "-o" "[[HOSTOBJ:.+\.o]]"{{.*}} "-DFOO" "-DBAR"
 
-// RUN: %clang_cl -fsycl --offload-new-driver -fsycl-host-compiler=cl -fsycl-host-compiler-options="/DFOO /DBAR /O2" %s -### 2>&1 \
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-host-compiler=cl -fsycl-host-compiler-options="/DFOO /DBAR /O2" %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_OPTIONS_CL %s
 // HOST_OPTIONS_CL: cl{{.*}} "-Fo[[HOSTOBJ:.+\.obj]]"{{.*}} "/DFOO" "/DBAR" "/O2"
 
 /// Object output check.
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-host-compiler=g++ -c %s -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-host-compiler=g++ -c %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_OBJECT %s
 // HOST_OBJECT: g++{{.*}} "-c"{{.*}} "-o" "[[OBJOUT:.+\.o]]"
 // HOST_OBJECT: clang-offload-bundler{{.*}} "-input={{.*}}.bc" "-input=[[OBJOUT]]"
 
-// RUN: %clang_cl -fsycl --offload-new-driver -fsycl-host-compiler=cl -c %s -### 2>&1 \
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-host-compiler=cl -c %s -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_OBJECT_CL %s
 // HOST_OBJECT_CL: cl{{.*}} "-c"{{.*}} "-Fo[[OBJOUT:.+\.obj]]"
 // HOST_OBJECT_CL: clang-offload-bundler{{.*}} "-input={{.*}}.bc" "-input=[[OBJOUT]]"
 
 /// Missing argument error -fsycl-host-compiler=.
-// RUN: not %clangxx -fsycl --offload-new-driver -fsycl-host-compiler= -c -### %s 2>&1 \
+// RUN: not %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-host-compiler= -c -### %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_COMPILER_NOARG %s
 // HOST_COMPILER_NOARG: missing argument to '-fsycl-host-compiler='
 
 /// Error for -fsycl-host-compiler and -fsycl-unnamed-lambda combination.
-// RUN: not %clangxx -fsycl --offload-new-driver -fsycl-host-compiler=g++ -fsycl-unnamed-lambda -c -### %s 2>&1 \
+// RUN: not %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-host-compiler=g++ -fsycl-unnamed-lambda -c -### %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=HOST_COMPILER_AND_UNNAMED_LAMBDA %s
 // HOST_COMPILER_AND_UNNAMED_LAMBDA: error: cannot specify '-fsycl-unnamed-lambda' along with '-fsycl-host-compiler'
 
 // -fsycl-host-compiler implies -fno-sycl-unnamed-lambda.
-// RUN: %clangxx -### -fsycl --offload-new-driver -fsycl-host-compiler=g++ -c -### %s 2>&1 \
+// RUN: %clangxx -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-host-compiler=g++ -c -### %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=IMPLY-NO-SYCL-UNNAMED-LAMBDA %s
 // IMPLY-NO-SYCL-UNNAMED-LAMBDA: clang{{.*}} "-fno-sycl-unnamed-lambda"
 
 // Zc:__cplusplus, Zc:__cplusplus- check.
-// RUN: %clang_cl -### -fsycl-host-compiler=cl -fsycl --offload-new-driver %s 2>&1 | FileCheck -check-prefix=CHECK-ZC-CPLUSPLUS %s
-// RUN: %clang_cl -### -fsycl-host-compiler=cl -fsycl --offload-new-driver -fsycl-host-compiler-options=/Zc:__cplusplus- %s 2>&1 | FileCheck -check-prefix=CHECK-ZC-CPLUSPLUS-MINUS %s
+// RUN: %clang_cl -### -fsycl-host-compiler=cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck -check-prefix=CHECK-ZC-CPLUSPLUS %s
+// RUN: %clang_cl -### -fsycl-host-compiler=cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-host-compiler-options=/Zc:__cplusplus- %s 2>&1 | FileCheck -check-prefix=CHECK-ZC-CPLUSPLUS-MINUS %s
 // RUN: %clang_cl -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-ZC-CPLUSPLUS %s
-// RUN: %clang_cl -### -fsycl-host-compiler=g++ -fsycl --offload-new-driver %s 2>&1 | FileCheck -check-prefix=CHECK-NO-ZC-CPLUSPLUS %s
+// RUN: %clang_cl -### -fsycl-host-compiler=g++ -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck -check-prefix=CHECK-NO-ZC-CPLUSPLUS %s
 // CHECK-ZC-CPLUSPLUS: "/Zc:__cplusplus"
 // CHECK-ZC-CPLUSPLUS-MINUS: "/Zc:__cplusplus-"
 // CHECK-NO-ZC-CPLUSPLUS-NOT: "/Zc:__cplusplus"
 
 /// -fsycl-host-compiler -save-temps behavior
-// RUN: %clangxx -### -fsycl-host-compiler=g++ -fsycl --offload-new-driver \
+// RUN: %clangxx -### -fsycl-host-compiler=g++ -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -save-temps -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK_SAVE_TEMPS %s
 // CHECK_SAVE_TEMPS-NOT: error: unsupported output type when using external host compiler
@@ -100,7 +100,7 @@
 // RUN: touch %t/test_path/clang++ && chmod +x %t/test_path/clang++
 // RUN: env "PATH=%t/test_path%{pathsep}%PATH%" \
 // RUN: %clangxx -### -fsycl -fsycl-host-compiler=clang++ \
-// RUN:   -fsycl-host-compiler-options=-DDUMMY_OPT --offload-new-driver \
+// RUN:   -fsycl-host-compiler-options=-DDUMMY_OPT --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   %s 2>&1 \
 // RUN: | FileCheck -check-prefix=PATH_CHECK %s
 // PATH_CHECK: {{(/|\\\\)}}test_path{{(/|\\\\)}}clang++{{.*}} "-DDUMMY_OPT"

--- a/clang/test/Driver/sycl-instrumentation.cpp
+++ b/clang/test/Driver/sycl-instrumentation.cpp
@@ -21,17 +21,17 @@
 
 // ITT annotations in device code are disabled by default. However, for SYCL offloading,
 // we still link ITT annotations libraries to ensure ABI compatibility with previous release.
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=spir64 -### %s 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-ITT-LINK-ONLY %s
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv -nocudalib -### %s 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv -nocudalib -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 
 // CHECK-ITT-LINK-ONLY-NOT: "-fsycl-instrument-device-code"
 // CHECK-ITT-LINK-ONLY: "-mlink-builtin-bitcode" "{{.*}}libsycl-itt-{{.*}}"
 
-// RUN: %clangxx -fsycl --offload-new-driver -fno-sycl-instrument-device-code -fsycl-targets=spir64 -### %s 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -fno-sycl-libspirv -nocudalib -### %s 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -fno-sycl-libspirv -nocudalib -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 
 // CHECK-NONPASSED-NOT: "-fsycl-instrument-device-code"

--- a/clang/test/Driver/sycl-int-header-footer.cpp
+++ b/clang/test/Driver/sycl-int-header-footer.cpp
@@ -1,5 +1,5 @@
 /// Check compilation tool steps when using the integration footer
-// RUN:  %clangxx -fsycl --offload-new-driver -I cmdline/dir -include dummy.h %/s -### 2>&1 \
+// RUN:  %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -I cmdline/dir -include dummy.h %/s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER %s -DSRCDIR=%/S -DCMDDIR=cmdline/dir
 
 // FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}"{{.*}} "-include" "dummy.h"
@@ -9,7 +9,7 @@
 // FOOTER-NOT: "-include-internal-header" "[[INTHEADER]]"
 
 /// Preprocessed file creation with integration footer
-// RUN: %clangxx -fsycl --offload-new-driver -E %/s -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -E %/s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER_PREPROC_GEN %s
 // FOOTER_PREPROC_GEN: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-fsycl-int-footer=[[INTFOOTER:.+\h]]" "-sycl-std={{.*}}" "-o" "[[PREPROC_DEVICE:.+\.ii]]"
 // FOOTER_PREPROC_GEN: clang{{.*}} "-fsycl-is-host"
@@ -21,18 +21,18 @@
 
 /// Preprocessed file use with integration footer
 // RUN: touch %t.ii
-// RUN:  %clangxx -fsycl --offload-new-driver %t.ii -### 2>&1 \
+// RUN:  %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %t.ii -### 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER_PREPROC_USE %s
 // FOOTER_PREPROC_USE: clang{{.*}} "-fsycl-is-host"
 
 /// Check that integration footer can be disabled
-// RUN:  %clangxx -fsycl --offload-new-driver -fno-sycl-use-footer %s -### 2>&1 \
+// RUN:  %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-use-footer %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix NO-FOOTER --implicit-check-not "-fsycl-int-footer" %s
 // NO-FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-sycl-std={{.*}}"
 // NO-FOOTER: clang{{.*}} "-fsycl-is-host"{{.*}} "-include-internal-header" "[[INTHEADER]]"
 
 /// Check phases without integration footer
-// RUN: %clangxx -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fno-sycl-use-footer -target x86_64-unknown-linux-gnu %s -ccc-print-phases 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -fno-sycl-use-footer -target x86_64-unknown-linux-gnu %s -ccc-print-phases 2>&1 \
 // RUN:   | FileCheck -check-prefix NO-FOOTER-PHASES -check-prefix COMMON-PHASES %s
 // NO-FOOTER-PHASES: 0: input, "{{.*}}", c++, (host-sycl)
 // NO-FOOTER-PHASES: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -42,7 +42,7 @@
 // NO-FOOTER-PHASES: [[#DEVICE_IR:]]: compiler, {4}, ir, (device-sycl)
 
 /// Check phases with integration footer
-// RUN: %clangxx -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -target x86_64-unknown-linux-gnu %s -ccc-print-phases 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -target x86_64-unknown-linux-gnu %s -ccc-print-phases 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER-PHASES -check-prefix COMMON-PHASES %s
 // FOOTER-PHASES: 0: input, "{{.*}}", c++, (host-sycl)
 // FOOTER-PHASES: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -59,14 +59,14 @@
 // COMMON-PHASES: [[#OFFLOAD+6]]: clang-linker-wrapper, {[[#OFFLOAD+5]]}, image, (host-sycl)
 
 /// Test for -fsycl-footer-path=<dir>
-// RUN:  %clangxx -fsycl --offload-new-driver -fsycl-footer-path=dummy_dir %s -### 2>&1 \
+// RUN:  %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-footer-path=dummy_dir %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix FOOTER_PATH %s
 // FOOTER_PATH: clang{{.*}} "-fsycl-is-device"
 // FOOTER_PATH-SAME: "-fsycl-int-footer=dummy_dir{{(/|\\\\)}}{{.*}}-footer-{{.*}}.h"
 // FOOTER_PATH: clang{{.*}} "-include-internal-footer" "dummy_dir{{(/|\\\\)}}{{.*}}-footer-{{.*}}.h"
 
 /// Check behaviors for dependency generation
-// RUN:  %clangxx -fsycl --offload-new-driver -MD -c %s -### 2>&1 \
+// RUN:  %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -MD -c %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix DEP_GEN %s
 // DEP_GEN:  clang{{.*}} "-fsycl-is-device"
 // DEP_GEN-SAME: "-dependency-file" "[[DEPFILE:.+\.d]]"
@@ -77,7 +77,7 @@
 // DEP_GEN-SAME: "-dependency-file" "[[DEPFILE]]"
 
 /// Dependency generation phases
-// RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -MD -c %s -ccc-print-phases 2>&1 \
+// RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -MD -c %s -ccc-print-phases 2>&1 \
 // RUN:   | FileCheck -check-prefix DEP_GEN_PHASES %s
 // DEP_GEN_PHASES: 0: input, "[[INPUTFILE:.+\.cpp]]", c++, (host-sycl)
 // DEP_GEN_PHASES: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -93,6 +93,6 @@
 // DEP_GEN_PHASES: 11: assembler, {10}, object, (host-sycl)
 
 /// Allow for -o and preprocessing
-// RUN:  %clangxx -fsycl --offload-new-driver -MD -c %s -o dummy -### 2>&1 \
+// RUN:  %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -MD -c %s -o dummy -### 2>&1 \
 // RUN:   | FileCheck -check-prefix DEP_GEN_OUT_ERROR %s
 // DEP_GEN_OUT_ERROR-NOT: cannot specify -o when generating multiple output files

--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -5,11 +5,11 @@
 // CHECK-ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
 
 // Verify we error when using the new offload driver but with device code split set to off.
-// RUN: not %clangxx -fsycl --offload-new-driver -foffload-lto=thin -fsycl-device-code-split=off %s -### 2>&1 | FileCheck -check-prefix=CHECK-SPLIT-ERROR %s
+// RUN: not %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -foffload-lto=thin -fsycl-device-code-split=off %s -### 2>&1 | FileCheck -check-prefix=CHECK-SPLIT-ERROR %s
 // CHECK-SPLIT-ERROR: '-fsycl-device-code-split=off' is not supported when '-foffload-lto=thin' is set with '-fsycl'
 
 // Verify there's no error and we see the expected cc1 flags and tool invocations with the new offload driver.
-// RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -foffload-lto=thin %s -### 2>&1 | \
 // RUN: FileCheck -check-prefix=CHECK-SUPPORTED -implicit-check-not=-emit-only-kernels-as-entry-points %s
 // CHECK-SUPPORTED: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"
 // CHECK-SUPPORTED: sycl-post-link

--- a/clang/test/Driver/sycl-obj-remove.cpp
+++ b/clang/test/Driver/sycl-obj-remove.cpp
@@ -8,7 +8,7 @@
 // RUN: not ls %t.o
 
 // RUN: touch %t.o
-// RUN: not %clangxx --offload-new-driver -fsycl -Xsycl-target-frontend -DCOMPILE_FAIL=1 -c -o %t.o %s
+// RUN: not %clangxx --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl -Xsycl-target-frontend -DCOMPILE_FAIL=1 -c -o %t.o %s
 // RUN: not ls %t.o
 
 /// Force failure during compilation
@@ -17,7 +17,7 @@
 // RUN: not ls %t.o
 
 // RUN: touch %t.o
-// RUN: not %clangxx --offload-new-driver -fsycl -DCOMPILE_FAIL=1 -c -o %t.o %s
+// RUN: not %clangxx --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl -DCOMPILE_FAIL=1 -c -o %t.o %s
 // RUN: not ls %t.o
 
 void func(){};

--- a/clang/test/Driver/sycl-offload-arch-intel-cpu.cpp
+++ b/clang/test/Driver/sycl-offload-arch-intel-cpu.cpp
@@ -3,62 +3,62 @@
 
 // SYCL AOT compilation to Intel CPUs using --offload-arch
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=broadwell %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=broadwell %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=broadwell
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=coffeelake %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=coffeelake %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=coffeelake
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=icelake-client %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=icelake-client %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=icelake-client
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=skylake-avx512 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=skylake-avx512 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=skylake-avx512
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=core-avx2 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=core-avx2 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=core-avx2
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=corei7-avx %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=corei7-avx %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=corei7-avx
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=corei7 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=corei7 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=corei7
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=westmere %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=westmere %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=westmere
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=sandybridge %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=sandybridge %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=sandybridge
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=ivybridge %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=ivybridge %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=ivybridge
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=alderlake %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=alderlake %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=alderlake
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=skylake %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=skylake %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=skylake
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=skx %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=skx %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=skx
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=cascadelake %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=cascadelake %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=cascadelake
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=icelake-server %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=icelake-server %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=icelake-server
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=sapphirerapids %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=sapphirerapids %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=sapphirerapids
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=graniterapids %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=graniterapids %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=graniterapids
 
 // Tests for handling a missing architecture.
 //
-// RUN:  %clangxx --offload-new-driver -fsycl --offload-arch= %s -### 2>&1 \
+// RUN:  %clangxx --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch= %s -### 2>&1 \
 // RUN:   | FileCheck --check-prefixes=TARGET-TRIPLE-DEFAULT,CLANG-OFFLOAD-PACKAGER-DEFAULT %s
-// RUN:  %clang_cl --offload-new-driver -fsycl --offload-arch= %s -### 2>&1 \
+// RUN:  %clang_cl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl --offload-arch= %s -### 2>&1 \
 // RUN:   | FileCheck --check-prefixes=TARGET-TRIPLE-DEFAULT,CLANG-OFFLOAD-PACKAGER-DEFAULT %s
 
 // TARGET-TRIPLE-CPU: clang{{.*}} "-triple" "spir64_x86_64-unknown-unknown"
@@ -70,9 +70,9 @@
 
 // Tests for handling a incorrect architecture.
 //
-// RUN: not %clangxx --offload-new-driver -fsycl --offload-arch=badArch %s -### 2>&1 \
+// RUN: not %clangxx --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=badArch %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix=BAD-ARCH %s
-// RUN: not %clang_cl --offload-new-driver -fsycl --offload-arch=badArch %s -### 2>&1 \
+// RUN: not %clang_cl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl --offload-arch=badArch %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix=BAD-ARCH %s
 
 // BAD-ARCH: error: unsupported offload gpu architecture: badArch

--- a/clang/test/Driver/sycl-offload-arch-intel-gpu.cpp
+++ b/clang/test/Driver/sycl-offload-arch-intel-gpu.cpp
@@ -3,118 +3,118 @@
 
 // SYCL AOT compilation to Intel GPUs using --offload-arch
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=bdw %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=bdw %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=bdw -DMAC_STR=BDW
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=skl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=skl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=skl -DMAC_STR=SKL
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=kbl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=kbl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=kbl -DMAC_STR=KBL
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=cfl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=cfl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=cfl -DMAC_STR=CFL
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=apl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=apl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=apl -DMAC_STR=APL
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=bxt %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=bxt %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=apl -DMAC_STR=APL
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=glk %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=glk %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=glk -DMAC_STR=GLK
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=whl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=whl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=whl -DMAC_STR=WHL
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=aml %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=aml %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=aml -DMAC_STR=AML
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=cml %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=cml %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=cml -DMAC_STR=CML
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=icllp %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=icllp %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=icllp -DMAC_STR=ICLLP
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=icl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=icl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=icllp -DMAC_STR=ICLLP
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=ehl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=ehl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=ehl -DMAC_STR=EHL
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=jsl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=jsl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=ehl -DMAC_STR=EHL
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=tgllp %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=tgllp %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=tgllp -DMAC_STR=TGLLP
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=tgl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=tgl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=tgllp -DMAC_STR=TGLLP
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=rkl %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=rkl %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=rkl -DMAC_STR=RKL
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=adl_s %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=adl_s %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=adl_s -DMAC_STR=ADL_S
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=rpl_s %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=rpl_s %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=adl_s -DMAC_STR=ADL_S
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=adl_p %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=adl_p %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=adl_p -DMAC_STR=ADL_P
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=adl_n %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=adl_n %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=adl_n -DMAC_STR=ADL_N
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=dg1 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=dg1 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=dg1 -DMAC_STR=DG1
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=acm_g10 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=acm_g10 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=acm_g10 -DMAC_STR=ACM_G10
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=dg2_g10 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=dg2_g10 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=acm_g10 -DMAC_STR=ACM_G10
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=acm_g11 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=acm_g11 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=acm_g11 -DMAC_STR=ACM_G11
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=dg2_g11 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=dg2_g11 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=acm_g11 -DMAC_STR=ACM_G11
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=acm_g12 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=acm_g12 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=acm_g12 -DMAC_STR=ACM_G12
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=dg2_g12 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=dg2_g12 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=acm_g12 -DMAC_STR=ACM_G12
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=pvc %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=pvc %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=pvc -DMAC_STR=PVC
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=pvc_vg %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=pvc_vg %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=pvc_vg -DMAC_STR=PVC_VG
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=mtl_u %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=mtl_u %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=mtl_u -DMAC_STR=MTL_U
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=mtl_s %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=mtl_s %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=mtl_u -DMAC_STR=MTL_U
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=arl_u %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=arl_u %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=mtl_u -DMAC_STR=MTL_U
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=arl_s %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=arl_s %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=mtl_u -DMAC_STR=MTL_U
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=mtl_h %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=mtl_h %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=mtl_h -DMAC_STR=MTL_H
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=arl_h %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=arl_h %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=arl_h -DMAC_STR=ARL_H
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=bmg_g21 %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=bmg_g21 %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=bmg_g21 -DMAC_STR=BMG_G21
 
-// RUN: %clangxx -### --offload-new-driver -fsycl --offload-arch=lnl_m %s 2>&1 | \
+// RUN: %clangxx -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl --offload-arch=lnl_m %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU-OPTS -DDEV_STR=lnl_m -DMAC_STR=LNL_M
 
 // TARGET-TRIPLE-GPU: clang{{.*}} "-triple" "spir64_gen-unknown-unknown"

--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -1,9 +1,9 @@
 /// Perform several driver tests for SYCL offloading for JIT
 
 /// Check the phases graph with -fsycl. Use of -fsycl enables offload
-// RUN: %clang --offload-new-driver -ccc-print-phases --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
+// RUN: %clang --offload-new-driver --sysroot=%S/Inputs/SYCL -ccc-print-phases --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-PHASES %s
-// RUN: %clang_cl --offload-new-driver -ccc-print-phases --target=x86_64-pc-windows-msvc -fsycl -- %s 2>&1 \
+// RUN: %clang_cl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -ccc-print-phases --target=x86_64-pc-windows-msvc -fsycl -- %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-PHASES %s
 // CHK-PHASES: 0: input, "[[INPUT:.+\.cpp]]", c++, (host-sycl)
 // CHK-PHASES-NEXT: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -21,7 +21,7 @@
 
 /// Check expected default values for device compilation when using -fsycl as
 /// well as llvm-offload-binary inputs.
-// RUN: %clang --offload-new-driver -### -fsycl -c --target=x86_64-unknown-linux-gnu %s 2>&1 \
+// RUN: %clang --offload-new-driver --sysroot=%S/Inputs/SYCL -### -fsycl -c --target=x86_64-unknown-linux-gnu %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DEVICE-TRIPLE %s
 // CHK-DEVICE-TRIPLE: "-cc1"{{.*}} "-triple" "spir64-unknown-unknown"
 // CHK-DEVICE-TRIPLE-SAME: "-aux-triple" "x86_64-unknown-linux-gnu"
@@ -31,7 +31,7 @@
 
 // Check if path to libsycl.so is passed to clang-linker-wrapper tool by default for SYCL compilation.
 // The test also checks if SYCL header include paths are added to the SYCL host and device compilation.
-// INTEL-RUN: %clang --offload-new-driver -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
+// INTEL-RUN: %clang --offload-new-driver --sysroot=%S/Inputs/SYCL -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
 // CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
 // CHECK-SYCL-HEADERS-HOST: "-fsycl-is-host"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
@@ -43,13 +43,13 @@
 
 /// Check -fsycl-is-device is passed when compiling for the device.
 /// Check -fsycl-is-host is passed when compiling for host.
-// RUN: %clang --offload-new-driver -### -fsycl -c %s 2>&1 \
+// RUN: %clang --offload-new-driver --sysroot=%S/Inputs/SYCL -### -fsycl -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-FSYCL-IS-DEVICE,CHK-FSYCL-IS-HOST %s
-// RUN: %clang --offload-new-driver -### -fsycl -fsycl-device-only %s 2>&1 \
+// RUN: %clang --offload-new-driver --sysroot=%S/Inputs/SYCL -### -fsycl -fsycl-device-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-IS-DEVICE %s
-// RUN: %clang_cl --offload-new-driver -### -fsycl -c -- %s 2>&1 \
+// RUN: %clang_cl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -### -fsycl -c -- %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-FSYCL-IS-DEVICE,CHK-FSYCL-IS-HOST %s
-// RUN: %clang --offload-new-driver -### -fsycl -fsycl-host-only %s 2>&1 \
+// RUN: %clang --offload-new-driver --sysroot=%S/Inputs/SYCL -### -fsycl -fsycl-host-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-IS-HOST %s
 // CHK-FSYCL-IS-DEVICE: "-cc1"{{.*}} "-fsycl-is-device" {{.*}} "-emit-llvm-bc"
 // CHK-FSYCL-IS-HOST: "-cc1"{{.*}} "-fsycl-is-host"

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: system-linux
 /// Verify --offload-new-driver option phases
-// RUN:  %clang --target=x86_64-unknown-linux-gnu -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64 --offload-new-driver -ccc-print-phases %s 2>&1 \
+// RUN:  %clang --target=x86_64-unknown-linux-gnu -fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64 --offload-new-driver --sysroot=%S/Inputs/SYCL -ccc-print-phases %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=OFFLOAD-NEW-DRIVER %s
 // OFFLOAD-NEW-DRIVER: 0: input, "[[INPUT:.+\.cpp]]", c++, (host-sycl)
 // OFFLOAD-NEW_DRIVER: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -23,7 +23,7 @@
 // OFFLOAD-NEW_DRIVER: 18: clang-linker-wrapper, {17}, image, (host-sycl)
 
 /// Check the toolflow for SYCL compilation using new offload model
-// RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64 --offload-new-driver %s 2>&1 | FileCheck -check-prefix=CHK-FLOW %s
+// RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64 --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck -check-prefix=CHK-FLOW %s
 // CHK-FLOW: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" "-aux-triple" "x86_64-unknown-linux-gnu" "-fsycl-is-device" {{.*}} "-fsycl-int-header=[[HEADER:.*]].h" "-fsycl-int-footer=[[FOOTER:.*]].h" {{.*}} "--offload-new-driver" {{.*}} "-o" "[[CC1DEVOUT:.*]]" "-x" "c++" "[[INPUT:.*]]"
 // CHK-FLOW-NEXT: llvm-offload-binary{{.*}} "-o" "[[PACKOUT:.*]]" "--image=file=[[CC1DEVOUT]],triple=spir64-unknown-unknown,arch=generic,kind=sycl{{.*}}"
 // CHK-FLOW-NEXT: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu"{{.*}} "-fsycl-is-host"{{.*}} "-include-internal-header" "[[HEADER]].h" "-dependency-filter" "[[HEADER]].h" {{.*}} "-include-internal-footer" "[[FOOTER]].h" "-dependency-filter" "[[FOOTER]].h"{{.*}} "--offload-new-driver" {{.*}} "-fembed-offload-object=[[PACKOUT]]" {{.*}} "-o" "[[CC1FINALOUT:.*]]" "-x" "c++" "[[INPUT]]"
@@ -44,21 +44,21 @@
 // SPIRV_OBJ: [[#SPVOBJ+4]]: llvm-spirv, {[[#SPVOBJ+3]]}, spirv, (device-sycl)
 // SPIRV_OBJ: [[#SPVOBJ+5]]: offload, "device-sycl (spir64-unknown-unknown)" {[[#SPVOBJ+4]]}, {{.*}}
 
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -Xspirv-translator -translator-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_TRANSLATOR %s
 // WRAPPER_OPTIONS_TRANSLATOR: clang-linker-wrapper{{.*}} "--llvm-spirv-options={{.*}}-translator-opt{{.*}}"
 
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -Xdevice-post-link -post-link-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_POSTLINK %s
 // WRAPPER_OPTIONS_POSTLINK: clang-linker-wrapper{{.*}} "--sycl-post-link-options=-O2 -device-globals -post-link-opt"
 
 // -fsycl-device-only behavior
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fsycl-device-only -ccc-print-phases %s 2>&1 \
 // RUN   | FileCheck -check-prefix DEVICE_ONLY %s
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          --offload-device-only -ccc-print-phases %s 2>&1 \
 // RUN:  | FileCheck -check-prefix DEVICE_ONLY %s
 // DEVICE_ONLY: 0: input, "{{.*}}", c++, (device-sycl)
@@ -68,28 +68,28 @@
 // DEVICE_ONLY: 4: offload, "device-sycl (spir64-unknown-unknown)" {3}, none
 
 /// check for -shared transmission to clang-linker-wrapper tool
-// RUN: %clangxx -### -fsycl --offload-new-driver -target x86_64-unknown-linux-gnu \
+// RUN: %clangxx -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-linux-gnu \
 // RUN:          -shared %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_SHARED %s
 // CHECK_SHARED: clang-linker-wrapper{{.*}} "-shared"
 
 // Verify 'arch' offload-packager values for known targets
 // RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
-// RUN:          -fsycl-targets=spir64 --offload-new-driver %s 2>&1 \
+// RUN:          -fsycl-targets=spir64 --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK_ARCH \
 // RUN:              -DTRIPLE=spir64-unknown-unknown -DARCH= %s
 // RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
-// RUN:          -fsycl-targets=intel_gpu_pvc --offload-new-driver %s 2>&1 \
+// RUN:          -fsycl-targets=intel_gpu_pvc --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK_ARCH \
 // RUN:              -DTRIPLE=spir64_gen-unknown-unknown -DARCH=pvc %s
 // RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
 // RUN:          -fno-sycl-libspirv -fsycl-targets=amd_gpu_gfx900 \
-// RUN:          -nogpulib --offload-new-driver %s 2>&1 \
+// RUN:          -nogpulib --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK_ARCH \
 // RUN:              -DTRIPLE=amdgcn-amd-amdhsa -DARCH=gfx900 %s
 // RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
 // RUN:          -fno-sycl-libspirv -fsycl-targets=nvidia_gpu_sm_75 \
-// RUN:          -nogpulib --offload-new-driver %s 2>&1 \
+// RUN:          -nogpulib --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK_ARCH \
 // RUN:              -DTRIPLE=nvptx64-nvidia-cuda -DARCH=sm_75 %s
 // CHK_ARCH: clang{{.*}} "-triple" "[[TRIPLE]]"
@@ -103,7 +103,7 @@
 // RUN:          -Xsycl-target-backend=intel_gpu_pvc -spir64_gen-opt \
 // RUN:          -Xsycl-target-linker=spir64 -spir64-link-opt \
 // RUN:          -Xsycl-target-linker=intel_gpu_pvc -spir64_gen-link-opt \
-// RUN:          --offload-new-driver %s 2>&1 \
+// RUN:          --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK_PACKAGER_OPTS %s
 // CHK_PACKAGER_OPTS: llvm-offload-binary{{.*}} "-o"
 // CHK_PACKAGER_OPTS-SAME: {{.*}}triple=spir64-unknown-unknown,arch=generic,kind=sycl,compile-opts={{.*}}-spir64-opt,link-opts=-spir64-link-opt
@@ -134,18 +134,18 @@
 // MULT_TARG_PHASES: 16: assembler, {15}, object, (host-sycl)
 
 /// Test option passing behavior for clang-offload-wrapper options.
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -Xsycl-target-backend -backend-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_BACKEND %s
 // WRAPPER_OPTIONS_BACKEND: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64-unknown-unknown=-backend-opt"
 
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -Xsycl-target-linker -link-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_LINK %s
 // WRAPPER_OPTIONS_LINK: clang-linker-wrapper{{.*}} "--device-linker=sycl:spir64-unknown-unknown=-link-opt"
 
 /// Test option passing behavior for clang-offload-wrapper options for AOT.
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fsycl-targets=spir64_gen,spir64_x86_64 \
 // RUN:          -Xsycl-target-backend=spir64_gen -backend-gen-opt \
 // RUN:          -Xsycl-target-backend=spir64_x86_64 -backend-cpu-opt \
@@ -157,79 +157,70 @@
 
 /// Verify arch settings for nvptx and amdgcn targets
 // RUN: %clangxx -fsycl -### -fsycl-targets=amdgcn-amd-amdhsa -fno-sycl-libspirv \
-// RUN:          -nocudalib --offload-new-driver \
+// RUN:          -nocudalib --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx600 \
 // RUN:          %s 2>&1 \
 // RUN:   | FileCheck -check-prefix AMD_ARCH %s
 // AMD_ARCH: llvm-offload-binary{{.*}} "--image=file={{.*}},triple=amdgcn-amd-amdhsa,arch=gfx600,kind=sycl,compile-opts=--offload-arch=gfx600"
 
 // RUN: %clangxx -fsycl -### -fsycl-targets=nvptx64-nvidia-cuda \
-// RUN:          -fno-sycl-libspirv -nocudalib --offload-new-driver %s 2>&1 \
+// RUN:          -fno-sycl-libspirv -nocudalib --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:   | FileCheck -check-prefix NVPTX_DEF_ARCH %s
 // NVPTX_DEF_ARCH: llvm-offload-binary{{.*}} "--image=file={{.*}},triple=nvptx64-nvidia-cuda,arch=sm_75,kind=sycl"
 
 /// check for -sycl-embed-ir transmission to clang-linker-wrapper tool
 // RUN: %clangxx -fsycl -### -fsycl-targets=nvptx64-nvidia-cuda \
-// RUN:          -fno-sycl-libspirv -nocudalib --offload-new-driver \
+// RUN:          -fno-sycl-libspirv -nocudalib --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fsycl-embed-ir %s 2>&1 \
 // RUN:  | FileCheck -check-prefix CHECK_EMBED_IR %s
 // CHECK_EMBED_IR: clang-linker-wrapper{{.*}} "-sycl-embed-ir"
 
 /// Verify the filename being passed to the packager does not contain commas
 /// that are used in -device settings.
-// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver \
+// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -Xsycl-target-backend=spir64_gen "-device pvc,bdw" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix COMMA_FILE %s
 // COMMA_FILE: llvm-offload-binary{{.*}} "--image=file={{.*}}pvc@bdw{{.*}},triple=spir64_gen-unknown-unknown,arch=pvc,arch=bdw,kind=sycl,compile-opts=-device_options pvc -ze-intel-enable-auto-large-GRF-mode -device pvc,compile-opts=bdw"
 
 /// Verify the arch value for the packager is populated with different
 /// scenarios for spir64_gen
-// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver \
+// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -Xsycl-target-backend=spir64_gen "-device bdw" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix ARCH_CHECK %s
-// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver \
+// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -Xsycl-target-backend "-device bdw" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix ARCH_CHECK %s
 // RUN: %clangxx -fsycl -### -fsycl-targets=intel_gpu_bdw \
-// RUN: --offload-new-driver %s 2>&1 \
+// RUN: --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:   | FileCheck -check-prefix ARCH_CHECK %s
-// RUN: %clang_cl -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver \
+// RUN: %clang_cl -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL \
 // RUN:   -Xsycl-target-backend=spir64_gen "-device bdw" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix ARCH_CHECK %s
-// RUN: %clang_cl -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver \
+// RUN: %clang_cl -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL \
 // RUN:   -Xsycl-target-backend "-device bdw" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix ARCH_CHECK %s
 // RUN: %clang_cl -fsycl -### -fsycl-targets=intel_gpu_bdw \
-// RUN: --offload-new-driver %s 2>&1 \
+// RUN: --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:   | FileCheck -check-prefix ARCH_CHECK %s
 // ARCH_CHECK: llvm-offload-binary{{.*}} "--image=file={{.*}}triple=spir64_gen-unknown-unknown,arch=bdw,kind=sycl{{.*}}"
 
 // Verify when a comma-separated list of architectures is provided in -device, they are
 // passed to llvm-offload-binary correctly.
-// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver \
+// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -Xsycl-target-backend "-device pvc,bdw" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix MULTI_ARCH %s
-// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver \
+// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -Xsycl-target-backend=spir64_gen "-device pvc,bdw" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix MULTI_ARCH %s
-// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver \
+// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -Xs "-device pvc,bdw" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix MULTI_ARCH %s
 // MULTI_ARCH: llvm-offload-binary{{.*}} "--image=file={{.*}}triple=spir64_gen-unknown-unknown,arch=pvc,arch=bdw,kind=sycl
 // MULTI_ARCH-SAME: compile-opts=-device_options pvc -ze-intel-enable-auto-large-GRF-mode -device pvc,compile-opts=bdw"
 
-// Verify that when an object produced by llvm-offload-binary with multiple Intel GPU architectures
-// clang-linker-wrapper will call ocloc with -device listing all architectures.
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen --offload-new-driver \
-// RUN:  -Xsycl-target-backend=spir64_gen "-device pvc,bdw" -c %s -o %t_multiarch_test.o
-// RUN: clang-linker-wrapper --dry-run --linker-path=/usr/bin/ld \
-// RUN:  --host-triple=x86_64-unknown-linux-gnu %t_multiarch_test.o 2>&1 \
-// RUN:  | FileCheck -check-prefix=OCLOC_MULTI_ARCH %s
-// OCLOC_MULTI_ARCH: ocloc{{.*}}-device pvc,bdw
-
 // Verify for multiple targets with -Xsycl-target-backend= with commas in the values
 // are passed correctly to llvm-offload-binary.
-// RUN: %clangxx -fsycl -### --offload-new-driver -fno-sycl-libspirv \
+// RUN: %clangxx -fsycl -### --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-libspirv \
 // RUN:  -fsycl-targets=nvptx64-nvidia-cuda,amdgcn-amd-amdhsa,spir64_gen \
 // RUN:  -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908,gfx1010 \
 // RUN:  -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_86,sm_87,sm_89 \
@@ -244,7 +235,7 @@
 // MULTI_ARCH2-SAME: "--image=file={{.*}}triple=spir64_gen-unknown-unknown,arch=pvc,arch=bdw,kind=sycl,compile-opts=-device_options pvc -ze-intel-enable-auto-large-GRF-mode -device pvc,compile-opts=bdw,link-opts=-DFOO,link-opts=BAR"
 
 // Verify that the driver correctly handles link-opt and compile-opt values with commas
-// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver \
+// RUN: %clangxx -fsycl -### -fsycl-targets=spir64_gen --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:   -Xsycl-target-backend "-device bdw -FOO a,b" \
 // RUN:   -Xsycl-target-linker "-BAR x,y" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix COMMA_OPTS %s
@@ -253,39 +244,39 @@
 /// Verify that --cuda-path is passed to clang-linker-wrapper for SYCL offload
 // RUN: %clangxx -fsycl -### -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-libspirv \
 // RUN:          --cuda-gpu-arch=sm_20 --cuda-path=%S/Inputs/CUDA_80/usr/local/cuda %s \
-// RUN:          --offload-new-driver 2>&1 \
+// RUN:          --offload-new-driver --sysroot=%S/Inputs/SYCL 2>&1 \
 // RUN:   | FileCheck -check-prefix NVPTX_CUDA_PATH %s
 // NVPTX_CUDA_PATH: clang-linker-wrapper{{.*}}--cuda-path={{.*}}Inputs/CUDA_80/usr/local/cuda"
 
 /// Check for -sycl-allow-device-image-dependencies transmission to clang-linker-wrapper tool
-// RUN: %clangxx -fsycl -###  --offload-new-driver \
+// RUN: %clangxx -fsycl -###  --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fsycl-allow-device-image-dependencies %s 2>&1 \
 // RUN:  | FileCheck -check-prefix CHECK_DYNAMIC_LINKING %s
 // CHECK_DYNAMIC_LINKING: clang-linker-wrapper{{.*}} "-sycl-allow-device-image-dependencies"
 
 /// Check that -sycl-allow-device-image-dependencies is not passed to clang-linker-wrapper tool
-// RUN: %clangxx -fsycl -### --offload-new-driver \
+// RUN: %clangxx -fsycl -### --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fno-sycl-allow-device-image-dependencies %s 2>&1 \
 // RUN:  | FileCheck -check-prefix CHECK_NO_DYNAMIC_LINKING %s
 
 /// Check that -sycl-allow-device-image-dependencies is not passed to clang-linker-wrapper tool
-// RUN: %clangxx -fsycl -### --offload-new-driver %s 2>&1 \
+// RUN: %clangxx -fsycl -### --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:  | FileCheck -check-prefix CHECK_NO_DYNAMIC_LINKING %s
 // CHECK_NO_DYNAMIC_LINKING-NOT: clang-linker-wrapper{{.*}} "-sycl-allow-device-image-dependencies"
 
 // Check if fsycl-targets correctly processes multiple NVidia
 // and AMD GPU targets.
-// RUN:   %clang -### -fsycl -fsycl-targets=nvidia_gpu_sm_60,nvidia_gpu_sm_70 -fno-sycl-libspirv -nocudalib --offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl -fsycl-targets=nvidia_gpu_sm_60,nvidia_gpu_sm_70 -fno-sycl-libspirv -nocudalib --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-MACRO-SM-60,CHK-MACRO-SM-70 %s
 // CHK-MACRO-SM-60: clang{{.*}} "-fsycl-is-device"{{.*}} "-D__SYCL_TARGET_NVIDIA_GPU_SM_60__"{{.*}}
 // CHK-MACRO-SM-70: clang{{.*}} "-fsycl-is-device"{{.*}} "-D__SYCL_TARGET_NVIDIA_GPU_SM_70__"{{.*}}
-// RUN:   %clang -### -fsycl -fsycl-targets=amd_gpu_gfx90a,amd_gpu_gfx90c -fno-sycl-libspirv -nogpulib --offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl -fsycl-targets=amd_gpu_gfx90a,amd_gpu_gfx90c -fno-sycl-libspirv -nogpulib --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-MACRO-GFX90A,CHK-MACRO-GFX90C %s
 // CHK-MACRO-GFX90A: clang{{.*}} "-fsycl-is-device"{{.*}} "-D__SYCL_TARGET_AMD_GPU_GFX90A__"{{.*}}
 // CHK-MACRO-GFX90C: clang{{.*}} "-fsycl-is-device"{{.*}} "-D__SYCL_TARGET_AMD_GPU_GFX90C__"{{.*}}
 
 /// Check that -sycl-device-link is passed to clang-linker-wrapper tool
-// RUN: %clangxx -fsycl -### --offload-new-driver \
+// RUN: %clangxx -fsycl -### --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fsycl-link %s 2>&1 \
 // RUN:  | FileCheck -check-prefix CHECK_SYCL_DEVICE_LINKING %s
 // CHECK_SYCL_DEVICE_LINKING: clang-linker-wrapper{{.*}} "--sycl-device-link"

--- a/clang/test/Driver/sycl-offload-save-temps.cpp
+++ b/clang/test/Driver/sycl-offload-save-temps.cpp
@@ -1,11 +1,11 @@
 /// SYCL offloading tests using -save-temps
 
 /// Verify that -save-temps does not crash
-// RUN: %clang -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-SAVE-TEMPS
-// RUN: %clang -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-SAVE-TEMPS
-// RUN: %clangxx -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHK-FSYCL-SAVE-TEMPS
 // CHK-FSYCL-SAVE-TEMPS: clang{{.*}} "-fsycl-is-device"{{.*}} "-o" "[[DEVICE_BASE_NAME:[a-z0-9-]+]].ii"
 // CHK-FSYCL-SAVE-TEMPS: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[HEADER_NAME:.+\-header.+\.h]]" "-fsycl-int-footer={{.*}}"{{.*}} "-o" "[[DEVICE_BASE_NAME]].bc"{{.*}} "[[DEVICE_BASE_NAME]].ii"
@@ -17,17 +17,17 @@
 // CHK-FSYCL-SAVE-TEMPS: ld{{.*}} "[[HOST_BASE_NAME]].o"
 
 /// Verify that -save-temps puts header/footer in a correct place
-// RUN: %clang -fsycl --offload-new-driver --no-offloadlib -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-DIR
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL --no-offloadlib -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-DIR
 // CHECK-SAVE-TEMPS-DIR: clang{{.*}} "-fsycl-int-header=sycl-offload-save-temps-header-{{[a-z0-9]*}}.h"{{.*}}"-fsycl-int-footer=sycl-offload-save-temps-footer-{{[a-z0-9]*}}.h"
 
 /// Verify that -save-temps=obj respects the -o dir
-// RUN: %clang -fsycl --offload-new-driver --no-offloadlib -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps=obj -o %S %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-OBJ-DIR
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL --no-offloadlib -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps=obj -o %S %s -### 2>&1 | FileCheck %s -check-prefixes=CHECK-SAVE-TEMPS-OBJ-DIR
 // CHECK-SAVE-TEMPS-OBJ-DIR: clang{{.*}}-fsycl-int-header={{.*[/\\]+clang[/\\]+test[/\\]+sycl-offload-save-temps-header-[a-z0-9]*}}.h{{.*}}-fsycl-int-footer={{.*[/\\]+clang[/\\]+test[/\\]+sycl-offload-save-temps-footer-[a-z0-9]*}}.h
 
 /// Usage of -save-temps should not set -disable-llvm-passes for device
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHK_LLVM_PASSES
-// RUN: %clang -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHK_LLVM_PASSES
 // CHK_LLVM_PASSES-NOT: clang{{.*}} "-triple" "spir64-unknown-unknown" {{.*}} "-disable-llvm-passes"
 // CHK_LLVM_PASSES: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-disable-llvm-passes"

--- a/clang/test/Driver/sycl-offload-with-split.cpp
+++ b/clang/test/Driver/sycl-offload-with-split.cpp
@@ -7,9 +7,9 @@
 /// ###########################################################################
 
 /// Ahead of Time compilation for gen, cpu - tool invocation
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fsycl-device-code-split -fsycl-targets=spir64_gen-unknown-unknown %s -### 2>&1 \
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -fsycl-device-code-split -fsycl-targets=spir64_gen-unknown-unknown %s -### 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=CHK-TOOLS-AOT
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fsycl-device-code-split -fsycl-targets=spir64_x86_64-unknown-unknown %s -### 2>&1 \
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -fsycl-device-code-split -fsycl-targets=spir64_x86_64-unknown-unknown %s -### 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=CHK-TOOLS-AOT
 // CHK-TOOLS-AOT: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INPUT1:.+\-header.+\.h]]" "-fsycl-int-footer={{.*}}"{{.*}} "-o" "[[OUTPUT1:.+\.bc]]"
 // CHK-TOOLS-AOT: llvm-offload-binary{{.*}}
@@ -19,42 +19,42 @@
 /// ###########################################################################
 
 // Check -fsycl-device-code-split=per_kernel option passing.
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-code-split=per_kernel %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-code-split=per_kernel %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-ONE-KERNEL
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-code-split=per_kernel %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-device-code-split=per_kernel %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-ONE-KERNEL
 // CHK-ONE-KERNEL: clang-linker-wrapper{{.*}} {{.*}}--sycl-post-link-options=-split=kernel
 
 // Check -fsycl-device-code-split=per_source option passing.
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-code-split=per_source %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-code-split=per_source %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-PER-SOURCE
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-code-split=per_source %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-device-code-split=per_source %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-PER-SOURCE
 // CHK-PER-SOURCE: clang-linker-wrapper{{.*}} {{.*}}--sycl-post-link-options=-split=source
 
 // Check -fsycl-device-code-split option passing.
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-code-split %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-code-split %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-AUTO
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-code-split %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-device-code-split %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-AUTO
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-code-split=auto %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-code-split=auto %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-AUTO
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-code-split=auto %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-device-code-split=auto %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-AUTO
 // CHK-AUTO: clang-linker-wrapper{{.*}} {{.*}}--sycl-post-link-options=-split=auto
 
 // Check -fsycl-device-code-split=off passes -split=none to the linker wrapper.
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-code-split=off %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-code-split=off %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-SPLIT-OFF
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-device-code-split=off %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-device-code-split=off %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-SPLIT-OFF
 // CHK-SPLIT-OFF: clang-linker-wrapper{{.*}} {{.*}}--sycl-post-link-options={{.*}}-split=none
 
 // Check that without -fsycl-device-code-split, no -split= option is passed
 // (sycl-post-link defaults to -split=auto).
-// RUN:   %clang -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-SPLIT-DEFAULT
-// RUN:   %clang_cl -### -fsycl --offload-new-driver %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix=CHK-SPLIT-DEFAULT
 // CHK-SPLIT-DEFAULT: clang-linker-wrapper
 // CHK-SPLIT-DEFAULT-NOT: -split=

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -7,27 +7,27 @@
 /// ###########################################################################
 
 /// Check whether an invalid SYCL target is specified:
-// RUN:   not %clang -### -fsycl --offload-new-driver -fsycl-targets=aaa-bbb-ccc-ddd %s 2>&1 \
+// RUN:   not %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=aaa-bbb-ccc-ddd %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INVALID-TARGET %s
-// RUN:   not %clang_cl -### -fsycl --offload-new-driver -fsycl-targets=aaa-bbb-ccc-ddd %s 2>&1 \
+// RUN:   not %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=aaa-bbb-ccc-ddd %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INVALID-TARGET %s
 // CHK-INVALID-TARGET: error: invalid or unsupported offload target: 'aaa-bbb-ccc-ddd'
 
 /// ###########################################################################
 
 /// Check whether an invalid SYCL target is specified:
-// RUN:   not %clang -### -fsycl --offload-new-driver -fsycl-targets=x86_64 %s 2>&1 \
+// RUN:   not %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=x86_64 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INVALID-REAL-TARGET %s
-// RUN:   not %clang_cl -### -fsycl --offload-new-driver -fsycl-targets=x86_64 %s 2>&1 \
+// RUN:   not %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=x86_64 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INVALID-REAL-TARGET %s
 // CHK-INVALID-REAL-TARGET: error: invalid or unsupported offload target: 'x86_64'
 
 /// ###########################################################################
 
 /// Check warning for empty -fsycl-targets
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-targets=  %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-EMPTY-SYCLTARGETS %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-targets=  %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-EMPTY-SYCLTARGETS %s
 // CHK-EMPTY-SYCLTARGETS: warning: joined argument expects additional value: '-fsycl-targets='
 
@@ -46,26 +46,26 @@
 /// ###########################################################################
 
 /// Validate SYCL option values
-// RUN:   not %clang -### -fsycl-device-code-split=bad_value -fsycl --offload-new-driver  %s 2>&1 \
+// RUN:   not %clang -### -fsycl-device-code-split=bad_value -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-BAD-OPT-VALUE -Doption=-fsycl-device-code-split %s
-// RUN:   not %clang -### -fsycl-link=bad_value -fsycl --offload-new-driver  %s 2>&1 \
+// RUN:   not %clang -### -fsycl-link=bad_value -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-BAD-OPT-VALUE -Doption=-fsycl-link %s
 // CHK-SYCL-BAD-OPT-VALUE: error: invalid argument 'bad_value' to [[option]]=
 
 /// Check no error for -fsycl-targets with good triple
-// RUN:   %clang -### -fsycl-targets=spir-unknown-unknown -fsycl --offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl-targets=spir-unknown-unknown -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
-// RUN:   %clang -### -fsycl-targets=spir64 -fsycl --offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl-targets=spir64 -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
-// RUN:   %clang_cl -### -fsycl-targets=spir-unknown-unknown -fsycl --offload-new-driver  %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl-targets=spir-unknown-unknown -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
-// RUN:   %clang -### -fsycl-targets=spirv32-unknown-unknown -fsycl --offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl-targets=spirv32-unknown-unknown -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
-// RUN:   %clang -### -fsycl-targets=spirv64-unknown-unknown -fsycl --offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl-targets=spirv64-unknown-unknown -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
-// RUN:   %clang -### -fsycl-targets=spirv32 -fsycl --offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl-targets=spirv32 -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
-// RUN:   %clang -### -fsycl-targets=spirv64 -fsycl --offload-new-driver  %s 2>&1 \
+// RUN:   %clang -### -fsycl-targets=spirv64 -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-TARGET %s
 // CHK-SYCL-TARGET-NOT: error: SYCL target is invalid
 
@@ -79,46 +79,46 @@
 /// ###########################################################################
 
 /// Check warning for duplicate offloading targets.
-// RUN:   %clang -### -ccc-print-phases -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown,spir64-unknown-unknown  %s 2>&1 \
+// RUN:   %clang -### -ccc-print-phases -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown,spir64-unknown-unknown  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DUPLICATES %s
 // CHK-DUPLICATES: warning: offloading target 'spir64-unknown-unknown' is similar to target 'spir64-unknown-unknown' already specified; will be ignored
 
-// RUN:   %clang -### -ccc-print-phases -fsycl --offload-new-driver -fsycl-targets=intel_gpu_pvc,intel_gpu_pvc  %s 2>&1 \
+// RUN:   %clang -### -ccc-print-phases -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=intel_gpu_pvc,intel_gpu_pvc  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DUPLICATES-GPU %s
 // CHK-DUPLICATES-GPU: warning: offloading target 'intel_gpu_pvc' is similar to target 'intel_gpu_pvc' already specified; will be ignored
 
 /// No duplicate warning should be emitted for 'like' triples but different
 /// arch targets.
-// RUN:   %clang -### -ccc-print-phases -fsycl --offload-new-driver -fsycl-targets=intel_gpu_pvc,intel_gpu_bdw  %s 2>&1 \
+// RUN:   %clang -### -ccc-print-phases -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=intel_gpu_pvc,intel_gpu_bdw  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DIFF-GPU %s
 // CHK-DIFF-GPU-NOT: warning: offloading target 'intel_gpu_bdw' is similar to target 'intel_gpu_pvc' already specified; will be ignored
 
 /// ###########################################################################
 
 /// Check -Xsycl-target-frontend triggers error when multiple triples are used.
-// RUN:   not %clang -### -no-canonical-prefixes -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown,spir-unknown-linux -Xsycl-target-frontend -DFOO %s 2>&1 \
+// RUN:   not %clang -### -no-canonical-prefixes -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown,spir-unknown-linux -Xsycl-target-frontend -DFOO %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-COMPILER-AMBIGUOUS-ERROR %s
-// RUN:   not %clang_cl -### -no-canonical-prefixes -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown,spir-unknown-linux -Xsycl-target-frontend -DFOO %s 2>&1 \
+// RUN:   not %clang_cl -### -no-canonical-prefixes -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown,spir-unknown-linux -Xsycl-target-frontend -DFOO %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-COMPILER-AMBIGUOUS-ERROR %s
 // CHK-FSYCL-COMPILER-AMBIGUOUS-ERROR: clang{{.*}} error: cannot deduce implicit triple value for '-Xsycl-target-frontend', specify triple using '-Xsycl-target-frontend=<triple>'
 
 /// ###########################################################################
 
 /// Check -Xsycl-target-frontend triggers error when an option requiring arguments is passed to it.
-// RUN:   not %clang -### -no-canonical-prefixes -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -Xsycl-target-frontend -Xsycl-target-frontend -mcpu=none %s 2>&1 \
+// RUN:   not %clang -### -no-canonical-prefixes -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -Xsycl-target-frontend -Xsycl-target-frontend -mcpu=none %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-COMPILER-NESTED-ERROR %s
-// RUN:   not %clang_cl -### -no-canonical-prefixes -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -Xsycl-target-frontend -Xsycl-target-frontend -mcpu=none %s 2>&1 \
+// RUN:   not %clang_cl -### -no-canonical-prefixes -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -Xsycl-target-frontend -Xsycl-target-frontend -mcpu=none %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-COMPILER-NESTED-ERROR %s
 // CHK-FSYCL-COMPILER-NESTED-ERROR: clang{{.*}} error: invalid -Xsycl-target-frontend argument: '-Xsycl-target-frontend -Xsycl-target-frontend', options requiring arguments are unsupported
 
 /// ###########################################################################
 
 /// Check -Xsycl-target-frontend= accepts triple aliases
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-targets=spir64 -Xsycl-target-frontend=spir64 -DFOO %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -Xsycl-target-frontend=spir64 -DFOO %s 2>&1 \
 // RUN:   | FileCheck -DARCH1=spir64 -check-prefixes=CHK-UNUSED-ARG-WARNING-1,CHK-TARGET-1 %s
 // CHK-UNUSED-ARG-WARNING-1-NOT: clang{{.*}} warning: argument unused during compilation: '-Xsycl-target-frontend={{.*}} -DFOO'
 // CHK-TARGET-1: clang{{.*}} "-cc1" "-triple" "[[ARCH1]]-unknown-unknown"{{.*}} "-D" "FOO"
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-targets=spirv64 -Xsycl-target-frontend=spirv64 -DFOO %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spirv64 -Xsycl-target-frontend=spirv64 -DFOO %s 2>&1 \
 // RUN:   | FileCheck -DARCH2=spirv64 -check-prefixes=CHK-UNUSED-ARG-WARNING-2,CHK-TARGET-2 %s
 // CHK-UNUSED-ARG-WARNING-2-NOT: clang{{.*}} warning: argument unused during compilation: '-Xsycl-target-frontend={{.*}} -DFOO'
 // CHK-TARGET-2: clang{{.*}} "-cc1" "-triple" "[[ARCH2]]-unknown-unknown"{{.*}} "-D" "FOO"
@@ -129,11 +129,11 @@
 /// We should have an offload action joining the host compile and device
 /// preprocessor and another one joining the device linking outputs to the host
 /// action.
-// RUN:   %clang -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
+// RUN:   %clang -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-PHASES %s
-// RUN:   %clang -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --no-offloadlib %s 2>&1 \
+// RUN:   %clang -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL --no-offloadlib %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-PHASES %s
-// RUN:   %clang_cl -ccc-print-phases --target=x86_64-pc-windows-msvc -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
+// RUN:   %clang_cl -ccc-print-phases --target=x86_64-pc-windows-msvc -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-PHASES %s
 // CHK-PHASES: 0: input, "[[INPUT:.+\.cpp]]", c++, (host-sycl)
 // CHK-PHASES: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -155,9 +155,9 @@
 /// We should have an offload action joining the host compile and device
 /// preprocessor and another one joining the device linking outputs to the host
 /// action.
-// RUN:   %clang -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spirv64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
+// RUN:   %clang -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spirv64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-PHASES-2 %s
-// RUN:   %clang_cl -ccc-print-phases --target=x86_64-pc-windows-msvc -fsycl --offload-new-driver -fsycl-targets=spirv64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
+// RUN:   %clang_cl -ccc-print-phases --target=x86_64-pc-windows-msvc -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spirv64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-PHASES-2 %s
 // CHK-PHASES-2: 0: input, "[[INPUT:.+\.cpp]]", c++, (host-sycl)
 // CHK-PHASES-2: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -176,7 +176,7 @@
 /// ###########################################################################
 
 /// Check the compilation flow to verify that the integrated header is filtered
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -c %s -### 2>&1 \
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -c %s -### 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=CHK-INT-HEADER
 // CHK-INT-HEADER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INPUT1:.+\-header.+\.h]]" "-fsycl-int-footer={{.*}}"
 // CHK-INT-HEADER: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-include-internal-header" "[[INPUT1]]" "-dependency-filter" "[[INPUT1]]"
@@ -185,7 +185,7 @@
 
 /// Check the phases also add a library to make sure it is treated as input by
 /// the device.
-// RUN:   %clang -ccc-print-phases -target x86_64-unknown-linux-gnu -lsomelib -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
+// RUN:   %clang -ccc-print-phases -target x86_64-unknown-linux-gnu -lsomelib -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-PHASES-LIB %s
 // CHK-PHASES-LIB: 0: input, "somelib", object, (host-sycl)
 // CHK-PHASES-LIB: 1: input, "[[INPUT:.+\.cpp]]", c++, (host-sycl)
@@ -206,7 +206,7 @@
 
 /// Check the phases when using and multiple source files
 // RUN:   echo " " > %t.cpp
-// RUN:   %clang -ccc-print-phases -lsomelib -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s %t.cpp 2>&1 \
+// RUN:   %clang -ccc-print-phases -lsomelib -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -fno-sycl-instrument-device-code --no-offloadlib %s %t.cpp 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-PHASES-FILES %s
 // CHK-PHASES-FILES: 0: input, "somelib", object, (host-sycl)
 // CHK-PHASES-FILES: 1: input, "[[INPUT1:.+\.cpp]]", c++, (host-sycl)
@@ -239,9 +239,9 @@
 
 /// Check -fsycl-is-device is passed when compiling for the device.
 /// also check for SPIR-V binary creation
-// RUN:   %clang -### -no-canonical-prefixes -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown %s 2>&1 \
+// RUN:   %clang -### -no-canonical-prefixes -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-IS-DEVICE %s
-// RUN:   %clang_cl -### -no-canonical-prefixes -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown %s 2>&1 \
+// RUN:   %clang_cl -### -no-canonical-prefixes -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-IS-DEVICE %s
 
 // CHK-FSYCL-IS-DEVICE: clang{{.*}} "-fsycl-is-device" {{.*}} "-emit-llvm-bc" {{.*}}.cpp
@@ -250,9 +250,9 @@
 
 /// Check -fsycl-is-device and emitting to .spv when compiling for the device
 /// when using -fsycl-device-obj=spirv
-// RUN:   %clang -### -fsycl-device-obj=spirv -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown %s 2>&1 \
+// RUN:   %clang -### -fsycl-device-obj=spirv -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-IS-DEVICE-NO-BITCODE %s
-// RUN:   %clang_cl -### -fsycl-device-obj=spirv -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl-device-obj=spirv -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-IS-DEVICE-NO-BITCODE %s
 
 // CHK-FSYCL-IS-DEVICE-NO-BITCODE: clang{{.*}} "-fsycl-is-device" {{.*}} "-emit-llvm-bc" {{.*}}.cpp
@@ -260,50 +260,50 @@
 /// ###########################################################################
 
 /// Check for default linking of -lsycl with -fsycl --offload-new-driver usage
-// RUN: %clang -fsycl --offload-new-driver -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-SYCL %s
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-SYCL %s
 // CHECK-LD-SYCL: "{{.*}}ld{{(.exe)?}}"
 // CHECK-LD-SYCL: "-lsycl"
 
 /// Check no SYCL runtime is linked with -nolibsycl
-// RUN: %clang -fsycl --offload-new-driver -nolibsycl -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOLIBSYCL %s
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -nolibsycl -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOLIBSYCL %s
 // CHECK-LD-NOLIBSYCL: "{{.*}}ld{{(.exe)?}}"
 // CHECK-LD-NOLIBSYCL-NOT: "-lsycl"
 
 /// Check no SYCL runtime is linked with -nostdlib
-// RUN: %clang -fsycl --offload-new-driver -nostdlib -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOSTDLIB %s
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -nostdlib -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOSTDLIB %s
 // CHECK-LD-NOSTDLIB: "{{.*}}ld{{(.exe)?}}"
 // CHECK-LD-NOSTDLIB-NOT: "-lsycl"
 
 /// Check for default linking of syclN.lib with -fsycl --offload-new-driver usage
-// RUN: %clang -fsycl --offload-new-driver -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL %s
-// RUN: %clang_cl -fsycl --offload-new-driver %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-CL %s
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL %s
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-CL %s
 // CHECK-LINK-SYCL-CL: "--dependent-lib=sycl{{[0-9]*}}"
 // CHECK-LINK-SYCL-CL-NOT: "-defaultlib:sycl{{[0-9]*}}.lib"
 // CHECK-LINK-SYCL: "-defaultlib:sycl{{[0-9]*}}.lib"
 
 /// Check no SYCL runtime is linked with -nolibsycl
-// RUN: %clang -fsycl --offload-new-driver -nolibsycl -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOLIBSYCL %s
-// RUN: %clang_cl -fsycl --offload-new-driver -nolibsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOLIBSYCL-CL %s
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -nolibsycl -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOLIBSYCL %s
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -nolibsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOLIBSYCL-CL %s
 // CHECK-LINK-NOLIBSYCL-CL-NOT: "--dependent-lib=sycl{{[0-9]*}}"
 // CHECK-LINK-NOLIBSYCL: "{{.*}}link{{(.exe)?}}"
 // CHECK-LINK-NOLIBSYCL-NOT: "-defaultlib:sycl{{[0-9]*}}.lib"
 
 /// Check SYCL runtime is linked despite -nostdlib on Windows, this is
 /// necessary for the Windows Clang CMake to work
-// RUN: %clang -fsycl --offload-new-driver -nostdlib -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOSTDLIB %s
-// RUN: %clang_cl -fsycl --offload-new-driver -nostdlib %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOSTDLIB-CL %s
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -nostdlib -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOSTDLIB %s
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -nostdlib %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOSTDLIB-CL %s
 // CHECK-LINK-NOSTDLIB-CL: "--dependent-lib=sycl{{[0-9]*}}"
 // CHECK-LINK-NOSTDLIB: "{{.*}}link{{(.exe)?}}"
 // CHECK-LINK-NOSTDLIB: "-defaultlib:sycl{{[0-9]*}}.lib"
 
 /// Check sycld.lib is chosen with /MDd
-// RUN:  %clang_cl -fsycl --offload-new-driver /MDd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
+// RUN:  %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL /MDd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
 /// Check sycld is pulled in when msvcrtd is used
-// RUN: %clangxx -fsycl --offload-new-driver -Xclang --dependent-lib=msvcrtd \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xclang --dependent-lib=msvcrtd \
 // RUN:   -target x86_64-unknown-windows-msvc -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
 /// Check sycld.lib is pulled in with -fms-runtime-lib=dll_dbg
-// RUN: %clangxx -fsycl --offload-new-driver -fms-runtime-lib=dll_dbg \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fms-runtime-lib=dll_dbg \
 // RUN:   -target x86_64-unknown-windows-msvc -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
 // CHECK-LINK-SYCL-DEBUG: "--dependent-lib=sycl{{[0-9]*}}d"
@@ -311,7 +311,7 @@
 
 /// Only a single instance of sycld should be pulled in when both the
 /// -Xclang --dependent-lib=msvcrtd and -fms-runtime-lib=dll_dbg is used.
-// RUN: %clangxx -fsycl --offload-new-driver -fms-runtime-lib=dll_dbg -Xclang \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fms-runtime-lib=dll_dbg -Xclang \
 // RUN:  --dependent-lib=msvcrtd --target=x86_64-unknown-windows-msvc -### %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK-LINK-SYCLD %s
 // CHECK-LINK-SYCLD: "--dependent-lib=sycl{{[0-9]*}}d"
@@ -320,73 +320,73 @@
 /// ###########################################################################
 
 /// Check -Xsycl-target-frontend does not trigger an error when no -fsycl-targets is specified
-// RUN:   %clang -### -fsycl --offload-new-driver -Xsycl-target-frontend -DFOO %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xsycl-target-frontend -DFOO %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-TARGET-ERROR %s
 // CHK-NO-FSYCL-TARGET-ERROR-NOT: clang{{.*}} error: cannot deduce implicit triple value for '-Xsycl-target-frontend', specify triple using '-Xsycl-target-frontend=<triple>'
 
 /// ###########################################################################
 
-// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-OPTS %s
 // CHK-TOOLS-OPTS: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64-unknown-unknown=-DFOO1 -DFOO2"
 
 /// Check for implied options (-g -O0)
-// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -g -O0 -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -g -O0 -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -Zi -Od -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -Zi -Od -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS %s
 // CHK-TOOLS-IMPLIED-OPTS: llvm-offload-binary{{.*}} {{.*}}compile-opts=-g{{.*}}-DFOO1 -DFOO2"
 
 /// Check for implied options (-O0)
-// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64 -O0 %s 2>&1 \
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -O0 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-O0 %s
-// RUN:   %clang_cl -### -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -Od %s 2>&1 \
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -Od %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-O0 %s
-// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64 -O0 -O2 %s 2>&1 \
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -O0 -O2 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-O0 %s
 // CHK-TOOLS-IMPLIED-OPTS-O0-NOT: llvm-offload-binary{{.*}} {{.*}}compile-opts={{.*}}-cl-opt-disable"
 
-// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown -Xsycl-target-linker "-DFOO1 -DFOO2" %s 2>&1 \
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown -Xsycl-target-linker "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-OPTS2 %s
 // CHK-TOOLS-OPTS2: clang-linker-wrapper{{.*}} "--device-linker=sycl:spir64-unknown-unknown=-DFOO1 -DFOO2"
 
 /// -fsycl-range-rounding settings
 ///
 /// // Check that driver flag is passed to cc1
-// RUN: %clang -### -fsycl --offload-new-driver -fsycl-range-rounding=disable %s 2>&1 \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-range-rounding=disable %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DRIVER-RANGE-ROUNDING-DISABLE %s
-// RUN: %clang -### -fsycl --offload-new-driver -fsycl-range-rounding=force %s 2>&1 \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-range-rounding=force %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DRIVER-RANGE-ROUNDING-FORCE %s
-// RUN: %clang -### -fsycl --offload-new-driver -fsycl-range-rounding=on %s 2>&1 \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-range-rounding=on %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DRIVER-RANGE-ROUNDING-ON %s
 // CHK-DRIVER-RANGE-ROUNDING-DISABLE: "-cc1{{.*}}-fsycl-range-rounding=disable"
 // CHK-DRIVER-RANGE-ROUNDING-FORCE: "-cc1{{.*}}-fsycl-range-rounding=force"
 // CHK-DRIVER-RANGE-ROUNDING-ON: "-cc1{{.*}}-fsycl-range-rounding=on"
 ///
 ///
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:        -fsycl-targets=spir64 -O0 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
-// RUN: %clang_cl -### -fsycl --offload-new-driver -fsycl-targets=spir64 -Od %s 2>&1 \
+// RUN: %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -Od %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:        -O0 -fsycl-range-rounding=force %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-OVERRIDE-RANGE-ROUNDING %s
-// RUN: %clang_cl -### -fsycl --offload-new-driver -Od %s 2>&1 -fsycl-range-rounding=force %s 2>&1 \
+// RUN: %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -Od %s 2>&1 -fsycl-range-rounding=force %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-OVERRIDE-RANGE-ROUNDING %s
 // CHK-DISABLE-RANGE-ROUNDING: "-fsycl-range-rounding=disable"
 // CHK-OVERRIDE-RANGE-ROUNDING: "-fsycl-range-rounding=force"
 // CHK-OVERRIDE-RANGE-ROUNDING-NOT: "-fsycl-range-rounding=disable"
 
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:        -fsycl-targets=spir64 -O2 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
-// RUN: %clang_cl -### -fsycl --offload-new-driver -fsycl-targets=spir64 -O2 %s 2>&1 \
+// RUN: %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -O2 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:        -fsycl-targets=spir64 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
-// RUN: %clang_cl -### -fsycl --offload-new-driver -fsycl-targets=spir64 %s 2>&1 \
+// RUN: %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
 // CHK-RANGE-ROUNDING-NOT: "-fsycl-disable-range-rounding"
 // CHK-RANGE-ROUNDING-NOT: "-fsycl-range-rounding=disable"
@@ -395,7 +395,7 @@
 /// ###########################################################################
 
 /// Verify that triple-boundarch pairs are correct with multi-targetting
-// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=nvptx64-nvidia-cuda,spir64 -ccc-print-phases %s 2>&1 \
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=nvptx64-nvidia-cuda,spir64 -ccc-print-phases %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-PHASE-MULTI-TARG-BOUND-ARCH %s
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH: 0: input, "[[INPUT:.+\.cpp]]", c++, (host-sycl)
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -416,7 +416,7 @@
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH: 16: assembler, {15}, object, (host-sycl)
 // CHK-PHASE-MULTI-TARG-BOUND-ARCH: 17: clang-linker-wrapper, {16}, image, (host-sycl)
 
-// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:     -fno-sycl-instrument-device-code --no-offloadlib \
 // RUN:     -fsycl-targets=nvptx64-nvidia-cuda,spir64_gen \
 // RUN:     -Xsycl-target-backend=spir64_gen "-device skl" \
@@ -444,7 +444,7 @@
 /// ###########################################################################
 
 // Check if valid bound arch behaviour occurs when compiling for spir-v,nvidia-gpu, and amd-gpu
-// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64,nvptx64-nvidia-cuda,amdgcn-amd-amdhsa -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_75 -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908 -ccc-print-phases %s 2>&1 \
+// RUN:  %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64,nvptx64-nvidia-cuda,amdgcn-amd-amdhsa -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_75 -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908 -ccc-print-phases %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD %s
 // CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 0: input, "[[INPUT:.+\.cpp]]", c++, (host-sycl)
 // CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -471,7 +471,7 @@
 // CHK-PHASE-MULTI-TARG-SPIRV-NVIDIA-AMD: 22: clang-linker-wrapper, {21}, image, (host-sycl)
 
 /// -fsycl --offload-new-driver with /Fo testing
-// RUN: %clang_cl -fsycl --offload-new-driver /Fosomefile.obj -c %s -### 2>&1 \
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL /Fosomefile.obj -c %s -### 2>&1 \
 // RUN:   | FileCheck -check-prefix=FO-CHECK %s
 // FO-CHECK: clang{{.*}} "-fsycl-int-header=[[HEADER:.+\.h]]" "-fsycl-int-footer={{.*}}"
 // FO-CHECK: clang{{.*}} "-include-internal-header" "[[HEADER]]" {{.*}} "-o" "somefile.obj"
@@ -492,47 +492,47 @@
 // LIB-NODEVICE: 1: clang-linker-wrapper, {0}, image, (host-sycl)
 
 // Checking for an error if c-compilation is forced
-// RUN: not %clangxx -### -c -fsycl --offload-new-driver -xc %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
-// RUN: not %clangxx -### -c -fsycl --offload-new-driver -xc-header %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
-// RUN: not %clangxx -### -c -fsycl --offload-new-driver -xcpp-output %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
+// RUN: not %clangxx -### -c -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -xc %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
+// RUN: not %clangxx -### -c -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -xc-header %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
+// RUN: not %clangxx -### -c -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -xcpp-output %s 2>&1 | FileCheck -check-prefixes=CHECK_XC_FSYCL %s
 // CHECK_XC_FSYCL: '-x c{{.*}}' must not be used in conjunction with '-fsycl'
 
 // -std=c++17 check (check all 3 compilations)
-// RUN: %clangxx -### -c -fsycl --offload-new-driver -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD %s
-// RUN: %clang_cl -### -c -fsycl --offload-new-driver -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD %s
+// RUN: %clangxx -### -c -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD %s
+// RUN: %clang_cl -### -c -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD %s
 // CHECK-STD: clang{{.*}} "-emit-llvm-bc" {{.*}} "-std=c++17"
 // CHECK-STD: clang{{.*}} "-emit-obj" {{.*}} "-std=c++17"
 
 // -std=c++17 override check
-// RUN: %clangxx -### -c -fsycl --offload-new-driver -std=c++20 -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
-// RUN: %clang_cl -### -c -fsycl --offload-new-driver /std:c++20 -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
+// RUN: %clangxx -### -c -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -std=c++20 -xc++ %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
+// RUN: %clang_cl -### -c -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL /std:c++20 -TP %s 2>&1 | FileCheck -check-prefix=CHECK-STD-OVR %s
 // CHECK-STD-OVR: clang{{.*}} "-emit-llvm-bc" {{.*}} "-std=c++20"
 // CHECK-STD-OVR: clang{{.*}} "-emit-obj" {{.*}} "-std=c++20"
 // CHECK-STD-OVR-NOT: clang{{.*}} "-std=c++17"
 
 // Check sycl-post-link optimization level.
 // Default is O2
-// RUN:   %clang    -### -fsycl --offload-new-driver %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O2
-// RUN:   %clang_cl -### -fsycl --offload-new-driver %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O2
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O2
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O2
 // Common options for %clang and %clang_cl
-// RUN:   %clang    -### -fsycl --offload-new-driver -O1 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O1
-// RUN:   %clang_cl -### -fsycl --offload-new-driver /O1 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Os
-// RUN:   %clang    -### -fsycl --offload-new-driver -O2 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O2
-// RUN:   %clang_cl -### -fsycl --offload-new-driver /O2 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O3
-// RUN:   %clang    -### -fsycl --offload-new-driver -Os %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Os
-// RUN:   %clang_cl -### -fsycl --offload-new-driver /Os %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Os
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -O1 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O1
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL /O1 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Os
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -O2 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O2
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL /O2 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O3
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Os %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Os
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL /Os %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Os
 // %clang options
-// RUN:   %clang    -### -fsycl --offload-new-driver -O0 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O0
-// RUN:   %clang    -### -fsycl --offload-new-driver -Ofast %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O3
-// RUN:   %clang    -### -fsycl --offload-new-driver -O3 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O3
-// RUN:   %clang    -### -fsycl --offload-new-driver -Oz %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Oz
-// RUN:   %clang    -### -fsycl --offload-new-driver -Og %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O1
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -O0 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O0
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Ofast %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O3
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -O3 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O3
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Oz %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Oz
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Og %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O1
 // %clang_cl options
-// RUN:   %clang_cl -### -fsycl --offload-new-driver /Od %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O0
-// RUN:   %clang_cl -### -fsycl --offload-new-driver /Ot %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O3
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL /Od %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O0
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL /Ot %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O3
 // only the last option is considered
-// RUN:   %clang    -### -fsycl --offload-new-driver -O2 -O1 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O1
-// RUN:   %clang_cl -### -fsycl --offload-new-driver /O2 /O1 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Os
+// RUN:   %clang    -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -O2 -O1 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-O1
+// RUN:   %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL /O2 /O1 %s 2>&1 | FileCheck %s -check-prefixes=CHK-POST-LINK-OPT-LEVEL-Os
 // CHK-POST-LINK-OPT-LEVEL-O0: --sycl-post-link-options=-O2
 // CHK-POST-LINK-OPT-LEVEL-O1: --sycl-post-link-options=-O1
 // CHK-POST-LINK-OPT-LEVEL-O2: --sycl-post-link-options=-O2
@@ -541,8 +541,8 @@
 // CHK-POST-LINK-OPT-LEVEL-Oz: --sycl-post-link-options=-Oz
 
 // Verify header search dirs are added with -fsycl
-// RUN: %clang -### -fsycl --offload-new-driver %s 2>&1 | FileCheck %s -check-prefixes=CHECK-HEADER-DIR
-// RUN: %clang_cl -### -fsycl --offload-new-driver %s 2>&1 | FileCheck %s -check-prefixes=CHECK-HEADER-DIR
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck %s -check-prefixes=CHECK-HEADER-DIR
+// RUN: %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck %s -check-prefixes=CHECK-HEADER-DIR
 // CHECK-HEADER-DIR: clang{{.*}} "-fsycl-is-device"
 // CHECK-HEADER-DIR-SAME: "-internal-isystem" "[[ROOT:[^"]*]]bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"
 // CHECK-HEADER-DIR-NOT: -internal-isystem
@@ -553,30 +553,30 @@
 // CHECK-HEADER-DIR-SAME: "-internal-isystem" "[[ROOT]]bin{{[/\\]+}}..{{[/\\]+}}include"
 
 /// Check for option incompatibility with -fsycl
-// RUN:   not %clang -### -fsycl --offload-new-driver -ffreestanding %s 2>&1 \
+// RUN:   not %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -ffreestanding %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INCOMPATIBILITY %s -DINCOMPATOPT=-ffreestanding
-// RUN:   not %clang -### -fsycl --offload-new-driver -static-libstdc++ %s 2>&1 \
+// RUN:   not %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -static-libstdc++ %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INCOMPATIBILITY %s -DINCOMPATOPT=-static-libstdc++
 // CHK-INCOMPATIBILITY: error: invalid argument '[[INCOMPATOPT]]' not allowed with '-fsycl'
 
 /// Using -fsyntax-only with -fsycl --offload-new-driver should not emit IR
-// RUN:   %clang -### -fsycl --offload-new-driver -fsyntax-only %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsyntax-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-FSYNTAX-ONLY %s
-// RUN:   %clang -### -fsycl --offload-new-driver -fsycl-device-only -fsyntax-only %s 2>&1 \
+// RUN:   %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-only -fsyntax-only %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHK-FSYNTAX-ONLY %s
 // CHK-FSYNTAX-ONLY-NOT: "-emit-llvm-bc"
 // CHK-FSYNTAX-ONLY: "-fsyntax-only"
 
 /// Check for linked sycl lib when using -fpreview-breaking-changes with -fsycl
-// RUN: %clang -### -fsycl --offload-new-driver -fpreview-breaking-changes -target x86_64-unknown-windows-msvc %s 2>&1 | FileCheck -check-prefix FSYCL-PREVIEW-BREAKING-CHANGES-CHECK %s
-// RUN: %clang_cl -### -fsycl --offload-new-driver -fpreview-breaking-changes %s 2>&1 | FileCheck -check-prefix FSYCL-PREVIEW-BREAKING-CHANGES-CHECK-CL %s
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fpreview-breaking-changes -target x86_64-unknown-windows-msvc %s 2>&1 | FileCheck -check-prefix FSYCL-PREVIEW-BREAKING-CHANGES-CHECK %s
+// RUN: %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fpreview-breaking-changes %s 2>&1 | FileCheck -check-prefix FSYCL-PREVIEW-BREAKING-CHANGES-CHECK-CL %s
 // FSYCL-PREVIEW-BREAKING-CHANGES-CHECK: -defaultlib:sycl{{[0-9]*}}-preview.lib
 // FSYCL-PREVIEW-BREAKING-CHANGES-CHECK-NOT: -defaultlib:sycl{{[0-9]*}}.lib
 // FSYCL-PREVIEW-BREAKING-CHANGES-CHECK-CL: "--dependent-lib=sycl{{[0-9]*}}-preview"
 
 /// Check for linked sycl lib when using -fpreview-breaking-changes with -fsycl
-// RUN: %clang -### -fsycl --offload-new-driver -fpreview-breaking-changes -target x86_64-unknown-windows-msvc -Xclang --dependent-lib=msvcrtd %s 2>&1 | FileCheck -check-prefix FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK %s
-// RUN: %clang_cl -### -fsycl --offload-new-driver -fpreview-breaking-changes /MDd %s 2>&1 | FileCheck -check-prefix FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK %s
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fpreview-breaking-changes -target x86_64-unknown-windows-msvc -Xclang --dependent-lib=msvcrtd %s 2>&1 | FileCheck -check-prefix FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK %s
+// RUN: %clang_cl -### -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fpreview-breaking-changes /MDd %s 2>&1 | FileCheck -check-prefix FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK %s
 // FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK: --dependent-lib=sycl{{[0-9]*}}-previewd
 // FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK-NOT: -defaultlib:sycl{{[0-9]*}}.lib
 // FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK-NOT: -defaultlib:sycl{{[0-9]*}}-preview.lib
@@ -594,7 +594,7 @@
 /// ###########################################################################
 
 /// Check "-aux-target-cpu" and "target-cpu" are passed when compiling for SYCL offload device and host codes:
-//  RUN:  %clang -### -fsycl --offload-new-driver -c %s 2>&1 | FileCheck -check-prefix=CHECK-OFFLOAD %s
+//  RUN:  %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -c %s 2>&1 | FileCheck -check-prefix=CHECK-OFFLOAD %s
 //  CHECK-OFFLOAD: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-device"
 //  CHECK-OFFLOAD-SAME: "-aux-target-cpu" "[[HOST_CPU_NAME:[^ ]+]]"
 //  CHECK-OFFLOAD: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-host"
@@ -604,7 +604,7 @@
 
 /// Check "-aux-target-cpu" with "-aux-target-feature" and "-target-cpu" with "-target-feature" are passed
 /// when compiling for SYCL offload device and host codes:
-//  RUN:  %clang -fsycl --offload-new-driver -mavx -c %s -### -o %t.o 2>&1 | FileCheck -check-prefix=OFFLOAD-AVX %s
+//  RUN:  %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -mavx -c %s -### -o %t.o 2>&1 | FileCheck -check-prefix=OFFLOAD-AVX %s
 //  OFFLOAD-AVX: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-device"
 //  OFFLOAD-AVX-SAME: "-aux-target-cpu" "[[HOST_CPU_NAME:[^ ]+]]" "-aux-target-feature" "+avx"
 //  OFFLOAD-AVX: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-host"
@@ -615,17 +615,17 @@
 /// Check that the needed -fsycl --offload-new-driver -fsycl-is-device and -fsycl-is-host options
 /// are passed to all of the needed compilation steps regardless of final
 /// phase.
-// RUN:  %clang -### -fsycl --offload-new-driver -c %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
-// RUN:  %clang -### -fsycl --offload-new-driver -E %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
-// RUN:  %clang -### -fsycl --offload-new-driver -S %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
-// RUN:  %clang -### -fsycl --offload-new-driver %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
+// RUN:  %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -c %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
+// RUN:  %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -E %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
+// RUN:  %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -S %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
+// RUN:  %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck -check-prefix=CHECK-OPTS %s
 // CHECK-OPTS: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-device"
 // CHECK-OPTS: clang{{.*}} "-cc1" {{.*}} "-fsycl-is-host"
 
 /// ###########################################################################
 
 /// Check that -fcoverage-mapping is disabled for device
-// RUN: %clang -### -fsycl --offload-new-driver -fprofile-instr-generate -fcoverage-mapping -target x86_64-unknown-linux-gnu -c %s 2>&1 \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fprofile-instr-generate -fcoverage-mapping -target x86_64-unknown-linux-gnu -c %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_COVERAGE_MAPPING %s
 // CHECK_COVERAGE_MAPPING: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}}
 // CHECK_COVERAGE_MAPPING-NOT: "-fprofile-instrument=clang"
@@ -635,7 +635,7 @@
 /// ###########################################################################
 
 /// Check that -fprofile-arcs -ftest-coverage is disabled for device
-// RUN: %clang -### -fsycl --offload-new-driver -fprofile-arcs -ftest-coverage -target x86_64-unknown-linux-gnu -c %s 2>&1 \
+// RUN: %clang -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fprofile-arcs -ftest-coverage -target x86_64-unknown-linux-gnu -c %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_TEST_COVERAGE %s
 // CHECK_TEST_COVERAGE: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}}
 // CHECK_TEST_COVERAGE-NOT: "-coverage-notes-file={{.*}}"
@@ -644,7 +644,7 @@
 /// ###########################################################################
 
 /// -S -emit-llvm should generate IR for device.
-// RUN: %clangxx -### -fsycl --offload-new-driver -S -emit-llvm %s 2>&1 \
+// RUN: %clangxx -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -S -emit-llvm %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK_S_LLVM %s
 // CHECK_S_LLVM: clang{{.*}} "-fsycl-is-device"{{.*}} "-emit-llvm-bc"
 // CHECK_S_LLVM: llvm-offload-binary{{.*}}
@@ -653,9 +653,9 @@
 /// ###########################################################################
 
 // RUN:  touch %t_empty.o
-// RUN:  %clangxx -### -fsycl --offload-new-driver -target x86_64-unknown-linux-gnu -fsycl-targets=spir64_x86_64 %t_empty.o %s 2>&1 \
+// RUN:  %clangxx -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-linux-gnu -fsycl-targets=spir64_x86_64 %t_empty.o %s 2>&1 \
 // RUN:    | FileCheck -check-prefix DEFAULT_LINK %s
-// RUN:  %clangxx -### -fsycl --offload-new-driver -target x86_64-unknown-linux-gnu -fsycl-targets=spir64_gen %t_empty.o %s 2>&1 \
+// RUN:  %clangxx -### -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-linux-gnu -fsycl-targets=spir64_gen %t_empty.o %s 2>&1 \
 // RUN:    | FileCheck -check-prefix DEFAULT_LINK %s
 // DEFAULT_LINK: clang-linker-wrapper{{.*}}
 
@@ -663,17 +663,17 @@
 
 /// Passing in the default triple should allow for -Xsycl-target options, both the
 /// "=<triple>" and the default spelling
-// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64 -Xsycl-target-backend=spir64 -DFOO -Xsycl-target-linker=spir64 -DFOO2 %S/Inputs/SYCL/objlin64.o 2>&1 \
+// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -Xsycl-target-backend=spir64 -DFOO -Xsycl-target-linker=spir64 -DFOO2 %S/Inputs/SYCL/objlin64.o 2>&1 \
 // RUN:    | FileCheck -check-prefixes=SYCL_TARGET_OPT %s
-// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -Xsycl-target-backend=spir64 -DFOO -Xsycl-target-linker=spir64 -DFOO2 %S/Inputs/SYCL/objlin64.o 2>&1 \
+// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xsycl-target-backend=spir64 -DFOO -Xsycl-target-linker=spir64 -DFOO2 %S/Inputs/SYCL/objlin64.o 2>&1 \
 // RUN:    | FileCheck -check-prefixes=SYCL_TARGET_OPT %s
 // SYCL_TARGET_OPT: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64-unknown-unknown=-DFOO" "--device-linker=sycl:spir64-unknown-unknown=-DFOO2"
 
 /// ###########################################################################
 
-// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64_x86_64 -Xsycl-target-backend -DFOO %S/Inputs/SYCL/objlin64.o 2>&1 \
+// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64_x86_64 -Xsycl-target-backend -DFOO %S/Inputs/SYCL/objlin64.o 2>&1 \
 // RUN:    | FileCheck -check-prefixes=SYCL_TARGET_OPT_AOT,SYCL_TARGET_OPT_CPU %s
-// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64_gen -Xsycl-target-backend -DFOO %S/Inputs/SYCL/objlin64.o 2>&1 \
+// RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64_gen -Xsycl-target-backend -DFOO %S/Inputs/SYCL/objlin64.o 2>&1 \
 // RUN:    | FileCheck -check-prefixes=SYCL_TARGET_OPT_AOT,SYCL_TARGET_OPT_GPU %s
 // SYCL_TARGET_OPT_AOT-NOT: error: cannot deduce implicit triple value for '-Xsycl-target-backend'
 // SYCL_TARGET_OPT_CPU: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64_x86_64-unknown-unknown=-DFOO"
@@ -682,17 +682,17 @@
 /// ###########################################################################
 
 /// Check -fsycl-targets=spir64 enables addition of -ffine-grained-bitfield-accesses option
-// RUN:   %clangxx -### -fsycl-device-only --offload-new-driver %s 2>&1 | FileCheck -check-prefixes=CHECK_BITFIELD_OPTION %s
+// RUN:   %clangxx -### -fsycl-device-only --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck -check-prefixes=CHECK_BITFIELD_OPTION %s
 // CHECK_BITFIELD_OPTION: clang{{.*}} "-ffine-grained-bitfield-accesses"
 
 /// ###########################################################################
 
 /// Using linker specific items at the end of the command should not fail when
 /// we are performing a non-linking compilation behavior
-// RUN: %clangxx -E -fsycl --offload-new-driver %S/Inputs/SYCL/liblin64.a \
+// RUN: %clangxx -E -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %S/Inputs/SYCL/liblin64.a \
 // RUN:          -target x86_64-unknown-linux-gnu -### 2>&1 \
 // RUN:  | FileCheck -check-prefix IGNORE_INPUT %s
-// RUN: %clangxx -c -fsycl --offload-new-driver %S/Inputs/SYCL/liblin64.a \
+// RUN: %clangxx -c -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %S/Inputs/SYCL/liblin64.a \
 // RUN:          -target x86_64-unknown-linux-gnu -### 2>&1 \
 // RUN:  | FileCheck -check-prefix IGNORE_INPUT %s
 // IGNORE_INPUT: input unused
@@ -700,23 +700,23 @@
 /// ###########################################################################
 
 /// Check if the clang with fsycl adds C++ libraries to the link line
-//  RUN:  %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver %s 2>&1 | FileCheck -check-prefix=CHECK-FSYCL-WITH-CLANG %s
+//  RUN:  %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s 2>&1 | FileCheck -check-prefix=CHECK-FSYCL-WITH-CLANG %s
 // CHECK-FSYCL-WITH-CLANG: "-lstdc++"
 
 /// ###########################################################################
 
 /// Check for correct handling of -fsycl-fp64-conv-emu option for different targets
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64 -fsycl-fp64-conv-emu %s 2>&1 | FileCheck -check-prefix=CHECK_WARNING %s
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -fsycl-fp64-conv-emu %s 2>&1 | FileCheck -check-prefix=CHECK_WARNING %s
 // CHECK_WARNING: warning: '-fsycl-fp64-conv-emu' option is supported only for AOT compilation of Intel GPUs. It will be ignored for other targets [-Wunused-command-line-argument]
 
-// RUN: %clang -### -Wno-unused-command-line-argument -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=spir64 -fsycl-fp64-conv-emu %s 2>&1 | FileCheck -check-prefix=CHECK_NO_WARNING %s
+// RUN: %clang -### -Wno-unused-command-line-argument -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -fsycl-fp64-conv-emu %s 2>&1 | FileCheck -check-prefix=CHECK_NO_WARNING %s
 // CHECK_NO_WARNING-NOT: warning: '-fsycl-fp64-conv-emu' option is supported only for AOT compilation of Intel GPUs. It will be ignored for other targets [-Wunused-command-line-argument]
 
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-targets=intel_gpu_pvc -fsycl-fp64-conv-emu %s 2>&1 | FileCheck -check-prefix=CHECK_FSYCL_FP64_CONV_EMU %s
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=intel_gpu_pvc -fsycl-fp64-conv-emu %s 2>&1 | FileCheck -check-prefix=CHECK_FSYCL_FP64_CONV_EMU %s
 // CHECK_FSYCL_FP64_CONV_EMU-NOT: clang{{.*}} "-cc1" "-triple x86_64-unknown-linux-gnu" {{.*}} "-fsycl-fp64-conv-emu"
 // CHECK_FSYCL_FP64_CONV_EMU-DAG: clang{{.*}} "-cc1" "-triple" "spir64_gen{{.*}}" "-fsycl-fp64-conv-emu"
 // CHECK_FSYCL_FP64_CONV_EMU-DAG: llvm-offload-binary{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch=pvc,kind=sycl,compile-opts={{.*}}-options -ze-fp64-gen-conv-emu{{.*}}"
-// RUN: %clang_cl -fsycl --offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown %s -fsycl-fp64-conv-emu -### 2>&1 \
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -fsycl-targets=spir64_gen-unknown-unknown %s -fsycl-fp64-conv-emu -### 2>&1 \
 // RUN:  | FileCheck %s -check-prefixes=CHECK_FSYCL_FP64_CONV_EMU_WIN
 // CHECK_FSYCL_FP64_CONV_EMU_WIN-NOT: clang{{.*}} "-cc1" "-triple x86_64-unknown-linux-gnu" {{.*}} "-fsycl-fp64-conv-emu"
 // CHECK_FSYCL_FP64_CONV_EMU_WIN-DAG: clang{{.*}} "-cc1" "-triple" "spir64_gen{{.*}}" "-fsycl-fp64-conv-emu"

--- a/clang/test/Driver/sycl-post-link-options.cpp
+++ b/clang/test/Driver/sycl-post-link-options.cpp
@@ -1,4 +1,6 @@
 /// Verify same set of sycl-post-link options generated for old and new offloading model
+// REQUIRES: libdevice
+
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl -### \
 // RUN:          --no-offload-new-driver -Xdevice-post-link -O0 %s --sysroot=%S/Inputs/SYCL 2>&1 \
 // RUN:   | FileCheck -check-prefix OPTIONS_POSTLINK_JIT_OLD %s

--- a/clang/test/Driver/sycl-preprocess.cpp
+++ b/clang/test/Driver/sycl-preprocess.cpp
@@ -1,4 +1,5 @@
 // Test the behaviors when enabling SYCL offloading with preprocessed files.
+// REQUIRES: libdevice
 
 /// Creating a preprocessed file is expected to do an integration header
 /// creation step.

--- a/clang/test/Driver/sycl-rtc-mode.cpp
+++ b/clang/test/Driver/sycl-rtc-mode.cpp
@@ -8,7 +8,7 @@
 // RUN: %clangxx -fsycl -fsycl-rtc-mode --no-offload-new-driver %s -### 2>&1 \
 // RUN:   | FileCheck %s
 
-// RUN: %clangxx -fsycl -fsycl-rtc-mode --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsycl -fsycl-rtc-mode --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN:   | FileCheck %s
 
 // CHECK: clang{{.*}} "-fsycl-is-device"
@@ -23,7 +23,7 @@
 // RUN: %clangxx -fsycl -fno-sycl-rtc-mode --no-offload-new-driver %s -### 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=NEGATIVE
 
-// RUN: %clangxx -fsycl -fno-sycl-rtc-mode --offload-new-driver %s -### 2>&1 \
+// RUN: %clangxx -fsycl -fno-sycl-rtc-mode --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=NEGATIVE
 
 // NEGATIVE: clang{{.*}} "-fsycl-is-device"

--- a/clang/test/Driver/sycl-save-offload-code.cpp
+++ b/clang/test/Driver/sycl-save-offload-code.cpp
@@ -3,31 +3,31 @@
 // Verify that -save-offload-code passes the option to
 // clang-linker-wrapper in the new offload model.
 
-// clang -fsycl --offload-new-driver -target x86_64-unknown-linux-gnu
-// RUN: %clang -fsycl --offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -target x86_64-unknown-linux-gnu -save-offload-code=/user/input/path %s -### 2>&1 \
+// clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-linux-gnu
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -target x86_64-unknown-linux-gnu -save-offload-code=/user/input/path %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHK-save-offload-code-NEW-OFFLOAD
 
-// clang -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown
-// RUN: %clang -fsycl --offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-offload-code=/user/input/path %s -### 2>&1 \
+// clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-offload-code=/user/input/path %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHK-save-offload-code-NEW-OFFLOAD
 
 // clang --driver-mode=g++
-// RUN: %clangxx -fsycl --offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-offload-code=/user/input/path %s -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-offload-code=/user/input/path %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHK-save-offload-code-NEW-OFFLOAD
 
 // Windows
-// RUN: %clang_cl -fsycl --offload-new-driver -Qsave-offload-code=/user/input/path %s -### 2>&1 \
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -Qsave-offload-code=/user/input/path %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHK-save-offload-code-WIN-NEW-OFFLOAD
 
 // CHK-save-offload-code-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code=/user/input/path"
 // CHK-save-offload-code-WIN-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code=/user/input/path"
 
 // Linux
-// RUN: %clang -fsycl --offload-new-driver  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-offload-code= %s -### 2>&1 \
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL  -fsycl-targets=spir64-unknown-unknown -target x86_64-unknown-linux-gnu -save-offload-code= %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHK-save-offload-code-CWD-NEW-OFFLOAD
 
 // Windows
-// RUN: %clang_cl -fsycl --offload-new-driver -Qsave-offload-code= %s -### 2>&1 \
+// RUN: %clang_cl -fsycl --offload-new-driver /clang:--sysroot=%S/Inputs/SYCL -Qsave-offload-code= %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefixes=CHK-save-offload-code-WIN-CWD-NEW-OFFLOAD
 
 // CHK-save-offload-code-CWD-NEW-OFFLOAD: clang-linker-wrapper{{.*}} "-sycl-dump-device-code="

--- a/clang/test/Driver/sycl-spirv-default-options.cpp
+++ b/clang/test/Driver/sycl-spirv-default-options.cpp
@@ -1,5 +1,5 @@
 // Generate .bc file as SYCL device library file.
-// REQUIRES: system-linux
+// REQUIRES: system-linux, libdevice
 //
 // RUN: touch %t.devicelib.bc
 

--- a/clang/test/Driver/sycl-spirv-ext.cpp
+++ b/clang/test/Driver/sycl-spirv-ext.cpp
@@ -1,5 +1,5 @@
 // Generate .bc file as SYCL device library file.
-// REQUIRES: system-linux
+// REQUIRES: system-linux, libdevice
 //
 // RUN: touch %t_1.devicelib.bc
 // RUN: touch %t_2.devicelib.bc

--- a/clang/test/Driver/sycl-spirv-obj.cpp
+++ b/clang/test/Driver/sycl-spirv-obj.cpp
@@ -3,7 +3,7 @@
 ///
 
 /// -fsycl-device-obj=spirv
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -c -fsycl --offload-new-driver -fsycl-device-obj=spirv -### %s 2>&1 | \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -c -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-obj=spirv -### %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix SPIRV_DEVICE_OBJ
 // SPIRV_DEVICE_OBJ: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"
 // SPIRV_DEVICE_OBJ-SAME: "-aux-triple" "x86_64-unknown-linux-gnu"
@@ -18,7 +18,7 @@
 // SPIRV_DEVICE_OBJ-SAME: "-fsycl-is-host"
 // SPIRV_DEVICE_OBJ-SAME: "-o" "[[HOST_OBJ:.+\.o]]"
 
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -c -fsycl --offload-new-driver -fsycl-device-obj=spirv -ccc-print-phases %s 2>&1 | \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -c -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-obj=spirv -ccc-print-phases %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix SPIRV_DEVICE_OBJ_PHASES
 // SPIRV_DEVICE_OBJ_PHASES: 0: input, "[[INPUTSRC:.+\.cpp]]", c++, (host-sycl)
 // SPIRV_DEVICE_OBJ_PHASES: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -36,6 +36,6 @@
 
 /// Use of -fsycl-device-obj=spirv should not be effective during linking
 // RUN: touch %t.o
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-device-obj=spirv -### %t.o 2>&1 | \
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-obj=spirv -### %t.o 2>&1 | \
 // RUN:  FileCheck %s -check-prefixes=LLVM_SPIRV_R
 // LLVM_SPIRV_R: clang-linker-wrapper{{.*}}

--- a/clang/test/Driver/sycl-spirv-opt.cpp
+++ b/clang/test/Driver/sycl-spirv-opt.cpp
@@ -2,10 +2,10 @@
 /// Tests for -Xspirv-translator
 ///
 
-// RUN: %clangxx -fsycl --offload-new-driver -Xspirv-translator "foo" -### %s 2>&1 | \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xspirv-translator "foo" -### %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET
 
-// RUN: %clangxx -fsycl --offload-new-driver -Xspirv-translator=spir64_gen "foo" -### %s 2>&1 | \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xspirv-translator=spir64_gen "foo" -### %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET-UNUSED --implicit-check-not 'llvm-spirv{{.*}} "foo"'
 
 // CHECK-SINGLE-TARGET: clang-linker-wrapper{{.*}} "--llvm-spirv-options=foo{{.*}}

--- a/clang/test/Driver/sycl-time-trace-actual.cpp
+++ b/clang/test/Driver/sycl-time-trace-actual.cpp
@@ -2,7 +2,7 @@
 // This test performs actual compilation
 // and verifies that both host and device trace JSON files are created.
 
-// REQUIRES: system-linux
+// REQUIRES: system-linux, libdevice
 
 // Setup: Create test directories and input file
 // RUN: rm -rf %t && mkdir -p %t/src %t/traces

--- a/clang/test/Driver/sycl-time-trace.cpp
+++ b/clang/test/Driver/sycl-time-trace.cpp
@@ -6,19 +6,19 @@
 // REQUIRES: system-linux
 
 // RUN: mkdir d e f && cp %s d/a.cpp && touch d/b.c
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver -c -ftime-trace -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -o e/a.o 2>&1 | FileCheck %s --check-prefixes=SYCL-DEVICE-COMPILE,SYCL-HOST-COMPILE
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -c -ftime-trace -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -o e/a.o 2>&1 | FileCheck %s --check-prefixes=SYCL-DEVICE-COMPILE,SYCL-HOST-COMPILE
 // SYCL-DEVICE-COMPILE: -cc1{{.*}} "-fsycl-is-device"{{.*}} "-ftime-trace=e{{/|\\\\}}a-sycl-spir64-unknown-unknown.json" "-ftime-trace-granularity=0" "-ftime-trace-verbose"
 // SYCL-HOST-COMPILE: -cc1{{.*}} "-fsycl-is-host"{{.*}} "-ftime-trace=e{{/|\\\\}}a-host-x86_64-unknown-linux-gnu.json" "-ftime-trace-granularity=0" "-ftime-trace-verbose"
 
 // Verify that the Clang driver generates JSON time-trace output for compile-only
 // invocation and propagates the time-trace options, respecting the specified dump directory.
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver -c -ftime-trace -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -dumpdir f/ 2>&1 | FileCheck %s --check-prefixes=SYCL-DEVICE-DUMPDIR,SYCL-HOST-DUMPDIR
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -c -ftime-trace -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -dumpdir f/ 2>&1 | FileCheck %s --check-prefixes=SYCL-DEVICE-DUMPDIR,SYCL-HOST-DUMPDIR
 // SYCL-DEVICE-DUMPDIR: -cc1{{.*}} "-fsycl-is-device"{{.*}} "-ftime-trace=f{{/|\\\\}}a-sycl-spir64-unknown-unknown.json" "-ftime-trace-granularity=0" "-ftime-trace-verbose"
 // SYCL-HOST-DUMPDIR: -cc1{{.*}} "-fsycl-is-host"{{.*}} "-ftime-trace=f{{/|\\\\}}a-host-x86_64-unknown-linux-gnu.json" "-ftime-trace-granularity=0" "-ftime-trace-verbose"
 
 // This test verifies that Clang driver correctly propagates time-trace related options
 // during a compile-and-link invocation and enables JSON time-trace output.
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver -ftime-trace=e -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -o f/x -dumpdir f/ 2>&1 | FileCheck %s --check-prefixes=LINK-DEVICE,LINK-HOST
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -ftime-trace=e -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -o f/x -dumpdir f/ 2>&1 | FileCheck %s --check-prefixes=LINK-DEVICE,LINK-HOST
 // LINK-DEVICE: -cc1{{.*}} "-fsycl-is-device"{{.*}} "-ftime-trace=e{{/|\\\\}}a-sycl-spir64-unknown-unknown.json" "-ftime-trace-granularity=0" "-ftime-trace-verbose"
 // LINK-HOST: -cc1{{.*}} "-fsycl-is-host"{{.*}} "-ftime-trace=e{{/|\\\\}}a-host-x86_64-unknown-linux-gnu.json" "-ftime-trace-granularity=0" "-ftime-trace-verbose"
 
@@ -45,12 +45,12 @@
 
 // Verify time tracing works with -fsycl-device-only (new driver model)
 // This test verifies device-only compilation generates the correct time-trace file
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-device-only -c -ftime-trace -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -o e/a.o 2>&1 | FileCheck %s --check-prefixes=DEVICE-ONLY-COMPILE
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-only -c -ftime-trace -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -o e/a.o 2>&1 | FileCheck %s --check-prefixes=DEVICE-ONLY-COMPILE
 // DEVICE-ONLY-COMPILE: -cc1{{.*}} "-fsycl-is-device"{{.*}} "-ftime-trace=e{{/|\\\\}}a-sycl-spir64-unknown-unknown.json" "-ftime-trace-granularity=0" "-ftime-trace-verbose"
 // DEVICE-ONLY-COMPILE-NOT: "-fsycl-is-host"
 
 // Verify device-only compilation with -dumpdir (new driver model)
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver -fsycl-device-only -c -ftime-trace -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -dumpdir f/ 2>&1 | FileCheck %s --check-prefixes=DEVICE-ONLY-DUMPDIR
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-device-only -c -ftime-trace -ftime-trace-granularity=0 -ftime-trace-verbose d/a.cpp -dumpdir f/ 2>&1 | FileCheck %s --check-prefixes=DEVICE-ONLY-DUMPDIR
 // DEVICE-ONLY-DUMPDIR: -cc1{{.*}} "-fsycl-is-device"{{.*}} "-ftime-trace=f{{/|\\\\}}a-sycl-spir64-unknown-unknown.json" "-ftime-trace-granularity=0" "-ftime-trace-verbose"
 // DEVICE-ONLY-DUMPDIR-NOT: "-fsycl-is-host"
 

--- a/clang/test/Driver/sycl-unique-prefix.cpp
+++ b/clang/test/Driver/sycl-unique-prefix.cpp
@@ -1,7 +1,7 @@
 /// Test for Unique prefix setting for SYCL compilations
 // RUN: touch %t_file1.cpp
 // RUN: touch %t_file2.cpp
-// RUN: %clangxx -fsycl --offload-new-driver -fsycl-targets=spir64-unknown-unknown,spir64_gen-unknown-unknown -c %t_file1.cpp %t_file2.cpp -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64-unknown-unknown,spir64_gen-unknown-unknown -c %t_file1.cpp %t_file2.cpp -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_PREFIX %s
 // CHECK_PREFIX: clang{{.*}} "-triple" "spir64-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX1:uid([A-z0-9]){16}]]"{{.*}} "{{.*}}_file1.cpp"
 // CHECK_PREFIX: clang{{.*}} "-triple" "spir64_gen-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX1]]"{{.*}} "{{.*}}_file1.cpp"
@@ -16,6 +16,6 @@
 /// the preprocessed files.  For now, just test what we are passing to the
 /// host compilation.
 // RUN: touch %t.ii
-// RUN: %clangxx -fsycl --offload-new-driver -c %t.ii -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -c %t.ii -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_PREFIX_II %s
 // CHECK_PREFIX_II: clang{{.*}} "-fsycl-is-host"{{.*}} "-fsycl-unique-prefix=[[PREFIX:uid([A-z0-9]){16}]]"{{.*}} "{{.*}}.ii"

--- a/clang/test/Driver/sycl-xarch.cpp
+++ b/clang/test/Driver/sycl-xarch.cpp
@@ -8,9 +8,9 @@
 
 /// test behavior of -Xarch_device with 1 option for SYCL compiler, the flag
 /// should be passed to device compilation only.
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device -fsanitize=address -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device -fsanitize=address -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_DEVICE_OPTION
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device -fsanitize=address -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device -fsanitize=address -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_DEVICE_ONLY
 // SYCL_XARCH_DEVICE_OPTION: clang{{.*}} "-fsycl-is-device"
 // SYCL_XARCH_DEVICE_OPTION-SAME: -fsanitize=address
@@ -23,13 +23,13 @@
 
 /// test behavior of -Xarch_device with multiple options for SYCL compiler, the
 /// flags should be passed to device compilation only.
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -DXARCH_DEVICE_TEST -mllvm -enable-merge-functions" -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -DXARCH_DEVICE_TEST -mllvm -enable-merge-functions" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_DEVICE_OPTIONS1
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -DXARCH_DEVICE_TEST -mllvm -enable-merge-functions" -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -DXARCH_DEVICE_TEST -mllvm -enable-merge-functions" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_DEVICE_OPTIONS1
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -DXARCH_DEVICE_TEST -mllvm -enable-merge-functions" -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -DXARCH_DEVICE_TEST -mllvm -enable-merge-functions" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_DEVICE_OPTIONS2
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -DXARCH_DEVICE_TEST -mllvm -enable-merge-functions" -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -DXARCH_DEVICE_TEST -mllvm -enable-merge-functions" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_DEVICE_OPTIONS3
 // SYCL_XARCH_DEVICE_OPTIONS1: clang{{.*}} "-fsycl-is-device"
 // SYCL_XARCH_DEVICE_OPTIONS1-SAME: -fsanitize=address
@@ -46,9 +46,9 @@
 
 /// test behavior of -Xarch_host with 1 option for SYCL compiler, the flag
 /// should be passed to host compilation only.
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host -fsanitize=address -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host -fsanitize=address -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_HOST_OPTION
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host -fsanitize=address -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host -fsanitize=address -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_HOST_ONLY
 // SYCL_XARCH_HOST_OPTION: clang{{.*}} "-fsycl-is-host"
 // SYCL_XARCH_HOST_OPTION-SAME: -fsanitize=address
@@ -60,11 +60,11 @@
 
 /// test behavior of -Xarch_host with multiple options for SYCL compiler, the
 /// flags should be passed to host compilation only.
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -DXARCH_HOST_TEST -mllvm -enable-merge-functions" -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -DXARCH_HOST_TEST -mllvm -enable-merge-functions" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_HOST_OPTIONS1
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -DXARCH_HOST_TEST -mllvm -enable-merge-functions" -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -DXARCH_HOST_TEST -mllvm -enable-merge-functions" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_HOST_OPTIONS2
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -DXARCH_HOST_TEST -mllvm -enable-merge-functions" -### 2>&1 \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -DXARCH_HOST_TEST -mllvm -enable-merge-functions" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_HOST_OPTIONS3
 // SYCL_XARCH_HOST_OPTIONS1: clang{{.*}} "-fsycl-is-host"
 // SYCL_XARCH_HOST_OPTIONS1-SAME: -fsanitize=address
@@ -75,25 +75,25 @@
 // SYCL_XARCH_HOST_OPTIONS3-SAME: "-mllvm" "-enable-merge-functions"
 
 // test behavior of combination of -Xarch_device and -Xarch_device.
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host "-fsanitize=memory -DUSE_XARCH_HOST -fno-builtin" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_COM_DEVICE_OPTIONS1
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host "-fsanitize=memory -DUSE_XARCH_HOST -fno-builtin" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_COM_DEVICE_OPTIONS2
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host "-fsanitize=memory -DUSE_XARCH_HOST -fno-builtin" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_COM_NO_DEVICE
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host "-fsanitize=memory -DUSE_XARCH_HOST -fno-builtin" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_COM_HOST_OPTIONS1
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host "-fsanitize=memory -DUSE_XARCH_HOST -fno-builtin" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_COM_HOST_OPTIONS2
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host "-fsanitize=memory -DUSE_XARCH_HOST -fno-builtin" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_COM_HOST_OPTIONS3
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_device "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host "-fsanitize=memory -DUSE_XARCH_HOST -fno-builtin" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_COM_NO_HOST
 // SYCL_XARCH_COM_DEVICE_OPTIONS1: clang{{.*}} "-fsycl-is-device"
@@ -120,25 +120,25 @@
 
 
 // test behavior of multiple usage of -Xarch_host in single command line
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host -DFOO -Xarch_host -DFOO1 -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_HOST_MULTIPLE1
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host -DFOO -Xarch_host -DFOO1 -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_HOST_MULTIPLE2
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host -DFOO -Xarch_host -DFOO1 -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_HOST_MULTIPLE3
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host -DFOO -Xarch_host -DFOO1 -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_HOST_MULTIPLE4
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host -DFOO -Xarch_host -DFOO1 -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_NO_DEVICE_MULTIPLE1
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host -DFOO -Xarch_host -DFOO1 -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_NO_DEVICE_MULTIPLE2
-// RUN: %clangxx -fsycl --offload-new-driver %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL %s -Xarch_host "-fsanitize=address -mllvm -enable-merge-functions" \
 // RUN:   -Xarch_host -DFOO -Xarch_host -DFOO1 -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_XARCH_NO_DEVICE_MULTIPLE3
 // SYCL_XARCH_HOST_MULTIPLE1: clang{{.*}} "-fsycl-is-host"


### PR DESCRIPTION
Recent updates to how the SYCL device libraries are pulled in during compile time for the new offloading model cause a requirement for the device libraries to be available, or the driver will error.

A number of tests fail when no device libraries are actually built with the compiler, some adjustments are needed to a number of tests to allow for clean LIT testing when no device libraries are built.

 - For tests that do true compiles with -fsycl, add libdevice as a requirement
 - Add --sysroot=%S/Inputs/SYCL for -### tests to resolve the libs