### PR TITLE
[UR] Revert #21930

### DIFF
--- a/unified-runtime/source/adapters/level_zero/image.cpp
+++ b/unified-runtime/source/adapters/level_zero/image.cpp
@@ -121,31 +121,15 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
   // We want to batch these commands to avoid extra submissions (costly)
   bool OkToBatch = true;
 
-  // External semaphore operations require an immediate command list per the
-  // Level Zero spec. If the queue is not using immediate command lists,
-  // we need to get one specifically for this operation.
-  bool NeedTempImmCmdList = !hQueue->UsingImmCmdLists;
-
   ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       numEventsInWaitList, phEventWaitList, hQueue, UseCopyEngine));
 
   // Get a new command list to be used on this call
   ur_command_list_ptr_t CommandList{};
-  if (NeedTempImmCmdList) {
-    // Ensure the queue group has ImmCmdLists initialized so we can
-    // obtain an immediate command list.
-    auto &QGroup = hQueue->getQueueGroup(UseCopyEngine);
-    if (QGroup.ImmCmdLists.empty()) {
-      QGroup.ImmCmdLists = std::vector<ur_command_list_ptr_t>(
-          QGroup.ZeQueues.size(), hQueue->CommandListMap.end());
-    }
-    CommandList = QGroup.getImmCmdList();
-  } else {
-    UR_CALL(hQueue->Context->getAvailableCommandList(
-        hQueue, CommandList, UseCopyEngine, numEventsInWaitList,
-        phEventWaitList, OkToBatch, nullptr /*ForcedCmdQueue*/));
-  }
+  UR_CALL(hQueue->Context->getAvailableCommandList(
+      hQueue, CommandList, UseCopyEngine, numEventsInWaitList, phEventWaitList,
+      OkToBatch, nullptr /*ForcedCmdQueue*/));
 
   ze_event_handle_t ZeEvent = nullptr;
   ur_event_handle_t InternalEvent;
@@ -173,15 +157,7 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
              (ZeCommandList, 1, &hExtSemaphore, &WaitParams, ZeEvent,
               WaitList.Length, WaitList.ZeEventList));
 
-  if (NeedTempImmCmdList) {
-    // Immediate command lists auto-execute; no explicit submission needed.
-    // Update LastCommandEvent for in-order queue semantics.
-    if (!CommandList->second.EventList.empty()) {
-      hQueue->LastCommandEvent = CommandList->second.EventList.back();
-    }
-  } else {
-    UR_CALL(hQueue->executeCommandList(CommandList, false, OkToBatch));
-  }
+  UR_CALL(hQueue->executeCommandList(CommandList, false, OkToBatch));
 
   return UR_RESULT_SUCCESS;
 }
@@ -203,31 +179,15 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
   // We want to batch these commands to avoid extra submissions (costly)
   bool OkToBatch = true;
 
-  // External semaphore operations require an immediate command list per the
-  // Level Zero spec. If the queue is not using immediate command lists,
-  // we need to get one specifically for this operation.
-  bool NeedTempImmCmdList = !hQueue->UsingImmCmdLists;
-
   ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
       numEventsInWaitList, phEventWaitList, hQueue, UseCopyEngine));
 
   // Get a new command list to be used on this call
   ur_command_list_ptr_t CommandList{};
-  if (NeedTempImmCmdList) {
-    // Ensure the queue group has ImmCmdLists initialized so we can
-    // obtain an immediate command list.
-    auto &QGroup = hQueue->getQueueGroup(UseCopyEngine);
-    if (QGroup.ImmCmdLists.empty()) {
-      QGroup.ImmCmdLists = std::vector<ur_command_list_ptr_t>(
-          QGroup.ZeQueues.size(), hQueue->CommandListMap.end());
-    }
-    CommandList = QGroup.getImmCmdList();
-  } else {
-    UR_CALL(hQueue->Context->getAvailableCommandList(
-        hQueue, CommandList, UseCopyEngine, numEventsInWaitList,
-        phEventWaitList, OkToBatch, nullptr /*ForcedCmdQueue*/));
-  }
+  UR_CALL(hQueue->Context->getAvailableCommandList(
+      hQueue, CommandList, UseCopyEngine, numEventsInWaitList, phEventWaitList,
+      OkToBatch, nullptr /*ForcedCmdQueue*/));
 
   ze_event_handle_t ZeEvent = nullptr;
   ur_event_handle_t InternalEvent;
@@ -256,15 +216,7 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
              (ZeCommandList, 1, &hExtSemaphore, &SignalParams, ZeEvent,
               WaitList.Length, WaitList.ZeEventList));
 
-  if (NeedTempImmCmdList) {
-    // Immediate command lists auto-execute; no explicit submission needed.
-    // Update LastCommandEvent for in-order queue semantics.
-    if (!CommandList->second.EventList.empty()) {
-      hQueue->LastCommandEvent = CommandList->second.EventList.back();
-    }
-  } else {
-    UR_CALL(hQueue->executeCommandList(CommandList, false, OkToBatch));
-  }
+  UR_CALL(hQueue->executeCommandList(CommandList, false, OkToBatch));
 
   return UR_RESULT_SUCCESS;
 }


### PR DESCRIPTION
Revert "[L0] Use immediate command lists for external semaphore wait/signal (#21930)"

This reverts commit e928aaedf443761c54d669f09db8fbf1dabc2ec5.


By putting the semaphore on an immediate command list, but still using the original regular command list for the other graphic operations, we introduce some unsoundness that can lead to races and problems where the regular command list is the default.  The better choice in the short term is to simply require that SYCL queues that are intended for semaphore usage use immediate command lists. I have a separate PR (in progress) that will make that change to the docs and tests and introduces a verification. 
https://github.com/intel/llvm/pull/22046

