### PR TITLE
[clang][Driver][lit] Fix two sycl-offload LIT tests

### DIFF
--- a/clang/test/Driver/sycl-offload-Xarch.cpp
+++ b/clang/test/Driver/sycl-offload-Xarch.cpp
@@ -24,8 +24,10 @@
 // RUN:   -Xarch_amdgcn --offload-arch=gfx90a,gfx906 -Xarch_nvptx64 --offload-arch=sm_52,sm_89 -S -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=MULTI-ARCH %s
 
-// O3ONCE-AMD: "-triple" "amdgcn-amd-amdhsa" "-O3"
-// O3ONCE-NVPTX: "-triple" "nvptx64-nvidia-cuda" "-O3"
+// O3ONCE-AMD: "-triple" "amdgcn-amd-amdhsa"
+// O3ONCE-AMD-SAME: "-O3"
+// O3ONCE-NVPTX: "-triple" "nvptx64-nvidia-cuda"
+// O3ONCE-NVPTX-SAME: "-O3"
 // INVALID-ARCH-FOR-TARGET: clang: error: invalid target ID 'sm_75'; format is a processor name followed by an optional colon-delimited list of features followed by an enable/disable sign (e.g., 'gfx908:sramecc+:xnack-')
 // AMD-ARCH: {{"[^"]*llvm-offload-binary[^"]*" "-o".* "--image=file=.*.bc,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=sycl"}}
 // NVPTX-ARCH: {{"[^"]*llvm-offload-binary[^"]*" "-o".* "--image=file=.*.bc,triple=nvptx64-nvidia-cuda,arch=sm_52,kind=sycl"}}

--- a/clang/test/Driver/sycl-offload-nvptx.cpp
+++ b/clang/test/Driver/sycl-offload-nvptx.cpp
@@ -15,7 +15,7 @@
 // RUN: -resource-dir %{resource_dir} %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-ACTIONS-WIN %s
 
-// CHK-ACTIONS: "-cc1" "-triple" "nvptx64-nvidia-cuda" "-{{.*}}"-aux-triple" "x86_64-unknown-linux-gnu"{{.*}} "-fsycl-is-device"{{.*}} "-Wno-sycl-strict"{{.*}} "-sycl-std=2020" {{.*}} "-emit-llvm-bc" {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libspirv.l64.signed_char.bc"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libdevice{{.*}}.10.bc"{{.*}} "-target-sdk-version=[[CUDA_VERSION:[0-9.]+]]"{{.*}} "-target-cpu" "sm_75"{{.*}} "-target-feature" "+ptx63"{{.*}} "-std=c++17"{{.*}}
+// CHK-ACTIONS: "-cc1" "-triple" "nvptx64-nvidia-cuda" "-aux-triple" "x86_64-unknown-linux-gnu"{{.*}} "-fsycl-is-device"{{.*}} "-Wno-sycl-strict"{{.*}} "-sycl-std=2020" {{.*}} "-emit-llvm-bc" {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libspirv.l64.signed_char.bc"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libdevice{{.*}}.10.bc"{{.*}} "-target-sdk-version=[[CUDA_VERSION:[0-9.]+]]"{{.*}} "-target-cpu" "sm_75"{{.*}} "-target-feature" "+ptx63"{{.*}} "-std=c++17"{{.*}}
 // CHK-ACTIONS: sycl-post-link
 // CHK-ACTIONS-NOT: -split
 // CHK-ACTIONS-SAME: -o
@@ -27,7 +27,7 @@
 // CHK-ACTIONS-NOT: "-mllvm -sycl-opt"
 // CHK-ACTIONS: clang-offload-wrapper"{{.*}} "-host=x86_64-unknown-linux-gnu" "-target=nvptx64" "-kind=sycl"{{.*}}
 
-// CHK-ACTIONS-WIN: "-cc1" "-triple" "nvptx64-nvidia-cuda" "-{{.*}}"-aux-triple" "x86_64-pc-windows-msvc"{{.*}} "-fsycl-is-device"{{.*}} "-Wno-sycl-strict"{{.*}} "-sycl-std=2020" {{.*}} "-emit-llvm-bc" {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libspirv.l32.signed_char.bc"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libdevice{{.*}}.10.bc"{{.*}} "-target-sdk-version=[[CUDA_VERSION:[0-9.]+]]"{{.*}} "-target-cpu" "sm_75"{{.*}} "-target-feature" "+ptx63"{{.*}}
+// CHK-ACTIONS-WIN: "-cc1" "-triple" "nvptx64-nvidia-cuda" "-aux-triple" "x86_64-pc-windows-msvc"{{.*}} "-fsycl-is-device"{{.*}} "-Wno-sycl-strict"{{.*}} "-sycl-std=2020" {{.*}} "-emit-llvm-bc" {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libspirv.l32.signed_char.bc"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libdevice{{.*}}.10.bc"{{.*}} "-target-sdk-version=[[CUDA_VERSION:[0-9.]+]]"{{.*}} "-target-cpu" "sm_75"{{.*}} "-target-feature" "+ptx63"{{.*}}
 // CHK-ACTIONS-WIN: sycl-post-link
 // CHK-ACTIONS-WIN-NOT: -split
 // CHK-ACTIONS-WIN-SAME: -o


### PR DESCRIPTION
The problem is the location of "-aux-target" moved, so just update the patterns.

Note this is for sycl-web.