### PR TITLE
[CI][Bench] Align timestamps on charts

### DIFF
--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -120,8 +120,6 @@ runs:
 
       export SAVE_NAME="${SAVE_PREFIX}_${GPU_TYPE}_${SAVE_SUFFIX}"
       echo "SAVE_NAME=$SAVE_NAME" >> $GITHUB_ENV
-      export SAVE_TIMESTAMP="$(date -u +'%Y%m%d_%H%M%S')"  # Timestamps are in UTC time
-      echo "SAVE_TIMESTAMP=$SAVE_TIMESTAMP" >> $GITHUB_ENV
 
       # By default, the benchmark scripts forceload level_zero
       FORCELOAD_ADAPTER="${TARGET_DEVICE%%:*}"
@@ -138,6 +136,11 @@ runs:
         echo "Using SYCL from: $SYCL_DIR"
         export CMPLR_ROOT=$SYCL_DIR
         echo "CMPLR_ROOT=$CMPLR_ROOT" >> $GITHUB_ENV
+
+        # Set timestamp based on the compiler library's time.
+        # It's useful for nightly to have a consistent timestamp for all runs.
+        export SAVE_TIMESTAMP="$(date -u -r "$CMPLR_ROOT/lib/libsycl.so" +'%Y%m%d_%H%M%S')"
+        echo "SAVE_TIMESTAMP=$SAVE_TIMESTAMP"
       else
         echo "INFO: SYCL directory '$SYCL_DIR' does not exist or is missing libsycl.so"
         echo "Checking if SYCL is installed in the system..."
@@ -147,6 +150,11 @@ runs:
         echo "Using SYCL from: $CMPLR_ROOT !"
         echo "CMPLR_ROOT=$CMPLR_ROOT" >> $GITHUB_ENV
       fi
+
+      if [ -z "$SAVE_TIMESTAMP" ]; then
+        export SAVE_TIMESTAMP="$(date -u +'%Y%m%d_%H%M%S')"  # Current timestamp in UTC time
+      fi
+      echo "SAVE_TIMESTAMP=$SAVE_TIMESTAMP" >> $GITHUB_ENV
   - name: Set NUMA node to run benchmarks on
     shell: bash
     run: |

--- a/devops/scripts/benchmarks/history.py
+++ b/devops/scripts/benchmarks/history.py
@@ -188,11 +188,19 @@ class BenchmarkHistory:
             log.warning("GPU information detection failed.")
             platform_info.gpu_info = []
 
+        run_date = (
+            datetime.strptime(
+                options.timestamp_override, options.TIMESTAMP_FORMAT
+            ).replace(tzinfo=timezone.utc)
+            if options.timestamp_override is not None
+            else datetime.now(tz=timezone.utc)
+        )
+
         return BenchmarkRun(
             name=name,
             git_hash=git_hash,
             github_repo=github_repo,
-            date=datetime.now(tz=timezone.utc),
+            date=run_date,
             results=results,
             hostname=hostname,
             compute_runtime=compute_runtime,

--- a/devops/scripts/benchmarks/tests/test_integration.py
+++ b/devops/scripts/benchmarks/tests/test_integration.py
@@ -81,8 +81,6 @@ class App:
                 self.OUTPUT_DIR,
                 "--preset",
                 "Minimal",
-                "--timestamp-override",
-                "20240102_030405",
                 "--stddev-threshold",
                 "999999999.9",
                 "--iterations",


### PR DESCRIPTION
In workflows where we build sycl, use its build time to establish results date and time. This is especially usefull for nightly runs, where we have 4 jobs and their time (before) was not aligned. It was hard to compare which run was from the same build.