### PR TITLE
[E2E] Add new features to build_specific_features

### DIFF
--- a/sycl/test-e2e/E2EExpr.py
+++ b/sycl/test-e2e/E2EExpr.py
@@ -19,6 +19,8 @@ class E2EExpr(BooleanExpression):
         "linux",
         "system-linux",
         "windows",
+        "O0",
+        "two-or-more-gpu-devices",
         "system-windows",
         "cl_options",
         "enable-perf-tests",


### PR DESCRIPTION
Fix failures

lit.py: ...llvm/llvm/utils/lit/lit/TestingConfig.py:164: fatal: unable to parse config file '...llvm/sycl/test-e2e/lit.cfg.py', traceback: Traceback (most recent call last):
  File "...llvm/llvm/utils/lit/lit/TestingConfig.py", line 153, in load_from_path
    exec(compile(data, path, "exec"), cfg_globals, None)
  File "...llvm/sycl/test-e2e/lit.cfg.py", line 1285, in <module>
    E2EExpr.check_build_features(config.available_features)
  File "...llvm/sycl/test-e2e/E2EExpr.py", line 142, in check_build_features
    raise ValueError(
ValueError: Runtime features: ['two-or-more-gpu-devices'] evaluated to True in build-only
If this is a new build specific feature append it to:`build_specific_features` in `sycl/test-e2e/E2EExpr.py`
