### PR TITLE
[SYCL] Re-enable vulkan_sycl_image_unsampled_timeline_semaphore e2e test on Linux DG2 and ARL 

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_unsampled_timeline_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_unsampled_timeline_semaphore.cpp
@@ -2,9 +2,6 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan
 
-// UNSUPPORTED: linux && (gpu-intel-dg2 || arch-intel_gpu_mtl_u)
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21764
-
 // XFAIL: windows && gpu-intel-dg2
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21985
 


### PR DESCRIPTION
This PR re-enables vulkan_sycl_image_unsampled_timeline_semaphore e2e test. 

The reason why I am re-enabling  this test is that I can't reproduce hang reported in https://github.com/intel/llvm/issues/21764
with new compute runtime version used by intel/llvm CI `26.18.38308.1`.

I was able to reproduce the issue when test is run in parallel.
It fails on certain version of compute runtime. Versions I have checked: 

```
26.01.36711.4 - Passes
26.09.37435.1 - Fails
26.14.37833.4 - Fails
26.18.38308.1 - Passes 
```