### PR TITLE
[UR][CTS][L0v2] Mark known failures in buffer tests

### DIFF
--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -113,6 +113,9 @@ UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferCopyMultiDeviceTest);
 TEST_P(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
   UUR_KNOWN_FAILURE_ON(uur::CUDA{});
 
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   // First queue does a fill.
   const uint32_t input = 42;
   ASSERT_SUCCESS(urEnqueueMemBufferFill(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -311,6 +311,9 @@ UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferCopyRectMultiDeviceTest);
 TEST_P(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
   UUR_KNOWN_FAILURE_ON(uur::CUDA{});
 
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   // First queue does a fill.
   const uint32_t input = 42;
   ASSERT_SUCCESS(urEnqueueMemBufferFill(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -212,6 +212,9 @@ using urEnqueueMemBufferFillMultiDeviceTest =
 UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferFillMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferFillMultiDeviceTest, FillReadDifferentQueues) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   // First queue does a fill.
   const uint32_t input = 42;
   ASSERT_SUCCESS(urEnqueueMemBufferFill(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -138,6 +138,9 @@ using urEnqueueMemBufferReadMultiDeviceTest =
 UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferReadMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferReadMultiDeviceTest, WriteReadDifferentQueues) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   // First queue does a blocking write of 42 into the buffer.
   std::vector<uint32_t> input(count, 42);
   ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -277,6 +277,9 @@ UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferReadRectMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferReadRectMultiDeviceTest,
        WriteRectReadDifferentQueues) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   // First queue does a blocking write of 42 into the buffer.
   // Then a rectangular write the buffer as 1024x1x1 1D.
   std::vector<uint32_t> input(count, 42);

--- a/unified-runtime/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
+++ b/unified-runtime/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
@@ -177,6 +177,9 @@ struct urMultiDeviceContextMemBufferTest : urMultiDeviceContextTest {
 UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMultiDeviceContextMemBufferTest);
 
 TEST_P(urMultiDeviceContextMemBufferTest, WriteRead) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -201,6 +204,9 @@ TEST_P(urMultiDeviceContextMemBufferTest, WriteRead) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, FillRead) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -225,6 +231,9 @@ TEST_P(urMultiDeviceContextMemBufferTest, FillRead) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, WriteKernelRead) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -262,6 +271,9 @@ TEST_P(urMultiDeviceContextMemBufferTest, WriteKernelRead) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, WriteKernelKernelRead) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -305,6 +317,9 @@ TEST_P(urMultiDeviceContextMemBufferTest, WriteKernelKernelRead) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, PingPongKernelExecution) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -353,6 +368,9 @@ TEST_P(urMultiDeviceContextMemBufferTest, PingPongKernelExecution) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, ComplexMigrationPattern) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -419,6 +437,9 @@ TEST_P(urMultiDeviceContextMemBufferTest, ComplexMigrationPattern) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, KernelsExecutionWithThreads) {
+  // Related issue: https://github.com/intel/llvm/issues/22058.
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
+
   if (num_devices <= 1) {
     GTEST_SKIP();
   }

--- a/unified-runtime/test/conformance/testing/include/uur/fixtures.h
+++ b/unified-runtime/test/conformance/testing/include/uur/fixtures.h
@@ -74,23 +74,6 @@ struct urPlatformTest : ::testing::Test,
   ur_platform_handle_t platform = nullptr;
 };
 
-inline std::pair<bool, std::vector<ur_device_handle_t>>
-GetDevices(ur_platform_handle_t platform) {
-  uint32_t count = 0;
-  if (urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count)) {
-    return {false, {}};
-  }
-  if (count == 0) {
-    return {false, {}};
-  }
-  std::vector<ur_device_handle_t> devices(count);
-  if (urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count, devices.data(),
-                  nullptr)) {
-    return {false, {}};
-  }
-  return {true, devices};
-}
-
 inline bool hasDevicePartitionSupport(ur_device_handle_t device,
                                       const ur_device_partition_t property) {
   std::vector<ur_device_partition_t> properties;

--- a/unified-runtime/test/conformance/testing/include/uur/known_failure.h
+++ b/unified-runtime/test/conformance/testing/include/uur/known_failure.h
@@ -112,11 +112,25 @@ inline bool isKnownFailureOn(ur_platform_handle_t platform,
   urPlatformGetInfo(platform, UR_PLATFORM_INFO_ADAPTER,
                     sizeof(ur_adapter_handle_t), &adapter, nullptr);
   auto adapterInfo = detail::getAdapterInfo(adapter);
-  std::string name;
-  uur::GetPlatformInfo<std::string>(platform, UR_PLATFORM_INFO_NAME, name);
+  std::string platformName, platformVersion;
+  uur::GetPlatformInfo<std::string>(platform, UR_PLATFORM_INFO_NAME,
+                                    platformName);
+  uur::GetPlatformInfo<std::string>(platform, UR_PLATFORM_INFO_VERSION,
+                                    platformVersion);
+  auto [_, devices] = uur::GetDevices(platform);
   for (const auto &matcher : matchers) {
-    if (matcher.matches(adapterInfo, name)) {
+    if (matcher.matches(adapterInfo, platformName)) {
       return true;
+    }
+    if (matcher.matches(adapterInfo, platformVersion)) {
+      return true;
+    }
+    for (const auto &device : devices) {
+      std::string deviceName;
+      uur::GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_NAME, deviceName);
+      if (matcher.matches(adapterInfo, deviceName)) {
+        return true;
+      }
     }
   }
   return false;

--- a/unified-runtime/test/conformance/testing/include/uur/utils.h
+++ b/unified-runtime/test/conformance/testing/include/uur/utils.h
@@ -18,6 +18,23 @@ inline size_t RoundUpToNearestFactor(size_t num, size_t factor) {
   return ((num + factor - 1) / factor) * factor;
 }
 
+inline std::pair<bool, std::vector<ur_device_handle_t>>
+GetDevices(ur_platform_handle_t platform) {
+  uint32_t count = 0;
+  if (urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count)) {
+    return {false, {}};
+  }
+  if (count == 0) {
+    return {false, {}};
+  }
+  std::vector<ur_device_handle_t> devices(count);
+  if (urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count, devices.data(),
+                  nullptr)) {
+    return {false, {}};
+  }
+  return {true, devices};
+}
+
 /// @brief Make a string a valid identifier for gtest.
 /// @param str The string to sanitize.
 inline std::string GTestSanitizeString(const std::string &str) {


### PR DESCRIPTION
Temporarily turn off buffer tests that started failing after L0 driver uplift to 26.18.38308.1.