### PR TITLE
[SYCL] Remove inappropriate move

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -398,7 +398,7 @@ queue_impl::submit_impl(const detail::type_erased_cgfo_ty &CGF,
 }
 
 EventImplPtr queue_impl::submit_kernel_scheduler_bypass(
-    KernelData &KData, std::vector<detail::EventImplPtr> &DepEvents,
+    KernelData &KData, std::vector<detail::EventImplPtr> DepEvents,
     bool EventNeeded, detail::kernel_impl *KernelImplPtr,
     detail::kernel_bundle_impl *KernelBundleImpPtr,
     const detail::code_location &CodeLoc, bool IsTopCodeLoc) {

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -398,7 +398,7 @@ queue_impl::submit_impl(const detail::type_erased_cgfo_ty &CGF,
 }
 
 EventImplPtr queue_impl::submit_kernel_scheduler_bypass(
-    KernelData &KData, std::vector<detail::EventImplPtr> DepEvents,
+    KernelData &KData, std::vector<detail::EventImplPtr> &DepEvents,
     bool EventNeeded, detail::kernel_impl *KernelImplPtr,
     detail::kernel_bundle_impl *KernelBundleImpPtr,
     const detail::code_location &CodeLoc, bool IsTopCodeLoc) {
@@ -469,8 +469,7 @@ EventImplPtr queue_impl::submit_kernel_scheduler_bypass(
     ResultEvent->setEnqueued();
     // connect returned event with dependent events
     if (!isInOrder()) {
-      // DepEvents is not used anymore, so can move.
-      ResultEvent->getPreparedDepsEvents() = std::move(DepEvents);
+      ResultEvent->getPreparedDepsEvents() = DepEvents;
       // ResultEvent is local for current thread, no need to lock.
       ResultEvent->cleanDepEventsThroughOneLevelUnlocked();
     }

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -421,7 +421,7 @@ public:
   ///
   /// \return a SYCL event representing submitted command or nullptr.
   EventImplPtr submit_kernel_scheduler_bypass(
-      KernelData &KData, std::vector<detail::EventImplPtr> DepEvents,
+      KernelData &KData, std::vector<detail::EventImplPtr> &DepEvents,
       bool EventNeeded, detail::kernel_impl *KernelImplPtr,
       detail::kernel_bundle_impl *KernelBundleImpPtr,
       const detail::code_location &CodeLoc, bool IsTopCodeLoc);

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -421,7 +421,7 @@ public:
   ///
   /// \return a SYCL event representing submitted command or nullptr.
   EventImplPtr submit_kernel_scheduler_bypass(
-      KernelData &KData, std::vector<detail::EventImplPtr> &DepEvents,
+      KernelData &KData, std::vector<detail::EventImplPtr> DepEvents,
       bool EventNeeded, detail::kernel_impl *KernelImplPtr,
       detail::kernel_bundle_impl *KernelBundleImpPtr,
       const detail::code_location &CodeLoc, bool IsTopCodeLoc);


### PR DESCRIPTION
Currently DepEevents is passed by ref and then moved causing coverity issue "Returning while reference parameter DepEvents is in a moved state.". Remove move.
closes https://github.com/intel/llvm/issues/21915