### PR TITLE
Revert "[SYCL] Re-enable vulkan_sycl_image_unsampled_timeline_semaphore e2e test on Linux DG2 and ARL "

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_unsampled_timeline_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_unsampled_timeline_semaphore.cpp
@@ -2,6 +2,9 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan
 
+// UNSUPPORTED: linux && (gpu-intel-dg2 || arch-intel_gpu_mtl_u)
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21764
+
 // XFAIL: windows && gpu-intel-dg2
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21985
 


### PR DESCRIPTION
Reverts intel/llvm#22071