### PR TITLE
[SYCL][Graph] Add destruction callback spec addition for modifiable command graph

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -729,6 +729,9 @@ public:
   std::vector<node> get_root_nodes() const;
 
   bool empty() const;
+
+  template <typename Func, typename... ArgTs>
+  void set_destruction_callback(Func&& Callback, ArgTs&&... CbArgs);
 };
 
 template<>
@@ -1532,6 +1535,41 @@ _Constraints:_ This member function is only available when the `command_graph` s
 
 _Returns:_ The total size in bytes of the memory required for
 <<graph-memory-allocations, graph-owned memory allocations>> in this graph.
+
+[source,c++]
+----
+template <typename Func, typename... ArgTs>
+void set_destruction_callback(Func&& Callback, ArgTs&&... CbArgs);
+----
+
+_Effects:_ Registers a user callback that will be invoked when the last
+reference to the underlying graph object is destroyed. All arguments are stored
+as their decayed types (`std::decay_t<ArgTs>`); references are not preserved.
+If `Callback` or any argument in `CbArgs` is passed as an lvalue, it is
+copy-constructed into internal storage. If passed as an rvalue, it is
+move-constructed into internal storage. Users who require reference semantics
+must pass `std::ref` or `std::cref` and are responsible for ensuring the
+referenced object outlives the graph. When the graph is destroyed the stored
+callable is invoked with the stored arguments as if by
+`std::apply(Callback, std::tuple(CbArgs...))`.
+Multiple callbacks may be registered on the same graph and all will be invoked
+on destruction, in an unspecified order.
+
+The following restrictions apply to the callback and callback arguments:
+
+* `Func` must be _Callable_ with parameter types matching `ArgTs...`.
+* `std::decay_t<Func>` must be _CopyConstructible_. If passed as an rvalue,
+  _MoveConstructible_ is used as an optimization and no copies are performed.
+* Each type in `std::decay_t<ArgTs>...` must be _CopyConstructible_. If passed
+  as an rvalue, _MoveConstructible_ is used as an optimization and no copies are performed.
+* The callback must not throw exceptions. If an exception escapes the callback
+  the behavior is undefined.
+* `Func` and `CbArgs` must not capture or reference the `command_graph` object
+  being destroyed, either directly or indirectly. Violating this requirement is
+  undefined behavior.
+
+_Constraints:_ This member function is only available when the `command_graph`
+state is `graph_state::modifiable`.
 
 =====  Member functions of the `command_graph` class for graph update
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -1531,17 +1531,17 @@ template <typename Func, typename... ArgTs>
 void set_destruction_callback(Func&& Callback, ArgTs&&... CbArgs);
 ----
 
-_Effects:_ Registers a user callback that will be invoked when the last
-reference to the underlying graph object is destroyed. All arguments are stored
-as their decayed types (`std::decay_t<ArgTs>...`); references are not preserved.
-If `Callback` or any argument in `CbArgs` is passed as an lvalue, it is
-copy-constructed into internal storage. If passed as an rvalue, it is
+_Effects:_ Registers a user callback that is invoked when the graph and any
+executable graphs finalized from it have all been destroyed. All arguments are
+stored as their decayed types (`std::decay_t<ArgTs>...`); references are not
+preserved. If `Callback` or any argument in `CbArgs` is passed as an lvalue, it
+is copy-constructed into internal storage. If passed as an rvalue, it is
 move-constructed into internal storage. Users who require reference semantics
 must pass `std::ref` or `std::cref` and are responsible for ensuring the
 referenced object outlives the graph. When the graph is destroyed the stored
 callable is invoked with the stored arguments. Multiple callbacks may be
-registered on the same graph and all will be invoked on destruction, in an
-unspecified order.
+registered on the same graph and will be invoked on destruction in order of
+registration.
 
 The following restrictions apply to the callback and callback arguments:
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -731,7 +731,7 @@ public:
   bool empty() const;
 
   template <typename Func, typename... ArgTs>
-  void set_destruction_callback(Func&& Callback, ArgTs&&... CbArgs);
+  void set_destruction_callback(Func&& callback, ArgTs&&... cbArgs);
 };
 
 template<>
@@ -1544,7 +1544,7 @@ void set_destruction_callback(Func&& Callback, ArgTs&&... CbArgs);
 
 _Effects:_ Registers a user callback that will be invoked when the last
 reference to the underlying graph object is destroyed. All arguments are stored
-as their decayed types (`std::decay_t<ArgTs>`); references are not preserved.
+as their decayed types (`std::decay_t<ArgTs>...`); references are not preserved.
 If `Callback` or any argument in `CbArgs` is passed as an lvalue, it is
 copy-constructed into internal storage. If passed as an rvalue, it is
 move-constructed into internal storage. Users who require reference semantics
@@ -1557,7 +1557,8 @@ on destruction, in an unspecified order.
 
 The following restrictions apply to the callback and callback arguments:
 
-* `Func` must be _Callable_ with parameter types matching `ArgTs...`.
+* `Func` must be _Callable_ with parameter types matching
+  `std::decay_t<ArgTs>...`.
 * `std::decay_t<Func>` must be _CopyConstructible_. If passed as an rvalue,
   _MoveConstructible_ is used as an optimization and no copies are performed.
 * Each type in `std::decay_t<ArgTs>...` must be _CopyConstructible_. If passed

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -1527,17 +1527,6 @@ _Returns:_ `true` if the graph contains no nodes, otherwise `false`.
 
 [source,c++]
 ----
-size_t get_required_mem_size() const noexcept;
-----
-
-_Constraints:_ This member function is only available when the `command_graph` state is
-`graph_state::executable`.
-
-_Returns:_ The total size in bytes of the memory required for
-<<graph-memory-allocations, graph-owned memory allocations>> in this graph.
-
-[source,c++]
-----
 template <typename Func, typename... ArgTs>
 void set_destruction_callback(Func&& Callback, ArgTs&&... CbArgs);
 ----
@@ -1550,10 +1539,9 @@ copy-constructed into internal storage. If passed as an rvalue, it is
 move-constructed into internal storage. Users who require reference semantics
 must pass `std::ref` or `std::cref` and are responsible for ensuring the
 referenced object outlives the graph. When the graph is destroyed the stored
-callable is invoked with the stored arguments as if by
-`std::apply(Callback, std::tuple(CbArgs...))`.
-Multiple callbacks may be registered on the same graph and all will be invoked
-on destruction, in an unspecified order.
+callable is invoked with the stored arguments. Multiple callbacks may be
+registered on the same graph and all will be invoked on destruction, in an
+unspecified order.
 
 The following restrictions apply to the callback and callback arguments:
 
@@ -1571,6 +1559,17 @@ The following restrictions apply to the callback and callback arguments:
 
 _Constraints:_ This member function is only available when the `command_graph`
 state is `graph_state::modifiable`.
+
+[source,c++]
+----
+size_t get_required_mem_size() const noexcept;
+----
+
+_Constraints:_ This member function is only available when the `command_graph` state is
+`graph_state::executable`.
+
+_Returns:_ The total size in bytes of the memory required for
+<<graph-memory-allocations, graph-owned memory allocations>> in this graph.
 
 =====  Member functions of the `command_graph` class for graph update
 


### PR DESCRIPTION
- Introduces spec for graph destruction callback registration functions. User's may provide a function and set of arguments to be invoked on graph destruction.
- This functionality is expected to be used by libraries that are captured in the graph. In many cases, these libraries allocate resources that should be destroyed alongside the graph. 