### PR TITLE
[SYCL][E2E] Disable vulkan_sycl_image_interop_read_1d.cpp on Win BMG

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
@@ -5,6 +5,9 @@
 // XFAIL: windows && gpu-intel-dg2
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21985
 
+// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22084
+
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 
 /*


### PR DESCRIPTION
It's hanging with the new Win driver so we need to disable it. See https://github.com/intel/llvm/issues/22084.