### PR TITLE
[SYCL][NFCI] Fix werror failure about unused field UrLoaderHandle

### DIFF
--- a/sycl/source/detail/adapter_impl.hpp
+++ b/sycl/source/detail/adapter_impl.hpp
@@ -218,7 +218,7 @@ private:
   // represents the unique ids of the last device of each platform
   // index of this vector corresponds to the index in UrPlatforms vector.
   std::vector<int> LastDeviceIds;
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(SYCL_UR_STATIC_LOADER)
   void *UrLoaderHandle = nullptr;
 #endif
   UrFuncPtrMapT UrFuncPtrs;


### PR DESCRIPTION
Fixes a postcommit Win build [error](https://github.com/intel/llvm/actions/runs/26280251772/job/77354368273). Started after https://github.com/intel/llvm/pull/22031.