### PR TITLE
[SYCL] Coverity: remove redundant move

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -329,7 +329,7 @@ public:
   device_image_impl(const std::string &Src, const context &Context,
                     devices_range Devices, syclex::source_language Lang,
                     include_pairs_t &&IncludePairsVec, private_tag)
-      : MBinImage(Src), MContext(std::move(Context)),
+      : MBinImage(Src), MContext(Context),
         MDevices(Devices.to<std::vector<device_impl *>>()),
         MState(bundle_state::ext_oneapi_source),
         MSpecConstsDefValBlob(getSpecConstsDefValBlob()),


### PR DESCRIPTION
This device_image_impl constructor accepts context by const ref. Makes no sense to move.
closes https://github.com/intel/llvm/issues/21916