### PR TITLE
[Driver][SYCL] Some new model settings performed with old model default

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5383,7 +5383,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       (JA.isHostOffloading(C.getActiveOffloadKinds()) &&
        Args.hasFlag(options::OPT_offload_new_driver,
                     options::OPT_no_offload_new_driver,
-                    C.getActiveOffloadKinds() != Action::OFK_None));
+                    (C.getActiveOffloadKinds() != Action::OFK_None &&
+                     C.getActiveOffloadKinds() != Action::OFK_SYCL)));
 
   bool IsRDCMode =
       Args.hasFlag(options::OPT_fgpu_rdc, options::OPT_fno_gpu_rdc, IsSYCL);
@@ -7789,7 +7790,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.append({"--offload-new-driver", "-foffload-via-llvm"});
   } else if (Args.hasFlag(options::OPT_offload_new_driver,
                           options::OPT_no_offload_new_driver,
-                          C.getActiveOffloadKinds() != Action::OFK_None)) {
+                          (C.getActiveOffloadKinds() != Action::OFK_None &&
+                           C.getActiveOffloadKinds() != Action::OFK_SYCL))) {
     CmdArgs.push_back("--offload-new-driver");
   }
 

--- a/clang/test/Driver/sycl-offload-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-old-model.cpp
@@ -1100,4 +1100,4 @@
 // RUN:   | FileCheck -check-prefix=CHECK-OLD-MODEL %s
 // RUN: %clang_cl -### -fsycl -- %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-OLD-MODEL %s
-// CHECK-OLD-MODEL-DEFAULT-NOT: "--offload-new-driver"
+// CHECK-OLD-MODEL-NOT: "--offload-new-driver"

--- a/clang/test/Driver/sycl-offload-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-old-model.cpp
@@ -1092,3 +1092,12 @@
 // CHECK_FSYCL_FP64_CONV_EMU_WIN-NOT: clang{{.*}} "-cc1" "-triple x86_64-unknown-linux-gnu" {{.*}} "-fsycl-fp64-conv-emu"
 // CHECK_FSYCL_FP64_CONV_EMU_WIN-DAG: clang{{.*}} "-cc1" "-triple" "spir64_gen{{.*}}" "-fsycl-fp64-conv-emu"
 // CHECK_FSYCL_FP64_CONV_EMU_WIN-DAG: ocloc{{.*}} "-options" "-ze-fp64-gen-conv-emu"
+
+/// Check that -fsycl alone does NOT use --offload-new-driver
+// RUN: %clangxx -### -fsycl --target=x86_64-unknown-linux-gnu %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-OLD-MODEL %s
+// RUN: %clangxx -### -fsycl --no-offload-new-driver --target=x86_64-unknown-linux-gnu %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-OLD-MODEL %s
+// RUN: %clang_cl -### -fsycl -- %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-OLD-MODEL %s
+// CHECK-OLD-MODEL-DEFAULT-NOT: "--offload-new-driver"


### PR DESCRIPTION
In the driver, the behavior between the old and the new offload model is dependent on having the old model as the default, and the new model enabled with a switch.  Some of the logic in which the old model is set was not strict enough, causing some new model settings be performed for SYCL device.