### PR TITLE
[libspirv] Fix unordered GreaterThan*/LessThan* relational built-ins

### DIFF
--- a/libclc/libspirv/lib/generic/relational/isgreater.cl
+++ b/libclc/libspirv/lib/generic/relational/isgreater.cl
@@ -16,5 +16,5 @@
 #undef _CLC_BUILTIN_IMPL
 
 #define _CLC_SPIRV_BUILTIN __spirv_FUnordGreaterThan
-#define _CLC_BUILTIN_IMPL(X, Y) X > Y
+#define _CLC_BUILTIN_IMPL(X, Y) ((__spirv_Unordered(X, Y)) || (X > Y))
 #include "genbinrelational.inc"

--- a/libclc/libspirv/lib/generic/relational/isgreaterequal.cl
+++ b/libclc/libspirv/lib/generic/relational/isgreaterequal.cl
@@ -16,5 +16,5 @@
 #undef _CLC_BUILTIN_IMPL
 
 #define _CLC_SPIRV_BUILTIN __spirv_FUnordGreaterThanEqual
-#define _CLC_BUILTIN_IMPL(X, Y) X >= Y
+#define _CLC_BUILTIN_IMPL(X, Y) ((__spirv_Unordered(X, Y)) || (X >= Y))
 #include "genbinrelational.inc"

--- a/libclc/libspirv/lib/generic/relational/isless.cl
+++ b/libclc/libspirv/lib/generic/relational/isless.cl
@@ -16,5 +16,5 @@
 #undef _CLC_BUILTIN_IMPL
 
 #define _CLC_SPIRV_BUILTIN __spirv_FUnordLessThan
-#define _CLC_BUILTIN_IMPL(X, Y) X < Y
+#define _CLC_BUILTIN_IMPL(X, Y) ((__spirv_Unordered(X, Y)) || (X < Y))
 #include "genbinrelational.inc"

--- a/libclc/libspirv/lib/generic/relational/islessequal.cl
+++ b/libclc/libspirv/lib/generic/relational/islessequal.cl
@@ -16,5 +16,5 @@
 #undef _CLC_BUILTIN_IMPL
 
 #define _CLC_SPIRV_BUILTIN __spirv_FUnordLessThanEqual
-#define _CLC_BUILTIN_IMPL(X, Y) X <= Y
+#define _CLC_BUILTIN_IMPL(X, Y) ((__spirv_Unordered(X, Y)) || (X <= Y))
 #include "genbinrelational.inc"


### PR DESCRIPTION
The old implementations was using ordered comparison. This PR fixes them to use unordered comparison which is required for NaN handling.
- FUnordGreaterThan: ogt -> ugt
- FUnordGreaterThanEqual: oge -> uge
- FUnordLessThan: olt -> ult
- FUnordLessThanEqual: ole -> ule

Example llvm-diff change (> is reference):
in function _Z25__spirv_FUnordGreaterThanff:
    >   %3 = fcmp contract ogt float %0, %1
    <   %3 = fcmp contract ugt float %0, %1