### PR TITLE
[libspirv] Use clc functions for __spirv_All/Any

### DIFF
--- a/libclc/libspirv/lib/generic/relational/all.cl
+++ b/libclc/libspirv/lib/generic/relational/all.cl
@@ -6,27 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <libspirv/spirv.h>
+#include "clc/relational/clc_all.h"
+#include "libspirv/spirv.h"
 
-#define _CLC_ALL(v) (((v) >> ((sizeof(v) * 8) - 1)) & 0x1)
-#define _CLC_ALL2(v) (_CLC_ALL((v).s0) & _CLC_ALL((v).s1))
-#define _CLC_ALL3(v) (_CLC_ALL2((v)) & _CLC_ALL((v).s2))
-#define _CLC_ALL4(v) (_CLC_ALL3((v)) & _CLC_ALL((v).s3))
-#define _CLC_ALL8(v)                                                           \
-  (_CLC_ALL4((v)) & _CLC_ALL((v).s4) & _CLC_ALL((v).s5) & _CLC_ALL((v).s6) &   \
-   _CLC_ALL((v).s7))
-#define _CLC_ALL16(v)                                                          \
-  (_CLC_ALL8((v)) & _CLC_ALL((v).s8) & _CLC_ALL((v).s9) & _CLC_ALL((v).sA) &   \
-   _CLC_ALL((v).sB) & _CLC_ALL((v).sC) & _CLC_ALL((v).sD) & _CLC_ALL((v).sE) & \
-   _CLC_ALL((v).sf))
+_CLC_OVERLOAD _CLC_DEF bool __spirv_All(char2 x) { return __clc_all(x); }
 
-#define ALL_ID(TYPE) _CLC_OVERLOAD _CLC_DEF bool __spirv_All(TYPE v)
+_CLC_OVERLOAD _CLC_DEF bool __spirv_All(char3 x) { return __clc_all(x); }
 
-#define ALL_VECTORIZE(TYPE)                                                    \
-  ALL_ID(TYPE##2) { return _CLC_ALL2(v); }                                     \
-  ALL_ID(TYPE##3) { return _CLC_ALL3(v); }                                     \
-  ALL_ID(TYPE##4) { return _CLC_ALL4(v); }                                     \
-  ALL_ID(TYPE##8) { return _CLC_ALL8(v); }                                     \
-  ALL_ID(TYPE##16) { return _CLC_ALL16(v); }
+_CLC_OVERLOAD _CLC_DEF bool __spirv_All(char4 x) { return __clc_all(x); }
 
-ALL_VECTORIZE(char)
+_CLC_OVERLOAD _CLC_DEF bool __spirv_All(char8 x) { return __clc_all(x); }
+
+_CLC_OVERLOAD _CLC_DEF bool __spirv_All(char16 x) { return __clc_all(x); }

--- a/libclc/libspirv/lib/generic/relational/any.cl
+++ b/libclc/libspirv/lib/generic/relational/any.cl
@@ -6,27 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <libspirv/spirv.h>
+#include "clc/relational/clc_any.h"
+#include "libspirv/spirv.h"
 
-#define _CLC_ANY(v) (((v) >> ((sizeof(v) * 8) - 1)) & 0x1)
-#define _CLC_ANY2(v) (_CLC_ANY((v).s0) | _CLC_ANY((v).s1))
-#define _CLC_ANY3(v) (_CLC_ANY2((v)) | _CLC_ANY((v).s2))
-#define _CLC_ANY4(v) (_CLC_ANY3((v)) | _CLC_ANY((v).s3))
-#define _CLC_ANY8(v)                                                           \
-  (_CLC_ANY4((v)) | _CLC_ANY((v).s4) | _CLC_ANY((v).s5) | _CLC_ANY((v).s6) |   \
-   _CLC_ANY((v).s7))
-#define _CLC_ANY16(v)                                                          \
-  (_CLC_ANY8((v)) | _CLC_ANY((v).s8) | _CLC_ANY((v).s9) | _CLC_ANY((v).sA) |   \
-   _CLC_ANY((v).sB) | _CLC_ANY((v).sC) | _CLC_ANY((v).sD) | _CLC_ANY((v).sE) | \
-   _CLC_ANY((v).sf))
+_CLC_OVERLOAD _CLC_DEF bool __spirv_Any(char2 x) { return __clc_any(x); }
 
-#define ANY_ID(TYPE) _CLC_OVERLOAD _CLC_DEF bool __spirv_Any(TYPE v)
+_CLC_OVERLOAD _CLC_DEF bool __spirv_Any(char3 x) { return __clc_any(x); }
 
-#define ANY_VECTORIZE(TYPE)                                                    \
-  ANY_ID(TYPE##2) { return _CLC_ANY2(v); }                                     \
-  ANY_ID(TYPE##3) { return _CLC_ANY3(v); }                                     \
-  ANY_ID(TYPE##4) { return _CLC_ANY4(v); }                                     \
-  ANY_ID(TYPE##8) { return _CLC_ANY8(v); }                                     \
-  ANY_ID(TYPE##16) { return _CLC_ANY16(v); }
+_CLC_OVERLOAD _CLC_DEF bool __spirv_Any(char4 x) { return __clc_any(x); }
 
-ANY_VECTORIZE(char)
+_CLC_OVERLOAD _CLC_DEF bool __spirv_Any(char8 x) { return __clc_any(x); }
+
+_CLC_OVERLOAD _CLC_DEF bool __spirv_Any(char16 x) { return __clc_any(x); }


### PR DESCRIPTION
They are now implemented with @llvm.vector.reduce.and/or, which can map to native hardware instruction. Example llvm-diff changes (> is reference): in function _Z11__spirv_AllDv2_c:
    >   %2 = extractelement <2 x i8> %0, i64 0
    >   %3 = extractelement <2 x i8> %0, i64 1
    >   %4 = and i8 %2, %3
    <   %2 = tail call i8 @llvm.vector.reduce.and.v2i8(<2 x i8> %0)
in function _Z11__spirv_AnyDv2_c:
    >   %2 = extractelement <2 x i8> %0, i64 0
    >   %3 = extractelement <2 x i8> %0, i64 1
    >   %4 = or i8 %2, %3
    <   %2 = tail call i8 @llvm.vector.reduce.or.v2i8(<2 x i8> %0)