### PR TITLE
[DeviceSanitizer][E2e] Use --check-prefixes instead of --check-prefix for multiple prefixes

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/block2d_load.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/block2d_load.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: linux, gpu && level_zero && arch-intel_gpu_pvc
 // RUN: %{build} %device_asan_flags -O2 -g -DOOB_SRC -Xspirv-translator -spirv-ext=+SPV_INTEL_2d_block_io -Xs "-options ' -cl-intel-enable-auto-large-GRF-mode'" -o %t1.out
-// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefix=CHECK,CHECK-SRC %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-SRC %s
 // RUN: %{build} %device_asan_flags -O2 -g -DOOB_DST -Xspirv-translator -spirv-ext=+SPV_INTEL_2d_block_io -Xs "-options ' -cl-intel-enable-auto-large-GRF-mode'" -o %t2.out
-// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefix=CHECK,CHECK-DST %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-DST %s
 
 // Test that ASAN detects out-of-bounds access from 2D block load operations.
 // The __spirv_Subgroup2DBlockLoadINTEL builtin is called directly to trigger

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/block2d_store.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/USM/block2d_store.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: linux, gpu && level_zero && arch-intel_gpu_pvc
 // RUN: %{build} %device_asan_flags -O2 -g -DOOB_SRC -Xspirv-translator -spirv-ext=+SPV_INTEL_2d_block_io -Xs "-options ' -cl-intel-enable-auto-large-GRF-mode'" -o %t1.out
-// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefix=CHECK,CHECK-SRC %s
+// RUN: %{run} not --crash %t1.out 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-SRC %s
 // RUN: %{build} %device_asan_flags -O2 -g -DOOB_DST -Xspirv-translator -spirv-ext=+SPV_INTEL_2d_block_io -Xs "-options ' -cl-intel-enable-auto-large-GRF-mode'" -o %t2.out
-// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefix=CHECK,CHECK-DST %s
+// RUN: %{run} not --crash %t2.out 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-DST %s
 
 // Test that ASAN detects out-of-bounds access from 2D block store operations.
 


### PR DESCRIPTION
Use the canonical --check-prefixes flag for specifying multiple FileCheck prefixes. Older FileCheck versions do not support comma-separated values with the --check-prefix alias.