### PR TITLE
[SYCL] Fix execution of kernels launched from 2 queues

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -187,7 +187,7 @@ Scheduler::GraphBuilder::getOrInsertMemObjRecord(queue_impl *Queue,
   if (nullptr != Record)
     return Record;
 
-  const size_t LeafLimit = 8;
+  const size_t LeafLimit = 7;
   LeavesCollection::AllocateDependencyF AllocateDependency =
       [this](Command *Dependant, Command *Dependency, MemObjRecord *Record,
              LeavesCollection::EnqueueListT &ToEnqueue) {


### PR DESCRIPTION
Kernels are expected to run in parallel, but due to an even size of an internal circular buffer, no cross-queue dependency was formed, allowing the GPU to execute in series.

More details can be found here: https://jira.devtools.intel.com/browse/URLZA-699