### PR TITLE
[HIP][UR] Fix uninitialized members in ur_sampler_handle_t_

### DIFF
--- a/unified-runtime/source/adapters/hip/sampler.hpp
+++ b/unified-runtime/source/adapters/hip/sampler.hpp
@@ -28,9 +28,9 @@
 struct ur_sampler_handle_t_ : ur::hip::handle_base {
   ur::RefCount RefCount;
   uint32_t Props;
-  float MinMipmapLevelClamp;
-  float MaxMipmapLevelClamp;
-  float MaxAnisotropy;
+  float MinMipmapLevelClamp{};
+  float MaxMipmapLevelClamp{};
+  float MaxAnisotropy{};
   ur_context_handle_t Context;
 
   ur_sampler_handle_t_(ur_context_handle_t Context)


### PR DESCRIPTION
Default-initialize MinMipmapLevelClamp, MaxMipmapLevelClamp, and MaxAnisotropy in ur_sampler_handle_t_ using brace initialization to silence Coverity CID 491850 (uninitialized non-static class members).

Issue: https://github.com/intel/llvm/issues/19499