### PR TITLE
[UR][L0] Fix unchecked return value of executeCommandList (Coverity)

### DIFF
--- a/unified-runtime/source/adapters/level_zero/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/memory.cpp
@@ -1398,8 +1398,8 @@ ur_result_t urEnqueueUSMAdvise(
   // so manually add command to signal our event.
   ZE2UR_CALL(zeCommandListAppendSignalEvent, (ZeCommandList, ZeEvent));
 
-  Queue->executeCommandList(CommandList, false /*IsBlocking*/,
-                            false /*OKToBatchCommand*/);
+  UR_CALL(Queue->executeCommandList(CommandList, false /*IsBlocking*/,
+                                    false /*OKToBatchCommand*/));
 
   return UR_RESULT_SUCCESS;
 }


### PR DESCRIPTION
In urEnqueueUSMAdvise, the return value of Queue->executeCommandList() was silently discarded. Wrap the call with UR_CALL so any error is propagated to the caller.

Issue: https://github.com/intel/llvm/issues/19229