### PR TITLE
[SYCL] Coverity: avoid std::string_view(nullptr) in sycl-trace collectors

### DIFF
--- a/sycl/tools/sycl-trace/cuda_trace_collector.cpp
+++ b/sycl/tools/sycl-trace/cuda_trace_collector.cpp
@@ -105,7 +105,8 @@ COLLECTOR_EXPORT_API void callback(uint16_t TraceType,
 }
 
 COLLECTOR_EXPORT_API void init() {
-  std::string_view PrinterType(std::getenv("SYCL_TRACE_PRINT_FORMAT"));
+  const char *PrinterTypeEnv = std::getenv("SYCL_TRACE_PRINT_FORMAT");
+  std::string_view PrinterType = PrinterTypeEnv ? PrinterTypeEnv : "";
   if (PrinterType == "classic") {
     std::cerr << "Classic output is unsupported for CUDA\n";
   } else if (PrinterType == "verbose") {

--- a/sycl/tools/sycl-trace/sycl_trace_collector.cpp
+++ b/sycl/tools/sycl-trace/sycl_trace_collector.cpp
@@ -135,7 +135,8 @@ XPTI_CALLBACK_API void syclCallback(uint16_t TraceType,
 }
 
 void syclPrintersInit() {
-  std::string_view PrinterType(std::getenv("SYCL_TRACE_PRINT_FORMAT"));
+  const char *PrinterTypeEnv = std::getenv("SYCL_TRACE_PRINT_FORMAT");
+  std::string_view PrinterType = PrinterTypeEnv ? PrinterTypeEnv : "";
   if (PrinterType == "classic") {
     std::cerr << "Classic output is not supported yet for SYCL API\n";
   } else if (PrinterType == "verbose") {

--- a/sycl/tools/sycl-trace/ur_trace_collector.cpp
+++ b/sycl/tools/sycl-trace/ur_trace_collector.cpp
@@ -88,7 +88,8 @@ static void setupPrettyPrinter(bool Verbose) {
 }
 
 void urPrintersInit() {
-  std::string_view PrinterType(std::getenv("SYCL_TRACE_PRINT_FORMAT"));
+  const char *PrinterTypeEnv = std::getenv("SYCL_TRACE_PRINT_FORMAT");
+  std::string_view PrinterType = PrinterTypeEnv ? PrinterTypeEnv : "";
 
   if (PrinterType == "classic") {
     setupClassicPrinter();

--- a/sycl/tools/sycl-trace/verification_collector.cpp
+++ b/sycl/tools/sycl-trace/verification_collector.cpp
@@ -24,7 +24,8 @@
 extern sycl::detail::SpinLock GlobalLock;
 
 void vPrintersInit() {
-  std::string_view PrinterType(std::getenv("SYCL_TRACE_PRINT_FORMAT"));
+  const char *PrinterTypeEnv = std::getenv("SYCL_TRACE_PRINT_FORMAT");
+  std::string_view PrinterType = PrinterTypeEnv ? PrinterTypeEnv : "";
   // all types are the same now
   std::ignore = PrinterType;
 

--- a/sycl/tools/sycl-trace/ze_trace_collector.cpp
+++ b/sycl/tools/sycl-trace/ze_trace_collector.cpp
@@ -308,7 +308,8 @@ COLLECTOR_EXPORT_API void callback(uint16_t TraceType,
 }
 
 COLLECTOR_EXPORT_API void init() {
-  std::string_view PrinterType(std::getenv("SYCL_TRACE_PRINT_FORMAT"));
+  const char *PrinterTypeEnv = std::getenv("SYCL_TRACE_PRINT_FORMAT");
+  std::string_view PrinterType = PrinterTypeEnv ? PrinterTypeEnv : "";
   if (PrinterType == "classic") {
     std::cerr << "Classic output is unsupported for Level Zero\n";
   } else if (PrinterType == "verbose") {


### PR DESCRIPTION
Related to #18506.

## Summary

Coverity reported potential null pointer issues in SYCL trace collectors where `std::string_view` was constructed directly from `std::getenv(...)`.
If the environment variable is not set, this can result in `std::string_view(nullptr)` (UB).

Affected CIDs from the issue:
CID `437235`:

https://github.com/intel/llvm/blob/f9a7cc8aaea55c1c173638f8130985446d247abe/sycl/tools/sycl-trace/sycl_trace_collector.cpp#L138

CID `442884`:

https://github.com/intel/llvm/blob/f9a7cc8aaea55c1c173638f8130985446d247abe/sycl/tools/sycl-trace/ur_trace_collector.cpp#L91

CID `440717`:

https://github.com/intel/llvm/blob/f9a7cc8aaea55c1c173638f8130985446d247abe/sycl/tools/sycl-trace/verification_collector.cpp#L27

CID `437184`:

https://github.com/intel/llvm/blob/f9a7cc8aaea55c1c173638f8130985446d247abe/sycl/tools/sycl-trace/ze_trace_collector.cpp#L311


## What changed

Replaced direct construction from `std::getenv(...)` with null-safe handling:

```cpp
const char *PrinterTypeEnv = std::getenv("SYCL_TRACE_PRINT_FORMAT");
std::string_view PrinterType = PrinterTypeEnv ? PrinterTypeEnv : "";
```

Applied in:
- `sycl/tools/sycl-trace/sycl_trace_collector.cpp`
- `sycl/tools/sycl-trace/ur_trace_collector.cpp`
- `sycl/tools/sycl-trace/verification_collector.cpp`
- `sycl/tools/sycl-trace/ze_trace_collector.cpp`
- `sycl/tools/sycl-trace/cuda_trace_collector.cpp` (same pattern, proactively fixed)

## Behavior impact

No functional change is intended for valid env values (`classic`, `verbose`, `compact`).
When `SYCL_TRACE_PRINT_FORMAT` is unset, behavior is now explicitly safe and well-defined.

