### PR TITLE
[SPIR-V] Reland "Translate icmp eq and icmp ne to PtrEqual and PtrNotEqual"

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -1614,9 +1614,14 @@ SPIRVInstruction *LLVMToSPIRVBase::transCmpInst(CmpInst *Cmp,
   auto *Op0 = Cmp->getOperand(0);
   SPIRVValue *TOp0 = transValue(Op0, BB);
   SPIRVValue *TOp1 = transValue(Cmp->getOperand(1), BB);
-  // TODO: once the translator supports SPIR-V 1.4, update the condition below:
-  // if (/* */->isPointerTy() && /* it is not allowed to use SPIR-V 1.4 */)
   if (Op0->getType()->isPointerTy()) {
+    auto P = Cmp->getPredicate();
+    if (BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_4) &&
+        (P == ICmpInst::ICMP_EQ || P == ICmpInst::ICMP_NE) &&
+        Cmp->getOperand(1)->getType()->isPointerTy()) {
+      Op OC = P == ICmpInst::ICMP_EQ ? OpPtrEqual : OpPtrNotEqual;
+      return BM->addBinaryInst(OC, transType(Cmp->getType()), TOp0, TOp1, BB);
+    }
     unsigned AS = cast<PointerType>(Op0->getType())->getAddressSpace();
     SPIRVType *Ty = transType(getSizetType(AS));
     TOp0 = BM->addUnaryInst(OpConvertPtrToU, Ty, TOp0, BB);

--- a/llvm-spirv/test/ComparePointers.cl
+++ b/llvm-spirv/test/ComparePointers.cl
@@ -9,10 +9,15 @@ kernel void test(int global *in, int global *in2) {
     return;
 }
 // RUN: %clang_cc1 -triple spir64 -x cl -cl-std=CL2.0 -O0 -emit-llvm-bc %s -o %t.bc
-// RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
+// RUN: llvm-spirv %t.bc --spirv-max-version=1.3 -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv %t.bc -spirv-text --spirv-max-version=1.3 -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
+// RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
+// RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV-14
 
 // CHECK-SPIRV:ConvertPtrToU 
 // CHECK-SPIRV:ConvertPtrToU
@@ -26,3 +31,12 @@ kernel void test(int global *in, int global *in2) {
 // CHECK-SPIRV:ConvertPtrToU
 // CHECK-SPIRV:ConvertPtrToU
 // CHECK-SPIRV:ULessThan
+
+// CHECK-SPIRV-14: PtrNotEqual
+// CHECK-SPIRV-14: PtrEqual
+// CHECK-SPIRV-14:ConvertPtrToU
+// CHECK-SPIRV-14:ConvertPtrToU
+// CHECK-SPIRV-14:UGreaterThan
+// CHECK-SPIRV-14:ConvertPtrToU
+// CHECK-SPIRV-14:ConvertPtrToU
+// CHECK-SPIRV-14:ULessThan

--- a/llvm-spirv/test/ComparePointers.cl
+++ b/llvm-spirv/test/ComparePointers.cl
@@ -8,6 +8,7 @@ kernel void test(int global *in, int global *in2) {
   if (in < in2)
     return;
 }
+// clang-format off
 // RUN: %clang_cc1 -triple spir64 -x cl -cl-std=CL2.0 -O0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc --spirv-max-version=1.3 -o %t.spv
 // RUN: spirv-val %t.spv
@@ -18,6 +19,7 @@ kernel void test(int global *in, int global *in2) {
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV-14
+// clang-format on
 
 // CHECK-SPIRV:ConvertPtrToU 
 // CHECK-SPIRV:ConvertPtrToU

--- a/llvm-spirv/test/addrspacecast_generic_null.ll
+++ b/llvm-spirv/test/addrspacecast_generic_null.ll
@@ -11,8 +11,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK: %_ptr_Workgroup_uchar = OpTypePointer Workgroup %uchar
 ; CHECK: %[[NULL:[0-9]+]] = OpConstantNull %_ptr_Generic_uchar
 ; CHECK: %[[CAST:[0-9]+]] = OpGenericCastToPtr %_ptr_Workgroup_uchar %[[NULL]]
-; CHECK: %[[PTR2U:[0-9]+]] = OpConvertPtrToU %ulong %[[CAST]]
-; CHECK: OpIEqual %bool %[[PTR2U]]
+; CHECK: OpPtrEqual %bool %[[CAST]]
 
 define spir_kernel void @bar_generic_null(ptr addrspace(3) %arg) {
   %expr = icmp eq ptr addrspace(3) addrspacecast (ptr addrspace(4) null to ptr addrspace(3)), %arg

--- a/llvm-spirv/test/addrspacecast_null.ll
+++ b/llvm-spirv/test/addrspacecast_null.ll
@@ -7,10 +7,7 @@
 
 ; CHECK: %_ptr_CrossWorkgroup_uchar = OpTypePointer CrossWorkgroup %uchar
 ; CHECK: %[[NULL:[0-9]+]] = OpConstantNull %_ptr_CrossWorkgroup_uchar
-; We don't support OpPtrEqual instruction after KhronosGroup/SPIRV-LLVM-Translator@5e0f14b5a09d961 was reverted.
-; TODO: use community check-lines after the change relands.
-; CHECK: %[[U:[0-9]+]] = OpConvertPtrToU %ulong %[[NULL]]
-; CHECK: OpIEqual %bool %[[U]]
+; CHECK: OpPtrEqual %bool %[[NULL]]
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
 target triple = "spir64-unknown-unknown"

--- a/llvm-spirv/test/instructions/ptrcmp.ll
+++ b/llvm-spirv/test/instructions/ptrcmp.ll
@@ -8,7 +8,6 @@
 ; RUN: %if spirv-backend %{ llvm-spirv -r %t.llc.spv -o %t.llc.rev.bc %}
 ; RUN: %if spirv-backend %{ llvm-dis %t.llc.rev.bc -o %t.llc.rev.ll %}
 ; RUN: %if spirv-backend %{ FileCheck %s --check-prefix=CHECK-LLVM < %t.llc.rev.ll %}
-; XFAIL: *
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir"

--- a/llvm-spirv/test/type-scavenger/ptr-abuse.ll
+++ b/llvm-spirv/test/type-scavenger/ptr-abuse.ll
@@ -22,9 +22,7 @@ define spir_kernel void @foo() {
 ; CHECK: 4 Bitcast [[FLOATPTR]] [[STOREB:[0-9]+]] [[IPTR]]
 ; CHECK: Store [[STOREB]] {{[0-9]+}}
 ; CHECK: 4 Bitcast [[INTPTR]] [[CMPB:[0-9]+]] [[FPTR]]
-; CHECK: 4 ConvertPtrToU [[SIZET:[0-9]+]] [[CMPL:[0-9]+]] [[IPTR]]
-; CHECK: 4 ConvertPtrToU [[SIZET]] [[CMPR:[0-9]+]] [[CMPB]]
-; CHECK: 5 IEqual {{[0-9]+}} {{[0-9]+}} [[CMPL]] [[CMPR]]
+; CHECK: 5 PtrEqual [[#]] [[#]] [[IPTR]] [[CMPB]]
 entry:
   %iptr = alloca i32, align 4
   %fptr = alloca float, align 4


### PR DESCRIPTION
Reapplies the LLVM-to-SPIR-V translation of pointer `icmp eq`/`icmp ne` to `OpPtrEqual` / `OpPtrNotEqual` when SPIR-V 1.4 is allowed.

Original Khronos PR: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2511

The change was reverted in c4be8858f391 due to a batch of SYCL E2E failures. The drivers are now expected to support these opcodes; CI on this PR validates that assumption.

It resolves p.6 of #7592 "Following patches are missing" section.