### PR TITLE
[Driver][SYCL][NewOffloadModel] Pull in device libraries at device compile (#21672)

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -100,6 +100,10 @@ def err_drv_hipspv_no_hip_path : Error<
   "'--hip-path' must be specified when offloading to SPIR-V unless '-nogpuinc' "
   "is given">;
 
+def err_drv_no_sycl_device_lib
+    : Error<"cannot find expected SYCL device library '%0'. Pass "
+            "'--no-offloadlib' to "
+            "build without the SYCL device libraries">;
 def err_drv_no_spv_tools : Error<"cannot find SPIR-V Tools binary '%0', which "
                                  "is required for SPIR-V compilation. "
                                  "It can be obtained from your system package "

--- a/clang/include/clang/Driver/SyclInstallationDetector.h
+++ b/clang/include/clang/Driver/SyclInstallationDetector.h
@@ -16,7 +16,6 @@ namespace driver {
 
 class SYCLInstallationDetector {
 public:
-  SYCLInstallationDetector(const Driver &D);
   SYCLInstallationDetector(const Driver &D, const llvm::Triple &HostTriple,
                            const llvm::opt::ArgList &Args);
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5002,7 +5002,8 @@ class OffloadingActionBuilder final {
                       const Driver::InputList &Inputs,
                       OffloadingActionBuilder &OAB)
         : DeviceActionBuilder(C, Args, Inputs, Action::OFK_SYCL, OAB),
-          SYCLInstallation(C.getDriver()) {}
+          SYCLInstallation(C.getDriver(), C.getDefaultToolChain().getTriple(),
+                           Args) {}
 
     void pushForeignAction(Action *A) override {
       // Accept a foreign action from the CudaActionBuilder for compiling CUDA
@@ -5526,12 +5527,9 @@ class OffloadingActionBuilder final {
         // is removed in compiler.
         bool SYCLDeviceLibLinked = false;
         Action *NativeCPULib = nullptr;
-        if (IsSPIR || IsNVPTX || IsAMDGCN || IsNativeCPU) {
+        if (IsSPIR || IsNVPTX || IsAMDGCN || IsNativeCPU)
           SYCLDeviceLibLinked = addSYCLDeviceLibs(
-              TC, SYCLDeviceLibs, IsSpirvAOT,
-              C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment(),
-              IsNativeCPU, NativeCPULib, BoundArch);
-        }
+              TC, SYCLDeviceLibs, IsNativeCPU, NativeCPULib, BoundArch);
         JobAction *LinkSYCLLibs =
             C.MakeAction<LinkJobAction>(SYCLDeviceLibs, types::TY_LLVM_BC);
         for (Action *FullLinkObject : FullLinkObjects) {
@@ -5756,20 +5754,25 @@ class OffloadingActionBuilder final {
     }
 
     bool addSYCLDeviceLibs(const ToolChain *TC, ActionList &DeviceLinkObjects,
-                           bool isSpirvAOT, bool isMSVCEnv, bool isNativeCPU,
-                           Action *&NativeCPULib, const char *BoundArch) {
+                           bool isNativeCPU, Action *&NativeCPULib,
+                           const char *BoundArch) {
       int NumOfDeviceLibLinked = 0;
       SmallVector<SmallString<128>, 4> LibLocCandidates;
       SYCLInstallation.getSYCLDeviceLibPath(LibLocCandidates);
 
-      SmallVector<std::string, 8> DeviceLibraries;
+      const toolchains::SYCLToolChain &SYCLTC =
+          static_cast<const toolchains::SYCLToolChain &>(*TC);
+      SmallVector<ToolChain::BitCodeLibraryInfo, 8> DeviceLibraries;
+      // TODO: Use the getDeviceLibs for each toolchain instead of using the
+      // specific libs and doing a separate directory search.  Each toolchain
+      // has their own getDeviceLibs that we can potentially use.
       DeviceLibraries =
-          tools::SYCL::getDeviceLibraries(C, TC->getTriple(), isSpirvAOT);
+          SYCLTC.getDeviceLibNames(C.getDriver(), Args, TC->getTriple());
 
       for (const auto &DeviceLib : DeviceLibraries) {
         for (const auto &LLCandidate : LibLocCandidates) {
           SmallString<128> LibName(LLCandidate);
-          llvm::sys::path::append(LibName, DeviceLib);
+          llvm::sys::path::append(LibName, DeviceLib.Path);
           if (llvm::sys::fs::exists(LibName)) {
             ++NumOfDeviceLibLinked;
             Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10921,7 +10921,8 @@ static void getNonTripleBasedSYCLPostLinkOpts(const ToolChain &TC,
   // For bfloat16 conversions LLVM IR devicelib, we only need to embed it
   // when non-AOT compilation is used.
   if (TC.getTriple().isSPIROrSPIRV() && !TC.getTriple().isSPIRAOT()) {
-    SYCLInstallationDetector SYCLInstall(TC.getDriver());
+    SYCLInstallationDetector SYCLInstall(TC.getDriver(), TC.getTriple(),
+                                         TCArgs);
     SmallVector<SmallString<128>, 4> DeviceLibLocCandidates;
     SmallString<128> NativeBfloat16Name("libsycl-native-bfloat16.bc");
     SYCLInstall.getSYCLDeviceLibPath(DeviceLibLocCandidates);
@@ -11452,7 +11453,8 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     // and use that location.  Base the location on relative to driver if this
     // is not resolved.
     SmallVector<SmallString<128>, 4> LibLocCandidates;
-    SYCLInstallationDetector SYCLInstallation(D);
+    SYCLInstallationDetector SYCLInstallation(D, getToolChain().getTriple(),
+                                              Args);
     SYCLInstallation.getSYCLDeviceLibPath(LibLocCandidates);
     SmallString<128> LibName("libsycl-crt");
     bool IsNewOffload = D.getUseNewOffloadingDriver();
@@ -11480,7 +11482,6 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     // one bitcode library to link in for a specific triple. Additionally, the
     // path is *not* relative to the -sycl-device-library-location - the full
     // path must be provided.
-    SmallString<256> LibList;
     SmallVector<std::string, 4> BCLibList;
 
     auto appendToList = [](SmallString<256> &List, const Twine &Arg) {
@@ -11493,19 +11494,21 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     for (const auto &[Kind, TC] :
          llvm::make_range(ToolChainRange.first, ToolChainRange.second)) {
       llvm::Triple TargetTriple = TC->getTriple();
-      bool IsSpirAOT = TargetTriple.isSPIRAOT();
-      SmallVector<std::string, 8> SYCLDeviceLibs =
-          SYCL::getDeviceLibraries(C, TargetTriple, IsSpirAOT);
+      const toolchains::SYCLToolChain &SYCLTC =
+          static_cast<const toolchains::SYCLToolChain &>(*TC);
+      SmallVector<ToolChain::BitCodeLibraryInfo, 8> SYCLDeviceLibs;
+      // SPIR or SPIR-V device libraries are compiled into the device compile
+      // step.
+      if (!TargetTriple.isSPIROrSPIRV())
+        SYCLDeviceLibs.append(SYCLTC.getDeviceLibNames(D, Args, TargetTriple));
       for (const auto &AddLib : SYCLDeviceLibs) {
-        if (llvm::sys::path::extension(AddLib) == ".bc") {
+        if (llvm::sys::path::extension(AddLib.Path) == ".bc") {
           SmallString<256> LibPath(DeviceLibDir);
-          llvm::sys::path::append(LibPath, AddLib);
+          llvm::sys::path::append(LibPath, AddLib.Path);
           BCLibList.push_back(
               (Twine(TC->getTriple().str()) + "=" + LibPath).str());
           continue;
         }
-
-        appendToList(LibList, AddLib);
       }
 
       if (TC->getTriple().isNVPTX())
@@ -11514,10 +11517,6 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
           BCLibList.push_back(
               (Twine(TC->getTriple().str()) + "=" + LibSpirvFile).str());
     }
-
-    if (LibList.size())
-      CmdArgs.push_back(
-          Args.MakeArgString(Twine("-sycl-device-libraries=") + LibList));
 
     if (BCLibList.size())
       for (const std::string &Lib : BCLibList)

--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -937,7 +937,7 @@ CudaToolChain::CudaToolChain(const Driver &D, const llvm::Triple &Triple,
                              const ToolChain &HostTC, const ArgList &Args,
                              const Action::OffloadKind OK)
     : NVPTXToolChain(D, Triple, HostTC.getTriple(), Args), HostTC(HostTC),
-      SYCLInstallation(D), OK(OK) {}
+      SYCLInstallation(D, HostTC.getTriple(), Args), OK(OK) {}
 
 void CudaToolChain::addClangTargetOptions(
     const llvm::opt::ArgList &DriverArgs, llvm::opt::ArgStringList &CC1Args,

--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -231,8 +231,8 @@ void AMDGCN::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 HIPAMDToolChain::HIPAMDToolChain(const Driver &D, const llvm::Triple &Triple,
                                  const ToolChain &HostTC, const ArgList &Args,
                                  const Action::OffloadKind OK)
-    : ROCMToolChain(D, Triple, Args), HostTC(HostTC), SYCLInstallation(D),
-      OK(OK) {
+    : ROCMToolChain(D, Triple, Args), HostTC(HostTC),
+      SYCLInstallation(D, HostTC.getTriple(), Args), OK(OK) {
   // Lookup binaries into the driver directory, this is used to
   // discover the clang-offload-bundler executable.
   getProgramPaths().push_back(getDriver().Dir);

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -22,15 +22,13 @@ using namespace clang::driver::tools;
 using namespace clang;
 using namespace llvm::opt;
 
-SYCLInstallationDetector::SYCLInstallationDetector(const Driver &D)
-    : D(D), InstallationCandidates() {
-  InstallationCandidates.emplace_back(D.Dir + "/..");
-}
-
 SYCLInstallationDetector::SYCLInstallationDetector(
     const Driver &D, const llvm::Triple &HostTriple,
     const llvm::opt::ArgList &Args)
-    : SYCLInstallationDetector(D) {}
+    : D(D), InstallationCandidates() {
+
+  InstallationCandidates.emplace_back(D.Dir + "/..");
+}
 
 static llvm::SmallString<64>
 getLibSpirvBasename(const llvm::Triple &DeviceTriple,
@@ -229,15 +227,14 @@ bool SYCL::shouldDoPerObjectFileLinking(const Compilation &C) {
 }
 
 // Return whether to use native bfloat16 library.
-static bool selectBfloatLibs(const llvm::Triple &Triple, const Compilation &C,
+static bool selectBfloatLibs(const llvm::opt::ArgList &Args,
+                             const llvm::Triple &Triple, const ToolChain &TC,
                              bool &UseNative) {
-
   static llvm::SmallSet<StringRef, 8> GPUArchsWithNBF16{
       "intel_gpu_pvc",     "intel_gpu_acm_g10", "intel_gpu_acm_g11",
       "intel_gpu_acm_g12", "intel_gpu_dg2_g10", "intel_gpu_dg2_g11",
       "intel_dg2_g12",     "intel_gpu_bmg_g21", "intel_gpu_lnl_m",
       "intel_gpu_ptl_h",   "intel_gpu_ptl_u",   "intel_gpu_wcl"};
-  const llvm::opt::ArgList &Args = C.getArgs();
   bool NeedLibs = false;
 
   // spir64 target is actually JIT compilation, so we defer selection of
@@ -246,21 +243,11 @@ static bool selectBfloatLibs(const llvm::Triple &Triple, const Compilation &C,
   NeedLibs = Triple.getSubArch() != llvm::Triple::NoSubArch &&
              !Triple.isNVPTX() && !Triple.isAMDGCN();
   UseNative = false;
-  if (NeedLibs && Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen &&
-      C.hasOffloadToolChain<Action::OFK_SYCL>()) {
+  if (NeedLibs && Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen) {
     ArgStringList TargArgs;
-    auto ToolChains = C.getOffloadToolChains<Action::OFK_SYCL>();
-    // Match up the toolchain with the incoming Triple so we are grabbing the
-    // expected arguments to scrutinize.
-    for (auto TI = ToolChains.first, TE = ToolChains.second; TI != TE; ++TI) {
-      llvm::Triple SYCLTriple = TI->second->getTriple();
-      if (SYCLTriple == Triple) {
-        const toolchains::SYCLToolChain *SYCLTC =
-            static_cast<const toolchains::SYCLToolChain *>(TI->second);
-        SYCLTC->TranslateBackendTargetArgs(Triple, Args, TargArgs);
-        break;
-      }
-    }
+    const toolchains::SYCLToolChain &SYCLTC =
+        static_cast<const toolchains::SYCLToolChain &>(TC);
+    SYCLTC.TranslateBackendTargetArgs(Triple, Args, TargArgs);
 
     // We need to select fallback/native bfloat16 devicelib in AOT compilation
     // targetting for Intel GPU devices. Users have 2 ways to apply AOT,
@@ -415,14 +402,23 @@ static bool checkPVCDevice(std::string SingleArg, std::string &DevArg) {
 }
 
 #if !defined(_WIN32)
-static void
-addSYCLDeviceSanitizerLibs(const Compilation &C, bool IsSpirvAOT,
-                           StringRef LibSuffix,
-                           SmallVector<std::string, 8> &LibraryList) {
-  const llvm::opt::ArgList &Args = C.getArgs();
+static void addSYCLDeviceSanitizerLibs(
+    const llvm::opt::ArgList &Args,
+    SmallVector<ToolChain::BitCodeLibraryInfo, 8> &LibraryList) {
   enum { JIT = 0, AOT_CPU, AOT_DG2, AOT_PVC };
-  auto addSingleLibrary = [&](StringRef DeviceLibName) {
-    LibraryList.push_back(Args.MakeArgString(Twine(DeviceLibName) + LibSuffix));
+  // TODO: Device code linking during the compilation phase provides the
+  // opportunity to link in the specific arch related sanitizer libraries
+  // without having to default to the fallback device sanitizer library when
+  // compiling for multiple targets.
+
+  // Default internalization to 'false' for these libraries, as they are
+  // expected to link with -mlink-bitcode-file, which does not link with
+  // only-needed.
+  auto addSingleLibrary = [&](StringRef DeviceLibName,
+                              bool Internalize = false) {
+    std::string FullLibName(Args.MakeArgString(DeviceLibName + ".bc"));
+    ToolChain::BitCodeLibraryInfo BitCodeLibrary({FullLibName, Internalize});
+    LibraryList.push_back(BitCodeLibrary);
   };
 
   // This function is used to check whether there is only one GPU device
@@ -445,9 +441,6 @@ addSYCLDeviceSanitizerLibs(const Compilation &C, bool IsSpirvAOT,
   };
 
   auto getSingleBuildTarget = [&]() -> size_t {
-    if (!IsSpirvAOT)
-      return JIT;
-
     llvm::opt::Arg *SYCLTarget =
         Args.getLastArg(options::OPT_offload_targets_EQ);
     if (!SYCLTarget || (SYCLTarget->getValues().size() != 1))
@@ -548,32 +541,37 @@ addSYCLDeviceSanitizerLibs(const Compilation &C, bool IsSpirvAOT,
 }
 #endif
 
-// Get the list of SYCL device libraries to link with user's device image.
-SmallVector<std::string, 8>
-SYCL::getDeviceLibraries(const Compilation &C, const llvm::Triple &TargetTriple,
-                         bool IsSpirvAOT) {
-  SmallVector<std::string, 8> LibraryList;
-  const llvm::opt::ArgList &Args = C.getArgs();
+// Returns the list of SYCL device library names for the given target.
+SmallVector<ToolChain::BitCodeLibraryInfo, 8>
+SYCLToolChain::getDeviceLibNames(const Driver &D,
+                                 const llvm::opt::ArgList &Args,
+                                 const llvm::Triple &TargetTriple) const {
+  SmallVector<ToolChain::BitCodeLibraryInfo, 8> LibraryList;
   bool NoOffloadLib =
       !Args.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib, true);
+  // Default internalization to 'true' for these libraries, as they are
+  // expected to link with -mlink-builtin-bitcode.
+  auto addLibToList = [&LibraryList](StringRef LibName,
+                                     bool Internalize = true) {
+    BitCodeLibraryInfo BitCodeLibrary({LibName, Internalize});
+    LibraryList.emplace_back(BitCodeLibrary);
+  };
   if (TargetTriple.isNVPTX()) {
     if (!NoOffloadLib)
-      LibraryList.push_back(
-          Args.MakeArgString("devicelib-nvptx64-nvidia-cuda.bc"));
+      addLibToList("devicelib-nvptx64-nvidia-cuda.bc");
     return LibraryList;
   }
 
   if (TargetTriple.isAMDGCN()) {
     if (!NoOffloadLib)
-      LibraryList.push_back(
-          Args.MakeArgString("devicelib-amdgcn-amd-amdhsa.bc"));
+      addLibToList("devicelib-amdgcn-amd-amdhsa.bc");
     return LibraryList;
   }
 
   // Ignore no-offloadlib for NativeCPU device library, it provides some
   // critical builtins which must be linked with user's device image.
   if (TargetTriple.isNativeCPU()) {
-    LibraryList.push_back(Args.MakeArgString("libsycl-nativecpu_utils.bc"));
+    addLibToList("libsycl-nativecpu_utils.bc");
     return LibraryList;
   }
 
@@ -597,17 +595,9 @@ SYCL::getDeviceLibraries(const Compilation &C, const llvm::Triple &TargetTriple,
                                              "libsycl-fallback-imf",
                                              "libsycl-fallback-imf-fp64",
                                              "libsycl-fallback-imf-bf16"};
-  bool IsWindowsMSVCEnv =
-      C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment();
-  bool IsNewOffload = C.getDriver().getUseNewOffloadingDriver();
-  StringRef LibSuffix = ".bc";
-  if (IsNewOffload)
-    // For new offload model, we use packaged .bc files.
-    LibSuffix = IsWindowsMSVCEnv ? ".new.obj" : ".new.o";
   auto addLibraries = [&](const SYCLDeviceLibsList &LibsList) {
-    for (const StringRef &Lib : LibsList) {
-      LibraryList.push_back(Args.MakeArgString(Twine(Lib) + LibSuffix));
-    }
+    for (const StringRef &Lib : LibsList)
+      addLibToList(Args.MakeArgString(Lib + ".bc"));
   };
 
   if (!NoOffloadLib)
@@ -627,7 +617,8 @@ SYCL::getDeviceLibraries(const Compilation &C, const llvm::Triple &TargetTriple,
   const SYCLDeviceLibsList SYCLDeviceBfloat16NativeLib = {
       "libsycl-native-bfloat16"};
   bool NativeBfloatLibs;
-  bool NeedBfloatLibs = selectBfloatLibs(TargetTriple, C, NativeBfloatLibs);
+  bool NeedBfloatLibs =
+      selectBfloatLibs(Args, TargetTriple, *this, NativeBfloatLibs);
   if (NeedBfloatLibs && !NoOffloadLib) {
     // Add native or fallback bfloat16 library.
     if (NativeBfloatLibs)
@@ -640,7 +631,7 @@ SYCL::getDeviceLibraries(const Compilation &C, const llvm::Triple &TargetTriple,
   // Linux platform only, so compiler only provides device sanitizer libraries
   // on Linux platform.
 #if !defined(_WIN32)
-  addSYCLDeviceSanitizerLibs(C, IsSpirvAOT, LibSuffix, LibraryList);
+  addSYCLDeviceSanitizerLibs(Args, LibraryList);
 #endif
 
   return LibraryList;
@@ -1449,6 +1440,30 @@ void SYCLToolChain::addClangTargetOptions(
     SYCLInstallation.addLibspirvLinkArgs(getEffectiveTriple(), DriverArgs,
                                          HostTC.getTriple(), CC1Args);
   }
+  // Only link device libraries at compile time for SPIR/SPIRV targets.
+  // Other targets (NVPTX, AMD) link at link time via clang-linker-wrapper.
+  // This is only done with the new offloading model, to fit with LLVM community
+  // implementation.
+  if (!getDriver().getUseNewOffloadingDriver() || !getTriple().isSPIROrSPIRV())
+    return;
+
+  llvm::SmallVector<BitCodeLibraryInfo, 12> BCLibs;
+  BCLibs.append(SYCLToolChain::getDeviceLibs(DriverArgs, DeviceOffloadingKind));
+  for (const auto &BCFile : BCLibs) {
+    CC1Args.push_back(BCFile.ShouldInternalize ? "-mlink-builtin-bitcode"
+                                               : "-mlink-bitcode-file");
+    CC1Args.push_back(DriverArgs.MakeArgString(BCFile.Path));
+  }
+  // Use -mlink-builtin-bitcode-postopt to link the device libraries after the
+  // middle-end passes. This makes sure the device libraries are added after
+  // the user code has been instrumented with the dependent calls to the
+  // added device libraries.
+  if (!BCLibs.empty())
+    CC1Args.push_back("-mlink-builtin-bitcode-postopt");
+
+  // FIXME: Turn off potential linker warnings when linking in device library
+  // files that are built for spir64, but we are compiling for AOT.
+  CC1Args.push_back("-Wno-linker-warnings");
 }
 
 llvm::opt::DerivedArgList *
@@ -1883,6 +1898,42 @@ void SYCLToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
 void SYCLToolChain::AddClangCXXStdlibIncludeArgs(const ArgList &Args,
                                                  ArgStringList &CC1Args) const {
   HostTC.AddClangCXXStdlibIncludeArgs(Args, CC1Args);
+}
+
+llvm::SmallVector<ToolChain::BitCodeLibraryInfo, 12>
+SYCLToolChain::getDeviceLibs(
+    const llvm::opt::ArgList &DriverArgs,
+    const Action::OffloadKind DeviceOffloadingKind) const {
+  llvm::SmallVector<ToolChain::BitCodeLibraryInfo, 12> BCLibs;
+
+  SmallVector<SmallString<128>, 4> LibraryPaths;
+  SYCLInstallation.getSYCLDeviceLibPath(LibraryPaths);
+
+  // Formulate all of the device libraries needed for this compilation.
+  SmallVector<BitCodeLibraryInfo, 8> DeviceLibs =
+      getDeviceLibNames(getDriver(), DriverArgs, getTriple());
+
+  // Create full path names to each device library.  If found, add to the list
+  // of device libraries that will be linked against.
+  for (const auto &DeviceLib : DeviceLibs) {
+    bool DeviceLibFound = false;
+    for (const auto &LibraryPath : LibraryPaths) {
+      SmallString<128> FullLibName(LibraryPath);
+      llvm::sys::path::append(FullLibName, DeviceLib.Path);
+      if (llvm::sys::fs::exists(FullLibName)) {
+        BitCodeLibraryInfo BitCodeLibrary(
+            {FullLibName, DeviceLib.ShouldInternalize});
+        BCLibs.emplace_back(BitCodeLibrary);
+        DeviceLibFound = true;
+        break;
+      }
+    }
+    // The device libraries are all known internal libraries.  If any are not
+    // found, emit an error.
+    if (!DeviceLibFound)
+      getDriver().Diag(diag::err_drv_no_sycl_device_lib) << DeviceLib.Path;
+  }
+  return BCLibs;
 }
 
 SanitizerMask SYCLToolChain::getSupportedSanitizers() const {

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -33,12 +33,6 @@ void constructLLVMForeachCommand(Compilation &C, const JobAction &JA,
                                  StringRef Increment, StringRef Ext = "out",
                                  StringRef ParallelJobs = "");
 
-// Provides a vector of device library names that are associated with the
-// given triple and AOT information.
-SmallVector<std::string, 8> getDeviceLibraries(const Compilation &C,
-                                               const llvm::Triple &TargetTriple,
-                                               bool IsSpirvAOT);
-
 // Populates the SYCL device traits macros.
 void populateSYCLDeviceTraitsMacrosArgs(
     Compilation &C, const llvm::opt::ArgList &Args,
@@ -160,6 +154,11 @@ public:
                           llvm::opt::OptSpecifier Opt,
                           llvm::opt::OptSpecifier Opt_EQ,
                           StringRef Device) const;
+  // Provides a vector of device library names that are associated with the
+  // given triple and AOT information.
+  SmallVector<ToolChain::BitCodeLibraryInfo, 8>
+  getDeviceLibNames(const Driver &D, const llvm::opt::ArgList &Args,
+                    const llvm::Triple &TargetTriple) const;
 
   bool useIntegratedAs() const override { return true; }
   bool isPICDefault() const override {
@@ -188,6 +187,12 @@ public:
   void AddClangCXXStdlibIncludeArgs(
       const llvm::opt::ArgList &Args,
       llvm::opt::ArgStringList &CC1Args) const override;
+
+  // Provides a vector of device library names including the full path that are
+  // associated with the offloading kind.
+  llvm::SmallVector<BitCodeLibraryInfo, 12>
+  getDeviceLibs(const llvm::opt::ArgList &Args,
+                const Action::OffloadKind DeviceOffloadingKind) const override;
 
   SanitizerMask getSupportedSanitizers() const override;
 

--- a/clang/test/Driver/sycl-device-lib-diag.cpp
+++ b/clang/test/Driver/sycl-device-lib-diag.cpp
@@ -1,0 +1,14 @@
+/// Test for SYCL device library diagnostic.
+
+// Only run when libdevice is not enabled.  This allows for a known
+// environment that does not have the device libraries installed.
+// UNSUPPORTED: libdevice
+
+/// Check for expected device library diagnostic.
+// RUN: not %clangxx -fsycl --offload-new-driver %s -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=SYCL-DEVICE-LIB-DIAG
+// SYCL-DEVICE-LIB-DIAG: error: cannot find expected SYCL device library 'libsycl-crt.bc'. Pass '--no-offloadlib' to build without the SYCL device libraries
+
+// RUN: %clangxx -fsycl --offload-new-driver %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=SYCL-DEVICE-LIB-NO-DIAG
+// SYCL-DEVICE-LIB-NO-DIAG-NOT: cannot find expected SYCL device library

--- a/clang/test/Driver/sycl-device-lib.cpp
+++ b/clang/test/Driver/sycl-device-lib.cpp
@@ -9,22 +9,23 @@
 /// test behavior of device library default link
 // RUN: %clangxx -fsycl --offload-new-driver %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_DEFAULT
-// SYCL_DEVICE_LIB_LINK_DEFAULT: clang-linker-wrapper{{.*}} "-sycl-device-libraries=libsycl-crt.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-complex.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-complex-fp64.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-cmath.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-imf.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-imf-fp64.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-imf-bf16.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-cstring.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-complex.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-complex-fp64.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-cmath.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-imf.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-imf-fp64.new.o
-// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-imf-bf16.new.o
+// SYCL_DEVICE_LIB_LINK_DEFAULT: clang{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-complex.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-complex-fp64.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "-mlink-builtin-bitcode-postopt"
 
 /// ###########################################################################
 
@@ -32,7 +33,7 @@
 // RUN: %clangxx -fsycl --offload-new-driver %s --no-offloadlib --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB
 // SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB: {{.*}}clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"
-// SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB-NOT: libsycl-cmath.new.o
+// SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB-NOT: libsycl-cmath.bc
 
 /// ###########################################################################
 
@@ -47,30 +48,28 @@
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_ASAN
 // RUN: %clangxx -fsycl --offload-new-driver %s --sysroot=%S/Inputs/SYCL -Xarch_device "-fsanitize=address -DUSE_SYCL_DEVICE_ASAN" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_ASAN
+// SYCL_DEVICE_LIB_ASAN: clang{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-complex.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN-SAME: "-mlink-bitcode-file" "{{.*}}libsycl-asan.bc"
+
 // RUN: %clangxx -fsycl --offload-new-driver %s --sysroot=%S/Inputs/SYCL -Xarch_device "-fsanitize=address -DUSE_SYCL_DEVICE_ASAN" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_ASAN_MACRO
-// SYCL_DEVICE_LIB_ASAN: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_ASAN: {{.*}}libsycl-crt.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-complex.
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-complex-fp64.
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-imf.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-cstring.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-complex.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-complex-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-imf.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-fallback-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN-SAME: {{.*}}libsycl-asan.new.o
-// SYCL_DEVICE_ASAN_MACRO: "-cc1"
+// SYCL_DEVICE_ASAN_MACRO: clang{{.*}} "-mlink-bitcode-file" "{{.*}}libsycl-asan.bc"
 // SYCL_DEVICE_ASAN_MACRO-SAME: "USE_SYCL_DEVICE_ASAN"
-// SYCL_DEVICE_ASAN_MACRO: libsycl-asan.new.o
-
 
 /// ###########################################################################
 /// test behavior of linking libsycl-asan-pvc for PVC target AOT compilation when asan flag is applied.
@@ -91,47 +90,87 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen --offload-new-driver %s --sysroot=%S/Inputs/SYCL \
 // RUN: -Xarch_device -fsanitize=address -Xs "-device 12.60.7" -### 2>&1 \
 // RUN: | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_ASAN_PVC
-// SYCL_DEVICE_LIB_ASAN_PVC: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_ASAN_PVC: {{.*}}libsycl-crt.new.o
+// SYCL_DEVICE_LIB_ASAN_PVC: clang{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc"
 // SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-complex.
 // SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-complex-fp64.
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-imf.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-cstring.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-complex.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-complex-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-imf.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-asan-pvc.new.o
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_PVC-SAME: "-mlink-bitcode-file" "{{.*}}libsycl-asan-pvc.bc"
 
 /// ###########################################################################
 /// test behavior of linking libsycl-asan-cpu for CPU target AOT compilation when asan flag is applied.
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 --offload-new-driver %s --sysroot=%S/Inputs/SYCL \
 // RUN: -Xarch_device -fsanitize=address -### 2>&1 | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_ASAN_CPU
-// SYCL_DEVICE_LIB_ASAN_CPU: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_ASAN_CPU: {{.*}}libsycl-crt.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-complex.
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-complex-fp64.
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-imf.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-cstring.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-complex.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-complex-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-imf.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-asan-cpu.new.o
+// SYCL_DEVICE_LIB_ASAN_CPU: clang{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-complex.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_CPU-SAME: "-mlink-bitcode-file" "{{.*}}libsycl-asan-cpu.bc"
+
+/// ###########################################################################
+/// Test link behavior for multiple targets. Currently, we default to the
+/// fallback JIT ASAN device library in this case.
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64,intel_gpu_pvc \
+// RUN: --offload-new-driver %s --sysroot=%S/Inputs/SYCL -Xarch_device \
+// RUN: -fsanitize=address -### 2>&1 \
+// RUN: | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_ASAN_CPU_GPU
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU: clang{{.*}} "-triple" "spir64_gen-unknown-unknown"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-complex.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: "-mlink-bitcode-file" "{{.*}}libsycl-asan.bc"
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU: clang{{.*}} "-triple" "spir64_x86_64-unknown-unknown"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-complex.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_CPU_GPU-SAME: "-mlink-bitcode-file" "{{.*}}libsycl-asan.bc"
 
 /// ###########################################################################
 /// test behavior of linking libsycl-asan-dg2 for DG2 target AOT compilation when asan flag is applied.
@@ -146,24 +185,23 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen --offload-new-driver %s --sysroot=%S/Inputs/SYCL \
 // RUN: -Xarch_device -fsanitize=address -Xs "-device dg2" -### 2>&1 \
 // RUN: | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_ASAN_DG2
-// SYCL_DEVICE_LIB_ASAN_DG2: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_ASAN_DG2: {{.*}}libsycl-crt.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-complex.
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-complex-fp64.
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-imf.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-cstring.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-complex.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-complex-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-imf.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-asan-dg2.new.o
+// SYCL_DEVICE_LIB_ASAN_DG2: clang{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-complex.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_DG2-SAME: "-mlink-bitcode-file" "{{.*}}libsycl-asan-dg2.bc"
 
 /// ###########################################################################
 /// test behavior of linking libsycl-asan for multiple targets AOT compilation
@@ -174,25 +212,23 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen --offload-new-driver %s --sysroot=%S/Inputs/SYCL \
 // RUN: -Xarch_device -fsanitize=address -Xsycl-target-backend=spir64_gen "-device pvc,dg2" -### 2>&1 \
 // RUN: | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_ASAN_MUL
-// SYCL_DEVICE_LIB_ASAN_MUL: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_ASAN_MUL: {{.*}}libsycl-crt.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-complex.
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-complex-fp64.
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-imf.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-cstring.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-complex.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-complex-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-cmath.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-imf.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-imf-fp64.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-imf-bf16.new.o
-// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-asan.new.o
-
+// SYCL_DEVICE_LIB_ASAN_MUL: clang{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-complex.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_ASAN_MUL-SAME: "-mlink-bitcode-file" "{{.*}}libsycl-asan.bc"
 
 /// ###########################################################################
 /// test behavior of libsycl-msan.o linking when -fsanitize=memory is available
@@ -206,41 +242,38 @@
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_MSAN
 // RUN: %clangxx -fsycl --offload-new-driver %s --sysroot=%S/Inputs/SYCL -Xarch_device "-fsanitize=memory -DUSE_SYCL_DEVICE_MSAN" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_MSAN
+// SYCL_DEVICE_LIB_MSAN: clang{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-complex.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-complex-fp64.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_MSAN-SAME: "-mlink-bitcode-file" "{{.*}}libsycl-msan.bc"
+
 // RUN: %clangxx -fsycl --offload-new-driver %s --sysroot=%S/Inputs/SYCL -Xarch_device "-fsanitize=memory -DUSE_SYCL_DEVICE_MSAN" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_MSAN_MACRO
-// SYCL_DEVICE_LIB_MSAN: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_MSAN: {{.*}}libsycl-crt.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-complex.
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-complex-fp64.
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-cmath.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-imf.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-imf-fp64.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-imf-bf16.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-cstring.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-complex.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-complex-fp64.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-cmath.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-imf.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-imf-fp64.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-fallback-imf-bf16.new.o
-// SYCL_DEVICE_LIB_MSAN-SAME: {{.*}}libsycl-msan.new.o
-// SYCL_DEVICE_MSAN_MACRO: "-cc1"
+// SYCL_DEVICE_MSAN_MACRO: clang{{.*}} "-mlink-bitcode-file" "{{.*}}libsycl-msan.bc"
 // SYCL_DEVICE_MSAN_MACRO-SAME: "USE_SYCL_DEVICE_MSAN"
-// SYCL_DEVICE_MSAN_MACRO: libsycl-msan.new.o
 
 /// test behavior of msan libdevice linking when -fsanitize=memory is available for AOT targets
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_pvc --offload-new-driver %s --sysroot=%S/Inputs/SYCL \
 // RUN: -fsanitize=memory -### 2>&1 | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_MSAN_PVC
-// SYCL_DEVICE_LIB_MSAN_PVC: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_MSAN_PVC-SAME: {{.*}}libsycl-msan-pvc.new.o
+// SYCL_DEVICE_LIB_MSAN_PVC: clang{{.*}} "-mlink-bitcode-file" "{{.*}}libsycl-msan-pvc.bc"
 
 /// test behavior of msan libdevice linking when -fsanitize=memory is available for AOT targets
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 --offload-new-driver %s --sysroot=%S/Inputs/SYCL \
 // RUN: -fsanitize=memory -### 2>&1 | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_MSAN_CPU
-// SYCL_DEVICE_LIB_MSAN_CPU: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_MSAN_CPU-SAME: {{.*}}libsycl-msan-cpu.new.o
+// SYCL_DEVICE_LIB_MSAN_CPU: clang{{.*}} "-mlink-bitcode-file" "{{.*}}libsycl-msan-cpu.bc"
 
 /// ###########################################################################
 /// test behavior of libsycl-tsan.o linking when -fsanitize=thread is available
@@ -254,38 +287,35 @@
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_TSAN
 // RUN: %clangxx -fsycl --offload-new-driver %s --sysroot=%S/Inputs/SYCL -Xarch_device "-fsanitize=thread -DUSE_SYCL_DEVICE_TSAN" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_TSAN
-// RUN: %clangxx -fsycl --offload-new-driver %s --sysroot=%S/Inputs/SYCL -Xarch_device "-fsanitize=thread -DUSE_SYCL_DEVICE_TSAN" -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_TSAN_MACRO
-// SYCL_DEVICE_LIB_TSAN: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_TSAN: {{.*}}libsycl-crt.new.o
+// SYCL_DEVICE_LIB_TSAN: clang{{.*}} "-mlink-builtin-bitcode" "{{.*}}libsycl-crt.bc"
 // SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-complex.
 // SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-complex-fp64.
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-cmath.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-imf.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-imf-fp64.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-imf-bf16.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-cstring.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-complex.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-complex-fp64.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-cmath.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-cmath-fp64.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-imf.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-imf-fp64.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-imf-bf16.new.o
-// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-tsan.new.o
-// SYCL_DEVICE_TSAN_MACRO: "-cc1"
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-cmath.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-cmath-fp64.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-imf.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-imf-fp64.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-imf-bf16.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-cstring.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-complex.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-complex-fp64.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-cmath.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-cmath-fp64.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-imf.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-imf-fp64.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: {{.*}}libsycl-fallback-imf-bf16.bc
+// SYCL_DEVICE_LIB_TSAN-SAME: "-mlink-bitcode-file" "{{.*}}libsycl-tsan.bc"
+
+// RUN: %clangxx -fsycl --offload-new-driver %s --sysroot=%S/Inputs/SYCL -Xarch_device "-fsanitize=thread -DUSE_SYCL_DEVICE_TSAN" -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_TSAN_MACRO
+// SYCL_DEVICE_TSAN_MACRO: clang{{.*}} "-mlink-bitcode-file" "{{.*}}libsycl-tsan.bc"
 // SYCL_DEVICE_TSAN_MACRO-SAME: "USE_SYCL_DEVICE_TSAN"
-// SYCL_DEVICE_TSAN_MACRO: libsycl-tsan.new.o
 
 /// test behavior of tsan libdevice linking when -fsanitize=thread is available for AOT targets
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_pvc --offload-new-driver %s --sysroot=%S/Inputs/SYCL \
 // RUN: -fsanitize=thread -### 2>&1 | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_TSAN_PVC
-// SYCL_DEVICE_LIB_TSAN_PVC: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_TSAN_PVC-SAME: {{.*}}libsycl-tsan-pvc.new.o
+// SYCL_DEVICE_LIB_TSAN_PVC: clang{{.*}} "-mlink-bitcode-file" "{{.*}}libsycl-tsan-pvc.bc"
 
 /// test behavior of tsan libdevice linking when -fsanitize=thread is available for AOT targets
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 --offload-new-driver %s --sysroot=%S/Inputs/SYCL \
 // RUN: -fsanitize=thread -### 2>&1 | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_TSAN_CPU
-// SYCL_DEVICE_LIB_TSAN_CPU: clang-linker-wrapper{{.*}} "-sycl-device-libraries
-// SYCL_DEVICE_LIB_TSAN_CPU-SAME: {{.*}}libsycl-tsan-cpu.new.o
+// SYCL_DEVICE_LIB_TSAN_CPU: clang{{.*}} "-mlink-bitcode-file" "{{.*}}libsycl-tsan-cpu.bc"

--- a/clang/test/Driver/sycl-instrumentation.cpp
+++ b/clang/test/Driver/sycl-instrumentation.cpp
@@ -14,10 +14,10 @@
 // RUN: | FileCheck -check-prefixes=CHECK-SPIRV %s
 
 // CHECK-SPIRV: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-instrument-device-code"
+// CHECK-SPIRV: "-mlink-builtin-bitcode" "{{.*}}libsycl-itt-user-wrappers.bc"
+// CHECK-SPIRV-SAME: libsycl-itt-compiler-wrappers.bc
+// CHECK-SPIRV-SAME: libsycl-itt-stubs.bc
 // CHECK-HOST-NOT: "-cc1"{{.*}} "-fsycl-is-host"{{.*}} "-fsycl-instrument-device-code"
-// CHECK-SPIRV: clang-linker-wrapper{{.*}} {{.*}}libsycl-itt-user-wrappers.new.o
-// CHECK-SPIRV-SAME: libsycl-itt-compiler-wrappers.new.o
-// CHECK-SPIRV-SAME: libsycl-itt-stubs.new.o
 
 // ITT annotations in device code are disabled by default. However, for SYCL offloading,
 // we still link ITT annotations libraries to ensure ABI compatibility with previous release.
@@ -27,7 +27,7 @@
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 
 // CHECK-ITT-LINK-ONLY-NOT: "-fsycl-instrument-device-code"
-// CHECK-ITT-LINK-ONLY: clang-linker-wrapper{{.*}} {{.*}}libsycl-itt-{{.*}}
+// CHECK-ITT-LINK-ONLY: "-mlink-builtin-bitcode" "{{.*}}libsycl-itt-{{.*}}"
 
 // RUN: %clangxx -fsycl --offload-new-driver -fno-sycl-instrument-device-code -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
@@ -35,4 +35,4 @@
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 
 // CHECK-NONPASSED-NOT: "-fsycl-instrument-device-code"
-// CHECK-NONPASSED-NOT: clang-linker-wrapper{{.*}} {{.*}}libsycl-itt-{{.*}}
+// CHECK-NONPASSED-NOT: {{.*}}libsycl-itt-{{.*}}

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -29,13 +29,6 @@
 // CHK-FLOW-NEXT: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu"{{.*}} "-fsycl-is-host"{{.*}} "-include-internal-header" "[[HEADER]].h" "-dependency-filter" "[[HEADER]].h" {{.*}} "-include-internal-footer" "[[FOOTER]].h" "-dependency-filter" "[[FOOTER]].h"{{.*}} "--offload-new-driver" {{.*}} "-fembed-offload-object=[[PACKOUT]]" {{.*}} "-o" "[[CC1FINALOUT:.*]]" "-x" "c++" "[[INPUT]]"
 // CHK-FLOW-NEXT: clang-linker-wrapper{{.*}} "--host-triple=x86_64-unknown-linux-gnu"{{.*}} "--linker-path={{.*}}/ld" {{.*}} "[[CC1FINALOUT]]"
 
-/// Verify options passed to clang-linker-wrapper
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
-// RUN:          --sysroot=%S/Inputs/SYCL -### %s 2>&1 \
-// RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS %s
-// WRAPPER_OPTIONS: clang-linker-wrapper{{.*}} "-sycl-device-libraries=libsycl-crt.new.o,libsycl-complex.new.o,libsycl-complex-fp64.new.o,libsycl-cmath.new.o,libsycl-cmath-fp64.new.o,libsycl-imf.new.o,libsycl-imf-fp64.new.o,libsycl-imf-bf16.new.o,libsycl-fallback-cstring.new.o,libsycl-fallback-complex.new.o,libsycl-fallback-complex-fp64.new.o,libsycl-fallback-cmath.new.o,libsycl-fallback-cmath-fp64.new.o,libsycl-fallback-imf.new.o,libsycl-fallback-imf-fp64.new.o,libsycl-fallback-imf-bf16.new.o,libsycl-itt-user-wrappers.new.o,libsycl-itt-compiler-wrappers.new.o,libsycl-itt-stubs.new.o"
-// WRAPPER_OPTIONS-SAME: "-sycl-device-library-location={{.*}}/lib"
-
 /// Verify phases used to generate SPIR-V instead of LLVM-IR
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
 // RUN:          -fsycl-device-obj=spirv -ccc-print-phases %s 2>&1 \

--- a/clang/test/Driver/sycl-spirv-default-options.cpp
+++ b/clang/test/Driver/sycl-spirv-default-options.cpp
@@ -1,4 +1,5 @@
 // Generate .o file as SYCL device library file.
+// REQUIRES: system-linux
 //
 // RUN: touch %t.devicelib.cpp
 // RUN: %clang %t.devicelib.cpp -fsycl -fsycl-targets=spir64-unknown-unknown -c --offload-new-driver -o %t_1.devicelib.o

--- a/clang/test/Driver/sycl-spirv-ext.cpp
+++ b/clang/test/Driver/sycl-spirv-ext.cpp
@@ -1,4 +1,5 @@
 // Generate .o file as SYCL device library file.
+// REQUIRES: system-linux
 //
 // RUN: touch %t.devicelib.cpp
 // RUN: %clang %t.devicelib.cpp -fsycl -fsycl-targets=spir64-unknown-unknown -c --offload-new-driver -o %t_1.devicelib.o

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -128,7 +128,8 @@ if config.clang_examples:
     config.available_features.add("examples")
 if config.llvm_examples:
     config.available_features.add("llvm-examples")
-
+if "libdevice" in config.enable_projects:
+    config.available_features.add("libdevice")
 
 def have_host_out_of_process_jit_feature_support():
     clang_repl_exe = lit.util.which("clang-repl", config.clang_tools_dir)

--- a/clang/test/lit.site.cfg.py.in
+++ b/clang/test/lit.site.cfg.py.in
@@ -47,6 +47,7 @@ config.ppc_linux_default_ieeelongdouble = @PPC_LINUX_DEFAULT_IEEELONGDOUBLE@
 config.have_llvm_driver = @LLVM_TOOL_LLVM_DRIVER_BUILD@
 config.spirv_tools_tests = @LLVM_INCLUDE_SPIRV_TOOLS_TESTS@
 config.substitutions.append(("%llvm-version-major", "@LLVM_VERSION_MAJOR@"))
+config.enable_projects = "@LLVM_ENABLE_PROJECTS@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1468,15 +1468,9 @@ static Expected<StringRef> linkDevice(ArrayRef<StringRef> InputFiles,
     ExtractedDeviceLibFiles.emplace_back(LibraryPath.str());
   }
 
-  // Make sure that SYCL device library files are available.
-  // Note: For AMD targets, we do not pass any SYCL device libraries.
-  if (ExtractedDeviceLibFiles.empty()) {
-    // TODO: Add NVPTX when ready
-    if (Triple.isSPIROrSPIRV())
-      WithColor::warning(errs(), LinkerExecutable)
-          << "SYCL device library file list is empty\n";
+  // No device library files provided, second device linking step not required.
+  if (ExtractedDeviceLibFiles.empty())
     return *LinkedFile;
-  }
 
   for (auto &File : ExtractedDeviceLibFiles)
     InputFilesVec.emplace_back(File);

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -1,21 +1,15 @@
 include(CheckCXXCompilerFlag)
 set(obj_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
-set(obj-new-offload_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 if (MSVC)
   set(obj-suffix obj)
-  set(obj-new-offload-suffix new.obj)
   set(devicelib_host_static_obj sycl-devicelib-host.lib)
-  set(devicelib_host_static_obj-new-offload sycl-devicelib-host.new.lib)
 else()
   set(obj-suffix o)
-  set(obj-new-offload-suffix new.o)
   set(devicelib_host_static_obj libsycl-devicelib-host.a)
-  set(devicelib_host_static_obj-new-offload libsycl-devicelib-host.new.a)
 endif()
 set(bc-suffix bc)
 set(bc_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 set(install_dest_obj lib${LLVM_LIBDIR_SUFFIX})
-set(install_dest_obj-new-offload lib${LLVM_LIBDIR_SUFFIX})
 set(install_dest_bc lib${LLVM_LIBDIR_SUFFIX})
 
 string(CONCAT sycl_targets_opt
@@ -75,7 +69,7 @@ endif()
 
 add_custom_target(libsycldevice)
 
-set(filetypes obj obj-new-offload bc)
+set(filetypes obj bc)
 
 foreach(filetype IN LISTS filetypes)
   add_custom_target(libsycldevice-${filetype})
@@ -103,8 +97,6 @@ endif()
 
 
 set(bc_device_compile_opts -fsycl-device-only -fsycl-device-obj=llvmir)
-set(obj-new-offload_device_compile_opts -fsycl -c --offload-new-driver
-  -foffload-lto=thin ${sycl_targets_opt})
 set(obj_device_compile_opts -fsycl -c ${sycl_targets_opt} --no-offload-new-driver)
 
 # Compiles and installs a single device library.
@@ -385,24 +377,6 @@ if (NOT MSVC AND UR_SANITIZER_INCLUDE_DIR)
                                 ${sanitizer_generic_compile_opts}
                                 -D__LIBDEVICE_DG2__)
 
-  set(sanitizer_pvc_compile_opts_obj-new-offload -fsycl -c --offload-new-driver
-                                            -foffload-lto=thin
-                                            ${sanitizer_generic_compile_opts}
-                                            ${sycl_pvc_target_opt}
-                                            -D__LIBDEVICE_PVC__)
-
-  set(sanitizer_cpu_compile_opts_obj-new-offload -fsycl -c --offload-new-driver
-                                            -foffload-lto=thin
-                                            ${sanitizer_generic_compile_opts}
-                                            ${sycl_cpu_target_opt}
-                                            -D__LIBDEVICE_CPU__)
-
-  set(sanitizer_dg2_compile_opts_obj-new-offload -fsycl -c --offload-new-driver
-                                            -foffload-lto=thin
-                                            ${sanitizer_generic_compile_opts}
-                                            ${sycl_dg2_target_opt}
-                                            -D__LIBDEVICE_DG2__)
-  
   set(msan_obj_deps
     device.h atomic.hpp spirv_vars.h
     ${UR_SANITIZER_INCLUDE_DIR}/msan/msan_libdevice.hpp
@@ -689,8 +663,6 @@ if (NOT WIN32)
   add_imf_host_cxx_flags_compile_flags_if_supported("-fcf-protection=full")
 endif()
 
-set(obj-new-offload_host_compile_opts ${imf_host_cxx_flags} --offload-new-driver
-  -foffload-lto=thin)
 set(obj_host_compile_opts ${imf_host_cxx_flags} --no-offload-new-driver)
 
 foreach(datatype IN ITEMS fp32 fp64 bf16)
@@ -819,60 +791,56 @@ foreach(arch IN LISTS full_build_archs)
            COMPONENT libsycldevice)
 endforeach()
 
-# Add host device imf libraries for obj and new offload objects.
+# Add host objects for host device imf libraries.
 foreach(dtype IN ITEMS bf16 fp32 fp64)
-  foreach(ftype IN ITEMS obj obj-new-offload)
-    set(tgt_name imf_fallback_${dtype}_host_${ftype})
+  set(tgt_name imf_fallback_${dtype}_host_obj)
 
-    add_lib_imf(fallback-imf-${dtype}-host
-      DIR ${${ftype}_binary_dir}
-      FTYPE ${ftype}
-      DTYPE ${dtype}
-      EXTRA_OPTS ${${ftype}_host_compile_opts}
-      TGT_NAME ${tgt_name})
+  add_lib_imf(fallback-imf-${dtype}-host
+    DIR ${obj_binary_dir}
+    FTYPE obj
+    DTYPE ${dtype}
+    EXTRA_OPTS ${obj_host_compile_opts}
+    TGT_NAME ${tgt_name})
 
-    set(wrapper_name imf_wrapper.cpp)
-    if (NOT ("${dtype}" STREQUAL "fp32"))
-      set(wrapper_name imf_wrapper_${dtype}.cpp)
-    endif()
-    add_custom_command(
-      OUTPUT ${${ftype}_binary_dir}/imf-${dtype}-host.${${ftype}-suffix}
-      COMMAND ${clang_exe} ${${ftype}_host_compile_opts}
-              ${CMAKE_CURRENT_SOURCE_DIR}/${wrapper_name}
-              -o ${${ftype}_binary_dir}/imf-${dtype}-host.${${ftype}-suffix}
-      MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/${wrapper_name}
-      DEPENDS ${imf_obj_deps}
-      VERBATIM)
-
-    add_custom_target(imf_${dtype}_host_${ftype} DEPENDS
-      ${obj_binary_dir}/imf-${dtype}-host.${${ftype}-suffix})
-  endforeach()
-endforeach()
-
-foreach(ftype IN ITEMS obj obj-new-offload)
-  add_custom_target(imf_host_${ftype}
-    DEPENDS ${${ftype}_binary_dir}/${devicelib_host_static_${ftype}})
+  set(wrapper_name imf_wrapper.cpp)
+  if (NOT ("${dtype}" STREQUAL "fp32"))
+    set(wrapper_name imf_wrapper_${dtype}.cpp)
+  endif()
   add_custom_command(
-    OUTPUT ${${ftype}_binary_dir}/${devicelib_host_static_${ftype}}
-    COMMAND ${llvm-ar_exe} rcs
-            ${${ftype}_binary_dir}/${devicelib_host_static_${ftype}}
-            ${${ftype}_binary_dir}/imf-fp32-host.${${ftype}-suffix}
-            ${${ftype}_binary_dir}/fallback-imf-fp32-host.${${ftype}-suffix}
-            ${${ftype}_binary_dir}/imf-fp64-host.${${ftype}-suffix}
-            ${${ftype}_binary_dir}/fallback-imf-fp64-host.${${ftype}-suffix}
-            ${${ftype}_binary_dir}/imf-bf16-host.${${ftype}-suffix}
-            ${${ftype}_binary_dir}/fallback-imf-bf16-host.${${ftype}-suffix}
-    DEPENDS imf_fp32_host_${ftype} imf_fallback_fp32_host_${ftype}
-    DEPENDS imf_fp64_host_${ftype} imf_fallback_fp64_host_${ftype}
-    DEPENDS imf_bf16_host_${ftype} imf_fallback_bf16_host_${ftype}
-    DEPENDS ${llvm-ar_target}
+    OUTPUT ${obj_binary_dir}/imf-${dtype}-host.${obj-suffix}
+    COMMAND ${clang_exe} ${obj_host_compile_opts}
+            ${CMAKE_CURRENT_SOURCE_DIR}/${wrapper_name}
+            -o ${obj_binary_dir}/imf-${dtype}-host.${obj-suffix}
+    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/${wrapper_name}
+    DEPENDS ${imf_obj_deps}
     VERBATIM)
-  add_dependencies(libsycldevice-obj imf_host_${ftype})
 
-  install( FILES ${obj_binary_dir}/${devicelib_host_static_${ftype}}
-           DESTINATION ${install_dest_obj}
-           COMPONENT libsycldevice)
+  add_custom_target(imf_${dtype}_host_obj DEPENDS
+    ${obj_binary_dir}/imf-${dtype}-host.${obj-suffix})
 endforeach()
+
+add_custom_target(imf_host_obj
+  DEPENDS ${obj_binary_dir}/${devicelib_host_static_obj})
+add_custom_command(
+  OUTPUT ${obj_binary_dir}/${devicelib_host_static_obj}
+  COMMAND ${llvm-ar_exe} rcs
+          ${obj_binary_dir}/${devicelib_host_static_obj}
+          ${obj_binary_dir}/imf-fp32-host.${obj-suffix}
+          ${obj_binary_dir}/fallback-imf-fp32-host.${obj-suffix}
+          ${obj_binary_dir}/imf-fp64-host.${obj-suffix}
+          ${obj_binary_dir}/fallback-imf-fp64-host.${obj-suffix}
+          ${obj_binary_dir}/imf-bf16-host.${obj-suffix}
+          ${obj_binary_dir}/fallback-imf-bf16-host.${obj-suffix}
+  DEPENDS imf_fp32_host_obj imf_fallback_fp32_host_obj
+  DEPENDS imf_fp64_host_obj imf_fallback_fp64_host_obj
+  DEPENDS imf_bf16_host_obj imf_fallback_bf16_host_obj
+  DEPENDS ${llvm-ar_target}
+  VERBATIM)
+add_dependencies(libsycldevice-obj imf_host_obj)
+
+install( FILES ${obj_binary_dir}/${devicelib_host_static_obj}
+         DESTINATION ${install_dest_obj}
+         COMPONENT libsycldevice)
 
 foreach(ftype IN LISTS filetypes)
   install(

--- a/libdevice/crt_wrapper.cpp
+++ b/libdevice/crt_wrapper.cpp
@@ -13,7 +13,7 @@
 #include <cstdint>
 
 #define RAND_NEXT_LEN 1024
-DeviceGlobal<uint64_t[RAND_NEXT_LEN]> RandNext;
+__attribute__((weak)) DeviceGlobal<uint64_t[RAND_NEXT_LEN]> RandNext;
 
 #if defined(__SPIR__) || defined(__SPIRV__) || defined(__NVPTX__) ||           \
     defined(__AMDGCN__)

--- a/libdevice/sanitizer/msan_rtl.cpp
+++ b/libdevice/sanitizer/msan_rtl.cpp
@@ -9,7 +9,7 @@
 #include "include/msan_rtl.hpp"
 #include "msan/msan_libdevice.hpp"
 
-DeviceGlobal<void *> __MsanLaunchInfo;
+__attribute__((weak)) DeviceGlobal<void *> __MsanLaunchInfo;
 #define GetMsanLaunchInfo                                                      \
   ((__SYCL_GLOBAL__ MsanRuntimeData *)__MsanLaunchInfo.get())
 

--- a/libdevice/sanitizer/tsan_rtl.cpp
+++ b/libdevice/sanitizer/tsan_rtl.cpp
@@ -8,7 +8,7 @@
 
 #include "include/tsan_rtl.hpp"
 
-DeviceGlobal<void *> __TsanLaunchInfo;
+__attribute__((weak)) DeviceGlobal<void *> __TsanLaunchInfo;
 
 #define TsanLaunchInfo                                                         \
   ((__SYCL_GLOBAL__ TsanRuntimeData *)__TsanLaunchInfo.get())


### PR DESCRIPTION
Backport of https://github.com/intel/llvm/commit/64c349be698edd4e28c9dc48b3c5b2cedad85792

Pull in the device libraries during compile time when using the new offload model. This is done by using the -mlink-builtin-bitcode option, passing in each individual device library as needed.

This frees up the responsibility of linking in the device libraries during link time, and requiring the driver to pass any libraries needed to the clang-linker-wrapper or having the clang-linker-wrapper figure out what device libraries are needed at link.

With this move, the new.o device libraries are no longer used during the device linking stage using the clang-linker-wrapper. Made updates to the build to stop creating these binaries.

Reland of
https://github.com/intel/llvm/commit/c2a9bf8624be441f01993ea5a0bb1b19b72d56b8

Updated the SYCLInstallationDetector constructor, as there were two and we only need one. The mix of these caused a disconnect in populating the library search locations.