### PR TITLE
Fix clang-offload-bundler archive handling after multi-CCOB support

### DIFF
--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -31,6 +31,7 @@
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/ArchiveWriter.h"
 #include "llvm/Object/Binary.h"
+#include "llvm/Object/Error.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Compiler.h"
@@ -1172,6 +1173,26 @@ class ArchiveFileHandler final : public FileHandler {
 public:
   ArchiveFileHandler(const OffloadBundlerConfig &BC) : BundlerConfig(BC) {}
   ~ArchiveFileHandler() = default;
+
+  /// Override listBundleIDs to prevent base class from doing multi-bundle iteration
+  /// which is not appropriate for archives.
+  Error listBundleIDs(MemoryBuffer &Input) override {
+    // For archives, we only call ReadHeader once on the whole archive
+    StringRef BufferString = Input.getBuffer();
+    Error Err = ReadHeader(BufferString);
+    if (Err)
+      return Err;
+
+    Err = forEachBundle(BufferString, [&](const BundleInfo &Info) -> Error {
+      llvm::outs() << Info.BundleID << '\n';
+      Error Err = listBundleIDsCallback(Input, Info);
+      if (Err)
+        return Err;
+      return Error::success();
+    });
+
+    return Err;
+  }
 
   Error ReadHeader(StringRef Input) override {
     assert(Mode != OutputType::Unknown && "unknown output mode");


### PR DESCRIPTION
After commit 5b93aeb21818, which added multi-CCOB support with multi-bundle iteration in the base FileHandler::listBundleIDs(), archive handling broke with "file too small to be an archive" errors.

The root cause is that the base class's multi-bundle iteration searches for multiple __CLANG_OFFLOAD_BUNDLE__ magic strings and calls ReadHeader() for each one. However, ArchiveFileHandler::ReadHeader() expects to be called only once on the complete archive file, not on individual bundles within.

Fix by overriding listBundleIDs() in ArchiveFileHandler to prevent the inappropriate multi-bundle iteration. Archives have their own internal member iteration via Archive::children(), so they should only call ReadHeader() once on the whole archive.

Fixes 6 failing tests in sycl-web:
- clang-offload-bundler-bc-archive-support-linux-old-model.cpp
- sycl-early-device-link-old-model.cpp
- sycl-force-target.cpp
- sycl-no-rdc-fat-archive-old-model.cpp
- sycl-offload-static-lib-2-old-model.cpp
- sycl-target-mismatch-nvptx.cpp