### PR TITLE
[CI][Bench] Use UR's shared lib loader

### DIFF
--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -270,13 +270,26 @@ jobs:
       toolchain_decompress_command: ${{ needs.build_nightly.outputs.toolchain_decompress_command }}
   # END nightly benchmarking path
 
-  # BEGIN benchmark framework builds and runs on PRs path
+  # BEGIN benchmark framework builds and runs on PRs path:
+  build_test:
+    name: '[PR] Build SYCL'
+    if: ${{ github.repository == 'intel/llvm' && (github.event_name == 'pull_request' && inputs.trigger_nightly != 'true') }}
+    uses: ./.github/workflows/sycl-linux-build.yml
+    with:
+      build_cache_root: "/__w/"
+      build_cache_suffix: "prod_noassert"
+      build_configure_extra_args: '--no-assertions --cmake-opt="-DUR_STATIC_LOADER=OFF"'
+      build_image: ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest
+      changes: '[]'
+      toolchain_artifact: sycl_linux_prod_noassert
+
   test_benchmark_framework:
     name: '[PR] Benchmark suite testing'
+    needs: [build_test]
     permissions:
       contents: write
       packages: read
-    if: github.event_name == 'pull_request'
+    if: ${{ !cancelled() && needs.build_test.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: 'Framework test only: L0, Minimal preset, dry-run'
@@ -290,4 +303,7 @@ jobs:
       benchmark_dry_run: true
       benchmark_exit_on_failure: true
       repo_ref: ${{ github.sha }}
+      toolchain_artifact: ${{ needs.build_test.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.build_test.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.build_test.outputs.toolchain_decompress_command }}
   # END benchmark framework builds and runs on PRs path

--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -271,6 +271,11 @@ jobs:
   # END nightly benchmarking path
 
   # BEGIN benchmark framework builds and runs on PRs path:
+  #
+  # Note: we needed to add custom SYCL build, instead of using the nightly build (from docker),
+  #   because we need shared ur_loader library, instead of default static one.
+  #   There's an issue in linking with other static libraries in CB build.
+  #
   build_test:
     name: '[PR] Build SYCL'
     if: ${{ github.repository == 'intel/llvm' && (github.event_name == 'pull_request' && inputs.trigger_nightly != 'true') }}

--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -184,7 +184,7 @@ jobs:
       build_ref: ${{ needs.sanitize_inputs_dispatch.outputs.build_ref }}
       build_cache_root: "/__w/"
       build_cache_suffix: "prod_noassert"
-      build_configure_extra_args: "--no-assertions"
+      build_configure_extra_args: "--no-assertions --cmake-opt='-DUR_STATIC_LOADER=OFF'"
       build_image: "ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest"
       changes: '[]'
       toolchain_artifact: sycl_linux_prod_noassert
@@ -231,7 +231,7 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_cache_suffix: "prod_noassert"
-      build_configure_extra_args: '--no-assertions'
+      build_configure_extra_args: '--no-assertions --cmake-opt="-DUR_STATIC_LOADER=OFF"'
       build_image: ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest
       changes: '[]'
       toolchain_artifact: sycl_linux_prod_noassert

--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -292,14 +292,14 @@ jobs:
     if: ${{ !cancelled() && needs.build_test.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
-      name: 'Framework test only: L0, Minimal preset, dry-run'
+      name: 'Framework test only: L0, Core preset, dry-run'
       runner: '["TEST_PERF"]'
       image: ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest
       image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
       target_devices: 'level_zero:gpu'
       tests_selector: benchmarks
       benchmark_upload_results: false
-      benchmark_preset: 'Minimal'
+      benchmark_preset: 'Core'
       benchmark_dry_run: true
       benchmark_exit_on_failure: true
       repo_ref: ${{ github.sha }}

--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -292,14 +292,14 @@ jobs:
     if: ${{ !cancelled() && needs.build_test.outputs.build_conclusion == 'success' }}
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
-      name: 'Framework test only: L0, Core preset, dry-run'
+      name: 'Framework test only: L0, Minimal preset, dry-run'
       runner: '["TEST_PERF"]'
       image: ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest
       image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
       target_devices: 'level_zero:gpu'
       tests_selector: benchmarks
       benchmark_upload_results: false
-      benchmark_preset: 'Core'
+      benchmark_preset: 'Minimal'
       benchmark_dry_run: true
       benchmark_exit_on_failure: true
       repo_ref: ${{ github.sha }}

--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -323,7 +323,7 @@ runs:
       echo "::endgroup::"
       echo "::group::compare_results"
 
-      if [ "$LLVM_BENCHMARKS_USE_GDB" == "0" ]; then
+      if [ "1" == "0" ]; then
         python3 ./devops/scripts/benchmarks/compare.py to_hist \
           --avg-type EWMA \
           --cutoff "$(date -u -d '7 days ago' +'%Y%m%d_%H%M%S')" \
@@ -336,7 +336,7 @@ runs:
           --produce-github-summary \
           ${{ inputs.dry_run == 'true' && '--dry-run' || '' }}
       else
-        echo "Skipping regression comparison due to GDB mode enabled."
+        echo "Skipping regression comparison due to XXX mode enabled."
       fi
 
       echo "::endgroup::"
@@ -347,13 +347,25 @@ runs:
       BENCH_WORKDIR: ${{ steps.establish_outputs.outputs.BENCH_WORKDIR }}
       LLVM_BENCHMARKS_UNIT_TESTING: 1
       COMPUTE_BENCHMARKS_BUILD_PATH: ${{ steps.establish_outputs.outputs.BENCH_WORKDIR }}/compute-benchmarks-build
+      SYCL_UR_TRACE: 1
+      UR_L0_DEBUG: 1
+      UMF_LOG: "level:debug;flush:debug;output:stderr;pid:no"
+      UR_LOG_LEVEL_ZERO: "level:error;flush:error"
+      UR_LOG_LOADER: "level:error;flush:error"
+      ZE_DEBUG: 1
+      ZE_ENABLE_LOADER_DEBUG_TRACE: 1
+      ZEL_ENABLE_LOADER_LOGGING: 1
+      ZEL_LOADER_LOGGING_LEVEL: trace
+      ZE_ENABLE_VALIDATION_LAYER: 1
+      ZEL_LOADER_LOG_CONSOLE: 1
     run: |
       # Run benchmarks' integration tests
 
       # NOTE: Each integration test prints its own group name as part of test script
-      python3 ./devops/scripts/benchmarks/tests/test_integration.py
+      python3 ./devops/scripts/benchmarks/tests/test_integration.py --verbose
   - name: Upload github summaries and cache changes
-    if: always()
+    # if: always()
+    if: false
     shell: bash
     env:
       BENCHMARK_RESULTS_REPO_PATH: ${{ steps.establish_outputs.outputs.BENCHMARK_RESULTS_REPO_PATH }}
@@ -369,7 +381,8 @@ runs:
         cp "$diff" "../cached_changes/$diff"
       done
   - name: Push benchmarks results
-    if: always() && inputs.upload_results == 'true' &&  inputs.gdb_mode == '0'
+    # if: always() && inputs.upload_results == 'true' &&  inputs.gdb_mode == '0'
+    if: false
     shell: bash
     env:
       BENCH_WORKDIR: ${{ steps.establish_outputs.outputs.BENCH_WORKDIR }}
@@ -421,7 +434,8 @@ runs:
         cd -
       done
   - name: Archive benchmark results
-    if: always()
+    # if: always()
+    if: false
     uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: Benchmark run ${{ github.run_id }} (${{ env.SAVE_NAME }})

--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -133,7 +133,6 @@ runs:
 
       # Check if SYCL dir exists and has SYCL lib; set CMPLR_ROOT if so
       if [ -d "$SYCL_DIR" ] && [ -f "$SYCL_DIR/lib/libsycl.so" ]; then
-        echo "Using SYCL from: $SYCL_DIR"
         export CMPLR_ROOT=$(realpath "$SYCL_DIR")
         echo "CMPLR_ROOT=$CMPLR_ROOT" >> $GITHUB_ENV
 
@@ -347,22 +346,11 @@ runs:
       BENCH_WORKDIR: ${{ steps.establish_outputs.outputs.BENCH_WORKDIR }}
       LLVM_BENCHMARKS_UNIT_TESTING: 1
       COMPUTE_BENCHMARKS_BUILD_PATH: ${{ steps.establish_outputs.outputs.BENCH_WORKDIR }}/compute-benchmarks-build
-      SYCL_UR_TRACE: 1
-      UR_L0_DEBUG: 1
-      UMF_LOG: "level:debug;flush:debug;output:stderr;pid:no"
-      UR_LOG_LEVEL_ZERO: "level:error;flush:error"
-      UR_LOG_LOADER: "level:error;flush:error"
-      ZE_DEBUG: 1
-      ZE_ENABLE_LOADER_DEBUG_TRACE: 1
-      ZEL_ENABLE_LOADER_LOGGING: 1
-      ZEL_LOADER_LOGGING_LEVEL: trace
-      ZE_ENABLE_VALIDATION_LAYER: 1
-      ZEL_LOADER_LOG_CONSOLE: 1
     run: |
       # Run benchmarks' integration tests
 
       # NOTE: Each integration test prints its own group name as part of test script
-      python3 ./devops/scripts/benchmarks/tests/test_integration.py --verbose
+      python3 ./devops/scripts/benchmarks/tests/test_integration.py
   - name: Upload github summaries and cache changes
     # if: always()
     if: false

--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -148,7 +148,7 @@ runs:
         export CMPLR_ROOT="$(dirname $(dirname $(which sycl-ls)))"
         echo "CMPLR_ROOT=$CMPLR_ROOT" >> $GITHUB_ENV
       fi
-      echo "Using SYCL from: $CMPLR_ROOT !"
+      echo "Using SYCL from: $CMPLR_ROOT"
 
       if [ -z "$SAVE_TIMESTAMP" ]; then
         export SAVE_TIMESTAMP="$(date -u +'%Y%m%d_%H%M%S')"  # Current timestamp in UTC time

--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -134,7 +134,7 @@ runs:
       # Check if SYCL dir exists and has SYCL lib; set CMPLR_ROOT if so
       if [ -d "$SYCL_DIR" ] && [ -f "$SYCL_DIR/lib/libsycl.so" ]; then
         echo "Using SYCL from: $SYCL_DIR"
-        export CMPLR_ROOT=$SYCL_DIR
+        export CMPLR_ROOT=$(realpath "$SYCL_DIR")
         echo "CMPLR_ROOT=$CMPLR_ROOT" >> $GITHUB_ENV
 
         # Set timestamp based on the compiler library's time.
@@ -147,9 +147,9 @@ runs:
         which sycl-ls
         sycl-ls
         export CMPLR_ROOT="$(dirname $(dirname $(which sycl-ls)))"
-        echo "Using SYCL from: $CMPLR_ROOT !"
         echo "CMPLR_ROOT=$CMPLR_ROOT" >> $GITHUB_ENV
       fi
+      echo "Using SYCL from: $CMPLR_ROOT !"
 
       if [ -z "$SAVE_TIMESTAMP" ]; then
         export SAVE_TIMESTAMP="$(date -u +'%Y%m%d_%H%M%S')"  # Current timestamp in UTC time

--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -322,7 +322,7 @@ runs:
       echo "::endgroup::"
       echo "::group::compare_results"
 
-      if [ "1" == "0" ]; then
+      if [ "$LLVM_BENCHMARKS_USE_GDB" == "0" ]; then
         python3 ./devops/scripts/benchmarks/compare.py to_hist \
           --avg-type EWMA \
           --cutoff "$(date -u -d '7 days ago' +'%Y%m%d_%H%M%S')" \
@@ -335,7 +335,7 @@ runs:
           --produce-github-summary \
           ${{ inputs.dry_run == 'true' && '--dry-run' || '' }}
       else
-        echo "Skipping regression comparison due to XXX mode enabled."
+        echo "Skipping regression comparison due to GDB mode enabled."
       fi
 
       echo "::endgroup::"
@@ -352,8 +352,7 @@ runs:
       # NOTE: Each integration test prints its own group name as part of test script
       python3 ./devops/scripts/benchmarks/tests/test_integration.py
   - name: Upload github summaries and cache changes
-    # if: always()
-    if: false
+    if: always()
     shell: bash
     env:
       BENCHMARK_RESULTS_REPO_PATH: ${{ steps.establish_outputs.outputs.BENCHMARK_RESULTS_REPO_PATH }}
@@ -369,8 +368,7 @@ runs:
         cp "$diff" "../cached_changes/$diff"
       done
   - name: Push benchmarks results
-    # if: always() && inputs.upload_results == 'true' &&  inputs.gdb_mode == '0'
-    if: false
+    if: always() && inputs.upload_results == 'true' &&  inputs.gdb_mode == '0'
     shell: bash
     env:
       BENCH_WORKDIR: ${{ steps.establish_outputs.outputs.BENCH_WORKDIR }}
@@ -422,8 +420,7 @@ runs:
         cd -
       done
   - name: Archive benchmark results
-    # if: always()
-    if: false
+    if: always()
     uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: Benchmark run ${{ github.run_id }} (${{ env.SAVE_NAME }})

--- a/devops/scripts/benchmarks/tests/test_integration.py
+++ b/devops/scripts/benchmarks/tests/test_integration.py
@@ -201,7 +201,7 @@ class TestE2E(unittest.TestCase):
         self.assertEqual(set(metadata.tags), tags)
         self._checkGroup(groupName, metadata, out)
 
-    def _test_record_and_replay(self):
+    def test_record_and_replay(self):
         self._checkCase(
             "record_and_replay_benchmark_l0 AppendCopy 1, AppendKern 10, CmdSetsInLvl 10, ForksInLvl 2, Instantiations 10, Lvls 4, Rec",
             "RecordGraph large",
@@ -215,7 +215,7 @@ class TestE2E(unittest.TestCase):
             {"UR", "latency", "micro", "submit"},
         )
 
-    def _test_submit_kernel(self):
+    def test_submit_kernel(self):
         self._checkCase(
             "api_overhead_benchmark_l0 SubmitKernel out of order with measure completion",
             "SubmitKernel out of order with completion using events",

--- a/devops/scripts/benchmarks/tests/test_integration.py
+++ b/devops/scripts/benchmarks/tests/test_integration.py
@@ -201,7 +201,7 @@ class TestE2E(unittest.TestCase):
         self.assertEqual(set(metadata.tags), tags)
         self._checkGroup(groupName, metadata, out)
 
-    def test_record_and_replay(self):
+    def _test_record_and_replay(self):
         self._checkCase(
             "record_and_replay_benchmark_l0 AppendCopy 1, AppendKern 10, CmdSetsInLvl 10, ForksInLvl 2, Instantiations 10, Lvls 4, Rec",
             "RecordGraph large",
@@ -215,7 +215,7 @@ class TestE2E(unittest.TestCase):
             {"UR", "latency", "micro", "submit"},
         )
 
-    def test_submit_kernel(self):
+    def _test_submit_kernel(self):
         self._checkCase(
             "api_overhead_benchmark_l0 SubmitKernel out of order with measure completion",
             "SubmitKernel out of order with completion using events",


### PR DESCRIPTION
for compute-benchmarks to work properly - they link to UR loader, and when it's static it misses links to ur_common and xpti.

ref. #22031