### PR TITLE
[CI] Fix nightly bug to re-enable sycl-cts on CPU

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -352,23 +352,14 @@ jobs:
       fail-fast: false
       matrix:
         enable_new_offload_model: ['False', 'True']
-        include:
-          - name: SYCL-CTS on OCL CPU
-            runner: '["Linux", "gen12"]'
-            image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
-            target_devices: opencl:cpu
-
-          - name: SYCL-CTS on L0 gen12
-            runner: '["Linux", "gen12"]'
-            image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
-            target_devices: level_zero:gpu
+        target_device: ['opencl:cpu', 'level_zero:gpu']
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
-      name: ${{ matrix.name }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: ${{ matrix.runner }}
+      name: SYCL CTS with ${{ matrix.target_device }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: '["Linux", "gen12"]'
       testing_mode: 'run-only'
-      image_options: ${{ matrix.image_options }}
-      target_devices: ${{ matrix.target_devices }}
+      image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
+      target_devices: ${{ matrix.target_device }}
       tests_selector: cts
       repo_ref: ${{ github.sha }}
       toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
@@ -376,46 +367,43 @@ jobs:
       toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
       binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
 
-  # build-sycl-cts-win:
-  #   needs: build-win
-  #   name: Build SYCL-CTS for Windows with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #   if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       enable_new_offload_model: ['False', 'True']
-  #   uses: ./.github/workflows/sycl-windows-run-tests.yml
-  #   with:
-  #     name: Build SYCL-CTS for Windows with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #     runner: '["Windows", "build"]'
-  #     testing_mode: 'build-only'
-  #     tests_selector: cts
-  #     repo_ref: ${{ github.sha }}
-  #     toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
-  #     binaries_artifact: sycl_cts_bin_win_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
-  #     extra_cmake_args: ${{ matrix.enable_new_offload_model == 'True' && '-DDPCPP_FLAGS=--offload-new-driver' || '' }}
+  build-sycl-cts-win:
+    needs: build-win
+    name: Build SYCL-CTS for Windows with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+    if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_new_offload_model: ['False', 'True']
+    uses: ./.github/workflows/sycl-windows-run-tests.yml
+    with:
+      name: Build SYCL-CTS for Windows with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: '["Windows", "build"]'
+      testing_mode: 'build-only'
+      tests_selector: cts
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
+      binaries_artifact: sycl_cts_bin_win_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
+      extra_cmake_args: ${{ matrix.enable_new_offload_model == 'True' && '-DDPCPP_FLAGS=--offload-new-driver' || '' }}
 
-  # run-sycl-cts-win:
-  #   needs: [build-win, build-sycl-cts-win]
-  #   if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       enable_new_offload_model: ['False', 'True']
-  #       include:
-  #         - name: SYCL-CTS on L0 gen12
-  #           runner: '["Windows", "gen12"]'
-  #           target_devices: level_zero:gpu
-  #   uses: ./.github/workflows/sycl-windows-run-tests.yml
-  #   with:
-  #     name: ${{ matrix.name }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #     runner: ${{ matrix.runner }}
-  #     testing_mode: 'run-only'
-  #     target_devices: ${{ matrix.target_devices }}
-  #     tests_selector: cts
-  #     repo_ref: ${{ github.sha }}
-  #     toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
-  #     binaries_artifact: sycl_cts_bin_win_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
+  run-sycl-cts-win:
+    needs: [build-win, build-sycl-cts-win]
+    if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_new_offload_model: ['False', 'True']
+        target_devices: ['level_zero:gpu']
+    uses: ./.github/workflows/sycl-windows-run-tests.yml
+    with:
+      name: SYCL-CTS with ${{ matrix.target_device }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: '["Windows", "gen12"]'
+      testing_mode: 'run-only'
+      target_devices: ${{ matrix.target_device }}
+      tests_selector: cts
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
+      binaries_artifact: sycl_cts_bin_win_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
 
   # build_and_test_blender_win:
   #   name: Build and Test Blender on Windows

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -352,7 +352,7 @@ jobs:
       fail-fast: false
       matrix:
         enable_new_offload_model: ['False', 'True']
-        include:
+        target:
           - name: SYCL-CTS on OCL CPU
             runner: '["Linux", "gen12"]'
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
@@ -364,11 +364,11 @@ jobs:
             target_devices: level_zero:gpu
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
-      name: ${{ matrix.name }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: ${{ matrix.runner }}
+      name: ${{ matrix.target.name }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: ${{ matrix.target.runner }}
       testing_mode: 'run-only'
-      image_options: ${{ matrix.image_options }}
-      target_devices: ${{ matrix.target_devices }}
+      image_options: ${{ matrix.target.image_options }}
+      target_devices: ${{ matrix.target.target_devices }}
       tests_selector: cts
       repo_ref: ${{ github.sha }}
       toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -33,21 +33,21 @@ jobs:
     - id: get_date
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-  ubuntu2204_build:
-    needs: get_date
-    if: github.repository == 'intel/llvm'
-    uses: ./.github/workflows/sycl-linux-build.yml
-    secrets: inherit
-    with:
-      build_cache_root: "/__w/"
-      build_configure_extra_args: '--cuda -DSYCL_BUILD_INFO="Nightly ${{ needs.get_date.outputs.date }}"'
-      build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
+  # ubuntu2204_build:
+  #   needs: get_date
+  #   if: github.repository == 'intel/llvm'
+  #   uses: ./.github/workflows/sycl-linux-build.yml
+  #   secrets: inherit
+  #   with:
+  #     build_cache_root: "/__w/"
+  #     build_configure_extra_args: '--cuda -DSYCL_BUILD_INFO="Nightly ${{ needs.get_date.outputs.date }}"'
+  #     build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
 
-      retention-days: 90
-      toolchain_artifact: sycl_linux_default
-      # We upload the build for people to download/use, override its name and
-      # prefer widespread gzip compression.
-      toolchain_artifact_filename: sycl_linux.tar.gz
+  #     retention-days: 90
+  #     toolchain_artifact: sycl_linux_default
+  #     # We upload the build for people to download/use, override its name and
+  #     # prefer widespread gzip compression.
+  #     toolchain_artifact_filename: sycl_linux.tar.gz
 
   # Build used for performance testing only: not intended for testing
   # linux_shared_build:
@@ -317,55 +317,55 @@ jobs:
   #   with:
   #     mode: stop
 
-  build-sycl-cts-linux:
-    needs: ubuntu2204_build
-    name: Build SYCL-CTS for Linux with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-    permissions:
-      contents: write
-      packages: read
-    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        enable_new_offload_model: ['False', 'True']
-    uses: ./.github/workflows/sycl-linux-run-tests.yml
-    with:
-      name: Build SYCL-CTS for Linux with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: '["Linux", "build"]'
-      testing_mode: 'build-only'
-      image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
-      tests_selector: cts
-      repo_ref: ${{ github.sha }}
-      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
-      binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
-      extra_cmake_args: ${{ matrix.enable_new_offload_model == 'True' && '-DDPCPP_FLAGS=--offload-new-driver' || '' }}
+  # build-sycl-cts-linux:
+  #   needs: ubuntu2204_build
+  #   name: Build SYCL-CTS for Linux with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #   permissions:
+  #     contents: write
+  #     packages: read
+  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       enable_new_offload_model: ['False', 'True']
+  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
+  #   with:
+  #     name: Build SYCL-CTS for Linux with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #     runner: '["Linux", "build"]'
+  #     testing_mode: 'build-only'
+  #     image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
+  #     tests_selector: cts
+  #     repo_ref: ${{ github.sha }}
+  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+  #     binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
+  #     extra_cmake_args: ${{ matrix.enable_new_offload_model == 'True' && '-DDPCPP_FLAGS=--offload-new-driver' || '' }}
 
-  run-sycl-cts-linux:
-    needs: [ubuntu2204_build, build-sycl-cts-linux]
-    permissions:
-      contents: write
-      packages: read
-    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        enable_new_offload_model: ['False', 'True']
-        target_device: ['opencl:cpu', 'level_zero:gpu']
-    uses: ./.github/workflows/sycl-linux-run-tests.yml
-    with:
-      name: SYCL CTS with ${{ matrix.target_device }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: '["Linux", "gen12"]'
-      testing_mode: 'run-only'
-      image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
-      target_devices: ${{ matrix.target_device }}
-      tests_selector: cts
-      repo_ref: ${{ github.sha }}
-      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
-      binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
+  # run-sycl-cts-linux:
+  #   needs: [ubuntu2204_build, build-sycl-cts-linux]
+  #   permissions:
+  #     contents: write
+  #     packages: read
+  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       enable_new_offload_model: ['False', 'True']
+  #       target_device: ['opencl:cpu', 'level_zero:gpu']
+  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
+  #   with:
+  #     name: SYCL CTS with ${{ matrix.target_device }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #     runner: '["Linux", "gen12"]'
+  #     testing_mode: 'run-only'
+  #     image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
+  #     target_devices: ${{ matrix.target_device }}
+  #     tests_selector: cts
+  #     repo_ref: ${{ github.sha }}
+  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+  #     binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
 
   build-sycl-cts-win:
     needs: build-win

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -352,14 +352,14 @@ jobs:
       fail-fast: false
       matrix:
         enable_new_offload_model: ['False', 'True']
-        target_device: ['opencl:cpu', 'level_zero:gpu']
+        target_devices: ['opencl:cpu', 'level_zero:gpu']
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
-      name: SYCL CTS with ${{ matrix.target_device }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      name: SYCL CTS with ${{ matrix.target_devices }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
       runner: '["Linux", "gen12"]'
       testing_mode: 'run-only'
       image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
-      target_devices: ${{ matrix.target_device }}
+      target_devices: ${{ matrix.target_devices }}
       tests_selector: cts
       repo_ref: ${{ github.sha }}
       toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
@@ -393,13 +393,13 @@ jobs:
       fail-fast: false
       matrix:
         enable_new_offload_model: ['False', 'True']
-        target_device: ['level_zero:gpu']
+        target_devices: ['level_zero:gpu']
     uses: ./.github/workflows/sycl-windows-run-tests.yml
     with:
-      name: SYCL-CTS with ${{ matrix.target_device }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      name: SYCL-CTS with ${{ matrix.target_devices }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
       runner: '["Windows", "gen12"]'
       testing_mode: 'run-only'
-      target_devices: ${{ matrix.target_device }}
+      target_devices: ${{ matrix.target_devices }}
       tests_selector: cts
       repo_ref: ${{ github.sha }}
       toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -233,18 +233,18 @@ jobs:
   #     toolchain_artifact_filename: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact_filename }}
   #     toolchain_decompress_command: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_decompress_command }}
 
-  # build-win:
-  #   needs: get_date
-  #   uses: ./.github/workflows/sycl-windows-build.yml
-  #   if: github.repository == 'intel/llvm'
-  #   with:
-  #     retention-days: 90
-  #     # We upload both Linux/Windows build via Github's "Releases"
-  #     # functionality, make sure Linux/Windows names follow the same pattern.
-  #     toolchain_artifact_filename: sycl_windows.tar.gz
-  #     # Disable the spirv-dis requirement as to not require SPIR-V Tools.
-  #     build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off -DSYCL_BUILD_INFO="Nightly ${{ needs.get_date.outputs.date }}"
-  #     build_target: all
+  build-win:
+    needs: get_date
+    uses: ./.github/workflows/sycl-windows-build.yml
+    if: github.repository == 'intel/llvm'
+    with:
+      retention-days: 90
+      # We upload both Linux/Windows build via Github's "Releases"
+      # functionality, make sure Linux/Windows names follow the same pattern.
+      toolchain_artifact_filename: sycl_windows.tar.gz
+      # Disable the spirv-dis requirement as to not require SPIR-V Tools.
+      build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off -DSYCL_BUILD_INFO="Nightly ${{ needs.get_date.outputs.date }}"
+      build_target: all
 
   # e2e-win:
   #   needs: build-win

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -33,205 +33,205 @@ jobs:
     - id: get_date
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-  # ubuntu2204_build:
-  #   needs: get_date
-  #   if: github.repository == 'intel/llvm'
-  #   uses: ./.github/workflows/sycl-linux-build.yml
-  #   secrets: inherit
-  #   with:
-  #     build_cache_root: "/__w/"
-  #     build_configure_extra_args: '--cuda -DSYCL_BUILD_INFO="Nightly ${{ needs.get_date.outputs.date }}"'
-  #     build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
+  ubuntu2204_build:
+    needs: get_date
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl-linux-build.yml
+    secrets: inherit
+    with:
+      build_cache_root: "/__w/"
+      build_configure_extra_args: '--cuda -DSYCL_BUILD_INFO="Nightly ${{ needs.get_date.outputs.date }}"'
+      build_image: ghcr.io/intel/llvm/ubuntu2204_build:latest
 
-  #     retention-days: 90
-  #     toolchain_artifact: sycl_linux_default
-  #     # We upload the build for people to download/use, override its name and
-  #     # prefer widespread gzip compression.
-  #     toolchain_artifact_filename: sycl_linux.tar.gz
+      retention-days: 90
+      toolchain_artifact: sycl_linux_default
+      # We upload the build for people to download/use, override its name and
+      # prefer widespread gzip compression.
+      toolchain_artifact_filename: sycl_linux.tar.gz
 
   # Build used for performance testing only: not intended for testing
-  # linux_shared_build:
-  #   if: github.repository == 'intel/llvm'
-  #   uses: ./.github/workflows/sycl-linux-build.yml
-  #   secrets: inherit
-  #   with:
-  #     build_cache_root: "/__w/"
-  #     build_cache_suffix: sprod_shared
-  #     build_configure_extra_args: '--shared-libs --cuda --native_cpu --no-assertions'
-  #     build_target: all
+  linux_shared_build:
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl-linux-build.yml
+    secrets: inherit
+    with:
+      build_cache_root: "/__w/"
+      build_cache_suffix: sprod_shared
+      build_configure_extra_args: '--shared-libs --cuda --native_cpu --no-assertions'
+      build_target: all
 
-  #     toolchain_artifact: sycl_linux_sprod_shared
-  #     toolchain_artifact_filename: sycl_linux_shared.tar.zst
+      toolchain_artifact: sycl_linux_sprod_shared
+      toolchain_artifact_filename: sycl_linux_shared.tar.zst
 
-  # ubuntu2404_oneapi_build:
-  #   if: github.repository == 'intel/llvm'
-  #   uses: ./.github/workflows/sycl-linux-build.yml
-  #   secrets: inherit
-  #   with:
-  #     build_cache_root: "/__w/"
-  #     build_cache_suffix: oneapi
-  #     build_configure_extra_args: -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
-  #     cc: icx
-  #     cxx: icpx
+  ubuntu2404_oneapi_build:
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl-linux-build.yml
+    secrets: inherit
+    with:
+      build_cache_root: "/__w/"
+      build_cache_suffix: oneapi
+      build_configure_extra_args: -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
+      cc: icx
+      cxx: icpx
 
-  #     toolchain_artifact: sycl_linux_oneapi
-  #     toolchain_artifact_filename: sycl_linux_oneapi.tar.zst
+      toolchain_artifact: sycl_linux_oneapi
+      toolchain_artifact_filename: sycl_linux_oneapi.tar.zst
 
-  # ubuntu2404_libcxx_build:
-  #   if: github.repository == 'intel/llvm'
-  #   uses: ./.github/workflows/sycl-linux-build.yml
-  #   secrets: inherit
-  #   with:
-  #     build_cache_root: "/__w/"
-  #     build_cache_suffix: libcxx
-  #     build_configure_extra_args: --use-libcxx -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=OFF
-  #     cc: clang-18
-  #     cxx: clang++-18
+  ubuntu2404_libcxx_build:
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl-linux-build.yml
+    secrets: inherit
+    with:
+      build_cache_root: "/__w/"
+      build_cache_suffix: libcxx
+      build_configure_extra_args: --use-libcxx -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=OFF
+      cc: clang-18
+      cxx: clang++-18
 
-  #     toolchain_artifact: sycl_linux_libcxx
-  #     toolchain_artifact_filename: sycl_linux_libcxx.tar.zst
+      toolchain_artifact: sycl_linux_libcxx
+      toolchain_artifact_filename: sycl_linux_libcxx.tar.zst
 
-  # ubuntu2204_test_nvidia_gen12:
-  #   needs: [ubuntu2204_build]
-  #   name: E2E NVIDIA and GEN12 OCL with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #   permissions:
-  #     contents: write
-  #     packages: read
-  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       enable_new_offload_model: ['False', 'True']
-  #       arch: ['cuda', 'gen12']
-  #       include:
-  #         - arch: 'cuda'
-  #           image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
-  #           target_devices: 'cuda:gpu'
+  ubuntu2204_test_nvidia_gen12:
+    needs: [ubuntu2204_build]
+    name: E2E NVIDIA and GEN12 OCL with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+    permissions:
+      contents: write
+      packages: read
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_new_offload_model: ['False', 'True']
+        arch: ['cuda', 'gen12']
+        include:
+          - arch: 'cuda'
+            image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
+            target_devices: 'cuda:gpu'
 
-  #         - arch: 'gen12'
-  #           target_devices: 'opencl:gpu'
+          - arch: 'gen12'
+            target_devices: 'opencl:gpu'
 
-  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
-  #   with:
-  #     name: ${{ matrix.arch }} (${{ matrix.target_devices }}) with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #     runner: '["Linux", "${{ matrix.arch }}"]'
-  #     image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' }}
-  #     target_devices: ${{ matrix.target_devices }}
-  #     tests_selector: e2e
-  #     extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
-  #     repo_ref: ${{ github.sha }}
-  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+    uses: ./.github/workflows/sycl-linux-run-tests.yml
+    with:
+      name: ${{ matrix.arch }} (${{ matrix.target_devices }}) with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: '["Linux", "${{ matrix.arch }}"]'
+      image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' }}
+      target_devices: ${{ matrix.target_devices }}
+      tests_selector: e2e
+      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-  # ubuntu2204_test_intel_level_zero:
-  #   needs: [ubuntu2204_build]
-  #   name: E2E L0 with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #   permissions:
-  #     contents: write
-  #     packages: read
-  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       enable_new_offload_model: ['False', 'True']
-  #       arch: ['gen12', 'pvc', 'bmg', 'arc']
+  ubuntu2204_test_intel_level_zero:
+    needs: [ubuntu2204_build]
+    name: E2E L0 with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+    permissions:
+      contents: write
+      packages: read
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_new_offload_model: ['False', 'True']
+        arch: ['gen12', 'pvc', 'bmg', 'arc']
 
-  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
-  #   with:
-  #     name: Intel L0 ${{ matrix.arch }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #     runner: '["Linux", "${{ matrix.arch }}"]'
-  #     image_options: '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN'
-  #     target_devices: level_zero:gpu
-  #     tests_selector: e2e
-  #     extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
-  #     repo_ref: ${{ github.sha }}
-  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+    uses: ./.github/workflows/sycl-linux-run-tests.yml
+    with:
+      name: Intel L0 ${{ matrix.arch }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: '["Linux", "${{ matrix.arch }}"]'
+      image_options: '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN'
+      target_devices: level_zero:gpu
+      tests_selector: e2e
+      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-  # ubuntu2204_test_intel_amd_opencl_cpu:
-  #   needs: [ubuntu2204_build]
-  #   name: E2E OpenCL CPU for Intel and AMD with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #   permissions:
-  #     contents: write
-  #     packages: read
-  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       enable_new_offload_model: ['False', 'True']
-  #       arch: ['amdcpu', 'gen12', 'arc']
-  #       include:
-  #         - arch: 'gen12'
-  #           image_options: --privileged --cap-add SYS_ADMIN
+  ubuntu2204_test_intel_amd_opencl_cpu:
+    needs: [ubuntu2204_build]
+    name: E2E OpenCL CPU for Intel and AMD with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+    permissions:
+      contents: write
+      packages: read
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_new_offload_model: ['False', 'True']
+        arch: ['amdcpu', 'gen12', 'arc']
+        include:
+          - arch: 'gen12'
+            image_options: --privileged --cap-add SYS_ADMIN
 
-  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
-  #   with:
-  #     name: ${{ matrix.arch }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #     runner: '["Linux", "${{ matrix.arch }}"]'
-  #     image_options: -u 1001 ${{ matrix.image_options }}
-  #     target_devices: opencl:cpu
-  #     tests_selector: e2e
-  #     extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
-  #     repo_ref: ${{ github.sha }}
-  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+    uses: ./.github/workflows/sycl-linux-run-tests.yml
+    with:
+      name: ${{ matrix.arch }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: '["Linux", "${{ matrix.arch }}"]'
+      image_options: -u 1001 ${{ matrix.image_options }}
+      target_devices: opencl:cpu
+      tests_selector: e2e
+      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-  # ubuntu2204_test_preview_mode:
-  #   needs: [ubuntu2204_build]
-  #   permissions:
-  #     contents: write
-  #     packages: read
-  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - name: Preview mode on NVIDIA/CUDA
-  #           runner: '["Linux", "cuda"]'
-  #           image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
-  #           target_devices: cuda:gpu
+  ubuntu2204_test_preview_mode:
+    needs: [ubuntu2204_build]
+    permissions:
+      contents: write
+      packages: read
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Preview mode on NVIDIA/CUDA
+            runner: '["Linux", "cuda"]'
+            image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
+            target_devices: cuda:gpu
 
-  #         - name: Preview mode on Intel L0 Battlemage GPU
-  #           runner: '["Linux", "bmg"]'
-  #           target_devices: level_zero:gpu
+          - name: Preview mode on Intel L0 Battlemage GPU
+            runner: '["Linux", "bmg"]'
+            target_devices: level_zero:gpu
 
-  #         - name: Preview mode on SPR/PVC
-  #           runner: '["Linux", "pvc"]'
-  #           target_devices: level_zero:gpu
+          - name: Preview mode on SPR/PVC
+            runner: '["Linux", "pvc"]'
+            target_devices: level_zero:gpu
 
-  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
-  #   with:
-  #     name: ${{ matrix.name }}
-  #     runner: ${{ matrix.runner }}
-  #     image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' }}
-  #     target_devices: ${{ matrix.target_devices }}
-  #     tests_selector: e2e
-  #     extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param test-preview-mode=True"
-  #     repo_ref: ${{ github.sha }}
-  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+    uses: ./.github/workflows/sycl-linux-run-tests.yml
+    with:
+      name: ${{ matrix.name }}
+      runner: ${{ matrix.runner }}
+      image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' }}
+      target_devices: ${{ matrix.target_devices }}
+      tests_selector: e2e
+      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param test-preview-mode=True"
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-  # ubuntu2404_oneapi_test:
-  #   needs: [ubuntu2404_oneapi_build]
-  #   permissions:
-  #     contents: write
-  #     packages: read
-  #   if: ${{ !cancelled() && needs.ubuntu2404_oneapi_build.outputs.build_conclusion == 'success' }}
-  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
-  #   with:
-  #     name: Intel PVC L0 oneAPI
-  #     runner: '["Linux", "pvc"]'
-  #     target_devices: level_zero:gpu
-  #     extra_lit_opts: -j 50
-  #     image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
-  #     repo_ref: ${{ github.sha }}
-  #     toolchain_artifact: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact }}
-  #     toolchain_artifact_filename: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact_filename }}
-  #     toolchain_decompress_command: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_decompress_command }}
+  ubuntu2404_oneapi_test:
+    needs: [ubuntu2404_oneapi_build]
+    permissions:
+      contents: write
+      packages: read
+    if: ${{ !cancelled() && needs.ubuntu2404_oneapi_build.outputs.build_conclusion == 'success' }}
+    uses: ./.github/workflows/sycl-linux-run-tests.yml
+    with:
+      name: Intel PVC L0 oneAPI
+      runner: '["Linux", "pvc"]'
+      target_devices: level_zero:gpu
+      extra_lit_opts: -j 50
+      image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_decompress_command }}
 
   build-win:
     needs: get_date
@@ -246,126 +246,126 @@ jobs:
       build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off -DSYCL_BUILD_INFO="Nightly ${{ needs.get_date.outputs.date }}"
       build_target: all
 
-  # e2e-win:
-  #   needs: build-win
-  #   name: E2E win with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #   # Continue if build was successful.
-  #   if: |
-  #     !cancelled()
-  #     && needs.build-win.outputs.build_conclusion == 'success'
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       enable_new_offload_model: ['False', 'True']
-  #       gpu_type: ['gen12', 'arc', 'bmg']
-  #       include:
-  #         - gpu_type: 'gen12'
-  #           name: Intel Gen12 GPU
-  #           runner: '["Windows", "gen12"]'
+  e2e-win:
+    needs: build-win
+    name: E2E win with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+    # Continue if build was successful.
+    if: |
+      !cancelled()
+      && needs.build-win.outputs.build_conclusion == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_new_offload_model: ['False', 'True']
+        gpu_type: ['gen12', 'arc', 'bmg']
+        include:
+          - gpu_type: 'gen12'
+            name: Intel Gen12 GPU
+            runner: '["Windows", "gen12"]'
 
-  #         - gpu_type: 'arc'
-  #           name: Intel Arc GPU
-  #           runner: '["Windows", "arc"]'
+          - gpu_type: 'arc'
+            name: Intel Arc GPU
+            runner: '["Windows", "arc"]'
 
-  #         - gpu_type: 'bmg'
-  #           name: Intel Battlemage GPU
-  #           runner: '["Windows", "bmg"]'
+          - gpu_type: 'bmg'
+            name: Intel Battlemage GPU
+            runner: '["Windows", "bmg"]'
 
-  #   uses: ./.github/workflows/sycl-windows-run-tests.yml
-  #   with:
-  #     name: ${{ matrix.name }}
-  #     runner: ${{ matrix.runner }}
-  #     target_devices: level_zero:gpu
-  #     toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
-  #     extra_lit_opts: --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}
+    uses: ./.github/workflows/sycl-windows-run-tests.yml
+    with:
+      name: ${{ matrix.name }}
+      runner: ${{ matrix.runner }}
+      target_devices: level_zero:gpu
+      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
+      extra_lit_opts: --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}
 
-  # cuda-aws-start:
-  #   needs: [ubuntu2204_build]
-  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-  #   uses: ./.github/workflows/sycl-aws.yml
-  #   secrets: inherit
-  #   with:
-  #     mode: start
+  cuda-aws-start:
+    needs: [ubuntu2204_build]
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    uses: ./.github/workflows/sycl-aws.yml
+    secrets: inherit
+    with:
+      mode: start
 
-  # cuda-run-tests:
-  #   needs: [ubuntu2204_build, cuda-aws-start]
-  #   permissions:
-  #     contents: write
-  #     packages: read
-  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
-  #   with:
-  #     name: CUDA E2E
-  #     runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
-  #     image: ghcr.io/intel/llvm/ubuntu2204_build:latest
-  #     image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
-  #     target_devices: cuda:gpu
-  #     repo_ref: ${{ github.sha }}
+  cuda-run-tests:
+    needs: [ubuntu2204_build, cuda-aws-start]
+    permissions:
+      contents: write
+      packages: read
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    uses: ./.github/workflows/sycl-linux-run-tests.yml
+    with:
+      name: CUDA E2E
+      runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
+      image: ghcr.io/intel/llvm/ubuntu2204_build:latest
+      image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
+      target_devices: cuda:gpu
+      repo_ref: ${{ github.sha }}
 
-  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-  #     # The AWS runner is not set up to use vulkan and it's out of our control.
-  #     extra_lit_opts: --filter-out bindless_images/vulkan_interop
+      # The AWS runner is not set up to use vulkan and it's out of our control.
+      extra_lit_opts: --filter-out bindless_images/vulkan_interop
 
-  # cuda-aws-stop:
-  #   needs: [cuda-aws-start, cuda-run-tests]
-  #   if: ${{ needs.cuda-aws-start.result != 'skipped' }}
-  #   uses: ./.github/workflows/sycl-aws.yml
-  #   secrets: inherit
-  #   with:
-  #     mode: stop
+  cuda-aws-stop:
+    needs: [cuda-aws-start, cuda-run-tests]
+    if: ${{ needs.cuda-aws-start.result != 'skipped' }}
+    uses: ./.github/workflows/sycl-aws.yml
+    secrets: inherit
+    with:
+      mode: stop
 
-  # build-sycl-cts-linux:
-  #   needs: ubuntu2204_build
-  #   name: Build SYCL-CTS for Linux with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #   permissions:
-  #     contents: write
-  #     packages: read
-  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       enable_new_offload_model: ['False', 'True']
-  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
-  #   with:
-  #     name: Build SYCL-CTS for Linux with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #     runner: '["Linux", "build"]'
-  #     testing_mode: 'build-only'
-  #     image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
-  #     tests_selector: cts
-  #     repo_ref: ${{ github.sha }}
-  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
-  #     binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
-  #     extra_cmake_args: ${{ matrix.enable_new_offload_model == 'True' && '-DDPCPP_FLAGS=--offload-new-driver' || '' }}
+  build-sycl-cts-linux:
+    needs: ubuntu2204_build
+    name: Build SYCL-CTS for Linux with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+    permissions:
+      contents: write
+      packages: read
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_new_offload_model: ['False', 'True']
+    uses: ./.github/workflows/sycl-linux-run-tests.yml
+    with:
+      name: Build SYCL-CTS for Linux with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: '["Linux", "build"]'
+      testing_mode: 'build-only'
+      image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
+      tests_selector: cts
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+      binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
+      extra_cmake_args: ${{ matrix.enable_new_offload_model == 'True' && '-DDPCPP_FLAGS=--offload-new-driver' || '' }}
 
-  # run-sycl-cts-linux:
-  #   needs: [ubuntu2204_build, build-sycl-cts-linux]
-  #   permissions:
-  #     contents: write
-  #     packages: read
-  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       enable_new_offload_model: ['False', 'True']
-  #       target_device: ['opencl:cpu', 'level_zero:gpu']
-  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
-  #   with:
-  #     name: SYCL CTS with ${{ matrix.target_device }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-  #     runner: '["Linux", "gen12"]'
-  #     testing_mode: 'run-only'
-  #     image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
-  #     target_devices: ${{ matrix.target_device }}
-  #     tests_selector: cts
-  #     repo_ref: ${{ github.sha }}
-  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
-  #     binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
+  run-sycl-cts-linux:
+    needs: [ubuntu2204_build, build-sycl-cts-linux]
+    permissions:
+      contents: write
+      packages: read
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_new_offload_model: ['False', 'True']
+        target_device: ['opencl:cpu', 'level_zero:gpu']
+    uses: ./.github/workflows/sycl-linux-run-tests.yml
+    with:
+      name: SYCL CTS with ${{ matrix.target_device }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: '["Linux", "gen12"]'
+      testing_mode: 'run-only'
+      image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
+      target_devices: ${{ matrix.target_device }}
+      tests_selector: cts
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+      binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
 
   build-sycl-cts-win:
     needs: build-win
@@ -405,103 +405,103 @@ jobs:
       toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
       binaries_artifact: sycl_cts_bin_win_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
 
-  # build_and_test_blender_win:
-  #   name: Build and Test Blender on Windows
-  #   needs: build-win
-  #   if: |
-  #     !cancelled()
-  #     && needs.build-win.outputs.build_conclusion == 'success'
-  #   uses: ./.github/workflows/sycl-blender-build-and-test.yml
-  #   with:
-  #     runner: '["Windows","blender"]'
-  #     level_zero_dir: "D:\\github\\level-zero_win-sdk"
-  #     ccache_dir: "D:\\github\\_work\\cache\\blender"
-  #     toolchain_artifact: sycl_windows_default
-  #     toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
+  build_and_test_blender_win:
+    name: Build and Test Blender on Windows
+    needs: build-win
+    if: |
+      !cancelled()
+      && needs.build-win.outputs.build_conclusion == 'success'
+    uses: ./.github/workflows/sycl-blender-build-and-test.yml
+    with:
+      runner: '["Windows","blender"]'
+      level_zero_dir: "D:\\github\\level-zero_win-sdk"
+      ccache_dir: "D:\\github\\_work\\cache\\blender"
+      toolchain_artifact: sycl_windows_default
+      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
 
-  # build_and_test_blender_linux:
-  #   name: Build and Test Blender on Linux
-  #   needs: ubuntu2204_build
-  #   if: |
-  #     !cancelled()
-  #     && needs.ubuntu2204_build.outputs.build_conclusion == 'success'
-  #   uses: ./.github/workflows/sycl-blender-build-and-test.yml
-  #   with:
-  #     runner: '["Linux","bmg"]'
-  #     level_zero_dir: ""
-  #     ccache_dir: "/__w/build_cache_blender"
-  #     toolchain_artifact: sycl_linux_default
-  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+  build_and_test_blender_linux:
+    name: Build and Test Blender on Linux
+    needs: ubuntu2204_build
+    if: |
+      !cancelled()
+      && needs.ubuntu2204_build.outputs.build_conclusion == 'success'
+    uses: ./.github/workflows/sycl-blender-build-and-test.yml
+    with:
+      runner: '["Linux","bmg"]'
+      level_zero_dir: ""
+      ccache_dir: "/__w/build_cache_blender"
+      toolchain_artifact: sycl_linux_default
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
 
   # Verification example:
   # cosign-windows-amd64.exe verify-blob sycl_linux.tar.gz \
   # --bundle sycl_linux.tar.gz.sigstore.json \
   # --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   # --certificate-identity https://github.com/intel/llvm/.github/workflows/sycl-nightly.yml@refs/heads/sycl
-  # nightly_build_upload:
-  #   name: Nightly Build Upload
-  #   if: ${{ github.ref_name == 'sycl' }}
-  #   needs: [get_date, ubuntu2204_build, build-win]
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write
-  #     id-token: write
-  #   steps:
-  #   - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-  #     with:
-  #       name: sycl_linux_default
-  #   - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-  #     with:
-  #       name: sycl_windows_default
-  #   - name: Sign with sigstore/cosign
-  #     uses: sigstore/gh-action-sigstore-python@a5caf349bc536fbef3668a10ed7f5cd309a4b53d # v3.2.0
-  #     with:
-  #       inputs: sycl_linux.tar.gz sycl_windows.tar.gz
-  #   - name: Compute tag
-  #     id: tag
-  #     run: |
-  #       if [ "${{ github.event_name == 'schedule' }}" == "true" ]; then
-  #         echo "TAG=${{ needs.get_date.outputs.date }}" >> "$GITHUB_OUTPUT"
-  #       else
-  #         # TODO: Use date of the commit?
-  #         echo "TAG=${{ needs.get_date.outputs.date }}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-  #       fi
-  #   - name: Upload binaries
-  #     uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-  #     with:
-  #       files: |
-  #         sycl_linux.tar.gz
-  #         sycl_windows.tar.gz
-  #         sycl_linux.tar.gz.sigstore.json
-  #         sycl_windows.tar.gz.sigstore.json
-  #       tag_name: nightly-${{ steps.tag.outputs.TAG }}
-  #       name: DPC++ daily ${{ steps.tag.outputs.TAG }}
-  #       prerelease: true
-  #       body: "Daily build ${{ steps.tag.outputs.TAG }}"
-  #       target_commitish: ${{ github.sha }}
+  nightly_build_upload:
+    name: Nightly Build Upload
+    if: ${{ github.ref_name == 'sycl' }}
+    needs: [get_date, ubuntu2204_build, build-win]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: sycl_linux_default
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: sycl_windows_default
+    - name: Sign with sigstore/cosign
+      uses: sigstore/gh-action-sigstore-python@a5caf349bc536fbef3668a10ed7f5cd309a4b53d # v3.2.0
+      with:
+        inputs: sycl_linux.tar.gz sycl_windows.tar.gz
+    - name: Compute tag
+      id: tag
+      run: |
+        if [ "${{ github.event_name == 'schedule' }}" == "true" ]; then
+          echo "TAG=${{ needs.get_date.outputs.date }}" >> "$GITHUB_OUTPUT"
+        else
+          # TODO: Use date of the commit?
+          echo "TAG=${{ needs.get_date.outputs.date }}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Upload binaries
+      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+      with:
+        files: |
+          sycl_linux.tar.gz
+          sycl_windows.tar.gz
+          sycl_linux.tar.gz.sigstore.json
+          sycl_windows.tar.gz.sigstore.json
+        tag_name: nightly-${{ steps.tag.outputs.TAG }}
+        name: DPC++ daily ${{ steps.tag.outputs.TAG }}
+        prerelease: true
+        body: "Daily build ${{ steps.tag.outputs.TAG }}"
+        target_commitish: ${{ github.sha }}
 
-  # docker_build_push:
-  #   if: github.repository == 'intel/llvm'
-  #   runs-on: [Linux, build]
-  #   permissions:
-  #     packages: write
-  #   needs: ubuntu2204_build
-  #   steps:
-  #   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-  #   - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-  #     with:
-  #       name: sycl_linux_default
-  #       path: devops/
-  #   - name: Build and Push Container
-  #     uses: ./devops/actions/build_container
-  #     with:
-  #       push: ${{ github.ref_name == 'sycl' }}
-  #       file: nightly
-  #       username: ${{ github.repository_owner }}
-  #       password: ${{ secrets.GITHUB_TOKEN }}
-  #       build-args: |
-  #         base_image=ghcr.io/intel/llvm/ubuntu2404_intel_drivers
-  #         base_tag=latest
-  #       tags: |
-  #         ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:${{ github.sha }}
-  #         ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:latest
+  docker_build_push:
+    if: github.repository == 'intel/llvm'
+    runs-on: [Linux, build]
+    permissions:
+      packages: write
+    needs: ubuntu2204_build
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: sycl_linux_default
+        path: devops/
+    - name: Build and Push Container
+      uses: ./devops/actions/build_container
+      with:
+        push: ${{ github.ref_name == 'sycl' }}
+        file: nightly
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        build-args: |
+          base_image=ghcr.io/intel/llvm/ubuntu2404_intel_drivers
+          base_tag=latest
+        tags: |
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:${{ github.sha }}
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:latest

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -352,7 +352,7 @@ jobs:
       fail-fast: false
       matrix:
         enable_new_offload_model: ['False', 'True']
-        target:
+        include:
           - name: SYCL-CTS on OCL CPU
             runner: '["Linux", "gen12"]'
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
@@ -364,11 +364,11 @@ jobs:
             target_devices: level_zero:gpu
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
-      name: ${{ matrix.target.name }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: ${{ matrix.target.runner }}
+      name: ${{ matrix.name }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: ${{ matrix.runner }}
       testing_mode: 'run-only'
-      image_options: ${{ matrix.target.image_options }}
-      target_devices: ${{ matrix.target.target_devices }}
+      image_options: ${{ matrix.image_options }}
+      target_devices: ${{ matrix.target_devices }}
       tests_selector: cts
       repo_ref: ${{ github.sha }}
       toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -393,7 +393,7 @@ jobs:
       fail-fast: false
       matrix:
         enable_new_offload_model: ['False', 'True']
-        target_devices: ['level_zero:gpu']
+        target_device: ['level_zero:gpu']
     uses: ./.github/workflows/sycl-windows-run-tests.yml
     with:
       name: SYCL-CTS with ${{ matrix.target_device }}, ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -50,272 +50,272 @@ jobs:
       toolchain_artifact_filename: sycl_linux.tar.gz
 
   # Build used for performance testing only: not intended for testing
-  linux_shared_build:
-    if: github.repository == 'intel/llvm'
-    uses: ./.github/workflows/sycl-linux-build.yml
-    secrets: inherit
-    with:
-      build_cache_root: "/__w/"
-      build_cache_suffix: sprod_shared
-      build_configure_extra_args: '--shared-libs --cuda --native_cpu --no-assertions'
-      build_target: all
+  # linux_shared_build:
+  #   if: github.repository == 'intel/llvm'
+  #   uses: ./.github/workflows/sycl-linux-build.yml
+  #   secrets: inherit
+  #   with:
+  #     build_cache_root: "/__w/"
+  #     build_cache_suffix: sprod_shared
+  #     build_configure_extra_args: '--shared-libs --cuda --native_cpu --no-assertions'
+  #     build_target: all
 
-      toolchain_artifact: sycl_linux_sprod_shared
-      toolchain_artifact_filename: sycl_linux_shared.tar.zst
+  #     toolchain_artifact: sycl_linux_sprod_shared
+  #     toolchain_artifact_filename: sycl_linux_shared.tar.zst
 
-  ubuntu2404_oneapi_build:
-    if: github.repository == 'intel/llvm'
-    uses: ./.github/workflows/sycl-linux-build.yml
-    secrets: inherit
-    with:
-      build_cache_root: "/__w/"
-      build_cache_suffix: oneapi
-      build_configure_extra_args: -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
-      cc: icx
-      cxx: icpx
+  # ubuntu2404_oneapi_build:
+  #   if: github.repository == 'intel/llvm'
+  #   uses: ./.github/workflows/sycl-linux-build.yml
+  #   secrets: inherit
+  #   with:
+  #     build_cache_root: "/__w/"
+  #     build_cache_suffix: oneapi
+  #     build_configure_extra_args: -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
+  #     cc: icx
+  #     cxx: icpx
 
-      toolchain_artifact: sycl_linux_oneapi
-      toolchain_artifact_filename: sycl_linux_oneapi.tar.zst
+  #     toolchain_artifact: sycl_linux_oneapi
+  #     toolchain_artifact_filename: sycl_linux_oneapi.tar.zst
 
-  ubuntu2404_libcxx_build:
-    if: github.repository == 'intel/llvm'
-    uses: ./.github/workflows/sycl-linux-build.yml
-    secrets: inherit
-    with:
-      build_cache_root: "/__w/"
-      build_cache_suffix: libcxx
-      build_configure_extra_args: --use-libcxx -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=OFF
-      cc: clang-18
-      cxx: clang++-18
+  # ubuntu2404_libcxx_build:
+  #   if: github.repository == 'intel/llvm'
+  #   uses: ./.github/workflows/sycl-linux-build.yml
+  #   secrets: inherit
+  #   with:
+  #     build_cache_root: "/__w/"
+  #     build_cache_suffix: libcxx
+  #     build_configure_extra_args: --use-libcxx -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=OFF
+  #     cc: clang-18
+  #     cxx: clang++-18
 
-      toolchain_artifact: sycl_linux_libcxx
-      toolchain_artifact_filename: sycl_linux_libcxx.tar.zst
+  #     toolchain_artifact: sycl_linux_libcxx
+  #     toolchain_artifact_filename: sycl_linux_libcxx.tar.zst
 
-  ubuntu2204_test_nvidia_gen12:
-    needs: [ubuntu2204_build]
-    name: E2E NVIDIA and GEN12 OCL with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-    permissions:
-      contents: write
-      packages: read
-    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        enable_new_offload_model: ['False', 'True']
-        arch: ['cuda', 'gen12']
-        include:
-          - arch: 'cuda'
-            image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
-            target_devices: 'cuda:gpu'
+  # ubuntu2204_test_nvidia_gen12:
+  #   needs: [ubuntu2204_build]
+  #   name: E2E NVIDIA and GEN12 OCL with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #   permissions:
+  #     contents: write
+  #     packages: read
+  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       enable_new_offload_model: ['False', 'True']
+  #       arch: ['cuda', 'gen12']
+  #       include:
+  #         - arch: 'cuda'
+  #           image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
+  #           target_devices: 'cuda:gpu'
 
-          - arch: 'gen12'
-            target_devices: 'opencl:gpu'
+  #         - arch: 'gen12'
+  #           target_devices: 'opencl:gpu'
 
-    uses: ./.github/workflows/sycl-linux-run-tests.yml
-    with:
-      name: ${{ matrix.arch }} (${{ matrix.target_devices }}) with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: '["Linux", "${{ matrix.arch }}"]'
-      image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' }}
-      target_devices: ${{ matrix.target_devices }}
-      tests_selector: e2e
-      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
-      repo_ref: ${{ github.sha }}
-      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
+  #   with:
+  #     name: ${{ matrix.arch }} (${{ matrix.target_devices }}) with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #     runner: '["Linux", "${{ matrix.arch }}"]'
+  #     image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' }}
+  #     target_devices: ${{ matrix.target_devices }}
+  #     tests_selector: e2e
+  #     extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
+  #     repo_ref: ${{ github.sha }}
+  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-  ubuntu2204_test_intel_level_zero:
-    needs: [ubuntu2204_build]
-    name: E2E L0 with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-    permissions:
-      contents: write
-      packages: read
-    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        enable_new_offload_model: ['False', 'True']
-        arch: ['gen12', 'pvc', 'bmg', 'arc']
+  # ubuntu2204_test_intel_level_zero:
+  #   needs: [ubuntu2204_build]
+  #   name: E2E L0 with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #   permissions:
+  #     contents: write
+  #     packages: read
+  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       enable_new_offload_model: ['False', 'True']
+  #       arch: ['gen12', 'pvc', 'bmg', 'arc']
 
-    uses: ./.github/workflows/sycl-linux-run-tests.yml
-    with:
-      name: Intel L0 ${{ matrix.arch }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: '["Linux", "${{ matrix.arch }}"]'
-      image_options: '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN'
-      target_devices: level_zero:gpu
-      tests_selector: e2e
-      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
-      repo_ref: ${{ github.sha }}
-      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
+  #   with:
+  #     name: Intel L0 ${{ matrix.arch }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #     runner: '["Linux", "${{ matrix.arch }}"]'
+  #     image_options: '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN'
+  #     target_devices: level_zero:gpu
+  #     tests_selector: e2e
+  #     extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
+  #     repo_ref: ${{ github.sha }}
+  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-  ubuntu2204_test_intel_amd_opencl_cpu:
-    needs: [ubuntu2204_build]
-    name: E2E OpenCL CPU for Intel and AMD with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-    permissions:
-      contents: write
-      packages: read
-    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        enable_new_offload_model: ['False', 'True']
-        arch: ['amdcpu', 'gen12', 'arc']
-        include:
-          - arch: 'gen12'
-            image_options: --privileged --cap-add SYS_ADMIN
+  # ubuntu2204_test_intel_amd_opencl_cpu:
+  #   needs: [ubuntu2204_build]
+  #   name: E2E OpenCL CPU for Intel and AMD with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #   permissions:
+  #     contents: write
+  #     packages: read
+  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       enable_new_offload_model: ['False', 'True']
+  #       arch: ['amdcpu', 'gen12', 'arc']
+  #       include:
+  #         - arch: 'gen12'
+  #           image_options: --privileged --cap-add SYS_ADMIN
 
-    uses: ./.github/workflows/sycl-linux-run-tests.yml
-    with:
-      name: ${{ matrix.arch }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: '["Linux", "${{ matrix.arch }}"]'
-      image_options: -u 1001 ${{ matrix.image_options }}
-      target_devices: opencl:cpu
-      tests_selector: e2e
-      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
-      repo_ref: ${{ github.sha }}
-      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
+  #   with:
+  #     name: ${{ matrix.arch }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #     runner: '["Linux", "${{ matrix.arch }}"]'
+  #     image_options: -u 1001 ${{ matrix.image_options }}
+  #     target_devices: opencl:cpu
+  #     tests_selector: e2e
+  #     extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
+  #     repo_ref: ${{ github.sha }}
+  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-  ubuntu2204_test_preview_mode:
-    needs: [ubuntu2204_build]
-    permissions:
-      contents: write
-      packages: read
-    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Preview mode on NVIDIA/CUDA
-            runner: '["Linux", "cuda"]'
-            image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
-            target_devices: cuda:gpu
+  # ubuntu2204_test_preview_mode:
+  #   needs: [ubuntu2204_build]
+  #   permissions:
+  #     contents: write
+  #     packages: read
+  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - name: Preview mode on NVIDIA/CUDA
+  #           runner: '["Linux", "cuda"]'
+  #           image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
+  #           target_devices: cuda:gpu
 
-          - name: Preview mode on Intel L0 Battlemage GPU
-            runner: '["Linux", "bmg"]'
-            target_devices: level_zero:gpu
+  #         - name: Preview mode on Intel L0 Battlemage GPU
+  #           runner: '["Linux", "bmg"]'
+  #           target_devices: level_zero:gpu
 
-          - name: Preview mode on SPR/PVC
-            runner: '["Linux", "pvc"]'
-            target_devices: level_zero:gpu
+  #         - name: Preview mode on SPR/PVC
+  #           runner: '["Linux", "pvc"]'
+  #           target_devices: level_zero:gpu
 
-    uses: ./.github/workflows/sycl-linux-run-tests.yml
-    with:
-      name: ${{ matrix.name }}
-      runner: ${{ matrix.runner }}
-      image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' }}
-      target_devices: ${{ matrix.target_devices }}
-      tests_selector: e2e
-      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param test-preview-mode=True"
-      repo_ref: ${{ github.sha }}
-      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
+  #   with:
+  #     name: ${{ matrix.name }}
+  #     runner: ${{ matrix.runner }}
+  #     image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN' }}
+  #     target_devices: ${{ matrix.target_devices }}
+  #     tests_selector: e2e
+  #     extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param test-preview-mode=True"
+  #     repo_ref: ${{ github.sha }}
+  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-  ubuntu2404_oneapi_test:
-    needs: [ubuntu2404_oneapi_build]
-    permissions:
-      contents: write
-      packages: read
-    if: ${{ !cancelled() && needs.ubuntu2404_oneapi_build.outputs.build_conclusion == 'success' }}
-    uses: ./.github/workflows/sycl-linux-run-tests.yml
-    with:
-      name: Intel PVC L0 oneAPI
-      runner: '["Linux", "pvc"]'
-      target_devices: level_zero:gpu
-      extra_lit_opts: -j 50
-      image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
-      repo_ref: ${{ github.sha }}
-      toolchain_artifact: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact }}
-      toolchain_artifact_filename: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact_filename }}
-      toolchain_decompress_command: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_decompress_command }}
+  # ubuntu2404_oneapi_test:
+  #   needs: [ubuntu2404_oneapi_build]
+  #   permissions:
+  #     contents: write
+  #     packages: read
+  #   if: ${{ !cancelled() && needs.ubuntu2404_oneapi_build.outputs.build_conclusion == 'success' }}
+  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
+  #   with:
+  #     name: Intel PVC L0 oneAPI
+  #     runner: '["Linux", "pvc"]'
+  #     target_devices: level_zero:gpu
+  #     extra_lit_opts: -j 50
+  #     image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
+  #     repo_ref: ${{ github.sha }}
+  #     toolchain_artifact: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact }}
+  #     toolchain_artifact_filename: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_artifact_filename }}
+  #     toolchain_decompress_command: ${{ needs.ubuntu2404_oneapi_build.outputs.toolchain_decompress_command }}
 
-  build-win:
-    needs: get_date
-    uses: ./.github/workflows/sycl-windows-build.yml
-    if: github.repository == 'intel/llvm'
-    with:
-      retention-days: 90
-      # We upload both Linux/Windows build via Github's "Releases"
-      # functionality, make sure Linux/Windows names follow the same pattern.
-      toolchain_artifact_filename: sycl_windows.tar.gz
-      # Disable the spirv-dis requirement as to not require SPIR-V Tools.
-      build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off -DSYCL_BUILD_INFO="Nightly ${{ needs.get_date.outputs.date }}"
-      build_target: all
+  # build-win:
+  #   needs: get_date
+  #   uses: ./.github/workflows/sycl-windows-build.yml
+  #   if: github.repository == 'intel/llvm'
+  #   with:
+  #     retention-days: 90
+  #     # We upload both Linux/Windows build via Github's "Releases"
+  #     # functionality, make sure Linux/Windows names follow the same pattern.
+  #     toolchain_artifact_filename: sycl_windows.tar.gz
+  #     # Disable the spirv-dis requirement as to not require SPIR-V Tools.
+  #     build_configure_extra_args: -DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=off -DSYCL_BUILD_INFO="Nightly ${{ needs.get_date.outputs.date }}"
+  #     build_target: all
 
-  e2e-win:
-    needs: build-win
-    name: E2E win with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-    # Continue if build was successful.
-    if: |
-      !cancelled()
-      && needs.build-win.outputs.build_conclusion == 'success'
-    strategy:
-      fail-fast: false
-      matrix:
-        enable_new_offload_model: ['False', 'True']
-        gpu_type: ['gen12', 'arc', 'bmg']
-        include:
-          - gpu_type: 'gen12'
-            name: Intel Gen12 GPU
-            runner: '["Windows", "gen12"]'
+  # e2e-win:
+  #   needs: build-win
+  #   name: E2E win with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #   # Continue if build was successful.
+  #   if: |
+  #     !cancelled()
+  #     && needs.build-win.outputs.build_conclusion == 'success'
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       enable_new_offload_model: ['False', 'True']
+  #       gpu_type: ['gen12', 'arc', 'bmg']
+  #       include:
+  #         - gpu_type: 'gen12'
+  #           name: Intel Gen12 GPU
+  #           runner: '["Windows", "gen12"]'
 
-          - gpu_type: 'arc'
-            name: Intel Arc GPU
-            runner: '["Windows", "arc"]'
+  #         - gpu_type: 'arc'
+  #           name: Intel Arc GPU
+  #           runner: '["Windows", "arc"]'
 
-          - gpu_type: 'bmg'
-            name: Intel Battlemage GPU
-            runner: '["Windows", "bmg"]'
+  #         - gpu_type: 'bmg'
+  #           name: Intel Battlemage GPU
+  #           runner: '["Windows", "bmg"]'
 
-    uses: ./.github/workflows/sycl-windows-run-tests.yml
-    with:
-      name: ${{ matrix.name }}
-      runner: ${{ matrix.runner }}
-      target_devices: level_zero:gpu
-      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
-      extra_lit_opts: --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}
+  #   uses: ./.github/workflows/sycl-windows-run-tests.yml
+  #   with:
+  #     name: ${{ matrix.name }}
+  #     runner: ${{ matrix.runner }}
+  #     target_devices: level_zero:gpu
+  #     toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
+  #     extra_lit_opts: --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}
 
-  cuda-aws-start:
-    needs: [ubuntu2204_build]
-    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-    uses: ./.github/workflows/sycl-aws.yml
-    secrets: inherit
-    with:
-      mode: start
+  # cuda-aws-start:
+  #   needs: [ubuntu2204_build]
+  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+  #   uses: ./.github/workflows/sycl-aws.yml
+  #   secrets: inherit
+  #   with:
+  #     mode: start
 
-  cuda-run-tests:
-    needs: [ubuntu2204_build, cuda-aws-start]
-    permissions:
-      contents: write
-      packages: read
-    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
-    uses: ./.github/workflows/sycl-linux-run-tests.yml
-    with:
-      name: CUDA E2E
-      runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
-      image: ghcr.io/intel/llvm/ubuntu2204_build:latest
-      image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
-      target_devices: cuda:gpu
-      repo_ref: ${{ github.sha }}
+  # cuda-run-tests:
+  #   needs: [ubuntu2204_build, cuda-aws-start]
+  #   permissions:
+  #     contents: write
+  #     packages: read
+  #   if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+  #   uses: ./.github/workflows/sycl-linux-run-tests.yml
+  #   with:
+  #     name: CUDA E2E
+  #     runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
+  #     image: ghcr.io/intel/llvm/ubuntu2204_build:latest
+  #     image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
+  #     target_devices: cuda:gpu
+  #     repo_ref: ${{ github.sha }}
 
-      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
-      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
-      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+  #     toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+  #     toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
-      # The AWS runner is not set up to use vulkan and it's out of our control.
-      extra_lit_opts: --filter-out bindless_images/vulkan_interop
+  #     # The AWS runner is not set up to use vulkan and it's out of our control.
+  #     extra_lit_opts: --filter-out bindless_images/vulkan_interop
 
-  cuda-aws-stop:
-    needs: [cuda-aws-start, cuda-run-tests]
-    if: ${{ needs.cuda-aws-start.result != 'skipped' }}
-    uses: ./.github/workflows/sycl-aws.yml
-    secrets: inherit
-    with:
-      mode: stop
+  # cuda-aws-stop:
+  #   needs: [cuda-aws-start, cuda-run-tests]
+  #   if: ${{ needs.cuda-aws-start.result != 'skipped' }}
+  #   uses: ./.github/workflows/sycl-aws.yml
+  #   secrets: inherit
+  #   with:
+  #     mode: stop
 
   build-sycl-cts-linux:
     needs: ubuntu2204_build
@@ -376,144 +376,144 @@ jobs:
       toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
       binaries_artifact: sycl_cts_bin_linux_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
 
-  build-sycl-cts-win:
-    needs: build-win
-    name: Build SYCL-CTS for Windows with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-    if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        enable_new_offload_model: ['False', 'True']
-    uses: ./.github/workflows/sycl-windows-run-tests.yml
-    with:
-      name: Build SYCL-CTS for Windows with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: '["Windows", "build"]'
-      testing_mode: 'build-only'
-      tests_selector: cts
-      repo_ref: ${{ github.sha }}
-      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
-      binaries_artifact: sycl_cts_bin_win_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
-      extra_cmake_args: ${{ matrix.enable_new_offload_model == 'True' && '-DDPCPP_FLAGS=--offload-new-driver' || '' }}
+  # build-sycl-cts-win:
+  #   needs: build-win
+  #   name: Build SYCL-CTS for Windows with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #   if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       enable_new_offload_model: ['False', 'True']
+  #   uses: ./.github/workflows/sycl-windows-run-tests.yml
+  #   with:
+  #     name: Build SYCL-CTS for Windows with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #     runner: '["Windows", "build"]'
+  #     testing_mode: 'build-only'
+  #     tests_selector: cts
+  #     repo_ref: ${{ github.sha }}
+  #     toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
+  #     binaries_artifact: sycl_cts_bin_win_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
+  #     extra_cmake_args: ${{ matrix.enable_new_offload_model == 'True' && '-DDPCPP_FLAGS=--offload-new-driver' || '' }}
 
-  run-sycl-cts-win:
-    needs: [build-win, build-sycl-cts-win]
-    if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        enable_new_offload_model: ['False', 'True']
-        include:
-          - name: SYCL-CTS on L0 gen12
-            runner: '["Windows", "gen12"]'
-            target_devices: level_zero:gpu
-    uses: ./.github/workflows/sycl-windows-run-tests.yml
-    with:
-      name: ${{ matrix.name }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
-      runner: ${{ matrix.runner }}
-      testing_mode: 'run-only'
-      target_devices: ${{ matrix.target_devices }}
-      tests_selector: cts
-      repo_ref: ${{ github.sha }}
-      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
-      binaries_artifact: sycl_cts_bin_win_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
+  # run-sycl-cts-win:
+  #   needs: [build-win, build-sycl-cts-win]
+  #   if: ${{ !cancelled() && needs.build-win.outputs.build_conclusion == 'success' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       enable_new_offload_model: ['False', 'True']
+  #       include:
+  #         - name: SYCL-CTS on L0 gen12
+  #           runner: '["Windows", "gen12"]'
+  #           target_devices: level_zero:gpu
+  #   uses: ./.github/workflows/sycl-windows-run-tests.yml
+  #   with:
+  #     name: ${{ matrix.name }} with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+  #     runner: ${{ matrix.runner }}
+  #     testing_mode: 'run-only'
+  #     target_devices: ${{ matrix.target_devices }}
+  #     tests_selector: cts
+  #     repo_ref: ${{ github.sha }}
+  #     toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
+  #     binaries_artifact: sycl_cts_bin_win_${{ matrix.enable_new_offload_model == 'True' && 'new_offload' || 'old_offload' }}
 
-  build_and_test_blender_win:
-    name: Build and Test Blender on Windows
-    needs: build-win
-    if: |
-      !cancelled()
-      && needs.build-win.outputs.build_conclusion == 'success'
-    uses: ./.github/workflows/sycl-blender-build-and-test.yml
-    with:
-      runner: '["Windows","blender"]'
-      level_zero_dir: "D:\\github\\level-zero_win-sdk"
-      ccache_dir: "D:\\github\\_work\\cache\\blender"
-      toolchain_artifact: sycl_windows_default
-      toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
+  # build_and_test_blender_win:
+  #   name: Build and Test Blender on Windows
+  #   needs: build-win
+  #   if: |
+  #     !cancelled()
+  #     && needs.build-win.outputs.build_conclusion == 'success'
+  #   uses: ./.github/workflows/sycl-blender-build-and-test.yml
+  #   with:
+  #     runner: '["Windows","blender"]'
+  #     level_zero_dir: "D:\\github\\level-zero_win-sdk"
+  #     ccache_dir: "D:\\github\\_work\\cache\\blender"
+  #     toolchain_artifact: sycl_windows_default
+  #     toolchain_artifact_filename: ${{ needs.build-win.outputs.toolchain_artifact_filename }}
 
-  build_and_test_blender_linux:
-    name: Build and Test Blender on Linux
-    needs: ubuntu2204_build
-    if: |
-      !cancelled()
-      && needs.ubuntu2204_build.outputs.build_conclusion == 'success'
-    uses: ./.github/workflows/sycl-blender-build-and-test.yml
-    with:
-      runner: '["Linux","bmg"]'
-      level_zero_dir: ""
-      ccache_dir: "/__w/build_cache_blender"
-      toolchain_artifact: sycl_linux_default
-      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+  # build_and_test_blender_linux:
+  #   name: Build and Test Blender on Linux
+  #   needs: ubuntu2204_build
+  #   if: |
+  #     !cancelled()
+  #     && needs.ubuntu2204_build.outputs.build_conclusion == 'success'
+  #   uses: ./.github/workflows/sycl-blender-build-and-test.yml
+  #   with:
+  #     runner: '["Linux","bmg"]'
+  #     level_zero_dir: ""
+  #     ccache_dir: "/__w/build_cache_blender"
+  #     toolchain_artifact: sycl_linux_default
+  #     toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
 
   # Verification example:
   # cosign-windows-amd64.exe verify-blob sycl_linux.tar.gz \
   # --bundle sycl_linux.tar.gz.sigstore.json \
   # --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   # --certificate-identity https://github.com/intel/llvm/.github/workflows/sycl-nightly.yml@refs/heads/sycl
-  nightly_build_upload:
-    name: Nightly Build Upload
-    if: ${{ github.ref_name == 'sycl' }}
-    needs: [get_date, ubuntu2204_build, build-win]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: sycl_linux_default
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: sycl_windows_default
-    - name: Sign with sigstore/cosign
-      uses: sigstore/gh-action-sigstore-python@a5caf349bc536fbef3668a10ed7f5cd309a4b53d # v3.2.0
-      with:
-        inputs: sycl_linux.tar.gz sycl_windows.tar.gz
-    - name: Compute tag
-      id: tag
-      run: |
-        if [ "${{ github.event_name == 'schedule' }}" == "true" ]; then
-          echo "TAG=${{ needs.get_date.outputs.date }}" >> "$GITHUB_OUTPUT"
-        else
-          # TODO: Use date of the commit?
-          echo "TAG=${{ needs.get_date.outputs.date }}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-        fi
-    - name: Upload binaries
-      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-      with:
-        files: |
-          sycl_linux.tar.gz
-          sycl_windows.tar.gz
-          sycl_linux.tar.gz.sigstore.json
-          sycl_windows.tar.gz.sigstore.json
-        tag_name: nightly-${{ steps.tag.outputs.TAG }}
-        name: DPC++ daily ${{ steps.tag.outputs.TAG }}
-        prerelease: true
-        body: "Daily build ${{ steps.tag.outputs.TAG }}"
-        target_commitish: ${{ github.sha }}
+  # nightly_build_upload:
+  #   name: Nightly Build Upload
+  #   if: ${{ github.ref_name == 'sycl' }}
+  #   needs: [get_date, ubuntu2204_build, build-win]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #     id-token: write
+  #   steps:
+  #   - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+  #     with:
+  #       name: sycl_linux_default
+  #   - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+  #     with:
+  #       name: sycl_windows_default
+  #   - name: Sign with sigstore/cosign
+  #     uses: sigstore/gh-action-sigstore-python@a5caf349bc536fbef3668a10ed7f5cd309a4b53d # v3.2.0
+  #     with:
+  #       inputs: sycl_linux.tar.gz sycl_windows.tar.gz
+  #   - name: Compute tag
+  #     id: tag
+  #     run: |
+  #       if [ "${{ github.event_name == 'schedule' }}" == "true" ]; then
+  #         echo "TAG=${{ needs.get_date.outputs.date }}" >> "$GITHUB_OUTPUT"
+  #       else
+  #         # TODO: Use date of the commit?
+  #         echo "TAG=${{ needs.get_date.outputs.date }}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+  #       fi
+  #   - name: Upload binaries
+  #     uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+  #     with:
+  #       files: |
+  #         sycl_linux.tar.gz
+  #         sycl_windows.tar.gz
+  #         sycl_linux.tar.gz.sigstore.json
+  #         sycl_windows.tar.gz.sigstore.json
+  #       tag_name: nightly-${{ steps.tag.outputs.TAG }}
+  #       name: DPC++ daily ${{ steps.tag.outputs.TAG }}
+  #       prerelease: true
+  #       body: "Daily build ${{ steps.tag.outputs.TAG }}"
+  #       target_commitish: ${{ github.sha }}
 
-  docker_build_push:
-    if: github.repository == 'intel/llvm'
-    runs-on: [Linux, build]
-    permissions:
-      packages: write
-    needs: ubuntu2204_build
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: sycl_linux_default
-        path: devops/
-    - name: Build and Push Container
-      uses: ./devops/actions/build_container
-      with:
-        push: ${{ github.ref_name == 'sycl' }}
-        file: nightly
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        build-args: |
-          base_image=ghcr.io/intel/llvm/ubuntu2404_intel_drivers
-          base_tag=latest
-        tags: |
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:${{ github.sha }}
-          ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:latest
+  # docker_build_push:
+  #   if: github.repository == 'intel/llvm'
+  #   runs-on: [Linux, build]
+  #   permissions:
+  #     packages: write
+  #   needs: ubuntu2204_build
+  #   steps:
+  #   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #   - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+  #     with:
+  #       name: sycl_linux_default
+  #       path: devops/
+  #   - name: Build and Push Container
+  #     uses: ./devops/actions/build_container
+  #     with:
+  #       push: ${{ github.ref_name == 'sycl' }}
+  #       file: nightly
+  #       username: ${{ github.repository_owner }}
+  #       password: ${{ secrets.GITHUB_TOKEN }}
+  #       build-args: |
+  #         base_image=ghcr.io/intel/llvm/ubuntu2404_intel_drivers
+  #         base_tag=latest
+  #       tags: |
+  #         ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:${{ github.sha }}
+  #         ghcr.io/${{ github.repository }}/sycl_ubuntu2404_nightly:latest


### PR DESCRIPTION
Recent change added the sycl-cts launch with new offload model, but sycl-cts on CPU was ignored. Update matrix to re-enable it.