### PR TITLE
[SYCL] Remove object format devicelib files (#21711)

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -1,10 +1,8 @@
 include(CheckCXXCompilerFlag)
 set(obj_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 if (MSVC)
-  set(obj-suffix obj)
   set(devicelib_host_static_obj sycl-devicelib-host.lib)
 else()
-  set(obj-suffix o)
   set(devicelib_host_static_obj libsycl-devicelib-host.a)
 endif()
 set(bc-suffix bc)
@@ -69,7 +67,7 @@ endif()
 
 add_custom_target(libsycldevice)
 
-set(filetypes obj bc)
+set(filetypes bc)
 
 foreach(filetype IN LISTS filetypes)
   add_custom_target(libsycldevice-${filetype})
@@ -97,7 +95,6 @@ endif()
 
 
 set(bc_device_compile_opts -fsycl-device-only -fsycl-device-obj=llvmir)
-set(obj_device_compile_opts -fsycl -c ${sycl_targets_opt} --no-offload-new-driver)
 
 # Compiles and installs a single device library.
 #
@@ -681,6 +678,8 @@ foreach(datatype IN ITEMS fp32 fp64 bf16)
      DEPENDS ${imf_${datatype}_fallback_src})
 endforeach()
 
+add_custom_target(libsycldevice-obj)
+add_dependencies(libsycldevice libsycldevice-obj)
 # Adds Intel math functions libraries.
 #
 # Arguments:

--- a/sycl/test-e2e/Config/kernel_from_file.cpp
+++ b/sycl/test-e2e/Config/kernel_from_file.cpp
@@ -4,11 +4,8 @@
 // As we are doing a separate device compilation here, we need to explicitly
 // add the device lib instrumentation (itt_compiler_wrapper)
 // RUN: %clangxx -Wno-error=ignored-attributes -DUSED_KERNEL -fno-sycl-dead-args-optimization %cxx_std_optionc++17 -fsycl-device-only -Xclang -fsycl-int-header=%t.h %s -o %t.bc -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict
-// >> ---- unbundle compiler wrapper and asan device objects
-// RUN: clang-offload-bundler -type=o -targets=sycl-spir64-unknown-unknown -input=%sycl_static_libs_dir/libsycl-itt-compiler-wrappers%obj_ext -output=%t_compiler_wrappers.bc -unbundle
-// RUN: %if linux %{ clang-offload-bundler -type=o -targets=sycl-spir64-unknown-unknown -input=%sycl_static_libs_dir/libsycl-asan%obj_ext -output=%t_asan.bc -unbundle %}
 // >> ---- link device code
-// RUN: %if linux %{ llvm-link -o=%t_app.bc %t.bc %t_compiler_wrappers.bc %t_asan.bc %} %else %{ llvm-link -o=%t_app.bc %t.bc %t_compiler_wrappers.bc %}
+// RUN: %if linux %{ llvm-link -o=%t_app.bc %t.bc %sycl_static_libs_dir/libsycl-itt-compiler-wrappers.bc %sycl_static_libs_dir/libsycl-asan.bc %} %else %{ llvm-link -o=%t_app.bc %t.bc %sycl_static_libs_dir/libsycl-itt-compiler-wrappers.bc %}
 // >> ---- translate to SPIR-V
 // RUN: llvm-spirv -o %t.spv %t_app.bc
 // Need to perform full compilation here since the SYCL runtime uses image

--- a/sycl/test-e2e/SeparateCompile/test.cpp
+++ b/sycl/test-e2e/SeparateCompile/test.cpp
@@ -29,13 +29,9 @@
 //
 // As we are doing a separate device compilation here, we need to explicitly
 // add the device lib instrumentation (itt_compiler_wrapper)
-// >> ---- unbundle compiler wrapper device object
-// RUN: clang-offload-bundler -type=o -targets=sycl-spir64-unknown-unknown -input=%sycl_static_libs_dir/libsycl-itt-compiler-wrappers%obj_ext -output=compiler_wrappers.bc -unbundle
-// RUN: clang-offload-bundler -type=o -targets=sycl-spir64-unknown-unknown -input=%sycl_static_libs_dir/libsycl-itt-stubs%obj_ext -output=itt_stubs.bc -unbundle
-// RUN: clang-offload-bundler -type=o -targets=sycl-spir64-unknown-unknown -input=%sycl_static_libs_dir/libsycl-itt-user-wrappers%obj_ext -output=user_wrappers.bc -unbundle
 //
 // >> ---- link device code
-// RUN: llvm-link -o=app.bc a_kernel.bc b_kernel.bc compiler_wrappers.bc itt_stubs.bc user_wrappers.bc
+// RUN: llvm-link -o=app.bc a_kernel.bc b_kernel.bc %sycl_static_libs_dir/libsycl-itt-compiler-wrappers.bc %sycl_static_libs_dir/libsycl-itt-stubs.bc %sycl_static_libs_dir/libsycl-itt-user-wrappers.bc
 //
 // >> ---- produce entries data
 // RUN: sycl-post-link -split=auto -emit-param-info -symbols -emit-exported-symbols  -o test.table app.bc


### PR DESCRIPTION
Cherry pick of https://github.com/intel/llvm/commit/c7b0546c601c08e9d5238afe31d07ac23d4932a8

In https://github.com/intel/llvm/pull/21672, we removed .new.o format devicelib file and use .bc format devicelib files for both new and old offloading model driver. This PR removes .o format devicelib files since they are not used in current pipeline either.

---------