### PR TITLE
[libdevice] Mark external C functions weak after f07988ff3ec8

### DIFF
--- a/libdevice/nativecpu_utils.cpp
+++ b/libdevice/nativecpu_utils.cpp
@@ -25,7 +25,7 @@ using __nativecpu_state = native_cpu::state;
 
 #undef DEVICE_EXTERNAL
 #undef DEVICE_EXTERN_C
-#define DEVICE_EXTERN_C extern "C" SYCL_EXTERNAL __attribute__((libclc_call))
+#define DEVICE_EXTERN_C extern "C" SYCL_EXTERNAL __attribute__((libclc_call, weak))
 #define DEVICE_EXTERNAL_C DEVICE_EXTERN_C __attribute__((always_inline))
 #define DEVICE_EXTERNAL                                                        \
   SYCL_EXTERNAL __attribute__((always_inline, libclc_call))


### PR DESCRIPTION
Cherry pick of https://github.com/intel/llvm/commit/588723b23b8acdb91cb903b3e15ab9be5382bafe

We relies on prepare-builtins.cpp to
`Set linkage of every external definition to linkonce_odr`

With f07988ff3ec8, prepare-builtins is no longer called, so we need to mark the weak in source directly.

Fixes multiple definition of `__dpcpp_nativecpu_get_global_id' etc in

SYCL :: native_cpu/multiple_tu.cpp