### PR TITLE
[CI] Use self-hosted runners for nightly get_date step

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -26,7 +26,7 @@ jobs:
         git diff --exit-code -I "^# RUN" origin/sycl-rel-6_3:sycl/test/abi/sycl_symbols_windows.dump sycl/test/abi/sycl_symbols_windows-sycl-rel-6_3.dump
 
   get_date:
-    runs-on: ubuntu-latest
+    runs-on: [Linux, aux-tasks]
     outputs:
       date: ${{ steps.get_date.outputs.date }}
     steps:


### PR DESCRIPTION
Currently we use the GitHub runners which can sometimes take multiple hours to allocate, and the command it's running takes much less than a second. Just use our runners.

Example run: https://github.com/intel/llvm/actions/runs/26529804406/job/78143135962