### PR TITLE
[UR/offload] Change CUDA package to CUDAToolkit in CMakeLists.txt

### DIFF
--- a/unified-runtime/source/adapters/offload/CMakeLists.txt
+++ b/unified-runtime/source/adapters/offload/CMakeLists.txt
@@ -110,7 +110,7 @@ endif()
 # simply always link the incoming program so it ends up as CUBIN. Try to find
 # the cuda driver so we can enable this where possible.
 if (NOT TARGET cudadrv)
-    find_package(CUDA 10.1)
+    find_package(CUDAToolkit 10.1)
     add_library(cudadrv SHARED IMPORTED GLOBAL)
     set_target_properties(
         cudadrv PROPERTIES


### PR DESCRIPTION
FindCUDA has been deprecated  (CMP0146)
Also the CUDAToolkit package defines CUDAToolkit_INCLUDE_DIRS, the CUDA package doesn't. 

This fixes a bug in which the UR offload adapter will fail to compile if the cuda adapter is not built alongside it since the cuda.h cannot be found (because CUDAToolkit_INCLUDE_DIRS is not set by the CUDA package) when compiling offload/program.cpp. UR_CUDA_ENABLED is still set because CUDA_cuda_driver_LIBRARY is still set by the CUDA package.