### PR TITLE
[sycl] Added doc for compiling FAT binaries with multiple device archs

### DIFF
--- a/sycl/doc/design/OffloadDesign.md
+++ b/sycl/doc/design/OffloadDesign.md
@@ -259,11 +259,11 @@ To support multiple device architectures, a new `--device-compiler` option must 
 
 Device specific optimizations for each of the device architectures should be specified after `-device <name>`.
 
-Here is an example of a clang-linker-wrapper invocation where ther user wants to create a FAT binary with PVC and SKL architectures to be run on a x86_64 Linux host. In addition, they would like to enable aggressive mathematical optimizations and are tolerant for slightly imprecise floating-point values just for SKL, that is, use the `-cl-unsafe-math-optimizations`. For PVC, they would like to enable the multiply and add instruction usage (`-cl-mad-enable`). The source binaries are called host.o and kernel.o and the output should be called out.exe.
+Here is an example of a clang-linker-wrapper invocation where ther user wants to create a FAT binary with PVC and SKL architectures to be run on a x86_64 Linux host. In addition, they would like to enable aggressive mathematical optimizations and are tolerant for slightly imprecise floating-point values just for SKL, that is, use the `-cl-unsafe-math-optimizations` flag. For PVC, they would like to enable the multiply and add instruction usage (`-cl-mad-enable`). The source binaries are called host.o and kernel.o and the output should be called out.exe.
 
 `clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu
- --device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options "cl-mad-enable"
---device-compiler=sycl:spir64_gen-unknown-unknown=-device skl -options "-cl-unsafe-math-optimizations"
+ --device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options "-cl-mad-enable"
+ --device-compiler=sycl:spir64_gen-unknown-unknown=-device skl -options "-cl-unsafe-math-optimizations" -- /usr/bin/ld
 host.o kernel.o -o out.exe`
 
 #### Other Supported Options

--- a/sycl/doc/design/OffloadDesign.md
+++ b/sycl/doc/design/OffloadDesign.md
@@ -251,7 +251,7 @@ The `--device-compiler` option uses the format `--device-compiler=[<kind>:][<tri
 
 In clang-linker-wrapper, the `<kind>` and `<triple>` are matched against the current compilation target. Only arguments that match both the offloading kind and target triple will be passed to the backend compiler. If `<kind>` is not specified, the arguments will match any offloading kind; if `<triple>` is not specified, the arguments will match any target triple; and if neither is specified, the arguments will be applied to all targets. 
 
-To support multiple device architectures, a new `--device-compiler` option must be specified for each device. For example, to compile for Ponte Vecchio (PVC) and Skylake (SKL) architectures and put them in a FAT binary, the user must add the following two `--device-compiler` options:
+To support multiple device architectures, a new `--device-compiler` option must be specified for each device. For example, to compile for Ponte Vecchio (PVC) and Skylake (SKL) architectures and put them in a fat binary, the user must add the following two `--device-compiler` options:
 
 `--device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options ...`
 

--- a/sycl/doc/design/OffloadDesign.md
+++ b/sycl/doc/design/OffloadDesign.md
@@ -251,6 +251,21 @@ The `--device-compiler` option uses the format `--device-compiler=[<kind>:][<tri
 
 In clang-linker-wrapper, the `<kind>` and `<triple>` are matched against the current compilation target. Only arguments that match both the offloading kind and target triple will be passed to the backend compiler. If `<kind>` is not specified, the arguments will match any offloading kind; if `<triple>` is not specified, the arguments will match any target triple; and if neither is specified, the arguments will be applied to all targets. 
 
+To support multiple device architectures, a new `--device-compiler` option must be specified for each device. For example, to compile for Ponte Vecchio (PVC) and Skylake (SKL) architectures and put them in a FAT binary, the user must add the following two `--device-compiler` options:
+
+`--device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options ...`
+
+`--device-compiler=sycl:spir64_gen-unknown-unknown=-device skl -options ...`
+
+Device specific optimizations for each of the device architectures should be specified after `-device <name>`.
+
+Here is an example of a clang-linker-wrapper invocation where ther user wants to create a FAT binary with PVC and SKL architectures to be run on a x86_64 Linux host. In addition, they would like to enable aggressive mathematical optimizations and are tolerant for slightly imprecise floating-point values just for SKL, that is, use the `-cl-unsafe-math-optimizations`. For PVC, they would like to enable the multiply and add instruction usage (`-cl-mad-enable`). The source binaries are called host.o and kernel.o and the output should be called out.exe.
+
+`clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu
+ --device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options "cl-mad-enable"
+--device-compiler=sycl:spir64_gen-unknown-unknown=-device skl -options "-cl-unsafe-math-optimizations"
+host.o kernel.o -o out.exe`
+
 #### Other Supported Options
 To complete the support needed for the various targets using the
 `clang-linker-wrapper` as the main interface, a few additional options will

--- a/sycl/doc/design/OffloadDesign.md
+++ b/sycl/doc/design/OffloadDesign.md
@@ -257,7 +257,7 @@ To support multiple device architectures, a new `--device-compiler` option must 
 
 `--device-compiler=sycl:spir64_gen-unknown-unknown=-device skl -options ...`
 
-Device specific optimizations for each of the device architectures should be specified after `-device <name>`.
+Device specific options for each of the device architectures should be specified after `-device <name>`.
 
 Here is an example of a clang-linker-wrapper invocation where ther user wants to create a FAT binary with PVC and SKL architectures to be run on a x86_64 Linux host. In addition, they would like to enable aggressive mathematical optimizations and are tolerant for slightly imprecise floating-point values just for SKL, that is, use the `-cl-unsafe-math-optimizations` flag. For PVC, they would like to enable the multiply and add instruction usage (`-cl-mad-enable`). The source binaries are called host.o and kernel.o and the output should be called out.exe.
 

--- a/sycl/doc/design/OffloadDesign.md
+++ b/sycl/doc/design/OffloadDesign.md
@@ -259,7 +259,7 @@ To support multiple device architectures, a new `--device-compiler` option must 
 
 Device specific options for each of the device architectures should be specified after `-device <name>`.
 
-Here is an example of a clang-linker-wrapper invocation where ther user wants to create a FAT binary with PVC and SKL architectures to be run on a x86_64 Linux host. In addition, they would like to enable aggressive mathematical optimizations and are tolerant for slightly imprecise floating-point values just for SKL, that is, use the `-cl-unsafe-math-optimizations` flag. For PVC, they would like to enable the multiply and add instruction usage (`-cl-mad-enable`). The source binaries are called host.o and kernel.o and the output should be called out.exe.
+Here is an example of a clang-linker-wrapper invocation where ther user wants to create a fat binary with PVC and SKL architectures to be run on a x86_64 Linux host. In addition, they would like to enable aggressive mathematical optimizations and are tolerant for slightly imprecise floating-point values just for SKL, that is, use the `-cl-unsafe-math-optimizations` flag. For PVC, they would like to enable the multiply and add instruction usage (`-cl-mad-enable`). The source binaries are called host.o and kernel.o and the output should be called out.exe.
 
 `clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu
  --device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options "-cl-mad-enable"


### PR DESCRIPTION
Added documentation on how to use `device-compiler` option to compile a FAT binary with multiple architectures.