### PR TITLE
[UR][L0V2] implement host-mediated buffer migration fallback

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/buffer_migrate_no_p2p.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/buffer_migrate_no_p2p.cpp
@@ -1,0 +1,96 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: env SYCL_UR_USE_LEVEL_ZERO_V2=1 SYCL_UR_L0_RESTRICT_USM_RESIDENCY_TO_P2P=1 %{run} %t.out
+//
+// Tests the host-mediated buffer migration fallback in
+// ur_discrete_buffer_handle_t::getDevicePtr, taken when a buffer must move
+// between two devices that lack P2P access.
+
+#include <iostream>
+#include <sycl/detail/core.hpp>
+#include <sycl/platform.hpp>
+#include <sycl/properties/all_properties.hpp>
+
+using namespace sycl;
+
+buffer<int, 1> createInitializedBuffer(std::size_t Size, int Value) {
+  buffer<int, 1> Buf{range<1>(Size)};
+  host_accessor Init{Buf, write_only};
+  for (std::size_t I = 0; I < Size; ++I)
+    Init[I] = Value;
+  return Buf;
+}
+
+property_list makeQueueProps(bool InOrder, bool Batched) {
+  if (InOrder && Batched)
+    return {property::queue::in_order(),
+            ext::intel::property::queue::no_immediate_command_list()};
+  if (InOrder)
+    return {property::queue::in_order()};
+  if (Batched)
+    return {ext::intel::property::queue::no_immediate_command_list()};
+  return {};
+}
+
+int runMigration(const context &Ctx, const std::vector<device> &Devices,
+                 bool InOrder, bool Batched) {
+  constexpr std::size_t NumBuffers = 8;
+  constexpr std::size_t Size = 256;
+
+  std::vector<buffer<int, 1>> Bufs;
+  for (std::size_t B = 0; B < NumBuffers; ++B)
+    Bufs.push_back(createInitializedBuffer(Size, 0));
+
+  device DevA = Devices[0], DevB = Devices[1];
+  property_list Props = makeQueueProps(InOrder, Batched);
+  queue QA(Ctx, DevA, Props);
+  queue QB(Ctx, DevB, Props);
+
+  for (auto &Buf : Bufs)
+    QA.submit([&](handler &H) {
+      accessor Acc{Buf, H, read_write};
+      H.parallel_for(range<1>(Size), [=](id<1> Id) { Acc[Id] = Id; });
+    });
+  QA.wait();
+
+  for (auto &Buf : Bufs)
+    QB.submit([&](handler &H) {
+      accessor Acc{Buf, H, read_write};
+      H.parallel_for(range<1>(Size), [=](id<1> Id) { Acc[Id] += 1; });
+    });
+  QB.wait();
+
+  std::cout << (Batched ? "batched " : "immediate ")
+            << (InOrder ? "in-order: " : "out-of-order: ");
+  for (auto &Buf : Bufs) {
+    host_accessor HostAcc{Buf, read_only};
+    for (std::size_t I = 0; I < Size; ++I)
+      if (HostAcc[I] != static_cast<int>(I) + 1) {
+        std::cout << "FAILED" << std::endl;
+        return 1;
+      }
+  }
+
+  std::cout << "PASSED" << std::endl;
+  return 0;
+}
+
+int main() {
+  auto Devices = platform(gpu_selector_v).get_devices(info::device_type::gpu);
+  if (Devices.size() < 2) {
+    std::cout << "Test requires at least two devices, skipping." << std::endl;
+    return 0;
+  }
+
+  context Ctx(Devices);
+
+  int Result = 0;
+  for (bool Batched : {false, true})
+    for (bool InOrder : {false, true})
+      Result |= runMigration(Ctx, Devices, InOrder, Batched);
+  return Result;
+}

--- a/sycl/test-e2e/Basic/buffer/buffer_migrate.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_migrate.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// UNSUPPORTED: arch-intel_gpu_pvc
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22058
-//
 // Test for buffer use in a context with multiple devices (all found
 // root-devices)
 //

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -338,10 +338,48 @@ void *ur_discrete_buffer_handle_t::getActiveDeviceAlloc(size_t offset) {
          offset;
 }
 
+static void migrateMemory(ze_command_list_handle_t cmdList, void *src,
+                          void *dst, size_t size, wait_list_view &waitListView);
+
+void *ur_discrete_buffer_handle_t::asyncMigrateDeviceAllocThroughHost(
+    ur_device_handle_t hDevice, size_t offset, ze_command_list_handle_t cmdList,
+    wait_list_view &waitListView) {
+  // Allocate a staging buffer on the host for the migration
+  void *stagingPtr{};
+
+  UR_CALL_THROWS(hContext->getDefaultUSMPool()->allocate(
+      hContext, nullptr, nullptr, UR_USM_TYPE_HOST, getSize(), &stagingPtr));
+
+  usm_unique_ptr_t stagingAlloc = usm_unique_ptr_t(stagingPtr, [this](void *p) {
+    auto ret = hContext->getDefaultUSMPool()->free(p);
+    if (ret != UR_RESULT_SUCCESS)
+      UR_LOG(ERR, "Failed to free mapped memory: {}", ret);
+  });
+
+  stagingAllocations.emplace_back(std::move(stagingAlloc));
+  auto const hostPtr = stagingAllocations.back().get();
+
+  // Copy data from the source device allocation to the staging buffer
+  migrateMemory(cmdList, getActiveDeviceAlloc(0), hostPtr, getSize(),
+                waitListView);
+
+  // Allocate the destination buffer, if necessary
+  auto const id = hDevice->Id.value();
+  auto const dstPtr = deviceAllocations[id].get()
+                          ? deviceAllocations[id].get()
+                          : allocateOnDevice(hDevice, getSize());
+
+  // Copy data from the staging buffer to the destination device allocation
+  ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
+                    (cmdList, dstPtr, hostPtr, getSize(), nullptr, 0, nullptr));
+  activeAllocationDevice = hDevice;
+  return getActiveDeviceAlloc(offset);
+}
+
 void *ur_discrete_buffer_handle_t::getDevicePtr(
     ur_device_handle_t hDevice, device_access_mode_t /*access*/, size_t offset,
-    size_t /*size*/, ze_command_list_handle_t /*cmdList*/,
-    wait_list_view & /*waitListView*/) {
+    size_t /*size*/, ze_command_list_handle_t cmdList,
+    wait_list_view &waitListView) {
   TRACK_SCOPE_LATENCY("ur_discrete_buffer_handle_t::getDevicePtr");
 
   if (!activeAllocationDevice) {
@@ -366,12 +404,12 @@ void *ur_discrete_buffer_handle_t::getDevicePtr(
                                  activeAllocationDevice) != p2pDevices.end();
 
   if (!p2pAccessible) {
-    // TODO: migrate buffer through the host
-    UR_LOG(WARN,
-           "p2p is not accessible: requesting device ptr:{} cannot access "
-           "allocation on device ptr:{}",
-           (void *)hDevice, (void *)activeAllocationDevice);
-    throw UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    UR_LOG(DEBUG,
+           "p2p is not accessible: migrating buffer through host: "
+           "from src device: {} to dst device: {}",
+           (void *)activeAllocationDevice, (void *)hDevice);
+    return asyncMigrateDeviceAllocThroughHost(hDevice, offset, cmdList,
+                                              waitListView);
   }
 
   // TODO: see if it's better to migrate the memory to the specified device

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -341,10 +341,48 @@ void *ur_discrete_buffer_handle_t::getActiveDeviceAlloc(size_t offset) {
          offset;
 }
 
+static void migrateMemory(ze_command_list_handle_t cmdList, void *src,
+                          void *dst, size_t size, wait_list_view &waitListView);
+
+void *ur_discrete_buffer_handle_t::asyncMigrateDeviceAllocThroughHost(
+    ur_device_handle_t hDevice, size_t offset, ze_command_list_handle_t cmdList,
+    wait_list_view &waitListView) {
+  // Allocate a staging buffer on the host for the migration
+  void *stagingPtr{};
+
+  UR_CALL_THROWS(hContext->getDefaultUSMPool()->allocate(
+      hContext, nullptr, nullptr, UR_USM_TYPE_HOST, getSize(), &stagingPtr));
+
+  usm_unique_ptr_t stagingAlloc = usm_unique_ptr_t(stagingPtr, [this](void *p) {
+    auto ret = hContext->getDefaultUSMPool()->free(p);
+    if (ret != UR_RESULT_SUCCESS)
+      UR_LOG(ERR, "Failed to free mapped memory: {}", ret);
+  });
+
+  stagingAllocations.emplace_back(std::move(stagingAlloc));
+  auto const hostPtr = stagingAllocations.back().get();
+
+  // Copy data from the source device allocation to the staging buffer
+  migrateMemory(cmdList, getActiveDeviceAlloc(0), hostPtr, getSize(),
+                waitListView);
+
+  // Allocate the destination buffer, if necessary
+  auto const id = hDevice->Id.value();
+  auto const dstPtr = deviceAllocations[id].get()
+                          ? deviceAllocations[id].get()
+                          : allocateOnDevice(hDevice, getSize());
+
+  // Copy data from the staging buffer to the destination device allocation
+  ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
+                    (cmdList, dstPtr, hostPtr, getSize(), nullptr, 0, nullptr));
+  activeAllocationDevice = hDevice;
+  return getActiveDeviceAlloc(offset);
+}
+
 void *ur_discrete_buffer_handle_t::getDevicePtr(
     ur_device_handle_t hDevice, device_access_mode_t /*access*/, size_t offset,
-    size_t /*size*/, ze_command_list_handle_t /*cmdList*/,
-    wait_list_view & /*waitListView*/) {
+    size_t /*size*/, ze_command_list_handle_t cmdList,
+    wait_list_view &waitListView) {
   TRACK_SCOPE_LATENCY("ur_discrete_buffer_handle_t::getDevicePtr");
 
   if (!activeAllocationDevice) {
@@ -369,12 +407,12 @@ void *ur_discrete_buffer_handle_t::getDevicePtr(
                                  activeAllocationDevice) != p2pDevices.end();
 
   if (!p2pAccessible) {
-    // TODO: migrate buffer through the host
-    UR_LOG(WARN,
-           "p2p is not accessible: requesting device ptr:{} cannot access "
-           "allocation on device ptr:{}",
-           (void *)hDevice, (void *)activeAllocationDevice);
-    throw UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    UR_LOG(DEBUG,
+           "p2p is not accessible: migrating buffer through host: "
+           "from src device: {} to dst device: {}",
+           (void *)activeAllocationDevice, (void *)hDevice);
+    return asyncMigrateDeviceAllocThroughHost(hDevice, offset, cmdList,
+                                              waitListView);
   }
 
   // TODO: see if it's better to migrate the memory to the specified device

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -412,7 +412,7 @@ void *ur_discrete_buffer_handle_t::getDevicePtr(
   auto p2pAccessible = std::find(p2pDevices.begin(), p2pDevices.end(),
                                  activeAllocationDevice) != p2pDevices.end();
 
-  if (!p2pAccessible) {
+  if (!p2pAccessible || restrictUsmResidencyToP2P()) {
     UR_LOG(DEBUG,
            "p2p is not accessible: migrating buffer through host: "
            "from src device: {} to dst device: {}",

--- a/unified-runtime/source/adapters/level_zero/v2/memory.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.cpp
@@ -347,34 +347,40 @@ static void migrateMemory(ze_command_list_handle_t cmdList, void *src,
 void *ur_discrete_buffer_handle_t::asyncMigrateDeviceAllocThroughHost(
     ur_device_handle_t hDevice, size_t offset, ze_command_list_handle_t cmdList,
     wait_list_view &waitListView) {
-  // Allocate a staging buffer on the host for the migration
-  void *stagingPtr{};
+  for (auto it = stagingAllocations.begin(); it != stagingAllocations.end();) {
+    if (zeEventQueryStatus(it->event->getZeEvent()) == ZE_RESULT_SUCCESS)
+      it = stagingAllocations.erase(it);
+    else
+      ++it;
+  }
+
+  void *hostPtr{};
 
   UR_CALL_THROWS(hContext->getDefaultUSMPool()->allocate(
-      hContext, nullptr, nullptr, UR_USM_TYPE_HOST, getSize(), &stagingPtr));
+      hContext, nullptr, nullptr, UR_USM_TYPE_HOST, getSize(), &hostPtr));
 
-  usm_unique_ptr_t stagingAlloc = usm_unique_ptr_t(stagingPtr, [this](void *p) {
+  usm_unique_ptr_t stagingAlloc = usm_unique_ptr_t(hostPtr, [this](void *p) {
     auto ret = hContext->getDefaultUSMPool()->free(p);
     if (ret != UR_RESULT_SUCCESS)
       UR_LOG(ERR, "Failed to free mapped memory: {}", ret);
   });
 
-  stagingAllocations.emplace_back(std::move(stagingAlloc));
-  auto const hostPtr = stagingAllocations.back().get();
-
-  // Copy data from the source device allocation to the staging buffer
   migrateMemory(cmdList, getActiveDeviceAlloc(0), hostPtr, getSize(),
                 waitListView);
 
-  // Allocate the destination buffer, if necessary
   auto const id = hDevice->Id.value();
   auto const dstPtr = deviceAllocations[id].get()
                           ? deviceAllocations[id].get()
                           : allocateOnDevice(hDevice, getSize());
 
-  // Copy data from the staging buffer to the destination device allocation
-  ZE2UR_CALL_THROWS(zeCommandListAppendMemoryCopy,
-                    (cmdList, dstPtr, hostPtr, getSize(), nullptr, 0, nullptr));
+  event_unique_ptr_t event{hContext->getNativeEventsPool().allocate(),
+                           [](ur_event_handle_t handle) { handle->release(); }};
+
+  ZE2UR_CALL_THROWS(
+      zeCommandListAppendMemoryCopy,
+      (cmdList, dstPtr, hostPtr, getSize(), event->getZeEvent(), 0, nullptr));
+
+  stagingAllocations.push_back({std::move(stagingAlloc), std::move(event)});
   activeAllocationDevice = hDevice;
   return getActiveDeviceAlloc(offset);
 }

--- a/unified-runtime/source/adapters/level_zero/v2/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.hpp
@@ -170,11 +170,17 @@ private:
   usm_unique_ptr_t mapToPtr;
 
   std::vector<host_allocation_desc_t> hostAllocations;
+  std::vector<usm_unique_ptr_t> stagingAllocations;
 
   void *getActiveDeviceAlloc(size_t offset = 0);
   void *allocateOnDevice(ur_device_handle_t hDevice, size_t size);
   ur_result_t migrateBufferTo(ur_device_handle_t hDevice, void *src,
                               size_t size);
+
+  void *asyncMigrateDeviceAllocThroughHost(ur_device_handle_t hDevice,
+                                           size_t offset,
+                                           ze_command_list_handle_t cmdList,
+                                           wait_list_view &waitListView);
 };
 
 struct ur_shared_buffer_handle_t : ur_mem_buffer_t {

--- a/unified-runtime/source/adapters/level_zero/v2/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.hpp
@@ -172,11 +172,17 @@ private:
   usm_unique_ptr_t mapToPtr;
 
   std::vector<host_allocation_desc_t> hostAllocations;
+  std::vector<usm_unique_ptr_t> stagingAllocations;
 
   void *getActiveDeviceAlloc(size_t offset = 0);
   void *allocateOnDevice(ur_device_handle_t hDevice, size_t size);
   ur_result_t migrateBufferTo(ur_device_handle_t hDevice, void *src,
                               size_t size);
+
+  void *asyncMigrateDeviceAllocThroughHost(ur_device_handle_t hDevice,
+                                           size_t offset,
+                                           ze_command_list_handle_t cmdList,
+                                           wait_list_view &waitListView);
 };
 
 struct ur_shared_buffer_handle_t : ur_mem_buffer_t {

--- a/unified-runtime/source/adapters/level_zero/v2/memory.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/memory.hpp
@@ -99,6 +99,14 @@ struct host_allocation_desc_t {
   ur_map_flags_t flags;
 };
 
+using event_unique_ptr_t =
+    std::unique_ptr<ur_event_handle_t_, void (*)(ur_event_handle_t)>;
+
+struct staging_allocation_t {
+  usm_unique_ptr_t allocation;
+  event_unique_ptr_t event;
+};
+
 // Manages memory buffer for integrated GPU.
 // For integrated devices the buffer has been allocated in host memory
 // and can be accessed by the device without copying.
@@ -172,7 +180,7 @@ private:
   usm_unique_ptr_t mapToPtr;
 
   std::vector<host_allocation_desc_t> hostAllocations;
-  std::vector<usm_unique_ptr_t> stagingAllocations;
+  std::vector<staging_allocation_t> stagingAllocations;
 
   void *getActiveDeviceAlloc(size_t offset = 0);
   void *allocateOnDevice(ur_device_handle_t hDevice, size_t size);


### PR DESCRIPTION
When two devices lack P2P access, getDevicePtr() was unconditionally throwing UR_RESULT_ERROR_UNSUPPORTED_FEATURE instead of migrating the buffer through a temporary host allocation. Implement the fallback: copy active-device -> host -> target device.