### PR TITLE
[SYCL][NFC] Fix incorrect UNSUPPORTED tracker link in bindless image/dx11 interop test read_write_unsampled_semaphore.cpp

### DIFF
--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled_semaphore.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22148
 
 // UNSUPPORTED: gpu-intel-dg2
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21159
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22155
 
 // RUN: %{build} %link-directx -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out


### PR DESCRIPTION
The UNSUPPORTED tracker for DG2 in `dx11_interop/read_write_unsampled_semaphore.cpp` corresponds to an issue about a different test. This PR replaces it with the correct link.