### PR TITLE
[SYCL] Re-apply 'Fix compiler version detection for oneAPI'

### DIFF
--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -91,8 +91,19 @@ execute_process(
     )
 
 if(CMPLR_RESULT EQUAL 0 AND CMPLR_VER)
-  string(REGEX MATCH "DPC\\+\\+ compiler ([0-9]+)" _ ${CMPLR_VER})
+  # CMAKE_CXX_COMPILER_ID will only be set in standalone mode, otherwise
+  # the compiler must be the just-built clang.
+  if(SYCL_TEST_E2E_STANDALONE AND CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
+    set(CMPLR_REGEX "Intel\\(R\\) oneAPI DPC\\+\\+/C\\+\\++ Compiler ([0-9]+)")
+  else()
+    set(CMPLR_REGEX "DPC\\+\\+ compiler ([0-9]+)")
+  endif()
+  string(REGEX MATCH ${CMPLR_REGEX} _ ${CMPLR_VER})
   set(DPCPP_VERSION_MAJOR "${CMAKE_MATCH_1}")
+endif()
+
+if("${DPCPP_VERSION_MAJOR}" STREQUAL "")
+  message(FATAL_ERROR "Could not detect SYCL compiler version")
 endif()
 
 if(SYCL_TEST_E2E_STANDALONE)


### PR DESCRIPTION
Reapply https://github.com/intel/llvm/pull/22131 with a minor change adding a check for `SYCL_TEST_E2E_STANDALONE` before checking `CMAKE_CXX_COMPILER_ID`.

I manually reproduced the problem that caused it to be reverted and verified the fix.