### PR TITLE
[E2E] Guard two-or-more-gpu-devices feature for runtime-only mode

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -686,9 +686,11 @@ with test_env():
     # Count physical GPU devices: each physical GPU produces one output line
     # that contains ":gpu]". Add a feature when at least two are present so
     # tests requiring multi-GPU hardware can be skipped on single-GPU machines.
-    gpu_device_lines = [l for l in sycl_ls_output.splitlines() if ":gpu]" in l]
-    if len(gpu_device_lines) >= 2:
-        config.available_features.add("two-or-more-gpu-devices")
+    # This is a runtime-only feature since it queries actual hardware.
+    if config.test_mode != "build-only":
+        gpu_device_lines = [l for l in sycl_ls_output.splitlines() if ":gpu]" in l]
+        if len(gpu_device_lines) >= 2:
+            config.available_features.add("two-or-more-gpu-devices")
 
     if len(config.sycl_devices) == 1 and config.sycl_devices[0] == "all":
         devices = set()


### PR DESCRIPTION
The two-or-more-gpu-devices feature queries actual hardware via sycl-ls
and should only be added when running tests, not during build-only mode.
This fixes the error: "Runtime features: ['two-or-more-gpu-devices']
evaluated to True in build-only".

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
