### PR TITLE
[Driver][SYCL] Restore libsycl.so detection on Linux/Unix

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -52,14 +52,14 @@ SYCLInstallationDetector::SYCLInstallationDetector(
         SYCLRTLibPath = LibDir;
     }
   } else {
-    // Linux/Unix: Check for libLLVMSYCL.so
+    // Linux/Unix: Check for libsycl.so
     SmallString<128> LibPath(DriverDir);
     llvm::sys::path::append(LibPath, "..", "lib", HostTriple.str(),
-                            "libLLVMSYCL.so");
+                            "libsycl.so");
     // Flat lib path for LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF builds,
     // where the library is installed directly in lib/ with no triple subdir.
     SmallString<128> FlatLibPath(DriverDir);
-    llvm::sys::path::append(FlatLibPath, "..", "lib", "libLLVMSYCL.so");
+    llvm::sys::path::append(FlatLibPath, "..", "lib", "libsycl.so");
 
     if (DriverDir.starts_with(SysRoot) &&
         Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {


### PR DESCRIPTION
Upstream commit ab31a3d590eb replaced the Linux/Unix library names with libLLVMSYCL.so as a side effect.
In intel/llvm sycl branch we need to use libsycl.so, libLLVMSYCL.so does not exist.
This is causing mutliple sycl test failures in sycl-web branch.