### PR TITLE
[Driver][SYCL] Allow native_cpu and CUDA-compat triples in SYCL device compilation

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -119,7 +119,9 @@ bool CompilerInstance::createTarget() {
   if (!hasTarget())
     return false;
 
-  if (getLangOpts().SYCLIsDevice && !getTarget().getTriple().isGPU()) {
+  if (getLangOpts().SYCLIsDevice && !getTarget().getTriple().isGPU() &&
+      !getTarget().getTriple().isNativeCPU() &&
+      !getLangOpts().SYCLCUDACompat) {
     getDiagnostics().Report(diag::err_sycl_device_invalid_target)
         << getTarget().getTriple().str();
     return false;

--- a/clang/test/CodeGenSYCL/kernel_functor.cpp
+++ b/clang/test/CodeGenSYCL/kernel_functor.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl-is-device -fno-sycl-unnamed-lambda -fsycl-int-header=%t.h %s -o /dev/null
+// RUN: %clang_cc1 -triple spirv64-unknown-unknown -fsycl-is-device -fno-sycl-unnamed-lambda -fsycl-int-header=%t.h %s -o /dev/null
 // RUN: FileCheck %s --input-file=%t.h --check-prefixes=NUL,CHECK
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl-is-device -fsycl-int-header=%t.h %s -o /dev/null
+// RUN: %clang_cc1 -triple spirv64-unknown-unknown -fsycl-is-device -fsycl-int-header=%t.h %s -o /dev/null
 // RUN: FileCheck %s --input-file=%t.h --check-prefixes=UL,CHECK
 
 // Checks that functors are supported as SYCL kernels.

--- a/clang/test/SemaSYCL/CudaCompat/sycl-cuda-compilation.cu
+++ b/clang/test/SemaSYCL/CudaCompat/sycl-cuda-compilation.cu
@@ -8,7 +8,7 @@
 // RUN:   -emit-llvm -o - -verify -verify-ignore-unexpected=note
 // RUN: %clang_cc1 %s -fsycl-is-device -D__sycl_device \
 // RUN:   -internal-isystem %S/../../SemaCUDA/Inputs \
-// RUN:   -fsycl-targets=nvptx64-nvidia-cuda -triple x86_64-unknown-linux\
+// RUN:   -fsycl-targets=nvptx64-nvidia-cuda -triple nvptx64-nvidia-cuda\
 // RUN:   -emit-llvm -o - -verify -verify-ignore-unexpected=note
 
 // This tests the errors emitted by SEMA in case of SYCL-CUDA compilation.

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s -DLINUX_ASM
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s -DLINUX_ASM -DSPIR_CHECK -triple spir64-unknown-unknown
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -triple x86_64-windows -fasm-blocks %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify -triple x86_64-windows -fasm-blocks %s
 
 #ifndef SPIR_CHECK
 //expected-no-diagnostics

--- a/clang/test/SemaSYCL/long-double-float128-host.cu
+++ b/clang/test/SemaSYCL/long-double-float128-host.cu
@@ -1,7 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl-is-host \
 // RUN:   -internal-isystem %S/Inputs -sycl-std=2020 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl-is-device \
-// RUN:   -internal-isystem %S/Inputs -sycl-std=2020 -fsyntax-only -verify %s
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl-is-host -fcuda-is-device \
 // RUN:   -internal-isystem %S/Inputs -sycl-std=2020 -fsyntax-only -verify %s
 

--- a/clang/test/SemaSYCL/long-double.cpp
+++ b/clang/test/SemaSYCL/long-double.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -triple spir64 -aux-triple x86_64-linux-gnu -fsycl-is-device -verify -fsyntax-only %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl-is-device -fsyntax-only %s
 // RUN: %clang_cc1 -triple spir64 -aux-triple x86_64-linux-gnu -fsycl-is-device -fsyntax-only -mlong-double-64 %s
 
 template <typename Name, typename Func>

--- a/clang/test/SemaSYCL/unique-stable-id.cpp
+++ b/clang/test/SemaSYCL/unique-stable-id.cpp
@@ -1,5 +1,4 @@
-// RUN: %clang_cc1 %s -std=c++17 -triple x86_64-pc-windows-msvc -fsycl-is-device -verify -fsyntax-only -Wno-unused
-// RUN: %clang_cc1 %s -std=c++17 -triple x86_64-linux-gnu -fsycl-is-device -verify -fsyntax-only -Wno-unused
+// RUN: %clang_cc1 %s -std=c++17 -triple spirv64-unknown-unknown -fsycl-is-device -verify -fsyntax-only -Wno-unused
 // Various Semantic analysis tests for the __builtin_unique_stable_id feature.
 
 #include "Inputs/sycl.hpp"

--- a/clang/test/SemaSYCL/unique-stable-name-anon-struct-crash.cpp
+++ b/clang/test/SemaSYCL/unique-stable-name-anon-struct-crash.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s %s -std=c++17 -triple x86_64-linux-gnu -Wno-sycl-2020-compat -fsycl-is-device -verify -fsyntax-only -Wno-unused
+// RUN: %clang_cc1 %s %s -std=c++17 -triple spirv64-unknown-unknown -Wno-sycl-2020-compat -fsycl-is-device -verify -fsyntax-only -Wno-unused
 
 // This would crash due to UniqueStableNameDiscriminator expecting only lambdas
 // as unnamed records.


### PR DESCRIPTION
Commit 32ab88d2bac6 added a check in CompilerInstance::createTarget() that rejects -fsycl-is-device with any non-GPU triple. There are two legitimate cases in intel/llv sycl branch not covered by isGPU():

- native_cpu
- SYCL CUDA compat mode (-fsycl-cuda-compatibility): uses x86_64 as the compilation triple with -fsycl-is-device to run SYCL diagnostics over CUDA-annotated code.

Extend the check to also allow isNativeCPU() and SYCLCUDACompat.

Update tests that were using x86_64 with -fsycl-is-device without either of these two justifications.