### PR TITLE
[SYCL][E2E] Disable two tests failing on DG2 Win

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/batch_test.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/batch_test.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: windows && gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
 
+// UNSUPPORTED: windows && gpu-intel-dg2
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22188
+
 // To test batching on out-of-order queue:
 // Set batching to 4 explicitly
 // RUN: env UR_L0_BATCH_SIZE=4 UR_L0_DEVICE_SCOPE_EVENTS=2 UR_L0_USE_IMMEDIATE_COMMANDLISTS=0 SYCL_UR_TRACE=2 UR_L0_DEBUG=1 %{run} %t.ooo.out 2>&1 | FileCheck --check-prefixes=CKALL,CKB4 %s

--- a/sycl/test-e2e/Basic/report_code_loc.cpp
+++ b/sycl/test-e2e/Basic/report_code_loc.cpp
@@ -7,7 +7,7 @@
 // UNSUPPORTED: windows && gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED: windows && (gpu-intel-dg2 || arch-intel_gpu_bmg_g21)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22163
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Failing in the [nightly](https://github.com/intel/llvm/actions/runs/26798510439/job/79088067762).