### PR TITLE
[SYCL] Enable indirect access in SYCLBIN kernels

### DIFF
--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -67,7 +67,8 @@ kernel_impl::kernel_impl(Managed<ur_kernel_handle_t> &&Kernel,
   // Enable USM indirect access for interop and non-sycl-jit source kernels.
   // sycl-jit kernels will enable this if needed through the regular kernel
   // path.
-  if (MCreatedFromSource || MIsInterop)
+  if (MCreatedFromSource || MIsInterop ||
+      (MDeviceImageImpl->getOriginMask() & ImageOriginSYCLBIN))
     enableUSMIndirectAccess();
 }
 

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -64,9 +64,9 @@ kernel_impl::kernel_impl(Managed<ur_kernel_handle_t> &&Kernel,
                             ? createCompileTimeKernelInfo(getName())
                             : createCompileTimeKernelInfo()) {
 
-  // Enable USM indirect access for interop and non-sycl-jit source kernels.
-  // sycl-jit kernels will enable this if needed through the regular kernel
-  // path.
+  // Enable USM indirect access for interop, SYCLBIN, and non-sycl-jit source
+  // kernels. sycl-jit kernels will enable this if needed through the regular
+  // kernel path.
   if (MCreatedFromSource || MIsInterop ||
       (MDeviceImageImpl->getOriginMask() & ImageOriginSYCLBIN))
     enableUSMIndirectAccess();

--- a/sycl/test-e2e/SYCLBIN/indirect_access.cpp
+++ b/sycl/test-e2e/SYCLBIN/indirect_access.cpp
@@ -5,7 +5,7 @@
 
 // RUN: %clangxx --offload-new-driver -fsyclbin=executable %{sycl_target_opts} %{syclbin_exec_opts} %S/Inputs/basic_kernel.cpp -o %t.syclbin
 // RUN: %{build} -o %t.out
-// RUN: %{run} env SYCL_UR_TRACE=-1 %t.out %t.syclbin | FileCheck %s
+// RUN: env SYCL_UR_TRACE=-1 %{run} %t.out %t.syclbin | FileCheck %s
 
 #define SYCLBIN_EXECUTABLE_STATE
 

--- a/sycl/test-e2e/SYCLBIN/indirect_access.cpp
+++ b/sycl/test-e2e/SYCLBIN/indirect_access.cpp
@@ -1,0 +1,15 @@
+// REQUIRES: aspect-usm_device_allocations
+
+// Check to ensure that the SYCL runtime sets the
+// UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS property to true for SYCLBIN kernels.
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=executable %{sycl_target_opts} %{syclbin_exec_opts} %S/Inputs/basic_kernel.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{run} env SYCL_UR_TRACE=-1 %t.out %t.syclbin | FileCheck %s
+
+#define SYCLBIN_EXECUTABLE_STATE
+
+#include "Inputs/basic.hpp"
+
+// CHECK: ---> urKernelSetExecInfo
+// CHECK-NEXT: <--- urKernelSetExecInfo(.hKernel = 0x{{[0-9a-fA-F]+}}, .propName = UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS, .propSize = 1, .pProperties = nullptr, .pPropValue = 0x{{[0-9a-fA-F]+}} (true)) -> UR_RESULT_SUCCESS;

--- a/sycl/test-e2e/SYCLBIN/indirect_access.cpp
+++ b/sycl/test-e2e/SYCLBIN/indirect_access.cpp
@@ -12,4 +12,4 @@
 #include "Inputs/basic.hpp"
 
 // CHECK: ---> urKernelSetExecInfo
-// CHECK-NEXT: <--- urKernelSetExecInfo(.hKernel = 0x{{[0-9a-fA-F]+}}, .propName = UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS, .propSize = 1, .pProperties = nullptr, .pPropValue = 0x{{[0-9a-fA-F]+}} (true)) -> UR_RESULT_SUCCESS;
+// CHECK: .propName = UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS


### PR DESCRIPTION
SYCLBIN kernels may use USM indirect access. This change ensures that `UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS` is set to true for these kernels to prevent a crash.