### PR TITLE
[SYCL] Fix use-after-free in FastKernelCache on dlclose

### DIFF
--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -253,8 +253,10 @@ public:
     ur_context_handle_t MUrContext = nullptr;
   };
 
+  // Key is std::string (not string_view) because the backing storage for kernel
+  // names lives in DSO offload tables that may be unmapped on dlclose.
   using FastKernelCacheT =
-      emhash8::HashMap<std::string_view, FastKernelSubcacheWrapper>;
+      emhash8::HashMap<std::string, FastKernelSubcacheWrapper>;
 
   // DS to hold data and functions related to Program cache eviction.
   struct EvictionList {
@@ -474,7 +476,8 @@ public:
     // smth in the cache
     traceKernel("Kernel inserted.", KernelName, true);
     MFastKernelCache.try_emplace(
-        KernelName, FastKernelSubcacheWrapper(KernelSubcache, getURContext()));
+        std::string(KernelName),
+        FastKernelSubcacheWrapper(KernelSubcache, getURContext()));
 
     FastKernelSubcacheWriteLockT SubcacheLock{KernelSubcache.Mutex};
     ur_context_handle_t Context = getURContext();
@@ -833,9 +836,8 @@ private:
 
   // Map between fast kernel cache keys and program handle.
   // MFastKernelCacheMutex will be used for synchronization.
-  std::unordered_map<
-      ur_program_handle_t,
-      std::vector<std::pair<std::string_view, ur_device_handle_t>>>
+  std::unordered_map<ur_program_handle_t,
+                     std::vector<std::pair<std::string, ur_device_handle_t>>>
       MProgramToFastKernelCacheKeyMap;
 
   EvictionList MEvictionList;

--- a/sycl/test-e2e/Regression/dlclose_shared_kernel_name.cpp
+++ b/sycl/test-e2e/Regression/dlclose_shared_kernel_name.cpp
@@ -18,7 +18,7 @@
 
 #ifdef BUILD_LIB
 // Both DSOs get the same SYCL mangled kernel name.
-void run_kernel() {
+extern "C" void run_kernel() {
   sycl::queue q;
   sycl::buffer<int, 1> b(1);
   q.submit([&](sycl::handler &cgh) {
@@ -36,8 +36,8 @@ int main() {
   void *hB = dlopen("libB_" STRINGIFY(FNAME) ".so", RTLD_NOW | RTLD_LOCAL);
   assert(hB && "failed to dlopen libB");
 
-  auto *fnA = (void (*)())dlsym(hA, "_Z10run_kernelv");
-  auto *fnB = (void (*)())dlsym(hB, "_Z10run_kernelv");
+  auto *fnA = (void (*)())dlsym(hA, "run_kernel");
+  auto *fnB = (void (*)())dlsym(hB, "run_kernel");
   assert(fnA && fnB && "failed to dlsym run_kernel");
 
   fnA();

--- a/sycl/test-e2e/Regression/dlclose_shared_kernel_name.cpp
+++ b/sycl/test-e2e/Regression/dlclose_shared_kernel_name.cpp
@@ -1,0 +1,54 @@
+// Regression test for use-after-free in ProgramManager::removeImages when two
+// DSOs define kernels with the same mangled name. After dlclose of the first
+// DSO, the kernel name storage is unmapped. A subsequent dlclose of the second
+// DSO would segfault while accessing those dangling pointers in
+// runtime's data structures (which used string_view keys before the fix).
+//
+// REQUIRES: linux
+//
+// RUN: rm -rf %t.dir && mkdir -p %t.dir
+// RUN: %{build} -DBUILD_LIB -fPIC -shared -o %t.dir/libA_%basename_t.so
+// RUN: %{build} -DBUILD_LIB -fPIC -shared -o %t.dir/libB_%basename_t.so
+// RUN: %{build} -DFNAME=%basename_t -ldl -Wl,-rpath,%t.dir -o %t.out
+// RUN: %{run} %t.out
+
+#include <cassert>
+#include <dlfcn.h>
+#include <sycl/detail/core.hpp>
+
+#ifdef BUILD_LIB
+// Both DSOs get the same SYCL mangled kernel name.
+void run_kernel() {
+  sycl::queue q;
+  sycl::buffer<int, 1> b(1);
+  q.submit([&](sycl::handler &cgh) {
+     sycl::accessor acc(b, cgh);
+     cgh.single_task<class SharedKernel>([=]() { acc[0] = 1; });
+   }).wait();
+}
+#else
+#define STRINGIFY_HELPER(A) #A
+#define STRINGIFY(A) STRINGIFY_HELPER(A)
+
+int main() {
+  void *hA = dlopen("libA_" STRINGIFY(FNAME) ".so", RTLD_NOW | RTLD_LOCAL);
+  assert(hA && "failed to dlopen libA");
+  void *hB = dlopen("libB_" STRINGIFY(FNAME) ".so", RTLD_NOW | RTLD_LOCAL);
+  assert(hB && "failed to dlopen libB");
+
+  auto *fnA = (void (*)())dlsym(hA, "_Z10run_kernelv");
+  auto *fnB = (void (*)())dlsym(hB, "_Z10run_kernelv");
+  assert(fnA && fnB && "failed to dlsym run_kernel");
+
+  fnA();
+  fnB();
+
+  // First dlclose unmaps libA's offload table, making any string_view keys
+  // pointing into it dangle. Second dlclose triggers the crash on an
+  // unpatched runtime because removeImages() hashes/compares those keys.
+  dlclose(hA);
+  dlclose(hB);
+
+  return 0;
+}
+#endif


### PR DESCRIPTION
MFastKernelCache and MProgramToFastKernelCacheKeyMap stored std::string_view keys pointing into DSO offload tables. After dlclose of the first DSO, those views dangle. When the second DSO is unloaded, removeProgramByKey segfaults.

Change both maps to own their key strings (std::string). Performance impact is negligible:
- MFastKernelCache (FastKernelCacheT key): saveKernel is called only on the first cache miss for a (kernel, program) pair, not on every submission.
- tryToGetKernelFast - the actual hot path - bypasses MFastKernelCache entirely. it goes directly to the FastKernelSubcacheT stored inside DeviceKernelInfo.
- MProgramToFastKernelCacheKeyMap: Same — only touched in saveKernel and during eviction/cleanup.

Add an e2e regression test: two DSOs sharing the same mangled kernel name, both run and then dlclose'd in sequence.

Assisted-by: Claude Sonnet 4.6