### PR TITLE
Fix sycl lit.cfg to use test.config.maxIndividualTestTime

### DIFF
--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -202,6 +202,6 @@ if not dump_only_tests:
 try:
     import psutil
 
-    lit_config.maxIndividualTestTime = 600
+    config.maxIndividualTestTime = 600
 except ImportError:
     pass


### PR DESCRIPTION
- Align with upstream move from global to test suite config in 2f08150
