### PR TITLE
[SYCL][E2E] Disable vulkan_sycl_image_unsampled_timeline_semaphore.cpp on DG2

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_unsampled_timeline_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_unsampled_timeline_semaphore.cpp
@@ -4,6 +4,9 @@
 
 // REQUIRES-INTEL-DRIVER: lin: 38303 win: 101.9999
 
+// UNSUPPORTED: linux && gpu-intel-dg2
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21764
+
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 
 // RUN: %{run} %t.out --type float --channels 1


### PR DESCRIPTION
Sporadically hanging, see https://github.com/intel/llvm/issues/21764