### PR TITLE
[SYCL][Driver] Imply cross-image symbol flags from -fsyclbin=input/object

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11156,6 +11156,19 @@ static void addArgs(ArgStringList &DstArgs, const llvm::opt::ArgList &Alloc,
 }
 
 static bool allowDeviceImageDependencies(const llvm::opt::ArgList &TCArgs) {
+  // -fsyclbin=input and -fsyclbin=object request a linkable SYCLBIN
+  // artifact whose cross-image SYCL_EXTERNAL references must be resolved
+  // at runtime via sycl::link. That requires the exported/imported symbol
+  // property sets emitted by sycl-post-link, so device-image dependencies
+  // are implied by these states unless the user explicitly opts out.
+  // -fsyclbin=executable does not imply, since it produces a fully linked
+  // artifact with no cross-image references.
+  bool SYCLBINImplies = false;
+  if (Arg *A = TCArgs.getLastArg(options::OPT_fsyclbin_EQ)) {
+    StringRef State = A->getValue();
+    SYCLBINImplies = (State == "input" || State == "object");
+  }
+
   // deprecated
   if (TCArgs.hasFlag(options::OPT_fsycl_allow_device_dependencies,
                      options::OPT_fno_sycl_allow_device_dependencies, false))
@@ -11163,7 +11176,8 @@ static bool allowDeviceImageDependencies(const llvm::opt::ArgList &TCArgs) {
 
   // preferred
   if (TCArgs.hasFlag(options::OPT_fsycl_allow_device_image_dependencies,
-                     options::OPT_fno_sycl_allow_device_image_dependencies, false))
+                     options::OPT_fno_sycl_allow_device_image_dependencies,
+                     SYCLBINImplies))
     return true;
 
   return false;
@@ -11928,9 +11942,42 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     if (Args.hasArg(options::OPT_fsycl_embed_ir))
       CmdArgs.push_back(Args.MakeArgString("-sycl-embed-ir"));
 
+    // -fsyclbin=input and -fsyclbin=object semantically request a linkable
+    // SYCLBIN artifact. Cross-image SYCL_EXTERNAL resolution at runtime
+    // requires the exported/imported symbol property sets emitted by
+    // sycl-post-link, so default -fsycl-allow-device-image-dependencies to
+    // true for those states. Users who want a single-image, fully
+    // optimized artifact should use -fsyclbin=executable instead.
+    //
+    // It is an error to combine -fsyclbin=input/object with
+    // -fno-sycl-allow-device-image-dependencies: an object SYCLBIN that
+    // forbids cross-image dependencies has no use case (it would be a
+    // worse-codegen equivalent of -fsyclbin=executable).
+    //
+    // Combining -fsyclbin=executable with
+    // -fsycl-allow-device-image-dependencies is harmless but pointless,
+    // so it is diagnosed as a warning.
+    bool SYCLBINImpliesAllowDeps = false;
+    if (Arg *A = Args.getLastArg(options::OPT_fsyclbin_EQ)) {
+      StringRef State = A->getValue();
+      bool IsLinkableState = (State == "input" || State == "object");
+      SYCLBINImpliesAllowDeps = IsLinkableState;
+      const Driver &D = getToolChain().getDriver();
+      if (Arg *NoDeps = Args.getLastArg(
+              options::OPT_fno_sycl_allow_device_image_dependencies);
+          NoDeps && IsLinkableState) {
+        D.Diag(diag::err_drv_argument_not_allowed_with)
+            << NoDeps->getAsString(Args) << A->getAsString(Args);
+      } else if (Arg *Deps = Args.getLastArg(
+                     options::OPT_fsycl_allow_device_image_dependencies);
+                 Deps && State == "executable") {
+        D.Diag(diag::warn_drv_argument_not_allowed_with)
+            << Deps->getAsString(Args) << A->getAsString(Args);
+      }
+    }
     if (Args.hasFlag(options::OPT_fsycl_allow_device_image_dependencies,
                      options::OPT_fno_sycl_allow_device_image_dependencies,
-                     false))
+                     SYCLBINImpliesAllowDeps))
       CmdArgs.push_back(
           Args.MakeArgString("-sycl-allow-device-image-dependencies"));
 

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1771,9 +1771,24 @@ void SYCLToolChain::AddSPIRVImpliedTargetArgs(const llvm::Triple &Triple,
     // -ftarget-compile-fast AOT
     if (Args.hasArg(options::OPT_ftarget_compile_fast))
       BeArgs.push_back("-igc_opts 'PartitionUnit=1,SubroutineThreshold=50000'");
-    // -ftarget-export-symbols
+    // -ftarget-export-symbols, also implied for -fsyclbin=input/object so
+    // that AOT-compiled native images keep cross-image SYCL_EXTERNAL
+    // symbols externally visible for runtime resolution via
+    // zeModuleDynamicLink. Users who want a fully-linked, internalized
+    // native image should use -fsyclbin=executable instead. The conflict
+    // case (-fsyclbin=input/object with
+    // -fno-sycl-allow-device-image-dependencies) is diagnosed earlier in
+    // the linker-wrapper construction; here we only need to keep the
+    // implication aligned with the device-image-dependencies setting so
+    // that an explicit opt-out for non-SYCLBIN AOT scenarios is honored.
+    bool SYCLBINImpliesExportSymbols = false;
+    if (Arg *A = Args.getLastArg(options::OPT_fsyclbin_EQ)) {
+      StringRef State = A->getValue();
+      SYCLBINImpliesExportSymbols = (State == "input" || State == "object");
+    }
     if (Args.hasFlag(options::OPT_ftarget_export_symbols,
-                     options::OPT_fno_target_export_symbols, false))
+                     options::OPT_fno_target_export_symbols,
+                     SYCLBINImpliesExportSymbols))
       BeArgs.push_back("-library-compilation");
     // -foffload-fp32-prec-[sqrt/div]
     if (Args.hasArg(options::OPT_foffload_fp32_prec_div) ||

--- a/clang/test/Driver/sycl-fsyclbin.cpp
+++ b/clang/test/Driver/sycl-fsyclbin.cpp
@@ -97,3 +97,55 @@
 // RUN: | FileCheck %s --check-prefix=CHECK_WIN_DEFAULT_OUTPUT
 // CHECK_WIN_DEFAULT_OUTPUT: clang-linker-wrapper
 // CHECK_WIN_DEFAULT_OUTPUT-SAME: "-out:{{.*}}fsyclbin.syclbin"
+
+/// -fsyclbin=input and -fsyclbin=object imply
+/// -fsycl-allow-device-image-dependencies, since cross-image symbol
+/// resolution is required for those bundle states.
+// RUN: %clangxx -fsyclbin=input --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_IMPLIED
+// RUN: %clangxx -fsyclbin=object --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_IMPLIED
+// CHECK_DEPS_IMPLIED: clang-linker-wrapper
+// CHECK_DEPS_IMPLIED-SAME: "-sycl-allow-device-image-dependencies"
+// CHECK_DEPS_IMPLIED-SAME: --sycl-post-link-options={{.*}}-allow-device-image-dependencies
+
+/// -fsyclbin=executable does not imply
+/// -fsycl-allow-device-image-dependencies, since the resulting bundle
+/// is fully linked and does not participate in cross-image link.
+// RUN: %clangxx -fsyclbin=executable --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_NOT_IMPLIED
+// CHECK_DEPS_NOT_IMPLIED-NOT: -sycl-allow-device-image-dependencies
+
+/// For AOT spir64_gen, -fsyclbin=input/object additionally implies
+/// -library-compilation in the backend options so symbols stay
+/// externally visible for runtime cross-image resolution.
+// RUN: %clangxx -fsyclbin=object -fsycl-targets=spir64_gen \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_LIBCOMP_IMPLIED
+// CHECK_LIBCOMP_IMPLIED: -library-compilation
+
+// RUN: %clangxx -fsyclbin=executable -fsycl-targets=spir64_gen \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_LIBCOMP_NOT_IMPLIED
+// CHECK_LIBCOMP_NOT_IMPLIED-NOT: -library-compilation
+
+/// Combining -fsyclbin=input/object with
+/// -fno-sycl-allow-device-image-dependencies is a contradiction: an
+/// object SYCLBIN that forbids cross-image dependencies has no use
+/// case, so the driver emits an error and redirects users to
+/// -fsyclbin=executable.
+// RUN: not %clangxx -fsyclbin=object -fno-sycl-allow-device-image-dependencies \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_CONFLICT
+// RUN: not %clangxx -fsyclbin=input -fno-sycl-allow-device-image-dependencies \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_CONFLICT
+// CHECK_DEPS_CONFLICT: error: invalid argument '-fno-sycl-allow-device-image-dependencies' not allowed with '-fsyclbin={{input|object}}'
+
+/// Combining -fsyclbin=executable with
+/// -fsycl-allow-device-image-dependencies is harmless but pointless,
+/// so the driver emits a warning.
+// RUN: %clangxx -fsyclbin=executable -fsycl-allow-device-image-dependencies \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_REDUNDANT
+// CHECK_DEPS_REDUNDANT: warning: invalid argument '-fsycl-allow-device-image-dependencies' not allowed with '-fsyclbin=executable'


### PR DESCRIPTION
When the user requests a linkable SYCLBIN artifact via -fsyclbin=input or -fsyclbin=object, the driver now implies:

* -fsycl-allow-device-image-dependencies, so sycl-post-link emits the SYCL/exported and SYCL/imported symbol property sets that the runtime link graph needs.
* -ftarget-export-symbols (-> -library-compilation) for AOT targets, so IGC keeps symbols externally visible in the resulting zebin for resolution via zeModuleDynamicLink.

-fsyclbin=executable is unchanged: closed-world codegen path preserved, no flag implied.

Diagnostics added for incompatible combinations:

* error on -fsyclbin=input/object combined with -fno-sycl-allow-device-image-dependencies (a contradiction; the message redirects users to -fsyclbin=executable).
* warning on -fsyclbin=executable combined with -fsycl-allow-device-image-dependencies (harmless but pointless).

Motivation: producing a SYCLBIN that participates in a runtime sycl::link previously required passing two extra flags in lockstep with -fsyclbin=. Missing either left users with a SYCLBIN that loaded but failed at runtime ("No exported symbol \"X\"" at sycl::link or "Unresolved Symbol \"X\"" inside
zeModuleDynamicLink). The state argument to -fsyclbin= already declares user intent, so the additional flags are now derived from it.

Waiting for approval from CE Compiler Options team.