### PR TITLE
[SYCL][KernelCompiler] Imply -fsycl-allow-device-image-dependencies for syclexp::compile

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -1039,6 +1039,46 @@ private:
     assert(MRTCBinInfo->MLanguage == syclex::source_language::sycl);
     assert(std::holds_alternative<std::string>(MBinImage));
 
+    // syclex::compile on an ext_oneapi_source bundle produces a
+    // bundle_state::object kernel_bundle, which the user is expected to
+    // hand to sycl::link for cross-image symbol resolution. Imply
+    // -fsycl-allow-device-image-dependencies for that path so that the
+    // RTC pipeline emits the SYCL/exported and SYCL/imported symbol
+    // property sets the runtime link graph needs. The implication
+    // mirrors the producer-side -fsyclbin=input/object behavior in the
+    // clang driver and is suppressed when the user explicitly opts out
+    // via -fno-sycl-allow-device-image-dependencies. State == executable
+    // is reached via syclex::build, which produces a fully-linked image
+    // with no cross-image references; no implication there.
+    constexpr std::string_view AllowDepsFlag =
+        "-fsycl-allow-device-image-dependencies";
+    constexpr std::string_view NoAllowDepsFlag =
+        "-fno-sycl-allow-device-image-dependencies";
+    auto OptionMatches = [](const sycl::detail::string_view &Opt,
+                            std::string_view Needle) {
+      return std::string_view{Opt.data()} == Needle;
+    };
+    bool UserOptedOut = std::any_of(
+        Options.begin(), Options.end(),
+        [&](const sycl::detail::string_view &Opt) {
+          return OptionMatches(Opt, NoAllowDepsFlag);
+        });
+    bool UserAlreadyOptedIn = std::any_of(
+        Options.begin(), Options.end(),
+        [&](const sycl::detail::string_view &Opt) {
+          return OptionMatches(Opt, AllowDepsFlag);
+        });
+    std::vector<sycl::detail::string_view> EffectiveOptions;
+    const std::vector<sycl::detail::string_view> *OptionsPtr = &Options;
+    if (State != bundle_state::executable && !UserOptedOut &&
+        !UserAlreadyOptedIn) {
+      EffectiveOptions.reserve(Options.size() + 1);
+      EffectiveOptions.emplace_back(AllowDepsFlag.data());
+      EffectiveOptions.insert(EffectiveOptions.end(), Options.begin(),
+                              Options.end());
+      OptionsPtr = &EffectiveOptions;
+    }
+
     // Build device images via the program manager.
     const std::string &SourceStr = std::get<std::string>(MBinImage);
     std::ostringstream SourceExt;
@@ -1064,7 +1104,7 @@ private:
 
     auto [Binaries, Prefix] = syclex::detail::SYCL_JIT_Compile(
         RegisteredKernelNames.empty() ? SourceStr : SourceExt.str(),
-        MRTCBinInfo->MIncludePairs, Options, LogPtr, Format);
+        MRTCBinInfo->MIncludePairs, *OptionsPtr, LogPtr, Format);
 
     auto &PM = detail::ProgramManager::getInstance();
 

--- a/sycl/test-e2e/KernelCompiler/sycl_link_implied_deps.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_link_implied_deps.cpp
@@ -1,0 +1,106 @@
+//==-- sycl_link_implied_deps.cpp - kernel_compiler implication test -------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: (opencl || level_zero)
+// REQUIRES: aspect-usm_shared_allocations
+
+// -- Regression test for CMPLRLLVM-75983: syclex::compile of an
+// -- ext_oneapi_source bundle should imply
+// -- -fsycl-allow-device-image-dependencies, since the resulting bundle is in
+// -- bundle_state::object and is intended to be passed to sycl::link. The
+// -- user should not have to repeat the flag via build_options for the
+// -- runtime cross-image link to find the SYCL/exported and SYCL/imported
+// -- symbol property sets.
+
+// Note linking is not supported on CUDA/HIP.
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// RUN: %{l0_leak_check} %{run} %t.out
+
+#include <sycl/detail/core.hpp>
+#include <sycl/kernel_bundle.hpp>
+#include <sycl/usm.hpp>
+
+namespace syclex = sycl::ext::oneapi::experimental;
+using source_kb = sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source>;
+using obj_kb = sycl::kernel_bundle<sycl::bundle_state::object>;
+using exe_kb = sycl::kernel_bundle<sycl::bundle_state::executable>;
+
+// TODO: remove SYCL_EXTERNAL from the kernel once it is no longer needed.
+auto constexpr SYCLImportSource = R"===(
+#include <sycl/sycl.hpp>
+
+SYCL_EXTERNAL void TestFunc(int *Ptr, int Size);
+
+extern "C" SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (sycl::ext::oneapi::experimental::single_task_kernel))
+void TestKernel(int *Ptr, int Size) {
+  TestFunc(Ptr, Size);
+}
+
+)===";
+
+auto constexpr SYCLExportSource = R"===(
+#include <sycl/sycl.hpp>
+
+SYCL_EXTERNAL void TestFunc(int *Ptr, int Size) {
+  for (size_t I = 0; I < Size; ++I)
+    Ptr[I] = I;
+}
+
+)===";
+
+int main() {
+  sycl::queue Q;
+
+  if (!Q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl)) {
+    std::cout << "Device does not support one of the source languages: "
+              << Q.get_device().get_info<sycl::info::device::name>()
+              << std::endl;
+    return 0;
+  }
+
+  source_kb ImportSourceKB = syclex::create_kernel_bundle_from_source(
+      Q.get_context(), syclex::source_language::sycl, SYCLImportSource);
+  source_kb ExportSourceKB = syclex::create_kernel_bundle_from_source(
+      Q.get_context(), syclex::source_language::sycl, SYCLExportSource);
+
+  // Intentionally do NOT pass
+  // build_options{"-fsycl-allow-device-image-dependencies"}: the runtime
+  // is expected to imply it for the object-state target of compile().
+  obj_kb ImportObjKB = syclex::compile(ImportSourceKB);
+  obj_kb ExportObjKB = syclex::compile(ExportSourceKB);
+
+  exe_kb ExecKB = sycl::link({ImportObjKB, ExportObjKB});
+
+  sycl::kernel Kernel = ExecKB.ext_oneapi_get_kernel("TestKernel");
+
+  constexpr int Range = 10;
+  int *USMPtr = sycl::malloc_shared<int>(Range, Q);
+
+  memset(USMPtr, 0, Range * sizeof(int));
+  Q.submit([&](sycl::handler &Handler) {
+    Handler.set_args(USMPtr, Range);
+    Handler.single_task(Kernel);
+  });
+  Q.wait();
+
+  int Failed = 0;
+  for (size_t I = 0; I < Range; ++I) {
+    if (USMPtr[I] != static_cast<int>(I)) {
+      std::cout << "Unexpected value at index " << I << ": " << USMPtr[I]
+                << " != " << I << std::endl;
+      ++Failed;
+    }
+  }
+
+  sycl::free(USMPtr, Q);
+
+  return Failed;
+}


### PR DESCRIPTION
The user-visible API contract for syclexp::compile on an ext_oneapi_source kernel_bundle is to produce a bundle in the object state, which is intended to be passed to sycl::link for cross-image symbol resolution. That requires the SYCL/exported and SYCL/imported symbol property sets emitted by the RTC sycl-post-link pass, which today is gated on the user passing build_options{"-fsycl-allow-device-image-dependencies"} to compile. Missing the flag leaves users with an object bundle that silently drops cross-image metadata, and a subsequent sycl::link fails with "No exported symbol \"X\" found in linked images." or "Unresolved Symbol \"X\"" depending on the backend.

Imply the flag from the operation. createSYCLImages adds the flag to the user options when the target state is not executable (i.e. compile path). The implication is suppressed when the user explicitly opts out via -fno-sycl-allow-device-image-dependencies in build_options. syclex::build (executable target) is unchanged; fully-linked images do not need the metadata.

Mirrors the producer-side coupling shipped for -fsyclbin=input/object in the clang driver, so the same implication holds at both layers.

Related to: #22206 