### PR TITLE
[SYCL][E2E] Disable level-zero-static-link-flow.cpp on Win BMG

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
+++ b/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: level_zero
 // UNSUPPORTED: ze_debug
 
-// UNSUPPORTED: windows && gpu-intel-gen12
+// UNSUPPORTED: windows && (gpu-intel-gen12 || arch-intel_gpu_bmg_g21)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
 
 // RUN: %{build} -o %t.out


### PR DESCRIPTION
Sporadically failing, see https://github.com/intel/llvm/issues/22192