### PR TITLE
Fix sycl lit.cfg to use test maxIndividualTestTime

### DIFF
--- a/sycl/test/format.py
+++ b/sycl/test/format.py
@@ -113,7 +113,7 @@ class SYCLHeadersTest(lit.formats.TestFormat):
                 command,
                 # TODO: do we need to pass some non-default cwd argument here?
                 env=test.config.environment,
-                timeout=litConfig.maxIndividualTestTime,
+                timeout=test.config.maxIndividualTestTime,
             )
             if is_xfail:
                 status = lit.Test.XPASS if exitCode == 0 else lit.Test.XFAIL

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -202,6 +202,6 @@ if not dump_only_tests:
 try:
     import psutil
 
-    lit_config.maxIndividualTestTime = 600
+    config.maxIndividualTestTime = 600
 except ImportError:
     pass


### PR DESCRIPTION
- Address move from global to test suite config in 2f08150

Follow up fix to sycl test format

- Related to upstream change 2f08150