### PR TITLE
[SYCL] Don't include OpenCL headers when compiling for SYCL device

### DIFF
--- a/sycl/include/sycl/detail/cl.h
+++ b/sycl/include/sycl/detail/cl.h
@@ -19,7 +19,7 @@
 #define CL_ENABLE_BETA_EXTENSIONS
 #endif
 
-#ifdef __SYCL_DEVICE_ONLY__
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__SYCL_JIT__)
 // Don't include the OpenCL headers when compiling for SYCL device, as they only
 // define the host-side API. Instead, define the necessary types as opaque
 // pointers to not break the SYCL headers that include this header.
@@ -32,7 +32,7 @@ using cl_mem = void *;
 using cl_platform_id = void *;
 using cl_program = void *;
 using cl_sampler = void *;
-#else // __SYCL_DEVICE_ONLY__
+#else // !defined(__SYCL_DEVICE_ONLY__) || !defined(__SYCL_JIT__)
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
-#endif // __SYCL_DEVICE_ONLY__
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__SYCL_JIT__)

--- a/sycl/include/sycl/detail/cl.h
+++ b/sycl/include/sycl/detail/cl.h
@@ -19,5 +19,20 @@
 #define CL_ENABLE_BETA_EXTENSIONS
 #endif
 
+#ifdef __SYCL_DEVICE_ONLY__
+// Don't include the OpenCL headers when compiling for SYCL device, as they only
+// define the host-side API. Instead, define the necessary types as opaque
+// pointers to not break the SYCL headers that include this header.
+using cl_command_queue = void *;
+using cl_context = void *;
+using cl_device_id = void *;
+using cl_event = void *;
+using cl_kernel = void *;
+using cl_mem = void *;
+using cl_platform_id = void *;
+using cl_program = void *;
+using cl_sampler = void *;
+#else // __SYCL_DEVICE_ONLY__
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
+#endif // __SYCL_DEVICE_ONLY__


### PR DESCRIPTION
The host-side OpenCL headers only define the host-side API, and may be
not available in SYCL JIT environment. Don't include them, when
compiling for SYCL device, and instead define the necessary types as
opaque pointers to not break the SYCL headers.