### PR TITLE
[SYCL][Bindless][SPIR-V] Always inline all `__invoke__Image` funcs

### DIFF
--- a/sycl/include/sycl/detail/image_ocl_types.hpp
+++ b/sycl/include/sycl/detail/image_ocl_types.hpp
@@ -78,7 +78,8 @@ __SYCL_INVOKE_SPIRV_CALL_ARG1(ImageQueryFormat)
 __SYCL_INVOKE_SPIRV_CALL_ARG1(ImageQueryOrder)
 
 template <typename ImageT, typename CoordT, typename ValT>
-void __invoke__ImageWrite(ImageT Img, CoordT Coords, ValT Val) {
+__attribute__((always_inline)) inline void
+__invoke__ImageWrite(ImageT Img, CoordT Coords, ValT Val) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   auto TmpCoords = sycl::detail::convertToOpenCLType(Coords);
@@ -89,7 +90,8 @@ void __invoke__ImageWrite(ImageT Img, CoordT Coords, ValT Val) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-RetType __invoke__ImageRead(ImageT Img, CoordT Coords) {
+__attribute__((always_inline)) inline RetType
+__invoke__ImageRead(ImageT Img, CoordT Coords) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -100,7 +102,8 @@ RetType __invoke__ImageRead(ImageT Img, CoordT Coords) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-RetType __invoke__ImageFetch(ImageT Img, CoordT Coords) {
+__attribute__((always_inline)) inline RetType
+__invoke__ImageFetch(ImageT Img, CoordT Coords) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -112,7 +115,8 @@ RetType __invoke__ImageFetch(ImageT Img, CoordT Coords) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-RetType __invoke__SampledImageFetch(ImageT Img, CoordT Coords) {
+__attribute__((always_inline)) inline RetType
+__invoke__SampledImageFetch(ImageT Img, CoordT Coords) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -124,10 +128,11 @@ RetType __invoke__SampledImageFetch(ImageT Img, CoordT Coords) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-std::enable_if_t<std::is_same_v<RetType, sycl::vec<float, 4>> ||
-                     std::is_same_v<RetType, sycl::vec<int, 4>> ||
-                     std::is_same_v<RetType, sycl::vec<unsigned int, 4>>,
-                 RetType>
+__attribute__((always_inline)) inline std::enable_if_t<
+    std::is_same_v<RetType, sycl::vec<float, 4>> ||
+        std::is_same_v<RetType, sycl::vec<int, 4>> ||
+        std::is_same_v<RetType, sycl::vec<unsigned int, 4>>,
+    RetType>
 __invoke__SampledImageGather(ImageT Img, CoordT Coords, unsigned Component) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
@@ -140,7 +145,8 @@ __invoke__SampledImageGather(ImageT Img, CoordT Coords, unsigned Component) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-RetType __invoke__ImageArrayFetch(ImageT Img, CoordT Coords, int ArrayLayer) {
+__attribute__((always_inline)) inline RetType
+__invoke__ImageArrayFetch(ImageT Img, CoordT Coords, int ArrayLayer) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -152,8 +158,8 @@ RetType __invoke__ImageArrayFetch(ImageT Img, CoordT Coords, int ArrayLayer) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-RetType __invoke__SampledImageArrayFetch(ImageT Img, CoordT Coords,
-                                         int ArrayLayer) {
+__attribute__((always_inline)) inline RetType
+__invoke__SampledImageArrayFetch(ImageT Img, CoordT Coords, int ArrayLayer) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -165,7 +171,8 @@ RetType __invoke__SampledImageArrayFetch(ImageT Img, CoordT Coords,
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-RetType __invoke__ImageArrayRead(ImageT Img, CoordT Coords, int ArrayLayer) {
+__attribute__((always_inline)) inline RetType
+__invoke__ImageArrayRead(ImageT Img, CoordT Coords, int ArrayLayer) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -177,8 +184,8 @@ RetType __invoke__ImageArrayRead(ImageT Img, CoordT Coords, int ArrayLayer) {
 }
 
 template <typename ImageT, typename CoordT, typename ValT>
-void __invoke__ImageArrayWrite(ImageT Img, CoordT Coords, int ArrayLayer,
-                               ValT Val) {
+__attribute__((always_inline)) inline void
+__invoke__ImageArrayWrite(ImageT Img, CoordT Coords, int ArrayLayer, ValT Val) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   auto TmpCoords = sycl::detail::convertToOpenCLType(Coords);
@@ -189,7 +196,8 @@ void __invoke__ImageArrayWrite(ImageT Img, CoordT Coords, int ArrayLayer,
 }
 
 template <typename RetType, typename SmpImageT, typename DirVecT>
-RetType __invoke__ImageReadCubemap(SmpImageT SmpImg, DirVecT DirVec) {
+__attribute__((always_inline)) inline RetType
+__invoke__ImageReadCubemap(SmpImageT SmpImg, DirVecT DirVec) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -201,7 +209,8 @@ RetType __invoke__ImageReadCubemap(SmpImageT SmpImg, DirVecT DirVec) {
 }
 
 template <typename RetType, typename SmpImageT, typename CoordT>
-RetType __invoke__ImageReadLod(SmpImageT SmpImg, CoordT Coords, float Level) {
+__attribute__((always_inline)) inline RetType
+__invoke__ImageReadLod(SmpImageT SmpImg, CoordT Coords, float Level) {
   // The result type of the SPIR-V instruction OpImageSampleExplicitLod must be
   // a vector of four components. Use the type trait to get the appropriate
   // temporary vector type based on the original return type.
@@ -234,8 +243,8 @@ RetType __invoke__ImageReadLod(SmpImageT SmpImg, CoordT Coords, float Level) {
 }
 
 template <typename RetType, typename SmpImageT, typename CoordT>
-RetType __invoke__ImageReadGrad(SmpImageT SmpImg, CoordT Coords, CoordT Dx,
-                                CoordT Dy) {
+__attribute__((always_inline)) inline RetType
+__invoke__ImageReadGrad(SmpImageT SmpImg, CoordT Coords, CoordT Dx, CoordT Dy) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -257,8 +266,9 @@ RetType __invoke__ImageReadGrad(SmpImageT SmpImg, CoordT Coords, CoordT Dx,
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-RetType __invoke__ImageReadSampler(ImageT Img, CoordT Coords,
-                                   const __ocl_sampler_t &Smpl) {
+__attribute__((always_inline)) inline RetType
+__invoke__ImageReadSampler(ImageT Img, CoordT Coords,
+                           const __ocl_sampler_t &Smpl) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;

--- a/sycl/test/check_device_code/image_invoke_always_inline.cpp
+++ b/sycl/test/check_device_code/image_invoke_always_inline.cpp
@@ -1,0 +1,149 @@
+// Check that __invoke__Image* functions are inlined into their callers even at
+// -O0. This is required for correct SPIR-V generation: the SPIR-V spec
+// (section 2.16.1) requires that OpSampledImage instructions (e.g. the result
+// of OpConvertHandleToSampledImageINTEL) are consumed in the same basic block
+// as the image operation that uses them (e.g. OpImageSampleExplicitLod).
+// Without always_inline, the __invoke__Image* wrappers would not be inlined at
+// -O0, placing the handle conversion in a different block from the consumer.
+
+// RUN: %clangxx -O0 -fsycl -fsycl-device-only -fno-discard-value-names -S -emit-llvm -fno-sycl-instrument-device-code -o - %s | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+using OCLImageTyRead =
+    typename sycl::detail::opencl_image_type<2, sycl::access::mode::read,
+                                             sycl::access::target::image>::type;
+
+using OCLImageTyWrite =
+    typename sycl::detail::opencl_image_type<2, sycl::access::mode::write,
+                                             sycl::access::target::image>::type;
+
+using OCLSampledImageTy =
+    typename sycl::detail::sampled_opencl_image_type<OCLImageTyRead>::type;
+
+// Test ImageRead - __invoke__ImageRead must be inlined, __spirv_ImageRead must
+// appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_read
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageRead
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_ImageRead
+SYCL_EXTERNAL sycl::float4 test_image_read(OCLImageTyRead img) {
+  return __invoke__ImageRead<sycl::float4>(img, sycl::int2(0, 0));
+}
+
+// Test ImageWrite - __invoke__ImageWrite must be inlined, __spirv_ImageWrite
+// must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_write
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageWrite
+// CHECK: call {{.*}} void @{{.*}}__spirv_ImageWrite
+SYCL_EXTERNAL void test_image_write(OCLImageTyWrite img, sycl::float4 val) {
+  __invoke__ImageWrite(img, sycl::int2(0, 0), val);
+}
+
+// Test ImageFetch - __invoke__ImageFetch must be inlined, __spirv_ImageFetch
+// must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_fetch
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageFetch
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_ImageFetch
+SYCL_EXTERNAL sycl::float4 test_image_fetch(OCLImageTyRead img) {
+  return __invoke__ImageFetch<sycl::float4>(img, sycl::int2(0, 0));
+}
+
+// Test SampledImageFetch - __invoke__SampledImageFetch must be inlined,
+// __spirv_SampledImageFetch must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_sampled_image_fetch
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__SampledImageFetch
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_SampledImageFetch
+SYCL_EXTERNAL sycl::float4 test_sampled_image_fetch(OCLSampledImageTy img) {
+  return __invoke__SampledImageFetch<sycl::float4>(img, sycl::int2(0, 0));
+}
+
+// Test ImageReadLod - __invoke__ImageReadLod must be inlined,
+// __spirv_ImageSampleExplicitLod must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_read_lod
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageReadLod
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_ImageSampleExplicitLod
+SYCL_EXTERNAL sycl::float4 test_image_read_lod(OCLSampledImageTy img) {
+  return __invoke__ImageReadLod<sycl::float4>(img, sycl::float2(0.f, 0.f), 0.f);
+}
+
+// Test ImageReadGrad - __invoke__ImageReadGrad must be inlined,
+// __spirv_ImageSampleExplicitLod must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_read_grad
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageReadGrad
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_ImageSampleExplicitLod
+SYCL_EXTERNAL sycl::float4 test_image_read_grad(OCLSampledImageTy img) {
+  return __invoke__ImageReadGrad<sycl::float4>(img, sycl::float2(0.f, 0.f),
+                                               sycl::float2(0.f, 0.f),
+                                               sycl::float2(0.f, 0.f));
+}
+
+// Test ImageReadCubemap - __invoke__ImageReadCubemap must be inlined,
+// __spirv_ImageSampleCubemap must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_read_cubemap
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageReadCubemap
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_ImageSampleCubemap
+SYCL_EXTERNAL sycl::float4 test_image_read_cubemap(OCLSampledImageTy img) {
+  return __invoke__ImageReadCubemap<sycl::float4>(img,
+                                                  sycl::float3(0.f, 0.f, 0.f));
+}
+
+// Test ImageReadSampler - __invoke__ImageReadSampler must be inlined,
+// __spirv_ImageSampleExplicitLod must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_read_sampler
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageReadSampler
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_ImageSampleExplicitLod
+SYCL_EXTERNAL sycl::float4
+test_image_read_sampler(OCLImageTyRead img, const __ocl_sampler_t &smpl) {
+  return __invoke__ImageReadSampler<sycl::float4>(img, sycl::float2(0.f, 0.f),
+                                                  smpl);
+}
+
+// Test ImageArrayRead - __invoke__ImageArrayRead must be inlined,
+// __spirv_ImageArrayRead must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_array_read
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageArrayRead
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_ImageArrayRead
+SYCL_EXTERNAL sycl::float4 test_image_array_read(OCLImageTyRead img) {
+  return __invoke__ImageArrayRead<sycl::float4>(img, sycl::int2(0, 0), 0);
+}
+
+// Test ImageArrayWrite - __invoke__ImageArrayWrite must be inlined,
+// __spirv_ImageArrayWrite must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_array_write
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageArrayWrite
+// CHECK: call {{.*}} void @{{.*}}__spirv_ImageArrayWrite
+SYCL_EXTERNAL void test_image_array_write(OCLImageTyWrite img,
+                                          sycl::float4 val) {
+  __invoke__ImageArrayWrite(img, sycl::int2(0, 0), 0, val);
+}
+
+// Test ImageArrayFetch - __invoke__ImageArrayFetch must be inlined,
+// __spirv_ImageArrayFetch must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_image_array_fetch
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__ImageArrayFetch
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_ImageArrayFetch
+SYCL_EXTERNAL sycl::float4 test_image_array_fetch(OCLImageTyRead img) {
+  return __invoke__ImageArrayFetch<sycl::float4>(img, sycl::int2(0, 0), 0);
+}
+
+// Test SampledImageArrayFetch - __invoke__SampledImageArrayFetch must be
+// inlined, __spirv_SampledImageArrayFetch must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_sampled_image_array_fetch
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__SampledImageArrayFetch
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_SampledImageArrayFetch
+SYCL_EXTERNAL sycl::float4
+test_sampled_image_array_fetch(OCLSampledImageTy img) {
+  return __invoke__SampledImageArrayFetch<sycl::float4>(img, sycl::int2(0, 0),
+                                                        0);
+}
+
+// Test SampledImageGather - __invoke__SampledImageGather must be inlined,
+// __spirv_SampledImageGather must appear directly in the caller.
+// CHECK-LABEL: define {{.*}} @_Z{{.*}}test_sampled_image_gather
+// CHECK-NOT: call {{.*}} @{{.*}}__invoke__SampledImageGather
+// CHECK: call {{.*}} <4 x float> @{{.*}}__spirv_SampledImageGather
+SYCL_EXTERNAL sycl::vec<float, 4>
+test_sampled_image_gather(OCLSampledImageTy img) {
+  return __invoke__SampledImageGather<sycl::vec<float, 4>>(
+      img, sycl::float2(0.f, 0.f), 0);
+}


### PR DESCRIPTION
When using bindless images, DPC++ can violate the Data rule of OpSampledImage instructions where they must be in the same block as their Result<id> are consumed (§2.16.1, "Data rules").

This can happen when the handle conversion for bindless images (e.g. `__spirv_ConvertHandleToSampledImageINTEL`) is not in the same block as the consumer (e.g. `OpImageSampleExplicitLod`) due to the `__invoke__Image<...>` functions not being inlined. This issue can occur with `-O0` optimization for simple reproducers but it also can be seen with `-O1` and `-O2` for larger kernels, where the compiler's heuristics for inlining do not inline the `__invoke__Image<...>` functions.

This patch adds the `__attribute__((always_inline))` to each `__invoke__Image<...>` function to ensure that the SPIR-V image type is always generated in the same block as the consumer.

Related to https://github.com/intel/llvm/pull/21937.