### PR TITLE
[SYCL][clang-offload-wrapper] Remove getTombstoneKey from DenseMapInfo specialization

### DIFF
--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -101,10 +101,6 @@ template <> struct DenseMapInfo<OffloadKind> {
     return static_cast<OffloadKind>(DenseMapInfo<unsigned>::getEmptyKey());
   }
 
-  static inline OffloadKind getTombstoneKey() {
-    return static_cast<OffloadKind>(DenseMapInfo<unsigned>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const OffloadKind &Val) {
     return DenseMapInfo<unsigned>::getHashValue(static_cast<unsigned>(Val));
   }


### PR DESCRIPTION
- getTombstoneKey was removed from DenseMapInfo api 836bf567e622
