### PR TITLE
[SYCL][SYCLBIN] Fix kernel lookup after link of SYCLBIN + RTC bundles

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -273,6 +273,9 @@ def err_drv_argument_not_allowed_with : Error<
 def warn_drv_argument_not_allowed_with : Warning<
   "invalid argument '%0' not allowed with '%1'">,
   InGroup<OptionIgnored>;
+def warn_drv_argument_has_no_effect_with : Warning<
+  "'%0' has no effect with '%1'">,
+  InGroup<OptionIgnored>;
 def err_drv_sycl_requires_cxx17 : Error<
   "SYCL requires C++17 or later; '%0' is not supported">;
 def err_drv_cannot_open_randomize_layout_seed_file : Error<

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11211,7 +11211,7 @@ static bool allowDeviceImageDependencies(const llvm::opt::ArgList &TCArgs) {
   // -fsyclbin=executable does not imply, since it produces a fully linked
   // artifact with no cross-image references.
   bool SYCLBINImplies = false;
-  if (Arg *A = TCArgs.getLastArg(options::OPT_fsyclbin_EQ)) {
+  if (const Arg *A = TCArgs.getLastArg(options::OPT_fsyclbin_EQ)) {
     StringRef State = A->getValue();
     SYCLBINImplies = (State == "input" || State == "object");
   }
@@ -12005,17 +12005,19 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     // -fsycl-allow-device-image-dependencies is harmless but pointless,
     // so it is diagnosed as a warning.
     bool SYCLBINImpliesAllowDeps = false;
-    if (Arg *A = Args.getLastArg(options::OPT_fsyclbin_EQ)) {
+    if (const Arg *A = Args.getLastArg(options::OPT_fsyclbin_EQ)) {
       StringRef State = A->getValue();
       bool IsLinkableState = (State == "input" || State == "object");
-      SYCLBINImpliesAllowDeps = IsLinkableState;
+      SYCLBINImpliesAllowDeps = State == "input" || State == "object";
+      
+      And re-use SYCLBINImpliesAllowDeps instead of IsLinkableState
       const Driver &D = getToolChain().getDriver();
-      if (Arg *NoDeps = Args.getLastArg(
+      if (const Arg *NoDeps = Args.getLastArg(
               options::OPT_fno_sycl_allow_device_image_dependencies);
           NoDeps && IsLinkableState) {
         D.Diag(diag::err_drv_argument_not_allowed_with)
             << NoDeps->getAsString(Args) << A->getAsString(Args);
-      } else if (Arg *Deps = Args.getLastArg(
+      } else if (const Arg *Deps = Args.getLastArg(
                      options::OPT_fsycl_allow_device_image_dependencies);
                  Deps && State == "executable") {
         D.Diag(diag::warn_drv_argument_has_no_effect_with)

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11203,6 +11203,19 @@ static void addArgs(ArgStringList &DstArgs, const llvm::opt::ArgList &Alloc,
 }
 
 static bool allowDeviceImageDependencies(const llvm::opt::ArgList &TCArgs) {
+  // -fsyclbin=input and -fsyclbin=object request a linkable SYCLBIN
+  // artifact whose cross-image SYCL_EXTERNAL references must be resolved
+  // at runtime via sycl::link. That requires the exported/imported symbol
+  // property sets emitted by sycl-post-link, so device-image dependencies
+  // are implied by these states unless the user explicitly opts out.
+  // -fsyclbin=executable does not imply, since it produces a fully linked
+  // artifact with no cross-image references.
+  bool SYCLBINImplies = false;
+  if (Arg *A = TCArgs.getLastArg(options::OPT_fsyclbin_EQ)) {
+    StringRef State = A->getValue();
+    SYCLBINImplies = (State == "input" || State == "object");
+  }
+
   // deprecated
   if (TCArgs.hasFlag(options::OPT_fsycl_allow_device_dependencies,
                      options::OPT_fno_sycl_allow_device_dependencies, false))
@@ -11210,7 +11223,8 @@ static bool allowDeviceImageDependencies(const llvm::opt::ArgList &TCArgs) {
 
   // preferred
   if (TCArgs.hasFlag(options::OPT_fsycl_allow_device_image_dependencies,
-                     options::OPT_fno_sycl_allow_device_image_dependencies, false))
+                     options::OPT_fno_sycl_allow_device_image_dependencies,
+                     SYCLBINImplies))
     return true;
 
   return false;
@@ -11975,9 +11989,42 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     if (Args.hasArg(options::OPT_fsycl_embed_ir))
       CmdArgs.push_back(Args.MakeArgString("-sycl-embed-ir"));
 
+    // -fsyclbin=input and -fsyclbin=object semantically request a linkable
+    // SYCLBIN artifact. Cross-image SYCL_EXTERNAL resolution at runtime
+    // requires the exported/imported symbol property sets emitted by
+    // sycl-post-link, so default -fsycl-allow-device-image-dependencies to
+    // true for those states. Users who want a single-image, fully
+    // optimized artifact should use -fsyclbin=executable instead.
+    //
+    // It is an error to combine -fsyclbin=input/object with
+    // -fno-sycl-allow-device-image-dependencies: an object SYCLBIN that
+    // forbids cross-image dependencies has no use case (it would be a
+    // worse-codegen equivalent of -fsyclbin=executable).
+    //
+    // Combining -fsyclbin=executable with
+    // -fsycl-allow-device-image-dependencies is harmless but pointless,
+    // so it is diagnosed as a warning.
+    bool SYCLBINImpliesAllowDeps = false;
+    if (Arg *A = Args.getLastArg(options::OPT_fsyclbin_EQ)) {
+      StringRef State = A->getValue();
+      bool IsLinkableState = (State == "input" || State == "object");
+      SYCLBINImpliesAllowDeps = IsLinkableState;
+      const Driver &D = getToolChain().getDriver();
+      if (Arg *NoDeps = Args.getLastArg(
+              options::OPT_fno_sycl_allow_device_image_dependencies);
+          NoDeps && IsLinkableState) {
+        D.Diag(diag::err_drv_argument_not_allowed_with)
+            << NoDeps->getAsString(Args) << A->getAsString(Args);
+      } else if (Arg *Deps = Args.getLastArg(
+                     options::OPT_fsycl_allow_device_image_dependencies);
+                 Deps && State == "executable") {
+        D.Diag(diag::warn_drv_argument_has_no_effect_with)
+            << Deps->getAsString(Args) << A->getAsString(Args);
+      }
+    }
     if (Args.hasFlag(options::OPT_fsycl_allow_device_image_dependencies,
                      options::OPT_fno_sycl_allow_device_image_dependencies,
-                     false))
+                     SYCLBINImpliesAllowDeps))
       CmdArgs.push_back(
           Args.MakeArgString("-sycl-allow-device-image-dependencies"));
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -12007,14 +12007,12 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     bool SYCLBINImpliesAllowDeps = false;
     if (const Arg *A = Args.getLastArg(options::OPT_fsyclbin_EQ)) {
       StringRef State = A->getValue();
-      bool IsLinkableState = (State == "input" || State == "object");
-      SYCLBINImpliesAllowDeps = State == "input" || State == "object";
+      SYCLBINImpliesAllowDeps = (State == "input" || State == "object");
 
-      And re - use SYCLBINImpliesAllowDeps instead of
-                   IsLinkableState const Driver &D = getToolChain().getDriver();
+      const Driver &D = getToolChain().getDriver();
       if (const Arg *NoDeps = Args.getLastArg(
               options::OPT_fno_sycl_allow_device_image_dependencies);
-          NoDeps && IsLinkableState) {
+          NoDeps && SYCLBINImpliesAllowDeps) {
         D.Diag(diag::err_drv_argument_not_allowed_with)
             << NoDeps->getAsString(Args) << A->getAsString(Args);
       } else if (const Arg *Deps = Args.getLastArg(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -12009,9 +12009,9 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       StringRef State = A->getValue();
       bool IsLinkableState = (State == "input" || State == "object");
       SYCLBINImpliesAllowDeps = State == "input" || State == "object";
-      
-      And re-use SYCLBINImpliesAllowDeps instead of IsLinkableState
-      const Driver &D = getToolChain().getDriver();
+
+      And re - use SYCLBINImpliesAllowDeps instead of
+                   IsLinkableState const Driver &D = getToolChain().getDriver();
       if (const Arg *NoDeps = Args.getLastArg(
               options::OPT_fno_sycl_allow_device_image_dependencies);
           NoDeps && IsLinkableState) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11211,7 +11211,7 @@ static bool allowDeviceImageDependencies(const llvm::opt::ArgList &TCArgs) {
   // -fsyclbin=executable does not imply, since it produces a fully linked
   // artifact with no cross-image references.
   bool SYCLBINImplies = false;
-  if (const Arg *A = TCArgs.getLastArg(options::OPT_fsyclbin_EQ)) {
+  if (const Arg *A = TCArgs.getLastArgNoClaim(options::OPT_fsyclbin_EQ)) {
     StringRef State = A->getValue();
     SYCLBINImplies = (State == "input" || State == "object");
   }

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1824,9 +1824,24 @@ void SYCLToolChain::AddSPIRVImpliedTargetArgs(const llvm::Triple &Triple,
     // -ftarget-compile-fast AOT
     if (Args.hasArg(options::OPT_ftarget_compile_fast))
       BeArgs.push_back("-igc_opts 'PartitionUnit=1,SubroutineThreshold=50000'");
-    // -ftarget-export-symbols
+    // -ftarget-export-symbols, also implied for -fsyclbin=input/object so
+    // that AOT-compiled native images keep cross-image SYCL_EXTERNAL
+    // symbols externally visible for runtime resolution via
+    // zeModuleDynamicLink. Users who want a fully-linked, internalized
+    // native image should use -fsyclbin=executable instead. The conflict
+    // case (-fsyclbin=input/object with
+    // -fno-sycl-allow-device-image-dependencies) is diagnosed earlier in
+    // the linker-wrapper construction; here we only need to keep the
+    // implication aligned with the device-image-dependencies setting so
+    // that an explicit opt-out for non-SYCLBIN AOT scenarios is honored.
+    bool SYCLBINImpliesExportSymbols = false;
+    if (Arg *A = Args.getLastArg(options::OPT_fsyclbin_EQ)) {
+      StringRef State = A->getValue();
+      SYCLBINImpliesExportSymbols = (State == "input" || State == "object");
+    }
     if (Args.hasFlag(options::OPT_ftarget_export_symbols,
-                     options::OPT_fno_target_export_symbols, false))
+                     options::OPT_fno_target_export_symbols,
+                     SYCLBINImpliesExportSymbols))
       BeArgs.push_back("-library-compilation");
     // -foffload-fp32-prec-[sqrt/div]
     if (Args.hasArg(options::OPT_foffload_fp32_prec_div) ||

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1835,7 +1835,7 @@ void SYCLToolChain::AddSPIRVImpliedTargetArgs(const llvm::Triple &Triple,
     // implication aligned with the device-image-dependencies setting so
     // that an explicit opt-out for non-SYCLBIN AOT scenarios is honored.
     bool SYCLBINImpliesExportSymbols = false;
-    if (Arg *A = Args.getLastArg(options::OPT_fsyclbin_EQ)) {
+    if (const Arg *A = Args.getLastArg(options::OPT_fsyclbin_EQ)) {
       StringRef State = A->getValue();
       SYCLBINImpliesExportSymbols = (State == "input" || State == "object");
     }

--- a/clang/test/Driver/sycl-fsyclbin.cpp
+++ b/clang/test/Driver/sycl-fsyclbin.cpp
@@ -106,8 +106,8 @@
 // RUN: %clangxx -fsyclbin=object --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_DEPS_IMPLIED
 // CHECK_DEPS_IMPLIED: clang-linker-wrapper
-// CHECK_DEPS_IMPLIED-DAG: "-sycl-allow-device-image-dependencies"
-// CHECK_DEPS_IMPLIED-DAG: "--sycl-post-link-options={{.*}}-allow-device-image-dependencies{{.*}}"
+// CHECK_DEPS_IMPLIED-SAME: "--sycl-post-link-options={{[^"]*}}-allow-device-image-dependencies{{[^"]*}}"
+// CHECK_DEPS_IMPLIED-SAME: "-sycl-allow-device-image-dependencies"
 
 /// -fsyclbin=executable does not imply
 /// -fsycl-allow-device-image-dependencies, since the resulting bundle

--- a/clang/test/Driver/sycl-fsyclbin.cpp
+++ b/clang/test/Driver/sycl-fsyclbin.cpp
@@ -97,3 +97,55 @@
 // RUN: | FileCheck %s --check-prefix=CHECK_WIN_DEFAULT_OUTPUT
 // CHECK_WIN_DEFAULT_OUTPUT: clang-linker-wrapper
 // CHECK_WIN_DEFAULT_OUTPUT-SAME: "-out:{{.*}}fsyclbin.syclbin"
+
+/// -fsyclbin=input and -fsyclbin=object imply
+/// -fsycl-allow-device-image-dependencies, since cross-image symbol
+/// resolution is required for those bundle states.
+// RUN: %clangxx -fsyclbin=input --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_IMPLIED
+// RUN: %clangxx -fsyclbin=object --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_IMPLIED
+// CHECK_DEPS_IMPLIED: clang-linker-wrapper
+// CHECK_DEPS_IMPLIED-SAME: "-sycl-allow-device-image-dependencies"
+// CHECK_DEPS_IMPLIED-SAME: --sycl-post-link-options={{.*}}-allow-device-image-dependencies
+
+/// -fsyclbin=executable does not imply
+/// -fsycl-allow-device-image-dependencies, since the resulting bundle
+/// is fully linked and does not participate in cross-image link.
+// RUN: %clangxx -fsyclbin=executable --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_NOT_IMPLIED
+// CHECK_DEPS_NOT_IMPLIED-NOT: -sycl-allow-device-image-dependencies
+
+/// For AOT spir64_gen, -fsyclbin=input/object additionally implies
+/// -library-compilation in the backend options so symbols stay
+/// externally visible for runtime cross-image resolution.
+// RUN: %clangxx -fsyclbin=object -fsycl-targets=spir64_gen \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_LIBCOMP_IMPLIED
+// CHECK_LIBCOMP_IMPLIED: -library-compilation
+
+// RUN: %clangxx -fsyclbin=executable -fsycl-targets=spir64_gen \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_LIBCOMP_NOT_IMPLIED
+// CHECK_LIBCOMP_NOT_IMPLIED-NOT: -library-compilation
+
+/// Combining -fsyclbin=input/object with
+/// -fno-sycl-allow-device-image-dependencies is a contradiction: an
+/// object SYCLBIN that forbids cross-image dependencies has no use
+/// case, so the driver emits an error and redirects users to
+/// -fsyclbin=executable.
+// RUN: not %clangxx -fsyclbin=object -fno-sycl-allow-device-image-dependencies \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_CONFLICT
+// RUN: not %clangxx -fsyclbin=input -fno-sycl-allow-device-image-dependencies \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_CONFLICT
+// CHECK_DEPS_CONFLICT: error: invalid argument '-fno-sycl-allow-device-image-dependencies' not allowed with '-fsyclbin={{input|object}}'
+
+/// Combining -fsyclbin=executable with
+/// -fsycl-allow-device-image-dependencies is harmless but pointless,
+/// so the driver emits a warning.
+// RUN: %clangxx -fsyclbin=executable -fsycl-allow-device-image-dependencies \
+// RUN:   --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHECK_DEPS_REDUNDANT
+// CHECK_DEPS_REDUNDANT: warning: '-fsycl-allow-device-image-dependencies' has no effect with '-fsyclbin=executable'

--- a/clang/test/Driver/sycl-fsyclbin.cpp
+++ b/clang/test/Driver/sycl-fsyclbin.cpp
@@ -106,8 +106,8 @@
 // RUN: %clangxx -fsyclbin=object --offload-new-driver --sysroot=%S/Inputs/SYCL %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK_DEPS_IMPLIED
 // CHECK_DEPS_IMPLIED: clang-linker-wrapper
-// CHECK_DEPS_IMPLIED-SAME: "-sycl-allow-device-image-dependencies"
-// CHECK_DEPS_IMPLIED-SAME: --sycl-post-link-options={{.*}}-allow-device-image-dependencies
+// CHECK_DEPS_IMPLIED-DAG: "-sycl-allow-device-image-dependencies"
+// CHECK_DEPS_IMPLIED-DAG: "--sycl-post-link-options={{.*}}-allow-device-image-dependencies{{.*}}"
 
 /// -fsyclbin=executable does not imply
 /// -fsycl-allow-device-image-dependencies, since the resulting bundle

--- a/sycl/doc/design/SYCLBINDesign.md
+++ b/sycl/doc/design/SYCLBINDesign.md
@@ -238,8 +238,35 @@ based), this option currently requires `--offload-new-driver` to be set.
 </tr>
 </table>
 
-Additionally, `-fsycl-link` should work with .syclbin files. Semantics of how
-SYCLBIN files are linked together is yet to be specified.
+Additionally, `-fsycl-link` should work with .syclbin files.
+
+### Linking SYCLBIN files
+
+`sycl::link` of two or more `kernel_bundle<bundle_state::object>` objects
+that originate from SYCLBIN files (or from a mix of SYCLBIN and
+runtime-compiled source bundles) is supported. The runtime treats each
+`device_image` carried by the input bundles as a node in a per-device
+link graph and uses the `SYCL/exported symbols` / `SYCL/imported symbols`
+property sets emitted by sycl-post-link to drive resolution:
+
+* Each exported symbol entry maps to its defining image.
+* Each imported symbol must resolve to exactly one exported entry across
+  the input images. Unresolved imports throw `errc::invalid`.
+* Duplicate exports across input images throw `errc::invalid`.
+* Duplicate kernel names across input images throw `errc::invalid`
+  (`Conflicting kernel definitions: ...`).
+
+Three supported configurations:
+
+1. *SYCLBIN object + SYCLBIN object*. Each `.syclbin` is loaded with
+   `get_kernel_bundle<bundle_state::object>(ctx, file)`; both bundles are
+   passed to `sycl::link`.
+2. *SYCLBIN object + runtime-compiled object*. The SYCLBIN bundle is
+   loaded as in (1); the source bundle is produced with
+   `create_kernel_bundle_from_source` followed by `compile`.
+3. *SYCLBIN input*. Loaded with
+   `get_kernel_bundle<bundle_state::input>(ctx, devs, file)` and brought
+   to object state via `sycl::compile` before linking.
 
 
 ## clang-linker-wrapper changes

--- a/sycl/doc/design/SYCLBINDesign.md
+++ b/sycl/doc/design/SYCLBINDesign.md
@@ -256,7 +256,7 @@ property sets emitted by sycl-post-link to drive resolution:
 * Duplicate kernel names across input images throw `errc::invalid`
   (`Conflicting kernel definitions: ...`).
 
-Three supported configurations:
+There are three supported configurations:
 
 1. *SYCLBIN object + SYCLBIN object*. Each `.syclbin` is loaded with
    `get_kernel_bundle<bundle_state::object>(ctx, file)`; both bundles are

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_syclbin.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_syclbin.asciidoc
@@ -242,3 +242,55 @@ _{endnote}_]
 
 |====
 
+
+== Examples
+
+=== Linking a SYCLBIN with a runtime-compiled source bundle
+
+The following example shows how a precompiled SYCLBIN file
+(`kernels.syclbin`) is loaded at runtime, linked together with a kernel
+bundle compiled from a SYCL source string, and used to launch a kernel
+defined in the SYCLBIN. Kernels from either origin are reachable through
+`ext_oneapi_get_kernel` on the linked bundle.
+
+The SYCLBIN file is produced ahead of time:
+
+[source,console]
+----
+clang++ --offload-new-driver -fsyclbin=object \
+        kernels.cpp -o kernels.syclbin
+----
+
+[source,c++]
+----
+#include <sycl/sycl.hpp>
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+int main() {
+  sycl::queue q;
+
+  auto kbObj = syclexp::get_kernel_bundle<sycl::bundle_state::object>(
+      q.get_context(), "kernels.syclbin");
+
+  std::string source = R"""(
+    // SYCL source providing a SYCL_EXTERNAL function used by kernels in
+    // kernels.syclbin and/or a sibling kernel of its own.
+  )""";
+  auto kbSrc = syclexp::create_kernel_bundle_from_source(
+      q.get_context(), syclexp::source_language::sycl, source);
+
+  auto kbSrcObj = syclexp::compile(kbSrc);
+
+  auto kbExe = sycl::link({kbObj, kbSrcObj});
+
+  sycl::kernel k = kbExe.ext_oneapi_get_kernel("MyKernel");
+  q.submit([&](sycl::handler &cgh) {
+     // Set args and launch.
+   }).wait_and_throw();
+}
+----
+
+The same pattern applies when both inputs are SYCLBIN files and when a
+SYCLBIN is loaded in `bundle_state::input` and brought to object state
+with `sycl::compile` before linking.
+

--- a/sycl/source/detail/device_image_impl.cpp
+++ b/sycl/source/detail/device_image_impl.cpp
@@ -38,7 +38,14 @@ std::shared_ptr<kernel_impl> device_image_impl::tryGetExtensionKernel(
           std::move(UrKernel), *getSyclObjImpl(Context), shared_from_this(),
           OwnerBundle, ArgMask, UrProgram, CacheMutex);
     }
-    return nullptr;
+    // RTC lookup miss. After sycl::link({RTC_obj, SYCLBIN_obj}) the merged
+    // image carries both ImageOriginKernelCompiler and ImageOriginSYCLBIN.
+    // Kernels that came from the SYCLBIN contribution are not registered
+    // with the runtime kernel-compiler ProgramManager, so we must fall
+    // through to the SYCLBIN urKernelCreate path rather than reporting
+    // "not found" solely because MRTCBinInfo is set.
+    if (!(getOriginMask() & ImageOriginSYCLBIN) || !hasKernelName(Name))
+      return nullptr;
   }
 
   ur_program_handle_t UrProgram = get_ur_program();

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -1039,6 +1039,46 @@ private:
     assert(MRTCBinInfo->MLanguage == syclex::source_language::sycl);
     assert(std::holds_alternative<std::string>(MBinImage));
 
+    // syclex::compile on an ext_oneapi_source bundle produces a
+    // bundle_state::object kernel_bundle, which the user is expected to
+    // hand to sycl::link for cross-image symbol resolution. Imply
+    // -fsycl-allow-device-image-dependencies for that path so that the
+    // RTC pipeline emits the SYCL/exported and SYCL/imported symbol
+    // property sets the runtime link graph needs. The implication
+    // mirrors the producer-side -fsyclbin=input/object behavior in the
+    // clang driver and is suppressed when the user explicitly opts out
+    // via -fno-sycl-allow-device-image-dependencies. State == executable
+    // is reached via syclex::build, which produces a fully-linked image
+    // with no cross-image references; no implication there.
+    constexpr std::string_view AllowDepsFlag =
+        "-fsycl-allow-device-image-dependencies";
+    constexpr std::string_view NoAllowDepsFlag =
+        "-fno-sycl-allow-device-image-dependencies";
+    auto OptionMatches = [](const sycl::detail::string_view &Opt,
+                            std::string_view Needle) {
+      return std::string_view{Opt.data()} == Needle;
+    };
+    bool UserOptedOut =
+        std::any_of(Options.begin(), Options.end(),
+                    [&](const sycl::detail::string_view &Opt) {
+                      return OptionMatches(Opt, NoAllowDepsFlag);
+                    });
+    bool UserAlreadyOptedIn =
+        std::any_of(Options.begin(), Options.end(),
+                    [&](const sycl::detail::string_view &Opt) {
+                      return OptionMatches(Opt, AllowDepsFlag);
+                    });
+    std::vector<sycl::detail::string_view> EffectiveOptions;
+    const std::vector<sycl::detail::string_view> *OptionsPtr = &Options;
+    if (State != bundle_state::executable && !UserOptedOut &&
+        !UserAlreadyOptedIn) {
+      EffectiveOptions.reserve(Options.size() + 1);
+      EffectiveOptions.emplace_back(AllowDepsFlag.data());
+      EffectiveOptions.insert(EffectiveOptions.end(), Options.begin(),
+                              Options.end());
+      OptionsPtr = &EffectiveOptions;
+    }
+
     // Build device images via the program manager.
     const std::string &SourceStr = std::get<std::string>(MBinImage);
     std::ostringstream SourceExt;
@@ -1064,7 +1104,7 @@ private:
 
     auto [Binaries, Prefix] = syclex::detail::SYCL_JIT_Compile(
         RegisteredKernelNames.empty() ? SourceStr : SourceExt.str(),
-        MRTCBinInfo->MIncludePairs, Options, LogPtr, Format);
+        MRTCBinInfo->MIncludePairs, *OptionsPtr, LogPtr, Format);
 
     auto &PM = detail::ProgramManager::getInstance();
 

--- a/sycl/test-e2e/KernelCompiler/sycl_link_implied_deps.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_link_implied_deps.cpp
@@ -1,0 +1,106 @@
+//==-- sycl_link_implied_deps.cpp - kernel_compiler implication test -------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: (opencl || level_zero)
+// REQUIRES: aspect-usm_shared_allocations
+
+// -- Regression test for CMPLRLLVM-75983: syclex::compile of an
+// -- ext_oneapi_source bundle should imply
+// -- -fsycl-allow-device-image-dependencies, since the resulting bundle is in
+// -- bundle_state::object and is intended to be passed to sycl::link. The
+// -- user should not have to repeat the flag via build_options for the
+// -- runtime cross-image link to find the SYCL/exported and SYCL/imported
+// -- symbol property sets.
+
+// Note linking is not supported on CUDA/HIP.
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// RUN: %{l0_leak_check} %{run} %t.out
+
+#include <sycl/detail/core.hpp>
+#include <sycl/kernel_bundle.hpp>
+#include <sycl/usm.hpp>
+
+namespace syclex = sycl::ext::oneapi::experimental;
+using source_kb = sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source>;
+using obj_kb = sycl::kernel_bundle<sycl::bundle_state::object>;
+using exe_kb = sycl::kernel_bundle<sycl::bundle_state::executable>;
+
+// TODO: remove SYCL_EXTERNAL from the kernel once it is no longer needed.
+auto constexpr SYCLImportSource = R"===(
+#include <sycl/ext/oneapi/free_function_kernel_properties.hpp>
+
+SYCL_EXTERNAL void TestFunc(int *Ptr, int Size);
+
+extern "C" SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (sycl::ext::oneapi::experimental::single_task_kernel))
+void TestKernel(int *Ptr, int Size) {
+  TestFunc(Ptr, Size);
+}
+
+)===";
+
+auto constexpr SYCLExportSource = R"===(
+#include <cstddef>
+
+SYCL_EXTERNAL void TestFunc(int *Ptr, int Size) {
+  for (size_t I = 0; I < Size; ++I)
+    Ptr[I] = I;
+}
+
+)===";
+
+int main() {
+  sycl::queue Q;
+
+  if (!Q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl)) {
+    std::cout << "Device does not support one of the source languages: "
+              << Q.get_device().get_info<sycl::info::device::name>()
+              << std::endl;
+    return 0;
+  }
+
+  source_kb ImportSourceKB = syclex::create_kernel_bundle_from_source(
+      Q.get_context(), syclex::source_language::sycl, SYCLImportSource);
+  source_kb ExportSourceKB = syclex::create_kernel_bundle_from_source(
+      Q.get_context(), syclex::source_language::sycl, SYCLExportSource);
+
+  // Intentionally do NOT pass
+  // build_options{"-fsycl-allow-device-image-dependencies"}: the runtime
+  // is expected to imply it for the object-state target of compile().
+  obj_kb ImportObjKB = syclex::compile(ImportSourceKB);
+  obj_kb ExportObjKB = syclex::compile(ExportSourceKB);
+
+  exe_kb ExecKB = sycl::link({ImportObjKB, ExportObjKB});
+
+  sycl::kernel Kernel = ExecKB.ext_oneapi_get_kernel("TestKernel");
+
+  constexpr int Range = 10;
+  int *USMPtr = sycl::malloc_shared<int>(Range, Q);
+
+  memset(USMPtr, 0, Range * sizeof(int));
+  Q.submit([&](sycl::handler &Handler) {
+    Handler.set_args(USMPtr, Range);
+    Handler.single_task(Kernel);
+  });
+  Q.wait();
+
+  int Failed = 0;
+  for (size_t I = 0; I < Range; ++I) {
+    if (USMPtr[I] != static_cast<int>(I)) {
+      std::cout << "Unexpected value at index " << I << ": " << USMPtr[I]
+                << " != " << I << std::endl;
+      ++Failed;
+    }
+  }
+
+  sycl::free(USMPtr, Q);
+
+  return Failed;
+}

--- a/sycl/test-e2e/SYCLBIN/Inputs/importing_kernel_obj.cpp
+++ b/sycl/test-e2e/SYCLBIN/Inputs/importing_kernel_obj.cpp
@@ -1,0 +1,20 @@
+// SYCLBIN side of the cross-origin link tests: defines a kernel that imports
+// a SYCL_EXTERNAL function which is provided by the RTC-compiled source
+// bundle. Exercises the case symmetric to exporting_function.cpp +
+// importing kernel from RTC: here the kernel itself lives in the SYCLBIN
+// object and must remain reachable after sycl::link({RTC_obj, SYCLBIN_obj}).
+
+#include <sycl/ext/oneapi/free_function_kernel_properties.hpp>
+#include <sycl/khr/work_item_queries.hpp>
+
+namespace syclkhr = sycl::khr;
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+SYCL_EXTERNAL void TestFunc(int *Ptr, int Size);
+
+extern "C" SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (syclexp::nd_range_kernel<1>)) void TestKernelBin(int *Ptr, int Size) {
+  size_t I = syclkhr::this_nd_item<1>().get_global_linear_id();
+  if (static_cast<int>(I) < Size)
+    TestFunc(Ptr, Size);
+}

--- a/sycl/test-e2e/SYCLBIN/Inputs/link_rtc_bidir.hpp
+++ b/sycl/test-e2e/SYCLBIN/Inputs/link_rtc_bidir.hpp
@@ -1,0 +1,106 @@
+#include "common.hpp"
+
+#include <sycl/usm.hpp>
+
+// Cross-origin link regression: the SYCLBIN object provides a kernel
+// (TestKernelBin) that imports a SYCL_EXTERNAL function (TestFunc) defined
+// in a runtime-compiled SYCL source bundle. After sycl::link({RTC_obj,
+// SYCLBIN_obj}) both the RTC-origin kernel (TestKernelRTC) and the
+// SYCLBIN-origin kernel (TestKernelBin) must be reachable via
+// ext_oneapi_get_kernel and produce correct results.
+auto constexpr SYCLSource = R"===(
+#include <sycl/ext/oneapi/free_function_kernel_properties.hpp>
+#include <sycl/khr/work_item_queries.hpp>
+
+namespace syclkhr = sycl::khr;
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+SYCL_EXTERNAL void TestFunc(int *Ptr, int Size) {
+  size_t I = syclkhr::this_nd_item<1>().get_global_linear_id();
+  if (static_cast<int>(I) < Size)
+    Ptr[I] = static_cast<int>(I);
+}
+
+extern "C" SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (syclexp::nd_range_kernel<1>))
+void TestKernelRTC(int *Ptr, int Size) {
+  TestFunc(Ptr, Size);
+}
+
+)===";
+
+static constexpr size_t NUM = 32;
+static constexpr size_t WGSIZE = 16;
+
+int main(int argc, char *argv[]) {
+  assert(argc == 2);
+
+  sycl::queue Q;
+
+  if (!Q.get_device().ext_oneapi_can_compile(syclexp::source_language::sycl)) {
+    std::cout << "Device does not support SYCL source kernel compiler: "
+              << Q.get_device().get_info<sycl::info::device::name>()
+              << std::endl;
+    return 0;
+  }
+
+  int Failed = CommonLoadCheck(Q.get_context(), argv[1]);
+
+  // Load SYCLBIN object bundle (kernel side).
+#if defined(SYCLBIN_INPUT_STATE)
+  auto KBInput = syclexp::get_kernel_bundle<sycl::bundle_state::input>(
+      Q.get_context(), {Q.get_device()}, std::string{argv[1]});
+  auto KBSYCLBINObj = sycl::compile(KBInput);
+#elif defined(SYCLBIN_OBJECT_STATE)
+  auto KBSYCLBINObj = syclexp::get_kernel_bundle<sycl::bundle_state::object>(
+      Q.get_context(), std::string{argv[1]});
+#else
+#error "Test does not work with executable state."
+#endif
+
+  // Compile the RTC source bundle that provides TestFunc and a sibling
+  // kernel (TestKernelRTC).
+  auto KBSrc = syclexp::create_kernel_bundle_from_source(
+      Q.get_context(), syclexp::source_language::sycl, SYCLSource);
+  auto KBSrcObj = syclexp::compile(KBSrc);
+
+  // Link: this is the path that previously merged origins into a single
+  // image and routed all lookups through the RTC ProgramManager,
+  // making SYCLBIN-origin kernels unreachable.
+  auto KBExe = sycl::link({KBSYCLBINObj, KBSrcObj});
+
+  int *Ptr = sycl::malloc_shared<int>(NUM, Q);
+
+  // Sibling RTC-origin kernel: this case already worked before the fix.
+  assert(KBExe.ext_oneapi_has_kernel("TestKernelRTC"));
+  sycl::kernel KRTC = KBExe.ext_oneapi_get_kernel("TestKernelRTC");
+  Q.fill(Ptr, int{-1}, NUM).wait_and_throw();
+  Q.submit([&](sycl::handler &CGH) {
+     CGH.set_args(Ptr, int{NUM});
+     CGH.parallel_for(sycl::nd_range<1>{{NUM}, {WGSIZE}}, KRTC);
+   }).wait_and_throw();
+  for (size_t I = 0; I < NUM; ++I)
+    if (Ptr[I] != static_cast<int>(I)) {
+      std::cout << "TestKernelRTC: " << Ptr[I] << " != " << I << "\n";
+      ++Failed;
+    }
+
+  // SYCLBIN-origin kernel that imports TestFunc from the RTC bundle.
+  // This is the regression: ext_oneapi_get_kernel must not return null and
+  // the kernel must execute correctly after the cross-origin link.
+  assert(KBExe.ext_oneapi_has_kernel("TestKernelBin"));
+  sycl::kernel KBin = KBExe.ext_oneapi_get_kernel("TestKernelBin");
+  Q.fill(Ptr, int{-1}, NUM).wait_and_throw();
+  Q.submit([&](sycl::handler &CGH) {
+     CGH.set_args(Ptr, int{NUM});
+     CGH.parallel_for(sycl::nd_range<1>{{NUM}, {WGSIZE}}, KBin);
+   }).wait_and_throw();
+  for (size_t I = 0; I < NUM; ++I)
+    if (Ptr[I] != static_cast<int>(I)) {
+      std::cout << "TestKernelBin: " << Ptr[I] << " != " << I << "\n";
+      ++Failed;
+    }
+
+  sycl::free(Ptr, Q);
+  return Failed;
+}

--- a/sycl/test-e2e/SYCLBIN/link_rtc_bidir_input.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_rtc_bidir_input.cpp
@@ -1,0 +1,14 @@
+// REQUIRES: (opencl || level_zero)
+// REQUIRES: aspect-usm_shared_allocations
+
+// -- Same cross-origin link scenario as link_rtc_bidir_object.cpp but the
+// -- SYCLBIN is loaded in input state and compiled at runtime, exercising
+// -- the same merged-image lookup path on the link result.
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=input %S/Inputs/importing_kernel_obj.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out %t.syclbin
+
+#define SYCLBIN_INPUT_STATE
+
+#include "Inputs/link_rtc_bidir.hpp"

--- a/sycl/test-e2e/SYCLBIN/link_rtc_bidir_object.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_rtc_bidir_object.cpp
@@ -1,0 +1,19 @@
+// REQUIRES: (opencl || level_zero)
+// REQUIRES: aspect-usm_shared_allocations
+
+// -- Cross-origin link: SYCLBIN object provides a kernel that imports a
+// -- SYCL_EXTERNAL function from a runtime-compiled SYCL source bundle.
+// -- Both kernels (RTC-origin and SYCLBIN-origin) must be reachable after
+// -- sycl::link({RTC_obj, SYCLBIN_obj}).
+//
+// -- Regression test for the case where tryGetExtensionKernel routed all
+// -- lookups on the merged image through the RTC ProgramManager and made
+// -- SYCLBIN-origin kernels unreachable.
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=object %S/Inputs/importing_kernel_obj.cpp -o %t.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out %t.syclbin
+
+#define SYCLBIN_OBJECT_STATE
+
+#include "Inputs/link_rtc_bidir.hpp"


### PR DESCRIPTION
Closes `CMPLRLLVM-74442`. Addresses driver/runtime UX surface of `CMPLRLLVM-75983`
(runtime AOT fixes already landed upstream as #22196).

Three logical commits:

1. [SYCL][SYCLBIN] Fix kernel lookup after link of SYCLBIN + RTC bundles
   - `sycl::link({RTC_obj, SYCLBIN_obj})` merged image had origin bits
     OR'd to (KernelCompiler|SYCLBIN). tryGetExtensionKernel routed all
     lookups through RTC ProgramManager and missed SYCLBIN-origin
     kernels. Add fall-through to SYCLBIN urKernelCreate path.
   - 4 e2e tests covering input + object SYCLBIN cross-origin link.
   - SYCLBINDesign.md and sycl_ext_oneapi_syclbin.asciidoc describe
     the link semantics, 3 supported configurations, and one
     end-to-end example.

2. [SYCL][Driver] Imply cross-image symbol flags from -fsyclbin=input/object
   - Driver implies -fsycl-allow-device-image-dependencies and, for AOT
     spir64_gen, -library-compilation, when -fsyclbin=input/object.
   - -fsyclbin=input/object with -fno-sycl-allow-device-image-dependencies
     is a hard error.
   - -fsyclbin=executable with -fsycl-allow-device-image-dependencies
     emits warning (new diag warn_drv_argument_has_no_effect_with):
       "'-fsycl-allow-device-image-dependencies' has no effect with
        '-fsyclbin=executable' [-Woption-ignored]"
   - Approved by Compiler Options Team (Mike Toguchi, Greg Lueck), Jun 2026.

3. [SYCL][KernelCompiler] Imply `-fsycl-allow-device-image-dependencies`
   for syclexp::compile
   - createSYCLImages auto-adds the flag for the compile() target
     (object state). syclex::build (executable target) unchanged.
   - Opt-out via -fno- in build_options preserved.

E2E suite results:
- sycl/test-e2e/SYCLBIN/: 24 pass, 4 unsupported, 0 fail.
- sycl/test-e2e/KernelCompiler/: 41 pass, 1 unsupported, 0 fail.
- sycl/test/e2e_test_requirements/no_sycl_hpp_in_e2e_tests.cpp: pass.
