### PR TITLE
[SYCL][GRAPH][E2E] Add regression tests for L0 enhancements

### DIFF
--- a/sycl/test-e2e/Graph/Error/invalid_event_wait_recording.cpp
+++ b/sycl/test-e2e/Graph/Error/invalid_event_wait_recording.cpp
@@ -1,0 +1,9 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+#define GRAPH_E2E_RECORD_REPLAY
+#define GRAPH_E2E_NATIVE_RECORDING
+
+#include "../../Inputs/exception_recording_event_wait.cpp"

--- a/sycl/test-e2e/Graph/Error/invalid_queue_wait.cpp
+++ b/sycl/test-e2e/Graph/Error/invalid_queue_wait.cpp
@@ -1,25 +1,4 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Tests that waiting on a Queue in recording mode throws.
-
-#include "../graph_common.hpp"
-
-int main() {
-  queue Queue{};
-
-  ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
-                                                 Queue.get_device()};
-  Graph.begin_recording(Queue);
-
-  std::error_code ErrorCode = make_error_code(sycl::errc::success);
-
-  try {
-    Queue.wait();
-  } catch (const sycl::exception &e) {
-    ErrorCode = e.code();
-  }
-  assert(ErrorCode == sycl::errc::invalid);
-
-  return 0;
-}
+#include "../Inputs/exception_recording_queue_wait.cpp"

--- a/sycl/test-e2e/Graph/Error/invalid_recording_event_wait.cpp
+++ b/sycl/test-e2e/Graph/Error/invalid_recording_event_wait.cpp
@@ -3,7 +3,4 @@
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-#define GRAPH_E2E_RECORD_REPLAY
-#define GRAPH_E2E_NATIVE_RECORDING
-
-#include "../../Inputs/exception_recording_event_wait.cpp"
+#include "../Inputs/exception_recording_event_wait.cpp"

--- a/sycl/test-e2e/Graph/Inputs/exception_recording_event_wait.cpp
+++ b/sycl/test-e2e/Graph/Inputs/exception_recording_event_wait.cpp
@@ -1,0 +1,43 @@
+// Tests that waiting on an event signaled during graph recording
+// throws.
+
+#include "../graph_common.hpp"
+
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  queue Queue{property::queue::in_order{}};
+
+#ifdef GRAPH_E2E_NATIVE_RECORDING
+  exp_ext::command_graph Graph{
+      Queue.get_context(),
+      Queue.get_device(),
+      {exp_ext::property::graph::enable_native_recording{}}};
+#else
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+#endif
+
+  Graph.begin_recording(Queue);
+
+  auto GraphEvent = Queue.single_task([]() {});
+
+  // TODO: The SYCL graph spec mandates errc::invalid but L0 graph's generic
+  // error codes make it difficult to determine the root cause. Once L0 graph
+  // expands their error codes we can add our handling and return the correct
+  // SYCL code along with a descriptive message to the user.
+#ifdef GRAPH_E2E_NATIVE_RECORDING
+  if (!expectException([&]() { GraphEvent.wait(); },
+                       "event wait during graph recording", errc::runtime)) {
+    return 1;
+  }
+#else
+  if (!expectException([&]() { GraphEvent.wait(); },
+                       "event wait during graph recording", errc::invalid)) {
+    return 1;
+  }
+#endif
+
+  Graph.end_recording();
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Inputs/exception_recording_queue_wait.cpp
+++ b/sycl/test-e2e/Graph/Inputs/exception_recording_queue_wait.cpp
@@ -1,0 +1,38 @@
+// Tests that waiting on a Queue in recording mode throws.
+
+#include "../graph_common.hpp"
+
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  queue Queue{property::queue::in_order{}};
+
+#ifdef GRAPH_E2E_NATIVE_RECORDING
+  exp_ext::command_graph Graph{
+      Queue.get_context(),
+      Queue.get_device(),
+      {exp_ext::property::graph::enable_native_recording{}}};
+#else
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+#endif
+  Graph.begin_recording(Queue);
+
+  // TODO: The SYCL graph spec mandates errc::invalid but L0 graph's generic
+  // error codes make it difficult to determine the root cause. Once L0 graph
+  // expands their error codes we can add our handling and return the correct
+  // SYCL code along with a descriptive message to the user.
+#ifdef GRAPH_E2E_NATIVE_RECORDING
+  if (!expectException([&]() { Queue.wait(); },
+                       "event wait during graph recording", errc::runtime)) {
+    return 1;
+  }
+#else
+  if (!expectException([&]() { Queue.wait(); },
+                       "event wait during graph recording", errc::invalid)) {
+    return 1;
+  }
+#endif
+  Graph.end_recording();
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/Inputs/exception_recording_queue_wait.cpp
+++ b/sycl/test-e2e/Graph/Inputs/exception_recording_queue_wait.cpp
@@ -23,12 +23,12 @@ int main() {
   // SYCL code along with a descriptive message to the user.
 #ifdef GRAPH_E2E_NATIVE_RECORDING
   if (!expectException([&]() { Queue.wait(); },
-                       "event wait during graph recording", errc::runtime)) {
+                       "queue wait during graph recording", errc::runtime)) {
     return 1;
   }
 #else
   if (!expectException([&]() { Queue.wait(); },
-                       "event wait during graph recording", errc::invalid)) {
+                       "queue wait during graph recording", errc::invalid)) {
     return 1;
   }
 #endif

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_recording_event_wait.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_recording_event_wait.cpp
@@ -1,0 +1,15 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+// REQUIRES: linux
+// REQUIRES-INTEL-DRIVER: lin: 38583
+
+// TODO: add minimum windows driver version once available
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+#define GRAPH_E2E_RECORD_REPLAY
+#define GRAPH_E2E_NATIVE_RECORDING
+
+#include "../../Inputs/exception_recording_event_wait.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_recording_event_wait.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_recording_event_wait.cpp
@@ -2,14 +2,13 @@
 // REQUIRES: linux
 // REQUIRES-INTEL-DRIVER: lin: 38583
 
-// TODO: add minimum windows driver version once available
+// TODO: Add minimum Windows driver version once available
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-#define GRAPH_E2E_RECORD_REPLAY
 #define GRAPH_E2E_NATIVE_RECORDING
 
 #include "../../Inputs/exception_recording_event_wait.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_recording_queue_wait.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_recording_queue_wait.cpp
@@ -5,7 +5,6 @@
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-#define GRAPH_E2E_RECORD_REPLAY
 #define GRAPH_E2E_NATIVE_RECORDING
 
 #include "../../Inputs/exception_recording_queue_wait.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_recording_queue_wait.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_recording_queue_wait.cpp
@@ -1,0 +1,11 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+#define GRAPH_E2E_RECORD_REPLAY
+#define GRAPH_E2E_NATIVE_RECORDING
+
+#include "../../Inputs/exception_recording_queue_wait.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/multi_queue_barrier_post_join_signal.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/multi_queue_barrier_post_join_signal.cpp
@@ -1,0 +1,56 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+// REQUIRES: linux
+// REQUIRES-INTEL-DRIVER: lin: 38591
+
+// TODO: add minimum Windows driver when available
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Test for native recording that unconsumed event signals are valid post-join
+
+#include "../../graph_common.hpp"
+
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  device Dev;
+  context Ctx{Dev};
+
+  queue Queue1{Ctx, Dev, {property::queue::in_order{}}};
+  queue Queue2{Ctx, Dev, {property::queue::in_order{}}};
+
+  QueueStateVerifier verifier(Queue1, Queue2);
+
+  exp_ext::command_graph Graph{
+      Ctx, Dev, {exp_ext::property::graph::enable_native_recording{}}};
+
+  verifier.verify(EXECUTING, EXECUTING);
+
+  // 1) record on Queue1
+  Graph.begin_recording(Queue1);
+  verifier.verify(RECORDING, EXECUTING);
+
+  // 2) barrier (ext_oneapi_barrier) and recording transition on Queue2
+  event ForkBarrier = Queue1.ext_oneapi_submit_barrier();
+  exp_ext::partial_barrier(Queue2, {ForkBarrier});
+  verifier.verify(RECORDING, RECORDING);
+
+  // 3) join barrier
+  event JoinBarrier = Queue2.ext_oneapi_submit_barrier();
+  exp_ext::partial_barrier(Queue1, {JoinBarrier});
+
+  // 4) post join signal
+  Queue2.ext_oneapi_submit_barrier();
+
+  Graph.end_recording();
+  verifier.verify(EXECUTING, EXECUTING);
+
+  // We only need to check the graph finalizes without error
+  [[maybe_unused]] auto ExecutableGraph = Graph.finalize();
+
+  return 0;
+}


### PR DESCRIPTION
- Tests exceptions thrown when events and queues wait during recording. With native recording, `errc::runtime` is still thrown which will be resolved with additional L0 error codes and SYCL graph handling later.
- A test is added ensuring post join signals from a forked command list are supported.