### PR TITLE
[SYCL] Disable printing in SYCL headers when compiling for device

### DIFF
--- a/sycl/include/sycl/detail/backend_types_io.hpp
+++ b/sycl/include/sycl/detail/backend_types_io.hpp
@@ -10,6 +10,8 @@
 
 #include <sycl/backend_types.hpp>
 
+#if !defined(__SYCL_DEVICE_ONLY__)
+
 #include <ostream>
 
 namespace sycl {
@@ -46,3 +48,5 @@ inline std::ostream &operator<<(std::ostream &Out, backend be) {
 
 } // namespace _V1
 } // namespace sycl
+
+#endif // !defined(__SYCL_DEVICE_ONLY__)

--- a/sycl/include/sycl/detail/backend_types_io.hpp
+++ b/sycl/include/sycl/detail/backend_types_io.hpp
@@ -10,14 +10,13 @@
 
 #include <sycl/backend_types.hpp>
 
-#if !defined(__SYCL_DEVICE_ONLY__)
-
 #include <ostream>
 
 namespace sycl {
 inline namespace _V1 {
 
 inline std::ostream &operator<<(std::ostream &Out, backend be) {
+#if !defined(__SYCL_DEVICE_ONLY__)
   switch (be) {
   case backend::host:
     Out << "host";
@@ -43,10 +42,9 @@ inline std::ostream &operator<<(std::ostream &Out, backend be) {
   case backend::all:
     Out << "all";
   }
+#endif // !defined(__SYCL_DEVICE_ONLY__)
   return Out;
 }
 
 } // namespace _V1
 } // namespace sycl
-
-#endif // !defined(__SYCL_DEVICE_ONLY__)

--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -244,7 +244,7 @@ struct ArrayCreator<DataT, FlattenF> {
 };
 
 // to output exceptions caught in ~destructors
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(__SYCL_DEVICE_ONLY__)
 #define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, e)                              \
   {                                                                            \
     std::cerr << str << " " << e.what() << std::endl;                          \

--- a/sycl/include/sycl/detail/range_rounding.hpp
+++ b/sycl/include/sycl/detail/range_rounding.hpp
@@ -227,9 +227,11 @@ std::tuple<range<Dims>, bool> getRoundedRange(range<Dims> UserRange,
 
   bool DidAdjust = false;
   auto Adjust = [&](int Dim, size_t Value) {
+#if !defined(__SYCL_DEVICE_ONLY__)
     if (RangeRoundingTrace())
       std::cout << "parallel_for range adjusted at dim " << Dim << " from "
                 << RoundedRange[Dim] << " to " << Value << std::endl;
+#endif // !defined(__SYCL_DEVICE_ONLY__)
     RoundedRange[Dim] = Value;
     DidAdjust = true;
   };

--- a/sycl/include/sycl/exception_list.hpp
+++ b/sycl/include/sycl/exception_list.hpp
@@ -56,6 +56,7 @@ namespace detail {
 // Default implementation of async_handler used by queue and context when no
 // user-defined async_handler is specified.
 inline void defaultAsyncHandler(exception_list Exceptions) {
+#if !defined(__SYCL_DEVICE_ONLY__)
   std::cerr << "Default async_handler caught exceptions:";
   for (auto &EIt : Exceptions) {
     try {
@@ -67,6 +68,7 @@ inline void defaultAsyncHandler(exception_list Exceptions) {
     }
   }
   std::cerr << std::endl;
+#endif // !defined(__SYCL_DEVICE_ONLY__)
   std::terminate();
 }
 } // namespace detail


### PR DESCRIPTION
The SYCL device/JIT environment don't support printing, so disable it in
the SYCL headers when compiling for device. This is needed to avoid
compilation errors when the headers are included in device code.