### PR TITLE
[Driver][SYCL] Do not claim RDC flag for option enabling

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5386,8 +5386,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                     (C.getActiveOffloadKinds() != Action::OFK_None &&
                      C.getActiveOffloadKinds() != Action::OFK_SYCL)));
 
-  bool IsRDCMode =
-      Args.hasFlag(options::OPT_fgpu_rdc, options::OPT_fno_gpu_rdc, IsSYCL);
+  bool IsRDCMode = Args.hasFlagNoClaim(options::OPT_fgpu_rdc,
+                                       options::OPT_fno_gpu_rdc, IsSYCL);
   auto LTOMode = IsDeviceOffloadAction ? D.getOffloadLTOMode() : D.getLTOMode();
   bool IsUsingLTO = LTOMode != LTOK_None;
   const bool IsSYCLCUDACompat = isSYCLCudaCompatEnabled(Args);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5386,6 +5386,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                     (C.getActiveOffloadKinds() != Action::OFK_None &&
                      C.getActiveOffloadKinds() != Action::OFK_SYCL)));
 
+  // Do not claim the RDC arg at this point as it is not indicative of proper
+  // support. Not claiming here allows for the 'unused argument' diagnostic to
+  // be emitted depending on actual support when comparing the old and new
+  // offload model paths.
   bool IsRDCMode = Args.hasFlagNoClaim(options::OPT_fgpu_rdc,
                                        options::OPT_fno_gpu_rdc, IsSYCL);
   auto LTOMode = IsDeviceOffloadAction ? D.getOffloadLTOMode() : D.getLTOMode();

--- a/sycl/test-e2e/AOT/early_aot.cpp
+++ b/sycl/test-e2e/AOT/early_aot.cpp
@@ -1,6 +1,7 @@
 // Test early-AOT behaviors with -fsycl -fno-sycl-rdc.  This targets spir64_gen
 
 // REQUIRES: ocloc, gpu, target-spir
+// XFAIL: new-offload-model
 
 // Build the early AOT device binaries
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DADD_CPP %s -o %t_add.o

--- a/sycl/test-e2e/AOT/early_aot.cpp
+++ b/sycl/test-e2e/AOT/early_aot.cpp
@@ -2,6 +2,7 @@
 
 // REQUIRES: ocloc, gpu, target-spir
 // XFAIL: new-offload-model
+// XFAIL-TRACKER: CMPLRLLVM-51875
 
 // Build the early AOT device binaries
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DADD_CPP %s -o %t_add.o

--- a/sycl/test-e2e/AOT/early_aot.cpp
+++ b/sycl/test-e2e/AOT/early_aot.cpp
@@ -3,8 +3,8 @@
 // REQUIRES: ocloc, gpu, target-spir
 
 // Build the early AOT device binaries
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DADD_CPP %s -o %t_add.o
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DSUB_CPP %s -o %t_sub.o
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DADD_CPP %s -o %t_add.o -Werror=unused-command-line-argument
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DSUB_CPP %s -o %t_sub.o -Werror=unused-command-line-argument
 // RUN: %clangxx -fsycl -DMAIN_CPP %s %t_add.o %t_sub.o -o %t.out
 
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/AOT/early_aot.cpp
+++ b/sycl/test-e2e/AOT/early_aot.cpp
@@ -3,8 +3,8 @@
 // REQUIRES: ocloc, gpu, target-spir
 
 // Build the early AOT device binaries
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DADD_CPP %s -o %t_add.o -Werror=unused-command-line-argument
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DSUB_CPP %s -o %t_sub.o -Werror=unused-command-line-argument
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DADD_CPP %s -o %t_add.o
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -fno-sycl-rdc -c -DSUB_CPP %s -o %t_sub.o
 // RUN: %clangxx -fsycl -DMAIN_CPP %s %t_add.o %t_sub.o -o %t.out
 
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/SYCLBIN/link_object_fast_link.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_object_fast_link.cpp
@@ -8,7 +8,7 @@
 // RUN: %clangxx --offload-new-driver -fsyclbin=object %{syclbin_exec_opts} -fsycl-allow-device-image-dependencies %S/Inputs/importing_kernel.cpp -o %t.import_w_aot.syclbin
 // RUN: %clangxx --offload-new-driver -fsyclbin=object -fsycl-allow-device-image-dependencies %S/Inputs/exporting_function.cpp -o %t.export.syclbin
 // RUN: %clangxx --offload-new-driver -fsyclbin=object -fsycl-allow-device-image-dependencies %S/Inputs/importing_kernel.cpp -o %t.import.syclbin
-// RUN: %{build} -o %t.ou t
+// RUN: %{build} -o %t.out
 
 // RUN: %{run} %t.out %t.export.syclbin %t.import.syclbin
 // RUN: %{run} %t.out %t.export_w_aot.syclbin %t.import_w_aot.syclbin

--- a/sycl/test-e2e/SYCLBIN/link_object_fast_link.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_object_fast_link.cpp
@@ -4,11 +4,11 @@
 
 // REQUIRES: target-spir
 
-// RUN: %clangxx --offload-new-driver -fsycl-rdc -fsyclbin=object %{syclbin_exec_opts} -fsycl-allow-device-image-dependencies %S/Inputs/exporting_function.cpp -o %t.export_w_aot.syclbin
-// RUN: %clangxx --offload-new-driver -fsycl-rdc -fsyclbin=object %{syclbin_exec_opts} -fsycl-allow-device-image-dependencies %S/Inputs/importing_kernel.cpp -o %t.import_w_aot.syclbin
+// RUN: %clangxx --offload-new-driver -fsyclbin=object %{syclbin_exec_opts} -fsycl-allow-device-image-dependencies %S/Inputs/exporting_function.cpp -o %t.export_w_aot.syclbin
+// RUN: %clangxx --offload-new-driver -fsyclbin=object %{syclbin_exec_opts} -fsycl-allow-device-image-dependencies %S/Inputs/importing_kernel.cpp -o %t.import_w_aot.syclbin
 // RUN: %clangxx --offload-new-driver -fsyclbin=object -fsycl-allow-device-image-dependencies %S/Inputs/exporting_function.cpp -o %t.export.syclbin
 // RUN: %clangxx --offload-new-driver -fsyclbin=object -fsycl-allow-device-image-dependencies %S/Inputs/importing_kernel.cpp -o %t.import.syclbin
-// RUN: %{build} -o %t.out
+// RUN: %{build} -o %t.ou t
 
 // RUN: %{run} %t.out %t.export.syclbin %t.import.syclbin
 // RUN: %{run} %t.out %t.export_w_aot.syclbin %t.import_w_aot.syclbin


### PR DESCRIPTION
In the driver, any touch of an option with hasFlag, or hasArg, etc will claim that the option has been used.  In the new offloading model, -fno-sycl-rdc is not yet implemented, so any actual use of the option is not representative of true usage.

Do not mark use of -fno-gpu-rdc (-fno-sycl-rdc is an alias) when being used to add an option to the `-cc1` step.  This allows for the driver to properly recognize that -fno-sycl-rdc is not being used when the new model is enabled.

This change allows for any true -fno-sycl-rdc testing to emit a diagnostic when used with the new offload model.  We can then error on this diagnostic to show failure with the new model for improved visibility and tracking of functionality.

The update to sycl/test-e2e/SYCLBIN/link_object_fast_link.cpp is to prevent test failure due to usage of `-fsycl-rdc`.  The use of this option is not doing anything, as `-fsycl-rdc` is the default mode.  Builds are performed with `-Werror` causing the unused argument warning to become an error.