### PR TITLE
[SYCL] Fix missing event handle in MemCpyCommandHost discard mode

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1752,7 +1752,9 @@ ur_result_t MemCpyCommandHost::enqueueImp() {
   if (MDstReq.MAccessMode == access::mode::discard_read_write ||
       MDstReq.MAccessMode == access::mode::discard_write) {
     Command::waitForEvents(Queue, EventImpls, UREvent);
-
+    // Store the event so downstream commands can correctly depend on this
+    // node even when no actual copy is performed.
+    MEvent->setHandle(UREvent);
     return UR_RESULT_SUCCESS;
   }
 


### PR DESCRIPTION
When the destination access mode is discard_write or discard_read_write,
MemCpyCommandHost::enqueueImp skips the actual copy but still calls
Command::waitForEvents to set up GPU-side dependencies. The UR event
returned by that call was silently dropped, leaving MEvent with no
underlying handle. Any downstream device command that depends on this
node would therefore have no real event to track, breaking the
dependency chain and potentially allowing it to execute before its
prerequisites have completed.

Fix: call MEvent->setHandle(UREvent) before the early return so
subsequent nodes in the dependency graph receive a valid event to
track.