### PR TITLE
[SYCL] Use barrier in Command::waitForEvents for device-queue path

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -520,7 +520,12 @@ void Command::waitForEvents(queue_impl *Queue,
       flushCrossQueueDeps(EventImpls);
       adapter_impl &Adapter = Queue->getAdapter();
 
-      Adapter.call<UrApiKind::urEnqueueEventsWait>(
+      // Use a barrier rather than a plain event-wait so that all prior
+      // in-flight work on the queue is included in the dependency, not only
+      // the explicitly listed events.  This provides the stronger ordering
+      // guarantee needed when this node is used as a completion checkpoint
+      // (e.g. before a host-visible copy or an accessor creation).
+      Adapter.call<UrApiKind::urEnqueueEventsWaitWithBarrier>(
           Queue->getHandleRef(), RawEvents.size(), &RawEvents[0], &Event);
     }
   }


### PR DESCRIPTION
Command::waitForEvents previously used urEnqueueEventsWait when a
device queue was available.  urEnqueueEventsWait only waits for the
explicitly listed events; on out-of-order queues, any other in-flight
work on the same queue that was not captured in EventImpls could race
with the command that follows.

Switch to urEnqueueEventsWaitWithBarrier, which waits for all prior
commands on the queue in addition to the listed events.  This closes
the ordering gap on out-of-order queues.  For the common in-order
queue case the change is a no-op in practice: the Level-Zero adapter's
urEnqueueEventsWaitWithBarrier returns LastCommandEvent directly when
the wait list is empty (same-queue events are filtered out by
getUrEvents), so no extra hardware barrier is appended.

Affected callers that reach the changed branch (non-null queue):
- MemCpyCommandHost::enqueueImp (discard-mode path)
- ReleaseCommand::enqueueImp (SkipRelease path)
- UpdateHostRequirementCommand::enqueueImp
- UpdateCommandBufferCommand::enqueueImp
