### PR TITLE
[UR][L0] Simplify in-order barrier shortcut to empty-wait-list only

### DIFF
--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -248,14 +248,21 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
   ur_event_handle_t ResultEvent = nullptr;
   bool IsInternal = OutEvent == nullptr;
 
-  // For in-order queue and wait-list which is empty or has events from
-  // the same queue just use the last command event as the barrier event.
-  // This optimization is disabled when profiling is enabled to ensure
-  // accurate profiling values & the overhead that profiling incurs.
+  // For in-order queues with no explicit wait list, the last command event
+  // is equivalent to a full barrier because commands execute in submission
+  // order.  Return it directly without inserting an additional barrier command.
+  //
+  // The optimisation is intentionally restricted to NumEventsInWaitList == 0.
+  // When callers supply explicit events we must append a real barrier so that
+  // the returned event correctly tracks completion of every listed dependency,
+  // even if some of those events originate from a different queue or represent
+  // cross-queue work that is not yet reflected in LastCommandEvent.
+  //
+  // The optimisation is also disabled when profiling is enabled to ensure
+  // accurate timestamps (see zeCommandListAppendSignalEvent spec note).
   if (Queue->isInOrderQueue() && !Queue->isProfilingEnabled() &&
-      WaitListEmptyOrAllEventsFromSameQueue(Queue, NumEventsInWaitList,
-                                            EventWaitList) &&
-      Queue->LastCommandEvent && !Queue->LastCommandEvent->IsDiscarded) {
+      NumEventsInWaitList == 0 && Queue->LastCommandEvent &&
+      !Queue->LastCommandEvent->IsDiscarded) {
     UR_CALL(ur::level_zero::urEventRetain(Queue->LastCommandEvent));
     ResultEvent = Queue->LastCommandEvent;
     if (OutEvent) {


### PR DESCRIPTION
urEnqueueEventsWaitWithBarrierExt contained an optimisation for
in-order queues: when all events in the wait list belonged to the same
queue, it returned LastCommandEvent directly without appending a real
barrier to the command list.

The same-queue case was logically sound — WaitListEmptyOrAllEventsFromSameQueue
already excluded cross-queue events, the exclusive Queue->Mutex held
throughout prevents concurrent submissions from updating LastCommandEvent
between the wait-list check and the shortcut, and the in-order
dependency chain guarantees LastCommandEvent completing implies all
prior same-queue events have completed.

However, the compound condition
  (empty list) OR (all events from same queue)
makes the invariant harder to reason about and future-proof.  The
empty-list sub-case is the only one where no explicit ordering
constraint is given by the caller; the same-queue sub-case smuggles
in an implicit semantic assumption about in-order chaining that is
non-obvious to readers.

Simplify to NumEventsInWaitList == 0 only: when no explicit events
are provided the shortcut is trivially correct; when explicit events
are provided, always fall through to the full barrier insertion path.
This removes the WaitListEmptyOrAllEventsFromSameQueue dependency from
this code path (the function is still used in createAndRetainUrZeEventList)
and makes the barrier semantics straightforward to verify.
