### PR TITLE
Revert llvm-spirv lifetime intrinsic customizations

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -5053,16 +5053,8 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
 
     unsigned PtrAS = cast<PointerType>(LLVMPtrOp->getType())->getAddressSpace();
     auto *PtrOp = transValue(LLVMPtrOp, BB);
-    // INTEL_CUSTOMIZATION begin
-    // Workaround to make older versions of SPIRVReader working with new
-    // rules of LLVM lifetime intrinsics.
-    // TODO: to remove the W/A.
-    if (PtrAS == SPIRAS_Private) {
-      auto *Int8PtrTy =
-          transPointerType(Type::getInt8Ty(M->getContext()), SPIRAS_Private);
-      PtrOp = BM->addUnaryInst(OpBitcast, Int8PtrTy, PtrOp, BB);
+    if (PtrAS == SPIRAS_Private)
       return BM->addLifetimeInst(OC, PtrOp, Size, BB);
-    }
     // If pointer address space is Generic - use original allocation.
     BM->getErrorLog().checkError(
         PtrAS == SPIRAS_Generic, SPIRVEC_InvalidInstruction, II,
@@ -5070,11 +5062,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     if (PtrOp->getOpCode() == OpPtrCastToGeneric) {
       auto *UI = static_cast<SPIRVUnary *>(PtrOp);
       PtrOp = UI->getOperand(0);
-      auto *Int8PtrTy =
-          transPointerType(Type::getInt8Ty(M->getContext()), SPIRAS_Private);
-      PtrOp = BM->addUnaryInst(OpBitcast, Int8PtrTy, PtrOp, BB);
     }
-    // INTEL_CUSTOMIZATION end
     return BM->addLifetimeInst(OC, PtrOp, Size, BB);
   }
   // We don't want to mix translation of regular code and debug info, because

--- a/llvm-spirv/test/llvm-intrinsics/lifetime.ll
+++ b/llvm-spirv/test/llvm-intrinsics/lifetime.ll
@@ -19,30 +19,20 @@
 ; CHECK-SPIRV-DAG: TypeStruct [[#StructTy:]] [[#]]
 ; CHECK-SPIRV-DAG: TypePointer [[#PrivatePtrTy:]] 7 [[#StructTy]]
 
-; INTEL_CUSTOMIZATION:
 ; CHECK-SPIRV: Function [[#]] [[#SimpleF:]]
-; CHECK-SPIRV: Variable [[#]] [[#Var:]]
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast1:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStart [[#Cast1]] 4
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast2:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStop [[#Cast2]] 4
+; CHECK-SPIRV: LifetimeStart [[#Tmp:]] 0
+; CHECK-SPIRV: LifetimeStop [[#Tmp]] 0
 
 ; CHECK-SPIRV: Function [[#]] [[#SizedF:]]
-; CHECK-SPIRV: Variable [[#]] [[#Var:]]
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast1:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStart [[#Cast1]] 1
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast2:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStop [[#Cast2]] 1
+; CHECK-SPIRV: LifetimeStart [[#Tmp:]] 1
+; CHECK-SPIRV: LifetimeStop [[#Tmp]] 1
 
 ; CHECK-SPIRV: Function [[#]] [[#GenericF:]]
 ; CHECK-SPIRV: Variable [[#PrivatePtrTy]] [[#Var:]] 7
-; CHECK-SPIRV: PtrCastToGeneric [[#]] [[#ASCast:]] [[#Var]]
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast1:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStart [[#Cast1]] 1
-; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#ASCast]]
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast2:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStop [[#Cast2]] 1
-; INTEL_CUSTOMIZATION end
+; CHECK-SPIRV: PtrCastToGeneric [[#]] [[#Cast1:]] [[#Var]]
+; CHECK-SPIRV: LifetimeStart [[#Var]] 0
+; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#Cast1]]
+; CHECK-SPIRV: LifetimeStop [[#Var]] 0
 
 ; CHECK-LLVM-LABEL: lifetime_simple
 ; CHECK-LLVM: %[[#Alloca:]] = alloca i32
@@ -68,43 +58,44 @@ target triple = "spir64-unknown-unknown"
 %class.anon = type { i8 }
 
 ; Function Attrs: nounwind
-define spir_kernel void @lifetime_simple(ptr addrspace(1) captures(none) %res, ptr addrspace(1) captures(none) %lhs, ptr addrspace(1) captures(none) %rhs) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
+define spir_kernel void @lifetime_simple(i32 addrspace(1)* captures(none) %res, i32 addrspace(1)* captures(none) %lhs, i32 addrspace(1)* captures(none) %rhs) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
   %1 = alloca i32
   %2 = call spir_func i64 @_Z13get_global_idj(i32 0) #1
   %3 = shl i64 %2, 32
   %4 = ashr exact i64 %3, 32
-  %5 = getelementptr inbounds i32, ptr addrspace(1) %lhs, i64 %4
-  %6 = load i32, ptr addrspace(1) %5, align 4
-  %7 = getelementptr inbounds i32, ptr addrspace(1) %rhs, i64 %4
+  %5 = getelementptr inbounds i32, i32 addrspace(1)* %lhs, i64 %4
+  %6 = load i32, i32 addrspace(1)* %5, align 4
+  %7 = getelementptr inbounds i32, i32 addrspace(1)* %rhs, i64 %4
   %8 = load i32, i32 addrspace(1)* %7, align 4
   %9 = sub i32 %6, %8
-  call void @llvm.lifetime.start.p0(ptr %1)
-  store i32 %9, ptr %1
-  %11 = load i32, ptr %1
-  call void @llvm.lifetime.end.p0(ptr %1)
-  %12 = getelementptr inbounds i32, ptr addrspace(1) %res, i64 %4
-  store i32 %11, ptr addrspace(1) %12, align 4
+  %10 = bitcast i32* %1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i32 %9, i32* %1
+  %11 = load i32, i32* %1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %12 = getelementptr inbounds i32, i32 addrspace(1)* %res, i64 %4
+  store i32 %11, i32 addrspace(1)* %12, align 4
   ret void
 }
 
 define spir_kernel void @lifetime_sized() #0 !kernel_arg_addr_space !8 !kernel_arg_access_qual !8 !kernel_arg_type !8 !kernel_arg_base_type !8 !kernel_arg_type_qual !8 {
 entry:
   %0 = alloca i8, align 1
-  call void @llvm.lifetime.start.p0(ptr %0) #0
-  call spir_func void @goo(ptr %0)
-  call void @llvm.lifetime.end.p0(ptr %0) #0
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %0) #0
+  call spir_func void @goo(i8* %0)
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %0) #0
   ret void
 }
 
-declare spir_func void @foo(ptr %this) #0
+declare spir_func void @foo(%class.anon* %this) #0
 
-declare spir_func void @goo(ptr %this) #0
-
-; Function Attrs: nounwind
-declare void @llvm.lifetime.start.p0(ptr captures(none)) #0
+declare spir_func void @goo(i8* %this) #0
 
 ; Function Attrs: nounwind
-declare void @llvm.lifetime.end.p0(ptr captures(none)) #0
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* captures(none)) #0
+
+; Function Attrs: nounwind
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* captures(none)) #0
 
 ; Function Attrs: nounwind readnone
 declare spir_func i64 @_Z13get_global_idj(i32) #1
@@ -112,19 +103,19 @@ declare spir_func i64 @_Z13get_global_idj(i32) #1
 define spir_kernel void @lifetime_generic() #0 !kernel_arg_addr_space !8 !kernel_arg_access_qual !8 !kernel_arg_type !8 !kernel_arg_base_type !8 !kernel_arg_type_qual !8 {
 entry:
   %0 = alloca %class.anon, align 1, addrspace(4)
-  call void @llvm.lifetime.start.p4(ptr addrspace(4) %0) #0
-  call spir_func void @boo(ptr addrspace(4) %0)
-  call void @llvm.lifetime.end.p4(ptr addrspace(4) %0) #0
+  call void @llvm.lifetime.start.p4i8(i64 -1, i8 addrspace(4)* %0) #0
+  call spir_func void @boo(%class.anon addrspace(4)* %0)
+  call void @llvm.lifetime.end.p4i8(i64 -1, i8 addrspace(4)* %0) #0
   ret void
 }
 
-declare spir_func void @boo(ptr addrspace(4) %this) #0
+declare spir_func void @boo(%class.anon addrspace(4)* %this) #0
 
 ; Function Attrs: nounwind
-declare void @llvm.lifetime.start.p4(ptr addrspace(4) captures(none)) #0
+declare void @llvm.lifetime.start.p4i8(i64 immarg, i8 addrspace(4)* captures(none)) #0
 
 ; Function Attrs: nounwind
-declare void @llvm.lifetime.end.p4(ptr addrspace(4) captures(none)) #0
+declare void @llvm.lifetime.end.p4i8(i64 immarg, i8 addrspace(4)* captures(none)) #0
 
 
 attributes #0 = { nounwind }

--- a/llvm-spirv/test/llvm-intrinsics/lifetime.ll
+++ b/llvm-spirv/test/llvm-intrinsics/lifetime.ll
@@ -58,44 +58,43 @@ target triple = "spir64-unknown-unknown"
 %class.anon = type { i8 }
 
 ; Function Attrs: nounwind
-define spir_kernel void @lifetime_simple(i32 addrspace(1)* captures(none) %res, i32 addrspace(1)* captures(none) %lhs, i32 addrspace(1)* captures(none) %rhs) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
+define spir_kernel void @lifetime_simple(ptr addrspace(1) captures(none) %res, ptr addrspace(1) captures(none) %lhs, ptr addrspace(1) captures(none) %rhs) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
   %1 = alloca i32
   %2 = call spir_func i64 @_Z13get_global_idj(i32 0) #1
   %3 = shl i64 %2, 32
   %4 = ashr exact i64 %3, 32
-  %5 = getelementptr inbounds i32, i32 addrspace(1)* %lhs, i64 %4
-  %6 = load i32, i32 addrspace(1)* %5, align 4
-  %7 = getelementptr inbounds i32, i32 addrspace(1)* %rhs, i64 %4
+  %5 = getelementptr inbounds i32, ptr addrspace(1) %lhs, i64 %4
+  %6 = load i32, ptr addrspace(1) %5, align 4
+  %7 = getelementptr inbounds i32, ptr addrspace(1) %rhs, i64 %4
   %8 = load i32, i32 addrspace(1)* %7, align 4
   %9 = sub i32 %6, %8
-  %10 = bitcast i32* %1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i32 %9, i32* %1
-  %11 = load i32, i32* %1
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %12 = getelementptr inbounds i32, i32 addrspace(1)* %res, i64 %4
-  store i32 %11, i32 addrspace(1)* %12, align 4
+  call void @llvm.lifetime.start.p0(ptr %1)
+  store i32 %9, ptr %1
+  %11 = load i32, ptr %1
+  call void @llvm.lifetime.end.p0(ptr %1)
+  %12 = getelementptr inbounds i32, ptr addrspace(1) %res, i64 %4
+  store i32 %11, ptr addrspace(1) %12, align 4
   ret void
 }
 
 define spir_kernel void @lifetime_sized() #0 !kernel_arg_addr_space !8 !kernel_arg_access_qual !8 !kernel_arg_type !8 !kernel_arg_base_type !8 !kernel_arg_type_qual !8 {
 entry:
   %0 = alloca i8, align 1
-  call void @llvm.lifetime.start.p0i8(i64 1, i8* %0) #0
-  call spir_func void @goo(i8* %0)
-  call void @llvm.lifetime.end.p0i8(i64 1, i8* %0) #0
+  call void @llvm.lifetime.start.p0(ptr %0) #0
+  call spir_func void @goo(ptr %0)
+  call void @llvm.lifetime.end.p0(ptr %0) #0
   ret void
 }
 
-declare spir_func void @foo(%class.anon* %this) #0
+declare spir_func void @foo(ptr %this) #0
 
-declare spir_func void @goo(i8* %this) #0
-
-; Function Attrs: nounwind
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* captures(none)) #0
+declare spir_func void @goo(ptr %this) #0
 
 ; Function Attrs: nounwind
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* captures(none)) #0
+declare void @llvm.lifetime.start.p0(ptr captures(none)) #0
+
+; Function Attrs: nounwind
+declare void @llvm.lifetime.end.p0(ptr captures(none)) #0
 
 ; Function Attrs: nounwind readnone
 declare spir_func i64 @_Z13get_global_idj(i32) #1
@@ -103,19 +102,19 @@ declare spir_func i64 @_Z13get_global_idj(i32) #1
 define spir_kernel void @lifetime_generic() #0 !kernel_arg_addr_space !8 !kernel_arg_access_qual !8 !kernel_arg_type !8 !kernel_arg_base_type !8 !kernel_arg_type_qual !8 {
 entry:
   %0 = alloca %class.anon, align 1, addrspace(4)
-  call void @llvm.lifetime.start.p4i8(i64 -1, i8 addrspace(4)* %0) #0
-  call spir_func void @boo(%class.anon addrspace(4)* %0)
-  call void @llvm.lifetime.end.p4i8(i64 -1, i8 addrspace(4)* %0) #0
+  call void @llvm.lifetime.start.p4(ptr addrspace(4) %0) #0
+  call spir_func void @boo(ptr addrspace(4) %0)
+  call void @llvm.lifetime.end.p4(ptr addrspace(4) %0) #0
   ret void
 }
 
-declare spir_func void @boo(%class.anon addrspace(4)* %this) #0
+declare spir_func void @boo(ptr addrspace(4) %this) #0
 
 ; Function Attrs: nounwind
-declare void @llvm.lifetime.start.p4i8(i64 immarg, i8 addrspace(4)* captures(none)) #0
+declare void @llvm.lifetime.start.p4(ptr addrspace(4) captures(none)) #0
 
 ; Function Attrs: nounwind
-declare void @llvm.lifetime.end.p4i8(i64 immarg, i8 addrspace(4)* captures(none)) #0
+declare void @llvm.lifetime.end.p4(ptr addrspace(4) captures(none)) #0
 
 
 attributes #0 = { nounwind }

--- a/llvm-spirv/test/llvm-intrinsics/memmove.ll
+++ b/llvm-spirv/test/llvm-intrinsics/memmove.ll
@@ -2,20 +2,14 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-TYPED-PTR
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; INTEL_CUSTOMIZATION begin
-; https://github.com/intel/llvm/issues/22248
-; RUNx: spirv-val %t.spv
-; INTEL_CUSTOMIZATION end
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt --spirv-ext=+SPV_KHR_untyped_pointers
 ; RUN: FileCheck < %t.txt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-UNTYPED-PTR
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_KHR_untyped_pointers
-; INTEL_CUSTOMIZATION begin
-; https://github.com/intel/llvm/issues/22248
-; RUNx: spirv-val %t.spv
-; INTEL_CUSTOMIZATION end
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/llvm-spirv/test/llvm-intrinsics/memmove.ll
+++ b/llvm-spirv/test/llvm-intrinsics/memmove.ll
@@ -30,16 +30,13 @@
 ; CHECK-SPIRV: FunctionParameter [[#I8GLOBAL_PTR]] [[#ARG_IN:]]
 ; CHECK-SPIRV: FunctionParameter [[#I8GLOBAL_PTR]] [[#ARG_OUT:]]
 ;
-; INTEL_CUSTOMIZATION begin
 ; CHECK-SPIRV: Variable [[#]] [[#MEM:]]
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_IN:]] [[#ARG_IN]]
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_OUT:]] [[#ARG_OUT]]
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_1:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStart [[#MEM_CAST_1]]
+; CHECK-SPIRV: LifetimeStart [[#MEM]]
 ; CHECK-SPIRV: CopyMemorySized [[#MEM]] [[#I8_ARG_IN]] [[#C128]] 2 64
 ; CHECK-SPIRV: CopyMemorySized [[#I8_ARG_OUT]] [[#MEM]] [[#C128]] 2 64
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_2:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStop [[#MEM_CAST_2]]
+; CHECK-SPIRV: LifetimeStop [[#MEM]]
 
 ; CHECK-SPIRV-LABEL: [[#]] Function [[#]]
 ; CHECK-SPIRV: FunctionParameter [[#I8GLOBAL_PTR]] [[#ARG_IN:]]
@@ -49,25 +46,20 @@
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_IN:]] [[#ARG_IN]]
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_OUT_GENERIC:]] [[#ARG_OUT]]
 ; CHECK-SPIRV: GenericCastToPtr [[#]] [[#I8_ARG_OUT:]] [[#I8_ARG_OUT_GENERIC]]
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_1:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStart [[#MEM_CAST_1]]
+; CHECK-SPIRV: LifetimeStart [[#MEM]]
 ; CHECK-SPIRV: CopyMemorySized [[#MEM]] [[#I8_ARG_IN]] [[#C68]] 2 64
 ; CHECK-SPIRV: CopyMemorySized [[#I8_ARG_OUT]] [[#MEM]] [[#C68]] 2 64
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_2:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStop [[#MEM_CAST_2]]
+; CHECK-SPIRV: LifetimeStop [[#MEM]]
 
 ; CHECK-SPIRV-LABEL: [[#]] Function [[#]]
 ; CHECK-SPIRV: FunctionParameter [[#]] [[#ARG_IN:]]
 ; CHECK-SPIRV: FunctionParameter [[#]] [[#ARG_OUT:]]
 ;
 ; CHECK-SPIRV: Variable [[#]] [[#MEM:]]
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_1:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStart [[#MEM_CAST_1]]
+; CHECK-SPIRV: LifetimeStart [[#MEM]]
 ; CHECK-SPIRV: CopyMemorySized [[#MEM]] [[#ARG_IN]] [[#C72]] 0
 ; CHECK-SPIRV: CopyMemorySized [[#ARG_OUT]] [[#MEM]] [[#C72]] 0
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_2:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStop [[#MEM_CAST_2]]
-; INTEL_CUSTOMIZATION end
+; CHECK-SPIRV: LifetimeStop [[#MEM]]
 
 ; xCHECK-SPIRV-LABEL: [[#]] Function [[#]]
 ;


### PR DESCRIPTION
Revert https://github.com/intel/llvm/pull/20287 and https://github.com/intel/llvm/pull/22249.

The customization was made to handle older GPU Drivers not having the corresponding SPIRV Reader change, but all the drivers we use in CI (even Gen12 Windows) seems to work fine, so we don't need this anymore and it generates SPIR-V that causes `spirv-val` to complain, causing us to have to disable a test.

CTS run: https://github.com/intel/llvm/actions/runs/27163769503/job/80193821812
 
Closes: https://github.com/intel/llvm/issues/22248