### PR TITLE
[SYCL] Support libdevice build when only SYCL headers are enabled

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -779,4 +779,6 @@ add_custom_target(install-libsycldevice
   COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_COMPONENT=libsycldevice -P ${CMAKE_BINARY_DIR}/cmake_install.cmake
   DEPENDS ${libsycldevice_build_targets}
 )
-add_dependencies(deploy-sycl-toolchain install-libsycldevice)
+if (TARGET deploy-sycl-toolchain)
+  add_dependencies(deploy-sycl-toolchain install-libsycldevice)
+endif()

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -355,6 +355,26 @@ endif()
 set(SYCL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(SYCL_HEADERS_ONLY)
+  # The libdevice project can be built alongside the SYCL headers without the
+  # full SYCL runtime. It depends on the `sycl-compiler` aggregate target to
+  # ensure the tools used to build the device libraries are available. The full
+  # `sycl-compiler` target is defined after this early return, so provide a
+  # minimal equivalent here that aggregates whichever toolchain components are
+  # present in this build (e.g. for SPIR/SPIRV device libraries only clang,
+  # llvm-link and llvm-spirv are required).
+  if(NOT TARGET sycl-compiler)
+    add_custom_target(sycl-compiler)
+    foreach(sycl_compiler_tool
+        append-file clang clang-offload-bundler clang-offload-deps
+        clang-offload-extract clang-offload-wrapper clang-linker-wrapper
+        file-table-tform llc llvm-ar llvm-foreach llvm-link
+        llvm-offload-binary llvm-objcopy llvm-spirv spirv-to-ir-wrapper
+        sycl-post-link)
+      if(TARGET ${sycl_compiler_tool})
+        add_dependencies(sycl-compiler ${sycl_compiler_tool})
+      endif()
+    endforeach()
+  endif()
   return()
 endif()
 


### PR DESCRIPTION
For the device JIT environment we don't need to build the whole SYCL
runtime library. Only the headers and the libdevice are required. This
patch fixes the build system to support building of the libdevice when
the whole SYCL runtime library is not built, and only the SYCL headers
are enabled.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>