### PR TITLE
[SYCL][xpti] Make .pc file relocatable (#22255)

### DIFF
--- a/sycl/pkgconfig/sycl.pc.in
+++ b/sycl/pkgconfig/sycl.pc.in
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=${pcfiledir}/../..
 includedir=${prefix}/@SYCL_INCLUDE_DIR@
 libdir=${prefix}/lib@LLVM_LIBDIR_SUFFIX@
 sycl_version=@SYCL_VERSION_STRING@

--- a/xpti/xpti.pc.in
+++ b/xpti/xpti.pc.in
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=${pcfiledir}/../..
 includedir=${prefix}/include
 libdir=${prefix}/lib@LLVM_LIBDIR_SUFFIX@
 

--- a/xptifw/xptifw.pc.in
+++ b/xptifw/xptifw.pc.in
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=${pcfiledir}/../..
 includedir=${prefix}/include
 libdir=${prefix}/lib@LLVM_LIBDIR_SUFFIX@
 


### PR DESCRIPTION
Cherry pick of https://github.com/intel/llvm/commit/bf0b9ec76e829ce41898a1d967a9a67bbf599773

This commit makes xpti and sycl `.pc` files relocatable which avoids patching `.pc` files in the compiler packages available at github. Before the change prefix was set in the CI builds as:
```
prefix=/__w/llvm/llvm/toolchain
```

CC: @sarnex