### PR TITLE
[SYCL][Windows] Don't do backend calls in DLL_PROCESS_DETACH

### DIFF
--- a/sycl/source/detail/adapter_impl.cpp
+++ b/sycl/source/detail/adapter_impl.cpp
@@ -14,6 +14,10 @@
 
 #include "adapter_impl.hpp"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
@@ -38,6 +42,16 @@ void adapter_impl::ur_failed_throw_exception(sycl::errc errc,
   throw set_ur_error(sycl::exception(sycl::make_error_code(errc), message),
                      ur_result);
 }
+
+#ifdef _WIN32
+bool isProcessShuttingDown() {
+  using RtlDllShutdownInProgress_t = BOOLEAN(WINAPI *)();
+  static RtlDllShutdownInProgress_t FnPtr =
+      reinterpret_cast<RtlDllShutdownInProgress_t>(GetProcAddress(
+          GetModuleHandleA("ntdll.dll"), "RtlDllShutdownInProgress"));
+  return FnPtr && FnPtr();
+}
+#endif
 
 } // namespace detail
 } // namespace _V1

--- a/sycl/source/detail/adapter_impl.hpp
+++ b/sycl/source/detail/adapter_impl.hpp
@@ -224,6 +224,15 @@ private:
   UrFuncPtrMapT UrFuncPtrs;
 }; // class adapter_impl
 
+#ifdef _WIN32
+// Returns true once ExitProcess()/LdrShutdownProcess() has begun for the
+// current process, regardless of which module's context this is called
+// from. Unlike DllMain's lpReserved parameter, this is safe to query from
+// code that is not itself running inside a DllMain callback (e.g. an
+// atexit() callback registered by a separately-loaded DLL).
+bool isProcessShuttingDown();
+#endif
+
 template <typename URResource> class Managed {
   static constexpr auto Release = []() constexpr {
     if constexpr (std::is_same_v<URResource, ur_program_handle_t>)
@@ -278,6 +287,17 @@ public:
       return;
 
     try {
+#ifdef _WIN32
+      if (Adapter->getBackend() != backend::ext_oneapi_level_zero &&
+          isProcessShuttingDown()) {
+        // The process is exiting and it is unsafe to make this backend call
+        // (e.g. this destructor is running from a separately-loaded DLL's
+        // own atexit teardown after ExitProcess has begun). Leak the
+        // resource rather than risk a crash; the OS will reclaim it.
+        R = nullptr;
+        return;
+      }
+#endif
       Adapter->call<Release>(R);
     } catch (std::exception &e) {
       __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~Managed", e);

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -310,10 +310,20 @@ void shutdown_early(bool CanJoinThreads = true) {
   if (!GlobalHandler::RTGlobalObjHandler)
     return;
 
-#if defined(XPTI_ENABLE_INSTRUMENTATION) && defined(_WIN32)
-  if (xptiTraceEnabled())
-    return; // When doing xpti tracing, we can't safely shutdown on Win.
-            // TODO: figure out why XPTI prevents release.
+#if defined(_WIN32)
+  // In Windows ExitProcess all non host threads are forcibly terminated prior
+  // to DLL_PROCESS_DETACH. However, backend calls may rely on these threads
+  // being active. In such cases, making backend calls at DLL_PROCESS_DETACH
+  // can lead to hangs or memory corruption in the backend. Because of this it
+  // is best to not unload the backend after thread destruction.
+  //
+  // Process is exiting
+  if (CanJoinThreads) {
+    // If spawned threads using the Windows CRT are forcibly killed, this can
+    // prevent stdout buffer being flushed at the program end.
+    std::fflush(stdout);
+    return;
+  }
 #endif
 
   // Now that we are shutting down, we will no longer defer MemObj releases.
@@ -355,10 +365,17 @@ void shutdown_late() {
   if (!GlobalHandler::RTGlobalObjHandler)
     return;
 
-#if defined(XPTI_ENABLE_INSTRUMENTATION) && defined(_WIN32)
-  if (xptiTraceEnabled())
-    return; // When doing xpti tracing, we can't safely shutdown on Win.
-            // TODO: figure out why XPTI prevents release.
+#if defined(_WIN32)
+  // In Windows ExitProcess all non host threads are forcibly terminated prior
+  // to DLL_PROCESS_DETACH. However, backend calls may rely on these threads
+  // being active. In such cases, making backend calls at DLL_PROCESS_DETACH
+  // can lead to hangs or use-after-free in the backend. Because of this it is
+  // best to not unload the backend after thread destruction.
+  //
+  // If spawned threads using the Windows CRT are forcibly killed, this can
+  // prevent stdout buffer being flushed at the program end.
+  std::fflush(stdout);
+  return;
 #endif
 
   // First, release resources, that may access adapters.

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -310,6 +310,9 @@ void shutdown_early(bool CanJoinThreads = true) {
   if (!GlobalHandler::RTGlobalObjHandler)
     return;
 
+  // Now that we are shutting down, we will no longer defer MemObj releases.
+  GlobalHandler::RTGlobalObjHandler->endDeferredRelease();
+
 #if defined(_WIN32)
   // In Windows ExitProcess all non host threads are forcibly terminated prior
   // to DLL_PROCESS_DETACH. However, backend or XPTI calls may rely on these
@@ -338,9 +341,6 @@ void shutdown_early(bool CanJoinThreads = true) {
     }
   }
 #endif
-
-  // Now that we are shutting down, we will no longer defer MemObj releases.
-  GlobalHandler::RTGlobalObjHandler->endDeferredRelease();
 
   // Ensure neither host task is working so that no default context is accessed
   // upon its release

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -312,17 +312,30 @@ void shutdown_early(bool CanJoinThreads = true) {
 
 #if defined(_WIN32)
   // In Windows ExitProcess all non host threads are forcibly terminated prior
-  // to DLL_PROCESS_DETACH. However, backend calls may rely on these threads
-  // being active. In such cases, making backend calls at DLL_PROCESS_DETACH
-  // can lead to hangs or memory corruption in the backend. Because of this it
-  // is best to not unload the backend after thread destruction.
-  //
+  // to DLL_PROCESS_DETACH. However, backend or XPTI calls may rely on these
+  // threads being active. In such cases, making XPTI or backend calls at
+  // DLL_PROCESS_DETACH can lead to hangs or memory corruption. Because of this
+  // it is best to not unload the backend after thread destruction.
+#if defined(XPTI_ENABLE_INSTRUMENTATION)
+  if (xptiTraceEnabled())
+    return;
+#endif
   // Process is exiting
   if (CanJoinThreads) {
-    // If spawned threads using the Windows CRT are forcibly killed, this can
-    // prevent stdout buffer being flushed at the program end.
-    std::fflush(stdout);
-    return;
+    // Level zero relies on unloading cleanup for UR_L0_LEAKS_DEBUG
+    // functionality on Windows so don't exit early for L0 platforms.
+    if (auto PlatformCache =
+            GlobalHandler::RTGlobalObjHandler->getPlatformCache();
+        !std::any_of(PlatformCache.begin(), PlatformCache.end(),
+                     [](const std::shared_ptr<platform_impl> &p) {
+                       return p->getBackend() == backend::ext_oneapi_level_zero;
+                     })) {
+
+      // If spawned threads using the Windows CRT are forcibly killed, this
+      // can prevent stdout buffer being flushed at the program end.
+      std::fflush(stdout);
+      return;
+    }
   }
 #endif
 
@@ -367,15 +380,27 @@ void shutdown_late() {
 
 #if defined(_WIN32)
   // In Windows ExitProcess all non host threads are forcibly terminated prior
-  // to DLL_PROCESS_DETACH. However, backend calls may rely on these threads
-  // being active. In such cases, making backend calls at DLL_PROCESS_DETACH
-  // can lead to hangs or use-after-free in the backend. Because of this it is
-  // best to not unload the backend after thread destruction.
-  //
-  // If spawned threads using the Windows CRT are forcibly killed, this can
-  // prevent stdout buffer being flushed at the program end.
-  std::fflush(stdout);
-  return;
+  // to DLL_PROCESS_DETACH. However, backend or XPTI calls may rely on these
+  // threads being active. In such cases, making XPTI or backend calls at
+  // DLL_PROCESS_DETACH can lead to hangs or memory corruption. Because of this
+  // it is best to not unload the backend after thread destruction.
+#if defined(XPTI_ENABLE_INSTRUMENTATION)
+  if (xptiTraceEnabled())
+    return;
+#endif
+  // Level zero relies on unloading cleanup for UR_L0_LEAKS_DEBUG
+  // functionality on Windows so don't exit early for L0 platforms.
+  if (auto PlatformCache =
+          GlobalHandler::RTGlobalObjHandler->getPlatformCache();
+      !std::any_of(PlatformCache.begin(), PlatformCache.end(),
+                   [](const std::shared_ptr<platform_impl> &p) {
+                     return p->getBackend() == backend::ext_oneapi_level_zero;
+                   })) {
+    // If spawned threads using the Windows CRT are forcibly killed, this can
+    // prevent stdout buffer being flushed at the program end.
+    std::fflush(stdout);
+    return;
+  }
 #endif
 
   // First, release resources, that may access adapters.

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -303,7 +303,7 @@ void GlobalHandler::drainThreadPool() {
 }
 
 #if defined(_WIN32)
-inline bool shutdown_win_early_exit(bool ProcessExiting = true) {
+bool GlobalHandler::winEarlyExitCheck(bool ProcessExiting = true) {
   // In Windows ExitProcess all non host threads are forcibly terminated prior
   // to DLL_PROCESS_DETACH. However, backend or XPTI calls may rely on these
   // threads being active. In such cases, making XPTI or backend calls at
@@ -345,7 +345,7 @@ void shutdown_early(bool CanJoinThreads = true) {
   GlobalHandler::RTGlobalObjHandler->endDeferredRelease();
 
 #ifdef _WIN32
-  if (shutdown_win_early_exit(CanJoinThreads))
+  if (GlobalHandler::winEarlyExitCheck(CanJoinThreads))
     return;
 #endif
 
@@ -386,7 +386,7 @@ void shutdown_late() {
     return;
 
 #ifdef _WIN32
-  if (shutdown_win_early_exit())
+  if (GlobalHandler::winEarlyExitCheck())
     return;
 #endif
 

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -302,18 +302,8 @@ void GlobalHandler::drainThreadPool() {
     MHostTaskThreadPool.Inst->drain();
 }
 
-// Note: this function can be called on Windows twice:
-//  1) when library is unloaded via FreeLibrary
-//  2) when process is being terminated
-void shutdown_early(bool CanJoinThreads = true) {
-  const LockGuard Lock{GlobalHandler::MSyclGlobalHandlerProtector};
-  if (!GlobalHandler::RTGlobalObjHandler)
-    return;
-
-  // Now that we are shutting down, we will no longer defer MemObj releases.
-  GlobalHandler::RTGlobalObjHandler->endDeferredRelease();
-
 #if defined(_WIN32)
+inline bool shutdown_win_early_exit(bool ProcessExiting = true) {
   // In Windows ExitProcess all non host threads are forcibly terminated prior
   // to DLL_PROCESS_DETACH. However, backend or XPTI calls may rely on these
   // threads being active. In such cases, making XPTI or backend calls at
@@ -321,10 +311,9 @@ void shutdown_early(bool CanJoinThreads = true) {
   // it is best to not unload the backend after thread destruction.
 #if defined(XPTI_ENABLE_INSTRUMENTATION)
   if (xptiTraceEnabled())
-    return;
+    return true;
 #endif
-  // Process is exiting
-  if (CanJoinThreads) {
+  if (ProcessExiting) {
     // Level zero relies on unloading cleanup for UR_L0_LEAKS_DEBUG
     // functionality on Windows so don't exit early for L0 platforms.
     if (auto PlatformCache =
@@ -337,9 +326,27 @@ void shutdown_early(bool CanJoinThreads = true) {
       // If spawned threads using the Windows CRT are forcibly killed, this
       // can prevent stdout buffer being flushed at the program end.
       std::fflush(stdout);
-      return;
+      return true;
     }
   }
+  return false;
+}
+#endif
+
+// Note: this function can be called on Windows twice:
+//  1) when library is unloaded via FreeLibrary
+//  2) when process is being terminated
+void shutdown_early(bool CanJoinThreads = true) {
+  const LockGuard Lock{GlobalHandler::MSyclGlobalHandlerProtector};
+  if (!GlobalHandler::RTGlobalObjHandler)
+    return;
+
+  // Now that we are shutting down, we will no longer defer MemObj releases.
+  GlobalHandler::RTGlobalObjHandler->endDeferredRelease();
+
+#ifdef _WIN32
+  if (shutdown_win_early_exit(CanJoinThreads))
+    return;
 #endif
 
   // Ensure neither host task is working so that no default context is accessed
@@ -378,29 +385,9 @@ void shutdown_late() {
   if (!GlobalHandler::RTGlobalObjHandler)
     return;
 
-#if defined(_WIN32)
-  // In Windows ExitProcess all non host threads are forcibly terminated prior
-  // to DLL_PROCESS_DETACH. However, backend or XPTI calls may rely on these
-  // threads being active. In such cases, making XPTI or backend calls at
-  // DLL_PROCESS_DETACH can lead to hangs or memory corruption. Because of this
-  // it is best to not unload the backend after thread destruction.
-#if defined(XPTI_ENABLE_INSTRUMENTATION)
-  if (xptiTraceEnabled())
+#ifdef _WIN32
+  if (shutdown_win_early_exit())
     return;
-#endif
-  // Level zero relies on unloading cleanup for UR_L0_LEAKS_DEBUG
-  // functionality on Windows so don't exit early for L0 platforms.
-  if (auto PlatformCache =
-          GlobalHandler::RTGlobalObjHandler->getPlatformCache();
-      !std::any_of(PlatformCache.begin(), PlatformCache.end(),
-                   [](const std::shared_ptr<platform_impl> &p) {
-                     return p->getBackend() == backend::ext_oneapi_level_zero;
-                   })) {
-    // If spawned threads using the Windows CRT are forcibly killed, this can
-    // prevent stdout buffer being flushed at the program end.
-    std::fflush(stdout);
-    return;
-  }
 #endif
 
   // First, release resources, that may access adapters.

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -105,6 +105,10 @@ private:
     SpinLock Lock;
   };
 
+#ifdef _WIN32
+  static bool winEarlyExitCheck(bool);
+#endif
+
   template <typename T, typename... Types>
   T &getOrCreate(InstWithLock<T> &IWL, Types &&...Args);
 

--- a/sycl/test-e2e/Adapters/adapter-release.cpp
+++ b/sycl/test-e2e/Adapters/adapter-release.cpp
@@ -1,5 +1,7 @@
-// Only L0 does adapter release on Windows
 // UNSUPPORTED: windows && (opencl || cuda)
+// UNSUPPORTED-INTENDED: Only L0 does adapter release on Windows. Windows
+// recommends not doing cleanup at unloading, however L0 still requires this in
+// order to enable UR_L0_LEAKS_DEBUG on Windows.
 
 // ensure that urAdapterRelease is called
 

--- a/sycl/test-e2e/Adapters/adapter-release.cpp
+++ b/sycl/test-e2e/Adapters/adapter-release.cpp
@@ -1,3 +1,6 @@
+// Only L0 does adapter release on Windows
+// UNSUPPORTED: windows && (opencl || cuda)
+
 // ensure that urAdapterRelease is called
 
 // RUN: env SYCL_UR_TRACE=2 %{run-unfiltered-devices} sycl-ls 2>&1| FileCheck %s

--- a/sycl/test-e2e/Adapters/dll-detach-order.cpp
+++ b/sycl/test-e2e/Adapters/dll-detach-order.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: windows
+// REQUIRES: windows && level_zero
 // RUN: env SYCL_UR_TRACE=-1 %{run-unfiltered-devices} sycl-ls 2>&1 | FileCheck %s
 
 // ensure that the adapters are detached AFTER urLoaderTearDown is done


### PR DESCRIPTION
In Windows, ExitProcess kills spawned threads before calling DLL_PROCESS_DETACH. This can lead to issues if the backend relies on threads.

https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-exitprocess

This MS devblog recommends that DLL_PROCESS_DETACH should be as minimal as possible.

https://devblogs.microsoft.com/oldnewthing/20120105-00/?p=8683

Additionally, if helper threads are forcibly terminated this can prevent the stdout buffer from being flushed, so add explicit flushing of the stdout buffer after the threads are killed.

Only cleanup early if L0 is not being used, otherwise `UR_L0_LEAKS_DEBUG` will break.

Also extends the functionality to other libraries that may contain SYCL objects through the `Managed` class.