### PR TITLE
[CI] Fix Linux Level Zero version

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.29.0",
-      "version": "v1.29.0",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.29.0",
+      "github_tag": "v1.28.2",
+      "version": "v1.28.2",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.28.2",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
We should match the driver listed in the GPU runtime, listed as 1.28.2 [here](https://github.com/intel/compute-runtime/releases/tag/26.18.38308.1).