### PR TITLE
[SYCL][E2E] Disable Adapters/level_zero/interop-buffer.cpp on Win BMG

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
@@ -4,6 +4,8 @@
 // UNSUPPORTED: ze_debug
 // UNSUPPORTED: windows && gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
+// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22284
 // RUN: %{build} -Wno-error=deprecated-declarations %level_zero_options -o %t.out
 // RUN: env UR_L0_DEBUG=1 %{run} %t.out
 


### PR DESCRIPTION
Sporadic fail, see https://github.com/intel/llvm/issues/22284