### PR TITLE
[SYCL][E2E] Disable Basic/alloc_pinned_host_memory.cpp on Win BMG

### DIFF
--- a/sycl/test-e2e/Basic/alloc_pinned_host_memory.cpp
+++ b/sycl/test-e2e/Basic/alloc_pinned_host_memory.cpp
@@ -3,6 +3,9 @@
 // UNSUPPORTED: windows && gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
 
+// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22287
+
 // RUN: %{build} -o %t2.out
 // RUN: env SYCL_UR_TRACE=2 UR_L0_DEBUG=1 %{run} %t2.out %if level_zero %{ 2>&1 | FileCheck %s %}
 // RUN: %{run} %t2.out


### PR DESCRIPTION
Sporadic fail, see https://github.com/intel/llvm/issues/22287