### PR TITLE
Revert llvm-spirv lifetime intrinsic customizations (#22253)

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -4936,16 +4936,8 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
 
     unsigned PtrAS = cast<PointerType>(LLVMPtrOp->getType())->getAddressSpace();
     auto *PtrOp = transValue(LLVMPtrOp, BB);
-    // INTEL_CUSTOMIZATION begin
-    // Workaround to make older versions of SPIRVReader working with new
-    // rules of LLVM lifetime intrinsics.
-    // TODO: to remove the W/A.
-    if (PtrAS == SPIRAS_Private) {
-      auto *Int8PtrTy =
-          transPointerType(Type::getInt8Ty(M->getContext()), SPIRAS_Private);
-      PtrOp = BM->addUnaryInst(OpBitcast, Int8PtrTy, PtrOp, BB);
+    if (PtrAS == SPIRAS_Private)
       return BM->addLifetimeInst(OC, PtrOp, Size, BB);
-    }
     // If pointer address space is Generic - use original allocation.
     BM->getErrorLog().checkError(
         PtrAS == SPIRAS_Generic, SPIRVEC_InvalidInstruction, II,
@@ -4953,11 +4945,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     if (PtrOp->getOpCode() == OpPtrCastToGeneric) {
       auto *UI = static_cast<SPIRVUnary *>(PtrOp);
       PtrOp = UI->getOperand(0);
-      auto *Int8PtrTy =
-          transPointerType(Type::getInt8Ty(M->getContext()), SPIRAS_Private);
-      PtrOp = BM->addUnaryInst(OpBitcast, Int8PtrTy, PtrOp, BB);
     }
-    // INTEL_CUSTOMIZATION end
     return BM->addLifetimeInst(OC, PtrOp, Size, BB);
   }
   // We don't want to mix translation of regular code and debug info, because

--- a/llvm-spirv/test/llvm-intrinsics/lifetime.ll
+++ b/llvm-spirv/test/llvm-intrinsics/lifetime.ll
@@ -18,30 +18,20 @@
 ; CHECK-SPIRV-DAG: TypeStruct [[#StructTy:]] [[#]]
 ; CHECK-SPIRV-DAG: TypePointer [[#PrivatePtrTy:]] 7 [[#StructTy]]
 
-; INTEL_CUSTOMIZATION:
 ; CHECK-SPIRV: Function [[#]] [[#SimpleF:]]
-; CHECK-SPIRV: Variable [[#]] [[#Var:]]
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast1:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStart [[#Cast1]] 4
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast2:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStop [[#Cast2]] 4
+; CHECK-SPIRV: LifetimeStart [[#Tmp:]] 0
+; CHECK-SPIRV: LifetimeStop [[#Tmp]] 0
 
 ; CHECK-SPIRV: Function [[#]] [[#SizedF:]]
-; CHECK-SPIRV: Variable [[#]] [[#Var:]]
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast1:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStart [[#Cast1]] 1
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast2:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStop [[#Cast2]] 1
+; CHECK-SPIRV: LifetimeStart [[#Tmp:]] 1
+; CHECK-SPIRV: LifetimeStop [[#Tmp]] 1
 
 ; CHECK-SPIRV: Function [[#]] [[#GenericF:]]
 ; CHECK-SPIRV: Variable [[#PrivatePtrTy]] [[#Var:]] 7
-; CHECK-SPIRV: PtrCastToGeneric [[#]] [[#ASCast:]] [[#Var]]
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast1:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStart [[#Cast1]] 1
-; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#ASCast]]
-; CHECK-SPIRV: Bitcast [[#]] [[#Cast2:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStop [[#Cast2]] 1
-; INTEL_CUSTOMIZATION end
+; CHECK-SPIRV: PtrCastToGeneric [[#]] [[#Cast1:]] [[#Var]]
+; CHECK-SPIRV: LifetimeStart [[#Var]] 0
+; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#Cast1]]
+; CHECK-SPIRV: LifetimeStop [[#Var]] 0
 
 ; CHECK-LLVM-LABEL: lifetime_simple
 ; CHECK-LLVM: %[[#Alloca:]] = alloca i32

--- a/llvm-spirv/test/llvm-intrinsics/memmove.ll
+++ b/llvm-spirv/test/llvm-intrinsics/memmove.ll
@@ -30,16 +30,13 @@
 ; CHECK-SPIRV: FunctionParameter [[#I8GLOBAL_PTR]] [[#ARG_IN:]]
 ; CHECK-SPIRV: FunctionParameter [[#I8GLOBAL_PTR]] [[#ARG_OUT:]]
 ;
-; INTEL_CUSTOMIZATION begin
 ; CHECK-SPIRV: Variable [[#]] [[#MEM:]]
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_IN:]] [[#ARG_IN]]
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_OUT:]] [[#ARG_OUT]]
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_1:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStart [[#MEM_CAST_1]]
+; CHECK-SPIRV: LifetimeStart [[#MEM]]
 ; CHECK-SPIRV: CopyMemorySized [[#MEM]] [[#I8_ARG_IN]] [[#C128]] 2 64
 ; CHECK-SPIRV: CopyMemorySized [[#I8_ARG_OUT]] [[#MEM]] [[#C128]] 2 64
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_2:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStop [[#MEM_CAST_2]]
+; CHECK-SPIRV: LifetimeStop [[#MEM]]
 
 ; CHECK-SPIRV-LABEL: [[#]] Function [[#]]
 ; CHECK-SPIRV: FunctionParameter [[#I8GLOBAL_PTR]] [[#ARG_IN:]]
@@ -49,25 +46,20 @@
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_IN:]] [[#ARG_IN]]
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_OUT_GENERIC:]] [[#ARG_OUT]]
 ; CHECK-SPIRV: GenericCastToPtr [[#]] [[#I8_ARG_OUT:]] [[#I8_ARG_OUT_GENERIC]]
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_1:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStart [[#MEM_CAST_1]]
+; CHECK-SPIRV: LifetimeStart [[#MEM]]
 ; CHECK-SPIRV: CopyMemorySized [[#MEM]] [[#I8_ARG_IN]] [[#C68]] 2 64
 ; CHECK-SPIRV: CopyMemorySized [[#I8_ARG_OUT]] [[#MEM]] [[#C68]] 2 64
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_2:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStop [[#MEM_CAST_2]]
+; CHECK-SPIRV: LifetimeStop [[#MEM]]
 
 ; CHECK-SPIRV-LABEL: [[#]] Function [[#]]
 ; CHECK-SPIRV: FunctionParameter [[#]] [[#ARG_IN:]]
 ; CHECK-SPIRV: FunctionParameter [[#]] [[#ARG_OUT:]]
 ;
 ; CHECK-SPIRV: Variable [[#]] [[#MEM:]]
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_1:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStart [[#MEM_CAST_1]]
+; CHECK-SPIRV: LifetimeStart [[#MEM]]
 ; CHECK-SPIRV: CopyMemorySized [[#MEM]] [[#ARG_IN]] [[#C72]] 0
 ; CHECK-SPIRV: CopyMemorySized [[#ARG_OUT]] [[#MEM]] [[#C72]] 0
-; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_2:]] [[#MEM]]
-; CHECK-SPIRV: LifetimeStop [[#MEM_CAST_2]]
-; INTEL_CUSTOMIZATION end
+; CHECK-SPIRV: LifetimeStop [[#MEM]]
 
 ; xCHECK-SPIRV-LABEL: [[#]] Function [[#]]
 ;


### PR DESCRIPTION
Revert https://github.com/intel/llvm/pull/20287 and https://github.com/intel/llvm/pull/22249.

The customization was made to handle older GPU Drivers not having the corresponding SPIRV Reader change, but all the drivers we use in CI (even Gen12 Windows) seems to work fine, so we don't need this anymore and it generates SPIR-V that causes `spirv-val` to complain, causing us to have to disable a test.

CTS run:
https://github.com/intel/llvm/actions/runs/27163769503/job/80193821812
 
Closes: https://github.com/intel/llvm/issues/22248

---------