### PR TITLE
[UR][L0] Revert Level Zero loader tag back to v1.28.2

### DIFF
--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -13,7 +13,7 @@ find_package(PkgConfig QUIET)
 # just try to search for the path.
 if(NOT UR_FORCE_FETCH_LEVEL_ZERO)
   if(PkgConfig_FOUND)
-    pkg_check_modules(level-zero level-zero>=1.29.0)
+    pkg_check_modules(level-zero level-zero>=1.28.2)
     if(level-zero_FOUND)
       set(LEVEL_ZERO_INCLUDE_DIR "${level-zero_INCLUDEDIR}/level_zero")
       set(LEVEL_ZERO_LIBRARY_SRC "${level-zero_LIBDIR}")
@@ -54,7 +54,7 @@ if(NOT LEVEL_ZERO_LIB_NAME AND NOT LEVEL_ZERO_LIBRARY)
   set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
   # Remember to update the pkg_check_modules minimum version above when updating the
   # clone tag
-  set(UR_LEVEL_ZERO_LOADER_TAG v1.29.0)
+  set(UR_LEVEL_ZERO_LOADER_TAG v1.28.2)
 
   # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
   set(CMAKE_INCLUDE_CURRENT_DIR OFF)


### PR DESCRIPTION
Revert the Level Zero loader tag back to v1.28.2,
because it is used by compute-runtime v26.18.38308.1.

It partially reverts e7ae7344c977.

Ref: #22276
