### PR TITLE
[SYCL][E2E] Disable dx11_interop/read_write_unsampled_semaphore.cpp on Win BMG

### DIFF
--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled_semaphore.cpp
@@ -8,6 +8,9 @@
 // UNSUPPORTED: gpu-intel-dg2
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22155
 
+// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22298
+
 // RUN: %{build} %link-directx -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out
 


### PR DESCRIPTION
Sporadically failing, see https://github.com/intel/llvm/issues/22298