### PR TITLE
[SYCL][Doc] Specify negative conversion to E8M0

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
@@ -1553,6 +1553,7 @@ Conversions to E8M0 using one of the non-stochastic rounding modes and with
 `saturation::finite` work as follows:
 
 * NaN is converted to NaN while dropping the sign.
+* Negative values are converted to an unspecified E8M0 value.
 * Other values are rounded according to the rounding mode.
 * If the resulting value is larger in magnitude than the max normal value, it is
   converted to the max normal value while dropping the sign.


### PR DESCRIPTION
We decided that the result of converting a negative value to E8M0 should be unspecified.  This never happens in practice, so we don't expect to see applications that really do this.  The hardware instruction specs we looked at don't specify the behavior in this situation.  Therefore, if we want SYCL to implement this in hardware, we have to say that the result is unspecified.