### PR TITLE
[SYCL][Doc] Guarantee alignment of FP8 types

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_fp8.asciidoc
@@ -248,6 +248,7 @@ This extension adds the `fp8_e4m3_x` type, which represents a set of packed E4M3
 values and provides various conversions to other types.
 The number of packed elements is defined by the `N` template parameter, which
 must be either 1 or 2.
+When `N` is 2, objects of this type have 2-byte alignment.
 
 [source,c++]
 ----
@@ -656,6 +657,7 @@ This extension adds the `fp8_e5m2_x` type, which represents a set of packed E5M2
 values and provides various conversions to other types.
 The number of packed elements is defined by the `N` template parameter, which
 must be either 1 or 2.
+When `N` is 2, objects of this type have 2-byte alignment.
 
 [source,c++]
 ----
@@ -1196,6 +1198,7 @@ This extension adds the `fp8_e8m0_x` type, which represents a set of packed E8M0
 values and provides various conversions to other types.
 The number of packed elements is defined by the `N` template parameter, which
 must be either 1 or 2.
+When `N` is 2, objects of this type have 2-byte alignment.
 
 [source,c++]
 ----


### PR DESCRIPTION
When the FP8 types have 2 elements, provide a guarantee that the object is 2-byte aligned.  This allows us to implement the conversions more efficiently.