### PR TITLE
[SYCL] second guard to msvc inclusion

### DIFF
--- a/sycl/include/sycl/stl_wrappers/__msvc_bit_utils.hpp
+++ b/sycl/include/sycl/stl_wrappers/__msvc_bit_utils.hpp
@@ -10,7 +10,9 @@
 
 // Mark this header as a system header so the `sycl_global_var` attribute
 // below is accepted.
+#ifdef __clang__
 #pragma clang system_header
+#endif
 
 // VS2026 MSVC STL's <__msvc_bit_utils.hpp> declares `__isa_available` (a
 // runtime CPU-feature global) and other STL headers (<bit>, <vector>,

--- a/sycl/include/sycl/stl_wrappers/__msvc_bit_utils.hpp
+++ b/sycl/include/sycl/stl_wrappers/__msvc_bit_utils.hpp
@@ -8,6 +8,10 @@
 
 #pragma once
 
+// Mark this header as a system header so the `sycl_global_var` attribute
+// below is accepted.
+#pragma clang system_header
+
 // VS2026 MSVC STL's <__msvc_bit_utils.hpp> declares `__isa_available` (a
 // runtime CPU-feature global) and other STL headers (<bit>, <vector>,
 // <numeric>, <bitset>, <complex>, <__msvc_int128.hpp>) include this header

--- a/sycl/test/regression/msvc_bit_utils_wrapper_system_header.cpp
+++ b/sycl/test/regression/msvc_bit_utils_wrapper_system_header.cpp
@@ -1,0 +1,23 @@
+// To properly get the STL headers on MSVC, the
+// stl_wrappers/__msvc_bit_utils.hppp wrapper decorates std::__isa_available
+// with sycl_global_var and qualifies with #pragma clang system_header.  This
+// test verifies that that compilation proceeds correctly when the shim is
+// included via a system or non-system path. A failure will see
+// "'sycl_global_var' attribute only supported within a system header"
+
+//
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -D_MSC_VER=1900 \
+// RUN:   -include %sycl_include/sycl/stl_wrappers/__msvc_bit_utils.hpp \
+// RUN:   -x c++ /dev/null
+//
+// Reproduce the original: preprocess with -E and recompile the .ii. Mirrors
+// what --offload-new-driver does internally.
+//
+// RUN: %if system-windows %{ \
+// RUN:   %clangxx -fsycl -fsycl-targets=spir64 --offload-new-driver -E %s -o %t.ii && \
+// RUN:   %clangxx -fsycl -fsycl-targets=spir64 --offload-new-driver -fsyntax-only %t.ii \
+// RUN: %}
+
+#include <sycl/detail/core.hpp>
+
+int main() { return 0; }

--- a/sycl/test/regression/msvc_bit_utils_wrapper_system_header.cpp
+++ b/sycl/test/regression/msvc_bit_utils_wrapper_system_header.cpp
@@ -1,23 +1,12 @@
 // To properly get the STL headers on MSVC, the
-// stl_wrappers/__msvc_bit_utils.hppp wrapper decorates std::__isa_available
-// with sycl_global_var and qualifies with #pragma clang system_header.  This
-// test verifies that that compilation proceeds correctly when the shim is
-// included via a system or non-system path. A failure will see
-// "'sycl_global_var' attribute only supported within a system header"
+// stl_wrappers/__msvc_bit_utils.hpp wrapper decorates std::__isa_available
+// with sycl_global_var and qualifies with #pragma clang system_header. This
+// test verifies that compilation proceeds correctly when the shim is
+// included via a system or non-system path. A failure will show
+// "'sycl_global_var' attribute only supported within a system header".
 
 //
-// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -D_MSC_VER=1900 \
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only \
+// RUN:   -U_MSC_VER -D_MSC_VER=1900 -Wno-macro-redefined \
 // RUN:   -include %sycl_include/sycl/stl_wrappers/__msvc_bit_utils.hpp \
 // RUN:   -x c++ /dev/null
-//
-// Reproduce the original: preprocess with -E and recompile the .ii. Mirrors
-// what --offload-new-driver does internally.
-//
-// RUN: %if system-windows %{ \
-// RUN:   %clangxx -fsycl -fsycl-targets=spir64 --offload-new-driver -E %s -o %t.ii && \
-// RUN:   %clangxx -fsycl -fsycl-targets=spir64 --offload-new-driver -fsyntax-only %t.ii \
-// RUN: %}
-
-#include <sycl/detail/core.hpp>
-
-int main() { return 0; }

--- a/sycl/test/regression/msvc_bit_utils_wrapper_system_header.cpp
+++ b/sycl/test/regression/msvc_bit_utils_wrapper_system_header.cpp
@@ -2,11 +2,11 @@
 // stl_wrappers/__msvc_bit_utils.hpp wrapper decorates std::__isa_available
 // with sycl_global_var and qualifies with #pragma clang system_header. This
 // test verifies that compilation proceeds correctly when the shim is
-// included via a system or non-system path. A failure will show
+// included via non-system path. A failure will show
 // "'sycl_global_var' attribute only supported within a system header".
 
 //
 // RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only \
 // RUN:   -U_MSC_VER -D_MSC_VER=1900 -Wno-macro-redefined \
 // RUN:   -include %sycl_include/sycl/stl_wrappers/__msvc_bit_utils.hpp \
-// RUN:   -x c++ /dev/null
+// RUN:   -x c++ %s


### PR DESCRIPTION
Need to mark our STL shim as system header or we can get failures. Adding a test that ensures it works with non-system inclusion.

