### PR TITLE
[clang][SYCL] Fix compilation of thiscall calling convention on Windows

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5949,29 +5949,15 @@ bool Sema::CheckCallingConvAttr(const ParsedAttr &Attrs, CallingConv &CC,
       A = HostTI->checkCallingConvention(CC);
     if (A == TargetInfo::CCCR_OK && CheckDevice && DeviceTI)
       A = DeviceTI->checkCallingConvention(CC);
-  } else if (LangOpts.SYCLIsDevice) {
-    // During device compilation, calling conventions that are valid for the
-    // host, for the device, and for both the host and the device may be
-    // encountered. Diagnostics are desired for cases where the calling
-    // convention is not supported by either the host or the device. If Aux is
-    // null (which should rarely be the case), it isn't possible to check
-    // whether the calling convention is supported by the host, so just assume
-    // that it is. If the calling convention is supported for the device, there
-    // is no need to check the host; the device target gets priority since this
-    // check is only performed during device compilation.
+  } else if (LangOpts.SYCLIsDevice && TI.getTriple().isAMDGPU() &&
+             CC == CC_X86VectorCall) {
+    // Assuming SYCL Device AMDGPU CC_X86VectorCall functions are always to be
+    // emitted on the host. The MSVC STL has CC-based specializations so we
+    // cannot change the CC to be the default as that will cause a clash with
+    // another specialization.
     A = TI.checkCallingConvention(CC);
-    if (Aux && A == TargetInfo::CCCR_Warning) {
-      // If the calling convention would provoke a warning for the device, check
-      // the host and preserve the warning only if the calling convention would
-      // provoke an error for the host. Otherwise, assume this calling
-      // convention is only used for host only functions.
+    if (Aux && A != TargetInfo::CCCR_OK)
       A = Aux->checkCallingConvention(CC);
-      if (A == TargetInfo::CCCR_Error)
-        A = TargetInfo::CCCR_Warning;
-    } else if (Aux && A == TargetInfo::CCCR_Error) {
-      // Assume this calling convention is only used for host only functions.
-      A = Aux->checkCallingConvention(CC);
-    }
   } else {
     A = TI.checkCallingConvention(CC);
   }

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -16,7 +16,7 @@ void bar() {
 }
 
 // Check some weird calling convention that is not supported even by x86_64 aux.
-// no-aux-warning@+1 {{'__swiftasynccall__' calling convention is not supported for this target}}
+// expected-warning@+1 {{'__swiftasynccall__' calling convention is not supported for this target}}
 void __attribute__((__swiftasynccall__)) g(void) {}
 
 template <typename name, typename Func>
@@ -51,6 +51,16 @@ static void callee() noexcept {
 void foo() {
    invoke(callee);
 }
+
+class A {
+public:
+  // expected-warning@+1 {{'thiscall' calling convention is not supported for this target}}
+  virtual void  __attribute__((thiscall)) boo() {}
+};
+
+class B : public A {
+  virtual void boo() override {}
+};
 
 int main() {
   //expected-error@+1 {{SYCL device code does not support variadic functions}}


### PR DESCRIPTION
f7424c7486397dc350952873fc3063fe75bf824d resulted in thiscall calling convention attribute transformed to CC_C calling convention since this is how host behaves for this attribtue. Since for SPIR/SPIR-V targets default calling convention is different from CC_C this caused clash for the code like

```
class A {
public:
  virtual void  __attribute__((thiscall)) boo() {}
};

class B : public A {
  virtual void boo() override {}
};

```
since A::boo will have CC_C calling convention and B::boo will have CC_SpirFunction calling convention. The upstream needs a more complex solution which will require some time, so this patch effectively reverts remaning changes made by f7424c7486397dc350952873fc3063fe75bf824d and 94ca49099ef77751a33e4babe41b2ae03ff228e1 since some of them were already reverted by 15c3371ed8d79ad4940af0fcfe8d6be3470914f5 to unblock the pulldown.

Fixes https://github.com/intel/llvm/issues/22265