### PR TITLE
[SYCL] Decouple <sycl/builtins.hpp> from <sycl/usm.hpp>

### DIFF
--- a/sycl/include/sycl/detail/sycl_mem_obj_allocator.hpp
+++ b/sycl/include/sycl/detail/sycl_mem_obj_allocator.hpp
@@ -10,7 +10,6 @@
 
 #include <sycl/detail/aligned_allocator.hpp> // for aligned_allocator
 
-#include <algorithm>   // for max
 #include <cstddef>     // for size_t
 #include <type_traits> // for enable_if_t
 
@@ -84,7 +83,8 @@ private:
 
   template <typename T = AllocatorT>
   EnableIfDefaultAllocator<T> setAlignImpl(std::size_t RequiredAlign) {
-    MAllocator.setAlignment(std::max<size_t>(RequiredAlign, 64));
+    MAllocator.setAlignment(RequiredAlign < size_t{64} ? size_t{64}
+                                                       : RequiredAlign);
   }
 
   AllocatorT MAllocator;

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -19,7 +19,6 @@
 #include <sycl/ext/intel/esimd/simd_view.hpp>
 #include <sycl/half_type.hpp>
 
-#include <algorithm>
 #include <cstdint>
 
 namespace sycl {

--- a/sycl/include/sycl/ext/oneapi/bindless_images_descriptor.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images_descriptor.hpp
@@ -13,7 +13,6 @@
 #include <sycl/image.hpp>        // for image_channel_order, image_channel_type
 #include <sycl/range.hpp>        // for range
 
-#include <algorithm>    // for max
 #include <stddef.h>     // for size_t
 #include <system_error> // for error_code
 
@@ -106,12 +105,14 @@ struct image_descriptor {
 
     // Generate a new descriptor which represents the level accordingly
     // Do not allow height/depth values to be clamped to 1 when naturally 0
-    size_t width = std::max<size_t>(this->width >> level, 1);
-    size_t height = this->height == 0
-                        ? this->height
-                        : std::max<size_t>(this->height >> level, 1);
-    size_t depth = this->depth == 0 ? this->depth
-                                    : std::max<size_t>(this->depth >> level, 1);
+    constexpr auto at_least_1 = [](size_t v) constexpr {
+      return v < size_t{1} ? size_t{1} : v;
+    };
+    size_t width = at_least_1(this->width >> level);
+    size_t height =
+        this->height == 0 ? this->height : at_least_1(this->height >> level);
+    size_t depth =
+        this->depth == 0 ? this->depth : at_least_1(this->depth >> level);
 
     // This will generate the new descriptor with image_type standard
     // since individual mip levels are standard images

--- a/sycl/include/sycl/ext/oneapi/bindless_images_descriptor.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images_descriptor.hpp
@@ -105,14 +105,14 @@ struct image_descriptor {
 
     // Generate a new descriptor which represents the level accordingly
     // Do not allow height/depth values to be clamped to 1 when naturally 0
-    constexpr auto at_least_1 = [](size_t v) constexpr {
+    constexpr auto clamp_mip_dim = [](size_t v) constexpr {
       return v < size_t{1} ? size_t{1} : v;
     };
-    size_t width = at_least_1(this->width >> level);
+    size_t width = clamp_mip_dim(this->width >> level);
     size_t height =
-        this->height == 0 ? this->height : at_least_1(this->height >> level);
+        this->height == 0 ? this->height : clamp_mip_dim(this->height >> level);
     size_t depth =
-        this->depth == 0 ? this->depth : at_least_1(this->depth >> level);
+        this->depth == 0 ? this->depth : clamp_mip_dim(this->depth >> level);
 
     // This will generate the new descriptor with image_type standard
     // since individual mip levels are standard images

--- a/sycl/include/sycl/ext/oneapi/experimental/float_8bit/types.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/float_8bit/types.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <sycl/access/access.hpp>
+#include <sycl/builtins.hpp> // for device-side __assert_fail (SYCL_EXTERNAL)
 #include <sycl/multi_ptr.hpp>
 
 #include <sycl/ext/oneapi/bfloat16.hpp>

--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -28,7 +28,6 @@
 #include <sycl/ext/oneapi/properties/property.hpp>       // build_options
 #include <sycl/ext/oneapi/properties/property_value.hpp> // and log
 
-#include <algorithm> // for find_if
 #include <array>      // for array
 #include <cstddef>    // for std::byte
 #include <cstring>    // for size_t, memcpy
@@ -1014,12 +1013,12 @@ struct include_files
     record.emplace_back(name, content);
   }
   void add(const std::string &name, const std::string &content) {
-    if (std::find_if(record.begin(), record.end(), [&name](auto &p) {
-          return p.first == name;
-        }) != record.end()) {
-      throw sycl::exception(make_error_code(errc::invalid),
-                            "Include file '" + name +
-                                "' is already registered");
+    for (auto &p : record) {
+      if (p.first == name) {
+        throw sycl::exception(make_error_code(errc::invalid),
+                              "Include file '" + name +
+                                  "' is already registered");
+      }
     }
     record.emplace_back(name, content);
   }

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -45,7 +45,6 @@
 #include <sycl/sycl_span.hpp>                       // for dynamic_e...
 #include <sycl/usm.hpp>                             // for malloc_de...
 
-#include <algorithm>   // for min
 #include <array>       // for array
 #include <assert.h>    // for assert
 #include <cstddef>     // for size_t
@@ -1426,7 +1425,7 @@ void doTreeReduction(size_t WorkSize, nd_item<Dim> NDIt, LocalRedsTy &LocalReds,
     // Otherwise we have no guarantee and we need to first reduce the amount of
     // work to fit into the local memory.
     size_t WGSize = NDIt.get_local_range().size();
-    AdjustedWorkSize = std::min(WorkSize, WGSize);
+    AdjustedWorkSize = WorkSize < WGSize ? WorkSize : WGSize;
     if (LID < AdjustedWorkSize) {
       auto LocalSum = AccessFunc(LID);
       for (size_t I = LID + WGSize; I < WorkSize; I += WGSize)
@@ -2711,12 +2710,12 @@ void reduction_parallel_for(handler &CGH, range<Dims> Range,
   size_t PrefWGSize = reduGetPreferredWGSize(CGH, OneElemSize);
 
   size_t NWorkItems = Range.size();
-  size_t WGSize = std::min(NWorkItems, PrefWGSize);
+  size_t WGSize = NWorkItems < PrefWGSize ? NWorkItems : PrefWGSize;
   size_t NWorkGroups = NWorkItems / WGSize;
   if (NWorkItems % WGSize)
     NWorkGroups++;
   size_t MaxNWorkGroups = NumConcurrentWorkGroups;
-  NWorkGroups = std::min(NWorkGroups, MaxNWorkGroups);
+  NWorkGroups = NWorkGroups < MaxNWorkGroups ? NWorkGroups : MaxNWorkGroups;
   size_t NDRItems = NWorkGroups * WGSize;
   nd_range<1> NDRange{range<1>{NDRItems}, range<1>{WGSize}};
 

--- a/sycl/include/sycl/usm.hpp
+++ b/sycl/include/sycl/usm.hpp
@@ -7,7 +7,6 @@
 // ===--------------------------------------------------------------------=== //
 #pragma once
 
-#include <sycl/builtins.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/device.hpp>
@@ -16,7 +15,6 @@
 #include <sycl/queue.hpp>
 #include <sycl/usm/usm_pointer_info.hpp>
 
-#include <algorithm> // for max
 #include <cstddef>   // for size_t
 
 namespace sycl {
@@ -192,9 +190,9 @@ T *aligned_alloc_device(
   if (is_not_power_of_two(Alignment)) {
     return nullptr;
   }
-  return static_cast<T *>(aligned_alloc_device(max(Alignment, alignof(T)),
-                                               Count * sizeof(T), Dev, Ctxt,
-                                               PropList, CodeLoc));
+  size_t Align = Alignment < alignof(T) ? alignof(T) : Alignment;
+  return static_cast<T *>(aligned_alloc_device(Align, Count * sizeof(T), Dev,
+                                               Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
@@ -249,9 +247,9 @@ T *aligned_alloc_host(
   if (is_not_power_of_two(Alignment)) {
     return nullptr;
   }
-  return static_cast<T *>(aligned_alloc_host(std ::max(Alignment, alignof(T)),
-                                             Count * sizeof(T), Ctxt, PropList,
-                                             CodeLoc));
+  size_t Align = Alignment < alignof(T) ? alignof(T) : Alignment;
+  return static_cast<T *>(
+      aligned_alloc_host(Align, Count * sizeof(T), Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
@@ -274,9 +272,9 @@ T *aligned_alloc_shared(
   if (is_not_power_of_two(Alignment)) {
     return nullptr;
   }
-  return static_cast<T *>(aligned_alloc_shared(max(Alignment, alignof(T)),
-                                               Count * sizeof(T), Dev, Ctxt,
-                                               PropList, CodeLoc));
+  size_t Align = Alignment < alignof(T) ? alignof(T) : Alignment;
+  return static_cast<T *>(aligned_alloc_shared(Align, Count * sizeof(T), Dev,
+                                               Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
@@ -317,9 +315,9 @@ T *aligned_alloc(
   if (is_not_power_of_two(Alignment)) {
     return nullptr;
   }
-  return static_cast<T *>(aligned_alloc(max(Alignment, alignof(T)),
-                                        Count * sizeof(T), Dev, Ctxt, Kind,
-                                        PropList, CodeLoc));
+  size_t Align = Alignment < alignof(T) ? alignof(T) : Alignment;
+  return static_cast<T *>(aligned_alloc(Align, Count * sizeof(T), Dev, Ctxt,
+                                        Kind, PropList, CodeLoc));
 }
 
 template <typename T>

--- a/sycl/test-e2e/Adapters/level_zero/ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/ext_intel_cslice.cpp
@@ -30,6 +30,7 @@
 
 // RUN: %{setup_env} env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 \
 // RUN:  UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
+#include <algorithm>
 #include <iostream>
 
 #include "../../helpers.hpp"

--- a/sycl/test-e2e/Adapters/level_zero/interop-device.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-device.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 #include <iostream>
 
+#include <algorithm>
 #include <numeric>
 #include <sycl/backend.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/barrier_order.cpp
+++ b/sycl/test-e2e/Basic/barrier_order.cpp
@@ -7,6 +7,7 @@
 
 #include <sycl/detail/core.hpp>
 
+#include <sycl/builtins.hpp>
 #include <sycl/usm.hpp>
 
 int main() {

--- a/sycl/test-e2e/Basic/device_config_file_consistency.cpp
+++ b/sycl/test-e2e/Basic/device_config_file_consistency.cpp
@@ -16,6 +16,7 @@
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21594
 #include <iostream>
 
+#include <algorithm>
 #include <map>
 
 #include <llvm/SYCLLowerIR/DeviceConfigFile.hpp>

--- a/sycl/test-e2e/Basic/multi_context_wait.cpp
+++ b/sycl/test-e2e/Basic/multi_context_wait.cpp
@@ -8,6 +8,7 @@
 #include <sycl/usm.hpp>
 
 #include <iostream>
+#include <sycl/builtins.hpp>
 #include <vector>
 
 std::vector<sycl::event> submit_dependencies(sycl::queue q1, sycl::queue q2,

--- a/sycl/test-e2e/Basic/platform_get_devices.cpp
+++ b/sycl/test-e2e/Basic/platform_get_devices.cpp
@@ -4,6 +4,7 @@
 // Tests platform::get_devices for each device type.
 #include <iostream>
 
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 #include <sycl/platform.hpp>
 #include <unordered_set>

--- a/sycl/test-e2e/Basic/sub_group_size_prop.cpp
+++ b/sycl/test-e2e/Basic/sub_group_size_prop.cpp
@@ -4,6 +4,7 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/sub_group.hpp>
 
+#include <algorithm>
 #include <iostream>
 
 using namespace sycl;

--- a/sycl/test-e2e/CompositeDevice/composite_device.cpp
+++ b/sycl/test-e2e/CompositeDevice/composite_device.cpp
@@ -4,6 +4,7 @@
 // RUN: env ZE_FLAT_DEVICE_HIERARCHY=FLAT %{run} %t.out
 
 #include "../helpers.hpp"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/composite_device.hpp>
 #include <sycl/platform.hpp>

--- a/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/discard_events_using_assert.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/discard_events_using_assert.cpp
@@ -18,3 +18,4 @@
 // CHECK: The test passed.
 
 #include "discard_events_kernel_using_assert.hpp"
+#include <sycl/builtins.hpp>

--- a/sycl/test-e2e/DeviceCodeSplit/split-per-source-main.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/split-per-source-main.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "Inputs/split-per-source.h"
+#include <algorithm>
 
 int main() {
   sycl::queue Q;

--- a/sycl/test-e2e/DeviceLib/built-ins/offload-prec-div-sqrt.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/offload-prec-div-sqrt.cpp
@@ -5,6 +5,7 @@
 // -foffload-fp32-prec-div -foffload-fp32-prec-sqrt are passed.
 
 #include <cmath>
+#include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iostream>
+#include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/DeviceLib/cmath_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_test.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <std/experimental/simd.hpp>
+#include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 enum USM_TEST_RES { USM_ALLOC_FAIL = -1, USM_TEST_PASS = 0, USM_TEST_FAIL = 1 };

--- a/sycl/test-e2e/Experimental/launch_queries/max_sub_group_size.cpp
+++ b/sycl/test-e2e/Experimental/launch_queries/max_sub_group_size.cpp
@@ -14,6 +14,7 @@
 #include <sycl/sub_group.hpp>
 #include <sycl/usm.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 

--- a/sycl/test-e2e/FreeFunctionKernels/free_function_kernels_as_device_host_functions.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/free_function_kernels_as_device_host_functions.cpp
@@ -12,6 +12,7 @@
 #include <sycl/ext/oneapi/free_function_queries.hpp>
 
 #include "helpers.hpp"
+#include <algorithm>
 
 template <typename T, int Dims>
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<Dims>))

--- a/sycl/test-e2e/FreeFunctionKernels/kernel_bundle.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/kernel_bundle.cpp
@@ -1,6 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/get_kernel_info.hpp>

--- a/sycl/test-e2e/FreeFunctionKernels/marray_as_kernel_parameter.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/marray_as_kernel_parameter.cpp
@@ -10,6 +10,7 @@
 #include <sycl/ext/oneapi/free_function_queries.hpp>
 
 #include "helpers.hpp"
+#include <sycl/marray.hpp>
 
 static constexpr size_t M_ARRAY_SIZE = 5;
 

--- a/sycl/test-e2e/FreeFunctionKernels/templates_cpp_non_integral_type.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/templates_cpp_non_integral_type.cpp
@@ -5,7 +5,9 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/free_function_queries.hpp>
 #include <sycl/kernel_bundle.hpp>
+#include <sycl/marray.hpp>
 #include <sycl/usm.hpp>
+#include <sycl/vector.hpp>
 
 namespace syclext = sycl::ext::oneapi;
 namespace syclexp = sycl::ext::oneapi::experimental;

--- a/sycl/test-e2e/FreeFunctionKernels/vec_as_kernel_parameter.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/vec_as_kernel_parameter.cpp
@@ -10,6 +10,7 @@
 #include <sycl/ext/oneapi/free_function_queries.hpp>
 
 #include "helpers.hpp"
+#include <sycl/vector.hpp>
 
 static constexpr size_t VEC_SIZE = 3;
 

--- a/sycl/test-e2e/Graph/Explicit/opencl_local_acc.cpp
+++ b/sycl/test-e2e/Graph/Explicit/opencl_local_acc.cpp
@@ -8,3 +8,4 @@
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/opencl_local_acc.cpp"
+#include <sycl/vector.hpp>

--- a/sycl/test-e2e/Graph/Explicit/sub_group_prop.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_group_prop.cpp
@@ -7,3 +7,4 @@
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/sub_group_prop.cpp"
+#include <algorithm>

--- a/sycl/test-e2e/Graph/Inputs/sub_group_prop.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_group_prop.cpp
@@ -4,6 +4,8 @@
 #include "../graph_common.hpp"
 #include <sycl/sub_group.hpp>
 
+#include <algorithm>
+
 enum class Variant { Function, Functor, FunctorAndProperty };
 
 template <Variant KernelVariant, size_t SGSize> class SubGroupKernel;

--- a/sycl/test-e2e/Graph/RecordReplay/opencl_local_acc.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/opencl_local_acc.cpp
@@ -8,3 +8,4 @@
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/opencl_local_acc.cpp"
+#include <sycl/vector.hpp>

--- a/sycl/test-e2e/Graph/RecordReplay/sub_group_prop.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_group_prop.cpp
@@ -7,3 +7,4 @@
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/sub_group_prop.cpp"
+#include <algorithm>

--- a/sycl/test-e2e/GroupAlgorithm/load_store/odd_wg_size.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/load_store/odd_wg_size.cpp
@@ -4,6 +4,7 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 
+#include <algorithm>
 #include <numeric>
 
 using namespace sycl;

--- a/sycl/test-e2e/GroupAlgorithm/load_store/partial_sg.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/load_store/partial_sg.cpp
@@ -1,6 +1,7 @@
 // RUN: %{build} -Wno-error=incorrect-sub-group-size -o %t.out
 // RUN: %{run} %t.out
 
+#include <algorithm>
 #include <numeric>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/group_load_store.hpp>

--- a/sycl/test-e2e/GroupAlgorithm/shuffle_marray.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/shuffle_marray.cpp
@@ -4,6 +4,7 @@
 // Tests that marray works in sub-group shuffles.
 #include <iostream>
 
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 #include <sycl/group_algorithm.hpp>
 #include <sycl/marray.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_bad_opcode.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_bad_opcode.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/Negative/asm_bad_operand_syntax.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_bad_operand_syntax.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/Negative/asm_duplicate_label.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_duplicate_label.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/Negative/asm_illegal_exec_size.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_illegal_exec_size.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/Negative/asm_missing_label.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_missing_label.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/Negative/asm_missing_region.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_missing_region.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/Negative/asm_simple.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_simple.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/Negative/asm_undefined_decl.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_undefined_decl.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/Negative/asm_undefined_pred.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_undefined_pred.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/Negative/asm_wrong_declare.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_wrong_declare.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 struct KernelFunctor {

--- a/sycl/test-e2e/InlineAsm/asm_16_empty.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_empty.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_16_matrix_mult.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_matrix_mult.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_16_no_input_int.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_no_input_int.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_16_no_opts.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_no_opts.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_arbitrary_ops_order.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_arbitrary_ops_order.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_decl_in_scope.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_decl_in_scope.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_float_add.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_float_add.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/asm_float_imm_arg.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_float_imm_arg.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/asm_float_neg.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_float_neg.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_if.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_if.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 using DataType = sycl::opencl::cl_int;

--- a/sycl/test-e2e/InlineAsm/asm_imm_arg.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_imm_arg.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_loop.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_loop.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/asm_mul.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_mul.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_no_operands.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_no_operands.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 class no_operands_kernel;
 

--- a/sycl/test-e2e/InlineAsm/asm_no_output.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_no_output.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_plus_mod.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_plus_mod.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/asm_switch.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_switch.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 
 using DataType = sycl::opencl::cl_int;

--- a/sycl/test-e2e/InlineAsm/include/asmhelper.h
+++ b/sycl/test-e2e/InlineAsm/include/asmhelper.h
@@ -1,5 +1,6 @@
 #include <sycl/detail/core.hpp>
 
+#include <algorithm>
 #include <iostream>
 #include <memory>
 #include <vector>

--- a/sycl/test-e2e/InlineAsm/letter_example.cpp
+++ b/sycl/test-e2e/InlineAsm/letter_example.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/InlineAsm/malloc_shared_32.cpp
+++ b/sycl/test-e2e/InlineAsm/malloc_shared_32.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/InlineAsm/malloc_shared_in_out_dif.cpp
+++ b/sycl/test-e2e/InlineAsm/malloc_shared_in_out_dif.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/InlineAsm/malloc_shared_no_input.cpp
+++ b/sycl/test-e2e/InlineAsm/malloc_shared_no_input.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "include/asmhelper.h"
+#include <algorithm>
 #include <iostream>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/KernelAndProgram/free_function_apis.cpp
+++ b/sycl/test-e2e/KernelAndProgram/free_function_apis.cpp
@@ -2,6 +2,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/free_function_traits.hpp>

--- a/sycl/test-e2e/KernelAndProgram/kernel-bundle-get-kernel-ids.cpp
+++ b/sycl/test-e2e/KernelAndProgram/kernel-bundle-get-kernel-ids.cpp
@@ -5,6 +5,7 @@
 // in the source regardless of whether they are expressed as lambdas,
 // function objects or free functions.
 
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/free_function_traits.hpp>
 #include <sycl/kernel_bundle.hpp>

--- a/sycl/test-e2e/KernelAndProgram/spec_constants_after_link.cpp
+++ b/sycl/test-e2e/KernelAndProgram/spec_constants_after_link.cpp
@@ -21,6 +21,7 @@
 #include <sycl/kernel_bundle.hpp>
 #include <sycl/specialization_id.hpp>
 
+#include <algorithm>
 #include <optional>
 #include <vector>
 

--- a/sycl/test-e2e/KernelCompiler/opencl_local_mem.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_local_mem.cpp
@@ -15,6 +15,7 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
 #include <sycl/usm.hpp>
+#include <sycl/vector.hpp>
 
 using namespace sycl;
 namespace syclex = sycl::ext::oneapi::experimental;

--- a/sycl/test-e2e/KernelCompiler/spirv.cpp
+++ b/sycl/test-e2e/KernelCompiler/spirv.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <string>
 #include <sycl/detail/core.hpp>
+#include <sycl/half_type.hpp>
 #include <sycl/kernel_bundle.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_apply_bf16_impl.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_apply_bf16_impl.hpp
@@ -7,6 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <algorithm>
+
 template <typename T, size_t TM, size_t TK> class add;
 template <typename T, size_t TM, size_t TK> class add_func;
 

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_apply_bf16.cpp
@@ -24,3 +24,4 @@
 #define SG_SZ 32
 
 #include "joint_matrix_apply_bf16_impl.hpp"
+#include <algorithm>

--- a/sycl/test-e2e/Matrix/runtime_query_tensorcores.cpp
+++ b/sycl/test-e2e/Matrix/runtime_query_tensorcores.cpp
@@ -10,6 +10,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+#include <algorithm>
+
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 

--- a/sycl/test-e2e/NewOffloadDriver/split-per-source-main.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/split-per-source-main.cpp
@@ -3,6 +3,7 @@
 // RUN: %{run} %t.out
 
 #include "Inputs/split-per-source.h"
+#include <algorithm>
 
 int main() {
   sycl::queue Q;

--- a/sycl/test-e2e/NonUniformGroups/fragment.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fragment.cpp
@@ -9,6 +9,7 @@
 // REQUIRES: aspect-ext_oneapi_fragment
 #include <iostream>
 
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/chunk.hpp>
 #include <sycl/ext/oneapi/experimental/fragment.hpp>

--- a/sycl/test-e2e/NonUniformGroups/opportunistic.cpp
+++ b/sycl/test-e2e/NonUniformGroups/opportunistic.cpp
@@ -9,6 +9,7 @@
 // REQUIRES: aspect-ext_oneapi_fragment
 #include <iostream>
 
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/fragment.hpp>
 #include <vector>

--- a/sycl/test-e2e/NonUniformGroups/tangle.cpp
+++ b/sycl/test-e2e/NonUniformGroups/tangle.cpp
@@ -9,6 +9,7 @@
 // REQUIRES: aspect-ext_oneapi_tangle
 #include <iostream>
 
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/tangle.hpp>
 #include <vector>

--- a/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_multiple.cpp
+++ b/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_multiple.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 
 #include "Inputs/private_alloca_test.hpp"
+#include <algorithm>
 
 constexpr sycl::specialization_id<std::size_t> size(10);
 constexpr sycl::specialization_id<int> isize(10);

--- a/sycl/test-e2e/Reduction/reduction_deterministic.cpp
+++ b/sycl/test-e2e/Reduction/reduction_deterministic.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <random>
 
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/reduction_properties.hpp>
 

--- a/sycl/test-e2e/Regression/barrier_with_work.cpp
+++ b/sycl/test-e2e/Regression/barrier_with_work.cpp
@@ -14,6 +14,7 @@
 
 #include <sycl/detail/core.hpp>
 
+#include <sycl/builtins.hpp>
 #include <sycl/usm.hpp>
 
 constexpr size_t NElemsPerSplit = 1000;

--- a/sycl/test-e2e/Regression/commandlist/Inputs/main.cpp
+++ b/sycl/test-e2e/Regression/commandlist/Inputs/main.cpp
@@ -2,6 +2,7 @@
 
 #include <sycl/properties/all_properties.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>

--- a/sycl/test-e2e/Regression/device_num.cpp
+++ b/sycl/test-e2e/Regression/device_num.cpp
@@ -6,6 +6,7 @@
 // RUN: env ONEAPI_DEVICE_SELECTOR="*:3" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out
 
 #include "../helpers.hpp"
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <map>

--- a/sycl/test-e2e/SpecConstants/2020/marray_vec.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/marray_vec.cpp
@@ -2,8 +2,10 @@
 // RUN: %{run} %t.out
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/marray.hpp>
 #include <sycl/specialization_id.hpp>
 #include <sycl/usm.hpp>
+#include <sycl/vector.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/SubGroup/info.cpp
+++ b/sycl/test-e2e/SubGroup/info.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 
 #include "helper.hpp"
+#include <algorithm>
 class kernel_sg;
 using namespace sycl;
 

--- a/sycl/test-e2e/USM/P2P/p2p_access.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_access.cpp
@@ -3,10 +3,12 @@
 // RUN:  %{run} %t.out
 #include <iostream>
 
+#include <algorithm>
 #include <cassert>
 #include <sycl/detail/core.hpp>
 #include <sycl/platform.hpp>
 #include <sycl/usm.hpp>
+#include <sycl/vector.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/USM/P2P/p2p_atomics.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_atomics.cpp
@@ -9,6 +9,7 @@
 
 #include <sycl/detail/core.hpp>
 
+#include <algorithm>
 #include <sycl/atomic_ref.hpp>
 #include <sycl/platform.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/USM/P2P/p2p_copy.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_copy.cpp
@@ -3,6 +3,7 @@
 // RUN:  %{run} %t.out
 #include <iostream>
 
+#include <algorithm>
 #include <cassert>
 #include <numeric>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/USM/copy.cpp
+++ b/sycl/test-e2e/USM/copy.cpp
@@ -10,6 +10,7 @@
 // RUN: %{run} %t1.out
 
 #include <sycl/detail/core.hpp>
+#include <sycl/half_type.hpp>
 #include <sycl/usm.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/USM/fill.cpp
+++ b/sycl/test-e2e/USM/fill.cpp
@@ -10,6 +10,7 @@
 // RUN: %{run} %t1.out
 
 #include <sycl/detail/core.hpp>
+#include <sycl/half_type.hpp>
 #include <sycl/usm.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/USM/math.cpp
+++ b/sycl/test-e2e/USM/math.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <sycl/builtins.hpp>
 
 namespace s = sycl;
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_common.hpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_common.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sycl/detail/core.hpp>
+#include <sycl/half_type.hpp>
 #include <sycl/usm.hpp>
 
 #include "memops2d_utils.hpp"

--- a/sycl/test-e2e/USM/memops2d/fill2d.cpp
+++ b/sycl/test-e2e/USM/memops2d/fill2d.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 
 #include <sycl/detail/core.hpp>
+#include <sycl/half_type.hpp>
 #include <sycl/usm.hpp>
 
 #include "memops2d_utils.hpp"

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_common.hpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_common.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sycl/detail/core.hpp>
+#include <sycl/half_type.hpp>
 #include <sycl/usm.hpp>
 
 #include "memops2d_utils.hpp"

--- a/sycl/test-e2e/USM/pointer_query.cpp
+++ b/sycl/test-e2e/USM/pointer_query.cpp
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <algorithm>
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/WorkGroupMemory/common.hpp
+++ b/sycl/test-e2e/WorkGroupMemory/common.hpp
@@ -3,10 +3,12 @@
 #include <cassert>
 #include <iostream>
 #include <sycl/atomic_ref.hpp>
+#include <sycl/builtins.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/work_group_memory.hpp>
 #include <sycl/ext/oneapi/free_function_queries.hpp>
 #include <sycl/group_barrier.hpp>
+#include <sycl/half_type.hpp>
 #include <sycl/marray.hpp>
 #include <sycl/usm.hpp>
 #include <sycl/vector.hpp>

--- a/sycl/test-e2e/WorkGroupMemory/reduction_free_function.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/reduction_free_function.cpp
@@ -5,6 +5,7 @@
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/18230
 
 #include "common_free_function.hpp"
+#include <sycl/half_type.hpp>
 
 // Basic usage reduction test using free function kernels.
 // A global buffer is allocated using USM and it is passed to the kernel on the

--- a/sycl/test-e2e/WorkGroupMemory/reduction_lambda.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/reduction_lambda.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 
 #include "common.hpp"
+#include <sycl/half_type.hpp>
 
 queue q;
 context ctx = q.get_context();

--- a/sycl/test-e2e/bindless_images/array/fetch_sampled_array.cpp
+++ b/sycl/test-e2e/bindless_images/array/fetch_sampled_array.cpp
@@ -11,6 +11,7 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/half_type.hpp>
+#include <sycl/vector.hpp>
 
 namespace syclexp = sycl::ext::oneapi::experimental;
 

--- a/sycl/test-e2e/bindless_images/array/read_sampled_array.cpp
+++ b/sycl/test-e2e/bindless_images/array/read_sampled_array.cpp
@@ -21,6 +21,7 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/half_type.hpp>
+#include <sycl/vector.hpp>
 
 namespace syclexp = sycl::ext::oneapi::experimental;
 

--- a/sycl/test-e2e/bindless_images/array/read_write_unsampled_array.cpp
+++ b/sycl/test-e2e/bindless_images/array/read_write_unsampled_array.cpp
@@ -14,6 +14,7 @@
 
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/half_type.hpp>
+#include <sycl/vector.hpp>
 #include <type_traits>
 
 namespace syclexp = sycl::ext::oneapi::experimental;

--- a/sycl/test-e2e/bindless_images/copies/device_to_device_copy.cpp
+++ b/sycl/test-e2e/bindless_images/copies/device_to_device_copy.cpp
@@ -9,7 +9,9 @@
 #include <numeric>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>
+#include <sycl/half_type.hpp>
 #include <sycl/usm.hpp>
+#include <sycl/vector.hpp>
 
 // Uncomment to print additional test information
 // #define VERBOSE_PRINT

--- a/sycl/test-e2e/bindless_images/helpers/common.hpp
+++ b/sycl/test-e2e/bindless_images/helpers/common.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/bindless_images/helpers/sampling.hpp
+++ b/sycl/test-e2e/bindless_images/helpers/sampling.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/bindless_images/read_norm_types.cpp
+++ b/sycl/test-e2e/bindless_images/read_norm_types.cpp
@@ -10,6 +10,7 @@
 #include <limits>
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
+#include <sycl/vector.hpp>
 
 #include "helpers/common.hpp"
 #include <sycl/ext/oneapi/bindless_images.hpp>

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -26,6 +26,7 @@
 
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/half_type.hpp>
+#include <sycl/vector.hpp>
 
 namespace syclexp = sycl::ext::oneapi::experimental;
 

--- a/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
@@ -18,6 +18,7 @@
 
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/half_type.hpp>
+#include <sycl/vector.hpp>
 #include <type_traits>
 
 static sycl::device dev;

--- a/sycl/test-e2e/bindless_images/sampling_2D_half.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D_half.cpp
@@ -15,7 +15,9 @@
 #include <sycl/detail/core.hpp>
 
 #include <sycl/ext/oneapi/bindless_images.hpp>
+#include <sycl/half_type.hpp>
 #include <sycl/usm.hpp>
+#include <sycl/vector.hpp>
 
 // Uncomment to print additional test information
 // #define VERBOSE_PRINT

--- a/sycl/test-e2e/bindless_images/sampling_gather2D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_gather2D.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <sycl/detail/core.hpp>
 
+#include <sycl/builtins.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/matrix_aspect.cpp
+++ b/sycl/test-e2e/matrix_aspect.cpp
@@ -13,6 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <algorithm>
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/platform.hpp>

--- a/sycl/test/basic_tests/device_config_file_aspects.cpp
+++ b/sycl/test/basic_tests/device_config_file_aspects.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -fsycl %s -o %t.out -I %llvm_main_include_dir
 // RUN: %t.out
 //
+#include <algorithm>
 #include <map>
 
 #include <llvm/SYCLLowerIR/DeviceConfigFile.hpp>

--- a/sycl/test/native_cpu/scalar_args.cpp
+++ b/sycl/test/native_cpu/scalar_args.cpp
@@ -4,6 +4,7 @@
 
 #include <sycl/sycl.hpp>
 
+#include <algorithm>
 #include <iostream>
 
 using namespace sycl;

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -18,6 +18,7 @@
 //
 #include <sycl/sycl.hpp>
 
+#include <algorithm>
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
<sycl/usm.hpp> transitively pulled in <sycl/builtins.hpp> (and through it <sycl/half_type.hpp>, <algorithm>, vec/marray definitions, libc device declarations like __assert_fail, etc.). User code and tests came to rely on this implicit re-export chain.

Once `sycl_khr_split_headers` ships, <sycl/usm.hpp> is meant to deliver only USM symbols. Keeping the <sycl/builtins.hpp> include would either defeat the purpose of split-headers or force a source break later.

Fix the dependency now:

  * Drop <sycl/builtins.hpp> and <algorithm> from <sycl/usm.hpp>.
  * Replace four unqualified max(...) callsites (which previously resolved to sycl::max via builtins) with inline ternaries.
  * Add the explicit headers each affected test/common helper actually needs:
      - <algorithm>             for std::any_of / all_of / find / sort etc.
      - <sycl/half_type.hpp>    for sycl::half as a complete type.
      - <sycl/vector.hpp>       for sycl::vec.
      - <sycl/marray.hpp>       for sycl::marray.
      - <sycl/builtins.hpp>     for sycl math builtins or device-side
                                assert / libc declarations.