### PR TITLE
[SYCL] Unregister `sycl::queue` upon destruction

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -432,10 +432,7 @@ void device_impl::wait() {
   // not-yet-enqueued commands and host_task.
   {
     std::lock_guard<std::mutex> Lock(MQueuesMutex);
-    for (const std::weak_ptr<queue_impl> &WQueue : MQueues) {
-      std::shared_ptr<queue_impl> Queue = WQueue.lock();
-      assert(Queue && "Queue should never be dangling in the list of queues "
-                      "associated with the device!");
+    for (queue_impl *Queue : MQueues) {
       Queue->waitForRuntimeLevelCmdsAndClear();
     }
   }

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -2289,12 +2289,14 @@ public:
   // Dispatch all unconsumed asynchronous exception to the appropriate handlers.
   void throwAsynchronous();
 
-  void registerQueue(const std::weak_ptr<queue_impl> &Q) {
+  // Called by queue_impl in its constructor.
+  void registerQueue(queue_impl *Q) {
     std::lock_guard<std::mutex> Lock(MQueuesMutex);
     MQueues.insert(Q);
   }
 
-  void unregisterQueue(const std::weak_ptr<queue_impl> &Q) {
+  // Called by queue_impl in its destructor.
+  void unregisterQueue(queue_impl *Q) {
     std::lock_guard<std::mutex> Lock(MQueuesMutex);
     MQueues.erase(Q);
   }
@@ -2309,9 +2311,7 @@ private:
   // Devices track a list of active queues on it, to allow for synchronization
   // with host_task and not-yet-enqueued commands.
   std::mutex MQueuesMutex;
-  std::set<std::weak_ptr<queue_impl>,
-           std::owner_less<std::weak_ptr<queue_impl>>>
-      MQueues;
+  std::set<queue_impl *> MQueues;
 
   // Order of caches matters! UR must come before SYCL info descriptors (because
   // get_info calls get_info_impl but the opposite never happens) and both

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -240,11 +240,12 @@ public:
   static std::shared_ptr<queue_impl> create(Ts &&...args) {
     auto ImplPtr =
         std::make_shared<queue_impl>(std::forward<Ts>(args)..., private_tag{});
-    ImplPtr->getDeviceImpl().registerQueue(ImplPtr);
+    ImplPtr->getDeviceImpl().registerQueue(ImplPtr.get());
     return ImplPtr;
   }
 
   ~queue_impl() {
+    getDeviceImpl().unregisterQueue(this);
     try {
 #if XPTI_ENABLE_INSTRUMENTATION
       // The trace event created in the constructor should be active through the

--- a/sycl/test-e2e/DeviceWait/basic.cpp
+++ b/sycl/test-e2e/DeviceWait/basic.cpp
@@ -24,6 +24,14 @@ int main() try {
       sycl::queue{Contexts[1], D},
       sycl::queue{Contexts[1], D, sycl::property::queue::in_order()}};
 
+  // Queue registers itself to the per-device queue list when it's created,
+  // And unregisters itself when it's destructed. This test verifies that the
+  // queue list is updated correctly when the queue is destructed. Otherwise,
+  // ext_oneapi_wait call would assert fail.
+  {
+    sycl::queue QTemp{Contexts[0], D};
+  }
+
   std::vector<sycl::event> Events;
   Events.reserve(NQueues);
   for (sycl::queue &Q : Queues) {

--- a/sycl/test-e2e/DeviceWait/basic.cpp
+++ b/sycl/test-e2e/DeviceWait/basic.cpp
@@ -24,12 +24,13 @@ int main() try {
       sycl::queue{Contexts[1], D},
       sycl::queue{Contexts[1], D, sycl::property::queue::in_order()}};
 
-  // Queue registers itself to the per-device queue list when it's created,
-  // And unregisters itself when it's destructed. This test verifies that the
-  // queue list is updated correctly when the queue is destructed. Otherwise,
-  // ext_oneapi_wait call would assert fail.
+  // A queue registers itself in the per-device queue list when it is created
+  // and unregisters itself when it is destroyed. This test verifies that the
+  // queue list is updated correctly when the queue is destroyed; otherwise the
+  // ext_oneapi_wait() call would hit an assertion failure.
   {
     sycl::queue QTemp{Contexts[0], D};
+    (void)QTemp;
   }
 
   std::vector<sycl::event> Events;


### PR DESCRIPTION
Currently, queue registers itself to the per-device queue list when it's created but do not unregister itself when it's destructed. This causes `ext_oneapi_wait` call to assert fail. On release build, it leads to segmentation fault.
