### PR TITLE
[SYCL][Test] Fix stack-use-after-scope in graph destruction_callback test

### DIFF
--- a/sycl/test-e2e/Graph/Inputs/destruction_callback.cpp
+++ b/sycl/test-e2e/Graph/Inputs/destruction_callback.cpp
@@ -40,6 +40,10 @@ int main() {
   const size_t N = 64;
   int *Data = malloc_device<int>(N, Queue);
 
+  // Lvalue arg: must be copied into the graph's stored tuple.
+  bool LvalueCopied = false, LvalueMoved = false;
+  // Rvalue arg: move-constructible optimization should kick in.
+  bool RvalueCopied = false, RvalueMoved = false;
   {
 #ifdef GRAPH_E2E_NATIVE_RECORDING
     exp_ext::command_graph Graph{
@@ -69,16 +73,12 @@ int main() {
     SizeCopy = 0;
     assert(!CleanupCallbackInvoked && "Cleanup callback should not fire yet");
 
-    // Lvalue arg: must be copied into the graph's stored tuple.
-    bool LvalueCopied = false, LvalueMoved = false;
     CopyMoveTracker LvalueTracker{42, &LvalueCopied, &LvalueMoved};
     Graph.set_destruction_callback(
         [](CopyMoveTracker T, int *Out) { *Out = T.Value; }, LvalueTracker,
         &ObservedLvalue);
     assert(LvalueCopied && "Lvalue arg should be copied");
 
-    // Rvalue arg: move-constructible optimization should kick in.
-    bool RvalueCopied = false, RvalueMoved = false;
     CopyMoveTracker RvalueTracker{99, &RvalueCopied, &RvalueMoved};
     Graph.set_destruction_callback(
         [](CopyMoveTracker T, int *Out) { *Out = T.Value; },


### PR DESCRIPTION
Hoist the LvalueCopied/LvalueMoved/RvalueCopied/RvalueMoved flags out of the inner block so they outlive the command_graph. The graph inside the block, its destruction callbacks copy the stored CopyMoveTracker arguments, and that copy constructor writes through the tracker's flag pointers. With the flags as inner-scope locals, those writes hit memory whose lifetime has already ended, which causes a stack-use-after-scope problem.