### PR TITLE
[SYCL] do not test assertions in no assertions build

### DIFF
--- a/sycl/unittests/Extensions/fp8/fp8_e4m3.cpp
+++ b/sycl/unittests/Extensions/fp8/fp8_e4m3.cpp
@@ -686,7 +686,8 @@ TEST(FP8E4M3Test, X2NotAssignableFromSingleULL) {
   EXPECT_FALSE((std::is_assignable_v<fp8_e4m3_x2 &, unsigned long long>));
 }
 
-TEST(FP8E4M3Test, DISABLED_CArrayHalfRejectsUpwardRounding) {
+#if LLVM_ENABLE_ASSERTIONS
+TEST(FP8E4M3Test, CArrayHalfRejectsUpwardRounding) {
   const sycl::half in[2] = {sycl::half(1.0f), sycl::half(2.0f)};
   EXPECT_DEATH(
       {
@@ -696,7 +697,7 @@ TEST(FP8E4M3Test, DISABLED_CArrayHalfRejectsUpwardRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_CArrayHalfRejectsTowardZeroRounding) {
+TEST(FP8E4M3Test, CArrayHalfRejectsTowardZeroRounding) {
   const sycl::half in[2] = {sycl::half(1.0f), sycl::half(2.0f)};
   EXPECT_DEATH(
       {
@@ -706,7 +707,7 @@ TEST(FP8E4M3Test, DISABLED_CArrayHalfRejectsTowardZeroRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_CArrayBFloat16RejectsUpwardRounding) {
+TEST(FP8E4M3Test, CArrayBFloat16RejectsUpwardRounding) {
   const sycl::ext::oneapi::bfloat16 in[2] = {sycl::ext::oneapi::bfloat16(1.0f),
                                              sycl::ext::oneapi::bfloat16(2.0f)};
   EXPECT_DEATH(
@@ -717,7 +718,7 @@ TEST(FP8E4M3Test, DISABLED_CArrayBFloat16RejectsUpwardRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_CArrayBFloat16RejectsTowardZeroRounding) {
+TEST(FP8E4M3Test, CArrayBFloat16RejectsTowardZeroRounding) {
   const sycl::ext::oneapi::bfloat16 in[2] = {sycl::ext::oneapi::bfloat16(1.0f),
                                              sycl::ext::oneapi::bfloat16(2.0f)};
   EXPECT_DEATH(
@@ -728,7 +729,7 @@ TEST(FP8E4M3Test, DISABLED_CArrayBFloat16RejectsTowardZeroRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_CArrayFloatRejectsUpwardRounding) {
+TEST(FP8E4M3Test, CArrayFloatRejectsUpwardRounding) {
   const float in[2] = {1.0f, 2.0f};
   EXPECT_DEATH(
       {
@@ -738,7 +739,7 @@ TEST(FP8E4M3Test, DISABLED_CArrayFloatRejectsUpwardRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_CArrayFloatRejectsTowardZeroRounding) {
+TEST(FP8E4M3Test, CArrayFloatRejectsTowardZeroRounding) {
   const float in[2] = {1.0f, 2.0f};
   EXPECT_DEATH(
       {
@@ -748,7 +749,7 @@ TEST(FP8E4M3Test, DISABLED_CArrayFloatRejectsTowardZeroRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_MarrayHalfRejectsUpwardRounding) {
+TEST(FP8E4M3Test, MarrayHalfRejectsUpwardRounding) {
   const sycl::marray<sycl::half, 2> in = {sycl::half(1.0f), sycl::half(2.0f)};
   EXPECT_DEATH(
       {
@@ -758,7 +759,7 @@ TEST(FP8E4M3Test, DISABLED_MarrayHalfRejectsUpwardRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_MarrayHalfRejectsTowardZeroRounding) {
+TEST(FP8E4M3Test, MarrayHalfRejectsTowardZeroRounding) {
   const sycl::marray<sycl::half, 2> in = {sycl::half(1.0f), sycl::half(2.0f)};
   EXPECT_DEATH(
       {
@@ -768,7 +769,7 @@ TEST(FP8E4M3Test, DISABLED_MarrayHalfRejectsTowardZeroRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_MarrayBFloat16RejectsUpwardRounding) {
+TEST(FP8E4M3Test, MarrayBFloat16RejectsUpwardRounding) {
   const sycl::marray<sycl::ext::oneapi::bfloat16, 2> in = {
       sycl::ext::oneapi::bfloat16(1.0f), sycl::ext::oneapi::bfloat16(2.0f)};
   EXPECT_DEATH(
@@ -779,7 +780,7 @@ TEST(FP8E4M3Test, DISABLED_MarrayBFloat16RejectsUpwardRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_MarrayBFloat16RejectsTowardZeroRounding) {
+TEST(FP8E4M3Test, MarrayBFloat16RejectsTowardZeroRounding) {
   const sycl::marray<sycl::ext::oneapi::bfloat16, 2> in = {
       sycl::ext::oneapi::bfloat16(1.0f), sycl::ext::oneapi::bfloat16(2.0f)};
   EXPECT_DEATH(
@@ -790,7 +791,7 @@ TEST(FP8E4M3Test, DISABLED_MarrayBFloat16RejectsTowardZeroRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_MarrayFloatRejectsUpwardRounding) {
+TEST(FP8E4M3Test, MarrayFloatRejectsUpwardRounding) {
   const sycl::marray<float, 2> in = {1.0f, 2.0f};
   EXPECT_DEATH(
       {
@@ -800,7 +801,7 @@ TEST(FP8E4M3Test, DISABLED_MarrayFloatRejectsUpwardRounding) {
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E4M3Test, DISABLED_MarrayFloatRejectsTowardZeroRounding) {
+TEST(FP8E4M3Test, MarrayFloatRejectsTowardZeroRounding) {
   const sycl::marray<float, 2> in = {1.0f, 2.0f};
   EXPECT_DEATH(
       {
@@ -809,6 +810,7 @@ TEST(FP8E4M3Test, DISABLED_MarrayFloatRejectsTowardZeroRounding) {
       },
       "fp8_e4m3_x: only rounding::to_even is supported");
 }
+#endif // LLVM_ENABLE_ASSERTIONS
 
 TEST(FP8E4M3Test, VariadicFloatReferences) {
   float x = 1.0f;

--- a/sycl/unittests/Extensions/fp8/fp8_e5m2.cpp
+++ b/sycl/unittests/Extensions/fp8/fp8_e5m2.cpp
@@ -738,7 +738,8 @@ TEST(FP8E5M2Test, X2NotAssignableFromSingleULL) {
   EXPECT_FALSE((std::is_assignable_v<fp8_e5m2_x2 &, unsigned long long>));
 }
 
-TEST(FP8E5M2Test, DISABLED_CArrayHalfUpwardRounding) {
+#if LLVM_ENABLE_ASSERTIONS
+TEST(FP8E5M2Test, CArrayHalfUpwardRounding) {
   const sycl::half in[2] = {sycl::half(1.0f), sycl::half(2.0f)};
   EXPECT_DEATH(
       {
@@ -748,7 +749,7 @@ TEST(FP8E5M2Test, DISABLED_CArrayHalfUpwardRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_CArrayHalfTowardZeroRounding) {
+TEST(FP8E5M2Test, CArrayHalfTowardZeroRounding) {
   const sycl::half in[2] = {sycl::half(1.0f), sycl::half(2.0f)};
   EXPECT_DEATH(
       {
@@ -758,7 +759,7 @@ TEST(FP8E5M2Test, DISABLED_CArrayHalfTowardZeroRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_CArrayBFloat16UpwardRounding) {
+TEST(FP8E5M2Test, CArrayBFloat16UpwardRounding) {
   const sycl::ext::oneapi::bfloat16 in[2] = {sycl::ext::oneapi::bfloat16(1.0f),
                                              sycl::ext::oneapi::bfloat16(2.0f)};
   EXPECT_DEATH(
@@ -769,7 +770,7 @@ TEST(FP8E5M2Test, DISABLED_CArrayBFloat16UpwardRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_CArrayBFloat16TowardZeroRounding) {
+TEST(FP8E5M2Test, CArrayBFloat16TowardZeroRounding) {
   const sycl::ext::oneapi::bfloat16 in[2] = {sycl::ext::oneapi::bfloat16(1.0f),
                                              sycl::ext::oneapi::bfloat16(2.0f)};
   EXPECT_DEATH(
@@ -780,7 +781,7 @@ TEST(FP8E5M2Test, DISABLED_CArrayBFloat16TowardZeroRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_CArrayFloatUpwardRounding) {
+TEST(FP8E5M2Test, CArrayFloatUpwardRounding) {
   const float in[2] = {1.0f, 2.0f};
   EXPECT_DEATH(
       {
@@ -790,7 +791,7 @@ TEST(FP8E5M2Test, DISABLED_CArrayFloatUpwardRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_CArrayFloatTowardZeroRounding) {
+TEST(FP8E5M2Test, CArrayFloatTowardZeroRounding) {
   const float in[2] = {1.0f, 2.0f};
   EXPECT_DEATH(
       {
@@ -800,7 +801,7 @@ TEST(FP8E5M2Test, DISABLED_CArrayFloatTowardZeroRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_MarrayHalfUpwardRounding) {
+TEST(FP8E5M2Test, MarrayHalfUpwardRounding) {
   const sycl::marray<sycl::half, 2> in = {sycl::half(1.0f), sycl::half(2.0f)};
   EXPECT_DEATH(
       {
@@ -810,7 +811,7 @@ TEST(FP8E5M2Test, DISABLED_MarrayHalfUpwardRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_MarrayHalfTowardZeroRounding) {
+TEST(FP8E5M2Test, MarrayHalfTowardZeroRounding) {
   const sycl::marray<sycl::half, 2> in = {sycl::half(1.0f), sycl::half(2.0f)};
   EXPECT_DEATH(
       {
@@ -820,7 +821,7 @@ TEST(FP8E5M2Test, DISABLED_MarrayHalfTowardZeroRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_MarrayBFloat16UpwardRounding) {
+TEST(FP8E5M2Test, MarrayBFloat16UpwardRounding) {
   const sycl::marray<sycl::ext::oneapi::bfloat16, 2> in = {
       sycl::ext::oneapi::bfloat16(1.0f), sycl::ext::oneapi::bfloat16(2.0f)};
   EXPECT_DEATH(
@@ -831,7 +832,7 @@ TEST(FP8E5M2Test, DISABLED_MarrayBFloat16UpwardRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_MarrayBFloat16TowardZeroRounding) {
+TEST(FP8E5M2Test, MarrayBFloat16TowardZeroRounding) {
   const sycl::marray<sycl::ext::oneapi::bfloat16, 2> in = {
       sycl::ext::oneapi::bfloat16(1.0f), sycl::ext::oneapi::bfloat16(2.0f)};
   EXPECT_DEATH(
@@ -842,7 +843,7 @@ TEST(FP8E5M2Test, DISABLED_MarrayBFloat16TowardZeroRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_MarrayFloatUpwardRounding) {
+TEST(FP8E5M2Test, MarrayFloatUpwardRounding) {
   const sycl::marray<float, 2> in = {1.0f, 2.0f};
   EXPECT_DEATH(
       {
@@ -852,7 +853,7 @@ TEST(FP8E5M2Test, DISABLED_MarrayFloatUpwardRounding) {
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
 
-TEST(FP8E5M2Test, DISABLED_MarrayFloatTowardZeroRounding) {
+TEST(FP8E5M2Test, MarrayFloatTowardZeroRounding) {
   const sycl::marray<float, 2> in = {1.0f, 2.0f};
   EXPECT_DEATH(
       {
@@ -861,6 +862,7 @@ TEST(FP8E5M2Test, DISABLED_MarrayFloatTowardZeroRounding) {
       },
       "fp8_e5m2_x: only rounding::to_even is supported");
 }
+#endif // LLVM_ENABLE_ASSERTIONS
 
 TEST(FP8E5M2Test, VariadicFloatReferences) {
   float x = 1.0f;

--- a/sycl/unittests/Extensions/fp8/fp8_e8m0.cpp
+++ b/sycl/unittests/Extensions/fp8/fp8_e8m0.cpp
@@ -15,9 +15,11 @@ using namespace sycl::ext::oneapi::experimental;
 
 namespace {
 
+#if LLVM_ENABLE_ASSERTIONS
 constexpr const char *UnsupportedRoundingAssertRegex =
     "fp8_e8m0_x: only rounding::upward and rounding::toward_zero are "
     "\" \"supported";
+#endif // LLVM_ENABLE_ASSERTIONS
 
 bool checkCode(float Input, rounding Mode, uint8_t Expected) {
   const float Values[1] = {Input};

--- a/sycl/unittests/Extensions/fp8/fp8_e8m0.cpp
+++ b/sycl/unittests/Extensions/fp8/fp8_e8m0.cpp
@@ -441,6 +441,7 @@ TEST(FP8E8M0Test, X2NotAssignableFromSingleULL) {
   EXPECT_FALSE((std::is_assignable_v<fp8_e8m0_x2 &, unsigned long long>));
 }
 
+#if LLVM_ENABLE_ASSERTIONS
 TEST(FP8E8M0Test, CArrayHalfToEvenRounding) {
   const sycl::half in[2] = {sycl::half(1.0f), sycl::half(2.0f)};
   EXPECT_DEATH(
@@ -502,6 +503,7 @@ TEST(FP8E8M0Test, MarrayFloatToEvenRounding) {
       },
       UnsupportedRoundingAssertRegex);
 }
+#endif // LLVM_ENABLE_ASSERTIONS
 
 TEST(FP8E8M0Test, VariadicFloatReferences) {
   float x = 1.0f;


### PR DESCRIPTION
intel/llvm has different options to configure and compile. One of the is build with option --no-assertions which is equal to `LLVM_ENABLE_ASSERTIONS=OFF`. In this case, we should not test fp8 data types assertions
Previous [PR ](https://github.com/intel/llvm/pull/22309) disabled some of these checks.

This PR adds conditional compilation of tests depending on `LLVM_ENABLE_ASSERTIONS`