### PR TITLE
[SYCL] Deprecate removed extension leftover

### DIFF
--- a/sycl/include/sycl/ext/oneapi/functional.hpp
+++ b/sycl/include/sycl/ext/oneapi/functional.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
 #include <sycl/detail/spirv.hpp>
 #include <sycl/functional.hpp> // for maximum, minimum
 
@@ -17,13 +18,26 @@ namespace sycl {
 inline namespace _V1 {
 namespace ext::oneapi {
 
-template <typename T = void> using plus = std::plus<T>;
-template <typename T = void> using multiplies = std::multiplies<T>;
-template <typename T = void> using bit_or = std::bit_or<T>;
-template <typename T = void> using bit_xor = std::bit_xor<T>;
-template <typename T = void> using bit_and = std::bit_and<T>;
-template <typename T = void> using maximum = sycl::maximum<T>;
-template <typename T = void> using minimum = sycl::minimum<T>;
+template <typename T = void>
+using plus __SYCL2020_DEPRECATED("Use sycl::plus<> instead") = std::plus<T>;
+template <typename T = void>
+using multiplies __SYCL2020_DEPRECATED("Use sycl::multiplies<> instead") =
+    std::multiplies<T>;
+template <typename T = void>
+using bit_or
+    __SYCL2020_DEPRECATED("Use sycl::bit_or<> instead") = std::bit_or<T>;
+template <typename T = void>
+using bit_xor
+    __SYCL2020_DEPRECATED("Use sycl::bit_xor<> instead") = std::bit_xor<T>;
+template <typename T = void>
+using bit_and
+    __SYCL2020_DEPRECATED("Use sycl::bit_and<> instead") = std::bit_and<T>;
+template <typename T = void>
+using maximum
+    __SYCL2020_DEPRECATED("Use sycl::maximum<> instead") = sycl::maximum<T>;
+template <typename T = void>
+using minimum
+    __SYCL2020_DEPRECATED("Use sycl::minimum<> instead") = sycl::minimum<T>;
 
 } // namespace ext::oneapi
 

--- a/sycl/test-e2e/Reduction/reduction_big_data.cpp
+++ b/sycl/test-e2e/Reduction/reduction_big_data.cpp
@@ -83,8 +83,8 @@ template <class T> struct BigCustomVecPlus {
 int main() {
   queue Q;
   printDeviceInfo(Q);
-  int NumErrors = test<class A1, float, 0, ext::oneapi::maximum<>>(
-      Q, getMinimumFPValue<float>());
+  int NumErrors =
+      test<class A1, float, 0, maximum<>>(Q, getMinimumFPValue<float>());
 
   using BCV = BigCustomVec<long long>;
   NumErrors += test<class A2, BCV, 1, BigCustomVecPlus<long long>>(Q, BCV(0));

--- a/sycl/test-e2e/Reduction/reduction_ctor.cpp
+++ b/sycl/test-e2e/Reduction/reduction_ctor.cpp
@@ -125,27 +125,27 @@ void testBoth(T Identity, BinaryOperation BOp, T A, T B) {
 
 int main() {
   testBoth<class KernelName_DpWavJTNjhJtrHmLWt, int>(
-      0, ext::oneapi::plus<int>(), 1, 7);
+      0, plus<int>(), 1, 7);
   testBoth<class KernelName_MHRtc, int>(1, std::multiplies<int>(), 1, 7);
   testBoth<class KernelName_eYhurMyKBZvzctmqwUZ, int>(
-      0, ext::oneapi::bit_or<int>(), 1, 8);
+      0, bit_or<int>(), 1, 8);
   testBoth<class KernelName_DpVPIUBjUMGZEwBFHH, int>(
-      0, ext::oneapi::bit_xor<int>(), 7, 3);
+      0, bit_xor<int>(), 7, 3);
   testBoth<class KernelName_vGKFactgrkngMXd, int>(
-      ~0, ext::oneapi::bit_and<int>(), 7, 3);
+      ~0, bit_and<int>(), 7, 3);
   testBoth<class KernelName_GLpknSBxclKWjm, int>(
-      (std::numeric_limits<int>::max)(), ext::oneapi::minimum<int>(), 7, 3);
+      (std::numeric_limits<int>::max)(), minimum<int>(), 7, 3);
   testBoth<class KernelName_EvOaOYQ, int>((std::numeric_limits<int>::min)(),
-                                          ext::oneapi::maximum<int>(), 7, 3);
+                                          maximum<int>(), 7, 3);
 
   testBoth<class KernelName_iFbcoTtPeDtUEK, float>(
-      0, ext::oneapi::plus<float>(), 1, 7);
+      0, plus<float>(), 1, 7);
   testBoth<class KernelName_PEMJanstdNezDSXnP, float>(
       1, std::multiplies<float>(), 1, 7);
   testBoth<class KernelName_wOEuftXSjCLpoTOMrYHR, float>(
-      getMaximumFPValue<float>(), ext::oneapi::minimum<float>(), 7, 3);
+      getMaximumFPValue<float>(), minimum<float>(), 7, 3);
   testBoth<class KernelName_HzFCIZQKeV, float>(
-      getMinimumFPValue<float>(), ext::oneapi::maximum<float>(), 7, 3);
+      getMinimumFPValue<float>(), maximum<float>(), 7, 3);
 
   testUnknown<class KernelName_sJOZPgFeiALyqwIWnFP, CustomVec<float>, 0,
               CustomVecPlus<float>>(CustomVec<float>(0), CustomVecPlus<float>(),
@@ -160,13 +160,13 @@ int main() {
   int2 IdentityI2 = {0, 0};
   int2 AI2 = {1, 2};
   int2 BI2 = {7, 13};
-  testUnknown<class KNI2, int2, 0>(IdentityI2, ext::oneapi::plus<int2>(), AI2,
+  testUnknown<class KNI2, int2, 0>(IdentityI2, plus<int2>(), AI2,
                                    BI2);
 
   float4 IdentityF4 = {0, 0, 0, 0};
   float4 AF4 = {1, 2, -1, -34};
   float4 BF4 = {7, 13, 0, 35};
-  testUnknown<class KNF4, float4, 0>(IdentityF4, ext::oneapi::plus<>(), AF4,
+  testUnknown<class KNF4, float4, 0>(IdentityF4, plus<>(), AF4,
                                      BF4);
 
   std::cout << "Test passed\n";

--- a/sycl/test-e2e/Reduction/reduction_ctor.cpp
+++ b/sycl/test-e2e/Reduction/reduction_ctor.cpp
@@ -124,28 +124,23 @@ void testBoth(T Identity, BinaryOperation BOp, T A, T B) {
 }
 
 int main() {
-  testBoth<class KernelName_DpWavJTNjhJtrHmLWt, int>(
-      0, plus<int>(), 1, 7);
+  testBoth<class KernelName_DpWavJTNjhJtrHmLWt, int>(0, plus<int>(), 1, 7);
   testBoth<class KernelName_MHRtc, int>(1, std::multiplies<int>(), 1, 7);
-  testBoth<class KernelName_eYhurMyKBZvzctmqwUZ, int>(
-      0, bit_or<int>(), 1, 8);
-  testBoth<class KernelName_DpVPIUBjUMGZEwBFHH, int>(
-      0, bit_xor<int>(), 7, 3);
-  testBoth<class KernelName_vGKFactgrkngMXd, int>(
-      ~0, bit_and<int>(), 7, 3);
+  testBoth<class KernelName_eYhurMyKBZvzctmqwUZ, int>(0, bit_or<int>(), 1, 8);
+  testBoth<class KernelName_DpVPIUBjUMGZEwBFHH, int>(0, bit_xor<int>(), 7, 3);
+  testBoth<class KernelName_vGKFactgrkngMXd, int>(~0, bit_and<int>(), 7, 3);
   testBoth<class KernelName_GLpknSBxclKWjm, int>(
       (std::numeric_limits<int>::max)(), minimum<int>(), 7, 3);
   testBoth<class KernelName_EvOaOYQ, int>((std::numeric_limits<int>::min)(),
                                           maximum<int>(), 7, 3);
 
-  testBoth<class KernelName_iFbcoTtPeDtUEK, float>(
-      0, plus<float>(), 1, 7);
+  testBoth<class KernelName_iFbcoTtPeDtUEK, float>(0, plus<float>(), 1, 7);
   testBoth<class KernelName_PEMJanstdNezDSXnP, float>(
       1, std::multiplies<float>(), 1, 7);
   testBoth<class KernelName_wOEuftXSjCLpoTOMrYHR, float>(
       getMaximumFPValue<float>(), minimum<float>(), 7, 3);
-  testBoth<class KernelName_HzFCIZQKeV, float>(
-      getMinimumFPValue<float>(), maximum<float>(), 7, 3);
+  testBoth<class KernelName_HzFCIZQKeV, float>(getMinimumFPValue<float>(),
+                                               maximum<float>(), 7, 3);
 
   testUnknown<class KernelName_sJOZPgFeiALyqwIWnFP, CustomVec<float>, 0,
               CustomVecPlus<float>>(CustomVec<float>(0), CustomVecPlus<float>(),
@@ -160,14 +155,12 @@ int main() {
   int2 IdentityI2 = {0, 0};
   int2 AI2 = {1, 2};
   int2 BI2 = {7, 13};
-  testUnknown<class KNI2, int2, 0>(IdentityI2, plus<int2>(), AI2,
-                                   BI2);
+  testUnknown<class KNI2, int2, 0>(IdentityI2, plus<int2>(), AI2, BI2);
 
   float4 IdentityF4 = {0, 0, 0, 0};
   float4 AF4 = {1, 2, -1, -34};
   float4 BF4 = {7, 13, 0, 35};
-  testUnknown<class KNF4, float4, 0>(IdentityF4, plus<>(), AF4,
-                                     BF4);
+  testUnknown<class KNF4, float4, 0>(IdentityF4, plus<>(), AF4, BF4);
 
   std::cout << "Test passed\n";
   return 0;

--- a/sycl/test-e2e/Reduction/reduction_nd_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_dw.cpp
@@ -32,10 +32,10 @@ int main() {
   tests<class B3, int>(Q, 0, 99, std::bit_or<>{}, 8, 128);
   tests<class B4, int>(Q, 0, 99, std::bit_xor<>{}, 16, 256);
   tests<class B5, int>(Q, ~0, 99, std::bit_and<>{}, 32, 256);
-  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, 64, 256);
-  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       maximum<>{}, 128, 256);
+  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       64, 256);
+  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99, maximum<>{},
+                       128, 256);
   tests<class B8, int>(Q, 0, 99, std::plus<>{}, 256, 256);
 
   // Check with various types.

--- a/sycl/test-e2e/Reduction/reduction_nd_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_dw.cpp
@@ -33,15 +33,15 @@ int main() {
   tests<class B4, int>(Q, 0, 99, std::bit_xor<>{}, 16, 256);
   tests<class B5, int>(Q, ~0, 99, std::bit_and<>{}, 32, 256);
   tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, 64, 256);
+                       minimum<>{}, 64, 256);
   tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       ext::oneapi::maximum<>{}, 128, 256);
+                       maximum<>{}, 128, 256);
   tests<class B8, int>(Q, 0, 99, std::plus<>{}, 256, 256);
 
   // Check with various types.
   tests<class C1, float>(Q, 1, 99, std::multiplies<>{}, 8, 24);
-  tests<class C2, short>(Q, 0x7fff, -99, ext::oneapi::minimum<>{}, 8, 256);
-  tests<class C3, unsigned char>(Q, 0, 99, ext::oneapi::maximum<>{}, 8, 256);
+  tests<class C2, short>(Q, 0x7fff, -99, minimum<>{}, 8, 256);
+  tests<class C3, unsigned char>(Q, 0, 99, maximum<>{}, 8, 256);
 
   // Check with CUSTOM type.
   using CV = CustomVec<long long>;

--- a/sycl/test-e2e/Reduction/reduction_nd_ext_type.hpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_ext_type.hpp
@@ -34,15 +34,13 @@ template <typename T> int runTests(sycl::aspect ExtAspect) {
   tests<class B1, T>(Q, 0, 77, std::plus<T>{}, 4, 32, init_to_identity());
   tests<class B2, T>(Q, 0, 33, std::plus<T>{}, 3, 3 * 5);
 
-  tests<class C1, T>(Q, getMaximumFPValue<T>(), -10.0,
-                     minimum<T>{}, 7, 7 * 512, init_to_identity());
-  tests<class C2, T>(Q, getMaximumFPValue<T>(), 99.0, minimum<T>{},
-                     7, 7);
+  tests<class C1, T>(Q, getMaximumFPValue<T>(), -10.0, minimum<T>{}, 7, 7 * 512,
+                     init_to_identity());
+  tests<class C2, T>(Q, getMaximumFPValue<T>(), 99.0, minimum<T>{}, 7, 7);
 
-  tests<class D1, T>(Q, getMinimumFPValue<T>(), 99.0, maximum<>{},
-                     3, 3, init_to_identity());
-  tests<class D2, T>(Q, getMinimumFPValue<T>(), 99.0, maximum<>{},
-                     7, 7 * 5);
+  tests<class D1, T>(Q, getMinimumFPValue<T>(), 99.0, maximum<>{}, 3, 3,
+                     init_to_identity());
+  tests<class D2, T>(Q, getMinimumFPValue<T>(), 99.0, maximum<>{}, 7, 7 * 5);
 
   printFinalStatus(NumErrors);
   return NumErrors;

--- a/sycl/test-e2e/Reduction/reduction_nd_ext_type.hpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_ext_type.hpp
@@ -35,13 +35,13 @@ template <typename T> int runTests(sycl::aspect ExtAspect) {
   tests<class B2, T>(Q, 0, 33, std::plus<T>{}, 3, 3 * 5);
 
   tests<class C1, T>(Q, getMaximumFPValue<T>(), -10.0,
-                     ext::oneapi::minimum<T>{}, 7, 7 * 512, init_to_identity());
-  tests<class C2, T>(Q, getMaximumFPValue<T>(), 99.0, ext::oneapi::minimum<T>{},
+                     minimum<T>{}, 7, 7 * 512, init_to_identity());
+  tests<class C2, T>(Q, getMaximumFPValue<T>(), 99.0, minimum<T>{},
                      7, 7);
 
-  tests<class D1, T>(Q, getMinimumFPValue<T>(), 99.0, ext::oneapi::maximum<>{},
+  tests<class D1, T>(Q, getMinimumFPValue<T>(), 99.0, maximum<>{},
                      3, 3, init_to_identity());
-  tests<class D2, T>(Q, getMinimumFPValue<T>(), 99.0, ext::oneapi::maximum<>{},
+  tests<class D2, T>(Q, getMinimumFPValue<T>(), 99.0, maximum<>{},
                      7, 7 * 5);
 
   printFinalStatus(NumErrors);

--- a/sycl/test-e2e/Reduction/reduction_nd_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_reducer_skip.cpp
@@ -41,10 +41,10 @@ int main() {
   tests<class B3, int>(Q, 0, 99, std::bit_or<>{}, 8, 128);
   tests<class B4, int>(Q, 0, 99, std::bit_xor<>{}, 16, 256);
   tests<class B5, int>(Q, ~0, 99, std::bit_and<>{}, 32, 256);
-  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, 64, 256);
-  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       maximum<>{}, 128, 256);
+  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       64, 256);
+  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99, maximum<>{},
+                       128, 256);
   tests<class B8, int>(Q, 0, 99, std::plus<>{}, 256, 256);
 
   // Check with various types.

--- a/sycl/test-e2e/Reduction/reduction_nd_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_reducer_skip.cpp
@@ -42,15 +42,15 @@ int main() {
   tests<class B4, int>(Q, 0, 99, std::bit_xor<>{}, 16, 256);
   tests<class B5, int>(Q, ~0, 99, std::bit_and<>{}, 32, 256);
   tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, 64, 256);
+                       minimum<>{}, 64, 256);
   tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       ext::oneapi::maximum<>{}, 128, 256);
+                       maximum<>{}, 128, 256);
   tests<class B8, int>(Q, 0, 99, std::plus<>{}, 256, 256);
 
   // Check with various types.
   tests<class C1, float>(Q, 1, 99, std::multiplies<>{}, 8, 24);
-  tests<class C2, short>(Q, 0x7fff, -99, ext::oneapi::minimum<>{}, 8, 256);
-  tests<class C3, unsigned char>(Q, 0, 99, ext::oneapi::maximum<>{}, 8, 256);
+  tests<class C2, short>(Q, 0x7fff, -99, minimum<>{}, 8, 256);
+  tests<class C3, unsigned char>(Q, 0, 99, maximum<>{}, 8, 256);
 
   // Check with CUSTOM type.
   using CV = CustomVec<long long>;

--- a/sycl/test-e2e/Reduction/reduction_nd_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_rw.cpp
@@ -43,10 +43,10 @@ int main() {
   tests<class C2, int>(Q, 0, 99, std::bit_or<>{}, 8, 128);
   tests<class C3, int>(Q, 0, 99, std::bit_xor<>{}, 16, 256);
   tests<class C4, int>(Q, ~0, 99, std::bit_and<>{}, 32, 256);
-  tests<class C5, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, 64, 256);
-  tests<class C6, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       maximum<>{}, 128, 256);
+  tests<class C5, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       64, 256);
+  tests<class C6, int>(Q, (std::numeric_limits<int>::min)(), 99, maximum<>{},
+                       128, 256);
   tests<class C7, int>(Q, 0, 99, std::plus<>{}, 256, 256);
   tests<class C8, int>(Q, 1, 2, std::multiplies<>{}, 8, 8);
   tests<class C9, float>(Q, 1, 1.2, std::multiplies<>{}, 8, 16);

--- a/sycl/test-e2e/Reduction/reduction_nd_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_rw.cpp
@@ -44,9 +44,9 @@ int main() {
   tests<class C3, int>(Q, 0, 99, std::bit_xor<>{}, 16, 256);
   tests<class C4, int>(Q, ~0, 99, std::bit_and<>{}, 32, 256);
   tests<class C5, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, 64, 256);
+                       minimum<>{}, 64, 256);
   tests<class C6, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       ext::oneapi::maximum<>{}, 128, 256);
+                       maximum<>{}, 128, 256);
   tests<class C7, int>(Q, 0, 99, std::plus<>{}, 256, 256);
   tests<class C8, int>(Q, 1, 2, std::multiplies<>{}, 8, 8);
   tests<class C9, float>(Q, 1, 1.2, std::multiplies<>{}, 8, 16);

--- a/sycl/test-e2e/Reduction/reduction_range_1d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_dw.cpp
@@ -47,9 +47,9 @@ int main() {
   if constexpr (Enable64Bit)
     tests<class B8, uint64_t>(Q, 1, 2, std::multiplies<>{}, 31);
   tests<class B9, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, MaxWGSize * 2);
+                       minimum<>{}, MaxWGSize * 2);
   tests<class B10, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                        ext::oneapi::maximum<>{}, 8);
+                        maximum<>{}, 8);
   tests<class B11, float>(Q, 1, 99, std::multiplies<>{}, 10);
 
   // Check with CUSTOM type.

--- a/sycl/test-e2e/Reduction/reduction_range_1d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_dw.cpp
@@ -46,10 +46,10 @@ int main() {
   tests<class B7, int>(Q, 0, 0x3400, std::bit_or<>{}, MaxWGSize * 4);
   if constexpr (Enable64Bit)
     tests<class B8, uint64_t>(Q, 1, 2, std::multiplies<>{}, 31);
-  tests<class B9, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, MaxWGSize * 2);
-  tests<class B10, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                        maximum<>{}, 8);
+  tests<class B9, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       MaxWGSize * 2);
+  tests<class B10, int>(Q, (std::numeric_limits<int>::min)(), 99, maximum<>{},
+                        8);
   tests<class B11, float>(Q, 1, 99, std::multiplies<>{}, 10);
 
   // Check with CUSTOM type.

--- a/sycl/test-e2e/Reduction/reduction_range_1d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_rw.cpp
@@ -37,9 +37,9 @@ int main() {
   tests<class B4, uint64_t>(Q, 1, 2, std::multiplies<>{}, range<1>(16));
   tests<class B5, float>(Q, 1, 3, std::multiplies<>{}, range<1>(11));
   tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, range<1>(MaxWGSize * 2));
+                       minimum<>{}, range<1>(MaxWGSize * 2));
   tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       ext::oneapi::maximum<>{}, range<1>(8));
+                       maximum<>{}, range<1>(8));
 
   // Check with CUSTOM type.
   tests<class C1, CustomVec<long long>>(Q, 0, 99, CustomVecPlus<long long>{},

--- a/sycl/test-e2e/Reduction/reduction_range_1d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_rw.cpp
@@ -36,10 +36,10 @@ int main() {
   tests<class B3, int>(Q, 0, 0x3400, std::bit_or<>{}, range<1>(MaxWGSize * 3));
   tests<class B4, uint64_t>(Q, 1, 2, std::multiplies<>{}, range<1>(16));
   tests<class B5, float>(Q, 1, 3, std::multiplies<>{}, range<1>(11));
-  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, range<1>(MaxWGSize * 2));
-  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       maximum<>{}, range<1>(8));
+  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       range<1>(MaxWGSize * 2));
+  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99, maximum<>{},
+                       range<1>(8));
 
   // Check with CUSTOM type.
   tests<class C1, CustomVec<long long>>(Q, 0, 99, CustomVecPlus<long long>{},

--- a/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
@@ -36,10 +36,10 @@ int main() {
   tests<class B3, int>(Q, 0, 99, std::bit_or<>{}, range<2>{2, 2});
   tests<class B4, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<2>{8, 3});
   tests<class B5, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<2>{3, 7});
-  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, range<2>{8, 3});
-  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       maximum<>{}, range<2>{3, 3});
+  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       range<2>{8, 3});
+  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99, maximum<>{},
+                       range<2>{3, 3});
   tests<class B8, float>(Q, 1, 99, std::multiplies<>{}, range<2>{3, 3});
 
   tests<class C1>(Q, CustomVec<long long>(0), CustomVec<long long>(99),

--- a/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
@@ -37,9 +37,9 @@ int main() {
   tests<class B4, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<2>{8, 3});
   tests<class B5, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<2>{3, 7});
   tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, range<2>{8, 3});
+                       minimum<>{}, range<2>{8, 3});
   tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       ext::oneapi::maximum<>{}, range<2>{3, 3});
+                       maximum<>{}, range<2>{3, 3});
   tests<class B8, float>(Q, 1, 99, std::multiplies<>{}, range<2>{3, 3});
 
   tests<class C1>(Q, CustomVec<long long>(0), CustomVec<long long>(99),

--- a/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
@@ -36,9 +36,9 @@ int main() {
   tests<class B4, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<2>{8, 3});
   tests<class B5, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<2>{3, 8});
   tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, range<2>{8, 3});
+                       minimum<>{}, range<2>{8, 3});
   tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       ext::oneapi::maximum<>{}, range<2>{3, 3});
+                       maximum<>{}, range<2>{3, 3});
   tests<class B8, float>(Q, 1, 99, std::multiplies<>{}, range<2>{3, 3});
 
   tests<class C1, CustomVec<long long>>(Q, 0, 99, CustomVecPlus<long long>{},

--- a/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
@@ -35,10 +35,10 @@ int main() {
   tests<class B3, int>(Q, 0, 99, std::bit_or<>{}, range<2>{2, 2});
   tests<class B4, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<2>{8, 3});
   tests<class B5, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<2>{3, 8});
-  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, range<2>{8, 3});
-  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       maximum<>{}, range<2>{3, 3});
+  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       range<2>{8, 3});
+  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99, maximum<>{},
+                       range<2>{3, 3});
   tests<class B8, float>(Q, 1, 99, std::multiplies<>{}, range<2>{3, 3});
 
   tests<class C1, CustomVec<long long>>(Q, 0, 99, CustomVecPlus<long long>{},

--- a/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
@@ -48,10 +48,10 @@ int main() {
                        range<3>{2, 2, MaxWGSize * 3});
   tests<class B4, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<3>{2, 3, 5});
   tests<class B5, uint64_t>(Q, 1, 2, std::multiplies<>{}, range<3>{2, 3, 8});
-  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, range<3>{MaxWGSize, 8, 3});
-  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       maximum<>{}, range<3>{3, MaxWGSize, 3});
+  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       range<3>{MaxWGSize, 8, 3});
+  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99, maximum<>{},
+                       range<3>{3, MaxWGSize, 3});
   tests<class B8, float>(Q, 1, 99, std::multiplies<>{}, range<3>{3, 3, 5});
 
   tests<class C1, CustomVec<long long>>(Q, 0, 99, CustomVecPlus<long long>{},

--- a/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
@@ -49,9 +49,9 @@ int main() {
   tests<class B4, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<3>{2, 3, 5});
   tests<class B5, uint64_t>(Q, 1, 2, std::multiplies<>{}, range<3>{2, 3, 8});
   tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, range<3>{MaxWGSize, 8, 3});
+                       minimum<>{}, range<3>{MaxWGSize, 8, 3});
   tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       ext::oneapi::maximum<>{}, range<3>{3, MaxWGSize, 3});
+                       maximum<>{}, range<3>{3, MaxWGSize, 3});
   tests<class B8, float>(Q, 1, 99, std::multiplies<>{}, range<3>{3, 3, 5});
 
   tests<class C1, CustomVec<long long>>(Q, 0, 99, CustomVecPlus<long long>{},

--- a/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
@@ -48,9 +48,9 @@ int main() {
   tests<class B4, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<3>{2, 3, 5});
   tests<class B5, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<3>{5, 2, 3});
   tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, range<3>{MaxWGSize, 8, 3});
+                       minimum<>{}, range<3>{MaxWGSize, 8, 3});
   tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       ext::oneapi::maximum<>{}, range<3>{3, MaxWGSize, 3});
+                       maximum<>{}, range<3>{3, MaxWGSize, 3});
   tests<class B8, float>(Q, 1, 99, std::multiplies<>{}, range<3>{3, 3, 4});
 
   tests<class C1, CustomVec<long long>>(Q, 0, 99, CustomVecPlus<long long>{},

--- a/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
@@ -47,10 +47,10 @@ int main() {
                        range<3>{2, 2, MaxWGSize * 3});
   tests<class B4, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<3>{2, 3, 5});
   tests<class B5, uint64_t>(Q, 1, 3, std::multiplies<>{}, range<3>{5, 2, 3});
-  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, range<3>{MaxWGSize, 8, 3});
-  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99,
-                       maximum<>{}, range<3>{3, MaxWGSize, 3});
+  tests<class B6, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       range<3>{MaxWGSize, 8, 3});
+  tests<class B7, int>(Q, (std::numeric_limits<int>::min)(), 99, maximum<>{},
+                       range<3>{3, MaxWGSize, 3});
   tests<class B8, float>(Q, 1, 99, std::multiplies<>{}, range<3>{3, 3, 4});
 
   tests<class C1, CustomVec<long long>>(Q, 0, 99, CustomVecPlus<long long>{},

--- a/sycl/test-e2e/Reduction/reduction_range_usm_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_usm_dw.cpp
@@ -38,8 +38,8 @@ int main() {
   tests<class B1, int>(Q, ~0, 99, std::bit_and<>{}, range<1>{8});
   tests<class B2, int>(Q, 0, 0xff99, std::bit_xor<>{}, range<1>{MaxWGSize + 1});
   tests<class B4, short>(Q, 1, 2, std::multiplies<>{}, range<1>{7});
-  tests<class B5, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       minimum<>{}, range<2>{MaxWGSize, 2});
+  tests<class B5, int>(Q, (std::numeric_limits<int>::max)(), -99, minimum<>{},
+                       range<2>{MaxWGSize, 2});
 
   // Check with CUSTOM type.
   tests<class C1>(Q, CustomVec<long long>(0), CustomVec<long long>(99),

--- a/sycl/test-e2e/Reduction/reduction_range_usm_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_usm_dw.cpp
@@ -39,7 +39,7 @@ int main() {
   tests<class B2, int>(Q, 0, 0xff99, std::bit_xor<>{}, range<1>{MaxWGSize + 1});
   tests<class B4, short>(Q, 1, 2, std::multiplies<>{}, range<1>{7});
   tests<class B5, int>(Q, (std::numeric_limits<int>::max)(), -99,
-                       ext::oneapi::minimum<>{}, range<2>{MaxWGSize, 2});
+                       minimum<>{}, range<2>{MaxWGSize, 2});
 
   // Check with CUSTOM type.
   tests<class C1>(Q, CustomVec<long long>(0), CustomVec<long long>(99),

--- a/sycl/test-e2e/Reduction/reduction_usm.cpp
+++ b/sycl/test-e2e/Reduction/reduction_usm.cpp
@@ -115,10 +115,10 @@ int main() {
   testUSM<class Atomic2, int, std::bit_or<>>(Q, 0, 0x7f007f00, 4, 32);
 
   // fast reduce
-  testUSM<class Reduce1, float, minimum<>>(
-      Q, getMaximumFPValue<float>(), -100.0, 17, 17);
-  testUSM<class Reduce2, float, maximum<>>(
-      Q, getMinimumFPValue<float>(), 100.0, 4, 32);
+  testUSM<class Reduce1, float, minimum<>>(Q, getMaximumFPValue<float>(),
+                                           -100.0, 17, 17);
+  testUSM<class Reduce2, float, maximum<>>(Q, getMinimumFPValue<float>(), 100.0,
+                                           4, 32);
 
   // generic algorithm
   testUSM<class Generic1, int, std::multiplies<>>(Q, 1, 5, 7, 7);

--- a/sycl/test-e2e/Reduction/reduction_usm.cpp
+++ b/sycl/test-e2e/Reduction/reduction_usm.cpp
@@ -115,9 +115,9 @@ int main() {
   testUSM<class Atomic2, int, std::bit_or<>>(Q, 0, 0x7f007f00, 4, 32);
 
   // fast reduce
-  testUSM<class Reduce1, float, ext::oneapi::minimum<>>(
+  testUSM<class Reduce1, float, minimum<>>(
       Q, getMaximumFPValue<float>(), -100.0, 17, 17);
-  testUSM<class Reduce2, float, ext::oneapi::maximum<>>(
+  testUSM<class Reduce2, float, maximum<>>(
       Q, getMinimumFPValue<float>(), 100.0, 4, 32);
 
   // generic algorithm

--- a/sycl/test-e2e/Reduction/reduction_usm_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_usm_dw.cpp
@@ -98,10 +98,10 @@ int main() {
   testUSM<class Atomic2, int, std::bit_or<>>(Q, 0, 0x7f007f00, 4, 32);
 
   // fast reduce
-  testUSM<class Reduce1, float, minimum<>>(
-      Q, getMaximumFPValue<float>(), -100.0, 17, 17);
-  testUSM<class Reduce2, float, maximum<>>(
-      Q, getMinimumFPValue<float>(), 100.0, 4, 32);
+  testUSM<class Reduce1, float, minimum<>>(Q, getMaximumFPValue<float>(),
+                                           -100.0, 17, 17);
+  testUSM<class Reduce2, float, maximum<>>(Q, getMinimumFPValue<float>(), 100.0,
+                                           4, 32);
 
   // generic algorithm
   testUSM<class Generic1, int, std::multiplies<>>(Q, 1, 5, 7, 7);

--- a/sycl/test-e2e/Reduction/reduction_usm_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_usm_dw.cpp
@@ -98,9 +98,9 @@ int main() {
   testUSM<class Atomic2, int, std::bit_or<>>(Q, 0, 0x7f007f00, 4, 32);
 
   // fast reduce
-  testUSM<class Reduce1, float, ext::oneapi::minimum<>>(
+  testUSM<class Reduce1, float, minimum<>>(
       Q, getMaximumFPValue<float>(), -100.0, 17, 17);
-  testUSM<class Reduce2, float, ext::oneapi::maximum<>>(
+  testUSM<class Reduce2, float, maximum<>>(
       Q, getMinimumFPValue<float>(), 100.0, 4, 32);
 
   // generic algorithm

--- a/sycl/test-e2e/Reduction/reduction_utils.hpp
+++ b/sycl/test-e2e/Reduction/reduction_utils.hpp
@@ -239,11 +239,9 @@ void printTestLabel(const RangeT &Range, bool ToCERR = false) {
 }
 
 template <typename BOp, typename T> constexpr bool isPreciseResultFP() {
-  return (std::is_floating_point_v<T> || std::is_same_v<T, sycl::half>)&&(
-      std::is_same_v<minimum<>, BOp> ||
-      std::is_same_v<minimum<T>, BOp> ||
-      std::is_same_v<maximum<>, BOp> ||
-      std::is_same_v<maximum<T>, BOp>);
+  return (std::is_floating_point_v<T> || std::is_same_v<T, sycl::half>) &&
+         (std::is_same_v<minimum<>, BOp> || std::is_same_v<minimum<T>, BOp> ||
+          std::is_same_v<maximum<>, BOp> || std::is_same_v<maximum<T>, BOp>);
 }
 
 template <typename BinaryOperation, typename T, typename RangeT>

--- a/sycl/test-e2e/Reduction/reduction_utils.hpp
+++ b/sycl/test-e2e/Reduction/reduction_utils.hpp
@@ -240,10 +240,10 @@ void printTestLabel(const RangeT &Range, bool ToCERR = false) {
 
 template <typename BOp, typename T> constexpr bool isPreciseResultFP() {
   return (std::is_floating_point_v<T> || std::is_same_v<T, sycl::half>)&&(
-      std::is_same_v<ext::oneapi::minimum<>, BOp> ||
-      std::is_same_v<ext::oneapi::minimum<T>, BOp> ||
-      std::is_same_v<ext::oneapi::maximum<>, BOp> ||
-      std::is_same_v<ext::oneapi::maximum<T>, BOp>);
+      std::is_same_v<minimum<>, BOp> ||
+      std::is_same_v<minimum<T>, BOp> ||
+      std::is_same_v<maximum<>, BOp> ||
+      std::is_same_v<maximum<T>, BOp>);
 }
 
 template <typename BinaryOperation, typename T, typename RangeT>

--- a/sycl/test-e2e/SubGroup/generic_reduce.cpp
+++ b/sycl/test-e2e/SubGroup/generic_reduce.cpp
@@ -79,8 +79,8 @@ int main() {
   // Test user-defined type
   // Use complex as a proxy for this
   using UDT = std::complex<float>;
-  check_op<UDT>(Queue, UDT(L, L), ext::oneapi::plus<UDT>(), false, G, L);
-  check_op<UDT>(Queue, UDT(0, 0), ext::oneapi::plus<UDT>(), true, G, L);
+  check_op<UDT>(Queue, UDT(L, L), plus<UDT>(), false, G, L);
+  check_op<UDT>(Queue, UDT(0, 0), plus<UDT>(), true, G, L);
 
   // Test user-defined operator
   auto UDOp = [=](const auto &lhs, const auto &rhs) { return lhs + rhs; };

--- a/sycl/test-e2e/SubGroup/reduce.hpp
+++ b/sycl/test-e2e/SubGroup/reduce.hpp
@@ -73,85 +73,85 @@ void check(queue &Queue, size_t G = 256, size_t L = 64) {
 
   check_op<
       sycl_subgr<SpecializationKernelName, class KernelName_cNsJzXxSBQfEKY>, T>(
-      Queue, T(L), ext::oneapi::plus<T>(), false, G, L);
+      Queue, T(L), plus<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_bWdCJaxe>, T>(
-      Queue, T(0), ext::oneapi::plus<T>(), true, G, L);
+      Queue, T(0), plus<T>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_wjspvpHJtI>,
-           T>(Queue, T(0), ext::oneapi::minimum<T>(), false, G, L);
+           T>(Queue, T(0), minimum<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_BUioaQYxhjN>,
-           T>(Queue, T(G), ext::oneapi::minimum<T>(), true, G, L);
+           T>(Queue, T(G), minimum<T>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_bIHcoJBNpiB>,
-           T>(Queue, T(G), ext::oneapi::maximum<T>(), false, G, L);
+           T>(Queue, T(G), maximum<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_bPPlfvdGShi>,
-           T>(Queue, T(0), ext::oneapi::maximum<T>(), true, G, L);
+           T>(Queue, T(0), maximum<T>(), true, G, L);
 
   // Transparent operator functors.
   check_op<sycl_subgr<SpecializationKernelName,
                       class KernelName_fkOyLRYirfMnvBcnbRFy>,
-           T>(Queue, T(L), ext::oneapi::plus<>(), false, G, L);
+           T>(Queue, T(L), plus<>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName,
                       class KernelName_zhzfRmSAFlswKWShyecv>,
-           T>(Queue, T(0), ext::oneapi::plus<>(), true, G, L);
+           T>(Queue, T(0), plus<>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName,
                       class KernelName_NaOzDnOmDPiDIXnXvaGy>,
-           T>(Queue, T(0), ext::oneapi::minimum<>(), false, G, L);
+           T>(Queue, T(0), minimum<>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_XXAfdcNmCNX>,
-           T>(Queue, T(G), ext::oneapi::minimum<>(), true, G, L);
+           T>(Queue, T(G), minimum<>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_pLlvjjZsPv>,
-           T>(Queue, T(G), ext::oneapi::maximum<>(), false, G, L);
+           T>(Queue, T(G), maximum<>(), false, G, L);
   check_op<
       sycl_subgr<SpecializationKernelName, class KernelName_BaCGaWDMFeMFqvotbk>,
-      T>(Queue, T(0), ext::oneapi::maximum<>(), true, G, L);
+      T>(Queue, T(0), maximum<>(), true, G, L);
 }
 
 template <typename SpecializationKernelName, typename T>
 void check_mul(queue &Queue, size_t G = 256, size_t L = 4) {
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_MulF>, T>(
-      Queue, T(G), ext::oneapi::multiplies<T>(), false, G, L);
+      Queue, T(G), multiplies<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_MulT>, T>(
-      Queue, T(1), ext::oneapi::multiplies<T>(), true, G, L);
+      Queue, T(1), multiplies<T>(), true, G, L);
 
   // Transparent operator functors.
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_MulFV>, T>(
-      Queue, T(G), ext::oneapi::multiplies<>(), false, G, L);
+      Queue, T(G), multiplies<>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_MulTV>, T>(
-      Queue, T(1), ext::oneapi::multiplies<>(), true, G, L);
+      Queue, T(1), multiplies<>(), true, G, L);
 }
 
 template <typename SpecializationKernelName, typename T>
 void check_bit_ops(queue &Queue, size_t G = 256, size_t L = 4) {
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ORF>, T>(
-      Queue, T(G), ext::oneapi::bit_or<T>(), false, G, L);
+      Queue, T(G), bit_or<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ORT>, T>(
-      Queue, T(0), ext::oneapi::bit_or<T>(), true, G, L);
+      Queue, T(0), bit_or<T>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_XORF>, T>(
-      Queue, T(G), ext::oneapi::bit_xor<T>(), false, G, L);
+      Queue, T(G), bit_xor<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_XORT>, T>(
-      Queue, T(0), ext::oneapi::bit_xor<T>(), true, G, L);
+      Queue, T(0), bit_xor<T>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ANDF>, T>(
-      Queue, T(G), ext::oneapi::bit_and<T>(), false, G, L);
+      Queue, T(G), bit_and<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ANDT>, T>(
-      Queue, ~T(0), ext::oneapi::bit_and<T>(), true, G, L);
+      Queue, ~T(0), bit_and<T>(), true, G, L);
 
   // Transparent operator functors
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ORFV>, T>(
-      Queue, T(G), ext::oneapi::bit_or<T>(), false, G, L);
+      Queue, T(G), bit_or<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ORTV>, T>(
-      Queue, T(0), ext::oneapi::bit_or<T>(), true, G, L);
+      Queue, T(0), bit_or<T>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_XORFV>, T>(
-      Queue, T(G), ext::oneapi::bit_xor<T>(), false, G, L);
+      Queue, T(G), bit_xor<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_XORTV>, T>(
-      Queue, T(0), ext::oneapi::bit_xor<T>(), true, G, L);
+      Queue, T(0), bit_xor<T>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ANDFV>, T>(
-      Queue, T(G), ext::oneapi::bit_and<T>(), false, G, L);
+      Queue, T(G), bit_and<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ANDTV>, T>(
-      Queue, ~T(0), ext::oneapi::bit_and<T>(), true, G, L);
+      Queue, ~T(0), bit_and<T>(), true, G, L);
 }

--- a/sycl/test-e2e/SubGroup/scan.hpp
+++ b/sycl/test-e2e/SubGroup/scan.hpp
@@ -91,13 +91,11 @@ void check(queue &Queue, size_t G = 256, size_t L = 64) {
   if (std::is_floating_point<T>::value || std::is_same<T, sycl::half>::value) {
     check_op<
         sycl_subgr<SpecializationKernelName, class KernelName_LylCkHSTmrFhMH>,
-        T>(Queue, std::numeric_limits<T>::infinity(), minimum<T>(),
-           true, G, L);
+        T>(Queue, std::numeric_limits<T>::infinity(), minimum<T>(), true, G, L);
   } else {
     check_op<sycl_subgr<SpecializationKernelName,
                         class KernelName_gYWXQQXGnzJEpaftEQly>,
-             T>(Queue, std::numeric_limits<T>::max(), minimum<T>(),
-                true, G, L);
+             T>(Queue, std::numeric_limits<T>::max(), minimum<T>(), true, G, L);
   }
 
   check_op<
@@ -106,12 +104,11 @@ void check(queue &Queue, size_t G = 256, size_t L = 64) {
   if (std::is_floating_point<T>::value || std::is_same<T, sycl::half>::value) {
     check_op<
         sycl_subgr<SpecializationKernelName, class KernelName_EBNigvpxbxYEyRcl>,
-        T>(Queue, -std::numeric_limits<T>::infinity(),
-           maximum<T>(), true, G, L);
+        T>(Queue, -std::numeric_limits<T>::infinity(), maximum<T>(), true, G,
+           L);
   } else {
     check_op<sycl_subgr<SpecializationKernelName, class KernelName_KayihC>, T>(
-        Queue, std::numeric_limits<T>::min(), maximum<T>(), true,
-        G, L);
+        Queue, std::numeric_limits<T>::min(), maximum<T>(), true, G, L);
   }
 
   // Transparent operator functors.
@@ -126,26 +123,22 @@ void check(queue &Queue, size_t G = 256, size_t L = 64) {
   if (std::is_floating_point<T>::value || std::is_same<T, sycl::half>::value) {
     check_op<
         sycl_subgr<SpecializationKernelName, class KernelName_fgMMknFqTMGts>,
-        T>(Queue, std::numeric_limits<T>::infinity(), minimum<>(),
-           true, G, L);
+        T>(Queue, std::numeric_limits<T>::infinity(), minimum<>(), true, G, L);
   } else {
     check_op<sycl_subgr<SpecializationKernelName,
                         class KernelName_FVbXDSctbMnggHMCz>,
-             T>(Queue, std::numeric_limits<T>::max(), minimum<>(),
-                true, G, L);
+             T>(Queue, std::numeric_limits<T>::max(), minimum<>(), true, G, L);
   }
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_zzvRru>, T>(
       Queue, T(G), maximum<>(), false, G, L);
   if (std::is_floating_point<T>::value || std::is_same<T, sycl::half>::value) {
     check_op<sycl_subgr<SpecializationKernelName, class KernelName_NJh>, T>(
-        Queue, -std::numeric_limits<T>::infinity(), maximum<>(),
-        true, G, L);
+        Queue, -std::numeric_limits<T>::infinity(), maximum<>(), true, G, L);
   } else {
     check_op<
         sycl_subgr<SpecializationKernelName, class KernelName_XjMHvRfLSQerFi>,
-        T>(Queue, std::numeric_limits<T>::min(), maximum<>(), true,
-           G, L);
+        T>(Queue, std::numeric_limits<T>::min(), maximum<>(), true, G, L);
   }
 }
 

--- a/sycl/test-e2e/SubGroup/scan.hpp
+++ b/sycl/test-e2e/SubGroup/scan.hpp
@@ -81,70 +81,70 @@ void check(queue &Queue, size_t G = 256, size_t L = 64) {
   }
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_UdKabTMplbvM>,
-           T>(Queue, T(L), ext::oneapi::plus<T>(), false, G, L);
+           T>(Queue, T(L), plus<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_hYvJ>, T>(
-      Queue, T(0), ext::oneapi::plus<T>(), true, G, L);
+      Queue, T(0), plus<T>(), true, G, L);
 
   check_op<
       sycl_subgr<SpecializationKernelName, class KernelName_eozPcciiaOmKkKUEp>,
-      T>(Queue, T(0), ext::oneapi::minimum<T>(), false, G, L);
+      T>(Queue, T(0), minimum<T>(), false, G, L);
   if (std::is_floating_point<T>::value || std::is_same<T, sycl::half>::value) {
     check_op<
         sycl_subgr<SpecializationKernelName, class KernelName_LylCkHSTmrFhMH>,
-        T>(Queue, std::numeric_limits<T>::infinity(), ext::oneapi::minimum<T>(),
+        T>(Queue, std::numeric_limits<T>::infinity(), minimum<T>(),
            true, G, L);
   } else {
     check_op<sycl_subgr<SpecializationKernelName,
                         class KernelName_gYWXQQXGnzJEpaftEQly>,
-             T>(Queue, std::numeric_limits<T>::max(), ext::oneapi::minimum<T>(),
+             T>(Queue, std::numeric_limits<T>::max(), minimum<T>(),
                 true, G, L);
   }
 
   check_op<
       sycl_subgr<SpecializationKernelName, class KernelName_NEgmAHtvPAWDyXPoo>,
-      T>(Queue, T(G), ext::oneapi::maximum<T>(), false, G, L);
+      T>(Queue, T(G), maximum<T>(), false, G, L);
   if (std::is_floating_point<T>::value || std::is_same<T, sycl::half>::value) {
     check_op<
         sycl_subgr<SpecializationKernelName, class KernelName_EBNigvpxbxYEyRcl>,
         T>(Queue, -std::numeric_limits<T>::infinity(),
-           ext::oneapi::maximum<T>(), true, G, L);
+           maximum<T>(), true, G, L);
   } else {
     check_op<sycl_subgr<SpecializationKernelName, class KernelName_KayihC>, T>(
-        Queue, std::numeric_limits<T>::min(), ext::oneapi::maximum<T>(), true,
+        Queue, std::numeric_limits<T>::min(), maximum<T>(), true,
         G, L);
   }
 
   // Transparent operator functors.
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_TPWS>, T>(
-      Queue, T(L), ext::oneapi::plus<>(), false, G, L);
+      Queue, T(L), plus<>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_hWZv>, T>(
-      Queue, T(0), ext::oneapi::plus<>(), true, G, L);
+      Queue, T(0), plus<>(), true, G, L);
 
   check_op<
       sycl_subgr<SpecializationKernelName, class KernelName_MdoesLriZMCljse>,
-      T>(Queue, T(0), ext::oneapi::minimum<>(), false, G, L);
+      T>(Queue, T(0), minimum<>(), false, G, L);
   if (std::is_floating_point<T>::value || std::is_same<T, sycl::half>::value) {
     check_op<
         sycl_subgr<SpecializationKernelName, class KernelName_fgMMknFqTMGts>,
-        T>(Queue, std::numeric_limits<T>::infinity(), ext::oneapi::minimum<>(),
+        T>(Queue, std::numeric_limits<T>::infinity(), minimum<>(),
            true, G, L);
   } else {
     check_op<sycl_subgr<SpecializationKernelName,
                         class KernelName_FVbXDSctbMnggHMCz>,
-             T>(Queue, std::numeric_limits<T>::max(), ext::oneapi::minimum<>(),
+             T>(Queue, std::numeric_limits<T>::max(), minimum<>(),
                 true, G, L);
   }
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_zzvRru>, T>(
-      Queue, T(G), ext::oneapi::maximum<>(), false, G, L);
+      Queue, T(G), maximum<>(), false, G, L);
   if (std::is_floating_point<T>::value || std::is_same<T, sycl::half>::value) {
     check_op<sycl_subgr<SpecializationKernelName, class KernelName_NJh>, T>(
-        Queue, -std::numeric_limits<T>::infinity(), ext::oneapi::maximum<>(),
+        Queue, -std::numeric_limits<T>::infinity(), maximum<>(),
         true, G, L);
   } else {
     check_op<
         sycl_subgr<SpecializationKernelName, class KernelName_XjMHvRfLSQerFi>,
-        T>(Queue, std::numeric_limits<T>::min(), ext::oneapi::maximum<>(), true,
+        T>(Queue, std::numeric_limits<T>::min(), maximum<>(), true,
            G, L);
   }
 }
@@ -152,46 +152,46 @@ void check(queue &Queue, size_t G = 256, size_t L = 64) {
 template <typename SpecializationKernelName, typename T>
 void check_mul(queue &Queue, size_t G = 256, size_t L = 4) {
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_MulF>, T>(
-      Queue, T(L), ext::oneapi::multiplies<T>(), false, G, L);
+      Queue, T(L), multiplies<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_MulT>, T>(
-      Queue, T(1), ext::oneapi::multiplies<>(), true, G, L);
+      Queue, T(1), multiplies<>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_MulFV>, T>(
-      Queue, T(L), ext::oneapi::multiplies<T>(), false, G, L);
+      Queue, T(L), multiplies<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_MulTV>, T>(
-      Queue, T(1), ext::oneapi::multiplies<>(), true, G, L);
+      Queue, T(1), multiplies<>(), true, G, L);
 }
 
 template <typename SpecializationKernelName, typename T>
 void check_bit_ops(queue &Queue, size_t G = 256, size_t L = 4) {
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ORF>, T>(
-      Queue, T(L), ext::oneapi::bit_or<T>(), false, G, L);
+      Queue, T(L), bit_or<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ORT>, T>(
-      Queue, T(0), ext::oneapi::bit_or<T>(), true, G, L);
+      Queue, T(0), bit_or<T>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_XORF>, T>(
-      Queue, T(L), ext::oneapi::bit_xor<T>(), false, G, L);
+      Queue, T(L), bit_xor<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_XORT>, T>(
-      Queue, T(0), ext::oneapi::bit_xor<T>(), true, G, L);
+      Queue, T(0), bit_xor<T>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ANDF>, T>(
-      Queue, T(L), ext::oneapi::bit_and<T>(), false, G, L);
+      Queue, T(L), bit_and<T>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ANDT>, T>(
-      Queue, ~T(0), ext::oneapi::bit_and<T>(), true, G, L);
+      Queue, ~T(0), bit_and<T>(), true, G, L);
 
   // Transparent operator functors.
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ORFV>, T>(
-      Queue, T(L), ext::oneapi::bit_or<>(), false, G, L);
+      Queue, T(L), bit_or<>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ORTV>, T>(
-      Queue, T(0), ext::oneapi::bit_or<>(), true, G, L);
+      Queue, T(0), bit_or<>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_XORFV>, T>(
-      Queue, T(L), ext::oneapi::bit_xor<>(), false, G, L);
+      Queue, T(L), bit_xor<>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_XORTV>, T>(
-      Queue, T(0), ext::oneapi::bit_xor<>(), true, G, L);
+      Queue, T(0), bit_xor<>(), true, G, L);
 
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ANDFV>, T>(
-      Queue, T(L), ext::oneapi::bit_and<>(), false, G, L);
+      Queue, T(L), bit_and<>(), false, G, L);
   check_op<sycl_subgr<SpecializationKernelName, class KernelName_ANDTV>, T>(
-      Queue, ~T(0), ext::oneapi::bit_and<>(), true, G, L);
+      Queue, ~T(0), bit_and<>(), true, G, L);
 }


### PR DESCRIPTION
In favor of existing SYCL2020 objects.
And update E2E tests to use standard SYCL2020 objects.
I believe these objects were introduced in https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/removed/sycl_ext_oneapi_group_algorithms.asciidoc