### PR TITLE
[SYCL] optimize fp8 load store

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/float_8bit/types.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/float_8bit/types.hpp
@@ -945,7 +945,8 @@ template <size_t N> class fp8_e4m3_x {
   void ConvertFromFP8_Vec2(sycl::marray<sycl::half, N> &ret,
                            rounding r = rounding::to_even) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    const ::sycl::detail::uint8_vec2 packed{vals[0], vals[1]};
+    const ::sycl::detail::uint8_vec2 packed =
+        *reinterpret_cast<const ::sycl::detail::uint8_vec2 *>(vals);
     ::sycl::detail::float16_vec2 hi =
         __builtin_spirv_ConvertE4M3ToFP16EXT(packed);
     ret[0] = sycl::bit_cast<sycl::half>(hi[0]);
@@ -970,7 +971,8 @@ template <size_t N> class fp8_e4m3_x {
   void ConvertBF16FromFP8_Vec2(sycl::marray<bfloat16, N> &ret,
                                rounding r = rounding::to_even) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    const ::sycl::detail::uint8_vec2 packed{vals[0], vals[1]};
+    const ::sycl::detail::uint8_vec2 packed =
+        *reinterpret_cast<const ::sycl::detail::uint8_vec2 *>(vals);
     ::sycl::detail::bfloat16_vec2 hi =
         __builtin_spirv_ConvertE4M3ToBF16EXT(packed);
     ret[0] = sycl::bit_cast<bfloat16>(hi[0]);
@@ -994,9 +996,8 @@ template <size_t N> class fp8_e4m3_x {
   } else {                                                                     \
     const VecType vec{sycl::bit_cast<CastType>(in[0]),                         \
                       sycl::bit_cast<CastType>(in[1])};                        \
-    const ::sycl::detail::uint8_vec2 result =                                  \
+    *reinterpret_cast<::sycl::detail::uint8_vec2 *>(vals) =                    \
         Convert##Prefix##ToFP8_Vec2(vec);                                      \
-    std::memcpy(vals, &result, sizeof(vals));                                  \
   }
 #else
 #define CONVERT_TO_FP8(VecType, CastType, in, Prefix)                          \
@@ -1295,7 +1296,7 @@ public:
   }
 
   // Intentionally public to allow access to the raw values.
-  uint8_t vals[N];
+  alignas(N == 2 ? 2 : alignof(uint8_t)) uint8_t vals[N];
 #undef CONVERT_TO_FP8
 };
 
@@ -1390,7 +1391,8 @@ template <size_t N> class fp8_e5m2_x {
   void ConvertFromFP8_Vec2(sycl::marray<sycl::half, N> &ret,
                            rounding r = rounding::to_even) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    const ::sycl::detail::uint8_vec2 packed{vals[0], vals[1]};
+    const ::sycl::detail::uint8_vec2 packed =
+        *reinterpret_cast<const ::sycl::detail::uint8_vec2 *>(vals);
     ::sycl::detail::float16_vec2 hi =
         __builtin_spirv_ConvertE5M2ToFP16EXT(packed);
     ret[0] = sycl::bit_cast<sycl::half>(hi[0]);
@@ -1415,7 +1417,8 @@ template <size_t N> class fp8_e5m2_x {
   void ConvertBF16FromFP8_Vec2(sycl::marray<bfloat16, N> &ret,
                                rounding r = rounding::to_even) const {
 #ifdef __SYCL_DEVICE_ONLY__
-    const ::sycl::detail::uint8_vec2 packed{vals[0], vals[1]};
+    const ::sycl::detail::uint8_vec2 packed =
+        *reinterpret_cast<const ::sycl::detail::uint8_vec2 *>(vals);
     ::sycl::detail::bfloat16_vec2 hi =
         __builtin_spirv_ConvertE5M2ToBF16EXT(packed);
     ret[0] = sycl::bit_cast<bfloat16>(hi[0]);
@@ -1439,9 +1442,8 @@ template <size_t N> class fp8_e5m2_x {
   } else {                                                                     \
     const VecType vec{sycl::bit_cast<CastType>(in[0]),                         \
                       sycl::bit_cast<CastType>(in[1])};                        \
-    const ::sycl::detail::uint8_vec2 result =                                  \
+    *reinterpret_cast<::sycl::detail::uint8_vec2 *>(vals) =                    \
         Convert##Prefix##ToFP8_Vec2(vec, s);                                   \
-    std::memcpy(vals, &result, sizeof(vals));                                  \
   }
 #else
 #define CONVERT_TO_FP8(VecType, CastType, in, s, Prefix)                       \
@@ -1875,8 +1877,7 @@ public:
   }
 
   // Intentionally public to allow access to the raw values.
-
-  uint8_t vals[N];
+  alignas(N == 2 ? 2 : alignof(uint8_t)) uint8_t vals[N];
 #undef CONVERT_TO_FP8
 };
 

--- a/sycl/test-e2e/Experimental/fp8/e4m3_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e4m3_x2_cri_conversion.cpp
@@ -335,6 +335,9 @@ template <typename T> int test_carray_conversion(sycl::queue &queue) {
 }
 
 int main() {
+  static_assert(alignof(fp8_e4m3_x2) == 2);
+  static_assert(sizeof(fp8_e4m3_x2) == 2);
+
   auto async_handler = [](sycl::exception_list exceptions) {
     for (const std::exception_ptr &e : exceptions) {
       try {

--- a/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
@@ -463,6 +463,9 @@ template <typename T> int test_carray_conversion(sycl::queue &queue) {
 }
 
 int main() {
+  static_assert(alignof(fp8_e5m2_x2) == 2);
+  static_assert(sizeof(fp8_e5m2_x2) == 2);
+
   auto async_handler = [](sycl::exception_list exceptions) {
     for (const std::exception_ptr &e : exceptions) {
       try {

--- a/sycl/test-e2e/Experimental/fp8/x2_alignment_codegen.cpp
+++ b/sycl/test-e2e/Experimental/fp8/x2_alignment_codegen.cpp
@@ -1,0 +1,46 @@
+// RUN: %clangxx -fsycl -fsycl-device-only -DNDEBUG -S -emit-llvm %s -o - | FileCheck %s
+
+// UNSUPPORTED: target-nvidia, target-amd
+// UNSUPPORTED-INTENDED: relies on SPIR-V FP8 conversion builtins
+
+#include <sycl/ext/oneapi/experimental/float_8bit/types.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+// Encode: two halfs are converted and stored into the `vals` array through a
+// single aligned `<2 x i8>` store.
+//
+// CHECK-LABEL: define {{.*}}encode_e4m3
+// CHECK: store <2 x i8> {{%[a-zA-Z0-9._]+}}, ptr {{.*}}, align 2
+SYCL_EXTERNAL void encode_e4m3(sycl::half a, sycl::half b, fp8_e4m3_x2 *out) {
+  sycl::half in[2] = {a, b};
+  *out = fp8_e4m3_x2(in);
+}
+
+// Decode: the two packed FP8 values are read through a single aligned
+// `<2 x i8>` load.
+//
+// CHECK-LABEL: define {{.*}}decode_e4m3
+// CHECK: load <2 x i8>, ptr {{.*}}, align 2
+SYCL_EXTERNAL void decode_e4m3(const fp8_e4m3_x2 *in, sycl::half *out) {
+  sycl::marray<sycl::half, 2> m = static_cast<sycl::marray<sycl::half, 2>>(*in);
+  out[0] = m[0];
+  out[1] = m[1];
+}
+
+// Same aligned vector store/load for the e5m2 variant.
+//
+// CHECK-LABEL: define {{.*}}encode_e5m2
+// CHECK: store <2 x i8> {{%[a-zA-Z0-9._]+}}, ptr {{.*}}, align 2
+SYCL_EXTERNAL void encode_e5m2(sycl::half a, sycl::half b, fp8_e5m2_x2 *out) {
+  sycl::half in[2] = {a, b};
+  *out = fp8_e5m2_x2(in);
+}
+
+// CHECK-LABEL: define {{.*}}decode_e5m2
+// CHECK: load <2 x i8>, ptr {{.*}}, align 2
+SYCL_EXTERNAL void decode_e5m2(const fp8_e5m2_x2 *in, sycl::half *out) {
+  sycl::marray<sycl::half, 2> m = static_cast<sycl::marray<sycl::half, 2>>(*in);
+  out[0] = m[0];
+  out[1] = m[1];
+}


### PR DESCRIPTION
When size == 2 of FP8 data type, it was used memcpy to store and copy data. However, if it is guaranteed that fp8 data type sizeof is 2 bytes, then we can optimize it to have one ir operation, This PR adds alignment for data types which are supported by hardware.