### PR TITLE
[lit] force execute_external=true after deprecation

### DIFF
--- a/llvm-spirv/test/lit.cfg.py
+++ b/llvm-spirv/test/lit.cfg.py
@@ -13,7 +13,7 @@ from lit.llvm.subst import FindTool
 config.name = 'LLVM_SPIRV'
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest(execute_external=not llvm_config.use_lit_shell, force_execute_external=True)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.cl', '.ll', '.spt', '.spvasm']

--- a/sycl-jit/test/lit.cfg.py
+++ b/sycl-jit/test/lit.cfg.py
@@ -8,7 +8,7 @@ from lit.llvm.subst import ToolSubst
 
 config.name = "SYCL-JIT"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest(execute_external=not llvm_config.use_lit_shell, force_execute_external=True)
 
 # Define suffixes for test discovery
 config.suffixes = [".ll"]


### PR DESCRIPTION
- Restore lit test environment after  [57109b](https://github.com/intel/llvm/commit/57109befac92811d2253109242ca6fa69c961fb2)
