### PR TITLE
[SYCL] resolve SPIRV extension FP8 e2e issue

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10979,7 +10979,8 @@ static void getSPIRVBackendOpts(const llvm::opt::ArgList &TCArgs,
     llvm::StringRef ArgValue(A->getValue());
     if (ArgValue.starts_with("--spirv-ext=")) {
       // Extract the extension list after --spirv-ext=
-      llvm::StringRef ExtList = ArgValue.substr(12); // strlen("--spirv-ext=") == 12
+      llvm::StringRef ExtList =
+          ArgValue.substr(12); // strlen("--spirv-ext=") == 12
       if (!ExtList.empty()) {
         ExtArg += "," + ExtList.str();
       }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10973,12 +10973,31 @@ static void getSPIRVBackendOpts(const llvm::opt::ArgList &TCArgs,
                           ",+SPV_KHR_shader_clock"
                           ",+SPV_KHR_uniform_group_instructions";
   ExtArg = ExtArg + DefaultExtArg + IntelExtArg + KHRExtArg;
-  BackendArgs.push_back(TCArgs.MakeArgString(ExtArg));
 
-  // TODO:
-  // - handle -Xspirv-translator option to avoid "argument unused during
-  // compilation" error
-  // - handle --spirv-ext=+<extension> and --spirv-ext=-<extension> options
+  // Handle -Xspirv-translator --spirv-ext options
+  for (const auto *A : TCArgs.filtered(options::OPT_Xspirv_translator)) {
+    llvm::StringRef ArgValue(A->getValue());
+    if (ArgValue.starts_with("--spirv-ext=")) {
+      // Extract the extension list after --spirv-ext=
+      llvm::StringRef ExtList = ArgValue.substr(12); // strlen("--spirv-ext=") == 12
+      if (!ExtList.empty()) {
+        ExtArg += "," + ExtList.str();
+      }
+    }
+  }
+  for (const auto *A : TCArgs.filtered(options::OPT_Xspirv_translator_EQ)) {
+    // For -Xspirv-translator=<triple> <arg>, getValue(0) is the triple,
+    // getValue(1) is the actual argument
+    llvm::StringRef ArgValue(A->getValue(1));
+    if (ArgValue.starts_with("--spirv-ext=")) {
+      llvm::StringRef ExtList = ArgValue.substr(12);
+      if (!ExtList.empty()) {
+        ExtArg += "," + ExtList.str();
+      }
+    }
+  }
+
+  BackendArgs.push_back(TCArgs.MakeArgString(ExtArg));
 }
 
 // Utility function to gather all llvm-spirv options.

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -178,7 +178,10 @@ static const StringMap<SPIRV::Extension::Extension> SPIRVExtensionMap = {
     {"SPV_INTEL_unstructured_loop_controls",
      SPIRV::Extension::Extension::SPV_INTEL_unstructured_loop_controls},
     {"SPV_AMD_weak_linkage", SPIRV::Extension::Extension::SPV_AMD_weak_linkage},
-    {"SPV_KHR_abort", SPIRV::Extension::Extension::SPV_KHR_abort}};
+    {"SPV_KHR_abort", SPIRV::Extension::Extension::SPV_KHR_abort},
+    {"SPV_INTEL_fp_conversions",
+     SPIRV::Extension::Extension::SPV_INTEL_fp_conversions},
+    {"SPV_EXT_float8", SPIRV::Extension::Extension::SPV_EXT_float8}};
 
 bool SPIRVExtensionsParser::parse(cl::Option &O, StringRef ArgName,
                                   StringRef ArgValue, ExtensionSet &Vals) {


### PR DESCRIPTION
Problem occurred in FP8 PR [post commit](https://github.com/intel/llvm/actions/runs/27552247291/job/81441472046):

` # | LLVM ERROR: OpTypeFloat type with bfloat requires the following SPIR-V extension: SPV_KHR_bfloat16`

when `-fsycl-use-spirv-backend-for-spirv-gen` is passed to compiler.

This PR fixes the problem, such that adding SPIRV extensions by passing to compiler `-Xspirv-translator --spirv-ext=+<>,+<>`
