### PR TITLE
[SYCL] mark spirv backend as unsupported in FP8 E2E tests

### DIFF
--- a/sycl/test-e2e/Experimental/fp8/e4m3_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e4m3_cri_conversion.cpp
@@ -2,8 +2,9 @@
 // RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
 // RUN: %{run} SYCL_UR_TRACE=1 %t.out
 
-// UNSUPPORTED: target-nvidia, target-amd
-// UNSUPPORTED-INTENDED: only supported by backends with CRI driver
+// UNSUPPORTED: target-nvidia, target-amd, spirv-backend
+// UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
+// SPIR-V backend does not support the required SPIR-V extensions
 
 #include <cmath>
 #include <limits>

--- a/sycl/test-e2e/Experimental/fp8/e4m3_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e4m3_x2_cri_conversion.cpp
@@ -3,8 +3,9 @@
 // RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
 // RUN: %{run} SYCL_UR_TRACE=1 %t.out
 
-// UNSUPPORTED: target-nvidia, target-amd
-// UNSUPPORTED-INTENDED: only supported by backends with CRI driver
+// UNSUPPORTED: target-nvidia, target-amd, spirv-backend
+// UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
+// SPIR-V backend does not support the required SPIR-V extensions
 
 #include <cmath>
 #include <limits>

--- a/sycl/test-e2e/Experimental/fp8/e5m2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e5m2_cri_conversion.cpp
@@ -2,8 +2,9 @@
 // RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
 // RUN: %{run} SYCL_UR_TRACE=1 %t.out
 
-// UNSUPPORTED: target-nvidia, target-amd
-// UNSUPPORTED-INTENDED: only supported by backends with CRI driver
+// UNSUPPORTED: target-nvidia, target-amd, spirv-backend
+// UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
+// SPIR-V backend does not support the required SPIR-V extensions
 
 #include <cmath>
 #include <cstdint>

--- a/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
@@ -464,9 +464,6 @@ template <typename T> int test_carray_conversion(sycl::queue &queue) {
 }
 
 int main() {
-  static_assert(alignof(fp8_e5m2_x2) == 2);
-  static_assert(sizeof(fp8_e5m2_x2) == 2);
-
   auto async_handler = [](sycl::exception_list exceptions) {
     for (const std::exception_ptr &e : exceptions) {
       try {

--- a/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
@@ -2,8 +2,9 @@
 // RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
 // RUN: %{run} SYCL_UR_TRACE=1 %t.out
 
-// UNSUPPORTED: target-nvidia, target-amd
-// UNSUPPORTED-INTENDED: only supported by backends with CRI driver
+// UNSUPPORTED: target-nvidia, target-amd, spirv-backend
+// UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
+// SPIR-V backend does not support the required SPIR-V extensions
 
 #include <cmath>
 #include <cstdint>
@@ -463,6 +464,9 @@ template <typename T> int test_carray_conversion(sycl::queue &queue) {
 }
 
 int main() {
+  static_assert(alignof(fp8_e5m2_x2) == 2);
+  static_assert(sizeof(fp8_e5m2_x2) == 2);
+
   auto async_handler = [](sycl::exception_list exceptions) {
     for (const std::exception_ptr &e : exceptions) {
       try {

--- a/sycl/test-e2e/Experimental/fp8/e8m0_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e8m0_cri_conversion.cpp
@@ -3,8 +3,9 @@
 // RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
 // RUN: %{run} SYCL_UR_TRACE=1 %t.out
 
-// UNSUPPORTED: target-nvidia, target-amd
-// UNSUPPORTED-INTENDED: only supported by backends with CRI driver
+// UNSUPPORTED: target-nvidia, target-amd, spirv-backend
+// UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
+// SPIR-V backend does not support the required SPIR-V extensions
 
 #include <cmath>
 #include <limits>

--- a/sycl/test-e2e/Experimental/fp8/e8m0_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e8m0_x2_cri_conversion.cpp
@@ -3,8 +3,9 @@
 // RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
 // RUN: %{run} SYCL_UR_TRACE=1 %t.out
 
-// UNSUPPORTED: target-nvidia, target-amd
-// UNSUPPORTED-INTENDED: only supported by backends with CRI driver
+// UNSUPPORTED: target-nvidia, target-amd, spirv-backend
+// UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
+// SPIR-V backend does not support the required SPIR-V extensions
 
 #include <cmath>
 #include <limits>


### PR DESCRIPTION
This PR adds SPIRV backend as unsupported in FP8 E2E tests to avoid build errors.