### PR TITLE
[SPIR-V] Correctly manage NamedId to avoid dangling IDs

### DIFF
--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1364,6 +1364,10 @@ SPIRVEntry *SPIRVModuleImpl::replaceForward(SPIRVForward *Forward,
     IdEntryMap.erase(Loc);
     Entry->setId(ForwardId);
     IdEntryMap[ForwardId] = Entry;
+    // Need explicit bookkeeping of named IDs here to make it consistent with
+    // IdEntryMap, otherwise in some cases the original Id may be dangling.
+    if (NamedId.erase(Id))
+      NamedId.insert(ForwardId);
     // Replace current Id with ForwardId in decorates.
     Entry->replaceTargetIdInDecorates(ForwardId);
   }

--- a/llvm-spirv/test/freeze.ll
+++ b/llvm-spirv/test/freeze.ll
@@ -34,7 +34,7 @@ define spir_func i32 @testfunction_i32A(i32 %val) {
 ; CHECK-LLVM-NEXT: ret i32
 define spir_func i32 @testfunction_i32B(i32 %val) {
    %1 = freeze i32 poison
-   %2 = add nsw i32 %1, 1   
+   %2 = add nsw i32 %1, 1
    ret i32 %2
 }
 
@@ -47,7 +47,7 @@ define spir_func i32 @testfunction_i32B(i32 %val) {
 ; CHECK-LLVM-NEXT: ret i32
 define spir_func i32 @testfunction_i32C(i32 %val) {
    %1 = freeze i32 undef
-   %2 = add nsw i32 %1, 1   
+   %2 = add nsw i32 %1, 1
    ret i32 %2
 }
 
@@ -139,3 +139,47 @@ define spir_func i64 @testfunction_ptrC(ptr addrspace(1) %val) {
 
 ; CHECK-LLC: @testfunction_ptrC
 ; CHECK-LLC-NEXT: ptrtoint ptr undef to i64
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; test forward-referenced freeze (regression for "Id is not in map" assertion)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; A named value (%retval.1) is consumed by a freeze (%cond.fr) that is referenced by
+; a loop-carried phi *before* it is defined.  When the freeze is moved away (no
+; SPV_KHR_poison_freeze), its forward placeholder is resolved to the named %retval.1
+; entry, re-keying that entry to the forward's id.  This used to leave the original
+; id dangling in the OpName set and crash with "Id is not in map" at emission time.
+; Now with explicit bookkeeping of NamedId in replaceForward, it shouldn't crash anymore.
+; CHECK-LLVM: @testfunction_freeze_forward_ref
+; CHECK-LLVM: %retval = phi i1 [ undef, %entry ], [ %cond.fr, %for.inc ]
+; CHECK-LLVM: %cond.fr = or i1 %cmp14, %acc
+define spir_func i1 @testfunction_freeze_forward_ref(ptr addrspace(4) %a, ptr addrspace(4) %b, i64 %n) {
+entry:
+  br label %for.cond
+
+for.cond:
+  %i       = phi i64 [ 0,         %entry   ], [ %i.inc,    %for.inc ]
+  %retval  = phi i1  [ undef,     %entry   ], [ %cond.fr,  %for.inc ]
+  %cmp5    = icmp slt i64 %i, %n
+  br i1 %cmp5, label %for.body, label %exit
+
+for.body:
+  %pa      = getelementptr i8, ptr addrspace(4) %a, i64 %i
+  %pb      = getelementptr i8, ptr addrspace(4) %b, i64 %i
+  %va      = load i8, ptr addrspace(4) %pa, align 1
+  %vb      = load i8, ptr addrspace(4) %pb, align 1
+  %cmp14   = icmp ult i8 %va, %vb
+  %cmp18   = icmp ule i8 %va, %vb
+  %acc     = and i1 %cmp18, %retval
+  %retval.1 = or i1 %cmp14, %acc
+  %cond.fr = freeze i1 %retval.1
+  %eq      = icmp eq i8 %va, %vb
+  br i1 %eq, label %for.inc, label %exit
+
+for.inc:
+  %i.inc   = add nuw nsw i64 %i, 1
+  br label %for.cond
+
+exit:
+  %r = phi i1 [ %retval, %for.cond ], [ %cond.fr, %for.body ]
+  ret i1 %r
+}


### PR DESCRIPTION
Fix assertion failure "Id is not in map" when a `FreezeInst` result is a forward reference when `SPV_KHR_poison_freeze` isn't enabled. Added a lit testcase as regression to cover this situation.