### PR TITLE
[SYCL] Add Support for Precompiled Headers

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -448,8 +448,6 @@ def err_drv_expecting_fsycl_with_sycl_opt : Error<
   "'%0' must be used in conjunction with '-fsycl' to enable offloading">;
 def err_drv_fsycl_with_c_type : Error<
   "'%0' must not be used in conjunction with '-fsycl', which expects C++ source">;
-def err_drv_fsycl_with_pch : Error<
-  "precompiled header generation is not supported with '-fsycl'">;
 def warn_drv_opt_requires_opt
   : Warning<"'%0' should be used only in conjunction with '%1'">, InGroup<UnusedCommandLineArgument>;
 def err_drv_sycl_missing_amdgpu_arch : Error<

--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -728,11 +728,17 @@ class OffloadPackagerExtractJobAction : public JobAction {
   void anchor() override;
 
 public:
-  OffloadPackagerExtractJobAction(ActionList &Inputs, types::ID Type);
+  OffloadPackagerExtractJobAction(ActionList &Inputs, types::ID Type,
+                                  const ToolChain *TC = nullptr);
 
   static bool classof(const Action *A) {
     return A->getKind() == OffloadPackagerExtractJobClass;
   }
+
+  const ToolChain *getToolChain() const { return OPEToolChain; }
+
+private:
+  const ToolChain *OPEToolChain = nullptr;
 };
 
 class OffloadDepsJobAction final : public JobAction {

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -880,6 +880,11 @@ private:
   mutable llvm::StringMap<const std::pair<StringRef, StringRef>>
       IntegrationFileList;
 
+  /// A list of triples and their corresponding unbundled precompiled header
+  /// file names.  This is generated when unbundling the fat precompiled
+  /// header file, and consumed by the host and the device compilations.
+  mutable llvm::StringMap<StringRef> SYCLPrecompiledHeaderFileList;
+
   /// Unique ID used for SYCL compilations.  Each file will use a different
   /// unique ID, but the same ID will be used for different compilation
   /// targets.
@@ -929,6 +934,19 @@ public:
   /// isSYCLDefaultTripleImplied - The default SYCL triple (spir64) has been
   /// added or should be added given proper criteria.
   bool isSYCLDefaultTripleImplied() const { return SYCLDefaultTripleImplied; };
+
+  /// addSYCLPrecompiledHeaderFiles - Add the precompiled header files
+  /// that were unbundled for each triple.
+  void addSYCLPrecompiledHeaderFiles(StringRef Triple,
+                                     StringRef FileName) const {
+    SYCLPrecompiledHeaderFileList.insert({Triple, FileName});
+  }
+
+  /// getSYCLPrecompiledHeaderFile - Get the precompiled header file
+  /// for a specific triple.
+  StringRef getSYCLPrecompiledHeaderFile(StringRef Triple) const {
+    return SYCLPrecompiledHeaderFileList[Triple];
+  }
 
   /// addIntegrationFiles - Add the integration files that will be populated
   /// by the device compilation and used by the host compile.

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -880,8 +880,8 @@ private:
   mutable llvm::StringMap<const std::pair<StringRef, StringRef>>
       IntegrationFileList;
 
-  /// A list of triples and their corresponding unbundled precompiled header
-  /// file names.  This is generated when unbundling the fat precompiled
+  /// A list of triples and their corresponding extracted precompiled header
+  /// file names.  This is generated when extracting the fat precompiled
   /// header file, and consumed by the host and the device compilations.
   mutable llvm::StringMap<StringRef> SYCLPrecompiledHeaderFileList;
 

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -90,14 +90,16 @@ void Action::propagateDeviceOffloadInfo(OffloadKind OKind, const char *OArch,
   // Deps job uses the host kinds.
   if (Kind == OffloadDepsJobClass)
     return;
-  // Packaging actions can use host kinds for preprocessing.  When packaging
-  // preprocessed files, these packaged files will contain both host and device
-  // files, where the host side does not have any device info to propagate.
-  bool hasPreprocessJob =
+  // Packaging actions can use host kinds for preprocessing or generating
+  // PCH files.  When packaging such files, these packaged files will contain
+  // both host and device files, where the host side does not have any device
+  // info to propagate.
+  bool hasPreprocessOrPCHJob =
       std::any_of(Inputs.begin(), Inputs.end(), [](const Action *A) {
-        return A->getKind() == PreprocessJobClass;
+        return A->getKind() == PreprocessJobClass ||
+               A->getKind() == PrecompileJobClass;
       });
-  if (Kind == OffloadPackagerJobClass && hasPreprocessJob)
+  if (Kind == OffloadPackagerJobClass && hasPreprocessOrPCHJob)
     return;
 
   assert((OffloadingDeviceKind == OKind || OffloadingDeviceKind == OFK_None) &&
@@ -501,8 +503,9 @@ OffloadPackagerJobAction::OffloadPackagerJobAction(ActionList &Inputs,
 void OffloadPackagerExtractJobAction::anchor() {}
 
 OffloadPackagerExtractJobAction::OffloadPackagerExtractJobAction(
-    ActionList &Inputs, types::ID Type)
-    : JobAction(OffloadPackagerExtractJobClass, Inputs, Type) {}
+    ActionList &Inputs, types::ID Type, const clang::driver::ToolChain *TC)
+    : JobAction(OffloadPackagerExtractJobClass, Inputs, Type),
+      OPEToolChain(TC) {}
 
 void OffloadDepsJobAction::anchor() {}
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7122,8 +7122,7 @@ static void extractPCH(bool UseNewOffloadingDriver,
                        OffloadingActionBuilder *OAB, Compilation &C,
                        DerivedArgList &Args, ActionList &AL,
                        const ToolChain *TC, const Arg *MainArg) {
-  if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
-      !Args.hasArg(options::OPT_offload_targets_EQ))
+  if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false))
     return;
 
   bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7114,15 +7114,14 @@ shouldBundleHIPAsmWithNewDriver(const Compilation &C,
   return HasAMDGCNHIPDevice;
 }
 
-/// This routine unbundles individual PCH files from a fat PCH bundle.
+/// This routine extracts individual PCH files from a fat PCH bundle.
 /// In the old offloading driver model, this routine invokes the clang
 /// offload bundler; in the new offloading driver model, it invokes the
 /// llvm offload binary.
-static void unbundlePCH(bool UseNewOffloadingDriver,
-                        OffloadingActionBuilder *OAB, Compilation &C,
-                        DerivedArgList &Args, ActionList &AL,
-                        const ToolChain *TC, const Arg *MainArg) {
-  // Unbundle a fat PCH file.
+static void extractPCH(bool UseNewOffloadingDriver,
+                       OffloadingActionBuilder *OAB, Compilation &C,
+                       DerivedArgList &Args, ActionList &AL,
+                       const ToolChain *TC, const Arg *MainArg) {
   if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
       !Args.hasArg(options::OPT_offload_targets_EQ))
     return;
@@ -7290,10 +7289,10 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     ActionList HIPAsmDeviceActions;
     if (Args.hasArg(options::OPT_include_pch) ||
         Args.getLastArg(options::OPT__SLASH_Yu)) {
-      // Unbundles the fat PCH file for the host.
-      unbundlePCH(UseNewOffloadingDriver, OffloadBuilder.get(), C, Args,
-                  Actions, /*ToolChain=*/nullptr,
-                  UseNewOffloadingDriver ? nullptr : InputArg);
+      // Extracts the fat PCH file for the host.
+      extractPCH(UseNewOffloadingDriver, OffloadBuilder.get(), C, Args,
+                 Actions, /*ToolChain=*/nullptr,
+                 UseNewOffloadingDriver ? nullptr : InputArg);
     }
 
     // Use the current host action in any of the offloading actions, if
@@ -7975,7 +7974,7 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
     if (isIncludePCHArg || isYuArg) {
       for (auto *TCAndArch = TCAndArchs.begin(); TCAndArch != TCAndArchs.end();
            ++TCAndArch) {
-        unbundlePCH(/*Offloading New Driver=*/true, /*Builder=*/nullptr, C,
+        extractPCH(/*Offloading New Driver=*/true, /*Builder=*/nullptr, C,
                     Args, OffloadActions, TCAndArch->first, nullptr);
       }
     }
@@ -10065,7 +10064,7 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     StringRef Name = llvm::sys::path::filename(BaseInput);
     std::pair<StringRef, StringRef> Split = Name.split('.');
     const char *Suffix =
-        types::getTypeTempSuffix(JA.getType(), IsCLMode() || IsDXCMode());
+        types::getTypeTempSuffix(JA.getType(), IsCLMode());
     return CreateTempFile(C, Split.first, Suffix, MultipleArchs, BoundArch,
                           JA.getType(), false);
   }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7290,8 +7290,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     if (Args.hasArg(options::OPT_include_pch) ||
         Args.getLastArg(options::OPT__SLASH_Yu)) {
       // Extracts the fat PCH file for the host.
-      extractPCH(UseNewOffloadingDriver, OffloadBuilder.get(), C, Args,
-                 Actions, /*ToolChain=*/nullptr,
+      extractPCH(UseNewOffloadingDriver, OffloadBuilder.get(), C, Args, Actions,
+                 /*ToolChain=*/nullptr,
                  UseNewOffloadingDriver ? nullptr : InputArg);
     }
 
@@ -7974,8 +7974,8 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
     if (isIncludePCHArg || isYuArg) {
       for (auto *TCAndArch = TCAndArchs.begin(); TCAndArch != TCAndArchs.end();
            ++TCAndArch) {
-        extractPCH(/*Offloading New Driver=*/true, /*Builder=*/nullptr, C,
-                    Args, OffloadActions, TCAndArch->first, nullptr);
+        extractPCH(/*Offloading New Driver=*/true, /*Builder=*/nullptr, C, Args,
+                   OffloadActions, TCAndArch->first, nullptr);
       }
     }
 
@@ -10063,8 +10063,7 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
       isa<OffloadPackagerExtractJobAction>(JA) && !SaveTempsEnabled) {
     StringRef Name = llvm::sys::path::filename(BaseInput);
     std::pair<StringRef, StringRef> Split = Name.split('.');
-    const char *Suffix =
-        types::getTypeTempSuffix(JA.getType(), IsCLMode());
+    const char *Suffix = types::getTypeTempSuffix(JA.getType(), IsCLMode());
     return CreateTempFile(C, Split.first, Suffix, MultipleArchs, BoundArch,
                           JA.getType(), false);
   }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7114,6 +7114,58 @@ shouldBundleHIPAsmWithNewDriver(const Compilation &C,
   return HasAMDGCNHIPDevice;
 }
 
+/// This routine unbundles individual PCH files from a fat PCH bundle.
+/// In the old offloading driver model, this routine invokes the clang
+/// offload bundler; in the new offloading driver model, it invokes the
+/// llvm offload binary.
+static void unbundlePCH(bool UseNewOffloadingDriver,
+                        OffloadingActionBuilder *OAB, Compilation &C,
+                        DerivedArgList &Args, ActionList &AL,
+                        const ToolChain *TC, const Arg *MainArg) {
+  // Unbundle a fat PCH file.
+  if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
+      !Args.hasArg(options::OPT_offload_targets_EQ))
+    return;
+
+  bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);
+  bool isYuArg = Args.hasArg(options::OPT__SLASH_Yu);
+  assert((isIncludePCHArg || isYuArg) && "Invalid PCH unbundle");
+  SmallString<128> PCHArgValue;
+  if (isIncludePCHArg)
+    PCHArgValue = Args.getLastArg(options::OPT_include_pch)->getValue();
+  else {
+    // /Yu accepts a header file as its argument.
+    PCHArgValue = Args.getLastArg(options::OPT__SLASH_Yu)->getValue();
+    llvm::sys::path::replace_extension(PCHArgValue, "pch");
+  }
+
+  Arg *InputArg = makeInputArg(Args, C.getDriver().getOpts(),
+                               Args.MakeArgString(PCHArgValue));
+  Action *A = C.MakeAction<InputAction>(*InputArg, types::TY_PCH);
+  if (!UseNewOffloadingDriver) {
+    assert(OAB && "Non-null builder expected in the old offload driver model");
+    auto UnbundlingHostAction =
+        C.MakeAction<OffloadUnbundlingJobAction>(A, A->getType());
+    UnbundlingHostAction->registerDependentActionInfo(
+        C.getSingleOffloadToolChain<Action::OFK_Host>(),
+        /*BoundArch=*/StringRef(), Action::OFK_Host);
+    OAB->addHostDependenceToDeviceActions(A, MainArg, Args);
+    auto PL = types::getCompilationPhases(types::TY_PCH);
+    OAB->addDeviceDependencesToHostAction(A, MainArg, phases::Compile,
+                                          PL.back(), PL);
+    AL.push_back(A);
+    OffloadAction::DeviceDependences DDep;
+    DDep.add(*UnbundlingHostAction,
+             *C.getSingleOffloadToolChain<Action::OFK_Host>(), nullptr,
+             C.getActiveOffloadKinds());
+  } else {
+    AL.push_back(A);
+    auto PackagerAction =
+        C.MakeAction<OffloadPackagerExtractJobAction>(AL, A->getType(), TC);
+    AL.push_back(PackagerAction);
+  }
+}
+
 void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
                           const InputList &Inputs, ActionList &Actions) const {
   llvm::PrettyStackTraceString CrashInfo("Building compilation actions");
@@ -7141,6 +7193,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     }
     for (auto &I : Inputs) {
       std::string SrcFileName(I.second->getAsString(Args));
+      bool IsHeaderFile =
+          I.first == types::TY_CHeader || I.first == types::TY_CXXHeader;
       if ((I.first == types::TY_PP_C || I.first == types::TY_PP_CXX ||
            types::isSrcFile(I.first))) {
         // Unique ID is generated for source files and preprocessed files.
@@ -7154,7 +7208,10 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       std::string TmpFileNameHeader;
       std::string TmpFileNameFooter;
       auto StemmedSrcFileName = llvm::sys::path::stem(SrcFileName).str();
-      if (IsSaveTemps) {
+      // If we are compiling a header file, the PCH will contain references
+      // to the integration header/footer files.  Those files need to be
+      // accessible at the time of PCH use, so they cannot be temporary.
+      if (IsSaveTemps || IsHeaderFile) {
         TmpFileNameHeader.append(C.getDriver().GetUniquePath(
             OutFileDir.c_str() + StemmedSrcFileName + "-header", "h"));
         TmpFileNameFooter.append(C.getDriver().GetUniquePath(
@@ -7165,17 +7222,24 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
         TmpFileNameFooter =
             C.getDriver().GetTemporaryPath(StemmedSrcFileName + "-footer", "h");
       }
+      // Also, do not add the integration files to the removal list.
       StringRef TmpFileHeader =
-          C.addTempFile(C.getArgs().MakeArgString(TmpFileNameHeader));
+          IsHeaderFile
+              ? C.getArgs().MakeArgString(TmpFileNameHeader)
+              : C.addTempFile(C.getArgs().MakeArgString(TmpFileNameHeader));
       StringRef TmpFileFooter =
-          C.addTempFile(C.getArgs().MakeArgString(TmpFileNameFooter));
+          IsHeaderFile
+              ? C.getArgs().MakeArgString(TmpFileNameFooter)
+              : C.addTempFile(C.getArgs().MakeArgString(TmpFileNameFooter));
       // Use of -fsycl-footer-path puts the integration footer into that
       // specified location.
       if (Arg *A = C.getArgs().getLastArg(options::OPT_fsycl_footer_path_EQ)) {
         SmallString<128> OutName(A->getValue());
         llvm::sys::path::append(OutName,
                                 llvm::sys::path::filename(TmpFileNameFooter));
-        TmpFileFooter = C.addTempFile(C.getArgs().MakeArgString(OutName));
+        TmpFileFooter = IsHeaderFile
+                            ? C.getArgs().MakeArgString(OutName)
+                            : C.addTempFile(C.getArgs().MakeArgString(OutName));
       }
       addIntegrationFiles(TmpFileHeader, TmpFileFooter, SrcFileName);
     }
@@ -7224,6 +7288,13 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     }
 
     ActionList HIPAsmDeviceActions;
+    if (Args.hasArg(options::OPT_include_pch) ||
+        Args.getLastArg(options::OPT__SLASH_Yu)) {
+      // Unbundles the fat PCH file for the host.
+      unbundlePCH(UseNewOffloadingDriver, OffloadBuilder.get(), C, Args,
+                  Actions, /*ToolChain=*/nullptr,
+                  UseNewOffloadingDriver ? nullptr : InputArg);
+    }
 
     // Use the current host action in any of the offloading actions, if
     // required.
@@ -7839,7 +7910,8 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
   // preprocessing only ignore embedding.  When needing to do bundling for
   // SYCL, allow the building of offloading actions to add the device side to
   // the bundle.
-  if (!(isa<CompileJobAction>(HostAction) || SYCLBundleFile ||
+  if (!(isa<CompileJobAction>(HostAction) ||
+        isa<PrecompileJobAction>(HostAction) || SYCLBundleFile ||
         getFinalPhase(Args) == phases::Preprocess))
     return HostAction;
 
@@ -7849,6 +7921,7 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
   const Action::OffloadKind OffloadKinds[] = {
       Action::OFK_OpenMP, Action::OFK_Cuda, Action::OFK_HIP, Action::OFK_SYCL};
 
+  SmallVector<std::pair<const ToolChain *, StringRef>> TCAndArchs;
   for (Action::OffloadKind Kind : OffloadKinds) {
     SmallVector<const ToolChain *, 2> ToolChains;
     ActionList DeviceActions;
@@ -7869,7 +7942,6 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
       continue;
 
     // Get the product of all bound architectures and toolchains.
-    SmallVector<std::pair<const ToolChain *, StringRef>> TCAndArchs;
     for (const ToolChain *TC : ToolChains) {
       for (StringRef Arch : getOffloadArchs(C, C.getArgs(), Kind, *TC)) {
         TCAndArchs.push_back(std::make_pair(TC, Arch));
@@ -7894,6 +7966,17 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
         }
         DeviceActions.push_back(
             C.MakeAction<InputAction>(*InputArg, InputType, CUID));
+      }
+    }
+
+    // Unbundle the fat PCH files for the offloading devices.
+    bool isIncludePCHArg = Args.hasArg(options::OPT_include_pch);
+    bool isYuArg = Args.hasArg(options::OPT__SLASH_Yu);
+    if (isIncludePCHArg || isYuArg) {
+      for (auto *TCAndArch = TCAndArchs.begin(); TCAndArch != TCAndArchs.end();
+           ++TCAndArch) {
+        unbundlePCH(/*Offloading New Driver=*/true, /*Builder=*/nullptr, C,
+                    Args, OffloadActions, TCAndArch->first, nullptr);
       }
     }
 
@@ -8071,6 +8154,41 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
     DDep.add(*LinkAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
              nullptr, C.getActiveOffloadKinds());
     return C.MakeAction<OffloadAction>(DDep, types::TY_Nothing);
+  } else if (C.isOffloadingHostKind(Action::OFK_SYCL) &&
+             isa<PrecompileJobAction>(HostAction)) {
+    // Performing precompilation only. Take the host and device preprocessed
+    // files and package them together.
+    ActionList PackagerActions;
+    // Only add the precompile actions from the device side.  When one is
+    // found, add an additional compilation to generate the integration
+    // header/footer that is used for the host compile.
+    for (auto OA : OffloadActions) {
+      if (const OffloadAction *CurOA = dyn_cast<OffloadAction>(OA)) {
+        CurOA->doOnEachDependence(
+            [&](Action *A, const ToolChain *TC, const char *BoundArch) {
+              assert(TC && "Unknown toolchain");
+              if (isa<PrecompileJobAction>(A)) {
+                PackagerActions.push_back(OA);
+                A->setCannotBeCollapsedWithNextDependentAction();
+                // The input to the compilation job is the precompiled job.
+                // Take that input action (it should be one input) which is
+                // the source file and compile that file to generate the
+                // integration header/footer.
+                ActionList PCHInputs = A->getInputs();
+                assert(PCHInputs.size() == 1 &&
+                       "Single input size to PCH action expected.");
+                Action *CompileAction = C.MakeAction<CompileJobAction>(
+                    PCHInputs.front(), types::TY_Nothing);
+                DDeps.add(*CompileAction, *TC, BoundArch, Action::OFK_SYCL);
+              }
+            });
+      }
+    }
+    PackagerActions.push_back(HostAction);
+    Action *PackagerAction =
+        C.MakeAction<OffloadPackagerJobAction>(PackagerActions, types::TY_PCH);
+    DDeps.add(*PackagerAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
+              nullptr, C.getActiveOffloadKinds());
   } else if (C.isOffloadingHostKind(Action::OFK_SYCL) &&
              isa<PreprocessJobAction>(HostAction) &&
              getFinalPhase(Args) == phases::Preprocess &&
@@ -9843,12 +9961,18 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     }
   }
 
-  // When generating preprocessed files (-E) with offloading enabled, redirect
-  // the output to a properly named output file.
-  if (JA.getType() == types::TY_PP_CXX && isa<OffloadPackagerJobAction>(JA)) {
+  // When generating preprocessed files (-E) or PCH files with offloading
+  // enabled, redirect the output to a properly named output file.
+  if ((JA.getType() == types::TY_PP_CXX || JA.getType() == types::TY_PCH) &&
+      isa<OffloadPackagerJobAction>(JA)) {
     if (Arg *FinalOutput =
             C.getArgs().getLastArg(options::OPT_o, options::OPT__SLASH_o))
       return C.addResultFile(FinalOutput->getValue(), &JA);
+    if (JA.getType() == types::TY_PCH) {
+      SmallString<128> BaseName = llvm::sys::path::filename(BaseInput);
+      llvm::sys::path::replace_extension(BaseName, ".pch");
+      return C.addResultFile(C.getArgs().MakeArgString(BaseName), &JA);
+    }
   }
 
   // Default to writing to stdout?
@@ -9935,6 +10059,17 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
   const bool FoInvalidForOffload =
       HasFo && (!IsHostOffloading || isa<OffloadUnbundlingJobAction>(JA) ||
                 JA.getOffloadingHostActiveKinds() > Action::OFK_Host);
+
+  if (JA.getType() == types::TY_PCH &&
+      isa<OffloadPackagerExtractJobAction>(JA) && !SaveTempsEnabled) {
+    StringRef Name = llvm::sys::path::filename(BaseInput);
+    std::pair<StringRef, StringRef> Split = Name.split('.');
+    const char *Suffix =
+        types::getTypeTempSuffix(JA.getType(), IsCLMode() || IsDXCMode());
+    return CreateTempFile(C, Split.first, Suffix, MultipleArchs, BoundArch,
+                          JA.getType(), false);
+  }
+
   // Output to a temporary file?
   if ((!AtTopLevel && !SaveTempsEnabled && (!HasFo || FoInvalidForOffload)) ||
       CCGenDiagnostics) {
@@ -10144,11 +10279,6 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     }
   }
 
-  // Emit an error if PCH(Pre-Compiled Header) file generation is forced in
-  // -fsycl mode.
-  if (C.getArgs().hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) &&
-      JA.getType() == types::TY_PCH)
-    Diag(clang::diag::err_drv_fsycl_with_pch);
   // As an annoying special case, PCH generation doesn't strip the pathname.
   if (JA.getType() == types::TY_PCH && !IsCLMode()) {
     llvm::sys::path::remove_filename(BasePath);

--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -1542,6 +1542,8 @@ CreateFileHandler(MemoryBuffer &FirstInput,
     return CreateObjectFileHandler(FirstInput, BundlerConfig);
   if (FilesType == "gch")
     return std::make_unique<BinaryFileHandler>(BundlerConfig);
+  if (FilesType == "pch")
+    return std::make_unique<BinaryFileHandler>(BundlerConfig);
   if (FilesType == "ast")
     return std::make_unique<BinaryFileHandler>(BundlerConfig);
   if (FilesTypeIsArchive(FilesType))

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -875,8 +875,6 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
                                     const InputInfo &Output,
                                     const InputInfoList &Inputs) const {
   const bool IsIAMCU = getToolChain().getTriple().isOSIAMCU();
-  bool SYCLDeviceCompilation = JA.isOffloading(Action::OFK_SYCL) &&
-                               JA.isDeviceOffloading(Action::OFK_SYCL);
 
   CheckPreprocessingOptions(D, Args);
 
@@ -1070,15 +1068,17 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
 
     if (YcArg || YuArg) {
       StringRef ThroughHeader = YcArg ? YcArg->getValue() : YuArg->getValue();
-      // If PCH file is available, include it while performing
-      // host compilation (-fsycl-is-host) in SYCL mode (-fsycl).
-      // as well as in non-sycl mode.
-
-      if (!isa<PrecompileJobAction>(JA) && !SYCLDeviceCompilation) {
+      StringRef PCHHeader = ThroughHeader;
+      // If a PCH file is being used, use the unbundled versions for SYCL.
+      if (YuArg && JA.isOffloading(Action::OFK_SYCL))
+        PCHHeader = D.getSYCLPrecompiledHeaderFile(
+            getToolChain().getTriple().getTriple());
+      // If a PCH file is available, include it.
+      if (!isa<PrecompileJobAction>(JA)) {
         CmdArgs.push_back("-include-pch");
         CmdArgs.push_back(Args.MakeArgString(D.GetClPchPath(
-            C, !ThroughHeader.empty()
-                   ? ThroughHeader
+            C, !PCHHeader.empty()
+                   ? PCHHeader
                    : llvm::sys::path::filename(Inputs[0].getBaseInput()))));
       }
 
@@ -1109,7 +1109,17 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
       // so that replace_extension does the right thing.
       P += ".dummy";
       llvm::sys::path::replace_extension(P, "pch");
-      if (D.getVFS().exists(P))
+      // If this is a SYCL compilation, we would have unbundled the PCH
+      // files from the fat binary, so use that instead.
+      if (JA.isOffloading(Action::OFK_SYCL)) {
+        SmallString<128> SYCLPCHFile = D.getSYCLPrecompiledHeaderFile(
+            getToolChain().getTriple().getTriple());
+        if (D.getVFS().exists(SYCLPCHFile)) {
+          P = SYCLPCHFile;
+          FoundPCH = true;
+        }
+      }
+      if (!FoundPCH && D.getVFS().exists(P))
         FoundPCH = true;
 
       if (!FoundPCH) {
@@ -1117,11 +1127,8 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
         llvm::sys::path::replace_extension(P, "gch");
         FoundPCH = gchProbe(D, P.str());
       }
-      // If PCH file is available, include it while performing
-      // host compilation (-fsycl-is-host) in SYCL mode (-fsycl).
-      // as well as in non-sycl mode.
-
-      if (FoundPCH && !SYCLDeviceCompilation) {
+      // If a PCH file is available, include it.
+      if (FoundPCH) {
         if (IsFirstImplicitInclude) {
           A->claim();
           CmdArgs.push_back("-include-pch");
@@ -5768,12 +5775,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         // header file.
         CmdArgs.push_back("-dependency-filter");
         CmdArgs.push_back(Args.MakeArgString(Header));
-
         // Since this is a host compilation and the integration header is
         // included, enable the integration header based diagnostics.
         CmdArgs.push_back("-fsycl-enable-int-header-diags");
       }
-
       StringRef Footer = D.getIntegrationFooter(Input.getBaseInput());
       if (types::getPreprocessedType(Input.getType()) != types::TY_INVALID &&
           !Args.hasArg(options::OPT_fno_sycl_use_footer) && !Footer.empty()) {
@@ -10381,11 +10386,14 @@ void OffloadBundler::ConstructJobMultipleOutputs(
     }
   }
   std::string TargetString(UA.getTargetString());
+  StringRef TargetTriples = Triples;
+  SmallVector<StringRef> Archs;
   if (!TargetString.empty()) {
     // The target string was provided, we will override the defaults and use
     // the string provided.
     SmallString<128> TSTriple("-targets=");
     TSTriple += TargetString;
+    TargetTriples = TargetString;
     CmdArgs.push_back(TCArgs.MakeArgString(TSTriple));
   } else {
     CmdArgs.push_back(TCArgs.MakeArgString(Triples));
@@ -10395,12 +10403,28 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   CmdArgs.push_back(
       TCArgs.MakeArgString(Twine("-input=") + InputFileName));
 
+  /* Save the individual arch triples for PCH. */
+  if (InputType == types::TY_PCH) {
+    auto TripleString = TargetTriples.split('=').second;
+    TripleString.split(Archs, ',');
+    assert(Archs.size() == Outputs.size() &&
+           "expected same number of triples as outputs");
+  }
+
   // Get unbundled files command.
   for (unsigned I = 0; I < Outputs.size(); ++I) {
     SmallString<128> UB;
     UB += "-output=";
-    UB += DepInfo[I].DependentToolChain->getInputFilename(Outputs[I]);
+    std::string IFName =
+        DepInfo[I].DependentToolChain->getInputFilename(Outputs[I]);
+    UB += IFName;
     CmdArgs.push_back(TCArgs.MakeArgString(UB));
+    /* If this is a bundled PCH file, save the triple-filename pair. */
+    if (InputType == types::TY_PCH) {
+      StringRef ArchName = Archs[I].split('-').second;
+      C.getDriver().addSYCLPrecompiledHeaderFiles(
+          TCArgs.MakeArgString(ArchName), TCArgs.MakeArgString(IFName));
+    }
   }
   CmdArgs.push_back("-unbundle");
   CmdArgs.push_back("-allow-missing-bundles");
@@ -10687,6 +10711,9 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Create the inputs to bundle the needed metadata.
   for (const InputInfo &Input : Inputs) {
+    // Do not bundle input PCH files into anything other than a PCH file.
+    if (Output.getType() != types::TY_PCH && Input.getType() == types::TY_PCH)
+      continue;
     const Action *OffloadAction = Input.getAction();
     const ToolChain *TC = OffloadAction->getOffloadingToolChain();
     if (!TC)
@@ -10807,7 +10834,12 @@ void OffloadPackagerExtract::ConstructJob(Compilation &C, const JobAction &JA,
                                           const char *LinkingOutput) const {
   ArgStringList CmdArgs;
   const Action *OffloadAction = Inputs[0].getAction();
-  const ToolChain *TC = OffloadAction->getOffloadingToolChain();
+  assert(isa<OffloadPackagerExtractJobAction>(JA) &&
+         "unexpected job action in OffloadPackagerExtract.");
+  const ToolChain *TC =
+      Output.getType() == types::TY_PCH
+          ? cast<OffloadPackagerExtractJobAction>(JA).getToolChain()
+          : OffloadAction->getOffloadingToolChain();
   if (!TC)
     TC = &C.getDefaultToolChain();
   const ArgList &TCArgs =
@@ -10835,6 +10867,12 @@ void OffloadPackagerExtract::ConstructJob(Compilation &C, const JobAction &JA,
       "kind=" + Kind.str(),
   };
   CmdArgs.push_back(Args.MakeArgString("--image=" + llvm::join(Parts, ",")));
+
+  if (Inputs[0].getType() == types::TY_PCH) {
+    C.getDriver().addSYCLPrecompiledHeaderFiles(
+        TCArgs.MakeArgString(TC->getTripleString().data()),
+        TCArgs.MakeArgString(File.str()));
+  }
 
   C.addCommand(std::make_unique<Command>(
       JA, *this, ResponseFileSupport::None(),

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1068,13 +1068,13 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
 
     if (YcArg || YuArg) {
       StringRef ThroughHeader = YcArg ? YcArg->getValue() : YuArg->getValue();
-      StringRef PCHHeader = ThroughHeader;
-      // If a PCH file is being used, use the unbundled versions for SYCL.
-      if (YuArg && JA.isOffloading(Action::OFK_SYCL))
-        PCHHeader = D.getSYCLPrecompiledHeaderFile(
-            getToolChain().getTriple().getTriple());
       // If a PCH file is available, include it.
       if (!isa<PrecompileJobAction>(JA)) {
+        StringRef PCHHeader = ThroughHeader;
+        // If a PCH file is being used, use the extracted versions for SYCL.
+        if (YuArg && JA.isOffloading(Action::OFK_SYCL))
+          PCHHeader = D.getSYCLPrecompiledHeaderFile(
+              getToolChain().getTriple().getTriple());
         CmdArgs.push_back("-include-pch");
         CmdArgs.push_back(Args.MakeArgString(D.GetClPchPath(
             C, !PCHHeader.empty()
@@ -1109,7 +1109,7 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
       // so that replace_extension does the right thing.
       P += ".dummy";
       llvm::sys::path::replace_extension(P, "pch");
-      // If this is a SYCL compilation, we would have unbundled the PCH
+      // If this is a SYCL compilation, we would have extracted the PCH
       // files from the fat binary, so use that instead.
       if (JA.isOffloading(Action::OFK_SYCL)) {
         SmallString<128> SYCLPCHFile = D.getSYCLPrecompiledHeaderFile(
@@ -10403,7 +10403,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
   CmdArgs.push_back(
       TCArgs.MakeArgString(Twine("-input=") + InputFileName));
 
-  /* Save the individual arch triples for PCH. */
+  // Save the individual arch triples for PCH.
   if (InputType == types::TY_PCH) {
     auto TripleString = TargetTriples.split('=').second;
     TripleString.split(Archs, ',');
@@ -10419,7 +10419,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
         DepInfo[I].DependentToolChain->getInputFilename(Outputs[I]);
     UB += IFName;
     CmdArgs.push_back(TCArgs.MakeArgString(UB));
-    /* If this is a bundled PCH file, save the triple-filename pair. */
+    // If this is a bundled PCH file, save the triple-filename pair.
     if (InputType == types::TY_PCH) {
       StringRef ArchName = Archs[I].split('-').second;
       C.getDriver().addSYCLPrecompiledHeaderFiles(

--- a/clang/test/Driver/sycl-pch-create.cpp
+++ b/clang/test/Driver/sycl-pch-create.cpp
@@ -78,7 +78,7 @@
 // WS_CREATE_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
 // WS_CREATE_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"
 
-// RUN: %clang_cl -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_TARGETS %s
+// RUN: %clang_cl -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h -### -- %s 2>&1 | FileCheck -check-prefix=WS_CREATE_TARGETS %s
 // WS_CREATE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
 // WS_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
 // WS_CREATE_TARGETS-SAME: "-o" "[[PCHFILE1:.+pch]]"
@@ -92,7 +92,7 @@
 // WS_CREATE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
 // WS_CREATE_TARGETS: "-targets=sycl-spir64{{.*}},sycl-spir64_gen{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]" "-input=[[PCHFILE3]]"
 
-// RUN: %clang_cl --offload-new-driver -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_TARGETS_OND %s
+// RUN: %clang_cl --offload-new-driver -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h -### -- %s 2>&1 | FileCheck -check-prefix=WS_CREATE_TARGETS_OND %s
 // WS_CREATE_TARGETS_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
 // WS_CREATE_TARGETS_OND-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
 // WS_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"

--- a/clang/test/Driver/sycl-pch-create.cpp
+++ b/clang/test/Driver/sycl-pch-create.cpp
@@ -1,0 +1,107 @@
+// This test checks that a PCH(Precompiled Header) file is
+// created while performing host and device compilations in
+// -fsycl mode.
+
+// RUN: echo "// Header file" > %t.h
+
+// Linux
+// RUN: %clang -fsycl -x c++-header -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE %s
+// LX_CREATE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE-SAME: "-include-internal-header" "[[HEADER1]]"
+// LX_CREATE-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// LX_CREATE-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE: clang-offload-bundler{{.*}} "-type=pch"
+// LX_CREATE: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
+
+// RUN: %clang --offload-new-driver -fsycl -x c++-header -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_OND %s
+// LX_CREATE_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_OND-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_OND-SAME: "-include-internal-header" "[[HEADER1]]"
+// LX_CREATE_OND-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// LX_CREATE_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// LX_CREATE_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"
+
+// RUN: %clang -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h -### 2>&1 | FileCheck -check-prefix=LX_CREATE_TARGETS %s
+// LX_CREATE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_TARGETS-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1]]"{{.*}} "-fsycl-int-footer=[[FOOTER1]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_TARGETS-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_TARGETS-SAME: "-include-internal-header" "[[HEADER1]]"
+// LX_CREATE_TARGETS-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// LX_CREATE_TARGETS-SAME: "-o" "[[PCHFILE3:.+pch]]"
+// LX_CREATE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
+// LX_CREATE_TARGETS: "-targets=sycl-spir64{{.*}},sycl-spir64_gen{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]" "-input=[[PCHFILE3]]"
+
+// RUN: %clang --offload-new-driver -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h -### 2>&1 | FileCheck -check-prefix=LX_CREATE_TARGETS_OND %s
+// LX_CREATE_TARGETS_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_TARGETS_OND-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_TARGETS_OND: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_TARGETS_OND-SAME: "-fsycl-int-header=[[HEADER1]]"{{.*}} "-fsycl-int-footer=[[FOOTER1]]"{{.*}} "-sycl-std=2020"
+// LX_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_TARGETS_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_TARGETS_OND-SAME: "-include-internal-header" "[[HEADER1]]"
+// LX_CREATE_TARGETS_OND-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// LX_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE3:.+pch]]"
+// LX_CREATE_TARGETS_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// LX_CREATE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}" "--image=file=[[PCHFILE3]]{{.*}}"
+
+// Windows
+// RUN: %clang_cl -fsycl -x c++-header %t.h -### 2>&1 | FileCheck -check-prefix=WS_CREATE %s
+// WS_CREATE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE-SAME: "-include-internal-header" "[[HEADER1]]"
+// WS_CREATE-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// WS_CREATE-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE: clang-offload-bundler{{.*}} "-type=pch"
+// WS_CREATE: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
+//
+// RUN: %clang_cl --offload-new-driver -fsycl -x c++-header %t.h -### 2>&1 | FileCheck -check-prefix=WS_CREATE_OND %s
+// WS_CREATE_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_OND-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_OND-SAME: "-include-internal-header" "[[HEADER1]]"
+// WS_CREATE_OND-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// WS_CREATE_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// WS_CREATE_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"
+
+// RUN: %clang_cl -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_TARGETS %s
+// WS_CREATE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_TARGETS-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_TARGETS-SAME: "-fsycl-int-header=[[HEADER1]]"{{.*}} "-fsycl-int-footer=[[FOOTER1]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_TARGETS-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_TARGETS-SAME: "-include-internal-header" "[[HEADER1]]"
+// WS_CREATE_TARGETS-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// WS_CREATE_TARGETS-SAME: "-o" "[[PCHFILE3:.+pch]]"
+// WS_CREATE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
+// WS_CREATE_TARGETS: "-targets=sycl-spir64{{.*}},sycl-spir64_gen{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]" "-input=[[PCHFILE3]]"
+
+// RUN: %clang_cl --offload-new-driver -fsycl -x c++-header -fsycl-targets=spir64,spir64_gen -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_TARGETS_OND %s
+// WS_CREATE_TARGETS_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_TARGETS_OND-SAME: "-fsycl-int-header=[[HEADER1:.+\.h]]"{{.*}} "-fsycl-int-footer=[[FOOTER1:.+\.h]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_TARGETS_OND: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_TARGETS_OND-SAME: "-fsycl-int-header=[[HEADER1]]"{{.*}} "-fsycl-int-footer=[[FOOTER1]]"{{.*}} "-sycl-std=2020"
+// WS_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_TARGETS_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_TARGETS_OND-SAME: "-include-internal-header" "[[HEADER1]]"
+// WS_CREATE_TARGETS_OND-SAME: "-include-internal-footer" "[[FOOTER1]]"
+// WS_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE3:.+pch]]"
+// WS_CREATE_TARGETS_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// WS_CREATE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}" "--image=file=[[PCHFILE3]]{{.*}}"

--- a/clang/test/Driver/sycl-pch-error.cpp
+++ b/clang/test/Driver/sycl-pch-error.cpp
@@ -1,19 +1,22 @@
-// This test checks that an error is emitted when 
-// PCH(Precompiled Header) file generation is forced in -fsycl mode.
+// This test checks that an error is emitted when
+// an invalid PCH(Precompiled Header) file is used in -fsycl mode.
 
 // RUN: touch %t.h
 
 // Linux
-// RUN: not %clang -c -fsycl -x c++-header %t.h -###  %s 2> %t1.txt
+// RUN: not %clang -c -fsycl -include-pch %t.h %s 2> %t1.txt
 // RUN: FileCheck %s -input-file=%t1.txt
-// CHECK: precompiled header generation is not supported with '-fsycl'
+// CHECK: input is not a PCH file
+//
+// RUN: not %clang --offload-new-driver -c -fsycl -include-pch %t.h %s 2> %t1.txt
+// RUN: FileCheck -check-prefix=CHECK-OND %s -input-file=%t1.txt
+// CHECK-OND: input is not a PCH file
 
 // Windows
-// RUN: not %clang_cl -c -fsycl -x c++-header %t.h -### -- %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-ERROR %s
-// CHECK-ERROR: precompiled header generation is not supported with '-fsycl'
-
-// /Yc
-// RUN: not %clang_cl -fsycl /Ycpchfile.h /FIpchfile.h /c -### -- %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-YC %s
-// CHECK-YC: precompiled header generation is not supported with '-fsycl'
+// /Yu
+// RUN: not %clang_cl -fsycl /Yu%t.h /c -- %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-YU %s
+// CHECK-YU: {{[Nn]}}o such file or directory
+// RUN: not %clang_cl --offload-new-driver -fsycl /Yu%t.h /c -- %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-YU-OND %s
+// CHECK-YU-OND: {{[Nn]}}o such file or directory

--- a/clang/test/Driver/sycl-pch-inlude.cpp
+++ b/clang/test/Driver/sycl-pch-inlude.cpp
@@ -1,5 +1,6 @@
-// This test checks that a PCH(Precompiled Header) file is 
-// included while performing host compilation in -fsycl mode.
+// This test checks that a PCH(Precompiled Header) file is
+// included while performing host and device compilation in
+// -fsycl mode.
 
 // RUN: touch %t.h
 
@@ -11,7 +12,7 @@
 // RUN: %clang -fsycl -include %t.h -###  %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHECK-SYCL-HOST,CHECK-SYCL-DEVICE %s
 // CHECK-SYCL-DEVICE: -fsycl-is-device
-// CHECK-SYCL-DEVICE-NOT: -include-pch
+// CHECK-SYCL-DEVICE-SAME: -include-pch
 // CHECK-SYCL-HOST: -fsycl-is-host
 // CHECK-SYCL-HOST-SAME: -include-pch
 
@@ -20,7 +21,7 @@
 // RUN: %clang -fsycl -include-pch %t.h.gch -###  %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHECK-PCH-HOST,CHECK-PCH-DEVICE %s
 // CHECK-PCH-DEVICE: -fsycl-is-device
-// CHECK-PCH-DEVICE-NOT: -include-pch
+// CHECK-PCH-DEVICE-SAME: -include-pch
 // CHECK-PCH-HOST: -fsycl-is-host
 // CHECK-PCH-HOST-SAME: -include-pch
 
@@ -28,6 +29,6 @@
 // RUN: %clang_cl -fsycl --target=x86_64-unknown-linux-gnu /Yupchfile.h /FIpchfile.h -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHECK-YU-HOST,CHECK-YU-DEVICE %s
 // CHECK-YU-DEVICE: -fsycl-is-device
-// CHECK-YU-DEVICE-NOT: -include-pch 
+// CHECK-YU-DEVICE-SAME: -include-pch
 // CHECK-YU-HOST: -fsycl-is-host
 // CHECK-YU-HOST-SAME: -include-pch

--- a/clang/test/Driver/sycl-pch-inlude.cpp
+++ b/clang/test/Driver/sycl-pch-inlude.cpp
@@ -26,7 +26,7 @@
 // CHECK-PCH-HOST-SAME: -include-pch
 
 // Windows
-// RUN: %clang_cl -fsycl --target=x86_64-unknown-linux-gnu /Yupchfile.h /FIpchfile.h -### %s 2>&1 \
+// RUN: %clang_cl -fsycl --target=x86_64-unknown-linux-gnu /Yupchfile.h /FIpchfile.h -### -- %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=CHECK-YU-HOST,CHECK-YU-DEVICE %s
 // CHECK-YU-DEVICE: -fsycl-is-device
 // CHECK-YU-DEVICE-SAME: -include-pch

--- a/clang/test/Driver/sycl-pch-use.cpp
+++ b/clang/test/Driver/sycl-pch-use.cpp
@@ -1,0 +1,99 @@
+// This test checks that a PCH(Precompiled Header) file is 
+// used while performing host and device compilations in
+// -fsycl mode.
+
+// RUN: echo "" > %t.h
+// RUN: %clang -c -x c++-header %t.h
+
+// Linux
+// RUN: %clang -fsycl -c -include-pch %t.h.pch %s -### 2>&1 | FileCheck -check-prefix=LX_USE %s
+// LX_USE: clang-offload-bundler{{.*}} "-type=pch"
+// LX_USE-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE1:.+\.pch]]" "-output=[[PCHFILE2:.+\.pch]]" "-unbundle"
+// LX_USE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// LX_USE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_USE-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
+// RUN: %clang --offload-new-driver -fsycl -c -include-pch %t.h.pch %s -### 2>&1 | FileCheck -check-prefix=LX_USE_OND %s
+// LX_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// LX_USE_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
+// LX_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"
+// LX_USE_OND-SAME: "--image=file=[[PCHFILE2:.+\.pch]],triple=spir64{{.*}},arch=generic,kind=sycl"
+// LX_USE_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_OND-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// LX_USE_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_USE_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
+// RUN: %clang -fsycl -c -include-pch %t.h.pch -fsycl-targets=spir64,spir64_gen %s -### 2>&1 | FileCheck -check-prefix=LX_USE_TARGETS %s
+// LX_USE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
+// LX_USE_TARGETS-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}},sycl-spir64_gen{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE3:.+\.pch]]" "-output=[[PCHFILE4:.+\.pch]]" "-output=[[PCHFILE5:.+\.pch]]" "-unbundle"
+// LX_USE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE4]]"{{.*}}
+// LX_USE_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE5]]"{{.*}}
+// LX_USE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+
+// RUN: %clang --offload-new-driver -fsycl -c -include-pch %t.h.pch -fsycl-targets=spir64,spir64_gen %s -### 2>&1 | FileCheck -check-prefix=LX_USE_TARGETS_OND %s
+// LX_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// LX_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
+// LX_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// LX_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE2:.+\.pch]],triple=spir64{{.*}},arch=generic,kind=sycl"
+// LX_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// LX_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE3:.+\.pch]],triple=spir64_gen{{.*}},arch=generic,kind=sycl"
+// LX_USE_TARGETS_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// LX_USE_TARGETS_OND: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+// LX_USE_TARGETS_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
+// Windows
+// RUN: %clang_cl -fsycl -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE %s
+// WS_USE: clang-offload-bundler{{.*}} "-type=pch"
+// WS_USE-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE1:.+\.pch]]" "-output=[[PCHFILE2:.+\.pch]]" "-unbundle"
+// WS_USE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// WS_USE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
+// RUN: %clang_cl --offload-new-driver -fsycl -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_OND %s
+// WS_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// WS_USE_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
+// WS_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"
+// WS_USE_OND-SAME: "--image=file=[[PCHFILE2:.+\.pch]],triple=spir64{{.*}},arch=generic,kind=sycl"
+// WS_USE_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_OND-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// WS_USE_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+
+// Windows
+// RUN: %clang_cl -fsycl -fsycl-targets=spir64,spir64_gen -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_TARGETS %s
+// WS_USE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
+// WS_USE_TARGETS-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}},sycl-spir64_gen{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE3:.+\.pch]]" "-output=[[PCHFILE4:.+\.pch]]" "-output=[[PCHFILE5:.+\.pch]]" "-unbundle"
+// WS_USE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE4]]"{{.*}}
+// WS_USE_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE5]]"{{.*}}
+// WS_USE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+
+// RUN: %clang_cl --offload-new-driver -fsycl -fsycl-targets=spir64,spir64_gen -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_TARGETS_OND %s
+// WS_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
+// WS_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
+// WS_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"
+// WS_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE2:.+\.pch]],triple=spir64{{.*}},arch=generic,kind=sycl"
+// WS_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"
+// WS_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE3:.+\.pch]],triple=spir64_gen{{.*}},arch=generic,kind=sycl"
+// WS_USE_TARGETS_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// WS_USE_TARGETS_OND: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+// WS_USE_TARGETS_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
+// WS_USE_TARGETS_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS_TARGETS-SAME: "-include-pch" "[[PCHFILE2]]"{{.*}}
+// WS_USE_TARGETS_TARGETS: clang{{.*}} "-triple" "spir64_gen{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_USE_TARGETS_TARGETS-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
+// WS_USE_TARGETS_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_USE_TARGETS_TARGETS-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}

--- a/clang/test/Driver/sycl-pch-use.cpp
+++ b/clang/test/Driver/sycl-pch-use.cpp
@@ -2,8 +2,7 @@
 // used while performing host and device compilations in
 // -fsycl mode.
 
-// RUN: echo "" > %t.h
-// RUN: %clang -c -x c++-header %t.h
+// RUN: touch %t.h.pch
 
 // Linux
 // RUN: %clang -fsycl -c -include-pch %t.h.pch %s -### 2>&1 | FileCheck -check-prefix=LX_USE %s

--- a/clang/test/Driver/sycl-pch-use.cpp
+++ b/clang/test/Driver/sycl-pch-use.cpp
@@ -49,7 +49,7 @@
 // LX_USE_TARGETS_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
 
 // Windows
-// RUN: %clang_cl -fsycl -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE %s
+// RUN: %clang_cl -fsycl -c /Yu%t.h -### -- %s 2>&1 | FileCheck -check-prefix=WS_USE %s
 // WS_USE: clang-offload-bundler{{.*}} "-type=pch"
 // WS_USE-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE1:.+\.pch]]" "-output=[[PCHFILE2:.+\.pch]]" "-unbundle"
 // WS_USE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
@@ -57,7 +57,7 @@
 // WS_USE: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
 // WS_USE-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
 
-// RUN: %clang_cl --offload-new-driver -fsycl -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_OND %s
+// RUN: %clang_cl --offload-new-driver -fsycl -c /Yu%t.h -### -- %s 2>&1 | FileCheck -check-prefix=WS_USE_OND %s
 // WS_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
 // WS_USE_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
 // WS_USE_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"
@@ -68,7 +68,7 @@
 // WS_USE_OND-SAME: "-include-pch" "[[PCHFILE1]]"{{.*}}
 
 // Windows
-// RUN: %clang_cl -fsycl -fsycl-targets=spir64,spir64_gen -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_TARGETS %s
+// RUN: %clang_cl -fsycl -fsycl-targets=spir64,spir64_gen -c /Yu%t.h -### -- %s 2>&1 | FileCheck -check-prefix=WS_USE_TARGETS %s
 // WS_USE_TARGETS: clang-offload-bundler{{.*}} "-type=pch"
 // WS_USE_TARGETS-SAME: "-targets=host-x86_64{{.*}},sycl-spir64{{.*}},sycl-spir64_gen{{.*}}" "-input=[[MAINPCHFILE:.+\.pch]]" "-output=[[PCHFILE3:.+\.pch]]" "-output=[[PCHFILE4:.+\.pch]]" "-output=[[PCHFILE5:.+\.pch]]" "-unbundle"
 // WS_USE_TARGETS: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
@@ -78,7 +78,7 @@
 // WS_USE_TARGETS: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
 // WS_USE_TARGETS-SAME: "-include-pch" "[[PCHFILE3]]"{{.*}}
 
-// RUN: %clang_cl --offload-new-driver -fsycl -fsycl-targets=spir64,spir64_gen -c /Yu%t.h %s -### 2>&1 | FileCheck -check-prefix=WS_USE_TARGETS_OND %s
+// RUN: %clang_cl --offload-new-driver -fsycl -fsycl-targets=spir64,spir64_gen -c /Yu%t.h -### -- %s 2>&1 | FileCheck -check-prefix=WS_USE_TARGETS_OND %s
 // WS_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE:.+\.pch]]"
 // WS_USE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1:.+\.pch]],triple=x86_64{{.*}},arch=generic,kind=host"
 // WS_USE_TARGETS_OND: llvm-offload-binary{{.*}} "[[MAINPCHFILE]]"

--- a/sycl/test/basic_tests/head.hpp
+++ b/sycl/test/basic_tests/head.hpp
@@ -1,0 +1,3 @@
+#include <cassert>
+#include <iostream>
+#include <sycl/sycl.hpp>

--- a/sycl/test/basic_tests/pch.cpp
+++ b/sycl/test/basic_tests/pch.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang -fsycl -c -x c++-header %S/head.hpp -o %S/head.pch
+// RUN: %clang -fsycl -c -include-pch %S/head.pch %s
+
+// RUN: %clang --offload-new-driver -fsycl -c -x c++-header %S/head.hpp -o %S/head.pch
+// RUN: %clang --offload-new-driver -fsycl -c -include-pch %S/head.pch %s
+
+// Verify a PCH file created from the header file can be
+// successfully included in a source file compilation.
+
+// expected-no-diagnostics
+
+#include "head.hpp"
+
+using namespace std;
+int main() {
+  sycl::range<3> three_dim_range(64, 1, 2);
+  assert(three_dim_range.size() == 128);
+  cout << "three_dim_range passed " << endl;
+}


### PR DESCRIPTION
Remove the restriction of using PCH with SYCL.

PCH files can be created with:
clang -fsycl -c -x c++-header header.h

This precompiles the header file header.h once for the device target,
and once for the host. The individual pch files generated are then 
bundled to form a fat header.pchi binary.

PCH files can be used with:
clang -fsycl -c -include-pch header.pchi file.cpp

This unbundles the fat header.pchi file into its respective target components
and uses the unbundled pchi files in the device target and host compilations.

In the old offload driver model, clang-offload-bundler is used for bundling and
unbundling; in the new model, llvm-offload-binary is used.