### PR TITLE
[SYCL] Align the kernel class with SYCL2020

### DIFF
--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -83,27 +83,29 @@ public:
 
   kernel() = delete;
 
-  __SYCL2020_DEPRECATED("Not part of any specification")
   kernel(const kernel &RHS) = default;
 
-  __SYCL2020_DEPRECATED("Not part of any specification")
   kernel(kernel &&RHS) = default;
 
-  __SYCL2020_DEPRECATED("Not part of any specification")
   kernel &operator=(const kernel &RHS) = default;
 
-  __SYCL2020_DEPRECATED("Not part of any specification")
   kernel &operator=(kernel &&RHS) = default;
 
-  __SYCL2020_DEPRECATED("Not part of any specification")
-  bool operator==(const kernel &RHS) const {
-    return impl == RHS.impl;
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+  __SYCL2020_DEPRECATED("Deprecated in favor of hidden friend operator==. "
+                        "Rebuild due to ABI-break will be required.")
+  bool operator==(const kernel &RHS) const { return impl == RHS.impl; }
+
+  __SYCL2020_DEPRECATED("Deprecated in favor of hidden friend operator!=. "
+                        "Rebuild due to ABI-break will be required.")
+  bool operator!=(const kernel &RHS) const { return !operator==(RHS); }
+#else
+  friend bool operator==(const &lhs, const T &rhs) {
+    return lhs.impl == rhs.impl;
   }
 
-  __SYCL2020_DEPRECATED("Not part of any specification")
-  bool operator!=(const kernel &RHS) const {
-    return !operator==(RHS);
-  }
+  friend bool operator!=(const T &lhs, const T &rhs) { return !(lhs == rhs); }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Get a valid OpenCL kernel handle
   ///

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -92,12 +92,10 @@ public:
   kernel &operator=(kernel &&RHS) = default;
 
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-  __SYCL2020_DEPRECATED("Deprecated in favor of hidden friend operator==. "
-                        "Rebuild due to ABI-break will be required.")
+  // SYCL 2020 declares hidden friend opearators, see 4.5.2. Common reference
+  // semantics.
   bool operator==(const kernel &RHS) const { return impl == RHS.impl; }
 
-  __SYCL2020_DEPRECATED("Deprecated in favor of hidden friend operator!=. "
-                        "Rebuild due to ABI-break will be required.")
   bool operator!=(const kernel &RHS) const { return !operator==(RHS); }
 #else
   friend bool operator==(const kernel &lhs, const kernel &rhs) {

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -100,11 +100,13 @@ public:
                         "Rebuild due to ABI-break will be required.")
   bool operator!=(const kernel &RHS) const { return !operator==(RHS); }
 #else
-  friend bool operator==(const &lhs, const T &rhs) {
+  friend bool operator==(const kernel &lhs, const kernel &rhs) {
     return lhs.impl == rhs.impl;
   }
 
-  friend bool operator!=(const T &lhs, const T &rhs) { return !(lhs == rhs); }
+  friend bool operator!=(const kernel &lhs, const kernel &rhs) {
+    return !(lhs == rhs);
+  }
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Get a valid OpenCL kernel handle

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -81,17 +81,29 @@ public:
   kernel(cl_kernel ClKernel, const context &SyclContext);
 #endif
 
+  kernel() = delete;
+
+  __SYCL2020_DEPRECATED("Not part of any specification")
   kernel(const kernel &RHS) = default;
 
+  __SYCL2020_DEPRECATED("Not part of any specification")
   kernel(kernel &&RHS) = default;
 
+  __SYCL2020_DEPRECATED("Not part of any specification")
   kernel &operator=(const kernel &RHS) = default;
 
+  __SYCL2020_DEPRECATED("Not part of any specification")
   kernel &operator=(kernel &&RHS) = default;
 
-  bool operator==(const kernel &RHS) const { return impl == RHS.impl; }
+  __SYCL2020_DEPRECATED("Not part of any specification")
+  bool operator==(const kernel &RHS) const {
+    return impl == RHS.impl;
+  }
 
-  bool operator!=(const kernel &RHS) const { return !operator==(RHS); }
+  __SYCL2020_DEPRECATED("Not part of any specification")
+  bool operator!=(const kernel &RHS) const {
+    return !operator==(RHS);
+  }
 
   /// Get a valid OpenCL kernel handle
   ///


### PR DESCRIPTION
Add the constructor & replace undocumented methods in the next ABI-break window.