### PR TITLE
[DEBUG][CI] Capture Windows crash dump + stack for program_manager SEH

### DIFF
--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -198,20 +198,28 @@ jobs:
         $env:SYCL_CONFIG_FILE_NAME = "null.cfg"
         $env:SYCL_DEVICELIB_NO_FALLBACK = "1"
         $env:ONEAPI_DEVICE_SELECTOR = "*:*"
-        # Locate cdb.exe robustly (path/version varies by runner).
+        # Let the access violation propagate instead of gtest swallowing it via
+        # __try/__except, so a debugger / WER actually sees the second-chance AV.
+        $env:GTEST_CATCH_EXCEPTIONS = "0"
+        # Locate cdb.exe; if absent, install the Debugging Tools for Windows.
         $cdb = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits","C:\Program Files\Windows Kits" -Filter cdb.exe -Recurse -ErrorAction SilentlyContinue |
                Where-Object { $_.FullName -match '\\x64\\' } | Select-Object -First 1 -ExpandProperty FullName
         if (-not $cdb) { $cdb = (Get-Command cdb.exe -ErrorAction SilentlyContinue).Source }
+        if (-not $cdb) {
+          Write-Host "cdb not found; installing WinDbg via winget"
+          winget install --id Microsoft.WinDbg --accept-source-agreements --accept-package-agreements --disable-interactivity 2>&1 | Write-Host
+          $cdb = Get-ChildItem -Path "$env:LOCALAPPDATA\Microsoft\WinDbg","C:\Program Files\Windows Kits" -Filter cdb.exe -Recurse -ErrorAction SilentlyContinue |
+                 Where-Object { $_.FullName -match 'amd64|x64' } | Select-Object -First 1 -ExpandProperty FullName
+        }
         Write-Host "cdb = $cdb"
         $exe = "build\tools\sycl\unittests\program_manager\ProgramManagerTests-Non_Preview_Tests.exe"
         New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\crashdumps" | Out-Null
         foreach ($t in @("SubDevices.BuildProgramForSubSubDevices","ImageRemoval.NativePrograms")) {
           Write-Host "=== $t ==="
           if ($cdb) {
-            # -g -G run to exit; on 2nd-chance AV write full dump, print all-thread stacks + modules.
-            & $cdb -g -G -c ".dump /ma $env:GITHUB_WORKSPACE\crashdumps\$t.dmp; kP 200; ~*kP 40; lmv; q" $exe --gtest_filter=$t 2>&1 | Write-Host
+            & $cdb -g -G -c ".dump /ma $env:GITHUB_WORKSPACE\crashdumps\$t.dmp; .ecxr; kP 200; ~*kP 40; lmv; q" $exe --gtest_filter=$t 2>&1 | Write-Host
           } else {
-            Write-Host "cdb not found; running bare (relies on WER LocalDumps)"
+            Write-Host "cdb still not found; running bare (relies on WER LocalDumps)"
             & ".\$exe" --gtest_filter=$t 2>&1 | Write-Host
           }
         }

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -199,30 +199,30 @@ jobs:
         $env:SYCL_DEVICELIB_NO_FALLBACK = "1"
         $env:ONEAPI_DEVICE_SELECTOR = "*:*"
         # Let the access violation propagate instead of gtest swallowing it via
-        # __try/__except, so a debugger / WER actually sees the second-chance AV.
+        # __try/__except, so the debugger sees the second-chance AV.
         $env:GTEST_CATCH_EXCEPTIONS = "0"
-        # Locate cdb.exe; if absent, install the Debugging Tools for Windows.
-        $cdb = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits","C:\Program Files\Windows Kits" -Filter cdb.exe -Recurse -ErrorAction SilentlyContinue |
-               Where-Object { $_.FullName -match '\\x64\\' } | Select-Object -First 1 -ExpandProperty FullName
-        if (-not $cdb) { $cdb = (Get-Command cdb.exe -ErrorAction SilentlyContinue).Source }
-        if (-not $cdb) {
-          Write-Host "cdb not found; installing WinDbg via winget"
-          winget install --id Microsoft.WinDbg --accept-source-agreements --accept-package-agreements --disable-interactivity 2>&1 | Write-Host
-          $cdb = Get-ChildItem -Path "$env:LOCALAPPDATA\Microsoft\WinDbg","C:\Program Files\Windows Kits" -Filter cdb.exe -Recurse -ErrorAction SilentlyContinue |
-                 Where-Object { $_.FullName -match 'amd64|x64' } | Select-Object -First 1 -ExpandProperty FullName
-        }
-        Write-Host "cdb = $cdb"
         $exe = "build\tools\sycl\unittests\program_manager\ProgramManagerTests-Non_Preview_Tests.exe"
-        New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\crashdumps" | Out-Null
+        $dumps = "$env:GITHUB_WORKSPACE\crashdumps"
+        New-Item -ItemType Directory -Force -Path $dumps | Out-Null
+        # No admin (HKLM WER denied) and no winget on this runner. Download
+        # standalone procdump (no install, no admin) to catch the AV + dump.
+        $procdump = "$dumps\procdump64.exe"
+        try {
+          Invoke-WebRequest -Uri "https://live.sysinternals.com/procdump64.exe" -OutFile $procdump -UseBasicParsing
+          Write-Host "procdump downloaded"
+        } catch { Write-Host "procdump download failed: $_" }
         foreach ($t in @("SubDevices.BuildProgramForSubSubDevices","ImageRemoval.NativePrograms")) {
           Write-Host "=== $t ==="
-          if ($cdb) {
-            & $cdb -g -G -c ".dump /ma $env:GITHUB_WORKSPACE\crashdumps\$t.dmp; .ecxr; kP 200; ~*kP 40; lmv; q" $exe --gtest_filter=$t 2>&1 | Write-Host
+          if (Test-Path $procdump) {
+            # -accepteula -ma full dump, -e catch unhandled exception, -x launch target.
+            & $procdump -accepteula -ma -e -x $dumps $exe --gtest_filter=$t 2>&1 | Write-Host
           } else {
-            Write-Host "cdb still not found; running bare (relies on WER LocalDumps)"
+            Write-Host "procdump unavailable; running bare"
             & ".\$exe" --gtest_filter=$t 2>&1 | Write-Host
           }
         }
+        Write-Host "=== dumps produced ==="
+        Get-ChildItem $dumps -Filter *.dmp -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_.FullName $_.Length }
     - name: Upload crash dumps (DEBUG)
       if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -191,19 +191,30 @@ jobs:
         cmake --build build --target check-sycl-unittests
     - name: Capture crashing program_manager test stack (DEBUG)
       if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
-      shell: cmd
+      shell: powershell
       continue-on-error: true
       run: |
-        set "PATH=%GITHUB_WORKSPACE%\build\bin;%PATH%"
-        set SYCL_CONFIG_FILE_NAME=null.cfg
-        set SYCL_DEVICELIB_NO_FALLBACK=1
-        set ONEAPI_DEVICE_SELECTOR=*:*
-        set "CDB=C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe"
-        if not exist "%CDB%" set "CDB=C:\Program Files\Windows Kits\10\Debuggers\x64\cdb.exe"
-        echo === SubDevices.BuildProgramForSubSubDevices ===
-        "%CDB%" -g -G -c "kP 200; ~*kP 50; lm; q" build\tools\sycl\unittests\program_manager\ProgramManagerTests-Non_Preview_Tests.exe --gtest_filter=SubDevices.BuildProgramForSubSubDevices
-        echo === ImageRemoval.NativePrograms ===
-        "%CDB%" -g -G -c "kP 200; ~*kP 50; lm; q" build\tools\sycl\unittests\program_manager\ProgramManagerTests-Non_Preview_Tests.exe --gtest_filter=ImageRemoval.NativePrograms
+        $env:PATH = "$env:GITHUB_WORKSPACE\build\bin;$env:PATH"
+        $env:SYCL_CONFIG_FILE_NAME = "null.cfg"
+        $env:SYCL_DEVICELIB_NO_FALLBACK = "1"
+        $env:ONEAPI_DEVICE_SELECTOR = "*:*"
+        # Locate cdb.exe robustly (path/version varies by runner).
+        $cdb = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits","C:\Program Files\Windows Kits" -Filter cdb.exe -Recurse -ErrorAction SilentlyContinue |
+               Where-Object { $_.FullName -match '\\x64\\' } | Select-Object -First 1 -ExpandProperty FullName
+        if (-not $cdb) { $cdb = (Get-Command cdb.exe -ErrorAction SilentlyContinue).Source }
+        Write-Host "cdb = $cdb"
+        $exe = "build\tools\sycl\unittests\program_manager\ProgramManagerTests-Non_Preview_Tests.exe"
+        New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\crashdumps" | Out-Null
+        foreach ($t in @("SubDevices.BuildProgramForSubSubDevices","ImageRemoval.NativePrograms")) {
+          Write-Host "=== $t ==="
+          if ($cdb) {
+            # -g -G run to exit; on 2nd-chance AV write full dump, print all-thread stacks + modules.
+            & $cdb -g -G -c ".dump /ma $env:GITHUB_WORKSPACE\crashdumps\$t.dmp; kP 200; ~*kP 40; lmv; q" $exe --gtest_filter=$t 2>&1 | Write-Host
+          } else {
+            Write-Host "cdb not found; running bare (relies on WER LocalDumps)"
+            & ".\$exe" --gtest_filter=$t 2>&1 | Write-Host
+          }
+        }
     - name: Upload crash dumps (DEBUG)
       if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -177,10 +177,46 @@ jobs:
       shell: bash
       run: |        
          cmake --build build --target check-sycl
+    - name: Enable Windows crash dumps (DEBUG)
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
+      shell: cmd
+      run: |
+        reg add "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" /v DumpType /t REG_DWORD /d 2 /f
+        reg add "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" /v DumpFolder /t REG_EXPAND_SZ /d "%GITHUB_WORKSPACE%\crashdumps" /f
+        reg add "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" /v DumpCount /t REG_DWORD /d 20 /f
+        if not exist "%GITHUB_WORKSPACE%\crashdumps" mkdir "%GITHUB_WORKSPACE%\crashdumps"
     - name: check-sycl-unittests
       if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
       run: |
         cmake --build build --target check-sycl-unittests
+    - name: Capture crashing program_manager test stack (DEBUG)
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
+      shell: cmd
+      continue-on-error: true
+      run: |
+        set "PATH=%GITHUB_WORKSPACE%\build\bin;%PATH%"
+        set SYCL_CONFIG_FILE_NAME=null.cfg
+        set SYCL_DEVICELIB_NO_FALLBACK=1
+        set ONEAPI_DEVICE_SELECTOR=*:*
+        set "CDB=C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe"
+        if not exist "%CDB%" set "CDB=C:\Program Files\Windows Kits\10\Debuggers\x64\cdb.exe"
+        echo === SubDevices.BuildProgramForSubSubDevices ===
+        "%CDB%" -g -G -c "kP 200; ~*kP 50; lm; q" build\tools\sycl\unittests\program_manager\ProgramManagerTests-Non_Preview_Tests.exe --gtest_filter=SubDevices.BuildProgramForSubSubDevices
+        echo === ImageRemoval.NativePrograms ===
+        "%CDB%" -g -G -c "kP 200; ~*kP 50; lm; q" build\tools\sycl\unittests\program_manager\ProgramManagerTests-Non_Preview_Tests.exe --gtest_filter=ImageRemoval.NativePrograms
+    - name: Upload crash dumps (DEBUG)
+      if: ${{ !cancelled() && contains(inputs.changes, 'sycl') }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: windows_crashdumps
+        path: |
+          crashdumps
+          build/tools/sycl/unittests/program_manager/ProgramManagerTests-Non_Preview_Tests.exe
+          build/tools/sycl/unittests/program_manager/ProgramManagerTests-Non_Preview_Tests.pdb
+          build/bin/sycl?.dll
+          build/bin/sycl?.pdb
+        if-no-files-found: ignore
+        retention-days: ${{ inputs.retention-days }}
     - name: check-llvm-spirv
       if: ${{ !cancelled() && contains(inputs.changes, 'llvm_spirv') }}
       run: |

--- a/sycl/source/detail/adapter_impl.hpp
+++ b/sycl/source/detail/adapter_impl.hpp
@@ -48,7 +48,7 @@ namespace detail {
 /// runtimes for the device-agnostic SYCL runtime.
 ///
 /// \ingroup sycl_ur
-class adapter_impl {
+class adapter_impl : public std::enable_shared_from_this<adapter_impl> {
 public:
   adapter_impl() = delete;
 
@@ -242,10 +242,16 @@ template <typename URResource> class Managed {
 
 public:
   Managed() = default;
-  Managed(URResource R, adapter_impl &Adapter) : R(R), Adapter(&Adapter) {}
-  Managed(adapter_impl &Adapter) : Adapter(&Adapter) {}
+  // The adapter is held by a shared_ptr so that a Managed handle keeps its
+  // owning adapter alive for as long as the handle exists. Otherwise a cached
+  // or in-flight Managed could outlive adapter teardown (unloadAdapters) and
+  // release its UR resource through a freed adapter (a use-after-free that
+  // manifests as a crash calling a null function pointer on Windows).
+  Managed(URResource R, adapter_impl &Adapter)
+      : R(R), Adapter(Adapter.shared_from_this()) {}
+  Managed(adapter_impl &Adapter) : Adapter(Adapter.shared_from_this()) {}
   Managed(const Managed &) = delete;
-  Managed(Managed &&Other) : Adapter(Other.Adapter) {
+  Managed(Managed &&Other) : Adapter(std::move(Other.Adapter)) {
     R = Other.R;
     Other.R = nullptr;
   }
@@ -257,7 +263,7 @@ public:
       Adapter->call<Release>(R);
     R = Temp;
 
-    Adapter = Other.Adapter;
+    Adapter = std::move(Other.Adapter);
     return *this;
   }
 
@@ -300,7 +306,7 @@ public:
 
 private:
   URResource R = nullptr;
-  adapter_impl *Adapter = nullptr;
+  std::shared_ptr<adapter_impl> Adapter = nullptr;
 };
 } // namespace detail
 } // namespace _V1

--- a/sycl/source/detail/adapter_impl.hpp
+++ b/sycl/source/detail/adapter_impl.hpp
@@ -68,7 +68,10 @@ public:
   adapter_impl &operator=(adapter_impl &&other) noexcept = delete;
   adapter_impl(adapter_impl &&other) noexcept = delete;
 
-  ~adapter_impl() = default;
+  ~adapter_impl() {
+    std::cerr << "[ADBG] ~adapter_impl this=" << static_cast<const void *>(this)
+              << std::endl;
+  }
 
   /// \throw SYCL 2020 exception(errc) if ur_result is not UR_RESULT_SUCCESS
   template <sycl::errc errc = sycl::errc::runtime>
@@ -110,6 +113,11 @@ public:
     if (!adapterReleased) {
       detail::UrFuncInfo<UrApiOffset> UrApiInfo;
       auto F = UrApiInfo.getFuncPtr(&UrFuncPtrs);
+      std::cerr << "[ADBG] call_nocheck this="
+                << static_cast<const void *>(this)
+                << " adapterReleased=" << adapterReleased
+                << " name=" << UrApiInfo.getFuncName()
+                << " F=" << reinterpret_cast<const void *>(F) << std::endl;
       R = F(std::forward<ArgsT>(Args)...);
     }
     return R;
@@ -276,6 +284,9 @@ public:
   }
 
   ~Managed() {
+    std::cerr << "[ADBG] ~Managed this=" << static_cast<const void *>(this)
+              << " R=" << static_cast<const void *>(R)
+              << " Adapter=" << static_cast<const void *>(Adapter) << std::endl;
     if (!R)
       return;
 
@@ -288,6 +299,9 @@ public:
 
   Managed retain() {
     assert(R && "Cannot retain unintialized resource!");
+    std::cerr << "[ADBG] retain this=" << static_cast<const void *>(this)
+              << " R=" << static_cast<const void *>(R)
+              << " Adapter=" << static_cast<const void *>(Adapter) << std::endl;
     Adapter->call<Retain>(R);
     return Managed{R, *Adapter};
   }

--- a/sycl/source/detail/adapter_impl.hpp
+++ b/sycl/source/detail/adapter_impl.hpp
@@ -68,10 +68,7 @@ public:
   adapter_impl &operator=(adapter_impl &&other) noexcept = delete;
   adapter_impl(adapter_impl &&other) noexcept = delete;
 
-  ~adapter_impl() {
-    std::cerr << "[ADBG] ~adapter_impl this=" << static_cast<const void *>(this)
-              << std::endl;
-  }
+  ~adapter_impl() = default;
 
   /// \throw SYCL 2020 exception(errc) if ur_result is not UR_RESULT_SUCCESS
   template <sycl::errc errc = sycl::errc::runtime>
@@ -113,11 +110,6 @@ public:
     if (!adapterReleased) {
       detail::UrFuncInfo<UrApiOffset> UrApiInfo;
       auto F = UrApiInfo.getFuncPtr(&UrFuncPtrs);
-      std::cerr << "[ADBG] call_nocheck this="
-                << static_cast<const void *>(this)
-                << " adapterReleased=" << adapterReleased
-                << " name=" << UrApiInfo.getFuncName()
-                << " F=" << reinterpret_cast<const void *>(F) << std::endl;
       R = F(std::forward<ArgsT>(Args)...);
     }
     return R;
@@ -284,9 +276,6 @@ public:
   }
 
   ~Managed() {
-    std::cerr << "[ADBG] ~Managed this=" << static_cast<const void *>(this)
-              << " R=" << static_cast<const void *>(R)
-              << " Adapter=" << static_cast<const void *>(Adapter) << std::endl;
     if (!R)
       return;
 
@@ -299,9 +288,6 @@ public:
 
   Managed retain() {
     assert(R && "Cannot retain unintialized resource!");
-    std::cerr << "[ADBG] retain this=" << static_cast<const void *>(this)
-              << " R=" << static_cast<const void *>(R)
-              << " Adapter=" << static_cast<const void *>(Adapter) << std::endl;
     Adapter->call<Retain>(R);
     return Managed{R, *Adapter};
   }

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -195,8 +195,9 @@ std::mutex &GlobalHandler::getFilterMutex() {
   return FilterMutex;
 }
 
-std::vector<adapter_impl *> &GlobalHandler::getAdapters() {
-  static std::vector<adapter_impl *> &adapters = getOrCreate(MAdapters);
+std::vector<std::shared_ptr<adapter_impl>> &GlobalHandler::getAdapters() {
+  static std::vector<std::shared_ptr<adapter_impl>> &adapters =
+      getOrCreate(MAdapters);
   enableOnCrashStackPrinting();
   return adapters;
 }
@@ -274,8 +275,10 @@ void GlobalHandler::unloadAdapters() {
   if (MAdapters.Inst) {
     for (const auto &Adapter : getAdapters()) {
       Adapter->release();
-      delete Adapter;
     }
+    // Adapters are owned by shared_ptr; the objects stay alive until the last
+    // Managed<> handle referencing them is destroyed (see Managed in
+    // adapter_impl.hpp). We only drop our owning references here.
   }
 
   UrFuncInfo<UrApiKind::urLoaderTearDown> loaderTearDownInfo;

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -64,7 +64,7 @@ public:
   std::mutex &getPlatformToDefaultContextCacheMutex();
   std::mutex &getPlatformMapMutex();
   std::mutex &getFilterMutex();
-  std::vector<adapter_impl *> &getAdapters();
+  std::vector<std::shared_ptr<adapter_impl>> &getAdapters();
   ods_target_list &getOneapiDeviceSelectorTargets(const std::string &InitValue);
   XPTIRegistry &getXPTIRegistry();
   ThreadPool &getHostTaskThreadPool();
@@ -118,7 +118,7 @@ private:
   InstWithLock<std::mutex> MPlatformToDefaultContextCacheMutex;
   InstWithLock<std::mutex> MPlatformMapMutex;
   InstWithLock<std::mutex> MFilterMutex;
-  InstWithLock<std::vector<adapter_impl *>> MAdapters;
+  InstWithLock<std::vector<std::shared_ptr<adapter_impl>>> MAdapters;
   InstWithLock<ods_target_list> MOneapiDeviceSelectorTargets;
   InstWithLock<XPTIRegistry> MXPTIRegistry;
   // Thread pool for host task and event callbacks execution

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -142,14 +142,14 @@ std::vector<platform> platform_impl::get_platforms() {
 
   // See which platform we want to be served by which adapter.
   // There should be just one adapter serving each backend.
-  std::vector<adapter_impl *> &Adapters = ur::initializeUr();
+  std::vector<std::shared_ptr<adapter_impl>> &Adapters = ur::initializeUr();
   std::vector<std::pair<platform, adapter_impl *>> PlatformsWithAdapter;
 
   // Then check backend-specific adapters
   for (auto &Adapter : Adapters) {
     const auto &AdapterPlatforms = getAdapterPlatforms(*Adapter);
     for (const auto &P : AdapterPlatforms) {
-      PlatformsWithAdapter.push_back({P, Adapter});
+      PlatformsWithAdapter.push_back({P, Adapter.get()});
     }
   }
 
@@ -484,13 +484,14 @@ void platform_impl::getDevicesImplHelper(ur_device_type_t UrDeviceType,
     // analysis. Doing adjustment by simple copy of last device num from
     // previous platform.
     // Needs non const adapter reference.
-    std::vector<adapter_impl *> &Adapters = ur::initializeUr();
-    auto It = std::find_if(Adapters.begin(), Adapters.end(),
-                           [&Platform = MPlatform](adapter_impl *&Adapter) {
-                             return Adapter->containsUrPlatform(Platform);
-                           });
+    std::vector<std::shared_ptr<adapter_impl>> &Adapters = ur::initializeUr();
+    auto It = std::find_if(
+        Adapters.begin(), Adapters.end(),
+        [&Platform = MPlatform](const std::shared_ptr<adapter_impl> &Adapter) {
+          return Adapter->containsUrPlatform(Platform);
+        });
     if (It != Adapters.end()) {
-      adapter_impl *&Adapter = *It;
+      std::shared_ptr<adapter_impl> &Adapter = *It;
       std::lock_guard<std::mutex> Guard(*Adapter->getAdapterMutex());
       Adapter->adjustLastDeviceId(MPlatform);
     }

--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -83,11 +83,12 @@ bool trace(TraceLevel Level) {
   return (TraceLevelMask & Level) == Level;
 }
 
-static void initializeAdapters(std::vector<adapter_impl *> &Adapters,
-                               ur_loader_config_handle_t LoaderConfig);
+static void
+initializeAdapters(std::vector<std::shared_ptr<adapter_impl>> &Adapters,
+                   ur_loader_config_handle_t LoaderConfig);
 
 // Initializes all available Adapters.
-std::vector<adapter_impl *> &
+std::vector<std::shared_ptr<adapter_impl>> &
 initializeUr(ur_loader_config_handle_t LoaderConfig) {
   // This uses static variable initialization to work around a gcc bug with
   // std::call_once and exceptions.
@@ -109,8 +110,9 @@ initializeUr(ur_loader_config_handle_t LoaderConfig) {
   return GlobalHandler::instance().getAdapters();
 }
 
-static void initializeAdapters(std::vector<adapter_impl *> &Adapters,
-                               ur_loader_config_handle_t LoaderConfig) {
+static void
+initializeAdapters(std::vector<std::shared_ptr<adapter_impl>> &Adapters,
+                   ur_loader_config_handle_t LoaderConfig) {
 #define CHECK_UR_SUCCESS(Call)                                                 \
   {                                                                            \
     if (ur_result_t error = Call) {                                            \
@@ -244,7 +246,8 @@ static void initializeAdapters(std::vector<adapter_impl *> &Adapters,
                                     sizeof(adapterBackend), &adapterBackend,
                                     nullptr));
     auto syclBackend = UrToSyclBackend(adapterBackend);
-    Adapters.emplace_back(new adapter_impl(UrAdapter, syclBackend));
+    Adapters.emplace_back(
+        std::make_shared<adapter_impl>(UrAdapter, syclBackend));
 
     const char *env_value = std::getenv("UR_LOG_CALLBACK");
     if (env_value == nullptr || std::string(env_value) != "disabled") {
@@ -264,7 +267,7 @@ template <backend BE> adapter_impl &getAdapter() {
 
   for (auto &P : ur::initializeUr())
     if (P->hasBackend(BE)) {
-      Adapter = P;
+      Adapter = P.get();
       return *Adapter;
     }
 

--- a/sycl/source/detail/ur.hpp
+++ b/sycl/source/detail/ur.hpp
@@ -39,7 +39,7 @@ namespace ur {
 void *getURLoaderLibrary();
 
 // Performs UR one-time initialization.
-std::vector<adapter_impl *> &
+std::vector<std::shared_ptr<adapter_impl>> &
 initializeUr(ur_loader_config_handle_t LoaderConfig = nullptr);
 
 // Get the adapter serving given backend.

--- a/sycl/unittests/program_manager/Cleanup.cpp
+++ b/sycl/unittests/program_manager/Cleanup.cpp
@@ -1,5 +1,6 @@
 #include <sycl/sycl.hpp>
 
+#include <detail/context_impl.hpp>
 #include <detail/device_binary_image.hpp>
 #include <detail/device_global_map.hpp>
 #include <detail/device_image_impl.hpp>
@@ -368,6 +369,13 @@ TEST(ImageRemoval, NativePrograms) {
   EXPECT_EQ(PM.getNativePrograms().size(), ImagesToKeepKernelOnly.size());
   EXPECT_TRUE(PM.getNativePrograms().count(ProgramA) > 0);
   EXPECT_TRUE(PM.getNativePrograms().count(ProgramB) > 0);
+
+  // getBuiltURProgram caches the built program (a Managed<ur_program_handle_t>
+  // that releases via the adapter) in this context's program cache. Drain it
+  // now, while the mock adapter is still alive: UrMock teardown only resets the
+  // default-context caches, so otherwise the cached program would be released
+  // against an already-destroyed adapter at context destruction.
+  sycl::detail::getSyclObjImpl(Ctx)->getKernelProgramCache().reset();
 }
 
 // Verify that removeImages cleans up device global initializer entries so that

--- a/sycl/unittests/program_manager/SubDevices.cpp
+++ b/sycl/unittests/program_manager/SubDevices.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <detail/context_impl.hpp>
 #include <detail/kernel_bundle_impl.hpp>
 
 #include <helpers/UrMock.hpp>
@@ -196,4 +197,11 @@ TEST(SubDevices, BuildProgramForSubSubDevices) {
 
   // Check that program is built only once.
   EXPECT_EQ(buildCallCount, 1);
+
+  // getBuiltURProgram caches the built program (a Managed<ur_program_handle_t>
+  // that releases via the adapter) in this explicit context's program cache.
+  // Drain it now, while the mock adapter is still alive: UrMock teardown only
+  // resets the default-context caches, so otherwise the cached program would be
+  // released against an already-destroyed adapter at context destruction.
+  sycl::detail::getSyclObjImpl(Ctx)->getKernelProgramCache().reset();
 }


### PR DESCRIPTION
Temporary debugging aid for the SubDevices.BuildProgramForSubSubDevices and ImageRemoval.NativePrograms SEH (0xC0000005) on build-win. Enables WER local dumps, runs the two failing tests under cdb to print the native stack into the job log, and uploads dumps + test exe/PDB + sycl.dll/PDB as an artifact.

To be reverted before merge.