### PR TITLE
[SYCL] Move device_selector to the detail namespace

### DIFF
--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -85,6 +85,12 @@ public:
   __SYCL2020_DEPRECATED("SYCL 1.2.1 device selectors are deprecated. Please "
                         "use SYCL 2020 device selectors instead.")
   explicit device(const device_selector &DeviceSelector);
+#else
+  /// Constructs a SYCL device instance using the device selected
+  /// by the DeviceSelector provided.
+  ///
+  /// \param DeviceSelector SYCL 1.2.1 device_selector to be used (see 4.6.1.1).
+  explicit device(const sycl::detail::device_selector &DeviceSelector);
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL device instance using the device

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -77,6 +77,7 @@ public:
   explicit device(cl_device_id DeviceId);
 #endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Constructs a SYCL device instance using the device selected
   /// by the DeviceSelector provided.
   ///
@@ -84,6 +85,7 @@ public:
   __SYCL2020_DEPRECATED("SYCL 1.2.1 device selectors are deprecated. Please "
                         "use SYCL 2020 device selectors instead.")
   explicit device(const device_selector &DeviceSelector);
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL device instance using the device
   /// identified by the device selector provided.

--- a/sycl/include/sycl/device_selector.hpp
+++ b/sycl/include/sycl/device_selector.hpp
@@ -29,6 +29,13 @@ namespace ext::oneapi {
 class filter_selector;
 } // namespace ext::oneapi
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+// device_selector has been removed in SYCL 2020. Moved it to detail:: to keep
+// support for legacy selectors while making it invisible to users.
+// TODO: remove __SYCL2020_DEPRECATED during the ABI-breaking window.
+namespace detail {
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+
 /// The SYCL 1.2.1 device_selector class provides ability to choose the
 /// best SYCL device based on heuristics specified by the user.
 ///
@@ -46,6 +53,10 @@ public:
   virtual int operator()(const device &device) const = 0;
 };
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+} // namespace detail
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+
 /// The default selector chooses the first available SYCL device.
 ///
 /// \sa device
@@ -53,7 +64,11 @@ public:
 /// \ingroup sycl_api_dev_sel
 class __SYCL_EXPORT __SYCL2020_DEPRECATED(
     "Use the callable sycl::default_selector_v instead.") default_selector
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+    : public detail::device_selector {
+#else
     : public device_selector {
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 public:
   int operator()(const device &dev) const override;
 };
@@ -65,7 +80,11 @@ public:
 /// \ingroup sycl_api_dev_sel
 class __SYCL_EXPORT __SYCL2020_DEPRECATED(
     "Use the callable sycl::gpu_selector_v instead.") gpu_selector
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+    : public detail::device_selector {
+#else
     : public device_selector {
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 public:
   int operator()(const device &dev) const override;
 };
@@ -77,7 +96,11 @@ public:
 /// \ingroup sycl_api_dev_sel
 class __SYCL_EXPORT __SYCL2020_DEPRECATED(
     "Use the callable sycl::cpu_selector_v instead.") cpu_selector
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+    : public detail::device_selector {
+#else
     : public device_selector {
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 public:
   int operator()(const device &dev) const override;
 };
@@ -89,7 +112,12 @@ public:
 /// \ingroup sycl_api_dev_sel
 class __SYCL_EXPORT
 __SYCL2020_DEPRECATED("Use the callable sycl::accelerator_selector_v instead.")
-    accelerator_selector : public device_selector {
+    accelerator_selector :
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+    public detail::device_selector {
+#else
+    public device_selector {
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 public:
   int operator()(const device &dev) const override;
 };
@@ -122,13 +150,19 @@ void fill_aspect_vector(std::vector<aspect> &V, FirstT F, OtherTs... O) {
 
 // Enable if DeviceSelector callable has matching signature, but
 // exclude if descended from filter_selector which is not purely callable or
-// if descended from it is descended from SYCL 1.2.1 device_selector.
+// if descended from SYCL 1.2.1 device_selector.
 // See [FilterSelector not Callable] in device_selector.cpp
 template <typename DeviceSelector>
 using EnableIfSYCL2020DeviceSelectorInvocable = std::enable_if_t<
     std::is_invocable_r_v<int, DeviceSelector &, const device &> &&
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    // TODO: Remove "or if descended from SYCL 1.2.1 device_selector" from the
+    // comment above during the ABI-breaking window.
     !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector> &&
     !std::is_base_of_v<device_selector, DeviceSelector>>;
+#else
+    !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 __SYCL_EXPORT device
 select_device(const DSelectorInvocableType &DeviceSelectorInvocable);

--- a/sycl/include/sycl/device_selector.hpp
+++ b/sycl/include/sycl/device_selector.hpp
@@ -153,15 +153,18 @@ void fill_aspect_vector(std::vector<aspect> &V, FirstT F, OtherTs... O) {
 // if descended from SYCL 1.2.1 device_selector.
 // See [FilterSelector not Callable] in device_selector.cpp
 template <typename DeviceSelector>
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 using EnableIfSYCL2020DeviceSelectorInvocable = std::enable_if_t<
     std::is_invocable_r_v<int, DeviceSelector &, const device &> &&
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-    // TODO: Remove "or if descended from SYCL 1.2.1 device_selector" from the
-    // comment above during the ABI-breaking window.
     !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector> &&
     !std::is_base_of_v<device_selector, DeviceSelector>>;
 #else
-    !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>;
+// TODO: Remove "or if descended from SYCL 1.2.1 device_selector" from the
+// comment above during the ABI-breaking window. Users can no longer inherit
+// from device_selector.
+using EnableIfSYCL2020DeviceSelectorInvocable = std::enable_if_t<
+    std::is_invocable_r_v<int, DeviceSelector &, const device &> &&
+    !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>>;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 __SYCL_EXPORT device

--- a/sycl/include/sycl/ext/oneapi/filter_selector.hpp
+++ b/sycl/include/sycl/ext/oneapi/filter_selector.hpp
@@ -22,7 +22,6 @@ inline namespace _V1 {
 
 // Forward declarations
 class device;
-class device_selector;
 #ifdef __SYCL_INTERNAL_API
 namespace ONEAPI {
 class filter_selector;
@@ -34,7 +33,11 @@ namespace detail {
 class filter_selector_impl;
 } // namespace detail
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 class __SYCL_EXPORT filter_selector : public device_selector {
+#else
+class __SYCL_EXPORT filter_selector : public detail::device_selector {
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 public:
   filter_selector(const std::string &filter)
       : filter_selector(sycl::detail::string_view{filter}) {}

--- a/sycl/include/sycl/ext/oneapi/filter_selector.hpp
+++ b/sycl/include/sycl/ext/oneapi/filter_selector.hpp
@@ -36,7 +36,7 @@ class filter_selector_impl;
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 class __SYCL_EXPORT filter_selector : public device_selector {
 #else
-class __SYCL_EXPORT filter_selector : public detail::device_selector {
+class __SYCL_EXPORT filter_selector : public sycl::detail::device_selector {
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 public:
   filter_selector(const std::string &filter)

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -85,6 +85,7 @@ public:
   explicit platform(cl_platform_id PlatformId);
 #endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Constructs a SYCL platform instance using a device_selector.
   ///
   /// One of the SYCL devices that is associated with the constructed SYCL
@@ -95,6 +96,7 @@ public:
   __SYCL2020_DEPRECATED("SYCL 1.2.1 device selectors are deprecated. Please "
                         "use SYCL 2020 device selectors instead.")
   explicit platform(const device_selector &DeviceSelector);
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL platform instance using the platform of the device
   /// identified by the device selector provided.

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -297,7 +297,7 @@ public:
   queue(const device_selector &DeviceSelector,
         const async_handler &AsyncHandler, const property_list &PropList = {})
       : queue(DeviceSelector.select_device(), AsyncHandler, PropList) {}
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL queue instance using the device provided.
   ///

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -273,6 +273,7 @@ public:
       : queue(syclContext, detail::select_device(deviceSelector, syclContext),
               AsyncHandler, propList) {}
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Constructs a SYCL queue instance using the device returned by the
   /// DeviceSelector provided.
   ///
@@ -296,6 +297,7 @@ public:
   queue(const device_selector &DeviceSelector,
         const async_handler &AsyncHandler, const property_list &PropList = {})
       : queue(DeviceSelector.select_device(), AsyncHandler, PropList) {}
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL queue instance using the device provided.
   ///
@@ -313,6 +315,7 @@ public:
   explicit queue(const device &SyclDevice, const async_handler &AsyncHandler,
                  const property_list &PropList = {});
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Constructs a SYCL queue instance that is associated with the context
   /// provided, using the device returned by the device selector.
   ///
@@ -336,6 +339,7 @@ public:
                         "use SYCL 2020 device selectors instead.")
   queue(const context &SyclContext, const device_selector &DeviceSelector,
         const async_handler &AsyncHandler, const property_list &PropList = {});
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL queue associated with the given context, device
   /// and optional properties list.

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -23,7 +23,6 @@ namespace sycl {
 inline namespace _V1 {
 
 // Forward declaration
-class device_selector;
 class device;
 
 namespace detail {

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -61,9 +61,11 @@ device::device(cl_device_id DeviceId) {
   __SYCL_OCL_CALL(clRetainDevice, DeviceId);
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 device::device(const device_selector &deviceSelector) {
   *this = deviceSelector.select_device();
 }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 std::vector<device> device::get_devices(info::device_type deviceType) {
   std::vector<device> devices;

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -63,6 +63,8 @@ device::device(cl_device_id DeviceId) {
 
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 device::device(const device_selector &deviceSelector) {
+#else
+device::device(const sycl::detail::device_selector &deviceSelector) {
   *this = deviceSelector.select_device();
 }
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -65,9 +65,9 @@ device::device(cl_device_id DeviceId) {
 device::device(const device_selector &deviceSelector) {
 #else
 device::device(const sycl::detail::device_selector &deviceSelector) {
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   *this = deviceSelector.select_device();
 }
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 std::vector<device> device::get_devices(info::device_type deviceType) {
   std::vector<device> devices;

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -300,9 +300,9 @@ device filter_selector::select_device() const {
 
   device Result =
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-    sycl::detail::device_selector::select_device();
+      sycl::detail::device_selector::select_device();
 #else
-    sycl::device_selector::select_device();
+      sycl::device_selector::select_device();
 #endif
 
   reset();

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -249,7 +249,11 @@ aspect_selector(const std::vector<aspect> &RequireList,
 
 // SYCL 1.2.1 device_selector class and sub-classes
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 device device_selector::select_device() const {
+#else
+device detail::device_selector::select_device() const {
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   return detail::select_device([&](const device &dev) { return (*this)(dev); });
 }
 
@@ -294,7 +298,12 @@ device filter_selector::select_device() const {
   std::lock_guard<std::mutex> Guard(
       sycl::detail::GlobalHandler::instance().getFilterMutex());
 
-  device Result = device_selector::select_device();
+  device Result =
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+    sycl::detail::device_selector::select_device();
+#else
+    sycl::device_selector::select_device();
+#endif
 
   reset();
 

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -37,9 +37,11 @@ platform::platform(cl_platform_id PlatformId) {
 // protected constructor for internal use
 platform::platform(const device &Device) { *this = Device.get_platform(); }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 platform::platform(const device_selector &dev_selector) {
   *this = dev_selector.select_device().get_platform();
 }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 cl_platform_id platform::get() const { return impl->get(); }
 

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -20,6 +20,7 @@
 namespace sycl {
 inline namespace _V1 {
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 queue::queue(const context &SyclContext, const device_selector &DeviceSelector,
              const async_handler &AsyncHandler, const property_list &PropList) {
   const std::vector<device> Devs = SyclContext.get_devices();
@@ -34,6 +35,7 @@ queue::queue(const context &SyclContext, const device_selector &DeviceSelector,
                                     *detail::getSyclObjImpl(SyclContext),
                                     AsyncHandler, PropList);
 }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 queue::queue(const context &SyclContext, const device &SyclDevice,
              const async_handler &AsyncHandler, const property_list &PropList) {
@@ -48,11 +50,13 @@ queue::queue(const device &SyclDevice, const async_handler &AsyncHandler,
                                     AsyncHandler, PropList);
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 queue::queue(const context &SyclContext, const device_selector &deviceSelector,
              const property_list &PropList)
     : queue(SyclContext, deviceSelector,
             detail::getSyclObjImpl(SyclContext)->get_async_handler(),
             PropList) {}
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 queue::queue(const context &SyclContext, const device &SyclDevice,
              const property_list &PropList)

--- a/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
@@ -20,9 +20,9 @@
 
 using namespace sycl;
 
-class DiscreteSelector : public sycl::device_selector {
+class DiscreteSelector {
 public:
-  int operator()(const sycl::device &Device) const final {
+  int operator()(const sycl::device &Device) const {
     if (!Device.is_gpu() ||
         Device.get_backend() != backend::ext_oneapi_level_zero)
       return -1;

--- a/sycl/unittests/buffer/SubbufferLargeSize.cpp
+++ b/sycl/unittests/buffer/SubbufferLargeSize.cpp
@@ -40,7 +40,7 @@ protected:
 
 TEST_F(LargeBufferSizeTest, MoreThan32bit) {
   sycl::context Context{Plt};
-  sycl::queue Queue{Context, sycl::accelerator_selector{}};
+  sycl::queue Queue{Context, sycl::accelerator_selector_v };
 
   using DataType = double;
   const size_t IndexStart = 16;


### PR DESCRIPTION
The class has been removed in SYCL 2020. Move it to the detail namespace to keep support for legacy selectors while making it invisible to users.

Prepare all classes/functions that are using this class for this move, i.e. update some to use detail::device_selector and remove the rest that is not part of SYCL 2020.

FYI - https://github.com/KhronosGroup/SYCL-Docs/pull/1018