### PR TITLE
[SYCL][CMake] Honor LLVM_LIBDIR_SUFFIX

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 #include "SYCL.h"
 #include "clang/Basic/Version.h"
+#include "clang/Config/config.h"
 #include "clang/Driver/CommonArgs.h"
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/Driver.h"
@@ -43,7 +44,7 @@ SYCLInstallationDetector::SYCLInstallationDetector(
     if (DriverDir.starts_with(SysRoot) &&
         Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
       SmallString<128> LibDir(DriverDir);
-      llvm::sys::path::append(LibDir, "..", "lib");
+      llvm::sys::path::append(LibDir, "..", CLANG_INSTALL_LIBDIR_BASENAME);
 
       // Verify SYCL runtime library exists
       SmallString<128> SYCLLibPath(LibDir);
@@ -54,21 +55,21 @@ SYCLInstallationDetector::SYCLInstallationDetector(
     }
   } else {
     SmallString<128> LibPath(DriverDir);
-    llvm::sys::path::append(LibPath, "..", "lib", HostTriple.str(),
+    llvm::sys::path::append(LibPath, "..", CLANG_INSTALL_LIBDIR_BASENAME, HostTriple.str(),
                             "libsycl.so");
     // Flat lib path for LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF builds,
     // where the library is installed directly in lib/ with no triple subdir.
     SmallString<128> FlatLibPath(DriverDir);
-    llvm::sys::path::append(FlatLibPath, "..", "lib", "libsycl.so");
+    llvm::sys::path::append(FlatLibPath, "..", CLANG_INSTALL_LIBDIR_BASENAME, "libsycl.so");
 
     if (DriverDir.starts_with(SysRoot) &&
         Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
       // LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON: library is in lib/<triple>/
       if (D.getVFS().exists(LibPath))
-        llvm::sys::path::append(DriverDir, "..", "lib", HostTriple.str());
+        llvm::sys::path::append(DriverDir, "..", CLANG_INSTALL_LIBDIR_BASENAME, HostTriple.str());
       // LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF: library is in lib/
       else if (D.getVFS().exists(FlatLibPath))
-        llvm::sys::path::append(DriverDir, "..", "lib");
+        llvm::sys::path::append(DriverDir, "..", CLANG_INSTALL_LIBDIR_BASENAME);
       else
         return; // Neither path exists : broken install, leave SYCLRTLibPath
                 // unset
@@ -79,19 +80,22 @@ SYCLInstallationDetector::SYCLInstallationDetector(
 #else // !INTEL_CUSTOMIZATION
   // Intel: SYCL RT is libsycl.so; Windows lib path is handled at link stage.
   SmallString<128> LibPath(DriverDir);
-  llvm::sys::path::append(LibPath, "..", "lib", HostTriple.str(), "libsycl.so");
+  llvm::sys::path::append(LibPath, "..", CLANG_INSTALL_LIBDIR_BASENAME,
+                          HostTriple.str(), "libsycl.so");
   // Flat lib path for LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF builds,
   // where the library is installed directly in lib/ with no triple subdir.
   SmallString<128> FlatLibPath(DriverDir);
-  llvm::sys::path::append(FlatLibPath, "..", "lib", "libsycl.so");
+  llvm::sys::path::append(FlatLibPath, "..", CLANG_INSTALL_LIBDIR_BASENAME,
+                          "libsycl.so");
 
   if (DriverDir.starts_with(SysRoot) &&
       Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
     // We put driver in bin/compiler, so one more ../ than llorg.
     if (D.getVFS().exists(DriverDir + "/../../lib/libsycl.so"))
-      llvm::sys::path::append(DriverDir, "..", "..", "lib");
+      llvm::sys::path::append(DriverDir, "..", "..",
+                              CLANG_INSTALL_LIBDIR_BASENAME);
     else
-      llvm::sys::path::append(DriverDir, "..", "lib");
+      llvm::sys::path::append(DriverDir, "..", CLANG_INSTALL_LIBDIR_BASENAME);
 
     SYCLRTLibPath = DriverDir;
   }
@@ -126,8 +130,8 @@ const char *SYCLInstallationDetector::findLibspirvPath(
 
   const SmallString<64> Basename = getLibSpirvBasename(HostTriple);
   SmallString<256> LibclcPath(D.ResourceDir);
-  llvm::sys::path::append(LibclcPath, "lib", DeviceTriple.getTriple(),
-                          Basename);
+  llvm::sys::path::append(LibclcPath, CLANG_INSTALL_LIBDIR_BASENAME,
+                          DeviceTriple.getTriple(), Basename);
   if (D.getVFS().exists(LibclcPath))
     return Args.MakeArgString(LibclcPath);
 
@@ -158,7 +162,8 @@ void SYCLInstallationDetector::addLibspirvLinkArgs(
 void SYCLInstallationDetector::getSYCLDeviceLibPath(
     llvm::SmallVector<llvm::SmallString<128>, 4> &DeviceLibPaths) const {
   std::string LinuxDirSuffix =
-      llvm::formatv("/lib/dpcpp-{0}/sycl", DPCPP_VERSION_MAJOR);
+      llvm::formatv("/{0}/dpcpp-{1}/sycl", CLANG_INSTALL_LIBDIR_BASENAME,
+                    DPCPP_VERSION_MAJOR);
   for (const auto &IC : InstallationCandidates) {
     if (!HostTriple.isWindowsMSVCEnvironment() &&
         !HostTriple.isWindowsItaniumEnvironment()) {
@@ -167,7 +172,7 @@ void SYCLInstallationDetector::getSYCLDeviceLibPath(
       DeviceLibPaths.emplace_back(InstallPath);
     }
     SmallString<128> InstallPath(IC);
-    llvm::sys::path::append(InstallPath, "lib");
+    llvm::sys::path::append(InstallPath, CLANG_INSTALL_LIBDIR_BASENAME);
     DeviceLibPaths.emplace_back(InstallPath);
   }
   if (!HostTriple.isWindowsMSVCEnvironment() &&
@@ -177,7 +182,7 @@ void SYCLInstallationDetector::getSYCLDeviceLibPath(
     DeviceLibPaths.emplace_back(Path.str());
   }
   SmallString<128> Path(D.SysRoot);
-  llvm::sys::path::append(Path, "lib");
+  llvm::sys::path::append(Path, CLANG_INSTALL_LIBDIR_BASENAME);
   DeviceLibPaths.emplace_back(Path.str());
 }
 

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -16,7 +16,7 @@ if(WIN32)
   set(bc_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 else()
   # On other platforms, install to lib/dpcpp-<major_ver>/sycl
-  set(bc_dir "lib/dpcpp-${DPCPP_VERSION_MAJOR}/sycl")
+  set(bc_dir "lib${LLVM_LIBDIR_SUFFIX}/dpcpp-${DPCPP_VERSION_MAJOR}/sycl")
   set(install_dest_bc ${bc_dir})
   set(bc_binary_dir "${CMAKE_BINARY_DIR}/${bc_dir}")
 endif()

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -16,6 +16,7 @@
 #include <clang/Basic/DiagnosticDriver.h>
 #include <clang/Basic/Version.h>
 #include <clang/CodeGen/CodeGenAction.h>
+#include <clang/Config/config.h>
 #include <clang/Driver/Compilation.h>
 #include <clang/Driver/CudaInstallationDetector.h>
 #include <clang/Driver/Driver.h>
@@ -170,9 +171,10 @@ template <> struct std::hash<auto_pch_key> {
 namespace {
 std::string getLibPathSuffix() {
 #ifdef _WIN32
-  return "/lib/";
+  return llvm::formatv("/{0}/", CLANG_INSTALL_LIBDIR_BASENAME);
 #else
-  return llvm::formatv("/lib/dpcpp-{0}/sycl/", DPCPP_VERSION_MAJOR);
+  return llvm::formatv("/{0}/dpcpp-{1}/sycl/", CLANG_INSTALL_LIBDIR_BASENAME,
+                       DPCPP_VERSION_MAJOR);
 #endif
 }
 class SYCLToolchain {

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -367,7 +367,7 @@ if(SYCL_HEADERS_ONLY)
     foreach(sycl_compiler_tool
         append-file clang clang-offload-bundler clang-offload-deps
         clang-offload-extract clang-offload-wrapper clang-linker-wrapper
-        file-table-tform llc llvm-ar llvm-foreach llvm-link
+        file-table-tform llc llvm-ar llvm-config llvm-foreach llvm-link
         llvm-offload-binary llvm-objcopy llvm-spirv spirv-to-ir-wrapper
         sycl-post-link)
       if(TARGET ${sycl_compiler_tool})
@@ -434,6 +434,7 @@ add_custom_target(sycl-compiler
           file-table-tform
           llc
           llvm-ar
+          llvm-config
           llvm-foreach
           llvm-spirv
           llvm-link
@@ -517,6 +518,7 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      file-table-tform
      llc
      llvm-ar
+     llvm-config
      llvm-foreach
      llvm-spirv
      llvm-link

--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -102,6 +102,27 @@ if(CMPLR_RESULT EQUAL 0 AND CMPLR_VER)
   set(DPCPP_VERSION_MAJOR "${CMAKE_MATCH_1}")
 endif()
 
+get_filename_component(DPCPP_ROOT_DIR ${SYCL_CXX_COMPILER} DIRECTORY)
+if(SYCL_TEST_E2E_STANDALONE)
+  execute_process(
+      COMMAND ${DPCPP_ROOT_DIR}/llvm-config${CMAKE_EXECUTABLE_SUFFIX} --libdir
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      RESULT_VARIABLE CMPLR_LIBS_RESULT
+      OUTPUT_VARIABLE CMPLR_LIBS_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if(NOT CMPLR_LIBS_RESULT EQUAL 0 OR NOT CMPLR_LIBS_DIR)
+    message(FATAL_ERROR "Failed to determine SYCL library directory")
+  endif()
+  set(SYCL_LIBDIR_BASENAME_FULL "${CMPLR_LIBS_DIR}")
+else()
+  set(SYCL_LIBDIR_BASENAME_FULL "${DPCPP_ROOT_DIR}/${CLANG_INSTALL_LIBDIR_BASENAME}")
+endif()
+
+# Extract out only the libdir folder name, don't use the full path so we can
+# be more portable.
+get_filename_component(SYCL_LIBDIR_BASENAME "${SYCL_LIBDIR_BASENAME_FULL}" NAME)
+
 if("${DPCPP_VERSION_MAJOR}" STREQUAL "")
   message(FATAL_ERROR "Could not detect SYCL compiler version")
 endif()

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -25,8 +25,8 @@ config.dump_ir_supported = lit_config.params.get("dump_ir", ("@DUMP_IR_SUPPORTED
 config.sycl_tools_dir = config.llvm_tools_dir
 config.sycl_include = os.path.join(config.dpcpp_root_dir, 'include')
 config.sycl_obj_root = "@CMAKE_CURRENT_BINARY_DIR@"
-config.sycl_libs_dir =  os.path.join(config.dpcpp_root_dir, ('bin' if platform.system() == "Windows" else 'lib'))
-config.sycl_device_libs_dir = os.path.join(config.dpcpp_root_dir, ('lib' if platform.system() == "Windows" else "lib/dpcpp-@DPCPP_VERSION_MAJOR@/sycl"))
+config.sycl_libs_dir =  os.path.join(config.dpcpp_root_dir, ('bin' if platform.system() == "Windows" else '@SYCL_LIBDIR_BASENAME@'))
+config.sycl_device_libs_dir = os.path.join(config.dpcpp_root_dir, ('@SYCL_LIBDIR_BASENAME@' if platform.system() == "Windows" else "@SYCL_LIBDIR_BASENAME@/dpcpp-@DPCPP_VERSION_MAJOR@/sycl"))
 
 config.opencl_libs_dir = (os.path.dirname("@OpenCL_LIBRARY@") if "@OpenCL_LIBRARY@" else "")
 config.level_zero_libs_dir = "@LEVEL_ZERO_LIBS_DIR@"

--- a/xpti/CMakeLists.txt
+++ b/xpti/CMakeLists.txt
@@ -93,7 +93,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/xpti
 # Install CMake config files.
 include(CMakePackageConfigHelpers)
 set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
-set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX})
+set(LIB_INSTALL_DIR lib${LLVM_LIBDIR_SUFFIX})
 set(CONFIG_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/xpti)
 
 configure_package_config_file(

--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 # Install CMake config files
 include(CMakePackageConfigHelpers)
 set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
-set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX})
+set(LIB_INSTALL_DIR lib${LLVM_LIBDIR_SUFFIX})
 set(CONFIG_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/xptifw)
 
 configure_package_config_file(


### PR DESCRIPTION
LLVM CMake has the `LLVM_LIBDIR_SUFFIX` option to optionally add a suffix to the install library directory, so setting `-DLLVM_LIBDIR_SUFFIX=64` would result in a `lib64` library directory.

We didn't honor the variable correctly in `libdevice`, `xpti`, `xptifw`, the driver, `sycl-jit` nor E2E testing.

This option will be set by Linux distros packing the repo, so we need it to work.

After this, further work is required to get Driver `lit` tests to pass with `LLVM_LIBDIR_SUFFIX` set, as the example device libraries we have are always in `lib`.

Closes: https://github.com/intel/llvm/issues/22355

