### PR TITLE
[SYCL][UT] Disable program_manager tests on Windows/icx 

### DIFF
--- a/sycl/unittests/program_manager/Cleanup.cpp
+++ b/sycl/unittests/program_manager/Cleanup.cpp
@@ -333,6 +333,14 @@ TEST(ImageRemoval, MultipleImagesPerEntry) {
 }
 
 TEST(ImageRemoval, NativePrograms) {
+#if defined(_WIN32) && defined(__INTEL_LLVM_COMPILER)
+  // Disabled on Windows built with icx: a Managed<ur_program_handle_t> can
+  // release its UR program through an already-freed adapter_impl (use-after-
+  // free), which on this configuration calls a null function pointer and
+  // crashes with SEH 0xC0000005. Tracked in
+  // https://github.com/intel/llvm/issues/22367
+  GTEST_SKIP() << "Disabled on Windows/icx, see intel/llvm#22367";
+#endif
   ProgramManagerExposed PM;
 
   sycl_device_binary_struct NativeImages[ImagesToKeepKernelOnly.size()];

--- a/sycl/unittests/program_manager/SubDevices.cpp
+++ b/sycl/unittests/program_manager/SubDevices.cpp
@@ -170,6 +170,14 @@ TEST(SubDevices, DISABLED_BuildProgramForSubdevices) {
 
 // Check that program is built once for all sub-sub-devices
 TEST(SubDevices, BuildProgramForSubSubDevices) {
+#if defined(_WIN32) && defined(__INTEL_LLVM_COMPILER)
+  // Disabled on Windows built with icx: a Managed<ur_program_handle_t> can
+  // release its UR program through an already-freed adapter_impl (use-after-
+  // free), which on this configuration calls a null function pointer and
+  // crashes with SEH 0xC0000005. Tracked in
+  // https://github.com/intel/llvm/issues/22367
+  GTEST_SKIP() << "Disabled on Windows/icx, see intel/llvm#22367";
+#endif
   sycl::unittest::UrMock<> Mock;
   mock::getCallbacks().set_after_callback("urDeviceGet", &redefinedDeviceGet);
   mock::getCallbacks().set_after_callback("urDeviceGetInfo",


### PR DESCRIPTION
SubDevices.BuildProgramForSubSubDevices and ImageRemoval.NativePrograms crash with SEH 0xC0000005 on the build-win (icx) configuration: a Managed<ur_program_handle_t> can release its UR program through an already-freed adapter_impl (use-after-free), and on Windows/icx the freed adapter's function-pointer table reads back null so the release calls a null pointers.

See #22367 
