### PR TITLE
[SYCL] Prepare deprecated aliases for removal

### DIFF
--- a/sycl/include/sycl/aliases.hpp
+++ b/sycl/include/sycl/aliases.hpp
@@ -29,15 +29,6 @@ class half;
   using ALIAS##N __SYCL2020_DEPRECATED(MESSAGE) = sycl::vec<TYPE, N>;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
-#define __SYCL_MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                     \
-  __SYCL_MAKE_VECTOR_ALIAS(char, char, N)                                      \
-  __SYCL_MAKE_VECTOR_ALIAS(short, short, N)                                    \
-  __SYCL_MAKE_VECTOR_ALIAS(int, int, N)                                        \
-  __SYCL_MAKE_VECTOR_ALIAS(long, long, N)                                      \
-  __SYCL_MAKE_VECTOR_ALIAS(float, float, N)                                    \
-  __SYCL_MAKE_VECTOR_ALIAS(double, double, N)                                  \
-  __SYCL_MAKE_VECTOR_ALIAS(half, half, N)
-
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 // There are no 'cl_*' vec aliases in SYCL 2020
 #define __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                         \
@@ -54,33 +45,13 @@ class half;
   __SYCL_2020_MAKE_DEPRECATED_VECTOR_ALIAS(cl_half, sycl::cl_half, N, "")
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
-#define __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)            \
-  __SYCL_MAKE_VECTOR_ALIAS(schar, signed char, N)                              \
-  __SYCL_MAKE_VECTOR_ALIAS(uchar, unsigned char, N)                            \
-  __SYCL_MAKE_VECTOR_ALIAS(ushort, unsigned short, N)                          \
-  __SYCL_MAKE_VECTOR_ALIAS(uint, unsigned int, N)                              \
-  __SYCL_MAKE_VECTOR_ALIAS(ulong, unsigned long, N)                            \
-  __SYCL_MAKE_VECTOR_ALIAS(longlong, long long, N)                             \
-  __SYCL_MAKE_VECTOR_ALIAS(ulonglong, unsigned long long, N)
-
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-#define __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                        \
-  __SYCL_MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                           \
-  __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                               \
-  __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)
-#else
-#define __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                        \
-  __SYCL_MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                           \
-  __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
-
 // FIXME: OpenCL vector aliases are not defined by SYCL 2020 spec and should be
 //        removed from here. See intel/llvm#7888. They are deprecated for now.
 // FIXME: schar, longlong and ulonglong aliases are not defined by SYCL 2020
 //        spec, but they are preserved in SYCL 2020 mode, because SYCL-CTS is
 //        still using them.
 //        See KhronosGroup/SYCL-CTS#446 and KhronosGroup/SYCL-Docs#335
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #define __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                   \
   __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                               \
   __SYCL_2020_MAKE_DEPRECATED_VECTOR_ALIAS(schar, std::int8_t, N, "")          \
@@ -98,7 +69,6 @@ class half;
   __SYCL_MAKE_VECTOR_ALIAS(double, double, N)                                  \
   __SYCL_MAKE_VECTOR_ALIAS(half, half, N)
 #else
-// TODO: remove the FIXME comments above.
 #define __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                   \
   __SYCL_MAKE_VECTOR_ALIAS(char, std::int8_t, N)                               \
   __SYCL_MAKE_VECTOR_ALIAS(uchar, std::uint8_t, N)                             \
@@ -153,8 +123,6 @@ using cl_double
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 namespace opencl {
-// Strictly speaking, cl_* aliases should not be defined in opencl namespace in
-// SYCL 1.2.1 mode, but we do so to simplify our implementation
 using cl_bool = bool;
 using cl_char = std::int8_t;
 using cl_uchar = std::uint8_t;
@@ -169,7 +137,6 @@ using cl_float = float;
 using cl_double = double;
 } // namespace opencl
 
-// Vector aliases are different between SYCL 1.2.1 and SYCL 2020
 __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(2)
 __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(3)
 __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(4)
@@ -179,10 +146,7 @@ __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(16)
 } // namespace sycl
 
 #undef __SYCL_MAKE_VECTOR_ALIAS
-#undef __SYCL_MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #undef __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
-#undef __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES
-#undef __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH
 #undef __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH

--- a/sycl/include/sycl/aliases.hpp
+++ b/sycl/include/sycl/aliases.hpp
@@ -24,8 +24,10 @@ class half;
 #define __SYCL_MAKE_VECTOR_ALIAS(ALIAS, TYPE, N)                               \
   using ALIAS##N = sycl::vec<TYPE, N>;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #define __SYCL_2020_MAKE_DEPRECATED_VECTOR_ALIAS(ALIAS, TYPE, N, MESSAGE)      \
   using ALIAS##N __SYCL2020_DEPRECATED(MESSAGE) = sycl::vec<TYPE, N>;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 #define __SYCL_MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                     \
   __SYCL_MAKE_VECTOR_ALIAS(char, char, N)                                      \
@@ -36,6 +38,7 @@ class half;
   __SYCL_MAKE_VECTOR_ALIAS(double, double, N)                                  \
   __SYCL_MAKE_VECTOR_ALIAS(half, half, N)
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 // There are no 'cl_*' vec aliases in SYCL 2020
 #define __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                         \
   __SYCL_2020_MAKE_DEPRECATED_VECTOR_ALIAS(cl_char, sycl::cl_char, N, "")      \
@@ -49,6 +52,7 @@ class half;
   __SYCL_2020_MAKE_DEPRECATED_VECTOR_ALIAS(cl_float, sycl::cl_float, N, "")    \
   __SYCL_2020_MAKE_DEPRECATED_VECTOR_ALIAS(cl_double, sycl::cl_double, N, "")  \
   __SYCL_2020_MAKE_DEPRECATED_VECTOR_ALIAS(cl_half, sycl::cl_half, N, "")
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 #define __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)            \
   __SYCL_MAKE_VECTOR_ALIAS(schar, signed char, N)                              \
@@ -59,10 +63,16 @@ class half;
   __SYCL_MAKE_VECTOR_ALIAS(longlong, long long, N)                             \
   __SYCL_MAKE_VECTOR_ALIAS(ulonglong, unsigned long long, N)
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #define __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                        \
   __SYCL_MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                           \
   __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                               \
   __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)
+#else
+#define __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                        \
+  __SYCL_MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES(N)                           \
+  __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 // FIXME: OpenCL vector aliases are not defined by SYCL 2020 spec and should be
 //        removed from here. See intel/llvm#7888. They are deprecated for now.
@@ -70,6 +80,7 @@ class half;
 //        spec, but they are preserved in SYCL 2020 mode, because SYCL-CTS is
 //        still using them.
 //        See KhronosGroup/SYCL-CTS#446 and KhronosGroup/SYCL-Docs#335
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #define __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                   \
   __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                               \
   __SYCL_2020_MAKE_DEPRECATED_VECTOR_ALIAS(schar, std::int8_t, N, "")          \
@@ -86,10 +97,26 @@ class half;
   __SYCL_MAKE_VECTOR_ALIAS(float, float, N)                                    \
   __SYCL_MAKE_VECTOR_ALIAS(double, double, N)                                  \
   __SYCL_MAKE_VECTOR_ALIAS(half, half, N)
+#else
+// TODO: remove the FIXME comments above.
+#define __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                   \
+  __SYCL_MAKE_VECTOR_ALIAS(char, std::int8_t, N)                               \
+  __SYCL_MAKE_VECTOR_ALIAS(uchar, std::uint8_t, N)                             \
+  __SYCL_MAKE_VECTOR_ALIAS(short, std::int16_t, N)                             \
+  __SYCL_MAKE_VECTOR_ALIAS(ushort, std::uint16_t, N)                           \
+  __SYCL_MAKE_VECTOR_ALIAS(int, std::int32_t, N)                               \
+  __SYCL_MAKE_VECTOR_ALIAS(uint, std::uint32_t, N)                             \
+  __SYCL_MAKE_VECTOR_ALIAS(long, std::int64_t, N)                              \
+  __SYCL_MAKE_VECTOR_ALIAS(ulong, std::uint64_t, N)                            \
+  __SYCL_MAKE_VECTOR_ALIAS(float, float, N)                                    \
+  __SYCL_MAKE_VECTOR_ALIAS(double, double, N)                                  \
+  __SYCL_MAKE_VECTOR_ALIAS(half, half, N)
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 namespace sycl {
 inline namespace _V1 {
 using byte __SYCL2020_DEPRECATED("use std::byte instead") = std::uint8_t;
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 using schar __SYCL2020_DEPRECATED("") = signed char;
 using uchar __SYCL2020_DEPRECATED("") = unsigned char;
 using ushort __SYCL2020_DEPRECATED("") = unsigned short;
@@ -97,8 +124,10 @@ using uint __SYCL2020_DEPRECATED("") = unsigned int;
 using ulong __SYCL2020_DEPRECATED("") = unsigned long;
 using longlong __SYCL2020_DEPRECATED("") = long long;
 using ulonglong __SYCL2020_DEPRECATED("") = unsigned long long;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 using half = sycl::detail::half_impl::half;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 using cl_bool __SYCL2020_DEPRECATED("use sycl::opencl::cl_bool instead") = bool;
 using cl_char
     __SYCL2020_DEPRECATED("use sycl::opencl::cl_char instead") = std::int8_t;
@@ -121,6 +150,7 @@ using cl_float
     __SYCL2020_DEPRECATED("use sycl::opencl::cl_float instead") = float;
 using cl_double
     __SYCL2020_DEPRECATED("use sycl::opencl::cl_double instead") = double;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 namespace opencl {
 // Strictly speaking, cl_* aliases should not be defined in opencl namespace in
@@ -150,7 +180,9 @@ __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(16)
 
 #undef __SYCL_MAKE_VECTOR_ALIAS
 #undef __SYCL_MAKE_VECTOR_ALIASES_FOR_ARITHMETIC_TYPES
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #undef __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #undef __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES
 #undef __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH
 #undef __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH

--- a/sycl/include/sycl/atomic.hpp
+++ b/sycl/include/sycl/atomic.hpp
@@ -201,19 +201,19 @@ public:
 
 #ifdef __SYCL_DEVICE_ONLY__
   template <typename T2 = T>
-  std::enable_if_t<!std::is_same<cl_float, T2>::value, T>
+  std::enable_if_t<!std::is_same<opencl::cl_float, T2>::value, T>
   load(memory_order Order = memory_order::relaxed) const {
     return __spirv_AtomicLoad(Ptr, SpirvScope,
                               detail::getSPIRVMemorySemanticsMask(Order));
   }
   template <typename T2 = T>
-  std::enable_if_t<std::is_same<cl_float, T2>::value, T>
+  std::enable_if_t<std::is_same<opencl::cl_float, T2>::value, T>
   load(memory_order Order = memory_order::relaxed) const {
     auto *TmpPtr = reinterpret_cast<typename multi_ptr<
-        cl_int, addressSpace, access::decorated::yes>::pointer>(Ptr);
-    cl_int TmpVal = __spirv_AtomicLoad(
+        opencl::cl_int, addressSpace, access::decorated::yes>::pointer>(Ptr);
+    opencl::cl_int TmpVal = __spirv_AtomicLoad(
         TmpPtr, SpirvScope, detail::getSPIRVMemorySemanticsMask(Order));
-    cl_float ResVal = sycl::bit_cast<cl_float>(TmpVal);
+    opencl::cl_float ResVal = sycl::bit_cast<opencl::cl_float>(TmpVal);
     return ResVal;
   }
 #else

--- a/sycl/include/sycl/detail/vector_convert.hpp
+++ b/sycl/include/sycl/detail/vector_convert.hpp
@@ -411,15 +411,15 @@ using enable_if_to_int_vector_t =
   __SYCL_VECTOR_INT_INT_CONVERT(Op, 8, DestType, SPVType)                      \
   __SYCL_VECTOR_INT_INT_CONVERT(Op, 16, DestType, SPVType)
 
-__SYCL_INT_INT_CONVERT(S, char, schar)
+__SYCL_INT_INT_CONVERT(S, char, signed char)
 __SYCL_INT_INT_CONVERT(S, short, short)
 __SYCL_INT_INT_CONVERT(S, int, int)
 __SYCL_INT_INT_CONVERT(S, long, long)
 
-__SYCL_INT_INT_CONVERT(U, uchar, uchar)
-__SYCL_INT_INT_CONVERT(U, ushort, ushort)
-__SYCL_INT_INT_CONVERT(U, uint, uint)
-__SYCL_INT_INT_CONVERT(U, ulong, ulong)
+__SYCL_INT_INT_CONVERT(U, unsigned char, unsigned char)
+__SYCL_INT_INT_CONVERT(U, unsigned short, unsigned short)
+__SYCL_INT_INT_CONVERT(U, unsigned int, unsigned int)
+__SYCL_INT_INT_CONVERT(U, unsigned long, unsigned long)
 
 #undef __SYCL_SCALAR_INT_INT_CONVERT
 #undef __SYCL_VECTOR_INT_INT_CONVERT
@@ -467,15 +467,15 @@ __SYCL_INT_INT_CONVERT(U, ulong, ulong)
   __SYCL_FLOAT_INT_CONVERT(Op, DestType, SPVType, rtp, Rtp)                    \
   __SYCL_FLOAT_INT_CONVERT(Op, DestType, SPVType, rtn, Rtn)
 
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, char, schar)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, char, signed char)
 __SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, short, short)
 __SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, int, int)
 __SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, long, long)
 
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, uchar, uchar)
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, ushort, ushort)
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, uint, uint)
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, ulong, ulong)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, unsigned char, unsigned char)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, unsigned short, unsigned short)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, unsigned int, unsigned int)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, unsigned long, unsigned long)
 
 #undef __SYCL_SCALAR_FLOAT_INT_CONVERT
 #undef __SYCL_VECTOR_FLOAT_INT_CONVERT
@@ -688,9 +688,9 @@ inline NativeBFT ConvertFToBF16Vec(NativeFloatT vec) {
   EXPAND_BF16_ROUNDING_MODE(type, type_str, sycl::rounding_mode::rtn, rd)      \
   EXPAND_BF16_ROUNDING_MODE(type, type_str, sycl::rounding_mode::rtz, rz)
 
-EXPAND_BF16_TYPE(uint, uint)
+EXPAND_BF16_TYPE(unsigned int, unsigned int)
 EXPAND_BF16_TYPE(int, int)
-EXPAND_BF16_TYPE(ushort, ushort)
+EXPAND_BF16_TYPE(unsigned short, unsigned short)
 EXPAND_BF16_TYPE(short, short)
 EXPAND_BF16_TYPE(long, ll)
 EXPAND_BF16_TYPE(unsigned long long, ull)

--- a/sycl/include/sycl/detail/vector_convert.hpp
+++ b/sycl/include/sycl/detail/vector_convert.hpp
@@ -411,15 +411,15 @@ using enable_if_to_int_vector_t =
   __SYCL_VECTOR_INT_INT_CONVERT(Op, 8, DestType, SPVType)                      \
   __SYCL_VECTOR_INT_INT_CONVERT(Op, 16, DestType, SPVType)
 
-__SYCL_INT_INT_CONVERT(S, char, signed char)
+__SYCL_INT_INT_CONVERT(S, char, schar)
 __SYCL_INT_INT_CONVERT(S, short, short)
 __SYCL_INT_INT_CONVERT(S, int, int)
 __SYCL_INT_INT_CONVERT(S, long, long)
 
-__SYCL_INT_INT_CONVERT(U, unsigned char, unsigned char)
-__SYCL_INT_INT_CONVERT(U, unsigned short, unsigned short)
-__SYCL_INT_INT_CONVERT(U, unsigned int, unsigned int)
-__SYCL_INT_INT_CONVERT(U, unsigned long, unsigned long)
+__SYCL_INT_INT_CONVERT(U, uchar, uchar)
+__SYCL_INT_INT_CONVERT(U, ushort, ushort)
+__SYCL_INT_INT_CONVERT(U, uint, uint)
+__SYCL_INT_INT_CONVERT(U, ulong, ulong)
 
 #undef __SYCL_SCALAR_INT_INT_CONVERT
 #undef __SYCL_VECTOR_INT_INT_CONVERT
@@ -467,15 +467,15 @@ __SYCL_INT_INT_CONVERT(U, unsigned long, unsigned long)
   __SYCL_FLOAT_INT_CONVERT(Op, DestType, SPVType, rtp, Rtp)                    \
   __SYCL_FLOAT_INT_CONVERT(Op, DestType, SPVType, rtn, Rtn)
 
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, char, signed char)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, char, schar)
 __SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, short, short)
 __SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, int, int)
 __SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToS, long, long)
 
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, unsigned char, unsigned char)
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, unsigned short, unsigned short)
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, unsigned int, unsigned int)
-__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, unsigned long, unsigned long)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, uchar, uchar)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, ushort, ushort)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, uint, uint)
+__SYCL_FLOAT_INT_CONVERT_FOR_TYPE(FToU, ulong, ulong)
 
 #undef __SYCL_SCALAR_FLOAT_INT_CONVERT
 #undef __SYCL_VECTOR_FLOAT_INT_CONVERT
@@ -688,9 +688,9 @@ inline NativeBFT ConvertFToBF16Vec(NativeFloatT vec) {
   EXPAND_BF16_ROUNDING_MODE(type, type_str, sycl::rounding_mode::rtn, rd)      \
   EXPAND_BF16_ROUNDING_MODE(type, type_str, sycl::rounding_mode::rtz, rz)
 
-EXPAND_BF16_TYPE(unsigned int, unsigned int)
+EXPAND_BF16_TYPE(uint, uint)
 EXPAND_BF16_TYPE(int, int)
-EXPAND_BF16_TYPE(unsigned short, unsigned short)
+EXPAND_BF16_TYPE(ushort, ushort)
 EXPAND_BF16_TYPE(short, short)
 EXPAND_BF16_TYPE(long, ll)
 EXPAND_BF16_TYPE(unsigned long long, ull)

--- a/sycl/include/sycl/detail/vector_convert.hpp
+++ b/sycl/include/sycl/detail/vector_convert.hpp
@@ -688,9 +688,9 @@ inline NativeBFT ConvertFToBF16Vec(NativeFloatT vec) {
   EXPAND_BF16_ROUNDING_MODE(type, type_str, sycl::rounding_mode::rtn, rd)      \
   EXPAND_BF16_ROUNDING_MODE(type, type_str, sycl::rounding_mode::rtz, rz)
 
-EXPAND_BF16_TYPE(uint, uint)
+EXPAND_BF16_TYPE(unsigned int, uint)
 EXPAND_BF16_TYPE(int, int)
-EXPAND_BF16_TYPE(ushort, ushort)
+EXPAND_BF16_TYPE(unsigned short, ushort)
 EXPAND_BF16_TYPE(short, short)
 EXPAND_BF16_TYPE(long, ll)
 EXPAND_BF16_TYPE(unsigned long long, ull)

--- a/sycl/source/builtins/integer_functions.cpp
+++ b/sycl/source/builtins/integer_functions.cpp
@@ -28,7 +28,7 @@ template <typename T> inline T __get_high_half(T a0b0, T a0b1, T a1b0, T a1b1) {
 // A helper function for mul_hi built-in for long
 template <typename T>
 inline void __get_half_products(T a, T b, T &a0b0, T &a0b1, T &a1b0, T &a1b1) {
-  constexpr sycl::cl_int halfsize = (sizeof(T) * 8) / 2;
+  constexpr sycl::opencl::cl_int halfsize = (sizeof(T) * 8) / 2;
   T a1 = a >> halfsize;
   T a0 = (a << halfsize) >> halfsize;
   T b1 = b >> halfsize;

--- a/sycl/test-e2e/Adapters/level_zero/eager_init.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/eager_init.cpp
@@ -58,8 +58,8 @@ void simple_vadd(sycl::queue &Queue, const std::array<T, N> &VA,
 
 int main() {
   const size_t array_size = 4;
-  std::array<sycl::cl_int, array_size> A = {{1, 2, 3, 4}}, B = {{1, 2, 3, 4}},
-                                       C;
+  std::array<sycl::opencl::cl_int, array_size> A = {{1, 2, 3, 4}},
+                                               B = {{1, 2, 3, 4}}, C;
   sycl::queue Q;
 
   // simple_vadd(Q, A, B, C);


### PR DESCRIPTION
This patch prepares deprecated aliases to be removed in the next ABI-breaking window (they're not a part of  SYCL 2020):
- cl_bool, cl_char etc. (replaced by sycl::opencl::cl_bool, sycl::opencl::cl_char etc.)
- schar, uchar etc (no new alternative)
- schar2, schar3 ... schar16, longlong2, longlong3 ... longlong16 etc. (no new alternative)
- cl_char2, cl_char3 ... cl_char16, cl_int2, cl_int3 ... cl_int16 etc. (no new alternative)

And removes dead code and comments related to SYCL 1.2.1 mode as we do not support it anymore.