### PR TITLE
[SYCL][Test] Add `-x c++` to clang unittests CompilerInvocationTest

### DIFF
--- a/clang/unittests/Frontend/CompilerInvocationTest.cpp
+++ b/clang/unittests/Frontend/CompilerInvocationTest.cpp
@@ -621,7 +621,7 @@ TEST_F(CommandLineTest, ConditionalParsingIfNonsenseSyclStdArg) {
 }
 
 TEST_F(CommandLineTest, ConditionalParsingIfTrueFlagNotPresentHost) {
-  const char *Args[] = {"-fsycl-is-host"};
+  const char *Args[] = {"-fsycl-is-host", "-x", "c++"};
 
   CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags);
 
@@ -636,7 +636,7 @@ TEST_F(CommandLineTest, ConditionalParsingIfTrueFlagNotPresentHost) {
 }
 
 TEST_F(CommandLineTest, ConditionalParsingIfTrueFlagNotPresentDevice) {
-  const char *Args[] = {"-fsycl-is-device"};
+  const char *Args[] = {"-fsycl-is-device", "-x", "c++"};
 
   CompilerInvocation::CreateFromArgs(Invocation, Args, *Diags);
 


### PR DESCRIPTION
Downstream added a frontend check that rejects C inputs when -fsycl-is-device/-fsycl-is-host is active, and updated the tests to pass -x c++ to avoid triggering that new error. The upstream intel/llvm doesn't have that enforcement yet, so its tests can still use bare -fsycl-is-device without a language specifier.

This PR upstreams the change to avoid downstream customization. The change make sense since SYCL implies C++.