### PR TITLE
[Driver][SYCL] Fix crash with SYCL AMDGCN targets when LTO enabled by default

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6182,9 +6182,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       if ((IsDeviceOffloadAction &&
            !JA.isDeviceOffloading(Action::OFK_OpenMP) && !Triple.isAMDGPU() &&
            !Triple.isSPIRV() && !IsUsingOffloadNewDriver) ||
-          (JA.isDeviceOffloading(Action::OFK_SYCL) && !IsSYCLLTOSupported)) {
+          (JA.isDeviceOffloading(Action::OFK_SYCL) && !IsSYCLLTOSupported &&
+           LTOArg)) {
         D.Diag(diag::err_drv_unsupported_opt_for_target)
-            << (LTOArg ? LTOArg->getAsString(Args) : "-foffload-lto")
+            << LTOArg->getAsString(Args)
             << Triple.getTriple();
       } else if (Triple.isNVPTX() && !IsRDCMode &&
                  JA.isDeviceOffloading(Action::OFK_Cuda)) {


### PR DESCRIPTION
After commit 859ee9d83ef2, HIPAMDToolChain::getDefaultLTOMode() returns LTOK_Full, which is the toolchain used for SYCL AMDGCN targets. This caused IsUsingLTO=true even without an explicit -foffload-lto flag, triggering the SYCL LTO unsupported diagnostic on a null LTOArg.

Guard the SYCL branch of the diagnostic with LTOArg being non-null, so the error only fires when the user explicitly passed -foffload-lto.

Fixes:
- clang/test/Driver/sycl-device-traits-macros-amdgcn.cpp CMPLRLLVM-76332
- libdevice build error: unsupported option '-foffload-lto' for target 'amdgcn-amd-amdhsa'