### PR TITLE
[Clang][SYCL] Fix test sycl-offload-new-driver.cpp for AMDGCN full LTO mode

### DIFF
--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -93,7 +93,7 @@
 // RUN:  | FileCheck -check-prefix=CHK_ARCH \
 // RUN:              -DTRIPLE=nvptx64-nvidia-cuda -DARCH=sm_75 %s
 // CHK_ARCH: clang{{.*}} "-triple" "[[TRIPLE]]"
-// CHK_ARCH-SAME: "-fsycl-is-device" {{.*}} "--offload-new-driver"{{.*}} "-o" "[[CC1DEVOUT:.+\.bc]]"
+// CHK_ARCH-SAME: "-fsycl-is-device" {{.*}} "--offload-new-driver"{{.*}} "-o" "[[CC1DEVOUT:.+\.(bc|o)]]"
 // CHK_ARCH-NEXT: llvm-offload-binary{{.*}} "--image=file=[[CC1DEVOUT]],triple=[[TRIPLE]],arch=[[ARCH]]{{.*}},kind=sycl{{.*}}"
 
 // Verify offload-packager option values


### PR DESCRIPTION
After 859ee9d83ef2, HIPAMDToolChain::getDefaultLTOMode() returns LTOK_Full for AMDGCN, so the device cc1 emits a fat LTO object (.o) rather than plain bitcode (.bc). Widen the CHK_ARCH capture pattern to accept both extensions.

CMPLRLLVM-76332