### PR TITLE
[Clang][SYCL] Fix new-driver Backend phase producing .ll instead of .bc when -S is passed

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -8393,15 +8393,14 @@ Action *Driver::ConstructPhaseAction(
       }
       return C.MakeAction<BackendJobAction>(Input, Output);
     }
-    if (Args.hasArg(options::OPT_emit_llvm) ||
-        (TargetDeviceOffloadKind == Action::OFK_SYCL &&
-         getUseNewOffloadingDriver())) {
+    // SYCL new-driver device backend output feeds llvm-offload-binary for
+    // packaging and must always be BC regardless of -S.
+    if (TargetDeviceOffloadKind == Action::OFK_SYCL &&
+        getUseNewOffloadingDriver())
+      return C.MakeAction<BackendJobAction>(Input, types::TY_LLVM_BC);
+    if (Args.hasArg(options::OPT_emit_llvm)) {
       types::ID Output =
-          Args.hasArg(options::OPT_S) &&
-                  (TargetDeviceOffloadKind == Action::OFK_None ||
-                   offloadDeviceOnly())
-              ? types::TY_LLVM_IR
-              : types::TY_LLVM_BC;
+          Args.hasArg(options::OPT_S) ? types::TY_LLVM_IR : types::TY_LLVM_BC;
       return C.MakeAction<BackendJobAction>(Input, Output);
     }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -8394,9 +8394,14 @@ Action *Driver::ConstructPhaseAction(
       return C.MakeAction<BackendJobAction>(Input, Output);
     }
     if (Args.hasArg(options::OPT_emit_llvm) ||
-        TargetDeviceOffloadKind == Action::OFK_SYCL) {
+        (TargetDeviceOffloadKind == Action::OFK_SYCL &&
+         getUseNewOffloadingDriver())) {
       types::ID Output =
-          Args.hasArg(options::OPT_S) ? types::TY_LLVM_IR : types::TY_LLVM_BC;
+          Args.hasArg(options::OPT_S) &&
+                  (TargetDeviceOffloadKind == Action::OFK_None ||
+                   offloadDeviceOnly())
+              ? types::TY_LLVM_IR
+              : types::TY_LLVM_BC;
       return C.MakeAction<BackendJobAction>(Input, Output);
     }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -8333,6 +8333,14 @@ Action *Driver::ConstructPhaseAction(
     return C.MakeAction<CompileJobAction>(Input, types::TY_LLVM_BC);
   }
   case phases::Backend: {
+    // SYCL new-driver backend outputs BC for llvm-offload-binary packaging.
+    // ThinLTO excluded (has its own sycl-post-link pipeline).
+    // LTO + -S excluded: AMD needs TY_LTO_IR so the image is .s assembly;
+    // LTOK_None targets (NVPTX, SPIR64) have no LTO branch so always hit this.
+    if (TargetDeviceOffloadKind == Action::OFK_SYCL &&
+        getUseNewOffloadingDriver() && TargetLTOMode != LTOK_Thin &&
+        (TargetLTOMode == LTOK_None || !Args.hasArg(options::OPT_S)))
+      return C.MakeAction<BackendJobAction>(Input, types::TY_LLVM_BC);
     if (TargetLTOMode != LTOK_None) {
       bool IsDeviceOffload = TargetDeviceOffloadKind != Action::OFK_None;
       if (!IsDeviceOffload) {
@@ -8393,11 +8401,6 @@ Action *Driver::ConstructPhaseAction(
       }
       return C.MakeAction<BackendJobAction>(Input, Output);
     }
-    // SYCL new-driver device backend output feeds llvm-offload-binary for
-    // packaging and must always be BC regardless of -S.
-    if (TargetDeviceOffloadKind == Action::OFK_SYCL &&
-        getUseNewOffloadingDriver())
-      return C.MakeAction<BackendJobAction>(Input, types::TY_LLVM_BC);
     if (Args.hasArg(options::OPT_emit_llvm)) {
       types::ID Output =
           Args.hasArg(options::OPT_S) ? types::TY_LLVM_IR : types::TY_LLVM_BC;

--- a/clang/test/Driver/sycl-offload-Xarch.cpp
+++ b/clang/test/Driver/sycl-offload-Xarch.cpp
@@ -29,10 +29,10 @@
 // O3ONCE-NVPTX: "-triple" "nvptx64-nvidia-cuda"
 // O3ONCE-NVPTX-SAME: "-O3"
 // INVALID-ARCH-FOR-TARGET: clang: error: invalid target ID 'sm_75'; format is a processor name followed by an optional colon-delimited list of features followed by an enable/disable sign (e.g., 'gfx908:sramecc+:xnack-')
-// AMD-ARCH: {{"[^"]*llvm-offload-binary[^"]*" "-o".* "--image=file=.*.bc,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=sycl"}}
+// AMD-ARCH: {{"[^"]*llvm-offload-binary[^"]*" "-o".* "--image=file=.*.s,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=sycl"}}
 // NVPTX-ARCH: {{"[^"]*llvm-offload-binary[^"]*" "-o".* "--image=file=.*.bc,triple=nvptx64-nvidia-cuda,arch=sm_52,kind=sycl"}}
-// MULTI-ARCH: {{"[^"]*llvm-offload-binary[^"]*" "-o".* "--image=file=.*.bc,triple=amdgcn-amd-amdhsa,arch=gfx906,kind=sycl"}}
-// MULTI-ARCH-SAME: {{"--image=file=.*.bc,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=sycl"}}
+// MULTI-ARCH: {{"[^"]*llvm-offload-binary[^"]*" "-o".* "--image=file=.*.s,triple=amdgcn-amd-amdhsa,arch=gfx906,kind=sycl"}}
+// MULTI-ARCH-SAME: {{"--image=file=.*.s,triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=sycl"}}
 // MULTI-ARCH-SAME: {{"--image=file=.*.bc,triple=nvptx64-nvidia-cuda,arch=sm_52,kind=sycl"}}
 // MULTI-ARCH-SAME: {{"--image=file=.*.bc,triple=nvptx64-nvidia-cuda,arch=sm_89,kind=sycl"}}
 


### PR DESCRIPTION
85863edfc94a (Merge from 'main' to 'sycl-web' (2 commits)) dropped the getUseNewOffloadingDriver() guard from the OFK_SYCL branch in ConstructPhaseAction when resolving a merge conflict. This caused SYCL new-driver Backend phases to emit TY_LLVM_IR when -S is present.

Upstream has a single SYCL compilation path, so bare OFK_SYCL is correct there. sycl-web has both old-driver and new-driver paths and must distinguish them: in the new-driver path, device backend output feeds llvm-offload-binary for packaging, which requires .bc. The -S flag is meaningful for host compilation only; the new-driver device Backend phase must always produce TY_LLVM_BC regardless of -S.

Restore the getUseNewOffloadingDriver() guard and restrict -S -> TY_LLVM_IR to TargetDeviceOffloadKind == OFK_None or offloadDeviceOnly().

Fix by separating the SYCL new-driver and emit_llvm branches with SYCL
new-driver checked first, restoring upstream behavior for OpenMP offload:
- SYCL new-driver + -emit-llvm -S: SYCL branch fires first -> BC
- SYCL new-driver, no -emit-llvm: SYCL branch -> BC
- OpenMP NVPTX + -emit-llvm -S: emit_llvm branch -> IR (upstream behavior restored)
- SYCL old-driver + -emit-llvm -S: emit_llvm branch -> IR (same as before)

Fixes
- clang/test/Driver/sycl-offload-nvptx.cpp
- clang/test/Driver/sycl-offload-static-lib-2-old-model.cpp
- clang/test/Driver/sycl-oneapi-gpu-nvidia.cpp
- clang/test/Driver/sycl-save-ptx-files.cpp
- clang/test/Driver/sycl-offload-Xarch.cpp
- clang/test/Driver/openmp-offload-gpu.c
- clang/test/Driver/sycl-offload.cpp
- clang/test/Driver/sycl-offload-new-driver.cpp

Also update sycl-offload-Xarch.cpp AMD-ARCH/MULTI-ARCH checks from .bc to .s for upstream 859ee9d83ef2 (AMDGCN now defaults to full LTO mode).

CMPLRLLVM-76332