### PR TITLE
[Driver][SYCL][lit] Fix tests broken by libspirv lookup in AMD new-driver path

### DIFF
--- a/clang/test/Driver/sycl-offload-amdgcn.cpp
+++ b/clang/test/Driver/sycl-offload-amdgcn.cpp
@@ -15,17 +15,18 @@
 // CHK-MULTI-ARCH: error: missing AMDGPU architecture for SYCL offloading; specify it with '-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=<arch-name>'
 
 /// Check action graph.
-// RUN: %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: %clangxx -### -std=c++17 -target x86_64-unknown-linux-gnu -fsycl \
 // RUN: -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib\
 // RUN: -fsycl-libspirv-path=%S/Inputs/SYCL/libspirv.bc %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-ACTIONS %s
-// CHK-ACTIONS: "-cc1" "-triple" "amdgcn-amd-amdhsa" "-aux-triple" "x86_64-unknown-linux-gnu"{{.*}} "-fsycl-is-device"{{.*}} "-Wno-sycl-strict"{{.*}} "-sycl-std=2020" {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libspirv.bc"{{.*}} "-target-cpu" "gfx906"{{.*}} "-std=c++11"{{.*}}
+// CHK-ACTIONS: "-cc1" "-triple" "amdgcn-amd-amdhsa" "-aux-triple" "x86_64-unknown-linux-gnu"{{.*}} "-fsycl-is-device"{{.*}} "-Wno-sycl-strict"{{.*}} "-sycl-std=2020" {{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include{{[/\\]+}}sycl{{[/\\]+}}stl_wrappers"{{.*}} "-mlink-builtin-bitcode" "{{.*}}libspirv.bc"{{.*}} "-target-cpu" "gfx906"{{.*}} "-std=c++17"{{.*}}
 // CHK-ACTIONS-NOT: "-mllvm -sycl-opt"
 // CHK-ACTIONS: clang-offload-wrapper"{{.*}} "-host=x86_64-unknown-linux-gnu" "-compile-opts=--offload-arch=gfx906" "-target=amdgcn" "-kind=sycl"{{.*}}
 
 /// Check phases w/out specifying a compute capability.
-// RUN: %clangxx -ccc-print-phases -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \
+// RUN: %clangxx -ccc-print-phases -std=c++17 -target x86_64-unknown-linux-gnu -fsycl \
 // RUN: -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 %s 2>&1 \
+// RUN: --sysroot=%S/Inputs/SYCL \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-NO-CC %s
 // CHK-PHASES-NO-CC: 0: input, "{{.*}}", c++, (host-sycl)
 // CHK-PHASES-NO-CC: 1: preprocessor, {0}, c++-cpp-output, (host-sycl)
@@ -55,11 +56,11 @@
 // RUN: %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -nogpulib \
 // RUN:   -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend \
 // RUN:   --offload-arch=gfx906 %s -L%S/Inputs/SYCL -llin64 2>&1 \
-// RUN: | FileCheck -check-prefix=CHK-ARCHIVE %s
+// RUN:   -fsycl-libspirv-path=%S/Inputs/SYCL/libspirv.bc | FileCheck -check-prefix=CHK-ARCHIVE %s
 // RUN: %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -nogpulib \
 // RUN:   -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend \
 // RUN:   --offload-arch=gfx906 %s %S/Inputs/SYCL/liblin64.a 2>&1 \
-// RUN: | FileCheck -check-prefix=CHK-ARCHIVE %s
+// RUN:   -fsycl-libspirv-path=%S/Inputs/SYCL/libspirv.bc | FileCheck -check-prefix=CHK-ARCHIVE %s
 // CHK-ARCHIVE: clang-offload-bundler{{.*}} "-input={{.*}}/Inputs/SYCL/liblin64.a"
 // CHK-ARCHIVE: llvm-link{{.*}}
 // CHK-ARCHIVE-NOT: clang-offload-bundler{{.*}} "-unbundle"

--- a/clang/test/Driver/sycl-target-mismatch-amdgpu.cpp
+++ b/clang/test/Driver/sycl-target-mismatch-amdgpu.cpp
@@ -1,26 +1,26 @@
 // REQUIRES: amdgpu-registered-target
 
-// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib\
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib -fno-sycl-libspirv\
 // RUN:   %S/Inputs/SYCL/libamdgcn-gfx908.a -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=AMDGCN_DIAG
-// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib\
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib -fno-sycl-libspirv\
 // RUN:   -L%S/Inputs/SYCL -lamdgcn-gfx908 -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=AMDGCN_DIAG
-// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib\
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib -fno-sycl-libspirv\
 // RUN:   %S/Inputs/SYCL/objamdgcn-gfx908.o -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=AMDGCN_DIAG
 // AMDGCN_DIAG: linked binaries do not contain expected 'amdgcn-amd-amdhsa-gfx906' target; found targets: 'amdgcn-amd-amdhsa-gfx908' [-Wsycl-target]
 
-// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib\
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib -fno-sycl-libspirv\
 // RUN:   %S/Inputs/SYCL/libamdgcn-gfx908.a -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=AMDGCN_MATCH_DIAG
-// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib\
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib -fno-sycl-libspirv\
 // RUN:   -L%S/Inputs/SYCL -lamdgcn-gfx908 -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=AMDGCN_MATCH_DIAG
-// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib\
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx908 -nogpulib -fno-sycl-libspirv\
 // RUN:   %S/Inputs/SYCL/objamdgcn-gfx908.o -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=AMDGCN_MATCH_DIAG
-// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib\
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -nogpulib -fno-sycl-libspirv\
 // RUN:   -Wno-sycl-target %S/Inputs/SYCL/objamdgcn-gfx908.o -### %s 2>&1 \
 // RUN:  | FileCheck %s -check-prefix=AMDGCN_MATCH_DIAG
 // AMDGCN_MATCH_DIAG-NOT: linked binaries do not contain expected

--- a/clang/test/Driver/sycl-triple-dae-flags.cpp
+++ b/clang/test/Driver/sycl-triple-dae-flags.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: nvptx-registered-target, amdgpu-registered-target
-
-// RUN: %clangxx -### -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -fsycl-dead-args-optimization -nogpulib %s 2> %t.rocm.out
+// RUN: %clangxx -### -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -fsycl-dead-args-optimization -nogpulib -fsycl-libspirv-path=%S/Inputs/SYCL/libspirv.bc %s 2> %t.rocm.out
 // RUN: FileCheck %s --input-file %t.rocm.out
 // CHECK-NOT: -fenable-sycl-dae
 // CHECK-NOT: -emit-param-info

--- a/clang/test/Driver/sycl-unsupported-arch.cpp
+++ b/clang/test/Driver/sycl-unsupported-arch.cpp
@@ -5,6 +5,6 @@
 // CHECK-PHASES: offload, "device-sycl (amdgcn-amd-amdhsa:gfx600)"
 
 /// Verify that preprocessor works (#8112)
-// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx600 -nogpulib -E %s 2>&1 | FileCheck %s --check-prefix=CHECK-PREPROCESSOR
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx600 -nogpulib -E -fno-sycl-libspirv  %s 2>&1 | FileCheck %s --check-prefix=CHECK-PREPROCESSOR
 // CHECK-PREPROCESSOR: // __CLANG_OFFLOAD_BUNDLE____START__ sycl-amdgcn-amd-amdhsa-gfx600
 


### PR DESCRIPTION
The tests fail on sycl-web branch.

All changes are copied from downstream:
- clang/test/Driver/sycl-triple-dae-flags.cpp
- clang/test/Driver/sycl-unsupported-arch.cpp
- clang/test/Driver/sycl-target-mismatch-amdgpu.cpp
- clang/test/Driver/sycl-offload-amdgcn.cpp