### PR TITLE
[SYCL][E2E] Disable memory_fill.cpp on DG2

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/memory_fill.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/memory_fill.cpp
@@ -2,7 +2,7 @@
 // UNSUPPORTED: level_zero_v2_adapter
 // UNSUPPORTED-INTENDED: v2 adapter does not allow specifying command queue.
 
-// UNSUPPORTED: windows && gpu-intel-gen12
+// UNSUPPORTED: windows && (gpu-intel-gen12 || gpu-intel-dg2)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
 
 // RUN: %{build} %level_zero_options -o %t.out


### PR DESCRIPTION
Failing on DG2, see [here](https://github.com/intel/llvm/issues/21556#issuecomment-4768918545).