### PR TITLE
[UR] Refactor reusable event API to pass device as urEventCreateExp parameter

### DIFF
--- a/unified-runtime/include/unified-runtime/ur_api.h
+++ b/unified-runtime/include/unified-runtime/ur_api.h
@@ -13839,8 +13839,6 @@ typedef struct ur_exp_event_desc_t {
   ur_structure_type_t stype;
   /// [in][optional] pointer to extension-specific structure
   const void *pNext;
-  /// [in] handle of the device object associated with this event
-  ur_device_handle_t hDevice;
   /// [in] combination of event creation flags. If
   /// ::UR_EXP_EVENT_FLAG_ENABLE_PROFILING is set, the event captures
   /// UR_PROFILING_INFO_COMMAND_START and UR_PROFILING_INFO_COMMAND_END
@@ -13868,7 +13866,7 @@ typedef struct ur_exp_event_desc_t {
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-///         + `NULL == pEventDesc->hDevice`
+///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pEventDesc`
 ///         + `NULL == phEvent`
@@ -13883,6 +13881,8 @@ typedef struct ur_exp_event_desc_t {
 UR_APIEXPORT ur_result_t UR_APICALL urEventCreateExp(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
+    /// [in] handle of the device object
+    ur_device_handle_t hDevice,
     /// [in] pointer to event creation descriptor
     const ur_exp_event_desc_t *pEventDesc,
     /// [out] pointer to the handle of the event object created
@@ -14566,6 +14566,7 @@ typedef struct ur_event_set_callback_params_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_event_create_exp_params_t {
   ur_context_handle_t *phContext;
+  ur_device_handle_t *phDevice;
   const ur_exp_event_desc_t **ppEventDesc;
   ur_event_handle_t **pphEvent;
 } ur_event_create_exp_params_t;

--- a/unified-runtime/include/unified-runtime/ur_ddi.h
+++ b/unified-runtime/include/unified-runtime/ur_ddi.h
@@ -304,7 +304,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetEventProcAddrTable_t)(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urEventCreateExp
 typedef ur_result_t(UR_APICALL *ur_pfnEventCreateExp_t)(
-    ur_context_handle_t, const ur_exp_event_desc_t *, ur_event_handle_t *);
+    ur_context_handle_t, ur_device_handle_t, const ur_exp_event_desc_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of EventExp functions pointers

--- a/unified-runtime/include/unified-runtime/ur_print.hpp
+++ b/unified-runtime/include/unified-runtime/ur_print.hpp
@@ -13480,11 +13480,6 @@ inline std::ostream &operator<<(std::ostream &os,
   ur::details::printStruct(os, (params.pNext));
 
   os << ", ";
-  os << ".hDevice = ";
-
-  ur::details::printPtr(os, (params.hDevice));
-
-  os << ", ";
   os << ".flags = ";
 
   ur::details::printFlag<ur_exp_event_flag_t>(os, (params.flags));
@@ -14430,6 +14425,11 @@ operator<<(std::ostream &os,
   os << ".hContext = ";
 
   ur::details::printPtr(os, *(params->phContext));
+
+  os << ", ";
+  os << ".hDevice = ";
+
+  ur::details::printPtr(os, *(params->phDevice));
 
   os << ", ";
   os << ".pEventDesc = ";

--- a/unified-runtime/scripts/core/exp-reusable-events.yml
+++ b/unified-runtime/scripts/core/exp-reusable-events.yml
@@ -42,9 +42,6 @@ desc: "Descriptor type for creating reusable events."
 name: $x_exp_event_desc_t
 base: $x_base_desc_t
 members:
-    - type: $x_device_handle_t
-      name: hDevice
-      desc: "[in] handle of the device object associated with this event"
     - type: $x_exp_event_flags_t
       name: flags
       desc: >
@@ -80,6 +77,9 @@ params:
     - type: $x_context_handle_t
       name: hContext
       desc: "[in] handle of the context object"
+    - type: $x_device_handle_t
+      name: hDevice
+      desc: "[in] handle of the device object"
     - type: "const $x_exp_event_desc_t*"
       name: pEventDesc
       desc: "[in] pointer to event creation descriptor"
@@ -89,7 +89,7 @@ params:
 returns:
   - $X_RESULT_ERROR_INVALID_NULL_HANDLE:
     - "`NULL == hContext`"
-    - "`NULL == pEventDesc->hDevice`"
+    - "`NULL == hDevice`"
   - $X_RESULT_ERROR_INVALID_NULL_POINTER:
     - "`NULL == pEventDesc`"
     - "`NULL == phEvent`"

--- a/unified-runtime/source/adapters/cuda/event.cpp
+++ b/unified-runtime/source/adapters/cuda/event.cpp
@@ -305,7 +305,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventCreateExp(
-    ur_context_handle_t, const ur_exp_event_desc_t *, ur_event_handle_t *) {
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventCreateExp(ur_context_handle_t, ur_device_handle_t,
+                 const ur_exp_event_desc_t *, ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/hip/event.cpp
+++ b/unified-runtime/source/adapters/hip/event.cpp
@@ -314,7 +314,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventCreateExp(
-    ur_context_handle_t, const ur_exp_event_desc_t *, ur_event_handle_t *) {
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventCreateExp(ur_context_handle_t, ur_device_handle_t,
+                 const ur_exp_event_desc_t *, ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/level_zero/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/event.cpp
@@ -1014,6 +1014,7 @@ ur_result_t urEventSetCallback(
 }
 
 ur_result_t urEventCreateExp(ur_context_handle_t /*hContext*/,
+                             ur_device_handle_t /*hDevice*/,
                              const ur_exp_event_desc_t * /*pEventDesc*/,
                              ur_event_handle_t * /*phEvent*/) {
   UR_LOG_LEGACY(ERR,

--- a/unified-runtime/source/adapters/level_zero/ur_interface_loader.hpp
+++ b/unified-runtime/source/adapters/level_zero/ur_interface_loader.hpp
@@ -856,6 +856,7 @@ ur_result_t urEnqueueNativeCommandExp(
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent);
 ur_result_t urEventCreateExp(ur_context_handle_t hContext,
+                             ur_device_handle_t hDevice,
                              const ur_exp_event_desc_t *pEventDesc,
                              ur_event_handle_t *phEvent);
 ur_result_t urGraphCreateExp(ur_context_handle_t hContext,

--- a/unified-runtime/source/adapters/level_zero/v2/event.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/event.cpp
@@ -417,6 +417,7 @@ urEventCreateWithNativeHandle(ur_native_handle_t hNativeEvent,
 }
 
 ur_result_t urEventCreateExp(ur_context_handle_t /*hContext*/,
+                             ur_device_handle_t /*hDevice*/,
                              const ur_exp_event_desc_t * /*pEventDesc*/,
                              ur_event_handle_t * /*phEvent*/) {
   UR_LOG(ERR, "{} function not implemented!", __FUNCTION__);

--- a/unified-runtime/source/adapters/mock/ur_mockddi.cpp
+++ b/unified-runtime/source/adapters/mock/ur_mockddi.cpp
@@ -12648,13 +12648,16 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 __urdlllocal ur_result_t UR_APICALL urEventCreateExp(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
+    /// [in] handle of the device object
+    ur_device_handle_t hDevice,
     /// [in] pointer to event creation descriptor
     const ur_exp_event_desc_t *pEventDesc,
     /// [out] pointer to the handle of the event object created
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
-  ur_event_create_exp_params_t params = {&hContext, &pEventDesc, &phEvent};
+  ur_event_create_exp_params_t params = {&hContext, &hDevice, &pEventDesc,
+                                         &phEvent};
 
   auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
       mock::getCallbacks().get_before_callback("urEventCreateExp"));

--- a/unified-runtime/source/adapters/native_cpu/event.cpp
+++ b/unified-runtime/source/adapters/native_cpu/event.cpp
@@ -108,10 +108,10 @@ urEnqueueTimestampRecordingExp(ur_queue_handle_t /*hQueue*/, bool /*blocking*/,
   DIE_NO_IMPLEMENTATION;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEventCreateExp(ur_context_handle_t /*hContext*/,
-                 const ur_exp_event_desc_t * /*pEventDesc*/,
-                 ur_event_handle_t * /*phEvent*/) {
+UR_APIEXPORT ur_result_t UR_APICALL urEventCreateExp(
+    ur_context_handle_t /*hContext*/, ur_device_handle_t /*hDevice*/,
+    const ur_exp_event_desc_t * /*pEventDesc*/,
+    ur_event_handle_t * /*phEvent*/) {
   DIE_NO_IMPLEMENTATION;
 }
 

--- a/unified-runtime/source/adapters/offload/event.cpp
+++ b/unified-runtime/source/adapters/offload/event.cpp
@@ -129,7 +129,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventCreateExp(
-    ur_context_handle_t, const ur_exp_event_desc_t *, ur_event_handle_t *) {
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventCreateExp(ur_context_handle_t, ur_device_handle_t,
+                 const ur_exp_event_desc_t *, ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/adapters/opencl/event.cpp
+++ b/unified-runtime/source/adapters/opencl/event.cpp
@@ -306,7 +306,8 @@ urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventCreateExp(
-    ur_context_handle_t, const ur_exp_event_desc_t *, ur_event_handle_t *) {
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventCreateExp(ur_context_handle_t, ur_device_handle_t,
+                 const ur_exp_event_desc_t *, ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/unified-runtime/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/unified-runtime/source/loader/layers/tracing/ur_trcddi.cpp
@@ -10747,6 +10747,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 __urdlllocal ur_result_t UR_APICALL urEventCreateExp(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
+    /// [in] handle of the device object
+    ur_device_handle_t hDevice,
     /// [in] pointer to event creation descriptor
     const ur_exp_event_desc_t *pEventDesc,
     /// [out] pointer to the handle of the event object created
@@ -10756,14 +10758,15 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateExp(
   if (nullptr == pfnCreateExp)
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 
-  ur_event_create_exp_params_t params = {&hContext, &pEventDesc, &phEvent};
+  ur_event_create_exp_params_t params = {&hContext, &hDevice, &pEventDesc,
+                                         &phEvent};
   uint64_t instance = getContext()->notify_begin(UR_FUNCTION_EVENT_CREATE_EXP,
                                                  "urEventCreateExp", &params);
 
   auto &logger = getContext()->logger;
   UR_LOG_L(logger, INFO, "   ---> urEventCreateExp\n");
 
-  ur_result_t result = pfnCreateExp(hContext, pEventDesc, phEvent);
+  ur_result_t result = pfnCreateExp(hContext, hDevice, pEventDesc, phEvent);
 
   getContext()->notify_end(UR_FUNCTION_EVENT_CREATE_EXP, "urEventCreateExp",
                            &params, &result, instance);

--- a/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
+++ b/unified-runtime/source/loader/layers/validation/ur_valddi.cpp
@@ -11594,6 +11594,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 __urdlllocal ur_result_t UR_APICALL urEventCreateExp(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
+    /// [in] handle of the device object
+    ur_device_handle_t hDevice,
     /// [in] pointer to event creation descriptor
     const ur_exp_event_desc_t *pEventDesc,
     /// [out] pointer to the handle of the event object created
@@ -11614,7 +11616,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateExp(
     if (NULL == hContext)
       return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
 
-    if (NULL == pEventDesc->hDevice)
+    if (NULL == hDevice)
       return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
 
     if (UR_EXP_EVENT_FLAGS_MASK & pEventDesc->flags)
@@ -11626,7 +11628,12 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateExp(
     URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
-  ur_result_t result = pfnCreateExp(hContext, pEventDesc, phEvent);
+  if (getContext()->enableLifetimeValidation &&
+      !getContext()->refCountContext->isReferenceValid(hDevice)) {
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
+  }
+
+  ur_result_t result = pfnCreateExp(hContext, hDevice, pEventDesc, phEvent);
 
   if (getContext()->enableLeakChecking && result == UR_RESULT_SUCCESS &&
       phEvent) {

--- a/unified-runtime/source/loader/ur_ldrddi.cpp
+++ b/unified-runtime/source/loader/ur_ldrddi.cpp
@@ -6112,6 +6112,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 __urdlllocal ur_result_t UR_APICALL urEventCreateExp(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
+    /// [in] handle of the device object
+    ur_device_handle_t hDevice,
     /// [in] pointer to event creation descriptor
     const ur_exp_event_desc_t *pEventDesc,
     /// [out] pointer to the handle of the event object created
@@ -6124,7 +6126,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateExp(
     return UR_RESULT_ERROR_UNINITIALIZED;
 
   // forward to device-platform
-  return pfnCreateExp(hContext, pEventDesc, phEvent);
+  return pfnCreateExp(hContext, hDevice, pEventDesc, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/unified-runtime/source/loader/ur_libapi.cpp
+++ b/unified-runtime/source/loader/ur_libapi.cpp
@@ -11207,7 +11207,7 @@ ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-///         + `NULL == pEventDesc->hDevice`
+///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pEventDesc`
 ///         + `NULL == phEvent`
@@ -11222,6 +11222,8 @@ ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 ur_result_t UR_APICALL urEventCreateExp(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
+    /// [in] handle of the device object
+    ur_device_handle_t hDevice,
     /// [in] pointer to event creation descriptor
     const ur_exp_event_desc_t *pEventDesc,
     /// [out] pointer to the handle of the event object created
@@ -11230,7 +11232,7 @@ ur_result_t UR_APICALL urEventCreateExp(
   if (nullptr == pfnCreateExp)
     return UR_RESULT_ERROR_UNINITIALIZED;
 
-  return pfnCreateExp(hContext, pEventDesc, phEvent);
+  return pfnCreateExp(hContext, hDevice, pEventDesc, phEvent);
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }

--- a/unified-runtime/source/ur_api.cpp
+++ b/unified-runtime/source/ur_api.cpp
@@ -9748,7 +9748,7 @@ ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-///         + `NULL == pEventDesc->hDevice`
+///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pEventDesc`
 ///         + `NULL == phEvent`
@@ -9763,6 +9763,8 @@ ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 ur_result_t UR_APICALL urEventCreateExp(
     /// [in] handle of the context object
     ur_context_handle_t hContext,
+    /// [in] handle of the device object
+    ur_device_handle_t hDevice,
     /// [in] pointer to event creation descriptor
     const ur_exp_event_desc_t *pEventDesc,
     /// [out] pointer to the handle of the event object created

--- a/unified-runtime/test/conformance/exp_reusable_events/reusable_events.cpp
+++ b/unified-runtime/test/conformance/exp_reusable_events/reusable_events.cpp
@@ -13,13 +13,12 @@ TEST_P(urEventCreateExpTest, Success) {
   ur_exp_event_desc_t desc = {
       UR_STRUCTURE_TYPE_EXP_EVENT_DESC,
       nullptr,
-      device,
       static_cast<ur_exp_event_flags_t>(0),
   };
 
   uur::raii::Event event = nullptr;
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-      urEventCreateExp(context, &desc, event.ptr()));
+      urEventCreateExp(context, device, &desc, event.ptr()));
 
   if (!event) {
     return;
@@ -32,13 +31,12 @@ TEST_P(urEventCreateExpTest, SuccessWithProfilingFlag) {
   ur_exp_event_desc_t desc = {
       UR_STRUCTURE_TYPE_EXP_EVENT_DESC,
       nullptr,
-      device,
       UR_EXP_EVENT_FLAG_ENABLE_PROFILING,
   };
 
   uur::raii::Event event = nullptr;
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-      urEventCreateExp(context, &desc, event.ptr()));
+      urEventCreateExp(context, device, &desc, event.ptr()));
 
   if (!event) {
     return;
@@ -51,44 +49,41 @@ TEST_P(urEventCreateExpTest, InvalidNullHandleContext) {
   ur_exp_event_desc_t desc = {
       UR_STRUCTURE_TYPE_EXP_EVENT_DESC,
       nullptr,
-      device,
       static_cast<ur_exp_event_flags_t>(0),
   };
 
   uur::raii::Event event = nullptr;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                   urEventCreateExp(nullptr, &desc, event.ptr()));
+                   urEventCreateExp(nullptr, device, &desc, event.ptr()));
 }
 
 TEST_P(urEventCreateExpTest, InvalidNullPointerEventDesc) {
   uur::raii::Event event = nullptr;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                   urEventCreateExp(context, nullptr, event.ptr()));
+                   urEventCreateExp(context, device, nullptr, event.ptr()));
 }
 
 TEST_P(urEventCreateExpTest, InvalidNullPointerEventHandle) {
   ur_exp_event_desc_t desc = {
       UR_STRUCTURE_TYPE_EXP_EVENT_DESC,
       nullptr,
-      device,
       static_cast<ur_exp_event_flags_t>(0),
   };
 
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                   urEventCreateExp(context, &desc, nullptr));
+                   urEventCreateExp(context, device, &desc, nullptr));
 }
 
 TEST_P(urEventCreateExpTest, InvalidNullHandleEventDevice) {
   ur_exp_event_desc_t desc = {
       UR_STRUCTURE_TYPE_EXP_EVENT_DESC,
       nullptr,
-      nullptr,
       static_cast<ur_exp_event_flags_t>(0),
   };
 
   uur::raii::Event event = nullptr;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                   urEventCreateExp(context, &desc, event.ptr()));
+                   urEventCreateExp(context, nullptr, &desc, event.ptr()));
 }
 
 struct urEnqueueEventsWaitWithBarrierReusableEventTest : uur::urQueueTest {};
@@ -100,13 +95,12 @@ TEST_P(urEnqueueEventsWaitWithBarrierReusableEventTest,
   ur_exp_event_desc_t desc = {
       UR_STRUCTURE_TYPE_EXP_EVENT_DESC,
       nullptr,
-      device,
       static_cast<ur_exp_event_flags_t>(0),
   };
 
   uur::raii::Event signal_event = nullptr;
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-      urEventCreateExp(context, &desc, signal_event.ptr()));
+      urEventCreateExp(context, device, &desc, signal_event.ptr()));
   if (!signal_event) {
     return;
   }


### PR DESCRIPTION
Remove hDevice data member from ur_exp_event_desc_t.
Insert hDevice as parameter of urEventCreateExp.