### PR TITLE
[UR][NFC] Update copyright date in ur_win_proxy_loader DLL metadata

### DIFF
--- a/sycl/ur_win_proxy_loader/CMakeLists.txt
+++ b/sycl/ur_win_proxy_loader/CMakeLists.txt
@@ -9,7 +9,7 @@ set_property(SOURCE ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc
                "RC_INTERNAL_NAME=\"ur_win_proxy_loader\""
                "RC_PRODUCT_NAME=\"ur_win_proxy_loader\""
                "RC_PRODUCT_VERSION=\"${SYCL_VERSION_STRING}\""
-               "RC_COPYRIGHT=\"Copyright (C) 2023 Intel Corporation\"")
+               "RC_COPYRIGHT=\"Part of the LLVM Project\"")
 configure_file(../../llvm/resources/windows_version_resource.rc ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc @ONLY)
 add_library(ur_win_proxy_loader SHARED  ur_win_proxy_loader.cpp  ${CMAKE_CURRENT_BINARY_DIR}/versioninfo.rc)
 add_dependencies(ur_win_proxy_loader UnifiedRuntimeLoader)


### PR DESCRIPTION
Update copyright string in ur_win_proxy_loader Windows DLL metadata from "Copyright (C) 2023 Intel Corporation" to "Part of the LLVM Project" to align with the LLVM Project license.