### PR TITLE
[SYCL] Prepare sub_group::barrier removal

### DIFF
--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -104,6 +104,7 @@ struct sub_group {
 #endif
   }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /* --- synchronization functions --- */
   __SYCL_DEPRECATED(
       "Sub-group barrier with no arguments is deprecated."
@@ -136,6 +137,7 @@ struct sub_group {
                           "Sub-groups are not supported on host.");
 #endif
   }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   linear_id_type get_group_linear_range() const {
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -10,7 +10,9 @@
 
 #include <sycl/__spirv/spirv_ops_subgroup.hpp>
 #include <sycl/detail/address_space_cast.hpp>
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL_DEPRECATED
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #include <sycl/id.hpp>                         // for id
 #include <sycl/memory_enums.hpp>               // for memory_scope
 #include <sycl/nd_item.hpp>

--- a/sycl/test-e2e/SubGroup/barrier.cpp
+++ b/sycl/test-e2e/SubGroup/barrier.cpp
@@ -20,8 +20,7 @@
 
 template <typename T> class sycl_subgr;
 using namespace sycl;
-template <typename T>
-void check(queue &Queue, size_t G = 240, size_t L = 60) {
+template <typename T> void check(queue &Queue, size_t G = 240, size_t L = 60) {
   try {
     nd_range<1> NdRange(G, L);
     std::vector<T> data(G);
@@ -32,22 +31,21 @@ void check(queue &Queue, size_t G = 240, size_t L = 60) {
       auto addacc = addbuf.template get_access<access::mode::read_write>(cgh);
       auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
 
-      cgh.parallel_for<sycl_subgr<T>>(
-          NdRange, [=](nd_item<1> NdItem) {
-            sycl::sub_group SG = NdItem.get_sub_group();
-            size_t lid = SG.get_local_id().get(0);
-            size_t gid = NdItem.get_global_id(0);
-            size_t SGoff = gid - lid;
+      cgh.parallel_for<sycl_subgr<T>>(NdRange, [=](nd_item<1> NdItem) {
+        sycl::sub_group SG = NdItem.get_sub_group();
+        size_t lid = SG.get_local_id().get(0);
+        size_t gid = NdItem.get_global_id(0);
+        size_t SGoff = gid - lid;
 
-            T res = 0;
-            for (size_t i = 0; i <= lid; i++) {
-              res += addacc[SGoff + i];
-            }
-            group_barrier(SG);
-            addacc[gid] = res;
-            if (NdItem.get_global_id(0) == 0)
-              sgsizeacc[0] = SG.get_max_local_range()[0];
-          });
+        T res = 0;
+        for (size_t i = 0; i <= lid; i++) {
+          res += addacc[SGoff + i];
+        }
+        group_barrier(SG);
+        addacc[gid] = res;
+        if (NdItem.get_global_id(0) == 0)
+          sgsizeacc[0] = SG.get_max_local_range()[0];
+      });
     });
     host_accessor addacc(addbuf);
     host_accessor sgsizeacc(sgsizebuf);

--- a/sycl/test-e2e/SubGroup/barrier.cpp
+++ b/sycl/test-e2e/SubGroup/barrier.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -Wno-error=deprecated-declarations -fsycl-device-code-split=per_kernel -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
 // XFAIL: windows && gpu-intel-gen12
@@ -18,9 +18,9 @@
 #include <numeric>
 #include <sycl/group_barrier.hpp>
 
-template <typename T, bool UseNewSyntax> class sycl_subgr;
+template <typename T> class sycl_subgr;
 using namespace sycl;
-template <typename T, bool UseNewSyntax = false>
+template <typename T>
 void check(queue &Queue, size_t G = 240, size_t L = 60) {
   try {
     nd_range<1> NdRange(G, L);
@@ -32,7 +32,7 @@ void check(queue &Queue, size_t G = 240, size_t L = 60) {
       auto addacc = addbuf.template get_access<access::mode::read_write>(cgh);
       auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
 
-      cgh.parallel_for<sycl_subgr<T, UseNewSyntax>>(
+      cgh.parallel_for<sycl_subgr<T>>(
           NdRange, [=](nd_item<1> NdItem) {
             sycl::sub_group SG = NdItem.get_sub_group();
             size_t lid = SG.get_local_id().get(0);
@@ -43,11 +43,7 @@ void check(queue &Queue, size_t G = 240, size_t L = 60) {
             for (size_t i = 0; i <= lid; i++) {
               res += addacc[SGoff + i];
             }
-            if constexpr (UseNewSyntax) {
-              group_barrier(SG);
-            } else {
-              SG.barrier(access::fence_space::global_space);
-            }
+            group_barrier(SG);
             addacc[gid] = res;
             if (NdItem.get_global_id(0) == 0)
               sgsizeacc[0] = SG.get_max_local_range()[0];
@@ -83,14 +79,8 @@ int main() {
   check<long>(Queue);
   check<unsigned long>(Queue);
   check<float>(Queue);
-  check<int, true>(Queue);
-  check<unsigned int, true>(Queue);
-  check<long, true>(Queue);
-  check<unsigned long, true>(Queue);
-  check<float, true>(Queue);
   if (Queue.get_device().has(sycl::aspect::fp64)) {
     check<double>(Queue);
-    check<double, true>(Queue);
   }
   std::cout << "Test passed." << std::endl;
   return 0;


### PR DESCRIPTION
This function has been removed in favor of group_barrier a long time ago. Remove in the next ABI-break window.