### PR TITLE
[SYCL] Fix skipped check for device_global property in SYCLPostLink

### DIFF
--- a/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
@@ -248,8 +248,9 @@ PropSetRegTy computeModuleProperties(const Module &M,
       if (!GV.hasExternalLinkage())
         continue;
 
+      // Only named structs carry the device_global type name.
       auto *ST = dyn_cast<StructType>(GV.getValueType());
-      if (!ST || ST->isLiteral()) // Literal structs don't have names.
+      if (!ST || !ST->hasName())
         continue;
 
       // Check if it's a device_global by type name (declarations don't have

--- a/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
@@ -248,11 +248,12 @@ PropSetRegTy computeModuleProperties(const Module &M,
       if (!GV.hasExternalLinkage())
         continue;
 
+      if (!isa<StructType>(GV.getValueType())
+        continue;
+
       // Check if it's a device_global by type name (declarations don't have
       // attributes).
-      std::string TypeName;
-      raw_string_ostream(TypeName) << *GV.getValueType();
-
+      StringRef TypeName = GV.getValueType()->getStructName();
       if (TypeName.find("device_global") == std::string::npos)
         continue;
 

--- a/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
@@ -248,7 +248,7 @@ PropSetRegTy computeModuleProperties(const Module &M,
       if (!GV.hasExternalLinkage())
         continue;
 
-      if (!isa<StructType>(GV.getValueType())
+      if (!isa<StructType>(GV.getValueType()))
         continue;
 
       // Check if it's a device_global by type name (declarations don't have

--- a/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
@@ -248,12 +248,13 @@ PropSetRegTy computeModuleProperties(const Module &M,
       if (!GV.hasExternalLinkage())
         continue;
 
-      if (!isa<StructType>(GV.getValueType()))
+      auto *ST = dyn_cast<StructType>(GV.getValueType());
+      if (!ST || ST->isLiteral()) // Literal structs don't have names.
         continue;
 
       // Check if it's a device_global by type name (declarations don't have
       // attributes).
-      StringRef TypeName = GV.getValueType()->getStructName();
+      StringRef TypeName = ST->getStructName();
       if (TypeName.find("device_global") == std::string::npos)
         continue;
 


### PR DESCRIPTION
This check used to be skipped in the release compilation mode because IR dumping is turned off there.

fixes: CMPLRLLVM-74325