### PR TITLE
[CI] Use latest `clang-format` in pr-code-format.yml

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install clang-format
         uses: aminya/setup-cpp@1f17f92d6a52bfcb1a25348e2c526c2e5cbb1134 # v1.8.0
         with:
-          clangformat: 20.1.8
+          clangformat: true
 
       - name: Setup Python env
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
We use 20.1.8 while the clang-format we obtained from building intel/llvm is 23.0.0. Due to this, clang-format run locally produces different formatting then the one proposed by CI workflow.