### PR TITLE
[sycl-jit] Centralize warning flags in sycl_jit

### DIFF
--- a/sycl-jit/CMakeLists.txt
+++ b/sycl-jit/CMakeLists.txt
@@ -9,16 +9,18 @@ set(SYCL_JIT_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 # directories, similar to how clang/CMakeLists.txt does it.
 set(LLVM_SPIRV_INCLUDE_DIRS "${LLVM_MAIN_SRC_DIR}/../llvm-spirv/include")
 
-if (NOT WIN32 AND NOT CYGWIN)
-  # Set library-wide warning options.
-  set(SYCL_JIT_WARNING_FLAGS -Wall -Wextra -Wconversion -Wimplicit-fallthrough)
+option(SYCL_JIT_ENABLE_WERROR "Treat all warnings as errors in SYCL JIT library" ON)
 
-  option(SYCL_JIT_ENABLE_WERROR "Treat all warnings as errors in SYCL JIT library" ON)
-  if(SYCL_JIT_ENABLE_WERROR)
-    list(APPEND SYCL_JIT_WARNING_FLAGS -Werror)
-  endif(SYCL_JIT_ENABLE_WERROR)
-endif()
-
+# sycl-jit warning flags; host GCC: -Wno-error=conversion on LLVM/Clang headers.
+function(sycl_jit_apply_target_warning_flags target)
+  if(WIN32 OR CYGWIN)
+    return()
+  endif()
+  target_compile_options(${target} PRIVATE
+    -Wall -Wextra -Wconversion -Wimplicit-fallthrough
+    $<$<BOOL:${SYCL_JIT_ENABLE_WERROR}>:-Werror>
+    $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=conversion>)
+endfunction()
 
 add_subdirectory(jit-compiler)
 add_subdirectory(passes)

--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -187,10 +187,7 @@ if(WIN32)
   target_link_libraries(sycl-jit PRIVATE Shlwapi)
 endif()
 
-target_compile_options(sycl-jit PRIVATE ${SYCL_JIT_WARNING_FLAGS})
-# Host GCC can hit -Werror=conversion on Clang headers in DeviceCompilation.cpp;
-target_compile_options(sycl-jit PRIVATE
-  $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=conversion>)
+sycl_jit_apply_target_warning_flags(sycl-jit)
 
 # Mark LLVM and SPIR-V headers as system headers to ignore warnigns in them.
 # This classification remains intact even if the same paths are added as normal

--- a/sycl-jit/passes/CMakeLists.txt
+++ b/sycl-jit/passes/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT WIN32 AND NOT CYGWIN)
     intrinsics_gen
   )
 
-  target_compile_options(SYCLJITPassesPlugin PRIVATE ${SYCL_JIT_WARNING_FLAGS})
+  sycl_jit_apply_target_warning_flags(SYCLJITPassesPlugin)
 
   # Mark LLVM headers as system headers to ignore warnigns in them. This
   # classification remains intact even if the same path is added as a normal
@@ -58,7 +58,7 @@ add_llvm_library(SYCLJITPasses
   SYCLLowerIR
 )
 
-target_compile_options(SYCLJITPasses PRIVATE ${SYCL_JIT_WARNING_FLAGS})
+sycl_jit_apply_target_warning_flags(SYCLJITPasses)
 
 # Mark LLVM headers as system headers to ignore warnigns in them. This
 # classification remains intact even if the same path is added as a normal


### PR DESCRIPTION
## Summary

- Fixes host **g++** builds of `SYCLJITPasses` / `SYCLJITPassesPlugin` failing on `-Werror=conversion` when compiling against LLVM headers (e.g. `SYCLSpecConstMaterializer.cpp`), same class of issue as [#21933](https://github.com/intel/llvm/pull/21933) for the `sycl-jit` target.
- Introduces `sycl_jit_apply_target_warning_flags()` as the single place for sycl-jit warning flags (`-Wconversion`, optional `-Werror`, and host GCC `-Wno-error=conversion` on LLVM/Clang headers).
- Switches `sycl-jit`, `SYCLJITPasses`, and `SYCLJITPassesPlugin` to that helper (replacing duplicated `target_compile_options` and `SYCL_JIT_WARNING_FLAGS`).
