### PR TITLE
[Clang][SYCL] Introduce warn_drv_unsupported_option_for_target_host_only

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -164,10 +164,9 @@ def warn_drv_unsupported_option_for_offload_arch_req_feature : Warning<
   "ignoring '%0' option for offload arch '%1' as it is not currently supported "
   "there. Use it with an offload arch containing '%2' instead">,
   InGroup<OptionIgnored>;
-def warn_drv_unsupported_option_for_target
-    : Warning<"ignoring '%0' option as it is not currently supported for "
-              "target '%1'%select{|; only supported for host compilation}2">,
-      InGroup<OptionIgnored>;
+def warn_drv_unsupported_option_for_target : Warning<
+  "ignoring '%0' option as it is not currently supported for target '%1'">,
+  InGroup<OptionIgnored>;
 def err_drv_unsupported_option_for_target : Error<
   "'%0' option is not currently supported for target '%1'">;
 def warn_drv_unsupported_option_part_for_target : Warning<
@@ -175,6 +174,10 @@ def warn_drv_unsupported_option_part_for_target : Warning<
   InGroup<OptionIgnored>;
 def err_drv_unsupported_option_part_for_target : Error<
   "'%0' in '%1' option is not currently supported for target '%2'">;
+def warn_drv_unsupported_option_for_target_host_only
+    : Warning<"ignoring '%0' option as it is not currently supported for "
+              "target '%1'; only supported for host compilation">,
+      InGroup<OptionIgnored>;
 def warn_drv_invalid_argument_for_flang : Warning<
   "'%0' is not valid for Fortran">,
   InGroup<OptionIgnored>;

--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1469,7 +1469,7 @@ void SanitizerArgs::addArgs(const ToolChain &TC, const llvm::opt::ArgList &Args,
 
     if (!SanitizeArg.empty())
       TC.getDriver().Diag(diag::warn_drv_unsupported_option_for_target)
-          << SanitizeArg << TC.getTripleString() << 0;
+          << SanitizeArg << TC.getTripleString();
 #endif
     return;
   }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3668,7 +3668,7 @@ static void RenderSSPOptions(const Driver &D, const ToolChain &TC,
 
     if (EffectiveTriple.isBPF() && StackProtectorLevel != LangOptions::SSPOff) {
       D.Diag(diag::warn_drv_unsupported_option_for_target)
-          << A->getSpelling() << EffectiveTriple.getTriple() << 0;
+          << A->getSpelling() << EffectiveTriple.getTriple();
       StackProtectorLevel = DefaultStackProtectorLevel;
     }
   } else {

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1493,8 +1493,8 @@ SYCLToolChain::SYCLToolChain(const Driver &D, const llvm::Triple &Triple,
             SanitizeVal == "thread")
           continue;
       }
-      D.Diag(clang::diag::warn_drv_unsupported_option_for_target)
-          << A->getAsString(Args) << getTriple().str() << 1;
+      D.Diag(clang::diag::warn_drv_unsupported_option_for_target_host_only)
+          << A->getAsString(Args) << getTriple().str();
     }
   }
 }


### PR DESCRIPTION
The diagnostic warn_drv_unsupported_option_for_target was extended with a %select to append "; only supported for host compilation" for SYCL's use case (commit 707093d9ea91), requiring a third argument at all call sites.

707093d9ea91's change now breaks test Driver/hip-sanitize-options.hip which only expects 2 args.

Fix by splitting the diagnostic into two:
- warn_drv_unsupported_option_for_target (2 args, same-as-upstream)
- warn_drv_unsupported_option_for_target_host_only (2 args, SYCL-specific)

Update SYCL.cpp to use the new variant; drop the stale << 0 third arg from SanitizerArgs.cpp and Clang.cpp. Now Clang.cpp part is the same as upstream.

CMPLRLLVM-76199