### PR TITLE
[SYCL] Re-enable bindless images array e2e tests

### DIFF
--- a/sycl/test-e2e/bindless_images/array/fetch_sampled_array.cpp
+++ b/sycl/test-e2e/bindless_images/array/fetch_sampled_array.cpp
@@ -2,8 +2,6 @@
 // REQUIRES: aspect-ext_oneapi_image_array
 // UNSUPPORTED: target-amd
 // UNSUPPORTED-INTENDED: image array not currently supported on AMD
-// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21 && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20223
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out

--- a/sycl/test-e2e/bindless_images/array/read_sampled_array.cpp
+++ b/sycl/test-e2e/bindless_images/array/read_sampled_array.cpp
@@ -4,9 +4,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21 && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20223
-
 // Print test names and pass status.
 // #define VERBOSE_LV1
 

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -3,9 +3,6 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-INTENDED: Returning non-FP values from sampling fails on HIP.
 
-// UNSUPPORTED: linux && arch-intel_gpu_bmg_g21 && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20223
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Related to https://github.com/intel/llvm/issues/20223. The issue why tests were marked as unsupported should be fixed in 26.22.38646.4 compute runtime release.