### PR TITLE
[SYCL] Prepare device_selector for removal

### DIFF
--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -85,6 +85,14 @@ public:
   __SYCL2020_DEPRECATED("SYCL 1.2.1 device selectors are deprecated. Please "
                         "use SYCL 2020 device selectors instead.")
   explicit device(const device_selector &DeviceSelector);
+#else
+  // TODO: consider rewriting the filter_selector class to be used with the new
+  // device(const DeviceSelector &deviceSelector) constructor.
+  /// Constructs a SYCL device instance using the device selected
+  /// by the DeviceSelector provided.
+  ///
+  /// \param DeviceSelector filter_selector to be used (see sycl_ext_oneapi_filter_selector).
+  explicit device(const ext::oneapi::filter_selector &DeviceSelector);
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL device instance using the device

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -77,6 +77,7 @@ public:
   explicit device(cl_device_id DeviceId);
 #endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Constructs a SYCL device instance using the device selected
   /// by the DeviceSelector provided.
   ///
@@ -84,6 +85,7 @@ public:
   __SYCL2020_DEPRECATED("SYCL 1.2.1 device selectors are deprecated. Please "
                         "use SYCL 2020 device selectors instead.")
   explicit device(const device_selector &DeviceSelector);
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL device instance using the device
   /// identified by the device selector provided.

--- a/sycl/include/sycl/device_selector.hpp
+++ b/sycl/include/sycl/device_selector.hpp
@@ -29,6 +29,7 @@ namespace ext::oneapi {
 class filter_selector;
 } // namespace ext::oneapi
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 /// The SYCL 1.2.1 device_selector class provides ability to choose the
 /// best SYCL device based on heuristics specified by the user.
 ///
@@ -45,6 +46,7 @@ public:
 
   virtual int operator()(const device &device) const = 0;
 };
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 /// The default selector chooses the first available SYCL device.
 ///
@@ -53,9 +55,17 @@ public:
 /// \ingroup sycl_api_dev_sel
 class __SYCL_EXPORT __SYCL2020_DEPRECATED(
     "Use the callable sycl::default_selector_v instead.") default_selector
-    : public device_selector {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    : public device_selector
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+{
 public:
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
+#else
+  device select_device() const;
+  int operator()(const device &dev) const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 
 /// Selects any SYCL GPU device.
@@ -65,9 +75,17 @@ public:
 /// \ingroup sycl_api_dev_sel
 class __SYCL_EXPORT __SYCL2020_DEPRECATED(
     "Use the callable sycl::gpu_selector_v instead.") gpu_selector
-    : public device_selector {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    : public device_selector
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+{
 public:
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
+#else
+  device select_device() const;
+  int operator()(const device &dev) const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 
 /// Selects any SYCL CPU device.
@@ -77,9 +95,17 @@ public:
 /// \ingroup sycl_api_dev_sel
 class __SYCL_EXPORT __SYCL2020_DEPRECATED(
     "Use the callable sycl::cpu_selector_v instead.") cpu_selector
-    : public device_selector {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    : public device_selector
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+{
 public:
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
+#else
+  device select_device() const;
+  int operator()(const device &dev) const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 
 /// Selects any SYCL accelerator device.
@@ -89,9 +115,18 @@ public:
 /// \ingroup sycl_api_dev_sel
 class __SYCL_EXPORT
 __SYCL2020_DEPRECATED("Use the callable sycl::accelerator_selector_v instead.")
-    accelerator_selector : public device_selector {
+    accelerator_selector
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    : public device_selector
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+{
 public:
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
+#else
+  device select_device() const;
+  int operator()(const device &dev) const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 
 // -------------- SYCL 2020
@@ -122,13 +157,17 @@ void fill_aspect_vector(std::vector<aspect> &V, FirstT F, OtherTs... O) {
 
 // Enable if DeviceSelector callable has matching signature, but
 // exclude if descended from filter_selector which is not purely callable or
-// if descended from it is descended from SYCL 1.2.1 device_selector.
+// if descended from SYCL 1.2.1 device_selector (deprecated & will be removed
+// soon).
 // See [FilterSelector not Callable] in device_selector.cpp
 template <typename DeviceSelector>
 using EnableIfSYCL2020DeviceSelectorInvocable = std::enable_if_t<
     std::is_invocable_r_v<int, DeviceSelector &, const device &> &&
-    !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector> &&
-    !std::is_base_of_v<device_selector, DeviceSelector>>;
+    !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    && !std::is_base_of_v<device_selector, DeviceSelector>
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+    >;
 
 __SYCL_EXPORT device
 select_device(const DSelectorInvocableType &DeviceSelectorInvocable);

--- a/sycl/include/sycl/device_selector.hpp
+++ b/sycl/include/sycl/device_selector.hpp
@@ -63,7 +63,6 @@ public:
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
 #else
-  device select_device() const;
   int operator()(const device &dev) const;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
@@ -83,7 +82,6 @@ public:
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
 #else
-  device select_device() const;
   int operator()(const device &dev) const;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
@@ -103,7 +101,6 @@ public:
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
 #else
-  device select_device() const;
   int operator()(const device &dev) const;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
@@ -124,7 +121,6 @@ public:
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
 #else
-  device select_device() const;
   int operator()(const device &dev) const;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
@@ -163,8 +159,8 @@ void fill_aspect_vector(std::vector<aspect> &V, FirstT F, OtherTs... O) {
 template <typename DeviceSelector>
 using EnableIfSYCL2020DeviceSelectorInvocable = std::enable_if_t<
     std::is_invocable_r_v<int, DeviceSelector &, const device &> &&
-    !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>
     && !std::is_base_of_v<device_selector, DeviceSelector>
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
     >;

--- a/sycl/include/sycl/device_selector.hpp
+++ b/sycl/include/sycl/device_selector.hpp
@@ -36,8 +36,9 @@ class filter_selector;
 /// \sa device
 ///
 /// \ingroup sycl_api_dev_sel
-class __SYCL_EXPORT __SYCL2020_DEPRECATED(
-    "Use SYCL 2020 callable device selectors instead.") device_selector {
+class __SYCL_EXPORT
+__SYCL2020_DEPRECATED("Use SYCL 2020 callable device selectors instead.")
+    device_selector {
 
 public:
   virtual ~device_selector() = default;
@@ -53,8 +54,9 @@ public:
 /// \sa device
 ///
 /// \ingroup sycl_api_dev_sel
-class __SYCL_EXPORT __SYCL2020_DEPRECATED(
-    "Use the callable sycl::default_selector_v instead.") default_selector
+class __SYCL_EXPORT
+__SYCL2020_DEPRECATED("Use the callable sycl::default_selector_v instead.")
+    default_selector
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
     : public device_selector
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
@@ -72,8 +74,9 @@ public:
 /// \sa device
 ///
 /// \ingroup sycl_api_dev_sel
-class __SYCL_EXPORT __SYCL2020_DEPRECATED(
-    "Use the callable sycl::gpu_selector_v instead.") gpu_selector
+class __SYCL_EXPORT
+__SYCL2020_DEPRECATED("Use the callable sycl::gpu_selector_v instead.")
+    gpu_selector
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
     : public device_selector
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
@@ -91,8 +94,9 @@ public:
 /// \sa device
 ///
 /// \ingroup sycl_api_dev_sel
-class __SYCL_EXPORT __SYCL2020_DEPRECATED(
-    "Use the callable sycl::cpu_selector_v instead.") cpu_selector
+class __SYCL_EXPORT
+__SYCL2020_DEPRECATED("Use the callable sycl::cpu_selector_v instead.")
+    cpu_selector
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
     : public device_selector
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
@@ -157,13 +161,17 @@ void fill_aspect_vector(std::vector<aspect> &V, FirstT F, OtherTs... O) {
 // soon).
 // See [FilterSelector not Callable] in device_selector.cpp
 template <typename DeviceSelector>
-using EnableIfSYCL2020DeviceSelectorInvocable = std::enable_if_t<
-    std::is_invocable_r_v<int, DeviceSelector &, const device &> &&
+using EnableIfSYCL2020DeviceSelectorInvocable =
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-    !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>
-    && !std::is_base_of_v<device_selector, DeviceSelector>
+    std::enable_if_t<
+        std::is_invocable_r_v<int, DeviceSelector &, const device &> &&
+        !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector> &&
+        !std::is_base_of_v<device_selector, DeviceSelector>>;
+#else
+    std::enable_if_t<
+        std::is_invocable_r_v<int, DeviceSelector &, const device &> &&
+        !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>>;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
-    >;
 
 __SYCL_EXPORT device
 select_device(const DSelectorInvocableType &DeviceSelectorInvocable);

--- a/sycl/include/sycl/ext/oneapi/filter_selector.hpp
+++ b/sycl/include/sycl/ext/oneapi/filter_selector.hpp
@@ -10,7 +10,9 @@
 
 #include <sycl/detail/export.hpp>   // for __SYCL_EXPORT
 #include <sycl/device.hpp>          // for device
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #include <sycl/device_selector.hpp> // for device_selector
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 #include <memory> // for shared_ptr
 #include <string> // for string
@@ -22,7 +24,6 @@ inline namespace _V1 {
 
 // Forward declarations
 class device;
-class device_selector;
 #ifdef __SYCL_INTERNAL_API
 namespace ONEAPI {
 class filter_selector;
@@ -34,13 +35,26 @@ namespace detail {
 class filter_selector_impl;
 } // namespace detail
 
-class __SYCL_EXPORT filter_selector : public device_selector {
+class __SYCL_EXPORT filter_selector
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    : public device_selector
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+{
 public:
+  virtual ~filter_selector() = default;
   filter_selector(const std::string &filter)
       : filter_selector(sycl::detail::string_view{filter}) {}
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
+#else
+  virtual int operator()(const device &dev) const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   void reset() const;
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   device select_device() const override;
+#else
+  virtual device select_device() const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #ifdef __SYCL_INTERNAL_API
   friend class sycl::ONEAPI::filter_selector;
 #endif

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -85,6 +85,7 @@ public:
   explicit platform(cl_platform_id PlatformId);
 #endif
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Constructs a SYCL platform instance using a device_selector.
   ///
   /// One of the SYCL devices that is associated with the constructed SYCL
@@ -95,6 +96,7 @@ public:
   __SYCL2020_DEPRECATED("SYCL 1.2.1 device selectors are deprecated. Please "
                         "use SYCL 2020 device selectors instead.")
   explicit platform(const device_selector &DeviceSelector);
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL platform instance using the platform of the device
   /// identified by the device selector provided.

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -273,6 +273,7 @@ public:
       : queue(syclContext, detail::select_device(deviceSelector, syclContext),
               AsyncHandler, propList) {}
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Constructs a SYCL queue instance using the device returned by the
   /// DeviceSelector provided.
   ///
@@ -296,6 +297,7 @@ public:
   queue(const device_selector &DeviceSelector,
         const async_handler &AsyncHandler, const property_list &PropList = {})
       : queue(DeviceSelector.select_device(), AsyncHandler, PropList) {}
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL queue instance using the device provided.
   ///
@@ -313,6 +315,7 @@ public:
   explicit queue(const device &SyclDevice, const async_handler &AsyncHandler,
                  const property_list &PropList = {});
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Constructs a SYCL queue instance that is associated with the context
   /// provided, using the device returned by the device selector.
   ///
@@ -336,6 +339,7 @@ public:
                         "use SYCL 2020 device selectors instead.")
   queue(const context &SyclContext, const device_selector &DeviceSelector,
         const async_handler &AsyncHandler, const property_list &PropList = {});
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Constructs a SYCL queue associated with the given context, device
   /// and optional properties list.

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -22,6 +22,7 @@
 #include <sycl/ext/oneapi/experimental/device_architecture.hpp>
 #include <sycl/ext/oneapi/experimental/forward_progress.hpp>
 #include <sycl/ext/oneapi/experimental/max_work_groups.hpp>
+#include <sycl/ext/oneapi/filter_selector.hpp>
 #include <sycl/ext/oneapi/info/device.hpp>
 #include <sycl/ext/oneapi/matrix/query-types.hpp>
 

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -65,7 +65,11 @@ device::device(cl_device_id DeviceId) {
 device::device(const device_selector &deviceSelector) {
   *this = deviceSelector.select_device();
 }
-#endif
+#else
+device::device(const ext::oneapi::filter_selector &deviceSelector) {
+  *this = deviceSelector.select_device();
+}
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 std::vector<device> device::get_devices(info::device_type deviceType) {
   std::vector<device> devices;

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -61,9 +61,11 @@ device::device(cl_device_id DeviceId) {
   __SYCL_OCL_CALL(clRetainDevice, DeviceId);
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 device::device(const device_selector &deviceSelector) {
   *this = deviceSelector.select_device();
 }
+#endif
 
 std::vector<device> device::get_devices(info::device_type deviceType) {
   std::vector<device> devices;

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -296,8 +296,8 @@ device filter_selector::select_device() const {
   std::lock_guard<std::mutex> Guard(
       sycl::detail::GlobalHandler::instance().getFilterMutex());
 
-  device Result =
-      detail::select_device([&](const device &dev) { return (*this)(dev); });
+  device Result = sycl::detail::select_device(
+      [&](const device &dev) { return (*this)(dev); });
 
   reset();
 

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -245,11 +245,6 @@ aspect_selector(const std::vector<aspect> &RequireList,
   };
 }
 
-static device selectDeprecatedSelectorDevice(
-    const detail::DSelectorInvocableType &Selector) {
-  return detail::select_device(Selector);
-}
-
 // -------------- SYCL 1.2.1
 
 // SYCL 1.2.1 device_selector class and sub-classes
@@ -258,47 +253,19 @@ static device selectDeprecatedSelectorDevice(
 device device_selector::select_device() const {
   return detail::select_device([&](const device &dev) { return (*this)(dev); });
 }
-#endif
-
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-device default_selector::select_device() const {
-  return selectDeprecatedSelectorDevice(
-      [&](const device &dev) { return (*this)(dev); });
-}
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 int default_selector::operator()(const device &dev) const {
   return default_selector_v(dev);
 }
 
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-device gpu_selector::select_device() const {
-  return selectDeprecatedSelectorDevice(
-      [&](const device &dev) { return (*this)(dev); });
-}
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
-
 int gpu_selector::operator()(const device &dev) const {
   return gpu_selector_v(dev);
 }
 
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-device cpu_selector::select_device() const {
-  return selectDeprecatedSelectorDevice(
-      [&](const device &dev) { return (*this)(dev); });
-}
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
-
 int cpu_selector::operator()(const device &dev) const {
   return cpu_selector_v(dev);
 }
-
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-device accelerator_selector::select_device() const {
-  return selectDeprecatedSelectorDevice(
-      [&](const device &dev) { return (*this)(dev); });
-}
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 int accelerator_selector::operator()(const device &dev) const {
   return accelerator_selector_v(dev);
@@ -329,8 +296,8 @@ device filter_selector::select_device() const {
   std::lock_guard<std::mutex> Guard(
       sycl::detail::GlobalHandler::instance().getFilterMutex());
 
-  device Result = selectDeprecatedSelectorDevice(
-      [&](const device &Dev) { return (*this)(Dev); });
+  device Result =
+      detail::select_device([&](const device &dev) { return (*this)(dev); });
 
   reset();
 

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -245,25 +245,60 @@ aspect_selector(const std::vector<aspect> &RequireList,
   };
 }
 
+static device selectDeprecatedSelectorDevice(
+    const detail::DSelectorInvocableType &Selector) {
+  return detail::select_device(Selector);
+}
+
 // -------------- SYCL 1.2.1
 
 // SYCL 1.2.1 device_selector class and sub-classes
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 device device_selector::select_device() const {
   return detail::select_device([&](const device &dev) { return (*this)(dev); });
 }
+#endif
+
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+device default_selector::select_device() const {
+  return selectDeprecatedSelectorDevice(
+      [&](const device &dev) { return (*this)(dev); });
+}
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 int default_selector::operator()(const device &dev) const {
   return default_selector_v(dev);
 }
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+device gpu_selector::select_device() const {
+  return selectDeprecatedSelectorDevice(
+      [&](const device &dev) { return (*this)(dev); });
+}
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+
 int gpu_selector::operator()(const device &dev) const {
   return gpu_selector_v(dev);
 }
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+device cpu_selector::select_device() const {
+  return selectDeprecatedSelectorDevice(
+      [&](const device &dev) { return (*this)(dev); });
+}
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+
 int cpu_selector::operator()(const device &dev) const {
   return cpu_selector_v(dev);
 }
+
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+device accelerator_selector::select_device() const {
+  return selectDeprecatedSelectorDevice(
+      [&](const device &dev) { return (*this)(dev); });
+}
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 int accelerator_selector::operator()(const device &dev) const {
   return accelerator_selector_v(dev);
@@ -294,7 +329,8 @@ device filter_selector::select_device() const {
   std::lock_guard<std::mutex> Guard(
       sycl::detail::GlobalHandler::instance().getFilterMutex());
 
-  device Result = device_selector::select_device();
+  device Result = selectDeprecatedSelectorDevice(
+      [&](const device &Dev) { return (*this)(Dev); });
 
   reset();
 

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -37,9 +37,11 @@ platform::platform(cl_platform_id PlatformId) {
 // protected constructor for internal use
 platform::platform(const device &Device) { *this = Device.get_platform(); }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 platform::platform(const device_selector &dev_selector) {
   *this = dev_selector.select_device().get_platform();
 }
+#endif
 
 cl_platform_id platform::get() const { return impl->get(); }
 

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -20,6 +20,7 @@
 namespace sycl {
 inline namespace _V1 {
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 queue::queue(const context &SyclContext, const device_selector &DeviceSelector,
              const async_handler &AsyncHandler, const property_list &PropList) {
   const std::vector<device> Devs = SyclContext.get_devices();
@@ -34,6 +35,7 @@ queue::queue(const context &SyclContext, const device_selector &DeviceSelector,
                                     *detail::getSyclObjImpl(SyclContext),
                                     AsyncHandler, PropList);
 }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 queue::queue(const context &SyclContext, const device &SyclDevice,
              const async_handler &AsyncHandler, const property_list &PropList) {
@@ -48,11 +50,13 @@ queue::queue(const device &SyclDevice, const async_handler &AsyncHandler,
                                     AsyncHandler, PropList);
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 queue::queue(const context &SyclContext, const device_selector &deviceSelector,
              const property_list &PropList)
     : queue(SyclContext, deviceSelector,
             detail::getSyclObjImpl(SyclContext)->get_async_handler(),
             PropList) {}
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 queue::queue(const context &SyclContext, const device &SyclDevice,
              const property_list &PropList)

--- a/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
@@ -22,9 +22,9 @@
 
 using namespace sycl;
 
-class DiscreteSelector : public sycl::device_selector {
+class DiscreteSelector {
 public:
-  int operator()(const sycl::device &Device) const final {
+  int operator()(const sycl::device &Device) const {
     if (!Device.is_gpu() ||
         Device.get_backend() != backend::ext_oneapi_level_zero)
       return -1;

--- a/sycl/test-e2e/FilterSelector/select.cpp
+++ b/sycl/test-e2e/FilterSelector/select.cpp
@@ -63,46 +63,46 @@ int main() {
   }
 
   if (!GPUs.empty()) {
-    device d2(filter_selector("gpu");
+    device d2(filter_selector("gpu"));
     assert(d2.is_gpu() && "filter_selector(\"gpu\") failed");
   }
 
   if (!CPUs.empty() || !GPUs.empty()) {
-    device d3(filter_selector("cpu,gpu");
+    device d3(filter_selector("cpu,gpu"));
     assert((d3.is_gpu() || d3.is_cpu()) &&
            "filter_selector(\"cpu,gpu\") failed");
   }
 
   if (HasOpenCLDevices) {
-    device d4(filter_selector("opencl");
+    device d4(filter_selector("opencl"));
     assert(d4.get_platform().get_backend() == backend::opencl &&
            "filter_selector(\"opencl\") failed");
 
     if (!CPUs.empty()) {
-      device d5(filter_selector("opencl:cpu");
+      device d5(filter_selector("opencl:cpu"));
       assert(d5.is_cpu() &&
              d5.get_platform().get_backend() == backend::opencl &&
              "filter_selector(\"opencl:cpu\") failed");
 
-      device d6(filter_selector("opencl:cpu:0");
+      device d6(filter_selector("opencl:cpu:0"));
       assert(d6.is_cpu() &&
              d6.get_platform().get_backend() == backend::opencl &&
              "filter_selector(\"opencl:cpu:0\") failed");
     }
 
     if (HasOpenCLGPU) {
-      device d7(filter_selector("opencl:gpu");
+      device d7(filter_selector("opencl:gpu"));
       assert(d7.is_gpu() &&
              d7.get_platform().get_backend() == backend::opencl &&
              "filter_selector(\"opencl:gpu\") failed");
     }
   }
 
-  device d8(filter_selector("0");
+  device d8(filter_selector("0"));
 
   try {
     // pick something crazy
-    device d9(filter_selector("gpu:999");
+    device d9(filter_selector("gpu:999"));
   } catch (const sycl::exception &e) {
     assert(e.code() == sycl::errc::runtime);
     const char *ErrorMesg =
@@ -113,7 +113,7 @@ int main() {
 
   try {
     // pick something crazy
-    device d10(filter_selector("bob:gpu");
+    device d10(filter_selector("bob:gpu"));
   } catch (const sycl::exception &e) {
     assert(e.code() == sycl::errc::invalid);
     const char *ErrorMesg = "Invalid filter string!";
@@ -123,7 +123,7 @@ int main() {
 
   try {
     // pick something crazy
-    device d11(filter_selector("opencl:bob");
+    device d11(filter_selector("opencl:bob"));
   } catch (const sycl::exception &e) {
     assert(e.code() == sycl::errc::invalid);
     const char *ErrorMesg = "Invalid filter string!";
@@ -132,17 +132,17 @@ int main() {
   }
 
   if (HasLevelZeroDevices && HasLevelZeroGPU) {
-    device d12(filter_selector("level_zero");
+    device d12(filter_selector("level_zero"));
     assert(d12.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
            "filter_selector(\"level_zero\") failed");
 
-    device d13(filter_selector("level_zero:gpu");
+    device d13(filter_selector("level_zero:gpu"));
     assert(d13.is_gpu() &&
            d13.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
            "filter_selector(\"level_zero:gpu\") failed");
 
     if (HasOpenCLDevices && !CPUs.empty()) {
-      device d14(filter_selector("level_zero:gpu,cpu");
+      device d14(filter_selector("level_zero:gpu,cpu"));
       assert((d14.is_gpu() || d14.is_cpu()) &&
              "filter_selector(\"level_zero:gpu,cpu\") failed");
       if (d14.is_gpu()) {
@@ -154,15 +154,15 @@ int main() {
   }
 
   if (Devs.size() > 1) {
-    device d15(filter_selector("1");
+    device d15(filter_selector("1"));
   }
 
   if (HasCUDADevices) {
-    device d16(filter_selector("cuda");
+    device d16(filter_selector("cuda"));
     assert(d16.get_platform().get_backend() == backend::ext_oneapi_cuda &&
            "filter_selector(\"cuda\") failed");
 
-    device d17(filter_selector("cuda:gpu");
+    device d17(filter_selector("cuda:gpu"));
     assert(d17.is_gpu() &&
            d17.get_platform().get_backend() == backend::ext_oneapi_cuda &&
            "filter_selector(\"cuda:gpu\") failed");

--- a/sycl/test-e2e/FilterSelector/select.cpp
+++ b/sycl/test-e2e/FilterSelector/select.cpp
@@ -58,51 +58,51 @@ int main() {
   }
 
   if (!CPUs.empty()) {
-    device d1(filter_selector("cpu"));
+    device d1 = filter_selector("cpu").select_device();
     assert(d1.is_cpu() && "filter_selector(\"cpu\") failed");
   }
 
   if (!GPUs.empty()) {
-    device d2(filter_selector("gpu"));
+    device d2 = filter_selector("gpu").select_device();
     assert(d2.is_gpu() && "filter_selector(\"gpu\") failed");
   }
 
   if (!CPUs.empty() || !GPUs.empty()) {
-    device d3(filter_selector("cpu,gpu"));
+    device d3 = filter_selector("cpu,gpu").select_device();
     assert((d3.is_gpu() || d3.is_cpu()) &&
            "filter_selector(\"cpu,gpu\") failed");
   }
 
   if (HasOpenCLDevices) {
-    device d4(filter_selector("opencl"));
+    device d4 = filter_selector("opencl").select_device();
     assert(d4.get_platform().get_backend() == backend::opencl &&
            "filter_selector(\"opencl\") failed");
 
     if (!CPUs.empty()) {
-      device d5(filter_selector("opencl:cpu"));
+      device d5 = filter_selector("opencl:cpu").select_device();
       assert(d5.is_cpu() &&
              d5.get_platform().get_backend() == backend::opencl &&
              "filter_selector(\"opencl:cpu\") failed");
 
-      device d6(filter_selector("opencl:cpu:0"));
+      device d6 = filter_selector("opencl:cpu:0").select_device();
       assert(d6.is_cpu() &&
              d6.get_platform().get_backend() == backend::opencl &&
              "filter_selector(\"opencl:cpu:0\") failed");
     }
 
     if (HasOpenCLGPU) {
-      device d7(filter_selector("opencl:gpu"));
+      device d7 = filter_selector("opencl:gpu").select_device();
       assert(d7.is_gpu() &&
              d7.get_platform().get_backend() == backend::opencl &&
              "filter_selector(\"opencl:gpu\") failed");
     }
   }
 
-  device d8(filter_selector("0"));
+  device d8 = filter_selector("0").select_device();
 
   try {
     // pick something crazy
-    device d9(filter_selector("gpu:999"));
+    device d9 = filter_selector("gpu:999").select_device();
   } catch (const sycl::exception &e) {
     assert(e.code() == sycl::errc::runtime);
     const char *ErrorMesg =
@@ -113,7 +113,7 @@ int main() {
 
   try {
     // pick something crazy
-    device d10(filter_selector("bob:gpu"));
+    device d10 = filter_selector("bob:gpu").select_device();
   } catch (const sycl::exception &e) {
     assert(e.code() == sycl::errc::invalid);
     const char *ErrorMesg = "Invalid filter string!";
@@ -123,7 +123,7 @@ int main() {
 
   try {
     // pick something crazy
-    device d11(filter_selector("opencl:bob"));
+    device d11 = filter_selector("opencl:bob").select_device();
   } catch (const sycl::exception &e) {
     assert(e.code() == sycl::errc::invalid);
     const char *ErrorMesg = "Invalid filter string!";
@@ -132,17 +132,17 @@ int main() {
   }
 
   if (HasLevelZeroDevices && HasLevelZeroGPU) {
-    device d12(filter_selector("level_zero"));
+      device d12 = filter_selector("level_zero").select_device();
     assert(d12.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
            "filter_selector(\"level_zero\") failed");
 
-    device d13(filter_selector("level_zero:gpu"));
+      device d13 = filter_selector("level_zero:gpu").select_device();
     assert(d13.is_gpu() &&
            d13.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
            "filter_selector(\"level_zero:gpu\") failed");
 
     if (HasOpenCLDevices && !CPUs.empty()) {
-      device d14(filter_selector("level_zero:gpu,cpu"));
+        device d14 = filter_selector("level_zero:gpu,cpu").select_device();
       assert((d14.is_gpu() || d14.is_cpu()) &&
              "filter_selector(\"level_zero:gpu,cpu\") failed");
       if (d14.is_gpu()) {
@@ -154,26 +154,26 @@ int main() {
   }
 
   if (Devs.size() > 1) {
-    device d15(filter_selector("1"));
+      device d15 = filter_selector("1").select_device();
   }
 
   if (HasCUDADevices) {
-    device d16(filter_selector("cuda"));
+      device d16 = filter_selector("cuda").select_device();
     assert(d16.get_platform().get_backend() == backend::ext_oneapi_cuda &&
            "filter_selector(\"cuda\") failed");
 
-    device d17(filter_selector("cuda:gpu"));
+      device d17 = filter_selector("cuda:gpu").select_device();
     assert(d17.is_gpu() &&
            d17.get_platform().get_backend() == backend::ext_oneapi_cuda &&
            "filter_selector(\"cuda:gpu\") failed");
   }
 
   if (HasHIPDevices) {
-    device d19(ext::oneapi::filter_selector("hip"));
+      device d19 = ext::oneapi::filter_selector("hip").select_device();
     assert(d19.get_platform().get_backend() == backend::ext_oneapi_hip &&
            "filter_selector(\"hip\") failed");
 
-    device d20(ext::oneapi::filter_selector("hip:gpu"));
+      device d20 = ext::oneapi::filter_selector("hip:gpu").select_device();
     assert(d20.is_gpu() &&
            d20.get_platform().get_backend() == backend::ext_oneapi_hip &&
            "filter_selector(\"hip:gpu\") failed");

--- a/sycl/test-e2e/FilterSelector/select.cpp
+++ b/sycl/test-e2e/FilterSelector/select.cpp
@@ -169,7 +169,7 @@ int main() {
   }
 
   if (HasHIPDevices) {
-    device d19 = (ext::oneapi::filter_selector("hip"));
+    device d19(ext::oneapi::filter_selector("hip"));
     assert(d19.get_platform().get_backend() == backend::ext_oneapi_hip &&
            "filter_selector(\"hip\") failed");
 

--- a/sycl/test-e2e/FilterSelector/select.cpp
+++ b/sycl/test-e2e/FilterSelector/select.cpp
@@ -132,17 +132,17 @@ int main() {
   }
 
   if (HasLevelZeroDevices && HasLevelZeroGPU) {
-      device d12 = filter_selector("level_zero").select_device();
+    device d12 = filter_selector("level_zero").select_device();
     assert(d12.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
            "filter_selector(\"level_zero\") failed");
 
-      device d13 = filter_selector("level_zero:gpu").select_device();
+    device d13 = filter_selector("level_zero:gpu").select_device();
     assert(d13.is_gpu() &&
            d13.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
            "filter_selector(\"level_zero:gpu\") failed");
 
     if (HasOpenCLDevices && !CPUs.empty()) {
-        device d14 = filter_selector("level_zero:gpu,cpu").select_device();
+      device d14 = filter_selector("level_zero:gpu,cpu").select_device();
       assert((d14.is_gpu() || d14.is_cpu()) &&
              "filter_selector(\"level_zero:gpu,cpu\") failed");
       if (d14.is_gpu()) {
@@ -154,26 +154,26 @@ int main() {
   }
 
   if (Devs.size() > 1) {
-      device d15 = filter_selector("1").select_device();
+    device d15 = filter_selector("1").select_device();
   }
 
   if (HasCUDADevices) {
-      device d16 = filter_selector("cuda").select_device();
+    device d16 = filter_selector("cuda").select_device();
     assert(d16.get_platform().get_backend() == backend::ext_oneapi_cuda &&
            "filter_selector(\"cuda\") failed");
 
-      device d17 = filter_selector("cuda:gpu").select_device();
+    device d17 = filter_selector("cuda:gpu").select_device();
     assert(d17.is_gpu() &&
            d17.get_platform().get_backend() == backend::ext_oneapi_cuda &&
            "filter_selector(\"cuda:gpu\") failed");
   }
 
   if (HasHIPDevices) {
-      device d19 = ext::oneapi::filter_selector("hip").select_device();
+    device d19 = ext::oneapi::filter_selector("hip").select_device();
     assert(d19.get_platform().get_backend() == backend::ext_oneapi_hip &&
            "filter_selector(\"hip\") failed");
 
-      device d20 = ext::oneapi::filter_selector("hip:gpu").select_device();
+    device d20 = ext::oneapi::filter_selector("hip:gpu").select_device();
     assert(d20.is_gpu() &&
            d20.get_platform().get_backend() == backend::ext_oneapi_hip &&
            "filter_selector(\"hip:gpu\") failed");

--- a/sycl/test-e2e/FilterSelector/select.cpp
+++ b/sycl/test-e2e/FilterSelector/select.cpp
@@ -58,51 +58,51 @@ int main() {
   }
 
   if (!CPUs.empty()) {
-    device d1 = filter_selector("cpu").select_device();
+    device d1(filter_selector("cpu"));
     assert(d1.is_cpu() && "filter_selector(\"cpu\") failed");
   }
 
   if (!GPUs.empty()) {
-    device d2 = filter_selector("gpu").select_device();
+    device d2(filter_selector("gpu");
     assert(d2.is_gpu() && "filter_selector(\"gpu\") failed");
   }
 
   if (!CPUs.empty() || !GPUs.empty()) {
-    device d3 = filter_selector("cpu,gpu").select_device();
+    device d3(filter_selector("cpu,gpu");
     assert((d3.is_gpu() || d3.is_cpu()) &&
            "filter_selector(\"cpu,gpu\") failed");
   }
 
   if (HasOpenCLDevices) {
-    device d4 = filter_selector("opencl").select_device();
+    device d4(filter_selector("opencl");
     assert(d4.get_platform().get_backend() == backend::opencl &&
            "filter_selector(\"opencl\") failed");
 
     if (!CPUs.empty()) {
-      device d5 = filter_selector("opencl:cpu").select_device();
+      device d5(filter_selector("opencl:cpu");
       assert(d5.is_cpu() &&
              d5.get_platform().get_backend() == backend::opencl &&
              "filter_selector(\"opencl:cpu\") failed");
 
-      device d6 = filter_selector("opencl:cpu:0").select_device();
+      device d6(filter_selector("opencl:cpu:0");
       assert(d6.is_cpu() &&
              d6.get_platform().get_backend() == backend::opencl &&
              "filter_selector(\"opencl:cpu:0\") failed");
     }
 
     if (HasOpenCLGPU) {
-      device d7 = filter_selector("opencl:gpu").select_device();
+      device d7(filter_selector("opencl:gpu");
       assert(d7.is_gpu() &&
              d7.get_platform().get_backend() == backend::opencl &&
              "filter_selector(\"opencl:gpu\") failed");
     }
   }
 
-  device d8 = filter_selector("0").select_device();
+  device d8(filter_selector("0");
 
   try {
     // pick something crazy
-    device d9 = filter_selector("gpu:999").select_device();
+    device d9(filter_selector("gpu:999");
   } catch (const sycl::exception &e) {
     assert(e.code() == sycl::errc::runtime);
     const char *ErrorMesg =
@@ -113,7 +113,7 @@ int main() {
 
   try {
     // pick something crazy
-    device d10 = filter_selector("bob:gpu").select_device();
+    device d10(filter_selector("bob:gpu");
   } catch (const sycl::exception &e) {
     assert(e.code() == sycl::errc::invalid);
     const char *ErrorMesg = "Invalid filter string!";
@@ -123,7 +123,7 @@ int main() {
 
   try {
     // pick something crazy
-    device d11 = filter_selector("opencl:bob").select_device();
+    device d11(filter_selector("opencl:bob");
   } catch (const sycl::exception &e) {
     assert(e.code() == sycl::errc::invalid);
     const char *ErrorMesg = "Invalid filter string!";
@@ -132,17 +132,17 @@ int main() {
   }
 
   if (HasLevelZeroDevices && HasLevelZeroGPU) {
-    device d12 = filter_selector("level_zero").select_device();
+    device d12(filter_selector("level_zero");
     assert(d12.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
            "filter_selector(\"level_zero\") failed");
 
-    device d13 = filter_selector("level_zero:gpu").select_device();
+    device d13(filter_selector("level_zero:gpu");
     assert(d13.is_gpu() &&
            d13.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
            "filter_selector(\"level_zero:gpu\") failed");
 
     if (HasOpenCLDevices && !CPUs.empty()) {
-      device d14 = filter_selector("level_zero:gpu,cpu").select_device();
+      device d14(filter_selector("level_zero:gpu,cpu");
       assert((d14.is_gpu() || d14.is_cpu()) &&
              "filter_selector(\"level_zero:gpu,cpu\") failed");
       if (d14.is_gpu()) {
@@ -154,26 +154,26 @@ int main() {
   }
 
   if (Devs.size() > 1) {
-    device d15 = filter_selector("1").select_device();
+    device d15(filter_selector("1");
   }
 
   if (HasCUDADevices) {
-    device d16 = filter_selector("cuda").select_device();
+    device d16(filter_selector("cuda");
     assert(d16.get_platform().get_backend() == backend::ext_oneapi_cuda &&
            "filter_selector(\"cuda\") failed");
 
-    device d17 = filter_selector("cuda:gpu").select_device();
+    device d17(filter_selector("cuda:gpu");
     assert(d17.is_gpu() &&
            d17.get_platform().get_backend() == backend::ext_oneapi_cuda &&
            "filter_selector(\"cuda:gpu\") failed");
   }
 
   if (HasHIPDevices) {
-    device d19 = ext::oneapi::filter_selector("hip").select_device();
+    device d19 = (ext::oneapi::filter_selector("hip"));
     assert(d19.get_platform().get_backend() == backend::ext_oneapi_hip &&
            "filter_selector(\"hip\") failed");
 
-    device d20 = ext::oneapi::filter_selector("hip:gpu").select_device();
+    device d20(ext::oneapi::filter_selector("hip:gpu"));
     assert(d20.is_gpu() &&
            d20.get_platform().get_backend() == backend::ext_oneapi_hip &&
            "filter_selector(\"hip:gpu\") failed");

--- a/sycl/test/abi/abi_crossing_type_traits.cpp
+++ b/sycl/test/abi/abi_crossing_type_traits.cpp
@@ -63,7 +63,9 @@ int main() {
   check_type_traits<vec<int, 4>, true, true, true>();
   check_type_traits<detail::PropertyWithDataBase, false, false, false>();
   check_type_traits<detail::SYCLMemObjAllocator, false, false, false>();
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   check_type_traits<device_selector, false, false, false>();
+#endif
 
   return 0;
 }

--- a/sycl/test/abi/symbol_size_alignment.cpp
+++ b/sycl/test/abi/symbol_size_alignment.cpp
@@ -50,7 +50,9 @@ int main() {
   check<cpu_selector, 8, 8>();
   check<device, 8, 8>();
   check<device_event, 8, 8>();
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   check<device_selector, 8, 8>();
+#endif
   check<event, 16, 8>();
   check<gpu_selector, 8, 8>();
   check<handler, 176, 8>();

--- a/sycl/test/abi/vtable.cpp
+++ b/sycl/test/abi/vtable.cpp
@@ -31,6 +31,7 @@ void foo(sycl::detail::SYCLMemObjAllocator &Allocator) {
 // CHECK-NEXT:   7 | std::size_t sycl::detail::SYCLMemObjAllocator::getValueSize() const [pure]
 // CHECK-NEXT:   8 | void sycl::detail::SYCLMemObjAllocator::setAlignment(std::size_t) [pure]
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 void foo(sycl::device_selector &DeviceSelector) {
   (void)DeviceSelector.select_device();
 }
@@ -42,3 +43,4 @@ void foo(sycl::device_selector &DeviceSelector) {
 // CHECK-NEXT:   3 | sycl::device_selector::~device_selector() [deleting]
 // CHECK-NEXT:   4 | device sycl::device_selector::select_device() const
 // CHECK-NEXT:   5 | int sycl::device_selector::operator()(const device &) const [pure]
+#endif

--- a/sycl/test/check_device_code/abi/user_mangling.cpp
+++ b/sycl/test/check_device_code/abi/user_mangling.cpp
@@ -70,8 +70,10 @@ void device_evt(sycl::device_event) {}
 // CHK-HOST: define dso_local void @_Z5eventN4sycl3_V15eventE({{.*}})
 void event(sycl::event) {}
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 // CHK-HOST: define dso_local void @_Z15device_selectorRN4sycl3_V115device_selectorE({{.*}})
 void device_selector(sycl::device_selector&) {}
+#endif
 
 // CHK-HOST: define dso_local void @_Z7handlerRN4sycl3_V17handlerE({{.*}})
 void handler(sycl::handler&) {}

--- a/sycl/test/helpers.hpp
+++ b/sycl/test/helpers.hpp
@@ -54,7 +54,8 @@ std::ostream &operator<<(std::ostream &Out,
 
 class TestQueue : public sycl::queue {
 public:
-  TestQueue(const sycl::device_selector &DevSelector,
+  template <typename DeviceSelector>
+  TestQueue(const DeviceSelector &DevSelector,
             const sycl::property_list &PropList = {})
       : sycl::queue(
             DevSelector,

--- a/sycl/test/invoke_simd/invoke_simd.cpp
+++ b/sycl/test/invoke_simd/invoke_simd.cpp
@@ -45,9 +45,10 @@ ESIMD_CALLEE(float *A, esimd::simd<float, VL> b, int i) SYCL_ESIMD_FUNCTION {
 
 float SPMD_CALLEE(float *A, float b, int i) { return A[i] + b; }
 
-class ESIMDSelector : public device_selector {
+class ESIMDSelector {
+public:
   // Require GPU device
-  virtual int operator()(const device &device) const {
+  int operator()(const device &device) const {
     if (const char *dev_filter = getenv("ONEAPI_DEVICE_SELECTOR")) {
       std::string filter_string(dev_filter);
       if (filter_string.find("gpu") != std::string::npos)

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -165,6 +165,7 @@ int main() {
   // expected-warning@+1{{'accelerator_selector' is deprecated: Use the callable sycl::accelerator_selector_v instead.}}
   sycl::accelerator_selector as;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   // expected-warning@+1{{Use SYCL 2020 callable device selectors instead.}}
   class user_defined_device_selector : public sycl::device_selector {
   public:
@@ -240,6 +241,7 @@ int main() {
   sycl::queue aq4{ctx, as, ah};
   // expected-warning@+1{{SYCL 1.2.1 device selectors are deprecated. Please use SYCL 2020 device selectors instead.}}
   sycl::queue udq4{ctx, uds, ah};
+#endif
 
   Queue.submit([&](sycl::handler &CGH) {
     // expected-warning@+1{{'local' is deprecated: use `local_accessor` instead}}

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -56,12 +56,12 @@ bool DiscardFilters;
 std::vector<std::string> FilterEnvVars;
 
 // Trivial custom selector that selects a device of the given type.
-class custom_selector : public device_selector {
+class custom_selector {
   info::device_type MType;
 
 public:
   custom_selector(info::device_type Type) : MType(Type) {}
-  int operator()(const device &Dev) const override {
+  int operator()(const device &Dev) const {
     return Dev.get_info<info::device::device_type>() == MType ? 1 : -1;
   }
 };
@@ -215,7 +215,8 @@ static void printDeviceInfo(const device &Device, bool Verbose,
   }
 }
 
-static void printSelectorChoice(const device_selector &Selector,
+template <typename SelectorT>
+static void printSelectorChoice(const SelectorT &Selector,
                                 const std::string &Prepend) {
   try {
     const auto &Device = device(Selector);


### PR DESCRIPTION
The device_selector class has been removed in SYCL 2020 a long time ago. Prepare it to be removed in the next ABI-breaking window:
- Make legacy selectors independent classes rather than subclasses of the device selector.
- Prepare functions accepting `device_selector` as an argument to be removed.
- Make ext::oneapi::filter_selector independent as well.