### PR TITLE
[SYCL] Disable CommandGraph/Scheduler unit tests on Win

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(CMAKE_CXX_EXTENSIONS OFF)
-
+if(WIN32)
+  # https://github.com/intel/llvm/issues/22425
+  return()
+endif()
 add_sycl_unittest(CommandGraphExtensionTests OBJECT
   Barrier.cpp
   CommandGraph.cpp

--- a/sycl/unittests/scheduler/CMakeLists.txt
+++ b/sycl/unittests/scheduler/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(WIN32)
+  # https://github.com/intel/llvm/issues/22425
+  return()
+endif()
 add_sycl_unittest(SchedulerTests OBJECT
     BlockedCommands.cpp
     Commands.cpp


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/22425