### PR TITLE
[llvm-spirv] Cherry-pick 'Fix SPIR-V module assert when translating freeze without SPV_KHR_poison_freeze'

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -725,6 +725,17 @@ bool SPIRVRegularizeLLVMBase::regularize() {
             BO->setIsExact(false);
         }
 
+        if (!Opts.isAllowedToUseExtension(ExtensionID::SPV_KHR_poison_freeze)) {
+          if (auto *FI = dyn_cast<FreezeInst>(&II)) {
+            Value *V = FI->getOperand(0);
+            if (isa<UndefValue>(V))
+              V = Constant::getNullValue(V->getType());
+            FI->replaceAllUsesWith(V);
+            FI->dropAllReferences();
+            ToErase.push_back(FI);
+          }
+        }
+
         // Remove metadata not supported by SPIRV
         static const char *MDs[] = {
             "tbaa",

--- a/llvm-spirv/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/llvm-spirv/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -35,6 +35,7 @@
 #ifndef SPIRV_SPIRVREGULARIZELLVM_H
 #define SPIRV_SPIRVREGULARIZELLVM_H
 
+#include "LLVMSPIRVOpts.h"
 #include "SPIRVInternal.h"
 
 #include "llvm/IR/Instructions.h"
@@ -45,7 +46,8 @@ namespace SPIRV {
 
 class SPIRVRegularizeLLVMBase {
 public:
-  SPIRVRegularizeLLVMBase() : M(nullptr), Ctx(nullptr) {}
+  explicit SPIRVRegularizeLLVMBase(const SPIRV::TranslatorOpts &Opts = {})
+      : M(nullptr), Ctx(nullptr), Opts(Opts) {}
 
   bool runRegularizeLLVM(llvm::Module &M);
   // Lower functions
@@ -116,12 +118,16 @@ public:
 private:
   llvm::Module *M;
   llvm::LLVMContext *Ctx;
+  const SPIRV::TranslatorOpts Opts;
 };
 
 class SPIRVRegularizeLLVMPass
     : public llvm::PassInfoMixin<SPIRVRegularizeLLVMPass>,
       public SPIRVRegularizeLLVMBase {
 public:
+  explicit SPIRVRegularizeLLVMPass(const SPIRV::TranslatorOpts &Opts = {})
+      : SPIRVRegularizeLLVMBase(Opts) {}
+
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM) {
     return runRegularizeLLVM(M) ? llvm::PreservedAnalyses::none()
@@ -134,7 +140,8 @@ public:
 class SPIRVRegularizeLLVMLegacy : public llvm::ModulePass,
                                   public SPIRVRegularizeLLVMBase {
 public:
-  SPIRVRegularizeLLVMLegacy() : ModulePass(ID) {
+  explicit SPIRVRegularizeLLVMLegacy(const SPIRV::TranslatorOpts &Opts = {})
+      : ModulePass(ID), SPIRVRegularizeLLVMBase(Opts) {
     initializeSPIRVRegularizeLLVMLegacyPass(*PassRegistry::getPassRegistry());
   }
 

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -1659,16 +1659,13 @@ SPIRVValue *LLVMToSPIRVBase::transUnaryInst(UnaryInstruction *U,
   }
 
   if (isa<FreezeInst>(U)) {
-    if (BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_poison_freeze)) {
-      auto *Op = transValue(U->getOperand(0), BB);
-      SPIRVType *TransTy = transScavengedType(U);
-      return BM->addFreezeKHRInst(TransTy, Op, BB);
-    }
-    // Without the extension, move the freeze away.
-    Value *Operand = U->getOperand(0);
-    if (isa<UndefValue>(Operand))
-      return BM->addNullConstant(transScavengedType(U));
-    return transValue(Operand, BB);
+    getErrorLog().checkError(
+        BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_poison_freeze),
+        SPIRVEC_InvalidInstruction, U,
+        "llvm.freeze requires SPV_KHR_poison_freeze\n");
+    auto *Op = transValue(U->getOperand(0), BB);
+    SPIRVType *TransTy = transScavengedType(U);
+    return BM->addFreezeKHRInst(TransTy, Op, BB);
   }
 
   Op BOC = OpNop;
@@ -7586,7 +7583,7 @@ void addPassesForSPIRV(ModulePassManager &PassMgr,
   PassMgr.addPass(PreprocessMetadataPass());
   PassMgr.addPass(SPIRVLowerOCLBlocksPass());
   PassMgr.addPass(OCLToSPIRVPass());
-  PassMgr.addPass(SPIRVRegularizeLLVMPass());
+  PassMgr.addPass(SPIRVRegularizeLLVMPass(Opts));
   PassMgr.addPass(SPIRVLowerConstExprPass());
   PassMgr.addPass(SPIRVLowerBoolPass());
   PassMgr.addPass(SPIRVLowerMemmovePass());

--- a/llvm-spirv/test/extensions/KHR/SPV_KHR_poison_freeze/freeze-phi-loop.ll
+++ b/llvm-spirv/test/extensions/KHR/SPV_KHR_poison_freeze/freeze-phi-loop.ll
@@ -1,0 +1,33 @@
+; RUN: llvm-spirv %s -o %t.noext.spv
+; RUN: llvm-spirv %t.noext.spv -to-text -o %t.noext.spt
+; RUN: FileCheck < %t.noext.spt %s --check-prefix=CHECK-NOEXT
+;
+; RUN: llvm-spirv %s -o %t.spv --spirv-ext=+SPV_KHR_poison_freeze
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-NOEXT-NOT: Capability PoisonFreezeKHR
+; CHECK-NOEXT-NOT: Extension "SPV_KHR_poison_freeze"
+; CHECK-NOEXT-NOT: FreezeKHR
+
+; CHECK-SPIRV: Capability PoisonFreezeKHR
+; CHECK-SPIRV: Extension "SPV_KHR_poison_freeze"
+; CHECK-SPIRV: FreezeKHR
+
+define spir_kernel void @kernel_freeze_phi(i1 %in) {
+entry:
+  br label %loop
+
+loop:
+  %acc = phi i1 [ %fr, %loop ], [ false, %entry ]
+  %fr = freeze i1 %in
+  br label %loop
+}
+
+!opencl.spir.version = !{!0}
+!spirv.Source = !{!1}
+!0 = !{i32 1, i32 2}
+!1 = !{i32 4, i32 100000}


### PR DESCRIPTION
Original commit https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/a2a27749b34a5c67cde5b920b6e780326a372c0e

This fixes a bug exposed by Pytorch, and I'm trying to add Pytorch testing to our CI here.

Closes: https://github.com/intel/llvm/issues/22308