### PR TITLE
[SYCL] Add -fno-sycl-use-header

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -7849,6 +7849,9 @@ def fsycl_fp64_conv_emu : Flag<["-"], "fsycl-fp64-conv-emu">,
            "conversion operations and no fp64 computation operations (requires "
            "Intel GPU backend supporting fp64 partial emulation).">,
   MarshallingInfoFlag<CodeGenOpts<"FP64ConvEmu">>;
+def fno_sycl_use_header : Flag<["-"], "fno-sycl-use-header">,
+  HelpText<"Disable usage of the integration header during SYCL enabled "
+           "compilations.">;
 def fno_sycl_use_footer : Flag<["-"], "fno-sycl-use-footer">,
   HelpText<"Disable usage of the integration footer during SYCL enabled "
            "compilations.">;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5714,12 +5714,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         CmdArgs.push_back("-Wno-sycl-strict");
       }
 
-      // Add the integration header option to generate the header.
-      StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
-      if (!Header.empty()) {
-        SmallString<128> HeaderOpt("-fsycl-int-header=");
-        HeaderOpt.append(Header);
-        CmdArgs.push_back(Args.MakeArgString(HeaderOpt));
+      if (!Args.hasArg(options::OPT_fno_sycl_use_header)) {
+        // Add the integration header option to generate the header.
+        StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
+        if (!Header.empty()) {
+          SmallString<128> HeaderOpt("-fsycl-int-header=");
+          HeaderOpt.append(Header);
+          CmdArgs.push_back(Args.MakeArgString(HeaderOpt));
+        }
       }
 
       if (!Args.hasArg(options::OPT_fno_sycl_use_footer)) {
@@ -5787,7 +5789,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // integration footer has been applied.  Check for the append job
       // action to determine this.
       if (types::getPreprocessedType(Input.getType()) != types::TY_INVALID &&
-          !Header.empty()) {
+          !Args.hasArg(options::OPT_fno_sycl_use_header) && !Header.empty()) {
         // Add the -include-internal-header option to add the integration header
         CmdArgs.push_back("-include-internal-header");
         CmdArgs.push_back(Args.MakeArgString(Header));

--- a/clang/test/Driver/sycl-int-footer-old-model.cpp
+++ b/clang/test/Driver/sycl-int-footer-old-model.cpp
@@ -33,6 +33,12 @@
 // NO-FOOTER-NOT: append-file
 // NO-FOOTER: clang{{.*}} "-fsycl-is-host"{{.*}} "-include-internal-header" "[[INTHEADER]]"
 
+/// Check that integration header can be disabled
+// RUN:  %clangxx -fsycl --no-offload-new-driver -fno-sycl-use-header %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix NO-HEADER --implicit-check-not "-fsycl-int-header" %s
+// NO-HEADER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-footer=[[INTFOOTER:.+\.h]]" "-sycl-std={{.*}}"
+// NO-HEADER: clang{{.*}} "-fsycl-is-host"{{.*}} "-include-internal-footer" "[[INTFOOTER]]"
+
 /// Check phases without integration footer
 // RUN: %clangxx -fsycl --no-offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fno-sycl-use-footer -target x86_64-unknown-linux-gnu %s -ccc-print-phases 2>&1 \
 // RUN:   | FileCheck -check-prefix NO-FOOTER-PHASES -check-prefix COMMON-PHASES %s

--- a/clang/test/Driver/sycl-int-header-footer.cpp
+++ b/clang/test/Driver/sycl-int-header-footer.cpp
@@ -31,6 +31,17 @@
 // NO-FOOTER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INTHEADER:.+\.h]]" "-sycl-std={{.*}}"
 // NO-FOOTER: clang{{.*}} "-fsycl-is-host"{{.*}} "-include-internal-header" "[[INTHEADER]]"
 
+/// Check that integration header can be disabled
+// RUN:  %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-use-header %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix NO-HEADER --implicit-check-not "-fsycl-int-header" %s
+// NO-HEADER: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-footer=[[INTFOOTER:.+\.h]]" "-sycl-std={{.*}}"
+// NO-HEADER: clang{{.*}} "-fsycl-is-host"{{.*}} "-include-internal-footer" "[[INTFOOTER]]"
+
+/// Check that both integration header anf foooter can be disabled
+// RUN:  %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-use-header -fno-sycl-use-footer %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix NO-BOTH --implicit-check-not "-fsycl-int-header" --implicit-check-not "-fsycl-int-footer" %s
+// NO-BOTH: clang{{.*}} "-fsycl-is-device"{{.*}} "-sycl-std={{.*}}"
+
 /// Check phases without integration footer
 // RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fno-sycl-instrument-device-code --no-offloadlib -fno-sycl-use-footer -target x86_64-unknown-linux-gnu %s -ccc-print-phases 2>&1 \
 // RUN:   | FileCheck -check-prefix NO-FOOTER-PHASES -check-prefix COMMON-PHASES %s

--- a/clang/test/Driver/sycl-pch-create.cpp
+++ b/clang/test/Driver/sycl-pch-create.cpp
@@ -55,6 +55,28 @@
 // LX_CREATE_TARGETS_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
 // LX_CREATE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}" "--image=file=[[PCHFILE3]]{{.*}}"
 
+// RUN: %clang -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_NOHF %s
+// LX_CREATE_NOHF: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_NOHF-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
+// LX_CREATE_NOHF-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_NOHF: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_NOHF-NOT: "-include-internal-header"
+// LX_CREATE_NOHF-NOT: "-include-internal-footer"
+// LX_CREATE_NOHF-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_NOHF: clang-offload-bundler{{.*}} "-type=pch"
+// LX_CREATE_NOHF: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
+
+// RUN: %clang --offload-new-driver -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=LX_CREATE_NOHF_OND %s
+// LX_CREATE_NOHF_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// LX_CREATE_NOHF_OND-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
+// LX_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// LX_CREATE_NOHF_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// LX_CREATE_NOHF_OND-NOT: "-include-internal-header"
+// LX_CREATE_NOHF_OND-NOT: "-include-internal-footer"
+// LX_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// LX_CREATE_NOHF_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+// LX_CREATE_NOHF_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"
+
 // Windows
 // RUN: %clang_cl -fsycl -x c++-header %t.h -### 2>&1 | FileCheck -check-prefix=WS_CREATE %s
 // WS_CREATE: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
@@ -105,3 +127,25 @@
 // WS_CREATE_TARGETS_OND-SAME: "-o" "[[PCHFILE3:.+pch]]"
 // WS_CREATE_TARGETS_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
 // WS_CREATE_TARGETS_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}" "--image=file=[[PCHFILE3]]{{.*}}"
+
+// RUN: %clang_cl -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_NOHF %s
+// WS_CREATE_NOHF: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_NOHF-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
+// WS_CREATE_NOHF-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_NOHF: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_NOHF-NOT: "-include-internal-header"
+// WS_CREATE_NOHF-NOT: "-include-internal-footer"
+// WS_CREATE_NOHF-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_NOHF: clang-offload-bundler{{.*}} "-type=pch"
+// WS_CREATE_NOHF: "-targets=sycl-spir64{{.*}},host-x86_64{{.*}}" "-output={{.*}}.pch" "-input=[[PCHFILE1]]" "-input=[[PCHFILE2]]"
+
+// RUN: %clang_cl --offload-new-driver -fsycl -x c++-header -fno-sycl-use-header -fno-sycl-use-footer -c %t.h %s -### 2>&1 | FileCheck -check-prefix=WS_CREATE_NOHF_OND %s
+// WS_CREATE_NOHF_OND: clang{{.*}} "-triple" "spir64{{.*}}"{{.*}} "-fsycl-is-device"
+// WS_CREATE_NOHF_OND-NOT: "-fsycl-int-header={{.*}}"{{.*}} "-fsycl-int-footer={{.*}}"{{.*}}
+// WS_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE1:.+pch]]"
+// WS_CREATE_NOHF_OND: clang{{.*}} "-triple" "x86_64{{.*}}"{{.*}} "-fsycl-is-host"
+// WS_CREATE_NOHF_OND-NOT: "-include-internal-header"
+// WS_CREATE_NOHF_OND-NOT: "-include-internal-footer"
+// WS_CREATE_NOHF_OND-SAME: "-o" "[[PCHFILE2:.+pch]]"
+// WS_CREATE_NOHF_OND: llvm-offload-binary{{.*}} "-o" "{{.*}}.pch"
+//  WS_CREATE_NOHF_OND-SAME: "--image=file=[[PCHFILE1]]{{.*}}" "--image=file=[[PCHFILE2]]{{.*}}"

--- a/clang/test/Driver/sycl-preproc-error.cpp
+++ b/clang/test/Driver/sycl-preproc-error.cpp
@@ -2,7 +2,7 @@
 /// in the source.  We always have an additional step to generate the
 /// integration header and footer, so if that fails we still want to produce
 /// preprocessing information in the subsequent passes.
-// RUN: %clang -fsycl -fno-sycl-use-footer -E -dM %s 2>&1 | FileCheck %s --check-prefix=PP_CHECK
+// RUN: %clang -fsycl -fno-sycl-use-header -fno-sycl-use-footer -E -dM %s 2>&1 | FileCheck %s --check-prefix=PP_CHECK
 // PP_CHECK: SYCL_PP_CHECK
 
 void foo(;


### PR DESCRIPTION
Akin to ``-fno-sycl-use-footer`` this PR adds ``-fno-sycl-use-header``.
Using the option disables the creation (during device compilation) and the use (during
host compilation) of the integration header.