### PR TITLE
[SYCL][Test] Fix nvvm-annotations test for 3-operand reqd_work_group_size

### DIFF
--- a/llvm/test/SYCLLowerIR/nvvm-annotations.ll
+++ b/llvm/test/SYCLLowerIR/nvvm-annotations.ll
@@ -87,8 +87,8 @@ define ptx_kernel void @foo_maxwgpermp() !max_work_groups_per_mp !3 {
 !2 = !{i32 2}
 !3 = !{i32 3}
 
-!4 = !{i32 4}
-!5 = !{i32 4, i32 8}
+!4 = !{i32 4, i32 1, i32 1}
+!5 = !{i32 4, i32 8, i32 1}
 !6 = !{i32 4, i32 8, i32 16}
 
 ;.
@@ -111,9 +111,9 @@ define ptx_kernel void @foo_maxwgpermp() !max_work_groups_per_mp !3 {
 ; CHECK: [[META16:![0-9]+]] = !{ptr @foo_minwgpercu0, !"minctasm", i32 2}
 ; CHECK: [[META17:![0-9]+]] = !{ptr @foo_maxwgpermp, !"maxclusterrank", i32 3}
 ; CHECK: [[META18]] = !{i32 4, i32 8, i32 16}
-; CHECK: [[META19]] = !{i32 4}
+; CHECK: [[META19]] = !{i32 4, i32 1, i32 1}
 ; CHECK: [[META20]] = !{i32 1}
-; CHECK: [[META21]] = !{i32 4, i32 8}
+; CHECK: [[META21]] = !{i32 4, i32 8, i32 1}
 ; CHECK: [[META22]] = !{i32 2}
 ; CHECK: [[META23]] = !{i32 3}
 ;.


### PR DESCRIPTION
Upstream commit 6794e31e894d added a verifier check requiring reqd_work_group_size to have exactly three operands. Pad the 1D and 2D test metadata nodes to comply; work_group_num_dim still limits which dimensions are emitted so behavior is unchanged.