### PR TITLE
[Clang][SYCL] Fix -march= corruption for NativeCPU when BoundArch is empty

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1585,7 +1585,7 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
   }
 
   const OptTable &Opts = getDriver().getOpts();
-  if (BA) {
+  if (!BA.empty()) {
     DAL->eraseArg(options::OPT_march_EQ);
     DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_march_EQ),
                       BA.ArchName);


### PR DESCRIPTION
BoundArch("") sets Arch=OffloadArch::Unknown (not Unused), so operator bool() returns true even for an empty arch name. This caused TranslateArgs to erase -march=<value> and re-add -march= (empty), producing "unsupported argument '' to option '-march='".

Fix: use !BA.empty() (checks ArchName string) instead of if (BA) (checks Arch != Unused).

Broken by 448b725bb78b.

Fixes test Driver/sycl-native-cpu.cpp
CMPLRLLVM-76405