### PR TITLE
[Driver][SYCL] Narrow amdgcn -m_Group pass-through to -mcpu only

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -2071,7 +2071,8 @@ llvm::opt::DerivedArgList *ToolChain::TranslateOffloadTargetArgs(
       if (SameTripleAsHost ||
           A->getOption().matches(options::OPT_mcode_object_version_EQ) ||
           A->getOption().matches(options::OPT_mlinker_version_EQ) ||
-          (Triple.getArch() == llvm::Triple::amdgcn && !IsSYCL)) {
+          (Triple.getArch() == llvm::Triple::amdgcn && !IsSYCL &&
+           A->getOption().matches(options::OPT_mcpu_EQ))) {
         DAL->append(A);
         continue;
       }


### PR DESCRIPTION
TranslateOffloadTargetArgs had a broad exception for amdgcn OpenMP that passed all -m_Group args to the device DAL. This silently claimed flags like -mxnack/-mno-sramecc, suppressing the expected "unused argument" warning tested by amdgpu-xnack-sramecc-flags.c.

The original intent was only to forward -mcpu to the device toolchain; narrow the condition accordingly.

Fixes Driver/amdgpu-xnack-sramecc-flags.c
CMPLRLLVM-76233