### PR TITLE
[SYCL] Prepare to remove sycl_ext_oneapi_group_algorithms leftover

### DIFF
--- a/sycl/include/sycl/ext/oneapi/functional.hpp
+++ b/sycl/include/sycl/ext/oneapi/functional.hpp
@@ -40,12 +40,11 @@ using maximum
 template <typename T = void>
 using minimum
     __SYCL2020_DEPRECATED("Use sycl::minimum<> instead") = sycl::minimum<T>;
+} // namespace ext::oneapi
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
-} // namespace ext::oneapi
-
-// TODO: I guess that's not a part of extension anymore, but part of the core
-// functional. Probably should be moved to the sycl dir.
+// TODO: The group operation helpers below are not extension-specific; consider
+// moving them to a non-extension header (e.g. sycl/functional.hpp).
 #ifdef __SYCL_DEVICE_ONLY__
 namespace detail {
 

--- a/sycl/include/sycl/ext/oneapi/functional.hpp
+++ b/sycl/include/sycl/ext/oneapi/functional.hpp
@@ -16,6 +16,8 @@
 
 namespace sycl {
 inline namespace _V1 {
+
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 namespace ext::oneapi {
 
 template <typename T = void>
@@ -38,9 +40,12 @@ using maximum
 template <typename T = void>
 using minimum
     __SYCL2020_DEPRECATED("Use sycl::minimum<> instead") = sycl::minimum<T>;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 } // namespace ext::oneapi
 
+// TODO: I guess that's not a part of extension anymore, but part of the core
+// functional. Probably should be moved to the sycl dir.
 #ifdef __SYCL_DEVICE_ONLY__
 namespace detail {
 


### PR DESCRIPTION
Deprecated here - https://github.com/intel/llvm/pull/22320
But forgot to guard with the preview macro.
Remove in the next ABI-break window.