### PR TITLE
[SYCL] Fix marray `~operator` for bool data type

### DIFF
--- a/sycl/include/sycl/marray.hpp
+++ b/sycl/include/sycl/marray.hpp
@@ -266,7 +266,8 @@ public:
       std::is_convertible_v<DataT, T> &&                                       \
           (std::is_fundamental_v<T> ||                                         \
            std::is_same_v<typename std::remove_const<T>::type, half>),         \
-      marray> operator BINOP(const marray & Lhs, const T & Rhs) {              \
+      marray>                                                                  \
+  operator BINOP(const marray &Lhs, const T &Rhs) {                            \
     return Lhs BINOP marray(static_cast<DataT>(Rhs));                          \
   }                                                                            \
   template <typename T>                                                        \
@@ -274,16 +275,17 @@ public:
       std::is_convertible_v<DataT, T> &&                                       \
           (std::is_fundamental_v<T> ||                                         \
            std::is_same_v<typename std::remove_const<T>::type, half>),         \
-      marray> operator BINOP(const T & Lhs, const marray & Rhs) {              \
+      marray>                                                                  \
+  operator BINOP(const T &Lhs, const marray &Rhs) {                            \
     return marray(static_cast<DataT>(Lhs)) BINOP Rhs;                          \
   }                                                                            \
-  friend marray &operator OPASSIGN(marray & Lhs, const marray & Rhs) {         \
+  friend marray &operator OPASSIGN(marray &Lhs, const marray &Rhs) {           \
     Lhs = Lhs BINOP Rhs;                                                       \
     return Lhs;                                                                \
   }                                                                            \
   template <std::size_t Num = NumElements>                                     \
   friend typename std::enable_if_t<Num != 1, marray &> operator OPASSIGN(      \
-      marray & Lhs, const DataT & Rhs) {                                       \
+      marray &Lhs, const DataT &Rhs) {                                         \
     Lhs = Lhs BINOP marray(Rhs);                                               \
     return Lhs;                                                                \
   }
@@ -309,29 +311,28 @@ public:
   friend typename std::enable_if_t<std::is_convertible_v<T, DataT> &&          \
                                        std::is_integral_v<T> &&                \
                                        std::is_integral_v<BaseT>,              \
-                                   marray> operator BINOP(const marray & Lhs,  \
-                                                          const T & Rhs) {     \
+                                   marray>                                     \
+  operator BINOP(const marray &Lhs, const T &Rhs) {                            \
     return Lhs BINOP marray(static_cast<DataT>(Rhs));                          \
   }                                                                            \
   template <typename T, typename BaseT = DataT>                                \
-  friend                                                                       \
-      typename std::enable_if_t<std::is_convertible_v<T, DataT> &&             \
-                                    std::is_integral_v<T> &&                   \
-                                    std::is_integral_v<BaseT>,                 \
-                                marray> operator BINOP(const T & Lhs,          \
-                                                       const marray & Rhs) {   \
+  friend typename std::enable_if_t<std::is_convertible_v<T, DataT> &&          \
+                                       std::is_integral_v<T> &&                \
+                                       std::is_integral_v<BaseT>,              \
+                                   marray>                                     \
+  operator BINOP(const T &Lhs, const marray &Rhs) {                            \
     return marray(static_cast<DataT>(Lhs)) BINOP Rhs;                          \
   }                                                                            \
   template <typename T = DataT,                                                \
             typename = std::enable_if_t<std::is_integral_v<T>, marray>>        \
-  friend marray &operator OPASSIGN(marray & Lhs, const marray & Rhs) {         \
+  friend marray &operator OPASSIGN(marray &Lhs, const marray &Rhs) {           \
     Lhs = Lhs BINOP Rhs;                                                       \
     return Lhs;                                                                \
   }                                                                            \
   template <std::size_t Num = NumElements, typename T = DataT>                 \
   friend                                                                       \
       typename std::enable_if_t<Num != 1 && std::is_integral_v<T>, marray &>   \
-      operator OPASSIGN(marray & Lhs, const DataT & Rhs) {                     \
+      operator OPASSIGN(marray &Lhs, const DataT &Rhs) {                       \
     Lhs = Lhs BINOP marray(Rhs);                                               \
     return Lhs;                                                                \
   }
@@ -359,8 +360,8 @@ public:
 #endif
 
 #define __SYCL_RELLOGOP(RELLOGOP)                                              \
-  friend marray<bool, NumElements> operator RELLOGOP(const marray & Lhs,       \
-                                                     const marray & Rhs) {     \
+  friend marray<bool, NumElements> operator RELLOGOP(const marray &Lhs,        \
+                                                     const marray &Rhs) {      \
     marray<bool, NumElements> Ret;                                             \
     if constexpr (use_ext_vector_type) {                                       \
       ext_vector_t LhsVec = sycl::bit_cast<ext_vector_t>(Lhs.MData);           \
@@ -377,19 +378,19 @@ public:
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
-  friend typename std::enable_if_t<                                            \
-      std::is_convertible_v<T, DataT> &&                                       \
-          (std::is_fundamental_v<T> || std::is_same_v<T, half>),               \
-      marray<bool, NumElements>> operator RELLOGOP(const marray & Lhs,         \
-                                                   const T & Rhs) {            \
+  friend typename std::enable_if_t<std::is_convertible_v<T, DataT> &&          \
+                                       (std::is_fundamental_v<T> ||            \
+                                        std::is_same_v<T, half>),              \
+                                   marray<bool, NumElements>>                  \
+  operator RELLOGOP(const marray &Lhs, const T &Rhs) {                         \
     return Lhs RELLOGOP marray(static_cast<const DataT &>(Rhs));               \
   }                                                                            \
   template <typename T>                                                        \
-  friend typename std::enable_if_t<                                            \
-      std::is_convertible_v<T, DataT> &&                                       \
-          (std::is_fundamental_v<T> || std::is_same_v<T, half>),               \
-      marray<bool, NumElements>> operator RELLOGOP(const T & Lhs,              \
-                                                   const marray & Rhs) {       \
+  friend typename std::enable_if_t<std::is_convertible_v<T, DataT> &&          \
+                                       (std::is_fundamental_v<T> ||            \
+                                        std::is_same_v<T, half>),              \
+                                   marray<bool, NumElements>>                  \
+  operator RELLOGOP(const T &Lhs, const marray &Rhs) {                         \
     return marray(static_cast<const DataT &>(Lhs)) RELLOGOP Rhs;               \
   }
 
@@ -457,10 +458,19 @@ public:
     if constexpr (use_ext_vector_type) {
       ext_vector_t LhsVec = sycl::bit_cast<ext_vector_t>(Lhs.MData);
       ext_vector_t ResVec = ~LhsVec;
-      sycl::detail::memcpy_no_adl(Ret.MData, &ResVec, sizeof(ResVec));
+      if constexpr (std::is_same_v<DataT, bool>) {
+        for (size_t I = 0; I < NumElements; ++I)
+          Ret[I] = ResVec[I] & 1;
+      } else {
+        storeVecResult(Ret.MData, ResVec);
+      }
     } else {
-      for (size_t I = 0; I < NumElements; ++I) {
-        Ret[I] = ~Lhs[I];
+      if constexpr (std::is_same_v<DataT, bool>) {
+        for (size_t I = 0; I < NumElements; ++I)
+          Ret[I] = !Lhs[I];
+      } else {
+        for (size_t I = 0; I < NumElements; ++I)
+          Ret[I] = ~Lhs[I];
       }
     }
     return Ret;

--- a/sycl/include/sycl/marray.hpp
+++ b/sycl/include/sycl/marray.hpp
@@ -456,11 +456,11 @@ public:
     marray Ret;
     if constexpr (use_ext_vector_type) {
       ext_vector_t LhsVec = sycl::bit_cast<ext_vector_t>(Lhs.MData);
-      ext_vector_t ResVec = ~LhsVec;
       if constexpr (std::is_same_v<DataT, bool>) {
         for (size_t I = 0; I < NumElements; ++I)
-          Ret[I] = ResVec[I] & 1;
+          Ret[I] = !LhsVec[I];
       } else {
+        ext_vector_t ResVec = ~LhsVec;
         storeVecResult(Ret.MData, ResVec);
       }
     } else {

--- a/sycl/include/sycl/marray.hpp
+++ b/sycl/include/sycl/marray.hpp
@@ -457,13 +457,14 @@ public:
       return !Lhs;
 
     marray Ret;
-    if constexpr (use_ext_vector_type && !std::is_same_v<DataT, bool>) {
+    if constexpr (use_ext_vector_type) {
       ext_vector_t LhsVec = sycl::bit_cast<ext_vector_t>(Lhs.MData);
       ext_vector_t ResVec = ~LhsVec;
       storeVecResult(Ret.MData, ResVec);
     } else {
-      for (size_t I = 0; I < NumElements; ++I)
+      for (size_t I = 0; I < NumElements; ++I) {
         Ret[I] = ~Lhs[I];
+      }
     }
     return Ret;
   }

--- a/sycl/include/sycl/marray.hpp
+++ b/sycl/include/sycl/marray.hpp
@@ -266,8 +266,7 @@ public:
       std::is_convertible_v<DataT, T> &&                                       \
           (std::is_fundamental_v<T> ||                                         \
            std::is_same_v<typename std::remove_const<T>::type, half>),         \
-      marray>                                                                  \
-  operator BINOP(const marray &Lhs, const T &Rhs) {                            \
+      marray> operator BINOP(const marray & Lhs, const T & Rhs) {              \
     return Lhs BINOP marray(static_cast<DataT>(Rhs));                          \
   }                                                                            \
   template <typename T>                                                        \
@@ -275,17 +274,16 @@ public:
       std::is_convertible_v<DataT, T> &&                                       \
           (std::is_fundamental_v<T> ||                                         \
            std::is_same_v<typename std::remove_const<T>::type, half>),         \
-      marray>                                                                  \
-  operator BINOP(const T &Lhs, const marray &Rhs) {                            \
+      marray> operator BINOP(const T & Lhs, const marray & Rhs) {              \
     return marray(static_cast<DataT>(Lhs)) BINOP Rhs;                          \
   }                                                                            \
-  friend marray &operator OPASSIGN(marray &Lhs, const marray &Rhs) {           \
+  friend marray &operator OPASSIGN(marray & Lhs, const marray & Rhs) {         \
     Lhs = Lhs BINOP Rhs;                                                       \
     return Lhs;                                                                \
   }                                                                            \
   template <std::size_t Num = NumElements>                                     \
   friend typename std::enable_if_t<Num != 1, marray &> operator OPASSIGN(      \
-      marray &Lhs, const DataT &Rhs) {                                         \
+      marray & Lhs, const DataT & Rhs) {                                       \
     Lhs = Lhs BINOP marray(Rhs);                                               \
     return Lhs;                                                                \
   }
@@ -311,28 +309,29 @@ public:
   friend typename std::enable_if_t<std::is_convertible_v<T, DataT> &&          \
                                        std::is_integral_v<T> &&                \
                                        std::is_integral_v<BaseT>,              \
-                                   marray>                                     \
-  operator BINOP(const marray &Lhs, const T &Rhs) {                            \
+                                   marray> operator BINOP(const marray & Lhs,  \
+                                                          const T & Rhs) {     \
     return Lhs BINOP marray(static_cast<DataT>(Rhs));                          \
   }                                                                            \
   template <typename T, typename BaseT = DataT>                                \
-  friend typename std::enable_if_t<std::is_convertible_v<T, DataT> &&          \
-                                       std::is_integral_v<T> &&                \
-                                       std::is_integral_v<BaseT>,              \
-                                   marray>                                     \
-  operator BINOP(const T &Lhs, const marray &Rhs) {                            \
+  friend                                                                       \
+      typename std::enable_if_t<std::is_convertible_v<T, DataT> &&             \
+                                    std::is_integral_v<T> &&                   \
+                                    std::is_integral_v<BaseT>,                 \
+                                marray> operator BINOP(const T & Lhs,          \
+                                                       const marray & Rhs) {   \
     return marray(static_cast<DataT>(Lhs)) BINOP Rhs;                          \
   }                                                                            \
   template <typename T = DataT,                                                \
             typename = std::enable_if_t<std::is_integral_v<T>, marray>>        \
-  friend marray &operator OPASSIGN(marray &Lhs, const marray &Rhs) {           \
+  friend marray &operator OPASSIGN(marray & Lhs, const marray & Rhs) {         \
     Lhs = Lhs BINOP Rhs;                                                       \
     return Lhs;                                                                \
   }                                                                            \
   template <std::size_t Num = NumElements, typename T = DataT>                 \
   friend                                                                       \
       typename std::enable_if_t<Num != 1 && std::is_integral_v<T>, marray &>   \
-      operator OPASSIGN(marray &Lhs, const DataT &Rhs) {                       \
+      operator OPASSIGN(marray & Lhs, const DataT & Rhs) {                     \
     Lhs = Lhs BINOP marray(Rhs);                                               \
     return Lhs;                                                                \
   }
@@ -360,8 +359,8 @@ public:
 #endif
 
 #define __SYCL_RELLOGOP(RELLOGOP)                                              \
-  friend marray<bool, NumElements> operator RELLOGOP(const marray &Lhs,        \
-                                                     const marray &Rhs) {      \
+  friend marray<bool, NumElements> operator RELLOGOP(const marray & Lhs,       \
+                                                     const marray & Rhs) {     \
     marray<bool, NumElements> Ret;                                             \
     if constexpr (use_ext_vector_type) {                                       \
       ext_vector_t LhsVec = sycl::bit_cast<ext_vector_t>(Lhs.MData);           \
@@ -378,19 +377,19 @@ public:
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
-  friend typename std::enable_if_t<std::is_convertible_v<T, DataT> &&          \
-                                       (std::is_fundamental_v<T> ||            \
-                                        std::is_same_v<T, half>),              \
-                                   marray<bool, NumElements>>                  \
-  operator RELLOGOP(const marray &Lhs, const T &Rhs) {                         \
+  friend typename std::enable_if_t<                                            \
+      std::is_convertible_v<T, DataT> &&                                       \
+          (std::is_fundamental_v<T> || std::is_same_v<T, half>),               \
+      marray<bool, NumElements>> operator RELLOGOP(const marray & Lhs,         \
+                                                   const T & Rhs) {            \
     return Lhs RELLOGOP marray(static_cast<const DataT &>(Rhs));               \
   }                                                                            \
   template <typename T>                                                        \
-  friend typename std::enable_if_t<std::is_convertible_v<T, DataT> &&          \
-                                       (std::is_fundamental_v<T> ||            \
-                                        std::is_same_v<T, half>),              \
-                                   marray<bool, NumElements>>                  \
-  operator RELLOGOP(const T &Lhs, const marray &Rhs) {                         \
+  friend typename std::enable_if_t<                                            \
+      std::is_convertible_v<T, DataT> &&                                       \
+          (std::is_fundamental_v<T> || std::is_same_v<T, half>),               \
+      marray<bool, NumElements>> operator RELLOGOP(const T & Lhs,              \
+                                                   const marray & Rhs) {       \
     return marray(static_cast<const DataT &>(Lhs)) RELLOGOP Rhs;               \
   }
 

--- a/sycl/include/sycl/marray.hpp
+++ b/sycl/include/sycl/marray.hpp
@@ -453,24 +453,17 @@ public:
   template <typename T = DataT>
   friend std::enable_if_t<std::is_integral_v<T>, marray>
   operator~(const marray &Lhs) {
+    if constexpr (std::is_same_v<DataT, bool>)
+      return !Lhs;
+
     marray Ret;
-    if constexpr (use_ext_vector_type) {
+    if constexpr (use_ext_vector_type && !std::is_same_v<DataT, bool>) {
       ext_vector_t LhsVec = sycl::bit_cast<ext_vector_t>(Lhs.MData);
-      if constexpr (std::is_same_v<DataT, bool>) {
-        for (size_t I = 0; I < NumElements; ++I)
-          Ret[I] = !LhsVec[I];
-      } else {
-        ext_vector_t ResVec = ~LhsVec;
-        storeVecResult(Ret.MData, ResVec);
-      }
+      ext_vector_t ResVec = ~LhsVec;
+      storeVecResult(Ret.MData, ResVec);
     } else {
-      if constexpr (std::is_same_v<DataT, bool>) {
-        for (size_t I = 0; I < NumElements; ++I)
-          Ret[I] = !Lhs[I];
-      } else {
-        for (size_t I = 0; I < NumElements; ++I)
-          Ret[I] = ~Lhs[I];
-      }
+      for (size_t I = 0; I < NumElements; ++I)
+        Ret[I] = ~Lhs[I];
     }
     return Ret;
   }

--- a/sycl/test-e2e/Basic/built-ins/marray_bitwise_not_bool.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_bitwise_not_bool.cpp
@@ -1,0 +1,99 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Test bitwise NOT operator (~) on marray<bool>
+
+#include <sycl/detail/core.hpp>
+#include <sycl/marray.hpp>
+
+#include <cassert>
+#include <iostream>
+
+using namespace sycl;
+
+template <size_t N>
+bool test_bitwise_not_bool(queue &q, const marray<bool, N> &input,
+                           const marray<bool, N> &expected) {
+  bool result[N];
+  {
+    buffer<bool> out_buf(result, N);
+    q.submit([&](handler &h) {
+       accessor out_acc(out_buf, h, write_only);
+       h.single_task([=]() {
+         marray<bool, N> res = ~input;
+         for (size_t i = 0; i < N; ++i) {
+           out_acc[i] = res[i];
+         }
+       });
+     }).wait();
+  }
+
+  // Verify results
+  for (size_t i = 0; i < N; ++i) {
+    if (result[i] != expected[i]) {
+      std::cout << "FAILED at index " << i << ": input=" << input[i]
+                << ", expected=" << expected[i] << ", got=" << result[i]
+                << std::endl;
+      return false;
+    }
+  }
+  return true;
+}
+
+int main() {
+  queue q;
+
+  std::cout << "Testing bitwise NOT (~) on marray<bool>\n";
+
+  // Test case 1: Size 2
+  {
+    marray<bool, 2> input{true, false};
+    marray<bool, 2> expected{false, true};
+    assert(test_bitwise_not_bool(q, input, expected) &&
+           "Test failed for size 2");
+  }
+
+  // Test case 2: Size 4
+  {
+    marray<bool, 4> input{true, false, true, false};
+    marray<bool, 4> expected{false, true, false, true};
+    assert(test_bitwise_not_bool(q, input, expected) &&
+           "Test failed for size 4");
+  }
+
+  // Test case 3: Size 3 (no padding, different code path)
+  {
+    marray<bool, 3> input{false, true, false};
+    marray<bool, 3> expected{true, false, true};
+    assert(test_bitwise_not_bool(q, input, expected) &&
+           "Test failed for size 3");
+  }
+
+  // Test case 4: Size 8
+  {
+    marray<bool, 8> input{true, true, false, false, true, false, true, false};
+    marray<bool, 8> expected{false, false, true,  true,
+                             false, true,  false, true};
+    assert(test_bitwise_not_bool(q, input, expected) &&
+           "Test failed for size 8");
+  }
+
+  // Test case 5: All true
+  {
+    marray<bool, 4> input{true, true, true, true};
+    marray<bool, 4> expected{false, false, false, false};
+    assert(test_bitwise_not_bool(q, input, expected) &&
+           "Test failed for all true");
+  }
+
+  // Test case 6: All false
+  {
+    marray<bool, 4> input{false, false, false, false};
+    marray<bool, 4> expected{true, true, true, true};
+    assert(test_bitwise_not_bool(q, input, expected) &&
+           "Test failed for all false");
+  }
+
+  std::cout << "All tests passed!\n";
+  return 0;
+}


### PR DESCRIPTION
We use uint8_t for bool when using `ext_vector_type` on device and
`~uint8_t(1) = 0xFE`, and `static_cast<bool>(0xFE)` is true, so the original `storeVecResult` path produced the wrong result for `marray<bool>`

Fixes CMPLRLLVM-76430