### PR TITLE
[SYCL][Doc] Move sycl_ext_oneapi_register_host_memory to experimental

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_register_host_memory.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_register_host_memory.asciidoc
@@ -49,12 +49,10 @@ This extension also depends on the following other SYCL extensions:
 
 == Status
 
-This is a proposed extension specification, intended to gather community
-feedback.
-Interfaces defined in this specification may not be implemented yet or may be in
-a preliminary state.
-The specification itself may also change in incompatible ways before it is
-finalized.
+This is an experimental extension specification, intended to provide early
+access to features and gather community feedback.  Interfaces defined in this
+specification are implemented in {dpcpp}, but they are not finalized and may
+change incompatibly in future versions of {dpcpp} without prior notice.
 *Shipping software products should not rely on APIs defined in this
 specification.*
 


### PR DESCRIPTION
The extension has been implemented in #22390