### PR TITLE
[SYCL][Test] Update check_device_code tests with nofree

### DIFF
--- a/sycl/test/check_device_code/extensions/address_cast.cpp
+++ b/sycl/test/check_device_code/extensions/address_cast.cpp
@@ -14,18 +14,18 @@ using namespace sycl::ext::oneapi::experimental;
 
 namespace static_as_cast {
 // CHECK-LABEL: define dso_local spir_func void @_ZN14static_as_cast19to_global_decoratedEN4sycl3_V19multi_ptrIiLNS1_6access13address_spaceE4ELNS3_9decoratedE1EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA8:![0-9]+]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA10:![0-9]+]]
 // CHECK-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-NEXT:    [[TMP2:%.*]] = addrspacecast ptr addrspace(4) [[TMP1]] to ptr addrspace(1)
 // CHECK-NEXT:    store ptr addrspace(1) [[TMP2]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA13:![0-9]+]], !alias.scope [[META15:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 // CHECK_ALLOCA_AS-LABEL: define dso_local spir_func void @_ZN14static_as_cast19to_global_decoratedEN4sycl3_V19multi_ptrIiLNS1_6access13address_spaceE4ELNS3_9decoratedE1EEE(
-// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
+// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr") align 8 captures(none) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
 // CHECK_ALLOCA_AS-NEXT:  [[ENTRY:.*:]]
-// CHECK_ALLOCA_AS-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA8:![0-9]+]]
+// CHECK_ALLOCA_AS-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA10:![0-9]+]]
 // CHECK_ALLOCA_AS-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK_ALLOCA_AS-NEXT:    [[TMP2:%.*]] = addrspacecast ptr addrspace(4) [[TMP1]] to ptr addrspace(1)
 // CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(1) [[TMP2]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA13:![0-9]+]], !alias.scope [[META15:![0-9]+]]
@@ -35,49 +35,49 @@ SYCL_EXTERNAL auto to_global_decorated(decorated_generic_ptr<int> p) {
   return static_address_cast<access::address_space::global_space>(p);
 }
 // CHECK-LABEL: define dso_local spir_func void @_ZN14static_as_cast23to_global_not_decoratedEPi(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.1") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.1") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = addrspacecast ptr addrspace(4) [[P]] to ptr addrspace(1)
-// CHECK-NEXT:    store ptr addrspace(1) [[TMP0]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA21:![0-9]+]], !alias.scope [[META23:![0-9]+]]
+// CHECK-NEXT:    store ptr addrspace(1) [[TMP0]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA20:![0-9]+]], !alias.scope [[META22:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 // CHECK_ALLOCA_AS-LABEL: define dso_local spir_func void @_ZN14static_as_cast23to_global_not_decoratedEPi(
-// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.1") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {{.*}}{
+// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.1") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {{.*}}{
 // CHECK_ALLOCA_AS-NEXT:  [[ENTRY:.*:]]
 // CHECK_ALLOCA_AS-NEXT:    [[TMP0:%.*]] = addrspacecast ptr addrspace(4) [[P]] to ptr addrspace(1)
-// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(1) [[TMP0]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA21:![0-9]+]], !alias.scope [[META23:![0-9]+]]
+// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(1) [[TMP0]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA20:![0-9]+]], !alias.scope [[META22:![0-9]+]]
 // CHECK_ALLOCA_AS-NEXT:    ret void
 //
 SYCL_EXTERNAL auto to_global_not_decorated(int *p) {
   return static_address_cast<access::address_space::global_space>(p);
 }
 // CHECK-LABEL: define dso_local spir_func void @_ZN14static_as_cast20to_generic_decoratedEN4sycl3_V19multi_ptrIiLNS1_6access13address_spaceE4ELNS3_9decoratedE1EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA8]]
-// CHECK-NEXT:    store i64 [[TMP0]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA8]], !alias.scope [[META27:![0-9]+]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA10]]
+// CHECK-NEXT:    store i64 [[TMP0]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA10]], !alias.scope [[META25:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 // CHECK_ALLOCA_AS-LABEL: define dso_local spir_func void @_ZN14static_as_cast20to_generic_decoratedEN4sycl3_V19multi_ptrIiLNS1_6access13address_spaceE4ELNS3_9decoratedE1EEE(
-// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK_ALLOCA_AS-NEXT:  [[ENTRY:.*:]]
-// CHECK_ALLOCA_AS-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA8]]
-// CHECK_ALLOCA_AS-NEXT:    store i64 [[TMP0]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA8]], !alias.scope [[META27:![0-9]+]]
+// CHECK_ALLOCA_AS-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA10]]
+// CHECK_ALLOCA_AS-NEXT:    store i64 [[TMP0]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA10]], !alias.scope [[META25:![0-9]+]]
 // CHECK_ALLOCA_AS-NEXT:    ret void
 //
 SYCL_EXTERNAL auto to_generic_decorated(decorated_generic_ptr<int> p) {
   return static_address_cast<access::address_space::generic_space>(p);
 }
 // CHECK-LABEL: define dso_local spir_func void @_ZN14static_as_cast24to_generic_not_decoratedEPi(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.2") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.2") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    store ptr addrspace(4) [[P]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA31:![0-9]+]], !alias.scope [[META33:![0-9]+]]
+// CHECK-NEXT:    store ptr addrspace(4) [[P]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA28:![0-9]+]], !alias.scope [[META30:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 // CHECK_ALLOCA_AS-LABEL: define dso_local spir_func void @_ZN14static_as_cast24to_generic_not_decoratedEPi(
-// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.2") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.2") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK_ALLOCA_AS-NEXT:  [[ENTRY:.*:]]
-// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(4) [[P]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA31:![0-9]+]], !alias.scope [[META33:![0-9]+]]
+// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(4) [[P]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA28:![0-9]+]], !alias.scope [[META30:![0-9]+]]
 // CHECK_ALLOCA_AS-NEXT:    ret void
 //
 SYCL_EXTERNAL auto to_generic_not_decorated(int *p) {
@@ -87,70 +87,70 @@ SYCL_EXTERNAL auto to_generic_not_decorated(int *p) {
 
 namespace dynamic_as_cast {
 // CHECK-LABEL: define dso_local spir_func void @_ZN15dynamic_as_cast19to_global_decoratedEN4sycl3_V19multi_ptrIiLNS1_6access13address_spaceE4ELNS3_9decoratedE1EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR2:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR2:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA8]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA10]]
 // CHECK-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK-NEXT:    [[CALL_I_I_I:%.*]] = tail call spir_func noundef ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobalPvi(ptr addrspace(4) noundef [[TMP1]], i32 noundef 5) #[[ATTR5:[0-9]+]]
-// CHECK-NEXT:    store ptr addrspace(1) [[CALL_I_I_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA13]], !alias.scope [[META49:![0-9]+]]
+// CHECK-NEXT:    store ptr addrspace(1) [[CALL_I_I_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA13]], !alias.scope [[META33:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 // CHECK_ALLOCA_AS-LABEL: define dso_local spir_func void @_ZN15dynamic_as_cast19to_global_decoratedEN4sycl3_V19multi_ptrIiLNS1_6access13address_spaceE4ELNS3_9decoratedE1EEE(
-// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR2:[0-9]+]] {{.*}}{
+// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr") align 8 captures(none) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR2:[0-9]+]] {{.*}}{
 // CHECK_ALLOCA_AS-NEXT:  [[ENTRY:.*:]]
-// CHECK_ALLOCA_AS-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA8]]
+// CHECK_ALLOCA_AS-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA10]]
 // CHECK_ALLOCA_AS-NEXT:    [[TMP1:%.*]] = inttoptr i64 [[TMP0]] to ptr addrspace(4)
 // CHECK_ALLOCA_AS-NEXT:    [[CALL_I_I_I:%.*]] = tail call spir_func noundef ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobalPvi(ptr addrspace(4) noundef [[TMP1]], i32 noundef 5) #[[ATTR5:[0-9]+]]
-// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(1) [[CALL_I_I_I]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA13]], !alias.scope [[META49:![0-9]+]]
+// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(1) [[CALL_I_I_I]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA13]], !alias.scope [[META33:![0-9]+]]
 // CHECK_ALLOCA_AS-NEXT:    ret void
 //
 SYCL_EXTERNAL auto to_global_decorated(decorated_generic_ptr<int> p) {
   return dynamic_address_cast<access::address_space::global_space>(p);
 }
 // CHECK-LABEL: define dso_local spir_func void @_ZN15dynamic_as_cast23to_global_not_decoratedEPi(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.1") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR4:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.1") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR4:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[CALL_I_I:%.*]] = tail call spir_func noundef ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobalPvi(ptr addrspace(4) noundef [[P]], i32 noundef 5) #[[ATTR5]]
-// CHECK-NEXT:    store ptr addrspace(1) [[CALL_I_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA21]], !alias.scope [[META55:![0-9]+]]
+// CHECK-NEXT:    store ptr addrspace(1) [[CALL_I_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA20]], !alias.scope [[META38:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 // CHECK_ALLOCA_AS-LABEL: define dso_local spir_func void @_ZN15dynamic_as_cast23to_global_not_decoratedEPi(
-// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.1") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR4:[0-9]+]] {{.*}}{
+// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.1") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR4:[0-9]+]] {{.*}}{
 // CHECK_ALLOCA_AS-NEXT:  [[ENTRY:.*:]]
 // CHECK_ALLOCA_AS-NEXT:    [[CALL_I_I:%.*]] = tail call spir_func noundef ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobalPvi(ptr addrspace(4) noundef [[P]], i32 noundef 5) #[[ATTR5]]
-// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(1) [[CALL_I_I]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA21]], !alias.scope [[META55:![0-9]+]]
+// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(1) [[CALL_I_I]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA20]], !alias.scope [[META38:![0-9]+]]
 // CHECK_ALLOCA_AS-NEXT:    ret void
 //
 SYCL_EXTERNAL auto to_global_not_decorated(int *p) {
   return dynamic_address_cast<access::address_space::global_space>(p);
 }
 // CHECK-LABEL: define dso_local spir_func void @_ZN15dynamic_as_cast20to_generic_decoratedEN4sycl3_V19multi_ptrIiLNS1_6access13address_spaceE4ELNS3_9decoratedE1EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA8]]
-// CHECK-NEXT:    store i64 [[TMP0]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA8]], !alias.scope [[META59:![0-9]+]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA10]]
+// CHECK-NEXT:    store i64 [[TMP0]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA10]], !alias.scope [[META41:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 // CHECK_ALLOCA_AS-LABEL: define dso_local spir_func void @_ZN15dynamic_as_cast20to_generic_decoratedEN4sycl3_V19multi_ptrIiLNS1_6access13address_spaceE4ELNS3_9decoratedE1EEE(
-// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::multi_ptr.0") align 8 captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK_ALLOCA_AS-NEXT:  [[ENTRY:.*:]]
-// CHECK_ALLOCA_AS-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA8]]
-// CHECK_ALLOCA_AS-NEXT:    store i64 [[TMP0]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA8]], !alias.scope [[META59:![0-9]+]]
+// CHECK_ALLOCA_AS-NEXT:    [[TMP0:%.*]] = load i64, ptr [[P]], align 8, !tbaa [[TBAA10]]
+// CHECK_ALLOCA_AS-NEXT:    store i64 [[TMP0]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA10]], !alias.scope [[META41:![0-9]+]]
 // CHECK_ALLOCA_AS-NEXT:    ret void
 //
 SYCL_EXTERNAL auto to_generic_decorated(decorated_generic_ptr<int> p) {
   return dynamic_address_cast<access::address_space::generic_space>(p);
 }
 // CHECK-LABEL: define dso_local spir_func void @_ZN15dynamic_as_cast24to_generic_not_decoratedEPi(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.2") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.2") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    store ptr addrspace(4) [[P]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA31]], !alias.scope [[META63:![0-9]+]]
+// CHECK-NEXT:    store ptr addrspace(4) [[P]], ptr addrspace(4) [[AGG_RESULT]], align 8, !tbaa [[TBAA28]], !alias.scope [[META44:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 // CHECK_ALLOCA_AS-LABEL: define dso_local spir_func void @_ZN15dynamic_as_cast24to_generic_not_decoratedEPi(
-// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::multi_ptr.2") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK_ALLOCA_AS-SAME: ptr dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::multi_ptr.2") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK_ALLOCA_AS-NEXT:  [[ENTRY:.*:]]
-// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(4) [[P]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA31]], !alias.scope [[META63:![0-9]+]]
+// CHECK_ALLOCA_AS-NEXT:    store ptr addrspace(4) [[P]], ptr [[AGG_RESULT]], align 8, !tbaa [[TBAA28]], !alias.scope [[META44:![0-9]+]]
 // CHECK_ALLOCA_AS-NEXT:    ret void
 //
 SYCL_EXTERNAL auto to_generic_not_decorated(int *p) {

--- a/sycl/test/check_device_code/vector/bf16_builtins_new_vec.cpp
+++ b/sycl/test/check_device_code/vector/bf16_builtins_new_vec.cpp
@@ -21,7 +21,7 @@ using namespace sycl::ext::oneapi;
 using namespace sycl::ext::oneapi::experimental;
 
 // CHECK-LABEL: define dso_local spir_func void @_Z8TestFMinN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi2EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec") align 4 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec") align 4 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I8_I:%.*]] = alloca <2 x float>, align 8
 // CHECK-NEXT:    [[DST_I_I_I_I9_I:%.*]] = alloca [2 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
@@ -31,37 +31,37 @@ using namespace sycl::ext::oneapi::experimental;
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [2 x float], align 4
 // CHECK-NEXT:    [[TMP0:%.*]] = load <2 x i16>, ptr [[A]], align 4
 // CHECK-NEXT:    [[TMP1:%.*]] = load <2 x i16>, ptr [[B]], align 4
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META11:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META14:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META14]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META10:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META13:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META13]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <2 x i16> [[TMP0]], ptr [[VEC_ADDR_I_I_I_I_I]], align 4, !tbaa [[TBAA17:![0-9]+]], !noalias [[META14]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5:[0-9]+]], !noalias [[META14]]
-// CHECK-NEXT:    [[TMP2:%.*]] = load <2 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META14]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META14]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META14]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META18:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META18]]
+// CHECK-NEXT:    store <2 x i16> [[TMP0]], ptr [[VEC_ADDR_I_I_I_I_I]], align 4, !tbaa [[TBAA16:![0-9]+]], !noalias [[META13]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5:[0-9]+]], !noalias [[META13]]
+// CHECK-NEXT:    [[TMP2:%.*]] = load <2 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META13]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META13]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META13]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META17:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META17]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I4_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I2_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I5_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I3_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <2 x i16> [[TMP1]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 4, !tbaa [[TBAA17]], !noalias [[META18]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META18]]
-// CHECK-NEXT:    [[TMP3:%.*]] = load <2 x float>, ptr [[DST_I_I_I_I3_I]], align 4, !tbaa [[TBAA17]], !noalias [[META18]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META18]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META18]]
+// CHECK-NEXT:    store <2 x i16> [[TMP1]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 4, !tbaa [[TBAA16]], !noalias [[META17]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META17]]
+// CHECK-NEXT:    [[TMP3:%.*]] = load <2 x float>, ptr [[DST_I_I_I_I3_I]], align 4, !tbaa [[TBAA16]], !noalias [[META17]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META17]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META17]]
 // CHECK-NEXT:    [[CALL2_I_I:%.*]] = call spir_func noundef <2 x float> @_Z16__spirv_ocl_fminDv2_fS_(<2 x float> noundef [[TMP2]], <2 x float> noundef [[TMP3]]) #[[ATTR6:[0-9]+]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META21:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I8_I]]), !noalias [[META24:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I9_I]]), !noalias [[META24]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META20:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I8_I]]), !noalias [[META23:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I9_I]]), !noalias [[META23]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I10_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I8_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I11_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I9_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <2 x float> [[CALL2_I_I]], ptr [[VEC_ADDR_I_I_I_I8_I]], align 8, !tbaa [[TBAA17]], !noalias [[META24]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I10_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I11_I]]) #[[ATTR5]], !noalias [[META24]]
-// CHECK-NEXT:    [[TMP4:%.*]] = load i32, ptr [[DST_I_I_I_I9_I]], align 2, !tbaa [[TBAA17]], !noalias [[META24]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I8_I]]), !noalias [[META24]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I9_I]]), !noalias [[META24]]
-// CHECK-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META24]]
+// CHECK-NEXT:    store <2 x float> [[CALL2_I_I]], ptr [[VEC_ADDR_I_I_I_I8_I]], align 8, !tbaa [[TBAA16]], !noalias [[META23]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I10_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I11_I]]) #[[ATTR5]], !noalias [[META23]]
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32, ptr [[DST_I_I_I_I9_I]], align 2, !tbaa [[TBAA16]], !noalias [[META23]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I8_I]]), !noalias [[META23]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I9_I]]), !noalias [[META23]]
+// CHECK-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META23]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFMin(vec<bfloat16, 2> a, vec<bfloat16, 2> b) {
@@ -69,7 +69,7 @@ SYCL_EXTERNAL auto TestFMin(vec<bfloat16, 2> a, vec<bfloat16, 2> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z8TestFMaxN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 8 captures(none) [[A:%.*]], ptr noundef readonly byval({{.*}}) align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.70") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.70") align 8 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.70") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I14_I:%.*]] = alloca <3 x float>, align 16
 // CHECK-NEXT:    [[DST_I_I_I_I15_I:%.*]] = alloca [4 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
@@ -79,46 +79,46 @@ SYCL_EXTERNAL auto TestFMin(vec<bfloat16, 2> a, vec<bfloat16, 2> b) {
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [4 x float], align 4
 // CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i16>, ptr [[A]], align 8
 // CHECK-NEXT:    [[TMP1:%.*]] = load <4 x i16>, ptr [[B]], align 8
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META25:![0-9]+]])
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META24:![0-9]+]])
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I:%.*]] = shufflevector <4 x i16> [[TMP0]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META28:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META28]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META27:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META27]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I_I]], align 8, !tbaa [[TBAA17]], !noalias [[META28]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META28]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I_I]], align 4, !noalias [[META28]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META28]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META28]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I_I]], align 8, !tbaa [[TBAA16]], !noalias [[META27]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META27]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I_I]], align 4, !noalias [[META27]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META27]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META27]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I5_I:%.*]] = shufflevector <4 x i16> [[TMP1]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META31:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META31]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META30:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META30]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I6_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I2_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I7_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I3_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I8_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I5_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I8_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 8, !tbaa [[TBAA17]], !noalias [[META31]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I6_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I7_I]]) #[[ATTR5]], !noalias [[META31]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I9_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I3_I]], align 4, !noalias [[META31]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META31]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META31]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I8_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 8, !tbaa [[TBAA16]], !noalias [[META30]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I6_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I7_I]]) #[[ATTR5]], !noalias [[META30]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I9_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I3_I]], align 4, !noalias [[META30]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META30]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META30]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I_I_I_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    [[EXTRACTVEC_I_I4_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I_I_I_I9_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    [[CALL2_I_I:%.*]] = call spir_func noundef <3 x float> @_Z16__spirv_ocl_fmaxDv3_fS_(<3 x float> noundef [[EXTRACTVEC_I_I_I_I]], <3 x float> noundef [[EXTRACTVEC_I_I4_I_I]]) #[[ATTR6]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META34:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META37:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META37]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META33:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META36:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META36]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I18_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I14_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I19_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I15_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I20_I:%.*]] = shufflevector <3 x float> [[CALL2_I_I]], <3 x float> <float undef, float poison, float poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I_I_I_I20_I]], ptr [[VEC_ADDR_I_I_I_I14_I]], align 16, !tbaa [[TBAA17]], !noalias [[META37]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I18_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I19_I]]) #[[ATTR5]], !noalias [[META37]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I21_I:%.*]] = load <4 x i16>, ptr [[DST_I_I_I_I15_I]], align 2, !noalias [[META37]]
+// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I_I_I_I20_I]], ptr [[VEC_ADDR_I_I_I_I14_I]], align 16, !tbaa [[TBAA16]], !noalias [[META36]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I18_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I19_I]]) #[[ATTR5]], !noalias [[META36]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I21_I:%.*]] = load <4 x i16>, ptr [[DST_I_I_I_I15_I]], align 2, !noalias [[META36]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I22_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I_I_I_I21_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META37]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META37]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META36]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META36]]
 // CHECK-NEXT:    [[EXTRACTVEC_I23_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I_I_I_I22_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I23_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META37]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I23_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META36]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFMax(vec<bfloat16, 3> a, vec<bfloat16, 3> b) {
@@ -126,25 +126,25 @@ SYCL_EXTERNAL auto TestFMax(vec<bfloat16, 3> a, vec<bfloat16, 3> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z9TestIsNanN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi4EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 8 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.146") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.183") align 8 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I_I:%.*]] = alloca <4 x i16>, align 8
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [4 x float], align 4
 // CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i16>, ptr [[A]], align 8
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META38:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META41:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META41]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META37:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META40:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META40]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <4 x i16> [[TMP0]], ptr [[VEC_ADDR_I_I_I_I_I]], align 8, !tbaa [[TBAA17]], !noalias [[META41]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec4(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META41]]
-// CHECK-NEXT:    [[TMP1:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META41]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META41]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META41]]
+// CHECK-NEXT:    store <4 x i16> [[TMP0]], ptr [[VEC_ADDR_I_I_I_I_I]], align 8, !tbaa [[TBAA16]], !noalias [[META40]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec4(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META40]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META40]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META40]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META40]]
 // CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = call spir_func noundef <4 x i8> @_Z13__spirv_IsNanDv4_f(<4 x float> noundef [[TMP1]]) #[[ATTR6]]
-// CHECK-NEXT:    [[MASK_I32:%.*]] = sext <4 x i8> [[CALL_I_I_I_I]] to <4 x i32>
-// CHECK-NEXT:    [[CALL_I_I_I2_I:%.*]] = call spir_func noundef <4 x i16> @_Z24__spirv_SConvert_Rshort4Dv4_i(<4 x i32> noundef [[MASK_I32]]) #[[ATTR6]]
-// CHECK-NEXT:    store <4 x i16> [[CALL_I_I_I2_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META44:![0-9]+]]
+// CHECK-NEXT:    [[CONV_I_I_I_I:%.*]] = sext <4 x i8> [[CALL_I_I_I_I]] to <4 x i32>
+// CHECK-NEXT:    [[CALL_I_I_I2_I:%.*]] = call spir_func noundef <4 x i16> @_Z24__spirv_SConvert_Rshort4Dv4_i(<4 x i32> noundef [[CONV_I_I_I_I]]) #[[ATTR6]]
+// CHECK-NEXT:    store <4 x i16> [[CALL_I_I_I2_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META43:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestIsNan(vec<bfloat16, 4> a) {
@@ -152,35 +152,35 @@ SYCL_EXTERNAL auto TestIsNan(vec<bfloat16, 4> a) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z8TestFabsN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi8EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.334") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.334") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I2_I:%.*]] = alloca <8 x float>, align 32
 // CHECK-NEXT:    [[DST_I_I_I_I3_I:%.*]] = alloca [8 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I_I:%.*]] = alloca <8 x i16>, align 16
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [8 x float], align 4
 // CHECK-NEXT:    [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <8 x i16>, ptr [[A]], align 16
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META47:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META50:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META50]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META46:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META49:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META49]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <8 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 16, !tbaa [[TBAA17]], !noalias [[META50]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META50]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load <8 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META50]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META50]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META50]]
+// CHECK-NEXT:    store <8 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 16, !tbaa [[TBAA16]], !noalias [[META49]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META49]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load <8 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META49]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META49]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META49]]
 // CHECK-NEXT:    [[CALL1_I_I:%.*]] = call spir_func noundef <8 x float> @_Z16__spirv_ocl_fabsDv8_f(<8 x float> noundef [[TMP0]]) #[[ATTR6]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META53:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META56:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META56]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META52:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META55:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META55]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I4_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I2_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I5_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I3_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <8 x float> [[CALL1_I_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 32, !tbaa [[TBAA17]], !noalias [[META56]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META56]]
-// CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i16>, ptr [[DST_I_I_I_I3_I]], align 2, !tbaa [[TBAA17]], !noalias [[META56]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META56]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META56]]
-// CHECK-NEXT:    store <8 x i16> [[TMP1]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META56]]
+// CHECK-NEXT:    store <8 x float> [[CALL1_I_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 32, !tbaa [[TBAA16]], !noalias [[META55]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META55]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i16>, ptr [[DST_I_I_I_I3_I]], align 2, !tbaa [[TBAA16]], !noalias [[META55]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META55]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META55]]
+// CHECK-NEXT:    store <8 x i16> [[TMP1]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META55]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFabs(vec<bfloat16, 8> a) {
@@ -188,35 +188,35 @@ SYCL_EXTERNAL auto TestFabs(vec<bfloat16, 8> a) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z8TestCeilN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi8EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.334") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.334") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I2_I:%.*]] = alloca <8 x float>, align 32
 // CHECK-NEXT:    [[DST_I_I_I_I3_I:%.*]] = alloca [8 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I_I:%.*]] = alloca <8 x i16>, align 16
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [8 x float], align 4
 // CHECK-NEXT:    [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <8 x i16>, ptr [[A]], align 16
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META57:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META60:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META60]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META56:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META59:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META59]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <8 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 16, !tbaa [[TBAA17]], !noalias [[META60]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META60]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load <8 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META60]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META60]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META60]]
+// CHECK-NEXT:    store <8 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 16, !tbaa [[TBAA16]], !noalias [[META59]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META59]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load <8 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META59]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META59]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META59]]
 // CHECK-NEXT:    [[CALL1_I_I:%.*]] = call spir_func noundef <8 x float> @_Z16__spirv_ocl_ceilDv8_f(<8 x float> noundef [[TMP0]]) #[[ATTR6]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META63:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META66:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META66]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META62:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META65:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META65]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I4_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I2_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I5_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I3_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <8 x float> [[CALL1_I_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 32, !tbaa [[TBAA17]], !noalias [[META66]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META66]]
-// CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i16>, ptr [[DST_I_I_I_I3_I]], align 2, !tbaa [[TBAA17]], !noalias [[META66]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META66]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META66]]
-// CHECK-NEXT:    store <8 x i16> [[TMP1]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META66]]
+// CHECK-NEXT:    store <8 x float> [[CALL1_I_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 32, !tbaa [[TBAA16]], !noalias [[META65]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META65]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i16>, ptr [[DST_I_I_I_I3_I]], align 2, !tbaa [[TBAA16]], !noalias [[META65]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META65]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META65]]
+// CHECK-NEXT:    store <8 x i16> [[TMP1]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META65]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestCeil(vec<bfloat16, 8> a) {
@@ -224,7 +224,7 @@ SYCL_EXTERNAL auto TestCeil(vec<bfloat16, 8> a) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestFMAN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi16EEES5_S5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 32 captures(none) initializes((0, 32)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 32 captures(none) [[A:%.*]], ptr noundef readonly byval({{.*}}) align 32 captures(none) [[B:%.*]], ptr noundef readonly byval({{.*}}) align 32 captures(none) [[C:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.410") align 32 captures(none) initializes((0, 32)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.410") align 32 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.410") align 32 captures(none) [[B:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.410") align 32 captures(none) [[C:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I14_I:%.*]] = alloca <16 x float>, align 64
 // CHECK-NEXT:    [[DST_I_I_I_I15_I:%.*]] = alloca [16 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
@@ -237,46 +237,46 @@ SYCL_EXTERNAL auto TestCeil(vec<bfloat16, 8> a) {
 // CHECK-NEXT:    [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <16 x i16>, ptr [[A]], align 32
 // CHECK-NEXT:    [[AGG_TMP1_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <16 x i16>, ptr [[B]], align 32
 // CHECK-NEXT:    [[AGG_TMP2_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <16 x i16>, ptr [[C]], align 32
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META67:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META70:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META70]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META66:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META69:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META69]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <16 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 32, !tbaa [[TBAA17]], !noalias [[META70]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META70]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META70]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META70]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META70]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I3_I]]), !noalias [[META73:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I4_I]]), !noalias [[META73]]
+// CHECK-NEXT:    store <16 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 32, !tbaa [[TBAA16]], !noalias [[META69]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META69]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META69]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META69]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META69]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I3_I]]), !noalias [[META72:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I4_I]]), !noalias [[META72]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I5_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I3_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I6_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I4_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <16 x i16> [[AGG_TMP1_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I3_I]], align 32, !tbaa [[TBAA17]], !noalias [[META73]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I5_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I6_I]]) #[[ATTR5]], !noalias [[META73]]
-// CHECK-NEXT:    [[TMP1:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I4_I]], align 4, !tbaa [[TBAA17]], !noalias [[META73]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I3_I]]), !noalias [[META73]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I4_I]]), !noalias [[META73]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I7_I]]), !noalias [[META76:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I8_I]]), !noalias [[META76]]
+// CHECK-NEXT:    store <16 x i16> [[AGG_TMP1_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I3_I]], align 32, !tbaa [[TBAA16]], !noalias [[META72]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I5_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I6_I]]) #[[ATTR5]], !noalias [[META72]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I4_I]], align 4, !tbaa [[TBAA16]], !noalias [[META72]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I3_I]]), !noalias [[META72]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I4_I]]), !noalias [[META72]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I7_I]]), !noalias [[META75:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I8_I]]), !noalias [[META75]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I9_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I7_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I10_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I8_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <16 x i16> [[AGG_TMP2_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I7_I]], align 32, !tbaa [[TBAA17]], !noalias [[META76]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I9_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I10_I]]) #[[ATTR5]], !noalias [[META76]]
-// CHECK-NEXT:    [[TMP2:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I8_I]], align 4, !tbaa [[TBAA17]], !noalias [[META76]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I7_I]]), !noalias [[META76]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I8_I]]), !noalias [[META76]]
+// CHECK-NEXT:    store <16 x i16> [[AGG_TMP2_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I7_I]], align 32, !tbaa [[TBAA16]], !noalias [[META75]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I9_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I10_I]]) #[[ATTR5]], !noalias [[META75]]
+// CHECK-NEXT:    [[TMP2:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I8_I]], align 4, !tbaa [[TBAA16]], !noalias [[META75]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I7_I]]), !noalias [[META75]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I8_I]]), !noalias [[META75]]
 // CHECK-NEXT:    [[CALL3_I_I:%.*]] = call spir_func noundef <16 x float> @_Z15__spirv_ocl_fmaDv16_fS_S_(<16 x float> noundef [[TMP0]], <16 x float> noundef [[TMP1]], <16 x float> noundef [[TMP2]]) #[[ATTR6]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META79:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META82:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META82]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META78:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META81:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META81]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I16_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I14_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I17_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I15_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <16 x float> [[CALL3_I_I]], ptr [[VEC_ADDR_I_I_I_I14_I]], align 64, !tbaa [[TBAA17]], !noalias [[META82]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I16_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I17_I]]) #[[ATTR5]], !noalias [[META82]]
-// CHECK-NEXT:    [[TMP3:%.*]] = load <16 x i16>, ptr [[DST_I_I_I_I15_I]], align 2, !tbaa [[TBAA17]], !noalias [[META82]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META82]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META82]]
-// CHECK-NEXT:    store <16 x i16> [[TMP3]], ptr addrspace(4) [[AGG_RESULT]], align 32, !alias.scope [[META82]]
+// CHECK-NEXT:    store <16 x float> [[CALL3_I_I]], ptr [[VEC_ADDR_I_I_I_I14_I]], align 64, !tbaa [[TBAA16]], !noalias [[META81]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I16_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I17_I]]) #[[ATTR5]], !noalias [[META81]]
+// CHECK-NEXT:    [[TMP3:%.*]] = load <16 x i16>, ptr [[DST_I_I_I_I15_I]], align 2, !tbaa [[TBAA16]], !noalias [[META81]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META81]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META81]]
+// CHECK-NEXT:    store <16 x i16> [[TMP3]], ptr addrspace(4) [[AGG_RESULT]], align 32, !alias.scope [[META81]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFMA(vec<bfloat16, 16> a, vec<bfloat16, 16> b,

--- a/sycl/test/check_device_code/vector/bf16_builtins_old_vec.cpp
+++ b/sycl/test/check_device_code/vector/bf16_builtins_old_vec.cpp
@@ -21,7 +21,7 @@ using namespace sycl::ext::oneapi;
 using namespace sycl::ext::oneapi::experimental;
 
 // CHECK-LABEL: define dso_local spir_func void @_Z8TestFMinN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi2EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec") align 4 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec") align 4 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I8_I:%.*]] = alloca <2 x float>, align 8
 // CHECK-NEXT:    [[DST_I_I_I_I9_I:%.*]] = alloca [2 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
@@ -31,37 +31,37 @@ using namespace sycl::ext::oneapi::experimental;
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [2 x float], align 4
 // CHECK-NEXT:    [[TMP0:%.*]] = load <2 x i16>, ptr [[A]], align 4
 // CHECK-NEXT:    [[TMP1:%.*]] = load <2 x i16>, ptr [[B]], align 4
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META11:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META14:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META14]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META10:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META13:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META13]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <2 x i16> [[TMP0]], ptr [[VEC_ADDR_I_I_I_I_I]], align 4, !tbaa [[TBAA17:![0-9]+]], !noalias [[META14]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5:[0-9]+]], !noalias [[META14]]
-// CHECK-NEXT:    [[TMP2:%.*]] = load <2 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META14]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META14]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META14]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META18:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META18]]
+// CHECK-NEXT:    store <2 x i16> [[TMP0]], ptr [[VEC_ADDR_I_I_I_I_I]], align 4, !tbaa [[TBAA16:![0-9]+]], !noalias [[META13]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5:[0-9]+]], !noalias [[META13]]
+// CHECK-NEXT:    [[TMP2:%.*]] = load <2 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META13]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META13]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META13]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META17:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META17]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I4_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I2_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I5_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I3_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <2 x i16> [[TMP1]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 4, !tbaa [[TBAA17]], !noalias [[META18]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META18]]
-// CHECK-NEXT:    [[TMP3:%.*]] = load <2 x float>, ptr [[DST_I_I_I_I3_I]], align 4, !tbaa [[TBAA17]], !noalias [[META18]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META18]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META18]]
+// CHECK-NEXT:    store <2 x i16> [[TMP1]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 4, !tbaa [[TBAA16]], !noalias [[META17]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META17]]
+// CHECK-NEXT:    [[TMP3:%.*]] = load <2 x float>, ptr [[DST_I_I_I_I3_I]], align 4, !tbaa [[TBAA16]], !noalias [[META17]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META17]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META17]]
 // CHECK-NEXT:    [[CALL2_I_I:%.*]] = call spir_func noundef <2 x float> @_Z16__spirv_ocl_fminDv2_fS_(<2 x float> noundef [[TMP2]], <2 x float> noundef [[TMP3]]) #[[ATTR6:[0-9]+]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META21:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I8_I]]), !noalias [[META24:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I9_I]]), !noalias [[META24]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META20:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I8_I]]), !noalias [[META23:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I9_I]]), !noalias [[META23]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I10_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I8_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I11_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I9_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <2 x float> [[CALL2_I_I]], ptr [[VEC_ADDR_I_I_I_I8_I]], align 8, !tbaa [[TBAA17]], !noalias [[META24]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I10_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I11_I]]) #[[ATTR5]], !noalias [[META24]]
-// CHECK-NEXT:    [[TMP4:%.*]] = load i32, ptr [[DST_I_I_I_I9_I]], align 2, !tbaa [[TBAA17]], !noalias [[META24]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I8_I]]), !noalias [[META24]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I9_I]]), !noalias [[META24]]
-// CHECK-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META24]]
+// CHECK-NEXT:    store <2 x float> [[CALL2_I_I]], ptr [[VEC_ADDR_I_I_I_I8_I]], align 8, !tbaa [[TBAA16]], !noalias [[META23]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec2(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I10_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I11_I]]) #[[ATTR5]], !noalias [[META23]]
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32, ptr [[DST_I_I_I_I9_I]], align 2, !tbaa [[TBAA16]], !noalias [[META23]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I8_I]]), !noalias [[META23]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I9_I]]), !noalias [[META23]]
+// CHECK-NEXT:    store i32 [[TMP4]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META23]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFMin(vec<bfloat16, 2> a, vec<bfloat16, 2> b) {
@@ -69,7 +69,7 @@ SYCL_EXTERNAL auto TestFMin(vec<bfloat16, 2> a, vec<bfloat16, 2> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z8TestFMaxN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 8 captures(none) [[A:%.*]], ptr noundef readonly byval({{.*}}) align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.70") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.70") align 8 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.70") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I14_I:%.*]] = alloca <3 x float>, align 16
 // CHECK-NEXT:    [[DST_I_I_I_I15_I:%.*]] = alloca [4 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
@@ -79,46 +79,46 @@ SYCL_EXTERNAL auto TestFMin(vec<bfloat16, 2> a, vec<bfloat16, 2> b) {
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [4 x float], align 4
 // CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i16>, ptr [[A]], align 8
 // CHECK-NEXT:    [[TMP1:%.*]] = load <4 x i16>, ptr [[B]], align 8
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META25:![0-9]+]])
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META24:![0-9]+]])
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I:%.*]] = shufflevector <4 x i16> [[TMP0]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META28:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META28]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META27:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META27]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I_I]], align 8, !tbaa [[TBAA17]], !noalias [[META28]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META28]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I_I]], align 4, !noalias [[META28]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META28]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META28]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I_I]], align 8, !tbaa [[TBAA16]], !noalias [[META27]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META27]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I_I]], align 4, !noalias [[META27]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META27]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META27]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I5_I:%.*]] = shufflevector <4 x i16> [[TMP1]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META31:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META31]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META30:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META30]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I6_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I2_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I7_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I3_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I8_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I5_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I8_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 8, !tbaa [[TBAA17]], !noalias [[META31]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I6_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I7_I]]) #[[ATTR5]], !noalias [[META31]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I9_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I3_I]], align 4, !noalias [[META31]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META31]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META31]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I8_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 8, !tbaa [[TBAA16]], !noalias [[META30]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I6_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I7_I]]) #[[ATTR5]], !noalias [[META30]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I9_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I3_I]], align 4, !noalias [[META30]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META30]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META30]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I_I_I_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    [[EXTRACTVEC_I_I4_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I_I_I_I9_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    [[CALL2_I_I:%.*]] = call spir_func noundef <3 x float> @_Z16__spirv_ocl_fmaxDv3_fS_(<3 x float> noundef [[EXTRACTVEC_I_I_I_I]], <3 x float> noundef [[EXTRACTVEC_I_I4_I_I]]) #[[ATTR6]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META34:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META37:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META37]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META33:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META36:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META36]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I18_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I14_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I19_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I15_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I20_I:%.*]] = shufflevector <3 x float> [[CALL2_I_I]], <3 x float> <float undef, float poison, float poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I_I_I_I20_I]], ptr [[VEC_ADDR_I_I_I_I14_I]], align 16, !tbaa [[TBAA17]], !noalias [[META37]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I18_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I19_I]]) #[[ATTR5]], !noalias [[META37]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I21_I:%.*]] = load <4 x i16>, ptr [[DST_I_I_I_I15_I]], align 2, !noalias [[META37]]
+// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I_I_I_I20_I]], ptr [[VEC_ADDR_I_I_I_I14_I]], align 16, !tbaa [[TBAA16]], !noalias [[META36]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I18_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I19_I]]) #[[ATTR5]], !noalias [[META36]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I21_I:%.*]] = load <4 x i16>, ptr [[DST_I_I_I_I15_I]], align 2, !noalias [[META36]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I22_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I_I_I_I21_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META37]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META37]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META36]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META36]]
 // CHECK-NEXT:    [[EXTRACTVEC_I23_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I_I_I_I22_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I23_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META37]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I23_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META36]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFMax(vec<bfloat16, 3> a, vec<bfloat16, 3> b) {
@@ -126,25 +126,25 @@ SYCL_EXTERNAL auto TestFMax(vec<bfloat16, 3> a, vec<bfloat16, 3> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z9TestIsNanN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi4EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 8 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.146") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.184") align 8 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I_I:%.*]] = alloca <4 x i16>, align 8
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [4 x float], align 4
 // CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i16>, ptr [[A]], align 8
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META38:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META41:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META41]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META37:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META40:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META40]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <4 x i16> [[TMP0]], ptr [[VEC_ADDR_I_I_I_I_I]], align 8, !tbaa [[TBAA17]], !noalias [[META41]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec4(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META41]]
-// CHECK-NEXT:    [[TMP1:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META41]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META41]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META41]]
+// CHECK-NEXT:    store <4 x i16> [[TMP0]], ptr [[VEC_ADDR_I_I_I_I_I]], align 8, !tbaa [[TBAA16]], !noalias [[META40]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec4(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META40]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META40]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META40]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META40]]
 // CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = call spir_func noundef <4 x i8> @_Z13__spirv_IsNanDv4_f(<4 x float> noundef [[TMP1]]) #[[ATTR6]]
-// CHECK-NEXT:    [[MASK_I32:%.*]] = sext <4 x i8> [[CALL_I_I_I_I]] to <4 x i32>
-// CHECK-NEXT:    [[CALL_I_I_I2_I:%.*]] = call spir_func noundef <4 x i16> @_Z24__spirv_SConvert_Rshort4Dv4_i(<4 x i32> noundef [[MASK_I32]]) #[[ATTR6]]
-// CHECK-NEXT:    store <4 x i16> [[CALL_I_I_I2_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META44:![0-9]+]]
+// CHECK-NEXT:    [[CONV_I_I_I_I:%.*]] = sext <4 x i8> [[CALL_I_I_I_I]] to <4 x i32>
+// CHECK-NEXT:    [[CALL_I_I_I2_I:%.*]] = call spir_func noundef <4 x i16> @_Z24__spirv_SConvert_Rshort4Dv4_i(<4 x i32> noundef [[CONV_I_I_I_I]]) #[[ATTR6]]
+// CHECK-NEXT:    store <4 x i16> [[CALL_I_I_I2_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META43:![0-9]+]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestIsNan(vec<bfloat16, 4> a) {
@@ -152,35 +152,35 @@ SYCL_EXTERNAL auto TestIsNan(vec<bfloat16, 4> a) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z8TestFabsN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi8EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.336") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.336") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I2_I:%.*]] = alloca <8 x float>, align 32
 // CHECK-NEXT:    [[DST_I_I_I_I3_I:%.*]] = alloca [8 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I_I:%.*]] = alloca <8 x i16>, align 16
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [8 x float], align 4
 // CHECK-NEXT:    [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <8 x i16>, ptr [[A]], align 16
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META47:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META50:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META50]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META46:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META49:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META49]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <8 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 16, !tbaa [[TBAA17]], !noalias [[META50]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META50]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load <8 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META50]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META50]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META50]]
+// CHECK-NEXT:    store <8 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 16, !tbaa [[TBAA16]], !noalias [[META49]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META49]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load <8 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META49]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META49]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META49]]
 // CHECK-NEXT:    [[CALL1_I_I:%.*]] = call spir_func noundef <8 x float> @_Z16__spirv_ocl_fabsDv8_f(<8 x float> noundef [[TMP0]]) #[[ATTR6]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META53:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META56:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META56]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META52:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META55:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META55]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I4_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I2_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I5_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I3_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <8 x float> [[CALL1_I_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 32, !tbaa [[TBAA17]], !noalias [[META56]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META56]]
-// CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i16>, ptr [[DST_I_I_I_I3_I]], align 2, !tbaa [[TBAA17]], !noalias [[META56]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META56]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META56]]
-// CHECK-NEXT:    store <8 x i16> [[TMP1]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META56]]
+// CHECK-NEXT:    store <8 x float> [[CALL1_I_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 32, !tbaa [[TBAA16]], !noalias [[META55]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META55]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i16>, ptr [[DST_I_I_I_I3_I]], align 2, !tbaa [[TBAA16]], !noalias [[META55]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META55]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META55]]
+// CHECK-NEXT:    store <8 x i16> [[TMP1]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META55]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFabs(vec<bfloat16, 8> a) {
@@ -188,35 +188,35 @@ SYCL_EXTERNAL auto TestFabs(vec<bfloat16, 8> a) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z8TestCeilN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi8EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.336") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.336") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I2_I:%.*]] = alloca <8 x float>, align 32
 // CHECK-NEXT:    [[DST_I_I_I_I3_I:%.*]] = alloca [8 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I_I:%.*]] = alloca <8 x i16>, align 16
 // CHECK-NEXT:    [[DST_I_I_I_I_I:%.*]] = alloca [8 x float], align 4
 // CHECK-NEXT:    [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <8 x i16>, ptr [[A]], align 16
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META57:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META60:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META60]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META56:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META59:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META59]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <8 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 16, !tbaa [[TBAA17]], !noalias [[META60]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META60]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load <8 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META60]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META60]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META60]]
+// CHECK-NEXT:    store <8 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 16, !tbaa [[TBAA16]], !noalias [[META59]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META59]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load <8 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META59]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META59]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META59]]
 // CHECK-NEXT:    [[CALL1_I_I:%.*]] = call spir_func noundef <8 x float> @_Z16__spirv_ocl_ceilDv8_f(<8 x float> noundef [[TMP0]]) #[[ATTR6]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META63:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META66:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META66]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META62:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META65:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META65]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I4_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I2_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I5_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I3_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <8 x float> [[CALL1_I_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 32, !tbaa [[TBAA17]], !noalias [[META66]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META66]]
-// CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i16>, ptr [[DST_I_I_I_I3_I]], align 2, !tbaa [[TBAA17]], !noalias [[META66]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META66]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META66]]
-// CHECK-NEXT:    store <8 x i16> [[TMP1]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META66]]
+// CHECK-NEXT:    store <8 x float> [[CALL1_I_I]], ptr [[VEC_ADDR_I_I_I_I2_I]], align 32, !tbaa [[TBAA16]], !noalias [[META65]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec8(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I4_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I5_I]]) #[[ATTR5]], !noalias [[META65]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i16>, ptr [[DST_I_I_I_I3_I]], align 2, !tbaa [[TBAA16]], !noalias [[META65]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I2_I]]), !noalias [[META65]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I3_I]]), !noalias [[META65]]
+// CHECK-NEXT:    store <8 x i16> [[TMP1]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META65]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestCeil(vec<bfloat16, 8> a) {
@@ -224,7 +224,7 @@ SYCL_EXTERNAL auto TestCeil(vec<bfloat16, 8> a) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestFMAN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi16EEES5_S5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret({{.*}}) align 32 captures(none) initializes((0, 32)) [[AGG_RESULT:%.*]], ptr noundef readonly byval({{.*}}) align 32 captures(none) [[A:%.*]], ptr noundef readonly byval({{.*}}) align 32 captures(none) [[B:%.*]], ptr noundef readonly byval({{.*}}) align 32 captures(none) [[C:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.412") align 32 captures(none) initializes((0, 32)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.412") align 32 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.412") align 32 captures(none) [[B:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.412") align 32 captures(none) [[C:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I14_I:%.*]] = alloca <16 x float>, align 64
 // CHECK-NEXT:    [[DST_I_I_I_I15_I:%.*]] = alloca [16 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
@@ -237,46 +237,46 @@ SYCL_EXTERNAL auto TestCeil(vec<bfloat16, 8> a) {
 // CHECK-NEXT:    [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <16 x i16>, ptr [[A]], align 32
 // CHECK-NEXT:    [[AGG_TMP1_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <16 x i16>, ptr [[B]], align 32
 // CHECK-NEXT:    [[AGG_TMP2_SROA_0_SROA_0_0_COPYLOAD:%.*]] = load <16 x i16>, ptr [[C]], align 32
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META67:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META70:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META70]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META66:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META69:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META69]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <16 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 32, !tbaa [[TBAA17]], !noalias [[META70]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META70]]
-// CHECK-NEXT:    [[TMP0:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA17]], !noalias [[META70]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META70]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META70]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I3_I]]), !noalias [[META73:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I4_I]]), !noalias [[META73]]
+// CHECK-NEXT:    store <16 x i16> [[AGG_TMP_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I_I]], align 32, !tbaa [[TBAA16]], !noalias [[META69]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I_I]]) #[[ATTR5]], !noalias [[META69]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I_I]], align 4, !tbaa [[TBAA16]], !noalias [[META69]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I_I]]), !noalias [[META69]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I_I]]), !noalias [[META69]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I3_I]]), !noalias [[META72:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I4_I]]), !noalias [[META72]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I5_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I3_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I6_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I4_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <16 x i16> [[AGG_TMP1_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I3_I]], align 32, !tbaa [[TBAA17]], !noalias [[META73]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I5_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I6_I]]) #[[ATTR5]], !noalias [[META73]]
-// CHECK-NEXT:    [[TMP1:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I4_I]], align 4, !tbaa [[TBAA17]], !noalias [[META73]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I3_I]]), !noalias [[META73]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I4_I]]), !noalias [[META73]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I7_I]]), !noalias [[META76:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I8_I]]), !noalias [[META76]]
+// CHECK-NEXT:    store <16 x i16> [[AGG_TMP1_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I3_I]], align 32, !tbaa [[TBAA16]], !noalias [[META72]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I5_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I6_I]]) #[[ATTR5]], !noalias [[META72]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I4_I]], align 4, !tbaa [[TBAA16]], !noalias [[META72]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I3_I]]), !noalias [[META72]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I4_I]]), !noalias [[META72]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I7_I]]), !noalias [[META75:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I8_I]]), !noalias [[META75]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I9_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I7_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I10_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I8_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <16 x i16> [[AGG_TMP2_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I7_I]], align 32, !tbaa [[TBAA17]], !noalias [[META76]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I9_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I10_I]]) #[[ATTR5]], !noalias [[META76]]
-// CHECK-NEXT:    [[TMP2:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I8_I]], align 4, !tbaa [[TBAA17]], !noalias [[META76]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I7_I]]), !noalias [[META76]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I8_I]]), !noalias [[META76]]
+// CHECK-NEXT:    store <16 x i16> [[AGG_TMP2_SROA_0_SROA_0_0_COPYLOAD]], ptr [[VEC_ADDR_I_I_I_I7_I]], align 32, !tbaa [[TBAA16]], !noalias [[META75]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I9_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I10_I]]) #[[ATTR5]], !noalias [[META75]]
+// CHECK-NEXT:    [[TMP2:%.*]] = load <16 x float>, ptr [[DST_I_I_I_I8_I]], align 4, !tbaa [[TBAA16]], !noalias [[META75]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I7_I]]), !noalias [[META75]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I8_I]]), !noalias [[META75]]
 // CHECK-NEXT:    [[CALL3_I_I:%.*]] = call spir_func noundef <16 x float> @_Z15__spirv_ocl_fmaDv16_fS_S_(<16 x float> noundef [[TMP0]], <16 x float> noundef [[TMP1]], <16 x float> noundef [[TMP2]]) #[[ATTR6]]
-// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META79:![0-9]+]])
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META82:![0-9]+]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META82]]
+// CHECK-NEXT:    call void @llvm.experimental.noalias.scope.decl(metadata [[META78:![0-9]+]])
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META81:![0-9]+]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META81]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I16_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I14_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I17_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I15_I]] to ptr addrspace(4)
-// CHECK-NEXT:    store <16 x float> [[CALL3_I_I]], ptr [[VEC_ADDR_I_I_I_I14_I]], align 64, !tbaa [[TBAA17]], !noalias [[META82]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I16_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I17_I]]) #[[ATTR5]], !noalias [[META82]]
-// CHECK-NEXT:    [[TMP3:%.*]] = load <16 x i16>, ptr [[DST_I_I_I_I15_I]], align 2, !tbaa [[TBAA17]], !noalias [[META82]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META82]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META82]]
-// CHECK-NEXT:    store <16 x i16> [[TMP3]], ptr addrspace(4) [[AGG_RESULT]], align 32, !alias.scope [[META82]]
+// CHECK-NEXT:    store <16 x float> [[CALL3_I_I]], ptr [[VEC_ADDR_I_I_I_I14_I]], align 64, !tbaa [[TBAA16]], !noalias [[META81]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec16(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I16_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I17_I]]) #[[ATTR5]], !noalias [[META81]]
+// CHECK-NEXT:    [[TMP3:%.*]] = load <16 x i16>, ptr [[DST_I_I_I_I15_I]], align 2, !tbaa [[TBAA16]], !noalias [[META81]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I14_I]]), !noalias [[META81]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I15_I]]), !noalias [[META81]]
+// CHECK-NEXT:    store <16 x i16> [[TMP3]], ptr addrspace(4) [[AGG_RESULT]], align 32, !alias.scope [[META81]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFMA(vec<bfloat16, 16> a, vec<bfloat16, 16> b,

--- a/sycl/test/check_device_code/vector/convert_bfloat_new_vec.cpp
+++ b/sycl/test/check_device_code/vector/convert_bfloat_new_vec.cpp
@@ -13,26 +13,26 @@ using namespace sycl;
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 
 // CHECK-LABEL: define dso_local spir_func void @_Z18TestBFtoFDeviceRNERN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I:%.*]] = alloca <3 x i16>, align 8
 // CHECK-NEXT:    [[DST_I_I_I_I:%.*]] = alloca [4 x float], align 4
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META11:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META11]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META10:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META10]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META11]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META11]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META10]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META10]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 8, !tbaa [[TBAA14:![0-9]+]], !noalias [[META11]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4:[0-9]+]], !noalias [[META11]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I]], align 4, !noalias [[META11]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 8, !tbaa [[TBAA13:![0-9]+]], !noalias [[META10]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4:[0-9]+]], !noalias [[META10]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I]], align 4, !noalias [[META10]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I_I_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META11]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META11]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META10]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META10]]
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x float> [[EXTRACTVEC_I_I_I_I_I]], <3 x float> <float undef, float poison, float poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META11]]
+// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META10]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestBFtoFDeviceRNE(vec<bfloat16, 3> &inp) {
@@ -40,26 +40,26 @@ SYCL_EXTERNAL auto TestBFtoFDeviceRNE(vec<bfloat16, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z17TestBFtoFDeviceRZRN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I:%.*]] = alloca <3 x i16>, align 8
 // CHECK-NEXT:    [[DST_I_I_I_I:%.*]] = alloca [4 x float], align 4
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META15:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META15]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META14:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META14]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META15]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META15]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META14]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META14]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 8, !tbaa [[TBAA14]], !noalias [[META15]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4]], !noalias [[META15]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I]], align 4, !noalias [[META15]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 8, !tbaa [[TBAA13]], !noalias [[META14]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4]], !noalias [[META14]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I]], align 4, !noalias [[META14]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I_I_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META15]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META15]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META14]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META14]]
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x float> [[EXTRACTVEC_I_I_I_I_I]], <3 x float> <float undef, float poison, float poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META15]]
+// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META14]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestBFtoFDeviceRZ(vec<bfloat16, 3> &inp) {
@@ -67,10 +67,10 @@ SYCL_EXTERNAL auto TestBFtoFDeviceRZ(vec<bfloat16, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z19TestBFtointDeviceRZRN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.70") align 16 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.70") align 16 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META18:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META18]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META17:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META17]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    br label [[FOR_COND_I_I_I:%.*]]
 // CHECK:       for.cond.i.i.i:
@@ -80,13 +80,13 @@ SYCL_EXTERNAL auto TestBFtoFDeviceRZ(vec<bfloat16, 3> &inp) {
 // CHECK-NEXT:    br i1 [[CMP_I_I_I]], label [[FOR_BODY_I_I_I]], label [[_ZNK4SYCL3_V13VECINS0_3EXT6ONEAPI8BFLOAT16ELI3EE7CONVERTIILNS_13ROUNDING_MODEE2EEENS1_IT_LI3EEEV_EXIT:%.*]]
 // CHECK:       for.body.i.i.i:
 // CHECK-NEXT:    [[VECEXT_I_I_I:%.*]] = extractelement <3 x i16> [[EXTRACTVEC_I_I]], i32 [[I_0_I_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef i32 @__imf_bfloat162int_rz(i16 noundef zeroext [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META18]]
+// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef i32 @__imf_bfloat162int_rz(i16 noundef zeroext [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META17]]
 // CHECK-NEXT:    [[VECINS_I_I_I]] = insertelement <3 x i32> [[RETVAL1_SROA_0_0_I_I_I]], i32 [[CALL_I_I_I_I]], i32 [[I_0_I_I_I]]
 // CHECK-NEXT:    [[INC_I_I_I]] = add nuw nsw i32 [[I_0_I_I_I]], 1
-// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP21:![0-9]+]]
+// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP20:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EE7convertIiLNS_13rounding_modeE2EEENS1_IT_Li3EEEv.exit:
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x i32> [[RETVAL1_SROA_0_0_I_I_I]], <3 x i32> <i32 undef, i32 poison, i32 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i32> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META18]]
+// CHECK-NEXT:    store <4 x i32> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META17]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestBFtointDeviceRZ(vec<bfloat16, 3> &inp) {
@@ -94,20 +94,20 @@ SYCL_EXTERNAL auto TestBFtointDeviceRZ(vec<bfloat16, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z20TestBFtointDeviceRNERN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi1EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.108") align 4 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 2 captures(none) dereferenceable(2) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.108") align 4 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 2 captures(none) dereferenceable(2) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META23:![0-9]+]])
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META22:![0-9]+]])
 // CHECK-NEXT:    br label [[FOR_COND_I:%.*]]
 // CHECK:       for.cond.i:
 // CHECK-NEXT:    [[RESULT_SROA_0_0_I:%.*]] = phi i32 [ undef, [[ENTRY:%.*]] ], [ [[CALL_I_I_I_I:%.*]], [[FOR_BODY_I:%.*]] ]
 // CHECK-NEXT:    [[CMP_I:%.*]] = phi i1 [ true, [[ENTRY]] ], [ false, [[FOR_BODY_I]] ]
 // CHECK-NEXT:    br i1 [[CMP_I]], label [[FOR_BODY_I]], label [[_ZNK4SYCL3_V13VECINS0_3EXT6ONEAPI8BFLOAT16ELI1EE7CONVERTIILNS_13ROUNDING_MODEE0EEENS1_IT_LI1EEEV_EXIT:%.*]]
 // CHECK:       for.body.i:
-// CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr addrspace(4) [[INP]], align 2, !tbaa [[TBAA14]], !noalias [[META23]]
-// CHECK-NEXT:    [[CALL_I_I_I_I]] = tail call spir_func noundef i32 @__imf_bfloat162int_rn(i16 noundef zeroext [[TMP0]]) #[[ATTR4]], !noalias [[META23]]
-// CHECK-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP26:![0-9]+]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr addrspace(4) [[INP]], align 2, !tbaa [[TBAA13]], !noalias [[META22]]
+// CHECK-NEXT:    [[CALL_I_I_I_I]] = tail call spir_func noundef i32 @__imf_bfloat162int_rn(i16 noundef zeroext [[TMP0]]) #[[ATTR4]], !noalias [[META22]]
+// CHECK-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP25:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi1EE7convertIiLNS_13rounding_modeE0EEENS1_IT_Li1EEEv.exit:
-// CHECK-NEXT:    store i32 [[RESULT_SROA_0_0_I]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META23]]
+// CHECK-NEXT:    store i32 [[RESULT_SROA_0_0_I]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META22]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestBFtointDeviceRNE(vec<bfloat16, 1> &inp) {
@@ -115,26 +115,26 @@ SYCL_EXTERNAL auto TestBFtointDeviceRNE(vec<bfloat16, 1> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z18TestFtoBFDeviceRNERN4sycl3_V13vecIfLi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I:%.*]] = alloca <3 x float>, align 16
 // CHECK-NEXT:    [[DST_I_I_I_I:%.*]] = alloca [4 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META27:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x float>, ptr addrspace(4) [[INP]], align 16, !noalias [[META27]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META26:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x float>, ptr addrspace(4) [[INP]], align 16, !noalias [[META26]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META27]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META27]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META26]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META26]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I:%.*]] = shufflevector <3 x float> [[EXTRACTVEC_I_I]], <3 x float> <float undef, float poison, float poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 16, !tbaa [[TBAA14]], !noalias [[META27]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4]], !noalias [[META27]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x i16>, ptr [[DST_I_I_I_I]], align 2, !noalias [[META27]]
+// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 16, !tbaa [[TBAA13]], !noalias [[META26]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4]], !noalias [[META26]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x i16>, ptr [[DST_I_I_I_I]], align 2, !noalias [[META26]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I_I_I_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META27]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META27]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META26]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META26]]
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I_I_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META27]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META26]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFtoBFDeviceRNE(vec<float, 3> &inp) {
@@ -142,10 +142,10 @@ SYCL_EXTERNAL auto TestFtoBFDeviceRNE(vec<float, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z17TestFtoBFDeviceRZRN4sycl3_V13vecIfLi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META30:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x float>, ptr addrspace(4) [[INP]], align 16, !noalias [[META30]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META29:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x float>, ptr addrspace(4) [[INP]], align 16, !noalias [[META29]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    br label [[FOR_COND_I_I_I:%.*]]
 // CHECK:       for.cond.i.i.i:
@@ -155,13 +155,13 @@ SYCL_EXTERNAL auto TestFtoBFDeviceRNE(vec<float, 3> &inp) {
 // CHECK-NEXT:    br i1 [[CMP_I_I_I]], label [[FOR_BODY_I_I_I]], label [[_ZNK4SYCL3_V13VECIFLI3EE7CONVERTINS0_3EXT6ONEAPI8BFLOAT16ELNS_13ROUNDING_MODEE2EEENS1_IT_LI3EEEV_EXIT:%.*]]
 // CHECK:       for.body.i.i.i:
 // CHECK-NEXT:    [[VECEXT_I_I_I:%.*]] = extractelement <3 x float> [[EXTRACTVEC_I_I]], i32 [[I_0_I_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_float2bfloat16_rz(float noundef [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META30]]
+// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_float2bfloat16_rz(float noundef [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META29]]
 // CHECK-NEXT:    [[VECINS_I_I_I]] = insertelement <3 x i16> [[RETVAL1_SROA_0_0_I_I_I]], i16 [[CALL_I_I_I_I]], i32 [[I_0_I_I_I]]
 // CHECK-NEXT:    [[INC_I_I_I]] = add nuw nsw i32 [[I_0_I_I_I]], 1
-// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP33:![0-9]+]]
+// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP32:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecIfLi3EE7convertINS0_3ext6oneapi8bfloat16ELNS_13rounding_modeE2EEENS1_IT_Li3EEEv.exit:
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x i16> [[RETVAL1_SROA_0_0_I_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META30]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META29]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFtoBFDeviceRZ(vec<float, 3> &inp) {
@@ -169,10 +169,10 @@ SYCL_EXTERNAL auto TestFtoBFDeviceRZ(vec<float, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z19TestInttoBFDeviceRZRN4sycl3_V13vecIiLi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META34:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i32>, ptr addrspace(4) [[INP]], align 16, !noalias [[META34]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META33:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i32>, ptr addrspace(4) [[INP]], align 16, !noalias [[META33]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x i32> [[LOADVECN_I_I]], <4 x i32> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    br label [[FOR_COND_I_I_I:%.*]]
 // CHECK:       for.cond.i.i.i:
@@ -182,13 +182,13 @@ SYCL_EXTERNAL auto TestFtoBFDeviceRZ(vec<float, 3> &inp) {
 // CHECK-NEXT:    br i1 [[CMP_I_I_I]], label [[FOR_BODY_I_I_I]], label [[_ZNK4SYCL3_V13VECIILI3EE7CONVERTINS0_3EXT6ONEAPI8BFLOAT16ELNS_13ROUNDING_MODEE2EEENS1_IT_LI3EEEV_EXIT:%.*]]
 // CHECK:       for.body.i.i.i:
 // CHECK-NEXT:    [[VECEXT_I_I_I:%.*]] = extractelement <3 x i32> [[EXTRACTVEC_I_I]], i32 [[I_0_I_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_int2bfloat16_rz(i32 noundef [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META34]]
+// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_int2bfloat16_rz(i32 noundef [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META33]]
 // CHECK-NEXT:    [[VECINS_I_I_I]] = insertelement <3 x i16> [[RETVAL1_SROA_0_0_I_I_I]], i16 [[CALL_I_I_I_I]], i32 [[I_0_I_I_I]]
 // CHECK-NEXT:    [[INC_I_I_I]] = add nuw nsw i32 [[I_0_I_I_I]], 1
-// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP37:![0-9]+]]
+// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP36:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecIiLi3EE7convertINS0_3ext6oneapi8bfloat16ELNS_13rounding_modeE2EEENS1_IT_Li3EEEv.exit:
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x i16> [[RETVAL1_SROA_0_0_I_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META34]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META33]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestInttoBFDeviceRZ(vec<int, 3> &inp) {
@@ -196,20 +196,20 @@ SYCL_EXTERNAL auto TestInttoBFDeviceRZ(vec<int, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z19TestLLtoBFDeviceRTPRN4sycl3_V13vecIxLi1EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.145") align 2 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.145") align 2 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META38:![0-9]+]])
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META37:![0-9]+]])
 // CHECK-NEXT:    br label [[FOR_COND_I:%.*]]
 // CHECK:       for.cond.i:
 // CHECK-NEXT:    [[RESULT_SROA_0_0_I:%.*]] = phi i16 [ undef, [[ENTRY:%.*]] ], [ [[CALL_I_I_I_I:%.*]], [[FOR_BODY_I:%.*]] ]
 // CHECK-NEXT:    [[CMP_I:%.*]] = phi i1 [ true, [[ENTRY]] ], [ false, [[FOR_BODY_I]] ]
 // CHECK-NEXT:    br i1 [[CMP_I]], label [[FOR_BODY_I]], label [[_ZNK4SYCL3_V13VECIXLI1EE7CONVERTINS0_3EXT6ONEAPI8BFLOAT16ELNS_13ROUNDING_MODEE3EEENS1_IT_LI1EEEV_EXIT:%.*]]
 // CHECK:       for.body.i:
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr addrspace(4) [[INP]], align 8, !tbaa [[TBAA41:![0-9]+]], !noalias [[META38]]
-// CHECK-NEXT:    [[CALL_I_I_I_I]] = tail call spir_func noundef zeroext i16 @__imf_ll2bfloat16_ru(i64 noundef [[TMP0]]) #[[ATTR4]], !noalias [[META38]]
-// CHECK-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP43:![0-9]+]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr addrspace(4) [[INP]], align 8, !tbaa [[TBAA40:![0-9]+]], !noalias [[META37]]
+// CHECK-NEXT:    [[CALL_I_I_I_I]] = tail call spir_func noundef zeroext i16 @__imf_ll2bfloat16_ru(i64 noundef [[TMP0]]) #[[ATTR4]], !noalias [[META37]]
+// CHECK-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP42:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecIxLi1EE7convertINS0_3ext6oneapi8bfloat16ELNS_13rounding_modeE3EEENS1_IT_Li1EEEv.exit:
-// CHECK-NEXT:    store i16 [[RESULT_SROA_0_0_I]], ptr addrspace(4) [[AGG_RESULT]], align 2, !alias.scope [[META38]]
+// CHECK-NEXT:    store i16 [[RESULT_SROA_0_0_I]], ptr addrspace(4) [[AGG_RESULT]], align 2, !alias.scope [[META37]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestLLtoBFDeviceRTP(vec<long long, 1> &inp) {
@@ -217,10 +217,10 @@ SYCL_EXTERNAL auto TestLLtoBFDeviceRTP(vec<long long, 1> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z22TestShorttoBFDeviceRTNRN4sycl3_V13vecIsLi2EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.226") align 4 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 4 captures(none) dereferenceable(4) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.226") align 4 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 4 captures(none) dereferenceable(4) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META44:![0-9]+]])
-// CHECK-NEXT:    [[TMP0:%.*]] = load <2 x i16>, ptr addrspace(4) [[INP]], align 4, !tbaa [[TBAA14]], !noalias [[META44]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META43:![0-9]+]])
+// CHECK-NEXT:    [[TMP0:%.*]] = load <2 x i16>, ptr addrspace(4) [[INP]], align 4, !tbaa [[TBAA13]], !noalias [[META43]]
 // CHECK-NEXT:    br label [[FOR_COND_I_I_I:%.*]]
 // CHECK:       for.cond.i.i.i:
 // CHECK-NEXT:    [[RETVAL1_0_I_I_I:%.*]] = phi <2 x i16> [ undef, [[ENTRY:%.*]] ], [ [[VECINS_I_I_I:%.*]], [[FOR_BODY_I_I_I:%.*]] ]
@@ -229,12 +229,12 @@ SYCL_EXTERNAL auto TestLLtoBFDeviceRTP(vec<long long, 1> &inp) {
 // CHECK-NEXT:    br i1 [[CMP_I_I_I]], label [[FOR_BODY_I_I_I]], label [[_ZNK4SYCL3_V13VECISLI2EE7CONVERTINS0_3EXT6ONEAPI8BFLOAT16ELNS_13ROUNDING_MODEE4EEENS1_IT_LI2EEEV_EXIT:%.*]]
 // CHECK:       for.body.i.i.i:
 // CHECK-NEXT:    [[VECEXT_I_I_I:%.*]] = extractelement <2 x i16> [[TMP0]], i32 [[I_0_I_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_short2bfloat16_rd(i16 noundef signext [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META44]]
+// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_short2bfloat16_rd(i16 noundef signext [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META43]]
 // CHECK-NEXT:    [[VECINS_I_I_I]] = insertelement <2 x i16> [[RETVAL1_0_I_I_I]], i16 [[CALL_I_I_I_I]], i32 [[I_0_I_I_I]]
 // CHECK-NEXT:    [[INC_I_I_I]] = add nuw nsw i32 [[I_0_I_I_I]], 1
-// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP47:![0-9]+]]
+// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP46:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecIsLi2EE7convertINS0_3ext6oneapi8bfloat16ELNS_13rounding_modeE4EEENS1_IT_Li2EEEv.exit:
-// CHECK-NEXT:    store <2 x i16> [[RETVAL1_0_I_I_I]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META44]]
+// CHECK-NEXT:    store <2 x i16> [[RETVAL1_0_I_I_I]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META43]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestShorttoBFDeviceRTN(vec<short, 2> &inp) {

--- a/sycl/test/check_device_code/vector/convert_bfloat_old_vec.cpp
+++ b/sycl/test/check_device_code/vector/convert_bfloat_old_vec.cpp
@@ -13,26 +13,26 @@ using namespace sycl;
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 
 // CHECK-LABEL: define dso_local spir_func void @_Z18TestBFtoFDeviceRNERN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I:%.*]] = alloca <3 x i16>, align 8
 // CHECK-NEXT:    [[DST_I_I_I_I:%.*]] = alloca [4 x float], align 4
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META11:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META11]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META10:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META10]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META11]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META11]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META10]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META10]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 8, !tbaa [[TBAA14:![0-9]+]], !noalias [[META11]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4:[0-9]+]], !noalias [[META11]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I]], align 4, !noalias [[META11]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 8, !tbaa [[TBAA13:![0-9]+]], !noalias [[META10]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4:[0-9]+]], !noalias [[META10]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I]], align 4, !noalias [[META10]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I_I_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META11]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META11]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META10]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META10]]
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x float> [[EXTRACTVEC_I_I_I_I_I]], <3 x float> <float undef, float poison, float poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META11]]
+// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META10]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestBFtoFDeviceRNE(vec<bfloat16, 3> &inp) {
@@ -40,26 +40,26 @@ SYCL_EXTERNAL auto TestBFtoFDeviceRNE(vec<bfloat16, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z17TestBFtoFDeviceRZRN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I:%.*]] = alloca <3 x i16>, align 8
 // CHECK-NEXT:    [[DST_I_I_I_I:%.*]] = alloca [4 x float], align 4
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META15:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META15]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META14:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META14]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META15]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META15]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META14]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META14]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 8, !tbaa [[TBAA14]], !noalias [[META15]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4]], !noalias [[META15]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I]], align 4, !noalias [[META15]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 8, !tbaa [[TBAA13]], !noalias [[META14]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertBF16ToFINTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4]], !noalias [[META14]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x float>, ptr [[DST_I_I_I_I]], align 4, !noalias [[META14]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I_I_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META15]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META15]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META14]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META14]]
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x float> [[EXTRACTVEC_I_I_I_I_I]], <3 x float> <float undef, float poison, float poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META15]]
+// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META14]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestBFtoFDeviceRZ(vec<bfloat16, 3> &inp) {
@@ -67,10 +67,10 @@ SYCL_EXTERNAL auto TestBFtoFDeviceRZ(vec<bfloat16, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z19TestBFtointDeviceRZRN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.70") align 16 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.70") align 16 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META18:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META18]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META17:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i16>, ptr addrspace(4) [[INP]], align 8, !noalias [[META17]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    br label [[FOR_COND_I_I_I:%.*]]
 // CHECK:       for.cond.i.i.i:
@@ -80,13 +80,13 @@ SYCL_EXTERNAL auto TestBFtoFDeviceRZ(vec<bfloat16, 3> &inp) {
 // CHECK-NEXT:    br i1 [[CMP_I_I_I]], label [[FOR_BODY_I_I_I]], label [[_ZNK4SYCL3_V13VECINS0_3EXT6ONEAPI8BFLOAT16ELI3EE7CONVERTIILNS_13ROUNDING_MODEE2EEENS1_IT_LI3EEEV_EXIT:%.*]]
 // CHECK:       for.body.i.i.i:
 // CHECK-NEXT:    [[VECEXT_I_I_I:%.*]] = extractelement <3 x i16> [[EXTRACTVEC_I_I]], i32 [[I_0_I_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef i32 @__imf_bfloat162int_rz(i16 noundef zeroext [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META18]]
+// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef i32 @__imf_bfloat162int_rz(i16 noundef zeroext [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META17]]
 // CHECK-NEXT:    [[VECINS_I_I_I]] = insertelement <3 x i32> [[RETVAL1_SROA_0_0_I_I_I]], i32 [[CALL_I_I_I_I]], i32 [[I_0_I_I_I]]
 // CHECK-NEXT:    [[INC_I_I_I]] = add nuw nsw i32 [[I_0_I_I_I]], 1
-// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP21:![0-9]+]]
+// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP20:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EE7convertIiLNS_13rounding_modeE2EEENS1_IT_Li3EEEv.exit:
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x i32> [[RETVAL1_SROA_0_0_I_I_I]], <3 x i32> <i32 undef, i32 poison, i32 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i32> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META18]]
+// CHECK-NEXT:    store <4 x i32> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 16, !alias.scope [[META17]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestBFtointDeviceRZ(vec<bfloat16, 3> &inp) {
@@ -94,20 +94,20 @@ SYCL_EXTERNAL auto TestBFtointDeviceRZ(vec<bfloat16, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z20TestBFtointDeviceRNERN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi1EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.108") align 4 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 2 captures(none) dereferenceable(2) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.108") align 4 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 2 captures(none) dereferenceable(2) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META23:![0-9]+]])
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META22:![0-9]+]])
 // CHECK-NEXT:    br label [[FOR_COND_I:%.*]]
 // CHECK:       for.cond.i:
 // CHECK-NEXT:    [[RESULT_SROA_0_0_I:%.*]] = phi i32 [ undef, [[ENTRY:%.*]] ], [ [[CALL_I_I_I_I:%.*]], [[FOR_BODY_I:%.*]] ]
 // CHECK-NEXT:    [[CMP_I:%.*]] = phi i1 [ true, [[ENTRY]] ], [ false, [[FOR_BODY_I]] ]
 // CHECK-NEXT:    br i1 [[CMP_I]], label [[FOR_BODY_I]], label [[_ZNK4SYCL3_V13VECINS0_3EXT6ONEAPI8BFLOAT16ELI1EE7CONVERTIILNS_13ROUNDING_MODEE0EEENS1_IT_LI1EEEV_EXIT:%.*]]
 // CHECK:       for.body.i:
-// CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr addrspace(4) [[INP]], align 2, !tbaa [[TBAA14]], !noalias [[META23]]
-// CHECK-NEXT:    [[CALL_I_I_I_I]] = tail call spir_func noundef i32 @__imf_bfloat162int_rn(i16 noundef zeroext [[TMP0]]) #[[ATTR4]], !noalias [[META23]]
-// CHECK-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP26:![0-9]+]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr addrspace(4) [[INP]], align 2, !tbaa [[TBAA13]], !noalias [[META22]]
+// CHECK-NEXT:    [[CALL_I_I_I_I]] = tail call spir_func noundef i32 @__imf_bfloat162int_rn(i16 noundef zeroext [[TMP0]]) #[[ATTR4]], !noalias [[META22]]
+// CHECK-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP25:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi1EE7convertIiLNS_13rounding_modeE0EEENS1_IT_Li1EEEv.exit:
-// CHECK-NEXT:    store i32 [[RESULT_SROA_0_0_I]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META23]]
+// CHECK-NEXT:    store i32 [[RESULT_SROA_0_0_I]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META22]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestBFtointDeviceRNE(vec<bfloat16, 1> &inp) {
@@ -115,26 +115,26 @@ SYCL_EXTERNAL auto TestBFtointDeviceRNE(vec<bfloat16, 1> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z18TestFtoBFDeviceRNERN4sycl3_V13vecIfLi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VEC_ADDR_I_I_I_I:%.*]] = alloca <3 x float>, align 16
 // CHECK-NEXT:    [[DST_I_I_I_I:%.*]] = alloca [4 x %"class.sycl::_V1::ext::oneapi::bfloat16"], align 2
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META27:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x float>, ptr addrspace(4) [[INP]], align 16, !noalias [[META27]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META26:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x float>, ptr addrspace(4) [[INP]], align 16, !noalias [[META26]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META27]]
-// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META27]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META26]]
+// CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META26]]
 // CHECK-NEXT:    [[VEC_ADDR_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[VEC_ADDR_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[DST_ASCAST_I_I_I_I:%.*]] = addrspacecast ptr [[DST_I_I_I_I]] to ptr addrspace(4)
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I:%.*]] = shufflevector <3 x float> [[EXTRACTVEC_I_I]], <3 x float> <float undef, float poison, float poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 16, !tbaa [[TBAA14]], !noalias [[META27]]
-// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4]], !noalias [[META27]]
-// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x i16>, ptr [[DST_I_I_I_I]], align 2, !noalias [[META27]]
+// CHECK-NEXT:    store <4 x float> [[EXTRACTVEC_I_I_I_I]], ptr [[VEC_ADDR_I_I_I_I]], align 16, !tbaa [[TBAA13]], !noalias [[META26]]
+// CHECK-NEXT:    call spir_func void @__devicelib_ConvertFToBF16INTELVec3(ptr addrspace(4) noundef [[VEC_ADDR_ASCAST_I_I_I_I]], ptr addrspace(4) noundef [[DST_ASCAST_I_I_I_I]]) #[[ATTR4]], !noalias [[META26]]
+// CHECK-NEXT:    [[LOADVECN_I_I_I_I_I:%.*]] = load <4 x i16>, ptr [[DST_I_I_I_I]], align 2, !noalias [[META26]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I_I_I_I:%.*]] = shufflevector <4 x i16> [[LOADVECN_I_I_I_I_I]], <4 x i16> poison, <3 x i32> <i32 0, i32 1, i32 2>
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META27]]
-// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META27]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[VEC_ADDR_I_I_I_I]]), !noalias [[META26]]
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[DST_I_I_I_I]]), !noalias [[META26]]
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x i16> [[EXTRACTVEC_I_I_I_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META27]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META26]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFtoBFDeviceRNE(vec<float, 3> &inp) {
@@ -142,10 +142,10 @@ SYCL_EXTERNAL auto TestFtoBFDeviceRNE(vec<float, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z17TestFtoBFDeviceRZRN4sycl3_V13vecIfLi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META30:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x float>, ptr addrspace(4) [[INP]], align 16, !noalias [[META30]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META29:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x float>, ptr addrspace(4) [[INP]], align 16, !noalias [[META29]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x float> [[LOADVECN_I_I]], <4 x float> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    br label [[FOR_COND_I_I_I:%.*]]
 // CHECK:       for.cond.i.i.i:
@@ -155,13 +155,13 @@ SYCL_EXTERNAL auto TestFtoBFDeviceRNE(vec<float, 3> &inp) {
 // CHECK-NEXT:    br i1 [[CMP_I_I_I]], label [[FOR_BODY_I_I_I]], label [[_ZNK4SYCL3_V13VECIFLI3EE7CONVERTINS0_3EXT6ONEAPI8BFLOAT16ELNS_13ROUNDING_MODEE2EEENS1_IT_LI3EEEV_EXIT:%.*]]
 // CHECK:       for.body.i.i.i:
 // CHECK-NEXT:    [[VECEXT_I_I_I:%.*]] = extractelement <3 x float> [[EXTRACTVEC_I_I]], i32 [[I_0_I_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_float2bfloat16_rz(float noundef [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META30]]
+// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_float2bfloat16_rz(float noundef [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META29]]
 // CHECK-NEXT:    [[VECINS_I_I_I]] = insertelement <3 x i16> [[RETVAL1_SROA_0_0_I_I_I]], i16 [[CALL_I_I_I_I]], i32 [[I_0_I_I_I]]
 // CHECK-NEXT:    [[INC_I_I_I]] = add nuw nsw i32 [[I_0_I_I_I]], 1
-// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP33:![0-9]+]]
+// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP32:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecIfLi3EE7convertINS0_3ext6oneapi8bfloat16ELNS_13rounding_modeE2EEENS1_IT_Li3EEEv.exit:
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x i16> [[RETVAL1_SROA_0_0_I_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META30]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META29]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestFtoBFDeviceRZ(vec<float, 3> &inp) {
@@ -169,10 +169,10 @@ SYCL_EXTERNAL auto TestFtoBFDeviceRZ(vec<float, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z19TestInttoBFDeviceRZRN4sycl3_V13vecIiLi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.32") align 8 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 16 captures(none) dereferenceable(16) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META34:![0-9]+]])
-// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i32>, ptr addrspace(4) [[INP]], align 16, !noalias [[META34]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META33:![0-9]+]])
+// CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i32>, ptr addrspace(4) [[INP]], align 16, !noalias [[META33]]
 // CHECK-NEXT:    [[EXTRACTVEC_I_I:%.*]] = shufflevector <4 x i32> [[LOADVECN_I_I]], <4 x i32> poison, <3 x i32> <i32 0, i32 1, i32 2>
 // CHECK-NEXT:    br label [[FOR_COND_I_I_I:%.*]]
 // CHECK:       for.cond.i.i.i:
@@ -182,13 +182,13 @@ SYCL_EXTERNAL auto TestFtoBFDeviceRZ(vec<float, 3> &inp) {
 // CHECK-NEXT:    br i1 [[CMP_I_I_I]], label [[FOR_BODY_I_I_I]], label [[_ZNK4SYCL3_V13VECIILI3EE7CONVERTINS0_3EXT6ONEAPI8BFLOAT16ELNS_13ROUNDING_MODEE2EEENS1_IT_LI3EEEV_EXIT:%.*]]
 // CHECK:       for.body.i.i.i:
 // CHECK-NEXT:    [[VECEXT_I_I_I:%.*]] = extractelement <3 x i32> [[EXTRACTVEC_I_I]], i32 [[I_0_I_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_int2bfloat16_rz(i32 noundef [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META34]]
+// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_int2bfloat16_rz(i32 noundef [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META33]]
 // CHECK-NEXT:    [[VECINS_I_I_I]] = insertelement <3 x i16> [[RETVAL1_SROA_0_0_I_I_I]], i16 [[CALL_I_I_I_I]], i32 [[I_0_I_I_I]]
 // CHECK-NEXT:    [[INC_I_I_I]] = add nuw nsw i32 [[I_0_I_I_I]], 1
-// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP37:![0-9]+]]
+// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP36:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecIiLi3EE7convertINS0_3ext6oneapi8bfloat16ELNS_13rounding_modeE2EEENS1_IT_Li3EEEv.exit:
 // CHECK-NEXT:    [[EXTRACTVEC_I:%.*]] = shufflevector <3 x i16> [[RETVAL1_SROA_0_0_I_I_I]], <3 x i16> <i16 undef, i16 poison, i16 poison>, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META34]]
+// CHECK-NEXT:    store <4 x i16> [[EXTRACTVEC_I]], ptr addrspace(4) [[AGG_RESULT]], align 8, !alias.scope [[META33]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestInttoBFDeviceRZ(vec<int, 3> &inp) {
@@ -196,20 +196,20 @@ SYCL_EXTERNAL auto TestInttoBFDeviceRZ(vec<int, 3> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z19TestLLtoBFDeviceRTPRN4sycl3_V13vecIxLi1EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.146") align 2 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.146") align 2 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 8 captures(none) dereferenceable(8) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META38:![0-9]+]])
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META37:![0-9]+]])
 // CHECK-NEXT:    br label [[FOR_COND_I:%.*]]
 // CHECK:       for.cond.i:
 // CHECK-NEXT:    [[RESULT_SROA_0_0_I:%.*]] = phi i16 [ undef, [[ENTRY:%.*]] ], [ [[CALL_I_I_I_I:%.*]], [[FOR_BODY_I:%.*]] ]
 // CHECK-NEXT:    [[CMP_I:%.*]] = phi i1 [ true, [[ENTRY]] ], [ false, [[FOR_BODY_I]] ]
 // CHECK-NEXT:    br i1 [[CMP_I]], label [[FOR_BODY_I]], label [[_ZNK4SYCL3_V13VECIXLI1EE7CONVERTINS0_3EXT6ONEAPI8BFLOAT16ELNS_13ROUNDING_MODEE3EEENS1_IT_LI1EEEV_EXIT:%.*]]
 // CHECK:       for.body.i:
-// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr addrspace(4) [[INP]], align 8, !tbaa [[TBAA41:![0-9]+]], !noalias [[META38]]
-// CHECK-NEXT:    [[CALL_I_I_I_I]] = tail call spir_func noundef zeroext i16 @__imf_ll2bfloat16_ru(i64 noundef [[TMP0]]) #[[ATTR4]], !noalias [[META38]]
-// CHECK-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP43:![0-9]+]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr addrspace(4) [[INP]], align 8, !tbaa [[TBAA40:![0-9]+]], !noalias [[META37]]
+// CHECK-NEXT:    [[CALL_I_I_I_I]] = tail call spir_func noundef zeroext i16 @__imf_ll2bfloat16_ru(i64 noundef [[TMP0]]) #[[ATTR4]], !noalias [[META37]]
+// CHECK-NEXT:    br label [[FOR_COND_I]], !llvm.loop [[LOOP42:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecIxLi1EE7convertINS0_3ext6oneapi8bfloat16ELNS_13rounding_modeE3EEENS1_IT_Li1EEEv.exit:
-// CHECK-NEXT:    store i16 [[RESULT_SROA_0_0_I]], ptr addrspace(4) [[AGG_RESULT]], align 2, !alias.scope [[META38]]
+// CHECK-NEXT:    store i16 [[RESULT_SROA_0_0_I]], ptr addrspace(4) [[AGG_RESULT]], align 2, !alias.scope [[META37]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestLLtoBFDeviceRTP(vec<long long, 1> &inp) {
@@ -217,10 +217,10 @@ SYCL_EXTERNAL auto TestLLtoBFDeviceRTP(vec<long long, 1> &inp) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z22TestShorttoBFDeviceRTNRN4sycl3_V13vecIsLi2EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.224") align 4 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) noundef readonly align 4 captures(none) dereferenceable(4) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.224") align 4 captures(none) [[AGG_RESULT:%.*]], ptr addrspace(4) nofree noundef readonly align 4 captures(none) dereferenceable(4) [[INP:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META44:![0-9]+]])
-// CHECK-NEXT:    [[TMP0:%.*]] = load <2 x i16>, ptr addrspace(4) [[INP]], align 4, !tbaa [[TBAA14]], !noalias [[META44]]
+// CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META43:![0-9]+]])
+// CHECK-NEXT:    [[TMP0:%.*]] = load <2 x i16>, ptr addrspace(4) [[INP]], align 4, !tbaa [[TBAA13]], !noalias [[META43]]
 // CHECK-NEXT:    br label [[FOR_COND_I_I_I:%.*]]
 // CHECK:       for.cond.i.i.i:
 // CHECK-NEXT:    [[RETVAL1_0_I_I_I:%.*]] = phi <2 x i16> [ undef, [[ENTRY:%.*]] ], [ [[VECINS_I_I_I:%.*]], [[FOR_BODY_I_I_I:%.*]] ]
@@ -229,12 +229,12 @@ SYCL_EXTERNAL auto TestLLtoBFDeviceRTP(vec<long long, 1> &inp) {
 // CHECK-NEXT:    br i1 [[CMP_I_I_I]], label [[FOR_BODY_I_I_I]], label [[_ZNK4SYCL3_V13VECISLI2EE7CONVERTINS0_3EXT6ONEAPI8BFLOAT16ELNS_13ROUNDING_MODEE4EEENS1_IT_LI2EEEV_EXIT:%.*]]
 // CHECK:       for.body.i.i.i:
 // CHECK-NEXT:    [[VECEXT_I_I_I:%.*]] = extractelement <2 x i16> [[TMP0]], i32 [[I_0_I_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_short2bfloat16_rd(i16 noundef signext [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META44]]
+// CHECK-NEXT:    [[CALL_I_I_I_I:%.*]] = tail call spir_func noundef zeroext i16 @__imf_short2bfloat16_rd(i16 noundef signext [[VECEXT_I_I_I]]) #[[ATTR4]], !noalias [[META43]]
 // CHECK-NEXT:    [[VECINS_I_I_I]] = insertelement <2 x i16> [[RETVAL1_0_I_I_I]], i16 [[CALL_I_I_I_I]], i32 [[I_0_I_I_I]]
 // CHECK-NEXT:    [[INC_I_I_I]] = add nuw nsw i32 [[I_0_I_I_I]], 1
-// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP47:![0-9]+]]
+// CHECK-NEXT:    br label [[FOR_COND_I_I_I]], !llvm.loop [[LOOP46:![0-9]+]]
 // CHECK:       _ZNK4sycl3_V13vecIsLi2EE7convertINS0_3ext6oneapi8bfloat16ELNS_13rounding_modeE4EEENS1_IT_Li2EEEv.exit:
-// CHECK-NEXT:    store <2 x i16> [[RETVAL1_0_I_I_I]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META44]]
+// CHECK-NEXT:    store <2 x i16> [[RETVAL1_0_I_I_I]], ptr addrspace(4) [[AGG_RESULT]], align 4, !alias.scope [[META43]]
 // CHECK-NEXT:    ret void
 //
 SYCL_EXTERNAL auto TestShorttoBFDeviceRTN(vec<short, 2> &inp) {

--- a/sycl/test/check_device_code/vector/math_ops_new_vec.cpp
+++ b/sycl/test/check_device_code/vector/math_ops_new_vec.cpp
@@ -19,7 +19,7 @@ using namespace sycl;
 /*************** Binary Arithmetic Ops ******************/
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecIiLi2EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec") align 8 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec") align 8 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META10:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META13:![0-9]+]])
@@ -32,7 +32,7 @@ using namespace sycl;
 SYCL_EXTERNAL auto TestAdd(vec<int, 2> a, vec<int, 2> b) { return a + b; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecIfLi3EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.33") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.33") align 16 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.33") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.33") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.33") align 16 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.33") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META21:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META24:![0-9]+]])
@@ -47,7 +47,7 @@ SYCL_EXTERNAL auto TestAdd(vec<int, 2> a, vec<int, 2> b) { return a + b; }
 SYCL_EXTERNAL auto TestAdd(vec<float, 3> a, vec<float, 3> b) { return a + b; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecIcLi16EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.72") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.72") align 16 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.72") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.72") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.72") align 16 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.72") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META28:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META31:![0-9]+]])
@@ -61,7 +61,7 @@ SYCL_EXTERNAL auto TestAdd(vec<char, 16> a, vec<char, 16> b) { return a + b; }
 
 // std::byte does not support '+'. Therefore, using bitwise XOR as a substitute.
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestXorN4sycl3_V13vecISt4byteLi8EEES3_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.111") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.111") align 8 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.111") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.111") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.111") align 8 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.111") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META35:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META38:![0-9]+]])
@@ -76,7 +76,7 @@ SYCL_EXTERNAL auto TestXor(vec<std::byte, 8> a, vec<std::byte, 8> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecIbLi4EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.150") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.150") align 4 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.150") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.150") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.150") align 4 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.150") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META45:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META48:![0-9]+]])
@@ -91,7 +91,7 @@ SYCL_EXTERNAL auto TestXor(vec<std::byte, 8> a, vec<std::byte, 8> b) {
 SYCL_EXTERNAL auto TestAdd(vec<bool, 4> a, vec<bool, 4> b) { return a + b; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecINS0_6detail9half_impl4halfELi3EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.189") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.189") align 8 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.189") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.189") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.189") align 8 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.189") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META57:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META60:![0-9]+]])
@@ -106,7 +106,7 @@ SYCL_EXTERNAL auto TestAdd(vec<bool, 4> a, vec<bool, 4> b) { return a + b; }
 SYCL_EXTERNAL auto TestAdd(vec<half, 3> a, vec<half, 3> b) { return a + b; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.228") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.228") align 8 [[A:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.228") align 8 [[B:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.228") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.228") align 8 [[A:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.228") align 8 [[B:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[REF_TMP_I_I_I_I:%.*]] = alloca float, align 4
 // CHECK-NEXT:    [[RES_I_I:%.*]] = alloca %"class.sycl::_V1::vec.228", align 8
@@ -126,11 +126,11 @@ SYCL_EXTERNAL auto TestAdd(vec<half, 3> a, vec<half, 3> b) { return a + b; }
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[A_ASCAST]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    [[ARRAYIDX_I12_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[B_ASCAST]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[REF_TMP_I_I_I_I]]), !noalias [[META74:![0-9]+]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR7:[0-9]+]], !noalias [[META77:![0-9]+]]
-// CHECK-NEXT:    [[CALL_I_I2_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I12_I_I]]) #[[ATTR7]], !noalias [[META77]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR6:[0-9]+]], !noalias [[META77:![0-9]+]]
+// CHECK-NEXT:    [[CALL_I_I2_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I12_I_I]]) #[[ATTR6]], !noalias [[META77]]
 // CHECK-NEXT:    [[ADD_I_I_I_I:%.*]] = fadd float [[CALL_I_I_I_I_I_I]], [[CALL_I_I2_I_I_I_I]]
 // CHECK-NEXT:    store float [[ADD_I_I_I_I]], ptr [[REF_TMP_I_I_I_I]], align 4, !tbaa [[TBAA80:![0-9]+]], !noalias [[META77]]
-// CHECK-NEXT:    [[CALL_I_I3_I_I_I_I:%.*]] = call spir_func noundef zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr addrspace(4) noundef align 4 dereferenceable(4) [[REF_TMP_ASCAST_I_I_I_I]]) #[[ATTR7]], !noalias [[META77]]
+// CHECK-NEXT:    [[CALL_I_I3_I_I_I_I:%.*]] = call spir_func noundef zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr addrspace(4) noundef align 4 dereferenceable(4) [[REF_TMP_ASCAST_I_I_I_I]]) #[[ATTR6]], !noalias [[META77]]
 // CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[REF_TMP_I_I_I_I]]), !noalias [[META74]]
 // CHECK-NEXT:    [[ARRAYIDX_I14_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[RES_I_I]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    store i16 [[CALL_I_I3_I_I_I_I]], ptr [[ARRAYIDX_I14_I_I]], align 2, !tbaa [[TBAA82:![0-9]+]], !noalias [[META73]]
@@ -150,7 +150,7 @@ SYCL_EXTERNAL auto TestAdd(vec<ext::oneapi::bfloat16, 3> a,
 /***************** Binary Logical Ops *******************/
 
 // CHECK-LABEL: define dso_local spir_func void @_Z15TestGreaterThanN4sycl3_V13vecIiLi16EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.265") align 64 captures(none) initializes((0, 64)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.265") align 64 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.265") align 64 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.265") align 64 captures(none) initializes((0, 64)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.265") align 64 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.265") align 64 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META86:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META89:![0-9]+]])
@@ -166,7 +166,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<int, 16> a, vec<int, 16> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z15TestGreaterThanN4sycl3_V13vecISt4byteLi3EEES3_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.305") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.342") align 4 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.342") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.305") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.342") align 4 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.342") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META93:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META96:![0-9]+]])
@@ -184,7 +184,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<std::byte, 3> a, vec<std::byte, 3> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z15TestGreaterThanN4sycl3_V13vecIbLi2EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.383") align 2 captures(none) initializes((0, 2)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.420") align 2 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.420") align 2 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.383") align 2 captures(none) initializes((0, 2)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.420") align 2 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.420") align 2 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META103:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META106:![0-9]+]])
@@ -200,7 +200,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<bool, 2> a, vec<bool, 2> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z15TestGreaterThanN4sycl3_V13vecINS0_6detail9half_impl4halfELi8EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.461") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.498") align 16 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.498") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.461") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.498") align 16 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.498") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META113:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META116:![0-9]+]])
@@ -216,7 +216,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<half, 8> a, vec<half, 8> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z15TestGreaterThanN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi4EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.539") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.576") align 8 [[A:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.576") align 8 [[B:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.539") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.576") align 8 [[A:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.576") align 8 [[B:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[RES_I_I:%.*]] = alloca %"class.sycl::_V1::vec.539", align 8
 // CHECK-NEXT:    [[A_ASCAST:%.*]] = addrspacecast ptr [[A]] to ptr addrspace(4)
@@ -233,8 +233,8 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<half, 8> a, vec<half, 8> b) {
 // CHECK:       for.body.i.i:
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[A_ASCAST]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    [[ARRAYIDX_I14_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[B_ASCAST]], i64 [[I_0_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR7]], !noalias [[META126]]
-// CHECK-NEXT:    [[CALL_I_I2_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I14_I_I]]) #[[ATTR7]], !noalias [[META126]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR6]], !noalias [[META126]]
+// CHECK-NEXT:    [[CALL_I_I2_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I14_I_I]]) #[[ATTR6]], !noalias [[META126]]
 // CHECK-NEXT:    [[CMP_I_I_I_I_I:%.*]] = fcmp ogt float [[CALL_I_I_I_I_I_I_I]], [[CALL_I_I2_I_I_I_I_I]]
 // CHECK-NEXT:    [[CONV6_I_I:%.*]] = sext i1 [[CMP_I_I_I_I_I]] to i16
 // CHECK-NEXT:    [[ARRAYIDX_I16_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[RES_I_I]], i64 [[I_0_I_I]]
@@ -255,7 +255,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<ext::oneapi::bfloat16, 4> a,
 /********************** Unary Ops **********************/
 
 // CHECK-LABEL: define dso_local spir_func void @_Z12TestNegationN4sycl3_V13vecIiLi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.613") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.613") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.613") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.613") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META128:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META131:![0-9]+]])
@@ -270,7 +270,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<ext::oneapi::bfloat16, 4> a,
 SYCL_EXTERNAL auto TestNegation(vec<int, 3> a) { return !a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z9TestMinusN4sycl3_V13vecIiLi4EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.651") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.651") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.651") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.651") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META135:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META138:![0-9]+]])
@@ -283,7 +283,7 @@ SYCL_EXTERNAL auto TestMinus(vec<int, 4> a) { return -a; }
 
 // Negation is not valid for std::byte. Therefore, using bitwise negation.
 // CHECK-LABEL: define dso_local spir_func void @_Z19TestBitwiseNegationN4sycl3_V13vecISt4byteLi16EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.689") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.689") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.689") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.689") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META142:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META145:![0-9]+]])
@@ -295,7 +295,7 @@ SYCL_EXTERNAL auto TestMinus(vec<int, 4> a) { return -a; }
 SYCL_EXTERNAL auto TestBitwiseNegation(vec<std::byte, 16> a) { return ~a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z12TestNegationN4sycl3_V13vecIbLi4EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.727") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.150") align 4 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.727") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.150") align 4 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META149:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META152:![0-9]+]])
@@ -308,7 +308,7 @@ SYCL_EXTERNAL auto TestBitwiseNegation(vec<std::byte, 16> a) { return ~a; }
 SYCL_EXTERNAL auto TestNegation(vec<bool, 4> a) { return !a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z12TestNegationN4sycl3_V13vecINS0_6detail9half_impl4halfELi2EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.765") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.802") align 4 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.765") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.802") align 4 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META159:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META162:![0-9]+]])
@@ -321,7 +321,7 @@ SYCL_EXTERNAL auto TestNegation(vec<bool, 4> a) { return !a; }
 SYCL_EXTERNAL auto TestNegation(vec<half, 2> a) { return !a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z9TestMinusN4sycl3_V13vecINS0_6detail9half_impl4halfELi8EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.498") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.498") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.498") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.498") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META169:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META172:![0-9]+]])
@@ -333,7 +333,7 @@ SYCL_EXTERNAL auto TestNegation(vec<half, 2> a) { return !a; }
 SYCL_EXTERNAL auto TestMinus(vec<half, 8> a) { return -a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z12TestNegationN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.841") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.228") align 8 [[A:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.841") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.228") align 8 [[A:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[RES_I_I:%.*]] = alloca %"class.sycl::_V1::vec.841", align 8
 // CHECK-NEXT:    [[A_ASCAST:%.*]] = addrspacecast ptr [[A]] to ptr addrspace(4)
@@ -348,7 +348,7 @@ SYCL_EXTERNAL auto TestMinus(vec<half, 8> a) { return -a; }
 // CHECK-NEXT:    br i1 [[CMP_I_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V16DETAILNTERKNS0_3VECINS0_3EXT6ONEAPI8BFLOAT16ELI3EEE_EXIT:%.*]]
 // CHECK:       for.body.i.i:
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[A_ASCAST]], i64 [[I_0_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR7]], !noalias [[META182]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR6]], !noalias [[META182]]
 // CHECK-NEXT:    [[TOBOOL_I_I_I:%.*]] = fcmp oeq float [[CALL_I_I_I_I_I]], 0.000000e+00
 // CHECK-NEXT:    [[CONV2_I_I:%.*]] = sext i1 [[TOBOOL_I_I_I]] to i16
 // CHECK-NEXT:    [[ARRAYIDX_I9_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[RES_I_I]], i64 [[I_0_I_I]]
@@ -364,7 +364,7 @@ SYCL_EXTERNAL auto TestMinus(vec<half, 8> a) { return -a; }
 SYCL_EXTERNAL auto TestNegation(vec<ext::oneapi::bfloat16, 3> a) { return !a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z9TestMinusN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi16EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.878") align 32 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.878") align 32 [[A:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.878") align 32 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.878") align 32 [[A:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[REF_TMP_I_I_I_I:%.*]] = alloca float, align 4
 // CHECK-NEXT:    [[RES_I_I:%.*]] = alloca %"class.sycl::_V1::vec.878", align 32
@@ -380,10 +380,10 @@ SYCL_EXTERNAL auto TestNegation(vec<ext::oneapi::bfloat16, 3> a) { return !a; }
 // CHECK:       for.body.i.i:
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[A_ASCAST]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[REF_TMP_I_I_I_I]]), !noalias [[META190:![0-9]+]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) [[ARRAYIDX_I_I_I]]) #[[ATTR7]], !noalias [[META193:![0-9]+]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) [[ARRAYIDX_I_I_I]]) #[[ATTR6]], !noalias [[META193:![0-9]+]]
 // CHECK-NEXT:    [[FNEG_I_I_I_I:%.*]] = fneg float [[CALL_I_I_I_I_I]]
 // CHECK-NEXT:    store float [[FNEG_I_I_I_I]], ptr [[REF_TMP_I_I_I_I]], align 4, !tbaa [[TBAA80]], !noalias [[META193]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I_I:%.*]] = call spir_func noundef zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr addrspace(4) noundef align 4 dereferenceable(4) [[REF_TMP_ASCAST_I_I_I_I]]) #[[ATTR7]], !noalias [[META193]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I_I:%.*]] = call spir_func noundef zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr addrspace(4) noundef align 4 dereferenceable(4) [[REF_TMP_ASCAST_I_I_I_I]]) #[[ATTR6]], !noalias [[META193]]
 // CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[REF_TMP_I_I_I_I]]), !noalias [[META190]]
 // CHECK-NEXT:    [[ARRAYIDX_I7_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[RES_I_I]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    store i16 [[CALL_I_I_I_I_I_I]], ptr [[ARRAYIDX_I7_I_I]], align 2, !tbaa [[TBAA82]], !noalias [[META187]]

--- a/sycl/test/check_device_code/vector/math_ops_old_vec.cpp
+++ b/sycl/test/check_device_code/vector/math_ops_old_vec.cpp
@@ -19,7 +19,7 @@ using namespace sycl;
 /*************** Binary Arithmetic Ops ******************/
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecIiLi2EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec") align 8 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec") align 8 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META10:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META13:![0-9]+]])
@@ -32,7 +32,7 @@ using namespace sycl;
 SYCL_EXTERNAL auto TestAdd(vec<int, 2> a, vec<int, 2> b) { return a + b; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecIfLi3EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.33") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.33") align 16 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.33") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.33") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.33") align 16 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.33") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META21:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META24:![0-9]+]])
@@ -47,7 +47,7 @@ SYCL_EXTERNAL auto TestAdd(vec<int, 2> a, vec<int, 2> b) { return a + b; }
 SYCL_EXTERNAL auto TestAdd(vec<float, 3> a, vec<float, 3> b) { return a + b; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecIcLi16EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.73") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.73") align 16 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.73") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.73") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.73") align 16 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.73") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META28:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META31:![0-9]+]])
@@ -61,7 +61,7 @@ SYCL_EXTERNAL auto TestAdd(vec<char, 16> a, vec<char, 16> b) { return a + b; }
 
 // std::byte does not support '+'. Therefore, using bitwise XOR as a substitute.
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestXorN4sycl3_V13vecISt4byteLi8EEES3_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.113") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.113") align 8 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.113") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.113") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.113") align 8 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.113") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META35:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META38:![0-9]+]])
@@ -76,7 +76,7 @@ SYCL_EXTERNAL auto TestXor(vec<std::byte, 8> a, vec<std::byte, 8> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecIbLi4EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.123") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.123") align 4 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.123") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.123") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.123") align 4 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.123") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META45:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META48:![0-9]+]])
@@ -91,7 +91,7 @@ SYCL_EXTERNAL auto TestXor(vec<std::byte, 8> a, vec<std::byte, 8> b) {
 SYCL_EXTERNAL auto TestAdd(vec<bool, 4> a, vec<bool, 4> b) { return a + b; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecINS0_6detail9half_impl4halfELi3EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.163") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.163") align 8 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.163") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.163") align 8 captures(none) initializes((0, 8)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.163") align 8 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.163") align 8 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META57:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META60:![0-9]+]])
@@ -106,7 +106,7 @@ SYCL_EXTERNAL auto TestAdd(vec<bool, 4> a, vec<bool, 4> b) { return a + b; }
 SYCL_EXTERNAL auto TestAdd(vec<half, 3> a, vec<half, 3> b) { return a + b; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z7TestAddN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.203") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.203") align 8 [[A:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.203") align 8 [[B:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.203") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.203") align 8 [[A:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.203") align 8 [[B:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[REF_TMP_I_I_I_I:%.*]] = alloca float, align 4
 // CHECK-NEXT:    [[RES_I_I:%.*]] = alloca %"class.sycl::_V1::vec.203", align 8
@@ -126,11 +126,11 @@ SYCL_EXTERNAL auto TestAdd(vec<half, 3> a, vec<half, 3> b) { return a + b; }
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[A_ASCAST]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    [[ARRAYIDX_I12_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[B_ASCAST]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[REF_TMP_I_I_I_I]]), !noalias [[META74:![0-9]+]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR8:[0-9]+]], !noalias [[META77:![0-9]+]]
-// CHECK-NEXT:    [[CALL_I_I2_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I12_I_I]]) #[[ATTR8]], !noalias [[META77]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR7:[0-9]+]], !noalias [[META77:![0-9]+]]
+// CHECK-NEXT:    [[CALL_I_I2_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I12_I_I]]) #[[ATTR7]], !noalias [[META77]]
 // CHECK-NEXT:    [[ADD_I_I_I_I:%.*]] = fadd float [[CALL_I_I_I_I_I_I]], [[CALL_I_I2_I_I_I_I]]
 // CHECK-NEXT:    store float [[ADD_I_I_I_I]], ptr [[REF_TMP_I_I_I_I]], align 4, !tbaa [[TBAA80:![0-9]+]], !noalias [[META77]]
-// CHECK-NEXT:    [[CALL_I_I3_I_I_I_I:%.*]] = call spir_func noundef zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr addrspace(4) noundef align 4 dereferenceable(4) [[REF_TMP_ASCAST_I_I_I_I]]) #[[ATTR8]], !noalias [[META77]]
+// CHECK-NEXT:    [[CALL_I_I3_I_I_I_I:%.*]] = call spir_func noundef zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr addrspace(4) noundef align 4 dereferenceable(4) [[REF_TMP_ASCAST_I_I_I_I]]) #[[ATTR7]], !noalias [[META77]]
 // CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[REF_TMP_I_I_I_I]]), !noalias [[META74]]
 // CHECK-NEXT:    [[ARRAYIDX_I14_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[RES_I_I]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    store i16 [[CALL_I_I3_I_I_I_I]], ptr [[ARRAYIDX_I14_I_I]], align 2, !tbaa [[TBAA82:![0-9]+]], !noalias [[META73]]
@@ -150,7 +150,7 @@ SYCL_EXTERNAL auto TestAdd(vec<ext::oneapi::bfloat16, 3> a,
 /***************** Binary Logical Ops *******************/
 
 // CHECK-LABEL: define dso_local spir_func void @_Z15TestGreaterThanN4sycl3_V13vecIiLi16EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.241") align 64 captures(none) initializes((0, 64)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.241") align 64 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.241") align 64 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.241") align 64 captures(none) initializes((0, 64)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.241") align 64 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.241") align 64 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META86:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META89:![0-9]+]])
@@ -166,7 +166,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<int, 16> a, vec<int, 16> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func noundef range(i8 -1, 1) <3 x i8> @_Z15TestGreaterThanN4sycl3_V13vecISt4byteLi3EEES3_(
-// CHECK-SAME: ptr noundef readonly byval(%"class.sycl::_V1::vec.282") align 4 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.282") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR3:[0-9]+]] {{.*}}{
+// CHECK-SAME: ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.282") align 4 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.282") align 4 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR3:[0-9]+]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[LOADVECN_I_I:%.*]] = load <4 x i8>, ptr [[A]], align 1
 // CHECK-NEXT:    [[LOADVECN_I_I2:%.*]] = load <4 x i8>, ptr [[B]], align 1
@@ -180,7 +180,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<std::byte, 3> a, vec<std::byte, 3> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z15TestGreaterThanN4sycl3_V13vecIbLi2EEES2_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.290") align 2 captures(none) initializes((0, 2)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.328") align 2 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.328") align 2 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.290") align 2 captures(none) initializes((0, 2)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.328") align 2 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.328") align 2 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META93:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META96:![0-9]+]])
@@ -196,7 +196,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<bool, 2> a, vec<bool, 2> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z15TestGreaterThanN4sycl3_V13vecINS0_6detail9half_impl4halfELi8EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.370") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.408") align 16 captures(none) [[A:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.408") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.370") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.408") align 16 captures(none) [[A:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.408") align 16 captures(none) [[B:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META103:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META106:![0-9]+]])
@@ -212,7 +212,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<half, 8> a, vec<half, 8> b) {
 }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z15TestGreaterThanN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi4EEES5_(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.450") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.488") align 8 [[A:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.488") align 8 [[B:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.450") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.488") align 8 [[A:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.488") align 8 [[B:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[RES_I_I:%.*]] = alloca %"class.sycl::_V1::vec.450", align 8
 // CHECK-NEXT:    [[A_ASCAST:%.*]] = addrspacecast ptr [[A]] to ptr addrspace(4)
@@ -229,8 +229,8 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<half, 8> a, vec<half, 8> b) {
 // CHECK:       for.body.i.i:
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[A_ASCAST]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    [[ARRAYIDX_I14_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[B_ASCAST]], i64 [[I_0_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR8]], !noalias [[META116]]
-// CHECK-NEXT:    [[CALL_I_I2_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I14_I_I]]) #[[ATTR8]], !noalias [[META116]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR7]], !noalias [[META116]]
+// CHECK-NEXT:    [[CALL_I_I2_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I14_I_I]]) #[[ATTR7]], !noalias [[META116]]
 // CHECK-NEXT:    [[CMP_I_I_I_I_I:%.*]] = fcmp ogt float [[CALL_I_I_I_I_I_I_I]], [[CALL_I_I2_I_I_I_I_I]]
 // CHECK-NEXT:    [[CONV6_I_I:%.*]] = sext i1 [[CMP_I_I_I_I_I]] to i16
 // CHECK-NEXT:    [[ARRAYIDX_I16_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[RES_I_I]], i64 [[I_0_I_I]]
@@ -251,7 +251,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<ext::oneapi::bfloat16, 4> a,
 /********************** Unary Ops **********************/
 
 // CHECK-LABEL: define dso_local spir_func void @_Z12TestNegationN4sycl3_V13vecIiLi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.526") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.526") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.526") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.526") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META118:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META121:![0-9]+]])
@@ -266,7 +266,7 @@ SYCL_EXTERNAL auto TestGreaterThan(vec<ext::oneapi::bfloat16, 4> a,
 SYCL_EXTERNAL auto TestNegation(vec<int, 3> a) { return !a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z9TestMinusN4sycl3_V13vecIiLi4EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.565") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.565") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.565") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.565") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META125:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META128:![0-9]+]])
@@ -279,7 +279,7 @@ SYCL_EXTERNAL auto TestMinus(vec<int, 4> a) { return -a; }
 
 // Negation is not valid for std::byte. Therefore, using bitwise negation.
 // CHECK-LABEL: define dso_local spir_func void @_Z19TestBitwiseNegationN4sycl3_V13vecISt4byteLi16EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.604") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.604") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.604") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.604") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META132:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META135:![0-9]+]])
@@ -291,7 +291,7 @@ SYCL_EXTERNAL auto TestMinus(vec<int, 4> a) { return -a; }
 SYCL_EXTERNAL auto TestBitwiseNegation(vec<std::byte, 16> a) { return ~a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z12TestNegationN4sycl3_V13vecIbLi4EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.613") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.123") align 4 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.613") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.123") align 4 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META139:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META142:![0-9]+]])
@@ -304,7 +304,7 @@ SYCL_EXTERNAL auto TestBitwiseNegation(vec<std::byte, 16> a) { return ~a; }
 SYCL_EXTERNAL auto TestNegation(vec<bool, 4> a) { return !a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z12TestNegationN4sycl3_V13vecINS0_6detail9half_impl4halfELi2EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.652") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.690") align 4 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.652") align 4 captures(none) initializes((0, 4)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.690") align 4 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META149:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META152:![0-9]+]])
@@ -317,7 +317,7 @@ SYCL_EXTERNAL auto TestNegation(vec<bool, 4> a) { return !a; }
 SYCL_EXTERNAL auto TestNegation(vec<half, 2> a) { return !a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z9TestMinusN4sycl3_V13vecINS0_6detail9half_impl4halfELi8EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.408") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr noundef readonly byval(%"class.sycl::_V1::vec.408") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.408") align 16 captures(none) initializes((0, 16)) [[AGG_RESULT:%.*]], ptr nofree noundef readonly byval(%"class.sycl::_V1::vec.408") align 16 captures(none) [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META159:![0-9]+]])
 // CHECK-NEXT:    tail call void @llvm.experimental.noalias.scope.decl(metadata [[META162:![0-9]+]])
@@ -329,7 +329,7 @@ SYCL_EXTERNAL auto TestNegation(vec<half, 2> a) { return !a; }
 SYCL_EXTERNAL auto TestMinus(vec<half, 8> a) { return -a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z12TestNegationN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi3EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.730") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.203") align 8 [[A:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.730") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.203") align 8 [[A:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[RES_I_I:%.*]] = alloca %"class.sycl::_V1::vec.730", align 8
 // CHECK-NEXT:    [[A_ASCAST:%.*]] = addrspacecast ptr [[A]] to ptr addrspace(4)
@@ -344,7 +344,7 @@ SYCL_EXTERNAL auto TestMinus(vec<half, 8> a) { return -a; }
 // CHECK-NEXT:    br i1 [[CMP_I_I]], label [[FOR_BODY_I_I]], label [[_ZN4SYCL3_V16DETAILNTERKNS0_3VECINS0_3EXT6ONEAPI8BFLOAT16ELI3EEE_EXIT:%.*]]
 // CHECK:       for.body.i.i:
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[A_ASCAST]], i64 [[I_0_I_I]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR8]], !noalias [[META172]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) dereferenceable_or_null(2) [[ARRAYIDX_I_I_I]]) #[[ATTR7]], !noalias [[META172]]
 // CHECK-NEXT:    [[TOBOOL_I_I_I:%.*]] = fcmp oeq float [[CALL_I_I_I_I_I]], 0.000000e+00
 // CHECK-NEXT:    [[CONV2_I_I:%.*]] = sext i1 [[TOBOOL_I_I_I]] to i16
 // CHECK-NEXT:    [[ARRAYIDX_I9_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[RES_I_I]], i64 [[I_0_I_I]]
@@ -360,7 +360,7 @@ SYCL_EXTERNAL auto TestMinus(vec<half, 8> a) { return -a; }
 SYCL_EXTERNAL auto TestNegation(vec<ext::oneapi::bfloat16, 3> a) { return !a; }
 
 // CHECK-LABEL: define dso_local spir_func void @_Z9TestMinusN4sycl3_V13vecINS0_3ext6oneapi8bfloat16ELi16EEE(
-// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias writable writeonly sret(%"class.sycl::_V1::vec.768") align 32 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.768") align 32 [[A:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
+// CHECK-SAME: ptr addrspace(4) dead_on_unwind noalias nofree writable writeonly sret(%"class.sycl::_V1::vec.768") align 32 captures(none) [[AGG_RESULT:%.*]], ptr noundef byval(%"class.sycl::_V1::vec.768") align 32 [[A:%.*]]) local_unnamed_addr #[[ATTR1]] {{.*}}{
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[REF_TMP_I_I_I_I:%.*]] = alloca float, align 4
 // CHECK-NEXT:    [[RES_I_I:%.*]] = alloca %"class.sycl::_V1::vec.768", align 32
@@ -376,10 +376,10 @@ SYCL_EXTERNAL auto TestNegation(vec<ext::oneapi::bfloat16, 3> a) { return !a; }
 // CHECK:       for.body.i.i:
 // CHECK-NEXT:    [[ARRAYIDX_I_I_I:%.*]] = getelementptr inbounds nuw [2 x i8], ptr addrspace(4) [[A_ASCAST]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[REF_TMP_I_I_I_I]]), !noalias [[META180:![0-9]+]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) [[ARRAYIDX_I_I_I]]) #[[ATTR8]], !noalias [[META183:![0-9]+]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I:%.*]] = call spir_func noundef float @__devicelib_ConvertBF16ToFINTEL(ptr addrspace(4) noundef align 2 dereferenceable(2) [[ARRAYIDX_I_I_I]]) #[[ATTR7]], !noalias [[META183:![0-9]+]]
 // CHECK-NEXT:    [[FNEG_I_I_I_I:%.*]] = fneg float [[CALL_I_I_I_I_I]]
 // CHECK-NEXT:    store float [[FNEG_I_I_I_I]], ptr [[REF_TMP_I_I_I_I]], align 4, !tbaa [[TBAA80]], !noalias [[META183]]
-// CHECK-NEXT:    [[CALL_I_I_I_I_I_I:%.*]] = call spir_func noundef zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr addrspace(4) noundef align 4 dereferenceable(4) [[REF_TMP_ASCAST_I_I_I_I]]) #[[ATTR8]], !noalias [[META183]]
+// CHECK-NEXT:    [[CALL_I_I_I_I_I_I:%.*]] = call spir_func noundef zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr addrspace(4) noundef align 4 dereferenceable(4) [[REF_TMP_ASCAST_I_I_I_I]]) #[[ATTR7]], !noalias [[META183]]
 // CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[REF_TMP_I_I_I_I]]), !noalias [[META180]]
 // CHECK-NEXT:    [[ARRAYIDX_I7_I_I:%.*]] = getelementptr inbounds [2 x i8], ptr [[RES_I_I]], i64 [[I_0_I_I]]
 // CHECK-NEXT:    store i16 [[CALL_I_I_I_I_I_I]], ptr [[ARRAYIDX_I7_I_I]], align 2, !tbaa [[TBAA82]], !noalias [[META177]]


### PR DESCRIPTION
89905ff added nofree to below tests:
- check_device_code/vector/bf16_builtins_new_vec.cpp
- check_device_code/vector/bf16_builtins_old_vec.cpp
- check_device_code/vector/convert_bfloat_new_vec.cpp
- check_device_code/vector/convert_bfloat_old_vec.cpp
- check_device_code/vector/math_ops_new_vec.cpp
- check_device_code/vector/math_ops_old_vec.cpp

CMPLRLLVM-76303