### PR TITLE
[SYCL][Test] Update native_cpu/esimd checks after addr space opt disable

### DIFF
--- a/sycl/test/check_device_code/esimd/NBarrierAttr.cpp
+++ b/sycl/test/check_device_code/esimd/NBarrierAttr.cpp
@@ -23,7 +23,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL ESIMD_NOINLINE void callee(int x) {
 // inherits SLMSize and NBarrierCount from callee
 void caller_abc(int x) {
   kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
-  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_abciE10kernel_abc() local_unnamed_addr #[[ATTR1:[0-9]+]]
+  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_abciE10kernel_abc(i32 {{.*}}) local_unnamed_addr #[[ATTR1:[0-9]+]]
 }
 
 // inherits only NBarrierCount from callee
@@ -33,7 +33,7 @@ void caller_xyz(int x) {
     auto y = __ESIMD_ENS::named_barrier_allocate<35>();
     __ESIMD_NS::named_barrier_wait(y);
   });
-  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz() local_unnamed_addr #[[ATTR2:[0-9]+]]
+  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz(i32 {{.*}}) local_unnamed_addr #[[ATTR2:[0-9]+]]
   // CHECK: call void @llvm.genx.nbarrier(i8 0, i8 13, i8 0)
 }
 

--- a/sycl/test/check_device_code/esimd/dae.cpp
+++ b/sycl/test/check_device_code/esimd/dae.cpp
@@ -1,8 +1,7 @@
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll
 // RUN: FileCheck %s --input-file %t.ll
 
-// Check SYCL FE metadata is updated when dead argument elimination removes an
-// argument
+// Check SYCL FE metadata for ESIMD kernel with captured int argument.
 
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
@@ -15,9 +14,9 @@ __attribute__((sycl_kernel)) void my_kernel(Func kernelFunc) {
 
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION ESIMD_NOINLINE void callee(int x) {}
 
-// CHECK: define {{.*}}spir_kernel {{.*}} !sycl_kernel_omit_args ![[#MD:]]
+// CHECK: define {{.*}}spir_kernel void {{.*}}(i32 {{.*}}) {{.*}} !kernel_arg_accessor_ptr ![[#MD:]]
 SYCL_EXTERNAL void __attribute__((noinline)) caller(int x) {
   my_kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
 }
 
-//CHECK: [[#MD]] = !{i1 true}
+//CHECK: [[#MD]] = !{i1 false}

--- a/sycl/test/check_device_code/esimd/genx_func_attr.cpp
+++ b/sycl/test/check_device_code/esimd/genx_func_attr.cpp
@@ -24,7 +24,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL ESIMD_NOINLINE void callee(int x) {
 // inherits SLMSize and NBarrierCount from callee
 void caller_abc(int x) {
   kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
-  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_abciE10kernel_abc() local_unnamed_addr #[[ATTR:[0-9]+]]
+  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_abciE10kernel_abc(i32 {{.*}}) local_unnamed_addr #[[ATTR:[0-9]+]]
 }
 
 // inherits only NBarrierCount from callee
@@ -33,7 +33,7 @@ void caller_xyz(int x) {
     slm_init(1235); // also works in non-O0
     callee(x);
   });
-  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz() local_unnamed_addr #[[ATTR]]
+  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz(i32 {{.*}}) local_unnamed_addr #[[ATTR]]
 }
 
 // CHECK: attributes #[[ATTR]] = { {{.*}} "VCNamedBarrierCount"="13" "VCSLMSize"="2469"

--- a/sycl/test/check_device_code/esimd/slm_init_specconst_size.cpp
+++ b/sycl/test/check_device_code/esimd/slm_init_specconst_size.cpp
@@ -21,7 +21,7 @@ int main() {
           [=](sycl::kernel_handler kh) SYCL_ESIMD_KERNEL {
             slm_init(kh.get_specialization_constant<Size>());
           });
-      // CHECK: define weak_odr dso_local spir_kernel void @{{.*}}() local_unnamed_addr #1
+      // CHECK: define weak_odr dso_local spir_kernel void @{{.*}}(ptr addrspace(1) {{.*}}) local_unnamed_addr #1
     });
   }
 

--- a/sycl/test/check_device_code/native_cpu/kernelhandler-scalar.cpp
+++ b/sycl/test/check_device_code/native_cpu/kernelhandler-scalar.cpp
@@ -47,7 +47,7 @@ int main() {
   return 0;
 }
 
-// CHECK-DAG: @_ZTS6init_aIiE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, i32 {{.*}}%2, ptr {{.*}}%3){{.*}}
-// CHECK-DAG: @_ZTS6init_aIjE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, i32 {{.*}}%2, ptr {{.*}}%3){{.*}}
-// CHECK-DAG: @_ZTS6init_aIfE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, float {{.*}}%2, ptr {{.*}}%3){{.*}}
-// CHECK-DAG: @_ZTS6init_aIdE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, double {{.*}}%2, ptr {{.*}}%3){{.*}}
+// CHECK-DAG: @_ZTS6init_aIiE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr {{.*}}%2, ptr {{.*}}%3, i32 {{.*}}%4, ptr {{.*}}%5){{.*}}
+// CHECK-DAG: @_ZTS6init_aIjE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr {{.*}}%2, ptr {{.*}}%3, i32 {{.*}}%4, ptr {{.*}}%5){{.*}}
+// CHECK-DAG: @_ZTS6init_aIfE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr {{.*}}%2, ptr {{.*}}%3, float {{.*}}%4, ptr {{.*}}%5){{.*}}
+// CHECK-DAG: @_ZTS6init_aIdE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr {{.*}}%2, ptr {{.*}}%3, double {{.*}}%4, ptr {{.*}}%5){{.*}}

--- a/sycl/test/check_device_code/native_cpu/native_cpu_subhandler.cpp
+++ b/sycl/test/check_device_code/native_cpu/native_cpu_subhandler.cpp
@@ -40,8 +40,12 @@ void test() {
   //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
   //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
   //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
+  //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
+  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
+  //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
+  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
   //CHECK:  %{{.*}} = load i32, ptr %{{.*}}
-  //CHECK:  call void @_ZTS6init_aIiE.NativeCPUKernel(ptr {{.*}}, ptr {{.*}}, i32 {{.*}}, ptr {{.*}})
+  //CHECK:  call void @_ZTS6init_aIiE.NativeCPUKernel(ptr addrspace(1) {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, i32 {{.*}}, ptr addrspace(1) {{.*}})
   //CHECK:  ret void
   //CHECK:}
   gen_test<float>(q);
@@ -49,11 +53,15 @@ void test() {
   //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
   //CHECK:  %{{.*}} = load ptr addrspace(1), ptr %{{.*}}
   //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
-  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}, align 8
+  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
+  //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
+  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
+  //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
+  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
   //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
   //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
   //CHECK:  %{{.*}} = load float, ptr %{{.*}}
-  //CHECK:  call void @_ZTS6init_aIfE.NativeCPUKernel(ptr {{.*}}, ptr {{.*}}, float {{.*}}, ptr {{.*}})
+  //CHECK:  call void @_ZTS6init_aIfE.NativeCPUKernel(ptr addrspace(1) {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, float {{.*}}, ptr addrspace(1) {{.*}})
   //CHECK:  ret void
   //CHECK:}
 
@@ -66,7 +74,7 @@ void test() {
     });
   });
   //CHECK:define void @_ZTS5Test1.SYCLNCPU(ptr %{{.*}}, ptr addrspace(1) %[[STATE2:.*]]) #{{.*}} {
-  //CHECK:       call void @_ZTS5Test1.NativeCPUKernel(ptr addrspace(1) %[[STATE2]])
+  //CHECK:       call void @_ZTS5Test1.NativeCPUKernel(ptr addrspace(1) {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr addrspace(1) %[[STATE2]])
   //CHECK-NEXT:  ret void
   //CHECK-NEXT:}
 


### PR DESCRIPTION
437f95c disabled address space optimization for kernel args, adding range/id byval struct params to NativeCPU kernel signatures (4->6 params). ESIMD kernels capturing int args now retain them in the signature.

Fixes
- check_device_code/esimd/NBarrierAttr.cpp
- check_device_code/esimd/dae.cpp
- check_device_code/esimd/genx_func_attr.cpp
- check_device_code/esimd/slm_init_specconst_size.cpp
- check_device_code/native_cpu/kernelhandler-scalar.cpp
- check_device_code/native_cpu/native_cpu_subhandler.cpp

CMPLRLLVM-76303