### PR TITLE
[SYCL][Test] Fix basic_tests/pch.cpp output dir

### DIFF
--- a/sycl/test/basic_tests/pch.cpp
+++ b/sycl/test/basic_tests/pch.cpp
@@ -1,8 +1,8 @@
-// RUN: %clang -fsycl -c -x c++-header %S/head.hpp -o %S/head.pch
-// RUN: %clang -fsycl -c -include-pch %S/head.pch %s
+// RUN: %clang -fsycl -c -x c++-header %S/head.hpp -o %t.pch
+// RUN: %clang -fsycl -c -include-pch %t.pch %s
 
-// RUN: %clang --offload-new-driver -fsycl -c -x c++-header %S/head.hpp -o %S/head.pch
-// RUN: %clang --offload-new-driver -fsycl -c -include-pch %S/head.pch %s
+// RUN: %clang --offload-new-driver -fsycl -c -x c++-header %S/head.hpp -o %t.pch
+// RUN: %clang --offload-new-driver -fsycl -c -include-pch %t.pch %s
 
 // Verify a PCH file created from the header file can be
 // successfully included in a source file compilation.


### PR DESCRIPTION
%S = source dir. Running lit writes the binary artifact directly into sycl/test/basic_tests source dir. Then the artifact could be accidently added to a commit.