### PR TITLE
[SYCL][DeadArgElim] Fix surveyFunction early-exit for weak_odr SYCL kernels

### DIFF
--- a/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
+++ b/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
@@ -491,9 +491,7 @@ DeadArgumentEliminationPass::surveyUses(const Value *V,
 void DeadArgumentEliminationPass::surveyFunction(const Function &F) {
   // We can't modify arguments if the function is not local
   // but we can do so for SYCL kernel functions.
-  bool FuncIsSyclKernel =
-      CheckSYCLKernels &&
-      (F.hasKernelCallingConv());
+  bool FuncIsSyclKernel = CheckSYCLKernels && F.hasKernelCallingConv();
 
   // Can only change function signature for functions with local linkage,
   // except SYCL kernel functions which are handled specially.

--- a/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
+++ b/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
@@ -489,8 +489,15 @@ DeadArgumentEliminationPass::surveyUses(const Value *V,
 /// We consider arguments of non-internal functions to be intrinsically alive as
 /// well as arguments to functions which have their "address taken".
 void DeadArgumentEliminationPass::surveyFunction(const Function &F) {
-  // Can only change function signature for functions with local linkage.
-  if (!F.hasLocalLinkage()) {
+  // We can't modify arguments if the function is not local
+  // but we can do so for SYCL kernel functions.
+  bool FuncIsSyclKernel =
+      CheckSYCLKernels &&
+      (F.getCallingConv() == CallingConv::SPIR_KERNEL || IsNVPTXKernel(&F));
+
+  // Can only change function signature for functions with local linkage,
+  // except SYCL kernel functions which are handled specially.
+  if (!F.hasLocalLinkage() && !FuncIsSyclKernel) {
     markFrozen(F);
     return;
   }
@@ -520,7 +527,8 @@ void DeadArgumentEliminationPass::surveyFunction(const Function &F) {
   }
 
   // Ensure function definition is available for interprocedural analysis.
-  if (!F.isDefinitionExact()) {
+  // SYCL kernels may have weak_odr linkage but still have a unique definition.
+  if (!F.isDefinitionExact() && !FuncIsSyclKernel) {
     markFrozen(F);
     return;
   }
@@ -546,17 +554,6 @@ void DeadArgumentEliminationPass::surveyFunction(const Function &F) {
       if (markFnOrRetTyFrozenOnMusttail(F))
         return;
     }
-  }
-
-  // We can't modify arguments if the function is not local
-  // but we can do so for SYCL kernel functions.
-  bool FuncIsSyclKernel =
-      CheckSYCLKernels &&
-      (F.getCallingConv() == CallingConv::SPIR_KERNEL || IsNVPTXKernel(&F));
-  bool FuncIsLive = !F.hasLocalLinkage() && !FuncIsSyclKernel;
-  if (FuncIsLive) {
-    markFrozen(F);
-    return;
   }
 
   // Do not modify arguments when the SYCL kernel is a free function kernel.

--- a/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
+++ b/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
@@ -493,7 +493,7 @@ void DeadArgumentEliminationPass::surveyFunction(const Function &F) {
   // but we can do so for SYCL kernel functions.
   bool FuncIsSyclKernel =
       CheckSYCLKernels &&
-      (F.getCallingConv() == CallingConv::SPIR_KERNEL || IsNVPTXKernel(&F));
+      (F.hasKernelCallingConv());
 
   // Can only change function signature for functions with local linkage,
   // except SYCL kernel functions which are handled specially.

--- a/sycl/test/check_device_code/esimd/NBarrierAttr.cpp
+++ b/sycl/test/check_device_code/esimd/NBarrierAttr.cpp
@@ -23,7 +23,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL ESIMD_NOINLINE void callee(int x) {
 // inherits SLMSize and NBarrierCount from callee
 void caller_abc(int x) {
   kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
-  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_abciE10kernel_abc(i32 {{.*}}) local_unnamed_addr #[[ATTR1:[0-9]+]]
+  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_abciE10kernel_abc() local_unnamed_addr #[[ATTR1:[0-9]+]]
 }
 
 // inherits only NBarrierCount from callee
@@ -33,7 +33,7 @@ void caller_xyz(int x) {
     auto y = __ESIMD_ENS::named_barrier_allocate<35>();
     __ESIMD_NS::named_barrier_wait(y);
   });
-  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz(i32 {{.*}}) local_unnamed_addr #[[ATTR2:[0-9]+]]
+  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz() local_unnamed_addr #[[ATTR2:[0-9]+]]
   // CHECK: call void @llvm.genx.nbarrier(i8 0, i8 13, i8 0)
 }
 

--- a/sycl/test/check_device_code/esimd/dae.cpp
+++ b/sycl/test/check_device_code/esimd/dae.cpp
@@ -1,7 +1,8 @@
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll
 // RUN: FileCheck %s --input-file %t.ll
 
-// Check SYCL FE metadata for ESIMD kernel with captured int argument.
+// Check SYCL FE metadata is updated when dead argument elimination removes an
+// argument
 
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
@@ -14,9 +15,9 @@ __attribute__((sycl_kernel)) void my_kernel(Func kernelFunc) {
 
 SYCL_EXTERNAL SYCL_ESIMD_FUNCTION ESIMD_NOINLINE void callee(int x) {}
 
-// CHECK: define {{.*}}spir_kernel void {{.*}}(i32 {{.*}}) {{.*}} !kernel_arg_accessor_ptr ![[#MD:]]
+// CHECK: define {{.*}}spir_kernel {{.*}} !sycl_kernel_omit_args ![[#MD:]]
 SYCL_EXTERNAL void __attribute__((noinline)) caller(int x) {
   my_kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
 }
 
-//CHECK: [[#MD]] = !{i1 false}
+//CHECK: [[#MD]] = !{i1 true}

--- a/sycl/test/check_device_code/esimd/genx_func_attr.cpp
+++ b/sycl/test/check_device_code/esimd/genx_func_attr.cpp
@@ -24,7 +24,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL ESIMD_NOINLINE void callee(int x) {
 // inherits SLMSize and NBarrierCount from callee
 void caller_abc(int x) {
   kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
-  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_abciE10kernel_abc(i32 {{.*}}) local_unnamed_addr #[[ATTR:[0-9]+]]
+  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_abciE10kernel_abc() local_unnamed_addr #[[ATTR:[0-9]+]]
 }
 
 // inherits only NBarrierCount from callee
@@ -33,7 +33,7 @@ void caller_xyz(int x) {
     slm_init(1235); // also works in non-O0
     callee(x);
   });
-  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz(i32 {{.*}}) local_unnamed_addr #[[ATTR]]
+  // CHECK: define {{.*}}spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz() local_unnamed_addr #[[ATTR]]
 }
 
 // CHECK: attributes #[[ATTR]] = { {{.*}} "VCNamedBarrierCount"="13" "VCSLMSize"="2469"

--- a/sycl/test/check_device_code/esimd/slm_init_specconst_size.cpp
+++ b/sycl/test/check_device_code/esimd/slm_init_specconst_size.cpp
@@ -21,7 +21,7 @@ int main() {
           [=](sycl::kernel_handler kh) SYCL_ESIMD_KERNEL {
             slm_init(kh.get_specialization_constant<Size>());
           });
-      // CHECK: define weak_odr dso_local spir_kernel void @{{.*}}(ptr addrspace(1) {{.*}}) local_unnamed_addr #1
+      // CHECK: define weak_odr dso_local spir_kernel void @{{.*}}() local_unnamed_addr #1
     });
   }
 

--- a/sycl/test/check_device_code/native_cpu/kernelhandler-scalar.cpp
+++ b/sycl/test/check_device_code/native_cpu/kernelhandler-scalar.cpp
@@ -47,7 +47,7 @@ int main() {
   return 0;
 }
 
-// CHECK-DAG: @_ZTS6init_aIiE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr {{.*}}%2, ptr {{.*}}%3, i32 {{.*}}%4, ptr {{.*}}%5){{.*}}
-// CHECK-DAG: @_ZTS6init_aIjE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr {{.*}}%2, ptr {{.*}}%3, i32 {{.*}}%4, ptr {{.*}}%5){{.*}}
-// CHECK-DAG: @_ZTS6init_aIfE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr {{.*}}%2, ptr {{.*}}%3, float {{.*}}%4, ptr {{.*}}%5){{.*}}
-// CHECK-DAG: @_ZTS6init_aIdE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr {{.*}}%2, ptr {{.*}}%3, double {{.*}}%4, ptr {{.*}}%5){{.*}}
+// CHECK-DAG: @_ZTS6init_aIiE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, i32 {{.*}}%2, ptr {{.*}}%3){{.*}}
+// CHECK-DAG: @_ZTS6init_aIjE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, i32 {{.*}}%2, ptr {{.*}}%3){{.*}}
+// CHECK-DAG: @_ZTS6init_aIfE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, float {{.*}}%2, ptr {{.*}}%3){{.*}}
+// CHECK-DAG: @_ZTS6init_aIdE.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, double {{.*}}%2, ptr {{.*}}%3){{.*}}

--- a/sycl/test/check_device_code/native_cpu/native_cpu_subhandler.cpp
+++ b/sycl/test/check_device_code/native_cpu/native_cpu_subhandler.cpp
@@ -40,12 +40,8 @@ void test() {
   //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
   //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
   //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
-  //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
-  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
-  //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
-  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
   //CHECK:  %{{.*}} = load i32, ptr %{{.*}}
-  //CHECK:  call void @_ZTS6init_aIiE.NativeCPUKernel(ptr addrspace(1) {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, i32 {{.*}}, ptr addrspace(1) {{.*}})
+  //CHECK:  call void @_ZTS6init_aIiE.NativeCPUKernel(ptr {{.*}}, ptr {{.*}}, i32 {{.*}}, ptr {{.*}})
   //CHECK:  ret void
   //CHECK:}
   gen_test<float>(q);
@@ -53,15 +49,11 @@ void test() {
   //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
   //CHECK:  %{{.*}} = load ptr addrspace(1), ptr %{{.*}}
   //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
-  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
-  //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
-  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
-  //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
-  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
+  //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}, align 8
   //CHECK:  %{{.*}} = getelementptr %{{.*}}, ptr %{{.*}}, i64 {{.*}}
   //CHECK:  %{{.*}} = load ptr, ptr %{{.*}}
   //CHECK:  %{{.*}} = load float, ptr %{{.*}}
-  //CHECK:  call void @_ZTS6init_aIfE.NativeCPUKernel(ptr addrspace(1) {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, float {{.*}}, ptr addrspace(1) {{.*}})
+  //CHECK:  call void @_ZTS6init_aIfE.NativeCPUKernel(ptr {{.*}}, ptr {{.*}}, float {{.*}}, ptr {{.*}})
   //CHECK:  ret void
   //CHECK:}
 
@@ -74,7 +66,7 @@ void test() {
     });
   });
   //CHECK:define void @_ZTS5Test1.SYCLNCPU(ptr %{{.*}}, ptr addrspace(1) %[[STATE2:.*]]) #{{.*}} {
-  //CHECK:       call void @_ZTS5Test1.NativeCPUKernel(ptr addrspace(1) {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr addrspace(1) %[[STATE2]])
+  //CHECK:       call void @_ZTS5Test1.NativeCPUKernel(ptr addrspace(1) %[[STATE2]])
   //CHECK-NEXT:  ret void
   //CHECK-NEXT:}
 


### PR DESCRIPTION
SYCL kernels generated from C++ templates use weak_odr linkage since identical instantiations across TUs are ODR-equivalent. Two early exits in surveyFunction fired before the SYCL kernel exception was reached: !hasLocalLinkage() and !isDefinitionExact() (the latter introduced by a079288a for the noipa attribute). Move FuncIsSyclKernel computation to the top of surveyFunction and guard both checks with !FuncIsSyclKernel. The weak_odr ODR guarantee makes bypassing isDefinitionExact() safe.

Revert wrong fix 0c0065bd8476

Fixes LLVM::Transforms/DeadArgElim/sycl-kernels.ll
CMPLRLLVM-76303