### PR TITLE
[SYCL] Add removal guard for `info::device::atomic64` use-cases

### DIFF
--- a/sycl/ReleaseNotes.md
+++ b/sycl/ReleaseNotes.md
@@ -51,39 +51,6 @@ in the next ABI-breaking release:
 
 - ...
 
-# Release notes ???'26
-Release notes for commit range 
-[b23d69e2c3](https://github.com/intel/llvm/commit/b23d69e2c3fda1d69351137991897c96bf6a586d)
-...
-[???]()
-
-## New Features
-
-
-
-## Misc
-
-## API/ABI breakages
-
-### Changes that are effective immediately
-
-### Deprecations
-
-Those APIs are still present and tested, but they will be removed in future
-releases:
-
-### Upcoming API/ABI breakages
-
-This changes are available for preview under `-fpreview-breaking-changes` flag.
-They will be enabled by default (with no option to switch to the old behavior)
-in the next ABI-breaking release:
-
-- Removed support for `info::device::atomic64` in favor of `aspects::atomic64` as per SYCL2020 specifications
-
-## Known Issues
-
-- ...
-
 # Release notes Mar'25
 
 Release notes for commit range

--- a/sycl/ReleaseNotes.md
+++ b/sycl/ReleaseNotes.md
@@ -51,6 +51,39 @@ in the next ABI-breaking release:
 
 - ...
 
+# Release notes ???'26
+Release notes for commit range 
+[b23d69e2c3](https://github.com/intel/llvm/commit/b23d69e2c3fda1d69351137991897c96bf6a586d)
+...
+[???]()
+
+## New Features
+
+
+
+## Misc
+
+## API/ABI breakages
+
+### Changes that are effective immediately
+
+### Deprecations
+
+Those APIs are still present and tested, but they will be removed in future
+releases:
+
+### Upcoming API/ABI breakages
+
+This changes are available for preview under `-fpreview-breaking-changes` flag.
+They will be enabled by default (with no option to switch to the old behavior)
+in the next ABI-breaking release:
+
+- Removed support for `info::device::atomic64` in favor of `aspects::atomic64` as per SYCL2020 specifications
+
+## Known Issues
+
+- ...
+
 # Release notes Mar'25
 
 Release notes for commit range

--- a/sycl/include/sycl/info/device.hpp
+++ b/sycl/include/sycl/info/device.hpp
@@ -412,10 +412,13 @@ struct __SYCL2020_DEPRECATED("deprecated in SYCL 2020, use "
 };
 
 // Extensions/deprecated
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 struct __SYCL_DEPRECATED("use sycl::aspect::atomic64 instead") atomic64
     : device_traits<UR_DEVICE_INFO_ATOMIC_64> {
   using return_type = bool;
 };
+#endif
+
 struct reference_count : device_traits<UR_DEVICE_INFO_REFERENCE_COUNT> {
   using return_type = uint32_t;
 };

--- a/sycl/include/sycl/info/device.hpp
+++ b/sycl/include/sycl/info/device.hpp
@@ -411,13 +411,12 @@ struct __SYCL2020_DEPRECATED("deprecated in SYCL 2020, use "
   using return_type = bool;
 };
 
-// Extensions/deprecated
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 struct __SYCL_DEPRECATED("use sycl::aspect::atomic64 instead") atomic64
     : device_traits<UR_DEVICE_INFO_ATOMIC_64> {
   using return_type = bool;
 };
-#endif
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 struct reference_count : device_traits<UR_DEVICE_INFO_REFERENCE_COUNT> {
   using return_type = uint32_t;

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -1248,9 +1248,13 @@ public:
     CASE(int64_extended_atomics) {
       return has_extension("cl_khr_int64_extended_atomics");
     }
+    CASE(atomic64) {
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-    CASE(atomic64) { return get_info<info::device::atomic64>(); }
-#endif
+      return get_info<info::device::atomic64>();
+#else
+      return get_info_impl<UR_DEVICE_INFO_ATOMIC_64>();
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+    }
     CASE(image) { return get_info<info::device::image_support>(); }
     CASE(online_compiler) {
       return get_info<info::device::is_compiler_available>();

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -1248,13 +1248,7 @@ public:
     CASE(int64_extended_atomics) {
       return has_extension("cl_khr_int64_extended_atomics");
     }
-    CASE(atomic64) {
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-      return get_info<info::device::atomic64>();
-#else
-      return get_info_impl<UR_DEVICE_INFO_ATOMIC_64>();
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
-    }
+    CASE(atomic64) { return get_info_impl<UR_DEVICE_INFO_ATOMIC_64>(); }
     CASE(image) { return get_info<info::device::image_support>(); }
     CASE(online_compiler) {
       return get_info<info::device::is_compiler_available>();

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -1248,7 +1248,9 @@ public:
     CASE(int64_extended_atomics) {
       return has_extension("cl_khr_int64_extended_atomics");
     }
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
     CASE(atomic64) { return get_info<info::device::atomic64>(); }
+#endif
     CASE(image) { return get_info<info::device::image_support>(); }
     CASE(online_compiler) {
       return get_info<info::device::is_compiler_available>();

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -281,7 +281,7 @@ __SYCL_DEVICE_INFO_INST(partition_type_affinity_domain,
                         info::partition_affinity_domain)
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 __SYCL_DEVICE_INFO_INST(atomic64, bool)
-#endif
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 __SYCL_DEVICE_INFO_INST(reference_count, uint32_t)
 __SYCL_DEVICE_INFO_INST(usm_device_allocations, bool)
 __SYCL_DEVICE_INFO_INST(usm_host_allocations, bool)

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -279,7 +279,9 @@ __SYCL_DEVICE_INFO_INST(partition_affinity_domains,
 __SYCL_DEVICE_INFO_INST(partition_type_property, info::partition_property)
 __SYCL_DEVICE_INFO_INST(partition_type_affinity_domain,
                         info::partition_affinity_domain)
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 __SYCL_DEVICE_INFO_INST(atomic64, bool)
+#endif
 __SYCL_DEVICE_INFO_INST(reference_count, uint32_t)
 __SYCL_DEVICE_INFO_INST(usm_device_allocations, bool)
 __SYCL_DEVICE_INFO_INST(usm_host_allocations, bool)


### PR DESCRIPTION
Fixes issue #14920 

This PR guards all `info::device::atomic64` related code in include guards for preview-breaking-changes