### PR TITLE
[SYCL][E2E] Fix invalid reqd_work_group_size in large-reqd-work-group-size.cpp

### DIFF
--- a/sycl/test-e2e/OptionalKernelFeatures/large-reqd-work-group-size.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/large-reqd-work-group-size.cpp
@@ -43,13 +43,13 @@ int main(int argc, char *argv[]) {
 
   throws_kernel_not_supported("nd_range<2>", [] {
     constexpr uint32_t N = std::numeric_limits<uint32_t>::max();
-    q.parallel_for<class K1>(nd_range<2>({N, N}, {N, N}),
+    q.parallel_for<class K1>(nd_range<2>({N, 1}, {N, 1}),
                              [=](auto) [[sycl::reqd_work_group_size(N, 1)]] {});
   });
 
   throws_kernel_not_supported("nd_range<3>", [] {
     constexpr uint32_t N = std::numeric_limits<uint32_t>::max();
-    q.parallel_for<class K2>(nd_range<3>({N, N, N}, {N, N, N}),
+    q.parallel_for<class K2>(nd_range<3>({N, 1, 1}, {N, 1, 1}),
                              [=](auto)
                                  [[sycl::reqd_work_group_size(N, 1, 1)]] {});
   });

--- a/sycl/test-e2e/OptionalKernelFeatures/large-reqd-work-group-size.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/large-reqd-work-group-size.cpp
@@ -44,14 +44,14 @@ int main(int argc, char *argv[]) {
   throws_kernel_not_supported("nd_range<2>", [] {
     constexpr uint32_t N = std::numeric_limits<uint32_t>::max();
     q.parallel_for<class K1>(nd_range<2>({N, N}, {N, N}),
-                             [=](auto) [[sycl::reqd_work_group_size(N, N)]] {});
+                             [=](auto) [[sycl::reqd_work_group_size(N, 1)]] {});
   });
 
   throws_kernel_not_supported("nd_range<3>", [] {
     constexpr uint32_t N = std::numeric_limits<uint32_t>::max();
     q.parallel_for<class K2>(nd_range<3>({N, N, N}, {N, N, N}),
                              [=](auto)
-                                 [[sycl::reqd_work_group_size(N, N, N)]] {});
+                                 [[sycl::reqd_work_group_size(N, 1, 1)]] {});
   });
 
   throws_kernel_not_supported("uint32_max+2", [] {


### PR DESCRIPTION
The test fails after 6794e31 which adds reqd_work_group_size product overflow check to IR verifier. This PR fixes the test.

SYCL 2020 spec (Secion 4.9.1.1, Table 79) defines range::size() as product of its dimensions and return type is size_t. The product of reqd_work_group_size should fit within range::size() return type.

CMPLRLLVM-76460