### PR TITLE
[SYCL][ABI] Guard old operator== function members and provide friend free functions

### DIFF
--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -114,9 +114,19 @@ public:
 
   platform &operator=(platform &&rhs) = default;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   bool operator==(const platform &rhs) const { return impl == rhs.impl; }
 
   bool operator!=(const platform &rhs) const { return !(*this == rhs); }
+#else
+  friend bool operator==(const platform &lhs, const platform &rhs) {
+    return lhs.impl == rhs.impl;
+  }
+
+  friend bool operator!=(const platform &lhs, const platform &rhs) {
+    return !(lhs == rhs);
+  }
+#endif
 
   /// Returns an OpenCL interoperability platform.
   ///

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -126,7 +126,7 @@ public:
   friend bool operator!=(const platform &lhs, const platform &rhs) {
     return !(lhs == rhs);
   }
-#endif
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Returns an OpenCL interoperability platform.
   ///


### PR DESCRIPTION
Fixes #22455 

This PR adds guards for removing the member operator== functions in the next major release and replaces them with free friend functions as per SYCL 2020 specifications