### PR TITLE
[SYCL][Test] Fix address-space-parameter-conversions after opencl_global_device deprecation

### DIFF
--- a/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
@@ -14,6 +14,8 @@ void tmpl(T *t){}
 
 void usages() {
   __attribute__((opencl_global)) int *GLOB;
+  __attribute__((opencl_global_device)) int *GLOBDEV; // expected-warning{{''opencl_global_device'' attribute is deprecated and may be removed in a future version of Clang}}
+  __attribute__((opencl_global_host)) int *GLOBHOST; // expected-warning{{''opencl_global_host'' attribute is deprecated and may be removed in a future version of Clang}}
   __attribute__((opencl_private)) int *PRIV;
   __attribute__((opencl_local)) int *LOC;
   int *NoAS;
@@ -21,6 +23,13 @@ void usages() {
   bar(*GLOB);
   bar2(*GLOB);
 
+  bar(*GLOBDEV);
+  bar2(*GLOBDEV);
+  bar3(*GLOBDEV);
+
+  bar(*GLOBHOST);
+  bar2(*GLOBHOST);
+  bar3(*GLOBHOST);
 
   bar(*PRIV);
   bar2(*PRIV);
@@ -33,6 +42,12 @@ void usages() {
 
   foo(GLOB);
   foo2(GLOB);
+  foo(GLOBDEV);
+  foo2(GLOBDEV);
+  foo3(GLOBDEV);
+  foo(GLOBDEV);
+  foo2(GLOBHOST);
+  foo3(GLOBHOST);
   foo(PRIV);
   foo2(PRIV);
   foo(NoAS);
@@ -41,12 +56,18 @@ void usages() {
   foo2(LOC);
 
   tmpl(GLOB);
+  tmpl(GLOBDEV);
+  tmpl(GLOBHOST);
   tmpl(PRIV);
   tmpl(NoAS);
   tmpl(LOC);
 
   (void)static_cast<int*>(GLOB);
   (void)static_cast<void*>(GLOB);
+  (void)static_cast<int *>(GLOBDEV);
+  (void)static_cast<void *>(GLOBDEV);
+  (void)static_cast<int *>(GLOBHOST);
+  (void)static_cast<void *>(GLOBHOST);
   // FIXME: determine if we can warn on the below conversions.
   int *i = GLOB;
   void *v = GLOB;

--- a/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
@@ -14,8 +14,6 @@ void tmpl(T *t){}
 
 void usages() {
   __attribute__((opencl_global)) int *GLOB;
-  __attribute__((opencl_global_device)) int *GLOBDEV;
-  __attribute__((opencl_global_host)) int *GLOBHOST;
   __attribute__((opencl_private)) int *PRIV;
   __attribute__((opencl_local)) int *LOC;
   int *NoAS;
@@ -23,13 +21,6 @@ void usages() {
   bar(*GLOB);
   bar2(*GLOB);
 
-  bar(*GLOBDEV);
-  bar2(*GLOBDEV);
-  bar3(*GLOBDEV);
-
-  bar(*GLOBHOST);
-  bar2(*GLOBHOST);
-  bar3(*GLOBHOST);
 
   bar(*PRIV);
   bar2(*PRIV);
@@ -42,12 +33,6 @@ void usages() {
 
   foo(GLOB);
   foo2(GLOB);
-  foo(GLOBDEV);
-  foo2(GLOBDEV);
-  foo3(GLOBDEV);
-  foo(GLOBDEV);
-  foo2(GLOBHOST);
-  foo3(GLOBHOST);
   foo(PRIV);
   foo2(PRIV);
   foo(NoAS);
@@ -56,18 +41,12 @@ void usages() {
   foo2(LOC);
 
   tmpl(GLOB);
-  tmpl(GLOBDEV);
-  tmpl(GLOBHOST);
   tmpl(PRIV);
   tmpl(NoAS);
   tmpl(LOC);
 
   (void)static_cast<int*>(GLOB);
   (void)static_cast<void*>(GLOB);
-  (void)static_cast<int *>(GLOBDEV);
-  (void)static_cast<void *>(GLOBDEV);
-  (void)static_cast<int *>(GLOBHOST);
-  (void)static_cast<void *>(GLOBHOST);
   // FIXME: determine if we can warn on the below conversions.
   int *i = GLOB;
   void *v = GLOB;


### PR DESCRIPTION
84c42fe09e05 deprecated opencl_global_device and opencl_global_host, causing unexpected warnings in the verify test. Delete uses in the test.

CMPLRLLVM-76496