### PR TITLE
[Clang] Fix -Wctad-maybe-unsupported error in clang-linker-wrapper

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -2430,7 +2430,7 @@ linkAndWrapDeviceFiles(ArrayRef<SmallVector<OffloadFile>> LinkerInputFiles,
 
     auto AppendImageToWrapperOutput = [&WrappedOutput,
                                        &ImageMtx](StringRef ImagePath) {
-      std::scoped_lock Guard(ImageMtx);
+      std::scoped_lock<decltype(ImageMtx)> Guard(ImageMtx);
       WrappedOutput.push_back(ImagePath);
     };
 


### PR DESCRIPTION
Provide explicit template argument to std::scoped_lock instead of
relying on class template argument deduction, which GCC 7.5's libstdc++
does not supply a deduction guide for. This matches the existing usage
elsewhere in the same file and fixes the -Werror build break.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
