### PR TITLE
[SYCL][AMDGPU] Set amdgpu-flat-work-group-size for SYCL reqd_work_group_size

### DIFF
--- a/clang/lib/CodeGen/Targets/AMDGPU.cpp
+++ b/clang/lib/CodeGen/Targets/AMDGPU.cpp
@@ -350,6 +350,17 @@ void AMDGPUTargetCodeGenInfo::setFunctionDeclAttributes(
   const auto *FlatWGS = FD->getAttr<AMDGPUFlatWorkGroupSizeAttr>();
   if (ReqdWGS || FlatWGS) {
     M.handleAMDGPUFlatWorkGroupSizeAttr(F, FlatWGS, ReqdWGS);
+  } else if (M.getLangOpts().SYCLIsDevice) {
+    if (const auto *SYCLReqdWGS = FD->getAttr<SYCLReqdWorkGroupSizeAttr>()) {
+      auto GetDim = [](std::optional<llvm::APSInt> V) -> unsigned {
+        return V ? (unsigned)V->getZExtValue() : 1;
+      };
+      unsigned Size = GetDim(SYCLReqdWGS->getXDimVal()) *
+                      GetDim(SYCLReqdWGS->getYDimVal()) *
+                      GetDim(SYCLReqdWGS->getZDimVal());
+      std::string AttrVal = llvm::utostr(Size) + "," + llvm::utostr(Size);
+      F->addFnAttr("amdgpu-flat-work-group-size", AttrVal);
+    }
   } else if (IsOpenCLKernel || IsHIPKernel) {
     // By default, restrict the maximum size to a value specified by
     // --gpu-max-threads-per-block=n or its default value for HIP.


### PR DESCRIPTION
AMDGPU verifier (added in 6794e31e894d) requires amdgpu-flat-work-group-size function attribute whenever reqd_work_group_size metadata is present. setFunctionDeclAttributes only handled OpenCL's ReqdWorkGroupSizeAttr; SYCL uses SYCLReqdWorkGroupSizeAttr which went through CodeGenFunction.cpp to emit the metadata but never set the function attribute, triggering the verifier error on amdgcn targets.

Fixes CodeGenSYCL/reqd-work-group-size.cpp and check-work-group-attributes-match.cpp
CMPLRLLVM-76303