### PR TITLE
[SYCL] Don't expose `getSyclObjImpl` via ADL

### DIFF
--- a/sycl/include/sycl/detail/impl_utils.hpp
+++ b/sycl/include/sycl/detail/impl_utils.hpp
@@ -41,11 +41,21 @@ struct ImplUtils {
   }
 };
 
-template <class Obj>
-auto getSyclObjImpl(const Obj &SyclObj)
-    -> decltype(ImplUtils::getSyclObjImpl(SyclObj)) {
-  return ImplUtils::getSyclObjImpl(SyclObj);
-}
+// Implemented as a function object (rather than a free function) so that it is
+// not exposed via argument-dependent lookup. SYCL interface classes inherit
+// from helper bases (e.g. OwnerLessBase) living in this namespace, which would
+// otherwise make `sycl::detail` an associated namespace and leak this internal
+// API into unqualified calls on user-facing objects. ADL never considers
+// variables, only functions, so a callable object stays invisible to ADL while
+// remaining usable via ordinary/qualified lookup.
+// Regression test for https://github.com/intel/llvm/issues/20820.
+inline constexpr struct GetSyclObjImpl {
+  template <class Obj>
+  auto operator()(const Obj &SyclObj) const
+      -> decltype(ImplUtils::getSyclObjImpl(SyclObj)) {
+    return ImplUtils::getSyclObjImpl(SyclObj);
+  }
+} getSyclObjImpl;
 
 template <typename SyclObject, typename From>
 SyclObject createSyclObjFromImpl(From &&from) {

--- a/sycl/include/sycl/detail/owner_less_base.hpp
+++ b/sycl/include/sycl/detail/owner_less_base.hpp
@@ -28,7 +28,7 @@ public:
   bool ext_oneapi_owner_before(
       const ext::oneapi::detail::weak_object_base<SyclObjT> &Other)
       const noexcept {
-    return getSyclObjImpl(*static_cast<const SyclObjT *>(this))
+    return detail::getSyclObjImpl(*static_cast<const SyclObjT *>(this))
         .owner_before(ext::oneapi::detail::getSyclWeakObjImpl(Other));
   }
 
@@ -38,8 +38,8 @@ public:
   /// \param Other is the object to compare ordering against.
   /// \return true if this object precedes \param Other and false otherwise.
   bool ext_oneapi_owner_before(const SyclObjT &Other) const noexcept {
-    return getSyclObjImpl(*static_cast<const SyclObjT *>(this))
-        .owner_before(getSyclObjImpl(Other));
+    return detail::getSyclObjImpl(*static_cast<const SyclObjT *>(this))
+        .owner_before(detail::getSyclObjImpl(Other));
   }
 #else
   // On device calls to these functions are disallowed, so declare them but

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -419,7 +419,7 @@ private:
   template <typename T, int Dimensions, typename AllocatorT>
   void addReduction(
       const std::shared_ptr<buffer<T, Dimensions, AllocatorT>> &ReduBuf) {
-    detail::markBufferAsInternal(getSyclObjImpl(*ReduBuf));
+    detail::markBufferAsInternal(detail::getSyclObjImpl(*ReduBuf));
     addReduction(std::shared_ptr<const void>(ReduBuf));
   }
 

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -299,7 +299,7 @@ event submit_kernel_direct_with_event_impl(
     sycl::span<const event> DepEvents,
     const detail::KernelPropertyHolderStructTy &Props,
     const detail::code_location &CodeLoc, bool IsTopCodeLoc) {
-  return getSyclObjImpl(Queue)->submit_kernel_direct_with_event(
+  return detail::getSyclObjImpl(Queue)->submit_kernel_direct_with_event(
       RangeView, HostKernel, DeviceKernelInfo, DepEvents, Props, CodeLoc,
       IsTopCodeLoc);
 }
@@ -311,7 +311,7 @@ void submit_kernel_direct_without_event_impl(
     sycl::span<const event> DepEvents,
     const detail::KernelPropertyHolderStructTy &Props,
     const detail::code_location &CodeLoc, bool IsTopCodeLoc) {
-  getSyclObjImpl(Queue)->submit_kernel_direct_without_event(
+  detail::getSyclObjImpl(Queue)->submit_kernel_direct_without_event(
       RangeView, HostKernel, DeviceKernelInfo, DepEvents, Props, CodeLoc,
       IsTopCodeLoc);
 }
@@ -322,8 +322,8 @@ event submit_graph_direct_with_event_impl(
         ext::oneapi::experimental::graph_state::executable> &G,
     sycl::span<const event> DepEvents, const detail::code_location &CodeLoc) {
   detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
-  return getSyclObjImpl(Queue)->submit_graph_direct_with_event(
-      getSyclObjImpl(G), DepEvents, TlsCodeLocCapture.query(),
+  return detail::getSyclObjImpl(Queue)->submit_graph_direct_with_event(
+      detail::getSyclObjImpl(G), DepEvents, TlsCodeLocCapture.query(),
       TlsCodeLocCapture.isToplevel());
 }
 
@@ -333,8 +333,8 @@ void submit_graph_direct_without_event_impl(
         ext::oneapi::experimental::graph_state::executable> &G,
     sycl::span<const event> DepEvents, const detail::code_location &CodeLoc) {
   detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
-  getSyclObjImpl(Queue)->submit_graph_direct_without_event(
-      getSyclObjImpl(G), DepEvents, TlsCodeLocCapture.query(),
+  detail::getSyclObjImpl(Queue)->submit_graph_direct_without_event(
+      detail::getSyclObjImpl(G), DepEvents, TlsCodeLocCapture.query(),
       TlsCodeLocCapture.isToplevel());
 }
 

--- a/sycl/test/basic_tests/adl_getSyclObjImpl.cpp
+++ b/sycl/test/basic_tests/adl_getSyclObjImpl.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
-// Tests that internal getSyclObjImpl API is not exposed via ADL
+// Tests that internal getSyclObjImpl API is not exposed via ADL for any of the
+// user-facing SYCL objects (many of which inherit from helper bases living in
+// the `sycl::detail` namespace, e.g. OwnerLessBase).
 // Regression test for https://github.com/intel/llvm/issues/20820
 
 #include <sycl/sycl.hpp>
@@ -8,10 +10,39 @@
 void test_no_adl() {
   sycl::device d;
   // getSyclObjImpl is internal and should not be found via ADL
-  auto id = getSyclObjImpl(
-      d); // expected-error {{use of undeclared identifier 'getSyclObjImpl'}}
+  // expected-error@+1 {{use of undeclared identifier 'getSyclObjImpl'}}
+  auto id = getSyclObjImpl(d);
 
   sycl::queue q;
-  auto iq = getSyclObjImpl(
-      q); // expected-error {{use of undeclared identifier 'getSyclObjImpl'}}
+  // expected-error@+1 {{use of undeclared identifier 'getSyclObjImpl'}}
+  auto iq = getSyclObjImpl(q);
+
+  sycl::platform p;
+  // expected-error@+1 {{use of undeclared identifier 'getSyclObjImpl'}}
+  auto ip = getSyclObjImpl(p);
+
+  sycl::context ctx;
+  // expected-error@+1 {{use of undeclared identifier 'getSyclObjImpl'}}
+  auto ictx = getSyclObjImpl(ctx);
+
+  sycl::event e;
+  // expected-error@+1 {{use of undeclared identifier 'getSyclObjImpl'}}
+  auto ie = getSyclObjImpl(e);
+
+  sycl::buffer<int, 1> buf{sycl::range<1>{1}};
+  // expected-error@+1 {{use of undeclared identifier 'getSyclObjImpl'}}
+  auto ibuf = getSyclObjImpl(buf);
+
+  sycl::host_accessor acc{buf};
+  // expected-error@+1 {{use of undeclared identifier 'getSyclObjImpl'}}
+  auto iacc = getSyclObjImpl(acc);
+
+  sycl::kernel_id kid = sycl::get_kernel_id<class SomeKernel>();
+  // expected-error@+1 {{use of undeclared identifier 'getSyclObjImpl'}}
+  auto ikid = getSyclObjImpl(kid);
+
+  sycl::kernel_bundle kb =
+      sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctx);
+  // expected-error@+1 {{use of undeclared identifier 'getSyclObjImpl'}}
+  auto ikb = getSyclObjImpl(kb);
 }

--- a/sycl/test/basic_tests/adl_getSyclObjImpl.cpp
+++ b/sycl/test/basic_tests/adl_getSyclObjImpl.cpp
@@ -1,0 +1,17 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+
+// Tests that internal getSyclObjImpl API is not exposed via ADL
+// Regression test for https://github.com/intel/llvm/issues/20820
+
+#include <sycl/sycl.hpp>
+
+void test_no_adl() {
+  sycl::device d;
+  // getSyclObjImpl is internal and should not be found via ADL
+  auto id = getSyclObjImpl(
+      d); // expected-error {{use of undeclared identifier 'getSyclObjImpl'}}
+
+  sycl::queue q;
+  auto iq = getSyclObjImpl(
+      q); // expected-error {{use of undeclared identifier 'getSyclObjImpl'}}
+}

--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -152,7 +152,7 @@ TEST_P(MultipleDeviceCacheTest, ProgramRetain) {
     // on number of device images. This test has one image, but other tests can
     // create other images. Additional variable is added to control count of
     // urProgramRetain calls.
-    detail::kernel_bundle_impl &BundleImpl = *getSyclObjImpl(Bundle);
+    detail::kernel_bundle_impl &BundleImpl = *detail::getSyclObjImpl(Bundle);
 
     // Bundle should only contain a single image, specifically the one with
     // MultipleDevsCacheTestKernel.


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/issues/20820