### PR TITLE
[SYCL] fix fp8 regression

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/float_8bit/types.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/float_8bit/types.hpp
@@ -16,7 +16,6 @@
 #include <sycl/marray.hpp>
 
 #include <cassert>
-#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -26,11 +25,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 
 namespace sycl {
+inline namespace _V1 {
 namespace detail {
 using float16_vec2 = _Float16 __attribute__((ext_vector_type(2)));
 using uint8_vec2 = uint8_t __attribute__((ext_vector_type(2)));
 using bfloat16_vec2 = __bf16 __attribute__((ext_vector_type(2)));
 } // namespace detail
+} // namespace _V1
 } // namespace sycl
 // FP8 builtins
 
@@ -865,7 +866,7 @@ static inline ToT ConvertFromE8M0_CPU(uint8_t code, rounding R) noexcept {
 
 } // namespace detail
 
-template <size_t N> class fp8_e4m3_x {
+template <size_t N> class alignas(N == 2 ? 2 : 1) fp8_e4m3_x {
   static constexpr size_t NExpBits = 4;
   static constexpr size_t NFracBits = 3;
 
@@ -1298,11 +1299,11 @@ public:
   }
 
   // Intentionally public to allow access to the raw values.
-  alignas(N == 2 ? 2 : alignof(uint8_t)) uint8_t vals[N];
+  uint8_t vals[N];
 #undef CONVERT_TO_FP8
 };
 
-template <size_t N> class fp8_e5m2_x {
+template <size_t N> class alignas(N == 2 ? 2 : 1) fp8_e5m2_x {
   static constexpr size_t NExpBits = 5;
   static constexpr size_t NFracBits = 2;
 
@@ -1882,7 +1883,7 @@ public:
   }
 
   // Intentionally public to allow access to the raw values.
-  alignas(N == 2 ? 2 : alignof(uint8_t)) uint8_t vals[N];
+  uint8_t vals[N];
 #undef CONVERT_TO_FP8
 };
 


### PR DESCRIPTION
This PR fixes regression found after merge of FP8 data types extension:
```
     UXFAIL -- SYCL :: basic_tests/builtins/builtin_unit_tests.cpp
     UXFAIL -- SYCL :: basic_tests/handler/unnamed-lambda-negative.cpp
     UXFAIL -- SYCL :: basic_tests/no_math_in_global_ns.cpp
     UXFAIL -- SYCL :: check_device_code/fp8_conversions.cpp
     UXFAIL -- SYCL :: gdb/accessors-device.cpp
     UXFAIL -- SYCL :: gdb/printers.cpp
     UXFAIL -- SYCL :: regression/bit_cast_lin.cpp
     UXFAIL -- SYCL :: regression/host_builtins_gcc.cpp
```