### PR TITLE
[SYCL][E2E] Disable alloc_pinned_host_memory.cpp on Level Zero

### DIFF
--- a/sycl/test-e2e/Basic/alloc_pinned_host_memory.cpp
+++ b/sycl/test-e2e/Basic/alloc_pinned_host_memory.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22287
 
-// UNSUPPORTED: linux && (arch-intel_gpu_pvc || arch-intel_gpu_bmg_g21)
+// UNSUPPORTED: linux && level_zero
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
 
 // RUN: %{build} -o %t2.out


### PR DESCRIPTION
Sporadic fall on all L0 GPUs, see https://github.com/intel/llvm/issues/22287 and https://github.com/intel/llvm/issues/22405