### PR TITLE
[CI] Disable werror for xpti on Mac 

### DIFF
--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -52,6 +52,7 @@ jobs:
           --ci-defaults --use-zstd $ARGS \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DLLVM_INSTALL_UTILS=ON
+          -DLLVM_INSTALL_UTILS=ON \
+          -DXPTI_ENABLE_WERROR=OFF
     - name: Compile
       run: cmake --build $GITHUB_WORKSPACE/build --target deploy-sycl-toolchain


### PR DESCRIPTION
We build on Mac in postcommit to verify we didn't break anything that would be a problem for pulldown/upstreaming, but we don't run any tests.

A dependency to `xptifw`, `parallel-hashmap`, cause warnings during the build on Mac, so just disable `werror` for XPTI/XPTIFW.

CI run: https://github.com/intel/llvm/actions/runs/28386217398/job/84101462283