### PR TITLE
[SYCL][ABI] Guard member equal comparison operator function members and provide free friend functions instead

### DIFF
--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -194,10 +194,19 @@ public:
 
   context &operator=(context &&rhs) = default;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   bool operator==(const context &rhs) const { return impl == rhs.impl; }
 
   bool operator!=(const context &rhs) const { return !(*this == rhs); }
+#else
+  friend bool operator==(const context &lhs, const context &rhs) {
+    return rhs.impl == lhs.impl;
+  }
 
+  friend bool operator!=(const context &lhs, const context &rhs) {
+    return !(lhs == rhs);
+  }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   /// Checks if this context has a property of type propertyT.
   ///
   /// \return true if this context has a property of type propertyT.

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -109,6 +109,7 @@ public:
   friend bool operator==(const device &lhs, const device &rhs) {
     return rhs.impl == lhs.impl;
   }
+
   friend bool operator!=(const device &lhs, const device &rhs) {
     return !(lhs == rhs);
   }

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -101,10 +101,18 @@ public:
   explicit device(const DeviceSelector &deviceSelector)
       : device(detail::select_device(deviceSelector)) {}
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   bool operator==(const device &rhs) const { return impl == rhs.impl; }
 
   bool operator!=(const device &rhs) const { return !(*this == rhs); }
-
+#else
+  friend bool operator==(const device &lhs, const device &rhs) {
+    return rhs.impl == lhs.impl;
+  }
+  friend bool operator!=(const device &lhs, const device &rhs) {
+    return !(lhs == rhs);
+  }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   device(const device &rhs);
 
   device(device &&rhs);

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -76,7 +76,6 @@ public:
   friend bool operator==(const event &lhs, const event &rhs);
 
   friend bool operator!=(const event &lhs, const event &rhs);
-
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Return the list of events that this event waits for.

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -68,9 +68,16 @@ public:
 
   event &operator=(event &&rhs) = default;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   bool operator==(const event &rhs) const;
 
   bool operator!=(const event &rhs) const;
+#else
+  friend bool operator==(const event &lhs, const event &rhs);
+
+  friend bool operator!=(const event &lhs, const event &rhs);
+
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Return the list of events that this event waits for.
   ///

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -73,9 +73,13 @@ public:
 
   bool operator!=(const event &rhs) const;
 #else
-  friend bool operator==(const event &lhs, const event &rhs);
+  friend bool operator==(const event &lhs, const event &rhs) {
+    return rhs.impl == lhs.impl;
+  }
 
-  friend bool operator!=(const event &lhs, const event &rhs);
+  friend bool operator!=(const event &lhs, const event &rhs) {
+    return !(lhs == rhs);
+  }
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Return the list of events that this event waits for.

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -377,10 +377,19 @@ public:
 
   queue &operator=(queue &&RHS) = default;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   bool operator==(const queue &RHS) const { return impl == RHS.impl; }
 
   bool operator!=(const queue &RHS) const { return !(*this == RHS); }
+#else
+  friend bool operator==(const queue &LHS, const queue &RHS) {
+    return LHS.impl == RHS.impl;
+  }
 
+  friend bool operator!=(const queue &LHS, const queue &RHS) {
+    return !(LHS == RHS);
+  }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   /// \return a valid instance of OpenCL queue, which is retained before being
   /// returned.
 #ifdef __SYCL_INTERNAL_API

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -39,6 +39,7 @@ bool event::operator!=(const event &rhs) const { return !(*this == rhs); }
 bool operator==(const event &lhs, const event &rhs) {
   return rhs.impl == lhs.impl;
 }
+
 bool operator!=(const event &lhs, const event &rhs) { return !(lhs == rhs); }
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -35,12 +35,6 @@ event::event(cl_event ClEvent, const context &SyclContext)
 bool event::operator==(const event &rhs) const { return rhs.impl == impl; }
 
 bool event::operator!=(const event &rhs) const { return !(*this == rhs); }
-#else
-bool operator==(const event &lhs, const event &rhs) {
-  return rhs.impl == lhs.impl;
-}
-
-bool operator!=(const event &lhs, const event &rhs) { return !(lhs == rhs); }
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 void event::wait() { impl->wait(); }

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -31,9 +31,16 @@ event::event(cl_event ClEvent, const context &SyclContext)
   __SYCL_OCL_CALL(clRetainEvent, ClEvent);
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 bool event::operator==(const event &rhs) const { return rhs.impl == impl; }
 
 bool event::operator!=(const event &rhs) const { return !(*this == rhs); }
+#else
+bool operator==(const event &lhs, const event &rhs) {
+  return rhs.impl == lhs.impl;
+}
+bool operator!=(const event &lhs, const event &rhs) { return !(lhs == rhs); }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 void event::wait() { impl->wait(); }
 


### PR DESCRIPTION
This PR guards the member functions for equal comparison `==` & `!=` for the `event`, `queue`, `device`, `context` classes in `__INTEL_PREVIEW_BREAKING_CHANGES` and provides free friend functions instead

fixes #22474 
fixes #22473 
fixes #22472 
fixes #22471 