### PR TITLE
[GHA] Uplift Linux GPU RT version to 26.22.38646.4

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.30.0",
-      "version": "v1.30.0",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.30.0",
+      "github_tag": "v1.31.0",
+      "version": "v1.31.0",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.31.0",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
Scheduled drivers uplift