### PR TITLE
[SYCL] Don't fetch device image and property for small ranges

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2599,74 +2599,76 @@ getCGKernelInfo(const CGExecKernel &CommandGroup, context_impl &ContextImpl,
   return std::make_tuple(UrKernel, DeviceImageImpl, EliminatedArgMask);
 }
 
+// Check if the provided global size and offset values are within the maximum
+// range supported by the kernel's id queries type, per dimension.
+// MaxRange is an inclusive upper bound for both offset and size.
+// Also checks if the total global size (product of global sizes across all
+// dimensions) is within the maximum range, to ensure that functions like
+// get_global_linear_id can safely return a value within the maximum range.
+// If NDRDesc.GlobalSize[I] is zero, it is treated as valid and does not exceed
+// the range.
+bool isNDRangeExceedsMaxRange(const NDRDescT &NDRDesc, uint64_t MaxRange) {
+  uint64_t TotalGlobalSize = 1;
+  for (size_t I = 0; I < NDRDesc.Dims; ++I) {
+    uint64_t GlobalOffset = NDRDesc.GlobalOffset[I];
+    if (GlobalOffset > MaxRange)
+      return true;
+    uint64_t GlobalSize = NDRDesc.GlobalSize[I];
+    if (GlobalSize > MaxRange - GlobalOffset)
+      return true;
+    TotalGlobalSize *= GlobalSize;
+    if (TotalGlobalSize > MaxRange)
+      return true;
+  }
+  return false;
+}
+
 void checkNDRangeBoundsAndThrow(const NDRDescT &NDRDesc,
                                 const uint32_t IdQueriesRange) {
-
   // Skipping the range check if the kernel supports size_t range for id
   // queries. Because, range exceeding size_t is not practically possible, and
   // for a 64-bit size_t, it'll take hundreds of years for such a kernel to
   // complete.
   if (IdQueriesRange == 2) {
-    // DPCPP supports up to size_t range for id queries, so we can skip the
-    // check in this case.
     return;
   }
 
-  uint64_t MaxRange = 0;
-  if (IdQueriesRange == 1) { /*uint32_t*/
-    MaxRange = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max());
-  } else { /*int*/
-    MaxRange = static_cast<uint64_t>(std::numeric_limits<int>::max());
+  if (IdQueriesRange == 1) {
+    uint64_t MaxRange = std::numeric_limits<uint32_t>::max();
+
+    // Early exit if kernel is compiled with -fsycl-id-queries-range=uint,
+    // and launched with a range lesser than or equal to UINT_MAX.
+    if (!isNDRangeExceedsMaxRange(NDRDesc, MaxRange))
+      return;
   }
 
-  // Check if the provided global size and offset values are within the maximum
-  // range supported by the kernel's id queries type, per dimension.
-  // Also check if the total global size (product of global sizes across all
-  // dimensions) is within the maximum range, to ensure that functions like
-  // get_global_linear_id can safely return a value within the maximum range.
-  bool ExceedsMaxRange = false;
-  uint64_t TotalGlobalSize = 1;
-  for (size_t I = 0; I < NDRDesc.Dims; ++I) {
-    const uint64_t GlobalSize = static_cast<uint64_t>(NDRDesc.GlobalSize[I]);
-    const uint64_t GlobalOffset =
-        static_cast<uint64_t>(NDRDesc.GlobalOffset[I]);
-    // Validate the maximum generated global id in each dimension:
-    // GlobalOffset + GlobalSize <= MaxRange.
-    if (GlobalOffset > MaxRange || GlobalSize > (MaxRange - GlobalOffset)) {
-      ExceedsMaxRange = true;
-      break;
-    }
-    TotalGlobalSize *= GlobalSize;
-    if (TotalGlobalSize > MaxRange) {
-      ExceedsMaxRange = true;
-      break;
-    }
+  // No need to check when IdQueriesRange is 0 (INT_MAX) because this
+  // function is only called when the kernel is executed with a range exceeding
+  // INT_MAX. In this case, the default range type is int, and the check is not
+  // required since the function is not called for ranges within INT_MAX.
+
+  // Throw an exception.
+  std::string ErrMsg;
+  switch (IdQueriesRange) {
+  case 1:
+    ErrMsg = "The kernel was compiled with -fsycl-id-queries-range=uint, but "
+             "the provided range/offset exceeds the maximum value storable in "
+             "an uint32_t. Either reduce the range/offset or "
+             "recompile the kernel with -fsycl-id-queries-range=size_t.";
+    break;
+  case 0:
+  default:
+    ErrMsg =
+        "The kernel was compiled with -fsycl-id-queries-range=int, but the "
+        "provided range/offset exceeds the maximum value storable in an "
+        "int. Either reduce the range/offset or "
+        "recompile the kernel with -fsycl-id-queries-range=[uint|size_t].";
   }
 
-  if (ExceedsMaxRange) {
-    std::string ErrMsg;
-    switch (IdQueriesRange) {
-    case 1:
-      ErrMsg =
-          "The kernel was compiled with -fsycl-id-queries-range=uint, but "
-          "the provided range/offset exceeds the maximum value storable in "
-          "an uint32_t. Either reduce the range/offset or "
-          "recompile the kernel with -fsycl-id-queries-range=size_t.";
-      break;
-    case 0:
-    default:
-      ErrMsg =
-          "The kernel was compiled with -fsycl-id-queries-range=int, but the "
-          "provided range/offset exceeds the maximum value storable in an "
-          "int. Either reduce the range/offset or "
-          "recompile the kernel with -fsycl-id-queries-range=[uint|size_t].";
-    }
-
-    throw detail::set_ur_error(
-        sycl::exception(sycl::make_error_code(sycl::errc::invalid),
-                        ErrMsg.c_str()),
-        UR_RESULT_ERROR_INVALID_VALUE);
-  }
+  throw detail::set_ur_error(
+      sycl::exception(sycl::make_error_code(sycl::errc::invalid),
+                      ErrMsg.c_str()),
+      UR_RESULT_ERROR_INVALID_VALUE);
 }
 
 ur_result_t enqueueImpCommandBufferKernel(
@@ -2828,7 +2830,6 @@ void enqueueImpKernel(
   std::shared_ptr<kernel_impl> SyclKernelImpl;
   device_image_impl *DeviceImageImpl = nullptr;
   FastKernelCacheValPtr KernelCacheVal;
-  uint32_t IdQueryRangeProp = 0;
 
   if (nullptr != MSyclKernel) {
     assert(MSyclKernel->get_info<info::kernel::context>() ==
@@ -2844,12 +2845,6 @@ void enqueueImpKernel(
     // their duplication in such cases.
     KernelMutex = &MSyclKernel->getNoncacheableEnqueueMutex();
     EliminatedArgMask = MSyclKernel->getKernelArgMask();
-
-    if (!MSyclKernel->isInteropOrSourceBased()) {
-      DeviceImageImpl = &MSyclKernel->getDeviceImage();
-      IdQueryRangeProp =
-          DeviceImageImpl->get_bin_image_ref()->getIdQueriesRangeProperties();
-    }
   } else if ((SyclKernelImpl =
                   KernelBundleImplPtr
                       ? KernelBundleImplPtr->tryGetKernel(DeviceKernelInfo.Name)
@@ -2860,9 +2855,6 @@ void enqueueImpKernel(
 
     EliminatedArgMask = SyclKernelImpl->getKernelArgMask();
     KernelMutex = SyclKernelImpl->getCacheMutex();
-
-    IdQueryRangeProp =
-        DeviceImageImpl->get_bin_image_ref()->getIdQueriesRangeProperties();
   } else {
     KernelCacheVal = detail::ProgramManager::getInstance().getOrCreateKernel(
         ContextImpl, DeviceImpl, DeviceKernelInfo, NDRDesc);
@@ -2870,11 +2862,6 @@ void enqueueImpKernel(
     KernelMutex = KernelCacheVal->MMutex;
     Program = KernelCacheVal->MProgramHandle;
     EliminatedArgMask = KernelCacheVal->MKernelArgMask;
-
-    const RTDeviceBinaryImage &DeviceImage =
-        detail::ProgramManager::getInstance().getDeviceImage(
-            DeviceKernelInfo.Name, ContextImpl, DeviceImpl);
-    IdQueryRangeProp = DeviceImage.getIdQueriesRangeProperties();
   }
 
   // We may need more events for the launch, so we make another reference.
@@ -2895,9 +2882,28 @@ void enqueueImpKernel(
     EventsWaitList = std::move(EventsWithDeviceGlobalInits);
   }
 
-  // Get Max number of work groups and linear id range that this kernel can
-  // accept. Skip the check for interop kernels.
-  {
+  // If the kernel was invoked with global range/offset greater than or equal to
+  // INT_MAX, we need to check if the kernel was compiled with
+  // -fsycl-id-queries-range=[uint32_t|size_t] flag.
+  const bool isRangeGreaterThanIntMax = isNDRangeExceedsMaxRange(
+      NDRDesc, static_cast<uint64_t>(std::numeric_limits<int>::max()));
+  if (isRangeGreaterThanIntMax) {
+    uint32_t IdQueryRangeProp = 0;
+
+    // Get device image of kernel and retrieve the id queries range property.
+    if (MSyclKernel != nullptr && !MSyclKernel->isInteropOrSourceBased()) {
+      DeviceImageImpl = &MSyclKernel->getDeviceImage();
+      IdQueryRangeProp =
+          DeviceImageImpl->get_bin_image_ref()->getIdQueriesRangeProperties();
+    } else if (DeviceImageImpl != nullptr) {
+      IdQueryRangeProp =
+          DeviceImageImpl->get_bin_image_ref()->getIdQueriesRangeProperties();
+    } else {
+      const RTDeviceBinaryImage &DeviceImage =
+          detail::ProgramManager::getInstance().getDeviceImage(
+              DeviceKernelInfo.Name, ContextImpl, DeviceImpl);
+      IdQueryRangeProp = DeviceImage.getIdQueriesRangeProperties();
+    }
     // If IdQueryRangeProp property is not present in the device image,
     // it means that the kernel was compiled without -fsycl-id-queries-range
     // option, so use the default range type of `int`.

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2607,7 +2607,7 @@ getCGKernelInfo(const CGExecKernel &CommandGroup, context_impl &ContextImpl,
 // get_global_linear_id can safely return a value within the maximum range.
 // If NDRDesc.GlobalSize[I] is zero, it is treated as valid and does not exceed
 // the range.
-bool isNDRangeExceedsMaxRange(const NDRDescT &NDRDesc, uint64_t MaxRange) {
+static bool isNDRangeExceedsMaxRange(const NDRDescT &NDRDesc, uint64_t MaxRange) {
   uint64_t TotalGlobalSize = 1;
   for (size_t I = 0; I < NDRDesc.Dims; ++I) {
     uint64_t GlobalOffset = NDRDesc.GlobalOffset[I];
@@ -2882,8 +2882,8 @@ void enqueueImpKernel(
     EventsWaitList = std::move(EventsWithDeviceGlobalInits);
   }
 
-  // If the kernel was invoked with global range/offset greater than or equal to
-  // INT_MAX, we need to check if the kernel was compiled with
+  // If the kernel was invoked with global range/offset exceeding INT_MAX, we
+  // need to check if the kernel was compiled with
   // -fsycl-id-queries-range=[uint32_t|size_t] flag.
   const bool isRangeGreaterThanIntMax = isNDRangeExceedsMaxRange(
       NDRDesc, static_cast<uint64_t>(std::numeric_limits<int>::max()));

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2607,7 +2607,8 @@ getCGKernelInfo(const CGExecKernel &CommandGroup, context_impl &ContextImpl,
 // get_global_linear_id can safely return a value within the maximum range.
 // If NDRDesc.GlobalSize[I] is zero, it is treated as valid and does not exceed
 // the range.
-static bool isNDRangeExceedsMaxRange(const NDRDescT &NDRDesc, uint64_t MaxRange) {
+static bool isNDRangeExceedsMaxRange(const NDRDescT &NDRDesc,
+                                     uint64_t MaxRange) {
   uint64_t TotalGlobalSize = 1;
   for (size_t I = 0; I < NDRDesc.Dims; ++I) {
     uint64_t GlobalOffset = NDRDesc.GlobalOffset[I];


### PR DESCRIPTION
Fixes CMPLRLLVM-75858

This PR fixes performance regression after https://github.com/intel/llvm/pull/21979 in kernel submission. The regression was because of us fetching device images to get `idQueriesRange` device image property. However, if a kernel is submitted with global range < `INT_MAX` which is a very common case, we can skip fetching device image and kernel property.
This PR improves kernel submission time by ~6% (on PVC) for PyTorch benchmarks.