### PR TITLE
[SYCL][test] Fix llvm.abs.i64 declaration in filter-non-spirv.ll

### DIFF
--- a/llvm/test/SYCLLowerIR/SYCLRemangleLibspirv/filter-non-spirv.ll
+++ b/llvm/test/SYCLLowerIR/SYCLRemangleLibspirv/filter-non-spirv.ll
@@ -23,7 +23,7 @@ define void @_Z10user_func1Dv4_l(<4 x i64>) { unreachable }
 ; CHECK-DAG: define void @_Z10user_func1Dv4_l(
 
 ; LLVM intrinsic.
-declare i64 @llvm.abs.i64(i64)
+declare i64 @llvm.abs.i64(i64, i1)
 ; CHECK-DAG: declare i64 @llvm.abs.i64(
 
 ; Non-mangled function.


### PR DESCRIPTION
llvm.abs requires 2 args (value, is_int_min_poison i1). The test used a 1-arg form introduced in 563401d956cd. The error was exposed by d5c982fb0ead which moved intrinsic signature verification to declarations.
CMPLRLLVM-76535