### PR TITLE
[SYCL] Remove iostream in favor of iostream_proxy

### DIFF
--- a/sycl/include/sycl/detail/iostream_proxy.hpp
+++ b/sycl/include/sycl/detail/iostream_proxy.hpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <istream> // for ostream, istream
+
+// Hotfix to account for the different namespaces in libstdc++ and libc++
+#ifdef _LIBCPP_BEGIN_NAMESPACE_STD
+_LIBCPP_BEGIN_NAMESPACE_STD
+#else
+namespace std {
+#endif
+
+#if defined(_MSC_VER) && defined(_MT) && defined(_DLL)
+#define __SYCL_EXTERN_STREAM_ATTRS __declspec(dllimport)
+#else
+#define __SYCL_EXTERN_STREAM_ATTRS
+#endif // defined(_MT) && defined(_DLL)
+
+/// Linked to standard input
+extern __SYCL_EXTERN_STREAM_ATTRS istream cin;
+/// Linked to standard output
+extern __SYCL_EXTERN_STREAM_ATTRS ostream cout;
+/// Linked to standard error (unbuffered)
+extern __SYCL_EXTERN_STREAM_ATTRS ostream cerr;
+/// Linked to standard error (buffered)
+extern __SYCL_EXTERN_STREAM_ATTRS ostream clog;
+#undef __SYCL_EXTERN_STREAM_ATTRS
+
+#ifdef _LIBCPP_END_NAMESPACE_STD
+_LIBCPP_END_NAMESPACE_STD
+#else
+} // namespace std
+#endif

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -36,7 +36,7 @@ can be disabled by setting SYCL_DISABLE_FSYCL_SYCLHPP_WARNING macro.")
 // <sycl/sycl.hpp> is not a iostream "provider", however iostream was included
 // in some of SYCL transitive headers. Customers relied on that inclusion, so it
 // should be kept for now and be removed once breaking changes are allowed.
-#include <iostream>
+#include <sycl/detail/iostream_proxy.hpp>
 #endif
 
 // All SYCL macro are provided through this header


### PR DESCRIPTION
In contrast to iostream, iostream_proxy does not include iostream, 
thus it does not bring in the static initialization constructors per TU.

Fixes concerns raised in: #22458 

I reverted the deletion of the file `sycl/include/sycl/detail/iostream_proxy.hpp`. I used the commit: 640a5b4f53c0e5810e0362615da55e94bb286406 to get it.