### PR TITLE
[SYCL] Cleanup the exception class

### DIFF
--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -111,7 +111,7 @@ __SYCL2020_DEPRECATED("The version of an exception constructor which takes "
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   const char *what() const noexcept final;
 #else
-  const char *what() const;
+  const char *what() const noexcept;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   bool has_context() const noexcept;

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -27,6 +27,7 @@ inline namespace _V1 {
 
 // Forward declaration
 class context;
+class exception;
 
 enum class errc : unsigned int {
   success = 0,

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -10,7 +10,9 @@
 
 // 4.9.2 Exception Class Interface
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #include <sycl/detail/export.hpp>             // for __SYCL_EXPORT
 #include <sycl/detail/string.hpp>
 
@@ -25,7 +27,6 @@ inline namespace _V1 {
 
 // Forward declaration
 class context;
-class exception;
 
 enum class errc : unsigned int {
   success = 0,
@@ -68,9 +69,11 @@ exception set_ur_error(exception &&e, int32_t ur_err);
 /// \ingroup sycl_api
 class __SYCL_EXPORT exception : public virtual std::exception {
 public:
-  __SYCL2020_DEPRECATED("The version of an exception constructor which takes "
-                        "no arguments is deprecated.")
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+__SYCL2020_DEPRECATED("The version of an exception constructor which takes "
+  "no arguments is deprecated.")
   exception() = default;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   virtual ~exception();
 
   exception(std::error_code Ec, const char *Msg)
@@ -104,7 +107,11 @@ public:
   const std::error_code &code() const noexcept;
   const std::error_category &category() const noexcept;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   const char *what() const noexcept final;
+#else
+  const char *what() const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   bool has_context() const noexcept;
 

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -111,7 +111,7 @@ public:
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   const char *what() const noexcept final;
 #else
-  const char *what() const noexcept;
+  const char *what() const noexcept override;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   bool has_context() const noexcept;

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -71,8 +71,8 @@ exception set_ur_error(exception &&e, int32_t ur_err);
 class __SYCL_EXPORT exception : public virtual std::exception {
 public:
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-__SYCL2020_DEPRECATED("The version of an exception constructor which takes "
-  "no arguments is deprecated.")
+  __SYCL2020_DEPRECATED("The version of an exception constructor which takes "
+                        "no arguments is deprecated.")
   exception() = default;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
   virtual ~exception();

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -766,7 +766,7 @@ public:
                 exception(make_error_code(Errc), BuildResult->Error.Msg),
                 BuildResult->Error.Code);
           else
-            throw exception();
+            throw exception(make_error_code(Errc));
         }
 
         // NewState == BuildState::BS_Initial

--- a/sycl/source/exception.cpp
+++ b/sycl/source/exception.cpp
@@ -27,15 +27,15 @@ exception::exception(std::error_code EC, std::shared_ptr<context> SharedPtrCtx,
 
 exception::~exception() {}
 
-const std::error_code &exception::code() const noexcept { return MErrC; }
+const std::error_code &exception::code() const { return MErrC; }
 
-const std::error_category &exception::category() const noexcept {
+const std::error_category &exception::category() const {
   return code().category();
 }
 
-const char *exception::what() const noexcept { return MMsg->c_str(); }
+const char *exception::what() const { return MMsg->c_str(); }
 
-bool exception::has_context() const noexcept { return (MContext != nullptr); }
+bool exception::has_context() const { return (MContext != nullptr); }
 
 context exception::get_context() const {
   if (!has_context())
@@ -44,12 +44,12 @@ context exception::get_context() const {
   return *MContext;
 }
 
-const std::error_category &sycl_category() noexcept {
+const std::error_category &sycl_category() {
   static const detail::SYCLCategory SYCLCategoryObj;
   return SYCLCategoryObj;
 }
 
-std::error_code make_error_code(sycl::errc Err) noexcept {
+std::error_code make_error_code(sycl::errc Err) {
   return {static_cast<int>(Err), sycl_category()};
 }
 

--- a/sycl/source/exception.cpp
+++ b/sycl/source/exception.cpp
@@ -27,15 +27,15 @@ exception::exception(std::error_code EC, std::shared_ptr<context> SharedPtrCtx,
 
 exception::~exception() {}
 
-const std::error_code &exception::code() const { return MErrC; }
+const std::error_code &exception::code() const noexcept { return MErrC; }
 
-const std::error_category &exception::category() const {
+const std::error_category &exception::category() const noexcept {
   return code().category();
 }
 
-const char *exception::what() const { return MMsg->c_str(); }
+const char *exception::what() const noexcept { return MMsg->c_str(); }
 
-bool exception::has_context() const { return (MContext != nullptr); }
+bool exception::has_context() const noexcept { return (MContext != nullptr); }
 
 context exception::get_context() const {
   if (!has_context())
@@ -44,12 +44,12 @@ context exception::get_context() const {
   return *MContext;
 }
 
-const std::error_category &sycl_category() {
+const std::error_category &sycl_category() noexcept {
   static const detail::SYCLCategory SYCLCategoryObj;
   return SYCLCategoryObj;
 }
 
-std::error_code make_error_code(sycl::errc Err) {
+std::error_code make_error_code(sycl::errc Err) noexcept {
   return {static_cast<int>(Err), sycl_category()};
 }
 


### PR DESCRIPTION
Prepare undocumented constructor for removal in the next ABI-break window.
Allow what() to be overrided.