### PR TITLE
[SYCL] Remove dead code

### DIFF
--- a/sycl/include/sycl/aspects.hpp
+++ b/sycl/include/sycl/aspects.hpp
@@ -16,13 +16,12 @@ inline namespace _V1 {
 #define __SYCL_ASPECT(ASPECT, ID) ASPECT = ID,
 #define __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE)                          \
   ASPECT __SYCL2020_DEPRECATED(MESSAGE) = ID,
-#define __SYCL_ASPECT_DEPRECATED_ALIAS(ASPECT, ID, MESSAGE)                    \
-  __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE)
+
 enum class __SYCL_TYPE(aspect) aspect {
 #include <sycl/info/aspects.def>
 #include <sycl/info/aspects_deprecated.def>
 };
-#undef __SYCL_ASPECT_DEPRECATED_ALIAS
+
 #undef __SYCL_ASPECT_DEPRECATED
 #undef __SYCL_ASPECT
 

--- a/sycl/include/sycl/device_aspect_traits.hpp
+++ b/sycl/include/sycl/device_aspect_traits.hpp
@@ -13,13 +13,6 @@
 
 #include <type_traits> // for bool_constant
 
-// This macro creates an alias from an aspect to another. To avoid
-// redeclarations, we need to define it empty for this file, otherwise we would
-// have multiple declarations of `any_device_has` and `all_devices_have`, one
-// for the original declaration of the aspect, and a subsequent one when finding
-// the alias.
-#define __SYCL_ASPECT_DEPRECATED_ALIAS(ASPECT, ID, MESSAGE)
-
 namespace sycl {
 template <aspect Aspect> struct all_devices_have;
 
@@ -73,5 +66,3 @@ constexpr bool all_devices_have_v = all_devices_have<Aspect>::value;
 template <aspect Aspect>
 constexpr bool any_device_has_v = any_device_has<Aspect>::value;
 } // namespace sycl
-
-#undef __SYCL_ASPECT_DEPRECATED_ALIAS

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -3033,9 +3033,6 @@ static std::string getAspectNameStr(sycl::aspect AspectNum) {
   case aspect::ASPECT:                                                         \
     return #ASPECT;
 #define __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE) __SYCL_ASPECT(ASPECT, ID)
-// We don't need "case aspect::usm_allocator" here because it will duplicate
-// "case aspect::usm_system_allocations", therefore leave this macro empty
-#define __SYCL_ASPECT_DEPRECATED_ALIAS(ASPECT, ID, MESSAGE)
   switch (AspectNum) {
 #include <sycl/info/aspects.def>
 #include <sycl/info/aspects_deprecated.def>
@@ -3043,7 +3040,6 @@ static std::string getAspectNameStr(sycl::aspect AspectNum) {
   throw sycl::exception(errc::kernel_not_supported,
                         "Unknown aspect " +
                             std::to_string(static_cast<unsigned>(AspectNum)));
-#undef __SYCL_ASPECT_DEPRECATED_ALIAS
 #undef __SYCL_ASPECT_DEPRECATED
 #undef __SYCL_ASPECT
 }

--- a/sycl/test-e2e/Basic/device_config_file_consistency.cpp
+++ b/sycl/test-e2e/Basic/device_config_file_consistency.cpp
@@ -22,9 +22,6 @@
 #include <llvm/SYCLLowerIR/DeviceConfigFile.hpp>
 #include <sycl/detail/core.hpp>
 
-#define __SYCL_ASPECT_DEPRECATED_ALIAS(ASPECT, ID, MESSAGE)                    \
-  __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE)
-
 using namespace sycl;
 
 const char *getArchName(const device &Device) {
@@ -143,5 +140,3 @@ int main() {
 
   return 0;
 }
-
-#undef __SYCL_ASPECT_DEPRECATED_ALIAS

--- a/sycl/test/basic_tests/device_config_file_aspects.cpp
+++ b/sycl/test/basic_tests/device_config_file_aspects.cpp
@@ -7,9 +7,6 @@
 #include <llvm/SYCLLowerIR/DeviceConfigFile.hpp>
 #include <sycl/sycl.hpp>
 
-#define __SYCL_ASPECT_DEPRECATED_ALIAS(ASPECT, ID, MESSAGE)                    \
-  __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE)
-
 int main() {
   auto testAspects = DeviceConfigFile::TargetTable.find("__TestAspectList");
   assert(testAspects != DeviceConfigFile::TargetTable.end());
@@ -37,5 +34,3 @@ int main() {
 
 #undef __SYCL_ASPECT_DEPRECATED
 }
-
-#undef __SYCL_ASPECT_DEPRECATED_ALIAS

--- a/sycl/unittests/SYCL2020/DeviceAspectTraits.cpp
+++ b/sycl/unittests/SYCL2020/DeviceAspectTraits.cpp
@@ -12,9 +12,6 @@
 
 #include <gtest/gtest.h>
 
-#define __SYCL_ASPECT_DEPRECATED_ALIAS(ASPECT, ID, MESSAGE)                    \
-  __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE)
-
 TEST(DeviceAspectTraits, AnyDeviceHasAspect) {
 #define __SYCL_ASPECT(ASPECT, ASPECT_VAL)                                      \
   constexpr bool CheckAnyDeviceHas##ASPECT =                                   \
@@ -53,5 +50,3 @@ TEST(DeviceAspectTraits, AllDevicesHaveAspect) {
 
 #undef __SYCL_ASPECT_DEPRECATED
 }
-
-#undef __SYCL_ASPECT_DEPRECATED_ALIAS


### PR DESCRIPTION
__SYCL_ASPECT_DEPRECATED_ALIAS was removed a long time ago in https://github.com/intel/llvm/pull/13279