### PR TITLE
[SYCL][CUDA][E2E] Disable tests failing on CUDA 13

### DIFF
--- a/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
@@ -1,5 +1,9 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17339
+
+// UNSUPPORTED: target-nvidia
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21806
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // XFAIL: spirv-backend

--- a/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
@@ -1,7 +1,7 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17339
 
-// UNSUPPORTED: target-nvidia
+// UNSUPPORTED: cuda-ge-13
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21806
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -3,7 +3,7 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-INTENDED: Returning non-FP values from sampling fails on HIP.
 
-// UNSUPPORTED: target-nvidia
+// UNSUPPORTED: cuda-ge-13
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21807
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -3,6 +3,9 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED-INTENDED: Returning non-FP values from sampling fails on HIP.
 
+// UNSUPPORTED: target-nvidia
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21807
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
@@ -2,7 +2,7 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan
 
-// UNSUPPORTED: target-nvidia
+// UNSUPPORTED: cuda-ge-13
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21808
 
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
@@ -2,6 +2,9 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import || (windows && level_zero && aspect-ext_oneapi_bindless_images)
 // REQUIRES: vulkan
 
+// UNSUPPORTED: target-nvidia
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21808
+
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 
 /*

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
@@ -6,6 +6,9 @@
 // UNSUPPORTED: windows
 // UNSUPPORTED-TRACKER: CMPLRLLVM-73525
 
+// UNSUPPORTED: target-nvidia
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21808
+
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 
 /*

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: windows
 // UNSUPPORTED-TRACKER: CMPLRLLVM-73525
 
-// UNSUPPORTED: target-nvidia
+// UNSUPPORTED: cuda-ge-13
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21808
 
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -8,6 +8,7 @@ import subprocess
 import textwrap
 import shlex
 import shutil
+import json
 
 import lit.formats
 import lit.util
@@ -808,6 +809,24 @@ if "cuda:gpu" in config.sycl_devices:
     else:
         config.cuda_libs_dir = os.path.join(os.environ["CUDA_PATH"], r"lib64")
         config.cuda_include = os.path.join(os.environ["CUDA_PATH"], "include")
+
+    # Detect CUDA version and add version-specific features for conditional test execution
+    cuda_version_json = os.path.join(os.environ["CUDA_PATH"], "version.json")
+    if os.path.exists(cuda_version_json):
+        try:
+            with open(cuda_version_json, 'r') as f:
+                version_data = json.load(f)
+                cuda_version_str = version_data.get("cuda", {}).get("version", "")
+                if cuda_version_str:
+                    major = int(cuda_version_str.split('.')[0])
+                    MIN_CUDA_VERSION = 11  # Minimum CUDA version supported by SYCL
+
+                    for version in range(MIN_CUDA_VERSION, major + 1):
+                        config.available_features.add(f"cuda-ge-{version}")
+
+                    lit_config.note(f"CUDA {cuda_version_str}: added features cuda-ge-{MIN_CUDA_VERSION}..cuda-ge-{major}")
+        except (json.JSONDecodeError, IOError, ValueError, KeyError) as e:
+            lit_config.warning(f"Failed to parse CUDA version from {cuda_version_json}: {e}")
 
 config.substitutions.append(("%threads_lib", config.sycl_threads_lib))
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -814,19 +814,23 @@ if "cuda:gpu" in config.sycl_devices:
     cuda_version_json = os.path.join(os.environ["CUDA_PATH"], "version.json")
     if os.path.exists(cuda_version_json):
         try:
-            with open(cuda_version_json, 'r') as f:
+            with open(cuda_version_json, "r") as f:
                 version_data = json.load(f)
                 cuda_version_str = version_data.get("cuda", {}).get("version", "")
                 if cuda_version_str:
-                    major = int(cuda_version_str.split('.')[0])
+                    major = int(cuda_version_str.split(".")[0])
                     MIN_CUDA_VERSION = 11  # Minimum CUDA version supported by SYCL
 
                     for version in range(MIN_CUDA_VERSION, major + 1):
                         config.available_features.add(f"cuda-ge-{version}")
 
-                    lit_config.note(f"CUDA {cuda_version_str}: added features cuda-ge-{MIN_CUDA_VERSION}..cuda-ge-{major}")
+                    lit_config.note(
+                        f"CUDA {cuda_version_str}: added features cuda-ge-{MIN_CUDA_VERSION}..cuda-ge-{major}"
+                    )
         except (json.JSONDecodeError, IOError, ValueError, KeyError) as e:
-            lit_config.warning(f"Failed to parse CUDA version from {cuda_version_json}: {e}")
+            lit_config.warning(
+                f"Failed to parse CUDA version from {cuda_version_json}: {e}"
+            )
 
 config.substitutions.append(("%threads_lib", config.sycl_threads_lib))
 


### PR DESCRIPTION
After enabling CUDA 13 workflow (see https://github.com/intel/llvm/pull/21564) few tests are failing sporadically: 
- WorkGroupMemory/basic_usage.cpp
- bindless_images/read_sampled.cpp
- bindless_images/vulkan_interop/vulkan_sycl_image_interop_read_1d.cpp
- bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp

This PR implements CUDA version detection in LIT configuration and conditionally disables these 4 tests on CUDA 13+.

Tracked in:
- #21806 
- #21807 
- #21808 