### PR TITLE
[SYCL][SYCLBIN] Fix native-AOT object-state cross-library link

### DIFF
--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -772,6 +772,19 @@ public:
         SYCLBIN->getBestCompatibleImages(Devs, State);
     MDeviceImages.reserve(BestImages.size());
     auto &PM = ProgramManager::getInstance();
+    // Reconcile an image's intrinsic classification with the state the SYCLBIN
+    // was loaded in. An export-only native AOT library classifies as
+    // executable but is surfaced for an object-state load so it can act as the
+    // provider side of a cross-library link; such an image must not be
+    // presented as already-linked. Only downgrade executable -> object for an
+    // object-state load; leave every other combination at the intrinsic state.
+    auto ReconcileState = [](bundle_state ImageState,
+                             bundle_state RequestedState) {
+      if (ImageState == bundle_state::executable &&
+          RequestedState == bundle_state::object)
+        return bundle_state::object;
+      return ImageState;
+    };
     for (const detail::RTDeviceBinaryImage *Image : BestImages) {
       // Build per-image kernel-id list from the [SYCL/kernel names] property
       // set so that the C++ kernel_id-based APIs (has_kernel<K>(),
@@ -788,14 +801,8 @@ public:
           KernelIDs->push_back(*MaybeID);
       std::sort(KernelIDs->begin(), KernelIDs->end(), LessByHash<kernel_id>{});
 
-      // The image's intrinsic classification may be "ahead" of the state the
-      // SYCLBIN was loaded in: an export-only native AOT library classifies as
-      // executable but is surfaced here for an object-state load so it can act
-      // as the provider side of a cross-library link. Clamp the created image
-      // to the requested state (the SYCLBIN's declared state, already
-      // validated above) so it is not mistaken for an already-linked image.
       const bundle_state ImgState =
-          std::min(ProgramManager::getBinImageState(Image), State);
+          ReconcileState(ProgramManager::getBinImageState(Image), State);
       MDeviceImages.emplace_back(device_image_impl::create(
           Image, Context, Devs, ImgState, std::move(KernelIDs),
           Managed<ur_program_handle_t>{}, ImageOriginSYCLBIN));

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -523,10 +523,16 @@ public:
       }();
 
       // If there AOT binaries, the link should allow unresolved symbols.
+      // Only invoke the JIT link (urProgramLinkExp) when there is at least one
+      // JIT image; an AOT-only link (e.g. cross-library link of native AOT
+      // object SYCLBINs) has no SPIR-V to link and passing an empty program
+      // list to urProgramLinkExp is invalid. The AOT images are handled by the
+      // dynamicLink path below.
       std::vector<device_image_plain> LinkedResults =
-          detail::ProgramManager::getInstance().link(
-              JITImgs, GraphDevs, PropList,
-              /*AllowUnresolvedSymbols=*/!AOTImgs.empty());
+          JITImgs.empty() ? std::vector<device_image_plain>{}
+                          : detail::ProgramManager::getInstance().link(
+                                JITImgs, GraphDevs, PropList,
+                                /*AllowUnresolvedSymbols=*/!AOTImgs.empty());
 
       if (!AOTImgs.empty()) {
         // urProgramLinkExp's ze_module_program_exp_desc_t carries a single
@@ -782,10 +788,17 @@ public:
           KernelIDs->push_back(*MaybeID);
       std::sort(KernelIDs->begin(), KernelIDs->end(), LessByHash<kernel_id>{});
 
+      // The image's intrinsic classification may be "ahead" of the state the
+      // SYCLBIN was loaded in: an export-only native AOT library classifies as
+      // executable but is surfaced here for an object-state load so it can act
+      // as the provider side of a cross-library link. Clamp the created image
+      // to the requested state (the SYCLBIN's declared state, already
+      // validated above) so it is not mistaken for an already-linked image.
+      const bundle_state ImgState =
+          std::min(ProgramManager::getBinImageState(Image), State);
       MDeviceImages.emplace_back(device_image_impl::create(
-          Image, Context, Devs, ProgramManager::getBinImageState(Image),
-          std::move(KernelIDs), Managed<ur_program_handle_t>{},
-          ImageOriginSYCLBIN));
+          Image, Context, Devs, ImgState, std::move(KernelIDs),
+          Managed<ur_program_handle_t>{}, ImageOriginSYCLBIN));
     }
     ProgramManager::getInstance().bringSYCLDeviceImagesToState(MDeviceImages,
                                                                State);

--- a/sycl/source/detail/syclbin.cpp
+++ b/sycl/source/detail/syclbin.cpp
@@ -904,10 +904,25 @@ SYCLBINBinaries::getBestCompatibleImages(device_impl &Dev, bundle_state State) {
     // non-executable requests, which made AOT-only object SYCLBINs
     // (produced via -fsyclbin=object with an AOT target) load as an empty
     // kernel_bundle and broke any subsequent sycl::link.
+    //
+    // Additionally, a native AOT image that only exports symbols (and imports
+    // none) classifies as executable, but it is still a library meant to be
+    // linked into: it must be loadable in object state so it can act as the
+    // provider side of a cross-library sycl::link. Surface such an image for
+    // an object-state request as well. The importing side still resolves its
+    // exported symbols via CreateLinkGraph, which reads the exported-symbol
+    // metadata directly and is independent of the image's classified state.
     if (const RTDeviceBinaryImage *Native =
-            FindCompatible(AMDesc.NativeBinaries, AMDesc.NumNativeBinaries);
-        Native && ProgramManager::getBinImageState(Native) == State)
-      Images.push_back(Native);
+            FindCompatible(AMDesc.NativeBinaries, AMDesc.NumNativeBinaries)) {
+      const bool StateMatches =
+          ProgramManager::getBinImageState(Native) == State;
+      const bool ExportOnlyLibForObject =
+          State == bundle_state::object &&
+          !Native->getExportedSymbols().empty() &&
+          Native->getImportedSymbols().empty();
+      if (StateMatches || ExportOnlyLibForObject)
+        Images.push_back(Native);
+    }
   }
   return Images;
 }

--- a/sycl/test-e2e/SYCLBIN/link_object_aot.cpp
+++ b/sycl/test-e2e/SYCLBIN/link_object_aot.cpp
@@ -1,0 +1,41 @@
+// REQUIRES: ocloc
+// REQUIRES: level_zero
+// REQUIRES: aspect-usm_shared_allocations
+
+// UNSUPPORTED: cuda, hip, cpu, opencl
+// UNSUPPORTED-INTENDED: CUDA and HIP targets produce only native device
+// binaries and can therefore not produce object-state SYCLBIN files. The
+// CPU device cannot consume the spir64_gen AOT image produced by this test.
+// Native-AOT cross-image link is currently only plumbed for Level Zero (via
+// the -library-compilation compile flag / zeModuleDynamicLink); the OpenCL
+// CPU/GPU AOT cross-image link uses a different mechanism (-create-library)
+// that is not yet implemented, so all OpenCL devices are excluded.
+
+// -- Link two AOT-only object-state SYCLBINs. Unlike link_object.cpp (JIT
+// -- spir64) this compiles for a native AOT target (spir64_gen), so the
+// -- object-state bundles carry native device code images with unresolved
+// -- imported symbols rather than SPIR-V. sycl::link must then route these
+// -- through the native-AOT partition in kernel_bundle_impl (they cannot go
+// -- through urProgramLinkExp, which requires SPIR-V): each AOT image is
+// -- built independently with ALLOW_UNRESOLVED_SYMBOLS via
+// -- ProgramManager::build and the cross-image references are resolved by
+// -- dynamicLink(). Regression coverage for #22196 (CMPLRLLVM-75983).
+//
+// -- The exporting bundle provides TestFunc; the importing bundle defines
+// -- TestKernel1 which imports it. Linking both and launching TestKernel1
+// -- exercises the full AOT object-state link-and-run path.
+
+// RUN: %clangxx --offload-new-driver -fsyclbin=object \
+// RUN:   -fsycl-targets=spir64_gen \
+// RUN:   -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts \
+// RUN:   %S/Inputs/exporting_function.cpp -o %t.export.syclbin
+// RUN: %clangxx --offload-new-driver -fsyclbin=object \
+// RUN:   -fsycl-targets=spir64_gen \
+// RUN:   -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts \
+// RUN:   %S/Inputs/importing_kernel.cpp -o %t.import.syclbin
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out %t.export.syclbin %t.import.syclbin
+
+#define SYCLBIN_OBJECT_STATE
+
+#include "Inputs/link.hpp"

--- a/sycl/unittests/helpers/RuntimeLinkingCommon.hpp
+++ b/sycl/unittests/helpers/RuntimeLinkingCommon.hpp
@@ -20,6 +20,7 @@ struct LinkingCapturesHolder {
 
   void clear() {
     NumOfUrProgramCreateCalls = 0;
+    NumOfUrProgramCreateWithBinaryCalls = 0;
     NumOfUrProgramLinkCalls = 0;
     ProgramUsedToCreateKernel = 0;
     LinkedPrograms.clear();

--- a/sycl/unittests/program_manager/AOTBinaryTarget.cpp
+++ b/sycl/unittests/program_manager/AOTBinaryTarget.cpp
@@ -1,0 +1,130 @@
+//==------------------- AOTBinaryTarget.cpp --------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for the native-AOT image classifiers added alongside the
+// object-state SYCLBIN load fix (see program_manager.cpp):
+//   - ProgramManager::isAOTBinaryTarget
+//   - ProgramManager::getBinImageState
+// Both are pure, static, and hardware-independent, so they can be exercised
+// directly without a UR mock. getBinImageState is what the SYCLBIN selector
+// and the kernel_bundle AOT partition rely on to agree on an image's state.
+//
+//===----------------------------------------------------------------------===//
+
+#include <detail/compiler.hpp>
+#include <detail/device_binary_image.hpp>
+#include <detail/program_manager/program_manager.hpp>
+
+#include <helpers/MockDeviceImage.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace sycl;
+
+namespace {
+
+// Build a MockPropertySet carrying an optional "imported symbols" set (its
+// presence marks a native-AOT image as still needing a link).
+unittest::MockPropertySet
+makePropSet(const std::vector<std::string> &ImportedSymbols) {
+  unittest::MockPropertySet PropSet;
+  if (!ImportedSymbols.empty()) {
+    std::vector<unittest::MockProperty> Props;
+    for (const std::string &Sym : ImportedSymbols) {
+      std::vector<char> Storage(sizeof(uint32_t), 0);
+      Props.emplace_back(Sym, Storage, SYCL_PROPERTY_TYPE_UINT32);
+    }
+    PropSet.insert(__SYCL_PROPERTY_SET_SYCL_IMPORTED_SYMBOLS, std::move(Props));
+  }
+  return PropSet;
+}
+
+// Build a real RTDeviceBinaryImage from a MockDeviceImage so we can query
+// getBinImageState/getImportedSymbols on it.
+//
+// MockDeviceImage's native handle stores raw pointers into the mock's own
+// string members, so the mock must not be moved after construction (a move
+// would leave those pointers dangling). We therefore construct the mock in
+// place inside the holder and rely on guaranteed copy elision (C++17 prvalue
+// return) so the holder itself is never moved after MImage captures &MStruct.
+class ImageHolder {
+public:
+  ImageHolder(const char *TargetSpec, sycl::detail::ur::DeviceBinaryType Format,
+              const std::vector<std::string> &ImportedSymbols)
+      : MMock(static_cast<uint8_t>(Format), TargetSpec,
+              /*CompileOptions=*/"", /*LinkOptions=*/"",
+              std::vector<unsigned char>{0},
+              unittest::makeEmptyKernels({"AOTBinaryTargetKernel"}),
+              makePropSet(ImportedSymbols)),
+        MStruct(MMock.convertToNativeType()), MImage(&MStruct) {}
+
+  ImageHolder(ImageHolder &&) = delete;
+  ImageHolder(const ImageHolder &) = delete;
+
+  const detail::RTDeviceBinaryImage &image() const { return MImage; }
+
+private:
+  unittest::MockDeviceImage MMock;
+  sycl_device_binary_struct MStruct;
+  detail::RTDeviceBinaryImage MImage;
+};
+
+} // namespace
+
+TEST(AOTBinaryTarget, IsAOTBinaryTarget) {
+  // Null spec must not dereference.
+  EXPECT_FALSE(detail::ProgramManager::isAOTBinaryTarget(nullptr));
+
+  // The two native-AOT targets.
+  EXPECT_TRUE(detail::ProgramManager::isAOTBinaryTarget(
+      __SYCL_DEVICE_BINARY_TARGET_SPIRV64_GEN));
+  EXPECT_TRUE(detail::ProgramManager::isAOTBinaryTarget(
+      __SYCL_DEVICE_BINARY_TARGET_SPIRV64_X86_64));
+
+  // JIT SPIR-V and every non-native-AOT target must be excluded, otherwise the
+  // kernel_bundle partition would route SPIR-V through the AOT dynamic-link
+  // path and break urProgramLinkExp.
+  EXPECT_FALSE(detail::ProgramManager::isAOTBinaryTarget(
+      __SYCL_DEVICE_BINARY_TARGET_SPIRV64));
+  EXPECT_FALSE(detail::ProgramManager::isAOTBinaryTarget(
+      __SYCL_DEVICE_BINARY_TARGET_SPIRV32));
+  EXPECT_FALSE(detail::ProgramManager::isAOTBinaryTarget(
+      __SYCL_DEVICE_BINARY_TARGET_NVPTX64));
+  EXPECT_FALSE(detail::ProgramManager::isAOTBinaryTarget(
+      __SYCL_DEVICE_BINARY_TARGET_AMDGCN));
+  EXPECT_FALSE(detail::ProgramManager::isAOTBinaryTarget(
+      __SYCL_DEVICE_BINARY_TARGET_NATIVE_CPU));
+  EXPECT_FALSE(detail::ProgramManager::isAOTBinaryTarget(
+      __SYCL_DEVICE_BINARY_TARGET_UNKNOWN));
+}
+
+TEST(AOTBinaryTarget, GetBinImageStateNonAOT) {
+  // A JIT SPIR-V image is always in the input state regardless of symbols.
+  ImageHolder JIT{__SYCL_DEVICE_BINARY_TARGET_SPIRV64,
+                  SYCL_DEVICE_BINARY_TYPE_SPIRV, /*ImportedSymbols=*/{"Dep"}};
+  EXPECT_EQ(detail::ProgramManager::getBinImageState(&JIT.image()),
+            bundle_state::input);
+}
+
+TEST(AOTBinaryTarget, GetBinImageStateAOTNoImports) {
+  // A native-AOT image with no imported symbols is already executable.
+  ImageHolder AOT{__SYCL_DEVICE_BINARY_TARGET_SPIRV64_GEN,
+                  SYCL_DEVICE_BINARY_TYPE_NATIVE, /*ImportedSymbols=*/{}};
+  EXPECT_EQ(detail::ProgramManager::getBinImageState(&AOT.image()),
+            bundle_state::executable);
+}
+
+TEST(AOTBinaryTarget, GetBinImageStateAOTWithImports) {
+  // A native-AOT image carrying imported symbols still needs a link, so it is
+  // classified as object. This is the exact case the SYCLBIN selector fix
+  // relies on: an AOT-only object SYCLBIN loaded as bundle_state::object.
+  ImageHolder AOT{__SYCL_DEVICE_BINARY_TARGET_SPIRV64_GEN,
+                  SYCL_DEVICE_BINARY_TYPE_NATIVE, /*ImportedSymbols=*/{"Dep"}};
+  EXPECT_EQ(detail::ProgramManager::getBinImageState(&AOT.image()),
+            bundle_state::object);
+}

--- a/sycl/unittests/program_manager/CMakeLists.txt
+++ b/sycl/unittests/program_manager/CMakeLists.txt
@@ -10,6 +10,7 @@ add_sycl_unittest(ProgramManagerTests OBJECT
   passing_link_and_compile_options.cpp
   Cleanup.cpp
   MultipleDevsKernelBundle.cpp
+  AOTBinaryTarget.cpp
 )
 endif()
 

--- a/sycl/unittests/program_manager/DynamicLinking/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking/DynamicLinking.cpp
@@ -1,6 +1,7 @@
 #include <sycl/sycl.hpp>
 
 #include <detail/device_image_impl.hpp>
+#include <detail/program_manager/program_manager.hpp>
 #include <helpers/MockDeviceImage.hpp>
 #include <helpers/MockKernelInfo.hpp>
 #include <helpers/RuntimeLinkingCommon.hpp>
@@ -502,5 +503,144 @@ TEST(DynamicLinking, KernelBundleSpecConstsBuild) {
   runSpecConstChecksUnlinked(InputKB);
   sycl::kernel_bundle BuiltKB = sycl::build(InputKB);
   runSpecConstChecksLinked(BuiltKB);
+}
+
+// Extract the single object-state device image for the given kernel from an
+// object-state bundle. Native-AOT images with imported symbols are classified
+// by getBinImageState as bundle_state::object, so they are the images that
+// ProgramManager::build must accept with AllowUnresolvedSymbols set.
+static sycl::detail::device_image_plain
+getObjectImage(sycl::queue &Q, const sycl::kernel_id &KernelID) {
+  sycl::kernel_bundle ObjectKB =
+      sycl::get_kernel_bundle<sycl::bundle_state::object>(Q.get_context(),
+                                                          {KernelID});
+  auto It = std::find_if(ObjectKB.begin(), ObjectKB.end(), [&](auto Image) {
+    return Image.has_kernel(KernelID);
+  });
+  EXPECT_NE(It, ObjectKB.end());
+  return *It;
+}
+
+// ProgramManager::build with AllowUnresolvedSymbols builds a native-AOT object
+// image while keeping its imported references unresolved (ready for a later
+// dynamicLink). This is the path kernel_bundle_impl uses for AOT object
+// SYCLBINs. Verify the build succeeds and that the AllowUnresolvedSymbols bit
+// participates in the program-cache key, so an unresolved-symbols build and a
+// normal build of the same image do not collide.
+TEST(DynamicLinking, AOTObjectBuildAllowUnresolvedSymbols) {
+  sycl::unittest::UrMock<> Mock;
+  setupRuntimeLinkingMock();
+
+  sycl::platform Plt = sycl::platform();
+  sycl::queue Q(Plt.get_devices()[0]);
+  sycl::detail::device_impl &DevImpl =
+      *sycl::detail::getSyclObjImpl(Plt.get_devices()[0]);
+
+  CapturedLinkingData.clear();
+
+  auto &PM = sycl::detail::ProgramManager::getInstance();
+
+  // Build once with unresolved symbols allowed (the AOT-object-link path)...
+  sycl::detail::device_image_plain AOTImg = getObjectImage(
+      Q, sycl::get_kernel_id<DynamicLinkingTest::AOTCaseKernel>());
+  sycl::detail::device_image_plain Built =
+      PM.build(sycl::detail::DevImgPlainWithDeps{AOTImg},
+               sycl::detail::devices_range{DevImpl},
+               /*PropList=*/{}, /*AllowUnresolvedSymbols=*/true);
+  EXPECT_EQ(sycl::detail::getSyclObjImpl(Built)->get_state(),
+            sycl::bundle_state::executable);
+  ASSERT_EQ(CapturedLinkingData.NumOfUrProgramCreateWithBinaryCalls, 1u);
+
+  // ...and again without. The AllowUnresolvedSymbols bit is part of the cache
+  // key, so this must trigger a second urProgramCreateWithBinary rather than
+  // hitting the cached unresolved-symbols entry.
+  sycl::detail::device_image_plain AOTImg2 = getObjectImage(
+      Q, sycl::get_kernel_id<DynamicLinkingTest::AOTCaseKernel>());
+  sycl::detail::device_image_plain Built2 =
+      PM.build(sycl::detail::DevImgPlainWithDeps{AOTImg2},
+               sycl::detail::devices_range{DevImpl},
+               /*PropList=*/{}, /*AllowUnresolvedSymbols=*/false);
+  EXPECT_EQ(sycl::detail::getSyclObjImpl(Built2)->get_state(),
+            sycl::bundle_state::executable);
+  ASSERT_EQ(CapturedLinkingData.NumOfUrProgramCreateWithBinaryCalls, 2u);
+}
+
+// When the adapter does not implement urProgramBuildExp, the
+// ALLOW_UNRESOLVED_SYMBOLS flag cannot be carried by the non-Exp build entry
+// point, so an AllowUnresolvedSymbols build must fail loudly with
+// feature_not_supported rather than silently drop the requested semantics.
+static ur_result_t redefined_urProgramBuildExpUnsupported(void *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+TEST(DynamicLinking, AOTObjectBuildNoBuildExp) {
+  sycl::unittest::UrMock<> Mock;
+  setupRuntimeLinkingMock();
+  mock::getCallbacks().set_replace_callback(
+      "urProgramBuildExp", redefined_urProgramBuildExpUnsupported);
+
+  sycl::platform Plt = sycl::platform();
+  sycl::queue Q(Plt.get_devices()[0]);
+  sycl::detail::device_impl &DevImpl =
+      *sycl::detail::getSyclObjImpl(Plt.get_devices()[0]);
+
+  CapturedLinkingData.clear();
+
+  auto &PM = sycl::detail::ProgramManager::getInstance();
+  sycl::detail::device_image_plain AOTImg = getObjectImage(
+      Q, sycl::get_kernel_id<DynamicLinkingTest::AOTCaseKernel>());
+
+  try {
+    PM.build(sycl::detail::DevImgPlainWithDeps{AOTImg},
+             sycl::detail::devices_range{DevImpl}, /*PropList=*/{},
+             /*AllowUnresolvedSymbols=*/true);
+    FAIL() << "Expected feature_not_supported exception";
+  } catch (sycl::exception &e) {
+    EXPECT_EQ(e.code(), sycl::errc::feature_not_supported);
+  }
+}
+
+// Same feature_not_supported guard, but on the link entry point rather than
+// the build entry point. When the image has dependencies, getBuiltURProgram
+// populates ProgramsToLink, so build() takes the compile-and-link path and
+// reaches urProgramLinkExp. If that returns UNSUPPORTED_FEATURE while
+// AllowUnresolvedSymbols is set, the non-Exp urProgramLink cannot carry the
+// flag, so build() must throw feature_not_supported rather than silently
+// dropping the requested semantics.
+static ur_result_t redefined_urProgramLinkExpUnsupported(void *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+TEST(DynamicLinking, AOTObjectBuildNoLinkExp) {
+  sycl::unittest::UrMock<> Mock;
+  setupRuntimeLinkingMock();
+  mock::getCallbacks().set_replace_callback(
+      "urProgramLinkExp", redefined_urProgramLinkExpUnsupported);
+
+  sycl::platform Plt = sycl::platform();
+  sycl::queue Q(Plt.get_devices()[0]);
+  sycl::detail::device_impl &DevImpl =
+      *sycl::detail::getSyclObjImpl(Plt.get_devices()[0]);
+
+  CapturedLinkingData.clear();
+
+  auto &PM = sycl::detail::ProgramManager::getInstance();
+  // A two-image bundle: the AOT image plus a dependency entry. Only the
+  // presence of a dependency matters here - it makes getBuiltURProgram
+  // populate ProgramsToLink, which forces build() down the compile-and-link
+  // path that reaches urProgramLinkExp. The same object image is reused as
+  // its own dependency to keep the test self-contained.
+  sycl::detail::device_image_plain MainImg = getObjectImage(
+      Q, sycl::get_kernel_id<DynamicLinkingTest::AOTCaseKernel>());
+  std::vector<sycl::detail::device_image_plain> ImgAndDep{MainImg, MainImg};
+
+  try {
+    PM.build(sycl::detail::DevImgPlainWithDeps{std::move(ImgAndDep)},
+             sycl::detail::devices_range{DevImpl}, /*PropList=*/{},
+             /*AllowUnresolvedSymbols=*/true);
+    FAIL() << "Expected feature_not_supported exception";
+  } catch (sycl::exception &e) {
+    EXPECT_EQ(e.code(), sycl::errc::feature_not_supported);
+  }
 }
 } // anonymous namespace


### PR DESCRIPTION
## Fix native-AOT object-state cross-library link

Loading an AOT-only object-state SYCLBIN and linking it via `sycl::link`
did not work end to end. #22196 enabled the importer-side object load
(and shipped a load-only e2e), but a full cross-library link of native
AOT objects hit three defects, none covered by that load-only test.

### Bugs fixed
1. **Export-only AOT library not loadable as `object`.**
   `SYCLBINBinaries::getBestCompatibleImages` gated the native-image
   fallback on `getBinImageState(img) == State`. An export-only library
   imports nothing, so it classifies as `executable` and was dropped for
   an `object` request .

2. **Assertion on loaded image state.** The SYCLBIN loader stamped the
   image with its intrinsic state (`executable`), tripping
   `DevImageState == bundle_state::object` in
   `bringSYCLDeviceImageToState`. The created image is now clamped to the
   requested (already-validated) declared state.

3. **Segfault on AOT-only link.** `kernel_bundle_impl::link` always
   invoked `ProgramManager::link` on the JIT image set; for an AOT-only
   link that set is empty, so `urProgramLinkExp` was called with zero
   programs and segfaulted in the L0 adapter. The JIT link is now skipped
   when there are no JIT images; AOT images are resolved via
   `dynamicLink`.

### Tests
- **e2e** `SYCLBIN/link_object_aot.cpp` — cross-library link of two
  AOT-only object SYCLBINs on Level Zero (spir64_gen). Exercises the AOT
  partition, `ProgramManager::build` with `AllowUnresolvedSymbols`, and
  `dynamicLink`. Restricted to L0 (`REQUIRES: level_zero, ocloc`); 
- **unit** `AOTBinaryTarget.cpp` — `isAOTBinaryTarget` and
  `getBinImageState` classifiers.
- **unit** `DynamicLinking.cpp` — `build` with `AllowUnresolvedSymbols`
  (happy path + program-cache-key bool), and `feature_not_supported`
  guards on the build and link entry points when the adapter lacks the
  Exp variants.
- Fixed `RuntimeLinkingCommon::clear()` to reset the
  CreateWithBinary counter (latent; exposed under `--gtest_shuffle`).
