### PR TITLE
[SYCL][KHR-SPLIT-HEADERS] Add async handler on exception.hpp

### DIFF
--- a/sycl/include/sycl/khr/split_headers/exception.hpp
+++ b/sycl/include/sycl/khr/split_headers/exception.hpp
@@ -11,6 +11,7 @@
 
 #include "version.hpp"
 
+#include <sycl/async_handler.hpp>
 #include <sycl/exception.hpp>
 #include <sycl/exception_list.hpp>
 


### PR DESCRIPTION
Aligns khr/split-headers/exception.hpp with the active KHR.