### PR TITLE
[SYCL][KHR-SPLIT-HEADERS] Add pointer to multi-ptr

### DIFF
--- a/sycl/include/sycl/khr/split_headers/multi_ptr.hpp
+++ b/sycl/include/sycl/khr/split_headers/multi_ptr.hpp
@@ -12,5 +12,6 @@
 #include "version.hpp"
 
 #include <sycl/multi_ptr.hpp>
+#include <sycl/pointers.hpp>
 
 #endif // __SYCL_KHR_SPLIT_HEADERS_MULTI_PTR


### PR DESCRIPTION
The split headers KHR requires the multi_ptr to provide "pointers" such as `decorated_private_ptr`. I add pointer.hpp to multiptr KHR header.