### PR TITLE
[Clang][SYCL] Use 3-component triple for all SYCL bundler targets

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10442,6 +10442,8 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
     } else {
       llvm::Triple EffTriple(CurTC->ComputeEffectiveClangTriple(
           TCArgs, CurDep->getOffloadingArch()));
+      // SYCL old-model bundler uses 3-component triples to match the triple
+      // format used during unbundling.
       if (CurKind == Action::OFK_SYCL)
         Triples += EffTriple.normalize();
       else

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10442,10 +10442,7 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
     } else {
       llvm::Triple EffTriple(CurTC->ComputeEffectiveClangTriple(
           TCArgs, CurDep->getOffloadingArch()));
-      // SYCL old-model bundler uses 3-component triples for SPIR-V and NVPTX
-      // targets to match the triple format used during unbundling.
-      if (CurKind == Action::OFK_SYCL &&
-          (EffTriple.isSPIROrSPIRV() || EffTriple.isNVPTX()))
+      if (CurKind == Action::OFK_SYCL)
         Triples += EffTriple.normalize();
       else
         Triples += EffTriple.normalize(llvm::Triple::CanonicalForm::FOUR_IDENT);


### PR DESCRIPTION
Partially revert 1c5ce7d792375 to align with downstream change.

The SYCL old-model bundler previously restricted 3-component triple normalization to SPIR-V and NVPTX targets, falling back to FOUR_IDENT (4-component) for other SYCL targets such as AMDGPU. But SYCL fat objects always embed 3-component section names (spir64-unknown-unknown, nvptx64-nvidia-cuda, amdgcn-amd-amdhsa), so the arch restriction could produce a bundler target that did not match the format used during unbundling.

Drop the isSPIROrSPIRV()/isNVPTX() guard so all SYCL targets use plain normalize() (3-component); non-SYCL targets (HIP, OpenMP, etc.) continue to use normalize(FOUR_IDENT).

No test in this repo is affected by this change.