### PR TITLE
[SYCL] Deprecate legacy info::platform::profile descriptor

### DIFF
--- a/sycl/include/sycl/info/platform.hpp
+++ b/sycl/include/sycl/info/platform.hpp
@@ -31,9 +31,12 @@ struct __SYCL2020_DEPRECATED("deprecated in SYCL 2020, use device::get_info() "
     : platform_traits<UR_PLATFORM_INFO_EXTENSIONS> {
   using return_type = std::vector<std::string>;
 };
-struct profile : platform_traits<UR_PLATFORM_INFO_PROFILE> {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+struct __SYCL_DEPRECATED("info::platform::profile is not part of SYCL 2020") profile
+    : platform_traits<UR_PLATFORM_INFO_PROFILE> {
   using return_type = std::string;
 };
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 struct version : platform_traits<UR_PLATFORM_INFO_VERSION> {
   using return_type = std::string;
 };

--- a/sycl/include/sycl/info/platform.hpp
+++ b/sycl/include/sycl/info/platform.hpp
@@ -32,8 +32,8 @@ struct __SYCL2020_DEPRECATED("deprecated in SYCL 2020, use device::get_info() "
   using return_type = std::vector<std::string>;
 };
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-struct __SYCL_DEPRECATED("info::platform::profile is not part of SYCL 2020") profile
-    : platform_traits<UR_PLATFORM_INFO_PROFILE> {
+struct __SYCL_DEPRECATED("info::platform::profile is not part of SYCL 2020")
+    profile : platform_traits<UR_PLATFORM_INFO_PROFILE> {
   using return_type = std::string;
 };
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -71,7 +71,9 @@ bool platform::has(aspect Aspect) const { return impl->has(Aspect); }
 #define __SYCL_PLATFORM_INFO_INST(NAME, RETURN_T)                              \
   template __SYCL_EXPORT detail::ABINeutralT_t<RETURN_T>                       \
   platform::get_info_impl<info::platform::NAME>() const;
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 __SYCL_PLATFORM_INFO_INST(profile, std::string)
+#endif
 __SYCL_PLATFORM_INFO_INST(version, std::string)
 __SYCL_PLATFORM_INFO_INST(name, std::string)
 __SYCL_PLATFORM_INFO_INST(vendor, std::string)

--- a/sycl/test-e2e/Basic/info.cpp
+++ b/sycl/test-e2e/Basic/info.cpp
@@ -391,7 +391,9 @@ int main() {
 
   std::cout << separator << "Platform information\n" << separator;
   platform plt(dev.get_platform());
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   print_info<info::platform::profile, std::string>(plt, "Profile");
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   print_info<info::platform::version, std::string>(plt, "Version");
   print_info<info::platform::name, std::string>(plt, "Name");
   print_info<info::platform::vendor, std::string>(plt, "Vendor");


### PR DESCRIPTION
Fixes #22506.

## Summary

`info::platform::profile` is a legacy SYCL 1.2.1 descriptor that has no equivalent in SYCL 2020. This PR deprecates it and schedules it for removal in the next ABI-break window, following the existing pattern used for `info::device::atomic64`.

## Changes

- `sycl/include/sycl/info/platform.hpp`: wrap `info::platform::profile` in `#ifndef __INTEL_PREVIEW_BREAKING_CHANGES` and mark it with `__SYCL_DEPRECATED` so users get a compiler warning.
- `sycl/test-e2e/Basic/info.cpp`: guard the `profile` query with the same macro so the test compiles in both modes.

## Behaviour

| Macro defined?                      | Effect                        |
|-------------------------------------|-------------------------------|
| `__INTEL_PREVIEW_BREAKING_CHANGES` not defined | `profile` available, emits deprecation warning |
| `__INTEL_PREVIEW_BREAKING_CHANGES` defined     | `profile` removed entirely   |
