### PR TITLE
[SYCL][DOC] Clarification related to the handle data size

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_inter_process_communication.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_inter_process_communication.asciidoc
@@ -144,7 +144,9 @@ released by the relevant IPC API or by the destruction of the original object.
 
 _Returns:_ The handle data associated with the IPC handle object. This data can
 be transferred to other processes, but cannot be used to recreate a `handle`
-object.
+object. For a given platform, the size of the handle data is the same for all
+handles associated with a particular SYCL object type (e.g., all physical_mem
+handles have the same data size).
 
 !====
 a!
@@ -512,7 +514,8 @@ handle and the USM device memory associated with this handle has not been freed.
 
 _Returns:_ The handle data associated with the IPC handle object. This data can
 be transferred to other processes, but cannot be used to recreate a `handle`
-object.
+object. For a given platform, the size of the handle data is the same for all
+handles associated with USM memory allocations.
 
 !====
 a!

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_inter_process_communication.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_inter_process_communication.asciidoc
@@ -144,9 +144,7 @@ released by the relevant IPC API or by the destruction of the original object.
 
 _Returns:_ The handle data associated with the IPC handle object. This data can
 be transferred to other processes, but cannot be used to recreate a `handle`
-object. For a given platform, the size of the handle data is the same for all
-handles associated with a particular SYCL object type (e.g., all physical_mem
-handles have the same data size).
+object.
 
 !====
 a!
@@ -514,8 +512,7 @@ handle and the USM device memory associated with this handle has not been freed.
 
 _Returns:_ The handle data associated with the IPC handle object. This data can
 be transferred to other processes, but cannot be used to recreate a `handle`
-object. For a given platform, the size of the handle data is the same for all
-handles associated with USM memory allocations.
+object.
 
 !====
 a!
@@ -945,7 +942,10 @@ handle get(const physical_mem &phys_mem)
 _Returns:_ An IPC "handle" to this physical memory object. The bytes of this
 handle can be transferred to another process on the same system, and the other
 process can use the handle to get a physical memory object representing the
-same memory allocation through a call to the `open` function.
+same memory allocation through a call to the `open` function. For a given
+platform, the size of the handle data (returned by `handle::data()` or
+`handle::data_view()`) is the same for all handles associated with physical_mem
+object type.
 
 _Throws:_ An exception with the `errc::invalid` error code if `phys_mem` was
 not created with inter-process sharing enabled via the `enable_ipc` property.


### PR DESCRIPTION
Clarified, that the handle data size is the same for all handles associated with physical_mem object type, within the same platform. This makes the handle data sharing more convenient for the applications.