### PR TITLE
[SYCL] Fix compatibility with gcc 7.5.0

### DIFF
--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -82,6 +82,7 @@ get_kernel_device_specific_info_helper(ur_kernel_handle_t Kernel,
                                        ur_device_handle_t Device,
                                        adapter_impl &Adapter, void *Result,
                                        size_t Size) {
+  // use explicit static cast for compatibility with gcc 7.5.0
   Adapter.call<UrApiKind::urKernelGetSubGroupInfo>(
       Kernel, Device,
       static_cast<ur_kernel_sub_group_info_t>(UrInfoCode<Param>::value), Size,
@@ -104,6 +105,7 @@ get_kernel_device_specific_info_helper(ur_kernel_handle_t Kernel,
                                        ur_device_handle_t Device,
                                        adapter_impl &Adapter, void *Result,
                                        size_t Size) {
+  // use explicit static cast for compatibility with gcc 7.5.0
   ur_result_t Error = Adapter.call_nocheck<UrApiKind::urKernelGetGroupInfo>(
       Kernel, Device,
       static_cast<ur_kernel_group_info_t>(UrInfoCode<Param>::value), Size,
@@ -166,6 +168,7 @@ uint32_t get_kernel_device_specific_info_with_input(ur_kernel_handle_t Kernel,
   // TODO catch an exception and put it to list of asynchronous exceptions
   Adapter.call<UrApiKind::urKernelGetSubGroupInfo>(
       Kernel, Device,
+      // use explicit static cast for compatibility with gcc 7.5.0
       static_cast<ur_kernel_sub_group_info_t>(UrInfoCode<Param>::value),
       sizeof(uint32_t), &Result, nullptr);
 

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -83,7 +83,9 @@ get_kernel_device_specific_info_helper(ur_kernel_handle_t Kernel,
                                        adapter_impl &Adapter, void *Result,
                                        size_t Size) {
   Adapter.call<UrApiKind::urKernelGetSubGroupInfo>(
-      Kernel, Device, UrInfoCode<Param>::value, Size, Result, nullptr);
+      Kernel, Device,
+      static_cast<ur_kernel_sub_group_info_t>(UrInfoCode<Param>::value), Size,
+      Result, nullptr);
 }
 
 template <typename Param>
@@ -103,10 +105,13 @@ get_kernel_device_specific_info_helper(ur_kernel_handle_t Kernel,
                                        adapter_impl &Adapter, void *Result,
                                        size_t Size) {
   ur_result_t Error = Adapter.call_nocheck<UrApiKind::urKernelGetGroupInfo>(
-      Kernel, Device, UrInfoCode<Param>::value, Size, Result, nullptr);
+      Kernel, Device,
+      static_cast<ur_kernel_group_info_t>(UrInfoCode<Param>::value), Size,
+      Result, nullptr);
   if (Error != UR_RESULT_SUCCESS)
-    kernel_get_group_info::handleErrorOrWarning(Error, UrInfoCode<Param>::value,
-                                                Adapter);
+    kernel_get_group_info::handleErrorOrWarning(
+        Error, static_cast<ur_kernel_group_info_t>(UrInfoCode<Param>::value),
+        Adapter);
 }
 
 template <typename Param>
@@ -160,8 +165,9 @@ uint32_t get_kernel_device_specific_info_with_input(ur_kernel_handle_t Kernel,
   uint32_t Result = 0;
   // TODO catch an exception and put it to list of asynchronous exceptions
   Adapter.call<UrApiKind::urKernelGetSubGroupInfo>(
-      Kernel, Device, UrInfoCode<Param>::value, sizeof(uint32_t), &Result,
-      nullptr);
+      Kernel, Device,
+      static_cast<ur_kernel_sub_group_info_t>(UrInfoCode<Param>::value),
+      sizeof(uint32_t), &Result, nullptr);
 
   return Result;
 }


### PR DESCRIPTION
gcc 7.5.0 fails to convert some types. Add explicit cast.