### PR TITLE
[SYCL][test] Fix sycl-offload-jit.cpp CHK-SPLIT tests for sycl-web

### DIFF
--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -63,27 +63,27 @@
 
 /// Check -fsycl-device-image-split= is forwarded to clang-sycl-linker as the
 /// corresponding --module-split-mode= value.
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split=kernel %s 2>&1 \
+// RUN: %clang --offload-new-driver -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split=kernel %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SPLIT-KERNEL %s
-// CHK-SPLIT-KERNEL: clang-linker-wrapper{{.*}}"--device-linker=spirv64-unknown-unknown=--module-split-mode=kernel"
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split=translation_unit %s 2>&1 \
+// CHK-SPLIT-KERNEL: clang-linker-wrapper{{.*}}"--device-linker=spir64-unknown-unknown=--module-split-mode=kernel"
+// RUN: %clang --offload-new-driver -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split=translation_unit %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SPLIT-TU %s
-// CHK-SPLIT-TU: clang-linker-wrapper{{.*}}"--device-linker=spirv64-unknown-unknown=--module-split-mode=translation_unit"
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split=link_unit %s 2>&1 \
+// CHK-SPLIT-TU: clang-linker-wrapper{{.*}}"--device-linker=spir64-unknown-unknown=--module-split-mode=translation_unit"
+// RUN: %clang --offload-new-driver -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split=link_unit %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SPLIT-LU %s
-// CHK-SPLIT-LU: clang-linker-wrapper{{.*}}"--device-linker=spirv64-unknown-unknown=--module-split-mode=link_unit"
+// CHK-SPLIT-LU: clang-linker-wrapper{{.*}}"--device-linker=spir64-unknown-unknown=--module-split-mode=link_unit"
 
 /// Check the bare -fsycl-device-image-split flag aliases to 'translation_unit'.
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split %s 2>&1 \
+// RUN: %clang --offload-new-driver -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SPLIT-TU %s
 
 /// Check that without -fsycl-device-image-split, no --module-split-mode= is passed.
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
+// RUN: %clang --offload-new-driver -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-NO-SPLIT %s
 // CHK-NO-SPLIT-NOT: --module-split-mode=
 
 /// Check an invalid -fsycl-device-image-split= value is diagnosed.
-// RUN: not %clang -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split=bogus %s 2>&1 \
+// RUN: not %clang --offload-new-driver -### --target=x86_64-unknown-linux-gnu -fsycl -fsycl-device-image-split=bogus %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SPLIT-INVALID %s
 // CHK-SPLIT-INVALID: error: invalid value 'bogus' in '-fsycl-device-image-split='
 


### PR DESCRIPTION
Tests added via 87a09a0ff00c were written for upstream 'main' defaults where -fsycl implicitly uses the new offloading driver and spirv64 as the default SYCL triple. In sycl-web, the new driver requires --offload-new-driver explicitly, and the default SYCL triple is spir64-unknown-unknown.

Add --offload-new-driver to CHK-SPLIT-* RUN lines and update expected triple from spirv64 to spir64.

CMPLRLLVM-76596