### PR TITLE
[Clang][SYCL][Test] update nontrivial_device_copyable.cpp regcall-cc-test.cpp param align

### DIFF
--- a/clang/test/CodeGenSYCL/nontrivial_device_copyable.cpp
+++ b/clang/test/CodeGenSYCL/nontrivial_device_copyable.cpp
@@ -29,7 +29,7 @@ int main() {
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name(ptr noundef byval(%struct.NontriviallyCopyable)
 // CHECK-NOT: define {{.*}}spir_func void @{{.*}}device_func{{.*}}({{.*}}byval(%struct.NontriviallyCopyable)
-// CHECK: define {{.*}}spir_func void @_Z11device_func20NontriviallyCopyable(ptr noundef dead_on_return %X)
+// CHECK: define {{.*}}spir_func void @_Z11device_func20NontriviallyCopyable(ptr noundef align 4 dead_on_return %X)
 // CHECK: %X.indirect_addr = alloca ptr addrspace(4)
 // CHECK: %X.ascast = addrspacecast ptr %X to ptr addrspace(4)
 // CHECK: store ptr %X, ptr %X.indirect_addr

--- a/clang/test/CodeGenSYCL/regcall-cc-test.cpp
+++ b/clang/test/CodeGenSYCL/regcall-cc-test.cpp
@@ -333,7 +333,7 @@ struct NonCopyable {
 // CHECK-DAG: %struct.NonCopyable = type { i32 }
 
 SYCL_DEVICE int __regcall bar(NonCopyable x) {
-// CHECK-DAG: define dso_local x86_regcallcc noundef i32 @_Z15__regcall3__bar11NonCopyable(ptr noundef dead_on_return %x)
+// CHECK-DAG: define dso_local x86_regcallcc noundef i32 @_Z15__regcall3__bar11NonCopyable(ptr noundef align 4 dead_on_return %x)
   return x.a;
 }
 


### PR DESCRIPTION
947dc92d1a88 now emits `align 4` on these indirect params.

CMPLRLLVM-76598