### PR TITLE
[SYCL] Don't include OpenCL headers when compiling for device

### DIFF
--- a/sycl/include/sycl/detail/cl.h
+++ b/sycl/include/sycl/detail/cl.h
@@ -20,36 +20,28 @@
 #define CL_ENABLE_BETA_EXTENSIONS
 #endif
 
-#if !defined(__SYCL_DEVICE_ONLY__) || !defined(__SYCL_JIT__)
+#ifndef __SYCL_DEVICE_ONLY__
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
+#else
+// On the SYCL device pass we don't need to include the OpenCL headers.
+// Just forward declare the opaque handle types used by SYCL headers.
+// We should not do "using cl_command_queue = void*" because that
+// can cause redifinition errors if the user application also
+// includes OpenCL headers.
+typedef struct _cl_command_queue *cl_command_queue;
+typedef struct _cl_context *cl_context;
+typedef struct _cl_device_id *cl_device_id;
+typedef struct _cl_event *cl_event;
+typedef struct _cl_kernel *cl_kernel;
+typedef struct _cl_mem *cl_mem;
+typedef struct _cl_platform_id *cl_platform_id;
+typedef struct _cl_program *cl_program;
+typedef struct _cl_sampler *cl_sampler;
 #endif
 
 namespace sycl {
 inline namespace _V1 {
-#if defined(__SYCL_DEVICE_ONLY__) && defined(__SYCL_JIT__)
-// Don't include the OpenCL headers when compiling for SYCL device, as they only
-// define the host-side API. Instead, define the necessary types as opaque
-// pointers to not break the SYCL headers that include this header.
-using OpenCLCommandQueueT = void *;
-using OpenCLContextT = void *;
-using OpenCLDeviceIdT = void *;
-using OpenCLEventT = void *;
-using OpenCLKernelT = void *;
-using OpenCLMemT = void *;
-using OpenCLPlatformT = void *;
-using OpenCLProgramT = void *;
-using OpenCLSamplerT = void *;
-namespace detail {
-inline void retainOpenCLCommandQueue(ur_native_handle_t) {}
-inline void retainOpenCLContext(ur_native_handle_t) {}
-inline void retainOpenCLDevice(ur_native_handle_t) {}
-inline void retainOpenCLEvent(ur_native_handle_t) {}
-inline void retainOpenCLKernel(ur_native_handle_t) {}
-inline void retainOpenCLMemObject(ur_native_handle_t) {}
-inline void retainOpenCLProgram(ur_native_handle_t) {}
-} // namespace detail
-#else  // !defined(__SYCL_DEVICE_ONLY__)
 using OpenCLCommandQueueT = cl_command_queue;
 using OpenCLContextT = cl_context;
 using OpenCLDeviceIdT = cl_device_id;
@@ -59,7 +51,17 @@ using OpenCLMemT = cl_mem;
 using OpenCLPlatformT = cl_platform_id;
 using OpenCLProgramT = cl_program;
 using OpenCLSamplerT = cl_sampler;
+
 namespace detail {
+#ifdef __SYCL_DEVICE_ONLY__
+inline void retainOpenCLCommandQueue(ur_native_handle_t) {}
+inline void retainOpenCLContext(ur_native_handle_t) {}
+inline void retainOpenCLDevice(ur_native_handle_t) {}
+inline void retainOpenCLEvent(ur_native_handle_t) {}
+inline void retainOpenCLKernel(ur_native_handle_t) {}
+inline void retainOpenCLMemObject(ur_native_handle_t) {}
+inline void retainOpenCLProgram(ur_native_handle_t) {}
+#else  // __SYCL_DEVICE_ONLY__
 inline void retainOpenCLCommandQueue(ur_native_handle_t Queue) {
   __SYCL_OCL_CALL(clRetainCommandQueue, ur::cast<OpenCLCommandQueueT>(Queue));
 }
@@ -81,7 +83,7 @@ inline void retainOpenCLMemObject(ur_native_handle_t MemObject) {
 inline void retainOpenCLProgram(ur_native_handle_t Program) {
   __SYCL_OCL_CALL(clRetainProgram, ur::cast<OpenCLProgramT>(Program));
 }
-} // namespace detail
 #endif // defined(__SYCL_DEVICE_ONLY__)
+} // namespace detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/test-e2e/Adapters/level_zero/imm_cmdlist_per_thread.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/imm_cmdlist_per_thread.cpp
@@ -12,6 +12,7 @@
 
 // CHECK-ONE-CMDLIST: zeCommandListCreateImmediate = 2
 // CHECK-PER-THREAD-CMDLIST: zeCommandListCreateImmediate = 4
+#include <CL/cl.h>
 #include <iostream>
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Adapters/luid-opencl.cpp
+++ b/sycl/test-e2e/Adapters/luid-opencl.cpp
@@ -6,6 +6,7 @@
 
 // Test that the LUID is read correctly from OpenCL.
 
+#include <CL/cl_ext.h>
 #include <iomanip>
 #include <iostream>
 #include <sstream>

--- a/sycl/test-e2e/Adapters/node_mask-opencl.cpp
+++ b/sycl/test-e2e/Adapters/node_mask-opencl.cpp
@@ -6,6 +6,7 @@
 
 // Test that the node mask is read correctly from OpenCL.
 
+#include <CL/cl_ext.h>
 #include <iomanip>
 #include <iostream>
 #include <sstream>

--- a/sycl/test-e2e/Basic/buffer/buffer_create.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_create.cpp
@@ -15,6 +15,7 @@
 // UNSUPPORTED: linux && arch-intel_gpu_mtl_u
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
 
+#include <CL/cl.h>
 #include <iostream>
 #include <level_zero/ze_api.h>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/interop/make_kernel_subdevice_l0.cpp
+++ b/sycl/test-e2e/Basic/interop/make_kernel_subdevice_l0.cpp
@@ -2,6 +2,7 @@
 // RUN: %{build} %level_zero_options %opencl_lib -o %t.ze.out
 // RUN: %{run-unfiltered-devices} env ONEAPI_DEVICE_SELECTOR="level_zero:*" %t.ze.out
 
+#include <CL/cl.h>
 #include <cstdlib>
 #include <iostream>
 #include <level_zero/ze_api.h>

--- a/sycl/test-e2e/Basic/kernel_info.cpp
+++ b/sycl/test-e2e/Basic/kernel_info.cpp
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/cl.h>
 #include <cassert>
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>

--- a/sycl/test-e2e/DeprecatedFeatures/kernel_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/kernel_interop.cpp
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include <CL/cl.h>
 #include <sycl/detail/core.hpp>
 
 #include <cassert>

--- a/sycl/test-e2e/DeprecatedFeatures/opencl_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/opencl_interop.cpp
@@ -3,6 +3,7 @@
 // RUN: %{build} -D__SYCL_INTERNAL_API -o %t.out %opencl_lib
 // RUN: %{run-unfiltered-devices} %t.out
 
+#include <CL/cl.h>
 #include <cassert>
 #include <exception>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeprecatedFeatures/sampler_ocl.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/sampler_ocl.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/cl.h>
 #include <cassert>
 #include <sycl/context.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeprecatedFeatures/set_arg_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/set_arg_interop.cpp
@@ -6,6 +6,7 @@
 // RUN: %{build} -D__SYCL_INTERNAL_API -o %t.out %opencl_lib -O3
 // RUN: %{run} %t.out
 
+#include <CL/cl.h>
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/DeprecatedFeatures/subbuffer_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/subbuffer_interop.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/cl.h>
 #include <sycl/detail/core.hpp>
 
 #include <cassert>

--- a/sycl/test-e2e/DeviceImageBackendContent/OCL_interop_test.cpp
+++ b/sycl/test-e2e/DeviceImageBackendContent/OCL_interop_test.cpp
@@ -2,6 +2,7 @@
 // RUN: %{build} %opencl_lib -fno-sycl-dead-args-optimization -o %t.out
 // RUN: %{run} %t.out
 //
+#include <CL/cl.h>
 #include <sycl/backend.hpp>
 #include <sycl/detail/cl.h>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Graph/NativeCommand/opencl_buffer.cpp
+++ b/sycl/test-e2e/Graph/NativeCommand/opencl_buffer.cpp
@@ -3,6 +3,7 @@
 // REQUIRES: opencl, opencl_icd
 
 #include <CL/cl.h>
+#include <CL/cl_ext.h>
 #include <sycl/backend.hpp>
 #include <sycl/detail/cl.h>
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test-e2e/Graph/NativeCommand/opencl_buffer.cpp
+++ b/sycl/test-e2e/Graph/NativeCommand/opencl_buffer.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 // REQUIRES: opencl, opencl_icd
 
+#define CL_ENABLE_BETA_EXTENSIONS
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
 #include <sycl/backend.hpp>

--- a/sycl/test-e2e/Graph/NativeCommand/opencl_buffer.cpp
+++ b/sycl/test-e2e/Graph/NativeCommand/opencl_buffer.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 // REQUIRES: opencl, opencl_icd
 
+#include <CL/cl.h>
 #include <sycl/backend.hpp>
 #include <sycl/detail/cl.h>
 #include <sycl/ext/oneapi/experimental/graph.hpp>

--- a/sycl/test-e2e/HostInteropTask/interop-task.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 // REQUIRES: opencl, opencl_icd
 
+#include <CL/cl.h>
 #include <iostream>
 #include <sycl/backend.hpp>
 #include <sycl/backend/opencl.hpp>

--- a/sycl/test-e2e/InorderQueue/in_order_buffs_ocl.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_buffs_ocl.cpp
@@ -8,6 +8,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include <CL/cl.h>
 #include <iostream>
 #include <sycl/backend.hpp>
 #include <sycl/backend/opencl.hpp>

--- a/sycl/test-e2e/InorderQueue/in_order_dmemll_ocl.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_dmemll_ocl.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/cl.h>
 #include <iostream>
 #include <sycl/backend.hpp>
 #include <sycl/backend/opencl.hpp>

--- a/sycl/test-e2e/InorderQueue/prop.cpp
+++ b/sycl/test-e2e/InorderQueue/prop.cpp
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/cl.h>
 #include <sycl/backend.hpp>
 #include <sycl/backend/opencl.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/KernelCompiler/opencl.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl.cpp
@@ -11,6 +11,7 @@
 // -- Test the kernel_compiler with OpenCL source.
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out
+#include <CL/cl.h>
 #include <iostream>
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/KernelCompiler/opencl_cache.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_cache.cpp
@@ -24,6 +24,7 @@
 // CHECK-READ-FROM-CACHE: [Persistent Cache]: enabled
 // CHECK-READ-FROM-CACHE-NOT: [kernel_compiler Persistent Cache]: binary has been cached
 // CHECK-READ-FROM-CACHE: [kernel_compiler Persistent Cache]: using cached binary
+#include <CL/cl.h>
 #include <iostream>
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
@@ -24,6 +24,7 @@
 // so long as ocloc is installed and should be able to
 // successfully run and pass these tests.
 
+#include <CL/cl.h>
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/KernelCompiler/spirv.cpp
+++ b/sycl/test-e2e/KernelCompiler/spirv.cpp
@@ -15,6 +15,7 @@
 // loads pre-compiled kernels from a SPIR-V file and runs them.
 #include <iostream>
 
+#include <CL/cl.h>
 #include <array>
 #include <cassert>
 #include <fstream>

--- a/sycl/test-e2e/PlatformDeviceIndex/sycl_ext_oneapi_platform_device_index.cpp
+++ b/sycl/test-e2e/PlatformDeviceIndex/sycl_ext_oneapi_platform_device_index.cpp
@@ -3,8 +3,8 @@
 // RUN: %{build} %level_zero_options %opencl_lib -o %t.out
 // RUN: %{run} %t.out
 
-#include <CL/cl.h>
 #include "../helpers.hpp"
+#include <CL/cl.h>
 
 #include <level_zero/ze_api.h>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/PlatformDeviceIndex/sycl_ext_oneapi_platform_device_index.cpp
+++ b/sycl/test-e2e/PlatformDeviceIndex/sycl_ext_oneapi_platform_device_index.cpp
@@ -3,6 +3,7 @@
 // RUN: %{build} %level_zero_options %opencl_lib -o %t.out
 // RUN: %{run} %t.out
 
+#include <CL/cl.h>
 #include "../helpers.hpp"
 
 #include <level_zero/ze_api.h>

--- a/sycl/test-e2e/Regression/local-arg-align.cpp
+++ b/sycl/test-e2e/Regression/local-arg-align.cpp
@@ -13,6 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/cl.h>
 #include <iostream>
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Regression/set-arg-local-accessor.cpp
+++ b/sycl/test-e2e/Regression/set-arg-local-accessor.cpp
@@ -2,6 +2,7 @@
 //
 // RUN: %{build} %opencl_lib -o %t.out
 // RUN: %{run} %t.out
+#include <CL/cl.h>
 #include <iostream>
 
 #include <sycl/backend.hpp>


### PR DESCRIPTION
IGC wants the ability to compile SYCL device code and they don't have OpenCL headers installed. OpenCL headers are anyway not used when compiling for device.