### PR TITLE
[SYCL] fix fp8 alignment test

### DIFF
--- a/sycl/test-e2e/Experimental/fp8/x2_alignment_codegen.cpp
+++ b/sycl/test-e2e/Experimental/fp8/x2_alignment_codegen.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -DNDEBUG -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-device-only -DNDEBUG -S -Xclang -emit-llvm %s -o - | FileCheck %s
 
 // UNSUPPORTED: target-nvidia, target-amd
 // UNSUPPORTED-INTENDED: relies on SPIR-V FP8 conversion builtins


### PR DESCRIPTION
This PR fixes build error on windows when -Werror passed 
`
executed command: icx.exe -Werror /EHsc -fsycl -fsycl-device-only -DNDEBUG -S -emit-llvm '<src>' -o -
| icx: error: unknown argument ignored in clang-cl: '-emit-llvm' [-Werror,-Wunknown-argument]
error: command failed with exit status: 1
`
