### PR TITLE
[SYCL] Fix bitwise not operator for `marray<bool>`

### DIFF
--- a/sycl/include/sycl/marray.hpp
+++ b/sycl/include/sycl/marray.hpp
@@ -453,9 +453,6 @@ public:
   template <typename T = DataT>
   friend std::enable_if_t<std::is_integral_v<T>, marray>
   operator~(const marray &Lhs) {
-    if constexpr (std::is_same_v<DataT, bool>)
-      return !Lhs;
-
     marray Ret;
     if constexpr (use_ext_vector_type) {
       ext_vector_t LhsVec = sycl::bit_cast<ext_vector_t>(Lhs.MData);

--- a/sycl/test-e2e/Basic/built-ins/marray_bitwise_not_bool.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_bitwise_not_bool.cpp
@@ -2,6 +2,10 @@
 // RUN: %{run} %t.out
 
 // Test bitwise NOT operator (~) on marray<bool>
+//
+// Per the SYCL spec, marray operators mirror the equivalent std::valarray
+// operator. For bool, ~ promotes to int, so ~v is always non-zero and casting
+// back to bool yields true for every element (matches ~std::valarray<bool>).
 
 #include <sycl/detail/core.hpp>
 #include <sycl/marray.hpp>
@@ -48,7 +52,7 @@ int main() {
   // Test case 1: Size 2
   {
     marray<bool, 2> input{true, false};
-    marray<bool, 2> expected{false, true};
+    marray<bool, 2> expected{true, true};
     assert(test_bitwise_not_bool(q, input, expected) &&
            "Test failed for size 2");
   }
@@ -56,7 +60,7 @@ int main() {
   // Test case 2: Size 4
   {
     marray<bool, 4> input{true, false, true, false};
-    marray<bool, 4> expected{false, true, false, true};
+    marray<bool, 4> expected{true, true, true, true};
     assert(test_bitwise_not_bool(q, input, expected) &&
            "Test failed for size 4");
   }
@@ -64,7 +68,7 @@ int main() {
   // Test case 3: Size 3 (no padding, different code path)
   {
     marray<bool, 3> input{false, true, false};
-    marray<bool, 3> expected{true, false, true};
+    marray<bool, 3> expected{true, true, true};
     assert(test_bitwise_not_bool(q, input, expected) &&
            "Test failed for size 3");
   }
@@ -72,8 +76,7 @@ int main() {
   // Test case 4: Size 8
   {
     marray<bool, 8> input{true, true, false, false, true, false, true, false};
-    marray<bool, 8> expected{false, false, true,  true,
-                             false, true,  false, true};
+    marray<bool, 8> expected{true, true, true, true, true, true, true, true};
     assert(test_bitwise_not_bool(q, input, expected) &&
            "Test failed for size 8");
   }
@@ -81,7 +84,7 @@ int main() {
   // Test case 5: All true
   {
     marray<bool, 4> input{true, true, true, true};
-    marray<bool, 4> expected{false, false, false, false};
+    marray<bool, 4> expected{true, true, true, true};
     assert(test_bitwise_not_bool(q, input, expected) &&
            "Test failed for all true");
   }


### PR DESCRIPTION
https://github.com/intel/llvm/pull/22440 added  `if constexpr (bool) return !Lhs;` to `operator~`, but that's wrong.

The bitwise-not operator ~ doesn't operate on bool (or char, short) directly. Before it runs, the operand undergoes integral promotion: any
  type smaller than int is promoted to int. So:

  - bool value true → promoted to int 1
  - bool value false → promoted to int 0

  Then ~ operates on that 32-bit int, flipping all bits:

  true  → 1  = 0x00000001 → ~ → 0xFFFFFFFE  = -2   (nonzero)
  false → 0  = 0x00000000 → ~ → 0xFFFFFFFF  = -1   (nonzero)

  Both results are nonzero. When that int is stored back into a bool (or cast to bool), it is always stored as true. So:

  - ~true  → -2 → bool → true
  - ~false → -1 → bool → true