### PR TITLE
[UR] don't link libirc when building with icpx

### DIFF
--- a/unified-runtime/cmake/helpers.cmake
+++ b/unified-runtime/cmake/helpers.cmake
@@ -117,9 +117,9 @@ function(add_ur_target_compile_options name)
             $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>
         )
         if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
-            # icx emits calls to _intel_fast_memcpy/_intel_fast_memset; link
-            # libirc directly so those symbols resolve.
-            target_link_libraries(${name} PRIVATE irc)
+            # icx by default emits calls to _intel_fast_memcpy/_intel_fast_memset.
+            # Use plain memcpy/memset so that no libirc dependency is introduced.
+            target_compile_options(${name} PRIVATE -no-intel-lib=libirc)
         endif()
         if (UR_DEVELOPER_MODE)
             target_compile_options(${name} PRIVATE -Werror -Wextra)

--- a/unified-runtime/source/loader/CMakeLists.txt
+++ b/unified-runtime/source/loader/CMakeLists.txt
@@ -221,6 +221,16 @@ if(UR_ENABLE_SANITIZER)
         target_sources(ur_loader
             PRIVATE ${symbolizer_sources}
         )
+        # Symbolizer dependencies may emit calls to
+        # _intel_fast_memcpy/_intel_fast_memset. Those are normally provided
+        # by libirc, but libsycl / ur doesn't link them. Use stubs forwarding to
+        # plain memcpy/memset. The stub is compiled with -no-intel-lib, which
+        # add_ur_target_compile_options() already applies to the whole target.
+        if(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
+            target_sources(ur_loader PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/sanitizer_common/linux/intel_fast_mem_stub.c
+            )
+        endif()
         target_include_directories(ur_loader PRIVATE ${LLVM_INCLUDE_DIRS})
         target_link_libraries(ur_loader PRIVATE LLVMSupport LLVMSymbolize)
         target_compile_definitions(ur_loader PRIVATE UR_HAVE_SYMBOLIZER)

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/intel_fast_mem_stub.c
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/linux/intel_fast_mem_stub.c
@@ -1,0 +1,30 @@
+/*
+ *
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ * Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * @file intel_fast_mem_stub.c
+ *
+ */
+
+// Stub implementations for Intel fast memory functions.
+//
+// The pre-built LLVM static archives that the symbolizer pulls in (LLVMSupport,
+// LLVMSymbolize, LLVMDebugInfoDWARF/GSYM/PDB, LLVMObject, LLVMDemangle, ...)
+// are compiled by icx, which by default emits calls to
+// _intel_fast_memcpy/_intel_fast_memset. Those symbols are normally provided by
+// libirc. ur_loader (and libsycl, which archives it) doesn't link with libirc,
+// so forward these calls to plain memcpy/memset instead.
+
+#include <string.h>
+
+void *_intel_fast_memcpy(void *dest, const void *src, size_t n) {
+  return memcpy(dest, src, n);
+}
+
+void *_intel_fast_memset(void *dest, int c, size_t n) {
+  return memset(dest, c, n);
+}


### PR DESCRIPTION
This breaks SYCL unittests in some configurations.