### PR TITLE
[SYCL][E2E] Add SYCL E2E test to cover marray operations on device

### DIFF
--- a/sycl/test-e2e/Basic/built-ins/marray_operators.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_operators.cpp
@@ -7,11 +7,11 @@
 #include <sycl/half_type.hpp>
 #include <sycl/marray.hpp>
 
+#include <algorithm>
 #include <cassert>
 
 using namespace sycl;
 
-// Runs Fn() inside a single-task kernel and returns its bool result.
 template <typename FnT> bool runOnDevice(queue &Q, FnT Fn) {
   buffer<bool, 1> ResultBuf{1};
   Q.submit([&](handler &Cgh) {
@@ -22,22 +22,19 @@ template <typename FnT> bool runOnDevice(queue &Q, FnT Fn) {
 }
 
 template <typename MArrayT> bool equal(const MArrayT &A, const MArrayT &B) {
-  for (size_t I = 0; I < A.size(); ++I)
-    if (A[I] != B[I])
-      return false;
-  return true;
+  return std::equal(A.begin(), A.end(), B.begin());
 }
 
-// Distinct input patterns so operators don't collapse to trivial values.
 template <typename T, size_t N> marray<T, N> makeA() {
   marray<T, N> Ret;
   for (size_t I = 0; I < N; ++I)
     if constexpr (std::is_same_v<T, bool>)
       Ret[I] = (I % 2 == 0);
     else
-      Ret[I] = T(I + 1); // 1,2,3,...
+      Ret[I] = T(I + 1);
   return Ret;
 }
+
 template <typename T, size_t N> marray<T, N> makeB() {
   if constexpr (std::is_same_v<T, bool>)
     return marray<T, N>(true);
@@ -55,7 +52,6 @@ void checkBinary(queue &Q, OpT Op) {
   assert(runOnDevice(Q, [=]() { return equal(Op(A, B), Expected); }));
 }
 
-// Scalar-operand overloads (marray-scalar, scalar-marray).
 template <typename T, size_t N, typename OpT>
 void checkScalarOrders(queue &Q, OpT Op) {
   auto A = makeA<T, N>();
@@ -73,7 +69,6 @@ void checkUnary(queue &Q, OpT Op) {
   assert(runOnDevice(Q, [=]() { return equal(Op(A), Expected); }));
 }
 
-// Compound assignment, marray rhs and scalar rhs.
 template <typename T, size_t N, typename OpT>
 void checkAssign(queue &Q, OpT Op) {
   auto A = makeA<T, N>();
@@ -107,16 +102,13 @@ void checkMutate(queue &Q, OpT Op) {
   }));
 }
 
-// Arithmetic/relational operators: +, ==, unary -, pre/post ++.
 template <typename T, size_t N> void checkNumericAt(queue &Q) {
   checkBinary<T, N>(Q, [](auto A, auto B) { return A + B; });
   checkBinary<T, N>(Q, [](auto A, auto B) { return A == B; });
   checkUnary<T, N>(Q, [](auto A) { return -A; });
   checkMutate<T, N>(Q, [](auto &X) { ++X; });
-  checkMutate<T, N>(Q, [](auto &X) { X++; });
 }
 
-// Integral-only operators: &, ~, !.
 template <typename T, size_t N> void checkIntegralAt(queue &Q) {
   checkBinary<T, N>(Q, [](auto A, auto B) { return A & B; });
   checkUnary<T, N>(Q, [](auto A) { return ~A; });
@@ -137,7 +129,6 @@ int main() {
   checkAssign<int, 4>(Q, [](auto &X, auto Y) { X += Y; });
   checkAssign<int, 4>(Q, [](auto &X, auto Y) { X &= Y; });
 
-  // half: floating-point element type.
   if (Q.get_device().has(aspect::fp16))
     checkBinary<half, 4>(Q, [](auto A, auto B) { return A + B; });
 

--- a/sycl/test-e2e/Basic/built-ins/marray_operators.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_operators.cpp
@@ -1,0 +1,155 @@
+// Verifies marray's raw operators produce identical results on host and device.
+//
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/detail/core.hpp>
+#include <sycl/half_type.hpp>
+#include <sycl/marray.hpp>
+
+#include <cassert>
+
+using namespace sycl;
+
+// Runs Fn() inside a single-task kernel and returns its bool result.
+template <typename FnT> bool runOnDevice(queue &Q, FnT Fn) {
+  buffer<bool, 1> ResultBuf{1};
+  Q.submit([&](handler &Cgh) {
+    accessor Result{ResultBuf, Cgh};
+    Cgh.single_task([=]() { Result[0] = Fn(); });
+  });
+  return host_accessor{ResultBuf}[0];
+}
+
+template <typename MArrayT> bool equal(const MArrayT &A, const MArrayT &B) {
+  for (size_t I = 0; I < A.size(); ++I)
+    if (A[I] != B[I])
+      return false;
+  return true;
+}
+
+// Distinct input patterns so operators don't collapse to trivial values.
+template <typename T, size_t N> marray<T, N> makeA() {
+  marray<T, N> Ret;
+  for (size_t I = 0; I < N; ++I)
+    if constexpr (std::is_same_v<T, bool>)
+      Ret[I] = (I % 2 == 0);
+    else
+      Ret[I] = T(I + 1); // 1,2,3,...
+  return Ret;
+}
+template <typename T, size_t N> marray<T, N> makeB() {
+  if constexpr (std::is_same_v<T, bool>)
+    return marray<T, N>(true);
+  else
+    return marray<T, N>(T(2));
+}
+
+// Binary op, marray-marray: the operand order whose result differs between the
+// vector and scalar execution branches. Host computes the oracle; device must
+// match.
+template <typename T, size_t N, typename OpT>
+void checkBinary(queue &Q, OpT Op) {
+  auto A = makeA<T, N>();
+  auto B = makeB<T, N>();
+  auto Expected = Op(A, B);
+  assert(runOnDevice(Q, [=]() { return equal(Op(A, B), Expected); }));
+}
+
+// Scalar-operand overloads (marray-scalar, scalar-marray). Overload resolution,
+// independent of N -- checked once.
+template <typename T, size_t N, typename OpT>
+void checkScalarOrders(queue &Q, OpT Op) {
+  auto A = makeA<T, N>();
+  T Scalar = T(2);
+  auto ExpectedRhs = Op(A, Scalar);
+  assert(runOnDevice(Q, [=]() { return equal(Op(A, Scalar), ExpectedRhs); }));
+  auto ExpectedLhs = Op(Scalar, A);
+  assert(runOnDevice(Q, [=]() { return equal(Op(Scalar, A), ExpectedLhs); }));
+}
+
+template <typename T, size_t N, typename OpT>
+void checkUnary(queue &Q, OpT Op) {
+  auto A = makeA<T, N>();
+  auto Expected = Op(A);
+  assert(runOnDevice(Q, [=]() { return equal(Op(A), Expected); }));
+}
+
+// Compound assignment, marray rhs and scalar rhs (the Num != 1 OPASSIGN).
+// Overload resolution, independent of N -- checked once.
+template <typename T, size_t N, typename OpT>
+void checkAssign(queue &Q, OpT Op) {
+  auto A = makeA<T, N>();
+  auto B = makeB<T, N>();
+  T Scalar = T(2);
+  auto ExpectedRhs = A;
+  Op(ExpectedRhs, B);
+  assert(runOnDevice(Q, [=]() {
+    auto Lhs = A;
+    Op(Lhs, B);
+    return equal(Lhs, ExpectedRhs);
+  }));
+  auto ExpectedScalar = A;
+  Op(ExpectedScalar, Scalar);
+  assert(runOnDevice(Q, [=]() {
+    auto Lhs = A;
+    Op(Lhs, Scalar);
+    return equal(Lhs, ExpectedScalar);
+  }));
+}
+
+template <typename T, size_t N, typename OpT>
+void checkMutate(queue &Q, OpT Op) {
+  auto A = makeA<T, N>();
+  auto Expected = A;
+  Op(Expected);
+  assert(runOnDevice(Q, [=]() {
+    auto Lhs = A;
+    Op(Lhs);
+    return equal(Lhs, Expected);
+  }));
+}
+
+// __SYCL_BINOP (+), __SYCL_RELLOGOP (==), unary -, __SYCL_UOP (++ pre/post).
+template <typename T, size_t N> void checkNumericAt(queue &Q) {
+  checkBinary<T, N>(Q, [](auto A, auto B) { return A + B; });
+  checkBinary<T, N>(Q, [](auto A, auto B) { return A == B; });
+  checkUnary<T, N>(Q, [](auto A) { return -A; });
+  checkMutate<T, N>(Q, [](auto &X) { ++X; });
+  checkMutate<T, N>(Q, [](auto &X) { X++; });
+}
+
+// __SYCL_BINOP_INTEGRAL (&), operator~, operator!.
+template <typename T, size_t N> void checkIntegralAt(queue &Q) {
+  checkBinary<T, N>(Q, [](auto A, auto B) { return A & B; });
+  checkUnary<T, N>(Q, [](auto A) { return ~A; });
+  checkUnary<T, N>(Q, [](auto A) { return !A; });
+}
+
+int main() {
+  queue Q;
+
+  // int: storeVecResult memcpy branch (vec_elem_ty == DataT). Run each op at a
+  // vectorizable N (ext_vector branch) then N=3 (scalar branch on device);
+  // scalar-operand overloads and compound-assign are N-independent, once each.
+  checkNumericAt<int, 4>(Q);
+  checkNumericAt<int, 3>(Q);
+  checkIntegralAt<int, 4>(Q);
+  checkIntegralAt<int, 3>(Q);
+  checkScalarOrders<int, 4>(Q, [](auto A, auto B) { return A + B; });
+  checkScalarOrders<int, 4>(Q, [](auto A, auto B) { return A & B; });
+  checkAssign<int, 4>(Q, [](auto &X, auto Y) { X += Y; });
+  checkAssign<int, 4>(Q, [](auto &X, auto Y) { X &= Y; });
+
+  // half: storeVecResult convert branch (half -> _Float16), vector path only.
+  if (Q.get_device().has(aspect::fp16))
+    checkBinary<half, 4>(Q, [](auto A, auto B) { return A + B; });
+
+  // bool: convert branch (bool -> uint8) via an integral op, plus operator~'s
+  // bool special-case (returns !Lhs). ++/-- are deprecated for marray<bool>.
+  checkBinary<bool, 4>(Q, [](auto A, auto B) { return A & B; });
+  checkUnary<bool, 4>(Q, [](auto A) { return ~A; });
+  checkUnary<bool, 4>(Q, [](auto A) { return !A; });
+
+  return 0;
+}

--- a/sycl/test-e2e/Basic/built-ins/marray_operators.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_operators.cpp
@@ -45,9 +45,8 @@ template <typename T, size_t N> marray<T, N> makeB() {
     return marray<T, N>(T(2));
 }
 
-// Binary op, marray-marray: the operand order whose result differs between the
-// vector and scalar execution branches. Host computes the oracle; device must
-// match.
+// Binary op, marray-marray. The same Op runs on host (the oracle) and device;
+// their results must match.
 template <typename T, size_t N, typename OpT>
 void checkBinary(queue &Q, OpT Op) {
   auto A = makeA<T, N>();
@@ -56,8 +55,7 @@ void checkBinary(queue &Q, OpT Op) {
   assert(runOnDevice(Q, [=]() { return equal(Op(A, B), Expected); }));
 }
 
-// Scalar-operand overloads (marray-scalar, scalar-marray). Overload resolution,
-// independent of N -- checked once.
+// Scalar-operand overloads (marray-scalar, scalar-marray).
 template <typename T, size_t N, typename OpT>
 void checkScalarOrders(queue &Q, OpT Op) {
   auto A = makeA<T, N>();
@@ -75,8 +73,7 @@ void checkUnary(queue &Q, OpT Op) {
   assert(runOnDevice(Q, [=]() { return equal(Op(A), Expected); }));
 }
 
-// Compound assignment, marray rhs and scalar rhs (the Num != 1 OPASSIGN).
-// Overload resolution, independent of N -- checked once.
+// Compound assignment, marray rhs and scalar rhs.
 template <typename T, size_t N, typename OpT>
 void checkAssign(queue &Q, OpT Op) {
   auto A = makeA<T, N>();
@@ -110,7 +107,7 @@ void checkMutate(queue &Q, OpT Op) {
   }));
 }
 
-// __SYCL_BINOP (+), __SYCL_RELLOGOP (==), unary -, __SYCL_UOP (++ pre/post).
+// Arithmetic/relational operators: +, ==, unary -, pre/post ++.
 template <typename T, size_t N> void checkNumericAt(queue &Q) {
   checkBinary<T, N>(Q, [](auto A, auto B) { return A + B; });
   checkBinary<T, N>(Q, [](auto A, auto B) { return A == B; });
@@ -119,7 +116,7 @@ template <typename T, size_t N> void checkNumericAt(queue &Q) {
   checkMutate<T, N>(Q, [](auto &X) { X++; });
 }
 
-// __SYCL_BINOP_INTEGRAL (&), operator~, operator!.
+// Integral-only operators: &, ~, !.
 template <typename T, size_t N> void checkIntegralAt(queue &Q) {
   checkBinary<T, N>(Q, [](auto A, auto B) { return A & B; });
   checkUnary<T, N>(Q, [](auto A) { return ~A; });
@@ -129,9 +126,8 @@ template <typename T, size_t N> void checkIntegralAt(queue &Q) {
 int main() {
   queue Q;
 
-  // int: storeVecResult memcpy branch (vec_elem_ty == DataT). Run each op at a
-  // vectorizable N (ext_vector branch) then N=3 (scalar branch on device);
-  // scalar-operand overloads and compound-assign are N-independent, once each.
+  // Run each op at a power-of-two N and at N=3, since the operators take
+  // different code paths depending on whether N is vectorizable.
   checkNumericAt<int, 4>(Q);
   checkNumericAt<int, 3>(Q);
   checkIntegralAt<int, 4>(Q);
@@ -141,12 +137,12 @@ int main() {
   checkAssign<int, 4>(Q, [](auto &X, auto Y) { X += Y; });
   checkAssign<int, 4>(Q, [](auto &X, auto Y) { X &= Y; });
 
-  // half: storeVecResult convert branch (half -> _Float16), vector path only.
+  // half: floating-point element type.
   if (Q.get_device().has(aspect::fp16))
     checkBinary<half, 4>(Q, [](auto A, auto B) { return A + B; });
 
-  // bool: convert branch (bool -> uint8) via an integral op, plus operator~'s
-  // bool special-case (returns !Lhs). ++/-- are deprecated for marray<bool>.
+  // bool: operator~ has a special case (returns !Lhs). ++/-- are deprecated for
+  // marray<bool>, so they are not exercised here.
   checkBinary<bool, 4>(Q, [](auto A, auto B) { return A & B; });
   checkUnary<bool, 4>(Q, [](auto A) { return ~A; });
   checkUnary<bool, 4>(Q, [](auto A) { return !A; });


### PR DESCRIPTION
To improve marray's code coverage. 

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>