### PR TITLE
[Driver][SYCL] Fix -check-section triple matching after f8cb6be61b99

### DIFF
--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -2054,7 +2054,8 @@ clang::CheckBundledSection(const OffloadBundlerConfig &BundlerConfig) {
   if (Error Err = FH->ReadHeader(Input.getBuffer()))
     return std::move(Err);
 
-  StringRef triple = BundlerConfig.TargetNames.front();
+  auto TargetInfo =
+      OffloadTargetInfo(BundlerConfig.TargetNames.front(), BundlerConfig);
 
   // Read all the bundles that are in the work list. If we find no bundles we
   // assume the file is meant for the host target.
@@ -2069,7 +2070,13 @@ clang::CheckBundledSection(const OffloadBundlerConfig &BundlerConfig) {
     if (!*CurTripleOrErr)
       break;
 
-    if (*CurTripleOrErr == triple) {
+    StringRef CurTriple = **CurTripleOrErr;
+    if (!checkOffloadBundleID(CurTriple))
+      return createStringError(errc::invalid_argument,
+                               "invalid bundle id read from the bundle");
+
+    if (isCodeObjectCompatible(OffloadTargetInfo(CurTriple, BundlerConfig),
+                               TargetInfo)) {
       found = true;
       break;
     }

--- a/clang/test/Driver/clang-offload-bundler-bc-archive-support-linux-old-model.cpp
+++ b/clang/test/Driver/clang-offload-bundler-bc-archive-support-linux-old-model.cpp
@@ -63,21 +63,21 @@
 // RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64-unknown-unknown
 // RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_gen
 // RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_x86_64
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown-a
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-x86_64-unknown-linux-gnu-b
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64-unknown-unknown-c
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_gen-d
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_x86_64-e
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown-a
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-x86_64-unknown-linux-gnu-b
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64-unknown-unknown-c
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_gen-d
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_x86_64-e
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-x86_64-unknown-linux-gnu
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64-unknown-unknown
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_gen
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_x86_64
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown-a
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-x86_64-unknown-linux-gnu-b
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64-unknown-unknown-c
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_gen-d
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_x86_64-e
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown-a
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-x86_64-unknown-linux-gnu-b
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64-unknown-unknown-c
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_gen-d
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_x86_64-e
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Unbundle object file to use as a reference result

--- a/clang/test/Driver/clang-offload-bundler-bc-archive-support-win-old-model.cpp
+++ b/clang/test/Driver/clang-offload-bundler-bc-archive-support-win-old-model.cpp
@@ -63,21 +63,21 @@
 // RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64-unknown-unknown
 // RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_gen
 // RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_x86_64
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown-a
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-x86_64-pc-windows-msvc-b
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64-unknown-unknown-c
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_gen-d
-// RUN: not clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_x86_64-e
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown-a
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-x86_64-pc-windows-msvc-b
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64-unknown-unknown-c
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_gen-d
+// RUN:     clang-offload-bundler -check-section -type=ao  -input=%t_bundled.a -targets=host-spir64_x86_64-e
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-x86_64-pc-windows-msvc
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64-unknown-unknown
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_gen
 // RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_x86_64
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown-a
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-x86_64-pc-windows-msvc-b
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64-unknown-unknown-c
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_gen-d
-// RUN: not clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_x86_64-e
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=sycl-spir64-unknown-unknown-a
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-x86_64-pc-windows-msvc-b
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64-unknown-unknown-c
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_gen-d
+// RUN:     clang-offload-bundler -check-section -type=aoo -input=%t_bundled.a -targets=host-spir64_x86_64-e
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Unbundle object file to use as a reference result


### PR DESCRIPTION
f8cb6be61b99 switched OffloadBundler::ConstructJob's host-triple from CurTC->getTriple() to CurTC->ComputeEffectiveClangTriple(), which for MSVCToolChain injects the detected MSVC toolset version into the environment field (e.g. host-x86_64-pc-windows-msvc19.29.30159).

That broke clang-offload-bundler -check-section, which compared the bundle's stored triple against the -targets= string via raw string equality, causing
`clang-offload-bundler -check-section -targets=host-x86_64-pc-windows-msvc` to fail to find the host bundle.

This PR aligns CheckBundledSection with the existing -unbundle path: both now go through OffloadTargetInfo/isCodeObjectCompatible(), which already relies on Triple::isCompatibleWith() and ignores the environment- version component. This fixes the root inconsistency between -check-section and -unbundle target matching.

Test's 6-component change is due to a pre-existing upstream behavior: OffloadTargetInfo's constructor silently drops an unrecognized trailing target-id component (i.e. "-b") as `TargetID = ""`. `-c`/`-d`/`-e` suffixed spir64/spir64_gen/spir64_x86_64 targets in the test still match their un-suffixed counterparts because those go through a different code path (target strings with fewer than 5 dash-separated components) where the bogus suffix lands in llvm::Triple's vendor/ environment field instead; Triple::isCompatibleWith compares those fields as enums, and any unrecognized string collapses to the same Unknown enum value, so it still matches.
These are pre-existing behaviors, out of scope for this change.

CMPLRLLVM-76621