### PR TITLE
[SYCL] Remove stale code previously used for FPGA loop counts, fusion, and coalescence

### DIFF
--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -570,13 +570,6 @@ SmallVector<Metadata *, 4> LoopInfo::createMetadata(
     LoopProperties.push_back(MDNode::get(Ctx, Vals));
   }
 
-  for (const auto &VC : Attrs.SYCLIntelFPGAVariantCount) {
-    Metadata *Vals[] = {MDString::get(Ctx, VC.first),
-                        ConstantAsMetadata::get(ConstantInt::get(
-                            llvm::Type::getInt32Ty(Ctx), VC.second))};
-    LoopProperties.push_back(MDNode::get(Ctx, Vals));
-  }
-  
   if (Attrs.SYCLMaxReinvocationDelayNCycles) {
     Metadata *Vals[] = {
         MDString::get(Ctx, "llvm.loop.intel.max_reinvocation_delay.count"),
@@ -630,7 +623,6 @@ void LoopAttributes::clear() {
   SYCLMaxConcurrencyNThreads.reset();
   SYCLLoopPipeliningDisable = false;
   SYCLMaxInterleavingNInvocations.reset();
-  SYCLIntelFPGAVariantCount.clear();
   SYCLMaxReinvocationDelayNCycles.reset();
   SYCLLoopPipeliningEnable = false;
   UnrollCount = 0;
@@ -665,8 +657,7 @@ LoopInfo::LoopInfo(BasicBlock *Header, const LoopAttributes &Attrs,
       Attrs.ArraySYCLIVDepInfo.empty() && Attrs.SYCLIInterval == 0 &&
       !Attrs.SYCLMaxConcurrencyNThreads &&
       Attrs.SYCLLoopPipeliningDisable == false &&
-      !Attrs.SYCLMaxInterleavingNInvocations &&
-      Attrs.SYCLIntelFPGAVariantCount.empty() && Attrs.UnrollCount == 0 &&
+      !Attrs.SYCLMaxInterleavingNInvocations && Attrs.UnrollCount == 0 &&
       !Attrs.SYCLMaxReinvocationDelayNCycles &&
       !Attrs.SYCLLoopPipeliningEnable && Attrs.UnrollAndJamCount == 0 &&
       !Attrs.PipelineDisabled && !Attrs.LICMDisabled &&

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -118,12 +118,6 @@ struct LoopAttributes {
   llvm::SmallVector<std::pair<const char *, unsigned int>, 2>
       SYCLIntelFPGAVariantCount;
 
-  /// Flag for llvm.loop.coalesce metadata.
-  bool SYCLLoopCoalesceEnable;
-
-  /// Value for llvm.loop.coalesce.count metadata.
-  unsigned SYCLLoopCoalesceNLevels;
-
   /// Flag for llvm.loop.intel.pipelining.enable, i32 0 metadata.
   bool SYCLLoopPipeliningDisable;
 
@@ -156,9 +150,6 @@ struct LoopAttributes {
 
   /// Value for llvm.loop.pipeline.iicount metadata.
   unsigned PipelineInitiationInterval;
-
-  /// Flag for llvm.loop.fusion.disable metatdata.
-  bool SYCLNofusionEnable;
 
   /// Value for 'llvm.loop.align' metadata.
   unsigned CodeAlign;
@@ -382,16 +373,6 @@ public:
     StagedAttrs.SYCLMaxConcurrencyNThreads = C;
   }
 
-  /// Set flag of loop_coalesce for the next loop pushed.
-  void setSYCLLoopCoalesceEnable() {
-    StagedAttrs.SYCLLoopCoalesceEnable = true;
-  }
-
-  /// Set value of coalesced levels for the next loop pushed.
-  void setSYCLLoopCoalesceNLevels(unsigned C) {
-    StagedAttrs.SYCLLoopCoalesceNLevels = C;
-  }
-
   /// Set flag of disable_loop_pipelining for the next loop pushed.
   void setSYCLLoopPipeliningDisable() {
     StagedAttrs.SYCLLoopPipeliningDisable = true;
@@ -425,9 +406,6 @@ public:
   void setPipelineInitiationInterval(unsigned C) {
     StagedAttrs.PipelineInitiationInterval = C;
   }
-
-  /// Set flag of nofusion for the next loop pushed.
-  void setSYCLNofusionEnable() { StagedAttrs.SYCLNofusionEnable = true; }
 
   /// Set value of code align for the next loop pushed.
   void setCodeAlign(unsigned C) { StagedAttrs.CodeAlign = C; }

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -114,10 +114,6 @@ struct LoopAttributes {
   /// Value for llvm.loop.max_concurrency.count metadata.
   std::optional<unsigned> SYCLMaxConcurrencyNThreads;
 
-  /// Value for count variant (min/max/avg) and count metadata.
-  llvm::SmallVector<std::pair<const char *, unsigned int>, 2>
-      SYCLIntelFPGAVariantCount;
-
   /// Flag for llvm.loop.intel.pipelining.enable, i32 0 metadata.
   bool SYCLLoopPipeliningDisable;
 
@@ -386,11 +382,6 @@ public:
   /// Set value of speculated iterations for the next loop pushed.
   void setSYCLSpeculatedIterationsNIterations(unsigned C) {
     StagedAttrs.SYCLSpeculatedIterationsNIterations = C;
-  }
-
-  /// Set value of variant and loop count for the next loop pushed.
-  void setSYCLIntelFPGAVariantCount(const char *Var, unsigned int Count) {
-    StagedAttrs.SYCLIntelFPGAVariantCount.push_back({Var, Count});
   }
 
   /// Set the unroll count for the next loop pushed.


### PR DESCRIPTION
Support for the `[[intel::loop_count(N)]]`, `[[intel::loop_count_avg(N)]]`, `[[intel::loop_count_min(N)]]`, `[[intel::loop_count_max(N)]]`, `[[intel::loop_coalesce]]`, and `[[intel::nofusion]]` attributes was previously removed by the following commits.
- 7102583: [SYCL] PR 2 - Remove FPGA attributes from SYCL FE (#21722)
- 3ee6128: [SYCL] PR 6 - Remove FPGA Attributes from SYCL FE (#21785)
- 136b1cd: [SYCL] PR 1 - Remove FPGA attributes from SYCL FE (#21710)

Removal of the attributes left a few data members and related setter functions unused. This change removes them.