### PR TITLE
[L0][V2] Enable host memory registration on Win

### DIFF
--- a/unified-runtime/source/adapters/level_zero/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/device.cpp
@@ -1284,7 +1284,7 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue(true);
   }
   case UR_DEVICE_INFO_USM_HOST_ALLOC_REGISTER_SUPPORT_EXP: {
-#if defined(UR_ADAPTER_LEVEL_ZERO_V2) && defined(__linux__)
+#if defined(UR_ADAPTER_LEVEL_ZERO_V2)
     // Registering existing host memory as a USM host allocation relies on the
     // external system memory mapping extension being supported by the driver.
     return ReturnValue(


### PR DESCRIPTION
Functionality works on Windows, so there is no reason to have this disabled.