### PR TITLE
[SYCL][Test] Relax check in layout_handler.cpp to pass on RHEL 8.8

### DIFF
--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -14,7 +14,7 @@ void foo() {
 // The order of field declarations and their types are important.
 // CHECK:        0 | class sycl::handler
 // CHECK-NEXT:   0 |   class std::unique_ptr<class sycl::detail::handler_impl> implOwner
-// CHECK-NEXT:   0 |       class std::__uniq_ptr_impl<class sycl::detail::handler_impl, struct std::default_delete<class sycl::detail::handler_impl> >
+// CHECK:        0 |       class std::__uniq_ptr_impl<class sycl::detail::handler_impl, struct std::default_delete<class sycl::detail::handler_impl> >
 // CHECK-NEXT:   0 |         class std::tuple<class sycl::detail::handler_impl *, struct std::default_delete<class sycl::detail::handler_impl> >
 // CHECK-NEXT:   0 |           struct std::_Tuple_impl<0, class sycl::detail::handler_impl *, struct std::default_delete<class sycl::detail::handler_impl> > (base)
 // CHECK-NEXT:   0 |             struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::handler_impl> > (base) (empty)

--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -14,8 +14,7 @@ void foo() {
 // The order of field declarations and their types are important.
 // CHECK:        0 | class sycl::handler
 // CHECK-NEXT:   0 |   class std::unique_ptr<class sycl::detail::handler_impl> implOwner
-// CHECK-NEXT:   0 |     struct std::__uniq_ptr_data<class sycl::detail::handler_impl, struct std::default_delete<class sycl::detail::handler_impl> >
-// CHECK-NEXT:   0 |       class std::__uniq_ptr_impl<class sycl::detail::handler_impl, struct std::default_delete<class sycl::detail::handler_impl> > (base)
+// CHECK-NEXT:   0 |       class std::__uniq_ptr_impl<class sycl::detail::handler_impl, struct std::default_delete<class sycl::detail::handler_impl> >
 // CHECK-NEXT:   0 |         class std::tuple<class sycl::detail::handler_impl *, struct std::default_delete<class sycl::detail::handler_impl> >
 // CHECK-NEXT:   0 |           struct std::_Tuple_impl<0, class sycl::detail::handler_impl *, struct std::default_delete<class sycl::detail::handler_impl> > (base)
 // CHECK-NEXT:   0 |             struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::handler_impl> > (base) (empty)
@@ -56,8 +55,7 @@ void foo() {
 // CHECK-NEXT:   128 |           pointer _M_finish
 // CHECK-NEXT:   136 |           pointer _M_end_of_storage
 // CHECK-NEXT:   144 |   class std::unique_ptr<class sycl::detail::HostKernelBase> MHostKernel
-// CHECK-NEXT:   144 |     struct std::__uniq_ptr_data<class sycl::detail::HostKernelBase, struct std::default_delete<class sycl::detail::HostKernelBase> >
-// CHECK:        144 |       class std::__uniq_ptr_impl<class sycl::detail::HostKernelBase, struct std::default_delete<class sycl::detail::HostKernelBase> > (base)
+// CHECK:        144 |       class std::__uniq_ptr_impl<class sycl::detail::HostKernelBase, struct std::default_delete<class sycl::detail::HostKernelBase> >
 // CHECK-NEXT:   144 |         class std::tuple<class sycl::detail::HostKernelBase *, struct std::default_delete<class sycl::detail::HostKernelBase> >
 // CHECK-NEXT:   144 |           struct std::_Tuple_impl<0, class sycl::detail::HostKernelBase *, struct std::default_delete<class sycl::detail::HostKernelBase> > (base)
 // CHECK-NEXT:   144 |             struct std::_Tuple_impl<1, struct std::default_delete<class sycl::detail::HostKernelBase> > (base) (empty)


### PR DESCRIPTION
`struct std::__uniq_ptr_data` line isn't present on el88 with gcc 8.5.

CMPLRLLVM-76646