### PR TITLE
[SYCL][Test] Disable 2 failing tests on old libstdc++ via lit features

### DIFF
--- a/sycl/test/basic_tests/device_only_no_iostream.cpp
+++ b/sycl/test/basic_tests/device_only_no_iostream.cpp
@@ -26,6 +26,8 @@
 // Filesystem transitively pulls in iostream, so we intentionally exclude
 // sycl.hpp from this test.
 //
+// UNSUPPORTED: linux && !glibcxx-ge-11
+//
 // RUN: %clangxx -fsycl -fsycl-device-only -include %S/Inputs/khr_all.hpp \
 // RUN:   -c %s -o %t.o -MD -MF - | FileCheck %s
 //

--- a/sycl/test/extensions/DeviceImageBackendContent/negative_test.cpp
+++ b/sycl/test/extensions/DeviceImageBackendContent/negative_test.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang -fsycl -fsyntax-only -std=c++20 -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
+// UNSUPPORTED: linux && !cpp_lib_span
 
 #include <sycl/detail/core.hpp>
 #include <sycl/kernel_bundle.hpp>

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -198,6 +198,38 @@ llvm_config.with_environment("UR_LOG_CALLBACK", "disabled")
 if not dump_only_tests:
     llvm_config.use_clang(additional_flags=additional_flags)
 
+    # Detect libstdc++ behavior that %clangxx picks up on this host, so tests
+    # can be gated on actual libstdc++ properties instead of a nonexistent
+    # "gcc11"-style feature. Modeled after libcxx's compilerMacros() in
+    # libcxx/utils/libcxx/test/dsl.py.
+    def get_predefined_macros(include, std=None):
+        probe = tempfile.NamedTemporaryFile(suffix=".cpp", delete=False)
+        try:
+            probe.write(("#include <%s>\n" % include).encode())
+            probe.close()
+            cmd = [config.clang, "-dM", "-E", probe.name]
+            if std:
+                cmd.insert(1, "-std=%s" % std)
+            return subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode()
+        except (subprocess.CalledProcessError, OSError):
+            return ""
+        finally:
+            os.unlink(probe.name)
+
+    if platform.system() == "Linux":
+        match = re.search(
+            r"#define _GLIBCXX_RELEASE (\d+)", get_predefined_macros("version")
+        )
+        if match and int(match.group(1)) >= 11:
+            config.available_features.add("glibcxx-ge-11")
+
+        # negative_test.cpp expects __cpp_lib_span-gated diagnostics; older
+        # libstdc++ versions don't provide <span>, so __cpp_lib_span stays
+        # undefined even with -std=c++20 and the expected-error annotations
+        # under "#ifdef __cpp_lib_span" never get compiled in.
+        if "#define __cpp_lib_span" in get_predefined_macros("span", std="c++20"):
+            config.available_features.add("cpp_lib_span")
+
 # Set timeout for test = 10 mins
 try:
     import psutil


### PR DESCRIPTION
Both tests fail on RHEL 8.8/gcc 8.5.

Add feature detection to sycl/test/lit.cfg.py, probing the predefined macros of the toolchain in use (modeled on libcxx's compilerMacros()):
- glibcxx-ge-11: from _GLIBCXX_RELEASE, for device_only_no_iostream.cpp, whose root cause is <bits/stl_iterator.h> pulling in <ostream> on older libstdc++.
- cpp_lib_span: from __cpp_lib_span with -std=c++20, for negative_test.cpp, whose root cause is <span> being unavailable on older libstdc++, not a C++20 language-mode issue.

CMPLRLLVM-76646