### PR TITLE
[SYCL][Graph] Only track in-partition predecessors in topological sort

### DIFF
--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -172,7 +172,7 @@ void propagatePartitionDown(node_impl &Node, int PartitionNum,
 /// A node is a root of its partition iff this count is zero.
 /// @param Node node to test
 /// @return Number of predecessors of `Node` in the same partition.
-size_t countPredecessorsInPartition(node_impl &Node) {
+size_t countPredecessorsInPartition(const node_impl &Node) {
   return static_cast<size_t>(
       std::count_if(Node.predecessors().begin(), Node.predecessors().end(),
                     [&Node](node_impl &Predecessor) {

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -109,14 +109,14 @@ void sortTopological(nodes_range Roots, std::list<node_impl *> &SortedNodes,
 
       // When bounded to a partition we only traverse edges internal to the
       // partition as predecessor nodes to an earlier partition are not part
-      // of the current partition's schedule.
+      // of the current partition's schedule. The same-partition in-degree is
+      // precomputed in makePartitions so this stays O(1) per edge; the
+      // unbounded caller (checkForCycles) has no partitions and counts all
+      // predecessors.
+      assert(!PartitionBounded || Succ.MSamePartitionPredecessors >= 0);
       size_t RequiredEdges =
           PartitionBounded
-              ? static_cast<size_t>(std::count_if(
-                    Succ.MPredecessors.begin(), Succ.MPredecessors.end(),
-                    [&Succ](node_impl *Pred) {
-                      return Pred->MPartitionNum == Succ.MPartitionNum;
-                    }))
+              ? static_cast<size_t>(Succ.MSamePartitionPredecessors)
               : Succ.MPredecessors.size();
 
       auto &TotalVisitedEdges = Succ.MTotalVisitedEdges;
@@ -171,17 +171,16 @@ void propagatePartitionDown(node_impl &Node, int PartitionNum,
   }
 }
 
-/// Tests if the node is a root of its partition (i.e. no predecessors that
-/// belong to the same partition)
+/// Counts the predecessors of `Node` that belong to the same partition.
+/// A node is a root of its partition iff this count is zero.
 /// @param Node node to test
-/// @return True is `Node` is a root of its partition
-bool isPartitionRoot(node_impl &Node) {
-  for (node_impl &Predecessor : Node.predecessors()) {
-    if (Predecessor.MPartitionNum == Node.MPartitionNum) {
-      return false;
-    }
-  }
-  return true;
+/// @return Number of predecessors of `Node` in the same partition.
+size_t countPredecessorsInPartition(node_impl &Node) {
+  return static_cast<size_t>(
+      std::count_if(Node.predecessors().begin(), Node.predecessors().end(),
+                    [&Node](node_impl &Predecessor) {
+                      return Predecessor.MPartitionNum == Node.MPartitionNum;
+                    }));
 }
 } // anonymous namespace
 
@@ -268,7 +267,8 @@ void exec_graph_impl::makePartitions() {
     for (node_impl &Node : nodes()) {
       if (Node.MPartitionNum == i) {
         MPartitionNodes[&Node] = PartitionFinalNum;
-        if (isPartitionRoot(Node)) {
+        Node.MSamePartitionPredecessors = countPredecessorsInPartition(Node);
+        if (Node.MSamePartitionPredecessors == 0) {
           Partition->MRoots.insert(&Node);
           if (Node.MCGType == CGType::CodeplayHostTask) {
             Partition->MIsHostTask = true;
@@ -311,6 +311,7 @@ void exec_graph_impl::makePartitions() {
   // Reset node groups (if node have to be re-processed - e.g. subgraph)
   for (node_impl &Node : nodes()) {
     Node.MPartitionNum = -1;
+    Node.MSamePartitionPredecessors = -1;
   }
 }
 

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -11,6 +11,7 @@
 #include "graph_impl.hpp"
 #include "dynamic_impl.hpp" // for dynamic classes
 #include "node_impl.hpp"    // for node_impl
+#include <algorithm>        // for count_if
 #include <detail/cg.hpp> // for CG, CGExecKernel, CGHostTask, ArgDesc, NDRDescT
 #include <detail/config.hpp>                          // for SYCLConfig
 #include <detail/event_impl.hpp>                      // for event_impl
@@ -21,7 +22,6 @@
 #include <detail/queue_impl.hpp>                      // for queue_impl
 #include <detail/sycl_mem_obj_t.hpp>                  // for SYCLMemObjT
 #include <detail/ur.hpp>                              // for UR APIs
-#include <algorithm>                                  // for count_if
 #include <stack>                                      // for stack
 #include <sycl/detail/common.hpp>      // for tls_code_loc_t etc..
 #include <sycl/detail/kernel_desc.hpp> // for kernel_param_kind_t

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -21,6 +21,7 @@
 #include <detail/queue_impl.hpp>                      // for queue_impl
 #include <detail/sycl_mem_obj_t.hpp>                  // for SYCLMemObjT
 #include <detail/ur.hpp>                              // for UR APIs
+#include <algorithm>                                  // for count_if
 #include <stack>                                      // for stack
 #include <sycl/detail/common.hpp>      // for tls_code_loc_t etc..
 #include <sycl/detail/kernel_desc.hpp> // for kernel_param_kind_t
@@ -106,9 +107,21 @@ void sortTopological(nodes_range Roots, std::list<node_impl *> &SortedNodes,
         continue;
       }
 
+      // When bounded to a partition we only traverse edges internal to the
+      // partition as predecessor nodes to an earlier partition are not part
+      // of the current partition's schedule.
+      size_t RequiredEdges =
+          PartitionBounded
+              ? static_cast<size_t>(std::count_if(
+                    Succ.MPredecessors.begin(), Succ.MPredecessors.end(),
+                    [&Succ](node_impl *Pred) {
+                      return Pred->MPartitionNum == Succ.MPartitionNum;
+                    }))
+              : Succ.MPredecessors.size();
+
       auto &TotalVisitedEdges = Succ.MTotalVisitedEdges;
       ++TotalVisitedEdges;
-      if (TotalVisitedEdges == Succ.MPredecessors.size()) {
+      if (TotalVisitedEdges == RequiredEdges) {
         Source.push(&Succ);
       }
     }

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -111,7 +111,7 @@ void sortTopological(nodes_range Roots, std::list<node_impl *> &SortedNodes,
       // as predecessor nodes to an earlier partition are not part of the
       // current schedule.
       assert(!PartitionBounded || Succ.MSamePartitionPredecessors >= 0);
-      size_t RequiredEdges =
+      const size_t RequiredEdges =
           PartitionBounded
               ? static_cast<size_t>(Succ.MSamePartitionPredecessors)
               : Succ.MPredecessors.size();

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -107,12 +107,9 @@ void sortTopological(nodes_range Roots, std::list<node_impl *> &SortedNodes,
         continue;
       }
 
-      // When bounded to a partition we only traverse edges internal to the
-      // partition as predecessor nodes to an earlier partition are not part
-      // of the current partition's schedule. The same-partition in-degree is
-      // precomputed in makePartitions so this stays O(1) per edge; the
-      // unbounded caller (checkForCycles) has no partitions and counts all
-      // predecessors.
+      // When PartitionBounded we only traverse edges internal to the partition
+      // as predecessor nodes to an earlier partition are not part of the
+      // current schedule.
       assert(!PartitionBounded || Succ.MSamePartitionPredecessors >= 0);
       size_t RequiredEdges =
           PartitionBounded

--- a/sycl/source/detail/graph/node_impl.hpp
+++ b/sycl/source/detail/graph/node_impl.hpp
@@ -106,9 +106,14 @@ public:
   size_t MTotalVisitedEdges = 0;
 
   /// Partition number needed to assign a Node to a a partition.
-  /// Note : This number is only used during the partitionning process and
+  /// Note : This number is only used during the partitioning process and
   /// cannot be used to find out the partion of a node outside of this process.
   int MPartitionNum = -1;
+
+  /// Number of predecessors of this node that belong to the same partition.
+  /// Note : This number is only used during the partitioning process and
+  /// cannot be used to find out the partion of a node outside of this process.
+  int MSamePartitionPredecessors = -1;
 
   // Out-of-class as need "complete" `nodes_range`:
   inline nodes_range successors() const;

--- a/sycl/source/detail/graph/node_impl.hpp
+++ b/sycl/source/detail/graph/node_impl.hpp
@@ -112,7 +112,8 @@ public:
 
   /// Number of predecessors of this node that belong to the same partition.
   /// Note : This number is only used during the partitioning process and
-  /// cannot be used to find out the partion of a node outside of this process.
+  /// cannot be used to find out the number of partition predecessors outside of
+  /// this process.
   int MSamePartitionPredecessors = -1;
 
   // Out-of-class as need "complete" `nodes_range`:

--- a/sycl/unittests/Extensions/CommandGraph/Regressions.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Regressions.cpp
@@ -178,3 +178,97 @@ TEST_F(CommandGraphTest, AsyncAllocInfiniteLoop) {
 
   Graph.end_recording(Queue);
 }
+
+// Regression test for a node being silently dropped from the command-buffer
+// schedule. When a host task partitions the graph, the topological sort per
+// partition only traverses edges internal to that partition, but it used to
+// wait for all predecessors (including cross-partition ones) to be visited
+// before scheduling a node. A node with a cross-partition predecessor could
+// therefore never reach its completion threshold and, along with everything
+// downstream of it, was omitted from the schedule and never enqueued.
+//
+// The topology below reproduces the issue with two in-order queues recording
+// into one graph and barriers creating the cross-queue edges:
+//
+//   Q2 chain:  BQ2a ---------> BQ2b --> BQ2c
+//              |               ^        |
+//              |[A]            |[B]     |[C]  (cross-queue barrier edges)
+//              v               |        v
+//   Q1 chain:  BQ1a --> HT --> BQ1b --> BQ1c --> K
+//
+// The host task HT splits the graph. BQ2a is pulled into HT's predecessor
+// partition, but its in-order successor BQ2b stays in the successor partition,
+// creating the cross-partition edge BQ2a -> BQ2b that lands on an interior
+// (non-root) node. Prior to the fix, BQ2b (and hence BQ2c, BQ1c and the kernel
+// K) were dropped from the schedule.
+TEST_F(CommandGraphTest, HostTaskPartitionCrossQueueBarrier) {
+  sycl::property_list InOrder{sycl::property::queue::in_order()};
+  sycl::queue Q1{Queue.get_context(), Dev, InOrder};
+  sycl::queue Q2{Queue.get_context(), Dev, InOrder};
+
+  experimental::command_graph<experimental::graph_state::modifiable> G{
+      Q1.get_context(), Q1.get_device()};
+
+  G.begin_recording({Q1, Q2});
+
+  // [A] pre-HT: Q2 -> Q1
+  {
+    sycl::event E = Q2.ext_oneapi_submit_barrier();
+    Q1.ext_oneapi_submit_barrier({E});
+  }
+
+  // Host task on Q1, which forces graph partitioning.
+  Q1.submit([&](sycl::handler &CGH) { CGH.host_task([]() {}); });
+
+  // [B] post-HT: Q1 -> Q2
+  {
+    sycl::event E = Q1.ext_oneapi_submit_barrier();
+    Q2.ext_oneapi_submit_barrier({E});
+  }
+
+  // [C] pre-K: Q2 -> Q1
+  {
+    sycl::event E = Q2.ext_oneapi_submit_barrier();
+    Q1.ext_oneapi_submit_barrier({E});
+  }
+
+  G.end_recording(Q2);
+
+  // Kernel K on Q1, downstream of the barrier chain. This is the node that was
+  // silently dropped prior to the fix.
+  auto KernelEvent = Q1.submit(
+      [&](sycl::handler &CGH) { CGH.single_task<TestKernel>([]() {}); });
+
+  G.end_recording();
+
+  experimental::detail::graph_impl &GraphImpl = *getSyclObjImpl(G);
+  experimental::detail::node_impl &KernelNode =
+      GraphImpl.getNodeForEvent(getSyclObjImpl(KernelEvent));
+
+  auto GraphExec = G.finalize();
+  experimental::detail::exec_graph_impl &ExecGraphImpl =
+      *getSyclObjImpl(GraphExec);
+
+  // Every node that requires enqueue must appear in the schedule. The kernel is
+  // the node that was dropped; assert on it explicitly, and also check that no
+  // enqueue-requiring node is missing overall.
+  const auto &Schedule = ExecGraphImpl.getSchedule();
+
+  size_t NumEnqueuedNodesInGraph = 0;
+  for (experimental::detail::node_impl &Node : GraphImpl.nodes()) {
+    if (Node.requiresEnqueue())
+      ++NumEnqueuedNodesInGraph;
+  }
+
+  size_t NumEnqueuedNodesInSchedule = 0;
+  bool KernelFoundInSchedule = false;
+  for (experimental::detail::node_impl *Node : Schedule) {
+    if (Node->requiresEnqueue())
+      ++NumEnqueuedNodesInSchedule;
+    if (Node->isSimilar(KernelNode))
+      KernelFoundInSchedule = true;
+  }
+
+  ASSERT_TRUE(KernelFoundInSchedule);
+  ASSERT_EQ(NumEnqueuedNodesInSchedule, NumEnqueuedNodesInGraph);
+}


### PR DESCRIPTION
- Graph topological sorting with multiple partitions led to nodes being silently dropped from the schedule when non-roots in the partition had predecessors to nodes in previous partitions.
- Nodes in earlier partitions are ordered strictly before roots in the current partition, so they are never visited.
- Topological sorting should only track nodes in the current partition which can be pre-computed in `makePartitions`