### PR TITLE
[SYCL] Avoid Windows min/max macro collision in float_8bit types.hpp

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/float_8bit/types.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/float_8bit/types.hpp
@@ -779,10 +779,10 @@ static inline ToT ConvertFromFP8ToBinaryFloat_CPU(uint8_t code,
 
     if (isInf) {
       if constexpr (Traits::IsSigned) {
-        return negative ? std::numeric_limits<ToT>::min()
-                        : std::numeric_limits<ToT>::max();
+        return negative ? (std::numeric_limits<ToT>::min)()
+                        : (std::numeric_limits<ToT>::max)();
       } else {
-        return negative ? ToT{0} : std::numeric_limits<ToT>::max();
+        return negative ? ToT{0} : (std::numeric_limits<ToT>::max)();
       }
     }
 
@@ -796,9 +796,9 @@ static inline ToT ConvertFromFP8ToBinaryFloat_CPU(uint8_t code,
       if (shift >= 64) {
         // Value is too large - saturate to max
         if constexpr (Traits::IsSigned)
-          return std::numeric_limits<ToT>::max();
+          return (std::numeric_limits<ToT>::max)();
         else
-          return std::numeric_limits<ToT>::max();
+          return (std::numeric_limits<ToT>::max)();
       }
       magnitude = static_cast<uint64_t>(significand) << shift;
     } else {
@@ -832,10 +832,10 @@ static inline ToT ConvertFromFP8ToBinaryFloat_CPU(uint8_t code,
 
     if (BitWidth(magnitude) > Traits::ValueBits) {
       if constexpr (Traits::IsSigned)
-        return negative ? std::numeric_limits<ToT>::min()
-                        : std::numeric_limits<ToT>::max();
+        return negative ? (std::numeric_limits<ToT>::min)()
+                        : (std::numeric_limits<ToT>::max)();
       else
-        return negative ? ToT{0} : std::numeric_limits<ToT>::max();
+        return negative ? ToT{0} : (std::numeric_limits<ToT>::max)();
     }
 
     const UnsignedT narrowed = static_cast<UnsignedT>(magnitude);


### PR DESCRIPTION
Windows.h's min/max macros swallow bare std::numeric_limits<ToT>::min()/max() calls, causing a macro-arity error when compiling with -fsycl-device-only on Windows. Wrap the calls in parens to suppress macro expansion.

Fix SYCL basic_tests/min_max_test.cpp on Windows in CMPLRLLVM-76728.