### PR TITLE
[clang][SYCL] Remove llvm.used addrspace customization

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3911,26 +3911,17 @@ static void emitUsed(CodeGenModule &CGM, StringRef Name,
   if (List.empty())
     return;
 
-  // For SYCL emit pointers in the default address space which is a superset of
-  // other address spaces, so that casts from any other address spaces will be
-  // valid.
-  llvm::PointerType *TargetType = CGM.Int8PtrTy;
-  if (CGM.getLangOpts().SYCLIsDevice)
-    TargetType = llvm::PointerType::get(
-        CGM.getLLVMContext(),
-        CGM.getContext().getTargetAddressSpace(LangAS::Default));
-
   // Convert List to what ConstantArray needs.
   SmallVector<llvm::Constant*, 8> UsedArray;
   UsedArray.resize(List.size());
   for (unsigned i = 0, e = List.size(); i != e; ++i) {
     UsedArray[i] = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(
-            cast<llvm::Constant>(&*List[i]), TargetType);
+        cast<llvm::Constant>(&*List[i]), CGM.Int8PtrTy);
   }
 
   if (UsedArray.empty())
     return;
-  llvm::ArrayType *ATy = llvm::ArrayType::get(TargetType, UsedArray.size());
+  llvm::ArrayType *ATy = llvm::ArrayType::get(CGM.Int8PtrTy, UsedArray.size());
 
   auto *GV = new llvm::GlobalVariable(
       CGM.getModule(), ATy, false, llvm::GlobalValue::AppendingLinkage,


### PR DESCRIPTION
We have a customization to use the default AS for `-fsycl-device-only` for `llvm.used`/`llvm.compiler.used`.

The SPIR target is not consistent on its address space definitions, there is conditional logic based on the compilation modes, causing problems if we try to link files with the same triple but different compilation flags together. 

The reason for this change is in the internal compiler we link pure OpenCL code against SYCL -fsycl-device-only code and run into a linking failure due to the two instances of `llvm.compiler.used` having different array element types (`ptr` vs `ptr addrspace(4)`).

The other option to fix the OpenCL failure would be try to add even more customizations, both here and in the internal compiler, to get the address spaces to match for this case and try not to break upstream OpenCL use cases which expect the current AS configuration.

Many targets upstream have different target address spaces, and they don't need this customization, so we shouldn't either.

Removing this causes no failures (actually fixes some in the internal compiler) and returns us to [match](https://github.com/llvm/llvm-project/blob/main/clang/lib/CodeGen/CodeGenModule.cpp#L3704) upstream.


