### PR TITLE
[SYCL][E2E] Disable hanging DX12 interop tests

### DIFF
--- a/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_timeline_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_buffer_timeline_semaphore.cpp
@@ -2,7 +2,8 @@
 // REQUIRES: aspect-ext_oneapi_external_semaphore_import
 // REQUIRES: windows
 
-// REQUIRES-INTEL-DRIVER: lin: 38303 win: 101.9999
+// UNSUPPORTED: windows && run-mode
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22576
 
 // RUN: %{build} %link-directx -o %t.exe %if target-spir %{ -Wno-ignored-attributes %}
 // RUN: %{run} %t.exe --no-sem

--- a/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_interop_2D_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_interop_2D_write_unsampled.cpp
@@ -2,7 +2,8 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import
 // REQUIRES: windows
 
-// REQUIRES-INTEL-DRIVER: lin: 38303 win: 101.9999
+// UNSUPPORTED: windows && run-mode
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22576
 
 // RUN: %{build} -o %t.exe %link-directx
 // RUN: %{run} %t.exe --type float --channels 4 32x33

--- a/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_interop_3D_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/D3D12_sycl_interop_3D_write_unsampled.cpp
@@ -2,7 +2,8 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import
 // REQUIRES: windows
 
-// REQUIRES-INTEL-DRIVER: lin: 38303 win: 101.9999
+// UNSUPPORTED: windows && run-mode
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22576
 
 // RUN: %{build} -o %t.exe %link-directx
 // RUN: %{run} %t.exe --type float --channels 4 8x8x8


### PR DESCRIPTION
I'm updating the Windows driver to 101.8860 (runtime version 1.15.38308), now we have a new enough version so the `REQUIRES-INTEL-DRIVER` checks pass, but unfortunately the tests still hang.

See https://github.com/intel/llvm/issues/22576