### PR TITLE
[UR][L0v2] Treat peers with statuses other than NO_CONNECTION as accessible for cross-device allocations

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -201,7 +201,8 @@ ur_context_handle_t_::getDevicesWhoseAllocationsCanBeAccessedFrom(
                    "there is no device:"
                        << candidateId << " in peers table, number of devices:"
                        << peers.size());
-        return peers[candidateId] == ur_device_handle_t_::PeerStatus::ENABLED;
+        return peers[candidateId] !=
+               ur_device_handle_t_::PeerStatus::NO_CONNECTION;
       });
 
   return retVal;

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -113,9 +113,6 @@ UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferCopyMultiDeviceTest);
 TEST_P(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
   UUR_KNOWN_FAILURE_ON(uur::CUDA{});
 
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   // First queue does a fill.
   const uint32_t input = 42;
   ASSERT_SUCCESS(urEnqueueMemBufferFill(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -311,9 +311,6 @@ UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferCopyRectMultiDeviceTest);
 TEST_P(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
   UUR_KNOWN_FAILURE_ON(uur::CUDA{});
 
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   // First queue does a fill.
   const uint32_t input = 42;
   ASSERT_SUCCESS(urEnqueueMemBufferFill(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -212,9 +212,6 @@ using urEnqueueMemBufferFillMultiDeviceTest =
 UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferFillMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferFillMultiDeviceTest, FillReadDifferentQueues) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   // First queue does a fill.
   const uint32_t input = 42;
   ASSERT_SUCCESS(urEnqueueMemBufferFill(

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -138,9 +138,6 @@ using urEnqueueMemBufferReadMultiDeviceTest =
 UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferReadMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferReadMultiDeviceTest, WriteReadDifferentQueues) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   // First queue does a blocking write of 42 into the buffer.
   std::vector<uint32_t> input(count, 42);
   ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size,

--- a/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/unified-runtime/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -277,9 +277,6 @@ UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferReadRectMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferReadRectMultiDeviceTest,
        WriteRectReadDifferentQueues) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   // First queue does a blocking write of 42 into the buffer.
   // Then a rectangular write the buffer as 1024x1x1 1D.
   std::vector<uint32_t> input(count, 42);

--- a/unified-runtime/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
+++ b/unified-runtime/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
@@ -177,9 +177,6 @@ struct urMultiDeviceContextMemBufferTest : urMultiDeviceContextTest {
 UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMultiDeviceContextMemBufferTest);
 
 TEST_P(urMultiDeviceContextMemBufferTest, WriteRead) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -204,9 +201,6 @@ TEST_P(urMultiDeviceContextMemBufferTest, WriteRead) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, FillRead) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -231,9 +225,6 @@ TEST_P(urMultiDeviceContextMemBufferTest, FillRead) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, WriteKernelRead) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -271,9 +262,6 @@ TEST_P(urMultiDeviceContextMemBufferTest, WriteKernelRead) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, WriteKernelKernelRead) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -317,9 +305,6 @@ TEST_P(urMultiDeviceContextMemBufferTest, WriteKernelKernelRead) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, PingPongKernelExecution) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -368,9 +353,6 @@ TEST_P(urMultiDeviceContextMemBufferTest, PingPongKernelExecution) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, ComplexMigrationPattern) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   if (num_devices <= 1) {
     GTEST_SKIP();
   }
@@ -437,9 +419,6 @@ TEST_P(urMultiDeviceContextMemBufferTest, ComplexMigrationPattern) {
 }
 
 TEST_P(urMultiDeviceContextMemBufferTest, KernelsExecutionWithThreads) {
-  // Related issue: https://github.com/intel/llvm/issues/22058.
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Data Center GPU Max"});
-
   if (num_devices <= 1) {
     GTEST_SKIP();
   }


### PR DESCRIPTION
Enables tests turned off in: https://github.com/intel/llvm/pull/22077