### PR TITLE
[SYCL] Fix -Wunused-template errors in headers

### DIFF
--- a/sycl/include/sycl/detail/group_sort_impl.hpp
+++ b/sycl/include/sycl/detail/group_sort_impl.hpp
@@ -30,9 +30,8 @@ namespace detail {
 // Helpers for sorting algorithms
 #ifdef __SYCL_DEVICE_ONLY__
 template <typename T, typename Group>
-static __SYCL_ALWAYS_INLINE T *align_scratch(sycl::span<std::byte> scratch,
-                                             Group g,
-                                             size_t number_of_elements) {
+__SYCL_ALWAYS_INLINE T *align_scratch(sycl::span<std::byte> scratch, Group g,
+                                      size_t number_of_elements) {
   // Adjust the scratch pointer based on alignment of the type T.
   // Per extension specification if scratch size is less than the value
   // returned by memory_required then behavior is undefined, so we don't check
@@ -56,7 +55,7 @@ static __SYCL_ALWAYS_INLINE T *align_scratch(sycl::span<std::byte> scratch,
 }
 
 template <typename KeyTy, typename ValueTy, typename Group>
-static __SYCL_ALWAYS_INLINE std::pair<KeyTy *, ValueTy *>
+__SYCL_ALWAYS_INLINE std::pair<KeyTy *, ValueTy *>
 align_key_value_scratch(sycl::span<std::byte> scratch, Group g,
                         size_t number_of_elements) {
   size_t KeysSize = number_of_elements * sizeof(KeyTy);

--- a/sycl/include/sycl/detail/image_ocl_types.hpp
+++ b/sycl/include/sycl/detail/image_ocl_types.hpp
@@ -78,7 +78,7 @@ __SYCL_INVOKE_SPIRV_CALL_ARG1(ImageQueryFormat)
 __SYCL_INVOKE_SPIRV_CALL_ARG1(ImageQueryOrder)
 
 template <typename ImageT, typename CoordT, typename ValT>
-static void __invoke__ImageWrite(ImageT Img, CoordT Coords, ValT Val) {
+void __invoke__ImageWrite(ImageT Img, CoordT Coords, ValT Val) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   auto TmpCoords = sycl::detail::convertToOpenCLType(Coords);
@@ -89,7 +89,7 @@ static void __invoke__ImageWrite(ImageT Img, CoordT Coords, ValT Val) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-static RetType __invoke__ImageRead(ImageT Img, CoordT Coords) {
+RetType __invoke__ImageRead(ImageT Img, CoordT Coords) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -100,7 +100,7 @@ static RetType __invoke__ImageRead(ImageT Img, CoordT Coords) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-static RetType __invoke__ImageFetch(ImageT Img, CoordT Coords) {
+RetType __invoke__ImageFetch(ImageT Img, CoordT Coords) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -112,7 +112,7 @@ static RetType __invoke__ImageFetch(ImageT Img, CoordT Coords) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-static RetType __invoke__SampledImageFetch(ImageT Img, CoordT Coords) {
+RetType __invoke__SampledImageFetch(ImageT Img, CoordT Coords) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -124,10 +124,10 @@ static RetType __invoke__SampledImageFetch(ImageT Img, CoordT Coords) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-static std::enable_if_t<std::is_same_v<RetType, sycl::vec<float, 4>> ||
-                            std::is_same_v<RetType, sycl::vec<int, 4>> ||
-                            std::is_same_v<RetType, sycl::vec<unsigned int, 4>>,
-                        RetType>
+std::enable_if_t<std::is_same_v<RetType, sycl::vec<float, 4>> ||
+                     std::is_same_v<RetType, sycl::vec<int, 4>> ||
+                     std::is_same_v<RetType, sycl::vec<unsigned int, 4>>,
+                 RetType>
 __invoke__SampledImageGather(ImageT Img, CoordT Coords, unsigned Component) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
@@ -140,8 +140,7 @@ __invoke__SampledImageGather(ImageT Img, CoordT Coords, unsigned Component) {
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-static RetType __invoke__ImageArrayFetch(ImageT Img, CoordT Coords,
-                                         int ArrayLayer) {
+RetType __invoke__ImageArrayFetch(ImageT Img, CoordT Coords, int ArrayLayer) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -153,8 +152,8 @@ static RetType __invoke__ImageArrayFetch(ImageT Img, CoordT Coords,
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-static RetType __invoke__SampledImageArrayFetch(ImageT Img, CoordT Coords,
-                                                int ArrayLayer) {
+RetType __invoke__SampledImageArrayFetch(ImageT Img, CoordT Coords,
+                                         int ArrayLayer) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -166,8 +165,7 @@ static RetType __invoke__SampledImageArrayFetch(ImageT Img, CoordT Coords,
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-static RetType __invoke__ImageArrayRead(ImageT Img, CoordT Coords,
-                                        int ArrayLayer) {
+RetType __invoke__ImageArrayRead(ImageT Img, CoordT Coords, int ArrayLayer) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -179,8 +177,8 @@ static RetType __invoke__ImageArrayRead(ImageT Img, CoordT Coords,
 }
 
 template <typename ImageT, typename CoordT, typename ValT>
-static void __invoke__ImageArrayWrite(ImageT Img, CoordT Coords, int ArrayLayer,
-                                      ValT Val) {
+void __invoke__ImageArrayWrite(ImageT Img, CoordT Coords, int ArrayLayer,
+                               ValT Val) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   auto TmpCoords = sycl::detail::convertToOpenCLType(Coords);
@@ -191,7 +189,7 @@ static void __invoke__ImageArrayWrite(ImageT Img, CoordT Coords, int ArrayLayer,
 }
 
 template <typename RetType, typename SmpImageT, typename DirVecT>
-static RetType __invoke__ImageReadCubemap(SmpImageT SmpImg, DirVecT DirVec) {
+RetType __invoke__ImageReadCubemap(SmpImageT SmpImg, DirVecT DirVec) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -203,8 +201,7 @@ static RetType __invoke__ImageReadCubemap(SmpImageT SmpImg, DirVecT DirVec) {
 }
 
 template <typename RetType, typename SmpImageT, typename CoordT>
-static RetType __invoke__ImageReadLod(SmpImageT SmpImg, CoordT Coords,
-                                      float Level) {
+RetType __invoke__ImageReadLod(SmpImageT SmpImg, CoordT Coords, float Level) {
   // The result type of the SPIR-V instruction OpImageSampleExplicitLod must be
   // a vector of four components. Use the type trait to get the appropriate
   // temporary vector type based on the original return type.
@@ -237,8 +234,8 @@ static RetType __invoke__ImageReadLod(SmpImageT SmpImg, CoordT Coords,
 }
 
 template <typename RetType, typename SmpImageT, typename CoordT>
-static RetType __invoke__ImageReadGrad(SmpImageT SmpImg, CoordT Coords,
-                                       CoordT Dx, CoordT Dy) {
+RetType __invoke__ImageReadGrad(SmpImageT SmpImg, CoordT Coords, CoordT Dx,
+                                CoordT Dy) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;
@@ -260,8 +257,8 @@ static RetType __invoke__ImageReadGrad(SmpImageT SmpImg, CoordT Coords,
 }
 
 template <typename RetType, typename ImageT, typename CoordT>
-static RetType __invoke__ImageReadSampler(ImageT Img, CoordT Coords,
-                                          const __ocl_sampler_t &Smpl) {
+RetType __invoke__ImageReadSampler(ImageT Img, CoordT Coords,
+                                   const __ocl_sampler_t &Smpl) {
 
   // Convert from sycl types to builtin types to get correct function mangling.
   using TempRetT = sycl::detail::ConvertToOpenCLType_t<RetType>;

--- a/sycl/include/sycl/ext/oneapi/functional.hpp
+++ b/sycl/include/sycl/ext/oneapi/functional.hpp
@@ -80,7 +80,7 @@ struct GroupOpTag<T, std::enable_if_t<detail::is_genbool_v<T>>> {
 
 #define __SYCL_CALC_OVERLOAD(GroupTag, SPIRVOperation, BinaryOperation)        \
   template <__spv::GroupOperation O, typename Group, typename T>               \
-  static T calc(Group g, GroupTag, T x, BinaryOperation) {                     \
+  T calc(Group g, GroupTag, T x, BinaryOperation) {                            \
     return sycl::detail::spirv::Group##SPIRVOperation<O>(g, x);                \
   }
 
@@ -123,8 +123,7 @@ __SYCL_CALC_OVERLOAD(GroupOpFP, LogicalOr, sycl::logical_or<T>)
 
 template <__spv::GroupOperation O, typename Group, typename T,
           template <typename> class BinaryOperation>
-static T calc(Group g, typename GroupOpTag<T>::type, T x,
-              BinaryOperation<void>) {
+T calc(Group g, typename GroupOpTag<T>::type, T x, BinaryOperation<void>) {
   return calc<O>(g, typename GroupOpTag<T>::type(), x, BinaryOperation<T>());
 }
 

--- a/sycl/include/sycl/ext/oneapi/weak_object.hpp
+++ b/sycl/include/sycl/ext/oneapi/weak_object.hpp
@@ -30,7 +30,7 @@ namespace detail {
 using namespace ::sycl::detail;
 
 // Helper for creating ranges for empty weak_objects.
-template <int Dims> static range<Dims> createDummyRange() {
+template <int Dims> range<Dims> createDummyRange() {
   static_assert(Dims >= 0 && Dims < 4, "Invalid dimensionality in range.");
   if constexpr (Dims == 0)
     return {};

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -208,22 +208,22 @@ class HostTask;
 using EventImplPtr = std::shared_ptr<event_impl>;
 
 template <typename RetType, typename Func, typename Arg>
-static Arg member_ptr_helper(RetType (Func::*)(Arg) const);
+Arg member_ptr_helper(RetType (Func::*)(Arg) const);
 
 // Non-const version of the above template to match functors whose 'operator()'
 // is declared w/o the 'const' qualifier.
 template <typename RetType, typename Func, typename Arg>
-static Arg member_ptr_helper(RetType (Func::*)(Arg));
+Arg member_ptr_helper(RetType (Func::*)(Arg));
 
 // Version with two arguments to handle the case when kernel_handler is passed
 // to a lambda
 template <typename RetType, typename Func, typename Arg1, typename Arg2>
-static Arg1 member_ptr_helper(RetType (Func::*)(Arg1, Arg2) const);
+Arg1 member_ptr_helper(RetType (Func::*)(Arg1, Arg2) const);
 
 // Non-const version of the above template to match functors whose 'operator()'
 // is declared w/o the 'const' qualifier.
 template <typename RetType, typename Func, typename Arg1, typename Arg2>
-static Arg1 member_ptr_helper(RetType (Func::*)(Arg1, Arg2));
+Arg1 member_ptr_helper(RetType (Func::*)(Arg1, Arg2));
 
 template <typename F, typename SuggestedArgType>
 decltype(member_ptr_helper(&F::operator())) argument_helper(int);
@@ -257,7 +257,7 @@ using sycl::detail::queue_impl;
 // Returns true if x*y will overflow in T;
 // otherwise, returns false and stores x*y in dst.
 template <typename T>
-static std::enable_if_t<std::is_unsigned_v<T>, bool>
+std::enable_if_t<std::is_unsigned_v<T>, bool>
 multiply_with_overflow_check(T &dst, T x, T y) {
   dst = x * y;
   return (y != 0) && (x > (std::numeric_limits<T>::max)() / y);


### PR DESCRIPTION
-Wunused-template was enabled under -Wall upstream (clang commit 1529d35adbd6), which now flags several `static` function templates in SYCL headers as unused within a single translation unit (they are only referenced from other TUs or from unevaluated contexts). Drop `static` from these templates, matching the fix already applied upstream for the analogous OpenMP __kmp_wait case. External linkage is fine as compiler will safely handle duplicate definitions across multiple TUs.

Fix SYCL::warnings/warnings.cpp in CMPLRLLVM-76767.