### PR TITLE
[SYCL][AMDGPU] Fix build after Triple::amdgcn rename to Triple::amdgpu

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1074,7 +1074,7 @@ static bool isValidSYCLTriple(llvm::Triple T) {
     return true;
 
   // 'amdgcn-amd-amdhsa' is the valid SYCL triple for AMD GPUs.
-  if (T.getArch() == llvm::Triple::amdgcn &&
+  if (T.getArch() == llvm::Triple::amdgpu &&
       T.getVendor() == llvm::Triple::AMD && T.getOS() == llvm::Triple::AMDHSA &&
       !T.hasEnvironment())
     return true;
@@ -10672,7 +10672,7 @@ const ToolChain &Driver::getOffloadToolChain(
         TC = std::make_unique<toolchains::CudaToolChain>(*this, Target, *HostTC,
                                                          Args, Kind);
       break;
-    case llvm::Triple::amdgcn:
+    case llvm::Triple::amdgpu:
       if (Kind == Action::OFK_SYCL)
         TC = std::make_unique<toolchains::HIPAMDToolChain>(*this, Target,
                                                            *HostTC, Args, Kind);

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -2075,7 +2075,7 @@ llvm::opt::DerivedArgList *ToolChain::TranslateOffloadTargetArgs(
       if (SameTripleAsHost ||
           A->getOption().matches(options::OPT_mcode_object_version_EQ) ||
           A->getOption().matches(options::OPT_mlinker_version_EQ) ||
-          (Triple.getArch() == llvm::Triple::amdgcn && !IsSYCL &&
+          (Triple.getArch() == llvm::Triple::amdgpu && !IsSYCL &&
            A->getOption().matches(options::OPT_mcpu_EQ))) {
         DAL->append(A);
         continue;

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1812,7 +1812,7 @@ invokeBackendForSYCLDevice(StringRef InputFile, const ArgList &Args,
   switch (Triple.getArch()) {
   case Triple::nvptx:
   case Triple::nvptx64:
-  case Triple::amdgcn:
+  case Triple::amdgpu:
   case Triple::native_cpu:
     return generic::clang({InputFile}, Args,
                           /*ActiveOffloadKindMask*/ OFK_SYCL);

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1609,7 +1609,7 @@ void AMDGPUPassConfig::addIRPasses() {
   if (isPassEnabled(EnableScalarIRPasses))
     addEarlyCSEOrGVNPass();
 
-  if (TM.getTargetTriple().getArch() == Triple::amdgcn &&
+  if (TM.getTargetTriple().getArch() == Triple::amdgpu &&
       TM.getTargetTriple().getOS() == Triple::OSType::AMDHSA) {
     addPass(createLocalAccessorToSharedMemoryPassLegacy());
     addPass(createGlobalOffsetPassLegacy());


### PR DESCRIPTION
Upstream commit 24a5231188bf ("AMDGPU: Introduce amdgpu triple arch") renamed the Triple::amdgcn enumerator to Triple::amdgpu. Update the remaining direct references in the SYCL driver and linker-wrapper code.