### PR TITLE
[SYCL][TableGen] Emit dynamic table variables as inline

### DIFF
--- a/llvm/test/TableGen/dynamic-tables.td
+++ b/llvm/test/TableGen/dynamic-tables.td
@@ -5,7 +5,7 @@
 include "llvm/TableGen/DynamicTable.td"
 
 // CHECK-LABEL: GET_ATable_IMPL
-// CHECK: std::map<std::string, AEntry> ATable = {
+// CHECK: inline std::map<std::string, AEntry> ATable = {
 // CHECK:   { "bar", {0x5, 0x3 }}, // 0
 // CHECK:   { "baz", {0x2, 0x6 }}, // 1
 // CHECK:   { "foo", {0x4, 0x4 }}, // 2
@@ -30,7 +30,7 @@ def ATable : DynamicTable {
 
 
 // CHECK-LABEL: GET_BTable_IMPL
-// CHECK: std::map<std::string, BTypeName> BTable = {
+// CHECK: inline std::map<std::string, BTypeName> BTable = {
 // CHECK:   { "BAlice", {0xAC, false,  }}, // 0
 // CHECK:   { "BBob", {0x14, false, Bob == 13 }}, // 1
 // CHECK:   { "BCharlie", {0x80, true, Charlie == 42 }}, // 2
@@ -57,7 +57,7 @@ def BTable : DynamicTable {
 }
 
 // CHECK-LABEL: GET_CTable_IMPL
-// CHECK: std::map<std::string, CEntry> CTable = {
+// CHECK: inline std::map<std::string, CEntry> CTable = {
 // CHECK:   { "alice", {0xA }}, // 0
 // CHECK:   { "alice", {0xD }}, // 1
 // CHECK:   { "bob", {0xF }}, // 2
@@ -78,7 +78,7 @@ def CTable : DynamicTable {
 }
 
 // CHECK-LABEL: GET_DTable_IMPL
-// CHECK: std::map<std::string, DEntry> DTable = {
+// CHECK: inline std::map<std::string, DEntry> DTable = {
 // CHECK:  };
 
 class DEntry<string name> {

--- a/llvm/utils/TableGen/DynamicTableEmitter.cpp
+++ b/llvm/utils/TableGen/DynamicTableEmitter.cpp
@@ -121,8 +121,8 @@ void DynamicTableEmitter::emitDynamicTable(const DynamicTable &Table,
   emitIfdef((Twine("GET_") + Table.PreprocessorGuard + "_IMPL"), OS);
 
   // The primary data table contains all the fields defined for this map.
-  OS << "std::map<std::string, " << Table.CppTypeName << "> " << Table.Name
-     << " = {\n";
+  OS << "inline std::map<std::string, " << Table.CppTypeName << "> "
+     << Table.Name << " = {\n";
   // Iterate over the key-value pairs the dynamic table will contain.
   for (unsigned I = 0; I < Table.Entries.size(); ++I) {
     const Record *Entry = Table.Entries[I];


### PR DESCRIPTION
DynamicTableEmitter generates a plain (non-inline) global map variable in a header that is #included from multiple translation units. When those TUs end up in different shared libraries loaded into the same process, this violates the One Definition Rule: two strong definitions of DeviceConfigFile::TargetTable get double destructed at exit, causing "double free or corruption" crashes.

0bb722138216 introduced non-inline global. It became a bug on 2026-04-08 with a8dff34478c9 which moved DeviceConfigFile.hpp usage into a second shared library, libLLVMSYCLPostLink.so, creating the second strong definition.

It surfaced as a visible crash on 2026-06-12 with b09acde14f87, which added fp8 unittest that links against sycl-jit -> pulling in both libclangDriver.so and libLLVMSYCLPostLink.so in the same process when BUILD_SHARED_LIBS=ON.

Fix many check-sycl fails in shared lib build, e.g.
  SYCL-Unit :: ur/./UrTests-Non_Preview_Tests/failed_to_discover_tests_from_gtest
  SYCL-Unit-Preview :: ur/Preview/./UrTests-Preview_Tests/failed_to_discover_tests_from_gtest
CMPLRLLVM-76620, CMPLRLLVM-76699