### PR TITLE
[SYCL][Test] Make get_invalid_kernel_id.cpp linker-agnostic

### DIFF
--- a/sycl/test/basic_tests/get_invalid_kernel_id.cpp
+++ b/sycl/test/basic_tests/get_invalid_kernel_id.cpp
@@ -5,7 +5,7 @@
 class NotAKernel;
 
 int main() {
-  // CHECK-LINUX: {{undefined reference to|undefined symbol}} {{.?}}sycl::_V1::detail::getKernelNameHelper(sycl::_V1::detail::KernelIdentity<NotAKernel>)
+  // CHECK-LINUX: {{undefined reference to|undefined symbol:}} {{.?}}sycl::_V1::detail::getKernelNameHelper(sycl::_V1::detail::KernelIdentity<NotAKernel>)
   // CHECK-WINDOWS: unresolved external symbol "char const * __cdecl sycl::_V1::detail::getKernelNameHelper(struct sycl::_V1::detail::KernelIdentity<class NotAKernel>)"
   sycl::get_kernel_id<NotAKernel>();
 }

--- a/sycl/test/basic_tests/get_invalid_kernel_id.cpp
+++ b/sycl/test/basic_tests/get_invalid_kernel_id.cpp
@@ -5,7 +5,7 @@
 class NotAKernel;
 
 int main() {
-  // CHECK-LINUX: {{undefined reference to|undefined symbol:}} {{.?}}sycl::_V1::detail::getKernelNameHelper(sycl::_V1::detail::KernelIdentity<NotAKernel>)
+  // CHECK-LINUX: {{undefined reference to|undefined symbol}} {{.?}}sycl::_V1::detail::getKernelNameHelper(sycl::_V1::detail::KernelIdentity<NotAKernel>)
   // CHECK-WINDOWS: unresolved external symbol "char const * __cdecl sycl::_V1::detail::getKernelNameHelper(struct sycl::_V1::detail::KernelIdentity<class NotAKernel>)"
   sycl::get_kernel_id<NotAKernel>();
 }

--- a/sycl/test/basic_tests/get_invalid_kernel_id.cpp
+++ b/sycl/test/basic_tests/get_invalid_kernel_id.cpp
@@ -5,7 +5,7 @@
 class NotAKernel;
 
 int main() {
-  // CHECK-LINUX: undefined reference to `sycl::_V1::detail::getKernelNameHelper(sycl::_V1::detail::KernelIdentity<NotAKernel>)
+  // CHECK-LINUX: {{undefined reference to|undefined symbol:}} {{.?}}sycl::_V1::detail::getKernelNameHelper(sycl::_V1::detail::KernelIdentity<NotAKernel>)
   // CHECK-WINDOWS: unresolved external symbol "char const * __cdecl sycl::_V1::detail::getKernelNameHelper(struct sycl::_V1::detail::KernelIdentity<class NotAKernel>)"
   sycl::get_kernel_id<NotAKernel>();
 }


### PR DESCRIPTION
CHECK-LINUX previously matched only ld.bfd's "undefined reference to" wording. Under parallel test execution, clang can select lld instead, which emits "undefined symbol:" with different punctuation, causing spurious FileCheck failures (test passes in isolation, flaky under check-sycl -j and on buildbot). Match both linker's phrasing.

Fix flaky fail in check-sycl:
ld: error: undefined symbol: sycl::_V1::detail::getKernelNameHelper(sycl::_V1::detail::KernelIdentity<NotAKernel>)
CMPLRLLVM-76620