### PR TITLE
[UR][OpenCL] Strip UR_API macros from functions exported via ddi tables

### DIFF
--- a/unified-runtime/source/adapters/opencl/adapter.cpp
+++ b/unified-runtime/source/adapters/opencl/adapter.cpp
@@ -91,9 +91,8 @@ ur_adapter_handle_t ur::cl::getAdapter() {
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterGet(uint32_t NumEntries, ur_adapter_handle_t *phAdapters,
-             uint32_t *pNumAdapters) {
+ur_result_t urAdapterGet(uint32_t NumEntries, ur_adapter_handle_t *phAdapters,
+                         uint32_t *pNumAdapters) {
   static std::mutex AdapterConstructionMutex{};
 
   // Always construct the adapter, even for count-only queries (NumEntries==0),
@@ -125,15 +124,13 @@ urAdapterGet(uint32_t NumEntries, ur_adapter_handle_t *phAdapters,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterRetain(ur_adapter_handle_t hAdapter) {
+ur_result_t urAdapterRetain(ur_adapter_handle_t hAdapter) {
   auto Adapter = cast(hAdapter);
   Adapter->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterRelease(ur_adapter_handle_t hAdapter) {
+ur_result_t urAdapterRelease(ur_adapter_handle_t hAdapter) {
   auto Adapter = cast(hAdapter);
   if (Adapter->RefCount.release()) {
     delete Adapter;
@@ -141,17 +138,17 @@ urAdapterRelease(ur_adapter_handle_t hAdapter) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
-    ur_adapter_handle_t, const char **ppMessage, int32_t *pError) {
+ur_result_t urAdapterGetLastError(ur_adapter_handle_t, const char **ppMessage,
+                                  int32_t *pError) {
   *ppMessage = cl_adapter::ErrorMessage;
   *pError = cl_adapter::ErrorMessageCode;
 
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterGetInfo(ur_adapter_handle_t hAdapter, ur_adapter_info_t propName,
-                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+ur_result_t urAdapterGetInfo(ur_adapter_handle_t hAdapter,
+                             ur_adapter_info_t propName, size_t propSize,
+                             void *pPropValue, size_t *pPropSizeRet) {
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
 
   switch (propName) {
@@ -170,7 +167,7 @@ urAdapterGetInfo(ur_adapter_handle_t hAdapter, ur_adapter_info_t propName,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+ur_result_t urAdapterSetLoggerCallback(
     ur_adapter_handle_t hAdapter, ur_logger_callback_t pfnLoggerCallback,
     void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
 
@@ -182,8 +179,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
-    ur_adapter_handle_t hAdapter, ur_logger_level_t level) {
+ur_result_t urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t hAdapter,
+                                            ur_logger_level_t level) {
 
   if (hAdapter) {
     auto Adapter = cast(hAdapter);

--- a/unified-runtime/source/adapters/opencl/async_alloc.cpp
+++ b/unified-runtime/source/adapters/opencl/async_alloc.cpp
@@ -11,32 +11,31 @@
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t urEnqueueUSMDeviceAllocExp(
+ur_result_t urEnqueueUSMDeviceAllocExp(
     ur_queue_handle_t, ur_usm_pool_handle_t, const size_t,
     const ur_exp_async_usm_alloc_properties_t *, uint32_t,
     const ur_event_handle_t *, void **, ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t urEnqueueUSMSharedAllocExp(
+ur_result_t urEnqueueUSMSharedAllocExp(
     ur_queue_handle_t, ur_usm_pool_handle_t, const size_t,
     const ur_exp_async_usm_alloc_properties_t *, uint32_t,
     const ur_event_handle_t *, void **, ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t urEnqueueUSMHostAllocExp(
-    ur_queue_handle_t, ur_usm_pool_handle_t, const size_t,
-    const ur_exp_async_usm_alloc_properties_t *, uint32_t,
-    const ur_event_handle_t *, void **, ur_event_handle_t *) {
+ur_result_t
+urEnqueueUSMHostAllocExp(ur_queue_handle_t, ur_usm_pool_handle_t, const size_t,
+                         const ur_exp_async_usm_alloc_properties_t *, uint32_t,
+                         const ur_event_handle_t *, void **,
+                         ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t urEnqueueUSMFreeExp(ur_queue_handle_t,
-                                             ur_usm_pool_handle_t, void *,
-                                             uint32_t,
-                                             const ur_event_handle_t *,
-                                             ur_event_handle_t *) {
+ur_result_t urEnqueueUSMFreeExp(ur_queue_handle_t, ur_usm_pool_handle_t, void *,
+                                uint32_t, const ur_event_handle_t *,
+                                ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/opencl/command_buffer.cpp
+++ b/unified-runtime/source/adapters/opencl/command_buffer.cpp
@@ -40,10 +40,11 @@ ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
   clReleaseCommandBufferKHR(CLCommandBuffer);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
-    ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    const ur_exp_command_buffer_desc_t *pCommandBufferDesc,
-    ur_exp_command_buffer_handle_t *phCommandBuffer) {
+ur_result_t
+urCommandBufferCreateExp(ur_context_handle_t hContext,
+                         ur_device_handle_t hDevice,
+                         const ur_exp_command_buffer_desc_t *pCommandBufferDesc,
+                         ur_exp_command_buffer_handle_t *phCommandBuffer) {
 
   auto Context = cast(hContext);
   cl_context CLContext = Context->CLContext;
@@ -112,14 +113,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
+ur_result_t
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
   auto CommandBuffer = cast(hCommandBuffer);
   CommandBuffer->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
+ur_result_t
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
   auto CommandBuffer = cast(hCommandBuffer);
   if (CommandBuffer->RefCount.release()) {
@@ -129,7 +130,7 @@ urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
+ur_result_t
 urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
   auto CommandBuffer = cast(hCommandBuffer);
   UR_ASSERT(!CommandBuffer->IsFinalized, UR_RESULT_ERROR_INVALID_OPERATION);
@@ -148,8 +149,7 @@ urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferAppendKernelLaunchWithArgsExp(
+ur_result_t urCommandBufferAppendKernelLaunchWithArgsExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_kernel_handle_t hKernel,
     uint32_t workDim, const size_t *pGlobalWorkOffset,
     const size_t *pGlobalWorkSize, const size_t *pLocalWorkSize,
@@ -228,7 +228,7 @@ urCommandBufferAppendKernelLaunchWithArgsExp(
       phCommandHandle);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+ur_result_t urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_kernel_handle_t hKernel,
     uint32_t workDim, const size_t *pGlobalWorkOffset,
     const size_t *pGlobalWorkSize, const size_t *pLocalWorkSize,
@@ -299,7 +299,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
+ur_result_t urCommandBufferAppendUSMMemcpyExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, void *pDst, const void *pSrc,
     size_t size, uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, uint32_t,
@@ -329,7 +329,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
+ur_result_t urCommandBufferAppendUSMFillExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, void *pMemory,
     const void *pPattern, size_t patternSize, size_t size,
     uint32_t numSyncPointsInWaitList,
@@ -361,7 +361,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
+ur_result_t urCommandBufferAppendMemBufferCopyExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_mem_handle_t hSrcMem,
     ur_mem_handle_t hDstMem, size_t srcOffset, size_t dstOffset, size_t size,
     uint32_t numSyncPointsInWaitList,
@@ -398,7 +398,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
+ur_result_t urCommandBufferAppendMemBufferCopyRectExp(
     [[maybe_unused]] ur_exp_command_buffer_handle_t hCommandBuffer,
     [[maybe_unused]] ur_mem_handle_t hSrcMem,
     [[maybe_unused]] ur_mem_handle_t hDstMem,
@@ -445,8 +445,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT
-ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
+ur_result_t urCommandBufferAppendMemBufferWriteExp(
     [[maybe_unused]] ur_exp_command_buffer_handle_t hCommandBuffer,
     [[maybe_unused]] ur_mem_handle_t hBuffer, [[maybe_unused]] size_t offset,
     [[maybe_unused]] size_t size, [[maybe_unused]] const void *pSrc,
@@ -461,8 +460,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT
-ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
+ur_result_t urCommandBufferAppendMemBufferReadExp(
     [[maybe_unused]] ur_exp_command_buffer_handle_t hCommandBuffer,
     [[maybe_unused]] ur_mem_handle_t hBuffer, [[maybe_unused]] size_t offset,
     [[maybe_unused]] size_t size, [[maybe_unused]] void *pDst,
@@ -477,8 +475,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT
-ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
+ur_result_t urCommandBufferAppendMemBufferWriteRectExp(
     [[maybe_unused]] ur_exp_command_buffer_handle_t hCommandBuffer,
     [[maybe_unused]] ur_mem_handle_t hBuffer,
     [[maybe_unused]] ur_rect_offset_t bufferOffset,
@@ -499,8 +496,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT
-ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
+ur_result_t urCommandBufferAppendMemBufferReadRectExp(
     [[maybe_unused]] ur_exp_command_buffer_handle_t hCommandBuffer,
     [[maybe_unused]] ur_mem_handle_t hBuffer,
     [[maybe_unused]] ur_rect_offset_t bufferOffset,
@@ -521,7 +517,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
+ur_result_t urCommandBufferAppendMemBufferFillExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ur_mem_handle_t hBuffer,
     const void *pPattern, size_t patternSize, size_t offset, size_t size,
     uint32_t numSyncPointsInWaitList,
@@ -555,7 +551,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
+ur_result_t urCommandBufferAppendUSMPrefetchExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, const void *mem, size_t size,
     ur_usm_migration_flags_t flags, uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
@@ -578,7 +574,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
+ur_result_t urCommandBufferAppendUSMAdviseExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, const void *mem, size_t size,
     ur_usm_advice_flags_t advice, uint32_t numSyncPointsInWaitList,
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList,
@@ -601,7 +597,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCommandBufferExp(
+ur_result_t urEnqueueCommandBufferExp(
     ur_queue_handle_t hQueue, ur_exp_command_buffer_handle_t hCommandBuffer,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
@@ -778,7 +774,7 @@ ur_result_t validateCommandDesc(
 }
 } // end anonymous namespace
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
+ur_result_t urCommandBufferUpdateKernelLaunchExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, uint32_t numKernelUpdates,
     const ur_exp_command_buffer_update_kernel_launch_desc_t
         *pUpdateKernelLaunch) {
@@ -876,23 +872,24 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
+ur_result_t urCommandBufferUpdateSignalEventExp(
     [[maybe_unused]] ur_exp_command_buffer_command_handle_t Command,
     [[maybe_unused]] ur_event_handle_t *Event) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
+ur_result_t urCommandBufferUpdateWaitEventsExp(
     [[maybe_unused]] ur_exp_command_buffer_command_handle_t Command,
     [[maybe_unused]] uint32_t NumEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *EventWaitList) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferGetInfoExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer,
-    ur_exp_command_buffer_info_t propName, size_t propSize, void *pPropValue,
-    size_t *pPropSizeRet) {
+ur_result_t
+urCommandBufferGetInfoExp(ur_exp_command_buffer_handle_t hCommandBuffer,
+                          ur_exp_command_buffer_info_t propName,
+                          size_t propSize, void *pPropValue,
+                          size_t *pPropSizeRet) {
 
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
   auto CommandBuffer = cast(hCommandBuffer);
@@ -917,8 +914,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferGetInfoExp(
   return UR_RESULT_ERROR_INVALID_ENUMERATION;
 }
 
-UR_APIEXPORT
-ur_result_t UR_APICALL urCommandBufferAppendNativeCommandExp(
+ur_result_t urCommandBufferAppendNativeCommandExp(
     ur_exp_command_buffer_handle_t hCommandBuffer,
     ur_exp_command_buffer_native_command_function_t pfnNativeCommand,
     void *pData, ur_exp_command_buffer_handle_t,
@@ -957,7 +953,7 @@ ur_result_t UR_APICALL urCommandBufferAppendNativeCommandExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
+ur_result_t
 urCommandBufferGetNativeHandleExp(ur_exp_command_buffer_handle_t hCommandBuffer,
                                   ur_native_handle_t *phNativeCommandBuffer) {
   auto CommandBuffer = cast(hCommandBuffer);

--- a/unified-runtime/source/adapters/opencl/context.cpp
+++ b/unified-runtime/source/adapters/opencl/context.cpp
@@ -63,9 +63,10 @@ ur_context_handle_t_::makeWithNative(native_type Ctx, uint32_t DevCount,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(
-    uint32_t DeviceCount, const ur_device_handle_t *phDevices,
-    const ur_context_properties_t *, ur_context_handle_t *phContext) {
+ur_result_t urContextCreate(uint32_t DeviceCount,
+                            const ur_device_handle_t *phDevices,
+                            const ur_context_properties_t *,
+                            ur_context_handle_t *phContext) {
 
   cl_int Ret;
   std::vector<cl_device_id> CLDevices(DeviceCount);
@@ -92,9 +93,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(
   return mapCLErrorToUR(Ret);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
-                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+ur_result_t urContextGetInfo(ur_context_handle_t hContext,
+                             ur_context_info_t propName, size_t propSize,
+                             void *pPropValue, size_t *pPropSizeRet) {
 
   auto Context = cast(hContext);
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
@@ -119,8 +120,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urContextRelease(ur_context_handle_t hContext) {
+ur_result_t urContextRelease(ur_context_handle_t hContext) {
   auto Context = cast(hContext);
   if (Context->RefCount.release()) {
     delete Context;
@@ -129,22 +129,21 @@ urContextRelease(ur_context_handle_t hContext) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urContextRetain(ur_context_handle_t hContext) {
+ur_result_t urContextRetain(ur_context_handle_t hContext) {
   auto Context = cast(hContext);
   Context->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext, ur_native_handle_t *phNativeContext) {
+ur_result_t urContextGetNativeHandle(ur_context_handle_t hContext,
+                                     ur_native_handle_t *phNativeContext) {
 
   auto Context = cast(hContext);
   *phNativeContext = reinterpret_cast<ur_native_handle_t>(Context->CLContext);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+ur_result_t urContextCreateWithNativeHandle(
     ur_native_handle_t hNativeContext, ur_adapter_handle_t, uint32_t numDevices,
     const ur_device_handle_t *phDevices,
     const ur_context_native_properties_t *pProperties,
@@ -158,9 +157,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
-    ur_context_handle_t hContext, ur_context_extended_deleter_t pfnDeleter,
-    void *pUserData) {
+ur_result_t
+urContextSetExtendedDeleter(ur_context_handle_t hContext,
+                            ur_context_extended_deleter_t pfnDeleter,
+                            void *pUserData) {
   if (!cast(ur::cl::getAdapter())->clSetContextDestructorCallbackFn) {
     UR_LOG_L(cast(ur::cl::getAdapter())->log, WARN,
              "clSetContextDestructorCallback not found, consider upgrading the "

--- a/unified-runtime/source/adapters/opencl/device.cpp
+++ b/unified-runtime/source/adapters/opencl/device.cpp
@@ -16,11 +16,9 @@
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(ur_platform_handle_t hPlatform,
-                                                ur_device_type_t DeviceType,
-                                                uint32_t,
-                                                ur_device_handle_t *phDevices,
-                                                uint32_t *pNumDevices) {
+ur_result_t urDeviceGet(ur_platform_handle_t hPlatform,
+                        ur_device_type_t DeviceType, uint32_t,
+                        ur_device_handle_t *phDevices, uint32_t *pNumDevices) {
 
   cl_device_type Type;
   switch (DeviceType) {
@@ -108,11 +106,9 @@ mapCLDeviceFpConfigToUR(cl_device_fp_config CLValue) {
   return URValue;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
-                                                    ur_device_info_t propName,
-                                                    size_t propSize,
-                                                    void *pPropValue,
-                                                    size_t *pPropSizeRet) {
+ur_result_t urDeviceGetInfo(ur_device_handle_t hDevice,
+                            ur_device_info_t propName, size_t propSize,
+                            void *pPropValue, size_t *pPropSizeRet) {
   /* We can convert between OpenCL and UR outputs because the sizes
    * of OpenCL types are the same as UR.
    * | CL                 | UR                     | Size |
@@ -1605,10 +1601,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
-    ur_device_handle_t hDevice,
-    const ur_device_partition_properties_t *pProperties, uint32_t NumDevices,
-    ur_device_handle_t *phSubDevices, uint32_t *pNumDevicesRet) {
+ur_result_t
+urDevicePartition(ur_device_handle_t hDevice,
+                  const ur_device_partition_properties_t *pProperties,
+                  uint32_t NumDevices, ur_device_handle_t *phSubDevices,
+                  uint32_t *pNumDevicesRet) {
 
   auto Device = cast(hDevice);
   std::vector<cl_device_partition_property> CLProperties(
@@ -1687,7 +1684,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
 }
 
 // Root devices ref count are unchanged through out the program lifetime.
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceRetain(ur_device_handle_t hDevice) {
+ur_result_t urDeviceRetain(ur_device_handle_t hDevice) {
   auto Device = cast(hDevice);
   if (Device->ParentDevice) {
     Device->RefCount.retain();
@@ -1697,8 +1694,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceRetain(ur_device_handle_t hDevice) {
 }
 
 // Root devices ref count are unchanged through out the program lifetime.
-UR_APIEXPORT ur_result_t UR_APICALL
-urDeviceRelease(ur_device_handle_t hDevice) {
+ur_result_t urDeviceRelease(ur_device_handle_t hDevice) {
   auto Device = cast(hDevice);
   if (Device->ParentDevice) {
     if (Device->RefCount.release()) {
@@ -1708,18 +1704,19 @@ urDeviceRelease(ur_device_handle_t hDevice) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice, ur_native_handle_t *phNativeDevice) {
+ur_result_t urDeviceGetNativeHandle(ur_device_handle_t hDevice,
+                                    ur_native_handle_t *phNativeDevice) {
 
   auto Device = cast(hDevice);
   *phNativeDevice = reinterpret_cast<ur_native_handle_t>(Device->CLDevice);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
-    ur_native_handle_t hNativeDevice, ur_adapter_handle_t,
-    const ur_device_native_properties_t *pProperties,
-    ur_device_handle_t *phDevice) {
+ur_result_t
+urDeviceCreateWithNativeHandle(ur_native_handle_t hNativeDevice,
+                               ur_adapter_handle_t,
+                               const ur_device_native_properties_t *pProperties,
+                               ur_device_handle_t *phDevice) {
 
   auto SetDeviceProps = [&]() {
     cast(*phDevice)->IsNativeHandleOwned =
@@ -1790,9 +1787,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
   return UR_RESULT_ERROR_INVALID_DEVICE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
-    ur_device_handle_t hDevice, uint64_t *pDeviceTimestamp,
-    uint64_t *pHostTimestamp) {
+ur_result_t urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
+                                        uint64_t *pDeviceTimestamp,
+                                        uint64_t *pHostTimestamp) {
   auto Device = cast(hDevice);
   oclv::OpenCLVersion DevVer, PlatVer;
   cl_device_id DeviceId = Device->CLDevice;
@@ -1825,9 +1822,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceSelectBinary(
-    ur_device_handle_t hDevice, const ur_device_binary_t *pBinaries,
-    uint32_t NumBinaries, uint32_t *pSelectedBinary) {
+ur_result_t urDeviceSelectBinary(ur_device_handle_t hDevice,
+                                 const ur_device_binary_t *pBinaries,
+                                 uint32_t NumBinaries,
+                                 uint32_t *pSelectedBinary) {
   // TODO: this is a bare-bones implementation for choosing a device image
   // that would be compatible with the targeted device. An AOT-compiled
   // image is preferred over SPIR-V for known devices (i.e. Intel devices)
@@ -1895,7 +1893,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceSelectBinary(
   return UR_RESULT_ERROR_INVALID_BINARY;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urDeviceWaitExp(ur_device_handle_t) {
+ur_result_t urDeviceWaitExp(ur_device_handle_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/opencl/enqueue.cpp
+++ b/unified-runtime/source/adapters/opencl/enqueue.cpp
@@ -44,9 +44,10 @@ void MapUREventsToCL(uint32_t numEvents, const ur_event_handle_t *UREvents,
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(
-    ur_queue_handle_t hQueue, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueEventsWait(ur_queue_handle_t hQueue,
+                                uint32_t numEventsInWaitList,
+                                const ur_event_handle_t *phEventWaitList,
+                                ur_event_handle_t *phEvent) {
   auto Queue = cast(hQueue);
   cl_event Event;
   std::vector<cl_event> CLWaitEvents(numEventsInWaitList);
@@ -60,7 +61,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+ur_result_t urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   auto Queue = cast(hQueue);
@@ -76,7 +77,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t urEnqueueEventsWaitWithBarrierExt(
+ur_result_t urEnqueueEventsWaitWithBarrierExt(
     ur_queue_handle_t hQueue, const ur_exp_enqueue_ext_properties_t *,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
@@ -84,10 +85,12 @@ UR_APIEXPORT ur_result_t urEnqueueEventsWaitWithBarrierExt(
                                                     phEventWaitList, phEvent);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingRead,
-    size_t offset, size_t size, void *pDst, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueMemBufferRead(ur_queue_handle_t hQueue,
+                                   ur_mem_handle_t hBuffer, bool blockingRead,
+                                   size_t offset, size_t size, void *pDst,
+                                   uint32_t numEventsInWaitList,
+                                   const ur_event_handle_t *phEventWaitList,
+                                   ur_event_handle_t *phEvent) {
   auto Queue = cast(hQueue);
   auto Buffer = cast(hBuffer);
   cl_event Event;
@@ -102,7 +105,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+ur_result_t urEnqueueMemBufferWrite(
     ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingWrite,
     size_t offset, size_t size, const void *pSrc, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
@@ -120,7 +123,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+ur_result_t urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingRead,
     ur_rect_offset_t bufferOrigin, ur_rect_offset_t hostOrigin,
     ur_rect_region_t region, size_t bufferRowPitch, size_t bufferSlicePitch,
@@ -147,7 +150,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+ur_result_t urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingWrite,
     ur_rect_offset_t bufferOrigin, ur_rect_offset_t hostOrigin,
     ur_rect_region_t region, size_t bufferRowPitch, size_t bufferSlicePitch,
@@ -174,11 +177,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hBufferSrc,
-    ur_mem_handle_t hBufferDst, size_t srcOffset, size_t dstOffset, size_t size,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueMemBufferCopy(ur_queue_handle_t hQueue,
+                                   ur_mem_handle_t hBufferSrc,
+                                   ur_mem_handle_t hBufferDst, size_t srcOffset,
+                                   size_t dstOffset, size_t size,
+                                   uint32_t numEventsInWaitList,
+                                   const ur_event_handle_t *phEventWaitList,
+                                   ur_event_handle_t *phEvent) {
   auto Queue = cast(hQueue);
   auto BufferSrc = cast(hBufferSrc);
   auto BufferDst = cast(hBufferDst);
@@ -195,7 +200,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+ur_result_t urEnqueueMemBufferCopyRect(
     ur_queue_handle_t hQueue, ur_mem_handle_t hBufferSrc,
     ur_mem_handle_t hBufferDst, ur_rect_offset_t srcOrigin,
     ur_rect_offset_t dstOrigin, ur_rect_region_t region, size_t srcRowPitch,
@@ -221,11 +226,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, const void *pPattern,
-    size_t patternSize, size_t offset, size_t size,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueMemBufferFill(ur_queue_handle_t hQueue,
+                                   ur_mem_handle_t hBuffer,
+                                   const void *pPattern, size_t patternSize,
+                                   size_t offset, size_t size,
+                                   uint32_t numEventsInWaitList,
+                                   const ur_event_handle_t *phEventWaitList,
+                                   ur_event_handle_t *phEvent) {
   auto Queue = cast(hQueue);
   auto Buffer = cast(hBuffer);
   // CL FillBuffer only allows pattern sizes up to the largest CL type:
@@ -285,7 +292,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
+ur_result_t urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ur_mem_handle_t hImage, bool blockingRead,
     ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
     size_t slicePitch, void *pDst, uint32_t numEventsInWaitList,
@@ -307,7 +314,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
+ur_result_t urEnqueueMemImageWrite(
     ur_queue_handle_t hQueue, ur_mem_handle_t hImage, bool blockingWrite,
     ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
     size_t slicePitch, void *pSrc, uint32_t numEventsInWaitList,
@@ -328,12 +335,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hImageSrc,
-    ur_mem_handle_t hImageDst, ur_rect_offset_t srcOrigin,
-    ur_rect_offset_t dstOrigin, ur_rect_region_t region,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+ur_result_t
+urEnqueueMemImageCopy(ur_queue_handle_t hQueue, ur_mem_handle_t hImageSrc,
+                      ur_mem_handle_t hImageDst, ur_rect_offset_t srcOrigin,
+                      ur_rect_offset_t dstOrigin, ur_rect_region_t region,
+                      uint32_t numEventsInWaitList,
+                      const ur_event_handle_t *phEventWaitList,
+                      ur_event_handle_t *phEvent) {
   auto Queue = cast(hQueue);
   auto ImageSrc = cast(hImageSrc);
   auto ImageDst = cast(hImageDst);
@@ -352,11 +360,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingMap,
-    ur_map_flags_t mapFlags, size_t offset, size_t size,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent, void **ppRetMap) {
+ur_result_t urEnqueueMemBufferMap(ur_queue_handle_t hQueue,
+                                  ur_mem_handle_t hBuffer, bool blockingMap,
+                                  ur_map_flags_t mapFlags, size_t offset,
+                                  size_t size, uint32_t numEventsInWaitList,
+                                  const ur_event_handle_t *phEventWaitList,
+                                  ur_event_handle_t *phEvent, void **ppRetMap) {
   auto Queue = cast(hQueue);
   auto Buffer = cast(hBuffer);
   cl_event Event;
@@ -372,10 +381,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
   return mapCLErrorToUR(Err);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue, ur_mem_handle_t hMem, void *pMappedPtr,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueMemUnmap(ur_queue_handle_t hQueue, ur_mem_handle_t hMem,
+                              void *pMappedPtr, uint32_t numEventsInWaitList,
+                              const ur_event_handle_t *phEventWaitList,
+                              ur_event_handle_t *phEvent) {
   auto Queue = cast(hQueue);
   auto Mem = cast(hMem);
   cl_event Event;
@@ -389,7 +398,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+ur_result_t urEnqueueDeviceGlobalVariableWrite(
     ur_queue_handle_t hQueue, ur_program_handle_t hProgram, const char *name,
     bool blockingWrite, size_t count, size_t offset, const void *pSrc,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
@@ -416,7 +425,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
   return mapCLErrorToUR(Res);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+ur_result_t urEnqueueDeviceGlobalVariableRead(
     ur_queue_handle_t hQueue, ur_program_handle_t hProgram, const char *name,
     bool blockingRead, size_t count, size_t offset, void *pDst,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
@@ -443,11 +452,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
   return mapCLErrorToUR(Res);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueReadHostPipe(
-    ur_queue_handle_t hQueue, ur_program_handle_t hProgram,
-    const char *pipe_symbol, bool blocking, void *pDst, size_t size,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueReadHostPipe(ur_queue_handle_t hQueue,
+                                  ur_program_handle_t hProgram,
+                                  const char *pipe_symbol, bool blocking,
+                                  void *pDst, size_t size,
+                                  uint32_t numEventsInWaitList,
+                                  const ur_event_handle_t *phEventWaitList,
+                                  ur_event_handle_t *phEvent) {
 
   auto Queue = cast(hQueue);
   auto Program = cast(hProgram);
@@ -474,11 +485,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueReadHostPipe(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
-    ur_queue_handle_t hQueue, ur_program_handle_t hProgram,
-    const char *pipe_symbol, bool blocking, void *pSrc, size_t size,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueWriteHostPipe(ur_queue_handle_t hQueue,
+                                   ur_program_handle_t hProgram,
+                                   const char *pipe_symbol, bool blocking,
+                                   void *pSrc, size_t size,
+                                   uint32_t numEventsInWaitList,
+                                   const ur_event_handle_t *phEventWaitList,
+                                   ur_event_handle_t *phEvent) {
 
   auto Queue = cast(hQueue);
   auto Program = cast(hProgram);
@@ -504,7 +517,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunchWithArgsExp(
+ur_result_t urEnqueueKernelLaunchWithArgsExp(
     ur_queue_handle_t hQueue, ur_kernel_handle_t hKernel, uint32_t workDim,
     const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
     const size_t *pLocalWorkSize, uint32_t numArgs,

--- a/unified-runtime/source/adapters/opencl/enqueue_native.cpp
+++ b/unified-runtime/source/adapters/opencl/enqueue_native.cpp
@@ -11,7 +11,7 @@
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueNativeCommandExp(
+ur_result_t urEnqueueNativeCommandExp(
     ur_queue_handle_t, ur_exp_enqueue_native_command_function_t, void *,
     uint32_t, const ur_mem_handle_t *,
     const ur_exp_enqueue_native_command_properties_t *, uint32_t,

--- a/unified-runtime/source/adapters/opencl/event.cpp
+++ b/unified-runtime/source/adapters/opencl/event.cpp
@@ -112,10 +112,11 @@ ur_command_t convertCLCommandTypeToUR(const cl_command_type &CommandType) {
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
-    ur_native_handle_t hNativeEvent, ur_context_handle_t hContext,
-    const ur_event_native_properties_t *pProperties,
-    ur_event_handle_t *phEvent) {
+ur_result_t
+urEventCreateWithNativeHandle(ur_native_handle_t hNativeEvent,
+                              ur_context_handle_t hContext,
+                              const ur_event_native_properties_t *pProperties,
+                              ur_event_handle_t *phEvent) {
   cl_event NativeHandle = reinterpret_cast<cl_event>(hNativeEvent);
   auto Context = cast(hContext);
   try {
@@ -132,13 +133,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
-    ur_event_handle_t hEvent, ur_native_handle_t *phNativeEvent) {
+ur_result_t urEventGetNativeHandle(ur_event_handle_t hEvent,
+                                   ur_native_handle_t *phNativeEvent) {
   auto Event = cast(hEvent);
   return getNativeHandle(Event->CLEvent, phNativeEvent);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
+ur_result_t urEventRelease(ur_event_handle_t hEvent) {
   auto Event = cast(hEvent);
   if (Event->RefCount.release()) {
     delete Event;
@@ -146,14 +147,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
+ur_result_t urEventRetain(ur_event_handle_t hEvent) {
   auto Event = cast(hEvent);
   Event->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
+ur_result_t urEventWait(uint32_t numEvents,
+                        const ur_event_handle_t *phEventWaitList) {
   ur_context_handle_t_ *hContext = cast(phEventWaitList[0])->Context;
   std::vector<cl_event> CLEvents;
   CLEvents.reserve(numEvents);
@@ -176,11 +177,9 @@ urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
-                                                   ur_event_info_t propName,
-                                                   size_t propSize,
-                                                   void *pPropValue,
-                                                   size_t *pPropSizeRet) {
+ur_result_t urEventGetInfo(ur_event_handle_t hEvent, ur_event_info_t propName,
+                           size_t propSize, void *pPropValue,
+                           size_t *pPropSizeRet) {
   auto Event = cast(hEvent);
   cl_event_info CLEventInfo = convertUREventInfoToCL(propName);
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
@@ -232,9 +231,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
-    ur_event_handle_t hEvent, ur_profiling_info_t propName, size_t propSize,
-    void *pPropValue, size_t *pPropSizeRet) {
+ur_result_t urEventGetProfilingInfo(ur_event_handle_t hEvent,
+                                    ur_profiling_info_t propName,
+                                    size_t propSize, void *pPropValue,
+                                    size_t *pPropSizeRet) {
   auto Event = cast(hEvent);
   cl_profiling_info CLProfilingInfo = convertURProfilingInfoToCL(propName);
   cl_int RetErr = clGetEventProfilingInfo(Event->CLEvent, CLProfilingInfo,
@@ -243,9 +243,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEventSetCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
-                   ur_event_callback_t pfnNotify, void *pUserData) {
+ur_result_t urEventSetCallback(ur_event_handle_t hEvent,
+                               ur_execution_info_t execStatus,
+                               ur_event_callback_t pfnNotify, void *pUserData) {
   auto Event = cast(hEvent);
   static std::unordered_map<ur_event_handle_t, std::set<ur_event_callback_t>>
       EventCallbackMap;
@@ -309,30 +309,27 @@ urEventSetCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
-                               const ur_event_handle_t *, ur_event_handle_t *) {
+ur_result_t urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
+                                           const ur_event_handle_t *,
+                                           ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEventCreateExp(ur_context_handle_t, ur_device_handle_t,
-                 const ur_exp_event_desc_t *, ur_event_handle_t *) {
+ur_result_t urEventCreateExp(ur_context_handle_t, ur_device_handle_t,
+                             const ur_exp_event_desc_t *, ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urIPCGetEventHandleExp(ur_event_handle_t,
-                                                           void **, size_t *) {
+ur_result_t urIPCGetEventHandleExp(ur_event_handle_t, void **, size_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urIPCPutEventHandleExp(ur_context_handle_t,
-                                                           void *) {
+ur_result_t urIPCPutEventHandleExp(ur_context_handle_t, void *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urIPCOpenEventHandleExp(
-    ur_context_handle_t, const void *, size_t, ur_event_handle_t *) {
+ur_result_t urIPCOpenEventHandleExp(ur_context_handle_t, const void *, size_t,
+                                    ur_event_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/opencl/graph.cpp
+++ b/unified-runtime/source/adapters/opencl/graph.cpp
@@ -11,56 +11,55 @@
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL urGraphCreateExp(
-    ur_context_handle_t /* hContext */, ur_exp_graph_handle_t * /* phGraph */) {
+ur_result_t urGraphCreateExp(ur_context_handle_t /* hContext */,
+                             ur_exp_graph_handle_t * /* phGraph */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urGraphDestroyExp(ur_exp_graph_handle_t /* hGraph */) {
+ur_result_t urGraphDestroyExp(ur_exp_graph_handle_t /* hGraph */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urGraphExecutableGraphDestroyExp(
+ur_result_t urGraphExecutableGraphDestroyExp(
     ur_exp_executable_graph_handle_t /* hExecutableGraph */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urGraphIsEmptyExp(ur_exp_graph_handle_t /* hGraph */, bool * /* pIsEmpty */) {
+ur_result_t urGraphIsEmptyExp(ur_exp_graph_handle_t /* hGraph */,
+                              bool * /* pIsEmpty */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urGraphGetIdExp(ur_exp_graph_handle_t /* hGraph */, uint64_t * /* pGraphId */) {
+ur_result_t urGraphGetIdExp(ur_exp_graph_handle_t /* hGraph */,
+                            uint64_t * /* pGraphId */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urGraphSetDestructionCallbackExp(
+ur_result_t urGraphSetDestructionCallbackExp(
     ur_exp_graph_handle_t /* hGraph */,
     ur_exp_graph_destruction_callback_t /* pfnCallback */,
     void * /* pUserData */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urGraphDumpContentsExp(
-    ur_exp_graph_handle_t /* hGraph */, const char * /* pDotFilePath */) {
+ur_result_t urGraphDumpContentsExp(ur_exp_graph_handle_t /* hGraph */,
+                                   const char * /* pDotFilePath */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urGraphInstantiateGraphExp(
+ur_result_t urGraphInstantiateGraphExp(
     ur_exp_graph_handle_t /* hGraph */,
     ur_exp_executable_graph_handle_t * /* phExecutableGraph */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
+ur_result_t
 urGraphGetNativeHandleExp(ur_exp_graph_handle_t /* hGraph */,
                           ur_native_handle_t * /* phNativeGraph */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urGraphExecutableGraphGetNativeHandleExp(
+ur_result_t urGraphExecutableGraphGetNativeHandleExp(
     ur_exp_executable_graph_handle_t /* hExecutableGraph */,
     ur_native_handle_t * /* phNativeExecutableGraph */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/opencl/image.cpp
+++ b/unified-runtime/source/adapters/opencl/image.cpp
@@ -12,34 +12,33 @@
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPitchedAllocExp(
-    [[maybe_unused]] ur_context_handle_t hContext,
-    [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] const ur_usm_desc_t *pUSMDesc,
-    [[maybe_unused]] ur_usm_pool_handle_t pool,
-    [[maybe_unused]] size_t widthInBytes, [[maybe_unused]] size_t height,
-    [[maybe_unused]] size_t elementSizeBytes, [[maybe_unused]] void **ppMem,
-    [[maybe_unused]] size_t *pResultPitch) {
+ur_result_t urUSMPitchedAllocExp([[maybe_unused]] ur_context_handle_t hContext,
+                                 [[maybe_unused]] ur_device_handle_t hDevice,
+                                 [[maybe_unused]] const ur_usm_desc_t *pUSMDesc,
+                                 [[maybe_unused]] ur_usm_pool_handle_t pool,
+                                 [[maybe_unused]] size_t widthInBytes,
+                                 [[maybe_unused]] size_t height,
+                                 [[maybe_unused]] size_t elementSizeBytes,
+                                 [[maybe_unused]] void **ppMem,
+                                 [[maybe_unused]] size_t *pResultPitch) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesUnsampledImageHandleDestroyExp(
-    [[maybe_unused]] ur_context_handle_t hContext,
-    [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_native_handle_t hImage) {
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-}
-
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesSampledImageHandleDestroyExp(
+ur_result_t urBindlessImagesUnsampledImageHandleDestroyExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_image_native_handle_t hImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+ur_result_t urBindlessImagesSampledImageHandleDestroyExp(
+    [[maybe_unused]] ur_context_handle_t hContext,
+    [[maybe_unused]] ur_device_handle_t hDevice,
+    [[maybe_unused]] ur_exp_image_native_handle_t hImage) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+ur_result_t urBindlessImagesImageAllocateExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
@@ -48,14 +47,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+ur_result_t urBindlessImagesImageFreeExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+ur_result_t urBindlessImagesUnsampledImageCreateExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
@@ -65,7 +64,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+ur_result_t urBindlessImagesSampledImageCreateExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
@@ -76,7 +75,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+ur_result_t urBindlessImagesImageCopyExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
     [[maybe_unused]] const void *pSrc, [[maybe_unused]] void *pDst,
     [[maybe_unused]] const ur_image_desc_t *pSrcImageDesc,
@@ -92,7 +91,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+ur_result_t urBindlessImagesImageGetInfoExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] ur_image_info_t propName,
@@ -100,8 +99,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesGetImageMemoryHandleTypeSupportExp(
+ur_result_t urBindlessImagesGetImageMemoryHandleTypeSupportExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
@@ -111,8 +109,7 @@ urBindlessImagesGetImageMemoryHandleTypeSupportExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesGetImageUnsampledHandleSupportExp(
+ur_result_t urBindlessImagesGetImageUnsampledHandleSupportExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
@@ -122,8 +119,7 @@ urBindlessImagesGetImageUnsampledHandleSupportExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesGetImageSampledHandleSupportExp(
+ur_result_t urBindlessImagesGetImageSampledHandleSupportExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
@@ -133,7 +129,7 @@ urBindlessImagesGetImageSampledHandleSupportExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+ur_result_t urBindlessImagesMipmapGetLevelExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
@@ -142,14 +138,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+ur_result_t urBindlessImagesMipmapFreeExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_image_mem_native_handle_t hMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
+ur_result_t urBindlessImagesImportExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice, [[maybe_unused]] size_t size,
     [[maybe_unused]] ur_exp_external_mem_type_t memHandleType,
@@ -158,7 +154,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+ur_result_t urBindlessImagesMapExternalArrayExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
@@ -168,7 +164,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
+ur_result_t urBindlessImagesMapExternalLinearMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] uint64_t offset, [[maybe_unused]] uint64_t size,
@@ -177,28 +173,27 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
+ur_result_t urBindlessImagesReleaseExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_external_mem_handle_t hExternalMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesFreeMappedLinearMemoryExp(
+ur_result_t urBindlessImagesFreeMappedLinearMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice, [[maybe_unused]] void *pMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesSupportsImportingHandleTypeExp(
+ur_result_t urBindlessImagesSupportsImportingHandleTypeExp(
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_external_mem_type_t memHandleType,
     [[maybe_unused]] ur_bool_t *pSupportedRet) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
+ur_result_t urBindlessImagesImportExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_external_semaphore_type_t semHandleType,
@@ -208,14 +203,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
+ur_result_t urBindlessImagesReleaseExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_external_semaphore_handle_t hExternalSemaphore) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
     [[maybe_unused]] ur_exp_external_semaphore_handle_t hSemaphore,
     [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t waitValue,
@@ -225,7 +220,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
     [[maybe_unused]] ur_exp_external_semaphore_handle_t hSemaphore,
     [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t signalValue,

--- a/unified-runtime/source/adapters/opencl/kernel.cpp
+++ b/unified-runtime/source/adapters/opencl/kernel.cpp
@@ -63,9 +63,9 @@ ur_result_t ur_kernel_handle_t_::makeWithNative(native_type NativeKernel,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
-               ur_kernel_handle_t *phKernel) {
+ur_result_t urKernelCreate(ur_program_handle_t hProgram,
+                           const char *pKernelName,
+                           ur_kernel_handle_t *phKernel) {
   try {
     auto Program = cast(hProgram);
     cl_int CLResult;
@@ -91,9 +91,9 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelSetArgLocal(ur_kernel_handle_t hKernel, uint32_t argIndex,
-                    size_t argSize, const ur_kernel_arg_local_properties_t *) {
+ur_result_t urKernelSetArgLocal(ur_kernel_handle_t hKernel, uint32_t argIndex,
+                                size_t argSize,
+                                const ur_kernel_arg_local_properties_t *) {
   auto Kernel = cast(hKernel);
 
   CL_RETURN_ON_FAILURE(clSetKernelArg(
@@ -131,11 +131,9 @@ static cl_int mapURKernelInfoToCL(ur_kernel_info_t URPropName) {
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
-                                                    ur_kernel_info_t propName,
-                                                    size_t propSize,
-                                                    void *pPropValue,
-                                                    size_t *pPropSizeRet) {
+ur_result_t urKernelGetInfo(ur_kernel_handle_t hKernel,
+                            ur_kernel_info_t propName, size_t propSize,
+                            void *pPropValue, size_t *pPropSizeRet) {
   auto Kernel = cast(hKernel);
 
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
@@ -191,10 +189,11 @@ static cl_int mapURKernelGroupInfoToCL(ur_kernel_group_info_t URPropName) {
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
-                     ur_kernel_group_info_t propName, size_t propSize,
-                     void *pPropValue, size_t *pPropSizeRet) {
+ur_result_t urKernelGetGroupInfo(ur_kernel_handle_t hKernel,
+                                 ur_device_handle_t hDevice,
+                                 ur_kernel_group_info_t propName,
+                                 size_t propSize, void *pPropValue,
+                                 size_t *pPropSizeRet) {
   auto Kernel = cast(hKernel);
   auto Device = cast(hDevice);
   // From the CL spec for GROUP_INFO_GLOBAL: "If device is not a custom device
@@ -239,10 +238,10 @@ mapURKernelSubGroupInfoToCL(ur_kernel_sub_group_info_t URPropName) {
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
-                        ur_kernel_sub_group_info_t propName, size_t,
-                        void *pPropValue, size_t *pPropSizeRet) {
+ur_result_t urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel,
+                                    ur_device_handle_t hDevice,
+                                    ur_kernel_sub_group_info_t propName, size_t,
+                                    void *pPropValue, size_t *pPropSizeRet) {
   auto Kernel = cast(hKernel);
   auto Device = cast(hDevice);
 
@@ -343,14 +342,13 @@ urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
+ur_result_t urKernelRetain(ur_kernel_handle_t hKernel) {
   auto Kernel = cast(hKernel);
   Kernel->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urKernelRelease(ur_kernel_handle_t hKernel) {
+ur_result_t urKernelRelease(ur_kernel_handle_t hKernel) {
   auto Kernel = cast(hKernel);
   if (Kernel->RefCount.release()) {
     delete Kernel;
@@ -409,9 +407,10 @@ static ur_result_t usmSetIndirectAccess(ur_kernel_handle_t hKernel) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
-    ur_kernel_handle_t hKernel, ur_kernel_exec_info_t propName, size_t propSize,
-    const ur_kernel_exec_info_properties_t *, const void *pPropValue) {
+ur_result_t urKernelSetExecInfo(ur_kernel_handle_t hKernel,
+                                ur_kernel_exec_info_t propName, size_t propSize,
+                                const ur_kernel_exec_info_properties_t *,
+                                const void *pPropValue) {
   auto Kernel = cast(hKernel);
 
   switch (propName) {
@@ -438,15 +437,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ur_native_handle_t *phNativeKernel) {
+ur_result_t urKernelGetNativeHandle(ur_kernel_handle_t hKernel,
+                                    ur_native_handle_t *phNativeKernel) {
   auto Kernel = cast(hKernel);
 
   *phNativeKernel = reinterpret_cast<ur_native_handle_t>(Kernel->CLKernel);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCount(
+ur_result_t urKernelSuggestMaxCooperativeGroupCount(
     [[maybe_unused]] ur_kernel_handle_t hKernel,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] uint32_t workDim,
@@ -456,7 +455,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCount(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+ur_result_t urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ur_context_handle_t hContext,
     ur_program_handle_t hProgram,
     [[maybe_unused]] const ur_kernel_native_properties_t *pProperties,
@@ -473,10 +472,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
-    ur_kernel_handle_t hKernel, ur_queue_handle_t hQueue, uint32_t workDim,
-    const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
-    size_t *pSuggestedLocalWorkSize) {
+ur_result_t urKernelGetSuggestedLocalWorkSize(ur_kernel_handle_t hKernel,
+                                              ur_queue_handle_t hQueue,
+                                              uint32_t workDim,
+                                              const size_t *pGlobalWorkOffset,
+                                              const size_t *pGlobalWorkSize,
+                                              size_t *pSuggestedLocalWorkSize) {
   auto Kernel = cast(hKernel);
   auto Queue = cast(hQueue);
   cl_device_id Device;
@@ -501,7 +502,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSizeWithArgs(
+ur_result_t urKernelGetSuggestedLocalWorkSizeWithArgs(
     ur_kernel_handle_t hKernel, ur_queue_handle_t hQueue, uint32_t workDim,
     const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
     uint32_t numArgs, const ur_exp_kernel_arg_properties_t *pArgs,
@@ -559,8 +560,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSizeWithArgs(
       pSuggestedLocalWorkSize);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelSetSpecializationConstants(
-    ur_kernel_handle_t, uint32_t, const ur_specialization_constant_info_t *) {
+ur_result_t
+urKernelSetSpecializationConstants(ur_kernel_handle_t, uint32_t,
+                                   const ur_specialization_constant_info_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/opencl/memory.cpp
+++ b/unified-runtime/source/adapters/opencl/memory.cpp
@@ -338,9 +338,10 @@ ur_result_t ur_mem_handle_t_::makeWithNative(native_type NativeMem,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
-    ur_context_handle_t hContext, ur_mem_flags_t flags, size_t size,
-    const ur_buffer_properties_t *pProperties, ur_mem_handle_t *phBuffer) {
+ur_result_t urMemBufferCreate(ur_context_handle_t hContext,
+                              ur_mem_flags_t flags, size_t size,
+                              const ur_buffer_properties_t *pProperties,
+                              ur_mem_handle_t *phBuffer) {
   auto Context = cast(hContext);
   cl_int RetErr = CL_INVALID_OPERATION;
   if (pProperties) {
@@ -412,10 +413,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
-    ur_context_handle_t hContext, ur_mem_flags_t flags,
-    const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
-    void *pHost, ur_mem_handle_t *phMem) {
+ur_result_t urMemImageCreate(ur_context_handle_t hContext, ur_mem_flags_t flags,
+                             const ur_image_format_t *pImageFormat,
+                             const ur_image_desc_t *pImageDesc, void *pHost,
+                             ur_mem_handle_t *phMem) {
 
   auto Context = cast(hContext);
   cl_int RetErr = CL_INVALID_OPERATION;
@@ -440,10 +441,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
-    ur_mem_handle_t hBuffer, ur_mem_flags_t flags,
-    ur_buffer_create_type_t bufferCreateType, const ur_buffer_region_t *pRegion,
-    ur_mem_handle_t *phMem) {
+ur_result_t urMemBufferPartition(ur_mem_handle_t hBuffer, ur_mem_flags_t flags,
+                                 ur_buffer_create_type_t bufferCreateType,
+                                 const ur_buffer_region_t *pRegion,
+                                 ur_mem_handle_t *phMem) {
 
   auto Buffer = cast(hBuffer);
   cl_int RetErr = CL_INVALID_OPERATION;
@@ -483,13 +484,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
   return mapCLErrorToUR(RetErr);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemGetNativeHandle(
-    ur_mem_handle_t hMem, ur_device_handle_t, ur_native_handle_t *phNativeMem) {
+ur_result_t urMemGetNativeHandle(ur_mem_handle_t hMem, ur_device_handle_t,
+                                 ur_native_handle_t *phNativeMem) {
   auto Mem = cast(hMem);
   return getNativeHandle(Mem->CLMemory, phNativeMem);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
+ur_result_t urMemBufferCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ur_context_handle_t hContext,
     const ur_mem_native_properties_t *pProperties, ur_mem_handle_t *phMem) {
   cl_mem NativeHandle = reinterpret_cast<cl_mem>(hNativeMem);
@@ -501,7 +502,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
+ur_result_t urMemImageCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ur_context_handle_t hContext,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
@@ -515,11 +516,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
-                                                 ur_mem_info_t propName,
-                                                 size_t propSize,
-                                                 void *pPropValue,
-                                                 size_t *pPropSizeRet) {
+ur_result_t urMemGetInfo(ur_mem_handle_t hMemory, ur_mem_info_t propName,
+                         size_t propSize, void *pPropValue,
+                         size_t *pPropSizeRet) {
 
   auto Memory = cast(hMemory);
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
@@ -549,11 +548,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
-                                                      ur_image_info_t propName,
-                                                      size_t propSize,
-                                                      void *pPropValue,
-                                                      size_t *pPropSizeRet) {
+ur_result_t urMemImageGetInfo(ur_mem_handle_t hMemory, ur_image_info_t propName,
+                              size_t propSize, void *pPropValue,
+                              size_t *pPropSizeRet) {
 
   auto Memory = cast(hMemory);
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
@@ -578,13 +575,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
+ur_result_t urMemRetain(ur_mem_handle_t hMem) {
   auto Mem = cast(hMem);
   Mem->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
+ur_result_t urMemRelease(ur_mem_handle_t hMem) {
   auto Mem = cast(hMem);
   if (Mem->RefCount.release()) {
     delete Mem;
@@ -592,47 +589,42 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urIPCGetMemHandleExp(ur_context_handle_t,
-                                                         void *, void **,
-                                                         size_t *) {
+ur_result_t urIPCGetMemHandleExp(ur_context_handle_t, void *, void **,
+                                 size_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urIPCPutMemHandleExp(ur_context_handle_t,
-                                                         void *) {
+ur_result_t urIPCPutMemHandleExp(ur_context_handle_t, void *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urIPCOpenMemHandleExp(ur_context_handle_t,
-                                                          ur_device_handle_t,
-                                                          void *, size_t,
-                                                          void **) {
+ur_result_t urIPCOpenMemHandleExp(ur_context_handle_t, ur_device_handle_t,
+                                  void *, size_t, void **) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urIPCCloseMemHandleExp(ur_context_handle_t,
-                                                           void *) {
+ur_result_t urIPCCloseMemHandleExp(ur_context_handle_t, void *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urIPCGetPhysMemHandleExp(
-    ur_context_handle_t, ur_physical_mem_handle_t, void **, size_t *) {
+ur_result_t urIPCGetPhysMemHandleExp(ur_context_handle_t,
+                                     ur_physical_mem_handle_t, void **,
+                                     size_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urIPCPutPhysMemHandleExp(ur_context_handle_t, const void *) {
+ur_result_t urIPCPutPhysMemHandleExp(ur_context_handle_t, const void *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urIPCOpenPhysMemHandleExp(ur_context_handle_t, ur_device_handle_t, const void *,
-                          size_t, ur_physical_mem_handle_t *) {
+ur_result_t urIPCOpenPhysMemHandleExp(ur_context_handle_t, ur_device_handle_t,
+                                      const void *, size_t,
+                                      ur_physical_mem_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urIPCClosePhysMemHandleExp(ur_context_handle_t, ur_physical_mem_handle_t) {
+ur_result_t urIPCClosePhysMemHandleExp(ur_context_handle_t,
+                                       ur_physical_mem_handle_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/opencl/memory_export.cpp
+++ b/unified-runtime/source/adapters/opencl/memory_export.cpp
@@ -12,7 +12,7 @@
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemoryExportAllocExportableMemoryExp(
+ur_result_t urMemoryExportAllocExportableMemoryExp(
     ur_context_handle_t /*hContext*/, ur_device_handle_t /*hDevice*/,
     size_t /*aligment*/, size_t /*size*/,
     ur_exp_external_mem_type_t /*handleTypeToExport*/, void ** /*ppMem*/) {
@@ -20,14 +20,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemoryExportAllocExportableMemoryExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemoryExportFreeExportableMemoryExp(
-    ur_context_handle_t /*hContext*/, ur_device_handle_t /*hDevice*/,
-    void * /*pMem*/) {
+ur_result_t
+urMemoryExportFreeExportableMemoryExp(ur_context_handle_t /*hContext*/,
+                                      ur_device_handle_t /*hDevice*/,
+                                      void * /*pMem*/) {
   UR_LOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urMemoryExportExportMemoryHandleExp(
+ur_result_t urMemoryExportExportMemoryHandleExp(
     ur_context_handle_t /*hContext*/, ur_device_handle_t /*hDevice*/,
     ur_exp_external_mem_type_t /*handleTypeToExport*/, void * /*pMem*/,
     void * /*pMemHandleRet*/) {

--- a/unified-runtime/source/adapters/opencl/physical_mem.cpp
+++ b/unified-runtime/source/adapters/opencl/physical_mem.cpp
@@ -13,25 +13,23 @@
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL urPhysicalMemCreate(
-    ur_context_handle_t, ur_device_handle_t, size_t,
-    const ur_physical_mem_properties_t *, ur_physical_mem_handle_t *) {
+ur_result_t urPhysicalMemCreate(ur_context_handle_t, ur_device_handle_t, size_t,
+                                const ur_physical_mem_properties_t *,
+                                ur_physical_mem_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urPhysicalMemRetain(ur_physical_mem_handle_t) {
+ur_result_t urPhysicalMemRetain(ur_physical_mem_handle_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urPhysicalMemRelease(ur_physical_mem_handle_t) {
+ur_result_t urPhysicalMemRelease(ur_physical_mem_handle_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urPhysicalMemGetInfo(ur_physical_mem_handle_t, ur_physical_mem_info_t, size_t,
-                     void *, size_t *) {
+ur_result_t urPhysicalMemGetInfo(ur_physical_mem_handle_t,
+                                 ur_physical_mem_info_t, size_t, void *,
+                                 size_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/opencl/platform.cpp
+++ b/unified-runtime/source/adapters/opencl/platform.cpp
@@ -75,9 +75,10 @@ static bool isBannedOpenCLDevice(cl_device_id device) {
 
 namespace ur::opencl {
 
-UR_DLLEXPORT ur_result_t UR_APICALL
-urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
-                  size_t propSize, void *pPropValue, size_t *pSizeRet) {
+UR_DLLEXPORT ur_result_t urPlatformGetInfo(ur_platform_handle_t hPlatform,
+                                           ur_platform_info_t propName,
+                                           size_t propSize, void *pPropValue,
+                                           size_t *pSizeRet) {
 
   UrReturnHelper ReturnValue(propSize, pPropValue, pSizeRet);
   const cl_int CLPropName = mapURPlatformInfoToCL(propName);
@@ -105,16 +106,16 @@ urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
   }
 }
 
-UR_DLLEXPORT ur_result_t UR_APICALL
+UR_DLLEXPORT ur_result_t
 urPlatformGetApiVersion([[maybe_unused]] ur_platform_handle_t hPlatform,
                         ur_api_version_t *pVersion) {
   *pVersion = UR_API_VERSION_CURRENT;
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urPlatformGet(ur_adapter_handle_t, uint32_t NumEntries,
-              ur_platform_handle_t *phPlatforms, uint32_t *pNumPlatforms) {
+ur_result_t urPlatformGet(ur_adapter_handle_t, uint32_t NumEntries,
+                          ur_platform_handle_t *phPlatforms,
+                          uint32_t *pNumPlatforms) {
   static std::mutex adapterPopulationMutex{};
   ur_adapter_handle_t AdapterHandle = nullptr;
   UR_RETURN_ON_FAILURE(ur::opencl::urAdapterGet(1, &AdapterHandle, nullptr));
@@ -189,15 +190,15 @@ urPlatformGet(ur_adapter_handle_t, uint32_t NumEntries,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform, ur_native_handle_t *phNativePlatform) {
+ur_result_t urPlatformGetNativeHandle(ur_platform_handle_t hPlatform,
+                                      ur_native_handle_t *phNativePlatform) {
   auto Platform = cast(hPlatform);
   *phNativePlatform =
       reinterpret_cast<ur_native_handle_t>(Platform->CLPlatform);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+ur_result_t urPlatformCreateWithNativeHandle(
     ur_native_handle_t hNativePlatform, ur_adapter_handle_t,
     const ur_platform_native_properties_t *, ur_platform_handle_t *phPlatform) {
   cl_platform_id NativeHandle =
@@ -223,9 +224,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 // Returns plugin specific backend option.
 // Current support is only for optimization options.
 // Return '-cl-opt-disable' for pFrontendOption = -O0 and '' for others.
-UR_APIEXPORT ur_result_t UR_APICALL
-urPlatformGetBackendOption(ur_platform_handle_t, const char *pFrontendOption,
-                           const char **ppPlatformOption) {
+ur_result_t urPlatformGetBackendOption(ur_platform_handle_t,
+                                       const char *pFrontendOption,
+                                       const char **ppPlatformOption) {
   using namespace std::literals;
   if (pFrontendOption == nullptr)
     return UR_RESULT_SUCCESS;

--- a/unified-runtime/source/adapters/opencl/program.cpp
+++ b/unified-runtime/source/adapters/opencl/program.cpp
@@ -46,9 +46,10 @@ ur_result_t ur_program_handle_t_::makeWithNative(native_type NativeProg,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithIL(
-    ur_context_handle_t hContext, const void *pIL, size_t length,
-    const ur_program_properties_t *, ur_program_handle_t *phProgram) {
+ur_result_t urProgramCreateWithIL(ur_context_handle_t hContext, const void *pIL,
+                                  size_t length,
+                                  const ur_program_properties_t *,
+                                  ur_program_handle_t *phProgram) {
 
   auto Context = cast(hContext);
   auto CurPlatform = Context->Devices[0]->Platform;
@@ -143,7 +144,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithIL(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
+ur_result_t urProgramCreateWithBinary(
     ur_context_handle_t hContext, uint32_t numDevices,
     ur_device_handle_t *phDevices, size_t *pLengths, const uint8_t **ppBinaries,
     const ur_program_properties_t *, ur_program_handle_t *phProgram) {
@@ -171,9 +172,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramCompile([[maybe_unused]] ur_context_handle_t hContext,
-                 ur_program_handle_t hProgram, const char *pOptions) {
+ur_result_t urProgramCompile([[maybe_unused]] ur_context_handle_t hContext,
+                             ur_program_handle_t hProgram,
+                             const char *pOptions) {
 
   auto Program = cast(hProgram);
   uint32_t DeviceCount = Program->NumDevices;
@@ -215,9 +216,9 @@ static cl_int mapURProgramInfoToCL(ur_program_info_t URPropName) {
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
-                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+ur_result_t urProgramGetInfo(ur_program_handle_t hProgram,
+                             ur_program_info_t propName, size_t propSize,
+                             void *pPropValue, size_t *pPropSizeRet) {
   auto Program = cast(hProgram);
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
 
@@ -254,9 +255,8 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramBuild([[maybe_unused]] ur_context_handle_t hContext,
-               ur_program_handle_t hProgram, const char *pOptions) {
+ur_result_t urProgramBuild([[maybe_unused]] ur_context_handle_t hContext,
+                           ur_program_handle_t hProgram, const char *pOptions) {
 
   auto Program = cast(hProgram);
   uint32_t DeviceCount = Program->NumDevices;
@@ -271,10 +271,10 @@ urProgramBuild([[maybe_unused]] ur_context_handle_t hContext,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramLink(ur_context_handle_t hContext, uint32_t count,
-              const ur_program_handle_t *phPrograms, const char *pOptions,
-              ur_program_handle_t *phProgram) {
+ur_result_t urProgramLink(ur_context_handle_t hContext, uint32_t count,
+                          const ur_program_handle_t *phPrograms,
+                          const char *pOptions,
+                          ur_program_handle_t *phProgram) {
 
   auto Context = cast(hContext);
   cl_int CLResult;
@@ -308,34 +308,30 @@ urProgramLink(ur_context_handle_t hContext, uint32_t count,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramCompileExp(ur_program_handle_t,
-                                                        uint32_t,
-                                                        ur_device_handle_t *,
-                                                        ur_exp_program_flags_t,
-                                                        const char *) {
+ur_result_t urProgramCompileExp(ur_program_handle_t, uint32_t,
+                                ur_device_handle_t *, ur_exp_program_flags_t,
+                                const char *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramBuildExp(ur_program_handle_t,
-                                                      uint32_t,
-                                                      ur_device_handle_t *,
-                                                      ur_exp_program_flags_t,
-                                                      const char *) {
+ur_result_t urProgramBuildExp(ur_program_handle_t, uint32_t,
+                              ur_device_handle_t *, ur_exp_program_flags_t,
+                              const char *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramLinkExp(ur_context_handle_t, uint32_t, ur_device_handle_t *,
-                 ur_exp_program_flags_t, uint32_t, const ur_program_handle_t *,
-                 const char *, ur_program_handle_t *phProgram) {
+ur_result_t urProgramLinkExp(ur_context_handle_t, uint32_t,
+                             ur_device_handle_t *, ur_exp_program_flags_t,
+                             uint32_t, const ur_program_handle_t *,
+                             const char *, ur_program_handle_t *phProgram) {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
   }
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramDynamicLinkExp(
-    ur_context_handle_t, uint32_t, const ur_program_handle_t *) {
+ur_result_t urProgramDynamicLinkExp(ur_context_handle_t, uint32_t,
+                                    const ur_program_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -378,10 +374,11 @@ mapCLBinaryTypeToUR(cl_program_binary_type binaryType) {
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
-                      ur_program_build_info_t propName, size_t propSize,
-                      void *pPropValue, size_t *pPropSizeRet) {
+ur_result_t urProgramGetBuildInfo(ur_program_handle_t hProgram,
+                                  ur_device_handle_t hDevice,
+                                  ur_program_build_info_t propName,
+                                  size_t propSize, void *pPropValue,
+                                  size_t *pPropSizeRet) {
   auto Program = cast(hProgram);
   auto Device = cast(hDevice);
   if (propName == UR_PROGRAM_BUILD_INFO_BINARY_TYPE) {
@@ -408,15 +405,13 @@ urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramRetain(ur_program_handle_t hProgram) {
+ur_result_t urProgramRetain(ur_program_handle_t hProgram) {
   auto Program = cast(hProgram);
   Program->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urProgramRelease(ur_program_handle_t hProgram) {
+ur_result_t urProgramRelease(ur_program_handle_t hProgram) {
   auto Program = cast(hProgram);
   if (Program->RefCount.release()) {
     delete Program;
@@ -424,15 +419,15 @@ urProgramRelease(ur_program_handle_t hProgram) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram, ur_native_handle_t *phNativeProgram) {
+ur_result_t urProgramGetNativeHandle(ur_program_handle_t hProgram,
+                                     ur_native_handle_t *phNativeProgram) {
 
   auto Program = cast(hProgram);
   *phNativeProgram = reinterpret_cast<ur_native_handle_t>(Program->CLProgram);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+ur_result_t urProgramCreateWithNativeHandle(
     ur_native_handle_t hNativeProgram, ur_context_handle_t hContext,
     const ur_program_native_properties_t *pProperties,
     ur_program_handle_t *phProgram) {
@@ -446,7 +441,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+ur_result_t urProgramSetSpecializationConstants(
     ur_program_handle_t hProgram, uint32_t count,
     const ur_specialization_constant_info_t *pSpecConstants) {
 
@@ -501,9 +496,10 @@ static bool isInSeparatedString(const std::string &Str, char Delimiter,
   return false;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
-    ur_device_handle_t hDevice, ur_program_handle_t hProgram,
-    const char *pFunctionName, void **ppFunctionPointer) {
+ur_result_t urProgramGetFunctionPointer(ur_device_handle_t hDevice,
+                                        ur_program_handle_t hProgram,
+                                        const char *pFunctionName,
+                                        void **ppFunctionPointer) {
 
   auto Program = cast(hProgram);
   auto Device = cast(hDevice);
@@ -558,7 +554,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+ur_result_t urProgramGetGlobalVariablePointer(
     ur_device_handle_t hDevice, ur_program_handle_t hProgram,
     const char *pGlobalVariableName, size_t *pGlobalVariableSizeRet,
     void **ppGlobalVariablePointerRet) {

--- a/unified-runtime/source/adapters/opencl/queue.cpp
+++ b/unified-runtime/source/adapters/opencl/queue.cpp
@@ -111,9 +111,10 @@ ur_result_t ur_queue_handle_t_::makeWithNative(native_type NativeQueue,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
-    ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    const ur_queue_properties_t *pProperties, ur_queue_handle_t *phQueue) {
+ur_result_t urQueueCreate(ur_context_handle_t hContext,
+                          ur_device_handle_t hDevice,
+                          const ur_queue_properties_t *pProperties,
+                          ur_queue_handle_t *phQueue) {
 
   auto Context = cast(hContext);
   auto Device = cast(hDevice);
@@ -171,11 +172,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
-                                                   ur_queue_info_t propName,
-                                                   size_t propSize,
-                                                   void *pPropValue,
-                                                   size_t *pPropSizeRet) {
+ur_result_t urQueueGetInfo(ur_queue_handle_t hQueue, ur_queue_info_t propName,
+                           size_t propSize, void *pPropValue,
+                           size_t *pPropSizeRet) {
   auto Queue = cast(hQueue);
   cl_command_queue_info CLCommandQueueInfo = mapURQueueInfoToCL(propName);
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
@@ -273,14 +272,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urQueueGetNativeHandle(ur_queue_handle_t hQueue, ur_queue_native_desc_t *,
-                       ur_native_handle_t *phNativeQueue) {
+ur_result_t urQueueGetNativeHandle(ur_queue_handle_t hQueue,
+                                   ur_queue_native_desc_t *,
+                                   ur_native_handle_t *phNativeQueue) {
   auto Queue = cast(hQueue);
   return getNativeHandle(Queue->CLQueue, phNativeQueue);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+ur_result_t urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ur_context_handle_t hContext,
     ur_device_handle_t hDevice, const ur_queue_native_properties_t *pProperties,
     ur_queue_handle_t *phQueue) {
@@ -298,27 +297,27 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(ur_queue_handle_t hQueue) {
+ur_result_t urQueueFinish(ur_queue_handle_t hQueue) {
   auto Queue = cast(hQueue);
   cl_int RetErr = clFinish(Queue->CLQueue);
   CL_RETURN_ON_FAILURE(RetErr);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueFlush(ur_queue_handle_t hQueue) {
+ur_result_t urQueueFlush(ur_queue_handle_t hQueue) {
   auto Queue = cast(hQueue);
   cl_int RetErr = clFlush(Queue->CLQueue);
   CL_RETURN_ON_FAILURE(RetErr);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
+ur_result_t urQueueRetain(ur_queue_handle_t hQueue) {
   auto Queue = cast(hQueue);
   Queue->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
+ur_result_t urQueueRelease(ur_queue_handle_t hQueue) {
   auto Queue = cast(hQueue);
   if (Queue->RefCount.release()) {
     delete Queue;
@@ -326,47 +325,47 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urQueueBeginGraphCaptureExp(ur_queue_handle_t /* hQueue */) {
+ur_result_t urQueueBeginGraphCaptureExp(ur_queue_handle_t /* hQueue */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueBeginCaptureIntoGraphExp(
-    ur_queue_handle_t /* hQueue */, ur_exp_graph_handle_t /* hGraph */) {
+ur_result_t
+urQueueBeginCaptureIntoGraphExp(ur_queue_handle_t /* hQueue */,
+                                ur_exp_graph_handle_t /* hGraph */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueEndGraphCaptureExp(
-    ur_queue_handle_t /* hQueue */, ur_exp_graph_handle_t * /* phGraph */) {
+ur_result_t urQueueEndGraphCaptureExp(ur_queue_handle_t /* hQueue */,
+                                      ur_exp_graph_handle_t * /* phGraph */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEnqueueGraphExp(ur_queue_handle_t /* hQueue */,
-                  ur_exp_executable_graph_handle_t /* hGraph */,
-                  uint32_t /* numEventsInWaitList */,
-                  const ur_event_handle_t * /* phEventWaitList */,
-                  ur_event_handle_t * /* phEvent */) {
+ur_result_t urEnqueueGraphExp(ur_queue_handle_t /* hQueue */,
+                              ur_exp_executable_graph_handle_t /* hGraph */,
+                              uint32_t /* numEventsInWaitList */,
+                              const ur_event_handle_t * /* phEventWaitList */,
+                              ur_event_handle_t * /* phEvent */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueIsGraphCaptureEnabledExp(
-    ur_queue_handle_t /* hQueue */, bool * /* hResult */) {
+ur_result_t urQueueIsGraphCaptureEnabledExp(ur_queue_handle_t /* hQueue */,
+                                            bool * /* hResult */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urQueueGetGraphExp(
-    ur_queue_handle_t /* hQueue */, ur_exp_graph_handle_t * /* phGraph */) {
+ur_result_t urQueueGetGraphExp(ur_queue_handle_t /* hQueue */,
+                               ur_exp_graph_handle_t * /* phGraph */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueHostTaskExp(
-    ur_queue_handle_t /* hQueue */,
-    ur_exp_host_task_function_t /* pfnHostTask */, void * /* data */,
-    const ur_exp_host_task_properties_t * /* pProperties */,
-    uint32_t /* numEventsInWaitList */,
-    const ur_event_handle_t * /* phEventWaitList */,
-    ur_event_handle_t * /* phEvent */) {
+ur_result_t
+urEnqueueHostTaskExp(ur_queue_handle_t /* hQueue */,
+                     ur_exp_host_task_function_t /* pfnHostTask */,
+                     void * /* data */,
+                     const ur_exp_host_task_properties_t * /* pProperties */,
+                     uint32_t /* numEventsInWaitList */,
+                     const ur_event_handle_t * /* phEventWaitList */,
+                     ur_event_handle_t * /* phEvent */) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/opencl/sampler.cpp
+++ b/unified-runtime/source/adapters/opencl/sampler.cpp
@@ -162,9 +162,9 @@ ur_result_t urSamplerCreate(ur_context_handle_t hContext,
   return mapCLErrorToUR(ErrorCode);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
-                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+ur_result_t urSamplerGetInfo(ur_sampler_handle_t hSampler,
+                             ur_sampler_info_t propName, size_t propSize,
+                             void *pPropValue, size_t *pPropSizeRet) {
   auto Sampler = cast(hSampler);
   cl_sampler_info SamplerInfo = ur2CLSamplerInfo(propName);
   static_assert(sizeof(cl_addressing_mode) ==
@@ -221,15 +221,13 @@ urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urSamplerRetain(ur_sampler_handle_t hSampler) {
+ur_result_t urSamplerRetain(ur_sampler_handle_t hSampler) {
   auto Sampler = cast(hSampler);
   Sampler->RefCount.retain();
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urSamplerRelease(ur_sampler_handle_t hSampler) {
+ur_result_t urSamplerRelease(ur_sampler_handle_t hSampler) {
   auto Sampler = cast(hSampler);
   if (Sampler->RefCount.release()) {
     delete Sampler;
@@ -237,14 +235,14 @@ urSamplerRelease(ur_sampler_handle_t hSampler) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler, ur_native_handle_t *phNativeSampler) {
+ur_result_t urSamplerGetNativeHandle(ur_sampler_handle_t hSampler,
+                                     ur_native_handle_t *phNativeSampler) {
   auto Sampler = cast(hSampler);
   *phNativeSampler = reinterpret_cast<ur_native_handle_t>(Sampler->CLSampler);
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+ur_result_t urSamplerCreateWithNativeHandle(
     ur_native_handle_t hNativeSampler, ur_context_handle_t hContext,
     const ur_sampler_native_properties_t *pProperties,
     ur_sampler_handle_t *phSampler) {

--- a/unified-runtime/source/adapters/opencl/usm.cpp
+++ b/unified-runtime/source/adapters/opencl/usm.cpp
@@ -101,9 +101,9 @@ usmDescToCLMemProperties(const ur_base_desc_t *Desc,
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMHostAlloc(ur_context_handle_t Context, const ur_usm_desc_t *pUSMDesc,
-               ur_usm_pool_handle_t, size_t size, void **ppMem) {
+ur_result_t urUSMHostAlloc(ur_context_handle_t Context,
+                           const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t,
+                           size_t size, void **ppMem) {
 
   auto hContext = cast(Context);
 
@@ -151,10 +151,10 @@ urUSMHostAlloc(ur_context_handle_t Context, const ur_usm_desc_t *pUSMDesc,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMDeviceAlloc(ur_context_handle_t Context, ur_device_handle_t hDevice,
-                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t,
-                 size_t size, void **ppMem) {
+ur_result_t urUSMDeviceAlloc(ur_context_handle_t Context,
+                             ur_device_handle_t hDevice,
+                             const ur_usm_desc_t *pUSMDesc,
+                             ur_usm_pool_handle_t, size_t size, void **ppMem) {
 
   auto hContext = cast(Context);
   auto Device = cast(hDevice);
@@ -203,10 +203,10 @@ urUSMDeviceAlloc(ur_context_handle_t Context, ur_device_handle_t hDevice,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMSharedAlloc(ur_context_handle_t Context, ur_device_handle_t hDevice,
-                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t,
-                 size_t size, void **ppMem) {
+ur_result_t urUSMSharedAlloc(ur_context_handle_t Context,
+                             ur_device_handle_t hDevice,
+                             const ur_usm_desc_t *pUSMDesc,
+                             ur_usm_pool_handle_t, size_t size, void **ppMem) {
 
   auto hContext = cast(Context);
   auto Device = cast(hDevice);
@@ -254,8 +254,7 @@ urUSMSharedAlloc(ur_context_handle_t Context, ur_device_handle_t hDevice,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMFree(ur_context_handle_t Context,
-                                              void *pMem) {
+ur_result_t urUSMFree(ur_context_handle_t Context, void *pMem) {
 
   auto hContext = cast(Context);
 
@@ -277,10 +276,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMFree(ur_context_handle_t Context,
   return RetVal;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
-    ur_queue_handle_t hQueue, void *ptr, size_t patternSize,
-    const void *pPattern, size_t size, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueUSMFill(ur_queue_handle_t hQueue, void *ptr,
+                             size_t patternSize, const void *pPattern,
+                             size_t size, uint32_t numEventsInWaitList,
+                             const ur_event_handle_t *phEventWaitList,
+                             ur_event_handle_t *phEvent) {
 
   auto Queue = cast(hQueue);
 
@@ -375,10 +375,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue, bool blocking, void *pDst, const void *pSrc,
-    size_t size, uint32_t numEventsInWaitList,
-    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueUSMMemcpy(ur_queue_handle_t hQueue, bool blocking,
+                               void *pDst, const void *pSrc, size_t size,
+                               uint32_t numEventsInWaitList,
+                               const ur_event_handle_t *phEventWaitList,
+                               ur_event_handle_t *phEvent) {
 
   auto Queue = cast(hQueue);
 
@@ -542,7 +543,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+ur_result_t urEnqueueUSMPrefetch(
     ur_queue_handle_t hQueue, [[maybe_unused]] const void *pMem,
     [[maybe_unused]] size_t size,
     [[maybe_unused]] ur_usm_migration_flags_t flags,
@@ -608,10 +609,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMAdvise(
-    ur_queue_handle_t hQueue, [[maybe_unused]] const void *pMem,
-    [[maybe_unused]] size_t size, [[maybe_unused]] ur_usm_advice_flags_t advice,
-    ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueUSMAdvise(ur_queue_handle_t hQueue,
+                               [[maybe_unused]] const void *pMem,
+                               [[maybe_unused]] size_t size,
+                               [[maybe_unused]] ur_usm_advice_flags_t advice,
+                               ur_event_handle_t *phEvent) {
 
   auto Queue = cast(hQueue);
 
@@ -642,7 +644,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMAdvise(
   */
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill2D(
+ur_result_t urEnqueueUSMFill2D(
     [[maybe_unused]] ur_queue_handle_t hQueue, [[maybe_unused]] void *pMem,
     [[maybe_unused]] size_t pitch, [[maybe_unused]] size_t patternSize,
     [[maybe_unused]] const void *pPattern, [[maybe_unused]] size_t width,
@@ -653,11 +655,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill2D(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue, bool blocking, void *pDst, size_t dstPitch,
-    const void *pSrc, size_t srcPitch, size_t width, size_t height,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+ur_result_t urEnqueueUSMMemcpy2D(ur_queue_handle_t hQueue, bool blocking,
+                                 void *pDst, size_t dstPitch, const void *pSrc,
+                                 size_t srcPitch, size_t width, size_t height,
+                                 uint32_t numEventsInWaitList,
+                                 const ur_event_handle_t *phEventWaitList,
+                                 ur_event_handle_t *phEvent) {
 
   auto Queue = cast(hQueue);
 
@@ -726,9 +729,9 @@ mapCLUSMTypeToUR(const cl_unified_shared_memory_type_intel &Type) {
   }
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMGetMemAllocInfo(
-    ur_context_handle_t Context, const void *pMem, ur_usm_alloc_info_t propName,
-    size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+ur_result_t urUSMGetMemAllocInfo(ur_context_handle_t Context, const void *pMem,
+                                 ur_usm_alloc_info_t propName, size_t propSize,
+                                 void *pPropValue, size_t *pPropSizeRet) {
 
   auto hContext = cast(Context);
 
@@ -779,104 +782,93 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMGetMemAllocInfo(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMImportExp([[maybe_unused]] ur_context_handle_t Context,
-               [[maybe_unused]] void *HostPtr, [[maybe_unused]] size_t Size) {
+ur_result_t urUSMImportExp([[maybe_unused]] ur_context_handle_t Context,
+                           [[maybe_unused]] void *HostPtr,
+                           [[maybe_unused]] size_t Size) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMReleaseExp([[maybe_unused]] ur_context_handle_t Context,
-                [[maybe_unused]] void *HostPtr) {
+ur_result_t urUSMReleaseExp([[maybe_unused]] ur_context_handle_t Context,
+                            [[maybe_unused]] void *HostPtr) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMPoolCreate([[maybe_unused]] ur_context_handle_t hContext,
-                [[maybe_unused]] ur_usm_pool_desc_t *pPoolDesc,
-                [[maybe_unused]] ur_usm_pool_handle_t *ppPool) {
+ur_result_t urUSMPoolCreate([[maybe_unused]] ur_context_handle_t hContext,
+                            [[maybe_unused]] ur_usm_pool_desc_t *pPoolDesc,
+                            [[maybe_unused]] ur_usm_pool_handle_t *ppPool) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMPoolRetain([[maybe_unused]] ur_usm_pool_handle_t pPool) {
+ur_result_t urUSMPoolRetain([[maybe_unused]] ur_usm_pool_handle_t pPool) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMPoolRelease([[maybe_unused]] ur_usm_pool_handle_t pPool) {
+ur_result_t urUSMPoolRelease([[maybe_unused]] ur_usm_pool_handle_t pPool) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolGetInfo(
-    [[maybe_unused]] ur_usm_pool_handle_t hPool,
-    [[maybe_unused]] ur_usm_pool_info_t propName,
-    [[maybe_unused]] size_t propSize, [[maybe_unused]] void *pPropValue,
-    [[maybe_unused]] size_t *pPropSizeRet) {
+ur_result_t urUSMPoolGetInfo([[maybe_unused]] ur_usm_pool_handle_t hPool,
+                             [[maybe_unused]] ur_usm_pool_info_t propName,
+                             [[maybe_unused]] size_t propSize,
+                             [[maybe_unused]] void *pPropValue,
+                             [[maybe_unused]] size_t *pPropSizeRet) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolCreateExp(ur_context_handle_t,
-                                                       ur_device_handle_t,
-                                                       ur_usm_pool_desc_t *,
-                                                       ur_usm_pool_handle_t *) {
+ur_result_t urUSMPoolCreateExp(ur_context_handle_t, ur_device_handle_t,
+                               ur_usm_pool_desc_t *, ur_usm_pool_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolDestroyExp(ur_context_handle_t,
-                                                        ur_device_handle_t,
-                                                        ur_usm_pool_handle_t) {
+ur_result_t urUSMPoolDestroyExp(ur_context_handle_t, ur_device_handle_t,
+                                ur_usm_pool_handle_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolSetInfoExp(ur_usm_pool_handle_t,
-                                                        ur_usm_pool_info_t,
-                                                        void *, size_t) {
+ur_result_t urUSMPoolSetInfoExp(ur_usm_pool_handle_t, ur_usm_pool_info_t,
+                                void *, size_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolGetDefaultDevicePoolExp(
-    ur_context_handle_t, ur_device_handle_t, ur_usm_pool_handle_t *) {
+ur_result_t urUSMPoolGetDefaultDevicePoolExp(ur_context_handle_t,
+                                             ur_device_handle_t,
+                                             ur_usm_pool_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolGetInfoExp(ur_usm_pool_handle_t,
-                                                        ur_usm_pool_info_t,
-                                                        void *, size_t *) {
+ur_result_t urUSMPoolGetInfoExp(ur_usm_pool_handle_t, ur_usm_pool_info_t,
+                                void *, size_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolGetDevicePoolExp(
-    ur_context_handle_t, ur_device_handle_t, ur_usm_pool_handle_t *) {
+ur_result_t urUSMPoolGetDevicePoolExp(ur_context_handle_t, ur_device_handle_t,
+                                      ur_usm_pool_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolSetDevicePoolExp(
-    ur_context_handle_t, ur_device_handle_t, ur_usm_pool_handle_t) {
+ur_result_t urUSMPoolSetDevicePoolExp(ur_context_handle_t, ur_device_handle_t,
+                                      ur_usm_pool_handle_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolTrimToExp(ur_context_handle_t,
-                                                       ur_device_handle_t,
-                                                       ur_usm_pool_handle_t,
-                                                       size_t) {
+ur_result_t urUSMPoolTrimToExp(ur_context_handle_t, ur_device_handle_t,
+                               ur_usm_pool_handle_t, size_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMContextMemcpyExp(ur_context_handle_t,
-                                                          void *, const void *,
-                                                          size_t) {
+ur_result_t urUSMContextMemcpyExp(ur_context_handle_t, void *, const void *,
+                                  size_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMHostAllocRegisterExp(
+ur_result_t urUSMHostAllocRegisterExp(
     ur_context_handle_t /*hContext*/, void * /*pHostMem*/, size_t /*size*/,
     const ur_exp_usm_host_alloc_register_properties_t * /*pProperties*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUSMHostAllocUnregisterExp(
-    ur_context_handle_t /*hContext*/, void * /*pHostMem*/) {
+ur_result_t urUSMHostAllocUnregisterExp(ur_context_handle_t /*hContext*/,
+                                        void * /*pHostMem*/) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/unified-runtime/source/adapters/opencl/usm_p2p.cpp
+++ b/unified-runtime/source/adapters/opencl/usm_p2p.cpp
@@ -11,7 +11,7 @@
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL
+ur_result_t
 urUsmP2PEnablePeerAccessExp([[maybe_unused]] ur_device_handle_t commandDevice,
                             [[maybe_unused]] ur_device_handle_t peerDevice) {
 
@@ -19,7 +19,7 @@ urUsmP2PEnablePeerAccessExp([[maybe_unused]] ur_device_handle_t commandDevice,
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
+ur_result_t
 urUsmP2PDisablePeerAccessExp([[maybe_unused]] ur_device_handle_t commandDevice,
                              [[maybe_unused]] ur_device_handle_t peerDevice) {
 
@@ -27,12 +27,13 @@ urUsmP2PDisablePeerAccessExp([[maybe_unused]] ur_device_handle_t commandDevice,
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
-    [[maybe_unused]] ur_device_handle_t commandDevice,
-    [[maybe_unused]] ur_device_handle_t peerDevice,
-    [[maybe_unused]] ur_exp_peer_info_t propName,
-    [[maybe_unused]] size_t propSize, [[maybe_unused]] void *pPropValue,
-    [[maybe_unused]] size_t *pPropSizeRet) {
+ur_result_t
+urUsmP2PPeerAccessGetInfoExp([[maybe_unused]] ur_device_handle_t commandDevice,
+                             [[maybe_unused]] ur_device_handle_t peerDevice,
+                             [[maybe_unused]] ur_exp_peer_info_t propName,
+                             [[maybe_unused]] size_t propSize,
+                             [[maybe_unused]] void *pPropValue,
+                             [[maybe_unused]] size_t *pPropSizeRet) {
 
   die("Experimental P2P feature is not implemented for OpenCL adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/unified-runtime/source/adapters/opencl/virtual_mem.cpp
+++ b/unified-runtime/source/adapters/opencl/virtual_mem.cpp
@@ -13,44 +13,40 @@
 
 namespace ur::opencl {
 
-UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
-    ur_context_handle_t, ur_device_handle_t, size_t,
-    ur_virtual_mem_granularity_info_t, size_t, void *, size_t *) {
+ur_result_t urVirtualMemGranularityGetInfo(ur_context_handle_t,
+                                           ur_device_handle_t, size_t,
+                                           ur_virtual_mem_granularity_info_t,
+                                           size_t, void *, size_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemReserve(ur_context_handle_t,
-                                                        const void *, size_t,
-                                                        void **) {
+ur_result_t urVirtualMemReserve(ur_context_handle_t, const void *, size_t,
+                                void **) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemFree(ur_context_handle_t,
-                                                     const void *, size_t) {
+ur_result_t urVirtualMemFree(ur_context_handle_t, const void *, size_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemSetAccess(
-    ur_context_handle_t, const void *, size_t, ur_virtual_mem_access_flags_t) {
+ur_result_t urVirtualMemSetAccess(ur_context_handle_t, const void *, size_t,
+                                  ur_virtual_mem_access_flags_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemMap(
-    ur_context_handle_t, const void *, size_t, ur_physical_mem_handle_t, size_t,
-    ur_virtual_mem_access_flags_t) {
+ur_result_t urVirtualMemMap(ur_context_handle_t, const void *, size_t,
+                            ur_physical_mem_handle_t, size_t,
+                            ur_virtual_mem_access_flags_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemUnmap(ur_context_handle_t,
-                                                      const void *, size_t) {
+ur_result_t urVirtualMemUnmap(ur_context_handle_t, const void *, size_t) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemGetInfo(ur_context_handle_t,
-                                                        const void *, size_t,
-                                                        ur_virtual_mem_info_t,
-                                                        size_t, void *,
-                                                        size_t *) {
+ur_result_t urVirtualMemGetInfo(ur_context_handle_t, const void *, size_t,
+                                ur_virtual_mem_info_t, size_t, void *,
+                                size_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 


### PR DESCRIPTION
Those macros were causing issues with opencl adapter being built as a dynamic library.