### PR TITLE
[XPTIFW] Suppress deprecation warnings from parallel-hashmap on macOS

### DIFF
--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -52,7 +52,6 @@ jobs:
           --ci-defaults --use-zstd $ARGS \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DLLVM_INSTALL_UTILS=ON \
-          -DXPTI_ENABLE_WERROR=OFF
+          -DLLVM_INSTALL_UTILS=ON
     - name: Compile
       run: cmake --build $GITHUB_WORKSPACE/build --target deploy-sycl-toolchain

--- a/xptifw/src/CMakeLists.txt
+++ b/xptifw/src/CMakeLists.txt
@@ -71,6 +71,12 @@ function(add_xpti_library LIB_NAME)
     $<BUILD_INTERFACE:${XPTIFW_PARALLEL_HASHMAP_HEADERS}>
   )
 
+  # Suppress deprecation warnings from parallel-hashmap on macOS
+  # parallel-hashmap uses std::allocator::pointer which is deprecated in C++17+
+  if(APPLE)
+    target_compile_options(${LIB_NAME} PRIVATE -Wno-deprecated-declarations)
+  endif()
+
   add_dependencies(${LIB_NAME} xpti)
 
   target_link_libraries(${LIB_NAME} PUBLIC $<BUILD_INTERFACE:emhash::emhash>)


### PR DESCRIPTION
parallel-hashmap uses std::allocator::pointer which is deprecated in C++17+ and causes build failures on macOS when -Werror is enabled.

With this fix we can undo the workaround in the Mac build CI.