### PR TITLE
[SYCL] Differentiate install targets for `clang*` binaries (#21598)

### DIFF
--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -322,7 +322,7 @@ jobs:
         testing_mode: build-only
         target_devices: all
         binaries_artifact: ${{ inputs.e2e_binaries_artifact }}
-        sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/clang++
+        sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/dpclang++
         extra_lit_opts: --param sycl_build_targets="spir;nvidia"
 
     - name: Build E2E tests with NewOffloadModel
@@ -337,7 +337,7 @@ jobs:
         testing_mode: build-only
         target_devices: all
         binaries_artifact: ${{ inputs.e2e_binaries_new_offload_model_artifact }}
-        sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/clang++
+        sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/dpclang++
         extra_lit_opts: --param sycl_build_targets="spir;nvidia" --param enable_new_offload_model=True
 
     - name: Build E2E tests with SPIR-V Backend
@@ -348,7 +348,7 @@ jobs:
         testing_mode: build-only
         target_devices: all
         binaries_artifact: ${{ inputs.e2e_binaries_spirv_backend_artifact }}
-        sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/clang++
+        sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/dpclang++
         extra_lit_opts: --param spirv-backend=True
 
     - name: Build E2E tests in Preview Mode
@@ -359,5 +359,5 @@ jobs:
         testing_mode: build-only
         target_devices: all
         binaries_artifact: ${{ inputs.e2e_binaries_preview_artifact }}
-        sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/clang++
+        sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/dpclang++
         extra_lit_opts: --param test-preview-mode=True

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -101,7 +101,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           testing_mode: full
           target_devices: native_cpu:cpu
-          sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/clang++
+          sycl_compiler: $GITHUB_WORKSPACE/toolchain/bin/dpclang++
           extra_lit_opts: --param sycl_build_targets="native_cpu"
           extra_cmake_args: -DSYCL_TEST_E2E_TARGETS="native_cpu:cpu" -DSYCL_TEST_E2E_STANDALONE=ON
 

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -315,9 +315,9 @@ jobs:
         tar xf sycl_linux.tar.gz -C toolchain
         echo PATH=$PWD/toolchain/bin/:$PATH >> $GITHUB_ENV
         echo LD_LIBRARY_PATH=$PWD/toolchain/lib/:$LD_LIBRARY_PATH >> $GITHUB_ENV
-    - run: which clang++ sycl-ls
-    - run: sycl-ls --verbose
-    - run: SYCL_UR_TRACE=1 sycl-ls
+    - run: which dpclang++ dpsycl-ls
+    - run: dpsycl-ls --verbose
+    - run: SYCL_UR_TRACE=1 dpsycl-ls
     - name: Print IGC version
       run: |
           if [ -f /usr/local/lib/igc/IGCTAG.txt ]; then

--- a/.github/workflows/sycl-prebuilt-e2e-container.yml
+++ b/.github/workflows/sycl-prebuilt-e2e-container.yml
@@ -109,7 +109,7 @@ jobs:
           echo LD_LIBRARY_PATH=$PWD/toolchain/lib:$LD_LIBRARY_PATH >> $GITHUB_ENV
           echo PATH=$PWD/toolchain/bin:$PATH >> $GITHUB_ENV
       - run: |
-          sycl-ls
+          dpsycl-ls
       - name: Run E2E tests
         uses: ./devops/actions/run-tests/linux/e2e
         timeout-minutes: 20

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -136,9 +136,9 @@ jobs:
         echo "PATH=$env:GITHUB_WORKSPACE\\install\\bin;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "LIB=$env:GITHUB_WORKSPACE\\install\\lib;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - run: |
-        sycl-ls
+        dpsycl-ls
     - run: |
-        sycl-ls --verbose
+        dpsycl-ls --verbose
 
     - name: Run E2E Tests
       if: inputs.tests_selector == 'e2e'

--- a/clang/tools/CMakeLists.txt
+++ b/clang/tools/CMakeLists.txt
@@ -2,6 +2,7 @@ create_subdirectory_options(CLANG TOOL)
 
 add_clang_subdirectory(diagtool)
 add_clang_subdirectory(driver)
+add_clang_subdirectory(dpllvm)
 if(CLANG_ENABLE_CIR)
   add_clang_subdirectory(cir-opt)
   add_clang_subdirectory(cir-translate)

--- a/clang/tools/dpllvm/CMakeLists.txt
+++ b/clang/tools/dpllvm/CMakeLists.txt
@@ -1,0 +1,48 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
+# dpllvm is the entry-point shim for the DPC++ toolchain.  It is installed into
+# bin/ next to the real tools; the public "dp"-prefixed names are symlinks
+# (copies on Windows, which lacks first-class symlinks) to it.  At runtime
+# dpllvm strips the "dp" prefix from argv[0] and execs the sibling real binary
+# (dpclang -> clang, dpclang++ -> clang++, dpsycl-ls -> sycl-ls, ...).
+#
+# These names must not collide with a system LLVM/Clang on PATH, hence the
+# prefix; the real binaries keep their original names because the clang driver
+# re-invokes itself by name and expects to find "clang"/"clang++".
+add_clang_tool(dpllvm
+  dpllvm.cpp
+  )
+
+# The public entry-points.  Each is a symlink/copy to dpllvm; the stripped name
+# (after removing "dp") must match a real binary installed next to dpllvm.
+#   dpclang*        -> clang, clang++, clang-cl, clang-cpp  (this project)
+#   dpsycl-ls       -> sycl-ls        (sycl/tools/sycl-ls)
+#   dpsyclbin-dump  -> syclbin-dump   (sycl/tools/syclbin-dump)
+#   dpsycl-prof     -> sycl-prof      (sycl/tools/sycl-prof, UNIX + XPTI only)
+#   dpsycl-sanitize -> sycl-sanitize  (sycl/tools/sycl-sanitize, UNIX + XPTI)
+#   dpsycl-trace    -> sycl-trace     (sycl/tools/sycl-trace, UNIX + XPTI)
+#
+# add_clang_symlink creates both the build-tree link (POST_BUILD of dpllvm, so
+# it lands in the same build bin/ as every real tool) and the install rule
+# (component "dpllvm").  The sycl-* entry-points are created here rather than in
+# their own tool directories so that all symlink creation lives in one place and
+# ships as a single component that deploy-sycl-toolchain pulls in; a symlink
+# whose target tool is not built on a given platform simply errors at runtime,
+# which is the same behavior as a missing tool.
+set(DPCPP_ENTRY_POINTS
+  dpclang
+  dpclang++
+  dpclang-cl
+  dpclang-cpp
+  dpsycl-ls
+  dpsyclbin-dump
+  dpsycl-prof
+  dpsycl-sanitize
+  dpsycl-trace
+  )
+
+foreach(link ${DPCPP_ENTRY_POINTS})
+  add_clang_symlink(${link} dpllvm)
+endforeach()

--- a/clang/tools/dpllvm/dpllvm.cpp
+++ b/clang/tools/dpllvm/dpllvm.cpp
@@ -1,0 +1,80 @@
+//===-- dpllvm.cpp - DPC++ tool entry-point shim --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The DPC++ toolchain ships public entry-points whose names are prefixed with
+// "dp" (dpclang, dpclang++, dpclang-cl, dpclang-cpp, dpsycl-ls, ...) so they
+// don't collide with the identically-named tools of a system LLVM/Clang
+// installation that may be on PATH.  Those entry-points are symlinks (real
+// copies on Windows, which has no first-class symlinks) that resolve to this
+// tool.
+//
+// dpllvm looks at how it was invoked (argv[0]), strips the leading "dp", and
+// re-executes the correspondingly-named real binary that lives next to it in
+// the same directory -- e.g. invoking "dpclang++" runs "clang++".  The real
+// binary keeps its original name ("clang++", not "dpclang++") because the
+// clang driver re-invokes itself by name (for -cc1, offloading sub-jobs, etc.)
+// and must find a binary called "clang"/"clang++".
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Program.h"
+
+int main(int argc, char *argv[]) {
+  using namespace llvm;
+  using namespace llvm::sys;
+
+  StringRef Executable = argv[0];
+  StringRef Alias = path::filename(Executable);
+
+  ExitOnError Exit((Alias + ": ").str());
+
+  // Derive the real tool's base name by dropping any executable extension and
+  // stripping the "dp" prefix (e.g. "dpclang++" / "dpclang++.exe" ->
+  // "clang++"). The extension is intentionally not carried over: how it appears
+  // in argv[0] is inconsistent across platforms (a Windows invocation may or
+  // may not include ".exe"), so it is left to findProgramByName below to append
+  // the right suffix when locating the real binary.
+  StringRef RealName = path::stem(Alias);
+  if (!RealName.consume_front("dp"))
+    Exit(createStringError("binary '" + Alias + "' not prefixed by 'dp'."));
+
+  // Locate the directory this tool was installed into so we can find the real
+  // binary sitting next to it, regardless of the current working directory or
+  // how the tool was found on PATH.
+  void *MainAddr = reinterpret_cast<void *>(main);
+  std::string DpllvmPath = fs::getMainExecutable(argv[0], MainAddr);
+  if (DpllvmPath.empty())
+    Exit(createStringError(
+        "couldn't determine the path to the DPC++ bin/ directory."));
+
+  StringRef BinaryDir = path::parent_path(DpllvmPath);
+
+  // findProgramByName searches the given directory and appends the platform
+  // executable suffix (".exe" on Windows), so this resolves the sibling real
+  // binary whether or not the invoking name carried an extension.
+  ErrorOr<std::string> BinaryPathOrErr =
+      findProgramByName(RealName, {BinaryDir});
+  if (!BinaryPathOrErr)
+    Exit(createStringError("binary '" + RealName + "' not found next to '" +
+                           DpllvmPath + "'."));
+  StringRef BinaryPath = *BinaryPathOrErr;
+
+  SmallVector<StringRef, 128> Args = {BinaryPath};
+  Args.append(argv + 1, argv + argc);
+
+  std::string ErrMsg;
+  int Result = ExecuteAndWait(BinaryPath, Args, /*Env=*/std::nullopt,
+                              /*Redirects=*/{}, /*SecondsToWait=*/0,
+                              /*MemoryLimit=*/0, &ErrMsg);
+  if (!ErrMsg.empty())
+    Exit(
+        createStringError("failed to execute '" + BinaryPath + "': " + ErrMsg));
+  return Result;
+}

--- a/devops/actions/run-tests/benchmark/action.yml
+++ b/devops/actions/run-tests/benchmark/action.yml
@@ -134,9 +134,9 @@ runs:
       else
         echo "INFO: SYCL directory '$SYCL_DIR' does not exist or is missing libsycl.so"
         echo "Checking if SYCL is installed in the system..."
-        which sycl-ls
-        sycl-ls
-        export CMPLR_ROOT="$(dirname $(dirname $(which sycl-ls)))"
+        which dpsycl-ls
+        dpsycl-ls
+        export CMPLR_ROOT="$(dirname $(dirname $(which dpsycl-ls)))"
         echo "Using SYCL from: $CMPLR_ROOT !"
         echo "CMPLR_ROOT=$CMPLR_ROOT" >> $GITHUB_ENV
       fi
@@ -261,11 +261,11 @@ runs:
       pip install --user --break-system-packages -r ./devops/scripts/benchmarks/requirements.txt
 
       echo "::endgroup::"
-  - name: Run sycl-ls
+  - name: Run dpsycl-ls
     shell: bash
     run: |
-      # Run sycl-ls
-      sycl-ls --verbose
+      # Run dpsycl-ls
+      dpsycl-ls --verbose
   - name: Build and run benchmarks
     shell: bash
     env:

--- a/devops/actions/run-tests/linux/cts/action.yml
+++ b/devops/actions/run-tests/linux/cts/action.yml
@@ -56,11 +56,11 @@ runs:
         echo "::endgroup::"
       fi
 
-      cmake -GNinja -B./build-cts -S./khronos_sycl_cts -DCMAKE_CXX_COMPILER=$(which clang++) \
+      cmake -GNinja -B./build-cts -S./khronos_sycl_cts -DCMAKE_CXX_COMPILER="$(which dpclang++)" \
       -DSYCL_IMPLEMENTATION=DPCPP \
       -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="$cts_exclude_filter" \
       -DSYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS=OFF \
-      -DDPCPP_INSTALL_DIR="$(dirname $(which clang++))/.." \
+      -DDPCPP_INSTALL_DIR="$(dirname $(which dpclang++))/.." \
       $CMAKE_EXTRA_ARGS
       # Ignore errors so that if one category build fails others still have a
       # chance to finish and be executed at the run stage. Note that

--- a/devops/actions/run-tests/linux/e2e/action.yml
+++ b/devops/actions/run-tests/linux/e2e/action.yml
@@ -66,7 +66,7 @@ runs:
     if: inputs.testing_mode != 'run-only'
     shell: bash
     run: |
-      cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.sycl_compiler || '$(which clang++)'}}" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" ${{ steps.cmake_opts.outputs.opts }}
+      cmake -GNinja -B./build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.sycl_compiler || '$(which dpclang++)'}}" -DLLVM_LIT="$PWD/llvm/llvm/utils/lit/lit.py" ${{ steps.cmake_opts.outputs.opts }}
   - name: SYCL End-to-end tests
     id: run_e2e
     continue-on-error: true

--- a/devops/actions/run-tests/windows/cts/action.yml
+++ b/devops/actions/run-tests/windows/cts/action.yml
@@ -60,7 +60,7 @@ runs:
       -DSYCL_IMPLEMENTATION=DPCPP \
       -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="$cts_exclude_filter" \
       -DSYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS=OFF \
-      -DDPCPP_INSTALL_DIR="$(dirname $(which clang++))/.." \
+      -DDPCPP_INSTALL_DIR="$(dirname $(which dpclang++))/.." \
       -DCMAKE_CXX_COMPILER=cl \
       -DCMAKE_BUILD_TYPE=Release \
       $CMAKE_EXTRA_ARGS

--- a/devops/actions/run-tests/windows/e2e/action.yml
+++ b/devops/actions/run-tests/windows/e2e/action.yml
@@ -64,7 +64,7 @@ runs:
   - name: Configure E2E tests
     shell: bash
     run: |
-      cmake -GNinja -B build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.sycl_compiler || '$(which clang++).exe' }}" -DLEVEL_ZERO_LIBS_DIR="D:\\github\\level-zero_win-sdk\\lib" -DLEVEL_ZERO_INCLUDE="D:\\github\\level-zero_win-sdk\\include" -DLLVM_LIT="..\\llvm\\llvm\\utils\\lit\\lit.py" ${{ steps.cmake_opts.outputs.opts }}
+      cmake -GNinja -B build-e2e -S./llvm/sycl/test-e2e -DCMAKE_CXX_COMPILER="${{ inputs.sycl_compiler || '$(which dpclang++).exe' }}" -DLEVEL_ZERO_LIBS_DIR="D:\\github\\level-zero_win-sdk\\lib" -DLEVEL_ZERO_INCLUDE="D:\\github\\level-zero_win-sdk\\include" -DLLVM_LIT="..\\llvm\\llvm\\utils\\lit\\lit.py" ${{ steps.cmake_opts.outputs.opts }}
 
   - name: Keep track of files after configuring E2E step
     if: ${{ !cancelled() && inputs.binaries_artifact != '' && inputs.testing_mode != 'run-only' }}

--- a/devops/scripts/benchmarks/utils/utils.py
+++ b/devops/scripts/benchmarks/utils/utils.py
@@ -204,7 +204,7 @@ def download(dir, url, file, untar=False, unzip=False, checksum=""):
 
 def get_device_architecture(additional_env_vars):
     sycl_ls_output = run(
-        ["sycl-ls", "--verbose"], add_sycl=True, env_vars=additional_env_vars
+        ["dpsycl-ls", "--verbose"], add_sycl=True, env_vars=additional_env_vars
     ).stdout.decode()
 
     architectures = set()
@@ -227,7 +227,7 @@ def warn_if_level_zero_is_not_found(additional_env_vars) -> bool:
     sycl_ls_found_l0 = False
 
     sycl_ls_output = run(
-        ["sycl-ls"], add_sycl=True, env_vars=additional_env_vars
+        ["dpsycl-ls"], add_sycl=True, env_vars=additional_env_vars
     ).stdout.decode()
 
     for line in sycl_ls_output.splitlines():

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -387,6 +387,7 @@ endif()
 add_custom_target(sycl-compiler
   DEPENDS append-file
           clang
+          dpllvm
           clang-offload-wrapper
           clang-offload-bundler
           clang-offload-deps
@@ -471,6 +472,7 @@ get_property(SYCL_TOOLCHAIN_DEPS GLOBAL PROPERTY SYCL_TOOLCHAIN_INSTALL_COMPONEN
 set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      append-file
      clang
+     dpllvm
      clang-offload-wrapper
      clang-offload-bundler
      clang-offload-deps

--- a/sycl/ReleaseNotes.md
+++ b/sycl/ReleaseNotes.md
@@ -58,6 +58,11 @@ intel/llvm#20018 intel/llvm#20490 intel/llvm#20095 intel/llvm#20804
 
 ### Compiler
 
+- Added symbolic links for the compiler binaries: `dpclang`, `dpclang++`,
+`dpclang-cl`, `dpclang-cpp`, `dpsycl-ls`, `dpsyclbin-dump`, `dpsycl-prof`,
+`dpsycl-sanitize`, `dpsycl-trace`. They point to the corresponding binaries
+without the `dp` prefix. For example, `dpclang++` points to `clang++`. Users are
+encouraged to use these wrappers instead of the underlying binaries. intel/llvm#21598
 - Enabled passing `-Xarch_<arch> <option>` to SYCL offload compilation. intel/llvm#21001
 
 ## Improvements and bugfixes

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -52,6 +52,9 @@ llvm_config.with_system_environment(
 )
 
 config.substitutions.append(("%python", '"%s"' % (sys.executable)))
+config.substitutions.append(
+    ("%dpclangxx", os.path.join(config.install_bin_dir, "dpclang++"))
+)
 
 # Propagate extra environment variables
 if config.extra_environment:

--- a/sycl/test/lit.site.cfg.py.in
+++ b/sycl/test/lit.site.cfg.py.in
@@ -24,6 +24,7 @@ config.sycl_clang_extra_flags = "@SYCL_CLANG_EXTRA_FLAGS@"
 config.test_include_path = "@TEST_INCLUDE_PATH@"
 
 config.llvm_enable_projects = "@LLVM_ENABLE_PROJECTS@"
+config.install_bin_dir = "@LLVM_TOOLS_DIR@"
 
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'
 config.sycl_use_libcxx = 'ON' if @LLVM_LIBCXX_USED@ else 'OFF'

--- a/sycl/test/tools/dpclang-basic-sycl.cpp
+++ b/sycl/test/tools/dpclang-basic-sycl.cpp
@@ -1,0 +1,15 @@
+// Verify that the dpclang++ binary can compile basic SYCL code.
+// RUN: %dpclangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_include -c %s -o %t.o
+
+#include <sycl/sycl.hpp>
+
+void test() {
+  sycl::queue q;
+  int result = 0;
+  sycl::buffer<int> buf(&result, 1);
+
+  q.submit([&](sycl::handler &h) {
+    sycl::accessor acc(buf, h, sycl::write_only);
+    h.single_task([=]() { acc[0] = 42; });
+  });
+}


### PR DESCRIPTION
This PR adds the following:
* The following symlinks in `CMAKE_INSTALL_PREFIX/bin` folder: `dpclang`, `dpclang++`, `dpclang-cl`, `dpclang-cpp`, `dpsycl-ls`, `dpsycl-prof`, etc. They WON'T point to real `clang`, `clang++`, etc binaries. They point to the tool below.
* Adds a tool similar to AMD's `amdllvm` tool: https://github.com/ROCm/llvm-project/tree/amd-staging/clang/tools/amdllvm. It is called `dpllvm`. What it does - when we run `dpclang++` symlink, it runs `dpllvm` tool. `dpllvm` gets "clang++" from "dpclang++" and executes `clang++`. The same will be with every other symlinks which start wqith `dp`. `clang` can run itself inside itself, so we need to keep the name of the binary - `clang++`. BTW, the same on Windows - but we will have tiny binaries `dpclang`, `dpclang++`, etc - as Windows does not support symlinks. So we will avoid renaming `clang++` to `dpclang++` on Windows and the size of binary distribution on Windows won't be bigger - there won't be copies of `clang`, `clang-cl`, etc binaries.
* Adds `dpllvm` and `dpclang`, `dpclang++`, `dpclang-cl`, `dpclang-cpp`, `dpsycl-ls`, `dpsycl-prof`, etc. not only to `CMAKE_INSTALL_PREFIX/bin` but also to `build/bin` - and use these binaries everywhere in LIT tests (like it is already done in this PR)

Fixes https://github.com/intel/llvm/issues/21511

---------