### PR TITLE
[SYCL][Graph] Avoid removing in-order event dependencies across the native recording capture boundary

### DIFF
--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -273,6 +273,24 @@ public:
   bool supportsEventProfiling();
   bool supportsIPCEvents();
 
+  /// @return True if any native graph recording is active on a queue
+  /// in this context.
+  bool isNativeRecordingActive() const {
+    return MNativeRecordingCount.load(std::memory_order_acquire) > 0;
+  }
+
+  /// Register that a native graph recording has begun on a queue in this
+  /// context.
+  void nativeRecordingBegan() {
+    MNativeRecordingCount.fetch_add(1, std::memory_order_release);
+  }
+
+  /// Register that a native graph recording has ended on a queue in this
+  /// context.
+  void nativeRecordingEnded() {
+    MNativeRecordingCount.fetch_sub(1, std::memory_order_release);
+  }
+
 private:
   // Returns whether every device in the context reports \p Info as true,
   // caching the result in \p Cache.
@@ -372,6 +390,12 @@ private:
       std::weak_ptr<sycl::ext::oneapi::experimental::detail::graph_impl>>
       MNativeGraphRegistry;
   mutable std::mutex MNativeGraphRegistryMutex;
+
+  // Count of active native graph recordings in this context. Incremented when
+  // a native capture begins on a queue and decremented when it ends. Used to
+  // preserve in-order dependencies that cross the native-recording capture
+  // boundary.
+  std::atomic<int64_t> MNativeRecordingCount{0};
 
   void verifyProps(const property_list &Props) const;
 };

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -288,7 +288,9 @@ public:
   /// Register that a native graph recording has ended on a queue in this
   /// context.
   void nativeRecordingEnded() {
-    MNativeRecordingCount.fetch_sub(1, std::memory_order_release);
+    [[maybe_unused]] int64_t Prev =
+        MNativeRecordingCount.fetch_sub(1, std::memory_order_release);
+    assert(Prev > 0 && "Native recording counter underflow");
   }
 
 private:

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -480,10 +480,10 @@ protected:
   /// Indicates that the event results from a command graph submission.
   bool MEventFromSubmittedExecCommandBuffer = false;
 
-  /// Set from the context of the worker queue when the event was signaled,
-  /// marking it as potentially captured if a native graph recording was active.
-  /// Used to preserve in-order dependencies that cross the native-recording
-  /// capture boundary.
+  /// Set from the context of the worker queue when the event is created for a
+  /// command submission, marking it as potentially captured if a native graph
+  /// recording was active. Used to preserve in-order dependencies that cross
+  /// the native-recording capture boundary.
   bool MPotentiallyNativeRecorded = false;
 
   // If this event represents a submission to a

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -360,6 +360,14 @@ public:
     return MEventFromSubmittedExecCommandBuffer;
   }
 
+  bool isPotentiallyNativeRecorded() const {
+    return MPotentiallyNativeRecorded;
+  }
+
+  void setPotentiallyNativeRecorded(bool Value) {
+    MPotentiallyNativeRecorded = Value;
+  }
+
   void setProfilingEnabled(bool Value) { MIsProfilingEnabled = Value; }
 
   // Sets a command-buffer command when this event represents an enqueue to a
@@ -471,6 +479,12 @@ protected:
   std::weak_ptr<ext::oneapi::experimental::detail::graph_impl> MGraph;
   /// Indicates that the event results from a command graph submission.
   bool MEventFromSubmittedExecCommandBuffer = false;
+
+  /// Set from the context of the worker queue when the event was signaled,
+  /// marking it as potentially captured if a native graph recording was active.
+  /// Used to preserve in-order dependencies that cross the native-recording
+  /// capture boundary.
+  bool MPotentiallyNativeRecorded = false;
 
   // If this event represents a submission to a
   // ur_exp_command_buffer_sync_point_t the sync point for that submission is

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -726,9 +726,12 @@ void graph_impl::clearQueues(bool NeedsLock) {
   for (auto &Queue : SwappedQueues) {
     if (auto ValidQueue = Queue.lock(); ValidQueue) {
       if (MNativeGraphHandle) {
-        [[maybe_unused]] ur_exp_graph_handle_t CapturedGraph =
-            ValidQueue->endNativeRecording();
-        assert(CapturedGraph == MNativeGraphHandle &&
+        auto EndResult = ValidQueue->endNativeRecording();
+        if (EndResult.Result != UR_RESULT_SUCCESS) {
+          throw sycl::exception(sycl::make_error_code(errc::runtime),
+                                "Error when ending native graph capture");
+        }
+        assert(EndResult.CapturedGraph == getNativeGraphHandle() &&
                "Captured graph handle must match the graph's native handle");
       } else {
         // Only call setCommandGraph for traditional recording
@@ -897,7 +900,14 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
         throw sycl::exception(sycl::make_error_code(errc::invalid),
                               "Queue is already in native graph capture mode");
       }
-      Queue.beginNativeRecording(MNativeGraphHandle);
+      auto BeginResult = Queue.beginNativeRecording(MNativeGraphHandle);
+      if (BeginResult.RecordingActive) {
+        addQueue(Queue);
+      }
+      if (BeginResult.Result != UR_RESULT_SUCCESS) {
+        throw sycl::exception(sycl::make_error_code(errc::runtime),
+                              "Failed to begin native UR graph capture");
+      }
     } else {
       // Non-native recording path
       if (AcquireQueueLock) {
@@ -905,8 +915,8 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
       } else {
         Queue.setCommandGraphUnlocked(shared_from_this());
       }
+      addQueue(Queue);
     }
-    addQueue(Queue);
   }
 }
 
@@ -2294,11 +2304,16 @@ void modifiable_command_graph::end_recording(queue &RecordingQueue) {
       // End native UR graph capture
       assert(impl->getNativeGraphHandle() &&
              "Native graph handle must be valid when ending native recording");
-      [[maybe_unused]] ur_exp_graph_handle_t CapturedGraph =
-          QueueImpl.endNativeRecording();
-      assert(CapturedGraph == impl->getNativeGraphHandle() &&
+      auto EndResult = QueueImpl.endNativeRecording();
+      if (!EndResult.RecordingActive) {
+        impl->removeQueue(QueueImpl);
+      }
+      if (EndResult.Result != UR_RESULT_SUCCESS) {
+        throw sycl::exception(sycl::make_error_code(errc::runtime),
+                              "Error when ending native graph capture");
+      }
+      assert(EndResult.CapturedGraph == impl->getNativeGraphHandle() &&
              "Captured graph handle must match the graph's native handle");
-      impl->removeQueue(QueueImpl);
     }
   } else {
     // Traditional recording path

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -726,23 +726,18 @@ void graph_impl::clearQueues(bool NeedsLock) {
   for (auto &Queue : SwappedQueues) {
     if (auto ValidQueue = Queue.lock(); ValidQueue) {
       if (MNativeGraphHandle) {
-        // End native UR graph capture
-        auto UrQueue = ValidQueue->getHandleRef();
-        ur_exp_graph_handle_t CapturedGraph = nullptr;
-        context_impl &ContextImpl = *sycl::detail::getSyclObjImpl(MContext);
-        sycl::detail::adapter_impl &Adapter = ContextImpl.getAdapter();
-        ur_result_t Result = Adapter.call_nocheck<
-            sycl::detail::UrApiKind::urQueueEndGraphCaptureExp>(UrQueue,
-                                                                &CapturedGraph);
-        if (Result != UR_RESULT_SUCCESS) {
-          throw sycl::exception(sycl::make_error_code(errc::runtime),
-                                "Failed to end native graph capture");
-        }
-        // CapturedGraph should be the same as MNativeGraphHandle
+        [[maybe_unused]] ur_exp_graph_handle_t CapturedGraph =
+            ValidQueue->endNativeRecording();
+        assert(CapturedGraph == MNativeGraphHandle &&
+               "Captured graph handle must match the graph's native handle");
       } else {
         // Only call setCommandGraph for traditional recording
         ValidQueue->setCommandGraph(nullptr);
       }
+    } else if (MNativeGraphHandle) {
+      // The primary recording queue was destroyed by the user. We must update
+      // the context that the recording is over.
+      getContextImpl().nativeRecordingEnded();
     }
   }
 }
@@ -898,22 +893,11 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
 
     // Use native UR graph recording if enabled
     if (MNativeGraphHandle) {
-      auto UrQueue = Queue.getHandleRef();
-      context_impl &ContextImpl = *sycl::detail::getSyclObjImpl(MContext);
-      sycl::detail::adapter_impl &Adapter = ContextImpl.getAdapter();
-
       if (Queue.isNativeRecording()) {
         throw sycl::exception(sycl::make_error_code(errc::invalid),
                               "Queue is already in native graph capture mode");
       }
-
-      ur_result_t Result = Adapter.call_nocheck<
-          sycl::detail::UrApiKind::urQueueBeginCaptureIntoGraphExp>(
-          UrQueue, MNativeGraphHandle);
-      if (Result != UR_RESULT_SUCCESS) {
-        throw sycl::exception(sycl::make_error_code(errc::runtime),
-                              "Failed to begin native UR graph capture");
-      }
+      Queue.beginNativeRecording(MNativeGraphHandle);
     } else {
       // Non-native recording path
       if (AcquireQueueLock) {
@@ -2310,19 +2294,8 @@ void modifiable_command_graph::end_recording(queue &RecordingQueue) {
       // End native UR graph capture
       assert(impl->getNativeGraphHandle() &&
              "Native graph handle must be valid when ending native recording");
-      auto UrQueue = QueueImpl.getHandleRef();
-      ur_exp_graph_handle_t CapturedGraph = nullptr;
-      context_impl &ContextImpl =
-          *sycl::detail::getSyclObjImpl(impl->getContext());
-      sycl::detail::adapter_impl &Adapter = ContextImpl.getAdapter();
-      ur_result_t Result =
-          Adapter
-              .call_nocheck<sycl::detail::UrApiKind::urQueueEndGraphCaptureExp>(
-                  UrQueue, &CapturedGraph);
-      if (Result != UR_RESULT_SUCCESS) {
-        throw sycl::exception(sycl::make_error_code(errc::runtime),
-                              "Failed to end native UR graph capture");
-      }
+      [[maybe_unused]] ur_exp_graph_handle_t CapturedGraph =
+          QueueImpl.endNativeRecording();
       assert(CapturedGraph == impl->getNativeGraphHandle() &&
              "Captured graph handle must match the graph's native handle");
       impl->removeQueue(QueueImpl);

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -731,8 +731,7 @@ void graph_impl::clearQueues(bool NeedsLock) {
           throw sycl::exception(sycl::make_error_code(errc::runtime),
                                 "Error when ending native graph capture");
         }
-        assert(EndResult.CapturedGraph == getNativeGraphHandle() &&
-               "Captured graph handle must match the graph's native handle");
+        // CapturedGraph should be the same as MNativeGraphHandle
       } else {
         // Only call setCommandGraph for traditional recording
         ValidQueue->setCommandGraph(nullptr);

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -464,6 +464,8 @@ EventImplPtr queue_impl::submit_kernel_scheduler_bypass(
     EnqueueKernel();
   } else {
     ResultEvent->setWorkerQueue(weak_from_this());
+    ResultEvent->setPotentiallyNativeRecorded(
+        getContextImpl().isNativeRecordingActive());
     ResultEvent->setStateIncomplete();
     ResultEvent->setSubmissionTime();
 
@@ -514,6 +516,8 @@ EventImplPtr queue_impl::submit_barrier_scheduler_bypass(
       ResEvent->setQueue(*this);
     }
     ResEvent->setWorkerQueue(weak_from_this());
+    ResEvent->setPotentiallyNativeRecorded(
+        getContextImpl().isNativeRecordingActive());
     ResEvent->setSubmissionTime();
     ResEvent->setEnqueued();
     ResEvent->setStateIncomplete();
@@ -658,6 +662,34 @@ bool queue_impl::isNativeRecording() const {
       getAdapter().call_nocheck<UrApiKind::urQueueIsGraphCaptureEnabledExp>(
           MQueue, &IsGraphCaptureEnabled);
   return Result == UR_RESULT_SUCCESS && IsGraphCaptureEnabled;
+}
+
+void queue_impl::beginNativeRecording(ur_exp_graph_handle_t Graph) {
+  std::lock_guard<std::mutex> Lock(MMutex);
+  ur_result_t Result =
+      getAdapter().call_nocheck<UrApiKind::urQueueBeginCaptureIntoGraphExp>(
+          MQueue, Graph);
+  if (Result != UR_RESULT_SUCCESS) {
+    throw sycl::exception(sycl::make_error_code(errc::runtime),
+                          "Failed to begin native UR graph capture");
+  }
+  getContextImpl().nativeRecordingBegan();
+}
+
+ur_exp_graph_handle_t queue_impl::endNativeRecording() {
+  std::lock_guard<std::mutex> Lock(MMutex);
+  ur_exp_graph_handle_t CapturedGraph = nullptr;
+  ur_result_t Result =
+      getAdapter().call_nocheck<UrApiKind::urQueueEndGraphCaptureExp>(
+          MQueue, &CapturedGraph);
+  if (Result == UR_RESULT_SUCCESS || !isNativeRecording()) {
+    getContextImpl().nativeRecordingEnded();
+  }
+  if (Result != UR_RESULT_SUCCESS) {
+    throw sycl::exception(sycl::make_error_code(errc::runtime),
+                          "Failed to end native graph capture");
+  }
+  return CapturedGraph;
 }
 
 ext::oneapi::experimental::queue_state

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -664,32 +664,32 @@ bool queue_impl::isNativeRecording() const {
   return Result == UR_RESULT_SUCCESS && IsGraphCaptureEnabled;
 }
 
-void queue_impl::beginNativeRecording(ur_exp_graph_handle_t Graph) {
+queue_impl::NativeRecordingResult
+queue_impl::beginNativeRecording(ur_exp_graph_handle_t Graph) {
   std::lock_guard<std::mutex> Lock(MMutex);
-  ur_result_t Result =
+  NativeRecordingResult BeginResult;
+  BeginResult.Result =
       getAdapter().call_nocheck<UrApiKind::urQueueBeginCaptureIntoGraphExp>(
           MQueue, Graph);
-  if (Result != UR_RESULT_SUCCESS) {
-    throw sycl::exception(sycl::make_error_code(errc::runtime),
-                          "Failed to begin native UR graph capture");
+  BeginResult.RecordingActive = BeginResult.Result == UR_RESULT_SUCCESS;
+  if (BeginResult.RecordingActive) {
+    getContextImpl().nativeRecordingBegan();
   }
-  getContextImpl().nativeRecordingBegan();
+  return BeginResult;
 }
 
-ur_exp_graph_handle_t queue_impl::endNativeRecording() {
+queue_impl::NativeRecordingResult queue_impl::endNativeRecording() {
   std::lock_guard<std::mutex> Lock(MMutex);
-  ur_exp_graph_handle_t CapturedGraph = nullptr;
-  ur_result_t Result =
+  NativeRecordingResult EndResult;
+  EndResult.Result =
       getAdapter().call_nocheck<UrApiKind::urQueueEndGraphCaptureExp>(
-          MQueue, &CapturedGraph);
-  if (Result == UR_RESULT_SUCCESS || !isNativeRecording()) {
+          MQueue, &EndResult.CapturedGraph);
+  EndResult.RecordingActive =
+      EndResult.Result != UR_RESULT_SUCCESS && isNativeRecording();
+  if (!EndResult.RecordingActive) {
     getContextImpl().nativeRecordingEnded();
   }
-  if (Result != UR_RESULT_SUCCESS) {
-    throw sycl::exception(sycl::make_error_code(errc::runtime),
-                          "Failed to end native graph capture");
-  }
-  return CapturedGraph;
+  return EndResult;
 }
 
 ext::oneapi::experimental::queue_state

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -664,9 +664,15 @@ public:
 
   bool isNativeRecording() const;
 
-  void beginNativeRecording(ur_exp_graph_handle_t Graph);
+  struct NativeRecordingResult {
+    ur_exp_graph_handle_t CapturedGraph = nullptr;
+    bool RecordingActive = false;
+    ur_result_t Result = UR_RESULT_SUCCESS;
+  };
 
-  ur_exp_graph_handle_t endNativeRecording();
+  NativeRecordingResult beginNativeRecording(ur_exp_graph_handle_t Graph);
+
+  NativeRecordingResult endNativeRecording();
 
   ext::oneapi::experimental::queue_state ext_oneapi_get_state_impl() const;
 

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -664,6 +664,10 @@ public:
 
   bool isNativeRecording() const;
 
+  void beginNativeRecording(ur_exp_graph_handle_t Graph);
+
+  ur_exp_graph_handle_t endNativeRecording();
+
   ext::oneapi::experimental::queue_state ext_oneapi_get_state_impl() const;
 
   std::shared_ptr<ext::oneapi::experimental::detail::graph_impl>

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -11,6 +11,7 @@
 
 #include <detail/context_impl.hpp>
 #include <detail/event_impl.hpp>
+#include <detail/graph/graph_impl.hpp>
 #include <detail/helpers.hpp>
 #include <detail/kernel_bundle_impl.hpp>
 #include <detail/kernel_impl.hpp>
@@ -209,6 +210,10 @@ static std::string commandToName(Command::CommandType Type) {
 std::vector<ur_event_handle_t> Command::getUrEvents(events_range Events,
                                                     queue_impl *CommandQueue,
                                                     bool IsHostTaskCommand) {
+  const bool CanRemoveRedundantEvent =
+      CommandQueue && CommandQueue->isInOrder() && !IsHostTaskCommand &&
+      !CommandQueue->getContextImpl().isNativeRecordingActive();
+
   std::vector<ur_event_handle_t> RetUrEvents;
   for (event_impl &Event : Events) {
     auto Handle = Event.getHandle();
@@ -219,8 +224,12 @@ std::vector<ur_event_handle_t> Command::getUrEvents(events_range Events,
     // At this stage dependency is definitely ur task and need to check if
     // current one is a host task. In this case we should not skip ur event due
     // to different sync mechanisms for different task types on in-order queue.
-    if (CommandQueue && Event.getWorkerQueue().get() == CommandQueue &&
-        CommandQueue->isInOrder() && !IsHostTaskCommand)
+    // When native recording is in-progress, then we must skip this optimization
+    // to let the driver runtime handle event dependencies crossing the graph
+    // capture boundary.
+    if (CanRemoveRedundantEvent &&
+        Event.getWorkerQueue().get() == CommandQueue &&
+        !Event.isPotentiallyNativeRecorded())
       continue;
 
     RetUrEvents.push_back(Handle);
@@ -532,8 +541,11 @@ Command::Command(
   if (Queue)
     MEvent->setSubmittedQueue(Queue);
   MEvent->setCommand(this);
-  if (MQueue)
-    MEvent->setContextImpl(MQueue->getContextImpl());
+  if (MQueue) {
+    context_impl &Context = MQueue->getContextImpl();
+    MEvent->setContextImpl(Context);
+    MEvent->setPotentiallyNativeRecorded(Context.isNativeRecordingActive());
+  }
   MEvent->setStateIncomplete();
   MEnqueueStatus = EnqueueResultT::SyclEnqueueReady;
 
@@ -1512,6 +1524,11 @@ MemCpyCommand::MemCpyCommand(const Requirement &SrcReq,
 
   MWorkerQueue = !MQueue ? MSrcQueue : MQueue;
   MEvent->setWorkerQueue(MWorkerQueue);
+  // When MQueue is non-null the base Command constructor already set this from
+  // MQueue's context.
+  if (!MQueue && MWorkerQueue)
+    MEvent->setPotentiallyNativeRecorded(
+        MWorkerQueue->getContextImpl().isNativeRecordingActive());
 
   emitInstrumentationDataProxy();
 }
@@ -1689,6 +1706,11 @@ MemCpyCommandHost::MemCpyCommandHost(const Requirement &SrcReq,
 
   MWorkerQueue = !MQueue ? MSrcQueue : MQueue;
   MEvent->setWorkerQueue(MWorkerQueue);
+  // When MQueue is non-null the base Command constructor already set this from
+  // MQueue's context.
+  if (!MQueue && MWorkerQueue)
+    MEvent->setPotentiallyNativeRecorded(
+        MWorkerQueue->getContextImpl().isNativeRecordingActive());
 
   emitInstrumentationDataProxy();
 }

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -11,7 +11,6 @@
 
 #include <detail/context_impl.hpp>
 #include <detail/event_impl.hpp>
-#include <detail/graph/graph_impl.hpp>
 #include <detail/helpers.hpp>
 #include <detail/kernel_bundle_impl.hpp>
 #include <detail/kernel_impl.hpp>

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/inorder_event_dependencies.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/inorder_event_dependencies.cpp
@@ -1,0 +1,190 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+
+// RUN: %{build} -o %t.out
+// RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_UR_TRACE=2 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// The SYCL RT prunes redundant in-order wait events on the same queue, but must
+// disable this while any native recording is active for proper handling in the
+// native runtime. Removing this is relevant for external graph events. SYCL is
+// unaware of queue recording status without querying the native runtime (e.g.
+// L0), so we instead conservatively disable this optimization when any native
+// recording is active on the queue's context. This avoids querying through the
+// native runtime on the hot kernel submission path.
+
+#include "../../graph_common.hpp"
+
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  device Dev;
+  context Ctx{Dev};
+
+  queue Queue1{Ctx, Dev, property::queue::in_order{}};
+  queue Queue2{Ctx, Dev, property::queue::in_order{}};
+
+  exp_ext::command_graph Graph{
+      Ctx, Dev, {exp_ext::property::graph::enable_native_recording{}}};
+
+  const size_t N = 1024;
+  int *Data1 = malloc_device<int>(N, Queue1);
+  int *Data2 = malloc_device<int>(N, Queue1);
+  int *Data3 = malloc_device<int>(N, Queue1);
+  int *Data4 = malloc_device<int>(N, Queue1);
+  int *Data5 = malloc_device<int>(N, Queue1);
+
+  QueueStateVerifier verifier(Queue1, Queue2);
+  verifier.verify(EXECUTING, EXECUTING);
+
+  // --- Case 1: optimization ON - SYCL RT removes event ---
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 0
+  event Event1 =
+      Queue1.parallel_for(range<1>{N}, [=](id<1> idx) { Data1[idx] = 5; });
+  // Same-queue in-order dependency is redundant, so it is pruned.
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 0
+  Queue1.submit([&](handler &CGH) {
+    CGH.depends_on(Event1);
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Data1[idx] += 1; });
+  });
+
+  // --- Case 2 (cross-boundary): pre-recording event used during recording ---
+  // Capture a no-op event on Queue1 before recording begins. It is used as a
+  // wait event during recording below.
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 0
+  event PreRecordEvent = Queue1.parallel_for(range<1>{N}, [=](id<1>) {});
+
+  // CHECK: <--- urQueueBeginCaptureIntoGraphExp
+  Graph.begin_recording(Queue1);
+  verifier.verify(RECORDING, EXECUTING);
+
+  // Cross-boundary: wait during recording on the pre-recording event from
+  // Queue1. This is event is not marked as an external wait, and it is expected
+  // to become an error in the native runtime.
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 1
+  try {
+    Queue1.submit([&](handler &CGH) {
+      CGH.depends_on(PreRecordEvent);
+      CGH.parallel_for(range<1>{N}, [=](id<1>) {});
+    });
+  } catch (const exception &) {
+  }
+
+  // --- Case 3: optimization OFF via the context recording counter ---
+  // Recording Queue1 bumps its context's recording counter. Queue2 shares that
+  // same context, so the optimization is disabled for it too, even though
+  // Queue2 is not yet recording or forked.
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 0
+  event Event2 =
+      Queue2.parallel_for(range<1>{N}, [=](id<1> idx) { Data2[idx] = 5; });
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 1
+  Queue2.submit([&](handler &CGH) {
+    CGH.depends_on(Event2);
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Data2[idx] += 1; });
+  });
+
+  // Implicit in-order deps should still show 0 wait events.
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 0
+  Queue1.parallel_for(range<1>{N}, [=](id<1> idx) { Data5[idx] = 5; });
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 0
+  Queue1.parallel_for(range<1>{N}, [=](id<1> idx) { Data5[idx] += 1; });
+
+  // --- Case 4: fork to Queue2, optimization still OFF ---
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 0
+  event Fork =
+      Queue1.parallel_for(range<1>{N}, [=](id<1> idx) { Data3[idx] = 5; });
+
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 1
+  event ForkConsumer = Queue2.submit([&](handler &CGH) {
+    CGH.depends_on(Fork);
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Data3[idx] += 10; });
+  });
+  verifier.verify(RECORDING, RECORDING);
+
+  // Same-queue dependency on the forked Queue2, optimization still off.
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 1
+  event Join = Queue2.submit([&](handler &CGH) {
+    CGH.depends_on(ForkConsumer);
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Data3[idx] += 1; });
+  });
+
+  // Join Queue2 back into Queue1 to close the native graph cleanly.
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 1
+  Queue1.submit([&](handler &CGH) {
+    CGH.depends_on(Join);
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Data3[idx] += 100; });
+  });
+
+  // --- Case 5: optimization ON again after recording ended ---
+  // CHECK: <--- urQueueEndGraphCaptureExp
+  Graph.end_recording(Queue1);
+  verifier.verify(EXECUTING, EXECUTING);
+
+  auto ExecutableGraph = Graph.finalize();
+  Queue1.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecutableGraph); });
+
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 0
+  event Event4 =
+      Queue1.parallel_for(range<1>{N}, [=](id<1> idx) { Data4[idx] = 5; });
+  // Same-queue dependency created with no recording active: pruned again.
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 0
+  Queue1.submit([&](handler &CGH) {
+    CGH.depends_on(Event4);
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Data4[idx] += 1; });
+  });
+
+  // --- Case 6 (cross-boundary): recorded event used after recording ---
+  // Wait on Queue2's Join event from the recording region. The dependency is
+  // retained. This is not an external graph event, and it is expected to become
+  // an error in the native runtime.
+  // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
+  // CHECK-SAME: .numEventsInWaitList = 1
+  try {
+    Queue2.submit([&](handler &CGH) {
+      CGH.depends_on(Join);
+      CGH.parallel_for(range<1>{N}, [=](id<1>) {});
+    });
+  } catch (const exception &) {
+  }
+
+  Queue1.wait();
+  Queue2.wait();
+
+  std::vector<int> Host1(N), Host2(N), Host3(N), Host4(N), Host5(N);
+  Queue1.memcpy(Host1.data(), Data1, N * sizeof(int));
+  Queue1.memcpy(Host2.data(), Data2, N * sizeof(int));
+  Queue1.memcpy(Host3.data(), Data3, N * sizeof(int));
+  Queue1.memcpy(Host4.data(), Data4, N * sizeof(int));
+  Queue1.memcpy(Host5.data(), Data5, N * sizeof(int));
+  Queue1.wait();
+
+  for (size_t i = 0; i < N; i++) {
+    assert(check_value(i, 6, Host1[i], "Data1"));
+    assert(check_value(i, 6, Host2[i], "Data2"));
+    assert(check_value(i, 116, Host3[i], "Data3"));
+    assert(check_value(i, 6, Host4[i], "Data4"));
+    assert(check_value(i, 6, Host5[i], "Data5"));
+  }
+
+  free(Data1, Queue1);
+  free(Data2, Queue1);
+  free(Data3, Queue1);
+  free(Data4, Queue1);
+  free(Data5, Queue1);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/inorder_event_dependencies.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/inorder_event_dependencies.cpp
@@ -62,7 +62,7 @@ int main() {
   verifier.verify(RECORDING, EXECUTING);
 
   // Cross-boundary: wait during recording on the pre-recording event from
-  // Queue1. This is event is not marked as an external wait, and it is expected
+  // Queue1. This event is not marked as an external wait, and it is expected
   // to become an error in the native runtime.
   // CHECK: <--- urEnqueueKernelLaunchWithArgsExp
   // CHECK-SAME: .numEventsInWaitList = 1


### PR DESCRIPTION
Wait event dependencies across the native graph capture boundary cannot be removed and must be processed by the native backend.  Due to transitive queue recording and interoperability with native backend calls (e.g. capturing direct L0 submissions), SYCL alone cannot track if a queue is recording. We can only determine if a queue is truly recording through an adapter call which is too expensive to perform on each command submission and muddles tracing tool output.

We solve this issue when a native recording is in progress while keeping the SYCL optimization for the general case with the following approach:
- Track on the context if any SYCL graph is native recording. Mark any events on any queue owned by the context during this period as `PotentiallyNativeRecorded`.
- For any `PotentiallyNativeRecorded` wait event or queue state, disable the in-order queue optimization removing the dependency.
- Acquire the primary queue lock around begin and end capture to ensure the native recording transition and atomic update are not split by a submission to the primary queue from a separate thread.