### PR TITLE
[CI] Workaround icpx miscompile in nightly

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -70,7 +70,8 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_cache_suffix: oneapi
-      build_configure_extra_args: -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise"
+      # -fno-unroll-loops is added to workaround icpx bug CMPLRLLVM-76831.
+      build_configure_extra_args: -DCMAKE_C_FLAGS="-no-intel-lib -ffp-model=precise -fno-unroll-loops" -DCMAKE_CXX_FLAGS="-no-intel-lib -ffp-model=precise -fno-unroll-loops"
       cc: icx
       cxx: icpx
 


### PR DESCRIPTION
An icx miscompile is causing `check-llvm` for the build-with-icx job in the nightly to hang, see [here](https://github.com/intel/llvm/actions/runs/29223423540/job/86732841235).

This workaround was suggested by the team owning the bug, see CMPLRLLVM-76831 for more info.

Shown working [here](https://github.com/intel/llvm/actions/runs/29261216659/job/86854789780).