### PR TITLE
[SYCL][NFC] Fix coverity warning on use of uninitialized variables.

### DIFF
--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -904,7 +904,7 @@ public:
       return get_info_impl<UR_DEVICE_INFO_MAX_WORK_GROUPS>();
     }
     CASE(ext::oneapi::experimental::info::device::max_work_groups<3>) {
-      size_t result[3];
+      size_t result[3] = {};
       getAdapter().call<UrApiKind::urDeviceGetInfo>(
           getHandleRef(), UR_DEVICE_INFO_MAX_WORK_GROUPS_3D, sizeof(result),
           &result, nullptr);


### PR DESCRIPTION
fixes https://github.com/intel/llvm/issues/21918