### PR TITLE
[SYCL] Use isAMDGCN for SYCL related passes guard in AMDGPUTargetMachine

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1610,7 +1610,7 @@ void AMDGPUPassConfig::addIRPasses() {
   if (isPassEnabled(EnableScalarIRPasses))
     addEarlyCSEOrGVNPass();
 
-  if (TM.getTargetTriple().getArch() == Triple::amdgpu &&
+  if (TM.getTargetTriple().isAMDGCN() &&
       TM.getTargetTriple().getOS() == Triple::OSType::AMDHSA) {
     addPass(createLocalAccessorToSharedMemoryPassLegacy());
     addPass(createGlobalOffsetPassLegacy());


### PR DESCRIPTION
isAMDGCN is functionally the same as previous check.