### PR TITLE
[CI] Run postcommit for pulldown PRs

### DIFF
--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - sycl
     - sycl-rel-**
+    - llvmspirv_pulldown
 
   pull_request:
     branches:


### PR DESCRIPTION
We need to run postcommit in pulldown PRs.

In this PR the job is running twice, once for the `push` action and once for `pull_request` since we modified the postcommit workflow, but in a normal pulldown won't happen.

We can't use the `pull_request` action because GitHub requires both `branches` and `paths` to be satisfied which won't be true for a normal pulldown.

See https://github.com/intel/llvm/pull/22620