### PR TITLE
[SYCL][E2E] Replace REQUIRES statement with UNSUPPORTED in p2p_usm_residency.cpp test

### DIFF
--- a/sycl/test-e2e/USM/P2P/p2p_usm_residency.cpp
+++ b/sycl/test-e2e/USM/P2P/p2p_usm_residency.cpp
@@ -24,7 +24,7 @@
 // Phase 4: Verify that a device-to-device memcpy succeeds after enabling P2P
 // and that the transferred data matches the fill pattern.
 //
-// REQUIRES: level_zero && two-or-more-gpu-devices
+// UNSUPPORTED: run-mode && !(two-or-more-gpu-devices && level_zero)
 // UNSUPPORTED: level_zero_v1_adapter
 // UNSUPPORTED-INTENDED: Test is specific to the Level Zero v2 adapter.
 //


### PR DESCRIPTION
Replace REQUIRES statement with UNSUPPORTED in p2p_usm_residency.cpp test,
so that it is not run when the binary has not been built.

Ref: CMPLRTST-28979