### PR TITLE
[SYCL][E2E] Remove XFAIL in array_input_sort.cpp

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/array_input_sort.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/array_input_sort.cpp
@@ -2,8 +2,6 @@
 // UNSUPPORTED: target-nvidia || target-amd
 // UNSUPPORTED-INTENDED: subgroup size requirement implicitly make nvptx/amdgcn
 // not supported
-// XFAIL: spirv-backend && run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21782
 
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
It's XPASSing, see [here](https://github.com/intel/llvm/actions/runs/29340973480/job/87154991033).

Closes: https://github.com/intel/llvm/issues/21782