### PR TITLE
[SYCL][ESIMD][E2E] Update REQUIRES for two ESIMD LSC tests

### DIFF
--- a/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u8_u16.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u8_u16.cpp
@@ -5,11 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: arch-intel_gpu_pvc || gpu-intel-dg2
-// TODO: GPU Driver fails with "add3 src operand only supports integer D/W type"
-// error. Enable the test when it is fixed.
-// UNSUPPORTED: gpu-intel-dg2 && level_zero
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22231
+// REQUIRES: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 #include <iostream>

--- a/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u8_u16_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u8_u16_64.cpp
@@ -5,11 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: arch-intel_gpu_pvc || gpu-intel-dg2
-// TODO: GPU Driver fails with "add3 src operand only supports integer D/W type"
-// error. Enable the test when it is fixed.
-// UNSUPPORTED: gpu-intel-dg2 && level_zero
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22231
+// REQUIRES: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
These tests use features that aren't supported on DG2.

Closes: https://github.com/intel/llvm/issues/22231