### PR TITLE
[CI] Update Blender version

### DIFF
--- a/devops/actions/blender/blender-build/action.yml
+++ b/devops/actions/blender/blender-build/action.yml
@@ -65,7 +65,7 @@ runs:
         OIDN_DIR_INPUT: ${{ inputs.oidn_dir }}
         SYCL_DIR_INPUT: ${{ inputs.sycl_dir }}
       run: |
-       unzip -q D:\\github\\blender_5_1_0_source.zip -d .
+       unzip -q D:\\github\\blender_5_2_0_source.zip -d .
        mv blender blender-src
        # Work around CMake issue using preinstalled Embree/OIDN.
        cp -RT "$EMBREE_DIR_INPUT" "blender-src/lib/windows_x64/embree"


### PR DESCRIPTION
5.2 was released so let's use that. I already made the zip referenced and put it on the runner.

CI run: https://github.com/intel/llvm/actions/runs/29360902234/job/87188381877

Build succeeds, but runtime fails because of https://github.com/intel/llvm/issues/22362, it's failing today because of this anyway.