### PR TITLE
[SYCL] Fix IPC unit test build on GCC 8 stdlib

### DIFF
--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -22,7 +22,7 @@
 #define __SYCL_HAS_BUILTIN_BIT_CAST 0
 #endif
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L && __has_include(<version>)
 #include <version> // defines __cpp_lib_bit_cast
 #endif
 

--- a/sycl/unittests/Extensions/InterProcessCommunication/PhysicalMemory.cpp
+++ b/sycl/unittests/Extensions/InterProcessCommunication/PhysicalMemory.cpp
@@ -210,6 +210,7 @@ TEST_F(IPCPhysMemTests, IPCOpenClose) {
   EXPECT_EQ(urIPCClosePhysMemHandleExp_counter, 1);
 }
 
+#if __cpp_lib_span
 TEST_F(IPCPhysMemTests, IPCOpenCloseView) {
   {
     syclexp::ipc::handle_data_view_t HandleDataView{DummyHandleData,
@@ -226,6 +227,7 @@ TEST_F(IPCPhysMemTests, IPCOpenCloseView) {
   EXPECT_EQ(urIPCOpenPhysMemHandleExp_counter, 1);
   EXPECT_EQ(urIPCClosePhysMemHandleExp_counter, 1);
 }
+#endif
 
 TEST_F(IPCPhysMemTests, IPCGetNoFlagEnableIpc) {
   syclexp::properties PropList{};


### PR DESCRIPTION
Guard <version> include with __has_include, guard PhysicalMemory view test with __cpp_lib_span to fix build on GCC 8 stdlib