### PR TITLE
[SYCL][AMDGPU] Fix warning SYCLInstallation initialized after ShouldLinkDeviceLibs

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -59,15 +59,15 @@ protected:
   /// FIXME: Should merge 2 linkers.
   const bool UseHIPLinker = false;
 
-  // Whether to link device libraries (for standalone OpenCL/LLVM IR
-  // compilation)
-  bool ShouldLinkDeviceLibs = false;
-
   // Offload kind this toolchain instance is used for (e.g. distinguishes
   // HIP from SYCL offloading to amdgcn).
   Action::OffloadKind OK;
 
   SYCLInstallationDetector SYCLInstallation;
+
+  // Whether to link device libraries (for standalone OpenCL/LLVM IR
+  // compilation)
+  bool ShouldLinkDeviceLibs = false;
 
   Tool *buildLinker() const override;
   StringRef getOptionDefault(options::ID OptID) const {


### PR DESCRIPTION
Fix -Wreorder-ctor. Reorder to match with initializer-list in constructor.