### PR TITLE
[UR][Offload] update args for olCreateEvent and olLaunchKernel

### DIFF
--- a/unified-runtime/source/adapters/offload/enqueue.cpp
+++ b/unified-runtime/source/adapters/offload/enqueue.cpp
@@ -41,7 +41,8 @@ ol_result_t makeEvent(ur_command_t Type, ol_queue_handle_t OlQueue,
                       ur_queue_handle_t UrQueue, ur_event_handle_t *UrEvent) {
   if (UrEvent) {
     auto *Event = new ur_event_handle_t_(Type, UrQueue);
-    if (auto Res = olCreateEvent(OlQueue, &Event->OffloadEvent)) {
+    if (auto Res =
+            olCreateEvent(OlQueue, OL_EVENT_FLAGS_NONE, &Event->OffloadEvent)) {
       delete Event;
       return Res;
     };
@@ -84,7 +85,8 @@ ur_result_t doWait(ur_queue_handle_t hQueue, uint32_t numEventsInWaitList,
       if (Q == TargetQueue) {
         continue;
       }
-      OL_RETURN_ON_ERR(olCreateEvent(Q, &OffloadHandles.emplace_back()));
+      OL_RETURN_ON_ERR(olCreateEvent(Q, OL_EVENT_FLAGS_NONE,
+                                     &OffloadHandles.emplace_back()));
     }
     OL_RETURN_ON_ERR(olWaitEvents(TargetQueue, OffloadHandles.data(),
                                   OffloadHandles.size()));
@@ -201,8 +203,9 @@ static ur_result_t urEnqueueKernelLaunch(
   LaunchArgs.DynSharedMemory = 0;
 
   OL_RETURN_ON_ERR(olLaunchKernel(
-      Queue, hQueue->OffloadDevice, hKernel->OffloadKernel,
-      hKernel->Args.getStorage(), hKernel->Args.getStorageSize(), &LaunchArgs));
+      Queue, hQueue->OffloadDevice, hKernel->OffloadKernel, &LaunchArgs,
+      /*Properties=*/nullptr, hKernel->Args.Pointers.size(),
+      hKernel->Args.Pointers.data(), hKernel->Args.ParamSizes.data()));
 
   OL_RETURN_ON_ERR(makeEvent(UR_COMMAND_KERNEL_LAUNCH, Queue, hQueue, phEvent));
   return UR_RESULT_SUCCESS;
@@ -261,7 +264,8 @@ ur_result_t doMemcpy(ur_command_t Command, ur_queue_handle_t hQueue,
       olMemcpy(Queue, DestPtr, DestDevice, SrcPtr, SrcDevice, size));
   if (phEvent) {
     auto *Event = new ur_event_handle_t_(Command, hQueue);
-    if (auto Res = olCreateEvent(Queue, &Event->OffloadEvent)) {
+    if (auto Res =
+            olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &Event->OffloadEvent)) {
       delete Event;
       return offloadResultToUR(Res);
     };


### PR DESCRIPTION
In upstream LLVM, olCreateEvent gained a `Flags` param - update UR adapter to pass OL_EVENT_FLAGS_NONE, matching the old behavior.

Concurrently, olLaunchKernel switched to a pointer array for the kernel launch args. Luckily the adapter already tracks the information needed for the new API, which can be passed directly.

This patch is concerned with resolving build errors with current upstream LLVM and retaining existing functionality, not with feature-completeness against new liboffload features.