### PR TITLE
[SYCL][UR][OpenCL] Fix profiling tag ordering on OpenCL GPU

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/profiling_tag.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/profiling_tag.hpp
@@ -21,22 +21,24 @@ namespace ext::oneapi::experimental {
 inline event submit_profiling_tag(queue &Queue,
                                   const sycl::detail::code_location &CodeLoc =
                                       sycl::detail::code_location::current()) {
-  if (Queue.get_device().has(aspect::ext_oneapi_queue_profiling_tag)) {
-    return Queue.submit(
-        [=](handler &CGH) {
-          sycl::detail::HandlerAccess::internalProfilingTagImpl(CGH);
-        },
-        CodeLoc);
-  }
-
-  // If it is not supported natively on the device, we use another path if
-  // profiling is enabled.
-  if (!Queue.has_property<sycl::property::queue::enable_profiling>())
+  // The profiling tag can be serviced natively when the device advertises the
+  // ext_oneapi_queue_profiling_tag aspect. Otherwise, we can still service it
+  // as long as the queue has profiling enabled. In both cases we submit an
+  // internal profiling-tag command group: the runtime records the timestamp
+  // using a native device command where possible and otherwise falls back to a
+  // barrier (see CGType::ProfilingTag handling in the scheduler).
+  if (!Queue.get_device().has(aspect::ext_oneapi_queue_profiling_tag) &&
+      !Queue.has_property<sycl::property::queue::enable_profiling>())
     throw sycl::exception(
         make_error_code(errc::invalid),
         "Device must either have aspect::ext_oneapi_queue_profiling_tag or the "
         "queue must have profiling enabled.");
-  return Queue.ext_oneapi_submit_barrier();
+
+  return Queue.submit(
+      [=](handler &CGH) {
+        sycl::detail::HandlerAccess::internalProfilingTagImpl(CGH);
+      },
+      CodeLoc);
 }
 
 } // namespace ext::oneapi::experimental

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -390,6 +390,8 @@ public:
 
   void markAsProfilingTagEvent() { MProfilingTagEvent = true; }
 
+  void clearProfilingTagEvent() { MProfilingTagEvent = false; }
+
   bool isProfilingTagEvent() const noexcept { return MProfilingTagEvent; }
 
   // Check if this event is an interoperability event.

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3651,17 +3651,13 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     assert(MQueue && "Profiling tag requires a valid queue");
     adapter_impl &Adapter = MQueue->getAdapter();
 
-    bool IsInOrderQueue = MQueue->isInOrder();
-    ur_event_handle_t *TimestampDeps = nullptr;
-    size_t NumTimestampDeps = 0;
-
-    // TO DO - once the following WA removed: to change call to call_nocheck and
-    // return operation result to Command::enqueue (see other CG types). Set
-    // UREvent to EventImpl only for successful case.
+    const bool IsInOrderQueue = MQueue->isInOrder();
 
     // If the queue is not in-order, the implementation will need to first
     // insert a marker event that the timestamp waits for.
     ur_event_handle_t PreTimestampMarkerEvent{};
+    ur_event_handle_t *TimestampDeps = nullptr;
+    size_t NumTimestampDeps = 0;
     if (!IsInOrderQueue) {
       // FIXME: urEnqueueEventsWait on the L0 adapter requires a double-release.
       //        Use that instead once it has been fixed.
@@ -3674,25 +3670,51 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
       NumTimestampDeps = 1;
     }
 
-    Adapter.call<UrApiKind::urEnqueueTimestampRecordingExp>(
-        MQueue->getHandleRef(),
-        /*blocking=*/false, NumTimestampDeps, TimestampDeps, Event);
+    // Try to record a device timestamp natively. Not every backend can do so:
+    // the OpenCL backend can only record a reliable timestamp on a
+    // profiling-enabled queue (see intel/llvm#22229). When the recording is
+    // unsupported we fall back to a plain barrier, whose event still carries
+    // (best-effort) profiling information and provides the same ordering.
+    ur_result_t TimestampResult =
+        Adapter.call_nocheck<UrApiKind::urEnqueueTimestampRecordingExp>(
+            MQueue->getHandleRef(),
+            /*blocking=*/false, NumTimestampDeps, TimestampDeps, Event);
 
-    // If the queue is not in-order, we need to insert a barrier. This barrier
-    // does not need output events as it will implicitly enforce the following
-    // enqueue is blocked until it finishes.
-    if (!IsInOrderQueue) {
-      // We also need to release the timestamp event from the marker.
-      Adapter.call<UrApiKind::urEventRelease>(PreTimestampMarkerEvent);
-      // FIXME: Due to a bug in the L0 UR adapter, we will leak events if we do
-      //        not pass an output event to the UR call. Once that is fixed,
-      //        this immediately-deleted event can be removed.
-      ur_event_handle_t PostTimestampBarrierEvent{};
-      Adapter.call<UrApiKind::urEnqueueEventsWaitWithBarrier>(
-          MQueue->getHandleRef(),
-          /*num_events_in_wait_list=*/0,
-          /*event_wait_list=*/nullptr, &PostTimestampBarrierEvent);
-      Adapter.call<UrApiKind::urEventRelease>(PostTimestampBarrierEvent);
+    if (TimestampResult == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+      // Release the marker the (unused) timestamp recording would have waited
+      // for.
+      if (!IsInOrderQueue)
+        Adapter.call<UrApiKind::urEventRelease>(PreTimestampMarkerEvent);
+      // A barrier with an empty wait list waits for all previously-submitted
+      // work and blocks subsequent work, providing the same ordering semantics
+      // as a native profiling tag.
+      if (auto Result =
+              Adapter.call_nocheck<UrApiKind::urEnqueueEventsWaitWithBarrier>(
+                  MQueue->getHandleRef(),
+                  /*num_events_in_wait_list=*/0,
+                  /*event_wait_list=*/nullptr, Event);
+          Result != UR_RESULT_SUCCESS)
+        return Result;
+    } else {
+      if (TimestampResult != UR_RESULT_SUCCESS)
+        return TimestampResult;
+
+      // If the queue is not in-order, we need to insert a barrier. This barrier
+      // does not need output events as it will implicitly enforce the following
+      // enqueue is blocked until it finishes.
+      if (!IsInOrderQueue) {
+        // We also need to release the timestamp event from the marker.
+        Adapter.call<UrApiKind::urEventRelease>(PreTimestampMarkerEvent);
+        // FIXME: Due to a bug in the L0 UR adapter, we will leak events if we
+        //        do not pass an output event to the UR call. Once that is
+        //        fixed, this immediately-deleted event can be removed.
+        ur_event_handle_t PostTimestampBarrierEvent{};
+        Adapter.call<UrApiKind::urEnqueueEventsWaitWithBarrier>(
+            MQueue->getHandleRef(),
+            /*num_events_in_wait_list=*/0,
+            /*event_wait_list=*/nullptr, &PostTimestampBarrierEvent);
+        Adapter.call<UrApiKind::urEventRelease>(PostTimestampBarrierEvent);
+      }
     }
 
     SetEventHandleOrDiscard();

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -22,6 +22,7 @@
 #include <detail/scheduler/commands.hpp>
 #include <detail/scheduler/scheduler.hpp>
 #include <detail/stream_impl.hpp>
+#include <detail/ur_utils.hpp>
 #include <detail/xpti_registry.hpp>
 #include <sycl/access/access.hpp>
 #include <sycl/backend_types.hpp>
@@ -3717,6 +3718,7 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     // If the queue is not in-order, the implementation will need to first
     // insert a marker event that the timestamp waits for.
     ur_event_handle_t PreTimestampMarkerEvent{};
+    std::optional<OwnedUrEvent> OwnedPreTimestampMarkerEvent;
     ur_event_handle_t *TimestampDeps = nullptr;
     size_t NumTimestampDeps = 0;
     if (!IsInOrderQueue) {
@@ -3727,6 +3729,8 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
           MQueue->getHandleRef(),
           /*num_events_in_wait_list=*/0,
           /*event_wait_list=*/nullptr, &PreTimestampMarkerEvent);
+      OwnedPreTimestampMarkerEvent.emplace(PreTimestampMarkerEvent, Adapter,
+                                           /*TakeOwnership=*/true);
       TimestampDeps = &PreTimestampMarkerEvent;
       NumTimestampDeps = 1;
     }
@@ -3742,20 +3746,22 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
             /*blocking=*/false, NumTimestampDeps, TimestampDeps, Event);
 
     if (TimestampResult == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-      // Release the marker the (unused) timestamp recording would have waited
-      // for.
-      if (!IsInOrderQueue)
-        Adapter.call<UrApiKind::urEventRelease>(PreTimestampMarkerEvent);
-      // A barrier with an empty wait list waits for all previously-submitted
-      // work and blocks subsequent work, providing the same ordering semantics
-      // as a native profiling tag.
-      if (auto Result =
-              Adapter.call_nocheck<UrApiKind::urEnqueueEventsWaitWithBarrier>(
-                  MQueue->getHandleRef(),
-                  /*num_events_in_wait_list=*/0,
-                  /*event_wait_list=*/nullptr, Event);
-          Result != UR_RESULT_SUCCESS)
-        return Result;
+      if (!IsInOrderQueue) {
+        // The pre-timestamp barrier already provides the required ordering and
+        // profiling information, so reuse its event instead of submitting a
+        // second barrier.
+        if (Event)
+          *Event = OwnedPreTimestampMarkerEvent->TransferOwnership();
+      } else {
+        // An in-order queue has no pre-timestamp barrier to reuse.
+        if (auto Result =
+                Adapter.call_nocheck<UrApiKind::urEnqueueEventsWaitWithBarrier>(
+                    MQueue->getHandleRef(),
+                    /*num_events_in_wait_list=*/0,
+                    /*event_wait_list=*/nullptr, Event);
+            Result != UR_RESULT_SUCCESS)
+          return Result;
+      }
     } else {
       if (TimestampResult != UR_RESULT_SUCCESS)
         return TimestampResult;
@@ -3764,8 +3770,6 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
       // does not need output events as it will implicitly enforce the following
       // enqueue is blocked until it finishes.
       if (!IsInOrderQueue) {
-        // We also need to release the timestamp event from the marker.
-        Adapter.call<UrApiKind::urEventRelease>(PreTimestampMarkerEvent);
         // FIXME: Due to a bug in the L0 UR adapter, we will leak events if we
         //        do not pass an output event to the UR call. Once that is
         //        fixed, this immediately-deleted event can be removed.

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3712,17 +3712,13 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     assert(MQueue && "Profiling tag requires a valid queue");
     adapter_impl &Adapter = MQueue->getAdapter();
 
-    bool IsInOrderQueue = MQueue->isInOrder();
-    ur_event_handle_t *TimestampDeps = nullptr;
-    size_t NumTimestampDeps = 0;
-
-    // TO DO - once the following WA removed: to change call to call_nocheck and
-    // return operation result to Command::enqueue (see other CG types). Set
-    // UREvent to EventImpl only for successful case.
+    const bool IsInOrderQueue = MQueue->isInOrder();
 
     // If the queue is not in-order, the implementation will need to first
     // insert a marker event that the timestamp waits for.
     ur_event_handle_t PreTimestampMarkerEvent{};
+    ur_event_handle_t *TimestampDeps = nullptr;
+    size_t NumTimestampDeps = 0;
     if (!IsInOrderQueue) {
       // FIXME: urEnqueueEventsWait on the L0 adapter requires a double-release.
       //        Use that instead once it has been fixed.
@@ -3735,25 +3731,51 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
       NumTimestampDeps = 1;
     }
 
-    Adapter.call<UrApiKind::urEnqueueTimestampRecordingExp>(
-        MQueue->getHandleRef(),
-        /*blocking=*/false, NumTimestampDeps, TimestampDeps, Event);
+    // Try to record a device timestamp natively. Not every backend can do so:
+    // the OpenCL backend can only record a reliable timestamp on a
+    // profiling-enabled queue (see intel/llvm#22229). When the recording is
+    // unsupported we fall back to a plain barrier, whose event still carries
+    // (best-effort) profiling information and provides the same ordering.
+    ur_result_t TimestampResult =
+        Adapter.call_nocheck<UrApiKind::urEnqueueTimestampRecordingExp>(
+            MQueue->getHandleRef(),
+            /*blocking=*/false, NumTimestampDeps, TimestampDeps, Event);
 
-    // If the queue is not in-order, we need to insert a barrier. This barrier
-    // does not need output events as it will implicitly enforce the following
-    // enqueue is blocked until it finishes.
-    if (!IsInOrderQueue) {
-      // We also need to release the timestamp event from the marker.
-      Adapter.call<UrApiKind::urEventRelease>(PreTimestampMarkerEvent);
-      // FIXME: Due to a bug in the L0 UR adapter, we will leak events if we do
-      //        not pass an output event to the UR call. Once that is fixed,
-      //        this immediately-deleted event can be removed.
-      ur_event_handle_t PostTimestampBarrierEvent{};
-      Adapter.call<UrApiKind::urEnqueueEventsWaitWithBarrier>(
-          MQueue->getHandleRef(),
-          /*num_events_in_wait_list=*/0,
-          /*event_wait_list=*/nullptr, &PostTimestampBarrierEvent);
-      Adapter.call<UrApiKind::urEventRelease>(PostTimestampBarrierEvent);
+    if (TimestampResult == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+      // Release the marker the (unused) timestamp recording would have waited
+      // for.
+      if (!IsInOrderQueue)
+        Adapter.call<UrApiKind::urEventRelease>(PreTimestampMarkerEvent);
+      // A barrier with an empty wait list waits for all previously-submitted
+      // work and blocks subsequent work, providing the same ordering semantics
+      // as a native profiling tag.
+      if (auto Result =
+              Adapter.call_nocheck<UrApiKind::urEnqueueEventsWaitWithBarrier>(
+                  MQueue->getHandleRef(),
+                  /*num_events_in_wait_list=*/0,
+                  /*event_wait_list=*/nullptr, Event);
+          Result != UR_RESULT_SUCCESS)
+        return Result;
+    } else {
+      if (TimestampResult != UR_RESULT_SUCCESS)
+        return TimestampResult;
+
+      // If the queue is not in-order, we need to insert a barrier. This barrier
+      // does not need output events as it will implicitly enforce the following
+      // enqueue is blocked until it finishes.
+      if (!IsInOrderQueue) {
+        // We also need to release the timestamp event from the marker.
+        Adapter.call<UrApiKind::urEventRelease>(PreTimestampMarkerEvent);
+        // FIXME: Due to a bug in the L0 UR adapter, we will leak events if we
+        //        do not pass an output event to the UR call. Once that is
+        //        fixed, this immediately-deleted event can be removed.
+        ur_event_handle_t PostTimestampBarrierEvent{};
+        Adapter.call<UrApiKind::urEnqueueEventsWaitWithBarrier>(
+            MQueue->getHandleRef(),
+            /*num_events_in_wait_list=*/0,
+            /*event_wait_list=*/nullptr, &PostTimestampBarrierEvent);
+        Adapter.call<UrApiKind::urEventRelease>(PostTimestampBarrierEvent);
+      }
     }
 
     SetEventHandleOrDiscard();

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3713,6 +3713,14 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     assert(MQueue && "Profiling tag requires a valid queue");
     adapter_impl &Adapter = MQueue->getAdapter();
 
+    // A fallback tag on a profiling-enabled queue is exposed as a regular
+    // profiling event, whose command_submit value comes from MSubmitTime.
+    // Ensure it is initialized before any marker or timestamp command is
+    // enqueued so it remains ordered before the fallback event on both in-order
+    // and out-of-order queues.
+    if (MQueue->MIsProfilingEnabled && MEvent->getSubmissionTime() == 0)
+      MEvent->setSubmissionTime();
+
     const bool IsInOrderQueue = MQueue->isInOrder();
 
     // If the queue is not in-order, the implementation will need to first
@@ -3746,6 +3754,12 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
             /*blocking=*/false, NumTimestampDeps, TimestampDeps, Event);
 
     if (TimestampResult == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+      // On a profiling-enabled queue, the barrier fallback is a regular
+      // profiling event. Use its runtime-recorded submission timestamp instead
+      // of requiring the backend event to provide one.
+      if (MQueue->MIsProfilingEnabled)
+        MEvent->clearProfilingTagEvent();
+
       if (!IsInOrderQueue) {
         // The pre-timestamp barrier already provides the required ordering and
         // profiling information, so reuse its event instead of submitting a

--- a/sycl/test-e2e/ProfilingTag/common.hpp
+++ b/sycl/test-e2e/ProfilingTag/common.hpp
@@ -63,7 +63,7 @@ int run_test_on_queue(sycl::queue &Queue) {
   CHECK(Failures, StartTagEnd != 0)
   CHECK(Failures, EndTagSubmit != 0)
   CHECK(Failures, EndTagStart != 0)
-  CHECK(Failures, StartTagSubmit != 0)
+  CHECK(Failures, EndTagEnd != 0)
 
   CHECK(Failures, StartTagSubmit <= StartTagEnd)
   CHECK(Failures, StartTagSubmit <= StartTagStart)

--- a/sycl/test-e2e/ProfilingTag/in_order_profiling_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/in_order_profiling_queue.cpp
@@ -8,11 +8,6 @@
 // Note: Extension should work even on devices that do not support the
 //       ext_oneapi_queue_profiling_tag aspect.
 
-// Bug in OpenCL GPU driver causes fallback solution to return end time later
-// than the submission of the following work.
-// UNSUPPORTED: opencl && gpu
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22229
-
 // HIP backend currently returns invalid values for submission time queries.
 // UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/12904

--- a/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
@@ -8,11 +8,6 @@
 // Note: Extension should work even on devices that do not support the
 //       ext_oneapi_queue_profiling_tag aspect.
 
-// Bug in OpenCL GPU driver causes fallback solution to return end time later
-// than the submission of the following work.
-// UNSUPPORTED: opencl && gpu
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22229
-
 // HIP backend currently returns invalid values for submission time queries.
 // UNSUPPORTED: hip
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/12904

--- a/sycl/unittests/Extensions/ProfilingTag.cpp
+++ b/sycl/unittests/Extensions/ProfilingTag.cpp
@@ -30,6 +30,14 @@ inline ur_result_t after_urEnqueueTimestampRecordingExp(void *) {
   return UR_RESULT_SUCCESS;
 }
 
+// Simulates a backend that cannot record a device timestamp (e.g. the OpenCL
+// backend on a queue without profiling enabled), so that the scheduler falls
+// back to a barrier.
+inline ur_result_t replace_urEnqueueTimestampRecordingExpUnsupported(void *) {
+  ++counter_urEnqueueTimestampRecordingExp;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
 thread_local std::optional<ur_profiling_info_t> LatestProfilingQuery;
 inline ur_result_t after_urEventGetProfilingInfo(void *pParams) {
   auto &Params =
@@ -205,24 +213,57 @@ TEST_F(ProfilingTagTest, ProfilingTagFallbackDefaultQueue) {
   }
 }
 
-TEST_F(ProfilingTagTest, ProfilingTagFallbackProfilingQueue) {
+// Without the aspect but with profiling enabled, the tag is still serviced via
+// the profiling-tag command group. If the backend can record a device
+// timestamp (as the OpenCL backend now does on a profiling-enabled queue), the
+// native recording path is used rather than a bare barrier.
+TEST_F(ProfilingTagTest, ProfilingTagFallbackProfilingQueueTimestamp) {
   mock::getCallbacks().set_after_callback("urDeviceGetInfo",
                                           &after_urDeviceGetInfo<false>);
   mock::getCallbacks().set_after_callback(
       "urEnqueueTimestampRecordingExp", &after_urEnqueueTimestampRecordingExp);
   mock::getCallbacks().set_after_callback(
-      "urEnqueueEventsWaitWithBarrierExt",
+      "urEnqueueEventsWaitWithBarrier",
       &after_urEnqueueEventsWaitWithBarrierExt);
 
   sycl::context Ctx{sycl::platform()};
   sycl::queue Queue{Ctx,
                     sycl::default_selector_v,
-                    {sycl::property::queue::enable_profiling()}};
+                    {sycl::property::queue::enable_profiling(),
+                     sycl::property::queue::in_order()}};
   sycl::device Dev = Queue.get_device();
 
   ASSERT_FALSE(Dev.has(sycl::aspect::ext_oneapi_queue_profiling_tag));
 
   sycl::event E = sycl::ext::oneapi::experimental::submit_profiling_tag(Queue);
-  ASSERT_EQ(size_t{0}, counter_urEnqueueTimestampRecordingExp);
+  ASSERT_EQ(size_t{1}, counter_urEnqueueTimestampRecordingExp);
+  ASSERT_EQ(size_t{0}, counter_urEnqueueEventsWaitWithBarrierExt);
+}
+
+// If the backend reports that it cannot record a device timestamp, the
+// scheduler must gracefully fall back to a barrier.
+TEST_F(ProfilingTagTest, ProfilingTagFallbackProfilingQueueBarrier) {
+  mock::getCallbacks().set_after_callback("urDeviceGetInfo",
+                                          &after_urDeviceGetInfo<false>);
+  mock::getCallbacks().set_replace_callback(
+      "urEnqueueTimestampRecordingExp",
+      &replace_urEnqueueTimestampRecordingExpUnsupported);
+  mock::getCallbacks().set_after_callback(
+      "urEnqueueEventsWaitWithBarrier",
+      &after_urEnqueueEventsWaitWithBarrierExt);
+
+  sycl::context Ctx{sycl::platform()};
+  sycl::queue Queue{Ctx,
+                    sycl::default_selector_v,
+                    {sycl::property::queue::enable_profiling(),
+                     sycl::property::queue::in_order()}};
+  sycl::device Dev = Queue.get_device();
+
+  ASSERT_FALSE(Dev.has(sycl::aspect::ext_oneapi_queue_profiling_tag));
+
+  sycl::event E = sycl::ext::oneapi::experimental::submit_profiling_tag(Queue);
+  // The timestamp recording is attempted and reports unsupported, so a single
+  // barrier is used as the fallback on this in-order queue.
+  ASSERT_EQ(size_t{1}, counter_urEnqueueTimestampRecordingExp);
   ASSERT_EQ(size_t{1}, counter_urEnqueueEventsWaitWithBarrierExt);
 }

--- a/sycl/unittests/Extensions/ProfilingTag.cpp
+++ b/sycl/unittests/Extensions/ProfilingTag.cpp
@@ -8,6 +8,7 @@
 
 #include <sycl/sycl.hpp>
 
+#include <detail/event_impl.hpp>
 #include <helpers/UrMock.hpp>
 
 #include <gtest/gtest.h>
@@ -38,6 +39,11 @@ inline ur_result_t replace_urEnqueueTimestampRecordingExpUnsupported(void *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
+inline ur_result_t replace_urEnqueueTimestampRecordingExpFailure(void *) {
+  ++counter_urEnqueueTimestampRecordingExp;
+  return UR_RESULT_ERROR_UNKNOWN;
+}
+
 thread_local std::optional<ur_profiling_info_t> LatestProfilingQuery;
 inline ur_result_t after_urEventGetProfilingInfo(void *pParams) {
   auto &Params =
@@ -47,8 +53,21 @@ inline ur_result_t after_urEventGetProfilingInfo(void *pParams) {
 }
 
 inline thread_local size_t counter_urEnqueueEventsWaitWithBarrierExt = 0;
-inline ur_result_t after_urEnqueueEventsWaitWithBarrierExt(void *) {
+inline thread_local ur_event_handle_t LatestBarrierEvent = nullptr;
+inline thread_local bool LatestBarrierEventReleased = false;
+inline ur_result_t after_urEnqueueEventsWaitWithBarrierExt(void *pParams) {
   ++counter_urEnqueueEventsWaitWithBarrierExt;
+  auto &Params =
+      *static_cast<ur_enqueue_events_wait_with_barrier_params_t *>(pParams);
+  if (*Params.pphEvent)
+    LatestBarrierEvent = **Params.pphEvent;
+  return UR_RESULT_SUCCESS;
+}
+
+inline ur_result_t before_urEventRelease(void *pParams) {
+  auto &Params = *static_cast<ur_event_release_params_t *>(pParams);
+  if (LatestBarrierEvent && *Params.phEvent == LatestBarrierEvent)
+    LatestBarrierEventReleased = true;
   return UR_RESULT_SUCCESS;
 }
 
@@ -60,6 +79,8 @@ protected:
   void SetUp() override {
     counter_urEnqueueTimestampRecordingExp = 0;
     counter_urEnqueueEventsWaitWithBarrierExt = 0;
+    LatestBarrierEvent = nullptr;
+    LatestBarrierEventReleased = false;
     LatestProfilingQuery = std::nullopt;
   }
 
@@ -266,4 +287,53 @@ TEST_F(ProfilingTagTest, ProfilingTagFallbackProfilingQueueBarrier) {
   // barrier is used as the fallback on this in-order queue.
   ASSERT_EQ(size_t{1}, counter_urEnqueueTimestampRecordingExp);
   ASSERT_EQ(size_t{1}, counter_urEnqueueEventsWaitWithBarrierExt);
+}
+
+TEST_F(ProfilingTagTest,
+       ProfilingTagFallbackProfilingOutOfOrderQueueReusesBarrier) {
+  mock::getCallbacks().set_after_callback("urDeviceGetInfo",
+                                          &after_urDeviceGetInfo<false>);
+  mock::getCallbacks().set_replace_callback(
+      "urEnqueueTimestampRecordingExp",
+      &replace_urEnqueueTimestampRecordingExpUnsupported);
+  mock::getCallbacks().set_after_callback(
+      "urEnqueueEventsWaitWithBarrier",
+      &after_urEnqueueEventsWaitWithBarrierExt);
+
+  sycl::context Ctx{sycl::platform()};
+  sycl::queue Queue{Ctx,
+                    sycl::default_selector_v,
+                    {sycl::property::queue::enable_profiling()}};
+  sycl::device Dev = Queue.get_device();
+
+  ASSERT_FALSE(Dev.has(sycl::aspect::ext_oneapi_queue_profiling_tag));
+
+  sycl::event E = sycl::ext::oneapi::experimental::submit_profiling_tag(Queue);
+  ASSERT_EQ(size_t{1}, counter_urEnqueueTimestampRecordingExp);
+  ASSERT_EQ(size_t{1}, counter_urEnqueueEventsWaitWithBarrierExt);
+  ASSERT_NE(nullptr, LatestBarrierEvent);
+  ASSERT_EQ(LatestBarrierEvent, sycl::detail::getSyclObjImpl(E)->getHandle());
+}
+
+TEST_F(ProfilingTagTest, ProfilingTagTimestampFailureReleasesMarker) {
+  mock::getCallbacks().set_after_callback("urDeviceGetInfo",
+                                          &after_urDeviceGetInfo<true>);
+  mock::getCallbacks().set_replace_callback(
+      "urEnqueueTimestampRecordingExp",
+      &replace_urEnqueueTimestampRecordingExpFailure);
+  mock::getCallbacks().set_after_callback(
+      "urEnqueueEventsWaitWithBarrier",
+      &after_urEnqueueEventsWaitWithBarrierExt);
+  mock::getCallbacks().set_before_callback("urEventRelease",
+                                           &before_urEventRelease);
+
+  sycl::context Ctx{sycl::platform()};
+  sycl::queue Queue{Ctx, sycl::default_selector_v};
+
+  EXPECT_THROW(sycl::ext::oneapi::experimental::submit_profiling_tag(Queue),
+               sycl::exception);
+  ASSERT_EQ(size_t{1}, counter_urEnqueueTimestampRecordingExp);
+  ASSERT_EQ(size_t{1}, counter_urEnqueueEventsWaitWithBarrierExt);
+  ASSERT_NE(nullptr, LatestBarrierEvent);
+  ASSERT_TRUE(LatestBarrierEventReleased);
 }

--- a/sycl/unittests/Extensions/ProfilingTag.cpp
+++ b/sycl/unittests/Extensions/ProfilingTag.cpp
@@ -52,6 +52,20 @@ inline ur_result_t after_urEventGetProfilingInfo(void *pParams) {
   return UR_RESULT_SUCCESS;
 }
 
+inline constexpr uint64_t FallbackSubmitTime = 42;
+inline thread_local size_t counter_urDeviceGetGlobalTimestamps = 0;
+inline ur_result_t replace_urDeviceGetGlobalTimestamps(void *pParams) {
+  auto &Params =
+      *static_cast<ur_device_get_global_timestamps_params_t *>(pParams);
+  const uint64_t Timestamp =
+      counter_urDeviceGetGlobalTimestamps++ == 0 ? 0 : FallbackSubmitTime;
+  if (*Params.ppDeviceTimestamp)
+    **Params.ppDeviceTimestamp = Timestamp;
+  if (*Params.ppHostTimestamp)
+    **Params.ppHostTimestamp = Timestamp;
+  return UR_RESULT_SUCCESS;
+}
+
 inline thread_local size_t counter_urEnqueueEventsWaitWithBarrierExt = 0;
 inline thread_local ur_event_handle_t LatestBarrierEvent = nullptr;
 inline thread_local bool LatestBarrierEventReleased = false;
@@ -78,6 +92,7 @@ public:
 protected:
   void SetUp() override {
     counter_urEnqueueTimestampRecordingExp = 0;
+    counter_urDeviceGetGlobalTimestamps = 0;
     counter_urEnqueueEventsWaitWithBarrierExt = 0;
     LatestBarrierEvent = nullptr;
     LatestBarrierEventReleased = false;
@@ -110,6 +125,11 @@ TEST_F(ProfilingTagTest, ProfilingTagSupportedDefaultQueue) {
   // TODO: We expect two barriers for now, while marker events leak. Adjust when
   //       addressed.
   ASSERT_EQ(size_t{2}, counter_urEnqueueEventsWaitWithBarrierExt);
+
+  ASSERT_TRUE(sycl::detail::getSyclObjImpl(E)->isProfilingTagEvent());
+  E.get_profiling_info<sycl::info::event_profiling::command_submit>();
+  ASSERT_TRUE(LatestProfilingQuery.has_value());
+  ASSERT_EQ(*LatestProfilingQuery, UR_PROFILING_INFO_COMMAND_SUBMIT);
 
   E.get_profiling_info<sycl::info::event_profiling::command_start>();
   ASSERT_TRUE(LatestProfilingQuery.has_value());
@@ -259,6 +279,7 @@ TEST_F(ProfilingTagTest, ProfilingTagFallbackProfilingQueueTimestamp) {
   sycl::event E = sycl::ext::oneapi::experimental::submit_profiling_tag(Queue);
   ASSERT_EQ(size_t{1}, counter_urEnqueueTimestampRecordingExp);
   ASSERT_EQ(size_t{0}, counter_urEnqueueEventsWaitWithBarrierExt);
+  ASSERT_TRUE(sycl::detail::getSyclObjImpl(E)->isProfilingTagEvent());
 }
 
 // If the backend reports that it cannot record a device timestamp, the
@@ -272,6 +293,8 @@ TEST_F(ProfilingTagTest, ProfilingTagFallbackProfilingQueueBarrier) {
   mock::getCallbacks().set_after_callback(
       "urEnqueueEventsWaitWithBarrier",
       &after_urEnqueueEventsWaitWithBarrierExt);
+  mock::getCallbacks().set_after_callback("urEventGetProfilingInfo",
+                                          &after_urEventGetProfilingInfo);
 
   sycl::context Ctx{sycl::platform()};
   sycl::queue Queue{Ctx,
@@ -282,11 +305,26 @@ TEST_F(ProfilingTagTest, ProfilingTagFallbackProfilingQueueBarrier) {
 
   ASSERT_FALSE(Dev.has(sycl::aspect::ext_oneapi_queue_profiling_tag));
 
+  // Reproduce a missing scheduler-recorded submission timestamp, as observed
+  // in the Native CPU E2E configuration. The profiling-tag enqueue must retry
+  // timestamp initialization before falling back to a barrier.
+  mock::getCallbacks().set_replace_callback(
+      "urDeviceGetGlobalTimestamps", &replace_urDeviceGetGlobalTimestamps);
+
   sycl::event E = sycl::ext::oneapi::experimental::submit_profiling_tag(Queue);
   // The timestamp recording is attempted and reports unsupported, so a single
   // barrier is used as the fallback on this in-order queue.
   ASSERT_EQ(size_t{1}, counter_urEnqueueTimestampRecordingExp);
   ASSERT_EQ(size_t{1}, counter_urEnqueueEventsWaitWithBarrierExt);
+
+  // A profiling-enabled queue has a runtime-recorded submission timestamp and
+  // must not require the fallback barrier event to provide one.
+  ASSERT_FALSE(sycl::detail::getSyclObjImpl(E)->isProfilingTagEvent());
+  ASSERT_EQ(size_t{2}, counter_urDeviceGetGlobalTimestamps);
+  ASSERT_EQ(
+      FallbackSubmitTime,
+      E.get_profiling_info<sycl::info::event_profiling::command_submit>());
+  ASSERT_FALSE(LatestProfilingQuery.has_value());
 }
 
 TEST_F(ProfilingTagTest,

--- a/unified-runtime/source/adapters/opencl/context.hpp
+++ b/unified-runtime/source/adapters/opencl/context.hpp
@@ -13,6 +13,7 @@
 #include "common/ur_ref_count.hpp"
 #include "device.hpp"
 
+#include <mutex>
 #include <vector>
 
 namespace ur::opencl {
@@ -24,6 +25,15 @@ struct ur_context_handle_t_ : handle_base {
   uint32_t DeviceCount;
   bool IsNativeHandleOwned = true;
   ur::RefCount RefCount;
+
+  // Small device buffer used to emulate a timestamp recording via a real,
+  // profilable command (see urEnqueueTimestampRecordingExp). Some OpenCL
+  // drivers timestamp synchronization-only commands (barriers/markers) at the
+  // point they are inserted into the pipeline rather than when the preceding
+  // work actually completes, which breaks profiling-tag orderings
+  // (see https://github.com/intel/llvm/issues/22229). Created lazily.
+  std::mutex TimestampRecordingBufferMutex;
+  cl_mem TimestampRecordingBuffer = nullptr;
 
   ur_context_handle_t_(const ur_context_handle_t_ &) = delete;
   ur_context_handle_t_ &operator=(const ur_context_handle_t_ &) = delete;
@@ -40,6 +50,21 @@ struct ur_context_handle_t_ : handle_base {
   static ur_result_t makeWithNative(native_type Ctx, uint32_t DevCount,
                                     const ur_device_handle_t *phDevices,
                                     ur_context_handle_t &Context);
+
+  // Returns the small internal buffer used by urEnqueueTimestampRecordingExp,
+  // creating it on first use. Thread-safe.
+  ur_result_t getTimestampRecordingBuffer(cl_mem *OutBuffer) {
+    std::lock_guard<std::mutex> Lock(TimestampRecordingBufferMutex);
+    if (!TimestampRecordingBuffer) {
+      cl_int CLErr = CL_SUCCESS;
+      TimestampRecordingBuffer = clCreateBuffer(
+          CLContext, CL_MEM_READ_WRITE, sizeof(cl_uint), nullptr, &CLErr);
+      CL_RETURN_ON_FAILURE(CLErr);
+    }
+    *OutBuffer = TimestampRecordingBuffer;
+    return UR_RESULT_SUCCESS;
+  }
+
   ~ur_context_handle_t_() noexcept {
     // If we're reasonably sure this context is about to be destroyed we should
     // clear the ext function pointer cache. This isn't foolproof sadly but it
@@ -49,6 +74,9 @@ struct ur_context_handle_t_ : handle_base {
 
     for (uint32_t i = 0; i < DeviceCount; i++) {
       ur::opencl::urDeviceRelease(cast(Devices[i]));
+    }
+    if (TimestampRecordingBuffer) {
+      clReleaseMemObject(TimestampRecordingBuffer);
     }
     if (IsNativeHandleOwned) {
       clReleaseContext(CLContext);

--- a/unified-runtime/source/adapters/opencl/context.hpp
+++ b/unified-runtime/source/adapters/opencl/context.hpp
@@ -75,8 +75,12 @@ struct ur_context_handle_t_ : handle_base {
     for (uint32_t i = 0; i < DeviceCount; i++) {
       ur::opencl::urDeviceRelease(cast(Devices[i]));
     }
-    if (TimestampRecordingBuffer) {
-      clReleaseMemObject(TimestampRecordingBuffer);
+    {
+      std::lock_guard<std::mutex> Lock(TimestampRecordingBufferMutex);
+      if (TimestampRecordingBuffer) {
+        clReleaseMemObject(TimestampRecordingBuffer);
+        TimestampRecordingBuffer = nullptr;
+      }
     }
     if (IsNativeHandleOwned) {
       clReleaseContext(CLContext);

--- a/unified-runtime/source/adapters/opencl/event.cpp
+++ b/unified-runtime/source/adapters/opencl/event.cpp
@@ -309,10 +309,52 @@ urEventSetCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
-                               const ur_event_handle_t *, ur_event_handle_t *) {
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, bool Blocking, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  // OpenCL has no native "record device timestamp" primitive. Some drivers
+  // (notably the Intel GPU driver) timestamp synchronization-only commands
+  // (barriers/markers) at the point they are inserted into the pipeline rather
+  // than when the preceding work actually completes, which breaks profiling-tag
+  // orderings (see https://github.com/intel/llvm/issues/22229). We therefore
+  // emulate a timestamp by enqueuing a lightweight *real* device command (a
+  // small buffer fill), whose profiling timestamps do reflect completion of the
+  // preceding work.
+  //
+  // This relies on OpenCL command profiling, which is only available when the
+  // queue was created with CL_QUEUE_PROFILING_ENABLE. If profiling is not
+  // enabled we cannot honor the request and report it as unsupported so the
+  // caller can fall back.
+  auto Queue = cast(hQueue);
+
+  cl_command_queue_properties QueueProperties = 0;
+  CL_RETURN_ON_FAILURE(clGetCommandQueueInfo(
+      Queue->CLQueue, CL_QUEUE_PROPERTIES, sizeof(QueueProperties),
+      &QueueProperties, nullptr));
+  if (!(QueueProperties & CL_QUEUE_PROFILING_ENABLE))
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+  cl_mem Buffer = nullptr;
+  UR_RETURN_ON_FAILURE(Queue->Context->getTimestampRecordingBuffer(&Buffer));
+
+  std::vector<cl_event> CLWaitEvents(numEventsInWaitList);
+  for (uint32_t I = 0; I < numEventsInWaitList; I++)
+    CLWaitEvents[I] = cast(phEventWaitList[I])->CLEvent;
+
+  const cl_uint Pattern = 0;
+  cl_event Event = nullptr;
+  CL_RETURN_ON_FAILURE(clEnqueueFillBuffer(
+      Queue->CLQueue, Buffer, &Pattern, sizeof(Pattern), /*offset=*/0,
+      /*size=*/sizeof(Pattern), numEventsInWaitList, CLWaitEvents.data(),
+      ifUrEvent(phEvent, Event)));
+
+  UR_RETURN_ON_FAILURE(
+      createUREvent(Event, cast(Queue->Context), cast(Queue), phEvent));
+
+  if (Blocking)
+    CL_RETURN_ON_FAILURE(clFinish(Queue->CLQueue));
+
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL

--- a/unified-runtime/source/adapters/opencl/event.cpp
+++ b/unified-runtime/source/adapters/opencl/event.cpp
@@ -309,10 +309,52 @@ ur_result_t urEventSetCallback(ur_event_handle_t hEvent,
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
-                                           const ur_event_handle_t *,
-                                           ur_event_handle_t *) {
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ur_result_t urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, bool Blocking, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  // OpenCL has no native "record device timestamp" primitive. Some drivers
+  // (notably the Intel GPU driver) timestamp synchronization-only commands
+  // (barriers/markers) at the point they are inserted into the pipeline rather
+  // than when the preceding work actually completes, which breaks profiling-tag
+  // orderings (see https://github.com/intel/llvm/issues/22229). We therefore
+  // emulate a timestamp by enqueuing a lightweight *real* device command (a
+  // small buffer fill), whose profiling timestamps do reflect completion of the
+  // preceding work.
+  //
+  // This relies on OpenCL command profiling, which is only available when the
+  // queue was created with CL_QUEUE_PROFILING_ENABLE. If profiling is not
+  // enabled we cannot honor the request and report it as unsupported so the
+  // caller can fall back.
+  auto Queue = cast(hQueue);
+
+  cl_command_queue_properties QueueProperties = 0;
+  CL_RETURN_ON_FAILURE(clGetCommandQueueInfo(
+      Queue->CLQueue, CL_QUEUE_PROPERTIES, sizeof(QueueProperties),
+      &QueueProperties, nullptr));
+  if (!(QueueProperties & CL_QUEUE_PROFILING_ENABLE))
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+  cl_mem Buffer = nullptr;
+  UR_RETURN_ON_FAILURE(Queue->Context->getTimestampRecordingBuffer(&Buffer));
+
+  std::vector<cl_event> CLWaitEvents(numEventsInWaitList);
+  for (uint32_t I = 0; I < numEventsInWaitList; I++)
+    CLWaitEvents[I] = cast(phEventWaitList[I])->CLEvent;
+
+  const cl_uint Pattern = 0;
+  cl_event Event = nullptr;
+  CL_RETURN_ON_FAILURE(clEnqueueFillBuffer(
+      Queue->CLQueue, Buffer, &Pattern, sizeof(Pattern), /*offset=*/0,
+      /*size=*/sizeof(Pattern), numEventsInWaitList, CLWaitEvents.data(),
+      ifUrEvent(phEvent, Event)));
+
+  UR_RETURN_ON_FAILURE(
+      createUREvent(Event, cast(Queue->Context), cast(Queue), phEvent));
+
+  if (Blocking)
+    CL_RETURN_ON_FAILURE(clFinish(Queue->CLQueue));
+
+  return UR_RESULT_SUCCESS;
 }
 
 ur_result_t urEventCreateExp(ur_context_handle_t, ur_device_handle_t,

--- a/unified-runtime/source/adapters/opencl/event.cpp
+++ b/unified-runtime/source/adapters/opencl/event.cpp
@@ -340,12 +340,14 @@ ur_result_t urEnqueueTimestampRecordingExp(
   std::vector<cl_event> CLWaitEvents(numEventsInWaitList);
   for (uint32_t I = 0; I < numEventsInWaitList; I++)
     CLWaitEvents[I] = cast(phEventWaitList[I])->CLEvent;
+  const cl_event *CLWaitList =
+      numEventsInWaitList ? CLWaitEvents.data() : nullptr;
 
   const cl_uint Pattern = 0;
   cl_event Event = nullptr;
   CL_RETURN_ON_FAILURE(clEnqueueFillBuffer(
       Queue->CLQueue, Buffer, &Pattern, sizeof(Pattern), /*offset=*/0,
-      /*size=*/sizeof(Pattern), numEventsInWaitList, CLWaitEvents.data(),
+      /*size=*/sizeof(Pattern), numEventsInWaitList, CLWaitList,
       ifUrEvent(phEvent, Event)));
 
   UR_RETURN_ON_FAILURE(


### PR DESCRIPTION
Related to #22229.

`submit_profiling_tag` returned timestamps in the wrong order on `opencl:gpu`: the end tag's `command_end` could be earlier than the completion of work submitted before it, so `E2End <= EndTagEnd` failed and the e2e tests were masked with `UNSUPPORTED: opencl && gpu`.

## Why

OpenCL devices don't advertise `ext_oneapi_queue_profiling_tag` (the adapter hard-codes `UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP` to `false`), so the tag fell back to `ext_oneapi_submit_barrier()` and read its profiling info straight off the barrier event.

The NEO driver timestamps `clEnqueueBarrierWithWaitList` / `clEnqueueMarkerWithWaitList` when the command enters the pipeline, not when the preceding work completes. So the barrier's `CL_PROFILING_COMMAND_END` can be earlier than the end of a kernel enqueued before it.

I confirmed this with a small pure-OpenCL reproducer on Intel Iris Xe (NEO 26.05.037020): any synchronization-only tag (barrier/marker, empty or explicit wait list) fails 100% of the time, while any real device command (kernel or buffer fill) gives correct timestamps - including a fill into a
dedicated buffer, which is what this PR does.

## Changes

- `unified-runtime/.../opencl/event.cpp`: implement urEnqueueTimestampRecordingExp` using `clEnqueueFillBuffer` on a small internal buffer, whose timestamps do reflect completion of prior work. It needs command profiling, so if the queue isn't profiling-enabled we return `UR_RESULT_ERROR_UNSUPPORTED_FEATURE`.

- `unified-runtime/.../opencl/context.hpp`: lazily-created, thread-safe 4-byte buffer per context, released with the context. It's never read - only the fill command's timestamps are used.

- `sycl/.../scheduler/commands.cpp` (`CGType::ProfilingTag`): issue the recording with `call_nocheck` and fall back to a barrier on `UR_RESULT_ERROR_UNSUPPORTED_FEATURE`. Also addresses the existing `TODO` here.

- `sycl/.../experimental/profiling_tag.hpp`: when the device lacks the aspect but the queue has profiling enabled, submit a profiling-tag command group (reusing the scheduler's in-order/out-of-order marker+barrier handling) instead of a bare barrier.

The device aspect stays `false` for OpenCL: the emulation needs queue profiling, but the aspect promises the tag works without it. Enabling the aspect (e.g. via an internal profiling queue) is a possible follow-up.

Level Zero / CUDA / HIP are unaffected - they advertise the aspect and already implement the recording, so they never take the fallback branch. The scheduler change only adds the fallback branch and turns a throwing call into a checked one; the success path is unchanged.

## Testing

- Unit tests (`sycl/unittests/Extensions/ProfilingTag.cpp`): split the old fallback test into two - native recording used on a profiling queue without the aspect, and the barrier fallback when the backend reports the recording unsupported.

- E2E: dropped `UNSUPPORTED: opencl && gpu` from `ProfilingTag/in_order_profiling_queue.cpp` and `ProfilingTag profiling_queue.cpp`.

- The reproducer's dedicated-buffer fill (matching this implementation) passes 200/200 iterations on Intel Iris Xe, vs. the old barrier fallback failing 200/200.

## **The NEO timestamping behavior is arguably a driver bug worth reporting separately; this is a runtime workaround that doesn't touch the public API or other backends.**


_P.S. I may have gone a little overboard with the code comments. If anyone else feels the same way, I will clean them up._