### PR TITLE
[SYCL][Unit] Always build unittests with `-Werror`

### DIFF
--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -23,6 +23,13 @@ if (SYCL_CXX_SUPPORTS_INCONSISTENT_MISSING_OVERRIDE_FLAG)
   add_compile_options("-Wno-inconsistent-missing-override")
 endif()
 
+if (MSVC)
+  add_compile_options("/WX")
+else()
+  add_compile_options("-Werror")
+endif()
+
+
 string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type_lower)
 
 include(AddSYCLUnitTest)


### PR DESCRIPTION
This would help us catch us `-Werror` related errors in SYCL (like https://github.com/intel/llvm/pull/22642) in pre-commit.