### PR TITLE
[SYCL][NFC] Fix device_impl.hpp build warning -Wdeprecated-this-capture

### DIFF
--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -1512,7 +1512,7 @@ public:
       try {
         return std::any_of(
             std::begin(supported_archs), std::end(supported_archs),
-            [=](const arch a) { return this->extOneapiArchitectureIs(a); });
+            [this](const arch a) { return this->extOneapiArchitectureIs(a); });
       } catch (const sycl::exception &) {
         // If we're here it means the device does not support architecture
         // querying


### PR DESCRIPTION
Exposed by downstream commit c7ce9b53fb2c. Fix using explicit capture.
CMPLRLLVM-76943