### PR TITLE
Add exception header to ur_util.hpp

### DIFF
--- a/unified-runtime/source/common/ur_util.hpp
+++ b/unified-runtime/source/common/ur_util.hpp
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
  */
-
+#include <exception>
 #include <algorithm>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
`ur_util.hpp` uses `std::exception_ptr` by value in `exceptionToResult()`, but only relies on a forward declaration transitively pulled in by another header. With this libc++/std combination, that transitive include of the full `<exception>` header no longer happens, so the type is incomplete at the point of use.

### Fix
Add an explicit `#include <exception>` to `unified-runtime/source/common/ur_util.hpp` so `std::exception_ptr` is fully defined regardless of what other headers happen to pull in transitively.

### Testing
Confirmed `ur_common` builds successfully with `clang++ -std=c++26` against the custom libc++ from LLVM upstream after the change.