### PR TITLE
Fix errorTo function signature with unused attribute

### DIFF
--- a/sycl-jit/jit-compiler/lib/helper/ErrorHelper.h
+++ b/sycl-jit/jit-compiler/lib/helper/ErrorHelper.h
@@ -16,7 +16,7 @@ namespace jit_compiler {
 std::string formatError(llvm::Error &&Err, const std::string &Msg);
 
 template <typename ResultType, typename... ExtraArgTypes>
-static ResultType errorTo(llvm::Error &&Err, const std::string &Msg,
+[[maybe_unused]] static ResultType errorTo(llvm::Error &&Err, const std::string &Msg,
                           ExtraArgTypes... ExtraArgs) {
   // Cannot throw an exception here if LLVM itself is compiled without exception
   // support.


### PR DESCRIPTION
ErrorHelper.h:19:19: error: unused function template 'errorTo' [-Werror,-Wunused-template]

this fixes error