### PR TITLE
[UR][*SAN] Check device ptr before AllocExportableMemoryExp call

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -97,6 +97,11 @@ ur_result_t AsanInterceptor::allocateMemory(ur_context_handle_t Context,
                          Params.Pool ? Params.Pool : ContextInfo->getUSMPool(),
                          Type, &Allocated));
   } else {
+    // Check if the device is not NULL as AllocExportableMemoryExp requires it
+    if (!Device) {
+      return UR_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     UR_CALL(
         getContext()->urDdiTable.MemoryExportExp.pfnAllocExportableMemoryExp(
             Context, Device, Alignment, NeededSize, Params.HandleTypeToExport,

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -75,6 +75,11 @@ ur_result_t MsanInterceptor::allocateMemory(ur_context_handle_t Context,
     UR_CALL(SafeAllocate(Context, Device, Size, &NewProperties, Params.Pool,
                          Type, &Allocated));
   } else {
+    // Check if the device is not NULL as AllocExportableMemoryExp requires it
+    if (!Device) {
+      return UR_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     UR_CALL(
         getContext()->urDdiTable.MemoryExportExp.pfnAllocExportableMemoryExp(
             Context, Device, Alignment, Size, Params.HandleTypeToExport,


### PR DESCRIPTION
Check device ptr before AllocExportableMemoryExp call.
This is a fix for Coverity CID 3591406 and 3591410 