### PR TITLE
[SYCL][Driver] Do not pass libsycl.so to host linker

### DIFF
--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -895,10 +895,6 @@ void Linux::addOffloadRTLibs(unsigned ActiveKinds, const ArgList &Args,
   llvm::SmallVector<std::pair<StringRef, StringRef>> Libraries;
   if (ActiveKinds & Action::OFK_HIP)
     Libraries.emplace_back(RocmInstallation->getLibPath(), "libamdhip64.so");
-  else if ((ActiveKinds & Action::OFK_SYCL) &&
-           !Args.hasArg(options::OPT_nolibsycl))
-    Libraries.emplace_back(SYCLInstallation->getSYCLRTLibPath(),
-                           "libsycl.so");
 
   for (auto [Path, Library] : Libraries) {
     if (Args.hasFlag(options::OPT_frtlib_add_rpath,

--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -29,13 +29,13 @@
 // CHK-DEVICE-TRIPLE-SAME: "-O2"
 // CHK-DEVICE-TRIPLE: llvm-offload-binary{{.*}} "--image=file={{.*}}.bc,triple=spir64-unknown-unknown,arch=generic,kind=sycl{{.*}}"
 
-// Check if path to libsycl.so is passed to clang-linker-wrapper tool by default for SYCL compilation.
+// Check that path to libsycl.so is not passed to clang-linker-wrapper tool by default for SYCL compilation, but that -lsycl is.
 // The test also checks if SYCL header include paths are added to the SYCL host and device compilation.
 // INTEL-RUN: %clang --offload-new-driver --sysroot=%S/Inputs/SYCL -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
+// RUN:   | FileCheck -implicit-check-not="libsycl.so" -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
 // CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
 // CHECK-SYCL-HEADERS-HOST: "-fsycl-is-host"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
-// CHECK-LSYCL: clang-linker-wrapper{{.*}} "{{.*}}libsycl.so"
+// CHECK-LSYCL: "-lsycl"
 // Check that -fsycl -fno-sycl does not pass libsycl.so to the linker.
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl -fno-sycl %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-RT %s


### PR DESCRIPTION
In previous compiler releases, we linked against `libsycl.so` just with
```
-L<dir>bin/../lib ... -lsycl ... 
```
Starting with upstream commit https://github.com/llvm/llvm-project/pull/174877, we added what should be a path to `libsycl.so`, resulting in the following in intel/llvm:

```
-L<dir>bin/../lib ... <dir>/bin/../lib/libsycl.so ... -lsycl ... 
```

So we do the same thing twice. Note we only do the `-lsycl` part in intel/llvm, that does not exist upstream.

We have a bug report (CMPLRLLVM-76960) where the path resolution is failing, we compute an empty path, so we end up trying to link a bare `libsycl.so` with no path, which fails.

Of course we should fix this, but I think the best solution is:
1) We revert the failing upstream behavior temporarily and return to the old 
```
-L<dir>bin/../lib ... -lsycl ... 
```
which has been working fine for years.

2) Separately, debug the failing `libsycl.so` path resolution and fix it

3) Remove the `-lsycl`  logic which exists in intel/llvm so that we match upstream and only use the path to `libsycl.so`, which upstream prefers.

I am not doing 2) and 3) in this PR because we just released intel/llvm release 7.0.0 and we are going to need 7.0.1 because of this issue, so I don't want to delay it. I also need to cherry pick this internally ASAP.

After this is merged and cherry picked I will work on steps 2 and 3.

I checked Windows and we do not have a similar issue, so this is the only fix required.
