### PR TITLE
[SYCL] reapproaching VS2026 guard for STL includes

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -249,12 +249,10 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
         auto *AuxInfo = Context.getAuxTargetInfo();
         if (!AuxInfo || !AuxInfo->getTriple().isWindowsMSVCEnvironment())
           return false;
+        if (!VD->isInStdNamespace())
+          return false;
         const IdentifierInfo *Id = VD->getIdentifier();
         if (!Id)
-          return false;
-        const auto *NS =
-            dyn_cast<NamespaceDecl>(VD->getDeclContext()->getRedeclContext());
-        if (!NS || !NS->getIdentifier() || NS->getName() != "std")
           return false;
         return llvm::StringSwitch<bool>(Id->getName())
             .Case("__isa_available", true)

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -237,6 +237,29 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
           ExprEvalContexts.empty() ||
           (!isUnevaluatedContext() && !isConstantEvaluatedContext());
       bool IsEsimdPrivateGlobal = SYCL().isSYCLEsimdPrivateGlobal(VD);
+      // Allowlist reads of specific MSVC STL runtime globals from device
+      // code. The MSVC STL reads globals like `std::__isa_available` from
+      // inline functions in <bit>, <vector>, <complex>, etc., which get
+      // pulled into SYCL device TUs. Without this exception, the
+      // non-const-global check below would reject those reads. SYCL's
+      // stl_wrappers provide device-side definitions of these globals.
+      // Mirrors the `isMsvcMathFn` allowlist below, which does the same for
+      // MSVC STL runtime function calls.
+      auto isMsvcSTLGlobalVar = [&](const VarDecl *VD) {
+        auto *AuxInfo = Context.getAuxTargetInfo();
+        if (!AuxInfo || !AuxInfo->getTriple().isWindowsMSVCEnvironment())
+          return false;
+        const IdentifierInfo *Id = VD->getIdentifier();
+        if (!Id)
+          return false;
+        const auto *NS =
+            dyn_cast<NamespaceDecl>(VD->getDeclContext()->getRedeclContext());
+        if (!NS || !NS->getIdentifier() || NS->getName() != "std")
+          return false;
+        return llvm::StringSwitch<bool>(Id->getName())
+            .Case("__isa_available", true)
+            .Default(false);
+      };
       // Non-const statics are not allowed in SYCL except for ESIMD or with the
       // SYCLGlobalVar or SYCLGlobalVariableAllowed attribute.
       if (IsRuntimeEvaluated && !IsEsimdPrivateGlobal && !IsConst &&
@@ -255,7 +278,8 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
                !SemaSYCL::isTypeDecoratedWithDeclAttribute<
                    SYCLGlobalVariableAllowedAttr>(VD->getType()) &&
                !SemaSYCL::isTypeDecoratedWithDeclAttribute<SYCLScopeAttr>(
-                   VD->getType()))
+                   VD->getType()) &&
+               !isMsvcSTLGlobalVar(VD))
         SYCL().DiagIfDeviceCode(*Locs.begin(), diag::err_sycl_restrict)
             << SemaSYCL::KernelGlobalVariable;
       // ESIMD globals cannot be used in a SYCL context.

--- a/clang/test/SemaSYCL/msvc-isa-available-allowlist.cpp
+++ b/clang/test/SemaSYCL/msvc-isa-available-allowlist.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-windows \
+// RUN:   -aux-triple x86_64-pc-windows-msvc -fsyntax-only -verify %s
+
+// The SYCL device pass rejects reads of non-const globals from kernels
+// via err_sycl_restrict / KernelGlobalVariable. `std::__isa_available` is
+// exempted by the isMsvcSTLGlobalVar allowlist in Sema so that MSVC STL
+// headers (e.g. <bit>) that read this global from inline functions
+// compile under SYCL device mode. This test verifies the allowlist
+// permits the read. We have a different test to verify the
+// stl_wrappers shim survives -E round-trip.
+
+// expected-no-diagnostics
+
+#include "Inputs/sycl.hpp"
+
+namespace std {
+extern "C" {
+inline int __isa_available = 0;
+}
+} // namespace std
+
+// A read of another non-const std:: global — not on the allowlist — must
+// still be rejected, so we don't accidentally exempt everything in std.
+
+int test() {
+  sycl::kernel_single_task<class kernel_read_isa_available>([=]() {
+    (void)std::__isa_available; // ok — allowlisted
+  });
+  return 0;
+}

--- a/clang/test/SemaSYCL/msvc-isa-available-allowlist.cpp
+++ b/clang/test/SemaSYCL/msvc-isa-available-allowlist.cpp
@@ -1,17 +1,15 @@
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-windows \
 // RUN:   -aux-triple x86_64-pc-windows-msvc -fsyntax-only -verify %s
 
-// The SYCL device pass rejects reads of non-const globals from kernels
-// via err_sycl_restrict / KernelGlobalVariable. `std::__isa_available` is
-// exempted by the isMsvcSTLGlobalVar allowlist in Sema so that MSVC STL
-// headers (e.g. <bit>) that read this global from inline functions
-// compile under SYCL device mode. This test verifies the allowlist
-// permits the read. We have a different test to verify the
-// stl_wrappers shim survives -E round-trip.
-
 // expected-no-diagnostics
 
-#include "Inputs/sycl.hpp"
+// The SYCL device pass rejects reads of non-const globals from device
+// code via err_sycl_restrict / KernelGlobalVariable. `std::__isa_available`
+// is exempted by the isMsvcSTLGlobalVar allowlist in Sema so that MSVC STL
+// headers (e.g. <bit>) that read this global from inline functions compile
+// under SYCL device mode. This test verifies the allowlist permits the
+// read. A separate regression test verifies the stl_wrappers shim
+// survives -E round-trip.
 
 namespace std {
 extern "C" {
@@ -19,12 +17,6 @@ inline int __isa_available = 0;
 }
 } // namespace std
 
-// A read of another non-const std:: global — not on the allowlist — must
-// still be rejected, so we don't accidentally exempt everything in std.
-
-int test() {
-  sycl::kernel_single_task<class kernel_read_isa_available>([=]() {
-    (void)std::__isa_available; // ok — allowlisted
-  });
-  return 0;
+__attribute__((sycl_device)) void kern() {
+  (void)std::__isa_available; // ok — allowlisted
 }

--- a/sycl/include/sycl/stl_wrappers/__msvc_bit_utils.hpp
+++ b/sycl/include/sycl/stl_wrappers/__msvc_bit_utils.hpp
@@ -29,7 +29,10 @@
 #if defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
 namespace std {
 extern "C" {
-int __isa_available = 0;
+// `inline` makes the definition ODR-safe: this header may be included by
+// several device TUs that are later device-linked into one image, and the
+// C++17 inline-variable rule tells the linker to keep exactly one copy.
+inline int __isa_available = 0;
 }
 } // namespace std
 #endif // defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)

--- a/sycl/include/sycl/stl_wrappers/__msvc_bit_utils.hpp
+++ b/sycl/include/sycl/stl_wrappers/__msvc_bit_utils.hpp
@@ -8,12 +8,6 @@
 
 #pragma once
 
-// Mark this header as a system header so the `sycl_global_var` attribute
-// below is accepted.
-#ifdef __clang__
-#pragma clang system_header
-#endif
-
 // VS2026 MSVC STL's <__msvc_bit_utils.hpp> declares `__isa_available` (a
 // runtime CPU-feature global) and other STL headers (<bit>, <vector>,
 // <numeric>, <bitset>, <complex>, <__msvc_int128.hpp>) include this header
@@ -26,14 +20,16 @@
 // reality (no x86 ISA), and selects the STL's scalar fallback paths if the
 // dispatches are ever reached.
 //
+// Reads of `std::__isa_available` from device code are permitted by a
+// named-symbol allowlist in clang's SemaExpr (see `isMsvcSTLGlobalVar`),
+// so no per-decl attribute is needed here.
+//
 // Mirror the source structure of MSVC STL's __msvc_bit_utils.hpp, which
-// declares the symbol inside `namespace std { extern "C" { ... } }`. The
-// `extern "C"` makes namespace placement linkage-neutral, but matching the
-// MSVC source layout keeps this wrapper visually aligned with what it shadows.
+// declares the symbol inside `namespace std { extern "C" { ... } }`.
 #if defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
 namespace std {
 extern "C" {
-int __isa_available __attribute__((sycl_global_var)) __attribute__((weak)) = 0;
+int __isa_available = 0;
 }
 } // namespace std
 #endif // defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)

--- a/sycl/test/regression/msvc_bit_utils_wrapper_preprocess_roundtrip.cpp
+++ b/sycl/test/regression/msvc_bit_utils_wrapper_preprocess_roundtrip.cpp
@@ -1,0 +1,18 @@
+// The stl_wrappers/__msvc_bit_utils.hpp shim provides a device-side
+// definition of `std::__isa_available`. An earlier revision decorated that
+// definition with `sycl_global_var` and gated the header with
+// `#pragma clang system_header`. That combination did not survive a
+// `-E` preprocess / recompile round-trip on MSVC targets: MSVC-style
+// `#line` directives emitted by `-E` do not carry the system-header flag,
+// so on the second parse the definition landed outside a system header and
+// Sema rejected it with:
+//   'sycl_global_var' attribute only supported within a system header
+// This test verifies the round-trip works — preprocess to a `.ii`, then
+// compile the `.ii`.
+//
+// RUN: %clangxx -fsycl -fsycl-device-only \
+// RUN:   -U_MSC_VER -D_MSC_VER=1900 -Wno-macro-redefined \
+// RUN:   -include %sycl_include/sycl/stl_wrappers/__msvc_bit_utils.hpp \
+// RUN:   -E -x c++ %s -o %t.ii
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only \
+// RUN:   -Wno-macro-redefined %t.ii


### PR DESCRIPTION
Our fix for VS2026 was being guarded by `sycl_global_var` so as to not trigger "non const global in device code" warnings. But that doesn't work when preprocessing ( `-E` flag), so now we are adjusting the guard to be closer to where the diagnostic is actually generated. This is is more straightforward, less magical, and exactly the same mechanism that is already used  (`isMsvcMathFn`).  