### PR TITLE
[SYCL][NFC] Move OpenCL macro defines under `__SYCL_IGC_COMPILER__` guard

### DIFF
--- a/sycl/include/sycl/detail/backend_traits_opencl.hpp
+++ b/sycl/include/sycl/detail/backend_traits_opencl.hpp
@@ -133,7 +133,7 @@ template <> struct BackendReturn<backend::opencl, kernel> {
 using graph = ext::oneapi::experimental::command_graph<
     ext::oneapi::experimental::graph_state::executable>;
 template <> struct BackendReturn<backend::opencl, graph> {
-  using type = cl_command_buffer_khr;
+  using type = OpenCLExtCommandBufferKHRT;
 };
 
 template <> struct InteropFeatureSupportMap<backend::opencl> {

--- a/sycl/include/sycl/detail/backend_traits_opencl.hpp
+++ b/sycl/include/sycl/detail/backend_traits_opencl.hpp
@@ -133,11 +133,6 @@ template <> struct BackendReturn<backend::opencl, kernel> {
 using graph = ext::oneapi::experimental::command_graph<
     ext::oneapi::experimental::graph_state::executable>;
 template <> struct BackendReturn<backend::opencl, graph> {
-#ifndef cl_khr_command_buffer
-  // Old cl_ext.h OpenCL-Header files might not have the command-buffer
-  // extension defined.
-  typedef struct _cl_command_buffer_khr *cl_command_buffer_khr;
-#endif
   using type = cl_command_buffer_khr;
 };
 

--- a/sycl/include/sycl/detail/cl.h
+++ b/sycl/include/sycl/detail/cl.h
@@ -9,23 +9,19 @@
 #pragma once
 #include <sycl/detail/ur.hpp>
 
-// Suppress a compiler message about undefined CL_TARGET_OPENCL_VERSION
-// and define all symbols up to OpenCL 3.0
-#ifndef CL_TARGET_OPENCL_VERSION
-#define CL_TARGET_OPENCL_VERSION 300
-#endif
-
-// Include symbols for beta extensions
-#ifndef CL_ENABLE_BETA_EXTENSIONS
-#define CL_ENABLE_BETA_EXTENSIONS
-#endif
-
 // FIXME: Drop OpenCL headers from both host and device.
 // Can not do that under preview breaking changes, because
 // SYCL CTS use -fpreview-breaking-changes and rely on
 // SYCL headers to include OpenCL headers. We need to fix
 // such tests before we can drop OpenCL headers.
 #ifndef __SYCL_IGC_COMPILER__
+
+// Include symbols for beta extensions.
+// Required for _cl_command_buffer_khr.
+#ifndef CL_ENABLE_BETA_EXTENSIONS
+#define CL_ENABLE_BETA_EXTENSIONS
+#endif
+
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
 #else
@@ -42,6 +38,7 @@ typedef struct _cl_mem *cl_mem;
 typedef struct _cl_platform_id *cl_platform_id;
 typedef struct _cl_program *cl_program;
 typedef struct _cl_sampler *cl_sampler;
+typedef struct _cl_command_buffer_khr *cl_command_buffer_khr;
 #endif
 
 namespace sycl {

--- a/sycl/include/sycl/detail/cl.h
+++ b/sycl/include/sycl/detail/cl.h
@@ -16,6 +16,12 @@
 // such tests before we can drop OpenCL headers.
 #ifndef __SYCL_IGC_COMPILER__
 
+// Pin the OpenCL API version, otherwise CL/cl_version.h emits a #pragma
+// message and defaults to 3.0 anyway.
+#ifndef CL_TARGET_OPENCL_VERSION
+#define CL_TARGET_OPENCL_VERSION 300
+#endif
+
 // Include symbols for beta extensions.
 // Required for _cl_command_buffer_khr.
 #ifndef CL_ENABLE_BETA_EXTENSIONS
@@ -38,6 +44,11 @@ typedef struct _cl_mem *cl_mem;
 typedef struct _cl_platform_id *cl_platform_id;
 typedef struct _cl_program *cl_program;
 typedef struct _cl_sampler *cl_sampler;
+#endif
+
+// Old cl_ext.h OpenCL-Header files might not have the command-buffer
+// extension defined.
+#ifndef cl_khr_command_buffer
 typedef struct _cl_command_buffer_khr *cl_command_buffer_khr;
 #endif
 
@@ -52,6 +63,7 @@ using OpenCLMemT = cl_mem;
 using OpenCLPlatformT = cl_platform_id;
 using OpenCLProgramT = cl_program;
 using OpenCLSamplerT = cl_sampler;
+using OpenCLExtCommandBufferKHRT = cl_command_buffer_khr;
 
 namespace detail {
 #ifdef __SYCL_DEVICE_ONLY__


### PR DESCRIPTION
Don't define OpenCL macro if `__SYCL_IGC_COMPILER__` is used as in that case, users should include OpenCL headers explicitly so they should define these macros if needed.