### PR TITLE
[UR][TSAN] Check device ptr before AllocExportableMemoryExp call

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_interceptor.cpp
@@ -143,6 +143,11 @@ ur_result_t TsanInterceptor::allocateMemory(ur_context_handle_t Context,
     UR_CALL(SafeAllocate(Context, Device, Size, Params.USMDesc, Params.Pool,
                          Type, &Allocated));
   } else {
+    // Check if the device is not NULL as AllocExportableMemoryExp requires it
+    if (!Device) {
+      return UR_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     UR_CALL(
         getContext()->urDdiTable.MemoryExportExp.pfnAllocExportableMemoryExp(
             Context, Device, Params.Alignment, Size, Params.HandleTypeToExport,


### PR DESCRIPTION
Check device ptr before AllocExportableMemoryExp call

This PR is a continuation of https://github.com/intel/llvm/pull/22652, where the TSAN fix was missed. 