### PR TITLE
[SYCL] Remove unused _PreviewBreakingChanges param from wrapSYCLBinaries

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -12334,12 +12334,6 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
-  // Enable preview breaking changes in clang-linker-wrapper,
-  // in case it needs to introduce any ABI breaking changes.
-  // For example, changes in offload binary descriptor format.
-  if (Args.hasArg(options::OPT_fpreview_breaking_changes))
-    CmdArgs.push_back("-fpreview-breaking-changes");
-
   // Propagate -no-canonical-prefixes.
   if (Args.hasArg(options::OPT_no_canonical_prefixes))
     CmdArgs.push_back("--no-canonical-prefixes");

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1183,9 +1183,8 @@ wrapSYCLBinariesFromFile(ArrayRef<module_split::SplitModule> SplitModules,
   M.setTargetTriple(Triple(
       Args.getLastArgValue(OPT_host_triple_EQ, sys::getDefaultTargetTriple())));
 
-  if (Error E = offloading::wrapSYCLBinaries(
-          M, Images, offloading::SYCLWrappingOptions(),
-          Args.hasArg(OPT_preview_breaking_changes)))
+  if (Error E = offloading::wrapSYCLBinaries(M, Images,
+                                             offloading::SYCLWrappingOptions()))
     return E;
 
   if (Args.hasArg(OPT_print_wrapped_module))

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -77,10 +77,6 @@ def should_extract : CommaJoined<["--"], "should-extract=">,
   Flags<[WrapperOnlyOption]>, MetaVarName<"<kind=file>">,
   HelpText<"Set of device architectures we should always extract if found.">;
 
-def preview_breaking_changes : Flag<["-"], "fpreview-breaking-changes">,
-  Flags<[WrapperOnlyOption]>,
-  HelpText<"Enables preview of breaking changes in the wrapper">;
-
 def emit_fatbin_only
     : Flag<["--"], "emit-fatbin-only">,
       Flags<[WrapperOnlyOption]>,

--- a/llvm/include/llvm/Frontend/Offloading/SYCLOffloadWrapper.h
+++ b/llvm/include/llvm/Frontend/Offloading/SYCLOffloadWrapper.h
@@ -71,13 +71,10 @@ struct SYCLWrappingOptions {
 /// Wraps the input bundled images and accompanied data into the module \p M
 /// as global symbols and registers the images with the SYCL Runtime.
 /// \param Options Settings that allows to turn on optional data and settings.
-/// \param _PreviewBreakingChanges Enable preview breaking changes that are not
-///        backward compatible with the existing SYCL Runtime.
 /// \returns Error if wrapping fails, success otherwise.
 llvm::Error
 wrapSYCLBinaries(llvm::Module &M, const llvm::SmallVector<SYCLImage> &Images,
-                 SYCLWrappingOptions Options = SYCLWrappingOptions(),
-                 bool _PreviewBreakingChanges = false);
+                 SYCLWrappingOptions Options = SYCLWrappingOptions());
 
 } // namespace offloading
 } // namespace llvm

--- a/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
+++ b/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
@@ -46,9 +46,6 @@ using namespace llvm::util;
 
 namespace {
 
-/// Enable preview breaking changes.
-static bool PreviewBreakingChanges = false;
-
 /// Note: Returned values are a part of ABI. If you want to change them
 /// then coordinate it with SYCL Runtime.
 int8_t binaryImageFormatToInt8(SYCLBinaryImageFormat Format) {
@@ -774,9 +771,7 @@ struct Wrapper {
 
 Error llvm::offloading::wrapSYCLBinaries(llvm::Module &M,
                                          const SmallVector<SYCLImage> &Images,
-                                         SYCLWrappingOptions Options,
-                                         bool _PreviewBreakingChanges) {
-  PreviewBreakingChanges = _PreviewBreakingChanges;
+                                         SYCLWrappingOptions Options) {
   Wrapper W(M, Options);
   GlobalVariable *Desc = W.createFatbinDesc(Images);
   if (!Desc)


### PR DESCRIPTION
Remove unused _PreviewBreakingChanges parameter from wrapSYCLBinaries

The change removes the _PreviewBreakingChanges bool parameter (and the file-scoped PreviewBreakingChanges static) from wrapSYCLBinaries and its sole caller. The value was stored but never read.