### PR TITLE
[SYCL][NewOffloadModel] Fix -Xdevice-post-link, -Xspirv-translator and -Xspirv-to-ir-wrapper

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -12085,15 +12085,12 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     };
     // --sycl-post-link-options="options" provides a string of options to be
     // passed along to the sycl-post-link tool during device link.
+    // Xdevice-post-link is processed separately later.
     SmallString<128> PostLinkOptString;
     ArgStringList PostLinkArgs;
     getNonTripleBasedSYCLPostLinkOpts(getToolChain(), JA, Args, PostLinkArgs);
     for (const auto &A : PostLinkArgs)
       appendOption(PostLinkOptString, A);
-    if (Args.hasArg(options::OPT_Xdevice_post_link)) {
-      for (const auto &A : Args.getAllArgValues(options::OPT_Xdevice_post_link))
-        appendOption(PostLinkOptString, A);
-    }
     if (!PostLinkOptString.empty())
       CmdArgs.push_back(
           Args.MakeArgString("--sycl-post-link-options=" + PostLinkOptString));
@@ -12117,11 +12114,8 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
     // --llvm-spirv-options="options" provides a string of options to be passed
     // along to the llvm-spirv (translation) step during device link.
+    // -Xspirv-translator is processed separately later.
     SmallString<128> OptString;
-    if (Args.hasArg(options::OPT_Xspirv_translator)) {
-      for (const auto &A : Args.getAllArgValues(options::OPT_Xspirv_translator))
-        appendOption(OptString, A);
-    }
     ArgStringList TranslatorArgs;
     getNonTripleBasedSPIRVTransOpts(C, Args, TranslatorArgs);
     for (const auto &A : TranslatorArgs)
@@ -12178,10 +12172,16 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back(
           Args.MakeArgString("-sycl-allow-device-image-dependencies"));
 
-    // Pass backend compiler and linker options specified at link time to
-    // clang-linker-wrapper. Link-time options passed via -Xsycl-target-backend
-    // are forwarded using --device-compiler, while options passed via
-    // -Xsycl-target-linker are forwarded using --device-linker.
+    // Pass backend compiler, linker options, sycl-post-link options,
+    // llvm-spirv options and spirv-to-ir-wrapper options specified at link
+    // time to clang-linker-wrapper. Link-time options passed via
+    // -Xsycl-target-backend are forwarded using --device-compiler, options
+    // passed via -Xsycl-target-linker are forwarded using --device-linker,
+    // options passed via -Xdevice-post-link are forwarded using
+    // --sycl-post-link-options, options passed via -Xspirv-translator are
+    // forwarded using --llvm-spirv-options, and options passed via
+    // -Xspirv-to-ir-wrapper are forwarded using
+    // --spirv-to-ir-wrapper-options.
     const toolchains::SYCLToolChain &SYCLTC =
         static_cast<const toolchains::SYCLToolChain &>(getToolChain());
     for (auto &ToolChainMember :
@@ -12217,6 +12217,45 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
             "--device-linker=" + Action::GetOffloadKindName(Action::OFK_SYCL) +
             ":" + TC->getTripleString() + "=" + LinkOptString));
       }
+
+      BuildArgs.clear();
+      SmallString<128> PostLinkOptString;
+      SYCLTC.TranslateTargetOpt(
+          TC->getTriple(), Args, BuildArgs, options::OPT_Xdevice_post_link,
+          options::OPT_Xdevice_post_link_EQ, /*Device=*/StringRef());
+      for (const auto &A : BuildArgs)
+        appendOption(PostLinkOptString, A);
+      if (!PostLinkOptString.empty())
+        CmdArgs.push_back(Args.MakeArgString(
+            "--sycl-post-link-options=" +
+            Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +
+            TC->getTripleString() + "=" + PostLinkOptString));
+
+      BuildArgs.clear();
+      SmallString<128> TransOptString;
+      SYCLTC.TranslateTargetOpt(
+          TC->getTriple(), Args, BuildArgs, options::OPT_Xspirv_translator,
+          options::OPT_Xspirv_translator_EQ, /*Device=*/StringRef());
+      for (const auto &A : BuildArgs)
+        appendOption(TransOptString, A);
+      if (!TransOptString.empty())
+        CmdArgs.push_back(Args.MakeArgString(
+            "--llvm-spirv-options=" +
+            Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +
+            TC->getTripleString() + "=" + TransOptString));
+
+      BuildArgs.clear();
+      SmallString<128> SpirvToIrOptString;
+      SYCLTC.TranslateTargetOpt(
+          TC->getTriple(), Args, BuildArgs, options::OPT_Xspirv_to_ir_wrapper,
+          options::OPT_Xspirv_to_ir_wrapper_EQ, /*Device=*/StringRef());
+      for (const auto &A : BuildArgs)
+        appendOption(SpirvToIrOptString, A);
+      if (!SpirvToIrOptString.empty())
+        CmdArgs.push_back(Args.MakeArgString(
+            "--spirv-to-ir-wrapper-options=" +
+            Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +
+            TC->getTripleString() + "=" + SpirvToIrOptString));
     }
 
     // Add option to enable creating of the .syclbin file.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -12100,7 +12100,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     };
     // --sycl-post-link-options="options" provides a string of options to be
     // passed along to the sycl-post-link tool during device link.
-    // Xdevice-post-link is processed separately later.
+    // -Xdevice-post-link is processed separately later.
     SmallString<128> PostLinkOptString;
     ArgStringList PostLinkArgs;
     getNonTripleBasedSYCLPostLinkOpts(getToolChain(), JA, Args, PostLinkArgs);
@@ -12187,16 +12187,14 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back(
           Args.MakeArgString("-sycl-allow-device-image-dependencies"));
 
-    // Pass backend compiler, linker options, sycl-post-link options,
-    // llvm-spirv options and spirv-to-ir-wrapper options specified at link
-    // time to clang-linker-wrapper. Link-time options passed via
-    // -Xsycl-target-backend are forwarded using --device-compiler, options
-    // passed via -Xsycl-target-linker are forwarded using --device-linker,
-    // options passed via -Xdevice-post-link are forwarded using
-    // --sycl-post-link-options, options passed via -Xspirv-translator are
-    // forwarded using --llvm-spirv-options, and options passed via
-    // -Xspirv-to-ir-wrapper are forwarded using
-    // --spirv-to-ir-wrapper-options.
+    // Pass backend compiler, linker, sycl-post-link,
+    // llvm-spirv, and spirv-to-ir-wrapper options specified at link
+    // time to clang-linker-wrapper, using the following mapping:
+    // -Xsycl-target-backend  -> --device-compiler
+    // -Xsycl-target-linker -> --device-linker
+    // -Xdevice-post-link -> --sycl-post-link-options
+    // -Xspirv-translator -> --llvm-spirv-options
+    // -Xspirv-to-ir-wrapper -> --spirv-to-ir-wrapper-options.
     const toolchains::SYCLToolChain &SYCLTC =
         static_cast<const toolchains::SYCLToolChain &>(getToolChain());
     for (auto &ToolChainMember :
@@ -12220,17 +12218,17 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
             ":" + TC->getTripleString() + "=" + A));
 
       BuildArgs.clear();
-      SmallString<128> PostLinkOptString;
+      SmallString<128> PerTargetPostLinkOptString;
       SYCLTC.TranslateTargetOpt(
           TC->getTriple(), Args, BuildArgs, options::OPT_Xdevice_post_link,
           options::OPT_Xdevice_post_link_EQ, /*Device=*/StringRef());
       for (const auto &A : BuildArgs)
-        appendOption(PostLinkOptString, A);
-      if (!PostLinkOptString.empty())
+        appendOption(PerTargetPostLinkOptString, A);
+      if (!PerTargetPostLinkOptString.empty())
         CmdArgs.push_back(Args.MakeArgString(
             "--sycl-post-link-options=" +
             Action::GetOffloadKindName(Action::OFK_SYCL) + ":" +
-            TC->getTripleString() + "=" + PostLinkOptString));
+            TC->getTripleString() + "=" + PerTargetPostLinkOptString));
 
       BuildArgs.clear();
       SmallString<128> TransOptString;

--- a/clang/test/Driver/sycl-device-post-link-opt.cpp
+++ b/clang/test/Driver/sycl-device-post-link-opt.cpp
@@ -8,11 +8,11 @@
 // RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xdevice-post-link=spir64_gen "foo" -### %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET-UNUSED --implicit-check-not 'sycl-post-link{{.*}} "foo"'
 
-// RUNx: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64,spir64_gen -Xdevice-post-link=spir64_gen "foo" -Xdevice-post-link=spir64 "bar" -### %s 2>&1 | \
-// RUNx:  FileCheck %s -check-prefix CHECK-MULTIPLE-TARGET --implicit-check-not 'sycl-post-link{{.*}} "foo" "bar"'
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64,spir64_gen -Xdevice-post-link=spir64_gen "foo" -Xdevice-post-link=spir64 "bar" -### %s 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-MULTIPLE-TARGET --implicit-check-not 'sycl-post-link{{.*}} "foo" "bar"'
 
 // CHECK-SINGLE-TARGET: clang-linker-wrapper{{.*}} {{.*}}--sycl-post-link-options={{.*}}foo{{.*}}
 
 // CHECK-SINGLE-TARGET-UNUSED: argument unused during compilation: '-Xdevice-post-link=spir64_gen foo'
 
-// CHECK-MULTIPLE-TARGET: clang-linker-wrapper{{.*}} {{.*}}--sycl-post-link-options={{.*}}foo{{.*}}bar{{.*}}
+// CHECK-MULTIPLE-TARGET: clang-linker-wrapper{{.*}} {{.*}}"--sycl-post-link-options=sycl:spir64-unknown-unknown=bar"{{.*}}"--sycl-post-link-options=sycl:spir64_gen-unknown-unknown=foo"

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -47,12 +47,12 @@
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -Xspirv-translator -translator-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_TRANSLATOR %s
-// WRAPPER_OPTIONS_TRANSLATOR: clang-linker-wrapper{{.*}} "--llvm-spirv-options={{.*}}-translator-opt{{.*}}"
+// WRAPPER_OPTIONS_TRANSLATOR: clang-linker-wrapper{{.*}} "--llvm-spirv-options=sycl:spir64-unknown-unknown=-translator-opt"
 
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -Xdevice-post-link -post-link-opt -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_POSTLINK %s
-// WRAPPER_OPTIONS_POSTLINK: clang-linker-wrapper{{.*}} "--sycl-post-link-options=-O2 -device-globals -post-link-opt"
+// WRAPPER_OPTIONS_POSTLINK: clang-linker-wrapper{{.*}} "--sycl-post-link-options=-O2 -device-globals"{{.*}} "--sycl-post-link-options=sycl:spir64-unknown-unknown=-post-link-opt"
 
 // -fsycl-device-only behavior
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \

--- a/clang/test/Driver/sycl-spirv-opt.cpp
+++ b/clang/test/Driver/sycl-spirv-opt.cpp
@@ -8,5 +8,9 @@
 // RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xspirv-translator=spir64_gen "foo" -### %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET-UNUSED --implicit-check-not 'llvm-spirv{{.*}} "foo"'
 
-// CHECK-SINGLE-TARGET: clang-linker-wrapper{{.*}} "--llvm-spirv-options=foo{{.*}}
+// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen --offload-new-driver --sysroot=%S/Inputs/SYCL -Xspirv-translator=spir64_gen "foo" -Xspirv-translator=spir64 "bar" -### %s 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-MULTIPLE-TARGET
+
+// CHECK-SINGLE-TARGET: clang-linker-wrapper{{.*}} "--llvm-spirv-options=sycl:spir64-unknown-unknown=foo{{.*}}
 // CHECK-SINGLE-TARGET-UNUSED: argument unused during compilation: '-Xspirv-translator=spir64_gen foo'
+// CHECK-MULTIPLE-TARGET: clang-linker-wrapper{{.*}} "--llvm-spirv-options=sycl:spir64-unknown-unknown=bar"{{.*}}"--llvm-spirv-options=sycl:spir64_gen-unknown-unknown=foo"

--- a/clang/test/Driver/sycl-spirv-to-ir-opt.cpp
+++ b/clang/test/Driver/sycl-spirv-to-ir-opt.cpp
@@ -1,0 +1,16 @@
+///
+/// Tests for -Xspirv-to-ir-wrapper
+///
+
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xspirv-to-ir-wrapper "foo" -### %s 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET
+
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -Xspirv-to-ir-wrapper=spir64_gen "foo" -### %s 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET-UNUSED --implicit-check-not 'spirv-to-ir-wrapper-options{{.*}}=foo'
+
+// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen --offload-new-driver --sysroot=%S/Inputs/SYCL -Xspirv-to-ir-wrapper=spir64_gen "foo" -Xspirv-to-ir-wrapper=spir64 "bar" -### %s 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-MULTIPLE-TARGET
+
+// CHECK-SINGLE-TARGET: clang-linker-wrapper{{.*}} "--spirv-to-ir-wrapper-options=sycl:spir64-unknown-unknown=foo{{.*}}
+// CHECK-SINGLE-TARGET-UNUSED: argument unused during compilation: '-Xspirv-to-ir-wrapper=spir64_gen foo'
+// CHECK-MULTIPLE-TARGET: clang-linker-wrapper{{.*}} "--spirv-to-ir-wrapper-options=sycl:spir64-unknown-unknown=bar"{{.*}}"--spirv-to-ir-wrapper-options=sycl:spir64_gen-unknown-unknown=foo"

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -622,6 +622,10 @@ static Expected<StringRef> convertSPIRVToIR(StringRef Filename,
   CmdArgs.push_back("--llvm-spirv-opts");
   CmdArgs.push_back("--spirv-preserve-auxdata --spirv-target-env=SPV-IR "
                     "--spirv-builtin-format=global");
+  for (const Arg *A : Args.filtered(OPT_spirv_to_ir_wrapper_arg_EQ)) {
+    StringRef(A->getValue())
+        .split(CmdArgs, " ", /* MaxSplit = */ -1, /* KeepEmpty = */ false);
+  }
   if (Error Err = executeCommands(*SPIRVToIRWrapperPath, CmdArgs))
     return std::move(Err);
   return *TempFileOrErr;
@@ -802,11 +806,10 @@ runSYCLPostLinkTool(ArrayRef<StringRef> InputFiles, const ArgList &Args,
     }
   }
   getTripleBasedSYCLPostLinkOpts(Args, CmdArgs, Triple);
-  StringRef SYCLPostLinkOptions;
-  if (Arg *A = Args.getLastArg(OPT_sycl_post_link_options_EQ))
-    SYCLPostLinkOptions = A->getValue();
-  SYCLPostLinkOptions.split(CmdArgs, " ", /* MaxSplit = */ -1,
-                            /* KeepEmpty = */ false);
+  for (const Arg *A : Args.filtered(OPT_sycl_post_link_arg_EQ)) {
+    StringRef(A->getValue())
+        .split(CmdArgs, " ", /* MaxSplit = */ -1, /* KeepEmpty = */ false);
+  }
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Args.MakeArgString(OutputPathWithArch));
   for (auto &File : InputFiles)
@@ -972,11 +975,10 @@ static Expected<StringRef> runLLVMToSPIRVTranslation(StringRef File,
   CmdArgs.push_back(*LLVMToSPIRVPath);
   const llvm::Triple Triple(Args.getLastArgValue(OPT_triple_EQ));
   getTripleBasedSPIRVTransOpts(Args, CmdArgs, Triple);
-  StringRef LLVMToSPIRVOptions;
-  if (Arg *A = Args.getLastArg(OPT_llvm_spirv_options_EQ))
-    LLVMToSPIRVOptions = A->getValue();
-  LLVMToSPIRVOptions.split(CmdArgs, " ", /* MaxSplit = */ -1,
-                           /* KeepEmpty = */ false);
+  for (const Arg *A : Args.filtered(OPT_llvm_spirv_arg_EQ)) {
+    StringRef(A->getValue())
+        .split(CmdArgs, " ", /* MaxSplit = */ -1, /* KeepEmpty = */ false);
+  }
   CmdArgs.push_back("-o");
 
   // Create a new file to write the translated file to.
@@ -2297,10 +2299,9 @@ DerivedArgList getLinkerArgs(ArrayRef<OffloadFile> Input,
   if (llvm::all_of(Input, ContainsBitcode))
     DAL.AddFlagArg(nullptr, Tbl.getOption(OPT_whole_program));
 
-  // This function filters the SYCL device compiler and linker options by target
-  // triple and offload kind.
-  // The device_linker_args and device_compiler_args options accept values
-  // in the form [<kind>:][<triple>=]<value>.
+  // This function filters the SYCL device compiler, linker, sycl-post-link,
+  // llvm-spirv and spirv-to-ir-wrapper options by target triple and offload
+  // kind. The options accept values in the form [<kind>:][<triple>=]<value>.
   // An example of passing such an option to clang-linker-wrapper is:
   // --device-compiler=sycl:spir64_gen-unknown-unknown=opt_val.
   const StringRef TripleStr = DAL.getLastArgValue(OPT_triple_EQ);
@@ -2334,6 +2335,10 @@ DerivedArgList getLinkerArgs(ArrayRef<OffloadFile> Input,
 
   ProcessDeviceArgs(OPT_device_linker_args_EQ, OPT_linker_arg_EQ);
   ProcessDeviceArgs(OPT_device_compiler_args_EQ, OPT_compiler_arg_EQ);
+  ProcessDeviceArgs(OPT_sycl_post_link_options_EQ, OPT_sycl_post_link_arg_EQ);
+  ProcessDeviceArgs(OPT_llvm_spirv_options_EQ, OPT_llvm_spirv_arg_EQ);
+  ProcessDeviceArgs(OPT_spirv_to_ir_wrapper_options_EQ,
+                    OPT_spirv_to_ir_wrapper_arg_EQ);
   return DAL;
 }
 

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -166,10 +166,15 @@ def sycl_device_library_location_EQ : Joined<["--", "-"],
   "sycl-device-library-location=">, Flags<[WrapperOnlyOption]>,
   HelpText<"Location of SYCL device library files">;
 
-// Special option to pass in sycl-post-link options
+// Special option to pass in sycl-post-link options. Accepts the
+// [<kind>:][<triple>=]<value> form so options can be scoped to a target; they
+// are filtered per-triple into -sycl-post-link-arg=.
 def sycl_post_link_options_EQ : Joined<["--", "-"], "sycl-post-link-options=">,
-  Flags<[WrapperOnlyOption]>,
+  Flags<[WrapperOnlyOption]>, MetaVarName<"[<kind>:][<triple>=]<value>">,
   HelpText<"Options that will control sycl-post-link step">;
+def sycl_post_link_arg_EQ : Joined<["--", "-"], "sycl-post-link-arg=">,
+  Flags<[DeviceOnlyOption, HelpHidden]>,
+  HelpText<"An extra argument to be passed to sycl-post-link">;
 
 def sycl_module_split_mode_EQ :
   Joined<["--", "-"], "sycl-module-split-mode=">,
@@ -185,10 +190,25 @@ def no_use_sycl_post_link_tool : Flag<["--", "-"], "no-use-sycl-post-link-tool">
   Flags<[WrapperOnlyOption]>,
   HelpText<"Use a SYCL library instead of sycl-post-link tool. (experimental)">;
 
-// Special option to pass in llvm-spirv options
+// Special option to pass in llvm-spirv options. Accepts the
+// [<kind>:][<triple>=]<value> form so options can be scoped to a target; they
+// are filtered per-triple into -llvm-spirv-arg=.
 def llvm_spirv_options_EQ : Joined<["--", "-"], "llvm-spirv-options=">,
-  Flags<[WrapperOnlyOption]>,
+  Flags<[WrapperOnlyOption]>, MetaVarName<"[<kind>:][<triple>=]<value>">,
   HelpText<"Options that will control llvm-spirv step">;
+def llvm_spirv_arg_EQ : Joined<["--", "-"], "llvm-spirv-arg=">,
+  Flags<[DeviceOnlyOption, HelpHidden]>,
+  HelpText<"An extra argument to be passed to llvm-spirv">;
+
+// Special option to pass in spirv-to-ir-wrapper options. Accepts the
+// [<kind>:][<triple>=]<value> form so options can be scoped to a target; they
+// are filtered per-triple into -spirv-to-ir-wrapper-arg=.
+def spirv_to_ir_wrapper_options_EQ : Joined<["--", "-"], "spirv-to-ir-wrapper-options=">,
+  Flags<[WrapperOnlyOption]>, MetaVarName<"[<kind>:][<triple>=]<value>">,
+  HelpText<"Options that will control spirv-to-ir-wrapper step">;
+def spirv_to_ir_wrapper_arg_EQ : Joined<["--", "-"], "spirv-to-ir-wrapper-arg=">,
+  Flags<[DeviceOnlyOption, HelpHidden]>,
+  HelpText<"An extra argument to be passed to spirv-to-ir-wrapper">;
 def sycl_is_windows_msvc_env : Flag<["--", "-"], "sycl-is-windows-msvc-env">,
   Flags<[WrapperOnlyOption, HelpHidden]>;
 

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -166,9 +166,6 @@ def sycl_device_library_location_EQ : Joined<["--", "-"],
   "sycl-device-library-location=">, Flags<[WrapperOnlyOption]>,
   HelpText<"Location of SYCL device library files">;
 
-// Special option to pass in sycl-post-link options. Accepts the
-// [<kind>:][<triple>=]<value> form so options can be scoped to a target; they
-// are filtered per-triple into -sycl-post-link-arg=.
 def sycl_post_link_options_EQ : Joined<["--", "-"], "sycl-post-link-options=">,
   Flags<[WrapperOnlyOption]>, MetaVarName<"[<kind>:][<triple>=]<value>">,
   HelpText<"Options that will control sycl-post-link step">;
@@ -190,9 +187,6 @@ def no_use_sycl_post_link_tool : Flag<["--", "-"], "no-use-sycl-post-link-tool">
   Flags<[WrapperOnlyOption]>,
   HelpText<"Use a SYCL library instead of sycl-post-link tool. (experimental)">;
 
-// Special option to pass in llvm-spirv options. Accepts the
-// [<kind>:][<triple>=]<value> form so options can be scoped to a target; they
-// are filtered per-triple into -llvm-spirv-arg=.
 def llvm_spirv_options_EQ : Joined<["--", "-"], "llvm-spirv-options=">,
   Flags<[WrapperOnlyOption]>, MetaVarName<"[<kind>:][<triple>=]<value>">,
   HelpText<"Options that will control llvm-spirv step">;
@@ -200,9 +194,6 @@ def llvm_spirv_arg_EQ : Joined<["--", "-"], "llvm-spirv-arg=">,
   Flags<[DeviceOnlyOption, HelpHidden]>,
   HelpText<"An extra argument to be passed to llvm-spirv">;
 
-// Special option to pass in spirv-to-ir-wrapper options. Accepts the
-// [<kind>:][<triple>=]<value> form so options can be scoped to a target; they
-// are filtered per-triple into -spirv-to-ir-wrapper-arg=.
 def spirv_to_ir_wrapper_options_EQ : Joined<["--", "-"], "spirv-to-ir-wrapper-options=">,
   Flags<[WrapperOnlyOption]>, MetaVarName<"[<kind>:][<triple>=]<value>">,
   HelpText<"Options that will control spirv-to-ir-wrapper step">;

--- a/sycl/test-e2e/Experimental/fp8/e4m3_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e4m3_cri_conversion.cpp
@@ -6,9 +6,6 @@
 // UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
 // SPIR-V backend does not support the required SPIR-V extensions
 
-// XFAIL: new-offload-model
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/22372
-
 #include <iostream>
 
 #include <cmath>

--- a/sycl/test-e2e/Experimental/fp8/e4m3_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e4m3_x2_cri_conversion.cpp
@@ -7,9 +7,6 @@
 // UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
 // SPIR-V backend does not support the required SPIR-V extensions
 
-// XFAIL: new-offload-model
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/22372
-
 #include <iostream>
 
 #include <cmath>

--- a/sycl/test-e2e/Experimental/fp8/e5m2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e5m2_cri_conversion.cpp
@@ -6,9 +6,6 @@
 // UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
 // SPIR-V backend does not support the required SPIR-V extensions
 
-// XFAIL: new-offload-model
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/22372
-
 #include <iostream>
 
 #include <cmath>

--- a/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
@@ -6,9 +6,6 @@
 // UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
 // SPIR-V backend does not support the required SPIR-V extensions
 
-// XFAIL: new-offload-model
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/22372
-
 #include <iostream>
 
 #include <cmath>

--- a/sycl/test-e2e/Experimental/fp8/e8m0_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e8m0_cri_conversion.cpp
@@ -7,9 +7,6 @@
 // UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
 // SPIR-V backend does not support the required SPIR-V extensions
 
-// XFAIL: new-offload-model
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/22372
-
 #include <iostream>
 
 #include <cmath>

--- a/sycl/test-e2e/Experimental/fp8/e8m0_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e8m0_x2_cri_conversion.cpp
@@ -7,9 +7,6 @@
 // UNSUPPORTED-INTENDED: only supported by backends with CRI driver, and the
 // SPIR-V backend does not support the required SPIR-V extensions
 
-// XFAIL: new-offload-model
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/22372
-
 #include <cmath>
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
We had some tests failing in the new offload model because they were doing:
```
-Xspirv-translator=spir64  ...
```

The `-Xspirv-translator=` form wasn't implemented, so implement it.

Also it seems no tests are doing it but we had the same problem with `-Xdevice-post-link=`, and `-Xspirv-to-ir-wrapper` wasn't implemented at all, so implement those too.

Closes: https://github.com/intel/llvm/issues/22372
CMPLRLLVM-76314
CMPLRLLVM-68973

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>