### PR TITLE
[SYCL] Fix AMD GPU architecture detection

### DIFF
--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -1979,7 +1979,7 @@ public:
           .value_or(ext::oneapi::experimental::architecture::unknown);
     } else if (is_gpu() && (backend::ext_oneapi_cuda == CurrentBackend ||
                             backend::ext_oneapi_hip == CurrentBackend)) {
-      auto MapArchIDToArchName = [&](const char *arch) {
+      auto MapArchIDToArchName = [&](std::string_view arch) {
         for (const auto &Item : NvidiaAmdGPUArchitectures) {
           if (std::string_view(Item.first) == arch)
             return Item.second;
@@ -1990,7 +1990,7 @@ public:
           get_info_impl<UrInfoCode<info::device::version>::value>();
       std::string_view DeviceArchSubstr =
           std::string_view{DeviceArch}.substr(0, DeviceArch.find(":"));
-      return MapArchIDToArchName(DeviceArchSubstr.data());
+      return MapArchIDToArchName(DeviceArchSubstr);
     } else if (is_cpu() && backend::opencl == CurrentBackend) {
       return LookupIPVersion(IntelCPUArchitectures)
           .value_or(ext::oneapi::experimental::architecture::x86_64);


### PR DESCRIPTION
get_architecture() stripped the feature-suffix (e.g. ":sramecc+:xnack-") from the device version string using string_view::substr, but then passed the view's .data() to a helper taking a const char*. Since .data() points into the original, non-truncated buffer, the lookup compared against the full "gfx942:sramecc+:xnack-" string and never matched, yielding architecture::unknown for AMD GPUs whose gcnArchName carries feature flags.
