### PR TITLE
[SYCL] Fix build after 1db2a088d8fd

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -57,7 +57,7 @@ size_t getLinearIndex(const T<Dims> &Index, const U<Dims> &Range) {
 // or ranges classes. When extending the new values are filled with
 // DefaultValue, truncation just removes extra values.
 template <int NewDim, int DefaultValue, template <int> class T, int OldDim>
-static T<NewDim> convertToArrayOfN(T<OldDim> OldObj) {
+T<NewDim> convertToArrayOfN(T<OldDim> OldObj) {
   T<NewDim> NewObj = detail::InitializedVal<NewDim, T>::template get<0>();
   const int CopyDims = NewDim > OldDim ? OldDim : NewDim;
   for (int I = 0; I < CopyDims; ++I)


### PR DESCRIPTION
The new fp4 extension unittest added by 1db2a088d8fd ([SYCL] Implement sycl_ext_oneapi_fp4 extension) includes float_4bit/types.hpp, which pulls in <sycl/marray.hpp> and thereby <sycl/detail/common.hpp>. That translation unit never instantiates the static function template convertToArrayOfN, so under -Werror,-Wunused-template (enabled by 1529d35adbd6) the build fails:

  include/sycl/detail/common.hpp:60:18: error: unused function template
  'convertToArrayOfN' [-Werror,-Wunused-template]

Remove the internal-linkage 'static' specifier from the template. This gives it external linkage, which suppresses -Wunused-template for a never-instantiated template (mirroring the fix in PR #22583 for other SYCL header templates) while keeping the existing callers in image.hpp and accessor_image.hpp working.

Fixes: CMPLRLLVM-76994