### PR TITLE
[AMDGPU][SYCL] Run global offset + attributor before AOT codegen

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -120,6 +120,12 @@ private:
   llvm::DenseMap<StringRef, DISubprogram *> DISubprogramMap;
 
   unsigned TargetAS = 0;
+  /// Address space of the pointer to the implicit offset passed to a kernel
+  /// entry point. On AMDGCN the kernel argument segment lives in addrspace(4);
+  /// a `byref` argument in the alloca address space is rejected by the
+  /// verifier, and a generic (addrspace(0)) one is rejected whenever the
+  /// module being verified has no AMDGPU data layout.
+  unsigned KernelOffsetArgAS = 0;
 };
 
 ModulePass *createGlobalOffsetPassLegacy();

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -95,7 +95,8 @@ void GlobalOffsetPass::createClonesAndPopulateVMap(
     const bool IsKernel = KCache.isKernel(*Func);
     FunctionType *FuncTy = Func->getFunctionType();
     Type *ImplicitArgumentType =
-        IsKernel ? KernelImplicitArgumentType->getPointerTo()
+        IsKernel ? PointerType::get(KernelImplicitArgumentType->getContext(),
+                                    KernelOffsetArgAS)
                  : ImplicitOffsetPtrType;
 
     // Construct an argument list containing all of the previous arguments.
@@ -160,6 +161,12 @@ PreservedAnalyses GlobalOffsetPass::run(Module &M, ModuleAnalysisManager &) {
     // For AMD allocas and pointers have to be to CONSTANT_PRIVATE (5), NVVM is
     // happy with ADDRESS_SPACE_GENERIC (0).
     TargetAS = T.isNVPTX() ? 0 : 5;
+    // The kernel argument segment is in CONSTANT (4) on AMDGCN, which is also
+    // where clang puts `byref` kernel arguments. Keeping the implicit offset
+    // pointer generic makes the module fail verification with "Calling
+    // convention disallows stack byref" whenever the alloca address space is
+    // 0, e.g. when the kernel is linked from a static archive.
+    KernelOffsetArgAS = T.isNVPTX() ? 0 : 4;
     KernelImplicitArgumentType =
         ArrayType::get(Type::getInt32Ty(M.getContext()), 3);
     ImplicitOffsetPtrType = PointerType::get(M.getContext(), TargetAS);
@@ -200,7 +207,7 @@ void GlobalOffsetPass::processKernelEntryPoint(
   // Add the new argument to all other kernel entry points, despite not
   // using the global offset.
   auto *NewFunc = addOffsetArgumentToFunction(
-                      M, Func, PointerType::getUnqual(Func->getContext()),
+                      M, Func, PointerType::get(Ctx, KernelOffsetArgAS),
                       /*KeepOriginal=*/true,
                       /*IsKernel=*/true)
                       .first;

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1076,12 +1076,24 @@ void AMDGPUTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
   PB.registerOptimizerLastEPCallback([this](ModulePassManager &MPM,
                                             OptimizationLevel Level,
                                             ThinOrFullLTOPhase Phase) {
-    if (Level != OptimizationLevel::O0) {
-      if (!isLTOPreLink(Phase)) {
-        if (EnableAMDGPUAttributor && getTargetTriple().isAMDGCN()) {
-          AMDGPUAttributorOptions Opts;
-          MPM.addPass(AMDGPUAttributorPass(*this, Opts, Phase));
-        }
+    if (Level != OptimizationLevel::O0 && getTargetTriple().isAMDGCN()) {
+      // Resolve the SYCL implicit global offset builtin (the pass self-gates
+      // to SYCL device modules) before running the attributor, so the
+      // attributor does not see an unresolved `__spirv_BuiltInGlobalOffset`
+      // callee and can prove that the conservative hidden kernel arguments
+      // (hostcall, default queue, completion action, heap) are unused.
+      //
+      // This must also run in the LTO prelink phase: for AMDGPU, SYCL AOT
+      // emits the device image with `clang -cc1 -flto=full -S`, i.e. the LTO
+      // prelink optimization pipeline immediately followed by codegen with no
+      // post-link step. If the attributor is skipped here (as it used to be
+      // for prelink), it never runs before codegen and the kernels keep the
+      // default hidden arguments, which HIP rejects at launch with
+      // hipErrorIllegalState on some GPUs (e.g. gfx1200). See intel/llvm#22606.
+      MPM.addPass(GlobalOffsetPass());
+      if (EnableAMDGPUAttributor) {
+        AMDGPUAttributorOptions Opts;
+        MPM.addPass(AMDGPUAttributorPass(*this, Opts, Phase));
       }
     }
   });
@@ -1105,6 +1117,11 @@ void AMDGPUTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
           PM.addPass(AMDGPUSwLowerLDSPass(*this));
         if (EnableLowerModuleLDS)
           PM.addPass(AMDGPULowerModuleLDSPass(*this));
+        // Also resolve the SYCL implicit global offset builtin before the
+        // post-link AMDGPUAttributor, for flows that defer codegen to the LTO
+        // link (self-gated to SYCL device modules). See intel/llvm#22606.
+        if (getTargetTriple().isAMDGCN())
+          PM.addPass(GlobalOffsetPass());
         if (Level != OptimizationLevel::O0) {
           // We only want to run this with O2 or higher since inliner and SROA
           // don't run in O1.

--- a/llvm/test/CodeGen/AMDGPU/global-offset-kernel.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-kernel.ll
@@ -1,0 +1,35 @@
+; RUN: opt -passes=globaloffset %s -S -o - | FileCheck %s
+
+; The implicit offset argument of an AMDGPU kernel entry point must point into
+; the kernel argument segment (addrspace(4)), which is where clang places
+; `byref` kernel arguments. A generic pointer verifies only while the module
+; carries a data layout whose alloca address space is not 0; tools that do not
+; infer one from the triple, such as llvm-link during an RDC device link,
+; reject it with "Calling convention disallows stack byref".
+
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7"
+target triple = "amdgcn-amd-amdhsa"
+
+declare i64 @_Z27__spirv_BuiltInGlobalOffseti(i32)
+
+declare void @use(i64)
+
+define amdgpu_kernel void @_ZTS14example_kernel() {
+; CHECK-LABEL: define amdgpu_kernel void @_ZTS14example_kernel() {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @use(i64 0)
+; CHECK-NEXT:    ret void
+; CHECK-NEXT:  }
+entry:
+  %0 = call i64 @_Z27__spirv_BuiltInGlobalOffseti(i32 2)
+  call void @use(i64 %0)
+  ret void
+}
+
+; CHECK-LABEL: define amdgpu_kernel void @_ZTS14example_kernel_with_offset(
+; CHECK-SAME:    ptr addrspace(4) byref([3 x i32]) [[OFFSET:%.*]])
+; CHECK:         [[ALLOCA:%.*]] = alloca [3 x i32], align 4, addrspace(5)
+; CHECK:         call void @llvm.memcpy{{.*}}(ptr addrspace(5) {{.*}}[[ALLOCA]], ptr addrspace(4) {{.*}}[[OFFSET]]
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"sycl-device", i32 1}

--- a/llvm/test/CodeGen/AMDGPU/print-pipeline-passes.ll
+++ b/llvm/test/CodeGen/AMDGPU/print-pipeline-passes.ll
@@ -3,7 +3,7 @@
 ; RUN: opt -mtriple=amdgcn--amdhsa -S -passes="lto<O2>" -print-pipeline-passes %s -o - | FileCheck %s
 ; RUN: opt -mtriple=amdgcn--amdhsa -S -passes="lto<O3>" -print-pipeline-passes %s -o - | FileCheck %s
 
-; RUN: opt -mtriple=amdgcn--amdhsa -S -passes="lto-pre-link<O0>" -print-pipeline-passes -amdgpu-internalize-symbols %s -o - | FileCheck --check-prefix=PRE %s
+; RUN: opt -mtriple=amdgcn--amdhsa -S -passes="lto-pre-link<O0>" -print-pipeline-passes -amdgpu-internalize-symbols %s -o - | FileCheck --check-prefix=PRE-O0 %s
 ; RUN: opt -mtriple=amdgcn--amdhsa -S -passes="lto-pre-link<O1>" -print-pipeline-passes -amdgpu-internalize-symbols %s -o - | FileCheck --check-prefix=PRE %s
 ; RUN: opt -mtriple=amdgcn--amdhsa -S -passes="lto-pre-link<O2>" -print-pipeline-passes -amdgpu-internalize-symbols %s -o - | FileCheck --check-prefix=PRE %s
 ; RUN: opt -mtriple=amdgcn--amdhsa -S -passes="lto-pre-link<O3>" -print-pipeline-passes -amdgpu-internalize-symbols %s -o - | FileCheck --check-prefix=PRE %s
@@ -12,9 +12,16 @@
 ; CHECK: amdgpu-attributor
 ; O0-NOT: amdgpu-attributor
 
+; SYCL AOT for AMDGPU runs codegen directly after the LTO pre-link pipeline
+; with no post-link step, so the global offset builtin has to be resolved and
+; the attributor has to run there as well.
 ; PRE-NOT: internalize
-; PRE-NOT: amdgpu-attributor
 ; PRE-NOT: printfToRuntime
+; PRE: globaloffset,amdgpu-attributor
+
+; PRE-O0-NOT: internalize
+; PRE-O0-NOT: amdgpu-attributor
+; PRE-O0-NOT: printfToRuntime
 
 define amdgpu_kernel void @kernel() {
 entry:


### PR DESCRIPTION
## Summary

Fixes DPC++ HIP `nd_range` kernel launch failures on gfx1200 (`hipErrorIllegalState` / error 401) reported in #22606.

For AMDGPU, SYCL AOT emits the device image with `clang -cc1 -flto=full -S`: the LTO **prelink** optimization pipeline immediately followed by codegen, with no post-link step. `AMDGPUAttributor` was gated to non-prelink phases, so in this flow it never ran before codegen and every kernel kept the default conservative hidden kernel arguments (hostcall buffer, default queue, completion action, heap). Additionally, the SYCL `GlobalOffsetPass` only ran in the legacy codegen pipeline (too late), so even when the attributor did run it saw an unresolved `__spirv_BuiltInGlobalOffset` callee and could not prove the hidden arguments away.

HIP tolerates these spurious hidden arguments on gfx942 but rejects them at launch on gfx1200.

## Fix

In `AMDGPUTargetMachine::registerPassBuilderCallbacks`:
- Run `GlobalOffsetPass` (self-gated to SYCL device modules) followed by `AMDGPUAttributorPass` at `OptimizerLast` for all non-O0 phases, **including LTO prelink**.
- Also resolve global offset before the post-link attributor, for flows that defer codegen to the LTO link.

This drops the kernel argument segment from 288/304 bytes to 32/44 bytes and removes the hidden arguments — the same result as the verified workaround `-Xoffload-linker=amdgcn-amd-amdhsa --lto-newpm-passes=globaloffset,lto`, but without any user-facing flags.

## Test plan

- [x] Reproduced the bug end-to-end on gfx942 (MI300A): kernarg segment 288/304 with `hidden_hostcall_buffer`/`hidden_heap_v1`/`hidden_default_queue`/`hidden_completion_action`.
- [x] With the fix, the same AOT build produces kernarg 32/44 with no hidden arguments, and the `nd_range` repro prints `42`.
- [x] Confirmed via `opt -passes='lto-pre-link<O3>'` + `llc` on the real device module that the attributor now runs and cleans the kernels.
- [ ] CI: some AMDGPU pipeline lit tests may need output updates, since the attributor now also runs in the LTO prelink phase for AMDGPU.
- [ ] Ideally verify on gfx1200 hardware (not available to me).

Refs #22606
