### PR TITLE
[SYCL][HIP] Fix GlobalOffset bad-signature crash and re-enable Assert tests

### DIFF
--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -224,8 +224,15 @@ void GlobalOffsetPass::addImplicitParameterToCallers(
 
   for (User *U : Users) {
     auto *CallToOld = dyn_cast<CallInst>(U);
-    if (!CallToOld)
-      return;
+    // Only direct calls where `Callee` is the callee are handled. If `Callee`
+    // is used in any other way (e.g. its address is taken or it is passed as a
+    // call argument), the implicit offset argument cannot be threaded through
+    // that use. Skipping such uses avoids constructing a call with a
+    // mismatched signature (which would otherwise crash the compiler). Note we
+    // must `continue` rather than `return` so remaining valid callers are still
+    // processed.
+    if (!CallToOld || CallToOld->getCalledOperand() != Callee)
+      continue;
 
     auto *Caller = CallToOld->getFunction();
 
@@ -273,10 +280,24 @@ void GlobalOffsetPass::addImplicitParameterToCallers(
       }
       ImplicitOffsets.push_back(ImplicitOffset);
 
+      // Build the callee type from the *original* call's function type rather
+      // than from the callee's declared signature, then append the implicit
+      // offset parameter. LLVM allows a call whose function type differs from
+      // the callee's declared type (e.g. SYCL device code frequently calls
+      // functions through address-space-mismatched pointer types such as
+      // generic `ptr` vs `ptr addrspace(4)`). Using the callee's declared
+      // signature here would create a call whose argument types disagree with
+      // the parameter types, tripping a "bad signature" assertion.
+      FunctionType *OldCallTy = CallToOld->getFunctionType();
+      SmallVector<Type *, 8> NewParamTypes(OldCallTy->params());
+      NewParamTypes.push_back(ImplicitOffset->getType());
+      FunctionType *NewCallTy = FunctionType::get(
+          OldCallTy->getReturnType(), NewParamTypes, OldCallTy->isVarArg());
+
       // Replace call to other function (which now has a new parameter),
       // with a call including the new parameter to that same function.
       auto *NewCallInst = CallInst::Create(
-          /* Ty= */ CalleeWithImplicitParam->getFunctionType(),
+          /* Ty= */ NewCallTy,
           /* Func= */ CalleeWithImplicitParam,
           /* Args= */ ImplicitOffsets,
           /* NameStr= */ Twine(),

--- a/sycl/test-e2e/Assert/assert_in_kernels.cpp
+++ b/sycl/test-e2e/Assert/assert_in_kernels.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: linux
 
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/7634
-//
 // XFAIL: (opencl && gpu)
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/11364
 

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: linux
 
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/7634
-//
 // UNSUPPORTED: cuda
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/8832
 //

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: linux
 
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/7634
-//
 // UNSUPPORTED: cuda
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/8832
 //

--- a/sycl/test-e2e/Assert/assert_in_one_kernel.cpp
+++ b/sycl/test-e2e/Assert/assert_in_one_kernel.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: linux
 
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/7634
-//
 // XFAIL: (opencl && gpu)
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/11364
 

--- a/sycl/test-e2e/Assert/assert_in_simultaneous_kernels.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneous_kernels.cpp
@@ -1,7 +1,5 @@
 // REQUIRES: linux
-// FIXME: Flaky on HIP and cuda
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
+// FIXME: Flaky on cuda
 // UNSUPPORTED: cuda
 // RUN: %{build} -o %t.out %threads_lib
 //

--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
@@ -1,8 +1,5 @@
-// FIXME flaky fail on CUDA and HIP
+// FIXME flaky fail on CUDA
 // UNSUPPORTED: cuda
-//
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
 //
 // XFAIL: (opencl && gpu)
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/11364

--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
@@ -1,6 +1,6 @@
 // FIXME flaky fail on CUDA
-// UNSUPPORTED: cuda, hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/7634
+// UNSUPPORTED: cuda
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/8832
 //
 // XFAIL: (opencl && gpu)
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/11364

--- a/sycl/test-e2e/Assert/check_resource_leak.cpp
+++ b/sycl/test-e2e/Assert/check_resource_leak.cpp
@@ -7,10 +7,6 @@
 // Therefore not planned to be supported at the moment. See
 // https://github.com/intel/llvm/issues/22228
 
-// TODO: Fails at JIT compilation for some reason.
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
-
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
 #define SYCL_FALLBACK_ASSERT 1

--- a/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/discard_events_using_assert.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/discard_events_using_assert.cpp
@@ -1,8 +1,5 @@
-// FIXME unsupported on CUDA and HIP until fallback libdevice becomes available
+// FIXME unsupported on CUDA until fallback libdevice becomes available
 // UNSUPPORTED: cuda
-//
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
 //
 // RUN: %{build} -o %t.out
 //


### PR DESCRIPTION
## Summary
- Fix a crash in `GlobalOffsetPass` caused by rebuilding implicit-offset calls with an incorrect call signature, which crashed `Assert` tests on HIP.
- Re-enable `Assert/check_resource_leak` and `DeprecatedFeatures/DiscardEvents/discard_events_using_assert` on HIP.

## Test plan
- [x] `Assert/assert_in_*` pass on gfx942
- [x] `Assert/check_resource_leak` passes on gfx942
- [x] `DiscardEvents/discard_events_using_assert` passes on gfx942

Relates to https://github.com/intel/llvm/issues/22300