### PR TITLE
[SYCL][HIP] Fix crash from SYCL buffer destructors during shutdown

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -293,18 +293,18 @@ bool Scheduler::removeMemoryObject(detail::SYCLMemObjI *MemObj,
     // No operations were performed on the mem object
     return true;
 
-#ifdef _WIN32
-  // If we are shutting down on Windows it may not be
-  // safe to wait on host threads, as the OS may
-  // abandon them. But no worries, the memory WILL be reclaimed.
+  // If we are shutting down it may not be safe to wait on in-flight work.
+  // On Windows the OS may have abandoned host threads. On any platform the
+  // adapters/contexts may already be partially torn down by early shutdown
+  // (e.g. the HIP runtime segfaults when synchronizing on an event whose
+  // stream/context has been released). During shutdown host memory is not
+  // written back either (see SYCLMemObjT::updateHostMemory), so waiting serves
+  // no purpose here and the memory WILL be reclaimed as the process exits.
   bool allowWait =
       MemObj->hasUserDataPtr() || GlobalHandler::instance().isOkToDefer();
   if (!allowWait) {
     StrictLock = false;
   }
-#else
-  bool allowWait = true;
-#endif
 
   if (allowWait) {
     // This only needs a shared mutex as it only involves enqueueing and

--- a/sycl/test-e2e/Regression/static-buffer-dtor.cpp
+++ b/sycl/test-e2e/Regression/static-buffer-dtor.cpp
@@ -12,10 +12,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Failing on HIP AMD
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
-
 #include <sycl/detail/core.hpp>
 
 int main() {

--- a/unified-runtime/source/adapters/hip/event.cpp
+++ b/unified-runtime/source/adapters/hip/event.cpp
@@ -53,11 +53,25 @@ ur_result_t ur_event_handle_t_::release() {
     return UR_RESULT_SUCCESS;
 
   assert(Queue != nullptr);
-  UR_CHECK_ERROR(hipEventDestroy(EvEnd));
+
+  // During runtime/process shutdown the HIP context may already have been
+  // destroyed (e.g. static SYCL buffer destructors that run after the SYCL
+  // runtime released its contexts). The backing events are torn down together
+  // with the context, so treat these shutdown-specific errors as a successful
+  // release rather than surfacing an exception (which would otherwise abort in
+  // the event_impl destructor).
+  auto destroyEvent = [](hipEvent_t Event) {
+    hipError_t Res = hipEventDestroy(Event);
+    if (Res == hipErrorContextIsDestroyed || Res == hipErrorDeinitialized)
+      return;
+    UR_CHECK_ERROR(Res);
+  };
+
+  destroyEvent(EvEnd);
 
   if (HasProfiling) {
-    UR_CHECK_ERROR(hipEventDestroy(EvQueued));
-    UR_CHECK_ERROR(hipEventDestroy(EvStart));
+    destroyEvent(EvQueued);
+    destroyEvent(EvStart);
   }
 
   return UR_RESULT_SUCCESS;


### PR DESCRIPTION
## Summary
- Fix a shutdown crash triggered by SYCL buffer destructors: make waits during shutdown optional and tolerate HIP errors (e.g. context already destroyed) during event release.
- Re-enable `Regression/static-buffer-dtor` on HIP.

## Test plan
- [x] `Regression/static-buffer-dtor` passes on gfx942 (repeated runs)

Relates to https://github.com/intel/llvm/issues/22300