### PR TITLE
[SYCL][E2E] Re-enable misc HIP tests no longer failing (issue 22300)

### DIFF
--- a/sycl/test-e2e/Basic/submit_time.cpp
+++ b/sycl/test-e2e/Basic/submit_time.cpp
@@ -3,10 +3,6 @@
 
 // Check that submission time is valid.
 
-// Test fails on hip flakily, disable temprorarily.
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
-
 // UNSUPPORTED: target-native_cpu
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20248
 

--- a/sycl/test-e2e/HierPar/hier_par_wgscope.cpp
+++ b/sycl/test-e2e/HierPar/hier_par_wgscope.cpp
@@ -1,10 +1,6 @@
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-//
-// Test hangs on AMD
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
 
 //==- hier_par_wgscope.cpp --- hierarchical parallelism test for WG scope---==//
 //

--- a/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options-env.cpp
+++ b/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options-env.cpp
@@ -5,8 +5,6 @@
 // Check that options are overrided
 // RUN: %{build} -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT=1 -Xsycl-target-linker=spir64 -DBAR -Xsycl-target-frontend=spir64 -DBAR_COMPILE -o %t2.out
 // RUN: env SYCL_UR_TRACE=2 SYCL_PROGRAM_COMPILE_OPTIONS=-DENV_COMPILE_OPTS SYCL_PROGRAM_LINK_OPTIONS=-DENV_LINK_OPTS SYCL_PROGRAM_APPEND_COMPILE_OPTIONS=-DENV_APPEND_COMPILE_OPTS SYCL_PROGRAM_APPEND_LINK_OPTIONS=-DENV_APPEND_LINK_OPTS %{run} %t2.out | FileCheck %s
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
 
 #include "kernel-bundle-merge-options.hpp"
 

--- a/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
+++ b/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
@@ -4,8 +4,6 @@
 // REQUIRES: gpu
 // RUN: %{build} -o %t.out %debug_option
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
 
 // Note that the UR call might be urProgramBuild OR urProgramBuildExp .
 // The same is true for Compile and Link.

--- a/sycl/test-e2e/Regression/no-split-reqd-wg-size-2.cpp
+++ b/sycl/test-e2e/Regression/no-split-reqd-wg-size-2.cpp
@@ -4,9 +4,6 @@
 // RUN: %{build} -fsycl-device-code-split=off -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
-
 #include <sycl/detail/core.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Regression/no-split-reqd-wg-size.cpp
+++ b/sycl/test-e2e/Regression/no-split-reqd-wg-size.cpp
@@ -4,9 +4,6 @@
 // RUN: %{build} -fsycl-device-code-split=off -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
-
 #include <sycl/detail/core.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Tracing/usm/queue_copy_released_pointer.cpp
+++ b/sycl/test-e2e/Tracing/usm/queue_copy_released_pointer.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
 // UNSUPPORTED: windows
 // RUN: %{build} -o %t.out
 // RUN: not --crash env SYCL_TRACE_TERMINATE_ON_WARNING=1 %{run} sycl-trace --verify %t.out | FileCheck %s

--- a/sycl/test-e2e/Tracing/usm/queue_single_task_nullptr.cpp
+++ b/sycl/test-e2e/Tracing/usm/queue_single_task_nullptr.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: target-amd
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
 // UNSUPPORTED: windows
 // RUN: %{build} -o %t.out
 // RUN: not --crash env SYCL_TRACE_TERMINATE_ON_WARNING=1 %{run} sycl-trace --verify %t.out | FileCheck %s

--- a/sycl/test-e2e/Tracing/usm/queue_single_task_released_pointer.cpp
+++ b/sycl/test-e2e/Tracing/usm/queue_single_task_released_pointer.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22300
 // UNSUPPORTED: windows
 // RUN: %{build} -o %t.out
 // RUN: not --crash env SYCL_TRACE_TERMINATE_ON_WARNING=1 %{run} sycl-trace --verify %t.out | FileCheck %s


### PR DESCRIPTION
## Summary
- Re-enable HIP e2e tests that were marked `UNSUPPORTED` under umbrella issue 22300 but now pass with no source changes required.
- Tests: `HierPar/hier_par_wgscope`, `KernelAndProgram/kernel-bundle-merge-options[-env]`, `Regression/no-split-reqd-wg-size[-2]`, `Tracing/usm/queue_copy_released_pointer`, `Tracing/usm/queue_single_task_nullptr`, `Tracing/usm/queue_single_task_released_pointer`, `Basic/submit_time`.

## Test plan
- [x] All 9 listed tests pass on gfx942 (verified 9/9)

Relates to https://github.com/intel/llvm/issues/22300