### PR TITLE
[SYCL][Unit] Fix crash when user sets ONEAPI_DEVICE_SELECTOR in shell

### DIFF
--- a/sycl/unittests/helpers/UrMock.hpp
+++ b/sycl/unittests/helpers/UrMock.hpp
@@ -562,6 +562,20 @@ public:
   /// This ensures UR is setup for adapter mocking and also injects our default
   /// entry-point overrides into the mock adapter.
   UrMock() {
+    // Device selector env vars are read into a process-wide cache on first
+    // use (see SYCLConfig<ONEAPI_DEVICE_SELECTOR>::get()). If left set in the
+    // ambient environment, they filter out the mock adapter's device (which
+    // reports itself as `Backend`, opencl by default) and every mock-based
+    // test aborts with "No device of requested type available". Clear them
+    // before any SYCL runtime code can read them.
+#ifdef _WIN32
+    _putenv_s("ONEAPI_DEVICE_SELECTOR", "");
+    _putenv_s("SYCL_DEVICE_FILTER", "");
+#else
+    unsetenv("ONEAPI_DEVICE_SELECTOR");
+    unsetenv("SYCL_DEVICE_FILTER");
+#endif
+
     if constexpr (Backend == backend::opencl) {
       // Some tests use the interop handles, so we need to ensure the mock
       // OpenCL library is loaded.


### PR DESCRIPTION
The mock adapter is not a real device backend, but ONEAPI_DEVICE_SELECTOR and SYCL_DEVICE_FILTER are still applied to it by platform_impl. If either is set in the ambient shell to a backend that doesn't match UrMock's declared Backend (opencl by default), the mock device gets filtered out and every mock-based unit test aborts with "No device of requested type available" instead of running deterministically.

Clear both env vars at the top of the UrMock constructor, before any SYCL runtime code caches their value.

Fixes case 1 in #22683.