### PR TITLE
[SYCL][Unit] Mock UR_DEVICE_INFO_PLATFORM in UrMock

### DIFF
--- a/sycl/unittests/helpers/UrMock.hpp
+++ b/sycl/unittests/helpers/UrMock.hpp
@@ -177,6 +177,14 @@ inline ur_result_t mock_urDeviceGetInfo(void *pParams) {
       **params->ppPropSizeRet = sizeof(MockDeviceName);
     return UR_RESULT_SUCCESS;
   }
+  case UR_DEVICE_INFO_PLATFORM: {
+    if (*params->ppPropValue)
+      *static_cast<ur_platform_handle_t *>(*params->ppPropValue) =
+          reinterpret_cast<ur_platform_handle_t>(1);
+    if (*params->ppPropSizeRet)
+      **params->ppPropSizeRet = sizeof(ur_platform_handle_t);
+    return UR_RESULT_SUCCESS;
+  }
   case UR_DEVICE_INFO_PARENT_DEVICE: {
     if (*params->ppPropValue)
       *static_cast<ur_device_handle_t *>(*params->ppPropValue) = nullptr;


### PR DESCRIPTION
Fixes `SYCL_UR_TRACE=1 ninja check-sycl-unittests` crash in #22683.

mock_urDeviceGetInfo() fell through to the default zero-fill case for UR_DEVICE_INFO_PLATFORM, so device::get_info<info::device::platform>() returned a platform wrapping a null UR handle. This is latent unless something queries that platform afterwards, which
detail::traceDeviceSelection() does whenever SYCL_UR_TRACE is enabled, causing urPlatformGetInfo to fail with UR_RESULT_ERROR_INVALID_NULL_HANDLE and the process to abort on the uncaught exception.