### PR TITLE
[SYCL][E2E] Disable usm_device_read_only.cpp on Win DG2

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/usm_device_read_only.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/usm_device_read_only.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: windows && gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
 
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED: windows && (gpu-intel-dg2 || arch-intel_gpu_bmg_g21)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22099
 
 // RUN: %{build} -o %t.out


### PR DESCRIPTION
Sporadic fail, see https://github.com/intel/llvm/issues/22099