### PR TITLE
[SYCL][E2E] Re-enable L0 leak check tests on Windows

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/event-leak.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/event-leak.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: level_zero, level_zero_dev_kit
 //
-// UNSUPPORTED: windows && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20852
-//
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out wait 2>&1 | FileCheck %s
 // RUN: %{l0_leak_check} %{run} %t.out nowait 2>&1 | FileCheck %s

--- a/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/discard_events_l0_leak.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/discard_events_l0_leak.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: level_zero
 //
-// UNSUPPORTED: windows && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20852
-//
 // RUN: %{build} -o %t.out
 //
 // RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 SYCL_PI_LEVEL_ZERO_BATCH_SIZE=4 ONEAPI_DEVICE_SELECTOR='level_zero:*' %{l0_leak_check} %{run} %t.out wait  2>&1 | FileCheck %s

--- a/sycl/test-e2e/ProfilingTag/profile_tag_leak.cpp
+++ b/sycl/test-e2e/ProfilingTag/profile_tag_leak.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: level_zero
 //
-// UNSUPPORTED: windows && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20852
-//
 // RUN: %{build} -o %t.out
 // RUN: %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK
 

--- a/sycl/test-e2e/USM/usm_leak_check.cpp
+++ b/sycl/test-e2e/USM/usm_leak_check.cpp
@@ -1,7 +1,4 @@
 // REQUIRES: level_zero
-//
-// UNSUPPORTED: windows && level_zero_v2_adapter
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20852
 
 // RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
 


### PR DESCRIPTION
Seems we have a new enough version on Windows now.

Issue: https://github.com/intel/llvm/issues/20852

One test from the GH issue still fails, so I can't close it yet.