### PR TITLE
Revert "[SYCL] Re-enable bindless images e2e tests on DG2 Windows"

### DIFF
--- a/sycl/test-e2e/bindless_images/dx11_interop/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/dx11_interop/lit.local.cfg
@@ -1,0 +1,2 @@
+if 'windows' in config.available_features:
+   config.unsupported_features.remove('gpu-intel-dg2')

--- a/sycl/test-e2e/bindless_images/dx12_interop/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/dx12_interop/lit.local.cfg
@@ -1,0 +1,2 @@
+if 'windows' in config.available_features:
+   config.unsupported_features.remove('gpu-intel-dg2')

--- a/sycl/test-e2e/bindless_images/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/lit.local.cfg
@@ -4,3 +4,7 @@ config.unsupported_features += ['target-native_cpu']
 config.unsupported_features += ['spirv-backend']
 
 cl_options = 'cl_options' in config.available_features
+
+# https://github.com/intel/llvm/issues/20562
+if 'windows' in config.available_features:
+  config.unsupported_features += ['gpu-intel-dg2']

--- a/sycl/test-e2e/bindless_images/vulkan_interop/lit.local.cfg
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/lit.local.cfg
@@ -1,2 +1,5 @@
 # Our PVC runners don't have the userspace Vulkan driver installed
 config.unsupported_features += ['arch-intel_gpu_pvc']
+
+if 'windows' in config.available_features:
+   config.unsupported_features.remove('gpu-intel-dg2')


### PR DESCRIPTION
Reverts intel/llvm#22612

See comments in https://github.com/intel/llvm/pull/22612