### PR TITLE
[SYCL] Fix abi/layout_* tests after enum diagnostic printing change

### DIFF
--- a/sycl/test/abi/layout_accessors_host.cpp
+++ b/sycl/test/abi/layout_accessors_host.cpp
@@ -24,7 +24,7 @@ void hostAcc(accessor<int, 1, access::mode::read, access::target::host_buffer> A
 // CHECK-NEXT:  0 |         class std::__shared_ptr_access<class sycl::detail::AccessorImplHost, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT:  0 |         element_type * _M_ptr
 // CHECK-NEXT:  8 |         class std::__shared_count<> _M_refcount
-// CHECK-NEXT:  8 |           _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT:  8 |           _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT:  0 |   class sycl::detail::accessor_common<int, 1, sycl::access::mode::read, sycl::access::target::host_buffer, sycl::access::placeholder::false_t> (base) (empty)
 // CHECK-NEXT:  0 |   class sycl::detail::OwnerLessBase<class sycl::accessor<int, 1, sycl::access::mode::read, sycl::access::target::host_buffer> > (base) (empty)
 // CHECK-NEXT: 16 | detail::AccHostDataT * MAccData
@@ -47,7 +47,7 @@ void hostAcc(accessor<int, 1, access::mode::read, access::target::device> Acc) {
 // CHECK-NEXT: 0 |         class std::__shared_ptr_access<class sycl::detail::AccessorImplHost, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT: 0 |         element_type * _M_ptr
 // CHECK-NEXT: 8 |         class std::__shared_count<> _M_refcount
-// CHECK-NEXT: 8 |           _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT: 8 |           _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT: 0 |   class sycl::detail::accessor_common<int, 1, sycl::access::mode::read, sycl::access::target::device, sycl::access::placeholder::false_t> (base) (empty)
 // CHECK-NEXT: 0 |   class sycl::detail::OwnerLessBase<class sycl::accessor<int, 1, sycl::access::mode::read, sycl::access::target::device> > (base) (empty)
 // CHECK-NEXT: 16 | detail::AccHostDataT * MAccData
@@ -71,7 +71,7 @@ void hostAcc(accessor<int, 1, access::mode::read_write, access::target::local> A
 // CHECK-NEXT: 0 |           class std::__shared_ptr_access<class sycl::detail::LocalAccessorImplHost, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT: 0 |           element_type * _M_ptr
 // CHECK-NEXT: 8 |           class std::__shared_count<> _M_refcount
-// CHECK-NEXT: 8 |             _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT: 8 |             _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT: 0 |     class sycl::detail::accessor_common<int, 1, sycl::access::mode::read_write, sycl::access::target::local, sycl::access::placeholder::false_t> (base) (empty)
 // CHECK-NEXT: 16 |     char[16] padding
 // CHECK-NEXT: 0 |   class sycl::detail::OwnerLessBase<class sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local> > (base) (empty)
@@ -90,7 +90,7 @@ void hostAcc(local_accessor<int, 1> Acc) {
 // CHECK-NEXT: 0 |           class std::__shared_ptr_access<class sycl::detail::LocalAccessorImplHost, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT: 0 |           element_type * _M_ptr
 // CHECK-NEXT: 8 |           class std::__shared_count<> _M_refcount
-// CHECK-NEXT: 8 |             _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT: 8 |             _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT: 0 |     class sycl::detail::accessor_common<int, 1, sycl::access::mode::read_write, sycl::access::target::local, sycl::access::placeholder::false_t> (base) (empty)
 // CHECK-NEXT: 16 |     char[16] padding
 // CHECK-NEXT: 0 |   class sycl::detail::OwnerLessBase<class sycl::local_accessor<int> > (base) (empty)
@@ -112,7 +112,7 @@ void hostAcc(accessor<int4, 1, access::mode::read_write, access::target::host_im
 // CHECK-NEXT: 0 |           class std::__shared_ptr_access<class sycl::detail::AccessorImplHost, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT: 0 |           element_type * _M_ptr
 // CHECK-NEXT: 8 |           class std::__shared_count<> _M_refcount
-// CHECK-NEXT: 8 |             _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT: 8 |             _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT: 16 |     size_t MImageCount
 // CHECK-NEXT: 24 |     image_channel_order MImgChannelOrder
 // CHECK-NEXT: 28 |     image_channel_type MImgChannelType
@@ -135,7 +135,7 @@ void hostAcc(accessor<int4, 1, access::mode::read, access::target::image> Acc) {
 // CHECK-NEXT: 0 |           class std::__shared_ptr_access<class sycl::detail::AccessorImplHost, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT: 0 |           element_type * _M_ptr
 // CHECK-NEXT: 8 |           class std::__shared_count<> _M_refcount
-// CHECK-NEXT: 8 |             _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT: 8 |             _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT: 16 |     size_t MImageCount
 // CHECK-NEXT: 24 |     image_channel_order MImgChannelOrder
 // CHECK-NEXT: 28 |     image_channel_type MImgChannelType

--- a/sycl/test/abi/layout_buffer.cpp
+++ b/sycl/test/abi/layout_buffer.cpp
@@ -15,7 +15,7 @@ void foo(sycl::buffer<int, 2>) {}
 // CHECK-NEXT:  0 |       class std::__shared_ptr_access<class sycl::detail::buffer_impl, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT:  0 |       element_type * _M_ptr
 // CHECK-NEXT:  8 |       class std::__shared_count<> _M_refcount
-// CHECK-NEXT:  8 |         _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT:  8 |         _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT:  0 | class sycl::detail::OwnerLessBase<class sycl::buffer<int, 2> > (base) (empty)
 // CHECK-NEXT: 16 |   class sycl::range<2> Range
 // CHECK-NEXT: 16 |     class sycl::detail::array<2> (base)

--- a/sycl/test/abi/layout_exception.cpp
+++ b/sycl/test/abi/layout_exception.cpp
@@ -19,14 +19,14 @@ void foo() {
 // CHECK-NEXT:         8 |       class std::__shared_ptr_access<class sycl::detail::string, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT:         8 |       element_type * _M_ptr
 // CHECK-NEXT:        16 |       class std::__shared_count<> _M_refcount
-// CHECK-NEXT:        16 |         _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT:        16 |         _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT:        24 |   int32_t MErr
 // CHECK-NEXT:        32 |   class std::shared_ptr<class sycl::context> MContext
 // CHECK-NEXT:        32 |     class std::__shared_ptr<class sycl::context> (base)
 // CHECK-NEXT:        32 |       class std::__shared_ptr_access<class sycl::context, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT:        32 |       element_type * _M_ptr
 // CHECK-NEXT:        40 |       class std::__shared_count<> _M_refcount
-// CHECK-NEXT:        40 |         _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT:        40 |         _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT:        48 |   {{class|struct}} std::error_code MErrC
 // CHECK-NEXT:        48 |     int _M_value
 // CHECK-NEXT:        56 |     const error_category * _M_cat

--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -43,7 +43,7 @@ void foo() {
 // CHECK-NEXT:   80 |       class std::__shared_ptr_access<class sycl::detail::kernel_impl, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT:   80 |       element_type * _M_ptr
 // CHECK-NEXT:   88 |       class std::__shared_count<> _M_refcount
-// CHECK-NEXT:   88 |         _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT:   88 |         _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT:   96 |   void * MSrcPtr
 // CHECK-NEXT:   104 |   void * MDstPtr
 // CHECK-NEXT:   112 |   size_t MLength

--- a/sycl/test/abi/layout_image.cpp
+++ b/sycl/test/abi/layout_image.cpp
@@ -18,7 +18,7 @@ sycl::image<2> Img1{sycl::image_channel_order::rgba, sycl::image_channel_type::f
 // CHECK-NEXT: 0 |             class std::__shared_ptr_access<class sycl::detail::image_impl, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT: 0 |             element_type * _M_ptr
 // CHECK-NEXT: 8 |             class std::__shared_count<> _M_refcount
-// CHECK-NEXT: 8 |               _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT: 8 |               _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT:   | [sizeof=16, dsize=16, align=8,
 // CHECK-NEXT:   |  nvsize=16, nvalign=8]
 
@@ -33,7 +33,7 @@ sycl::unsampled_image<2> Img2{sycl::image_format::r16b16g16a16_sfloat, sycl::ran
 // CHECK-NEXT: 0 |             class std::__shared_ptr_access<class sycl::detail::image_impl, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT: 0 |             element_type * _M_ptr
 // CHECK-NEXT: 8 |             class std::__shared_count<> _M_refcount
-// CHECK-NEXT: 8 |               _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT: 8 |               _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT: 0 |   class sycl::detail::OwnerLessBase<class sycl::unsampled_image<2> > (base) (empty)
 // CHECK-NEXT:   | [sizeof=16, dsize=16, align=8,
 // CHECK-NEXT:   |  nvsize=16, nvalign=8]
@@ -54,7 +54,7 @@ sycl::sampled_image<2> Img3{Data, sycl::image_format::r16b16g16a16_sfloat, Sampl
 // CHECK-NEXT: 0 |           class std::__shared_ptr_access<class sycl::detail::image_impl, __gnu_cxx::_S_atomic> (base) (empty)
 // CHECK-NEXT: 0 |           element_type * _M_ptr
 // CHECK-NEXT: 8 |           class std::__shared_count<> _M_refcount
-// CHECK-NEXT: 8 |             _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> * _M_pi
+// CHECK-NEXT: 8 |             _Sp_counted_base<__gnu_cxx::_S_atomic> * _M_pi
 // CHECK-NEXT: 0 |   class sycl::detail::OwnerLessBase<class sycl::sampled_image<2> > (base) (empty)
 // CHECK-NEXT:   | [sizeof=16, dsize=16, align=8,
 // CHECK-NEXT:   |  nvsize=16, nvalign=8]


### PR DESCRIPTION
Commit bdfcef52762c ("[clang] improve diagnostics for enums") made clang print enum-typed template arguments using their enumerator name rather than a C-style cast, changing -fdump-record-layouts output from _Sp_counted_base<(enum __gnu_cxx::_Lock_policy)2U> to _Sp_counted_base<__gnu_cxx::_S_atomic>.

CMPLRLLVM-77064