### PR TITLE
[SYCL] Prevent raising the SYCL undefined function diag if invalid

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5997,7 +5997,8 @@ void SemaSYCL::finalizeSYCLDelayedAnalysis(const FunctionDecl *Caller,
   // Diagnose if this is an undefined function and it is not a builtin.
   // Currently, there is an exception of "__failed_assertion" in libstdc++-11,
   // this undefined function is used to trigger a compiling error.
-  if (!Callee->isDefined() && !Callee->getBuiltinID() &&
+  if (!Callee->isInvalidDecl() && !Callee->isDefined() &&
+      !Callee->getBuiltinID() &&
       !Callee->isReplaceableGlobalAllocationFunction() &&
       !isSYCLUndefinedAllowed(Callee, SemaRef.getSourceManager())) {
     Diag(Loc, diag::err_sycl_restrict) << SemaSYCL::KernelCallUndefinedFunction;

--- a/clang/test/SemaSYCL/call-to-undefined-function-after-instantiation-error.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function-after-instantiation-error.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -ast-dump %s 2> /dev/null | FileCheck %s
+// RUN: not %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -ast-dump %s 2> /dev/null | FileCheck %s
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -verify -verify-ignore-unexpected=note -fsyntax-only %s
 
 // This function verifies we don't trigger the error
@@ -17,7 +17,7 @@ sycl::queue deviceQueue;
 // CHECK-NEXT: DeclRefExpr
 // CHECK-NEXT: SYCLKernelAttr
 
-// CHECK:      ClassTemplateSpecializationDecl {{.*}} struct Ker definition implicit_instantiation
+// CHECK:      ClassTemplateSpecializationDecl {{.*}} struct Ker definition {{.*}} implicit_instantiation
 // CHECK:      CXXRecordDecl {{.*}} implicit struct Ker
 // CHECK-NEXT: CXXMethodDecl [[MethodAddr]] {{.*}} used invalid operator() 'void () const'
 

--- a/clang/test/SemaSYCL/call-to-undefined-function-after-instantiation-error.cpp
+++ b/clang/test/SemaSYCL/call-to-undefined-function-after-instantiation-error.cpp
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -ast-dump %s 2> /dev/null | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -verify -verify-ignore-unexpected=note -fsyntax-only %s
+
+// This function verifies we don't trigger the error
+//  SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute
+// due to the failure to fully instantiate Ker
+
+#include "sycl.hpp"
+
+sycl::queue deviceQueue;
+
+// Checking we generate the AST of interest
+
+// CHECK:      CXXOperatorCallExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr {{.*}} 'void () const' lvalue CXXMethod [[MethodAddr:[0-9a-fx]*]] 'operator()' 'void () const'
+// CHECK-NEXT: DeclRefExpr
+// CHECK-NEXT: SYCLKernelAttr
+
+// CHECK:      ClassTemplateSpecializationDecl {{.*}} struct Ker definition implicit_instantiation
+// CHECK:      CXXRecordDecl {{.*}} implicit struct Ker
+// CHECK-NEXT: CXXMethodDecl [[MethodAddr]] {{.*}} used invalid operator() 'void () const'
+
+struct NoCopy {
+  NoCopy() {}
+  NoCopy(const NoCopy&) = delete;
+};
+
+template <typename Cb>
+struct Ker {
+  void operator()() const {
+    NoCopy Obj;
+    Cb{}(Obj); //  expected-error {{call to deleted constructor of 'NoCopy'}}
+  }
+};
+
+struct TakeByValue{
+    void operator()(NoCopy) {}
+};
+
+int main() {
+  deviceQueue.submit([&](sycl::handler &h) {
+  Ker<TakeByValue> K;
+    h.single_task<decltype(K)>(K);
+  });
+}


### PR DESCRIPTION
If during the instantiation of a templated function an error occur, a CallExpr to a FunctionDecl tagged as invalid can still be created. If this call appears in a SYCL device context, a spurious `SYCL kernel cannot call an undefined function` diagnostic was then raised because no body is attached to the Decl. The patch prevents the emission of this diagnostic.