### PR TITLE
[SYCL] Fix sycl-jit build

### DIFF
--- a/sycl-jit/jit-compiler/lib/helper/ErrorHelper.h
+++ b/sycl-jit/jit-compiler/lib/helper/ErrorHelper.h
@@ -16,8 +16,8 @@ namespace jit_compiler {
 std::string formatError(llvm::Error &&Err, const std::string &Msg);
 
 template <typename ResultType, typename... ExtraArgTypes>
-static ResultType errorTo(llvm::Error &&Err, const std::string &Msg,
-                          ExtraArgTypes... ExtraArgs) {
+ResultType errorTo(llvm::Error &&Err, const std::string &Msg,
+                   ExtraArgTypes... ExtraArgs) {
   // Cannot throw an exception here if LLVM itself is compiled without exception
   // support.
   return ResultType{formatError(std::move(Err), Msg).c_str(), ExtraArgs...};


### PR DESCRIPTION
This fixes compilation problems from -Werror,-Wunused-template compilation flags enabled by 1529d35.