### PR TITLE
[SYCL][E2E] Fix flaky DX11 interop tests

### DIFF
--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
@@ -59,6 +59,30 @@ void populateD3D11Texture(D3D11ProgramState &d3d11ProgramState,
   ThrowIfFailed(keyedMutex->ReleaseSync(d3d11ProgramState.key));
 }
 
+// Block the CPU until all previously-submitted D3D11 work has completed on
+// the GPU. UpdateSubresource may return once the copy is queued, before it
+// has actually completed on the D3D GPU. Holding the keyed mutex around the
+// SYCL kernel excludes other keyed-mutex participants, but a successful
+// AcquireSync gives the SYCL queue no execution dependency on the earlier
+// D3D upload, so the kernel could read stale/zero texels. Waiting on a
+// D3D11_QUERY_EVENT after the upload ensures the texture contents are ready
+// before SYCL reads them.
+void waitForD3D11Idle(D3D11ProgramState &d3d11ProgramState) {
+  assert(d3d11ProgramState.device && d3d11ProgramState.deviceContext);
+  D3D11_QUERY_DESC queryDesc{};
+  queryDesc.Query = D3D11_QUERY_EVENT;
+  queryDesc.MiscFlags = 0;
+  ComPtr<ID3D11Query> query;
+  ThrowIfFailed(d3d11ProgramState.device->CreateQuery(&queryDesc, &query));
+  d3d11ProgramState.deviceContext->End(query.Get());
+  d3d11ProgramState.deviceContext->Flush();
+  BOOL done = FALSE;
+  while (d3d11ProgramState.deviceContext->GetData(query.Get(), &done,
+                                                  sizeof(done), 0) != S_OK) {
+    // Spin until the GPU has processed everything up to the query.
+  }
+}
+
 syclexp::unsampled_image_handle
 syclImportTextureMem(HANDLE sharedHandle, size_t allocationSize,
                      const syclexp::image_descriptor &syclImageDesc,
@@ -377,6 +401,13 @@ int runTest(D3D11ProgramState &d3d11ProgramState, sycl::queue syclQueue,
         texFormat, inputData.data(), keyedMutex.Get());
   }
 
+#ifndef TEST_SEMAPHORE_IMPORT
+  // Ensure the asynchronous D3D11 upload above has actually completed on the
+  // D3D GPU before the SYCL kernel reads the shared texture. The semaphore
+  // variant orders this with an ID3D11Fence instead (see below).
+  waitForD3D11Idle(d3d11ProgramState);
+#endif
+
   // Unfortunately, DX11 does not expose the texture allocation information
   // like DX12, so we have to calculate it manually the best we can (no mips).
   const size_t allocationSize =
@@ -385,9 +416,14 @@ int runTest(D3D11ProgramState &d3d11ProgramState, sycl::queue syclQueue,
       sharedHandle, allocationSize, syclImageDesc, syclQueue);
 
 #ifdef TEST_SEMAPHORE_IMPORT
+  // Order the D3D11 upload before the SYCL kernel via the shared fence.
+  // The fence was created with initial value 0, so we must signal/wait on a
+  // fresh, monotonically-increasing value: waiting on 0 would be satisfied
+  // immediately (the fence already holds 0) and would not actually block on
+  // the queued D3D upload, defeating the synchronization.
+  ++fenceVal;
   ThrowIfFailed(context4->Signal(fence.Get(), fenceVal));
   syclQueue.ext_oneapi_wait_external_semaphore(syclSemaphore, fenceVal);
-  fenceVal++;
 #endif
   // Submit the SYCL kernel.
   // When IDXGIKeyedMutex importing into SYCL is implemented, we'll be able to
@@ -400,11 +436,12 @@ int runTest(D3D11ProgramState &d3d11ProgramState, sycl::queue syclQueue,
   ThrowIfFailed(keyedMutex->ReleaseSync(d3d11ProgramState.key));
 
 #ifdef TEST_SEMAPHORE_IMPORT
+  // Order the SYCL kernel's writes before the D3D11 read-back on a fresh value.
+  ++fenceVal;
   syclQueue.submit([&](sycl::handler &cgh) {
     cgh.ext_oneapi_signal_external_semaphore(syclSemaphore, fenceVal);
   });
   waitD3D11Fence(fence.Get(), fenceVal, fenceEvent);
-  fenceVal++;
 #endif
 
   // Read-back and verify


### PR DESCRIPTION
read_write_unsampled and its semaphore variant failed non-deterministically, mismatching at the first non-zero texel on a varying subset of configurations. Root cause is missing D3D11-to-SYCL synchronization in the test itself.

- Non-semaphore variant. Current incorrect sequence looks like this:
```
  AcquireSync(0); 
  UpdateSubresource(...);  // returns once the upload is queued 
  ReleaseSync(1);
  AcquireSync(1);          // succeeds: key matches last ReleaseSync
  submit_sycl_kernel();    // but the D3D GPU upload may still be running
```

`AcquireSync(1)` gives the SYCL queue no execution dependency on the earlier upload, so the kernel could read stale/zero texels. Fixed by waiting for the upload to complete (`D3D11_QUERY_EVENT` + `Flush`) before SYCL uses it.

- Semaphore variant. The `ID3D11Fence` is created with initial value `0`, so waiting for `0` is already satisfied before the D3D upload or signal executes.

```
  // Incorrect
  fence = CreateFence(initialValue = 0);
  D3D_upload_texture();  // queued asynchronously
  D3D_signal(fence, 0);  // queued after upload, but changes 0 -> 0
  SYCL_wait(fence, 0);   // already satisfied from fence initialization
  SYCL_launch_kernel();  // may run before the upload finishes
```

Fixed by using a value the fence has not reached yet:

```
  // Correct
  fence = CreateFence(initialValue = 0);
  D3D_upload_texture();
  D3D_signal(fence, 1);  // changes 0 -> 1 only after upload completes
  SYCL_wait(fence, 1);   // cannot complete while fence is still 0
  SYCL_launch_kernel();  // runs after the upload
```

The point is not that `1` is special: it is a value the fence has not reached yet, whereas `0` was already reached at creation.

Assisted-By: Claude