### PR TITLE
[SYCL][Graph] Add UR error code to native recording error messages

### DIFF
--- a/sycl/source/detail/adapter_impl.hpp
+++ b/sycl/source/detail/adapter_impl.hpp
@@ -77,6 +77,16 @@ public:
       ur_failed_throw_exception(errc, ur_result);
   }
 
+  /// \throw SYCL 2020 exception(errc) with \p Msg and the UR result code if
+  /// ur_result is not UR_RESULT_SUCCESS.
+  template <sycl::errc errc = sycl::errc::runtime>
+  void checkUrResult(ur_result_t ur_result, const std::string &Msg) const {
+    if (__builtin_expect(ur_result != UR_RESULT_SUCCESS, false))
+      throw set_ur_error(sycl::exception(sycl::make_error_code(errc),
+                                         Msg + ": " + codeToString(ur_result)),
+                         ur_result);
+  }
+
   std::vector<ur_platform_handle_t> &getUrPlatforms() {
     std::call_once(PlatformsPopulated, [&]() {
       uint32_t platformCount = 0;

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -359,13 +359,7 @@ graph_impl::graph_impl(const sycl::context &SyclContext,
 
     Result = Adapter.call_nocheck<sycl::detail::UrApiKind::urGraphCreateExp>(
         ContextImpl.getHandleRef(), &MNativeGraphHandle);
-    if (Result != UR_RESULT_SUCCESS) {
-      throw sycl::detail::set_ur_error(
-          sycl::exception(sycl::make_error_code(errc::runtime),
-                          "Failed to create native UR graph: " +
-                              sycl::detail::codeToString(Result)),
-          Result);
-    }
+    Adapter.checkUrResult(Result, "Failed to create native UR graph");
     assert(MNativeGraphHandle != nullptr &&
            "Native UR graph handle should not be null if graph creation "
            "succeeded");
@@ -413,13 +407,7 @@ graph_impl::~graph_impl() {
       ur_result_t Result =
           Adapter.call_nocheck<sycl::detail::UrApiKind::urGraphDestroyExp>(
               MNativeGraphHandle);
-      if (Result != UR_RESULT_SUCCESS) {
-        throw sycl::detail::set_ur_error(
-            sycl::exception(sycl::make_error_code(errc::runtime),
-                            "Failed to destroy native UR graph: " +
-                                sycl::detail::codeToString(Result)),
-            Result);
-      }
+      Adapter.checkUrResult(Result, "Failed to destroy native UR graph");
       MNativeGraphHandle = nullptr;
     }
     for (auto &Cb : MDestructionCallbacks) {
@@ -712,13 +700,8 @@ void graph_impl::setDestructionCallback(std::function<void()> Callback) {
           delete Fn;
         },
         Data.get());
-    if (Result != UR_RESULT_SUCCESS) {
-      throw sycl::detail::set_ur_error(
-          sycl::exception(sycl::make_error_code(errc::runtime),
-                          "Failed to register graph destruction callback: " +
-                              sycl::detail::codeToString(Result)),
-          Result);
-    }
+    Adapter.checkUrResult(Result,
+                          "Failed to register graph destruction callback");
     Data.release();
   } else {
     MDestructionCallbacks.push_back(std::move(Callback));
@@ -746,13 +729,8 @@ void graph_impl::clearQueues(bool NeedsLock) {
     if (auto ValidQueue = Queue.lock(); ValidQueue) {
       if (MNativeGraphHandle) {
         auto EndResult = ValidQueue->endNativeRecording();
-        if (EndResult.Result != UR_RESULT_SUCCESS) {
-          throw sycl::detail::set_ur_error(
-              sycl::exception(sycl::make_error_code(errc::runtime),
-                              "Error when ending native graph capture: " +
-                                  sycl::detail::codeToString(EndResult.Result)),
-              EndResult.Result);
-        }
+        getContextImpl().getAdapter().checkUrResult(
+            EndResult.Result, "Error when ending native graph capture");
         // CapturedGraph should be the same as MNativeGraphHandle
       } else {
         // Only call setCommandGraph for traditional recording
@@ -773,17 +751,10 @@ bool graph_impl::empty() const {
   }
 
   bool IsEmptyResult = true;
-  ur_result_t Result = getSyclObjImpl(MContext)
-                           ->getAdapter()
-                           .call_nocheck<UrApiKind::urGraphIsEmptyExp>(
-                               MNativeGraphHandle, &IsEmptyResult);
-  if (Result != UR_RESULT_SUCCESS) {
-    throw sycl::detail::set_ur_error(
-        sycl::exception(sycl::make_error_code(errc::runtime),
-                        "Failed to check if graph is empty: " +
-                            sycl::detail::codeToString(Result)),
-        Result);
-  }
+  sycl::detail::adapter_impl &Adapter = getContextImpl().getAdapter();
+  ur_result_t Result = Adapter.call_nocheck<UrApiKind::urGraphIsEmptyExp>(
+      MNativeGraphHandle, &IsEmptyResult);
+  Adapter.checkUrResult(Result, "Failed to check if graph is empty");
   return IsEmptyResult;
 }
 
@@ -929,13 +900,8 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
       if (BeginResult.RecordingActive) {
         addQueue(Queue);
       }
-      if (BeginResult.Result != UR_RESULT_SUCCESS) {
-        throw sycl::detail::set_ur_error(
-            sycl::exception(sycl::make_error_code(errc::runtime),
-                            "Failed to begin native UR graph capture: " +
-                                sycl::detail::codeToString(BeginResult.Result)),
-            BeginResult.Result);
-      }
+      getContextImpl().getAdapter().checkUrResult(
+          BeginResult.Result, "Failed to begin native UR graph capture");
     } else {
       // Non-native recording path
       if (AcquireQueueLock) {
@@ -1195,13 +1161,8 @@ exec_graph_impl::exec_graph_impl(sycl::context Context,
             .call_nocheck<sycl::detail::UrApiKind::urGraphInstantiateGraphExp>(
                 GraphImpl->getNativeGraphHandle(),
                 &MNativeExecutableGraphHandle);
-    if (Result != UR_RESULT_SUCCESS) {
-      throw sycl::detail::set_ur_error(
-          sycl::exception(sycl::make_error_code(errc::runtime),
-                          "Failed to instantiate native UR executable graph: " +
-                              sycl::detail::codeToString(Result)),
-          Result);
-    }
+    Adapter.checkUrResult(Result,
+                          "Failed to instantiate native UR executable graph");
   } else {
     // Copy nodes from GraphImpl and merge any subgraph nodes into this graph.
     duplicateNodes();
@@ -1232,13 +1193,8 @@ exec_graph_impl::~exec_graph_impl() {
       ur_result_t Res = Adapter.call_nocheck<
           sycl::detail::UrApiKind::urGraphExecutableGraphDestroyExp>(
           MNativeExecutableGraphHandle);
-      if (Res != UR_RESULT_SUCCESS) {
-        throw sycl::detail::set_ur_error(
-            sycl::exception(sycl::make_error_code(errc::runtime),
-                            "Failed to destroy native UR executable graph: " +
-                                sycl::detail::codeToString(Res)),
-            Res);
-      }
+      Adapter.checkUrResult(Res,
+                            "Failed to destroy native UR executable graph");
       MNativeExecutableGraphHandle = nullptr;
     }
 
@@ -2344,13 +2300,8 @@ void modifiable_command_graph::end_recording(queue &RecordingQueue) {
       if (!EndResult.RecordingActive) {
         impl->removeQueue(QueueImpl);
       }
-      if (EndResult.Result != UR_RESULT_SUCCESS) {
-        throw sycl::detail::set_ur_error(
-            sycl::exception(sycl::make_error_code(errc::runtime),
-                            "Error when ending native graph capture: " +
-                                sycl::detail::codeToString(EndResult.Result)),
-            EndResult.Result);
-      }
+      impl->getContextImpl().getAdapter().checkUrResult(
+          EndResult.Result, "Error when ending native graph capture");
       assert(EndResult.CapturedGraph == impl->getNativeGraphHandle() &&
              "Captured graph handle must match the graph's native handle");
     }

--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -360,8 +360,11 @@ graph_impl::graph_impl(const sycl::context &SyclContext,
     Result = Adapter.call_nocheck<sycl::detail::UrApiKind::urGraphCreateExp>(
         ContextImpl.getHandleRef(), &MNativeGraphHandle);
     if (Result != UR_RESULT_SUCCESS) {
-      throw sycl::exception(sycl::make_error_code(errc::runtime),
-                            "Failed to create native UR graph");
+      throw sycl::detail::set_ur_error(
+          sycl::exception(sycl::make_error_code(errc::runtime),
+                          "Failed to create native UR graph: " +
+                              sycl::detail::codeToString(Result)),
+          Result);
     }
     assert(MNativeGraphHandle != nullptr &&
            "Native UR graph handle should not be null if graph creation "
@@ -390,7 +393,13 @@ graph_impl::graph_impl(const sycl::context &SyclContext,
 
 graph_impl::~graph_impl() {
   try {
-    clearQueues(false /*Needs lock*/);
+    // Handle any exception when ending capture, so we avoid throwing
+    // and can still try to destroy the graph object when native recording.
+    try {
+      clearQueues(false /*Needs lock*/);
+    } catch (std::exception &e) {
+      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~graph_impl", e);
+    }
     for (auto &MemObj : MMemObjs) {
       MemObj->markNoLongerBeingUsedInGraph();
     }
@@ -405,8 +414,11 @@ graph_impl::~graph_impl() {
           Adapter.call_nocheck<sycl::detail::UrApiKind::urGraphDestroyExp>(
               MNativeGraphHandle);
       if (Result != UR_RESULT_SUCCESS) {
-        throw sycl::exception(sycl::make_error_code(errc::runtime),
-                              "Failed to destroy native UR graph");
+        throw sycl::detail::set_ur_error(
+            sycl::exception(sycl::make_error_code(errc::runtime),
+                            "Failed to destroy native UR graph: " +
+                                sycl::detail::codeToString(Result)),
+            Result);
       }
       MNativeGraphHandle = nullptr;
     }
@@ -701,8 +713,11 @@ void graph_impl::setDestructionCallback(std::function<void()> Callback) {
         },
         Data.get());
     if (Result != UR_RESULT_SUCCESS) {
-      throw sycl::exception(sycl::make_error_code(errc::runtime),
-                            "Failed to register graph destruction callback");
+      throw sycl::detail::set_ur_error(
+          sycl::exception(sycl::make_error_code(errc::runtime),
+                          "Failed to register graph destruction callback: " +
+                              sycl::detail::codeToString(Result)),
+          Result);
     }
     Data.release();
   } else {
@@ -732,8 +747,11 @@ void graph_impl::clearQueues(bool NeedsLock) {
       if (MNativeGraphHandle) {
         auto EndResult = ValidQueue->endNativeRecording();
         if (EndResult.Result != UR_RESULT_SUCCESS) {
-          throw sycl::exception(sycl::make_error_code(errc::runtime),
-                                "Error when ending native graph capture");
+          throw sycl::detail::set_ur_error(
+              sycl::exception(sycl::make_error_code(errc::runtime),
+                              "Error when ending native graph capture: " +
+                                  sycl::detail::codeToString(EndResult.Result)),
+              EndResult.Result);
         }
         // CapturedGraph should be the same as MNativeGraphHandle
       } else {
@@ -755,12 +773,16 @@ bool graph_impl::empty() const {
   }
 
   bool IsEmptyResult = true;
-  if (getSyclObjImpl(MContext)
-          ->getAdapter()
-          .call_nocheck<UrApiKind::urGraphIsEmptyExp>(
-              MNativeGraphHandle, &IsEmptyResult) != UR_RESULT_SUCCESS) {
-    throw sycl::exception(sycl::make_error_code(errc::runtime),
-                          "Failed to check if graph is empty");
+  ur_result_t Result = getSyclObjImpl(MContext)
+                           ->getAdapter()
+                           .call_nocheck<UrApiKind::urGraphIsEmptyExp>(
+                               MNativeGraphHandle, &IsEmptyResult);
+  if (Result != UR_RESULT_SUCCESS) {
+    throw sycl::detail::set_ur_error(
+        sycl::exception(sycl::make_error_code(errc::runtime),
+                        "Failed to check if graph is empty: " +
+                            sycl::detail::codeToString(Result)),
+        Result);
   }
   return IsEmptyResult;
 }
@@ -908,8 +930,11 @@ void graph_impl::beginRecordingImpl(sycl::detail::queue_impl &Queue,
         addQueue(Queue);
       }
       if (BeginResult.Result != UR_RESULT_SUCCESS) {
-        throw sycl::exception(sycl::make_error_code(errc::runtime),
-                              "Failed to begin native UR graph capture");
+        throw sycl::detail::set_ur_error(
+            sycl::exception(sycl::make_error_code(errc::runtime),
+                            "Failed to begin native UR graph capture: " +
+                                sycl::detail::codeToString(BeginResult.Result)),
+            BeginResult.Result);
       }
     } else {
       // Non-native recording path
@@ -1171,8 +1196,11 @@ exec_graph_impl::exec_graph_impl(sycl::context Context,
                 GraphImpl->getNativeGraphHandle(),
                 &MNativeExecutableGraphHandle);
     if (Result != UR_RESULT_SUCCESS) {
-      throw sycl::exception(sycl::make_error_code(errc::runtime),
-                            "Failed to instantiate native UR executable graph");
+      throw sycl::detail::set_ur_error(
+          sycl::exception(sycl::make_error_code(errc::runtime),
+                          "Failed to instantiate native UR executable graph: " +
+                              sycl::detail::codeToString(Result)),
+          Result);
     }
   } else {
     // Copy nodes from GraphImpl and merge any subgraph nodes into this graph.
@@ -1204,9 +1232,14 @@ exec_graph_impl::~exec_graph_impl() {
       ur_result_t Res = Adapter.call_nocheck<
           sycl::detail::UrApiKind::urGraphExecutableGraphDestroyExp>(
           MNativeExecutableGraphHandle);
-      if (Res == UR_RESULT_SUCCESS) {
-        MNativeExecutableGraphHandle = nullptr;
+      if (Res != UR_RESULT_SUCCESS) {
+        throw sycl::detail::set_ur_error(
+            sycl::exception(sycl::make_error_code(errc::runtime),
+                            "Failed to destroy native UR executable graph: " +
+                                sycl::detail::codeToString(Res)),
+            Res);
       }
+      MNativeExecutableGraphHandle = nullptr;
     }
 
     // Clean up any graph-owned allocations that were allocated
@@ -2312,8 +2345,11 @@ void modifiable_command_graph::end_recording(queue &RecordingQueue) {
         impl->removeQueue(QueueImpl);
       }
       if (EndResult.Result != UR_RESULT_SUCCESS) {
-        throw sycl::exception(sycl::make_error_code(errc::runtime),
-                              "Error when ending native graph capture");
+        throw sycl::detail::set_ur_error(
+            sycl::exception(sycl::make_error_code(errc::runtime),
+                            "Error when ending native graph capture: " +
+                                sycl::detail::codeToString(EndResult.Result)),
+            EndResult.Result);
       }
       assert(EndResult.CapturedGraph == impl->getNativeGraphHandle() &&
              "Captured graph handle must match the graph's native handle");

--- a/sycl/source/detail/graph/graph_impl.hpp
+++ b/sycl/source/detail/graph/graph_impl.hpp
@@ -326,8 +326,11 @@ public:
           Adapter.call_nocheck<sycl::detail::UrApiKind::urGraphDumpContentsExp>(
               MNativeGraphHandle, FilePath.c_str());
       if (Result != UR_RESULT_SUCCESS) {
-        throw sycl::exception(sycl::make_error_code(errc::runtime),
-                              "Failed to dump native UR graph contents");
+        throw sycl::detail::set_ur_error(
+            sycl::exception(sycl::make_error_code(errc::runtime),
+                            "Failed to dump native UR graph contents: " +
+                                sycl::detail::codeToString(Result)),
+            Result);
       }
     } else {
       /// Vector of nodes visited during the graph printing

--- a/sycl/source/detail/graph/graph_impl.hpp
+++ b/sycl/source/detail/graph/graph_impl.hpp
@@ -325,13 +325,7 @@ public:
       ur_result_t Result =
           Adapter.call_nocheck<sycl::detail::UrApiKind::urGraphDumpContentsExp>(
               MNativeGraphHandle, FilePath.c_str());
-      if (Result != UR_RESULT_SUCCESS) {
-        throw sycl::detail::set_ur_error(
-            sycl::exception(sycl::make_error_code(errc::runtime),
-                            "Failed to dump native UR graph contents: " +
-                                sycl::detail::codeToString(Result)),
-            Result);
-      }
+      Adapter.checkUrResult(Result, "Failed to dump native UR graph contents");
     } else {
       /// Vector of nodes visited during the graph printing
       std::vector<node_impl *> VisitedNodes;

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -714,8 +714,11 @@ queue_impl::ext_oneapi_get_graph_impl() const {
     if (Result == UR_RESULT_SUCCESS) {
       Graph = getContextImpl().getNativeGraph(UrGraphHandle);
     } else if (Result != UR_RESULT_ERROR_INVALID_OPERATION) {
-      throw sycl::exception(make_error_code(errc::runtime),
-                            "Failed to query native UR graph from queue.");
+      throw sycl::detail::set_ur_error(
+          sycl::exception(make_error_code(errc::runtime),
+                          "Failed to query native UR graph from queue: " +
+                              sycl::detail::codeToString(Result)),
+          Result);
     }
   }
   if (!Graph) {


### PR DESCRIPTION
The UR graph backend plans to add support for descriptive error codes when graph operations fail. To propagate this error to the user, we must include the UR error code alongside the custom message for graph operations that fail.

This is a prerequisite PR to displaying the new error codes.