### PR TITLE
[SYCL][Driver] Pass SYCL runtime library to linker by path on Linux

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -596,15 +596,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
       AddRunTimeLibs(ToolChain, D, CmdArgs, Args);
 
-      if (Args.hasArg(options::OPT_fsycl) &&
-          !Args.hasArg(options::OPT_nolibsycl)) {
-        if (Args.hasArg(options::OPT_fpreview_breaking_changes))
-          CmdArgs.push_back("-lsycl-preview");
-        else
-          CmdArgs.push_back("-lsycl");
-        CmdArgs.push_back("-lsycl-devicelib-host");
-      }
-
       // LLVM support for atomics on 32-bit SPARC V8+ is incomplete, so
       // forcibly link with libatomic as a workaround.
       // TODO: Issue #41880 and D118021.

--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -903,6 +903,17 @@ void Linux::addOffloadRTLibs(unsigned ActiveKinds, const ArgList &Args,
   llvm::SmallVector<std::pair<StringRef, StringRef>> Libraries;
   if (ActiveKinds & Action::OFK_HIP)
     Libraries.emplace_back(RocmInstallation->getLibPath(), "libamdhip64.so");
+  else if ((ActiveKinds & Action::OFK_SYCL) &&
+           !Args.hasArg(options::OPT_nolibsycl)) {
+    if (Args.hasArg(options::OPT_fpreview_breaking_changes))
+      Libraries.emplace_back(SYCLInstallation->getSYCLRTLibPath(),
+                             "libsycl-preview.so");
+    else
+      Libraries.emplace_back(SYCLInstallation->getSYCLRTLibPath(),
+                             "libsycl.so");
+    Libraries.emplace_back(SYCLInstallation->getSYCLRTLibPath(),
+                           "libsycl-devicelib-host.a");
+  }
 
   for (auto [Path, Library] : Libraries) {
     if (Args.hasFlag(options::OPT_frtlib_add_rpath,

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -31,7 +31,7 @@ SYCLInstallationDetector::SYCLInstallationDetector(
     : D(D), InstallationCandidates(), HostTriple(HostTriple) {
   // When -fsycl is active, locate the SYCL runtime library and record its
   // directory in SYCLRTLibPath for use by the linker.
-  StringRef SysRoot = D.SysRoot;
+  [[maybe_unused]] StringRef SysRoot = D.SysRoot;
   SmallString<128> DriverDir(D.Dir);
 
 #if 0 // !INTEL_CUSTOMIZATION
@@ -88,8 +88,7 @@ SYCLInstallationDetector::SYCLInstallationDetector(
   llvm::sys::path::append(FlatLibPath, "..", CLANG_INSTALL_LIBDIR_BASENAME,
                           "libsycl.so");
 
-  if (DriverDir.starts_with(SysRoot) &&
-      Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
+  if (Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false)) {
     // We put driver in bin/compiler, so one more ../ than llorg.
     if (D.getVFS().exists(DriverDir + "/../../lib/libsycl.so"))
       llvm::sys::path::append(DriverDir, "..", "..",

--- a/clang/test/Driver/sycl-offload-aot.cpp
+++ b/clang/test/Driver/sycl-offload-aot.cpp
@@ -80,13 +80,13 @@
 
 /// Ahead of Time compilation for gen, cpu - tool invocation
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64_gen-unknown-unknown %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-GEN
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-GEN -implicit-check-not="libsycl.so"
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64_x86_64-unknown-unknown %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-CPU
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-CPU  -implicit-check-not="libsycl.so"
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64_gen-unknown-unknown %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-GEN
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-GEN -implicit-check-not="libsycl.so"
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-instrument-device-code --no-offloadlib -fsycl-targets=spir64_x86_64-unknown-unknown %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-CPU
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-CPU -implicit-check-not="libsycl.so"
 // CHK-TOOLS-GEN: clang{{.*}} "-triple" "spir64_gen-unknown-unknown"
 // CHK-TOOLS-CPU: clang{{.*}} "-triple" "spir64_x86_64-unknown-unknown"
 // CHK-TOOLS-AOT: "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INPUT1:.+\-header.+\.h]]" "-fsycl-int-footer={{.*}}"{{.*}} "-o" "[[OUTPUT1:.+\.bc]]"

--- a/clang/test/Driver/sycl-offload-aot.cpp
+++ b/clang/test/Driver/sycl-offload-aot.cpp
@@ -104,7 +104,7 @@
 // CHK-TOOLS-GEN: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_gen{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
 // CHK-TOOLS-CPU: clang-offload-wrapper{{.*}} "-o=[[OUTPUT5:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_x86_64{{.*}}" "-kind=sycl" "-batch" "[[OUTPUT4]]"
 // CHK-TOOLS-AOT: clang{{.*}} "--target=[[HOST_TARGET]]" "-c" "-o" "[[OUTPUT6:.+\.o]]" "[[OUTPUT5]]"
-// CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT7]]" "[[OUTPUT6]]" {{.*}} "-lsycl"
+// CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT7]]" "[[OUTPUT6]]"
 
 // Check to be sure that for windows, the 'exe' tools are called
 // RUN: %clang_cl -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown -### -- %s 2>&1 \

--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -29,13 +29,13 @@
 // CHK-DEVICE-TRIPLE-SAME: "-O2"
 // CHK-DEVICE-TRIPLE: llvm-offload-binary{{.*}} "--image=file={{.*}}.bc,triple=spir64-unknown-unknown,arch=generic,kind=sycl{{.*}}"
 
-// Check that path to libsycl.so is not passed to clang-linker-wrapper tool by default for SYCL compilation, but that -lsycl is.
+// Check if path to libsycl.so is passed to clang-linker-wrapper tool by default for SYCL compilation.
 // The test also checks if SYCL header include paths are added to the SYCL host and device compilation.
 // INTEL-RUN: %clang --offload-new-driver --sysroot=%S/Inputs/SYCL -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
-// RUN:   | FileCheck -implicit-check-not="libsycl.so" -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
+// RUN:   | FileCheck -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
 // CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
 // CHECK-SYCL-HEADERS-HOST: "-fsycl-is-host"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
-// CHECK-LSYCL: "-lsycl"
+// CHECK-LSYCL: clang-linker-wrapper{{.*}} "{{.*}}libsycl.so"
 // Check that -fsycl -fno-sycl does not pass libsycl.so to the linker.
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl -fno-sycl %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-SYCL-RT %s

--- a/clang/test/Driver/sycl-offload-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-old-model.cpp
@@ -471,19 +471,19 @@
 /// ###########################################################################
 
 /// Check for default linking of -lsycl with -fsycl --no-offload-new-driver usage
-// RUN: %clang -fsycl --no-offload-new-driver -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-SYCL %s
+// RUN: %clang -fsycl --no-offload-new-driver -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -implicit-check-not="-lsycl" -check-prefix=CHECK-LD-SYCL %s
 // CHECK-LD-SYCL: "{{.*}}ld{{(.exe)?}}"
 // CHECK-LD-SYCL: "{{.*}}libsycl.so"
 
 /// Check no SYCL runtime is linked with -nolibsycl
 // RUN: %clang -fsycl --no-offload-new-driver -nolibsycl -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOLIBSYCL %s
 // CHECK-LD-NOLIBSYCL: "{{.*}}ld{{(.exe)?}}"
-// CHECK-LD-NOLIBSYCL-NOT: "-lsycl"
+// CHECK-LD-NOLIBSYCL-NOT: "libsycl.so"
 
 /// Check no SYCL runtime is linked with -nostdlib
 // RUN: %clang -fsycl --no-offload-new-driver -nostdlib -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOSTDLIB %s
 // CHECK-LD-NOSTDLIB: "{{.*}}ld{{(.exe)?}}"
-// CHECK-LD-NOSTDLIB-NOT: "-lsycl"
+// CHECK-LD-NOSTDLIB-NOT: "libsycl.so"
 
 /// Check for default linking of syclN.lib with -fsycl --no-offload-new-driver usage
 // RUN: %clang -fsycl --no-offload-new-driver -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL %s

--- a/clang/test/Driver/sycl-offload-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-old-model.cpp
@@ -473,7 +473,7 @@
 /// Check for default linking of -lsycl with -fsycl --no-offload-new-driver usage
 // RUN: %clang -fsycl --no-offload-new-driver -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-SYCL %s
 // CHECK-LD-SYCL: "{{.*}}ld{{(.exe)?}}"
-// CHECK-LD-SYCL: "-lsycl"
+// CHECK-LD-SYCL: "{{.*}}libsycl.so"
 
 /// Check no SYCL runtime is linked with -nolibsycl
 // RUN: %clang -fsycl --no-offload-new-driver -nolibsycl -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOLIBSYCL %s

--- a/clang/test/Driver/sycl-offload-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-old-model.cpp
@@ -474,6 +474,7 @@
 // RUN: %clang -fsycl --no-offload-new-driver -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -implicit-check-not="-lsycl" -check-prefix=CHECK-LD-SYCL %s
 // CHECK-LD-SYCL: "{{.*}}ld{{(.exe)?}}"
 // CHECK-LD-SYCL: "{{.*}}libsycl.so"
+// CHECK-LD-SYCL-SAME: "{{.*}}libsycl-devicelib-host.a"
 
 /// Check no SYCL runtime is linked with -nolibsycl
 // RUN: %clang -fsycl --no-offload-new-driver -nolibsycl -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOLIBSYCL %s

--- a/clang/test/Driver/sycl-offload-with-split-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-with-split-old-model.cpp
@@ -201,7 +201,7 @@
 // CHK-TOOLS-GEN: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_gen" "-kind=sycl" "-batch" "[[OUTPUT7]]"
 // CHK-TOOLS-CPU: clang-offload-wrapper{{.*}} "-o=[[OUTPUT8:.+\.bc]]" "-host=[[HOST_TARGET:.+]]" "-target=spir64_x86_64" "-kind=sycl" "-batch" "[[OUTPUT7]]"
 // CHK-TOOLS-AOT: clang{{.*}} "--target=[[HOST_TARGET]]" "-c" "-o" "[[OUTPUT9:.+\.o]]" "[[OUTPUT8]]"
-// CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT10]]" "[[OUTPUT9]]" {{.*}} "-lsycl"
+// CHK-TOOLS-AOT: ld{{.*}} "[[OUTPUT10]]" "[[OUTPUT9]]"
 
 /// ###########################################################################
 

--- a/clang/test/Driver/sycl-offload-with-split-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-with-split-old-model.cpp
@@ -185,9 +185,9 @@
 
 /// Ahead of Time compilation for gen, cpu - tool invocation
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fsycl-device-code-split -fsycl-targets=spir64_gen-unknown-unknown %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-GEN
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-GEN -implicit-check-not="libsycl.so"
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fno-sycl-instrument-device-code --no-offloadlib -fsycl-device-code-split -fsycl-targets=spir64_x86_64-unknown-unknown %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-CPU
+// RUN:  | FileCheck %s -check-prefixes=CHK-TOOLS-AOT,CHK-TOOLS-CPU -implicit-check-not="libsycl.so"
 // CHK-TOOLS-AOT: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-int-header=[[INPUT1:.+\-header.+\.h]]" "-fsycl-int-footer={{.*}}"{{.*}} "-o" "[[OUTPUT1:.+\.bc]]"
 // CHK-TOOLS-AOT: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-o" "[[OUTPUT10:.+\.o]]"
 // CHK-TOOLS-AOT: llvm-link{{.*}} "[[OUTPUT1]]" "-o" "[[OUTPUT2:.+\.bc]]"

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -263,6 +263,7 @@
 // RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -implicit-check-not="-lsycl" -check-prefix=CHECK-LD-SYCL %s
 // CHECK-LD-SYCL: "{{.*}}ld{{(.exe)?}}"
 // CHECK-LD-SYCL: "{{.*}}libsycl.so"
+// CHECK-LD-SYCL-SAME: "{{.*}}libsycl-devicelib-host.a"
 
 /// Check no SYCL runtime is linked with -nolibsycl
 // RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -nolibsycl -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOLIBSYCL %s

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -262,7 +262,7 @@
 /// Check for default linking of -lsycl with -fsycl --offload-new-driver usage
 // RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-SYCL %s
 // CHECK-LD-SYCL: "{{.*}}ld{{(.exe)?}}"
-// CHECK-LD-SYCL: "-lsycl"
+// CHECK-LD-SYCL: "{{.*}}libsycl.so"
 
 /// Check no SYCL runtime is linked with -nolibsycl
 // RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -nolibsycl -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOLIBSYCL %s

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -259,20 +259,20 @@
 
 /// ###########################################################################
 
-/// Check for default linking of -lsycl with -fsycl --offload-new-driver usage
-// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-SYCL %s
+/// Check for default linking of libsycl.so with -fsycl --offload-new-driver usage
+// RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -implicit-check-not="-lsycl" -check-prefix=CHECK-LD-SYCL %s
 // CHECK-LD-SYCL: "{{.*}}ld{{(.exe)?}}"
 // CHECK-LD-SYCL: "{{.*}}libsycl.so"
 
 /// Check no SYCL runtime is linked with -nolibsycl
 // RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -nolibsycl -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOLIBSYCL %s
 // CHECK-LD-NOLIBSYCL: "{{.*}}ld{{(.exe)?}}"
-// CHECK-LD-NOLIBSYCL-NOT: "-lsycl"
+// CHECK-LD-NOLIBSYCL-NOT: "libsycl.so"
 
 /// Check no SYCL runtime is linked with -nostdlib
 // RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -nostdlib -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOSTDLIB %s
 // CHECK-LD-NOSTDLIB: "{{.*}}ld{{(.exe)?}}"
-// CHECK-LD-NOSTDLIB-NOT: "-lsycl"
+// CHECK-LD-NOSTDLIB-NOT: "libsycl.so"
 
 /// Check for default linking of syclN.lib with -fsycl --offload-new-driver usage
 // RUN: %clang -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL %s

--- a/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
+++ b/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: system-linux && symlinks
 
-// Verify we still generate a path to libsycl.so even with sysroot set.
+// Verify we still generate a path to libsycl.so and libsycl-devicelib-host.a even with sysroot set.
 
 // RUN: rm -rf %t && mkdir -p %t/bin %t/lib
 // RUN: touch %t/lib/libsycl.so
@@ -9,3 +9,4 @@
 // RUN:   | FileCheck %s
 
 // CHECK: "{{.*}}/bin/../lib/libsycl.so"
+// CHECK-SAME: "{{.*}}/bin/../lib/libsycl-devicelib-host.a"

--- a/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
+++ b/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: system-linux && symlinks
 
-// Verify we still generate a path to libsycl.so even with sysroot is set.
+// Verify we still generate a path to libsycl.so even with sysroot set.
 
 // RUN: rm -rf %t && mkdir -p %t/bin %t/lib
 // RUN: touch %t/lib/libsycl.so

--- a/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
+++ b/clang/test/Driver/sycl-rtlib-sysroot-mismatch.cpp
@@ -1,0 +1,11 @@
+// REQUIRES: system-linux && symlinks
+
+// Verify we still generate a path to libsycl.so even with sysroot is set.
+
+// RUN: rm -rf %t && mkdir -p %t/bin %t/lib
+// RUN: touch %t/lib/libsycl.so
+// RUN: ln -s %clang %t/bin/clang
+// RUN: %t/bin/clang -### -no-canonical-prefixes --target=x86_64-unknown-linux-gnu -fsycl --sysroot=/nonexistent-prefix %s 2>&1 \
+// RUN:   | FileCheck %s
+
+// CHECK: "{{.*}}/bin/../lib/libsycl.so"

--- a/clang/test/Driver/sycl-time-trace-actual.cpp
+++ b/clang/test/Driver/sycl-time-trace-actual.cpp
@@ -39,7 +39,7 @@
 // In compile+link mode, trace files are named based on source file
 // RUN: rm -rf %t/traces3 && mkdir -p %t/traces3
 // RUN: %clang --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
-// RUN:   --no-offloadlib -fno-sycl-instrument-device-code \
+// RUN:   -fno-sycl-instrument-device-code \
 // RUN:   -ftime-trace=%t/traces3 %t/src/test.cpp -o %t/myapp
 
 // Frontend traces should still be generated (named after source file)


### PR DESCRIPTION
This reverts https://github.com/intel/llvm/pull/22654, fixes the original issue with the wrong path to `libsycl.so` causing that PR, and removes the code that passes `-lsycl -lsycl-devicelib-host` and pass it by path, matching upstream behavior for other targets. This change is Linux only.

Also, this fixes what I could consider a bug where we sometimes still passed the SYCL RT to the linker even if `--no-offloadlib` was passed, so there are some test updates about that, either removing the flag and keeping `libsycl.so` expectation or keeping the flag and removing the `libsycl.so` expectation.

I also applied this change to the internal compiler and ran a large test suite and there were no failures.