### PR TITLE
[CI][Bench] Move scheduled job an hour earlier

### DIFF
--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -5,8 +5,8 @@ name: SYCL Run Benchmarks
 
 on:
   schedule:
-    # 2 hours after SYCL nightly, every day after weekday (we built in the morning the next day)
-    - cron: '0 5 * * 2-6'
+    # 1:15 hour after SYCL nightly, every day after weekday (we built in the morning the next day)
+    - cron: '15 4 * * 2-6'
   # Run on pull requests only when a benchmark-related files were changed.
   pull_request:
     # These paths are exactly the same as in sycl-linux/windows-precommit.yml (to ignore over there)


### PR DESCRIPTION
Its actual start time is now around 8am (CEST) - it's super late.
We still want to wait for nightly job to publish dockers, though.