### PR TITLE
[UR][L0v2] Fix file descriptor's leak in urIPCGetPhysMemHandleExp()

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/physical_mem.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/physical_mem.cpp
@@ -146,24 +146,17 @@ ur_result_t urIPCGetPhysMemHandleExp(ur_context_handle_t,
   if (ExportFd.fd < 0)
     return UR_RESULT_ERROR_INVALID_VALUE;
 
-  // dup() the fd so urIPCPutPhysMemHandleExp can close HandleData->Fd without
-  // closing the original fd exported by the driver, which must remain open for
-  // the lifetime of the physical_mem object.  We own only the dup'd copy.
-  int DupFd = dup(ExportFd.fd);
-  if (DupFd < 0)
-    return UR_RESULT_ERROR_UNKNOWN;
-
   auto *HandleData = new (std::nothrow) ZeIPCPhysMemHandleData;
   if (!HandleData) {
-    close(DupFd);
+    close(ExportFd.fd);
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
 
-  // Store the exporting process's PID and dup'd fd.  The fd stays open until
-  // urIPCPutPhysMemHandleExp is called.  Cross-process consumers use
+  // Store the exporting process's PID and exported fd. The fd stays open until
+  // urIPCPutPhysMemHandleExp is called. Cross-process consumers use
   // pidfd_getfd(2) to obtain their own duplicate of this fd.
   HandleData->Pid = getpid();
-  HandleData->Fd = DupFd;
+  HandleData->Fd = ExportFd.fd;
   HandleData->Size = hPhysMem->Size;
 
   *ppIPCPhysMemHandleData = HandleData;


### PR DESCRIPTION
Previously, the exported fd (ExportFd.fd) obtained from
zePhysicalMemGetProperties() was dup()'d into DupFd, and only DupFd was
stored in HandleData->Fd and later closed by urIPCPutPhysMemHandleExp().
The original ExportFd.fd was never closed, leaking one file descriptor
per urIPCGetPhysMemHandleExp() call.

Store and own ExportFd.fd directly instead of dup()'ing it, so it is
properly closed by urIPCPutPhysMemHandleExp() (or on error paths in
urIPCGetPhysMemHandleExp() itself), eliminating the leak.

Fixes: URLZA-758