### PR TITLE
[CI][Benches] Exclude sycl graphs from old adapter bench

### DIFF
--- a/.github/workflows/sycl-ur-perf-benchmarking.yml
+++ b/.github/workflows/sycl-ur-perf-benchmarking.yml
@@ -301,7 +301,7 @@ jobs:
       runner: '["TEST_PERF"]'
       image: ghcr.io/intel/llvm/sycl_ubuntu2404_nightly:latest
       image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
-      target_devices: 'level_zero:gpu'
+      target_devices: 'level_zero_v2:gpu'
       tests_selector: benchmarks
       benchmark_upload_results: false
       benchmark_preset: 'Minimal'

--- a/devops/scripts/benchmarks/benches/compute/compute.py
+++ b/devops/scripts/benchmarks/benches/compute/compute.py
@@ -159,6 +159,13 @@ class ComputeBench(Suite):
             [5, 100],  # num_kernels
         )
         for runtime, with_graphs, num_kernels in sin_kernel_graph_params:
+            if (
+                (options.ur_adapter != "level_zero_v2")
+                and (runtime == RUNTIMES.SYCL or runtime == RUNTIMES.SYCL_PREVIEW)
+                and (with_graphs == 1)
+            ):
+                # old adapter doesn't support graph mode for SYCL
+                continue
             benches.append(
                 GraphApiSinKernelGraph(self, runtime, with_graphs, num_kernels)
             )


### PR DESCRIPTION
Old level zero adapter crashes while running graph record and replay with `UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP`.
Don't run `SinKernelGraph` SYCL benchmarks on the old adapter.

Also, use v2 adapter in per-PR benchmark tests.

Fixes: #22599
