### PR TITLE
[SYCL][E2E] Re-enable HIP tests disabled by flaky CI tracker #17464

### DIFF
--- a/sycl/test-e2e/Adapters/retain_events.cpp
+++ b/sycl/test-e2e/Adapters/retain_events.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17236
-
 #include <algorithm>
 #include <cstdio>
 #include <numeric>

--- a/sycl/test-e2e/HostInteropTask/host-task-dependency3.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-dependency3.cpp
@@ -4,9 +4,6 @@
 
 // RUN: %{run} %t.out 10
 
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17235
-
 #include <chrono>
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/WeakObject/weak_object_expired.cpp
+++ b/sycl/test-e2e/WeakObject/weak_object_expired.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17415
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
This re-enables three E2E tests that were marked `UNSUPPORTED: hip` as part of the flaky AMD/HIP CI cluster tracked in #17464. Those failures were not defects in the tests themselves — they were the parallel-execution memory faults/hangs on the AMD runner (worked around with `-j1`). The tests run and pass on an AMD Instinct MI210 (gfx90a):

- `WeakObject/weak_object_expired.cpp` (#17415)
- `HostInteropTask/host-task-dependency3.cpp` (#17235) — both `%{run}` invocations (default and `10`)
- `Adapters/retain_events.cpp` (#17236)

### Verification
Built with a recent DPC++ (`-fsycl -fsycl-targets=amdgcn-amd-amdhsa`, `--offload-arch=gfx90a`) and executed on an MI210 with ROCm 7.1.1; all three pass. Separately, the heavy-concurrency memory-fault signature from #17464 no longer reproduces on ROCm 7.1.1 (hundreds of concurrent runs, 0 faults/hangs), consistent with the underlying ROCm/driver bug having been resolved in newer ROCm.

Note: `WorkGroupMemory/basic_usage.cpp` (#17339) is intentionally left disabled — it currently triggers a separate device-compiler backend crash on gfx90a, unrelated to the #17464 concurrency issue.

### CI
Please run the HIP/AMD pre-commit to confirm these pass on the CI runners' ROCm version before merging.
