### PR TITLE
[SYCL][E2E] Re-enable WorkGroupMemory/basic_usage.cpp on HIP

### DIFF
--- a/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/basic_usage.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: hip
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/17339
-
 // UNSUPPORTED: cuda-ge-13
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21806
 


### PR DESCRIPTION
This test was marked UNSUPPORTED on HIP due to the flaky-CI hang tracked in #17339. The underlying failure mode on current ROCm is a compiler crash in GlobalOffsetPass ("Calling a function with a bad signature!") triggered by in-kernel asserts combined with get_global_id usage, which is fixed by #22677.

With that fix, the test compiles (asserts enabled) and passes on gfx942 (MI300A), so remove the UNSUPPORTED: hip marker.

Depends on #22677.
