### PR TITLE
[SSAF] Fix Expected return type in TypeConstrainedPointers deserialization (gcc 7.5.0)

### DIFF
--- a/clang/lib/ScalableStaticAnalysis/Analyses/OperatorNewDelete/OperatorNewDeletePointers.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/OperatorNewDelete/OperatorNewDeletePointers.cpp
@@ -203,7 +203,7 @@ deserializeSummary(const llvm::json::Object &Data, EntityIdTable &,
       std::make_unique<OperatorNewDeletePointersEntitySummary>();
 
   Sum->Entities = std::move(*EntityIDSet);
-  return Sum;
+  return std::unique_ptr<EntitySummary>(std::move(Sum));
 }
 
 struct OperatorNewDeletePointersJSONFormatInfo final : JSONFormat::FormatInfo {
@@ -237,7 +237,7 @@ deserializeAnalysisResult(const llvm::json::Object &Data,
       std::make_unique<OperatorNewDeletePointersAnalysisResult>();
 
   AR->Entities = std::move(*EntityIDSet);
-  return AR;
+  return std::unique_ptr<AnalysisResult>(std::move(AR));
 }
 
 JSONFormat::AnalysisResultRegistry::Add<OperatorNewDeletePointersAnalysisResult>


### PR DESCRIPTION
GCC 7.5.0 fails to compile this code. Use explicit upcasts from std::unique_ptr to std::unique_ptr in deserializeSummary and deserializeAnalysisResult. This resolves a compilation error where llvm::Expected<std::unique_ptr> could not be constructed from unique_ptr of derived summary/result types.

---
See: https://github.com/llvm/llvm-project/pull/211331
This file has been renamed in the upstream. The PR above should fix the issue in the upstream.
This one is to fix the toolchain build with gcc 7.5.0 before pulldown.