### PR TITLE
[SYCL][E2E] Drop new/old offload model mixing

### DIFF
--- a/sycl/test-e2e/NewOffloadDriver/multisource.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/multisource.cpp
@@ -20,22 +20,12 @@
 // RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl %{sycl_target_opts} --offload-new-driver %t.init.o %t.calc.o %t.main.o -o %t2.fat
 // RUN: %{run} %t2.fat
 
-// Multiple sources with kernel code with old-style objects
+// Multiple sources with kernel code in a static archive. Archive is built
+// via the objects above.
 // Test with `--offload-new-driver`
-// RUN: %{build} --no-offload-new-driver -c -o %t.init.o -DINIT_KERNEL
-// RUN: %{build} --no-offload-new-driver -c -o %t.calc.o -DCALC_KERNEL
-// RUN: %{build} --no-offload-new-driver -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl %{sycl_target_opts} --offload-new-driver %t.init.o %t.calc.o %t.main.o -o %t3.fat
-// RUN: %{run} %t3.fat
-
-// Multiple sources with kernel code with old-style objects in a static archive
-// Test with `--offload-new-driver`
-// RUN: %{build} --no-offload-new-driver -c -o %t.init.o -DINIT_KERNEL
-// RUN: %{build} --no-offload-new-driver -c -o %t.calc.o -DCALC_KERNEL
-// RUN: %{build} --no-offload-new-driver -c -o %t.main.o -DMAIN_APP
 // RUN: llvm-ar r %t.a %t.init.o %t.calc.o
-// RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl %{sycl_target_opts} --offload-new-driver %t.main.o %t.a -o %t4.fat
-// RUN: %{run} %t4.fat
+// RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl %{sycl_target_opts} --offload-new-driver %t.main.o %t.a -o %t3.fat
+// RUN: %{run} %t3.fat
 
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142

--- a/sycl/test-e2e/NewOffloadDriver/multisource.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/multisource.cpp
@@ -27,9 +27,6 @@
 // RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl %{sycl_target_opts} --offload-new-driver %t.main.o %t.a -o %t3.fat
 // RUN: %{run} %t3.fat
 
-// XFAIL: target-native_cpu
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
-
 #include <sycl/detail/core.hpp>
 
 #include <iostream>


### PR DESCRIPTION
The NewOffloadDriver/multisource.cpp test exercised the ability to create an old offload object and consume it with the new model.  This behavior is not supported.  In particular, the old model pulls in the device libraries at link time, while the new model pulls them in during compile time.  This separation causes issues when there is the assumption that the device libs will be linked in during the link phase.