### PR TITLE
[SYCL] Fix XPASS with libcxx in two check-sycl tests

### DIFF
--- a/sycl/test/regression/bit_cast_lin.cpp
+++ b/sycl/test/regression/bit_cast_lin.cpp
@@ -1,6 +1,4 @@
 // RUN: %clangxx -fsycl -fsycl-host-compiler=g++ -fsycl-host-compiler-options='-std=c++17' %s -o %t.out
 // UNSUPPORTED: windows
-// XFAIL: libcxx
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 
 #include "bit_cast.hpp"

--- a/sycl/test/regression/host_builtins_gcc.cpp
+++ b/sycl/test/regression/host_builtins_gcc.cpp
@@ -3,8 +3,6 @@
 // expected-no-diagnostics
 //
 // REQUIRES: linux
-// XFAIL: libcxx
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 //
 // Tests that using gcc as the host compiler correctly compiles SYCL builtins on
 // host.


### PR DESCRIPTION
XPASSing in the nightly, see [here](https://github.com/intel/llvm/actions/runs/29890078838/job/88828588819).

I confirmed libsycl is still being built with libcxx, probably some fix from the pulldown.

I updated the GH issue.