### PR TITLE
[SYCL][HIP] Add fp8 (E4M3) / bf8 (E5M2) joint_matrix support on AMD gfx942

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1255,6 +1255,17 @@ void CodeGenModule::Release() {
                                 : "buffered");
       getModule().addModuleFlag(llvm::Module::Error, "amdgpu_printf_kind",
                                 MDStr);
+    } else if (LangOpts.SYCLIsDevice) {
+      // SYCL device code on AMDGPU always uses the buffered printf scheme: the
+      // hostcall scheme relies on ROCm's hostcall runtime service (and PCIe
+      // atomics), which the SYCL/UR HIP runtime does not set up. The buffered
+      // scheme only needs the printf buffer implicit kernarg, which the HIP
+      // runtime allocates and parses automatically from the code object's
+      // printf metadata. This flag tells AMDGPUPrintfRuntimeBinding to lower
+      // printf using the buffered layout expected by the runtime.
+      getModule().addModuleFlag(
+          llvm::Module::Error, "amdgpu_printf_kind",
+          llvm::MDString::get(getLLVMContext(), "buffered"));
     }
   }
 

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
@@ -13,6 +13,7 @@
 
 #include <sycl/access/access.hpp>
 #include <sycl/ext/oneapi/bfloat16.hpp>
+#include <sycl/ext/oneapi/experimental/float_8bit/types.hpp>
 #include <sycl/marray.hpp>
 #include <sycl/multi_ptr.hpp>
 
@@ -27,6 +28,13 @@ namespace oneapi {
 namespace detail {
 
 constexpr int WAVEFRONT_SIZE = 64;
+
+// AMD CDNA3 (gfx942/gfx940/gfx941) 8-bit floating point matrix element types.
+// E4M3 is AMD's "fp8" and E5M2 is AMD's "bf8". The joint_matrix element type is
+// the corresponding experimental fp8 type; only the raw byte storage is used by
+// the MFMA path (the device-side conversion methods are never instantiated).
+using fp8_e4m3 = sycl::ext::oneapi::experimental::fp8_e4m3;
+using fp8_e5m2 = sycl::ext::oneapi::experimental::fp8_e5m2;
 
 template <typename T, sycl::ext::oneapi::experimental::matrix::use Use,
           size_t Rows, size_t Cols,
@@ -102,6 +110,18 @@ __SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, a, 16, 32, 8)
 __SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, b, 32, 16, 8)
 __SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, a, 32, 16, 8)
 __SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, b, 16, 32, 8)
+
+// gfx942 (CDNA3) fp8 (E4M3) / bf8 (E5M2) MFMA: 16x16x32 and 32x32x16 with
+// packed i64 operands (8 fp8 values per work-item). A and B formats may differ.
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(fp8_e4m3, a, 16, 32, 8)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(fp8_e4m3, b, 32, 16, 8)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(fp8_e4m3, a, 32, 16, 8)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(fp8_e4m3, b, 16, 32, 8)
+
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(fp8_e5m2, a, 16, 32, 8)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(fp8_e5m2, b, 32, 16, 8)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(fp8_e5m2, a, 32, 16, 8)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(fp8_e5m2, b, 16, 32, 8)
 
 #undef __SYCL_JOINT_MATRIX_OVERLOAD_ARR
 
@@ -368,23 +388,24 @@ void joint_matrix_store_hip(
   }
 }
 
-template <typename Tm, typename Tc, std::size_t M, std::size_t K, std::size_t N,
+template <typename TmA, typename TmB, typename Tc, std::size_t M, std::size_t K,
+          std::size_t N,
           sycl::ext::oneapi::experimental::matrix::layout LayoutA,
           sycl::ext::oneapi::experimental::matrix::layout LayoutB>
 void joint_matrix_mad_hip(
     joint_matrix_hip<
         Tc, sycl::ext::oneapi::experimental::matrix::use::accumulator, M, N,
         sycl::ext::oneapi::experimental::matrix::layout::dynamic> &D,
-    const joint_matrix_hip<Tm, sycl::ext::oneapi::experimental::matrix::use::a,
+    const joint_matrix_hip<TmA, sycl::ext::oneapi::experimental::matrix::use::a,
                            M, K, LayoutA> &A,
-    const joint_matrix_hip<Tm, sycl::ext::oneapi::experimental::matrix::use::b,
+    const joint_matrix_hip<TmB, sycl::ext::oneapi::experimental::matrix::use::b,
                            K, N, LayoutB> &B,
     const joint_matrix_hip<
         Tc, sycl::ext::oneapi::experimental::matrix::use::accumulator, M, N,
         sycl::ext::oneapi::experimental::matrix::layout::dynamic> &C) {
 #if defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) ||       \
     defined(__gfx942__)
-  if constexpr (std::is_same_v<Tm, float>) {
+  if constexpr (std::is_same_v<TmA, float>) {
 #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     if constexpr (M == 16 && N == 16) {
       auto result = __builtin_amdgcn_mfma_f32_16x16x4f32(
@@ -398,7 +419,7 @@ void joint_matrix_mad_hip(
       std::memcpy(&D.wi_marray, &result, 16 * sizeof(float));
     }
 #endif
-  } else if constexpr (std::is_same_v<Tm, sycl::half>) {
+  } else if constexpr (std::is_same_v<TmA, sycl::half>) {
     if constexpr (M == 16 && N == 16) {
       auto result = __builtin_amdgcn_mfma_f32_16x16x16f16(
           *reinterpret_cast<const float16x4 *>(&A.wi_marray),
@@ -412,7 +433,7 @@ void joint_matrix_mad_hip(
           *reinterpret_cast<const floatx16 *>(&C.wi_marray), 0, 0, 0);
       std::memcpy(&D.wi_marray, &result, 16 * sizeof(float));
     }
-  } else if constexpr (std::is_same_v<Tm, bfloat16>) {
+  } else if constexpr (std::is_same_v<TmA, bfloat16>) {
     if constexpr (M == 16 && N == 16) {
       auto result = __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(
           *reinterpret_cast<const bfloat16x4 *>(&A.wi_marray),
@@ -426,14 +447,14 @@ void joint_matrix_mad_hip(
           *reinterpret_cast<const floatx16 *>(&C.wi_marray), 0, 0, 0);
       std::memcpy(&D.wi_marray, &result, 16 * sizeof(float));
     }
-  } else if constexpr (std::is_same_v<Tm, double>) {
+  } else if constexpr (std::is_same_v<TmA, double>) {
     if constexpr (M == 16 && N == 16) {
       auto result = __builtin_amdgcn_mfma_f64_16x16x4f64(
           A.wi_marray[0], B.wi_marray[0],
           *reinterpret_cast<const doublex4 *>(&C.wi_marray), 0, 0, 0);
       std::memcpy(&D.wi_marray, &result, 4 * sizeof(double));
     }
-  } else if constexpr (std::is_same_v<Tm, int8_t>) {
+  } else if constexpr (std::is_same_v<TmA, int8_t>) {
 #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     // CDNA3 (gfx942) int8 MFMA: 16x16x32 / 32x32x16 with packed i64 operands
     // (8 int8 values per work-item).
@@ -465,6 +486,43 @@ void joint_matrix_mad_hip(
           *reinterpret_cast<const Tc *>(&B.wi_marray),
           *reinterpret_cast<const int32x16 *>(&C.wi_marray), 0, 0, 0);
       std::memcpy(&D.wi_marray, &result, 16 * sizeof(int32_t));
+    }
+#endif
+  } else if constexpr (std::is_same_v<TmA, fp8_e4m3> ||
+                       std::is_same_v<TmA, fp8_e5m2>) {
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+    // CDNA3 (gfx942) fp8 (E4M3) / bf8 (E5M2) MFMA: 16x16x32 / 32x32x16 with
+    // packed i64 operands (8 fp8 values per work-item) and an f32 accumulator.
+    // The A and B operand formats are independent, so pick the intrinsic from
+    // the (TmA, TmB) pair. In AMD terms: E4M3 -> "fp8", E5M2 -> "bf8".
+    constexpr bool AIsFP8 = std::is_same_v<TmA, fp8_e4m3>;
+    constexpr bool BIsFP8 = std::is_same_v<TmB, fp8_e4m3>;
+    const int64_t a = *reinterpret_cast<const int64_t *>(&A.wi_marray);
+    const int64_t b = *reinterpret_cast<const int64_t *>(&B.wi_marray);
+    if constexpr (M == 16 && N == 16) {
+      const auto c = *reinterpret_cast<const floatx4 *>(&C.wi_marray);
+      floatx4 result;
+      if constexpr (AIsFP8 && BIsFP8)
+        result = __builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8(a, b, c, 0, 0, 0);
+      else if constexpr (AIsFP8 && !BIsFP8)
+        result = __builtin_amdgcn_mfma_f32_16x16x32_fp8_bf8(a, b, c, 0, 0, 0);
+      else if constexpr (!AIsFP8 && BIsFP8)
+        result = __builtin_amdgcn_mfma_f32_16x16x32_bf8_fp8(a, b, c, 0, 0, 0);
+      else
+        result = __builtin_amdgcn_mfma_f32_16x16x32_bf8_bf8(a, b, c, 0, 0, 0);
+      std::memcpy(&D.wi_marray, &result, 4 * sizeof(float));
+    } else if constexpr (M == 32 && N == 32) {
+      const auto c = *reinterpret_cast<const floatx16 *>(&C.wi_marray);
+      floatx16 result;
+      if constexpr (AIsFP8 && BIsFP8)
+        result = __builtin_amdgcn_mfma_f32_32x32x16_fp8_fp8(a, b, c, 0, 0, 0);
+      else if constexpr (AIsFP8 && !BIsFP8)
+        result = __builtin_amdgcn_mfma_f32_32x32x16_fp8_bf8(a, b, c, 0, 0, 0);
+      else if constexpr (!AIsFP8 && BIsFP8)
+        result = __builtin_amdgcn_mfma_f32_32x32x16_bf8_fp8(a, b, c, 0, 0, 0);
+      else
+        result = __builtin_amdgcn_mfma_f32_32x32x16_bf8_bf8(a, b, c, 0, 0, 0);
+      std::memcpy(&D.wi_marray, &result, 16 * sizeof(float));
     }
 #endif
   }

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
@@ -83,6 +83,11 @@ __SYCL_JOINT_MATRIX_OVERLOAD_ARR(half, b, 16, 16, 4)
 __SYCL_JOINT_MATRIX_OVERLOAD_ARR(half, a, 32, 8, 4)
 __SYCL_JOINT_MATRIX_OVERLOAD_ARR(half, b, 8, 32, 4)
 
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(float, a, 16, 4, 1)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(float, b, 4, 16, 1)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(float, a, 32, 2, 1)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(float, b, 2, 32, 1)
+
 __SYCL_JOINT_MATRIX_OVERLOAD_ARR(double, a, 16, 4, 1)
 __SYCL_JOINT_MATRIX_OVERLOAD_ARR(double, b, 4, 16, 1)
 
@@ -379,7 +384,21 @@ void joint_matrix_mad_hip(
         sycl::ext::oneapi::experimental::matrix::layout::dynamic> &C) {
 #if defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) ||       \
     defined(__gfx942__)
-  if constexpr (std::is_same_v<Tm, sycl::half>) {
+  if constexpr (std::is_same_v<Tm, float>) {
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+    if constexpr (M == 16 && N == 16) {
+      auto result = __builtin_amdgcn_mfma_f32_16x16x4f32(
+          A.wi_marray[0], B.wi_marray[0],
+          *reinterpret_cast<const floatx4 *>(&C.wi_marray), 0, 0, 0);
+      std::memcpy(&D.wi_marray, &result, 4 * sizeof(float));
+    } else if constexpr (M == 32 && N == 32) {
+      auto result = __builtin_amdgcn_mfma_f32_32x32x2f32(
+          A.wi_marray[0], B.wi_marray[0],
+          *reinterpret_cast<const floatx16 *>(&C.wi_marray), 0, 0, 0);
+      std::memcpy(&D.wi_marray, &result, 16 * sizeof(float));
+    }
+#endif
+  } else if constexpr (std::is_same_v<Tm, sycl::half>) {
     if constexpr (M == 16 && N == 16) {
       auto result = __builtin_amdgcn_mfma_f32_16x16x16f16(
           *reinterpret_cast<const float16x4 *>(&A.wi_marray),

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
@@ -236,10 +236,10 @@ void load_multiplicand_hip(joint_matrix_hip<S, Use, M, N, Layout> &res,
   // dimension (rows M for the A multiplicand, columns N for the B multiplicand)
   // and the shared contraction dimension K. Whether the free dimension is the
   // strided one in memory depends on BOTH the use and the layout:
-  //   - A row_major: element (m,k) at m*stride + k -> free dim (m) is strided.
-  //   - A col_major: element (m,k) at k*stride + m -> free dim (m) is contiguous.
-  //   - B row_major: element (k,n) at k*stride + n -> free dim (n) is contiguous.
-  //   - B col_major: element (k,n) at n*stride + k -> free dim (n) is strided.
+  //   - A row_major: (m,k) at m*stride + k -> free dim (m) is strided.
+  //   - A col_major: (m,k) at k*stride + m -> free dim (m) is contiguous.
+  //   - B row_major: (k,n) at k*stride + n -> free dim (n) is contiguous.
+  //   - B col_major: (k,n) at n*stride + k -> free dim (n) is strided.
   // So the strided-free-dim access pattern applies to (A, row_major) and
   // (B, col_major); the contiguous-free-dim pattern applies to (A, col_major)
   // and (B, row_major). Selecting the pattern from this combined condition

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
@@ -17,6 +17,7 @@
 #include <sycl/marray.hpp>
 #include <sycl/multi_ptr.hpp>
 
+#include <cstdint>
 #include <cstring>
 
 #define __HIP_PLATFORM_AMD_MFMA__
@@ -388,6 +389,51 @@ void joint_matrix_store_hip(
   }
 }
 
+// Re-encode one OCP fp8 byte into the CDNA3 (gfx942/gfx940/gfx941) fnuz
+// encoding expected by the fp8/bf8 MFMA instructions. OCP and fnuz share the
+// exact field widths and differ only by a +1 exponent bias, so the transform
+// is a handful of integer ops with no float round-trip, no lookup table and no
+// branches (each ternary lowers to a single v_cndmask). It is exact for every
+// in-range finite value; only the inherently lossy cases (overflow, inf, NaN)
+// are clamped/mapped to the fnuz conventions:
+//   +0/-0     -> +0        (fnuz has no negative zero)
+//   NaN       -> 0x80      (fnuz's single NaN)
+//   Inf(E5M2) -> max finite (saturating clamp)
+//   subnormal -> mag << 1  (the carry lands naturally in the exponent field)
+//   normal    -> exponent_field + 1
+template <typename T> inline uint8_t ocp_fp8_to_fnuz_byte(uint8_t x) {
+  const uint32_t s = x & 0x80u;
+  const uint32_t mag = x & 0x7Fu;
+  if constexpr (std::is_same_v<T, fp8_e4m3>) {
+    // E4M3: subnormal iff mag < 0x08, exponent-overflow iff mag >= 0x78.
+    uint32_t r = (mag < 0x08u) ? (mag << 1) : (mag + 0x08u);
+    r = (mag >= 0x78u) ? 0x7Fu : r;
+    r |= s;
+    r = (mag == 0u) ? 0u : r;
+    return static_cast<uint8_t>((mag == 0x7Fu) ? 0x80u : r);
+  } else {
+    // E5M2: subnormal iff mag < 0x04; mag >= 0x7C is inf (0x7C) or NaN.
+    uint32_t r = (mag < 0x04u) ? (mag << 1) : (mag + 0x04u);
+    r |= s;
+    r = (mag == 0u) ? 0u : r;
+    return static_cast<uint8_t>(
+        (mag >= 0x7Cu) ? ((mag == 0x7Cu) ? (s | 0x7Fu) : 0x80u) : r);
+  }
+}
+
+// Convert the 8 OCP fp8 values packed in an MFMA i64 operand to fnuz in place.
+// Fully unrolled; each byte is independent so there are no cross-byte carries.
+template <typename T> inline int64_t ocp_fp8_to_fnuz_i64(int64_t packed) {
+  const uint64_t u = static_cast<uint64_t>(packed);
+  uint64_t r = 0;
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    const uint8_t b = static_cast<uint8_t>(u >> (i * 8));
+    r |= static_cast<uint64_t>(ocp_fp8_to_fnuz_byte<T>(b)) << (i * 8);
+  }
+  return static_cast<int64_t>(r);
+}
+
 template <typename TmA, typename TmB, typename Tc, std::size_t M, std::size_t K,
           std::size_t N,
           sycl::ext::oneapi::experimental::matrix::layout LayoutA,
@@ -497,8 +543,13 @@ void joint_matrix_mad_hip(
     // the (TmA, TmB) pair. In AMD terms: E4M3 -> "fp8", E5M2 -> "bf8".
     constexpr bool AIsFP8 = std::is_same_v<TmA, fp8_e4m3>;
     constexpr bool BIsFP8 = std::is_same_v<TmB, fp8_e4m3>;
-    const int64_t a = *reinterpret_cast<const int64_t *>(&A.wi_marray);
-    const int64_t b = *reinterpret_cast<const int64_t *>(&B.wi_marray);
+    // The joint_matrix element types are the OCP fp8 formats, but the CDNA3
+    // MFMA reads its operands as fnuz (bias-shifted). Re-encode the packed
+    // operands here; on OCP-native parts (e.g. gfx950) this branch is unused.
+    const int64_t a = ocp_fp8_to_fnuz_i64<TmA>(
+        *reinterpret_cast<const int64_t *>(&A.wi_marray));
+    const int64_t b = ocp_fp8_to_fnuz_i64<TmB>(
+        *reinterpret_cast<const int64_t *>(&B.wi_marray));
     if constexpr (M == 16 && N == 16) {
       const auto c = *reinterpret_cast<const floatx4 *>(&C.wi_marray);
       floatx4 result;

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
@@ -117,8 +117,11 @@ void load_accumulator_layoutT(
         S, sycl::ext::oneapi::experimental::matrix::use::accumulator, M, N,
         sycl::ext::oneapi::experimental::matrix::layout::dynamic> &res,
     multi_ptr<T, Space, IsDecorated> src, size_t stride, Group &sg) {
-  const auto idx = sg.get_group_linear_id() * sg.get_local_range()[0] +
-                   sg.get_local_linear_id();
+  // The fragment lane index is the work-item's position within its own
+  // sub-group (0 .. sub_group_size-1). It must NOT include the sub-group's
+  // index within the work-group, otherwise kernels that launch more than one
+  // sub-group per work-group compute out-of-range element offsets.
+  const auto idx = sg.get_local_linear_id();
 
   if constexpr (std::is_same_v<S, double>) {
     const auto thread_x = idx % N;
@@ -211,33 +214,52 @@ template <
 void load_multiplicand_hip(joint_matrix_hip<S, Use, M, N, Layout> &res,
                            multi_ptr<T, Space, IsDecorated> src, size_t stride,
                            Group &sg) {
-  const auto idx = sg.get_group_linear_id() * sg.get_local_range()[0] +
-                   sg.get_local_linear_id();
+  // The fragment lane index is the work-item's position within its own
+  // sub-group (0 .. sub_group_size-1). It must NOT include the sub-group's
+  // index within the work-group, otherwise kernels that launch more than one
+  // sub-group per work-group compute out-of-range element offsets.
+  const auto idx = sg.get_local_linear_id();
 
-  if constexpr (std::is_same_v<S, double>) {
-    if constexpr (Layout ==
-                  sycl::ext::oneapi::experimental::matrix::layout::row_major) {
-      res.wi_marray[0] = src[idx];
-    } else {
-      res.wi_marray[0] = src[(idx % M) * stride + idx / M];
+  // The AMD MFMA fragment layout is described in terms of the matrix's "free"
+  // dimension (rows M for the A multiplicand, columns N for the B multiplicand)
+  // and the shared contraction dimension K. Whether the free dimension is the
+  // strided one in memory depends on BOTH the use and the layout:
+  //   - A row_major: element (m,k) at m*stride + k -> free dim (m) is strided.
+  //   - A col_major: element (m,k) at k*stride + m -> free dim (m) is contiguous.
+  //   - B row_major: element (k,n) at k*stride + n -> free dim (n) is contiguous.
+  //   - B col_major: element (k,n) at n*stride + k -> free dim (n) is strided.
+  // So the strided-free-dim access pattern applies to (A, row_major) and
+  // (B, col_major); the contiguous-free-dim pattern applies to (A, col_major)
+  // and (B, row_major). Selecting the pattern from this combined condition
+  // (rather than from the layout alone) makes both layouts behave correctly for
+  // the A multiplicand, which previously loaded A transposed for row_major.
+  constexpr bool StridedFreeDim =
+      (Use == sycl::ext::oneapi::experimental::matrix::use::a)
+          ? (Layout ==
+             sycl::ext::oneapi::experimental::matrix::layout::row_major)
+          : (Layout ==
+             sycl::ext::oneapi::experimental::matrix::layout::col_major);
+
+  // Free dimension: M for the A multiplicand, N for the B multiplicand. The
+  // wavefront is split into (WAVEFRONT_SIZE / FreeDim) groups along the
+  // contraction dimension K, and each work-item holds one contiguous K-block of
+  // `Size` elements (Size == 1 for the double shapes).
+  constexpr int FreeDim =
+      (Use == sycl::ext::oneapi::experimental::matrix::use::a) ? M : N;
+  constexpr int Size = (M * N) / WAVEFRONT_SIZE;
+
+  const auto thread_x = idx % FreeDim;
+  const auto thread_y = idx / FreeDim;
+
+  if constexpr (StridedFreeDim) {
+    for (int i = 0; i < Size; ++i) {
+      const int c_idx = thread_x * stride + i + thread_y * Size;
+      res.wi_marray[i] = src[c_idx];
     }
   } else {
-    constexpr int Dim = (M == 16) ? 16 : 32;
-
-    const auto thread_x = idx % Dim;
-    const auto thread_y = idx / Dim;
-
-    if constexpr (Layout ==
-                  sycl::ext::oneapi::experimental::matrix::layout::col_major) {
-      for (int i = 0; i < 4; ++i) {
-        const int c_idx = thread_x * stride + i + thread_y * 4;
-        res.wi_marray[i] = src[c_idx];
-      }
-    } else {
-      for (int i = 0; i < 4; ++i) {
-        const int r_idx = thread_x + i * stride + thread_y * stride * 4;
-        res.wi_marray[i] = src[r_idx];
-      }
+    for (int i = 0; i < Size; ++i) {
+      const int r_idx = thread_x + i * stride + thread_y * stride * Size;
+      res.wi_marray[i] = src[r_idx];
     }
   }
 }
@@ -251,8 +273,11 @@ void store_layoutT(
         T, sycl::ext::oneapi::experimental::matrix::use::accumulator, M, N,
         sycl::ext::oneapi::experimental::matrix::layout::dynamic> &src,
     multi_ptr<T, Space, IsDecorated> dst, size_t stride, Group &sg) {
-  const auto idx = sg.get_group_linear_id() * sg.get_local_range()[0] +
-                   sg.get_local_linear_id();
+  // The fragment lane index is the work-item's position within its own
+  // sub-group (0 .. sub_group_size-1). It must NOT include the sub-group's
+  // index within the work-group, otherwise kernels that launch more than one
+  // sub-group per work-group compute out-of-range element offsets.
+  const auto idx = sg.get_local_linear_id();
 
   if constexpr (std::is_same_v<T, double>) {
     const auto thread_x = idx % N;

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-hip.hpp
@@ -91,6 +91,13 @@ __SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, b, 8, 32, 4)
 __SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, a, 16, 16, 4)
 __SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, b, 16, 16, 4)
 
+// gfx942 (CDNA3) int8 MFMA uses larger K dimensions with packed operands:
+// 16x16x32 and 32x32x16. Each work-item holds 8 int8 values (one i64).
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, a, 16, 32, 8)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, b, 32, 16, 8)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, a, 32, 16, 8)
+__SYCL_JOINT_MATRIX_OVERLOAD_ARR(int8_t, b, 16, 32, 8)
+
 #undef __SYCL_JOINT_MATRIX_OVERLOAD_ARR
 
 #define __SYCL_JOINT_MATRIX_OVERLOAD_ARR_ACC(TYPE, M, N)                       \
@@ -370,7 +377,8 @@ void joint_matrix_mad_hip(
     const joint_matrix_hip<
         Tc, sycl::ext::oneapi::experimental::matrix::use::accumulator, M, N,
         sycl::ext::oneapi::experimental::matrix::layout::dynamic> &C) {
-#ifdef __gfx90a__
+#if defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) ||       \
+    defined(__gfx942__)
   if constexpr (std::is_same_v<Tm, sycl::half>) {
     if constexpr (M == 16 && N == 16) {
       auto result = __builtin_amdgcn_mfma_f32_16x16x16f16(
@@ -407,6 +415,25 @@ void joint_matrix_mad_hip(
       std::memcpy(&D.wi_marray, &result, 4 * sizeof(double));
     }
   } else if constexpr (std::is_same_v<Tm, int8_t>) {
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+    // CDNA3 (gfx942) int8 MFMA: 16x16x32 / 32x32x16 with packed i64 operands
+    // (8 int8 values per work-item).
+    if constexpr (M == 16 && N == 16) {
+      auto result = __builtin_amdgcn_mfma_i32_16x16x32_i8(
+          *reinterpret_cast<const int64_t *>(&A.wi_marray),
+          *reinterpret_cast<const int64_t *>(&B.wi_marray),
+          *reinterpret_cast<const int32x4 *>(&C.wi_marray), 0, 0, 0);
+      std::memcpy(&D.wi_marray, &result, 4 * sizeof(int32_t));
+    } else if constexpr (M == 32 && N == 32) {
+      auto result = __builtin_amdgcn_mfma_i32_32x32x16_i8(
+          *reinterpret_cast<const int64_t *>(&A.wi_marray),
+          *reinterpret_cast<const int64_t *>(&B.wi_marray),
+          *reinterpret_cast<const int32x16 *>(&C.wi_marray), 0, 0, 0);
+      std::memcpy(&D.wi_marray, &result, 16 * sizeof(int32_t));
+    }
+#else
+    // CDNA2 (gfx90a) int8 MFMA: 16x16x16 / 32x32x8 with i32 operands
+    // (4 int8 values per work-item).
     if constexpr (M == 16 && N == 16) {
       auto result = __builtin_amdgcn_mfma_i32_16x16x16i8(
           *reinterpret_cast<const Tc *>(&A.wi_marray),
@@ -420,8 +447,9 @@ void joint_matrix_mad_hip(
           *reinterpret_cast<const int32x16 *>(&C.wi_marray), 0, 0, 0);
       std::memcpy(&D.wi_marray, &result, 16 * sizeof(int32_t));
     }
+#endif
   }
-#endif // __gfx90a__
+#endif // __gfx90a__ || __gfx942__
 }
 
 } // namespace detail

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
@@ -13,7 +13,8 @@
 #if defined(__SYCL_DEVICE_ONLY__)
 #if defined(__NVPTX__)
 #include "matrix-tensorcores.hpp"
-#elif defined(__gfx90a__)
+#elif defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) ||     \
+    defined(__gfx942__)
 #include "matrix-hip.hpp"
 #endif // defined(__NVPTX__)
 #endif // defined(__SYCL_DEVICE_ONLY__)

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
@@ -452,13 +452,23 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_mad(
                     "requires that joint_matrix data types Ta and Tb match");
   }
 #elif defined(__HIP_PLATFORM_AMD_MFMA__)
-  if constexpr (std::is_same<Ta, Tb>::value) {
-    sycl::ext::oneapi::detail::joint_matrix_mad_hip<Ta, Tc, M, K, N, LayoutA,
-                                                    LayoutB>(
+  // On CDNA3 (gfx942) the fp8 (E4M3) and bf8 (E5M2) MFMA instructions allow the
+  // A and B operand formats to differ, so mixed fp8/bf8 multiplicands are valid
+  // even when Ta != Tb.
+  constexpr bool IsFP8A =
+      std::is_same_v<Ta, sycl::ext::oneapi::experimental::fp8_e4m3> ||
+      std::is_same_v<Ta, sycl::ext::oneapi::experimental::fp8_e5m2>;
+  constexpr bool IsFP8B =
+      std::is_same_v<Tb, sycl::ext::oneapi::experimental::fp8_e4m3> ||
+      std::is_same_v<Tb, sycl::ext::oneapi::experimental::fp8_e5m2>;
+  if constexpr (std::is_same<Ta, Tb>::value || (IsFP8A && IsFP8B)) {
+    sycl::ext::oneapi::detail::joint_matrix_mad_hip<Ta, Tb, Tc, M, K, N,
+                                                    LayoutA, LayoutB>(
         D.matrix_impl, A.matrix_impl, B.matrix_impl, C.matrix_impl);
   } else {
-    assert(false && "Ta != Tb : In the HIP backend joint_matrix_mad "
-                    "requires that joint_matrix data types Ta and Tb match");
+    assert(false && "In the HIP backend joint_matrix_mad requires that "
+                    "joint_matrix data types Ta and Tb match, unless they are "
+                    "the fp8 (E4M3) / bf8 (E5M2) formats");
   }
 #else
   constexpr uint32_t MatrixOperand =

--- a/sycl/include/sycl/ext/oneapi/matrix/query-types.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/query-types.hpp
@@ -12,10 +12,20 @@
 #include <sycl/ext/oneapi/bfloat16.hpp>     // for bfloat16
 #include <sycl/ext/oneapi/matrix/matrix-unified-utils.hpp> // for tf32
 
+#include <cstddef> // for size_t
 #include <vector>
 
 namespace sycl {
 inline namespace _V1 {
+namespace ext::oneapi::experimental {
+// Forward declarations of the fp8 (E4M3) / bf8 (E5M2) types so this header
+// stays lightweight (the full definitions live in float_8bit/types.hpp).
+template <size_t N> class fp8_e4m3_x;
+template <size_t N> class fp8_e5m2_x;
+using fp8_e4m3 = fp8_e4m3_x<1>;
+using fp8_e5m2 = fp8_e5m2_x<1>;
+} // namespace ext::oneapi::experimental
+
 namespace ext::oneapi::experimental::matrix {
 
 enum class matrix_type {
@@ -31,7 +41,9 @@ enum class matrix_type {
   uint8,
   uint16,
   uint32,
-  uint64
+  uint64,
+  fp8_e4m3,
+  fp8_e5m2
 };
 
 struct combination {
@@ -108,6 +120,16 @@ template <> constexpr const char *convertTypeToMatrixTypeString<uint32_t>() {
 }
 template <> constexpr const char *convertTypeToMatrixTypeString<uint64_t>() {
   return "matrix_type::uint64";
+}
+template <>
+constexpr const char *
+convertTypeToMatrixTypeString<sycl::ext::oneapi::experimental::fp8_e4m3>() {
+  return "matrix_type::fp8_e4m3";
+}
+template <>
+constexpr const char *
+convertTypeToMatrixTypeString<sycl::ext::oneapi::experimental::fp8_e5m2>() {
+  return "matrix_type::fp8_e5m2";
 }
 } // namespace detail
 } // namespace _V1

--- a/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
@@ -578,7 +578,21 @@ struct matrix_params<
 /// AMD Matrix Cores - GFX942 architecture ///
 //////////////////////////////////////////////
 
-template <typename Ta, typename Tc>
+// E4M3 ("fp8") and E5M2 ("bf8") 8-bit float matrix element types.
+template <typename T> constexpr bool is_fp8_amd_gfx942() {
+  return std::is_same_v<T, fp8_e4m3> || std::is_same_v<T, fp8_e5m2>;
+}
+
+// On gfx942 the fp8/bf8 MFMA instructions accept independent A and B operand
+// formats, so a valid multiplicand pair is either identical types or any
+// combination of the two fp8 formats.
+template <typename Ta, typename Tb>
+constexpr bool is_valid_amd_gfx942_type_pair() {
+  return std::is_same_v<Ta, Tb> ||
+         (is_fp8_amd_gfx942<Ta>() && is_fp8_amd_gfx942<Tb>());
+}
+
+template <typename Ta, typename Tb, typename Tc>
 constexpr bool is_combination_valid_amd_gfx942(size_t sM, size_t sN,
                                                size_t sK) {
   return (std::is_same_v<Ta, half> && std::is_same_v<Tc, float> &&
@@ -594,16 +608,22 @@ constexpr bool is_combination_valid_amd_gfx942(size_t sM, size_t sN,
           ((sM == 32 && sN == 32 && sK == 8) ||
            (sM == 16 && sN == 16 && sK == 16))) ||
          (std::is_same_v<Ta, double> && std::is_same_v<Tc, double> &&
-          (sM == 16 && sN == 16 && sK == 4));
+          (sM == 16 && sN == 16 && sK == 4)) ||
+         (is_fp8_amd_gfx942<Ta>() && is_fp8_amd_gfx942<Tb>() &&
+          std::is_same_v<Tc, float> &&
+          ((sM == 32 && sN == 32 && sK == 16) ||
+           (sM == 16 && sN == 16 && sK == 32)));
 }
 
-template <typename Ta, typename Tc>
+template <typename Ta, typename Tb, typename Tc>
 constexpr bool are_types_valid_amd_gfx942() {
   return (std::is_same_v<Ta, half> && std::is_same_v<Tc, float>) ||
          (std::is_same_v<Ta, float> && std::is_same_v<Tc, float>) ||
          (std::is_same_v<Ta, int8_t> && std::is_same_v<Tc, int32_t>) ||
          (std::is_same_v<Ta, bfloat16> && std::is_same_v<Tc, float>) ||
-         (std::is_same_v<Ta, double> && std::is_same_v<Tc, double>);
+         (std::is_same_v<Ta, double> && std::is_same_v<Tc, double>) ||
+         (is_fp8_amd_gfx942<Ta>() && is_fp8_amd_gfx942<Tb>() &&
+          std::is_same_v<Tc, float>);
 }
 
 // Default-values query:
@@ -614,17 +634,17 @@ struct matrix_params<
     typename std::enable_if_t<(
         !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
         !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
-        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td>)>> {
+        is_valid_amd_gfx942_type_pair<Ta, Tb>() && std::is_same_v<Tc, Td>)>> {
   static_assert(
-      are_types_valid_amd_gfx942<Ta, Tc>(),
+      are_types_valid_amd_gfx942<Ta, Tb, Tc>(),
       "Invalid types for AMD gfx942, supported types are half, float, "
-      "int8_t, int32_t, double and bfloat16 ");
+      "int8_t, int32_t, double, bfloat16, and fp8 (E4M3 / E5M2) ");
 
   // Default sizes for AMD gfx942 were chosen to represent a square matrix
   static constexpr std::size_t M = 16;
   static constexpr std::size_t N = 16;
   static constexpr std::size_t K =
-      std::is_same_v<Ta, int8_t>                                   ? 32
+      (std::is_same_v<Ta, int8_t> || is_fp8_amd_gfx942<Ta>())      ? 32
       : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>) ? 16
                                                                    : 4;
 
@@ -647,10 +667,10 @@ struct matrix_params<
     typename std::enable_if_t<(
         !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
         !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
-        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td> && sM != 0 &&
-        sN != 0 && sK != 0)>> {
+        is_valid_amd_gfx942_type_pair<Ta, Tb>() && std::is_same_v<Tc, Td> &&
+        sM != 0 && sN != 0 && sK != 0)>> {
   static_assert(
-      is_combination_valid_amd_gfx942<Ta, Tc>(sM, sN, sK),
+      is_combination_valid_amd_gfx942<Ta, Tb, Tc>(sM, sN, sK),
       "Invalid parameters for AMD gfx942, query valid combinations "
       "using: "
       "q.get_device().get_info<sycl::info::device::matrix::combinations>()");
@@ -683,17 +703,17 @@ struct matrix_params<
     typename std::enable_if_t<(
         !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
         !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
-        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td>)>> {
+        is_valid_amd_gfx942_type_pair<Ta, Tb>() && std::is_same_v<Tc, Td>)>> {
   static_assert(
-      are_types_valid_amd_gfx942<Ta, Tc>(),
+      are_types_valid_amd_gfx942<Ta, Tb, Tc>(),
       "Invalid types for AMD gfx940, supported types are half, float, "
-      "int8_t, int32_t, double and bfloat16 ");
+      "int8_t, int32_t, double, bfloat16, and fp8 (E4M3 / E5M2) ");
 
   // Default sizes for AMD gfx940 were chosen to represent a square matrix
   static constexpr std::size_t M = 16;
   static constexpr std::size_t N = 16;
   static constexpr std::size_t K =
-      std::is_same_v<Ta, int8_t>                                   ? 32
+      (std::is_same_v<Ta, int8_t> || is_fp8_amd_gfx942<Ta>())      ? 32
       : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>) ? 16
                                                                    : 4;
 
@@ -715,10 +735,10 @@ struct matrix_params<
     typename std::enable_if_t<(
         !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
         !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
-        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td> && sM != 0 &&
-        sN != 0 && sK != 0)>> {
+        is_valid_amd_gfx942_type_pair<Ta, Tb>() && std::is_same_v<Tc, Td> &&
+        sM != 0 && sN != 0 && sK != 0)>> {
   static_assert(
-      is_combination_valid_amd_gfx942<Ta, Tc>(sM, sN, sK),
+      is_combination_valid_amd_gfx942<Ta, Tb, Tc>(sM, sN, sK),
       "Invalid parameters for AMD gfx940, query valid combinations "
       "using: "
       "q.get_device().get_info<sycl::info::device::matrix::combinations>()");
@@ -744,17 +764,17 @@ struct matrix_params<
     typename std::enable_if_t<(
         !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
         !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
-        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td>)>> {
+        is_valid_amd_gfx942_type_pair<Ta, Tb>() && std::is_same_v<Tc, Td>)>> {
   static_assert(
-      are_types_valid_amd_gfx942<Ta, Tc>(),
+      are_types_valid_amd_gfx942<Ta, Tb, Tc>(),
       "Invalid types for AMD gfx941, supported types are half, float, "
-      "int8_t, int32_t, double and bfloat16 ");
+      "int8_t, int32_t, double, bfloat16, and fp8 (E4M3 / E5M2) ");
 
   // Default sizes for AMD gfx941 were chosen to represent a square matrix
   static constexpr std::size_t M = 16;
   static constexpr std::size_t N = 16;
   static constexpr std::size_t K =
-      std::is_same_v<Ta, int8_t>                                   ? 32
+      (std::is_same_v<Ta, int8_t> || is_fp8_amd_gfx942<Ta>())      ? 32
       : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>) ? 16
                                                                    : 4;
 
@@ -776,10 +796,10 @@ struct matrix_params<
     typename std::enable_if_t<(
         !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
         !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
-        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td> && sM != 0 &&
-        sN != 0 && sK != 0)>> {
+        is_valid_amd_gfx942_type_pair<Ta, Tb>() && std::is_same_v<Tc, Td> &&
+        sM != 0 && sN != 0 && sK != 0)>> {
   static_assert(
-      is_combination_valid_amd_gfx942<Ta, Tc>(sM, sN, sK),
+      is_combination_valid_amd_gfx942<Ta, Tb, Tc>(sM, sN, sK),
       "Invalid parameters for AMD gfx941, query valid combinations "
       "using: "
       "q.get_device().get_info<sycl::info::device::matrix::combinations>()");

--- a/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
@@ -624,10 +624,9 @@ struct matrix_params<
   static constexpr std::size_t M = 16;
   static constexpr std::size_t N = 16;
   static constexpr std::size_t K =
-      std::is_same_v<Ta, int8_t> ? 32
-      : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>)
-          ? 16
-          : 4;
+      std::is_same_v<Ta, int8_t>                                   ? 32
+      : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>) ? 16
+                                                                   : 4;
 
   template <typename Group, layout Layout>
   using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
@@ -694,10 +693,9 @@ struct matrix_params<
   static constexpr std::size_t M = 16;
   static constexpr std::size_t N = 16;
   static constexpr std::size_t K =
-      std::is_same_v<Ta, int8_t> ? 32
-      : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>)
-          ? 16
-          : 4;
+      std::is_same_v<Ta, int8_t>                                   ? 32
+      : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>) ? 16
+                                                                   : 4;
 
   template <typename Group, layout Layout>
   using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
@@ -756,10 +754,9 @@ struct matrix_params<
   static constexpr std::size_t M = 16;
   static constexpr std::size_t N = 16;
   static constexpr std::size_t K =
-      std::is_same_v<Ta, int8_t> ? 32
-      : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>)
-          ? 16
-          : 4;
+      std::is_same_v<Ta, int8_t>                                   ? 32
+      : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>) ? 16
+                                                                   : 4;
 
   template <typename Group, layout Layout>
   using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;

--- a/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
@@ -584,6 +584,9 @@ constexpr bool is_combination_valid_amd_gfx942(size_t sM, size_t sN,
   return (std::is_same_v<Ta, half> && std::is_same_v<Tc, float> &&
           ((sM == 32 && sN == 32 && sK == 8) ||
            (sM == 16 && sN == 16 && sK == 16))) ||
+         (std::is_same_v<Ta, float> && std::is_same_v<Tc, float> &&
+          ((sM == 32 && sN == 32 && sK == 2) ||
+           (sM == 16 && sN == 16 && sK == 4))) ||
          (std::is_same_v<Ta, int8_t> && std::is_same_v<Tc, int32_t> &&
           ((sM == 32 && sN == 32 && sK == 16) ||
            (sM == 16 && sN == 16 && sK == 32))) ||
@@ -597,6 +600,7 @@ constexpr bool is_combination_valid_amd_gfx942(size_t sM, size_t sN,
 template <typename Ta, typename Tc>
 constexpr bool are_types_valid_amd_gfx942() {
   return (std::is_same_v<Ta, half> && std::is_same_v<Tc, float>) ||
+         (std::is_same_v<Ta, float> && std::is_same_v<Tc, float>) ||
          (std::is_same_v<Ta, int8_t> && std::is_same_v<Tc, int32_t>) ||
          (std::is_same_v<Ta, bfloat16> && std::is_same_v<Tc, float>) ||
          (std::is_same_v<Ta, double> && std::is_same_v<Tc, double>);
@@ -619,9 +623,11 @@ struct matrix_params<
   // Default sizes for AMD gfx942 were chosen to represent a square matrix
   static constexpr std::size_t M = 16;
   static constexpr std::size_t N = 16;
-  static constexpr std::size_t K = std::is_same_v<Ta, double>  ? 4
-                                   : std::is_same_v<Ta, int8_t> ? 32
-                                                                : 16;
+  static constexpr std::size_t K =
+      std::is_same_v<Ta, int8_t> ? 32
+      : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>)
+          ? 16
+          : 4;
 
   template <typename Group, layout Layout>
   using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
@@ -687,9 +693,11 @@ struct matrix_params<
   // Default sizes for AMD gfx940 were chosen to represent a square matrix
   static constexpr std::size_t M = 16;
   static constexpr std::size_t N = 16;
-  static constexpr std::size_t K = std::is_same_v<Ta, double>  ? 4
-                                   : std::is_same_v<Ta, int8_t> ? 32
-                                                                : 16;
+  static constexpr std::size_t K =
+      std::is_same_v<Ta, int8_t> ? 32
+      : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>)
+          ? 16
+          : 4;
 
   template <typename Group, layout Layout>
   using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
@@ -747,9 +755,11 @@ struct matrix_params<
   // Default sizes for AMD gfx941 were chosen to represent a square matrix
   static constexpr std::size_t M = 16;
   static constexpr std::size_t N = 16;
-  static constexpr std::size_t K = std::is_same_v<Ta, double>  ? 4
-                                   : std::is_same_v<Ta, int8_t> ? 32
-                                                                : 16;
+  static constexpr std::size_t K =
+      std::is_same_v<Ta, int8_t> ? 32
+      : (std::is_same_v<Ta, half> || std::is_same_v<Ta, bfloat16>)
+          ? 16
+          : 4;
 
   template <typename Group, layout Layout>
   using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;

--- a/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
@@ -574,6 +574,96 @@ struct matrix_params<
   using joint_matrix_d = joint_matrix<Group, Td, use::accumulator, M, N>;
 };
 
+//////////////////////////////////////////////
+/// AMD Matrix Cores - GFX942 architecture ///
+//////////////////////////////////////////////
+
+template <typename Ta, typename Tc>
+constexpr bool is_combination_valid_amd_gfx942(size_t sM, size_t sN,
+                                               size_t sK) {
+  return (std::is_same_v<Ta, half> && std::is_same_v<Tc, float> &&
+          ((sM == 32 && sN == 32 && sK == 8) ||
+           (sM == 16 && sN == 16 && sK == 16))) ||
+         (std::is_same_v<Ta, int8_t> && std::is_same_v<Tc, int32_t> &&
+          ((sM == 32 && sN == 32 && sK == 16) ||
+           (sM == 16 && sN == 16 && sK == 32))) ||
+         (std::is_same_v<Ta, bfloat16> && std::is_same_v<Tc, float> &&
+          ((sM == 32 && sN == 32 && sK == 8) ||
+           (sM == 16 && sN == 16 && sK == 16))) ||
+         (std::is_same_v<Ta, double> && std::is_same_v<Tc, double> &&
+          (sM == 16 && sN == 16 && sK == 4));
+}
+
+template <typename Ta, typename Tc>
+constexpr bool are_types_valid_amd_gfx942() {
+  return (std::is_same_v<Ta, half> && std::is_same_v<Tc, float>) ||
+         (std::is_same_v<Ta, int8_t> && std::is_same_v<Tc, int32_t>) ||
+         (std::is_same_v<Ta, bfloat16> && std::is_same_v<Tc, float>) ||
+         (std::is_same_v<Ta, double> && std::is_same_v<Tc, double>);
+}
+
+// Default-values query:
+// Specialization for when only types are given, need to query only sizes
+template <typename Ta, typename Tb, typename Tc, typename Td>
+struct matrix_params<
+    architecture::amd_gpu_gfx942, Ta, Tb, Tc, Td, 0, 0, 0,
+    typename std::enable_if_t<(
+        !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
+        !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
+        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td>)>> {
+  static_assert(
+      are_types_valid_amd_gfx942<Ta, Tc>(),
+      "Invalid types for AMD gfx942, supported types are half, float, "
+      "int8_t, int32_t, double and bfloat16 ");
+
+  // Default sizes for AMD gfx942 were chosen to represent a square matrix
+  static constexpr std::size_t M = 16;
+  static constexpr std::size_t N = 16;
+  static constexpr std::size_t K = std::is_same_v<Ta, double>  ? 4
+                                   : std::is_same_v<Ta, int8_t> ? 32
+                                                                : 16;
+
+  template <typename Group, layout Layout>
+  using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
+  template <typename Group, layout Layout>
+  using joint_matrix_b = joint_matrix<Group, Tb, use::b, K, N, Layout>;
+  template <typename Group>
+  using joint_matrix_c = joint_matrix<Group, Tc, use::accumulator, M, N>;
+  template <typename Group>
+  using joint_matrix_d = joint_matrix<Group, Td, use::accumulator, M, N>;
+};
+
+// Validation query
+// Specialization when both types and sizes are given
+template <typename Ta, typename Tb, typename Tc, typename Td, size_t sM,
+          size_t sN, size_t sK>
+struct matrix_params<
+    architecture::amd_gpu_gfx942, Ta, Tb, Tc, Td, sM, sN, sK,
+    typename std::enable_if_t<(
+        !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
+        !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
+        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td> && sM != 0 &&
+        sN != 0 && sK != 0)>> {
+  static_assert(
+      is_combination_valid_amd_gfx942<Ta, Tc>(sM, sN, sK),
+      "Invalid parameters for AMD gfx942, query valid combinations "
+      "using: "
+      "q.get_device().get_info<sycl::info::device::matrix::combinations>()");
+
+  static constexpr std::size_t M = sM;
+  static constexpr std::size_t N = sN;
+  static constexpr std::size_t K = sK;
+
+  template <typename Group, layout Layout>
+  using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
+  template <typename Group, layout Layout>
+  using joint_matrix_b = joint_matrix<Group, Tb, use::b, K, N, Layout>;
+  template <typename Group>
+  using joint_matrix_c = joint_matrix<Group, Tc, use::accumulator, M, N>;
+  template <typename Group>
+  using joint_matrix_d = joint_matrix<Group, Td, use::accumulator, M, N>;
+};
+
 /////////////////////////////////////////////////
 /// CUDA Tensor Cores - sm70, sm72 and sm80 ///
 /////////////////////////////////////////////////

--- a/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/static-query-use.hpp
@@ -664,6 +664,133 @@ struct matrix_params<
   using joint_matrix_d = joint_matrix<Group, Td, use::accumulator, M, N>;
 };
 
+//////////////////////////////////////////////////////
+/// AMD Matrix Cores - GFX940 / GFX941 architectures ///
+//////////////////////////////////////////////////////
+//
+// gfx940 and gfx941 are CDNA3 parts and share the exact same joint_matrix
+// support as gfx942, so they reuse the gfx942 type/combination helpers.
+
+// Default-values query for gfx940:
+template <typename Ta, typename Tb, typename Tc, typename Td>
+struct matrix_params<
+    architecture::amd_gpu_gfx940, Ta, Tb, Tc, Td, 0, 0, 0,
+    typename std::enable_if_t<(
+        !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
+        !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
+        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td>)>> {
+  static_assert(
+      are_types_valid_amd_gfx942<Ta, Tc>(),
+      "Invalid types for AMD gfx940, supported types are half, float, "
+      "int8_t, int32_t, double and bfloat16 ");
+
+  // Default sizes for AMD gfx940 were chosen to represent a square matrix
+  static constexpr std::size_t M = 16;
+  static constexpr std::size_t N = 16;
+  static constexpr std::size_t K = std::is_same_v<Ta, double>  ? 4
+                                   : std::is_same_v<Ta, int8_t> ? 32
+                                                                : 16;
+
+  template <typename Group, layout Layout>
+  using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
+  template <typename Group, layout Layout>
+  using joint_matrix_b = joint_matrix<Group, Tb, use::b, K, N, Layout>;
+  template <typename Group>
+  using joint_matrix_c = joint_matrix<Group, Tc, use::accumulator, M, N>;
+  template <typename Group>
+  using joint_matrix_d = joint_matrix<Group, Td, use::accumulator, M, N>;
+};
+
+// Validation query for gfx940:
+template <typename Ta, typename Tb, typename Tc, typename Td, size_t sM,
+          size_t sN, size_t sK>
+struct matrix_params<
+    architecture::amd_gpu_gfx940, Ta, Tb, Tc, Td, sM, sN, sK,
+    typename std::enable_if_t<(
+        !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
+        !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
+        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td> && sM != 0 &&
+        sN != 0 && sK != 0)>> {
+  static_assert(
+      is_combination_valid_amd_gfx942<Ta, Tc>(sM, sN, sK),
+      "Invalid parameters for AMD gfx940, query valid combinations "
+      "using: "
+      "q.get_device().get_info<sycl::info::device::matrix::combinations>()");
+
+  static constexpr std::size_t M = sM;
+  static constexpr std::size_t N = sN;
+  static constexpr std::size_t K = sK;
+
+  template <typename Group, layout Layout>
+  using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
+  template <typename Group, layout Layout>
+  using joint_matrix_b = joint_matrix<Group, Tb, use::b, K, N, Layout>;
+  template <typename Group>
+  using joint_matrix_c = joint_matrix<Group, Tc, use::accumulator, M, N>;
+  template <typename Group>
+  using joint_matrix_d = joint_matrix<Group, Td, use::accumulator, M, N>;
+};
+
+// Default-values query for gfx941:
+template <typename Ta, typename Tb, typename Tc, typename Td>
+struct matrix_params<
+    architecture::amd_gpu_gfx941, Ta, Tb, Tc, Td, 0, 0, 0,
+    typename std::enable_if_t<(
+        !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
+        !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
+        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td>)>> {
+  static_assert(
+      are_types_valid_amd_gfx942<Ta, Tc>(),
+      "Invalid types for AMD gfx941, supported types are half, float, "
+      "int8_t, int32_t, double and bfloat16 ");
+
+  // Default sizes for AMD gfx941 were chosen to represent a square matrix
+  static constexpr std::size_t M = 16;
+  static constexpr std::size_t N = 16;
+  static constexpr std::size_t K = std::is_same_v<Ta, double>  ? 4
+                                   : std::is_same_v<Ta, int8_t> ? 32
+                                                                : 16;
+
+  template <typename Group, layout Layout>
+  using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
+  template <typename Group, layout Layout>
+  using joint_matrix_b = joint_matrix<Group, Tb, use::b, K, N, Layout>;
+  template <typename Group>
+  using joint_matrix_c = joint_matrix<Group, Tc, use::accumulator, M, N>;
+  template <typename Group>
+  using joint_matrix_d = joint_matrix<Group, Td, use::accumulator, M, N>;
+};
+
+// Validation query for gfx941:
+template <typename Ta, typename Tb, typename Tc, typename Td, size_t sM,
+          size_t sN, size_t sK>
+struct matrix_params<
+    architecture::amd_gpu_gfx941, Ta, Tb, Tc, Td, sM, sN, sK,
+    typename std::enable_if_t<(
+        !std::is_same_v<Ta, void> && !std::is_same_v<Tb, void> &&
+        !std::is_same_v<Tc, void> && !std::is_same_v<Td, void> &&
+        std::is_same_v<Ta, Tb> && std::is_same_v<Tc, Td> && sM != 0 &&
+        sN != 0 && sK != 0)>> {
+  static_assert(
+      is_combination_valid_amd_gfx942<Ta, Tc>(sM, sN, sK),
+      "Invalid parameters for AMD gfx941, query valid combinations "
+      "using: "
+      "q.get_device().get_info<sycl::info::device::matrix::combinations>()");
+
+  static constexpr std::size_t M = sM;
+  static constexpr std::size_t N = sN;
+  static constexpr std::size_t K = sK;
+
+  template <typename Group, layout Layout>
+  using joint_matrix_a = joint_matrix<Group, Ta, use::a, M, K, Layout>;
+  template <typename Group, layout Layout>
+  using joint_matrix_b = joint_matrix<Group, Tb, use::b, K, N, Layout>;
+  template <typename Group>
+  using joint_matrix_c = joint_matrix<Group, Tc, use::accumulator, M, N>;
+  template <typename Group>
+  using joint_matrix_d = joint_matrix<Group, Td, use::accumulator, M, N>;
+};
+
 /////////////////////////////////////////////////
 /// CUDA Tensor Cores - sm70, sm72 and sm80 ///
 /////////////////////////////////////////////////

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -2240,6 +2240,25 @@ public:
            matrix_type::fp32, matrix_type::fp32},
           {0, 0, 0, 16, 16, 4, matrix_type::fp64, matrix_type::fp64,
            matrix_type::fp64, matrix_type::fp64},
+          // fp8 (E4M3) / bf8 (E5M2) MFMA: 16x16x32 and 32x32x16 with an fp32
+          // accumulator. The A and B operand formats may differ, so all four
+          // format pairs are listed for each shape.
+          {0, 0, 0, 32, 32, 16, matrix_type::fp8_e4m3, matrix_type::fp8_e4m3,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 32, matrix_type::fp8_e4m3, matrix_type::fp8_e4m3,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 32, 32, 16, matrix_type::fp8_e5m2, matrix_type::fp8_e5m2,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 32, matrix_type::fp8_e5m2, matrix_type::fp8_e5m2,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 32, 32, 16, matrix_type::fp8_e4m3, matrix_type::fp8_e5m2,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 32, matrix_type::fp8_e4m3, matrix_type::fp8_e5m2,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 32, 32, 16, matrix_type::fp8_e5m2, matrix_type::fp8_e4m3,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 32, matrix_type::fp8_e5m2, matrix_type::fp8_e4m3,
+           matrix_type::fp32, matrix_type::fp32},
       };
     else if (backend::ext_oneapi_cuda == CurrentBackend) {
       // TODO: Tho following can be simplified when comparison of

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -2222,6 +2222,25 @@ public:
           {0, 0, 0, 16, 16, 4, matrix_type::fp64, matrix_type::fp64,
            matrix_type::fp64, matrix_type::fp64},
       };
+    else if ((architecture::amd_gpu_gfx940 == DeviceArch) ||
+             (architecture::amd_gpu_gfx941 == DeviceArch) ||
+             (architecture::amd_gpu_gfx942 == DeviceArch))
+      return {
+          {0, 0, 0, 32, 32, 8, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 32, 32, 16, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {0, 0, 0, 16, 16, 32, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {0, 0, 0, 32, 32, 8, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 4, matrix_type::fp64, matrix_type::fp64,
+           matrix_type::fp64, matrix_type::fp64},
+      };
     else if (backend::ext_oneapi_cuda == CurrentBackend) {
       // TODO: Tho following can be simplified when comparison of
       // architectures using < and > will be implemented

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -3102,6 +3102,10 @@ convertMatrixTypeStringMatrixTypeEnumValue(
     return matrix_ext::matrix_type::uint32;
   else if ("uint64" == MatrixTypeStringView)
     return matrix_ext::matrix_type::uint64;
+  else if ("fp8_e4m3" == MatrixTypeStringView)
+    return matrix_ext::matrix_type::fp8_e4m3;
+  else if ("fp8_e5m2" == MatrixTypeStringView)
+    return matrix_ext::matrix_type::fp8_e5m2;
   return std::nullopt;
 }
 

--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_apply.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_apply.hpp
@@ -60,7 +60,7 @@ void hip_matrix_apply() {
                 joint_matrix<sub_group, OutType, use::accumulator, M, N> sub_c;
                 joint_matrix<sub_group, InType, use::b, K, N, layout::row_major>
                     sub_b;
-                joint_matrix<sub_group, InType, use::a, M, K, layout::col_major>
+                joint_matrix<sub_group, InType, use::a, M, K, layout::row_major>
                     sub_a;
 
                 joint_matrix_load(

--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_copy.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_copy.hpp
@@ -69,7 +69,7 @@ void hip_matrix_copy() {
                     sub_c_copy;
                 joint_matrix<sub_group, InType, use::b, K, N, layout::row_major>
                     sub_b, sub_b_copy;
-                joint_matrix<sub_group, InType, use::a, M, K, layout::col_major>
+                joint_matrix<sub_group, InType, use::a, M, K, layout::row_major>
                     sub_a, sub_a_copy;
 
                 joint_matrix_load(

--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_fill.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_fill.hpp
@@ -61,7 +61,7 @@ void hip_matrix_fill() {
                     sub_c{};
                 joint_matrix<sub_group, InType, use::b, K, N, layout::row_major>
                     sub_b{};
-                joint_matrix<sub_group, InType, use::a, M, K, layout::col_major>
+                joint_matrix<sub_group, InType, use::a, M, K, layout::row_major>
                     sub_a{};
 
                 joint_matrix_fill(sg, sub_a, 1);

--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_fp8_mfma.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_fp8_mfma.hpp
@@ -1,0 +1,133 @@
+//===---joint_matrix_hip_fp8_mfma.hpp - DPC++ joint_matrix----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <cmath>
+#include <iostream>
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/float_8bit/types.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <random>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental::matrix;
+using sycl::ext::oneapi::experimental::fp8_e4m3;
+using sycl::ext::oneapi::experimental::fp8_e5m2;
+
+// gfx942 (CDNA3) fp8 (E4M3) / bf8 (E5M2) MFMA. The A and B operand formats may
+// differ, so this helper is templated on separate InTypeA / InTypeB fp8 types.
+// Inputs are stored as fp8 codes and the reference GEMM decodes them back to
+// float, so it compares against exactly the values the device sees.
+template <typename InTypeA, typename InTypeB, size_t M, size_t N, size_t K,
+          size_t KX, layout OutLayout>
+void hip_matrix_fp8_mfma() {
+  InTypeA A[M * K * KX];
+  InTypeB B[K * N * KX];
+  float C[M * N];
+  float D[M * N];
+  float E[M * N];
+
+  std::mt19937 gen(0);
+  std::uniform_real_distribution<float> dist(-4, 4);
+
+  for (size_t i = 0; i < M * K * KX; ++i)
+    A[i] = InTypeA{dist(gen)};
+
+  for (size_t i = 0; i < K * N * KX; ++i)
+    B[i] = InTypeB{dist(gen)};
+
+  for (size_t i = 0; i < M * N; ++i) {
+    D[i] = 0;
+    C[i] = dist(gen);
+    if (OutLayout == layout::row_major)
+      E[i] = C[i];
+    else
+      E[(i % N) * M + int(i / M)] = C[i];
+  }
+
+  try {
+    auto defaultQueue = sycl::queue{};
+
+    auto bufA = sycl::buffer{A, sycl::range{M * K * KX}};
+    auto bufB = sycl::buffer{B, sycl::range{K * N * KX}};
+    auto bufC = sycl::buffer{C, sycl::range{M * N}};
+    auto bufD = sycl::buffer{D, sycl::range{M * N}};
+
+    defaultQueue
+        .submit([&](sycl::handler &cgh) {
+          sycl::accessor accA{bufA, cgh, sycl::read_only};
+          sycl::accessor accB{bufB, cgh, sycl::read_only};
+          sycl::accessor accC{bufC, cgh, sycl::read_only};
+          sycl::accessor accD{bufD, cgh, sycl::write_only};
+
+          cgh.parallel_for(
+              sycl::nd_range<2>{{4, 16}, {4, 16}}, [=](sycl::nd_item<2> idx) {
+                auto sg = idx.get_sub_group();
+                joint_matrix<sub_group, float, use::accumulator, M, N> sub_c;
+                joint_matrix<sub_group, InTypeB, use::b, K, N,
+                             layout::row_major>
+                    sub_b;
+                joint_matrix<sub_group, InTypeA, use::a, M, K,
+                             layout::row_major>
+                    sub_a;
+
+                joint_matrix_load(
+                    sg, sub_c,
+                    accC.template get_multi_ptr<access::decorated::yes>(), N,
+                    layout::row_major);
+
+                for (size_t kx = 0; kx < KX; ++kx) {
+                  joint_matrix_load(
+                      sg, sub_a,
+                      accA.template get_multi_ptr<access::decorated::yes>() +
+                          kx * K,
+                      K * KX);
+                  joint_matrix_load(
+                      sg, sub_b,
+                      accB.template get_multi_ptr<access::decorated::yes>() +
+                          kx * K * N,
+                      N);
+                  joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
+                }
+
+                joint_matrix_store(
+                    sg, sub_c,
+                    accD.template get_multi_ptr<access::decorated::yes>(), N,
+                    OutLayout);
+              });
+        })
+        .wait();
+
+    defaultQueue.throw_asynchronous();
+  } catch (const sycl::exception &e) {
+    std::cout << "Exception caught: " << e.what() << std::endl;
+  }
+
+  constexpr int LDA = K * KX;
+
+  for (size_t m = 0; m < M; m++) {
+    for (size_t n = 0; n < N; n++) {
+      float e = 0;
+      for (size_t k = 0; k < LDA; k++) {
+        e += static_cast<float>(A[m * LDA + k]) *
+             static_cast<float>(B[k * N + n]);
+      }
+      if (OutLayout == layout::row_major)
+        E[m * N + n] += e;
+      else
+        E[n * M + m] += e;
+    }
+  }
+
+  for (size_t i = 0; i < M * N; ++i) {
+    assert(std::abs(D[i] - E[i]) <= 1e-2f * std::abs(E[i]) + 1.0f &&
+           "Unexpected difference");
+  }
+};

--- a/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_mfma.hpp
+++ b/sycl/test-e2e/Matrix/Inputs/joint_matrix_hip_mfma.hpp
@@ -68,7 +68,7 @@ void hip_matrix_mfma() {
                 joint_matrix<sub_group, OutType, use::accumulator, M, N> sub_c;
                 joint_matrix<sub_group, InType, use::b, K, N, layout::row_major>
                     sub_b;
-                joint_matrix<sub_group, InType, use::a, M, K, layout::col_major>
+                joint_matrix<sub_group, InType, use::a, M, K, layout::row_major>
                     sub_a;
 
                 joint_matrix_load(

--- a/sycl/test-e2e/Matrix/joint_matrix_hip_all_layouts.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_all_layouts.cpp
@@ -66,24 +66,21 @@ template <layout AL, layout BL> bool run_combo() {
        accessor accA{bA, h, read_only};
        accessor accB{bB, h, read_only};
        accessor accC{bC, h, write_only};
-       h.parallel_for(
-           nd_range<2>{{4, 16}, {4, 16}}, [=](nd_item<2> it) {
-             auto sg = it.get_sub_group();
-             joint_matrix<sub_group, float, use::accumulator, M, N> c;
-             joint_matrix<sub_group, bfloat16, use::a, M, K, AL> a;
-             joint_matrix<sub_group, bfloat16, use::b, K, N, BL> b;
-             joint_matrix_fill(sg, c, 0.f);
-             joint_matrix_load(
-                 sg, a, accA.template get_multi_ptr<access::decorated::yes>(),
-                 lda);
-             joint_matrix_load(
-                 sg, b, accB.template get_multi_ptr<access::decorated::yes>(),
-                 ldb);
-             joint_matrix_mad(sg, c, a, b, c);
-             joint_matrix_store(
-                 sg, c, accC.template get_multi_ptr<access::decorated::yes>(), N,
-                 layout::row_major);
-           });
+       h.parallel_for(nd_range<2>{{4, 16}, {4, 16}}, [=](nd_item<2> it) {
+         auto sg = it.get_sub_group();
+         joint_matrix<sub_group, float, use::accumulator, M, N> c;
+         joint_matrix<sub_group, bfloat16, use::a, M, K, AL> a;
+         joint_matrix<sub_group, bfloat16, use::b, K, N, BL> b;
+         joint_matrix_fill(sg, c, 0.f);
+         joint_matrix_load(
+             sg, a, accA.template get_multi_ptr<access::decorated::yes>(), lda);
+         joint_matrix_load(
+             sg, b, accB.template get_multi_ptr<access::decorated::yes>(), ldb);
+         joint_matrix_mad(sg, c, a, b, c);
+         joint_matrix_store(
+             sg, c, accC.template get_multi_ptr<access::decorated::yes>(), N,
+             layout::row_major);
+       });
      }).wait();
   }
 

--- a/sycl/test-e2e/Matrix/joint_matrix_hip_all_layouts.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_all_layouts.cpp
@@ -1,0 +1,106 @@
+//===---joint_matrix_hip_all_layouts.cpp - DPC++ joint_matrix-------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa %amd_arch_options %s -o %t.out
+// RUN: %{run} %t.out
+
+// REQUIRES: target-amd
+
+// Regression test: a 16x16x16 bf16 -> float tile computed for every
+// combination of A/B memory layouts (row/col major), each stored in memory
+// according to its declared layout, and checked against a standard row-major
+// C = A*B reference. Guards against the AMD `use::a` load-path layout bug where
+// the row-major A multiplicand was loaded transposed.
+
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental::matrix;
+using sycl::ext::oneapi::bfloat16;
+
+constexpr int M = 16, N = 16, K = 16;
+
+template <layout AL, layout BL> bool run_combo() {
+  std::vector<float> Alog(M * K), Blog(K * N), Ref(M * N, 0.f);
+  for (int i = 0; i < M * K; ++i)
+    Alog[i] = static_cast<float>((i * 3 + 1) % 7) - 3.f;
+  for (int i = 0; i < K * N; ++i)
+    Blog[i] = static_cast<float>((i * 2 + 1) % 5) - 2.f;
+  for (int m = 0; m < M; ++m)
+    for (int n = 0; n < N; ++n) {
+      float e = 0.f;
+      for (int k = 0; k < K; ++k)
+        e += Alog[m * K + k] * Blog[k * N + n];
+      Ref[m * N + n] = e;
+    }
+
+  const int lda = (AL == layout::row_major) ? K : M;
+  const int ldb = (BL == layout::row_major) ? N : K;
+  std::vector<bfloat16> Amem(M * K), Bmem(K * N);
+  for (int m = 0; m < M; ++m)
+    for (int k = 0; k < K; ++k)
+      Amem[(AL == layout::row_major) ? m * lda + k : k * lda + m] =
+          bfloat16(Alog[m * K + k]);
+  for (int k = 0; k < K; ++k)
+    for (int n = 0; n < N; ++n)
+      Bmem[(BL == layout::row_major) ? k * ldb + n : n * ldb + k] =
+          bfloat16(Blog[k * N + n]);
+  std::vector<float> C(M * N, 0.f);
+
+  {
+    queue q;
+    buffer<bfloat16> bA(Amem.data(), range{M * K});
+    buffer<bfloat16> bB(Bmem.data(), range{K * N});
+    buffer<float> bC(C.data(), range{M * N});
+    q.submit([&](handler &h) {
+       accessor accA{bA, h, read_only};
+       accessor accB{bB, h, read_only};
+       accessor accC{bC, h, write_only};
+       h.parallel_for(
+           nd_range<2>{{4, 16}, {4, 16}}, [=](nd_item<2> it) {
+             auto sg = it.get_sub_group();
+             joint_matrix<sub_group, float, use::accumulator, M, N> c;
+             joint_matrix<sub_group, bfloat16, use::a, M, K, AL> a;
+             joint_matrix<sub_group, bfloat16, use::b, K, N, BL> b;
+             joint_matrix_fill(sg, c, 0.f);
+             joint_matrix_load(
+                 sg, a, accA.template get_multi_ptr<access::decorated::yes>(),
+                 lda);
+             joint_matrix_load(
+                 sg, b, accB.template get_multi_ptr<access::decorated::yes>(),
+                 ldb);
+             joint_matrix_mad(sg, c, a, b, c);
+             joint_matrix_store(
+                 sg, c, accC.template get_multi_ptr<access::decorated::yes>(), N,
+                 layout::row_major);
+           });
+     }).wait();
+  }
+
+  for (int i = 0; i < M * N; ++i)
+    if (std::fabs(C[i] - Ref[i]) > 2.f)
+      return false;
+  return true;
+}
+
+int main() {
+  bool rr = run_combo<layout::row_major, layout::row_major>();
+  bool rc = run_combo<layout::row_major, layout::col_major>();
+  bool cr = run_combo<layout::col_major, layout::row_major>();
+  bool cc = run_combo<layout::col_major, layout::col_major>();
+  assert(rr && "A=row B=row");
+  assert(rc && "A=row B=col");
+  assert(cr && "A=col B=row");
+  assert(cc && "A=col B=col");
+  return 0;
+}

--- a/sycl/test-e2e/Matrix/joint_matrix_hip_fp8_gfx942.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_fp8_gfx942.cpp
@@ -1,0 +1,36 @@
+//===---joint_matrix_hip_fp8_gfx942.cpp - DPC++ joint_matrix--------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx942 %s -o %t.out
+// RUN: %{run} %t.out
+
+// REQUIRES: target-amd
+// REQUIRES: arch-amd_gpu_gfx942
+
+#include "joint_matrix_hip_fp8_mfma.hpp"
+
+// gfx942 (CDNA3) fp8 (E4M3) / bf8 (E5M2) MFMA supports 16x16x32 and 32x32x16
+// with an fp32 accumulator. The A and B operand formats are independent, so all
+// four (E4M3, E5M2) format pairs are exercised for both shapes: 8 combinations.
+template <size_t KX> void matrix_fp8_mfma() {
+  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e4m3, 32, 32, 16, KX, layout::row_major>();
+  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e4m3, 16, 16, 32, KX, layout::row_major>();
+  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e5m2, 32, 32, 16, KX, layout::row_major>();
+  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e5m2, 16, 16, 32, KX, layout::row_major>();
+  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e5m2, 32, 32, 16, KX, layout::row_major>();
+  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e5m2, 16, 16, 32, KX, layout::row_major>();
+  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e4m3, 32, 32, 16, KX, layout::row_major>();
+  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e4m3, 16, 16, 32, KX, layout::row_major>();
+}
+
+int main() {
+  matrix_fp8_mfma<1>();
+  matrix_fp8_mfma<2>();
+  matrix_fp8_mfma<3>();
+  matrix_fp8_mfma<4>();
+}

--- a/sycl/test-e2e/Matrix/joint_matrix_hip_fp8_gfx942.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_fp8_gfx942.cpp
@@ -17,15 +17,21 @@
 // gfx942 (CDNA3) fp8 (E4M3) / bf8 (E5M2) MFMA supports 16x16x32 and 32x32x16
 // with an fp32 accumulator. The A and B operand formats are independent, so all
 // four (E4M3, E5M2) format pairs are exercised for both shapes: 8 combinations.
+// Each combination is run with a row_major and a col_major accumulator store.
+template <size_t KX, layout OutLayout> void matrix_fp8_mfma_layout() {
+  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e4m3, 32, 32, 16, KX, OutLayout>();
+  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e4m3, 16, 16, 32, KX, OutLayout>();
+  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e5m2, 32, 32, 16, KX, OutLayout>();
+  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e5m2, 16, 16, 32, KX, OutLayout>();
+  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e5m2, 32, 32, 16, KX, OutLayout>();
+  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e5m2, 16, 16, 32, KX, OutLayout>();
+  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e4m3, 32, 32, 16, KX, OutLayout>();
+  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e4m3, 16, 16, 32, KX, OutLayout>();
+}
+
 template <size_t KX> void matrix_fp8_mfma() {
-  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e4m3, 32, 32, 16, KX, layout::row_major>();
-  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e4m3, 16, 16, 32, KX, layout::row_major>();
-  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e5m2, 32, 32, 16, KX, layout::row_major>();
-  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e5m2, 16, 16, 32, KX, layout::row_major>();
-  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e5m2, 32, 32, 16, KX, layout::row_major>();
-  hip_matrix_fp8_mfma<fp8_e4m3, fp8_e5m2, 16, 16, 32, KX, layout::row_major>();
-  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e4m3, 32, 32, 16, KX, layout::row_major>();
-  hip_matrix_fp8_mfma<fp8_e5m2, fp8_e4m3, 16, 16, 32, KX, layout::row_major>();
+  matrix_fp8_mfma_layout<KX, layout::row_major>();
+  matrix_fp8_mfma_layout<KX, layout::col_major>();
 }
 
 int main() {

--- a/sycl/test-e2e/Matrix/joint_matrix_hip_gfx942.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_gfx942.cpp
@@ -1,0 +1,63 @@
+//===---joint_matrix_hip_gfx942.cpp - DPC++ joint_matrix-------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx942 %s -o %t.out
+// RUN: %{run} %t.out
+
+// REQUIRES: target-amd
+// REQUIRES: arch-amd_gpu_gfx942
+
+#include "joint_matrix_hip_apply.hpp"
+#include "joint_matrix_hip_copy.hpp"
+#include "joint_matrix_hip_fill.hpp"
+#include "joint_matrix_hip_mfma.hpp"
+
+// gfx942 (CDNA3) supports the same fp16/bf16/fp64 shapes as gfx90a, but its
+// int8 MFMA uses larger K dimensions: 16x16x32 and 32x32x16.
+template <size_t KX> void matrix_mfma() {
+  hip_matrix_mfma<int8_t, int32_t, 32, 32, 16, KX, layout::row_major>();
+  hip_matrix_mfma<int8_t, int32_t, 16, 16, 32, KX, layout::row_major>();
+  hip_matrix_mfma<bfloat16, float, 32, 32, 8, KX, layout::row_major>();
+  hip_matrix_mfma<bfloat16, float, 16, 16, 16, KX, layout::row_major>();
+  hip_matrix_mfma<double, double, 16, 16, 4, KX, layout::row_major>();
+  hip_matrix_mfma<int8_t, int32_t, 32, 32, 16, KX, layout::col_major>();
+  hip_matrix_mfma<int8_t, int32_t, 16, 16, 32, KX, layout::col_major>();
+  hip_matrix_mfma<bfloat16, float, 32, 32, 8, KX, layout::col_major>();
+  hip_matrix_mfma<bfloat16, float, 16, 16, 16, KX, layout::col_major>();
+  hip_matrix_mfma<double, double, 16, 16, 4, KX, layout::col_major>();
+}
+
+int main() {
+  matrix_mfma<1>();
+  matrix_mfma<2>();
+  matrix_mfma<3>();
+  matrix_mfma<4>();
+
+  hip_matrix_copy<int8_t, int32_t, 32, 32, 16, layout::row_major>();
+  hip_matrix_copy<int8_t, int32_t, 16, 16, 32, layout::row_major>();
+  hip_matrix_copy<bfloat16, float, 32, 32, 8, layout::row_major>();
+  hip_matrix_copy<bfloat16, float, 16, 16, 16, layout::row_major>();
+  hip_matrix_copy<double, double, 16, 16, 4, layout::row_major>();
+  hip_matrix_copy<int8_t, int32_t, 32, 32, 16, layout::col_major>();
+  hip_matrix_copy<int8_t, int32_t, 16, 16, 32, layout::col_major>();
+  hip_matrix_copy<bfloat16, float, 32, 32, 8, layout::col_major>();
+  hip_matrix_copy<bfloat16, float, 16, 16, 16, layout::col_major>();
+  hip_matrix_copy<double, double, 16, 16, 4, layout::col_major>();
+
+  hip_matrix_fill<int8_t, int32_t, 32, 32, 16>();
+  hip_matrix_fill<int8_t, int32_t, 16, 16, 32>();
+  hip_matrix_fill<bfloat16, float, 32, 32, 8>();
+  hip_matrix_fill<bfloat16, float, 16, 16, 16>();
+  hip_matrix_fill<double, double, 16, 16, 4>();
+
+  hip_matrix_apply<int8_t, int32_t, 32, 32, 16>();
+  hip_matrix_apply<int8_t, int32_t, 16, 16, 32>();
+  hip_matrix_apply<bfloat16, float, 32, 32, 8>();
+  hip_matrix_apply<bfloat16, float, 16, 16, 16>();
+  hip_matrix_apply<double, double, 16, 16, 4>();
+}

--- a/sycl/test-e2e/Matrix/joint_matrix_hip_half_gfx942.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_half_gfx942.cpp
@@ -1,0 +1,44 @@
+//===---joint_matrix_hip_half_gfx942.cpp - DPC++ joint_matrix-------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx942 %s -o %t.out
+// RUN: %{run} %t.out
+
+// REQUIRES: target-amd
+// REQUIRES: arch-amd_gpu_gfx942
+// REQUIRES: aspect-fp16
+
+#include "joint_matrix_hip_apply.hpp"
+#include "joint_matrix_hip_copy.hpp"
+#include "joint_matrix_hip_fill.hpp"
+#include "joint_matrix_hip_mfma.hpp"
+
+template <size_t KX> void half_matrix_mfma() {
+  hip_matrix_mfma<sycl::half, float, 32, 32, 8, KX, layout::row_major>();
+  hip_matrix_mfma<sycl::half, float, 16, 16, 16, KX, layout::row_major>();
+  hip_matrix_mfma<sycl::half, float, 32, 32, 8, KX, layout::col_major>();
+  hip_matrix_mfma<sycl::half, float, 16, 16, 16, KX, layout::col_major>();
+}
+
+int main() {
+  half_matrix_mfma<1>();
+  half_matrix_mfma<2>();
+  half_matrix_mfma<3>();
+  half_matrix_mfma<4>();
+
+  hip_matrix_copy<sycl::half, float, 32, 32, 8, layout::row_major>();
+  hip_matrix_copy<sycl::half, float, 16, 16, 16, layout::row_major>();
+  hip_matrix_copy<sycl::half, float, 32, 32, 8, layout::col_major>();
+  hip_matrix_copy<sycl::half, float, 16, 16, 16, layout::col_major>();
+
+  hip_matrix_fill<sycl::half, float, 32, 32, 8>();
+  hip_matrix_fill<sycl::half, float, 16, 16, 16>();
+
+  hip_matrix_apply<sycl::half, float, 32, 32, 8>();
+  hip_matrix_apply<sycl::half, float, 16, 16, 16>();
+}

--- a/sycl/test-e2e/Matrix/joint_matrix_hip_multi_subgroup.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_multi_subgroup.cpp
@@ -1,0 +1,99 @@
+//===---joint_matrix_hip_multi_subgroup.cpp - DPC++ joint_matrix----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa %amd_arch_options %s -o %t.out
+// RUN: %{run} %t.out
+
+// REQUIRES: target-amd
+
+// Regression test: a tiled GEMM whose work-group contains MORE THAN ONE
+// sub-group (a 64x64 output tile computed by a 4x4 grid of wavefronts). Guards
+// against the AMD fragment lane-index bug where the per-lane offset was derived
+// from the work-group linear id instead of the sub-group local id, which made
+// every sub-group beyond the first read/write out of range.
+
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental::matrix;
+using sycl::ext::oneapi::bfloat16;
+
+constexpr int T = 16;      // MFMA tile M=N=K
+constexpr int TILE = 64;   // work-group output tile (TILE x TILE)
+constexpr int S = 128;     // full square matrix dimension (multiple of TILE)
+
+int main() {
+  std::vector<float> Alog(S * S), Blog(S * S), Ref(S * S, 0.f);
+  for (int i = 0; i < S * S; ++i)
+    Alog[i] = static_cast<float>((i * 3 + 1) % 7) - 3.f;
+  for (int i = 0; i < S * S; ++i)
+    Blog[i] = static_cast<float>((i * 2 + 1) % 5) - 2.f;
+  for (int m = 0; m < S; ++m)
+    for (int n = 0; n < S; ++n) {
+      float e = 0.f;
+      for (int k = 0; k < S; ++k)
+        e += Alog[m * S + k] * Blog[k * S + n];
+      Ref[m * S + n] = e;
+    }
+
+  std::vector<bfloat16> Amem(S * S), Bmem(S * S); // A row-major, B col-major
+  for (int m = 0; m < S; ++m)
+    for (int k = 0; k < S; ++k)
+      Amem[m * S + k] = bfloat16(Alog[m * S + k]);
+  for (int k = 0; k < S; ++k)
+    for (int n = 0; n < S; ++n)
+      Bmem[n * S + k] = bfloat16(Blog[k * S + n]);
+  std::vector<float> C(S * S, 0.f);
+
+  {
+    queue q;
+    buffer<bfloat16> bA(Amem.data(), range{(size_t)S * S});
+    buffer<bfloat16> bB(Bmem.data(), range{(size_t)S * S});
+    buffer<float> bC(C.data(), range{(size_t)S * S});
+    // Work-group: {1, TILE/T, (TILE/T)*WAVE} where WAVE=64 -> 16 sub-groups.
+    const int nwarp = TILE / T; // 4
+    range<2> lws{(size_t)nwarp, (size_t)nwarp * 64};
+    range<2> gws{(size_t)(S / TILE) * nwarp, (size_t)(S / TILE) * nwarp * 64};
+    q.submit([&](handler &h) {
+       accessor accA{bA, h, read_only};
+       accessor accB{bB, h, read_only};
+       accessor accC{bC, h, write_only};
+       h.parallel_for(
+           nd_range<2>{gws, lws}, [=](nd_item<2> it) {
+             auto sg = it.get_sub_group();
+             const int warpM = it.get_local_id(0);
+             const int warpN = it.get_local_id(1) / 64;
+             const int row = (it.get_group(0) * (TILE / T) + warpM) * T;
+             const int col = (it.get_group(1) * (TILE / T) + warpN) * T;
+             auto pa = accA.template get_multi_ptr<access::decorated::yes>();
+             auto pb = accB.template get_multi_ptr<access::decorated::yes>();
+             auto pc = accC.template get_multi_ptr<access::decorated::yes>();
+             joint_matrix<sub_group, float, use::accumulator, T, T> c;
+             joint_matrix<sub_group, bfloat16, use::a, T, T, layout::row_major> a;
+             joint_matrix<sub_group, bfloat16, use::b, T, T, layout::col_major> b;
+             joint_matrix_fill(sg, c, 0.f);
+             for (int kk = 0; kk < S; kk += T) {
+               joint_matrix_load(sg, a, pa + row * S + kk, S);
+               joint_matrix_load(sg, b, pb + col * S + kk, S);
+               joint_matrix_mad(sg, c, a, b, c);
+             }
+             joint_matrix_store(sg, c, pc + row * S + col, S,
+                                layout::row_major);
+           });
+     }).wait();
+  }
+
+  for (int i = 0; i < S * S; ++i)
+    assert(std::fabs(C[i] - Ref[i]) < 4.f && "multi-subgroup GEMM mismatch");
+  return 0;
+}

--- a/sycl/test-e2e/Matrix/joint_matrix_hip_multi_subgroup.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_hip_multi_subgroup.cpp
@@ -28,9 +28,9 @@ using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 using sycl::ext::oneapi::bfloat16;
 
-constexpr int T = 16;      // MFMA tile M=N=K
-constexpr int TILE = 64;   // work-group output tile (TILE x TILE)
-constexpr int S = 128;     // full square matrix dimension (multiple of TILE)
+constexpr int T = 16;    // MFMA tile M=N=K
+constexpr int TILE = 64; // work-group output tile (TILE x TILE)
+constexpr int S = 128;   // full square matrix dimension (multiple of TILE)
 
 int main() {
   std::vector<float> Alog(S * S), Blog(S * S), Ref(S * S, 0.f);
@@ -68,28 +68,26 @@ int main() {
        accessor accA{bA, h, read_only};
        accessor accB{bB, h, read_only};
        accessor accC{bC, h, write_only};
-       h.parallel_for(
-           nd_range<2>{gws, lws}, [=](nd_item<2> it) {
-             auto sg = it.get_sub_group();
-             const int warpM = it.get_local_id(0);
-             const int warpN = it.get_local_id(1) / 64;
-             const int row = (it.get_group(0) * (TILE / T) + warpM) * T;
-             const int col = (it.get_group(1) * (TILE / T) + warpN) * T;
-             auto pa = accA.template get_multi_ptr<access::decorated::yes>();
-             auto pb = accB.template get_multi_ptr<access::decorated::yes>();
-             auto pc = accC.template get_multi_ptr<access::decorated::yes>();
-             joint_matrix<sub_group, float, use::accumulator, T, T> c;
-             joint_matrix<sub_group, bfloat16, use::a, T, T, layout::row_major> a;
-             joint_matrix<sub_group, bfloat16, use::b, T, T, layout::col_major> b;
-             joint_matrix_fill(sg, c, 0.f);
-             for (int kk = 0; kk < S; kk += T) {
-               joint_matrix_load(sg, a, pa + row * S + kk, S);
-               joint_matrix_load(sg, b, pb + col * S + kk, S);
-               joint_matrix_mad(sg, c, a, b, c);
-             }
-             joint_matrix_store(sg, c, pc + row * S + col, S,
-                                layout::row_major);
-           });
+       h.parallel_for(nd_range<2>{gws, lws}, [=](nd_item<2> it) {
+         auto sg = it.get_sub_group();
+         const int warpM = it.get_local_id(0);
+         const int warpN = it.get_local_id(1) / 64;
+         const int row = (it.get_group(0) * (TILE / T) + warpM) * T;
+         const int col = (it.get_group(1) * (TILE / T) + warpN) * T;
+         auto pa = accA.template get_multi_ptr<access::decorated::yes>();
+         auto pb = accB.template get_multi_ptr<access::decorated::yes>();
+         auto pc = accC.template get_multi_ptr<access::decorated::yes>();
+         joint_matrix<sub_group, float, use::accumulator, T, T> c;
+         joint_matrix<sub_group, bfloat16, use::a, T, T, layout::row_major> a;
+         joint_matrix<sub_group, bfloat16, use::b, T, T, layout::col_major> b;
+         joint_matrix_fill(sg, c, 0.f);
+         for (int kk = 0; kk < S; kk += T) {
+           joint_matrix_load(sg, a, pa + row * S + kk, S);
+           joint_matrix_load(sg, b, pb + col * S + kk, S);
+           joint_matrix_mad(sg, c, a, b, c);
+         }
+         joint_matrix_store(sg, c, pc + row * S + col, S, layout::row_major);
+       });
      }).wait();
   }
 

--- a/sycl/test-e2e/Matrix/runtime_query_hip_gfx942.cpp
+++ b/sycl/test-e2e/Matrix/runtime_query_hip_gfx942.cpp
@@ -1,0 +1,68 @@
+//===---runtime_query_hip_gfx942.cpp - DPC++ joint_matrix-----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: target-amd
+// REQUIRES: arch-amd_gpu_gfx942
+// RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx942 %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
+
+using namespace sycl::ext::oneapi::experimental::matrix;
+
+bool find_combination(const combination &comb,
+                      const std::vector<combination> &expected_combinations) {
+  return std::find_if(expected_combinations.begin(),
+                      expected_combinations.end(),
+                      [&comb](const auto &expected_comb) {
+                        return (comb.max_msize == expected_comb.max_msize &&
+                                comb.max_nsize == expected_comb.max_nsize &&
+                                comb.max_ksize == expected_comb.max_ksize &&
+                                comb.msize == expected_comb.msize &&
+                                comb.nsize == expected_comb.nsize &&
+                                comb.ksize == expected_comb.ksize &&
+                                comb.atype == expected_comb.atype &&
+                                comb.btype == expected_comb.btype &&
+                                comb.ctype == expected_comb.ctype &&
+                                comb.dtype == expected_comb.dtype);
+                      }) != expected_combinations.end();
+}
+
+int main() {
+  std::vector<combination> expected_combinations = {
+      {0, 0, 0, 32, 32, 8, matrix_type::fp16, matrix_type::fp16,
+       matrix_type::fp32, matrix_type::fp32},
+      {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+       matrix_type::fp32, matrix_type::fp32},
+      {0, 0, 0, 32, 32, 16, matrix_type::sint8, matrix_type::sint8,
+       matrix_type::sint32, matrix_type::sint32},
+      {0, 0, 0, 16, 16, 32, matrix_type::sint8, matrix_type::sint8,
+       matrix_type::sint32, matrix_type::sint32},
+      {0, 0, 0, 32, 32, 8, matrix_type::bf16, matrix_type::bf16,
+       matrix_type::fp32, matrix_type::fp32},
+      {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
+       matrix_type::fp32, matrix_type::fp32},
+      {0, 0, 0, 16, 16, 4, matrix_type::fp64, matrix_type::fp64,
+       matrix_type::fp64, matrix_type::fp64}};
+
+  sycl::queue q;
+  std::vector<combination> actual_combinations =
+      q.get_device()
+          .get_info<sycl::ext::oneapi::experimental::info::device::
+                        matrix_combinations>();
+
+  assert(actual_combinations.size() == expected_combinations.size() &&
+         "Number of combinations is not equal.");
+
+  for (auto &comb : actual_combinations) {
+    assert(find_combination(comb, expected_combinations) &&
+           "Some values in matrix runtime query for gfx942 are not expected.");
+  }
+  return 0;
+}

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-bfloat16-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-bfloat16-float-test.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: hip
-// REQUIRES: hip-arch-gfx90a
+// REQUIRES: hip-arch-gfx942
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
+
+// gfx942 (CDNA3) uses the same bfloat16 MFMA instructions and shapes as gfx90a.
 
 #include <sycl/sycl.hpp>
 
@@ -27,6 +29,7 @@ row_row_m16n16k16(sycl::accessor<bfloat16, 1, sycl::access::mode::read_write,
   joint_matrix<sub_group, float, use::accumulator, 16, 16> sub_c{};
   joint_matrix<sub_group, bfloat16, use::a, 16, 16, layout::row_major> sub_a{};
   joint_matrix<sub_group, bfloat16, use::b, 16, 16, layout::row_major> sub_b{};
+
   // CHECK: tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x16bf16.1k(<4 x i16> zeroinitializer, <4 x i16> zeroinitializer, <4 x float> zeroinitializer, i32 0, i32 0, i32 0)
   joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
   joint_matrix_store(sg, sub_c,

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-bfloat16-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-bfloat16-float-test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: hip
-// REQUIRES: hip-arch-gfx942
+// REQUIRES: hip-arch-gfx942 || hip-arch-gfx941 || hip-arch-gfx940
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
 
 // gfx942 (CDNA3) uses the same bfloat16 MFMA instructions and shapes as gfx90a.

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-double-double-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-double-double-test.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: hip
-// REQUIRES: hip-arch-gfx90a
+// REQUIRES: hip-arch-gfx942
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
+
+// gfx942 (CDNA3) uses the same double MFMA instruction and shape as gfx90a.
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-double-double-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-double-double-test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: hip
-// REQUIRES: hip-arch-gfx942
+// REQUIRES: hip-arch-gfx942 || hip-arch-gfx941 || hip-arch-gfx940
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
 
 // gfx942 (CDNA3) uses the same double MFMA instruction and shape as gfx90a.

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-float-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-float-float-test.cpp
@@ -1,0 +1,64 @@
+// REQUIRES: hip
+// REQUIRES: hip-arch-gfx942 || hip-arch-gfx941 || hip-arch-gfx940
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
+
+// CDNA3 supports one-block F32 MFMA shapes: 16x16x4 and 32x32x2.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental::matrix;
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+row_row_m16n16k4(sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                sycl::target::device>
+                     accA,
+                 sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                sycl::target::device>
+                     accB,
+                 sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                sycl::target::device>
+                     accC,
+                 sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                sycl::target::device>
+                     accD,
+                 nd_item<2> item) {
+  sycl::sub_group sg = item.get_sub_group();
+
+  joint_matrix<sub_group, float, use::accumulator, 16, 16> sub_c{};
+  joint_matrix<sub_group, float, use::a, 16, 4, layout::row_major> sub_a{};
+  joint_matrix<sub_group, float, use::b, 4, 16, layout::row_major> sub_b{};
+
+  // CHECK: tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x4f32(float {{.*}}, float {{.*}}, <4 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
+  joint_matrix_store(sg, sub_c,
+                     accD.template get_multi_ptr<access::decorated::yes>(), 16,
+                     layout::row_major);
+}
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+row_col_m32n32k2(sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                sycl::target::device>
+                     accA,
+                 sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                sycl::target::device>
+                     accB,
+                 sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                sycl::target::device>
+                     accC,
+                 sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                sycl::target::device>
+                     accD,
+                 nd_item<2> item) {
+  sycl::sub_group sg = item.get_sub_group();
+
+  joint_matrix<sub_group, float, use::accumulator, 32, 32> sub_c{};
+  joint_matrix<sub_group, float, use::a, 32, 2, layout::row_major> sub_a{};
+  joint_matrix<sub_group, float, use::b, 2, 32, layout::col_major> sub_b{};
+
+  // CHECK: tail call <16 x float> @llvm.amdgcn.mfma.f32.32x32x2f32(float {{.*}}, float {{.*}}, <16 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
+  joint_matrix_store(sg, sub_c,
+                     accD.template get_multi_ptr<access::decorated::yes>(), 32,
+                     layout::row_major);
+}

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-fp8-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-fp8-test.cpp
@@ -1,0 +1,158 @@
+// REQUIRES: hip
+// REQUIRES: hip-arch-gfx942 || hip-arch-gfx941 || hip-arch-gfx940
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
+
+// gfx942 (CDNA3) fp8 (E4M3) / bf8 (E5M2) MFMA: 16x16x32 and 32x32x16 with the
+// A/B operands packed into i64 values and an f32 accumulator. The A and B
+// operand formats are independent, so all four format pairs are exercised for
+// both shapes.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental::matrix;
+using sycl::ext::oneapi::experimental::fp8_e4m3;
+using sycl::ext::oneapi::experimental::fp8_e5m2;
+
+template <typename TA, typename TB, size_t M, size_t N, size_t K>
+static void
+mad(sycl::sub_group sg,
+    sycl::accessor<TA, 1, sycl::access::mode::read_write, sycl::target::device>
+        accA,
+    sycl::accessor<TB, 1, sycl::access::mode::read_write, sycl::target::device>
+        accB,
+    sycl::accessor<float, 1, sycl::access::mode::read_write,
+                   sycl::target::device>
+        accD) {
+  joint_matrix<sub_group, float, use::accumulator, M, N> sub_c{};
+  joint_matrix<sub_group, TA, use::a, M, K, layout::row_major> sub_a{};
+  joint_matrix<sub_group, TB, use::b, K, N, layout::row_major> sub_b{};
+  joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
+  joint_matrix_store(sg, sub_c,
+                     accD.template get_multi_ptr<access::decorated::yes>(), N,
+                     layout::row_major);
+}
+
+// --- 16x16x32 -------------------------------------------------------------
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+e4m3_e4m3_m16n16k32(sycl::accessor<fp8_e4m3, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accA,
+                    sycl::accessor<fp8_e4m3, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accB,
+                    sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accD,
+                    nd_item<2> item) {
+  // CHECK: call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.fp8.fp8(i64 {{.*}}, i64 {{.*}}, <4 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  mad<fp8_e4m3, fp8_e4m3, 16, 16, 32>(item.get_sub_group(), accA, accB, accD);
+}
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+e4m3_e5m2_m16n16k32(sycl::accessor<fp8_e4m3, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accA,
+                    sycl::accessor<fp8_e5m2, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accB,
+                    sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accD,
+                    nd_item<2> item) {
+  // CHECK: call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.fp8.bf8(i64 {{.*}}, i64 {{.*}}, <4 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  mad<fp8_e4m3, fp8_e5m2, 16, 16, 32>(item.get_sub_group(), accA, accB, accD);
+}
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+e5m2_e4m3_m16n16k32(sycl::accessor<fp8_e5m2, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accA,
+                    sycl::accessor<fp8_e4m3, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accB,
+                    sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accD,
+                    nd_item<2> item) {
+  // CHECK: call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf8.fp8(i64 {{.*}}, i64 {{.*}}, <4 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  mad<fp8_e5m2, fp8_e4m3, 16, 16, 32>(item.get_sub_group(), accA, accB, accD);
+}
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+e5m2_e5m2_m16n16k32(sycl::accessor<fp8_e5m2, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accA,
+                    sycl::accessor<fp8_e5m2, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accB,
+                    sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accD,
+                    nd_item<2> item) {
+  // CHECK: call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.bf8.bf8(i64 {{.*}}, i64 {{.*}}, <4 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  mad<fp8_e5m2, fp8_e5m2, 16, 16, 32>(item.get_sub_group(), accA, accB, accD);
+}
+
+// --- 32x32x16 -------------------------------------------------------------
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+e4m3_e4m3_m32n32k16(sycl::accessor<fp8_e4m3, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accA,
+                    sycl::accessor<fp8_e4m3, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accB,
+                    sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accD,
+                    nd_item<2> item) {
+  // CHECK: call <16 x float> @llvm.amdgcn.mfma.f32.32x32x16.fp8.fp8(i64 {{.*}}, i64 {{.*}}, <16 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  mad<fp8_e4m3, fp8_e4m3, 32, 32, 16>(item.get_sub_group(), accA, accB, accD);
+}
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+e4m3_e5m2_m32n32k16(sycl::accessor<fp8_e4m3, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accA,
+                    sycl::accessor<fp8_e5m2, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accB,
+                    sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accD,
+                    nd_item<2> item) {
+  // CHECK: call <16 x float> @llvm.amdgcn.mfma.f32.32x32x16.fp8.bf8(i64 {{.*}}, i64 {{.*}}, <16 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  mad<fp8_e4m3, fp8_e5m2, 32, 32, 16>(item.get_sub_group(), accA, accB, accD);
+}
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+e5m2_e4m3_m32n32k16(sycl::accessor<fp8_e5m2, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accA,
+                    sycl::accessor<fp8_e4m3, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accB,
+                    sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accD,
+                    nd_item<2> item) {
+  // CHECK: call <16 x float> @llvm.amdgcn.mfma.f32.32x32x16.bf8.fp8(i64 {{.*}}, i64 {{.*}}, <16 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  mad<fp8_e5m2, fp8_e4m3, 32, 32, 16>(item.get_sub_group(), accA, accB, accD);
+}
+
+SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
+e5m2_e5m2_m32n32k16(sycl::accessor<fp8_e5m2, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accA,
+                    sycl::accessor<fp8_e5m2, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accB,
+                    sycl::accessor<float, 1, sycl::access::mode::read_write,
+                                   sycl::target::device>
+                        accD,
+                    nd_item<2> item) {
+  // CHECK: call <16 x float> @llvm.amdgcn.mfma.f32.32x32x16.bf8.bf8(i64 {{.*}}, i64 {{.*}}, <16 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  mad<fp8_e5m2, fp8_e5m2, 32, 32, 16>(item.get_sub_group(), accA, accB, accD);
+}

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-half-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-half-float-test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: hip
-// REQUIRES: hip-arch-gfx942
+// REQUIRES: hip-arch-gfx942 || hip-arch-gfx941 || hip-arch-gfx940
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
 
 // gfx942 (CDNA3) uses the same half MFMA instructions and shapes as gfx90a.

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-half-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-half-float-test.cpp
@@ -1,18 +1,19 @@
 // REQUIRES: hip
-// REQUIRES: hip-arch-gfx90a
+// REQUIRES: hip-arch-gfx942
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
+
+// gfx942 (CDNA3) uses the same half MFMA instructions and shapes as gfx90a.
 
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using sycl::ext::oneapi::bfloat16;
 
 SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
-row_row_m16n16k16(sycl::accessor<bfloat16, 1, sycl::access::mode::read_write,
+row_row_m16n16k16(sycl::accessor<half, 1, sycl::access::mode::read_write,
                                  sycl::target::device>
                       accA,
-                  sycl::accessor<bfloat16, 1, sycl::access::mode::read_write,
+                  sycl::accessor<half, 1, sycl::access::mode::read_write,
                                  sycl::target::device>
                       accB,
                   sycl::accessor<float, 1, sycl::access::mode::read_write,
@@ -25,9 +26,10 @@ row_row_m16n16k16(sycl::accessor<bfloat16, 1, sycl::access::mode::read_write,
   sycl::sub_group sg = item.get_sub_group();
 
   joint_matrix<sub_group, float, use::accumulator, 16, 16> sub_c{};
-  joint_matrix<sub_group, bfloat16, use::a, 16, 16, layout::row_major> sub_a{};
-  joint_matrix<sub_group, bfloat16, use::b, 16, 16, layout::row_major> sub_b{};
-  // CHECK: tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x16bf16.1k(<4 x i16> zeroinitializer, <4 x i16> zeroinitializer, <4 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  joint_matrix<sub_group, half, use::a, 16, 16, layout::row_major> sub_a{};
+  joint_matrix<sub_group, half, use::b, 16, 16, layout::row_major> sub_b{};
+
+  // CHECK: tail call <4 x float> @llvm.amdgcn.mfma.f32.16x16x16f16(<4 x half> zeroinitializer, <4 x half> zeroinitializer, <4 x float> zeroinitializer, i32 0, i32 0, i32 0)
   joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
   joint_matrix_store(sg, sub_c,
                      accD.template get_multi_ptr<access::decorated::yes>(), 16,
@@ -35,10 +37,10 @@ row_row_m16n16k16(sycl::accessor<bfloat16, 1, sycl::access::mode::read_write,
 }
 
 SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
-row_col_m32n32k8(sycl::accessor<bfloat16, 1, sycl::access::mode::read_write,
+row_col_m32n32k8(sycl::accessor<half, 1, sycl::access::mode::read_write,
                                 sycl::target::device>
                      accA,
-                 sycl::accessor<bfloat16, 1, sycl::access::mode::read_write,
+                 sycl::accessor<half, 1, sycl::access::mode::read_write,
                                 sycl::target::device>
                      accB,
                  sycl::accessor<float, 1, sycl::access::mode::read_write,
@@ -51,10 +53,10 @@ row_col_m32n32k8(sycl::accessor<bfloat16, 1, sycl::access::mode::read_write,
   sycl::sub_group sg = item.get_sub_group();
 
   joint_matrix<sub_group, float, use::accumulator, 32, 32> sub_c{};
-  joint_matrix<sub_group, bfloat16, use::a, 32, 8, layout::row_major> sub_a{};
-  joint_matrix<sub_group, bfloat16, use::b, 8, 32, layout::col_major> sub_b{};
+  joint_matrix<sub_group, half, use::a, 32, 8, layout::row_major> sub_a{};
+  joint_matrix<sub_group, half, use::b, 8, 32, layout::col_major> sub_b{};
 
-  // CHECK: tail call <16 x float> @llvm.amdgcn.mfma.f32.32x32x8bf16.1k(<4 x i16> zeroinitializer, <4 x i16> zeroinitializer, <16 x float> zeroinitializer, i32 0, i32 0, i32 0)
+  // CHECK: tail call <16 x float> @llvm.amdgcn.mfma.f32.32x32x8f16(<4 x half> zeroinitializer, <4 x half> zeroinitializer, <16 x float> zeroinitializer, i32 0, i32 0, i32 0)
   joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
   joint_matrix_store(sg, sub_c,
                      accD.template get_multi_ptr<access::decorated::yes>(), 32,

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-int8-int32-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-int8-int32-test.cpp
@@ -1,6 +1,9 @@
 // REQUIRES: hip
-// REQUIRES: hip-arch-gfx90a
+// REQUIRES: hip-arch-gfx942
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
+
+// gfx942 (CDNA3) int8 MFMA uses larger K dimensions than gfx90a:
+// 16x16x32 and 32x32x16, with the A/B operands packed into i64 values.
 
 #include <sycl/sycl.hpp>
 
@@ -8,7 +11,7 @@ using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
 SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
-row_row_m16n16k16(sycl::accessor<int8_t, 1, sycl::access::mode::read_write,
+row_row_m16n16k32(sycl::accessor<int8_t, 1, sycl::access::mode::read_write,
                                  sycl::target::device>
                       accA,
                   sycl::accessor<int8_t, 1, sycl::access::mode::read_write,
@@ -24,10 +27,10 @@ row_row_m16n16k16(sycl::accessor<int8_t, 1, sycl::access::mode::read_write,
   sycl::sub_group sg = item.get_sub_group();
 
   joint_matrix<sub_group, int32_t, use::accumulator, 16, 16> sub_c{};
-  joint_matrix<sub_group, int8_t, use::a, 16, 16, layout::row_major> sub_a{};
-  joint_matrix<sub_group, int8_t, use::b, 16, 16, layout::row_major> sub_b{};
+  joint_matrix<sub_group, int8_t, use::a, 16, 32, layout::row_major> sub_a{};
+  joint_matrix<sub_group, int8_t, use::b, 32, 16, layout::row_major> sub_b{};
 
-  // CHECK: tail call <4 x i32> @llvm.amdgcn.mfma.i32.16x16x16i8(i32 {{.*}}, i32 {{.*}}, <4 x i32> zeroinitializer, i32 0, i32 0, i32 0)
+  // CHECK: tail call <4 x i32> @llvm.amdgcn.mfma.i32.16x16x32.i8(i64 {{.*}}, i64 {{.*}}, <4 x i32> zeroinitializer, i32 0, i32 0, i32 0)
   joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
   joint_matrix_store(sg, sub_c,
                      accD.template get_multi_ptr<access::decorated::yes>(), 16,
@@ -35,26 +38,26 @@ row_row_m16n16k16(sycl::accessor<int8_t, 1, sycl::access::mode::read_write,
 }
 
 SYCL_EXTERNAL [[sycl::reqd_work_group_size(1, 1, 64)]] void
-row_col_m32n32k8(sycl::accessor<int8_t, 1, sycl::access::mode::read_write,
-                                sycl::target::device>
-                     accA,
-                 sycl::accessor<int8_t, 1, sycl::access::mode::read_write,
-                                sycl::target::device>
-                     accB,
-                 sycl::accessor<int32_t, 1, sycl::access::mode::read_write,
-                                sycl::target::device>
-                     accC,
-                 sycl::accessor<int32_t, 1, sycl::access::mode::read_write,
-                                sycl::target::device>
-                     accD,
-                 nd_item<2> item) {
+row_col_m32n32k16(sycl::accessor<int8_t, 1, sycl::access::mode::read_write,
+                                 sycl::target::device>
+                      accA,
+                  sycl::accessor<int8_t, 1, sycl::access::mode::read_write,
+                                 sycl::target::device>
+                      accB,
+                  sycl::accessor<int32_t, 1, sycl::access::mode::read_write,
+                                 sycl::target::device>
+                      accC,
+                  sycl::accessor<int32_t, 1, sycl::access::mode::read_write,
+                                 sycl::target::device>
+                      accD,
+                  nd_item<2> item) {
   sycl::sub_group sg = item.get_sub_group();
 
   joint_matrix<sub_group, int32_t, use::accumulator, 32, 32> sub_c{};
-  joint_matrix<sub_group, int8_t, use::a, 32, 8, layout::row_major> sub_a{};
-  joint_matrix<sub_group, int8_t, use::b, 8, 32, layout::col_major> sub_b{};
+  joint_matrix<sub_group, int8_t, use::a, 32, 16, layout::row_major> sub_a{};
+  joint_matrix<sub_group, int8_t, use::b, 16, 32, layout::col_major> sub_b{};
 
-  // CHECK: tail call <16 x i32> @llvm.amdgcn.mfma.i32.32x32x8i8(i32 {{.*}}, i32 {{.*}}, <16 x i32> zeroinitializer, i32 0, i32 0, i32 0)
+  // CHECK: tail call <16 x i32> @llvm.amdgcn.mfma.i32.32x32x16.i8(i64 {{.*}}, i64 {{.*}}, <16 x i32> zeroinitializer, i32 0, i32 0, i32 0)
   joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
   joint_matrix_store(sg, sub_c,
                      accD.template get_multi_ptr<access::decorated::yes>(), 32,

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-int8-int32-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-int8-int32-test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: hip
-// REQUIRES: hip-arch-gfx942
+// REQUIRES: hip-arch-gfx942 || hip-arch-gfx941 || hip-arch-gfx940
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
 
 // gfx942 (CDNA3) int8 MFMA uses larger K dimensions than gfx90a:

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-half-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-half-float-test.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: hip
+// REQUIRES: hip-arch-gfx90a
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa -S %s -o -| FileCheck %s
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -177,14 +177,30 @@ if "nvptx64-nvidia-cuda" in triple:
 if "amdgcn-amd-amdhsa" in triple:
     llvm_config.with_system_environment("ROCM_PATH")
     config.available_features.add("hip")
-    # For AMD the specific GPU has to be specified with --offload-arch
-    if not any([f.startswith("--offload-arch") for f in additional_flags]):
-        # If the offload arch wasn't specified in SYCL_CLANG_EXTRA_FLAGS,
-        # hardcode it to gfx90a, this is fine because only compiler tests
+    # For AMD the specific GPU has to be specified with --offload-arch. The
+    # target arch used for every device compilation is configurable via the
+    # `amd_arch` lit param (default gfx90a), so the same suite can be run
+    # against new architectures without any harness changes, e.g.:
+    #   llvm-lit --param SYCL_TRIPLE=amdgcn-amd-amdhsa --param amd_arch=gfx942
+    #
+    # If SYCL_CLANG_EXTRA_FLAGS already provides --offload-arch, that value is
+    # honored instead. Either way, a `hip-arch-<arch>` feature is exposed so
+    # arch-specific tests (e.g. matrix codegen, whose emitted intrinsics differ
+    # per arch) can gate themselves with `REQUIRES: hip-arch-gfx942`. This means
+    # only the tests matching the selected arch run in a given invocation, which
+    # is the natural model since a single device compilation targets one arch.
+    offload_arch_flags = [
+        f for f in additional_flags if f.startswith("--offload-arch=")
+    ]
+    if offload_arch_flags:
+        amd_arch = offload_arch_flags[-1].split("=", 1)[1]
+    else:
+        amd_arch = lit_config.params.get("amd_arch", "gfx90a")
         additional_flags += [
             "-Xsycl-target-backend=amdgcn-amd-amdhsa",
-            "--offload-arch=gfx90a",
+            "--offload-arch=" + amd_arch,
         ]
+    config.available_features.add("hip-arch-" + amd_arch)
 
 config.sycl_headers_filter = lit_config.params.get("SYCL_HEADERS_FILTER", None)
 if config.sycl_headers_filter is not None:

--- a/sycl/test/matrix/hip/compile-query-hip-gfx942.cpp
+++ b/sycl/test/matrix/hip/compile-query-hip-gfx942.cpp
@@ -14,16 +14,25 @@ template <architecture Arch> void check_arch() {
   // Compile-time query to validate the matrix parameters
   using myparams =
       matrix_params<Arch, int8_t, int8_t, int32_t, int32_t, 32, 32, 16>;
+  using floatparams =
+      matrix_params<Arch, float, float, float, float, 32, 32, 2>;
 
   static_assert(myparams::M == 32);
   static_assert(myparams::N == 32);
   static_assert(myparams::K == 16);
+  static_assert(floatparams::M == 32);
+  static_assert(floatparams::N == 32);
+  static_assert(floatparams::K == 2);
 
   // Sizes-only compile-time query: types are given, generate default sizes
   using myparams2 = matrix_params<Arch, int8_t, int8_t, int32_t, int32_t>;
+  using floatparams2 = matrix_params<Arch, float, float, float, float>;
   static_assert(myparams2::M == 16);
   static_assert(myparams2::N == 16);
   static_assert(myparams2::K == 32);
+  static_assert(floatparams2::M == 16);
+  static_assert(floatparams2::N == 16);
+  static_assert(floatparams2::K == 4);
 }
 
 int main() {

--- a/sycl/test/matrix/hip/compile-query-hip-gfx942.cpp
+++ b/sycl/test/matrix/hip/compile-query-hip-gfx942.cpp
@@ -33,6 +33,25 @@ template <architecture Arch> void check_arch() {
   static_assert(floatparams2::M == 16);
   static_assert(floatparams2::N == 16);
   static_assert(floatparams2::K == 4);
+
+  // fp8 (E4M3) / bf8 (E5M2) with fp32 accumulator, including mixed A/B formats.
+  using fp8params =
+      matrix_params<Arch, fp8_e4m3, fp8_e4m3, float, float, 16, 16, 32>;
+  using bf8params =
+      matrix_params<Arch, fp8_e5m2, fp8_e5m2, float, float, 32, 32, 16>;
+  using mixed8params =
+      matrix_params<Arch, fp8_e4m3, fp8_e5m2, float, float, 16, 16, 32>;
+  static_assert(fp8params::M == 16 && fp8params::N == 16 && fp8params::K == 32);
+  static_assert(bf8params::M == 32 && bf8params::N == 32 && bf8params::K == 16);
+  static_assert(mixed8params::K == 32);
+
+  // Sizes-only query for fp8: default square shape with K == 32.
+  using fp8params2 = matrix_params<Arch, fp8_e4m3, fp8_e4m3, float, float>;
+  using mixed8params2 = matrix_params<Arch, fp8_e5m2, fp8_e4m3, float, float>;
+  static_assert(fp8params2::M == 16 && fp8params2::N == 16 &&
+                fp8params2::K == 32);
+  static_assert(mixed8params2::M == 16 && mixed8params2::N == 16 &&
+                mixed8params2::K == 32);
 }
 
 int main() {

--- a/sycl/test/matrix/hip/compile-query-hip-gfx942.cpp
+++ b/sycl/test/matrix/hip/compile-query-hip-gfx942.cpp
@@ -8,21 +8,28 @@ using namespace sycl;
 using namespace sycl::ext::oneapi::experimental;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-int main() {
+// gfx940, gfx941 and gfx942 are CDNA3 parts and expose identical joint_matrix
+// support, so the compile-time query must succeed for all three architectures.
+template <architecture Arch> void check_arch() {
   // Compile-time query to validate the matrix parameters
-  using myparams = matrix_params<architecture::amd_gpu_gfx942, int8_t, int8_t,
-                                 int32_t, int32_t, 32, 32, 16>;
+  using myparams =
+      matrix_params<Arch, int8_t, int8_t, int32_t, int32_t, 32, 32, 16>;
 
   static_assert(myparams::M == 32);
   static_assert(myparams::N == 32);
   static_assert(myparams::K == 16);
 
   // Sizes-only compile-time query: types are given, generate default sizes
-  using myparams2 = matrix_params<architecture::amd_gpu_gfx942, int8_t, int8_t,
-                                  int32_t, int32_t>;
+  using myparams2 = matrix_params<Arch, int8_t, int8_t, int32_t, int32_t>;
   static_assert(myparams2::M == 16);
   static_assert(myparams2::N == 16);
   static_assert(myparams2::K == 32);
+}
+
+int main() {
+  check_arch<architecture::amd_gpu_gfx940>();
+  check_arch<architecture::amd_gpu_gfx941>();
+  check_arch<architecture::amd_gpu_gfx942>();
 
   return 0;
 };

--- a/sycl/test/matrix/hip/compile-query-hip-gfx942.cpp
+++ b/sycl/test/matrix/hip/compile-query-hip-gfx942.cpp
@@ -1,0 +1,28 @@
+// REQUIRES: hip
+// RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx942 %s -o compile-query-hip
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental;
+using namespace sycl::ext::oneapi::experimental::matrix;
+
+int main() {
+  // Compile-time query to validate the matrix parameters
+  using myparams = matrix_params<architecture::amd_gpu_gfx942, int8_t, int8_t,
+                                 int32_t, int32_t, 32, 32, 16>;
+
+  static_assert(myparams::M == 32);
+  static_assert(myparams::N == 32);
+  static_assert(myparams::K == 16);
+
+  // Sizes-only compile-time query: types are given, generate default sizes
+  using myparams2 = matrix_params<architecture::amd_gpu_gfx942, int8_t, int8_t,
+                                  int32_t, int32_t>;
+  static_assert(myparams2::M == 16);
+  static_assert(myparams2::N == 16);
+  static_assert(myparams2::K == 32);
+
+  return 0;
+};


### PR DESCRIPTION
## Summary

Adds SYCL `joint_matrix` support for the experimental 8-bit floating-point types (`fp8_e4m3` / `fp8_e5m2` from `sycl::ext::oneapi::experimental`) on AMD **gfx942** (CDNA3 / MI300) matrix cores, using the `f32 = fp8/bf8 x fp8/bf8` MFMA instructions for the `16x16x32` and `32x32x16` shapes with an `f32` accumulator. All eight A/B format pairings (E4M3/E5M2 x E4M3/E5M2) are supported, including mixed formats.

Key points:
- Users can declare fragments directly with the experimental OCP fp8 types.
- The OCP fp8 element types are re-encoded to the CDNA3 **fnuz** encoding expected by the hardware MFMA via a branchless, integer-only, fully-unrolled conversion (no float round-trip, no lookup table). It is exact for all in-range finite values; only inherently lossy cases (E4M3 overflow, E5M2 inf, NaN, -0) are mapped to the fnuz conventions.
- Extends the compile-time (`static-query`) and runtime (`matrix_combinations`) query paths and the device-code `matrix_type` string parsing for the new fp8 types.

> [!NOTE]
> This PR is stacked on #22682 and its first four commits belong to that PR; they will drop out of this diff once #22682 is merged. Review the top four commits (fp8 support) here.

## Test plan

- [x] `sycl/test/check_device_code/hip/matrix/matrix-hip-gfx942-fp8-test.cpp` - FileCheck verifies all 8 fp8/bf8 MFMA intrinsics are emitted.
- [x] `sycl/test/matrix/hip/compile-query-hip-gfx942.cpp` - compile-time static-query assertions for fp8 combinations.
- [x] `sycl/test-e2e/Matrix/joint_matrix_hip_fp8_gfx942.cpp` - e2e over all 8 combos x 2 shapes x KX 1-4 x {row_major, col_major} store; passes on MI300A.
- [x] Additional off-tree random stress run on MI300A: ~1.5M element checks across 3 value ranges, 0 failures, bit-exact accumulator error.
