### PR TITLE
[UR][L0v2] Add tests to raise urIPC*PhysMemHandleExp coverage in physical_mem.cpp

### DIFF
--- a/unified-runtime/test/conformance/virtual_memory/urIPCOpenPhysMemHandleExp.cpp
+++ b/unified-runtime/test/conformance/virtual_memory/urIPCOpenPhysMemHandleExp.cpp
@@ -5,6 +5,11 @@
 
 #include "urIPCPhysMemHandleExpFixtures.hpp"
 
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
 using urIPCOpenPhysMemHandleExpTest = urIPCPhysMemHandleTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urIPCOpenPhysMemHandleExpTest);
 
@@ -54,4 +59,75 @@ TEST_P(urIPCOpenPhysMemHandleExpTest, InvalidValue) {
                                              ipc_handle_size + 1,
                                              &opened_physical_mem),
                    UR_RESULT_ERROR_INVALID_VALUE);
+}
+
+TEST_P(urIPCOpenPhysMemHandleExpTest, InvalidValueStaleHandle) {
+  // Obtain a second IPC handle for the same physical memory object and
+  // release it right away with urIPCPutPhysMemHandleExp, which closes its
+  // underlying file descriptor. urIPCPutPhysMemHandleExp also frees the
+  // handle data itself, so save a byte-for-byte copy beforehand and use that
+  // copy afterwards. Opening the stale copy must fail because the fd it
+  // refers to has already been closed.
+  void *stale_handle_data = nullptr;
+  size_t stale_handle_size = 0;
+  ASSERT_SUCCESS(urIPCGetPhysMemHandleExp(
+      context, physical_mem, &stale_handle_data, &stale_handle_size));
+  ASSERT_NE(stale_handle_data, nullptr);
+
+  std::vector<uint8_t> handle_copy(stale_handle_size);
+  std::memcpy(handle_copy.data(), stale_handle_data, stale_handle_size);
+
+  ASSERT_SUCCESS(urIPCPutPhysMemHandleExp(context, stale_handle_data));
+
+  ur_physical_mem_handle_t opened_physical_mem = nullptr;
+  ASSERT_EQ_RESULT(
+      urIPCOpenPhysMemHandleExp(context, device, handle_copy.data(),
+                                stale_handle_size, &opened_physical_mem),
+      UR_RESULT_ERROR_INVALID_VALUE);
+}
+
+// Mirrors the layout of the opaque handle data produced by the level_zero_v2
+// adapter (see unified-runtime/source/adapters/level_zero/v2/physical_mem.hpp
+// -- ZeIPCPhysMemHandleData). This IPC feature is currently only implemented
+// by that adapter, gated behind UR_DEVICE_INFO_IPC_PHYSICAL_MEMORY_SUPPORT_EXP
+// (checked in the fixture's SetUp(), which GTEST_SKIPs otherwise), so
+// mirroring its layout here is safe. It lets the tests below exercise
+// adapter-internal validation and cross-process-import error paths that
+// cannot be reached by treating the handle purely as an opaque blob.
+struct TestIPCPhysMemHandleData {
+  int Pid;
+  int Fd;
+  size_t Size;
+};
+
+TEST_P(urIPCOpenPhysMemHandleExpTest, InvalidValueCorruptedFields) {
+  ASSERT_EQ(ipc_handle_size, sizeof(TestIPCPhysMemHandleData));
+  TestIPCPhysMemHandleData corrupted;
+  std::memcpy(&corrupted, ipc_handle_data, sizeof(corrupted));
+  // A zero size fails the sanity checks performed at the top of
+  // urIPCOpenPhysMemHandleExp, before any fd is touched.
+  corrupted.Size = 0;
+
+  ur_physical_mem_handle_t opened_physical_mem = nullptr;
+  ASSERT_EQ_RESULT(urIPCOpenPhysMemHandleExp(context, device, &corrupted,
+                                             sizeof(corrupted),
+                                             &opened_physical_mem),
+                   UR_RESULT_ERROR_INVALID_VALUE);
+}
+
+TEST_P(urIPCOpenPhysMemHandleExpTest, InvalidValueUnknownPid) {
+  ASSERT_EQ(ipc_handle_size, sizeof(TestIPCPhysMemHandleData));
+  TestIPCPhysMemHandleData corrupted;
+  std::memcpy(&corrupted, ipc_handle_data, sizeof(corrupted));
+  // Use a PID that is (almost certainly) not in use so the cross-process
+  // import path (pidfd_open/pidfd_getfd) is exercised and fails.
+  corrupted.Pid = std::numeric_limits<int>::max();
+
+  ur_physical_mem_handle_t opened_physical_mem = nullptr;
+  ur_result_t result = urIPCOpenPhysMemHandleExp(
+      context, device, &corrupted, sizeof(corrupted), &opened_physical_mem);
+  EXPECT_TRUE(result == UR_RESULT_ERROR_INVALID_ARGUMENT ||
+              result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE ||
+              result == UR_RESULT_ERROR_INVALID_VALUE)
+      << "Unexpected result: " << result;
 }


### PR DESCRIPTION
Add three new conformance test cases to urIPCOpenPhysMemHandleExp.cpp
that exercise adapter-internal error paths in the level_zero_v2
physical_mem.cpp implementation which were not reachable through the
existing tests:

- InvalidValueStaleHandle: opens a handle whose underlying fd was
  already closed by urIPCPutPhysMemHandleExp, exercising the dup()
  failure branch.
- InvalidValueCorruptedFields: opens a handle with a corrupted (zero)
  Size field, exercising the Fd<0/Pid<=0/Size==0 validation branch.
- InvalidValueUnknownPid: opens a handle claiming an unused PID,
  exercising the cross-process pidfd_open/pidfd_getfd failure and
  errno-mapping branches.
