### PR TITLE
[UR][L0v2] Move TestIPCPhysMemHandleData-based tests to level_zero/v2

### DIFF
--- a/unified-runtime/test/adapters/level_zero/v2/CMakeLists.txt
+++ b/unified-runtime/test/adapters/level_zero/v2/CMakeLists.txt
@@ -66,6 +66,13 @@ add_l0_v2_devices_test(memory_residency
     ${PROJECT_SOURCE_DIR}/source/adapters/level_zero/ur_level_zero.cpp
 )
 
+add_l0_v2_devices_test(urIPCOpenPhysMemHandleExpInvalidHandleData
+    urIPCOpenPhysMemHandleExpInvalidHandleData.cpp
+)
+target_include_directories(urIPCOpenPhysMemHandleExpInvalidHandleData-test PRIVATE
+    ${UR_CONFORMANCE_TEST_DIR}/virtual_memory
+)
+
 add_l0_v2_devices_test(batched_queue
     batched_queue_test.cpp
    ${PROJECT_SOURCE_DIR}/source/adapters/level_zero/adapter.cpp

--- a/unified-runtime/test/adapters/level_zero/v2/urIPCOpenPhysMemHandleExpInvalidHandleData.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/urIPCOpenPhysMemHandleExpInvalidHandleData.cpp
@@ -1,0 +1,61 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %with-v2 ./urIPCOpenPhysMemHandleExpInvalidHandleData-test
+// REQUIRES: v2
+
+#include "urIPCPhysMemHandleExpFixtures.hpp"
+
+#include <cstring>
+#include <limits>
+
+using urIPCOpenPhysMemHandleExpTest = urIPCPhysMemHandleTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urIPCOpenPhysMemHandleExpTest);
+
+// Mirrors the layout of the opaque handle data produced by the level_zero_v2
+// adapter (see unified-runtime/source/adapters/level_zero/v2/physical_mem.hpp
+// -- ZeIPCPhysMemHandleData). This IPC feature is currently only implemented
+// by that adapter, gated behind UR_DEVICE_INFO_IPC_PHYSICAL_MEMORY_SUPPORT_EXP
+// (checked in the fixture's SetUp(), which GTEST_SKIPs otherwise), so
+// mirroring its layout here is safe. It lets the tests below exercise
+// adapter-internal validation and cross-process-import error paths that
+// cannot be reached by treating the handle purely as an opaque blob.
+struct TestIPCPhysMemHandleData {
+  int Pid;
+  int Fd;
+  size_t Size;
+};
+
+TEST_P(urIPCOpenPhysMemHandleExpTest, InvalidValueCorruptedFields) {
+  ASSERT_EQ(ipc_handle_size, sizeof(TestIPCPhysMemHandleData));
+  TestIPCPhysMemHandleData corrupted;
+  std::memcpy(&corrupted, ipc_handle_data, sizeof(corrupted));
+  // A zero size fails the sanity checks performed at the top of
+  // urIPCOpenPhysMemHandleExp, before any fd is touched.
+  corrupted.Size = 0;
+
+  ur_physical_mem_handle_t opened_physical_mem = nullptr;
+  ASSERT_EQ_RESULT(urIPCOpenPhysMemHandleExp(context, device, &corrupted,
+                                             sizeof(corrupted),
+                                             &opened_physical_mem),
+                   UR_RESULT_ERROR_INVALID_VALUE);
+}
+
+TEST_P(urIPCOpenPhysMemHandleExpTest, InvalidValueUnknownPid) {
+  ASSERT_EQ(ipc_handle_size, sizeof(TestIPCPhysMemHandleData));
+  TestIPCPhysMemHandleData corrupted;
+  std::memcpy(&corrupted, ipc_handle_data, sizeof(corrupted));
+  // Use a PID that is (almost certainly) not in use so the cross-process
+  // import path (pidfd_open/pidfd_getfd) is exercised and fails.
+  corrupted.Pid = std::numeric_limits<int>::max();
+
+  ur_physical_mem_handle_t opened_physical_mem = nullptr;
+  ur_result_t result = urIPCOpenPhysMemHandleExp(
+      context, device, &corrupted, sizeof(corrupted), &opened_physical_mem);
+  EXPECT_TRUE(result == UR_RESULT_ERROR_INVALID_ARGUMENT ||
+              result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE ||
+              result == UR_RESULT_ERROR_INVALID_VALUE)
+      << "Unexpected result: " << result;
+}

--- a/unified-runtime/test/conformance/virtual_memory/urIPCOpenPhysMemHandleExp.cpp
+++ b/unified-runtime/test/conformance/virtual_memory/urIPCOpenPhysMemHandleExp.cpp
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <limits>
 #include <vector>
 
 using urIPCOpenPhysMemHandleExpTest = urIPCPhysMemHandleTest;
@@ -86,48 +85,6 @@ TEST_P(urIPCOpenPhysMemHandleExpTest, InvalidValueStaleHandle) {
       UR_RESULT_ERROR_INVALID_VALUE);
 }
 
-// Mirrors the layout of the opaque handle data produced by the level_zero_v2
-// adapter (see unified-runtime/source/adapters/level_zero/v2/physical_mem.hpp
-// -- ZeIPCPhysMemHandleData). This IPC feature is currently only implemented
-// by that adapter, gated behind UR_DEVICE_INFO_IPC_PHYSICAL_MEMORY_SUPPORT_EXP
-// (checked in the fixture's SetUp(), which GTEST_SKIPs otherwise), so
-// mirroring its layout here is safe. It lets the tests below exercise
-// adapter-internal validation and cross-process-import error paths that
-// cannot be reached by treating the handle purely as an opaque blob.
-struct TestIPCPhysMemHandleData {
-  int Pid;
-  int Fd;
-  size_t Size;
-};
-
-TEST_P(urIPCOpenPhysMemHandleExpTest, InvalidValueCorruptedFields) {
-  ASSERT_EQ(ipc_handle_size, sizeof(TestIPCPhysMemHandleData));
-  TestIPCPhysMemHandleData corrupted;
-  std::memcpy(&corrupted, ipc_handle_data, sizeof(corrupted));
-  // A zero size fails the sanity checks performed at the top of
-  // urIPCOpenPhysMemHandleExp, before any fd is touched.
-  corrupted.Size = 0;
-
-  ur_physical_mem_handle_t opened_physical_mem = nullptr;
-  ASSERT_EQ_RESULT(urIPCOpenPhysMemHandleExp(context, device, &corrupted,
-                                             sizeof(corrupted),
-                                             &opened_physical_mem),
-                   UR_RESULT_ERROR_INVALID_VALUE);
-}
-
-TEST_P(urIPCOpenPhysMemHandleExpTest, InvalidValueUnknownPid) {
-  ASSERT_EQ(ipc_handle_size, sizeof(TestIPCPhysMemHandleData));
-  TestIPCPhysMemHandleData corrupted;
-  std::memcpy(&corrupted, ipc_handle_data, sizeof(corrupted));
-  // Use a PID that is (almost certainly) not in use so the cross-process
-  // import path (pidfd_open/pidfd_getfd) is exercised and fails.
-  corrupted.Pid = std::numeric_limits<int>::max();
-
-  ur_physical_mem_handle_t opened_physical_mem = nullptr;
-  ur_result_t result = urIPCOpenPhysMemHandleExp(
-      context, device, &corrupted, sizeof(corrupted), &opened_physical_mem);
-  EXPECT_TRUE(result == UR_RESULT_ERROR_INVALID_ARGUMENT ||
-              result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE ||
-              result == UR_RESULT_ERROR_INVALID_VALUE)
-      << "Unexpected result: " << result;
-}
+// Adapter-specific (level_zero_v2) tests that rely on the internal layout of
+// the opaque IPC handle data now live in
+// unified-runtime/test/adapters/level_zero/v2/urIPCOpenPhysMemHandleExpInvalidHandleData.cpp


### PR DESCRIPTION
The InvalidValueCorruptedFields and InvalidValueUnknownPid test cases
in urIPCOpenPhysMemHandleExp.cpp rely on the internal layout of the
level_zero_v2 adapter's opaque IPC handle data (struct
TestIPCPhysMemHandleData mirrors ZeIPCPhysMemHandleData), making them
L0v2-specific. Split them, along with that struct, into a new
urIPCOpenPhysMemHandleExpInvalidHandleData.cpp under
test/adapters/level_zero/v2/, built via add_l0_v2_devices_test with
the usual `RUN: %with-v2` / `REQUIRES: v2` lit directives, while the
rest of urIPCOpenPhysMemHandleExp.cpp (which only treats the IPC
handle as an opaque blob) stays in the generic
conformance/virtual_memory suite. The new file reuses the shared
urIPCPhysMemHandleExpFixtures.hpp fixture header still living in
conformance/virtual_memory/ via an added include directory.