### PR TITLE
[SYCL] Exclude MTL from XFAIL tags for certain SubGroup tests

### DIFF
--- a/sycl/test-e2e/SubGroup/barrier.cpp
+++ b/sycl/test-e2e/SubGroup/barrier.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: windows && gpu-intel-gen12
+// XFAIL: !arch-intel_gpu_mtl_u && windows && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21533
 
 //==---------- barrier.cpp - SYCL sub_group barrier test -------*- C++ -*---==//

--- a/sycl/test-e2e/SubGroup/reduce.cpp
+++ b/sycl/test-e2e/SubGroup/reduce.cpp
@@ -4,7 +4,7 @@
 // UNSUPPORTED: linux && gpu && !hip && !cuda
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20757
 
-// XFAIL: windows && gpu-intel-gen12
+// XFAIL: !arch-intel_gpu_mtl_u && windows && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21533
 
 //==--------------- reduce.cpp - SYCL sub_group reduce test ----*- C++ -*---==//

--- a/sycl/test-e2e/SubGroup/reduce_fp16.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_fp16.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: aspect-fp16
 // REQUIRES: gpu
 
-// XFAIL: windows && gpu-intel-gen12
+// XFAIL: !arch-intel_gpu_mtl_u && windows && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21533
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/SubGroup/reduce_spirv13.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_spirv13.cpp
@@ -4,7 +4,7 @@
 // UNSUPPORTED: arch-intel_gpu_pvc
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20361
 
-// XFAIL: windows && gpu-intel-gen12
+// XFAIL: !arch-intel_gpu_mtl_u && windows && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21533
 
 // This test verifies the correct work of SPIR-V 1.3 reduce algorithm

--- a/sycl/test-e2e/SubGroup/reduce_spirv13_fp16.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_spirv13_fp16.cpp
@@ -4,7 +4,7 @@
 // UNSUPPORTED: arch-intel_gpu_pvc
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20361
 
-// XFAIL: windows && gpu-intel-gen12
+// XFAIL: !arch-intel_gpu_mtl_u && windows && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21533
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/SubGroup/scan.cpp
+++ b/sycl/test-e2e/SubGroup/scan.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: windows && gpu-intel-gen12
+// XFAIL: !arch-intel_gpu_mtl_u && windows && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21533
 
 //==--------------- scan.cpp - SYCL sub_group scan test --------*- C++ -*---==//

--- a/sycl/test-e2e/SubGroup/scan_fp16.cpp
+++ b/sycl/test-e2e/SubGroup/scan_fp16.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: aspect-fp16
 // REQUIRES: gpu
 
-// XFAIL: windows && gpu-intel-gen12
+// XFAIL: !arch-intel_gpu_mtl_u && windows && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21533
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/SubGroup/scan_spirv13.cpp
+++ b/sycl/test-e2e/SubGroup/scan_spirv13.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: windows && gpu-intel-gen12
+// XFAIL: !arch-intel_gpu_mtl_u && windows && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21533
 
 // This test verifies the correct work of SPIR-V 1.3 exclusive_scan() and

--- a/sycl/test-e2e/SubGroup/scan_spirv13_fp16.cpp
+++ b/sycl/test-e2e/SubGroup/scan_spirv13_fp16.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: aspect-fp16
 // REQUIRES: gpu
 
-// XFAIL: windows && gpu-intel-gen12
+// XFAIL: !arch-intel_gpu_mtl_u && windows && gpu-intel-gen12
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/21533
 
 // RUN: %{build} -o %t.out


### PR DESCRIPTION
These tests are now passing on MTL GPUs and are causing "unexpected pass" failures. Therefore excluding MTL from the XFAIL tags.