### PR TITLE
[CI] Change MSVC env setup action

### DIFF
--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -118,9 +118,9 @@ jobs:
       with:
         sparse-checkout: |
           devops/actions
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+    - uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0
       with:
-        arch: amd64
+        arch: x64
     - name: Setup oneAPI env
       uses: ./devops/actions/setup_windows_oneapi_env
       if: ${{ !cancelled() && inputs.cxx == 'icx' }}

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -99,9 +99,9 @@ jobs:
         sparse-checkout: |
           devops/actions
           sycl/cts_exclude_filter
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+    - uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0
       with:
-        arch: amd64
+        arch: x64
     - name: Setup oneAPI env
       uses: ./devops/actions/setup_windows_oneapi_env
       if: ${{ !cancelled() && inputs.cxx == 'icx' }}

--- a/devops/actions/blender/blender-build/action.yml
+++ b/devops/actions/blender/blender-build/action.yml
@@ -24,10 +24,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+    - uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0
       if: runner.os == 'Windows'
       with:
-        arch: amd64
+        arch: x64
 
     - name: Setup environment (Windows)
       shell: powershell

--- a/devops/actions/blender/embree/action.yml
+++ b/devops/actions/blender/embree/action.yml
@@ -15,10 +15,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+    - uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0
       if: runner.os == 'Windows'
       with:
-        arch: amd64
+        arch: x64
 
     - name: Checkout Embree
       uses: ./devops/actions/cached_checkout

--- a/devops/actions/blender/oidn/action.yml
+++ b/devops/actions/blender/oidn/action.yml
@@ -15,10 +15,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+    - uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0
       if: runner.os == 'Windows'
       with:
-        arch: amd64
+        arch: x64
 
     - name: Source OneAPI TBB vars.sh
       if: runner.os == 'Linux'


### PR DESCRIPTION
Today we are using `ilammy/msvc-dev-cmd` which uses an old Node version that is about to be removd and nobody seems to be updating it so switch to a new one that does the same thing with a supported Node version

Nightly run (fail not related): https://github.com/intel/llvm/actions/runs/30016154671/job/89236726985

Co-Authored-By: Claude Opus 4.8 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)