### PR TITLE
[SYCL][E2E][NewOffloadModel] Mark AOT/multiple-devices.cpp UNSUPPORTED-INTENDED

### DIFF
--- a/sycl/test-e2e/AOT/multiple-devices.cpp
+++ b/sycl/test-e2e/AOT/multiple-devices.cpp
@@ -10,7 +10,8 @@
 // targets, and that compilation occurs for those targets.
 
 // UNSUPPORTED: new-offload-model
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20988
+// UNSUPPORTED-INTENDED: This test is specific to the old offload model. See
+// below for more info and a test for the new offload model.
 //
 // Explanation: Old offloading model was accepting compilation of a fat binary
 // for AOT target without specifying specific device. In that case specific


### PR DESCRIPTION
The test isn't supposed to work on the new model.