### PR TITLE
[SYCL][NewOffloadModel] Set image compile/link options for non-SPIR targets

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1954,8 +1954,10 @@ Expected<std::vector<module_split::SplitModule>> postLinkProcessModule(
   // TODO: Take into account Arch values considered as JIT: "native",
   // "spir64", "spir", "spirv32" and "spirv64" for SPIR and SPIR-V targets.
   // For now we only consider NoSubArch target as JIT.
-  bool IsJIT =
-      Triple.isSPIROrSPIRV() && Triple.getSubArch() == llvm::Triple::NoSubArch;
+  // TODO: We allow non-SPIR targets through this path, this logic matches what
+  // we do for the old offload model, it is somewhat strange but at least one
+  // test relies on this behavior: kernel-bundle-merge-options.cpp on NVPTX.
+  bool IsJIT = Triple.getSubArch() == llvm::Triple::NoSubArch;
   if (IsJIT)
     std::for_each(SplitModules.begin(), SplitModules.end(),
                   [&CompileLinkOptions](module_split::SplitModule &M) {

--- a/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
+++ b/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
@@ -1,6 +1,3 @@
-// XFAIL: new-offload-model && cuda
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/20797
-
 // REQUIRES: gpu
 // RUN: %{build} -o %t.out %debug_option
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s


### PR DESCRIPTION
This one is pretty weird.

We have a [test](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp#L15) that makes sure if we compile with `-g` that we pass `-g` at runtime to UR. 
The weird part is that they expect this for NVPTX, as well as SPIR.

In the old offload model we propagate `-g` to the image flags even for NVPTX, so do the same for the new offload model.

It is not totally clear if:
1) The test intended to check this for NVPTX
2) The old offload model intended to do this for NVPTX

The code that adds this for the old offload model is [here](https://github.com/intel/llvm/blob/sycl/clang/lib/Driver/ToolChains/Clang.cpp#L10696), you can see the triple check at the link but the flag is actually added in `AddSPIRVImpliedTargetArgs`

The change is low impact and trivial so IMO let's just match support for the old offload model and move on.
