### PR TITLE
[SYCL][NewOffloadModel][E2E] Re-enable previously flaky tests

### DIFF
--- a/sycl/test-e2e/KernelCompiler/sycl_join.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_join.cpp
@@ -12,10 +12,6 @@
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{run} %t.out
 // RUN: %if hip %{ env SYCL_JIT_AMDGCN_PTX_TARGET_CPU=%{amd_arch} %} %{l0_leak_check} %{run} %t.out
 
-// This test is flaky in NewOffloadModel model for Arc GPU in windows.
-// UNSUPPORTED: new-offload-model && windows && run-mode
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20797
-
 // XFAIL: target-native_cpu
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/20142
 #include <iostream>

--- a/sycl/test-e2e/Regression/reduction_resource_leak_dw.cpp
+++ b/sycl/test-e2e/Regression/reduction_resource_leak_dw.cpp
@@ -1,8 +1,3 @@
-// This test is flaky in NewOffloadModel mode among different targets at
-// Windows.
-// UNSUPPORTED: new-offload-model && windows && run-mode
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/20797
-
 // REQUIRES: level_zero
 //
 // UNSUPPORTED: windows


### PR DESCRIPTION
They seem working now, I doubt it was related to the new offload model anyway.