### PR TITLE
[libclc] Define 64-bit atomic compare_exchange for NVPTX

### DIFF
--- a/libclc/clc/lib/generic/atomic/clc_atomic_compare_exchange.inc
+++ b/libclc/clc/lib/generic/atomic/clc_atomic_compare_exchange.inc
@@ -8,16 +8,16 @@
 
 #ifdef __CLC_SCALAR
 
-#if defined(__SPIR32__) || defined(__NVPTX__)
+#ifdef __SPIR32__
 #if (defined(__CLC_FPSIZE) && __CLC_FPSIZE <= 32) ||                           \
     (defined(__CLC_GENSIZE) && (__CLC_GENSIZE == 32))
 #define __CLC_HAS_ATOMIC
 #endif
-#else // defined(__SPIR32__) || defined(__NVPTX__)
+#else // __SPIR32__
 #if defined(__CLC_FPSIZE) || (__CLC_GENSIZE >= 32)
 #define __CLC_HAS_ATOMIC
 #endif
-#endif // defined(__SPIR32__) || defined(__NVPTX__)
+#endif // __SPIR32__
 
 #ifdef __CLC_HAS_ATOMIC
 


### PR DESCRIPTION
## Summary
The `compare_exchange` definition guard in `clc_atomic_compare_exchange.inc` grouped `__NVPTX__` together with `__SPIR32__` and only emitted atomics for 32-bit types. As a result, the 64-bit integer `__clc_atomic_compare_exchange` was declared (via `atomic_decl.inc`) but never *defined* for CUDA, producing `Unresolved extern function '_Z29__clc_atomic_compare_exchange...'` (ptxas fatal) whenever a 64-bit compare-and-swap was used on NVPTX.

This changes the guard to match the sibling `clc_atomic_def.inc` (restrict only `__SPIR32__` to 32-bit), so both CUDA (NVPTX) and HIP (AMDGPU) get 64-bit `compare_exchange` definitions.

## Test plan
- Rebuilt the NVPTX `libspirv.bc`/`libclc.bc` and confirmed the 64-bit `__spirv_AtomicCompareExchange` for `int64` (`...liiill`) and `uint64` (`...miiimm`) are now defined in both global (AS1) and local (AS3) address spaces (previously unresolved).
- Built and ran the `local-ht-sycl` benchmark (HeCBench) with `-fsycl-targets=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_80` on an NVIDIA A100 (CUDA 12.8): all four Kmer sizes (21, 33, 55, 77) PASSED.
