### PR TITLE
[SYCL] Add CUDA/HIP hardware acceleration for dot_acc (dp4a)

### DIFF
--- a/sycl/include/sycl/ext/oneapi/dot_product.hpp
+++ b/sycl/include/sycl/ext/oneapi/dot_product.hpp
@@ -10,67 +10,186 @@
 
 #pragma once
 
+#include <sycl/bit_cast.hpp>
 #include <sycl/vector.hpp>
+
+#include <cstdint>
 
 namespace sycl {
 inline namespace _V1 {
 namespace ext::oneapi {
 
-union Us {
-  char s[4];
-  int32_t i;
-};
-union Uu {
-  unsigned char s[4];
-  uint32_t i;
-};
+namespace detail {
 
-int32_t dot_acc(int32_t pa, int32_t pb, int32_t c) {
-  Us a = *(reinterpret_cast<Us *>(&pa));
-  Us b = *(reinterpret_cast<Us *>(&pb));
-  return a.s[0] * b.s[0] + a.s[1] * b.s[1] + a.s[2] * b.s[2] + a.s[3] * b.s[3] +
-         c;
+// Scalar (portable) fallback implementations. The four combinations differ
+// only in how each of the four packed bytes is extended to 32-bit before the
+// multiply (signed vs. unsigned).
+// Values are promoted to `int` for the multiply.
+inline int32_t dp4a_ss_fallback(int32_t pa, int32_t pb, int32_t c) {
+  const int8_t *a = reinterpret_cast<const int8_t *>(&pa);
+  const int8_t *b = reinterpret_cast<const int8_t *>(&pb);
+  return int{a[0]} * int{b[0]} + int{a[1]} * int{b[1]} + int{a[2]} * int{b[2]} +
+         int{a[3]} * int{b[3]} + c;
+}
+inline int32_t dp4a_uu_fallback(uint32_t pa, uint32_t pb, int32_t c) {
+  const uint8_t *a = reinterpret_cast<const uint8_t *>(&pa);
+  const uint8_t *b = reinterpret_cast<const uint8_t *>(&pb);
+  return int{a[0]} * int{b[0]} + int{a[1]} * int{b[1]} + int{a[2]} * int{b[2]} +
+         int{a[3]} * int{b[3]} + c;
+}
+inline int32_t dp4a_su_fallback(int32_t pa, uint32_t pb, int32_t c) {
+  const int8_t *a = reinterpret_cast<const int8_t *>(&pa);
+  const uint8_t *b = reinterpret_cast<const uint8_t *>(&pb);
+  return int{a[0]} * int{b[0]} + int{a[1]} * int{b[1]} + int{a[2]} * int{b[2]} +
+         int{a[3]} * int{b[3]} + c;
+}
+inline int32_t dp4a_us_fallback(uint32_t pa, int32_t pb, int32_t c) {
+  const uint8_t *a = reinterpret_cast<const uint8_t *>(&pa);
+  const int8_t *b = reinterpret_cast<const int8_t *>(&pb);
+  return int{a[0]} * int{b[0]} + int{a[1]} * int{b[1]} + int{a[2]} * int{b[2]} +
+         int{a[3]} * int{b[3]} + c;
 }
 
-int32_t dot_acc(uint32_t pa, uint32_t pb, int32_t c) {
-  Uu a = *(reinterpret_cast<Uu *>(&pa));
-  Uu b = *(reinterpret_cast<Uu *>(&pb));
-  return a.s[0] * b.s[0] + a.s[1] * b.s[1] + a.s[2] * b.s[2] + a.s[3] * b.s[3] +
-         c;
+// Hardware-accelerated implementations.
+//
+// NVPTX (CUDA):  the `dp4a` instruction is available since sm_61 (Pascal).
+//                PTX supports independent signedness of the two operands via
+//                `dp4a.atype.btype` where atype/btype in {s32, u32}.
+// AMDGCN (HIP):  `__builtin_amdgcn_sdot4` / `__builtin_amdgcn_udot4` map to
+//                the `v_dot4_i32_i8` / `v_dot4_u32_u8` instructions available
+//                on gfx906+, CDNA and RDNA2 (sdot4 needs `dot1-insts`, udot4
+//                needs `dot7-insts`). Mixed-signedness dot products use
+//                `__builtin_amdgcn_sudot4` (`v_dot4_i32_iu8`, needs
+//                `dot8-insts`), whose per-operand sign flags exist only on
+//                gfx11 (RDNA3) and gfx12/RDNA4 -- the CDNA3 gfx94x parts,
+//                including MI300, lack `dot8-insts`. Since RDNA3+ dropped
+//                `v_dot4_i32_i8`, the signed-signed case also falls through
+//                to `sudot4` (both operands signed) there. Every path is
+//                guarded with `__builtin_amdgcn_is_invocable` (a compile-time
+//                constant), so architectures that lack a given instruction
+//                use the scalar fallback.
+
+inline int32_t dp4a_ss(int32_t a, int32_t b, int32_t c) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__) &&                     \
+    (__SYCL_CUDA_ARCH__ >= 610)
+  int32_t d;
+  asm("dp4a.s32.s32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(b), "r"(c));
+  return d;
+#elif defined(__SYCL_DEVICE_ONLY__) && defined(__AMDGCN__)
+#if __has_builtin(__builtin_amdgcn_is_invocable) &&                            \
+    __has_builtin(__builtin_amdgcn_sdot4)
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_sdot4))
+    return __builtin_amdgcn_sdot4(a, b, c, false);
+#endif
+#if __has_builtin(__builtin_amdgcn_is_invocable) &&                            \
+    __has_builtin(__builtin_amdgcn_sudot4)
+  // RDNA3+/gfx12 dropped `v_dot4_i32_i8` (sdot4) but can still perform a signed
+  // dot product via `v_dot4_i32_iu8` (sudot4) with both operands marked signed.
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_sudot4))
+    return __builtin_amdgcn_sudot4(/*a_sign=*/true, a, /*b_sign=*/true, b, c,
+                                   false);
+#endif
+  return dp4a_ss_fallback(a, b, c);
+#else
+  return dp4a_ss_fallback(a, b, c);
+#endif
 }
 
-int32_t dot_acc(int32_t pa, uint32_t pb, int32_t c) {
-  Us a = *(reinterpret_cast<Us *>(&pa));
-  Uu b = *(reinterpret_cast<Uu *>(&pb));
-  return a.s[0] * b.s[0] + a.s[1] * b.s[1] + a.s[2] * b.s[2] + a.s[3] * b.s[3] +
-         c;
+inline int32_t dp4a_uu(uint32_t a, uint32_t b, int32_t c) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__) &&                     \
+    (__SYCL_CUDA_ARCH__ >= 610)
+  int32_t d;
+  asm("dp4a.u32.u32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(b), "r"(c));
+  return d;
+#elif defined(__SYCL_DEVICE_ONLY__) && defined(__AMDGCN__)
+#if __has_builtin(__builtin_amdgcn_is_invocable) &&                            \
+    __has_builtin(__builtin_amdgcn_udot4)
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_udot4))
+    return __builtin_amdgcn_udot4(a, b, c, false);
+#endif
+  return dp4a_uu_fallback(a, b, c);
+#else
+  return dp4a_uu_fallback(a, b, c);
+#endif
 }
 
-int32_t dot_acc(uint32_t pa, int32_t pb, int32_t c) {
-  Uu a = *(reinterpret_cast<Uu *>(&pa));
-  Us b = *(reinterpret_cast<Us *>(&pb));
-  return a.s[0] * b.s[0] + a.s[1] * b.s[1] + a.s[2] * b.s[2] + a.s[3] * b.s[3] +
-         c;
+inline int32_t dp4a_su(int32_t a, uint32_t b, int32_t c) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__) &&                     \
+    (__SYCL_CUDA_ARCH__ >= 610)
+  int32_t d;
+  asm("dp4a.s32.u32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(b), "r"(c));
+  return d;
+#elif defined(__SYCL_DEVICE_ONLY__) && defined(__AMDGCN__)
+#if __has_builtin(__builtin_amdgcn_is_invocable) &&                            \
+    __has_builtin(__builtin_amdgcn_sudot4)
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_sudot4))
+    return __builtin_amdgcn_sudot4(/*a_sign=*/true, a, /*b_sign=*/false,
+                                   static_cast<int32_t>(b), c, false);
+#endif
+  return dp4a_su_fallback(a, b, c);
+#else
+  return dp4a_su_fallback(a, b, c);
+#endif
 }
 
-int32_t dot_acc(vec<int8_t, 4> a, vec<int8_t, 4> b, int32_t c) {
-  return a.s0() * b.s0() + a.s1() * b.s1() + a.s2() * b.s2() + a.s3() * b.s3() +
-         c;
+inline int32_t dp4a_us(uint32_t a, int32_t b, int32_t c) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__) &&                     \
+    (__SYCL_CUDA_ARCH__ >= 610)
+  int32_t d;
+  asm("dp4a.u32.s32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(b), "r"(c));
+  return d;
+#elif defined(__SYCL_DEVICE_ONLY__) && defined(__AMDGCN__)
+#if __has_builtin(__builtin_amdgcn_is_invocable) &&                            \
+    __has_builtin(__builtin_amdgcn_sudot4)
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_sudot4))
+    return __builtin_amdgcn_sudot4(/*a_sign=*/false, static_cast<int32_t>(a),
+                                   /*b_sign=*/true, b, c, false);
+#endif
+  return dp4a_us_fallback(a, b, c);
+#else
+  return dp4a_us_fallback(a, b, c);
+#endif
 }
 
-int32_t dot_acc(vec<uint8_t, 4> a, vec<uint8_t, 4> b, int32_t c) {
-  return a.s0() * b.s0() + a.s1() * b.s1() + a.s2() * b.s2() + a.s3() * b.s3() +
-         c;
+} // namespace detail
+
+inline int32_t dot_acc(int32_t pa, int32_t pb, int32_t c) {
+  return detail::dp4a_ss(pa, pb, c);
 }
 
-int32_t dot_acc(vec<uint8_t, 4> a, vec<int8_t, 4> b, int32_t c) {
-  return a.s0() * b.s0() + a.s1() * b.s1() + a.s2() * b.s2() + a.s3() * b.s3() +
-         c;
+inline int32_t dot_acc(uint32_t pa, uint32_t pb, int32_t c) {
+  return detail::dp4a_uu(pa, pb, c);
 }
 
-int32_t dot_acc(vec<int8_t, 4> a, vec<uint8_t, 4> b, int32_t c) {
-  return a.s0() * b.s0() + a.s1() * b.s1() + a.s2() * b.s2() + a.s3() * b.s3() +
-         c;
+inline int32_t dot_acc(int32_t pa, uint32_t pb, int32_t c) {
+  return detail::dp4a_su(pa, pb, c);
+}
+
+inline int32_t dot_acc(uint32_t pa, int32_t pb, int32_t c) {
+  return detail::dp4a_us(pa, pb, c);
+}
+
+// The 4-byte vectors are bit-cast directly to the packed 32-bit word. `dot_acc`
+// sums four independent lane products, so byte order (endianness) does not
+// affect the result as long as both operands are packed identically.
+inline int32_t dot_acc(vec<int8_t, 4> a, vec<int8_t, 4> b, int32_t c) {
+  return detail::dp4a_ss(sycl::bit_cast<int32_t>(a), sycl::bit_cast<int32_t>(b),
+                         c);
+}
+
+inline int32_t dot_acc(vec<uint8_t, 4> a, vec<uint8_t, 4> b, int32_t c) {
+  return detail::dp4a_uu(sycl::bit_cast<uint32_t>(a),
+                         sycl::bit_cast<uint32_t>(b), c);
+}
+
+inline int32_t dot_acc(vec<uint8_t, 4> a, vec<int8_t, 4> b, int32_t c) {
+  return detail::dp4a_us(sycl::bit_cast<uint32_t>(a),
+                         sycl::bit_cast<int32_t>(b), c);
+}
+
+inline int32_t dot_acc(vec<int8_t, 4> a, vec<uint8_t, 4> b, int32_t c) {
+  return detail::dp4a_su(sycl::bit_cast<int32_t>(a),
+                         sycl::bit_cast<uint32_t>(b), c);
 }
 
 } // namespace ext::oneapi

--- a/sycl/test-e2e/DotProduct/dot_product_int_test.cpp
+++ b/sycl/test-e2e/DotProduct/dot_product_int_test.cpp
@@ -1,5 +1,7 @@
-// This test checks dp4a support
-// For now we only check fallback support because DG1 hardware is not widespread
+// This test checks dp4a support.
+// On NVPTX (sm_61+) and AMDGCN (gfx906+/CDNA/RDNA2+) targets dot_acc lowers to
+// the hardware dp4a instruction; other targets use the scalar fallback. The
+// numerical result is identical, so this test validates both paths.
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/DotProduct/dot_product_vec_test.cpp
+++ b/sycl/test-e2e/DotProduct/dot_product_vec_test.cpp
@@ -1,5 +1,7 @@
-// This test checks dp4a support with vec<> arguments
-// For now we only check fallback support because DG1 hardware is not widespread
+// This test checks dp4a support with vec<> arguments.
+// On NVPTX (sm_61+) and AMDGCN (gfx906+/CDNA/RDNA2+) targets dot_acc lowers to
+// the hardware dp4a instruction; other targets use the scalar fallback. The
+// numerical result is identical, so this test validates both paths.
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test/check_device_code/cuda/dp4a.cpp
+++ b/sycl/test/check_device_code/cuda/dp4a.cpp
@@ -1,0 +1,39 @@
+// Check that the sycl_ext_oneapi_dot_accumulate extension (dot_acc / dp4a)
+// lowers to the hardware `dp4a` instruction on NVPTX (sm_61+).
+//
+// REQUIRES: cuda
+//
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda \
+// RUN:   -Xsycl-target-backend --cuda-gpu-arch=sm_90 -S -Xclang -emit-llvm \
+// RUN:   %s -o - | FileCheck %s
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/dot_product.hpp>
+
+using namespace sycl::ext::oneapi;
+
+// CHECK: dp4a.s32.s32
+SYCL_EXTERNAL int32_t test_ss(int32_t a, int32_t b, int32_t c) {
+  return dot_acc(a, b, c);
+}
+
+// CHECK: dp4a.u32.u32
+SYCL_EXTERNAL int32_t test_uu(uint32_t a, uint32_t b, int32_t c) {
+  return dot_acc(a, b, c);
+}
+
+// CHECK: dp4a.s32.u32
+SYCL_EXTERNAL int32_t test_su(int32_t a, uint32_t b, int32_t c) {
+  return dot_acc(a, b, c);
+}
+
+// CHECK: dp4a.u32.s32
+SYCL_EXTERNAL int32_t test_us(uint32_t a, int32_t b, int32_t c) {
+  return dot_acc(a, b, c);
+}
+
+// CHECK: dp4a.s32.s32
+SYCL_EXTERNAL int32_t test_vec(sycl::vec<int8_t, 4> a, sycl::vec<int8_t, 4> b,
+                               int32_t c) {
+  return dot_acc(a, b, c);
+}

--- a/sycl/test/check_device_code/hip/dp4a.cpp
+++ b/sycl/test/check_device_code/hip/dp4a.cpp
@@ -1,0 +1,72 @@
+// Check that the sycl_ext_oneapi_dot_accumulate extension (dot_acc / dp4a)
+// lowers to the hardware `v_dot4` family on AMDGCN via the amdgcn dot builtins.
+//
+// Same-signedness dot products use `__builtin_amdgcn_sdot4` (needs dot1-insts,
+// available on CDNA/RDNA2 but *not* RDNA3) and `__builtin_amdgcn_udot4` (needs
+// dot7-insts). Mixed-signedness dot products use `__builtin_amdgcn_sudot4`
+// (`v_dot4_i32_iu8`, needs dot8-insts), which exists on gfx11 (RDNA3) and gfx12
+// only -- CDNA, including the gfx94x MI300 parts, lacks it and uses the scalar
+// fallback for the mixed cases. All paths are guarded by
+// `__builtin_amdgcn_is_invocable` so unsupported architectures fall back.
+//
+// REQUIRES: hip
+//
+// gfx90a (CDNA2, e.g. MI210/MI250): sdot4 + udot4, mixed falls back to scalar.
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xsycl-target-backend --offload-arch=gfx90a -S -Xclang -emit-llvm \
+// RUN:   %s -o - | FileCheck %s --check-prefixes=CHECK,GCN-DOT4
+//
+// gfx942 (CDNA3, MI300): same as gfx90a -- no sudot4 for the mixed cases.
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xsycl-target-backend --offload-arch=gfx942 -S -Xclang -emit-llvm \
+// RUN:   %s -o - | FileCheck %s --check-prefixes=CHECK,GCN-DOT4
+//
+// gfx1030 (RDNA2): sdot4 + udot4, mixed falls back to scalar (no dot8-insts).
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xsycl-target-backend --offload-arch=gfx1030 -S -Xclang -emit-llvm \
+// RUN:   %s -o - | FileCheck %s --check-prefixes=CHECK,GCN-DOT4
+//
+// gfx1100 (RDNA3): all signed/mixed cases lower to sudot4 (v_dot4_i32_iu8).
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xsycl-target-backend --offload-arch=gfx1100 -S -Xclang -emit-llvm \
+// RUN:   %s -o - | FileCheck %s --check-prefixes=CHECK,GCN-SUDOT
+//
+// gfx1200 (RDNA4): same as RDNA3 -- signed/mixed cases lower to sudot4.
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xsycl-target-backend --offload-arch=gfx1200 -S -Xclang -emit-llvm \
+// RUN:   %s -o - | FileCheck %s --check-prefixes=CHECK,GCN-SUDOT
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/dot_product.hpp>
+
+using namespace sycl::ext::oneapi;
+
+// On CDNA/RDNA2 the signed case uses sdot4; RDNA3+/gfx12 lack v_dot4_i32_i8 and
+// perform the signed dot product via sudot4 with both operands marked signed.
+// GCN-DOT4: call{{.*}}@llvm.amdgcn.sdot4
+// GCN-SUDOT: call{{.*}}@llvm.amdgcn.sudot4(i1 true, i32 %{{.*}}, i1 true,
+SYCL_EXTERNAL int32_t test_ss(int32_t a, int32_t b, int32_t c) {
+  return dot_acc(a, b, c);
+}
+
+// CHECK: call{{.*}}@llvm.amdgcn.udot4
+SYCL_EXTERNAL int32_t test_uu(uint32_t a, uint32_t b, int32_t c) {
+  return dot_acc(a, b, c);
+}
+
+// GCN-DOT4: call{{.*}}@llvm.amdgcn.sdot4
+// GCN-SUDOT: call{{.*}}@llvm.amdgcn.sudot4(i1 true, i32 %{{.*}}, i1 true,
+SYCL_EXTERNAL int32_t test_vec(sycl::vec<int8_t, 4> a, sycl::vec<int8_t, 4> b,
+                               int32_t c) {
+  return dot_acc(a, b, c);
+}
+
+// GCN-SUDOT: call{{.*}}@llvm.amdgcn.sudot4(i1 true, i32 %{{.*}}, i1 false,
+SYCL_EXTERNAL int32_t test_su(int32_t a, uint32_t b, int32_t c) {
+  return dot_acc(a, b, c);
+}
+
+// GCN-SUDOT: call{{.*}}@llvm.amdgcn.sudot4(i1 false, i32 %{{.*}}, i1 true,
+SYCL_EXTERNAL int32_t test_us(uint32_t a, int32_t b, int32_t c) {
+  return dot_acc(a, b, c);
+}


### PR DESCRIPTION
## Summary

Lower the `sycl_ext_oneapi_dot_accumulate` `dot_acc` helpers to the native **dp4a** instruction on hardware that supports it, keeping the existing scalar implementation as a portable fallback. The numerical result is identical on every path.

- **NVPTX (CUDA):** emit `dp4a.{s32,u32}.{s32,u32}` on sm_61+ (Pascal and later) for all four operand-signedness combinations.
- **AMDGCN (HIP):** use `__builtin_amdgcn_sdot4` / `udot4` (`v_dot4`, gfx906+/CDNA/RDNA2) and `__builtin_amdgcn_sudot4` (`v_dot4_i32_iu8`, gfx11/RDNA3+ and gfx12/RDNA4) for the mixed-sign cases and, where `sdot4` is unavailable (RDNA3+ dropped `v_dot4_i32_i8`), the same-sign signed case. Every path is guarded by `__builtin_amdgcn_is_invocable`, so architectures lacking a given instruction fall back to scalar.

### Cleanups
- Move the scalar fallbacks into `detail` and drop the `Us`/`Uu` unions that leaked into the public `sycl::ext::oneapi` namespace.
- Read the packed words through `int8_t`/`uint8_t` views instead of a `char`-based union: fixes signedness on targets where plain `char` is unsigned (e.g. AArch64) and removes type-punning UB.
- `vec<*8_t, 4>` overloads now `sycl::bit_cast` directly to the packed 32-bit word.

## Test plan

- [x] New `check_device_code` codegen tests:
  - CUDA `sm_90`: `dp4a.s32.s32`, `dp4a.u32.u32`, `dp4a.s32.u32`, `dp4a.u32.s32`.
  - HIP `gfx90a`, `gfx942`, `gfx1030` (`sdot4`/`udot4`) and `gfx1100`, `gfx1200` (`sudot4`).
- [x] E2E `DotProduct` int + vec tests (all four sign combinations) pass on:
  - NVIDIA H100 (sm_90)
  - AMD Instinct MI210 (gfx90a) and MI300A (gfx942)
- [x] Host equivalence of the refactored fallbacks vs. reference: 0 mismatches over millions of random inputs.
