### PR TITLE
[SYCL][Graph] Fix lock order inversion during native recording host task submission

### DIFF
--- a/sycl/source/detail/graph/graph_impl.cpp
+++ b/sycl/source/detail/graph/graph_impl.cpp
@@ -710,7 +710,7 @@ void graph_impl::setDestructionCallback(std::function<void()> Callback) {
 
 sycl::detail::EnqueueHostTaskData *graph_impl::addNativeHostTaskCallback(
     std::unique_ptr<sycl::detail::EnqueueHostTaskData> Data) {
-  graph_impl::WriteLock Lock(MMutex);
+  std::lock_guard<std::mutex> Lock(MNativeHostTaskCallbacksMutex);
   MNativeHostTaskCallbacks.push_back(std::move(Data));
   return MNativeHostTaskCallbacks.back().get();
 }

--- a/sycl/source/detail/graph/graph_impl.hpp
+++ b/sycl/source/detail/graph/graph_impl.hpp
@@ -640,6 +640,10 @@ private:
   /// Callback data for host tasks recorded in native recording mode.
   std::vector<std::unique_ptr<detail::EnqueueHostTaskData>>
       MNativeHostTaskCallbacks;
+  /// Mutex for modifying the host task callback container. A separate
+  /// lock is used to prevent lock order inversion when acquiring both
+  /// the queue and graph lock during native recording.
+  std::mutex MNativeHostTaskCallbacksMutex;
 
   /// Mapping from queues to barrier nodes. For each queue the last barrier
   /// node recorded to the graph from the queue is stored.

--- a/sycl/source/detail/graph/graph_impl.hpp
+++ b/sycl/source/detail/graph/graph_impl.hpp
@@ -18,6 +18,7 @@
 #include <functional>   // for function
 #include <list>         // for list
 #include <memory>       // for shared_ptr
+#include <mutex>        // for mutex
 #include <optional>     // for optional
 #include <set>          // for set
 #include <shared_mutex> // for shared_mutex

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/Threading/host_task_concurrent_end_recording.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/Threading/host_task_concurrent_end_recording.cpp
@@ -1,0 +1,68 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+// REQUIRES-INTEL-DRIVER: lin: 37561, win: 101.8724
+
+// RUN: %{build} %threads_lib -o %t.out
+// RUN: %{run} %t.out
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Regression test for a lock-order inversion in native recording between the
+// queue mutex and the graph mutex.
+//
+// Two lock orders exist on the native-recording paths:
+//   * graph -> queue: end_recording() takes graph_impl::MMutex then the queue
+//     mutex (via queue_impl::endNativeRecording()).
+//   * queue -> graph: submitting a restricted host task runs
+//   handler::finalize()
+//     under the queue mutex, which used to take graph_impl::MMutex via
+//     graph_impl::addNativeHostTaskCallback().
+//
+// Running both concurrently on the same queue and graph could deadlock.
+// The fix gives the native host-task callback list its own leaf mutex so the
+// submit path never acquires graph_impl::MMutex.
+
+#include "../../../graph_common.hpp"
+
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/properties/all_properties.hpp>
+
+#include <thread>
+
+constexpr size_t HostTasksPerIter = 32;
+
+int main() {
+  queue Queue{property::queue::in_order{}};
+
+  const sycl::context Context = Queue.get_context();
+  const sycl::device Device = Queue.get_device();
+
+  for (size_t Iter = 0; Iter < Iterations; ++Iter) {
+    exp_ext::command_graph Graph{
+        Context, Device, {exp_ext::property::graph::enable_native_recording{}}};
+
+    Graph.begin_recording(Queue);
+
+    // Tighten the race window: the submitting thread and the ending thread
+    // start their contended operation at (nearly) the same time.
+    Barrier Sync{2};
+
+    // Submitting thread takes the queue -> graph lock order for every
+    // restricted host task captured into the native graph.
+    std::thread Submitter([&]() {
+      Sync.wait();
+      for (size_t i = 0; i < HostTasksPerIter; ++i) {
+        // Side-effect-free host task: valid whether it is captured (while
+        // recording) or run as a normal host task (after recording ends).
+        exp_ext::host_task(Queue, [] {});
+      }
+    });
+
+    // Main thread takes the graph -> queue lock order.
+    Sync.wait();
+    Graph.end_recording(Queue);
+
+    Submitter.join();
+    Queue.wait_and_throw();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
If a user concurrently ends capture while submitting a native host task, then the thread ending capture acquires the `graph lock -> queue lock` and the host task submission thread acquires `queue lock -> graph lock` through the handler. This was introduced after we added locking around graph capture in https://github.com/intel/llvm/pull/22604.

The graph lock is acquired during host task submission to extend the lifetime of the user's callback. This container can be given its own mutex as it is just a lifetime extender that does not require locking the full graph and prevents deadlock.