### PR TITLE
[UR][CUDA][HIP] Add UR_{CUDA,HIP}_STACK_SIZE env var for per-thread s…

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -171,12 +171,14 @@ For a description of parallel for range rounding in DPC++ see
 | Environment variable | Values | Description |
 | -------------------- | ------ | ----------- |
 | `SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE` | Integer | Specifies the maximum size of a local memory allocation in bytes. If the value exceeds the device's capabilities then a `sycl::runtime_error` is thrown. In order for the full error message to be printed, `SYCL_RT_WARNING_LEVEL=2` must be set. The default value for `SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE` is determined by the hardware. |
+| `UR_CUDA_STACK_SIZE` | Integer | Specifies the per-thread stack size limit in bytes, applied to each CUDA device at initialization via `cuCtxSetLimit(CU_LIMIT_STACK_SIZE, ...)` (the driver-level equivalent of `cudaDeviceSetLimit(cudaLimitStackSize, ...)`). This is useful for kernels with deep recursion or large per-thread private data that would otherwise overflow the small default stack. If the value is not a positive integer, or the driver rejects it, an error is reported (set `SYCL_RT_WARNING_LEVEL=2` to see the full message). The default is determined by the CUDA driver. |
 
 ## Controlling DPC++ HIP Adapter
 
 | Environment variable | Values | Description |
 | -------------------- | ------ | ----------- |
 | `SYCL_PI_HIP_MAX_LOCAL_MEM_SIZE` | Integer | Specifies the maximum size of a local memory allocation in bytes. If the value exceeds the device's capabilities then a `sycl::runtime_error` is thrown. In order for the full error message to be printed, `SYCL_RT_WARNING_LEVEL=2` must be set. The default value for `SYCL_PI_HIP_MAX_LOCAL_MEM_SIZE` is determined by the hardware. |
+| `UR_HIP_STACK_SIZE` | Integer | Specifies the per-thread stack size limit in bytes, applied to each HIP device at initialization via `hipDeviceSetLimit(hipLimitStackSize, ...)` (the equivalent of `cudaDeviceSetLimit(cudaLimitStackSize, ...)`). This is useful for kernels with deep recursion or large per-thread private data that would otherwise overflow the small default stack. If the value is not a positive integer, or the runtime does not support setting this limit, an error is reported (set `SYCL_RT_WARNING_LEVEL=2` to see the full message). The default is determined by the HIP runtime. |
 
 ## Tools variables
 

--- a/sycl/test-e2e/Adapters/device-stack-size.cpp
+++ b/sycl/test-e2e/Adapters/device-stack-size.cpp
@@ -1,0 +1,38 @@
+// REQUIRES: cuda || hip
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %if cuda %{UR_CUDA_STACK_SIZE%} %else %{UR_HIP_STACK_SIZE%}=0 %t.out 2>&1 | FileCheck --check-prefixes=CHECK-INVALID %s
+// RUN: %{run} %if cuda %{UR_CUDA_STACK_SIZE%} %else %{UR_HIP_STACK_SIZE%}=abc %t.out 2>&1 | FileCheck --check-prefixes=CHECK-INVALID %s
+// RUN: %{run} %if cuda %{UR_CUDA_STACK_SIZE%} %else %{UR_HIP_STACK_SIZE%}=16384 %t.out 2>&1 | FileCheck --check-prefixes=CHECK-VALID %s
+
+//==-------------------------- device-stack-size.cpp ----------------------===//
+//==--- SYCL test to test UR_{CUDA,HIP}_STACK_SIZE env var ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies the behavior of the per-thread stack size limit env var:
+//   * An invalid value (non-positive or non-numeric) is rejected with a
+//     diagnostic at device initialization.
+//   * A valid value is accepted and device initialization plus a trivial
+//     kernel launch succeed.
+
+#include <cstdio>
+#include <sycl/detail/core.hpp>
+
+int main() {
+  try {
+    sycl::queue Q{};
+    Q.submit([&](sycl::handler &cgh) {
+       cgh.single_task([=]() {});
+     }).wait();
+    std::puts("PASS");
+  } catch (const std::exception &e) {
+    std::puts(e.what());
+  }
+  // CHECK-INVALID: Invalid value specified for
+  // CHECK-VALID: PASS
+}

--- a/sycl/test-e2e/Adapters/device-stack-size.cpp
+++ b/sycl/test-e2e/Adapters/device-stack-size.cpp
@@ -26,9 +26,7 @@
 int main() {
   try {
     sycl::queue Q{};
-    Q.submit([&](sycl::handler &cgh) {
-       cgh.single_task([=]() {});
-     }).wait();
+    Q.submit([&](sycl::handler &cgh) { cgh.single_task([=]() {}); }).wait();
     std::puts("PASS");
   } catch (const std::exception &e) {
     std::puts(e.what());

--- a/unified-runtime/scripts/core/CUDA.rst
+++ b/unified-runtime/scripts/core/CUDA.rst
@@ -155,6 +155,12 @@ Other Notes
   order to exceed the default max dynamic local memory size. More information
   can be found
   `here <https://intel.github.io/llvm-docs/EnvironmentVariables.html#controlling-dpc-cuda-plugin>`_.
+- The environment variable ``UR_CUDA_STACK_SIZE`` can be set to a positive
+  integer to configure the per-thread stack size limit (in bytes) applied to
+  each device at initialization via ``cuCtxSetLimit(CU_LIMIT_STACK_SIZE, ...)``,
+  the driver-level equivalent of ``cudaDeviceSetLimit(cudaLimitStackSize, ...)``.
+  This is useful for kernels with deep recursion or large per-thread private
+  data that would otherwise overflow the small default stack.
 - The size of primitive datatypes may differ in host and device code. For
   instance, NVCC treats ``long double`` as 8 bytes for device and 16 bytes for
   host.

--- a/unified-runtime/scripts/core/HIP.rst
+++ b/unified-runtime/scripts/core/HIP.rst
@@ -95,6 +95,12 @@ Other Notes
 ===========
 
 - In kernel ``printf`` may not work for certain ROCm versions.
+- The environment variable ``UR_HIP_STACK_SIZE`` can be set to a positive
+  integer to configure the per-thread stack size limit (in bytes) applied to
+  each device at initialization via ``hipDeviceSetLimit(hipLimitStackSize, ...)``,
+  the equivalent of ``cudaDeviceSetLimit(cudaLimitStackSize, ...)``. This is
+  useful for kernels with deep recursion or large per-thread private data that
+  would otherwise overflow the small default stack.
 
 Contributors
 ------------

--- a/unified-runtime/source/adapters/cuda/device.hpp
+++ b/unified-runtime/source/adapters/cuda/device.hpp
@@ -16,6 +16,9 @@
 #include "common.hpp"
 #include "common/ur_ref_count.hpp"
 
+#include <cerrno>
+#include <cstdlib>
+
 struct ur_device_handle_t_ : ur::cuda::handle_base {
 private:
   using native_type = CUdevice;
@@ -33,6 +36,7 @@ private:
   int MaxRegsPerBlock{0};
   int MaxCapacityLocalMem{0};
   int MaxChosenLocalMem{0};
+  size_t MaxChosenStackSize{0};
   uint32_t NumComputeUnits{0};
   std::once_flag NVMLInitFlag;
   std::optional<nvmlDevice_t> NVMLDevice;
@@ -83,6 +87,25 @@ public:
       // Cap chosen local mem size to device capacity, kernel enqueue will fail
       // if it actually needs more.
       MaxChosenLocalMem = std::min(MaxChosenLocalMem, MaxCapacityLocalMem);
+    }
+
+    // Set the per-thread stack size limit if the env var is present. This maps
+    // to CUDA's CU_LIMIT_STACK_SIZE (the driver-level equivalent of
+    // cudaLimitStackSize) and is useful for kernels with deep recursion or
+    // large per-thread private data that would otherwise overflow the small
+    // default stack. The primary context is already current here (see
+    // ScopedContext in platform.cpp), so cuCtxSetLimit applies to it.
+    if (const char *StackSizePtr = std::getenv("UR_CUDA_STACK_SIZE")) {
+      errno = 0;
+      char *End = nullptr;
+      const unsigned long long Parsed = std::strtoull(StackSizePtr, &End, 10);
+      if (errno != 0 || End == StackSizePtr || *End != '\0' || Parsed == 0) {
+        setErrorMessage("Invalid value specified for UR_CUDA_STACK_SIZE",
+                        UR_RESULT_ERROR_INVALID_VALUE);
+        throw UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+      }
+      MaxChosenStackSize = static_cast<size_t>(Parsed);
+      UR_CHECK_ERROR(cuCtxSetLimit(CU_LIMIT_STACK_SIZE, MaxChosenStackSize));
     }
 
     // Max size of memory object allocation in bytes.
@@ -160,6 +183,8 @@ public:
   int getMaxCapacityLocalMem() const noexcept { return MaxCapacityLocalMem; };
 
   int getMaxChosenLocalMem() const noexcept { return MaxChosenLocalMem; };
+
+  size_t getMaxChosenStackSize() const noexcept { return MaxChosenStackSize; };
 
   uint32_t getNumComputeUnits() const noexcept { return NumComputeUnits; };
 

--- a/unified-runtime/source/adapters/hip/device.hpp
+++ b/unified-runtime/source/adapters/hip/device.hpp
@@ -13,6 +13,9 @@
 
 #include <ur/ur.hpp>
 
+#include <cerrno>
+#include <cstdlib>
+
 /// UR device mapping to a hipDevice_t.
 /// Includes an observer pointer to the platform,
 /// and implements the reference counting semantics since
@@ -30,6 +33,7 @@ private:
   size_t MaxBlockDim[3];
   int MaxCapacityLocalMem{0};
   int MaxChosenLocalMem{0};
+  size_t MaxChosenStackSize{0};
   int ManagedMemSupport{0};
   int ConcurrentManagedAccess{0};
   bool HardwareImageSupport{false};
@@ -92,6 +96,25 @@ public:
       // if it actually needs more.
       MaxChosenLocalMem = std::min(MaxChosenLocalMem, MaxCapacityLocalMem);
     }
+
+    // Set the per-thread stack size limit if the env var is present. This maps
+    // to HIP's hipLimitStackSize (the equivalent of cudaLimitStackSize) and is
+    // useful for kernels with deep recursion or large per-thread private data
+    // that would otherwise overflow the small default stack. This device is
+    // already current here (hipSetDevice is called before construction in
+    // platform.cpp), so hipDeviceSetLimit applies to it.
+    if (const char *StackSizePtr = std::getenv("UR_HIP_STACK_SIZE")) {
+      errno = 0;
+      char *End = nullptr;
+      const unsigned long long Parsed = std::strtoull(StackSizePtr, &End, 10);
+      if (errno != 0 || End == StackSizePtr || *End != '\0' || Parsed == 0) {
+        setErrorMessage("Invalid value specified for UR_HIP_STACK_SIZE",
+                        UR_RESULT_ERROR_INVALID_VALUE);
+        throw UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+      }
+      MaxChosenStackSize = static_cast<size_t>(Parsed);
+      UR_CHECK_ERROR(hipDeviceSetLimit(hipLimitStackSize, MaxChosenStackSize));
+    }
   }
 
   ~ur_device_handle_t_() noexcept(false) {}
@@ -115,6 +138,8 @@ public:
   int getMaxCapacityLocalMem() const noexcept { return MaxCapacityLocalMem; };
 
   int getMaxChosenLocalMem() const noexcept { return MaxChosenLocalMem; };
+
+  size_t getMaxChosenStackSize() const noexcept { return MaxChosenStackSize; };
 
   int getManagedMemSupport() const noexcept { return ManagedMemSupport; };
 


### PR DESCRIPTION
Add support for configuring the per-thread device stack size limit at device initialization via the UR_CUDA_STACK_SIZE and UR_HIP_STACK_SIZE environment variables. These map to cuCtxSetLimit(CU_LIMIT_STACK_SIZE) and hipDeviceSetLimit(hipLimitStackSize) respectively (the driver-level equivalent of cudaDeviceSetLimit(cudaLimitStackSize)), which is useful for kernels with deep recursion or large per-thread private data that would otherwise overflow the small default stack.

An invalid value (non-positive or non-numeric) is rejected with a diagnostic at device initialization. Documentation and an E2E test covering the invalid/valid cases are included.

Addresses https://github.com/intel/llvm/issues/12271