### PR TITLE
[Sema][SYCL] Only defer device diags for constexpr var init under SYCL

### DIFF
--- a/clang/lib/Sema/SemaBase.cpp
+++ b/clang/lib/Sema/SemaBase.cpp
@@ -57,7 +57,7 @@ void SemaBase::SemaDiagnosticBuilder::AddFixItHint(
 
 SemaBase::SemaDiagnosticBuilder::DeferredDiagnosticsType &
 SemaBase::SemaDiagnosticBuilder::getDeviceDeferredDiags() const {
-  if (S.InConstexprVarInit)
+  if (S.InConstexprVarInit && S.getLangOpts().SYCLIsDevice)
     return S.MaybeDeviceDeferredDiags;
   return S.DeviceDeferredDiags;
 }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19161,7 +19161,8 @@ void Sema::ActOnCXXEnterDeclInitializer(Scope *S, Decl *D) {
     EnterDeclaratorContext(S, D->getDeclContext());
 
   if (auto *VD = dyn_cast<VarDecl>(D);
-      VD && (VD->mightBeUsableInConstantExpressions(Context)))
+      VD && LangOpts.SYCLIsDevice &&
+      VD->mightBeUsableInConstantExpressions(Context))
     InConstexprVarInit = true;
   PushExpressionEvaluationContext(
       ExpressionEvaluationContext::PotentiallyEvaluated, D,

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19161,8 +19161,7 @@ void Sema::ActOnCXXEnterDeclInitializer(Scope *S, Decl *D) {
     EnterDeclaratorContext(S, D->getDeclContext());
 
   if (auto *VD = dyn_cast<VarDecl>(D);
-      VD && LangOpts.SYCLIsDevice &&
-      VD->mightBeUsableInConstantExpressions(Context))
+      VD && (VD->mightBeUsableInConstantExpressions(Context)))
     InConstexprVarInit = true;
   PushExpressionEvaluationContext(
       ExpressionEvaluationContext::PotentiallyEvaluated, D,

--- a/clang/test/SemaHIP/amdgpu-builtin-in-lambda.hip
+++ b/clang/test/SemaHIP/amdgpu-builtin-in-lambda.hip
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -std=c++20 -triple amdgcn -target-cpu gfx90a -fsyntax-only -fcuda-is-device -verify=gfx90a -o - %s
 // RUN: %clang_cc1 -std=c++20 -triple amdgcn -target-cpu gfx950 -fsyntax-only -fcuda-is-device -o - %s
-// XFAIL: *
 
 #define __device__ __attribute__((device))
 #define __shared__ __attribute__((shared))


### PR DESCRIPTION
InConstexprVarInit marks that Sema is parsing a possibly
constant-evaluated variable initializer and should stay accurate for
all languages. What's SYCL-specific is SemaSYCL's "manifestly
constant-evaluated" exemption, which reroutes device diagnostics into
MaybeDeviceDeferredDiags and discards them if the variable turns out
constant-initialized. 10fee976924b made InConstexprVarInit
unconditional, so this also started swallowing CUDA/HIP deferred
diagnostics (e.g. AMDGPU builtin checks in a global constexpr lambda).

Gate the consumption instead: getDeviceDeferredDiags() only reroutes
to MaybeDeviceDeferredDiags when SYCLIsDevice is set.

Fix clang/test/SemaHIP/amdgpu-builtin-in-lambda.hip
CMPLRLLVM-77209